### PR TITLE
fix(web): scope pull request errors to their environment

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestListFilters.test.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestListFilters.test.tsx
@@ -3,7 +3,7 @@ import { CircleIcon } from "lucide-react";
 import { Children, isValidElement, type ReactElement, type ReactNode } from "react";
 import { describe, expect, it, vi } from "vite-plus/test";
 
-import { PullRequestFiltersMenu } from "./PullRequestListFilters";
+import { PullRequestFiltersMenu, pullRequestProjectKey } from "./PullRequestListFilters";
 
 function findValueChange(
   node: ReactNode,
@@ -129,7 +129,7 @@ describe("pull request filters menu", () => {
     const radioGroup = findValueChange(view);
     expect(radioGroup).toBeDefined();
 
-    radioGroup?.props.onValueChange(`${environmentId} ${projectId}`);
+    radioGroup?.props.onValueChange(pullRequestProjectKey({ id: projectId, environmentId }));
     expect(onProject).not.toHaveBeenCalled();
 
     radioGroup?.props.onValueChange("all");
@@ -159,7 +159,23 @@ describe("pull request filters menu", () => {
     const radioGroup = findValueChange(view);
     expect(radioGroup).toBeDefined();
 
-    radioGroup?.props.onValueChange(`env-2 ${projectId}`);
+    radioGroup?.props.onValueChange(
+      pullRequestProjectKey({ id: projectId, environmentId: "env-2" as EnvironmentId }),
+    );
     expect(onProject).toHaveBeenCalledWith(projectId, "env-2");
+  });
+
+  it("does not collide when environment and project ids contain spaces", () => {
+    expect(
+      pullRequestProjectKey({
+        environmentId: "a b" as EnvironmentId,
+        id: "c" as ProjectId,
+      }),
+    ).not.toBe(
+      pullRequestProjectKey({
+        environmentId: "a" as EnvironmentId,
+        id: "b c" as ProjectId,
+      }),
+    );
   });
 });

--- a/apps/web/src/components/pullRequest/PullRequestListFilters.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestListFilters.tsx
@@ -122,10 +122,10 @@ const UNFILTERED_VALUE = "all";
  * A project's own radio value, carrying the server along with the id: the id alone is only
  * unique within its own server, so two rows sharing one would otherwise both read as checked.
  */
-const projectMenuValue = (project: {
+export const pullRequestProjectKey = (project: {
   readonly id: ProjectId;
   readonly environmentId: EnvironmentId;
-}) => `${project.environmentId} ${project.id}`;
+}) => JSON.stringify([project.environmentId, project.id]);
 
 const DRAFT_OPTIONS = [
   { value: UNFILTERED_VALUE, label: "All", Icon: LayersIcon },
@@ -350,7 +350,7 @@ export function PullRequestFiltersMenu({
           value={
             projectId === undefined || projectEnvironmentId === undefined
               ? ALL_PROJECTS_VALUE
-              : projectMenuValue({ id: projectId, environmentId: projectEnvironmentId })
+              : pullRequestProjectKey({ id: projectId, environmentId: projectEnvironmentId })
           }
           onValueChange={(next) => {
             if (next === ALL_PROJECTS_VALUE) {
@@ -359,7 +359,7 @@ export function PullRequestFiltersMenu({
             }
             // The value carries both halves, since the id alone cannot tell two servers' rows
             // apart once they share one.
-            const project = projects.find((candidate) => projectMenuValue(candidate) === next);
+            const project = projects.find((candidate) => pullRequestProjectKey(candidate) === next);
             if (
               project !== undefined &&
               (project.id !== projectId || project.environmentId !== projectEnvironmentId)
@@ -380,15 +380,15 @@ export function PullRequestFiltersMenu({
           {projects
             .toSorted(
               (left, right) =>
-                Number(unavailable.has(projectMenuValue(left))) -
-                Number(unavailable.has(projectMenuValue(right))),
+                Number(unavailable.has(pullRequestProjectKey(left))) -
+                Number(unavailable.has(pullRequestProjectKey(right))),
             )
             .map((project) => {
-              const reason = unavailable.get(projectMenuValue(project));
+              const reason = unavailable.get(pullRequestProjectKey(project));
               return (
                 <MenuRadioItem
-                  key={projectMenuValue(project)}
-                  value={projectMenuValue(project)}
+                  key={pullRequestProjectKey(project)}
+                  value={pullRequestProjectKey(project)}
                   disabled={reason !== undefined}
                   title={reason}
                 >

--- a/apps/web/src/components/pullRequest/PullRequestListFilters.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestListFilters.tsx
@@ -247,7 +247,7 @@ export function PullRequestFiltersMenu({
    * the reader is already choosing between projects, rather than as a count above the list
    * that says something is missing without saying which.
    */
-  unavailable: ReadonlyMap<ProjectId, string>;
+  unavailable: ReadonlyMap<string, string>;
   /** The environment comes with the project id, since picking a row picks a specific server's copy of it. */
   onProject: (projectId: ProjectId | undefined, environmentId: EnvironmentId | undefined) => void;
 }) {
@@ -379,10 +379,12 @@ export function PullRequestFiltersMenu({
               as a broken menu rather than as a workspace with three unreadable repositories. */}
           {projects
             .toSorted(
-              (left, right) => Number(unavailable.has(left.id)) - Number(unavailable.has(right.id)),
+              (left, right) =>
+                Number(unavailable.has(projectMenuValue(left))) -
+                Number(unavailable.has(projectMenuValue(right))),
             )
             .map((project) => {
-              const reason = unavailable.get(project.id);
+              const reason = unavailable.get(projectMenuValue(project));
               return (
                 <MenuRadioItem
                   key={projectMenuValue(project)}

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
@@ -1,4 +1,4 @@
-import type { EnvironmentId, PullRequestListEntry } from "@t3tools/contracts";
+import type { EnvironmentId, ProjectId, PullRequestListEntry } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
 import {
@@ -708,6 +708,20 @@ describe("merging the environments' own listings", () => {
     expect(pullRequestEntryKey({ ...row, environmentId: ENV_1 })).not.toBe(
       pullRequestEntryKey({ ...row, environmentId: ENV_2 }),
     );
+  });
+
+  it("keeps project errors scoped to the environment that reported them", () => {
+    const error = {
+      projectId: "project-1" as ProjectId,
+      projectTitle: "Web",
+      message: "Not signed in",
+    } as const;
+    const merged = mergePullRequestLists([
+      [ENV_1, answer({ errors: [error] })],
+      [ENV_2, answer()],
+    ]);
+
+    expect(merged?.errors).toEqual([{ ...error, environmentId: ENV_1 }]);
   });
 
   it("folds a host reached from two environments into one switcher row", () => {

--- a/apps/web/src/components/pullRequest/pullRequestList.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.ts
@@ -3,6 +3,7 @@ import * as Schema from "effect/Schema";
 import {
   EnvironmentId,
   PullRequestListEntry,
+  PullRequestListProjectError,
   PullRequestListResult,
   resolvePullRequestAuthorFilter,
 } from "@t3tools/contracts";
@@ -24,6 +25,10 @@ export interface EnvironmentPullRequestEntry extends PullRequestListEntry {
 }
 
 export interface EnvironmentPullRequestStat extends PullRequestDiffStat {
+  readonly environmentId: EnvironmentId;
+}
+
+export interface EnvironmentPullRequestError extends PullRequestListProjectError {
   readonly environmentId: EnvironmentId;
 }
 
@@ -452,7 +457,7 @@ export interface MergedPullRequestList {
   readonly viewers: PullRequestViewers;
   readonly providers: PullRequestListResult["providers"];
   readonly entries: ReadonlyArray<EnvironmentPullRequestEntry>;
-  readonly errors: PullRequestListResult["errors"];
+  readonly errors: ReadonlyArray<EnvironmentPullRequestError>;
   readonly truncated: boolean;
   readonly nextCursors: Readonly<Record<string, PullRequestListCursors>>;
   /**
@@ -476,7 +481,7 @@ export function mergePullRequestLists(
   const truncatedEnvironments: string[] = [];
   const providers = new Map<string, PullRequestListResult["providers"][number]>();
   const entries: EnvironmentPullRequestEntry[] = [];
-  const errors: Array<PullRequestListResult["errors"][number]> = [];
+  const errors: EnvironmentPullRequestError[] = [];
   const nextCursors: Record<string, PullRequestListCursors> = {};
   let truncated = false;
   for (const [environmentId, answer] of answers) {
@@ -498,7 +503,7 @@ export function mergePullRequestLists(
       );
     }
     entries.push(...answer.entries.map((entry) => ({ ...entry, environmentId })));
-    errors.push(...answer.errors);
+    errors.push(...answer.errors.map((error) => ({ ...error, environmentId })));
     truncated ||= answer.truncated;
     if (answer.truncated) truncatedEnvironments.push(environmentId);
     if (Object.keys(answer.nextCursors).length > 0) {
@@ -559,12 +564,18 @@ const EnvironmentPullRequestEntrySchema = Schema.Struct({
   environmentId: EnvironmentId,
 });
 
+const EnvironmentPullRequestErrorSchema = Schema.Struct({
+  ...PullRequestListProjectError.fields,
+  environmentId: EnvironmentId,
+});
+
 const decodeSnapshot = Schema.decodeUnknownOption(
   Schema.Struct({
     scope: Schema.String,
     data: Schema.Struct({
       ...PullRequestListResult.fields,
       entries: Schema.Array(EnvironmentPullRequestEntrySchema),
+      errors: Schema.Array(EnvironmentPullRequestErrorSchema),
       // Per environment here, unlike the wire shape, which is per repository within one.
       nextCursors: Schema.Record(Schema.String, PullRequestListResult.fields.nextCursors),
       truncatedEnvironments: Schema.Array(Schema.String),

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -60,6 +60,7 @@ import {
   PullRequestFiltersMenu,
   PullRequestSearchInput,
   pullRequestHostLabel,
+  pullRequestProjectKey,
   type PullRequestExpectedHost,
   type PullRequestFilterOption,
 } from "../components/pullRequest/PullRequestListFilters";
@@ -1253,7 +1254,11 @@ function PullRequestsRouteView() {
     () =>
       new Map(
         listErrors.map(
-          (error) => [`${error.environmentId} ${error.projectId}`, error.message] as const,
+          (error) =>
+            [
+              pullRequestProjectKey({ id: error.projectId, environmentId: error.environmentId }),
+              error.message,
+            ] as const,
         ),
       ),
     [listErrors],

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1250,7 +1250,12 @@ function PullRequestsRouteView() {
 
   /** Reported per project rather than as a count, so the reader can see which one it was. */
   const unavailableProjects = useMemo(
-    () => new Map(listErrors.map((error) => [error.projectId, error.message] as const)),
+    () =>
+      new Map(
+        listErrors.map(
+          (error) => [`${error.environmentId} ${error.projectId}`, error.message] as const,
+        ),
+      ),
     [listErrors],
   );
 


### PR DESCRIPTION
## What Changed

Pull request list errors now retain the environment that reported them when results from multiple servers are merged. The project filter uses the environment and project ID together when deciding which project is unavailable.

## Why

Project IDs are local to an environment and can collide across servers. Previously, an error from one environment could disable a healthy project with the same ID in another environment.

## UI Changes

No layout or styling changes. In the colliding-ID case, only the project from the failing environment is now marked unavailable. Before/after screenshots are intentionally omitted for this PR.

## Validation

- `vp test run apps/web/src/components/pullRequest/pullRequestList.logic.test.ts` (95 tests passed)
- `vp run --filter @t3tools/web typecheck`
- `git diff --check origin/main...HEAD`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] No animation or interaction video is required

Generated with GPT-5.6 via the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted fix to multi-environment PR list merging and filter keys; behavior change is correcting wrong cross-environment disabling with added tests.
> 
> **Overview**
> **Pull request list errors are scoped per environment** when merging results from multiple servers. Each error carries `environmentId`, and the project filter’s unavailable map keys rows with **`pullRequestProjectKey`** (environment + project) instead of bare `projectId`, so a failure on one server no longer marks the same project ID on another as unavailable.
> 
> **`pullRequestProjectKey`** is exported and encodes `[environmentId, projectId]` via `JSON.stringify` instead of a space-separated string, avoiding ambiguous keys when IDs contain spaces. Snapshot decoding expects errors with `environmentId`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67987a70fe0830093f32dda9eb19a2eab93245f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope pull request errors to their environment using combined environment+project keys
> - Introduces `EnvironmentPullRequestError` in [`pullRequestList.logic.ts`](https://github.com/pingdotgg/t3code/pull/6490/files#diff-f8ca5dc8d0f0bac3b412ba2abaf7fca00497f36286660cfeb38242768c60e478), extending project errors with `environmentId` so merged errors are scoped to the environment that reported them.
> - Exports `pullRequestProjectKey` from [`PullRequestListFilters.tsx`](https://github.com/pingdotgg/t3code/pull/6490/files#diff-fd9dd9257b8efd9938eb6b5c261a6b72d507bd400bac5f42876e6f363be34a27), encoding keys as JSON tuples `[environmentId, projectId]` instead of space-separated strings to prevent collisions when ids contain spaces.
> - Updates `unavailableProjects` in [`_chat.pull-requests.tsx`](https://github.com/pingdotgg/t3code/pull/6490/files#diff-514a5b26d9687035b089d834742d874da174aa0a8a0c7c2fd47c61d11795afa5) to key entries by `pullRequestProjectKey` so identical project ids across environments are handled correctly.
> - Behavioral Change: `PullRequestFiltersMenu`'s `unavailable` prop now expects keys built with `pullRequestProjectKey` rather than bare `ProjectId` values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 67987a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->