### PR TITLE
feat(desktop): add stash to composer context menu

### DIFF
--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -542,7 +542,7 @@ describe("DesktopWindow", () => {
 
         const { template } = yield* Deferred.await(composerPopup);
         assert.deepEqual(executeJavaScript.mock.calls, [
-          ['document.elementFromPoint(40, 60)?.closest("[data-composer-stash]") !== null'],
+          ['Boolean(document.elementFromPoint(40, 60)?.closest("[data-composer-stash]"))'],
         ]);
         assert.deepEqual(
           template.slice(0, 4).map((item) => item.role),

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -64,6 +64,7 @@ function makeFakeBrowserWindow() {
   const webContents = {
     copyImageAt: vi.fn(),
     getURL: vi.fn(() => "t3code-dev://app/"),
+    getZoomFactor: vi.fn(() => 1),
     isLoadingMainFrame: vi.fn(() => false),
     on: vi.fn((eventName: string, listener: (...args: readonly unknown[]) => void) => {
       webContentsListeners.set(eventName, listener);
@@ -107,6 +108,7 @@ function makeFakeBrowserWindow() {
     window: window as unknown as Electron.BrowserWindow,
     getBounds: window.getBounds,
     getNormalBounds: window.getNormalBounds,
+    getZoomFactor: webContents.getZoomFactor,
     isDestroyed: window.isDestroyed,
     isFullScreen: window.isFullScreen,
     isMaximized: window.isMaximized,
@@ -519,9 +521,10 @@ describe("DesktopWindow", () => {
         }
 
         const executeJavaScript = vi.fn(() => Promise.resolve(true));
+        fakeWindow.getZoomFactor.mockReturnValue(1.5);
         const params = {
-          x: 40,
-          y: 60,
+          x: 60,
+          y: 90,
           frame: { executeJavaScript },
           isEditable: true,
           misspelledWord: "",

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -186,6 +186,7 @@ function makeTestLayer(input: {
     bounds: DesktopAppSettings.DesktopWindowBounds,
   ) => Effect.Effect<void>;
   readonly openedExternalUrls?: unknown[];
+  readonly electronMenu?: ElectronMenu.ElectronMenu["Service"];
 }) {
   let desktopSettings = input.desktopSettings ?? DesktopAppSettings.DEFAULT_DESKTOP_SETTINGS;
   const desktopAppSettingsLayer = Layer.succeed(DesktopAppSettings.DesktopAppSettings, {
@@ -248,7 +249,9 @@ function makeTestLayer(input: {
         desktopAppSettingsLayer,
         desktopServerExposureLayer,
         DesktopState.layer,
-        electronMenuLayer,
+        input.electronMenu
+          ? Layer.succeed(ElectronMenu.ElectronMenu, input.electronMenu)
+          : electronMenuLayer,
         Layer.succeed(ElectronShell.ElectronShell, {
           openExternal: (url) =>
             Effect.sync(() => {
@@ -479,6 +482,99 @@ describe("DesktopWindow", () => {
         prevented = false;
         beforeInput(event, { ...input, meta: false });
         assert.isFalse(prevented);
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
+  it.effect("adds Stash to the native context menu only for the composer", () =>
+    Effect.gen(function* () {
+      const fakeWindow = makeFakeBrowserWindow();
+      const createCount = yield* Ref.make(0);
+      const mainWindow = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(Option.none());
+      const composerPopup = yield* Deferred.make<ElectronMenu.ElectronMenuTemplateInput>();
+      const otherPopup = yield* Deferred.make<ElectronMenu.ElectronMenuTemplateInput>();
+      const popups = [composerPopup, otherPopup];
+      let popupIndex = 0;
+      const layer = makeTestLayer({
+        window: fakeWindow.window,
+        createCount,
+        mainWindow,
+        electronMenu: {
+          setApplicationMenu: () => Effect.void,
+          showContextMenu: () => Effect.succeed(Option.none()),
+          popupTemplate: (input) => {
+            const popup = popups[popupIndex++];
+            return popup ? Deferred.succeed(popup, input).pipe(Effect.asVoid) : Effect.void;
+          },
+        },
+      });
+
+      yield* Effect.gen(function* () {
+        const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        yield* desktopWindow.handleBackendReady(new URL("http://127.0.0.1:3773"));
+
+        const contextMenu = fakeWindow.webContentsListeners.get("context-menu");
+        if (!contextMenu) {
+          return yield* Effect.die("context-menu listener was not registered");
+        }
+
+        const executeJavaScript = vi.fn(() => Promise.resolve(true));
+        contextMenu(
+          { preventDefault: vi.fn() },
+          {
+            x: 40,
+            y: 60,
+            frame: { executeJavaScript },
+            isEditable: true,
+            misspelledWord: "",
+            dictionarySuggestions: [],
+            linkURL: "",
+            mediaType: "none",
+            editFlags: {
+              canCut: true,
+              canCopy: true,
+              canPaste: true,
+              canSelectAll: true,
+            },
+          },
+        );
+
+        const { template } = yield* Deferred.await(composerPopup);
+        assert.deepEqual(executeJavaScript.mock.calls, [
+          ['document.elementFromPoint(40, 60)?.closest("[data-composer-stash]") !== null'],
+        ]);
+        assert.deepEqual(
+          template.slice(0, 4).map((item) => item.role),
+          ["cut", "copy", "paste", "selectAll"],
+        );
+        const stash = template.find((item) => item.label === "Stash");
+        assert.isDefined(stash);
+        assert.equal(stash.accelerator, "CmdOrCtrl+S");
+        stash.click?.({} as Electron.MenuItem, fakeWindow.window, {} as Electron.KeyboardEvent);
+        assert.deepEqual(fakeWindow.send.mock.calls, [[MENU_ACTION_CHANNEL, "composer.stash"]]);
+
+        executeJavaScript.mockResolvedValueOnce(false);
+        contextMenu(
+          { preventDefault: vi.fn() },
+          {
+            x: 40,
+            y: 60,
+            frame: { executeJavaScript },
+            isEditable: true,
+            misspelledWord: "",
+            dictionarySuggestions: [],
+            linkURL: "",
+            mediaType: "none",
+            editFlags: {
+              canCut: true,
+              canCopy: true,
+              canPaste: true,
+              canSelectAll: true,
+            },
+          },
+        );
+        const otherTemplate = (yield* Deferred.await(otherPopup)).template;
+        assert.isUndefined(otherTemplate.find((item) => item.label === "Stash"));
       }).pipe(Effect.provide(layer));
     }),
   );

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -519,25 +519,23 @@ describe("DesktopWindow", () => {
         }
 
         const executeJavaScript = vi.fn(() => Promise.resolve(true));
-        contextMenu(
-          { preventDefault: vi.fn() },
-          {
-            x: 40,
-            y: 60,
-            frame: { executeJavaScript },
-            isEditable: true,
-            misspelledWord: "",
-            dictionarySuggestions: [],
-            linkURL: "",
-            mediaType: "none",
-            editFlags: {
-              canCut: true,
-              canCopy: true,
-              canPaste: true,
-              canSelectAll: true,
-            },
+        const params = {
+          x: 40,
+          y: 60,
+          frame: { executeJavaScript },
+          isEditable: true,
+          misspelledWord: "",
+          dictionarySuggestions: [],
+          linkURL: "",
+          mediaType: "none",
+          editFlags: {
+            canCut: true,
+            canCopy: true,
+            canPaste: true,
+            canSelectAll: true,
           },
-        );
+        };
+        contextMenu({ preventDefault: vi.fn() }, params);
 
         const { template } = yield* Deferred.await(composerPopup);
         assert.deepEqual(executeJavaScript.mock.calls, [
@@ -554,25 +552,7 @@ describe("DesktopWindow", () => {
         assert.deepEqual(fakeWindow.send.mock.calls, [[MENU_ACTION_CHANNEL, "composer.stash"]]);
 
         executeJavaScript.mockResolvedValueOnce(false);
-        contextMenu(
-          { preventDefault: vi.fn() },
-          {
-            x: 40,
-            y: 60,
-            frame: { executeJavaScript },
-            isEditable: true,
-            misspelledWord: "",
-            dictionarySuggestions: [],
-            linkURL: "",
-            mediaType: "none",
-            editFlags: {
-              canCut: true,
-              canCopy: true,
-              canPaste: true,
-              canSelectAll: true,
-            },
-          },
-        );
+        contextMenu({ preventDefault: vi.fn() }, params);
         const otherTemplate = (yield* Deferred.await(otherPopup)).template;
         assert.isUndefined(otherTemplate.find((item) => item.label === "Stash"));
       }).pipe(Effect.provide(layer));

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -524,8 +524,10 @@ export const make = Effect.gen(function* () {
         return;
       }
 
-      const x = Math.trunc(params.x);
-      const y = Math.trunc(params.y);
+      // Electron reports window coordinates; DOM hit-testing expects zoom-adjusted CSS pixels.
+      const zoomFactor = window.webContents.getZoomFactor();
+      const x = Math.trunc(params.x / zoomFactor);
+      const y = Math.trunc(params.y / zoomFactor);
       void params.frame
         .executeJavaScript(
           `document.elementFromPoint(${x}, ${y})?.closest("[data-composer-stash]") !== null`,

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -530,7 +530,7 @@ export const make = Effect.gen(function* () {
       const y = Math.trunc(params.y / zoomFactor);
       void params.frame
         .executeJavaScript(
-          `document.elementFromPoint(${x}, ${y})?.closest("[data-composer-stash]") !== null`,
+          `Boolean(document.elementFromPoint(${x}, ${y})?.closest("[data-composer-stash]"))`,
         )
         .then(
           (isComposerTarget) => showContextMenu(isComposerTarget === true),

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -504,7 +504,36 @@ export const make = Effect.gen(function* () {
         { role: "selectAll", enabled: params.editFlags.canSelectAll },
       );
 
-      void runPromise(electronMenu.popupTemplate({ window, template: menuTemplate }));
+      const showContextMenu = (includeComposerStash: boolean) => {
+        if (includeComposerStash) {
+          menuTemplate.push(
+            { type: "separator" },
+            {
+              label: "Stash",
+              accelerator: "CmdOrCtrl+S",
+              click: () => window.webContents.send(MENU_ACTION_CHANNEL, "composer.stash"),
+            },
+          );
+        }
+
+        void runPromise(electronMenu.popupTemplate({ window, template: menuTemplate }));
+      };
+
+      if (!params.isEditable || !params.frame) {
+        showContextMenu(false);
+        return;
+      }
+
+      const x = Math.trunc(params.x);
+      const y = Math.trunc(params.y);
+      void params.frame
+        .executeJavaScript(
+          `document.elementFromPoint(${x}, ${y})?.closest("[data-composer-stash]") !== null`,
+        )
+        .then(
+          (isComposerTarget) => showContextMenu(isComposerTarget === true),
+          () => showContextMenu(false),
+        );
     });
 
     window.webContents.setWindowOpenHandler(({ url }) => {

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -882,6 +882,7 @@ interface ComposerPromptEditorProps {
   terminalContexts: ReadonlyArray<TerminalContextDraft>;
   skills: ReadonlyArray<ServerProviderSkill>;
   disabled: boolean;
+  stashEnabled?: boolean;
   placeholder: string;
   className?: string;
   onRemoveTerminalContext: (contextId: string) => void;
@@ -1531,6 +1532,7 @@ function ComposerPromptEditorInner({
   terminalContexts,
   skills,
   disabled,
+  stashEnabled = false,
   placeholder,
   className,
   onRemoveTerminalContext,
@@ -1758,6 +1760,7 @@ function ComposerPromptEditorInner({
                 className,
               )}
               data-testid="composer-editor"
+              data-composer-stash={stashEnabled ? "" : undefined}
               aria-placeholder={placeholder}
               placeholder={<span />}
               onPaste={onPaste}
@@ -1793,6 +1796,7 @@ export function ComposerPromptEditor({
   terminalContexts,
   skills,
   disabled,
+  stashEnabled = false,
   placeholder,
   className,
   onRemoveTerminalContext,
@@ -1831,6 +1835,7 @@ export function ComposerPromptEditor({
         terminalContexts={terminalContexts}
         skills={skills}
         disabled={disabled}
+        stashEnabled={stashEnabled}
         placeholder={placeholder}
         onRemoveTerminalContext={onRemoveTerminalContext}
         onChange={onChange}

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -882,7 +882,6 @@ interface ComposerPromptEditorProps {
   terminalContexts: ReadonlyArray<TerminalContextDraft>;
   skills: ReadonlyArray<ServerProviderSkill>;
   disabled: boolean;
-  stashEnabled?: boolean;
   placeholder: string;
   className?: string;
   onRemoveTerminalContext: (contextId: string) => void;
@@ -1532,7 +1531,6 @@ function ComposerPromptEditorInner({
   terminalContexts,
   skills,
   disabled,
-  stashEnabled = false,
   placeholder,
   className,
   onRemoveTerminalContext,
@@ -1760,7 +1758,6 @@ function ComposerPromptEditorInner({
                 className,
               )}
               data-testid="composer-editor"
-              data-composer-stash={stashEnabled ? "" : undefined}
               aria-placeholder={placeholder}
               placeholder={<span />}
               onPaste={onPaste}
@@ -1796,7 +1793,6 @@ export function ComposerPromptEditor({
   terminalContexts,
   skills,
   disabled,
-  stashEnabled = false,
   placeholder,
   className,
   onRemoveTerminalContext,
@@ -1835,7 +1831,6 @@ export function ComposerPromptEditor({
         terminalContexts={terminalContexts}
         skills={skills}
         disabled={disabled}
-        stashEnabled={stashEnabled}
         placeholder={placeholder}
         onRemoveTerminalContext={onRemoveTerminalContext}
         onChange={onChange}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -3019,7 +3019,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                 </div>
               )}
 
-            <div className="relative">
+            <div className="relative" data-composer-stash={stashCommandEnabled ? "" : undefined}>
               <ComposerPromptEditor
                 editorRef={composerEditorRef}
                 value={
@@ -3057,7 +3057,6 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                               : "Ask anything, @tag files/folders, $use skills, or / for commands"
                 }
                 disabled={isConnecting || isComposerApprovalState || projectSelectionRequired}
-                stashEnabled={stashCommandEnabled}
               />
               {showMobilePendingAnswerActions ? (
                 <div

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -2237,6 +2237,27 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     setIsStashMenuOpen(false);
   }, [prompt]);
 
+  const stashCommandEnabled =
+    !isComposerApprovalState &&
+    pendingUserInputs.length === 0 &&
+    !projectSelectionRequired &&
+    activePendingProgress === null;
+
+  const runStashCommand = useCallback(() => {
+    if (isCommandPaletteOpen() || !stashCommandEnabled) {
+      return;
+    }
+    void stashCurrentPrompt();
+  }, [stashCommandEnabled, stashCurrentPrompt]);
+
+  useEffect(() => {
+    const onMenuAction = window.desktopBridge?.onMenuAction;
+    if (!onMenuAction) return;
+    return onMenuAction((action) => {
+      if (action === "composer.stash") runStashCommand();
+    });
+  }, [runStashCommand]);
+
   useEffect(() => {
     const handler = (event: globalThis.KeyboardEvent) => {
       const command = resolveShortcutCommand(event, keybindings, {
@@ -2251,29 +2272,11 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       // even when the composer is in a state that can't stash.
       event.preventDefault();
       event.stopPropagation();
-      if (
-        isCommandPaletteOpen() ||
-        isComposerApprovalState ||
-        pendingUserInputs.length > 0 ||
-        projectSelectionRequired ||
-        activePendingProgress !== null
-      ) {
-        return;
-      }
-      void stashCurrentPrompt();
+      runStashCommand();
     };
     window.addEventListener("keydown", handler, true);
     return () => window.removeEventListener("keydown", handler, true);
-  }, [
-    activePendingProgress,
-    isComposerApprovalState,
-    isComposerModelPickerOpen,
-    keybindings,
-    pendingUserInputs.length,
-    projectSelectionRequired,
-    stashCurrentPrompt,
-    terminalOpen,
-  ]);
+  }, [isComposerModelPickerOpen, keybindings, runStashCommand, terminalOpen]);
 
   // ------------------------------------------------------------------
   // Callbacks: images
@@ -3054,6 +3057,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                               : "Ask anything, @tag files/folders, $use skills, or / for commands"
                 }
                 disabled={isConnecting || isComposerApprovalState || projectSelectionRequired}
+                stashEnabled={stashCommandEnabled}
               />
               {showMobilePendingAnswerActions ? (
                 <div


### PR DESCRIPTION
The Electron composer context menu only exposed the standard editing actions, so prompt stashing was discoverable through the keyboard shortcut and stash badge but not from the native right-click menu.

This adds a native **Stash** item with the platform `CmdOrCtrl+S` accelerator when the context-menu target is the active chat composer. The main process dispatches the existing `composer.stash` menu action back to the renderer, where it shares the same guarded stash path as the keyboard shortcut. Other editable fields keep the existing native menu unchanged, and composer states where stashing is unavailable do not advertise the action.

User impact: desktop users can stash the current prompt directly from the existing Cut/Copy/Paste/Select All menu without changing web or mobile context-menu behavior.

## Validation

- `pnpm exec vp test run apps/desktop/src/window/DesktopWindow.test.ts apps/web/src/keybindings.test.ts apps/web/src/promptStashStore.test.ts` (78 tests passed)
- targeted lint for the four changed files
- `pnpm exec vp run --filter @t3tools/web --filter @t3tools/desktop typecheck`
- manual Electron verification: the macOS native menu exposed Cut, Copy, Paste, Select All, and Stash; selecting Stash used the existing stash flow

## Visual verification

| Before | After |
|:--:|:--:|
| <img width="1748" height="900" alt="Before: native composer menu with standard editing actions" src="https://github.com/user-attachments/assets/9e96c414-af76-45a1-905d-606075daf3f8" /> | <img width="1693" height="929" alt="After: native composer menu with Stash and Command-S shortcut" src="https://github.com/user-attachments/assets/2f62aae9-9200-4256-9470-8db6e67a6242" /> |


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Stash option to the native context menu in the desktop composer
> - Adds a 'Stash' menu item (Cmd/Ctrl+S) to the native right-click context menu in [DesktopWindow.ts](https://github.com/pingdotgg/t3code/pull/6484/files#diff-d92229c509071d1e9d3595d187fe2f1f13c394b22e1d9d2070ed6fb99678f429), shown only when the click target is inside an element marked with `data-composer-stash`.
> - Clicking the item sends a `composer.stash` action over `MENU_ACTION_CHANNEL` to the renderer; [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/6484/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a) handles this via `desktopBridge.onMenuAction` and routes it through the existing stash gate.
> - The `data-composer-stash` attribute is conditionally added to the composer container when stashing is allowed (not in approval, no pending inputs, no active progress), enabling the hit-test in Electron.
> - Zoom factor is applied when converting window pixel coordinates to CSS pixels for accurate hit testing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 17b7d6e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop-only UX wiring reuses the existing stash guards and menu-action channel; no auth, persistence, or web behavior changes.
> 
> **Overview**
> Desktop users can **Stash** the current prompt from the native right-click menu on the chat composer, not only via the keyboard shortcut.
> 
> In **`DesktopWindow`**, editable context menus run a zoom-adjusted `elementFromPoint` hit-test for `[data-composer-stash]` before showing the menu. When the target is the composer, the menu adds **Stash** (`CmdOrCtrl+S`), which sends `composer.stash` over the existing menu-action IPC channel.
> 
> In **`ChatComposer`**, the editor wrapper gets `data-composer-stash` only when stashing is allowed; stash eligibility and execution are centralized in `runStashCommand`, used by both the shortcut handler and `desktopBridge.onMenuAction`. Other editable fields keep the standard Cut/Copy/Paste menu without **Stash**.
> 
> Tests cover composer vs non-composer menus, zoom-adjusted coordinates, and the IPC payload on **Stash** click.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17b7d6e1007a7bfe971572d5d015508b6d455197. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->