### PR TITLE
feat(desktop): show update download progress

### DIFF
--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -126,6 +126,7 @@ import { Kbd } from "./ui/kbd";
 import {
   getArm64IntelBuildWarningDescription,
   getDesktopUpdateActionError,
+  getDesktopUpdateProgressLabel,
   getDesktopUpdateInstallConfirmationMessage,
   isDesktopUpdateButtonDisabled,
   resolveDesktopUpdateButtonAction,
@@ -2761,6 +2762,7 @@ interface SidebarProjectsContentProps {
   arm64IntelBuildWarningDescription: string | null;
   desktopUpdateButtonAction: "download" | "install" | "none";
   desktopUpdateButtonDisabled: boolean;
+  desktopUpdateProgressLabel: string | null;
   desktopUpdateActionPending: boolean;
   handleDesktopUpdateButtonClick: () => void;
   projectSortOrder: SidebarProjectSortOrder;
@@ -2803,6 +2805,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     arm64IntelBuildWarningDescription,
     desktopUpdateButtonAction,
     desktopUpdateButtonDisabled,
+    desktopUpdateProgressLabel,
     desktopUpdateActionPending,
     handleDesktopUpdateButtonClick,
     projectSortOrder,
@@ -2892,7 +2895,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
             <TriangleAlertIcon />
             <AlertTitle>Intel build on Apple Silicon</AlertTitle>
             <AlertDescription>{arm64IntelBuildWarningDescription}</AlertDescription>
-            {desktopUpdateButtonAction !== "none" ? (
+            {desktopUpdateButtonAction !== "none" || desktopUpdateProgressLabel ? (
               <AlertAction>
                 <Button
                   size="xs"
@@ -2900,9 +2903,10 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                   disabled={desktopUpdateButtonDisabled || desktopUpdateActionPending}
                   onClick={handleDesktopUpdateButtonClick}
                 >
-                  {desktopUpdateButtonAction === "download"
-                    ? "Download ARM build"
-                    : "Install ARM build"}
+                  {desktopUpdateProgressLabel ??
+                    (desktopUpdateButtonAction === "download"
+                      ? "Download ARM build"
+                      : "Install ARM build")}
                 </Button>
               </AlertAction>
             ) : null}
@@ -3525,6 +3529,9 @@ export default function LegacySidebar() {
   const desktopUpdateButtonAction = desktopUpdateState
     ? resolveDesktopUpdateButtonAction(desktopUpdateState)
     : "none";
+  const desktopUpdateProgressLabel = desktopUpdateState
+    ? getDesktopUpdateProgressLabel(desktopUpdateState)
+    : null;
   const showArm64IntelBuildWarning =
     isElectron && shouldShowArm64IntelBuildWarning(desktopUpdateState);
   const arm64IntelBuildWarningDescription =
@@ -3663,6 +3670,7 @@ export default function LegacySidebar() {
         arm64IntelBuildWarningDescription={arm64IntelBuildWarningDescription}
         desktopUpdateButtonAction={desktopUpdateButtonAction}
         desktopUpdateButtonDisabled={desktopUpdateButtonDisabled}
+        desktopUpdateProgressLabel={desktopUpdateProgressLabel}
         desktopUpdateActionPending={desktopUpdateActionPending}
         handleDesktopUpdateButtonClick={handleDesktopUpdateButtonClick}
         projectSortOrder={sidebarProjectSortOrder}

--- a/apps/web/src/components/desktopUpdate.logic.test.ts
+++ b/apps/web/src/components/desktopUpdate.logic.test.ts
@@ -6,6 +6,7 @@ import {
   getArm64IntelBuildWarningDescription,
   getDesktopUpdateActionError,
   getDesktopUpdateButtonTooltip,
+  getDesktopUpdateProgressLabel,
   getDesktopUpdateInstallConfirmationMessage,
   getDesktopUpdateReleaseUrl,
   isDesktopUpdateButtonDisabled,
@@ -333,5 +334,41 @@ describe("getDesktopUpdateButtonTooltip", () => {
     expect(getDesktopUpdateButtonTooltip({ ...baseState, status: "up-to-date" })).toBe(
       "Up to date",
     );
+  });
+});
+
+describe("getDesktopUpdateProgressLabel", () => {
+  it("shows rounded download progress", () => {
+    expect(
+      getDesktopUpdateProgressLabel({
+        ...baseState,
+        status: "downloading",
+        downloadPercent: 42.9,
+      }),
+    ).toBe("Downloading 42%");
+  });
+
+  it("falls back to indeterminate copy when progress is unavailable", () => {
+    expect(
+      getDesktopUpdateProgressLabel({
+        ...baseState,
+        status: "downloading",
+        downloadPercent: null,
+      }),
+    ).toBe("Downloading…");
+  });
+
+  it("clamps updater values to a valid percentage", () => {
+    expect(
+      getDesktopUpdateProgressLabel({
+        ...baseState,
+        status: "downloading",
+        downloadPercent: 101.2,
+      }),
+    ).toBe("Downloading 100%");
+  });
+
+  it("omits progress outside the download state", () => {
+    expect(getDesktopUpdateProgressLabel(baseState)).toBeNull();
   });
 });

--- a/apps/web/src/components/desktopUpdate.logic.ts
+++ b/apps/web/src/components/desktopUpdate.logic.ts
@@ -95,6 +95,15 @@ export function getDesktopUpdateButtonTooltip(state: DesktopUpdateState): string
   return "Up to date";
 }
 
+export function getDesktopUpdateProgressLabel(state: DesktopUpdateState): string | null {
+  if (state.status !== "downloading") return null;
+  if (typeof state.downloadPercent !== "number" || !Number.isFinite(state.downloadPercent)) {
+    return "Downloading…";
+  }
+  const percent = Math.min(100, Math.max(0, Math.floor(state.downloadPercent)));
+  return `Downloading ${percent}%`;
+}
+
 export function getDesktopUpdateInstallConfirmationMessage(
   state: Pick<DesktopUpdateState, "availableVersion" | "downloadedVersion">,
   platform = "",

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -42,6 +42,7 @@ import { APP_VERSION, HOSTED_APP_CHANNEL, HOSTED_APP_CHANNEL_LABEL } from "../..
 import {
   canCheckForUpdate,
   getDesktopUpdateButtonTooltip,
+  getDesktopUpdateProgressLabel,
   getDesktopUpdateInstallConfirmationMessage,
   isDesktopUpdateButtonDisabled,
   resolveDesktopUpdateButtonAction,
@@ -357,7 +358,10 @@ function AboutVersionSection() {
     "up-to-date": "Up to Date",
   };
   const buttonLabel =
-    actionLabel[action] ?? statusLabel[updateState?.status ?? ""] ?? "Check for Updates";
+    (updateState ? getDesktopUpdateProgressLabel(updateState) : null) ??
+    actionLabel[action] ??
+    statusLabel[updateState?.status ?? ""] ??
+    "Check for Updates";
   const description =
     action === "download" || action === "install"
       ? "Update available."

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -10,6 +10,7 @@ import {
   getArm64IntelBuildWarningDescription,
   getDesktopUpdateActionError,
   getDesktopUpdateButtonTooltip,
+  getDesktopUpdateProgressLabel,
   getDesktopUpdateInstallConfirmationMessage,
   isDesktopUpdateButtonDisabled,
   resolveDesktopUpdateButtonAction,
@@ -113,6 +114,7 @@ function SidebarUpdateControl() {
 
   const action = state ? resolveDesktopUpdateButtonAction(state) : "none";
   const isDownloading = state?.status === "downloading";
+  const progressLabel = state ? getDesktopUpdateProgressLabel(state) : null;
   const isUpdateState = action !== "none" || isDownloading;
   const tooltip = isUpdateState
     ? state
@@ -252,7 +254,14 @@ function SidebarUpdateControl() {
               )}
               onClick={handleAction}
             >
-              {action === "install" ? (
+              {isDownloading && typeof state.downloadPercent === "number" ? (
+                <span
+                  className="text-[9px] leading-none font-semibold tabular-nums"
+                  aria-hidden="true"
+                >
+                  {Math.min(100, Math.max(0, Math.floor(state.downloadPercent)))}%
+                </span>
+              ) : action === "install" ? (
                 <RotateCwIcon className="size-4" />
               ) : isUpdateState ? (
                 <DownloadIcon className="size-4" />
@@ -286,7 +295,7 @@ function SidebarUpdateControl() {
           variant={isUpdateState ? "glass" : "default"}
         >
           {isUpdateState && state ? (
-            <SidebarUpdateReleaseNotesTooltip state={state} tooltip={tooltip} />
+            <SidebarUpdateReleaseNotesTooltip state={state} tooltip={progressLabel ?? tooltip} />
           ) : (
             tooltip
           )}


### PR DESCRIPTION
## What changed

- show the live download percentage in the compact desktop update control
- show `Downloading N%` in Settings → About and the legacy Apple Silicon update action
- clamp updater progress to a valid percentage and retain an indeterminate fallback
- cover progress-label behavior with focused unit tests

## Why

Clicking Download previously changed the control to a generic downloading state, even though the desktop updater already publishes throttled percentage updates. Surfacing that existing state makes long downloads feel responsive and gives users clear feedback that the update is advancing.

Closes #6459.

## Impact

Desktop users now see determinate progress while an application update downloads. Web and mobile behavior are unchanged because this state is desktop-only.

## Validation

- `git diff --check`
- browser-rendered representative state inspected in the collaborative preview
- focused tests could not load because the interrupted dependency install is missing Vite Plus's native `darwin-arm64` binding
- web typecheck could not resolve installed dependencies such as React, contracts, and Vite for the same reason
- dependency installation was retried twice and repeatedly failed while fetching large optional platform tarballs from the package registry; disk space and inodes are healthy

UI example was reviewed at both compact sidebar and Settings button sizes.

Generated by GPT-5.6-Sol in the Codex harness.
