### PR TITLE
fix(mobile): prevent invalid HTML entities from crashing markdown

### DIFF
--- a/apps/mobile/modules/t3-markdown-text/src/nativeMarkdownText.ts
+++ b/apps/mobile/modules/t3-markdown-text/src/nativeMarkdownText.ts
@@ -70,15 +70,22 @@ const EMPTY_CONTEXT: RunContext = {
 
 const INLINE_HTML_TAG_PATTERN = /<\/?(?:kbd|mark|sub|sup|u)(?:\s[^>]*)?>/gi;
 
+function decodeCodePoint(codePoint: number, entity: string): string {
+  if (!Number.isInteger(codePoint) || codePoint < 0 || codePoint > 0x10ffff) {
+    return entity;
+  }
+  return String.fromCodePoint(codePoint);
+}
+
 function decodeHtmlEntitiesOnce(value: string): string {
   return value.replace(
     /&(?:#(\d+)|#x([0-9a-f]+)|amp|apos|gt|lt|nbsp|quot);/gi,
     (entity, decimal: string | undefined, hexadecimal: string | undefined) => {
       if (decimal) {
-        return String.fromCodePoint(Number.parseInt(decimal, 10));
+        return decodeCodePoint(Number.parseInt(decimal, 10), entity);
       }
       if (hexadecimal) {
-        return String.fromCodePoint(Number.parseInt(hexadecimal, 16));
+        return decodeCodePoint(Number.parseInt(hexadecimal, 16), entity);
       }
       switch (entity.toLowerCase()) {
         case "&amp;":

--- a/apps/mobile/src/lib/nativeMarkdownText.test.ts
+++ b/apps/mobile/src/lib/nativeMarkdownText.test.ts
@@ -126,6 +126,22 @@ describe("nativeMarkdownTextRuns", () => {
     ]);
   });
 
+  it.each([
+    ["&#128512;", "😀"],
+    ["&#x1f680;", "🚀"],
+    ["&#9999999999;", "&#9999999999;"],
+    ["&#x110000;", "&#x110000;"],
+    ["&amp;#9999999999;", "&#9999999999;"],
+    ["&amp;#x110000;", "&#x110000;"],
+  ])("normalizes numeric entity %s without throwing", (content, expected) => {
+    const node: MarkdownNode = {
+      type: "paragraph",
+      children: [{ type: "text", content }],
+    };
+
+    expect(nativeMarkdownTextRuns(node)).toEqual([{ text: expected }]);
+  });
+
   it("reads inline content from nested text nodes", () => {
     const node: MarkdownNode = {
       type: "paragraph",


### PR DESCRIPTION
## What Changed

Mobile's native Markdown renderer could throw when user or provider content contained a numeric HTML entity outside Unicode's valid code-point range.

Numeric entities are now range-checked before calling `String.fromCodePoint`. Valid decimal and hexadecimal entities still decode normally, while invalid ones remain literal. Focused tests cover valid, out-of-range, and double-encoded entities.

## Why

An invalid entity could abort rendering and make the affected thread unavailable on mobile. Preserving malformed input as text keeps the renderer usable without changing valid Markdown output.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (not applicable; no UI changes)
- [x] I included a video for animation/interaction changes (not applicable; no animation or interaction changes)

Created with **gpt-5.6-sol** using the Codex harness in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix invalid HTML entities crashing markdown by adding safe `decodeCodePoint` helper
> Numeric HTML entities with out-of-range or non-integer code points previously caused a `RangeError` from `String.fromCodePoint`, crashing markdown rendering on mobile.
>
> - Adds a `decodeCodePoint` helper in [nativeMarkdownText.ts](https://github.com/pingdotgg/t3code/pull/6495/files#diff-6ca1a8722a1053a74dedf7789620201e8345f0d095c5b9f9307c754fa0a4147a) that validates the code point is an integer within `[0, 0x10FFFF]` before calling `String.fromCodePoint`, returning the original entity string on failure.
> - Updates `decodeHtmlEntitiesOnce` to route decimal and hex numeric entity decoding through `decodeCodePoint` instead of calling `String.fromCodePoint` directly.
> - Extends the test suite with parameterized cases covering valid BMP/astral code points, out-of-range values, and ampersand-escaped numeric entities.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f3d2032.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to entity decoding with tests; no auth, data, or API surface impact.
> 
> **Overview**
> **Numeric HTML entities** that are out of Unicode range (or non-integers) no longer crash the mobile native markdown renderer. A new `decodeCodePoint` helper validates code points in `[0, 0x10FFFF]` before calling `String.fromCodePoint`; invalid values are left as the original entity string.
> 
> `decodeHtmlEntitiesOnce` now routes decimal and hex numeric entities through that helper instead of calling `String.fromCodePoint` directly. Tests cover valid BMP/astral entities, oversized values, and ampersand-escaped numeric forms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3d203294482aa978f972c3b42ed02b25c2a124f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->