### PR TITLE
fix(mobile): recover the QR pairing scanner when camera access is denied

### DIFF
--- a/apps/mobile/src/features/connection/ConnectionsNewRouteScreen.tsx
+++ b/apps/mobile/src/features/connection/ConnectionsNewRouteScreen.tsx
@@ -3,7 +3,7 @@ import { NativeHeaderToolbar, NativeStackScreenOptions } from "../../native/Stac
 import { StackActions, useNavigation, type StaticScreenProps } from "@react-navigation/native";
 import { AsyncResult } from "effect/unstable/reactivity";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Alert, Platform, ScrollView, View } from "react-native";
+import { Alert, Linking, Platform, ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useThemeColor } from "../../lib/useThemeColor";
 
@@ -95,9 +95,21 @@ export function ConnectionsNewRouteScreen({
       return;
     }
 
+    if (permission.canAskAgain) {
+      Alert.alert(
+        "Camera access needed",
+        "Allow camera access to scan an environment pairing QR code.",
+      );
+      return;
+    }
+
     Alert.alert(
       "Camera access needed",
-      "Allow camera access to scan an environment pairing QR code.",
+      "Camera access was denied for this app. Open Settings to enable it.",
+      [
+        { text: "Cancel", style: "cancel" },
+        { text: "Open Settings", onPress: () => void Linking.openSettings() },
+      ],
     );
   }, [cameraPermission?.granted, requestCameraPermission]);
 


### PR DESCRIPTION
## What Changed

`openScanner` in `ConnectionsNewRouteScreen` now reads `canAskAgain` off the camera permission result. When the system can still prompt, the existing one-button alert stays. When it cannot, the alert gains Cancel and Open Settings, and Open Settings calls `Linking.openSettings()`.

Both buttons that open the scanner, the header icon and the Allow camera button on the fallback card, call `openScanner`, so one branch covers both.

## Why

Tap Don't Allow on the camera prompt once and the QR scanner is finished. Every later tap calls `requestCameraPermission()`, which resolves denied with no OS prompt, and the screen shows a one-button alert that leads nowhere. The user cannot reach the camera from inside the app again.

The Settings screen already solves this for notifications. `SettingsRouteScreen` checks `canAskAgain` on the denied result and offers Cancel and Open Settings. This copies that shape.

Fixes #6486

## UI Changes

Before: one alert, "Camera access needed", body "Allow camera access to scan an environment pairing QR code.", OK.

_Before and after screenshots attach below._

After, when the system will not prompt again: "Camera access needed", body "Camera access was denied for this app. Open Settings to enable it.", Cancel and Open Settings.


<img width="1170" height="2532" alt="before" src="https://github.com/user-attachments/assets/8e4f1f93-a17b-4d96-9705-3db7b4fe3d28" />

<img width="1170" height="2532" alt="after" src="https://github.com/user-attachments/assets/e7304b88-efdc-40df-8e6a-cc8430d51098" />


## Verification

`tsc --noEmit` in `apps/mobile` exits clean. `vp lint` and `vp fmt --check` on the changed file both pass.

The screenshots above come from an iPhone 16e simulator on iOS 26.3 with camera access already denied. The whole recovery was walked on that build. The header button showed the new alert, Open Settings left the app and landed on Settings under Privacy and Security, Camera, the app's toggle there turned camera access back on, and the header button then opened the scanner instead of the alert.

No test comes with this. Every test under `apps/mobile` is a pure-logic `.test.ts` file and the repo carries no React Native testing library, so covering an alert branch would mean adding that infrastructure first.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix QR pairing scanner recovery when camera access is permanently denied
> Updates the camera permission denied handling in [ConnectionsNewRouteScreen.tsx](https://github.com/pingdotgg/t3code/pull/6487/files#diff-5b38079b9ca3fa4c9984db793c45baf58112ead2f32998b9ca570d1c9cd48f25) to distinguish between two denied states. If the permission can still be requested again, an informational alert is shown. If the permission is permanently denied, the alert includes an "Open Settings" action that calls `Linking.openSettings()` so users can grant access from the OS settings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 19fad59.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UX change in connection pairing; no auth, data, or API changes.
> 
> **Overview**
> **Fixes a dead-end** when users deny camera permission and the OS will not show the prompt again on the Add Environment QR flow.
> 
> `openScanner` now branches on `permission.canAskAgain` after a denied `requestCameraPermission()` result. If the system can still ask, the existing informational alert remains. If not, the alert explains that access was denied and adds **Cancel** and **Open Settings**, with **Open Settings** calling `Linking.openSettings()`—matching the notification permission recovery pattern in settings.
> 
> Both entry points (header scanner control and the fallback **Allow camera** button) use `openScanner`, so recovery applies everywhere the scanner is opened.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19fad592ddc2b7058db690f833197c2ba05a1902. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->