### PR TITLE
Add direct model and reasoning keybindings

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -156,7 +156,12 @@ import {
 } from "@t3tools/client-runtime/state/subagentRuntime";
 import { DiffWorkerPoolProvider } from "./DiffWorkerPoolProvider";
 import { BranchToolbar } from "./BranchToolbar";
-import { resolveShortcutCommand, shortcutLabelForCommand } from "../keybindings";
+import {
+  modelSelectTargetFromCommand,
+  reasoningEffortFromCommand,
+  resolveShortcutCommand,
+  shortcutLabelForCommand,
+} from "../keybindings";
 import ThreadTerminalDrawer from "./ThreadTerminalDrawer";
 import {
   AlarmClockIcon,
@@ -4663,7 +4668,7 @@ function ChatViewContent(props: ChatViewProps) {
         event.stopPropagation();
         return;
       }
-      if (!activeThreadId || isCommandPaletteOpen()) {
+      if (isCommandPaletteOpen()) {
         return;
       }
       const terminalFocusOwner = getTerminalFocusOwner();
@@ -4675,6 +4680,27 @@ function ChatViewContent(props: ChatViewProps) {
         terminalOpen: Boolean(terminalUiState.terminalOpen),
         modelPickerOpen: composerRef.current?.isModelPickerOpen() ?? false,
       };
+
+      const command = resolveShortcutCommand(event, keybindings, {
+        context: shortcutContext,
+      });
+
+      const modelTarget = command ? modelSelectTargetFromCommand(command) : null;
+      if (modelTarget) {
+        event.preventDefault();
+        event.stopPropagation();
+        composerRef.current?.selectModel(modelTarget.instanceId, modelTarget.model);
+        return;
+      }
+
+      const reasoningEffort = command ? reasoningEffortFromCommand(command) : null;
+      if (reasoningEffort && composerRef.current?.selectReasoningEffort(reasoningEffort)) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+
+      if (!activeThreadId) return;
 
       if (
         !shortcutContext.terminalFocus &&
@@ -4688,9 +4714,6 @@ function ChatViewContent(props: ChatViewProps) {
         }
       }
 
-      const command = resolveShortcutCommand(event, keybindings, {
-        context: shortcutContext,
-      });
       if (!command) return;
 
       if (command === "terminal.toggle") {

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -100,6 +100,7 @@ import {
   getComposerProviderState,
   renderProviderTraitsMenuContent,
   renderProviderTraitsPicker,
+  selectComposerReasoningEffort,
 } from "./composerProviderState";
 import { ContextWindowMeter } from "./ContextWindowMeter";
 import { buildExpandedImagePreview, type ExpandedImagePreview } from "./ExpandedImagePreview";
@@ -454,6 +455,8 @@ export interface ChatComposerHandle {
   openModelPicker: () => void;
   toggleModelPicker: () => void;
   isModelPickerOpen: () => boolean;
+  selectModel: (instanceId: ProviderInstanceId, model: string) => void;
+  selectReasoningEffort: (effort: string) => boolean;
   readSnapshot: () => {
     value: string;
     cursor: number;
@@ -708,6 +711,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const clearComposerDraftPromptAndImages = useComposerDraftStore(
     (store) => store.clearComposerPromptAndImages,
   );
+  const setProviderModelOptions = useComposerDraftStore((store) => store.setProviderModelOptions);
   const syncComposerDraftPersistedAttachments = useComposerDraftStore(
     (store) => store.syncPersistedAttachments,
   );
@@ -2545,6 +2549,25 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         setIsComposerModelPickerOpen((open) => !open);
       },
       isModelPickerOpen: () => isComposerModelPickerOpen,
+      selectModel: (instanceId: ProviderInstanceId, model: string) => {
+        onProviderModelSelect(instanceId, model);
+      },
+      selectReasoningEffort: (effort: string) => {
+        const nextOptions = selectComposerReasoningEffort({
+          provider: selectedProvider,
+          model: selectedModel,
+          models: selectedProviderModels,
+          modelOptions: selectedModelOptionsForDispatch,
+          effort,
+        });
+        if (nextOptions === null) return false;
+        setProviderModelOptions(composerDraftTarget, selectedProvider, nextOptions, {
+          instanceId: selectedInstanceId,
+          model: selectedModel,
+          persistSticky: true,
+        });
+        return true;
+      },
       readSnapshot: () => {
         return readComposerSnapshot();
       },
@@ -2643,6 +2666,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       selectedPromptEffort,
       selectedProvider,
       selectedProviderModels,
+      selectedInstanceId,
+      setProviderModelOptions,
+      onProviderModelSelect,
     ],
   );
 

--- a/apps/web/src/components/chat/composerProviderState.test.tsx
+++ b/apps/web/src/components/chat/composerProviderState.test.tsx
@@ -10,6 +10,7 @@ import {
   getComposerProviderState,
   renderProviderTraitsMenuContent,
   renderProviderTraitsPicker,
+  selectComposerReasoningEffort,
 } from "./composerProviderState";
 
 // Everything in composerProviderState is now data-driven by the model's
@@ -225,6 +226,41 @@ describe("getComposerProviderState", () => {
     expect(state).not.toHaveProperty("composerFrameClassName");
     expect(state).not.toHaveProperty("composerSurfaceClassName");
     expect(state).not.toHaveProperty("modelPickerIconClassName");
+  });
+});
+
+describe("selectComposerReasoningEffort", () => {
+  const models = modelWith([
+    selectDescriptor("reasoningEffort", [
+      { id: "low", label: "Low" },
+      { id: "medium", label: "Medium", isDefault: true },
+      { id: "high", label: "High" },
+    ]),
+    booleanDescriptor("fastMode"),
+  ]);
+
+  it("changes the primary select option and preserves other options", () => {
+    expect(
+      selectComposerReasoningEffort({
+        provider: PROVIDER,
+        model: MODEL,
+        models,
+        modelOptions: selections(["reasoningEffort", "medium"], ["fastMode", true]),
+        effort: "high",
+      }),
+    ).toEqual(selections(["reasoningEffort", "high"], ["fastMode", true]));
+  });
+
+  it("rejects effort values the selected model does not support", () => {
+    expect(
+      selectComposerReasoningEffort({
+        provider: PROVIDER,
+        model: MODEL,
+        models,
+        modelOptions: undefined,
+        effort: "xhigh",
+      }),
+    ).toBeNull();
   });
 });
 

--- a/apps/web/src/components/chat/composerProviderState.tsx
+++ b/apps/web/src/components/chat/composerProviderState.tsx
@@ -1,6 +1,7 @@
 import {
   type ProviderDriverKind,
   type ProviderInstanceId,
+  type ProviderOptionDescriptor,
   type ProviderOptionSelection,
   type ScopedThreadRef,
   type ServerProviderModel,
@@ -35,6 +36,33 @@ export type ComposerProviderState = {
   composerSurfaceClassName?: string;
   modelPickerIconClassName?: string;
 };
+
+export function selectComposerReasoningEffort(input: {
+  provider: ProviderDriverKind;
+  model: string;
+  models: ReadonlyArray<ServerProviderModel>;
+  modelOptions: ReadonlyArray<ProviderOptionSelection> | null | undefined;
+  effort: string;
+}): ReadonlyArray<ProviderOptionSelection> | null {
+  const caps = getProviderModelCapabilities(input.models, input.model, input.provider);
+  const descriptors = getProviderOptionDescriptors({
+    caps,
+    selections: input.modelOptions,
+  });
+  const primarySelectDescriptor = descriptors.find(
+    (descriptor): descriptor is Extract<ProviderOptionDescriptor, { type: "select" }> =>
+      descriptor.type === "select",
+  );
+  if (!primarySelectDescriptor?.options.some((option) => option.id === input.effort)) {
+    return null;
+  }
+  const nextDescriptors = descriptors.map((descriptor) =>
+    descriptor.type === "select" && descriptor.id === primarySelectDescriptor.id
+      ? { ...descriptor, currentValue: input.effort }
+      : descriptor,
+  );
+  return buildProviderOptionSelectionsFromDescriptors(nextDescriptors) ?? [];
+}
 
 type TraitsRenderInput = {
   provider: ProviderDriverKind;

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -20,6 +20,8 @@ import {
   isTerminalSplitShortcut,
   isTerminalSplitVerticalShortcut,
   isTerminalToggleShortcut,
+  modelSelectTargetFromCommand,
+  reasoningEffortFromCommand,
   resolveShortcutCommand,
   shouldShowModelPickerJumpHints,
   shouldShowThreadJumpHints,
@@ -31,6 +33,24 @@ import {
   threadTraversalDirectionFromCommand,
   type ShortcutEventLike,
 } from "./keybindings";
+
+describe("direct model and reasoning commands", () => {
+  it("parses a provider instance and dotted model slug", () => {
+    assert.deepEqual(modelSelectTargetFromCommand("model.select.codex.gpt-5.6-sol"), {
+      instanceId: "codex",
+      model: "gpt-5.6-sol",
+    });
+    assert.deepEqual(modelSelectTargetFromCommand("model.select.claudeAgent.claude-opus-5[1m]"), {
+      instanceId: "claudeAgent",
+      model: "claude-opus-5[1m]",
+    });
+  });
+
+  it("parses reasoning effort commands", () => {
+    assert.strictEqual(reasoningEffortFromCommand("reasoning.select.low"), "low");
+    assert.isNull(reasoningEffortFromCommand("modelPicker.toggle"));
+  });
+});
 
 function event(overrides: Partial<ShortcutEventLike> = {}): ShortcutEventLike {
   return {

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -2,6 +2,7 @@ import {
   type KeybindingCommand,
   type KeybindingShortcut,
   type KeybindingWhenNode,
+  ProviderInstanceId,
   MODEL_PICKER_JUMP_KEYBINDING_COMMANDS,
   type ResolvedKeybindingsConfig,
   THREAD_JUMP_KEYBINDING_COMMANDS,
@@ -63,6 +64,32 @@ const EVENT_CODE_KEY_ALIASES: Readonly<Record<string, readonly string[]>> = {
   Digit8: ["8"],
   Digit9: ["9"],
 };
+
+const MODEL_SELECT_COMMAND_PREFIX = "model.select.";
+const REASONING_SELECT_COMMAND_PREFIX = "reasoning.select.";
+
+export interface ModelSelectKeybindingTarget {
+  instanceId: ProviderInstanceId;
+  model: string;
+}
+
+export function modelSelectTargetFromCommand(
+  command: KeybindingCommand | string,
+): ModelSelectKeybindingTarget | null {
+  if (!command.startsWith(MODEL_SELECT_COMMAND_PREFIX)) return null;
+  const target = command.slice(MODEL_SELECT_COMMAND_PREFIX.length);
+  const separatorIndex = target.indexOf(".");
+  if (separatorIndex <= 0 || separatorIndex === target.length - 1) return null;
+  return {
+    instanceId: ProviderInstanceId.make(target.slice(0, separatorIndex)),
+    model: target.slice(separatorIndex + 1),
+  };
+}
+
+export function reasoningEffortFromCommand(command: KeybindingCommand | string): string | null {
+  if (!command.startsWith(REASONING_SELECT_COMMAND_PREFIX)) return null;
+  return command.slice(REASONING_SELECT_COMMAND_PREFIX.length) || null;
+}
 
 function normalizeEventKey(key: string): string {
   const normalized = key.toLowerCase();

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -96,6 +96,18 @@ it.effect("parses keybinding rules", () =>
     });
     assert.strictEqual(parsedModelPickerJump.command, "modelPicker.jump.1");
 
+    const parsedModelSelect = yield* decode(KeybindingRule, {
+      key: "f15",
+      command: "model.select.codex.gpt-5.6-sol",
+    });
+    assert.strictEqual(parsedModelSelect.command, "model.select.codex.gpt-5.6-sol");
+
+    const parsedReasoningSelect = yield* decode(KeybindingRule, {
+      key: "f19",
+      command: "reasoning.select.high",
+    });
+    assert.strictEqual(parsedReasoningSelect.command, "reasoning.select.high");
+
     const parsedThreadPrevious = yield* decode(KeybindingRule, {
       key: "mod+shift+[",
       command: "thread.previous",
@@ -113,6 +125,21 @@ it.effect("rejects invalid command values", () =>
       }),
     );
     assert.strictEqual(result._tag, "Failure");
+  }),
+);
+
+it.effect("rejects malformed direct selection commands", () =>
+  Effect.gen(function* () {
+    for (const command of [
+      "model.select.codex",
+      "model.select.1bad.model",
+      "model.select.codex.model with spaces",
+      "reasoning.select.",
+      "reasoning.select.extra.high",
+    ]) {
+      const result = yield* Effect.exit(decode(KeybindingRule, { key: "f13", command }));
+      assert.strictEqual(result._tag, "Failure");
+    }
   }),
 );
 

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -5,6 +5,7 @@ export const MAX_KEYBINDING_VALUE_LENGTH = 64;
 export const MAX_KEYBINDING_WHEN_LENGTH = 256;
 export const MAX_WHEN_EXPRESSION_DEPTH = 64;
 export const MAX_SCRIPT_ID_LENGTH = 24;
+export const MAX_MODEL_KEYBINDING_ID_LENGTH = 128;
 export const MAX_KEYBINDINGS_COUNT = 256;
 
 export const THREAD_JUMP_KEYBINDING_COMMANDS = [
@@ -83,9 +84,38 @@ export const SCRIPT_RUN_COMMAND_PATTERN = Schema.TemplateLiteral([
   Schema.Literal(".run"),
 ]);
 
+const PROVIDER_INSTANCE_COMMAND_SEGMENT = Schema.NonEmptyString.check(
+  Schema.isMaxLength(64),
+  Schema.isPattern(/^[a-zA-Z][a-zA-Z0-9_-]*$/),
+);
+const MODEL_COMMAND_SEGMENT = Schema.NonEmptyString.check(
+  Schema.isMaxLength(MAX_MODEL_KEYBINDING_ID_LENGTH),
+  Schema.isPattern(/^\S+$/),
+);
+const REASONING_COMMAND_SEGMENT = Schema.NonEmptyString.check(
+  Schema.isMaxLength(64),
+  Schema.isPattern(/^[a-zA-Z][a-zA-Z0-9_-]*$/),
+);
+
+export const MODEL_SELECT_COMMAND_PATTERN = Schema.TemplateLiteral([
+  Schema.Literal("model.select."),
+  PROVIDER_INSTANCE_COMMAND_SEGMENT,
+  Schema.Literal("."),
+  MODEL_COMMAND_SEGMENT,
+]);
+export type ModelSelectKeybindingCommand = typeof MODEL_SELECT_COMMAND_PATTERN.Type;
+
+export const REASONING_SELECT_COMMAND_PATTERN = Schema.TemplateLiteral([
+  Schema.Literal("reasoning.select."),
+  REASONING_COMMAND_SEGMENT,
+]);
+export type ReasoningSelectKeybindingCommand = typeof REASONING_SELECT_COMMAND_PATTERN.Type;
+
 export const KeybindingCommand = Schema.Union([
   Schema.Literals(STATIC_KEYBINDING_COMMANDS),
   SCRIPT_RUN_COMMAND_PATTERN,
+  MODEL_SELECT_COMMAND_PATTERN,
+  REASONING_SELECT_COMMAND_PATTERN,
 ]);
 export type KeybindingCommand = typeof KeybindingCommand.Type;
 


### PR DESCRIPTION
## What Changed

- Add dynamic `model.select.<provider>.<model>` keybinding commands.
- Add dynamic `reasoning.select.<effort>` keybinding commands.
- Route both command families through the active composer while preserving other provider options.
- Add parser and composer-state coverage.

## Why

Direct commands let users bind hardware keys or shortcut chords to frequently used models and reasoning levels without opening the model picker.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No visual UI changes
- [x] Verified direct model selection in the browser
- [x] 58 focused web tests pass
- [x] Formatting and lint checks pass for all changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Composer and keybinding wiring only; no auth or data-path changes, with validation and unit tests for parsers and reasoning selection.
> 
> **Overview**
> Adds **direct keybindings** so users can switch provider/model and reasoning effort without opening the model picker.
> 
> New command shapes are validated in contracts: `model.select.<instanceId>.<model>` and `reasoning.select.<effort>`, with parsers in `keybindings.ts`. **ChatView** resolves these before thread-only shortcuts and calls new **ChatComposer** imperative APIs (`selectModel`, `selectReasoningEffort`). Reasoning updates go through `selectComposerReasoningEffort`, which only applies supported effort values and keeps other model options intact via sticky `setProviderModelOptions`.
> 
> **Behavior change:** model/reasoning shortcuts can fire when the command palette is closed even if no thread is active (the `activeThreadId` guard no longer blocks them).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4da4b24546d7df4930dfb730e8d417a8d19d5ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add direct model and reasoning effort keybindings to the chat composer
> - Adds two new keybinding command patterns — `model.select.<instance>.<model>` and `reasoning.select.<effort>` — to the `KeybindingCommand` schema in [keybindings.ts](https://github.com/pingdotgg/t3code/pull/6507/files#diff-4eff8b6cf08dc64a9d8f37ff97b369a5719340e4c6203ab7070cc8cfffd28db6) with validation for length and character constraints.
> - Adds `modelSelectTargetFromCommand` and `reasoningEffortFromCommand` parser utilities in [keybindings.ts](https://github.com/pingdotgg/t3code/pull/6507/files#diff-0c56a39781768a3ed42f3d306e35b87e9d2426ccb4a81010bc2c4fe735001385) to extract typed targets from matching command strings at runtime.
> - Extends `ChatComposerHandle` with `selectModel` and `selectReasoningEffort` methods that update composer state; reasoning effort changes preserve existing provider option selections and persist sticky state.
> - Updates the global keydown handler in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/6507/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to dispatch model and reasoning commands via `composerRef`, even when no active thread exists — other shortcuts still require an active thread.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4da4b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->