### PR TITLE
fix(web): restore desktop update download progress

### DIFF
--- a/apps/web/src/components/desktopUpdate.logic.test.ts
+++ b/apps/web/src/components/desktopUpdate.logic.test.ts
@@ -6,6 +6,7 @@ import {
   getArm64IntelBuildWarningDescription,
   getDesktopUpdateActionError,
   getDesktopUpdateButtonTooltip,
+  getDesktopUpdateDownloadPercent,
   getDesktopUpdateInstallConfirmationMessage,
   getDesktopUpdateReleaseUrl,
   isDesktopUpdateButtonDisabled,
@@ -333,5 +334,18 @@ describe("getDesktopUpdateButtonTooltip", () => {
     expect(getDesktopUpdateButtonTooltip({ ...baseState, status: "up-to-date" })).toBe(
       "Up to date",
     );
+  });
+
+  it("uses the same bounded whole percentage shown by the progress control", () => {
+    const downloading = (downloadPercent: number): DesktopUpdateState => ({
+      ...baseState,
+      status: "downloading",
+      downloadPercent,
+    });
+
+    expect(getDesktopUpdateDownloadPercent(downloading(42.9))).toBe(42);
+    expect(getDesktopUpdateButtonTooltip(downloading(42.9))).toBe("Downloading update (42%)");
+    expect(getDesktopUpdateDownloadPercent(downloading(-5))).toBe(0);
+    expect(getDesktopUpdateDownloadPercent(downloading(105))).toBe(100);
   });
 });

--- a/apps/web/src/components/desktopUpdate.logic.ts
+++ b/apps/web/src/components/desktopUpdate.logic.ts
@@ -56,6 +56,16 @@ export function isDesktopUpdateButtonDisabled(state: DesktopUpdateState | null):
   return state?.status === "downloading";
 }
 
+export function getDesktopUpdateDownloadPercent(state: DesktopUpdateState): number | null {
+  if (state.status !== "downloading" || typeof state.downloadPercent !== "number") {
+    return null;
+  }
+  if (!Number.isFinite(state.downloadPercent)) {
+    return null;
+  }
+  return Math.min(100, Math.max(0, Math.floor(state.downloadPercent)));
+}
+
 export function getArm64IntelBuildWarningDescription(state: DesktopUpdateState): string {
   if (!shouldShowArm64IntelBuildWarning(state)) {
     return "This install is using the correct architecture.";
@@ -76,8 +86,8 @@ export function getDesktopUpdateButtonTooltip(state: DesktopUpdateState): string
     return `Update ${state.availableVersion ?? "available"} ready to download`;
   }
   if (state.status === "downloading") {
-    const progress =
-      typeof state.downloadPercent === "number" ? ` (${Math.floor(state.downloadPercent)}%)` : "";
+    const percent = getDesktopUpdateDownloadPercent(state);
+    const progress = percent === null ? "" : ` (${percent}%)`;
     return `Downloading update${progress}`;
   }
   if (state.status === "downloaded") {

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.test.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.test.tsx
@@ -1,0 +1,15 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import { SidebarUpdateDownloadProgress } from "./SidebarUpdatePill";
+
+describe("SidebarUpdateDownloadProgress", () => {
+  it("renders a determinate circular ring around the download icon", () => {
+    const markup = renderToStaticMarkup(<SidebarUpdateDownloadProgress percent={42} />);
+
+    expect(markup).toContain('stroke-dashoffset="58"');
+    expect(markup).toContain('pathLength="100"');
+    expect(markup).toContain('viewBox="0 0 32 32"');
+    expect(markup).toContain("lucide-download");
+  });
+});

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -277,15 +277,15 @@ function SidebarUpdateControl() {
               type="button"
               aria-label={tooltip}
               aria-disabled={disabled || isActionPending || undefined}
-              disabled={isActionPending && !isDownloading}
+              disabled={(disabled || isActionPending) && !isDownloading}
               className={cn(
                 "inline-flex size-8 items-center justify-center rounded-full outline-hidden ring-ring transition-colors focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-60",
-                isDownloading ? "cursor-default" : "cursor-pointer",
+                isDownloading ? "cursor-default" : "enabled:cursor-pointer",
                 isDownloading
                   ? "bg-transparent text-update-foreground hover:bg-update/8"
                   : isUpdateState
-                    ? "bg-update-surface text-update-foreground hover:bg-update/12"
-                    : "text-[var(--sidebar-icon-color)] hover:bg-sidebar-row-hover hover:text-sidebar-foreground",
+                    ? "bg-update-surface text-update-foreground enabled:hover:bg-update/12"
+                    : "text-[var(--sidebar-icon-color)] enabled:hover:bg-sidebar-row-hover enabled:hover:text-sidebar-foreground",
               )}
               onClick={handleAction}
             >

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -10,6 +10,7 @@ import {
   getArm64IntelBuildWarningDescription,
   getDesktopUpdateActionError,
   getDesktopUpdateButtonTooltip,
+  getDesktopUpdateDownloadPercent,
   getDesktopUpdateInstallConfirmationMessage,
   isDesktopUpdateButtonDisabled,
   resolveDesktopUpdateButtonAction,
@@ -83,6 +84,38 @@ function SidebarUpdateReleaseNotesTooltip({
   );
 }
 
+export function SidebarUpdateDownloadProgress({ percent }: { readonly percent: number }) {
+  return (
+    <span className="relative flex size-full items-center justify-center">
+      <svg aria-hidden="true" className="absolute inset-0 size-full -rotate-90" viewBox="0 0 32 32">
+        <circle
+          cx="16"
+          cy="16"
+          r="14"
+          fill="none"
+          stroke="currentColor"
+          strokeOpacity="0.22"
+          strokeWidth="1.5"
+        />
+        <circle
+          cx="16"
+          cy="16"
+          r="14"
+          fill="none"
+          pathLength="100"
+          stroke="currentColor"
+          strokeDasharray="100"
+          strokeDashoffset={100 - percent}
+          strokeLinecap="round"
+          strokeWidth="1.5"
+          className="transition-[stroke-dashoffset] duration-300 ease-out motion-reduce:transition-none"
+        />
+      </svg>
+      <DownloadIcon className="size-3.5" />
+    </span>
+  );
+}
+
 export function SidebarUpdateArchitectureWarning() {
   return isElectron ? <SidebarUpdateArchitectureWarningContent /> : null;
 }
@@ -113,6 +146,7 @@ function SidebarUpdateControl() {
 
   const action = state ? resolveDesktopUpdateButtonAction(state) : "none";
   const isDownloading = state?.status === "downloading";
+  const downloadPercent = state ? getDesktopUpdateDownloadPercent(state) : null;
   const isUpdateState = action !== "none" || isDownloading;
   const tooltip = isUpdateState
     ? state
@@ -243,17 +277,22 @@ function SidebarUpdateControl() {
               type="button"
               aria-label={tooltip}
               aria-disabled={disabled || isActionPending || undefined}
-              disabled={disabled || isActionPending}
+              disabled={isActionPending && !isDownloading}
               className={cn(
-                "inline-flex size-8 items-center justify-center rounded-full outline-hidden ring-ring transition-colors enabled:cursor-pointer focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-60",
-                isUpdateState
-                  ? "bg-update-surface text-update-foreground enabled:hover:bg-update/12"
-                  : "text-[var(--sidebar-icon-color)] enabled:hover:bg-sidebar-row-hover enabled:hover:text-sidebar-foreground",
+                "inline-flex size-8 items-center justify-center rounded-full outline-hidden ring-ring transition-colors focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-60",
+                isDownloading ? "cursor-default" : "cursor-pointer",
+                isDownloading
+                  ? "bg-transparent text-update-foreground hover:bg-update/8"
+                  : isUpdateState
+                    ? "bg-update-surface text-update-foreground hover:bg-update/12"
+                    : "text-[var(--sidebar-icon-color)] hover:bg-sidebar-row-hover hover:text-sidebar-foreground",
               )}
               onClick={handleAction}
             >
               {action === "install" ? (
                 <RotateCwIcon className="size-4" />
+              ) : isDownloading ? (
+                <SidebarUpdateDownloadProgress percent={downloadPercent ?? 0} />
               ) : isUpdateState ? (
                 <DownloadIcon className="size-4" />
               ) : (


### PR DESCRIPTION
The compact sidebar footer replaced the old full-width update container, which removed the persistent download-progress visualization. Users could no longer tell how far an app update had downloaded without relying on transient state.

This restores that feedback within the current compact design:

- renders download progress as an outline ring around the existing download icon
- keeps the control hoverable while downloading so the tooltip reports the current percentage
- normalizes progress to a bounded whole percentage shared by the ring and tooltip
- preserves reduced-motion behavior and the existing available/downloaded states

### Visual behavior

**Before:** the download icon sat inside a filled circular button with no visible completion indicator.

**After:** the button becomes a transparent outlined progress ring that fills from 0–100%, while hover text reports the matching percentage.

Verified in an isolated development client at 30% progress and at completion.

### Validation

- `vp test run apps/web/src/components/desktopUpdate.logic.test.ts apps/web/src/components/sidebar/SidebarUpdatePill.test.tsx` — 31 tests passed
- `vp run --filter @t3tools/web typecheck`
- targeted lint and formatting checks
- `git diff --check`

Generated with GPT-5.6-Sol via the Codex harness in T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore desktop update download progress ring in sidebar
> - Adds `SidebarUpdateDownloadProgress`, a circular SVG progress ring wrapping the download icon, shown during active downloads instead of the static icon.
> - Introduces `getDesktopUpdateDownloadPercent` in [`desktopUpdate.logic.ts`](https://github.com/pingdotgg/t3code/pull/6491/files#diff-ad19260d118b0d961892078ed35b67240d359da2ae4b4c8bd33e258537c503af) to produce a bounded integer percent (0–100) or `null` for invalid/non-downloading states.
> - Updates the downloading tooltip in `getDesktopUpdateButtonTooltip` to use the same bounded percent, omitting the value when `downloadPercent` is non-finite or absent.
> - While downloading, the sidebar button is no longer set to the native `disabled` state (click is still guarded), with adjusted cursor and hover styles.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ddac4c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to the Electron sidebar update control with shared percent logic and tests; no auth, data, or backend impact.
> 
> **Overview**
> Restores visible download progress on the compact sidebar desktop update control after the full-width update UI was removed.
> 
> Adds **`getDesktopUpdateDownloadPercent`** so the tooltip and UI share a single **0–100 floored** percent (invalid or out-of-range values are clamped or omitted). **`getDesktopUpdateButtonTooltip`** now uses that helper for the “Downloading update (N%)” text.
> 
> While **`downloading`**, the pill shows **`SidebarUpdateDownloadProgress`**: a circular SVG ring around the download icon instead of a filled button with no indicator. The control stays **enabled for hover** (not HTML-disabled) so the percentage tooltip works, with updated styling for the transparent ring state. Tests cover the percent helper and static markup for the ring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddac4c89245675b9c6b56c6f2be484570d7b1724. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->