### PR TITLE
fix(desktop): terminal selection copies from every entry point on macOS

### DIFF
--- a/apps/desktop/src/electron/ElectronMenu.test.ts
+++ b/apps/desktop/src/electron/ElectronMenu.test.ts
@@ -113,6 +113,56 @@ describe("ElectronMenu", () => {
     }).pipe(Effect.provide(TestLayer)),
   );
 
+  it.effect("passes an item accelerator through to the native menu item", () =>
+    Effect.gen(function* () {
+      buildFromTemplateMock.mockImplementation(() => ({
+        popup: (options: Electron.PopupOptions) => {
+          options.callback?.();
+        },
+      }));
+
+      const electronMenu = yield* ElectronMenu.ElectronMenu;
+      yield* electronMenu.showContextMenu({
+        window: makeWindow(),
+        items: [
+          { id: "add-to-chat", label: "Add to chat" },
+          { id: "copy", label: "Copy", accelerator: "Cmd+C" },
+        ],
+        position: Option.none(),
+      });
+
+      const template = buildFromTemplateMock.mock.calls[0]?.[0] as
+        | Electron.MenuItemConstructorOptions[]
+        | undefined;
+      assert.isDefined(template);
+      assert.isUndefined(template[0]?.accelerator);
+      assert.equal(template[1]?.accelerator, "Cmd+C");
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect("drops an empty accelerator instead of forwarding it", () =>
+    Effect.gen(function* () {
+      buildFromTemplateMock.mockImplementation(() => ({
+        popup: (options: Electron.PopupOptions) => {
+          options.callback?.();
+        },
+      }));
+
+      const electronMenu = yield* ElectronMenu.ElectronMenu;
+      yield* electronMenu.showContextMenu({
+        window: makeWindow(),
+        items: [{ id: "copy", label: "Copy", accelerator: "" }],
+        position: Option.none(),
+      });
+
+      const template = buildFromTemplateMock.mock.calls[0]?.[0] as
+        | Electron.MenuItemConstructorOptions[]
+        | undefined;
+      assert.isDefined(template);
+      assert.isUndefined(template[0]?.accelerator);
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
   it.effect("defers popupTemplate side effects until the returned Effect runs", () =>
     Effect.gen(function* () {
       const popupMock = vi.fn();

--- a/apps/desktop/src/electron/ElectronMenu.ts
+++ b/apps/desktop/src/electron/ElectronMenu.ts
@@ -80,6 +80,10 @@ function normalizeContextMenuItems(source: readonly ContextMenuItem[]): ContextM
       disabled: sourceItem.disabled === true,
     };
 
+    if (typeof sourceItem.accelerator === "string" && sourceItem.accelerator.length > 0) {
+      normalizedItem.accelerator = sourceItem.accelerator;
+    }
+
     if (sourceItem.children) {
       const normalizedChildren = normalizeContextMenuItems(sourceItem.children);
       if (normalizedChildren.length === 0) {
@@ -152,6 +156,13 @@ export const make = Effect.gen(function* () {
         label: item.label,
         enabled: !item.disabled,
       };
+      // On macOS a key equivalent of an open menu fires while the menu is
+      // tracking, which is how a shortcut like Cmd+C stays functional while
+      // the selection menu owns the keyboard. A closed popup menu's
+      // accelerators are inert, so this never registers a global shortcut.
+      if (item.accelerator !== undefined) {
+        itemOption.accelerator = item.accelerator;
+      }
       if (item.children && item.children.length > 0) {
         itemOption.submenu = buildTemplate(item.children, complete);
       } else {

--- a/apps/desktop/src/electron/ElectronShell.test.ts
+++ b/apps/desktop/src/electron/ElectronShell.test.ts
@@ -46,6 +46,15 @@ describe("ElectronShell", () => {
     }).pipe(Effect.provide(ElectronShell.layer)),
   );
 
+  it.effect("writes copied text through the main-process clipboard", () =>
+    Effect.gen(function* () {
+      const electronShell = yield* ElectronShell.ElectronShell;
+      yield* electronShell.copyText("line one\nline two");
+
+      assert.deepEqual(writeTextMock.mock.calls, [["line one\nline two"]]);
+    }).pipe(Effect.provide(ElectronShell.layer)),
+  );
+
   it.effect("returns false when Electron rejects openExternal", () =>
     Effect.gen(function* () {
       openExternalMock.mockRejectedValue(new Error("open failed"));

--- a/apps/desktop/src/ipc/DesktopIpcHandlers.ts
+++ b/apps/desktop/src/ipc/DesktopIpcHandlers.ts
@@ -40,6 +40,7 @@ import {
   pickThemeFiles,
   setTheme,
   showContextMenu,
+  writeClipboardText,
 } from "./methods/window.ts";
 import * as PreviewIpc from "./methods/preview.ts";
 import { getWslState, setWslBackendEnabled, setWslDistro, setWslOnly } from "./methods/wsl.ts";
@@ -83,6 +84,7 @@ export const installDesktopIpcHandlers = Effect.fn("desktop.ipc.installHandlers"
   yield* ipc.handle(setTheme);
   yield* ipc.handle(showContextMenu);
   yield* ipc.handle(openExternal);
+  yield* ipc.handle(writeClipboardText);
   yield* ipc.handle(getUpdateState);
   yield* ipc.handle(setUpdateChannel);
   yield* ipc.handle(downloadUpdate);

--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -3,6 +3,7 @@ export const PICK_THEME_FILES_CHANNEL = "desktop:pick-theme-files";
 export const SET_THEME_CHANNEL = "desktop:set-theme";
 export const CONTEXT_MENU_CHANNEL = "desktop:context-menu";
 export const OPEN_EXTERNAL_CHANNEL = "desktop:open-external";
+export const WRITE_CLIPBOARD_TEXT_CHANNEL = "desktop:write-clipboard-text";
 export const MENU_ACTION_CHANNEL = "desktop:menu-action";
 export const GET_WINDOW_FULLSCREEN_STATE_CHANNEL = "desktop:get-window-fullscreen-state";
 export const WINDOW_FULLSCREEN_STATE_CHANNEL = "desktop:window-fullscreen-state";

--- a/apps/desktop/src/ipc/methods/window.test.ts
+++ b/apps/desktop/src/ipc/methods/window.test.ts
@@ -7,8 +7,13 @@ import type * as Electron from "electron";
 
 import * as DesktopBackendManager from "../../backend/DesktopBackendManager.ts";
 import * as DesktopBackendPool from "../../backend/DesktopBackendPool.ts";
+import * as ElectronShell from "../../electron/ElectronShell.ts";
 import * as ElectronWindow from "../../electron/ElectronWindow.ts";
-import { getLocalEnvironmentBootstraps, getWindowFullscreenState } from "./window.ts";
+import {
+  getLocalEnvironmentBootstraps,
+  getWindowFullscreenState,
+  writeClipboardText,
+} from "./window.ts";
 
 const readyWslConfig: DesktopBackendManager.DesktopBackendStartConfig = {
   executablePath: "wsl.exe",
@@ -141,6 +146,45 @@ describe("getWindowFullscreenState", () => {
       Effect.provide(
         Layer.mock(ElectronWindow.ElectronWindow)({
           currentMainOrFirst: Effect.succeed(Option.some(window)),
+        }),
+      ),
+    );
+  });
+});
+
+describe("writeClipboardText", () => {
+  it.effect("delegates the decoded text to the main-process clipboard", () => {
+    const copied: string[] = [];
+
+    return Effect.gen(function* () {
+      yield* writeClipboardText.handler("terminal selection\nline two");
+      assert.deepEqual(copied, ["terminal selection\nline two"]);
+    }).pipe(
+      Effect.provide(
+        Layer.mock(ElectronShell.ElectronShell)({
+          copyText: (text) =>
+            Effect.sync(() => {
+              copied.push(text);
+            }),
+        }),
+      ),
+    );
+  });
+
+  it.effect("rejects a non-string payload at the schema boundary", () => {
+    const copied: string[] = [];
+
+    return Effect.gen(function* () {
+      const exit = yield* Effect.exit(writeClipboardText.handler(42));
+      assert.equal(exit._tag, "Failure");
+      assert.deepEqual(copied, []);
+    }).pipe(
+      Effect.provide(
+        Layer.mock(ElectronShell.ElectronShell)({
+          copyText: (text) =>
+            Effect.sync(() => {
+              copied.push(text);
+            }),
         }),
       ),
     );

--- a/apps/desktop/src/ipc/methods/window.ts
+++ b/apps/desktop/src/ipc/methods/window.ts
@@ -261,6 +261,20 @@ export const openExternal = DesktopIpc.makeIpcMethod({
   }),
 });
 
+// Main-process clipboard write. The renderer's navigator.clipboard refuses
+// writes while the document is unfocused, and macOS shows context menus on
+// inactive windows without activating them — so a menu-driven copy must not
+// depend on renderer focus.
+export const writeClipboardText = DesktopIpc.makeIpcMethod({
+  channel: IpcChannels.WRITE_CLIPBOARD_TEXT_CHANNEL,
+  payload: Schema.String,
+  result: Schema.Void,
+  handler: Effect.fn("desktop.ipc.window.writeClipboardText")(function* (text) {
+    const shell = yield* ElectronShell.ElectronShell;
+    yield* shell.copyText(text);
+  }),
+});
+
 /** Theme files are a few KB; anything larger returns empty text and lets the
  *  renderer reject it by size without the contents ever crossing the bridge. */
 const PICKED_THEME_FILE_MAX_BYTES = 256 * 1024;

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -105,6 +105,8 @@ contextBridge.exposeInMainWorld("desktopBridge", {
       ...(position === undefined ? {} : { position }),
     }),
   openExternal: (url: string) => ipcRenderer.invoke(IpcChannels.OPEN_EXTERNAL_CHANNEL, url),
+  writeClipboardText: (text: string) =>
+    ipcRenderer.invoke(IpcChannels.WRITE_CLIPBOARD_TEXT_CHANNEL, text),
   onMenuAction: (listener) => {
     const wrappedListener = (_event: Electron.IpcRendererEvent, action: unknown) => {
       if (typeof action !== "string") return;

--- a/apps/web/src/components/ThreadTerminalDrawer.test.ts
+++ b/apps/web/src/components/ThreadTerminalDrawer.test.ts
@@ -4,8 +4,11 @@ import {
   resolveTerminalSelectionActionPosition,
   shouldHandleTerminalExit,
   shouldHandleTerminalSelectionMouseUp,
+  shouldOpenTerminalSelectionContextMenu,
+  shouldRefocusTerminalAfterSelectionMenuDismissal,
   terminalSelectionActionDelayForClickCount,
   terminalSelectionLineRange,
+  terminalSelectionMenuItems,
 } from "./ThreadTerminalDrawer";
 
 describe("resolveTerminalSelectionActionPosition", () => {
@@ -88,5 +91,62 @@ describe("resolveTerminalSelectionActionPosition", () => {
     expect(shouldHandleTerminalExit("exited", "running", false)).toBe(true);
     expect(shouldHandleTerminalExit("exited", "exited", false)).toBe(false);
     expect(shouldHandleTerminalExit("closed", "running", true)).toBe(false);
+  });
+});
+
+describe("terminalSelectionMenuItems", () => {
+  it("gives the Copy item the platform's terminal copy chord as accelerator", () => {
+    // On macOS the open native menu owns the keyboard, so the accelerator is
+    // what keeps Cmd+C copying while the menu is up.
+    expect(terminalSelectionMenuItems("MacIntel")).toEqual([
+      { id: "add-to-chat", label: "Add to chat" },
+      { id: "copy", label: "Copy", accelerator: "Cmd+C" },
+    ]);
+    // Plain Ctrl+C stays SIGINT off macOS, so the menu advertises Ctrl+Shift+C.
+    expect(terminalSelectionMenuItems("Win32")).toEqual([
+      { id: "add-to-chat", label: "Add to chat" },
+      { id: "copy", label: "Copy", accelerator: "Ctrl+Shift+C" },
+    ]);
+  });
+});
+
+describe("shouldOpenTerminalSelectionContextMenu", () => {
+  it("opens the selection menu only for a right-click with a Ghostty selection", () => {
+    expect(
+      shouldOpenTerminalSelectionContextMenu({ hasSelection: true, defaultPrevented: false }),
+    ).toBe(true);
+    expect(
+      shouldOpenTerminalSelectionContextMenu({ hasSelection: false, defaultPrevented: false }),
+    ).toBe(false);
+  });
+
+  it("leaves right-click to a mouse-reporting app that already claimed it", () => {
+    expect(
+      shouldOpenTerminalSelectionContextMenu({ hasSelection: true, defaultPrevented: true }),
+    ).toBe(false);
+  });
+});
+
+describe("shouldRefocusTerminalAfterSelectionMenuDismissal", () => {
+  const terminalMount = (containsActive: boolean) => ({ contains: () => containsActive });
+  const element = {} as Element;
+  const body = {} as Element;
+
+  it("returns focus to the terminal when dismissal left focus in it or nowhere", () => {
+    expect(
+      shouldRefocusTerminalAfterSelectionMenuDismissal(terminalMount(true), element, body),
+    ).toBe(true);
+    expect(shouldRefocusTerminalAfterSelectionMenuDismissal(terminalMount(false), null, body)).toBe(
+      true,
+    );
+    expect(shouldRefocusTerminalAfterSelectionMenuDismissal(terminalMount(false), body, body)).toBe(
+      true,
+    );
+  });
+
+  it("keeps focus where the dismissing click put it", () => {
+    expect(
+      shouldRefocusTerminalAfterSelectionMenuDismissal(terminalMount(false), element, body),
+    ).toBe(false);
   });
 });

--- a/apps/web/src/components/ThreadTerminalDrawer.test.ts
+++ b/apps/web/src/components/ThreadTerminalDrawer.test.ts
@@ -6,6 +6,7 @@ import {
   shouldHandleTerminalSelectionMouseUp,
   shouldOpenTerminalSelectionContextMenu,
   shouldRefocusTerminalAfterSelectionMenuDismissal,
+  shouldReopenTerminalSelectionMenu,
   terminalSelectionActionDelayForClickCount,
   terminalSelectionLineRange,
   terminalSelectionMenuItems,
@@ -123,6 +124,40 @@ describe("shouldOpenTerminalSelectionContextMenu", () => {
   it("leaves right-click to a mouse-reporting app that already claimed it", () => {
     expect(
       shouldOpenTerminalSelectionContextMenu({ hasSelection: true, defaultPrevented: true }),
+    ).toBe(false);
+  });
+});
+
+describe("shouldReopenTerminalSelectionMenu", () => {
+  const pointer = { x: 10, y: 20 };
+
+  it("reopens after a dismissal caused by a new right-click on a live selection", () => {
+    expect(
+      shouldReopenTerminalSelectionMenu({
+        clicked: null,
+        reopenPointer: pointer,
+        hasSelection: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not reopen after an item click, without a parked pointer, or without a selection", () => {
+    expect(
+      shouldReopenTerminalSelectionMenu({
+        clicked: "copy",
+        reopenPointer: pointer,
+        hasSelection: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldReopenTerminalSelectionMenu({ clicked: null, reopenPointer: null, hasSelection: true }),
+    ).toBe(false);
+    expect(
+      shouldReopenTerminalSelectionMenu({
+        clicked: null,
+        reopenPointer: pointer,
+        hasSelection: false,
+      }),
     ).toBe(false);
   });
 });

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -271,6 +271,19 @@ export function shouldOpenTerminalSelectionContextMenu(options: {
 }
 
 /**
+ * Whether a menu dismissal should immediately reopen the selection menu: only
+ * when the dismissal was caused by a new right-click (which parked a pointer)
+ * and the selection it would act on still exists.
+ */
+export function shouldReopenTerminalSelectionMenu(options: {
+  clicked: string | null;
+  reopenPointer: { x: number; y: number } | null;
+  hasSelection: boolean;
+}): boolean {
+  return options.clicked === null && options.reopenPointer !== null && options.hasSelection;
+}
+
+/**
  * Whether dismissing the selection menu should return focus to the terminal
  * input, so the keyboard copy shortcut keeps targeting the still-highlighted
  * selection. When the dismissal moved focus elsewhere (the web fallback menu
@@ -377,6 +390,7 @@ export function TerminalViewport({
   const selectionActionRequestIdRef = useRef(0);
   const selectionActionMenuOpenRef = useRef(false);
   const selectionActionTimerRef = useRef<number | null>(null);
+  const pendingSelectionMenuPointerRef = useRef<{ x: number; y: number } | null>(null);
   const keybindingsRef = useRef(keybindings);
   const runtimeEnvKey = useMemo(() => runtimeEnvSignature(runtimeEnv), [runtimeEnv]);
   const handleSessionExited = useEffectEvent(() => {
@@ -523,6 +537,7 @@ export function TerminalViewport({
 
       const clearSelectionAction = () => {
         selectionActionRequestIdRef.current += 1;
+        pendingSelectionMenuPointerRef.current = null;
         if (selectionActionTimerRef.current !== null) {
           window.clearTimeout(selectionActionTimerRef.current);
           selectionActionTimerRef.current = null;
@@ -600,6 +615,13 @@ export function TerminalViewport({
           return;
         }
         if (selectionActionMenuOpenRef.current) {
+          // A right-click that dismisses the open native menu still reaches
+          // the renderer before the menu's IPC resolution does, so the gesture
+          // would otherwise end menu-less. Park the pointer; the settling
+          // handler below reopens there.
+          if (explicitPointer) {
+            pendingSelectionMenuPointerRef.current = explicitPointer;
+          }
           return;
         }
         const nextAction = readSelectionAction(explicitPointer);
@@ -614,6 +636,22 @@ export function TerminalViewport({
           .finally(() => {
             selectionActionMenuOpenRef.current = false;
           });
+        // A dismissal caused by a new right-click reopens at that pointer.
+        // This runs before the staleness check because the dismissing click's
+        // own pointerdown already bumped the request id.
+        const reopenPointer = pendingSelectionMenuPointerRef.current;
+        pendingSelectionMenuPointerRef.current = null;
+        if (
+          shouldReopenTerminalSelectionMenu({
+            clicked,
+            reopenPointer,
+            hasSelection: terminalRef.current?.hasSelection() === true,
+          }) &&
+          reopenPointer
+        ) {
+          void showSelectionAction(reopenPointer);
+          return;
+        }
         if (requestId !== selectionActionRequestIdRef.current) {
           return;
         }
@@ -804,11 +842,23 @@ export function TerminalViewport({
         event.preventDefault();
         void showSelectionAction({ x: event.clientX, y: event.clientY });
       };
+      // A parked pointer must not outlive the gesture that parked it: any
+      // newer pointerdown anywhere (composer, another split terminal) or a
+      // focus departure supersedes it, or a long-delayed dismissal would
+      // reopen a menu the user has moved on from. The parking right-click is
+      // unaffected — its own pointerdown precedes its contextmenu.
+      const clearParkedSelectionMenuPointer = () => {
+        pendingSelectionMenuPointerRef.current = null;
+      };
       window.addEventListener("mouseup", handleMouseUp);
+      window.addEventListener("pointerdown", clearParkedSelectionMenuPointer, true);
+      window.addEventListener("blur", clearParkedSelectionMenuPointer);
       mount.addEventListener("pointerdown", handlePointerDown);
       mount.addEventListener("contextmenu", handleContextMenu);
       setupCleanups.push(() => {
         window.removeEventListener("mouseup", handleMouseUp);
+        window.removeEventListener("pointerdown", clearParkedSelectionMenuPointer, true);
+        window.removeEventListener("blur", clearParkedSelectionMenuPointer);
         mount.removeEventListener("pointerdown", handlePointerDown);
         mount.removeEventListener("contextmenu", handleContextMenu);
       });

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -13,6 +13,7 @@ import {
   XIcon,
 } from "lucide-react";
 import {
+  type ContextMenuItem,
   type ResolvedKeybindingsConfig,
   type ScopedThreadRef,
   type ThreadId,
@@ -32,7 +33,7 @@ import {
 } from "react";
 import { Popover, PopoverPopup, PopoverTrigger } from "~/components/ui/popover";
 import { writeTextToClipboard } from "~/hooks/useCopyToClipboard";
-import { cn } from "~/lib/utils";
+import { cn, isMacPlatform } from "~/lib/utils";
 import { type TerminalContextSelection } from "~/lib/terminalContext";
 import {
   GhosttyTerminalSurface,
@@ -234,6 +235,53 @@ export function resolveTerminalSelectionActionPosition(options: {
 
 export function terminalSelectionActionDelayForClickCount(clickCount: number): number {
   return clickCount >= 2 ? MULTI_CLICK_SELECTION_ACTION_DELAY_MS : 0;
+}
+
+export type TerminalSelectionMenuItemId = "add-to-chat" | "copy";
+
+/**
+ * Items for the selection menu. The Copy accelerator matches the platform's
+ * terminal copy chord: on macOS the open native menu owns the keyboard, so the
+ * accelerator is what keeps Cmd+C copying while the menu is up.
+ */
+export function terminalSelectionMenuItems(
+  platform = navigator.platform,
+): ContextMenuItem<TerminalSelectionMenuItemId>[] {
+  return [
+    { id: "add-to-chat", label: "Add to chat" },
+    {
+      id: "copy",
+      label: "Copy",
+      accelerator: isMacPlatform(platform) ? "Cmd+C" : "Ctrl+Shift+C",
+    },
+  ];
+}
+
+/**
+ * Whether a right-click should open the selection menu instead of the host's
+ * generic context menu. A mouse-reporting app owns right-click (the surface
+ * already prevented the event), and without a Ghostty selection the generic
+ * menu with its paste entries is the right one.
+ */
+export function shouldOpenTerminalSelectionContextMenu(options: {
+  hasSelection: boolean;
+  defaultPrevented: boolean;
+}): boolean {
+  return options.hasSelection && !options.defaultPrevented;
+}
+
+/**
+ * Whether dismissing the selection menu should return focus to the terminal
+ * input, so the keyboard copy shortcut keeps targeting the still-highlighted
+ * selection. When the dismissal moved focus elsewhere (the web fallback menu
+ * lets the dismissing click land), the user's new focus wins.
+ */
+export function shouldRefocusTerminalAfterSelectionMenuDismissal(
+  mount: { contains(node: Node | null): boolean },
+  activeElement: Element | null,
+  body: Element | null,
+): boolean {
+  return activeElement === null || activeElement === body || mount.contains(activeElement);
 }
 
 export function shouldHandleTerminalSelectionMouseUp(
@@ -482,7 +530,34 @@ export function TerminalViewport({
       };
       setupCleanups.push(clearSelectionAction);
 
-      const readSelectionAction = (): {
+      // The single Ghostty-aware copy operation. Every copy entry point — the
+      // terminal copy shortcut, the selection menu (opened automatically or
+      // from right-click), and the menu's own accelerator — lands here with
+      // the Ghostty selection as the value. The local clipboard API writes in
+      // the desktop main process: renderer clipboard writes need a focused
+      // document, and a copy driven from a native context menu (which macOS
+      // shows without activating the window) cannot rely on that.
+      const copySelectionText = async (text: string): Promise<void> => {
+        try {
+          if (localApi) {
+            await localApi.clipboard.writeText(text, "terminal selection");
+          } else {
+            await writeTextToClipboard(text, "terminal selection");
+          }
+        } catch (error) {
+          const activeTerminal = terminalRef.current;
+          if (!activeTerminal) return;
+          writeSystemMessage(
+            activeTerminal,
+            error instanceof Error ? error.message : "Unable to copy terminal selection",
+          );
+        }
+      };
+
+      const readSelectionAction = (explicitPointer?: {
+        x: number;
+        y: number;
+      }): {
         position: { x: number; y: number };
         clipboardText: string;
         selection: TerminalContextSelection;
@@ -502,8 +577,9 @@ export function TerminalViewport({
         const bounds = mountElement.getBoundingClientRect();
         const position = resolveTerminalSelectionActionPosition({
           bounds,
-          selectionRect: activeTerminal.getSelectionEndClientRect(),
-          pointer: selectionPointerRef.current,
+          // A right-click menu belongs at the cursor, not at the selection end.
+          selectionRect: explicitPointer ? null : activeTerminal.getSelectionEndClientRect(),
+          pointer: explicitPointer ?? selectionPointerRef.current,
         });
         return {
           position,
@@ -518,7 +594,7 @@ export function TerminalViewport({
         };
       };
 
-      const showSelectionAction = async () => {
+      const showSelectionAction = async (explicitPointer?: { x: number; y: number }) => {
         if (!localApi) {
           clearSelectionAction();
           return;
@@ -526,7 +602,7 @@ export function TerminalViewport({
         if (selectionActionMenuOpenRef.current) {
           return;
         }
-        const nextAction = readSelectionAction();
+        const nextAction = readSelectionAction(explicitPointer);
         if (!nextAction) {
           clearSelectionAction();
           return;
@@ -534,17 +610,11 @@ export function TerminalViewport({
         const requestId = ++selectionActionRequestIdRef.current;
         selectionActionMenuOpenRef.current = true;
         const clicked = await localApi.contextMenu
-          .show(
-            [
-              { id: "add-to-chat", label: "Add to chat" },
-              { id: "copy", label: "Copy" },
-            ],
-            nextAction.position,
-          )
+          .show(terminalSelectionMenuItems(), nextAction.position)
           .finally(() => {
             selectionActionMenuOpenRef.current = false;
           });
-        if (requestId !== selectionActionRequestIdRef.current || clicked === null) {
+        if (requestId !== selectionActionRequestIdRef.current) {
           return;
         }
         switch (clicked) {
@@ -554,24 +624,28 @@ export function TerminalViewport({
             terminalRef.current?.focus();
             return;
           case "copy":
-            try {
-              await writeTextToClipboard(nextAction.clipboardText, "terminal selection");
-            } catch (error) {
-              if (requestId !== selectionActionRequestIdRef.current) {
-                return;
-              }
-              const activeTerminal = terminalRef.current;
-              if (activeTerminal) {
-                writeSystemMessage(
-                  activeTerminal,
-                  error instanceof Error ? error.message : "Unable to copy terminal selection",
-                );
-              }
-            }
+            await copySelectionText(nextAction.clipboardText);
             if (requestId === selectionActionRequestIdRef.current) {
               terminalRef.current?.focus();
             }
             return;
+          default: {
+            // Dismissal must not strand the still-highlighted selection: the
+            // terminal input is where the copy shortcut is handled, so give it
+            // focus back unless the dismissal itself focused something else.
+            const mountElement = containerRef.current;
+            if (
+              mountElement &&
+              shouldRefocusTerminalAfterSelectionMenuDismissal(
+                mountElement,
+                document.activeElement,
+                document.body,
+              )
+            ) {
+              terminalRef.current?.focus();
+            }
+            return;
+          }
         }
       };
 
@@ -669,14 +743,7 @@ export function TerminalViewport({
       }
 
       function handleCopy(text: string): void {
-        void writeTextToClipboard(text, "terminal selection").catch((error: unknown) => {
-          const activeTerminal = terminalRef.current;
-          if (!activeTerminal) return;
-          writeSystemMessage(
-            activeTerminal,
-            error instanceof Error ? error.message : "Unable to copy terminal selection",
-          );
-        });
+        void copySelectionText(text);
       }
 
       function handleData(data: string): void {
@@ -720,11 +787,30 @@ export function TerminalViewport({
         clearSelectionAction();
         selectionGestureActiveRef.current = event.button === 0;
       };
+      // Ghostty owns the selection in canvas state, which the host's generic
+      // context menu cannot see: its Copy is a DOM-selection role and stays
+      // disabled. With a selection, right-click opens the selection menu whose
+      // Copy formats the Ghostty selection instead.
+      const handleContextMenu = (event: MouseEvent) => {
+        if (!localApi) return;
+        if (
+          !shouldOpenTerminalSelectionContextMenu({
+            hasSelection: terminalRef.current?.hasSelection() === true,
+            defaultPrevented: event.defaultPrevented,
+          })
+        ) {
+          return;
+        }
+        event.preventDefault();
+        void showSelectionAction({ x: event.clientX, y: event.clientY });
+      };
       window.addEventListener("mouseup", handleMouseUp);
       mount.addEventListener("pointerdown", handlePointerDown);
+      mount.addEventListener("contextmenu", handleContextMenu);
       setupCleanups.push(() => {
         window.removeEventListener("mouseup", handleMouseUp);
         mount.removeEventListener("pointerdown", handlePointerDown);
+        mount.removeEventListener("contextmenu", handleContextMenu);
       });
 
       const themeObserver = new MutationObserver(() => {

--- a/apps/web/src/localApi.ts
+++ b/apps/web/src/localApi.ts
@@ -2,6 +2,7 @@ import type { ConfirmDialogOptions, ContextMenuItem, LocalApi } from "@t3tools/c
 
 import { requestConfirmDialog } from "./confirmDialog";
 import { showContextMenuFallback } from "./contextMenuFallback";
+import { writeTextToClipboard } from "./hooks/useCopyToClipboard";
 import { readBrowserClientSettings, writeBrowserClientSettings } from "./clientPersistenceStorage";
 import { resetRequestLatencyStateForTests } from "./rpc/requestLatencyState";
 
@@ -40,6 +41,14 @@ function createBrowserLocalApi(): LocalApi {
           return window.desktopBridge.showContextMenu(items, position) as Promise<T | null>;
         }
         return showContextMenuFallback(items, position);
+      },
+    },
+    clipboard: {
+      writeText: async (text, target) => {
+        if (window.desktopBridge?.writeClipboardText) {
+          return window.desktopBridge.writeClipboardText(text);
+        }
+        await writeTextToClipboard(text, target);
       },
     },
     persistence: {

--- a/apps/web/src/terminal/ghostty/runtimeAbi.test.ts
+++ b/apps/web/src/terminal/ghostty/runtimeAbi.test.ts
@@ -631,4 +631,152 @@ describe("vendored libghostty-vt WebAssembly", () => {
     call("ghostty_wasm_free_opaque", terminalSlot);
     free(terminalOptions, 8);
   });
+
+  it("formats the installed selection as the copied value through the pinned options ABI", async () => {
+    const result = await WebAssembly.instantiate(
+      decodeWasmDataUrl(wasmDataUrl).buffer as ArrayBuffer,
+      { env: { log: () => {} } },
+    );
+    const instance = result instanceof WebAssembly.Instance ? result : result.instance;
+    const memory = instance.exports.memory as WebAssembly.Memory;
+    const call = (name: string, ...args: number[]) =>
+      (instance.exports[name] as WasmFunction)(...args);
+    const alloc = (size: number) => {
+      const pointer = call("ghostty_wasm_alloc_u8_array", size);
+      new Uint8Array(memory.buffer, pointer, size).fill(0);
+      return pointer;
+    };
+    const free = (pointer: number, size: number) =>
+      call("ghostty_wasm_free_u8_array", pointer, size);
+
+    const jsonPointer = call("ghostty_type_json");
+    const jsonBytes = new Uint8Array(memory.buffer, jsonPointer);
+    const layouts = JSON.parse(
+      new TextDecoder().decode(jsonBytes.subarray(0, jsonBytes.indexOf(0))),
+    ) as Record<string, { size: number; fields: Record<string, { offset: number; size: number }> }>;
+    const gridRefSize = layouts.GhosttyGridRef?.size;
+    const pointLayout = layouts.GhosttyPoint;
+    const selectionLayout = layouts.GhosttySelection;
+    if (!gridRefSize || !pointLayout || !selectionLayout) {
+      throw new Error("Ghostty selection layouts are missing");
+    }
+
+    const terminalOptions = alloc(8);
+    const terminalOptionsView = new DataView(memory.buffer, terminalOptions, 8);
+    terminalOptionsView.setUint16(0, 80, true);
+    terminalOptionsView.setUint16(2, 24, true);
+    terminalOptionsView.setUint32(4, 1_000, true);
+    const terminalSlot = call("ghostty_wasm_alloc_opaque");
+    expect(call("ghostty_terminal_new", 0, terminalSlot, terminalOptions)).toBe(0);
+    const terminal = new DataView(memory.buffer).getUint32(terminalSlot, true);
+
+    const input = new TextEncoder().encode("line one alpha\r\nline two bravo\r\nline three\r\n$ ");
+    const inputPointer = alloc(input.length);
+    new Uint8Array(memory.buffer, inputPointer, input.length).set(input);
+    call("ghostty_terminal_vt_write", terminal, inputPointer, input.length);
+    free(inputPointer, input.length);
+
+    // A viewport-tagged grid ref, exactly as GhosttyTerminalCore.gridRef builds it.
+    const gridRef = (col: number, row: number) => {
+      const point = alloc(pointLayout.size);
+      const tagField = pointLayout.fields.tag;
+      const valueField = pointLayout.fields.value;
+      if (!tagField || !valueField) throw new Error("GhosttyPoint fields are missing");
+      new DataView(memory.buffer, point + tagField.offset, tagField.size).setUint32(0, 1, true);
+      const valueView = new DataView(memory.buffer, point + valueField.offset, valueField.size);
+      valueView.setUint16(0, col, true);
+      valueView.setUint32(4, row, true);
+      const ref = alloc(gridRefSize);
+      new DataView(memory.buffer, ref, 4).setUint32(0, gridRefSize, true);
+      expect(call("ghostty_terminal_grid_ref", terminal, point, ref)).toBe(0);
+      free(point, pointLayout.size);
+      return ref;
+    };
+
+    // Install a selection through option 21, as GhosttyTerminalCore.setSelection does.
+    const setSelection = (start: [number, number], end: [number, number]) => {
+      const startRef = gridRef(start[0], start[1]);
+      const endRef = gridRef(end[0], end[1]);
+      const selection = alloc(selectionLayout.size);
+      new DataView(memory.buffer, selection, 4).setUint32(0, selectionLayout.size, true);
+      const startField = selectionLayout.fields.start;
+      const endField = selectionLayout.fields.end;
+      if (!startField || !endField) throw new Error("GhosttySelection fields are missing");
+      new Uint8Array(memory.buffer, selection + startField.offset, startField.size).set(
+        new Uint8Array(memory.buffer, startRef, startField.size),
+      );
+      new Uint8Array(memory.buffer, selection + endField.offset, endField.size).set(
+        new Uint8Array(memory.buffer, endRef, endField.size),
+      );
+      expect(call("ghostty_terminal_set", terminal, 21, selection)).toBe(0);
+      free(startRef, gridRefSize);
+      free(endRef, gridRefSize);
+      free(selection, selectionLayout.size);
+    };
+
+    // The pinned 16-byte GhosttyTerminalSelectionFormatOptions layout from
+    // GhosttyTerminalCore.selectionText: plain output, unwrap and trim set, a
+    // null selection pointer meaning "the terminal's active selection".
+    const formatActiveSelection = () => {
+      const formatOptions = alloc(16);
+      const optionsView = new DataView(memory.buffer, formatOptions, 16);
+      optionsView.setUint32(0, 16, true);
+      optionsView.setUint8(8, 1);
+      optionsView.setUint8(9, 1);
+      const written = call("ghostty_wasm_alloc_usize");
+      const sizeResult = call(
+        "ghostty_terminal_selection_format_buf",
+        terminal,
+        formatOptions,
+        0,
+        0,
+        written,
+      );
+      const outputSize = new DataView(memory.buffer, written, 4).getUint32(0, true);
+      let text = "";
+      if (sizeResult === -3 && outputSize > 0) {
+        const output = alloc(outputSize);
+        expect(
+          call(
+            "ghostty_terminal_selection_format_buf",
+            terminal,
+            formatOptions,
+            output,
+            outputSize,
+            written,
+          ),
+        ).toBe(0);
+        const outputLength = new DataView(memory.buffer, written, 4).getUint32(0, true);
+        text = new TextDecoder().decode(new Uint8Array(memory.buffer, output, outputLength));
+        free(output, outputSize);
+      }
+      call("ghostty_wasm_free_usize", written);
+      free(formatOptions, 16);
+      return text;
+    };
+
+    // No active selection formats to nothing, which is what hasSelection()
+    // reads — Ctrl+C without a selection must stay terminal input.
+    expect(formatActiveSelection()).toBe("");
+
+    setSelection([0, 0], [7, 0]);
+    expect(formatActiveSelection()).toBe("line one");
+
+    // A multiline selection joins rows with newlines and trims per row.
+    setSelection([0, 0], [9, 2]);
+    expect(formatActiveSelection()).toBe("line one alpha\nline two bravo\nline three");
+
+    // Output arriving after the selection is installed must not corrupt the
+    // copied value; the terminal-owned selection tracks its cells.
+    const more = new TextEncoder().encode("later output\r\n");
+    const morePointer = alloc(more.length);
+    new Uint8Array(memory.buffer, morePointer, more.length).set(more);
+    call("ghostty_terminal_vt_write", terminal, morePointer, more.length);
+    free(morePointer, more.length);
+    expect(formatActiveSelection()).toBe("line one alpha\nline two bravo\nline three");
+
+    call("ghostty_terminal_free", terminal);
+    call("ghostty_wasm_free_opaque", terminalSlot);
+    free(terminalOptions, 8);
+  });
 });

--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -10,6 +10,7 @@ import {
   isTerminalCompositionCommitInput,
   isTerminalCopyShortcut,
   isTerminalLinkPointerGesture,
+  isTerminalMacSecondaryClick,
   isTerminalPasteShortcut,
   loadTerminalFontFamily,
   shouldBlinkTerminalCursor,
@@ -421,6 +422,18 @@ describe("isTerminalLinkPointerGesture", () => {
     expect(isTerminalLinkPointerGesture({ ctrlKey: false, metaKey: true }, "Linux x86_64")).toBe(
       false,
     );
+  });
+});
+
+describe("isTerminalMacSecondaryClick", () => {
+  it("treats a button-0 Ctrl+click as secondary only on macOS", () => {
+    // Firefox reports macOS Ctrl+click as button 0; starting a selection from
+    // it would destroy the selection the following contextmenu needs.
+    expect(isTerminalMacSecondaryClick({ button: 0, ctrlKey: true }, "MacIntel")).toBe(true);
+    expect(isTerminalMacSecondaryClick({ button: 0, ctrlKey: false }, "MacIntel")).toBe(false);
+    expect(isTerminalMacSecondaryClick({ button: 0, ctrlKey: true }, "Linux x86_64")).toBe(false);
+    // Chromium already delivers macOS Ctrl+click as button 2.
+    expect(isTerminalMacSecondaryClick({ button: 2, ctrlKey: true }, "MacIntel")).toBe(false);
   });
 });
 

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -405,6 +405,19 @@ export function isTerminalLinkPointerGesture(
     : event.ctrlKey && !event.metaKey;
 }
 
+/**
+ * macOS Ctrl+click is a secondary click. Chromium translates it to button 2
+ * before the page sees it, but engines that report button 0 (Firefox) must
+ * not let it start a new selection: the contextmenu that follows needs the
+ * existing selection intact.
+ */
+export function isTerminalMacSecondaryClick(
+  event: Pick<MouseEvent, "button" | "ctrlKey">,
+  platform = navigator.platform,
+): boolean {
+  return event.button === 0 && event.ctrlKey && isMacPlatform(platform);
+}
+
 export function shouldShowTerminalLinkHover(
   mouseTracking: boolean,
   linkModifierActive: boolean,
@@ -530,6 +543,13 @@ export class GhosttyTerminalSurface {
   private canvasConfigured = false;
   private theme: GhosttyTheme;
   private readonly suppressedKeyCodes = new Set<string>();
+  // Codes whose press this surface encoded to the PTY. A release is only
+  // reportable for such a press: a keyup whose keydown was consumed elsewhere
+  // (for example by a native menu accelerator) must not inject a release-only
+  // Kitty sequence for a key the application never saw go down. Like the
+  // suppressions, entries survive blur so a key held across a focus move can
+  // still deliver its release.
+  private readonly encodedPressKeyCodes = new Set<string>();
   private pasteShortcutToken = 0;
   private wheelRemainder = 0;
   private dprMedia: MediaQueryList | null = null;
@@ -937,6 +957,7 @@ export class GhosttyTerminalSurface {
     const data = this.core.encodeKey(event);
     if (data.length === 0) return;
     this.suppressedKeyCodes.delete(event.code);
+    this.encodedPressKeyCodes.add(event.code);
     event.preventDefault();
     event.stopPropagation();
     this.options.onData(data);
@@ -945,6 +966,7 @@ export class GhosttyTerminalSurface {
   private readonly onKeyUp = (event: KeyboardEvent) => {
     this.updateLinkModifier(event);
     if (this.suppressedKeyCodes.delete(event.code)) return;
+    if (!this.encodedPressKeyCodes.delete(event.code)) return;
     if (event.isComposing || this.composing || event.key === "Process" || event.keyCode === 229) {
       return;
     }
@@ -1055,6 +1077,7 @@ export class GhosttyTerminalSurface {
       this.canvas.setPointerCapture(event.pointerId);
       return;
     }
+    if (isTerminalMacSecondaryClick(event)) return;
     if (event.button !== 0) return;
     if (isTerminalLinkPointerGesture(event)) {
       event.preventDefault();

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -110,6 +110,12 @@ export interface ContextMenuItem<T extends string = string> {
   header?: boolean;
   /** Icon keyword resolved by the web fallback. Stripped on desktop native menus. */
   icon?: string;
+  /**
+   * Electron accelerator for the desktop native menu item. On macOS the open
+   * menu owns the keyboard, so this is what lets the shortcut keep working
+   * while the menu is up. Ignored by the web fallback.
+   */
+  accelerator?: string;
   children?: readonly ContextMenuItem<T>[];
 }
 
@@ -120,6 +126,7 @@ export interface ContextMenuItemSchemaType {
   readonly disabled?: boolean;
   readonly header?: boolean;
   readonly icon?: string;
+  readonly accelerator?: string;
   readonly children?: readonly ContextMenuItemSchemaType[];
 }
 
@@ -130,6 +137,7 @@ export const ContextMenuItemSchema: Schema.Codec<ContextMenuItemSchemaType> = Sc
   disabled: Schema.optionalKey(Schema.Boolean),
   header: Schema.optionalKey(Schema.Boolean),
   icon: Schema.optionalKey(Schema.String),
+  accelerator: Schema.optionalKey(Schema.String),
   children: Schema.optionalKey(
     Schema.Array(
       Schema.suspend((): Schema.Codec<ContextMenuItemSchemaType> => ContextMenuItemSchema),
@@ -1048,6 +1056,13 @@ export interface DesktopBridge {
     position?: { x: number; y: number },
   ) => Promise<T | null>;
   openExternal: (url: string) => Promise<boolean>;
+  /**
+   * Main-process clipboard write. Renderer clipboard writes require a focused
+   * document, which a copy driven from a native context menu cannot rely on.
+   * Optional: older desktop builds lack it, and web callers fall back to
+   * navigator.clipboard.
+   */
+  writeClipboardText?: (text: string) => Promise<void>;
   onMenuAction: (listener: (action: string) => void) => () => void;
   getWindowFullscreenState: () => boolean;
   onWindowFullscreenStateChange: (listener: (fullscreen: boolean) => void) => () => void;
@@ -1165,6 +1180,15 @@ export interface LocalApi {
       items: readonly ContextMenuItem<T>[],
       position?: { x: number; y: number },
     ) => Promise<T | null>;
+  };
+  clipboard: {
+    /**
+     * Writes text to the system clipboard, throwing on failure. On desktop
+     * this runs in the main process, so it works while the renderer document
+     * is unfocused — the state a native context menu leaves behind. The
+     * optional target names what is being copied in browser error messages.
+     */
+    writeText: (text: string, target?: string) => Promise<void>;
   };
   persistence: {
     getClientSettings: () => Promise<ClientSettings | null>;


### PR DESCRIPTION
## What Changed

Terminal copying on macOS failed because each copy entry point resolved against a different owner, and only one of them could see the Ghostty selection (which lives in canvas/WASM state, not the DOM):

- Cmd+C only worked while the hidden terminal textarea was focused — and the selection menu that auto-opens after every drag steals the keyboard while it's up, so the natural "select, then Cmd+C" died in the native menu's tracking loop.
- Right-click → Copy was Electron's generic DOM-role menu; `editFlags.canCopy` is always false for a canvas selection, so Copy stayed disabled.
- The clipboard write itself used `navigator.clipboard.writeText`, which Chromium rejects while the document is unfocused — and macOS shows context menus on inactive windows without activating them, so menu-driven copies could fail with an error even when everything upstream worked.

All entry points now route through one Ghostty-aware copy:

- The selection menu's Copy item carries the platform copy accelerator (`Cmd+C` / `Ctrl+Shift+C`), so pressing it while the open menu owns the keyboard activates Copy natively (`ContextMenuItem` gains an optional `accelerator`, forwarded by `ElectronMenu`).
- Right-click on a highlighted selection opens the same Add to chat / Copy menu instead of the DOM-role menu. Mouse-reporting apps keep owning right-click, and right-click without a selection keeps the generic paste menu.
- Dismissing the menu refocuses the terminal input (unless the dismissal legitimately focused something else), so the keyboard shortcut keeps working against the still-highlighted selection.
- Desktop clipboard writes happen in the main process via a new `desktop:write-clipboard-text` IPC (`LocalApi.clipboard.writeText`), removing the document-focus dependency; browsers fall back to `navigator.clipboard`.
- Two hardening fixes from review: macOS Ctrl+click no longer clobbers the selection in engines that report it as button 0 (Firefox), and a keyup whose keydown was consumed by the native menu no longer injects a release-only Kitty key sequence.

Ctrl+C without a selection stays SIGINT on every platform.

## Why

Fixes #6173 — copying from the integrated terminal on macOS was broken enough to block work entirely (Cmd+C, the selection menu, and right-click Copy all failed in common flows).

## UI Changes

Two visible deltas, both restoring expected behavior: the selection menu's Copy item now shows the ⌘C shortcut hint, and right-clicking a highlighted terminal selection shows the Add to chat / Copy menu instead of a generic menu with Copy disabled. Happy to attach screenshots on request.

## Verification

- New tests: real-WASM ABI test pinning selection formatting (single-line, multiline, and after subsequent PTY output), menu accelerator pass-through, main-process clipboard IPC at the schema boundary, drawer menu/right-click/refocus logic, macOS secondary-click predicate. ~310 of the 570 changed lines are tests.
- Manually verified on macOS desktop: select → Cmd+C, blur/refocus → Cmd+C, and the unfocused-window right-click → Copy failure that the renderer-clipboard path produced.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Implemented by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches terminal input encoding, IPC clipboard, and native menu keyboard handling—user-visible on macOS but scoped to selection/copy flows with broad test coverage.
> 
> **Overview**
> Fixes macOS integrated-terminal copy by routing **every** copy path (keyboard shortcut, auto-open selection menu, right-click) through one Ghostty-aware `copySelectionText` that writes via **`LocalApi.clipboard.writeText`** — on desktop, a new **`desktop:write-clipboard-text`** IPC to the main process so copies work when the renderer is unfocused (e.g. native context menus on inactive windows).
> 
> **Selection menu & native menus:** `ContextMenuItem` gains optional **`accelerator`**; `ElectronMenu` forwards non-empty accelerators so **Cmd+C** / **Ctrl+Shift+C** work while the menu tracks on macOS. The drawer shows **Add to chat / Copy** with platform chords, opens that menu on **right-click when a Ghostty selection exists** (not the generic DOM menu), reopens after dismiss-by-right-click, and refocuses the terminal after dismiss unless focus moved elsewhere.
> 
> **Terminal input hardening:** macOS **Ctrl+click** (`button 0`) no longer starts a new selection before context menu (`isTerminalMacSecondaryClick`). Key **release** to the PTY is only sent if that key’s **press** was encoded (`encodedPressKeyCodes`), avoiding release-only Kitty sequences when a native menu consumed the keydown.
> 
> Contracts expose **`accelerator`** on context menu items and **`clipboard.writeText`** / optional **`writeClipboardText`** on desktop bridge; web falls back to `navigator.clipboard`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ab350a220f492758ecc3792deb55a4d670a4f13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix terminal selection copy on macOS by routing clipboard writes through the main process
> - Adds a `writeClipboardText` IPC channel so the renderer can request clipboard writes via the Electron main process, working around renderer focus constraints that prevented `navigator.clipboard.writeText` from succeeding on macOS.
> - Adds a right-click context menu for terminal selections with platform-specific accelerators (`Cmd+C` on macOS, `Ctrl+Shift+C` elsewhere), auto-reopen after right-click dismissal, and focus restoration to the terminal after dismissal.
> - Fixes macOS Ctrl+click (reported as button 0 in some browsers) so it no longer clears an existing selection before opening the context menu.
> - Fixes stray Kitty key-release sequences by tracking which keypresses were encoded to the PTY and suppressing releases for keys whose press was consumed by an accelerator.
> - `LocalApi.clipboard.writeText` prefers `desktopBridge.writeClipboardText` on desktop and falls back to `navigator.clipboard` in the browser.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ab350a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->