### PR TITLE
fix(web): bound OKLCH gamut mapping

### DIFF
--- a/apps/web/src/themePalette.test.ts
+++ b/apps/web/src/themePalette.test.ts
@@ -246,6 +246,18 @@ describe("theme files", () => {
     }
   });
 
+  it("gamut maps extreme finite OKLCH chroma from theme files", () => {
+    const theme = parseThemeFile({
+      version: THEME_FILE_VERSION,
+      name: "Extreme chroma",
+      appearance: "light",
+      colors: { accent: "oklch(0.5 1e303 0)" },
+    });
+
+    expect(theme.colors.accent).toBe("oklch(0.5 1e+303 0)");
+    expect(themeColorToHex(theme.colors.accent)).toBe("#b5005e");
+  });
+
   it("rejects unknown roles and invalid color values", () => {
     expect(() =>
       parseThemeFile({

--- a/apps/web/src/themePalette.ts
+++ b/apps/web/src/themePalette.ts
@@ -902,7 +902,11 @@ function mapThemeOklchToSrgbGamut(color: ThemeOklch): ThemeOklch {
 
   let low = 0;
   let high = color.C;
-  const steps = Math.max(1, Math.ceil(Math.log2(Math.max(color.C, 0.000001) / 0.000001)));
+  const chromaResolution = 0.000001;
+  const steps = Math.max(
+    1,
+    Math.ceil(Math.log2(Math.max(color.C, chromaResolution)) - Math.log2(chromaResolution)),
+  );
   for (let step = 0; step < steps; step += 1) {
     const mid = (low + high) / 2;
     if (isInGamut(mid)) low = mid;


### PR DESCRIPTION
## What Changed

Theme color gamut mapping now calculates its binary-search iteration count by subtracting base-2 logarithms instead of dividing chroma by the target resolution. This keeps the count finite for every finite OKLCH chroma accepted by the theme parser.

A focused regression imports a theme containing `oklch(0.5 1e303 0)`, verifies that parsing preserves the magnitude, and checks the mapped sRGB result.

Verified with the 31-test `themePalette` suite, the web package typecheck, and focused lint and formatting checks.

## Why

The previous `chroma / resolution` calculation could overflow to `Infinity` even when chroma itself was finite. That made the loop bound infinite and could hang the web or desktop renderer when an imported theme with extreme chroma was converted for the color editor.

The logarithm subtraction is algebraically equivalent for ordinary colors, preserves the existing chroma resolution, and avoids the overflowing intermediate value.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] UI screenshots are not applicable
- [x] UI motion video is not applicable

Made with GPT-5.6 using the Codex harness in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix overflow in `mapThemeOklchToSrgbGamut` for extremely large OKLCH chroma values
> The bisection step count in [`themePalette.ts`](https://github.com/pingdotgg/t3code/pull/6485/files#diff-064fba647ceaa3b988839d538985299275f3a7ab7bd18e98ad03158fa06d31ad) previously computed `log2(C / chromaResolution)`, which overflows to `Infinity` when `C` is extremely large (e.g. `1e303`). This is fixed by computing `log2(C) - log2(chromaResolution)` instead, which avoids intermediate overflow while preserving the same effective resolution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 335b00b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized numeric fix in theme color conversion with a targeted test; no auth, storage, or API surface changes.
> 
> **Overview**
> **Fixes a hang** when imported themes contain OKLCH colors with astronomically large but finite chroma (e.g. `oklch(0.5 1e303 0)`).
> 
> `mapThemeOklchToSrgbGamut` now computes the bisection iteration count as `log2(C) - log2(chromaResolution)` instead of `log2(C / chromaResolution)`. That avoids intermediate overflow to `Infinity` (which made the loop unbounded) while keeping the same effective resolution for normal colors.
> 
> A regression test parses extreme chroma through `parseThemeFile`, asserts the canonical OKLCH string is preserved, and checks `themeColorToHex` returns `#b5005e`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 335b00b71fa1c9f20f01778b5f534c70b187d149. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->