### PR TITLE
fix(web): avoid duplicate command details

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1,11 +1,42 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
+  buildToolCallExpandedBody,
   computeStableMessagesTimelineRows,
   computeMessageDurationStart,
   deriveMessagesTimelineRows,
   normalizeCompactToolLabel,
   resolveAssistantMessageCopyState,
 } from "./MessagesTimeline.logic";
+
+describe("buildToolCallExpandedBody", () => {
+  it("renders duplicate command metadata only once", () => {
+    const rawCommand = "/bin/zsh -lc 'npx --yes react-doctor@0.9.12 --help'";
+
+    expect(
+      buildToolCallExpandedBody(
+        {
+          command: "npx --yes react-doctor@0.9.12 --help",
+          rawCommand,
+          detail: rawCommand,
+        },
+        undefined,
+      ),
+    ).toBe(rawCommand);
+  });
+
+  it("keeps command output that differs from the command", () => {
+    expect(
+      buildToolCallExpandedBody(
+        {
+          command: "pwd",
+          rawCommand: "/bin/zsh -lc 'pwd'",
+          detail: "/Users/imran/projects/t3code",
+        },
+        undefined,
+      ),
+    ).toBe("/bin/zsh -lc 'pwd'\n\n/Users/imran/projects/t3code");
+  });
+});
 
 describe("computeMessageDurationStart", () => {
   it("returns message createdAt when there is no preceding user message", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -7,6 +7,7 @@ import {
   type TurnPlanEntry,
   type WorkLogEntry,
 } from "../../session-logic";
+import { formatWorkspaceRelativePath } from "../../filePathDisplay";
 import { type ChatMessage, type ProposedPlan, type TurnDiffSummary } from "../../types";
 import { type MessageId, type OrchestrationLatestTurn, type TurnId } from "@t3tools/contracts";
 
@@ -236,6 +237,47 @@ export function computeMessageDurationStart(
 
 export function normalizeCompactToolLabel(value: string): string {
   return value.replace(/\s+(?:complete|completed)\s*$/i, "").trim();
+}
+
+function workEntryRawCommand(
+  workEntry: Pick<WorkLogEntry, "command" | "rawCommand">,
+): string | null {
+  const rawCommand = workEntry.rawCommand?.trim();
+  if (!rawCommand || !workEntry.command) {
+    return null;
+  }
+  return rawCommand === workEntry.command.trim() ? null : rawCommand;
+}
+
+export function buildToolCallExpandedBody(
+  workEntry: Pick<
+    WorkLogEntry,
+    "changedFiles" | "command" | "detail" | "itemType" | "rawCommand" | "toolData"
+  >,
+  workspaceRoot: string | undefined,
+): string | null {
+  const blocks: string[] = [];
+  const appendUniqueBlock = (value: string | null | undefined) => {
+    const trimmed = value?.trim();
+    if (trimmed && !blocks.includes(trimmed)) {
+      blocks.push(trimmed);
+    }
+  };
+
+  if (workEntry.itemType === "mcp_tool_call" && workEntry.toolData !== undefined) {
+    appendUniqueBlock(`MCP call\n${JSON.stringify(workEntry.toolData, null, 2)}`);
+  }
+  appendUniqueBlock(workEntryRawCommand(workEntry) ?? workEntry.command);
+  appendUniqueBlock(workEntry.detail);
+  if ((workEntry.changedFiles?.length ?? 0) > 0) {
+    appendUniqueBlock(
+      workEntry
+        .changedFiles!.map((filePath) => formatWorkspaceRelativePath(filePath, workspaceRoot))
+        .join("\n"),
+    );
+  }
+
+  return blocks.length > 0 ? blocks.join("\n\n") : null;
 }
 
 export function resolveAssistantMessageCopyState({

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -72,6 +72,7 @@ import { ChangedFilesCard } from "./ChangedFilesTree";
 import { shouldAutoExpandChangedFiles } from "./changedFilesPresentation";
 import { MessageCopyButton } from "./MessageCopyButton";
 import {
+  buildToolCallExpandedBody,
   computeStableMessagesTimelineRows,
   deriveMessagesTimelineRows,
   normalizeCompactToolLabel,
@@ -2017,44 +2018,6 @@ function workEntryPreview(
   return workEntry.changedFiles!.length === 1
     ? displayPath
     : `${displayPath} +${workEntry.changedFiles!.length - 1} more`;
-}
-
-function workEntryRawCommand(
-  workEntry: Pick<TimelineWorkEntry, "command" | "rawCommand">,
-): string | null {
-  const rawCommand = workEntry.rawCommand?.trim();
-  if (!rawCommand || !workEntry.command) {
-    return null;
-  }
-  return rawCommand === workEntry.command.trim() ? null : rawCommand;
-}
-
-function buildToolCallExpandedBody(
-  workEntry: TimelineWorkEntry,
-  workspaceRoot: string | undefined,
-): string | null {
-  const blocks: string[] = [];
-  if (workEntry.itemType === "mcp_tool_call" && workEntry.toolData !== undefined) {
-    blocks.push(`MCP call\n${JSON.stringify(workEntry.toolData, null, 2)}`);
-  }
-  const raw = workEntryRawCommand(workEntry);
-  if (raw?.trim()) {
-    blocks.push(raw.trim());
-  } else if (workEntry.command?.trim()) {
-    blocks.push(workEntry.command.trim());
-  }
-  if (workEntry.detail?.trim()) {
-    blocks.push(workEntry.detail.trim());
-  }
-  const changedFiles = workEntry.changedFiles ?? [];
-  if (changedFiles.length > 0) {
-    blocks.push(
-      changedFiles
-        .map((filePath) => formatWorkspaceRelativePath(filePath, workspaceRoot))
-        .join("\n"),
-    );
-  }
-  return blocks.length > 0 ? blocks.join("\n\n") : null;
 }
 
 function workEntryIconName(workEntry: TimelineWorkEntry): WorkEntryIconName {


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

- Deduplicated repeated command metadata in expanded web and desktop tool-call rows.
- Preserved distinct command output and file details.
- Added regression coverage for duplicate commands and legitimate command output.

## Why

Codex command activities can contain the same shell-wrapped command in both `rawCommand` and `detail`. The expanded renderer displayed both fields without deduplication, making it look like every command ran twice.

Deduplicating display blocks in the presentation layer fixes existing and active sessions without changing provider data or command execution behavior. It also matches the existing mobile implementation.
## UI Changes

### Before

<img width="853" height="271" alt="file-8e1320a96958fa062798e0f4b0446d80" src="https://github.com/user-attachments/assets/d59e816b-5c1c-4bf2-928f-33f90ff047b3" />

### After

<img width="590" height="129" alt="image" src="https://github.com/user-attachments/assets/6c01fbb1-3e2b-4942-823e-8e4dd183afa8" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only presentation change in the messages timeline with no backend or execution impact; behavior is covered by new unit tests.
> 
> **Overview**
> Expanded chat tool-call rows no longer repeat the same command when Codex activities put an identical shell-wrapped string in both `rawCommand` and `detail`.
> 
> **`buildToolCallExpandedBody`** is moved from `MessagesTimeline.tsx` into **`MessagesTimeline.logic.ts`** and builds the expanded body from ordered, **deduplicated** blocks (MCP payload, command/raw command, detail, changed files). Distinct output—e.g. `pwd` vs its cwd—is still shown on separate lines. Regression tests cover duplicate metadata and legitimate multi-block output.
> 
> Provider data and command execution are unchanged; this is presentation-only and aligns with the mobile `appendUniqueBlock` pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4610025fcaa7e64962dbc91d5acda3b63f7d4617. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix duplicate command details in tool call expanded body
> Extracts `buildToolCallExpandedBody` and `workEntryRawCommand` from [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/6498/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) into [MessagesTimeline.logic.ts](https://github.com/pingdotgg/t3code/pull/6498/files#diff-6cdfacc6ebbdbc5c4b4058c0a430b87d768ac2b6accf35fb4c9dfc23500914fe) and adds de-duplication logic so that identical `command` and `detail` blocks are not both rendered in the expanded tool call view.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4610025.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->