### PR TITLE
fix(web): show background policy tooltips sooner

### DIFF
--- a/apps/web/src/components/settings/settingsLayout.tsx
+++ b/apps/web/src/components/settings/settingsLayout.tsx
@@ -88,6 +88,7 @@ export function PolicyTooltip({ children }: { readonly children: string }) {
   return (
     <Tooltip>
       <TooltipTrigger
+        delay={200}
         render={
           <button
             type="button"


### PR DESCRIPTION
## Problem

Background-policy info tooltips inherit Base UI’s 600 ms delay, which makes them feel unresponsive.

## Fix

Set the shared policy tooltip trigger delay to 200 ms.

## Testing

Before

https://github.com/user-attachments/assets/c7f35020-3ba3-4dc6-8e3c-bfe2b8eedcd1

After

https://github.com/user-attachments/assets/07e9456a-c29a-4868-b82e-ed48b165e8be


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show policy tooltips sooner by reducing trigger delay to 200ms
> Adds `delay={200}` to the `TooltipTrigger` in the `PolicyTooltip` component in [settingsLayout.tsx](https://github.com/pingdotgg/t3code/pull/6506/files#diff-b320015b8831dfe0790cf2606a38785fca21e9a39f13b7d8afefbead69523dc9), reducing the time before the tooltip appears on hover.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7bddc4f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->