### PR TITLE
fix(web): show unlinked icon when viewport aspect ratio is unlocked

### DIFF
--- a/apps/web/src/browser/BrowserDeviceToolbar.tsx
+++ b/apps/web/src/browser/BrowserDeviceToolbar.tsx
@@ -7,7 +7,7 @@ import {
   type PreviewViewportSetting,
 } from "@t3tools/contracts";
 import { PREVIEW_VIEWPORT_PRESETS, resolvePreviewViewport } from "@t3tools/shared/previewViewport";
-import { Link2, X } from "lucide-react";
+import { Link2, Unlink2, X } from "lucide-react";
 import { useState } from "react";
 
 import { Button } from "~/components/ui/button";
@@ -310,7 +310,11 @@ export function BrowserDeviceToolbar({
         onPointerDown={(event) => event.preventDefault()}
         onClick={toggleAspectRatio}
       >
-        <Link2 className={cn(aspectRatio !== null && "text-foreground")} />
+        {aspectRatio === null ? (
+          <Unlink2 className={cn(aspectRatio !== null && "text-foreground")} />
+        ) : (
+          <Link2 className={cn(aspectRatio !== null && "text-foreground")} />
+        )}
       </Button>
       <Button
         variant="ghost"


### PR DESCRIPTION
## What Changed

Changed the aspect ratio lock button in the device toolbar of the in-app browser. The linked (locked) and unlinked (unlocked) states now use distinct icons: Link2 when the ratio is locked, Unlink2 (the matching broken-chain icon from Lucide) when it is unlocked.

## Why

Both states previously rendered the same Link2 icon, which gave no visual signal of the current state. The difference was not clear visually. Unlink2 is the exact counterpart to Link2.

## UI Changes

Before:
<img width="231" height="47" alt="image" src="https://github.com/user-attachments/assets/586a9681-b230-4bc6-aa1f-3fbc71d4e202" />
<img width="236" height="51" alt="image" src="https://github.com/user-attachments/assets/e362aef1-71be-42d9-a484-28f6c13d3b0f" />

After:
<img width="237" height="55" alt="image" src="https://github.com/user-attachments/assets/689a9829-c206-48e2-bb54-9709020eb40b" />
<img width="244" height="54" alt="image" src="https://github.com/user-attachments/assets/277fd2b9-3d70-4388-a828-f90286332e34" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely visual icon swap in the preview device toolbar with no logic or API changes.
> 
> **Overview**
> The browser device toolbar aspect-ratio lock control now uses **two icons** instead of always showing `Link2`: **`Unlink2` when the ratio is unlocked** (`aspectRatio === null`) and **`Link2` when it is locked**. Labels, `aria-pressed`, and toggle behavior are unchanged—only the icon reflects state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ea17258b99dfa1a46359c40a81b5cb1f435f01d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show unlinked icon in `BrowserDeviceToolbar` when viewport aspect ratio is unlocked
> The aspect ratio toggle button previously always showed the `Link2` icon regardless of lock state. It now conditionally renders `Unlink2` when `aspectRatio` is `null` and `Link2` when locked.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 207a588.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->