### PR TITLE
fix(preview): discover named dev server URLs

### DIFF
--- a/apps/server/src/preview/PortScanner.test.ts
+++ b/apps/server/src/preview/PortScanner.test.ts
@@ -7,7 +7,7 @@ import {
   PREVIEW_URL_MAX_LENGTH,
   type DiscoveredLocalServer,
 } from "@t3tools/contracts";
-import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Net from "@t3tools/shared/Net";
 import * as Cause from "effect/Cause";
 import * as Clock from "effect/Clock";
@@ -61,6 +61,7 @@ const makeProbeFailureLayer = (
     Layer.provide(
       Layer.mergeAll(
         NodeServices.layer,
+        Layer.succeed(HostProcessEnvironment, {}),
         Layer.succeed(ProcessRunner.ProcessRunner, { run }),
         Layer.succeed(Net.NetService, {
           canListenOnHost: () => Effect.succeed(true),
@@ -79,6 +80,7 @@ const TestPortDiscoveryLive = PortScanner.layer.pipe(
   Layer.provide(
     Layer.mergeAll(
       NodeServices.layer,
+      Layer.succeed(HostProcessEnvironment, {}),
       TestProcessRunner,
       TestIntegrationNet,
       Layer.succeed(HostProcessPlatform, "win32"),
@@ -97,6 +99,7 @@ const makeLsofScannerLayer = (input: {
     Layer.provide(
       Layer.mergeAll(
         NodeServices.layer,
+        Layer.succeed(HostProcessEnvironment, {}),
         Layer.succeed(ProcessRunner.ProcessRunner, {
           run: () =>
             Effect.succeed({
@@ -142,7 +145,7 @@ describe("Portless route enrichment", () => {
 
     expect(routes.get(4058)).toBe("https://eng-1252-simplify-the-onboarding.artelo.localhost");
     expect(
-      PortScanner.__testing.applyPortlessRoutes(
+      PortScanner.__testing.applyNamedRoutes(
         [
           {
             host: "localhost",
@@ -192,6 +195,89 @@ describe("Portless route enrichment", () => {
 
     expect([...routes]).toEqual([[3001, "https://current.test"]]);
   });
+});
+
+describe("ngrok route enrichment", () => {
+  it("maps public HTTP tunnels to their loopback target and prefers HTTPS", () => {
+    const routes = PortScanner.__testing.parseNgrokTunnelSnapshot({
+      tunnels: [
+        {
+          public_url: "http://feature.ngrok-free.app",
+          config: { addr: "http://localhost:4058" },
+        },
+        {
+          public_url: "https://feature.ngrok-free.app",
+          config: { addr: "http://127.0.0.1:4058" },
+        },
+      ],
+    });
+
+    expect(routes && [...routes]).toEqual([[4058, "https://feature.ngrok-free.app/"]]);
+  });
+
+  it("accepts current forwards_to entries and ignores unsafe or non-web tunnels", () => {
+    const routes = PortScanner.__testing.parseNgrokTunnelSnapshot({
+      tunnels: [
+        { public_url: "https://docs.example.com", forwards_to: "[::1]:4312" },
+        { public_url: "https://invalid.example.com", forwards_to: "internal.example.com:4313" },
+        { public_url: "tcp://1.tcp.ngrok.io:12345", config: { addr: "localhost:4314" } },
+        { public_url: "https://user:secret@example.com", config: { addr: "4315" } },
+      ],
+    });
+
+    expect(routes && [...routes]).toEqual([[4312, "https://docs.example.com/"]]);
+  });
+
+  it("returns null when the agent response does not match the tunnel list contract", () => {
+    expect(PortScanner.__testing.parseNgrokTunnelSnapshot({ tunnels: "invalid" })).toBeNull();
+  });
+});
+
+effectIt.effect("replaces a discovered listener with its ngrok public URL", () => {
+  const targetPort = 43_127;
+  const configuredUrl = `http://localhost:${targetPort}/docs?mode=test#results`;
+  const requests: string[] = [];
+  const fetchFn = ((input: Parameters<typeof globalThis.fetch>[0]) => {
+    const url = String(input);
+    requests.push(url);
+    if (url === "http://localhost:4040/api/tunnels") {
+      return Promise.resolve(
+        Response.json({
+          tunnels: [
+            {
+              public_url: "https://feature.ngrok-free.app",
+              config: { addr: `http://localhost:${targetPort}` },
+            },
+          ],
+        }),
+      );
+    }
+    return Promise.resolve(new Response("app", { headers: { "content-type": "text/html" } }));
+  }) as typeof globalThis.fetch;
+  const layer = makeProbeFailureLayer(
+    () =>
+      Effect.succeed({
+        stdout: `p1234\ncnode\nn*:${targetPort}\np5678\ncngrok\nn127.0.0.1:4040\n`,
+        stderr: "",
+        code: null,
+        timedOut: false,
+        stdoutTruncated: false,
+        stderrTruncated: false,
+        stdoutInvalidUtf8: false,
+        stderrInvalidUtf8: false,
+      }),
+    fetchFn,
+  );
+
+  return Effect.gen(function* () {
+    const scanner = yield* PortScanner.PortDiscovery;
+    const servers = yield* scanner.scan([configuredUrl]);
+    expect(servers.map((server) => [server.port, server.url])).toEqual([
+      [targetPort, "https://feature.ngrok-free.app/docs?mode=test#results"],
+    ]);
+    expect(requests).toContain("http://localhost:4040/api/tunnels");
+    expect(requests).toContain(configuredUrl);
+  }).pipe(Effect.provide(layer));
 });
 
 const openServer = (

--- a/apps/server/src/preview/PortScanner.test.ts
+++ b/apps/server/src/preview/PortScanner.test.ts
@@ -719,6 +719,23 @@ effectIt.effect("keeps a full configured URL when the discovered server root fai
   }).pipe(Effect.provide(layer));
 });
 
+effectIt.effect("does not duplicate configured paths across loopback aliases", () => {
+  const configuredUrl = `http://127.0.0.1:${LSOF_TEST_PORT}/docs`;
+  const fetchFn = ((input: Parameters<typeof globalThis.fetch>[0]) =>
+    Promise.resolve(
+      new Response(String(input), { headers: { "content-type": "text/html" } }),
+    )) as typeof globalThis.fetch;
+  const layer = makeLsofScannerLayer({ pid: () => 1234, fetch: fetchFn });
+
+  return Effect.gen(function* () {
+    const scanner = yield* PortScanner.PortDiscovery;
+    const servers = yield* scanner.scan([configuredUrl]);
+
+    expect(servers).toHaveLength(1);
+    expect(servers[0]?.url).toBe(configuredUrl);
+  }).pipe(Effect.provide(layer));
+});
+
 effectIt.effect("probes configured custom ports through a canonical loopback host", () => {
   const customPort = 43_124;
   const configuredUrl = `http://0.0.0.0:${customPort}/docs`;

--- a/apps/server/src/preview/PortScanner.test.ts
+++ b/apps/server/src/preview/PortScanner.test.ts
@@ -143,7 +143,10 @@ describe("Portless route enrichment", () => {
       isProcessAlive: (pid) => pid === 123,
     });
 
-    expect(routes.get(4058)).toBe("https://eng-1252-simplify-the-onboarding.artelo.localhost");
+    expect(routes.get(4058)).toEqual({
+      url: "https://eng-1252-simplify-the-onboarding.artelo.localhost",
+      urlKind: "local-proxy",
+    });
     expect(
       PortScanner.__testing.applyNamedRoutes(
         [
@@ -163,6 +166,7 @@ describe("Portless route enrichment", () => {
         host: "localhost",
         port: 4058,
         url: "https://eng-1252-simplify-the-onboarding.artelo.localhost",
+        urlKind: "local-proxy",
         processName: "node",
         pid: 456,
         terminal: null,
@@ -182,7 +186,9 @@ describe("Portless route enrichment", () => {
       isProcessAlive: (pid) => pid === 222,
     });
 
-    expect([...routes]).toEqual([[3001, "http://current.test:8080"]]);
+    expect([...routes]).toEqual([
+      [3001, { url: "http://current.test:8080", urlKind: "local-proxy" }],
+    ]);
   });
 
   it.each(["8080abc", "443.5"])("ignores a malformed proxy port of %s", (proxyPortRaw) => {
@@ -193,7 +199,7 @@ describe("Portless route enrichment", () => {
       isProcessAlive: (pid) => pid === 222,
     });
 
-    expect([...routes]).toEqual([[3001, "https://current.test"]]);
+    expect([...routes]).toEqual([[3001, { url: "https://current.test", urlKind: "local-proxy" }]]);
   });
 });
 
@@ -212,7 +218,9 @@ describe("ngrok route enrichment", () => {
       ],
     });
 
-    expect(routes && [...routes]).toEqual([[4058, "https://feature.ngrok-free.app/"]]);
+    expect(routes && [...routes]).toEqual([
+      [4058, { url: "https://feature.ngrok-free.app/", urlKind: "public-tunnel" }],
+    ]);
   });
 
   it("accepts current forwards_to entries and ignores unsafe or non-web tunnels", () => {
@@ -225,7 +233,9 @@ describe("ngrok route enrichment", () => {
       ],
     });
 
-    expect(routes && [...routes]).toEqual([[4312, "https://docs.example.com/"]]);
+    expect(routes && [...routes]).toEqual([
+      [4312, { url: "https://docs.example.com/", urlKind: "public-tunnel" }],
+    ]);
   });
 
   it("returns null when the agent response does not match the tunnel list contract", () => {
@@ -272,11 +282,39 @@ effectIt.effect("replaces a discovered listener with its ngrok public URL", () =
   return Effect.gen(function* () {
     const scanner = yield* PortScanner.PortDiscovery;
     const servers = yield* scanner.scan([configuredUrl]);
-    expect(servers.map((server) => [server.port, server.url])).toEqual([
-      [targetPort, "https://feature.ngrok-free.app/docs?mode=test#results"],
+    expect(servers.map((server) => [server.port, server.url, server.urlKind])).toEqual([
+      [targetPort, "https://feature.ngrok-free.app/docs?mode=test#results", "public-tunnel"],
     ]);
     expect(requests).toContain("http://localhost:4040/api/tunnels");
     expect(requests).toContain(configuredUrl);
+  }).pipe(Effect.provide(layer));
+});
+
+effectIt.effect("keeps a non-ngrok web server on the default agent port", () => {
+  const fetchFn = ((input: Parameters<typeof globalThis.fetch>[0]) =>
+    Promise.resolve(
+      String(input) === "http://localhost:4040/api/tunnels"
+        ? Response.json({ tunnels: [] })
+        : new Response("app", { headers: { "content-type": "text/html" } }),
+    )) as typeof globalThis.fetch;
+  const layer = makeProbeFailureLayer(
+    () =>
+      Effect.succeed({
+        stdout: "p1234\ncnode\nn*:4040\n",
+        stderr: "",
+        code: null,
+        timedOut: false,
+        stdoutTruncated: false,
+        stderrTruncated: false,
+        stdoutInvalidUtf8: false,
+        stderrInvalidUtf8: false,
+      }),
+    fetchFn,
+  );
+
+  return Effect.gen(function* () {
+    const scanner = yield* PortScanner.PortDiscovery;
+    expect(yield* scanner.scan()).toMatchObject([{ port: 4040, url: "http://localhost:4040" }]);
   }).pipe(Effect.provide(layer));
 });
 

--- a/apps/server/src/preview/PortScanner.test.ts
+++ b/apps/server/src/preview/PortScanner.test.ts
@@ -5,6 +5,7 @@ import { it as effectIt } from "@effect/vitest";
 import {
   CONFIGURED_LOCAL_SERVER_URLS_MAX_ITEMS,
   PREVIEW_URL_MAX_LENGTH,
+  ThreadId,
   type DiscoveredLocalServer,
 } from "@t3tools/contracts";
 import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
@@ -141,6 +142,7 @@ describe("Portless route enrichment", () => {
       ]),
       proxyPortRaw: "443\n",
       tls: true,
+      proxyListening: true,
       isProcessAlive: (pid) => pid === 123,
     });
 
@@ -184,6 +186,7 @@ describe("Portless route enrichment", () => {
       ]),
       proxyPortRaw: "8080",
       tls: false,
+      proxyListening: true,
       isProcessAlive: (pid) => pid === 222,
     });
 
@@ -197,10 +200,23 @@ describe("Portless route enrichment", () => {
       routesJson: JSON.stringify([{ hostname: "current.test", port: 3001, pid: 222 }]),
       proxyPortRaw,
       tls: true,
+      proxyListening: true,
       isProcessAlive: (pid) => pid === 222,
     });
 
     expect([...routes]).toEqual([[3001, { url: "https://current.test", urlKind: "local-proxy" }]]);
+  });
+
+  it("ignores routes when the Portless proxy is no longer listening", () => {
+    const routes = PortScanner.__testing.parsePortlessRouteSnapshot({
+      routesJson: JSON.stringify([{ hostname: "stale.localhost", port: 3001, pid: 222 }]),
+      proxyPortRaw: "443",
+      tls: true,
+      proxyListening: false,
+      isProcessAlive: () => true,
+    });
+
+    expect([...routes]).toEqual([]);
   });
 });
 
@@ -241,6 +257,39 @@ describe("ngrok route enrichment", () => {
 
   it("returns null when the agent response does not match the tunnel list contract", () => {
     expect(PortScanner.__testing.parseNgrokTunnelSnapshot({ tunnels: "invalid" })).toBeNull();
+  });
+
+  it("keeps app terminal ownership when ngrok runs in another terminal", () => {
+    const appTerminal = { threadId: ThreadId.make("thread-app"), terminalId: "term-app" } as const;
+    const ngrokTerminal = {
+      threadId: ThreadId.make("thread-ngrok"),
+      terminalId: "term-ngrok",
+    } as const;
+    const [server] = PortScanner.__testing.applyNamedRoutes(
+      [
+        {
+          host: "localhost",
+          port: 4058,
+          url: "http://localhost:4058",
+          processName: "node",
+          pid: 456,
+          terminal: appTerminal,
+        },
+      ],
+      new Map([
+        [
+          4058,
+          {
+            url: "https://feature.ngrok-free.app/",
+            urlKind: "public-tunnel" as const,
+            terminal: ngrokTerminal,
+          },
+        ],
+      ]),
+    );
+
+    expect(server?.terminal).toEqual(appTerminal);
+    expect(server?.url).toBe("https://feature.ngrok-free.app/");
   });
 });
 
@@ -385,9 +434,11 @@ effectIt.effect("replaces a discovered listener with its Tailscale Serve URL", (
   const targetPort = 43_128;
   const configuredUrl = `http://localhost:${targetPort}/docs?mode=test#results`;
   let tailscaleStatusRuns = 0;
-  const fetchFn = ((_input: Parameters<typeof globalThis.fetch>[0]) =>
+  const fetchFn = ((input: Parameters<typeof globalThis.fetch>[0]) =>
     Promise.resolve(
-      new Response("app", { headers: { "content-type": "text/html" } }),
+      String(input) === configuredUrl
+        ? new Response("app", { headers: { "content-type": "text/html" } })
+        : new Response("not found", { status: 404 }),
     )) as typeof globalThis.fetch;
   const layer = makeProbeFailureLayer((input) => {
     if (input.command === "tailscale") tailscaleStatusRuns += 1;

--- a/apps/server/src/preview/PortScanner.test.ts
+++ b/apps/server/src/preview/PortScanner.test.ts
@@ -21,6 +21,7 @@ import * as Scope from "effect/Scope";
 import * as TestClock from "effect/testing/TestClock";
 import { describe, expect, it } from "vite-plus/test";
 import { FetchHttpClient } from "effect/unstable/http";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
 import * as ProcessRunner from "../processRunner.ts";
 import * as PortScanner from "./PortScanner.ts";
@@ -243,6 +244,87 @@ describe("ngrok route enrichment", () => {
   });
 });
 
+describe("Tailscale Serve route enrichment", () => {
+  it("maps legacy Serve routes to their loopback targets and prefers HTTPS", () => {
+    const routes = PortScanner.__testing.parseTailscaleServeStatus(
+      JSON.stringify({
+        TCP: {
+          80: { HTTP: true },
+          443: { HTTPS: true },
+        },
+        Web: {
+          "desktop.example-tailnet.ts.net:80": {
+            Handlers: { "/": { Proxy: "http://127.0.0.1:4058" } },
+          },
+          "desktop.example-tailnet.ts.net:443": {
+            Handlers: { "/": { Proxy: "https+insecure://localhost:4058" } },
+          },
+        },
+      }),
+    );
+
+    expect([...routes]).toEqual([
+      [
+        4058,
+        {
+          url: "https://desktop.example-tailnet.ts.net/",
+        },
+      ],
+    ]);
+  });
+
+  it("supports Tailscale Services and preserves a non-root mount", () => {
+    const routes = PortScanner.__testing.parseTailscaleServeStatus(
+      JSON.stringify({
+        Services: {
+          "svc:docs": {
+            TCP: { 8443: { HTTPS: true } },
+            Web: {
+              "docs.example-tailnet.ts.net:8443": {
+                Handlers: { "/preview": { Proxy: "http://[::1]:4312/docs" } },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect([...routes]).toEqual([
+      [
+        4312,
+        {
+          url: "https://docs.example-tailnet.ts.net:8443/preview",
+        },
+      ],
+    ]);
+  });
+
+  it("ignores malformed, credentialed, non-tailnet, and non-loopback routes", () => {
+    const routes = PortScanner.__testing.parseTailscaleServeStatus(
+      JSON.stringify({
+        TCP: { 443: { HTTPS: true } },
+        Web: {
+          "user:secret@desktop.example-tailnet.ts.net:443": {
+            Handlers: { "/": { Proxy: "http://localhost:3000" } },
+          },
+          "public.example.com:443": {
+            Handlers: { "/": { Proxy: "http://localhost:3001" } },
+          },
+          "desktop.example-tailnet.ts.net:443": {
+            Handlers: {
+              "//redirect": { Proxy: "http://localhost:3002" },
+              "/": { Proxy: "http://internal.example.com:3003" },
+            },
+          },
+        },
+      }),
+    );
+
+    expect([...routes]).toEqual([]);
+    expect(PortScanner.__testing.parseTailscaleServeStatus("not json").size).toBe(0);
+  });
+});
+
 effectIt.effect("replaces a discovered listener with its ngrok public URL", () => {
   const targetPort = 43_127;
   const configuredUrl = `http://localhost:${targetPort}/docs?mode=test#results`;
@@ -296,6 +378,58 @@ effectIt.effect("replaces a discovered listener with its ngrok public URL", () =
     });
     expect(requests).toContain("http://localhost:4040/api/tunnels");
     expect(requests).toContain(configuredUrl);
+  }).pipe(Effect.provide(layer));
+});
+
+effectIt.effect("replaces a discovered listener with its Tailscale Serve URL", () => {
+  const targetPort = 43_128;
+  const configuredUrl = `http://localhost:${targetPort}/docs?mode=test#results`;
+  let tailscaleStatusRuns = 0;
+  const fetchFn = ((_input: Parameters<typeof globalThis.fetch>[0]) =>
+    Promise.resolve(
+      new Response("app", { headers: { "content-type": "text/html" } }),
+    )) as typeof globalThis.fetch;
+  const layer = makeProbeFailureLayer((input) => {
+    if (input.command === "tailscale") tailscaleStatusRuns += 1;
+    return Effect.succeed({
+      stdout:
+        input.command === "tailscale"
+          ? JSON.stringify({
+              TCP: { 443: { HTTPS: true } },
+              Web: {
+                "desktop.example-tailnet.ts.net:443": {
+                  Handlers: { "/": { Proxy: `http://localhost:${targetPort}` } },
+                },
+              },
+            })
+          : `p1234\ncnode\nn*:${targetPort}\n`,
+      stderr: "",
+      code: ChildProcessSpawner.ExitCode(0),
+      timedOut: false,
+      stdoutTruncated: false,
+      stderrTruncated: false,
+      stdoutInvalidUtf8: false,
+      stderrInvalidUtf8: false,
+    });
+  }, fetchFn);
+
+  return Effect.gen(function* () {
+    const scanner = yield* PortScanner.PortDiscovery;
+    yield* scanner.registerTerminalProcesses({
+      threadId: "thread-tailscale",
+      terminalId: "term-dev-server",
+      processIds: [1234],
+    });
+    const servers = yield* scanner.scan([configuredUrl]);
+    expect(servers.map((server) => [server.port, server.url, server.urlKind])).toEqual([
+      [targetPort, "https://desktop.example-tailnet.ts.net/docs?mode=test#results", undefined],
+    ]);
+    expect(servers[0]?.terminal).toEqual({
+      threadId: "thread-tailscale",
+      terminalId: "term-dev-server",
+    });
+    expect(yield* scanner.scan([configuredUrl])).toEqual(servers);
+    expect(tailscaleStatusRuns).toBe(1);
   }).pipe(Effect.provide(layer));
 });
 

--- a/apps/server/src/preview/PortScanner.test.ts
+++ b/apps/server/src/preview/PortScanner.test.ts
@@ -449,7 +449,7 @@ effectIt.effect("replaces a discovered listener with its Tailscale Serve URL", (
               TCP: { 443: { HTTPS: true } },
               Web: {
                 "desktop.example-tailnet.ts.net:443": {
-                  Handlers: { "/": { Proxy: `http://localhost:${targetPort}` } },
+                  Handlers: { "/preview": { Proxy: `http://localhost:${targetPort}` } },
                 },
               },
             })
@@ -473,7 +473,11 @@ effectIt.effect("replaces a discovered listener with its Tailscale Serve URL", (
     });
     const servers = yield* scanner.scan([configuredUrl]);
     expect(servers.map((server) => [server.port, server.url, server.urlKind])).toEqual([
-      [targetPort, "https://desktop.example-tailnet.ts.net/docs?mode=test#results", undefined],
+      [
+        targetPort,
+        "https://desktop.example-tailnet.ts.net/preview/docs?mode=test#results",
+        undefined,
+      ],
     ]);
     expect(servers[0]?.terminal).toEqual({
       threadId: "thread-tailscale",

--- a/apps/server/src/preview/PortScanner.test.ts
+++ b/apps/server/src/preview/PortScanner.test.ts
@@ -181,6 +181,17 @@ describe("Portless route enrichment", () => {
 
     expect([...routes]).toEqual([[3001, "http://current.test:8080"]]);
   });
+
+  it.each(["8080abc", "443.5"])("ignores a malformed proxy port of %s", (proxyPortRaw) => {
+    const routes = PortScanner.__testing.parsePortlessRouteSnapshot({
+      routesJson: JSON.stringify([{ hostname: "current.test", port: 3001, pid: 222 }]),
+      proxyPortRaw,
+      tls: true,
+      isProcessAlive: (pid) => pid === 222,
+    });
+
+    expect([...routes]).toEqual([[3001, "https://current.test"]]);
+  });
 });
 
 const openServer = (

--- a/apps/server/src/preview/PortScanner.test.ts
+++ b/apps/server/src/preview/PortScanner.test.ts
@@ -348,6 +348,32 @@ describe("Tailscale Serve route enrichment", () => {
     ]);
   });
 
+  it("maps foreground Serve routes", () => {
+    const routes = PortScanner.__testing.parseTailscaleServeStatus(
+      JSON.stringify({
+        Foreground: {
+          "session-1": {
+            TCP: { 443: { HTTPS: true } },
+            Web: {
+              "desktop.example-tailnet.ts.net:443": {
+                Handlers: { "/": { Proxy: "http://127.0.0.1:5173" } },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect([...routes]).toEqual([
+      [
+        5173,
+        {
+          url: "https://desktop.example-tailnet.ts.net/",
+        },
+      ],
+    ]);
+  });
+
   it("ignores malformed, credentialed, non-tailnet, and non-loopback routes", () => {
     const routes = PortScanner.__testing.parseTailscaleServeStatus(
       JSON.stringify({

--- a/apps/server/src/preview/PortScanner.test.ts
+++ b/apps/server/src/preview/PortScanner.test.ts
@@ -281,10 +281,19 @@ effectIt.effect("replaces a discovered listener with its ngrok public URL", () =
 
   return Effect.gen(function* () {
     const scanner = yield* PortScanner.PortDiscovery;
+    yield* scanner.registerTerminalProcesses({
+      threadId: "thread-ngrok",
+      terminalId: "term-ngrok",
+      processIds: [5678],
+    });
     const servers = yield* scanner.scan([configuredUrl]);
     expect(servers.map((server) => [server.port, server.url, server.urlKind])).toEqual([
       [targetPort, "https://feature.ngrok-free.app/docs?mode=test#results", "public-tunnel"],
     ]);
+    expect(servers[0]?.terminal).toEqual({
+      threadId: "thread-ngrok",
+      terminalId: "term-ngrok",
+    });
     expect(requests).toContain("http://localhost:4040/api/tunnels");
     expect(requests).toContain(configuredUrl);
   }).pipe(Effect.provide(layer));

--- a/apps/server/src/preview/PortScanner.test.ts
+++ b/apps/server/src/preview/PortScanner.test.ts
@@ -1,5 +1,6 @@
 import * as NodeNet from "node:net";
 
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it as effectIt } from "@effect/vitest";
 import {
   CONFIGURED_LOCAL_SERVER_URLS_MAX_ITEMS,
@@ -18,7 +19,7 @@ import * as Layer from "effect/Layer";
 import * as PlatformError from "effect/PlatformError";
 import * as Scope from "effect/Scope";
 import * as TestClock from "effect/testing/TestClock";
-import { expect } from "vite-plus/test";
+import { describe, expect, it } from "vite-plus/test";
 import { FetchHttpClient } from "effect/unstable/http";
 
 import * as ProcessRunner from "../processRunner.ts";
@@ -59,6 +60,7 @@ const makeProbeFailureLayer = (
   PortScanner.layer.pipe(
     Layer.provide(
       Layer.mergeAll(
+        NodeServices.layer,
         Layer.succeed(ProcessRunner.ProcessRunner, { run }),
         Layer.succeed(Net.NetService, {
           canListenOnHost: () => Effect.succeed(true),
@@ -76,6 +78,7 @@ const makeProbeFailureLayer = (
 const TestPortDiscoveryLive = PortScanner.layer.pipe(
   Layer.provide(
     Layer.mergeAll(
+      NodeServices.layer,
       TestProcessRunner,
       TestIntegrationNet,
       Layer.succeed(HostProcessPlatform, "win32"),
@@ -93,6 +96,7 @@ const makeLsofScannerLayer = (input: {
   PortScanner.layer.pipe(
     Layer.provide(
       Layer.mergeAll(
+        NodeServices.layer,
         Layer.succeed(ProcessRunner.ProcessRunner, {
           run: () =>
             Effect.succeed({
@@ -120,6 +124,64 @@ const makeLsofScannerLayer = (input: {
       ),
     ),
   );
+
+describe("Portless route enrichment", () => {
+  it("uses the live Portless URL for its target listener", () => {
+    const routes = PortScanner.__testing.parsePortlessRouteSnapshot({
+      routesJson: JSON.stringify([
+        {
+          hostname: "eng-1252-simplify-the-onboarding.artelo.localhost",
+          port: 4058,
+          pid: 123,
+        },
+      ]),
+      proxyPortRaw: "443\n",
+      tls: true,
+      isProcessAlive: (pid) => pid === 123,
+    });
+
+    expect(routes.get(4058)).toBe("https://eng-1252-simplify-the-onboarding.artelo.localhost");
+    expect(
+      PortScanner.__testing.applyPortlessRoutes(
+        [
+          {
+            host: "localhost",
+            port: 4058,
+            url: "http://localhost:4058",
+            processName: "node",
+            pid: 456,
+            terminal: null,
+          },
+        ],
+        routes,
+      ),
+    ).toEqual([
+      {
+        host: "localhost",
+        port: 4058,
+        url: "https://eng-1252-simplify-the-onboarding.artelo.localhost",
+        processName: "node",
+        pid: 456,
+        terminal: null,
+      },
+    ]);
+  });
+
+  it("ignores stale routes and preserves custom proxy settings", () => {
+    const routes = PortScanner.__testing.parsePortlessRouteSnapshot({
+      routesJson: JSON.stringify([
+        { hostname: "stale.localhost", port: 3000, pid: 111 },
+        { hostname: "current.test", port: 3001, pid: 222 },
+        { hostname: "not a hostname", port: 3002, pid: 222 },
+      ]),
+      proxyPortRaw: "8080",
+      tls: false,
+      isProcessAlive: (pid) => pid === 222,
+    });
+
+    expect([...routes]).toEqual([[3001, "http://current.test:8080"]]);
+  });
+});
 
 const openServer = (
   port: number,

--- a/apps/server/src/preview/PortScanner.ts
+++ b/apps/server/src/preview/PortScanner.ts
@@ -300,7 +300,9 @@ const applyNamedRoutes = (
 const hasNamedRoute = (server: DiscoveredLocalServer): boolean => {
   if (server.urlKind !== undefined) return true;
   try {
-    return new URL(server.url).hostname !== server.host;
+    const urlHost = new URL(server.url).hostname;
+    if (isLoopbackHost(urlHost) && isLoopbackHost(server.host)) return false;
+    return urlHost !== server.host;
   } catch {
     return false;
   }

--- a/apps/server/src/preview/PortScanner.ts
+++ b/apps/server/src/preview/PortScanner.ts
@@ -129,6 +129,7 @@ const decodeTailscaleServeStatus = Schema.decodeUnknownOption(
       TCP: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
       Web: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
       Services: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
+      Foreground: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
     }),
   ),
 );
@@ -236,6 +237,9 @@ const parseTailscaleServeStatus = (raw: string): ReadonlyMap<number, NamedRoute>
   const configs: Array<typeof TailscaleServeConfig.Type> = [decoded.value];
   for (const service of Object.values(decoded.value.Services ?? {})) {
     if (isTailscaleServeConfig(service)) configs.push(service);
+  }
+  for (const foreground of Object.values(decoded.value.Foreground ?? {})) {
+    if (isTailscaleServeConfig(foreground)) configs.push(foreground);
   }
 
   const routesByTargetPort = new Map<number, NamedRoute>();

--- a/apps/server/src/preview/PortScanner.ts
+++ b/apps/server/src/preview/PortScanner.ts
@@ -83,6 +83,7 @@ const WEB_PROBE_CACHE_TTL_MS = Duration.toMillis(Duration.seconds(15));
 const WEB_PROBE_CONCURRENCY = 16;
 const NAVIGATION_REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 const NGROK_DEFAULT_AGENT_API_PORT = 4040;
+const TAILSCALE_SERVE_STATUS_TIMEOUT = Duration.millis(1_500);
 
 const PortlessRoute = Schema.Struct({
   hostname: Schema.String,
@@ -106,6 +107,32 @@ const decodeNgrokTunnelList = Schema.decodeUnknownOption(
   Schema.Struct({ tunnels: Schema.Array(Schema.Unknown) }),
 );
 
+const TailscaleServeEndpoint = Schema.Struct({
+  HTTP: Schema.optional(Schema.Boolean),
+  HTTPS: Schema.optional(Schema.Boolean),
+});
+const isTailscaleServeEndpoint = Schema.is(TailscaleServeEndpoint);
+const TailscaleServeHandler = Schema.Struct({ Proxy: Schema.optional(Schema.String) });
+const isTailscaleServeHandler = Schema.is(TailscaleServeHandler);
+const TailscaleServeWeb = Schema.Struct({
+  Handlers: Schema.Record(Schema.String, Schema.Unknown),
+});
+const isTailscaleServeWeb = Schema.is(TailscaleServeWeb);
+const TailscaleServeConfig = Schema.Struct({
+  TCP: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
+  Web: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
+});
+const isTailscaleServeConfig = Schema.is(TailscaleServeConfig);
+const decodeTailscaleServeStatus = Schema.decodeUnknownOption(
+  Schema.fromJsonString(
+    Schema.Struct({
+      TCP: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
+      Web: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
+      Services: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
+    }),
+  ),
+);
+
 interface PortlessRouteSnapshot {
   readonly routesJson: string;
   readonly proxyPortRaw: string | null;
@@ -115,7 +142,7 @@ interface PortlessRouteSnapshot {
 
 interface NamedRoute {
   readonly url: string;
-  readonly urlKind: DiscoveredLocalServerUrlKind;
+  readonly urlKind?: DiscoveredLocalServerUrlKind;
   readonly terminal?: Exclude<DiscoveredLocalServer["terminal"], null>;
 }
 
@@ -159,7 +186,7 @@ const parseLoopbackTargetPort = (raw: string): number | null => {
 
   try {
     const url = new URL(target.includes("://") ? target : `http://${target}`);
-    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    if (!["http:", "https:", "https+insecure:"].includes(url.protocol)) return null;
     if (!isLoopbackHost(url.hostname)) return null;
     const port = urlPort(url);
     return port > 0 && port < 65_536 ? port : null;
@@ -196,6 +223,59 @@ const parseNgrokTunnelSnapshot = (input: unknown): ReadonlyMap<number, NamedRout
         url: publicUrl.href,
         urlKind: "public-tunnel",
       });
+    }
+  }
+  return routesByTargetPort;
+};
+
+const parseTailscaleServeStatus = (raw: string): ReadonlyMap<number, NamedRoute> => {
+  const decoded = decodeTailscaleServeStatus(raw);
+  if (Option.isNone(decoded)) return new Map();
+
+  const configs: Array<typeof TailscaleServeConfig.Type> = [decoded.value];
+  for (const service of Object.values(decoded.value.Services ?? {})) {
+    if (isTailscaleServeConfig(service)) configs.push(service);
+  }
+
+  const routesByTargetPort = new Map<number, NamedRoute>();
+  for (const config of configs) {
+    for (const [authority, rawWeb] of Object.entries(config.Web ?? {})) {
+      if (!isTailscaleServeWeb(rawWeb)) continue;
+
+      let inboundUrl: URL;
+      try {
+        inboundUrl = new URL(`http://${authority}`);
+      } catch {
+        continue;
+      }
+      if (inboundUrl.username || inboundUrl.password) continue;
+      if (!inboundUrl.hostname.toLowerCase().endsWith(".ts.net")) continue;
+
+      const inboundPort = urlPort(inboundUrl);
+      const rawEndpoint = config.TCP?.[String(inboundPort)];
+      if (!isTailscaleServeEndpoint(rawEndpoint)) continue;
+      const protocol =
+        rawEndpoint.HTTPS === true ? "https" : rawEndpoint.HTTP === true ? "http" : null;
+      if (protocol === null) continue;
+
+      for (const [mountPath, rawHandler] of Object.entries(rawWeb.Handlers)) {
+        if (!isTailscaleServeHandler(rawHandler) || rawHandler.Proxy === undefined) continue;
+        if (!mountPath.startsWith("/") || mountPath.startsWith("//")) continue;
+        const targetPort = parseLoopbackTargetPort(rawHandler.Proxy);
+        if (targetPort === null) continue;
+
+        const routeUrl = new URL(`${protocol}://${inboundUrl.host}`);
+        routeUrl.pathname = mountPath;
+        const candidate = { url: routeUrl.href };
+        const current = routesByTargetPort.get(targetPort);
+        const shouldReplace =
+          current === undefined ||
+          (current.url.startsWith("http:") && routeUrl.protocol === "https:") ||
+          (current.url.startsWith(`${routeUrl.protocol}//`) &&
+            new URL(current.url).pathname !== "/" &&
+            routeUrl.pathname === "/");
+        if (shouldReplace) routesByTargetPort.set(targetPort, candidate);
+      }
     }
   }
   return routesByTargetPort;
@@ -251,6 +331,11 @@ interface WebProbeSnapshot {
   readonly configured: ReadonlyMap<string, DiscoveredLocalServer>;
 }
 
+interface NamedRouteCacheEntry {
+  readonly routes: ReadonlyMap<number, NamedRoute>;
+  readonly expiresAtMillis: number;
+}
+
 const terminalOwnerKey = (owner: {
   readonly threadId: string;
   readonly terminalId: string;
@@ -301,7 +386,13 @@ const projectWebProbeSnapshot = (
   const visibleByServer = new Map<string, DiscoveredLocalServer>();
   const namedRouteByServer = new Map<string, DiscoveredLocalServer>();
   for (const server of snapshot.discovered) {
-    if (server.urlKind !== undefined) {
+    let isNamedRoute = server.urlKind !== undefined;
+    try {
+      isNamedRoute ||= new URL(server.url).hostname !== server.host;
+    } catch {
+      // The scanner only emits parsed HTTP(S) URLs, but keep projection total.
+    }
+    if (isNamedRoute) {
       namedRouteByServer.set(localServerKey(server.host, server.port), server);
     }
   }
@@ -457,6 +548,10 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
     retainCount: 0,
   });
   const webProbeCacheRef = yield* Ref.make<ReadonlyMap<string, WebProbeCacheEntry>>(new Map());
+  const tailscaleRouteCacheRef = yield* Ref.make<NamedRouteCacheEntry>({
+    routes: new Map(),
+    expiresAtMillis: 0,
+  });
   const scanSemaphore = yield* Semaphore.make(1);
 
   const readPortlessRoutes = Effect.fn("PortDiscovery.readPortlessRoutes")(function* () {
@@ -540,6 +635,42 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
       }
     }
     return { agentPorts, routes };
+  });
+
+  const readTailscaleRoutes = Effect.fn("PortDiscovery.readTailscaleRoutes")(function* () {
+    const nowMillis = yield* Clock.currentTimeMillis;
+    const cached = yield* Ref.get(tailscaleRouteCacheRef);
+    if (cached.expiresAtMillis > nowMillis) return cached.routes;
+
+    const result = yield* processRunner
+      .run({
+        command: hostPlatform === "win32" ? "tailscale.exe" : "tailscale",
+        args: ["serve", "status", "--json"],
+        timeout: TAILSCALE_SERVE_STATUS_TIMEOUT,
+        maxOutputBytes: 1024 * 1024,
+        outputMode: "truncate",
+      })
+      .pipe(Effect.option);
+    if (
+      Option.isNone(result) ||
+      result.value.code !== 0 ||
+      result.value.timedOut ||
+      result.value.stdoutTruncated ||
+      result.value.stdoutInvalidUtf8
+    ) {
+      const routes = new Map<number, NamedRoute>();
+      yield* Ref.set(tailscaleRouteCacheRef, {
+        routes,
+        expiresAtMillis: nowMillis + WEB_PROBE_CACHE_TTL_MS,
+      });
+      return routes;
+    }
+    const routes = parseTailscaleServeStatus(result.value.stdout);
+    yield* Ref.set(tailscaleRouteCacheRef, {
+      routes,
+      expiresAtMillis: nowMillis + WEB_PROBE_CACHE_TTL_MS,
+    });
+    return routes;
   });
 
   const probeCommonPorts = Effect.fn("PortDiscovery.probeCommonPorts")(function* () {
@@ -713,15 +844,16 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
     servers: ReadonlyArray<DiscoveredLocalServer>,
     configuredUrls: ReadonlyArray<string>,
   ) {
-    const [portlessRoutes, ngrok] = yield* Effect.all([
-      readPortlessRoutes(),
-      readNgrokRoutes(servers),
-    ]);
+    const [portlessRoutes, tailscaleRoutes, ngrok] = yield* Effect.all(
+      [readPortlessRoutes(), readTailscaleRoutes(), readNgrokRoutes(servers)],
+      { concurrency: "unbounded" },
+    );
     const snapshot = yield* probeWebServers(
       servers.filter((server) => !ngrok.agentPorts.has(server.port)),
       configuredUrls,
     );
     const namedRoutes = new Map(portlessRoutes);
+    for (const [targetPort, route] of tailscaleRoutes) namedRoutes.set(targetPort, route);
     for (const [targetPort, route] of ngrok.routes) namedRoutes.set(targetPort, route);
     return { ...snapshot, discovered: applyNamedRoutes(snapshot.discovered, namedRoutes) };
   });
@@ -929,4 +1061,5 @@ export const __testing = {
   parseLoopbackTargetPort,
   parseNgrokTunnelSnapshot,
   parsePortlessRouteSnapshot,
+  parseTailscaleServeStatus,
 };

--- a/apps/server/src/preview/PortScanner.ts
+++ b/apps/server/src/preview/PortScanner.ts
@@ -137,6 +137,7 @@ interface PortlessRouteSnapshot {
   readonly routesJson: string;
   readonly proxyPortRaw: string | null;
   readonly tls: boolean;
+  readonly proxyListening: boolean;
   readonly isProcessAlive: (pid: number) => boolean;
 }
 
@@ -150,7 +151,7 @@ const parsePortlessRouteSnapshot = (
   input: PortlessRouteSnapshot,
 ): ReadonlyMap<number, NamedRoute> => {
   const decoded = decodePortlessRouteEntries(input.routesJson);
-  if (Option.isNone(decoded)) return new Map();
+  if (Option.isNone(decoded) || !input.proxyListening) return new Map();
 
   const defaultProxyPort = input.tls ? 443 : 80;
   const parsedProxyPort = Number(input.proxyPortRaw?.trim() ?? "");
@@ -287,8 +288,19 @@ const applyNamedRoutes = (
 ): ReadonlyArray<DiscoveredLocalServer> =>
   servers.map((server) => {
     const route = routesByTargetPort.get(server.port);
-    return route === undefined ? server : { ...server, ...route };
+    return route === undefined
+      ? server
+      : { ...server, ...route, terminal: server.terminal ?? route.terminal ?? null };
   });
+
+const hasNamedRoute = (server: DiscoveredLocalServer): boolean => {
+  if (server.urlKind !== undefined) return true;
+  try {
+    return new URL(server.url).hostname !== server.host;
+  } catch {
+    return false;
+  }
+};
 
 type Listener = (servers: ReadonlyArray<DiscoveredLocalServer>) => Effect.Effect<void>;
 
@@ -386,13 +398,7 @@ const projectWebProbeSnapshot = (
   const visibleByServer = new Map<string, DiscoveredLocalServer>();
   const namedRouteByServer = new Map<string, DiscoveredLocalServer>();
   for (const server of snapshot.discovered) {
-    let isNamedRoute = server.urlKind !== undefined;
-    try {
-      isNamedRoute ||= new URL(server.url).hostname !== server.host;
-    } catch {
-      // The scanner only emits parsed HTTP(S) URLs, but keep projection total.
-    }
-    if (isNamedRoute) {
+    if (hasNamedRoute(server)) {
       namedRouteByServer.set(localServerKey(server.host, server.port), server);
     }
   }
@@ -403,7 +409,8 @@ const projectWebProbeSnapshot = (
     if (visibleByServer.has(serverKey)) continue;
     const configured = snapshot.configured.get(webProbeCacheKey(raw));
     if (!configured) continue;
-    const namedRoute = namedRouteByServer.get(serverKey);
+    const namedRoute =
+      namedRouteByServer.get(serverKey) ?? (hasNamedRoute(configured) ? configured : null);
     if (!namedRoute) {
       visibleByServer.set(serverKey, { ...configured, url: raw });
       continue;
@@ -570,11 +577,23 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
     const tls = yield* fileSystem
       .exists(path.join(stateDir, "proxy.tls"))
       .pipe(Effect.orElseSucceed(() => false));
+    const defaultProxyPort = tls ? 443 : 80;
+    const parsedProxyPort = Number(Option.getOrNull(proxyPortRaw)?.trim() ?? "");
+    const proxyPort =
+      Number.isInteger(parsedProxyPort) && parsedProxyPort > 0 && parsedProxyPort < 65_536
+        ? parsedProxyPort
+        : defaultProxyPort;
+    const proxyListening = yield* Effect.zipWith(
+      net.hasListenerOnHost(proxyPort, "127.0.0.1"),
+      net.hasListenerOnHost(proxyPort, "::1"),
+      (ipv4, ipv6) => ipv4 || ipv6,
+    );
 
     return parsePortlessRouteSnapshot({
       routesJson: routesJson.value,
       proxyPortRaw: Option.getOrNull(proxyPortRaw),
       tls,
+      proxyListening,
       isProcessAlive: (pid) => {
         try {
           process.kill(pid, 0);
@@ -855,7 +874,15 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
     const namedRoutes = new Map(portlessRoutes);
     for (const [targetPort, route] of tailscaleRoutes) namedRoutes.set(targetPort, route);
     for (const [targetPort, route] of ngrok.routes) namedRoutes.set(targetPort, route);
-    return { ...snapshot, discovered: applyNamedRoutes(snapshot.discovered, namedRoutes) };
+    return {
+      discovered: applyNamedRoutes(snapshot.discovered, namedRoutes),
+      configured: new Map(
+        [...snapshot.configured].map(([key, server]) => [
+          key,
+          applyNamedRoutes([server], namedRoutes)[0] ?? server,
+        ]),
+      ),
+    };
   });
 
   const recoverProcessProbeFailure =

--- a/apps/server/src/preview/PortScanner.ts
+++ b/apps/server/src/preview/PortScanner.ts
@@ -16,6 +16,8 @@
  * Polling is reference-counted via scoped `retain`. A single layer-scoped fiber
  * polls forever, but each tick is a no-op when the retain count is zero.
  */
+import * as NodeOS from "node:os";
+
 import {
   CONFIGURED_LOCAL_SERVER_URLS_MAX_ITEMS,
   PREVIEW_URL_MAX_LENGTH,
@@ -30,10 +32,13 @@ import * as Clock from "effect/Clock";
 import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Path from "effect/Path";
 import * as Ref from "effect/Ref";
 import * as Schedule from "effect/Schedule";
+import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 import * as Semaphore from "effect/Semaphore";
 import { FetchHttpClient, HttpClient } from "effect/unstable/http";
@@ -77,6 +82,60 @@ const WEB_PROBE_TIMEOUT = Duration.seconds(1);
 const WEB_PROBE_CACHE_TTL_MS = Duration.toMillis(Duration.seconds(15));
 const WEB_PROBE_CONCURRENCY = 16;
 const NAVIGATION_REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+const PortlessRoute = Schema.Struct({
+  hostname: Schema.String,
+  port: Schema.Int.check(Schema.isGreaterThan(0)).check(Schema.isLessThan(65536)),
+  pid: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+});
+const isPortlessRoute = Schema.is(PortlessRoute);
+const decodePortlessRouteEntries = Schema.decodeUnknownOption(
+  Schema.fromJsonString(Schema.Array(Schema.Unknown)),
+);
+const PORTLESS_HOSTNAME_PATTERN =
+  /^(?=.{1,253}$)(?:[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?\.)*[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?$/i;
+
+interface PortlessRouteSnapshot {
+  readonly routesJson: string;
+  readonly proxyPortRaw: string | null;
+  readonly tls: boolean;
+  readonly isProcessAlive: (pid: number) => boolean;
+}
+
+const parsePortlessRouteSnapshot = (input: PortlessRouteSnapshot): ReadonlyMap<number, string> => {
+  const decoded = decodePortlessRouteEntries(input.routesJson);
+  if (Option.isNone(decoded)) return new Map();
+
+  const defaultProxyPort = input.tls ? 443 : 80;
+  const parsedProxyPort = Number.parseInt(input.proxyPortRaw?.trim() ?? "", 10);
+  const proxyPort =
+    Number.isInteger(parsedProxyPort) && parsedProxyPort > 0 && parsedProxyPort < 65536
+      ? parsedProxyPort
+      : defaultProxyPort;
+  const protocol = input.tls ? "https" : "http";
+  const urlsByTargetPort = new Map<number, string>();
+
+  for (const entry of decoded.value) {
+    if (!isPortlessRoute(entry)) continue;
+    if (entry.pid !== 0 && !input.isProcessAlive(entry.pid)) continue;
+    if (!PORTLESS_HOSTNAME_PATTERN.test(entry.hostname)) continue;
+    if (urlsByTargetPort.has(entry.port)) continue;
+
+    const portSuffix = proxyPort === defaultProxyPort ? "" : `:${proxyPort}`;
+    urlsByTargetPort.set(entry.port, `${protocol}://${entry.hostname}${portSuffix}`);
+  }
+
+  return urlsByTargetPort;
+};
+
+const applyPortlessRoutes = (
+  servers: ReadonlyArray<DiscoveredLocalServer>,
+  urlsByTargetPort: ReadonlyMap<number, string>,
+): ReadonlyArray<DiscoveredLocalServer> =>
+  servers.map((server) => {
+    const portlessUrl = urlsByTargetPort.get(server.port);
+    return portlessUrl === undefined ? server : { ...server, url: portlessUrl };
+  });
 
 type Listener = (servers: ReadonlyArray<DiscoveredLocalServer>) => Effect.Effect<void>;
 
@@ -294,6 +353,8 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
   const processRunner = yield* ProcessRunner.ProcessRunner;
   const hostPlatform = yield* HostProcessPlatform;
   const httpClient = (yield* HttpClient.HttpClient).pipe(HttpClient.withScope);
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
   const stateRef = yield* Ref.make<ScannerState>({
     listeners: new Map(),
     terminalProcesses: new Map(),
@@ -301,6 +362,36 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
   });
   const webProbeCacheRef = yield* Ref.make<ReadonlyMap<string, WebProbeCacheEntry>>(new Map());
   const scanSemaphore = yield* Semaphore.make(1);
+
+  const readPortlessRoutes = Effect.fn("PortDiscovery.readPortlessRoutes")(function* () {
+    const configuredStateDir = process.env.PORTLESS_STATE_DIR?.trim();
+    const stateDir = configuredStateDir || path.join(NodeOS.homedir(), ".portless");
+    const routesJson = yield* fileSystem
+      .readFileString(path.join(stateDir, "routes.json"))
+      .pipe(Effect.option);
+    if (Option.isNone(routesJson)) return new Map<number, string>();
+
+    const proxyPortRaw = yield* fileSystem
+      .readFileString(path.join(stateDir, "proxy.port"))
+      .pipe(Effect.option);
+    const tls = yield* fileSystem
+      .exists(path.join(stateDir, "proxy.tls"))
+      .pipe(Effect.orElseSucceed(() => false));
+
+    return parsePortlessRouteSnapshot({
+      routesJson: routesJson.value,
+      proxyPortRaw: Option.getOrNull(proxyPortRaw),
+      tls,
+      isProcessAlive: (pid) => {
+        try {
+          process.kill(pid, 0);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+    });
+  });
 
   const probeCommonPorts = Effect.fn("PortDiscovery.probeCommonPorts")(function* () {
     const results = yield* Effect.forEach(
@@ -481,6 +572,7 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
     configuredUrls: ReadonlyArray<string>,
   ) {
     const state = yield* Ref.get(stateRef);
+    const portlessRoutes = yield* readPortlessRoutes();
     const terminalByProcessId = new Map<number, TerminalProcessOwner>();
     for (const registration of state.terminalProcesses.values()) {
       for (const processId of registration.processIds) {
@@ -509,8 +601,11 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
             ProcessTimeoutError: recoverWindowsProbeFailure,
           }),
         );
-      if (listeners !== null) return yield* probeWebServers(listeners, configuredUrls);
-      return yield* probeWebServers(yield* probeCommonPorts(), configuredUrls);
+      const snapshot = yield* probeWebServers(
+        listeners ?? (yield* probeCommonPorts()),
+        configuredUrls,
+      );
+      return { ...snapshot, discovered: applyPortlessRoutes(snapshot.discovered, portlessRoutes) };
     }
     const recoverLsofProbeFailure = recoverProcessProbeFailure("lsof");
     const lsofResult = yield* processRunner
@@ -531,8 +626,11 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
           ProcessTimeoutError: recoverLsofProbeFailure,
         }),
       );
-    if (lsofResult !== null) return yield* probeWebServers(lsofResult, configuredUrls);
-    return yield* probeWebServers(yield* probeCommonPorts(), configuredUrls);
+    const snapshot = yield* probeWebServers(
+      lsofResult ?? (yield* probeCommonPorts()),
+      configuredUrls,
+    );
+    return { ...snapshot, discovered: applyPortlessRoutes(snapshot.discovered, portlessRoutes) };
   });
 
   const scanSnapshot = Effect.fn("PortDiscovery.scanSnapshot")(
@@ -662,3 +760,8 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
 }).pipe(Effect.withSpan("PortDiscovery.make"));
 
 export const layer = Layer.effect(PortDiscovery, make);
+
+export const __testing = {
+  applyPortlessRoutes,
+  parsePortlessRouteSnapshot,
+};

--- a/apps/server/src/preview/PortScanner.ts
+++ b/apps/server/src/preview/PortScanner.ts
@@ -39,7 +39,7 @@ import * as Schedule from "effect/Schedule";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 import * as Semaphore from "effect/Semaphore";
-import { FetchHttpClient, HttpClient } from "effect/unstable/http";
+import { FetchHttpClient, HttpClient, HttpClientResponse } from "effect/unstable/http";
 
 import * as ProcessRunner from "../processRunner.ts";
 
@@ -70,7 +70,8 @@ export class PortDiscovery extends Context.Service<
 >()("t3/preview/PortScanner/PortDiscovery") {}
 
 export const COMMON_DEV_PORTS: ReadonlyArray<number> = Object.freeze([
-  3000, 3001, 3333, 4173, 4200, 4321, 5000, 5173, 5174, 5175, 5500, 8000, 8080, 8081, 8888, 9000,
+  3000, 3001, 3333, 4040, 4173, 4200, 4321, 5000, 5173, 5174, 5175, 5500, 8000, 8080, 8081, 8888,
+  9000,
 ]);
 
 const POLL_INTERVAL = Duration.seconds(3);
@@ -80,6 +81,7 @@ const WEB_PROBE_TIMEOUT = Duration.seconds(1);
 const WEB_PROBE_CACHE_TTL_MS = Duration.toMillis(Duration.seconds(15));
 const WEB_PROBE_CONCURRENCY = 16;
 const NAVIGATION_REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const NGROK_DEFAULT_AGENT_API_PORT = 4040;
 
 const PortlessRoute = Schema.Struct({
   hostname: Schema.String,
@@ -92,6 +94,16 @@ const decodePortlessRouteEntries = Schema.decodeUnknownOption(
 );
 const PORTLESS_HOSTNAME_PATTERN =
   /^(?=.{1,253}$)(?:[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?\.)*[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?$/i;
+
+const NgrokTunnel = Schema.Struct({
+  public_url: Schema.String,
+  config: Schema.optional(Schema.Struct({ addr: Schema.String })),
+  forwards_to: Schema.optional(Schema.String),
+});
+const isNgrokTunnel = Schema.is(NgrokTunnel);
+const decodeNgrokTunnelList = Schema.decodeUnknownOption(
+  Schema.Struct({ tunnels: Schema.Array(Schema.Unknown) }),
+);
 
 interface PortlessRouteSnapshot {
   readonly routesJson: string;
@@ -126,13 +138,58 @@ const parsePortlessRouteSnapshot = (input: PortlessRouteSnapshot): ReadonlyMap<n
   return urlsByTargetPort;
 };
 
-const applyPortlessRoutes = (
+const parseLoopbackTargetPort = (raw: string): number | null => {
+  const target = raw.trim();
+  if (/^\d+$/.test(target)) {
+    const port = Number(target);
+    return port > 0 && port < 65_536 ? port : null;
+  }
+
+  try {
+    const url = new URL(target.includes("://") ? target : `http://${target}`);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    if (!isLoopbackHost(url.hostname)) return null;
+    const port = urlPort(url);
+    return port > 0 && port < 65_536 ? port : null;
+  } catch {
+    return null;
+  }
+};
+
+const parseNgrokTunnelSnapshot = (input: unknown): ReadonlyMap<number, string> | null => {
+  const decoded = decodeNgrokTunnelList(input);
+  if (Option.isNone(decoded)) return null;
+
+  const urlsByTargetPort = new Map<number, string>();
+  for (const entry of decoded.value.tunnels) {
+    if (!isNgrokTunnel(entry)) continue;
+    const targetPort = parseLoopbackTargetPort(entry.config?.addr ?? entry.forwards_to ?? "");
+    if (targetPort === null) continue;
+
+    let publicUrl: URL;
+    try {
+      publicUrl = new URL(entry.public_url.trim());
+    } catch {
+      continue;
+    }
+    if (publicUrl.protocol !== "http:" && publicUrl.protocol !== "https:") continue;
+    if (publicUrl.username || publicUrl.password) continue;
+
+    const current = urlsByTargetPort.get(targetPort);
+    if (current === undefined || (current.startsWith("http:") && publicUrl.protocol === "https:")) {
+      urlsByTargetPort.set(targetPort, publicUrl.href);
+    }
+  }
+  return urlsByTargetPort;
+};
+
+const applyNamedRoutes = (
   servers: ReadonlyArray<DiscoveredLocalServer>,
   urlsByTargetPort: ReadonlyMap<number, string>,
 ): ReadonlyArray<DiscoveredLocalServer> =>
   servers.map((server) => {
-    const portlessUrl = urlsByTargetPort.get(server.port);
-    return portlessUrl === undefined ? server : { ...server, url: portlessUrl };
+    const namedUrl = urlsByTargetPort.get(server.port);
+    return namedUrl === undefined ? server : { ...server, url: namedUrl };
   });
 
 type Listener = (servers: ReadonlyArray<DiscoveredLocalServer>) => Effect.Effect<void>;
@@ -224,13 +281,29 @@ const projectWebProbeSnapshot = (
   configuredUrls: ReadonlyArray<string>,
 ): ReadonlyArray<DiscoveredLocalServer> => {
   const visibleByServer = new Map<string, DiscoveredLocalServer>();
+  const namedRouteByServer = new Map<string, DiscoveredLocalServer>();
+  for (const server of snapshot.discovered) {
+    if (new URL(server.url).hostname !== server.host) {
+      namedRouteByServer.set(localServerKey(server.host, server.port), server);
+    }
+  }
   for (const raw of normalizeConfiguredUrls(configuredUrls)) {
     const url = new URL(raw);
     const port = urlPort(url);
     const serverKey = localServerKey(url.hostname, port);
     if (visibleByServer.has(serverKey)) continue;
     const configured = snapshot.configured.get(webProbeCacheKey(raw));
-    if (configured) visibleByServer.set(serverKey, { ...configured, url: raw });
+    if (!configured) continue;
+    const namedRoute = namedRouteByServer.get(serverKey);
+    if (!namedRoute) {
+      visibleByServer.set(serverKey, { ...configured, url: raw });
+      continue;
+    }
+    const namedUrl = new URL(namedRoute.url);
+    namedUrl.pathname = url.pathname;
+    namedUrl.search = url.search;
+    namedUrl.hash = url.hash;
+    visibleByServer.set(serverKey, { ...configured, url: namedUrl.href });
   }
   for (const server of snapshot.discovered) {
     const key = localServerKey(server.host, server.port);
@@ -392,6 +465,47 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
         }
       },
     });
+  });
+
+  const readNgrokRoutes = Effect.fn("PortDiscovery.readNgrokRoutes")(function* (
+    servers: ReadonlyArray<DiscoveredLocalServer>,
+  ) {
+    const candidatePorts = [
+      ...new Set(
+        servers
+          .filter(
+            (server) =>
+              server.port === NGROK_DEFAULT_AGENT_API_PORT ||
+              server.processName?.toLowerCase().includes("ngrok") === true,
+          )
+          .map((server) => server.port),
+      ),
+    ];
+    const responses = yield* Effect.forEach(
+      candidatePorts,
+      (port) =>
+        httpClient.get(`http://localhost:${port}/api/tunnels`).pipe(
+          Effect.flatMap(HttpClientResponse.filterStatusOk),
+          Effect.flatMap((response) => response.json),
+          Effect.map((body) => {
+            const routes = parseNgrokTunnelSnapshot(body);
+            return routes === null ? null : { port, routes };
+          }),
+          Effect.scoped,
+          Effect.timeoutOption(WEB_PROBE_TIMEOUT),
+          Effect.map(Option.getOrNull),
+          Effect.orElseSucceed(() => null),
+        ),
+      { concurrency: "unbounded" },
+    );
+    const agentPorts = new Set<number>();
+    const routes = new Map<number, string>();
+    for (const response of responses) {
+      if (response === null) continue;
+      agentPorts.add(response.port);
+      for (const [targetPort, publicUrl] of response.routes) routes.set(targetPort, publicUrl);
+    }
+    return { agentPorts, routes };
   });
 
   const probeCommonPorts = Effect.fn("PortDiscovery.probeCommonPorts")(function* () {
@@ -561,6 +675,23 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
     return { discovered, configured } satisfies WebProbeSnapshot;
   });
 
+  const probeAndEnrichWebServers = Effect.fn("PortDiscovery.probeAndEnrichWebServers")(function* (
+    servers: ReadonlyArray<DiscoveredLocalServer>,
+    configuredUrls: ReadonlyArray<string>,
+  ) {
+    const [portlessRoutes, ngrok] = yield* Effect.all([
+      readPortlessRoutes(),
+      readNgrokRoutes(servers),
+    ]);
+    const snapshot = yield* probeWebServers(
+      servers.filter((server) => !ngrok.agentPorts.has(server.port)),
+      configuredUrls,
+    );
+    const namedRoutes = new Map(portlessRoutes);
+    for (const [targetPort, publicUrl] of ngrok.routes) namedRoutes.set(targetPort, publicUrl);
+    return { ...snapshot, discovered: applyNamedRoutes(snapshot.discovered, namedRoutes) };
+  });
+
   const recoverProcessProbeFailure =
     (probe: "lsof" | "windows-listeners") => (error: ProcessRunner.ProcessRunError) =>
       Effect.logDebug("preview port process probe failed; falling back to common-port probes", {
@@ -573,7 +704,6 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
     configuredUrls: ReadonlyArray<string>,
   ) {
     const state = yield* Ref.get(stateRef);
-    const portlessRoutes = yield* readPortlessRoutes();
     const terminalByProcessId = new Map<number, TerminalProcessOwner>();
     for (const registration of state.terminalProcesses.values()) {
       for (const processId of registration.processIds) {
@@ -602,11 +732,10 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
             ProcessTimeoutError: recoverWindowsProbeFailure,
           }),
         );
-      const snapshot = yield* probeWebServers(
+      return yield* probeAndEnrichWebServers(
         listeners ?? (yield* probeCommonPorts()),
         configuredUrls,
       );
-      return { ...snapshot, discovered: applyPortlessRoutes(snapshot.discovered, portlessRoutes) };
     }
     const recoverLsofProbeFailure = recoverProcessProbeFailure("lsof");
     const lsofResult = yield* processRunner
@@ -627,11 +756,10 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
           ProcessTimeoutError: recoverLsofProbeFailure,
         }),
       );
-    const snapshot = yield* probeWebServers(
+    return yield* probeAndEnrichWebServers(
       lsofResult ?? (yield* probeCommonPorts()),
       configuredUrls,
     );
-    return { ...snapshot, discovered: applyPortlessRoutes(snapshot.discovered, portlessRoutes) };
   });
 
   const scanSnapshot = Effect.fn("PortDiscovery.scanSnapshot")(
@@ -763,6 +891,8 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
 export const layer = Layer.effect(PortDiscovery, make);
 
 export const __testing = {
-  applyPortlessRoutes,
+  applyNamedRoutes,
+  parseLoopbackTargetPort,
+  parseNgrokTunnelSnapshot,
   parsePortlessRouteSnapshot,
 };

--- a/apps/server/src/preview/PortScanner.ts
+++ b/apps/server/src/preview/PortScanner.ts
@@ -21,6 +21,7 @@ import {
   PREVIEW_URL_MAX_LENGTH,
   ThreadId,
   type DiscoveredLocalServer,
+  type DiscoveredLocalServerUrlKind,
 } from "@t3tools/contracts";
 import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Net from "@t3tools/shared/Net";
@@ -112,7 +113,14 @@ interface PortlessRouteSnapshot {
   readonly isProcessAlive: (pid: number) => boolean;
 }
 
-const parsePortlessRouteSnapshot = (input: PortlessRouteSnapshot): ReadonlyMap<number, string> => {
+interface NamedRoute {
+  readonly url: string;
+  readonly urlKind: DiscoveredLocalServerUrlKind;
+}
+
+const parsePortlessRouteSnapshot = (
+  input: PortlessRouteSnapshot,
+): ReadonlyMap<number, NamedRoute> => {
   const decoded = decodePortlessRouteEntries(input.routesJson);
   if (Option.isNone(decoded)) return new Map();
 
@@ -123,19 +131,22 @@ const parsePortlessRouteSnapshot = (input: PortlessRouteSnapshot): ReadonlyMap<n
       ? parsedProxyPort
       : defaultProxyPort;
   const protocol = input.tls ? "https" : "http";
-  const urlsByTargetPort = new Map<number, string>();
+  const routesByTargetPort = new Map<number, NamedRoute>();
 
   for (const entry of decoded.value) {
     if (!isPortlessRoute(entry)) continue;
     if (entry.pid !== 0 && !input.isProcessAlive(entry.pid)) continue;
     if (!PORTLESS_HOSTNAME_PATTERN.test(entry.hostname)) continue;
-    if (urlsByTargetPort.has(entry.port)) continue;
+    if (routesByTargetPort.has(entry.port)) continue;
 
     const portSuffix = proxyPort === defaultProxyPort ? "" : `:${proxyPort}`;
-    urlsByTargetPort.set(entry.port, `${protocol}://${entry.hostname}${portSuffix}`);
+    routesByTargetPort.set(entry.port, {
+      url: `${protocol}://${entry.hostname}${portSuffix}`,
+      urlKind: "local-proxy",
+    });
   }
 
-  return urlsByTargetPort;
+  return routesByTargetPort;
 };
 
 const parseLoopbackTargetPort = (raw: string): number | null => {
@@ -156,11 +167,11 @@ const parseLoopbackTargetPort = (raw: string): number | null => {
   }
 };
 
-const parseNgrokTunnelSnapshot = (input: unknown): ReadonlyMap<number, string> | null => {
+const parseNgrokTunnelSnapshot = (input: unknown): ReadonlyMap<number, NamedRoute> | null => {
   const decoded = decodeNgrokTunnelList(input);
   if (Option.isNone(decoded)) return null;
 
-  const urlsByTargetPort = new Map<number, string>();
+  const routesByTargetPort = new Map<number, NamedRoute>();
   for (const entry of decoded.value.tunnels) {
     if (!isNgrokTunnel(entry)) continue;
     const targetPort = parseLoopbackTargetPort(entry.config?.addr ?? entry.forwards_to ?? "");
@@ -175,21 +186,27 @@ const parseNgrokTunnelSnapshot = (input: unknown): ReadonlyMap<number, string> |
     if (publicUrl.protocol !== "http:" && publicUrl.protocol !== "https:") continue;
     if (publicUrl.username || publicUrl.password) continue;
 
-    const current = urlsByTargetPort.get(targetPort);
-    if (current === undefined || (current.startsWith("http:") && publicUrl.protocol === "https:")) {
-      urlsByTargetPort.set(targetPort, publicUrl.href);
+    const current = routesByTargetPort.get(targetPort);
+    if (
+      current === undefined ||
+      (current.url.startsWith("http:") && publicUrl.protocol === "https:")
+    ) {
+      routesByTargetPort.set(targetPort, {
+        url: publicUrl.href,
+        urlKind: "public-tunnel",
+      });
     }
   }
-  return urlsByTargetPort;
+  return routesByTargetPort;
 };
 
 const applyNamedRoutes = (
   servers: ReadonlyArray<DiscoveredLocalServer>,
-  urlsByTargetPort: ReadonlyMap<number, string>,
+  routesByTargetPort: ReadonlyMap<number, NamedRoute>,
 ): ReadonlyArray<DiscoveredLocalServer> =>
   servers.map((server) => {
-    const namedUrl = urlsByTargetPort.get(server.port);
-    return namedUrl === undefined ? server : { ...server, url: namedUrl };
+    const route = routesByTargetPort.get(server.port);
+    return route === undefined ? server : { ...server, ...route };
   });
 
 type Listener = (servers: ReadonlyArray<DiscoveredLocalServer>) => Effect.Effect<void>;
@@ -283,7 +300,7 @@ const projectWebProbeSnapshot = (
   const visibleByServer = new Map<string, DiscoveredLocalServer>();
   const namedRouteByServer = new Map<string, DiscoveredLocalServer>();
   for (const server of snapshot.discovered) {
-    if (new URL(server.url).hostname !== server.host) {
+    if (server.urlKind !== undefined) {
       namedRouteByServer.set(localServerKey(server.host, server.port), server);
     }
   }
@@ -303,7 +320,11 @@ const projectWebProbeSnapshot = (
     namedUrl.pathname = url.pathname;
     namedUrl.search = url.search;
     namedUrl.hash = url.hash;
-    visibleByServer.set(serverKey, { ...configured, url: namedUrl.href });
+    visibleByServer.set(serverKey, {
+      ...configured,
+      url: namedUrl.href,
+      urlKind: namedRoute.urlKind,
+    });
   }
   for (const server of snapshot.discovered) {
     const key = localServerKey(server.host, server.port);
@@ -408,6 +429,7 @@ const serversEqual = (
       a.host !== b.host ||
       a.port !== b.port ||
       a.url !== b.url ||
+      a.urlKind !== b.urlKind ||
       a.processName !== b.processName ||
       a.pid !== b.pid ||
       a.terminal?.threadId !== b.terminal?.threadId ||
@@ -439,11 +461,11 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
     const configuredStateDir = hostEnvironment.PORTLESS_STATE_DIR?.trim();
     const homeDirectory = hostEnvironment.HOME?.trim() || hostEnvironment.USERPROFILE?.trim();
     const stateDir = configuredStateDir || (homeDirectory && path.join(homeDirectory, ".portless"));
-    if (!stateDir) return new Map<number, string>();
+    if (!stateDir) return new Map<number, NamedRoute>();
     const routesJson = yield* fileSystem
       .readFileString(path.join(stateDir, "routes.json"))
       .pipe(Effect.option);
-    if (Option.isNone(routesJson)) return new Map<number, string>();
+    if (Option.isNone(routesJson)) return new Map<number, NamedRoute>();
 
     const proxyPortRaw = yield* fileSystem
       .readFileString(path.join(stateDir, "proxy.port"))
@@ -470,26 +492,21 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
   const readNgrokRoutes = Effect.fn("PortDiscovery.readNgrokRoutes")(function* (
     servers: ReadonlyArray<DiscoveredLocalServer>,
   ) {
-    const candidatePorts = [
-      ...new Set(
-        servers
-          .filter(
-            (server) =>
-              server.port === NGROK_DEFAULT_AGENT_API_PORT ||
-              server.processName?.toLowerCase().includes("ngrok") === true,
-          )
-          .map((server) => server.port),
-      ),
-    ];
+    const candidatesByPort = new Map<number, boolean>();
+    for (const server of servers) {
+      const processNameIsNgrok = server.processName?.toLowerCase() === "ngrok";
+      if (server.port !== NGROK_DEFAULT_AGENT_API_PORT && !processNameIsNgrok) continue;
+      candidatesByPort.set(server.port, candidatesByPort.get(server.port) || processNameIsNgrok);
+    }
     const responses = yield* Effect.forEach(
-      candidatePorts,
-      (port) =>
+      candidatesByPort,
+      ([port, processNameIsNgrok]) =>
         httpClient.get(`http://localhost:${port}/api/tunnels`).pipe(
           Effect.flatMap(HttpClientResponse.filterStatusOk),
           Effect.flatMap((response) => response.json),
           Effect.map((body) => {
             const routes = parseNgrokTunnelSnapshot(body);
-            return routes === null ? null : { port, routes };
+            return routes === null ? null : { port, processNameIsNgrok, routes };
           }),
           Effect.scoped,
           Effect.timeoutOption(WEB_PROBE_TIMEOUT),
@@ -499,11 +516,11 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
       { concurrency: "unbounded" },
     );
     const agentPorts = new Set<number>();
-    const routes = new Map<number, string>();
+    const routes = new Map<number, NamedRoute>();
     for (const response of responses) {
       if (response === null) continue;
-      agentPorts.add(response.port);
-      for (const [targetPort, publicUrl] of response.routes) routes.set(targetPort, publicUrl);
+      if (response.routes.size > 0 || response.processNameIsNgrok) agentPorts.add(response.port);
+      for (const [targetPort, route] of response.routes) routes.set(targetPort, route);
     }
     return { agentPorts, routes };
   });
@@ -688,7 +705,7 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
       configuredUrls,
     );
     const namedRoutes = new Map(portlessRoutes);
-    for (const [targetPort, publicUrl] of ngrok.routes) namedRoutes.set(targetPort, publicUrl);
+    for (const [targetPort, route] of ngrok.routes) namedRoutes.set(targetPort, route);
     return { ...snapshot, discovered: applyNamedRoutes(snapshot.discovered, namedRoutes) };
   });
 

--- a/apps/server/src/preview/PortScanner.ts
+++ b/apps/server/src/preview/PortScanner.ts
@@ -116,6 +116,7 @@ interface PortlessRouteSnapshot {
 interface NamedRoute {
   readonly url: string;
   readonly urlKind: DiscoveredLocalServerUrlKind;
+  readonly terminal?: Exclude<DiscoveredLocalServer["terminal"], null>;
 }
 
 const parsePortlessRouteSnapshot = (
@@ -324,6 +325,7 @@ const projectWebProbeSnapshot = (
       ...configured,
       url: namedUrl.href,
       urlKind: namedRoute.urlKind,
+      terminal: namedRoute.terminal,
     });
   }
   for (const server of snapshot.discovered) {
@@ -492,21 +494,31 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
   const readNgrokRoutes = Effect.fn("PortDiscovery.readNgrokRoutes")(function* (
     servers: ReadonlyArray<DiscoveredLocalServer>,
   ) {
-    const candidatesByPort = new Map<number, boolean>();
+    const candidatesByPort = new Map<
+      number,
+      {
+        readonly processNameIsNgrok: boolean;
+        readonly terminal: DiscoveredLocalServer["terminal"];
+      }
+    >();
     for (const server of servers) {
       const processNameIsNgrok = server.processName?.toLowerCase() === "ngrok";
       if (server.port !== NGROK_DEFAULT_AGENT_API_PORT && !processNameIsNgrok) continue;
-      candidatesByPort.set(server.port, candidatesByPort.get(server.port) || processNameIsNgrok);
+      const current = candidatesByPort.get(server.port);
+      candidatesByPort.set(server.port, {
+        processNameIsNgrok: current?.processNameIsNgrok === true || processNameIsNgrok,
+        terminal: current?.terminal ?? server.terminal,
+      });
     }
     const responses = yield* Effect.forEach(
       candidatesByPort,
-      ([port, processNameIsNgrok]) =>
+      ([port, candidate]) =>
         httpClient.get(`http://localhost:${port}/api/tunnels`).pipe(
           Effect.flatMap(HttpClientResponse.filterStatusOk),
           Effect.flatMap((response) => response.json),
           Effect.map((body) => {
             const routes = parseNgrokTunnelSnapshot(body);
-            return routes === null ? null : { port, processNameIsNgrok, routes };
+            return routes === null ? null : { port, ...candidate, routes };
           }),
           Effect.scoped,
           Effect.timeoutOption(WEB_PROBE_TIMEOUT),
@@ -520,7 +532,12 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
     for (const response of responses) {
       if (response === null) continue;
       if (response.routes.size > 0 || response.processNameIsNgrok) agentPorts.add(response.port);
-      for (const [targetPort, route] of response.routes) routes.set(targetPort, route);
+      for (const [targetPort, route] of response.routes) {
+        routes.set(
+          targetPort,
+          response.terminal === null ? route : { ...route, terminal: response.terminal },
+        );
+      }
     }
     return { agentPorts, routes };
   });

--- a/apps/server/src/preview/PortScanner.ts
+++ b/apps/server/src/preview/PortScanner.ts
@@ -16,15 +16,13 @@
  * Polling is reference-counted via scoped `retain`. A single layer-scoped fiber
  * polls forever, but each tick is a no-op when the retain count is zero.
  */
-import * as NodeOS from "node:os";
-
 import {
   CONFIGURED_LOCAL_SERVER_URLS_MAX_ITEMS,
   PREVIEW_URL_MAX_LENGTH,
   ThreadId,
   type DiscoveredLocalServer,
 } from "@t3tools/contracts";
-import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Net from "@t3tools/shared/Net";
 import { isLoopbackHost, LSOF_LOCAL_HOST_TOKENS } from "@t3tools/shared/preview";
 import * as Cause from "effect/Cause";
@@ -107,7 +105,7 @@ const parsePortlessRouteSnapshot = (input: PortlessRouteSnapshot): ReadonlyMap<n
   if (Option.isNone(decoded)) return new Map();
 
   const defaultProxyPort = input.tls ? 443 : 80;
-  const parsedProxyPort = Number.parseInt(input.proxyPortRaw?.trim() ?? "", 10);
+  const parsedProxyPort = Number(input.proxyPortRaw?.trim() ?? "");
   const proxyPort =
     Number.isInteger(parsedProxyPort) && parsedProxyPort > 0 && parsedProxyPort < 65536
       ? parsedProxyPort
@@ -351,6 +349,7 @@ const serversEqual = (
 export const make = Effect.gen(function* PortDiscoveryMake() {
   const net = yield* Net.NetService;
   const processRunner = yield* ProcessRunner.ProcessRunner;
+  const hostEnvironment = yield* HostProcessEnvironment;
   const hostPlatform = yield* HostProcessPlatform;
   const httpClient = (yield* HttpClient.HttpClient).pipe(HttpClient.withScope);
   const fileSystem = yield* FileSystem.FileSystem;
@@ -364,8 +363,10 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
   const scanSemaphore = yield* Semaphore.make(1);
 
   const readPortlessRoutes = Effect.fn("PortDiscovery.readPortlessRoutes")(function* () {
-    const configuredStateDir = process.env.PORTLESS_STATE_DIR?.trim();
-    const stateDir = configuredStateDir || path.join(NodeOS.homedir(), ".portless");
+    const configuredStateDir = hostEnvironment.PORTLESS_STATE_DIR?.trim();
+    const homeDirectory = hostEnvironment.HOME?.trim() || hostEnvironment.USERPROFILE?.trim();
+    const stateDir = configuredStateDir || (homeDirectory && path.join(homeDirectory, ".portless"));
+    if (!stateDir) return new Map<number, string>();
     const routesJson = yield* fileSystem
       .readFileString(path.join(stateDir, "routes.json"))
       .pipe(Effect.option);

--- a/apps/server/src/preview/PortScanner.ts
+++ b/apps/server/src/preview/PortScanner.ts
@@ -376,6 +376,18 @@ const webProbeCacheKey = (raw: string): string => {
   return url.href;
 };
 
+const projectConfiguredPath = (namedUrl: URL, configuredUrl: URL): void => {
+  const mountPath = namedUrl.pathname.replace(/\/+$/, "");
+  namedUrl.pathname =
+    mountPath.length === 0
+      ? configuredUrl.pathname
+      : configuredUrl.pathname === "/"
+        ? namedUrl.pathname
+        : `${mountPath}/${configuredUrl.pathname.replace(/^\/+/, "")}`;
+  namedUrl.search = configuredUrl.search;
+  namedUrl.hash = configuredUrl.hash;
+};
+
 const normalizeConfiguredUrls = (urls: ReadonlyArray<string>): ReadonlyArray<string> => [
   ...new Set(
     urls
@@ -416,9 +428,7 @@ const projectWebProbeSnapshot = (
       continue;
     }
     const namedUrl = new URL(namedRoute.url);
-    namedUrl.pathname = url.pathname;
-    namedUrl.search = url.search;
-    namedUrl.hash = url.hash;
+    projectConfiguredPath(namedUrl, url);
     visibleByServer.set(serverKey, {
       ...configured,
       url: namedUrl.href,

--- a/apps/web/src/browser/browserTargetResolver.test.ts
+++ b/apps/web/src/browser/browserTargetResolver.test.ts
@@ -206,6 +206,18 @@ describe("browser target resolver", () => {
     ).toBe("https://feature.ngrok-free.app/dashboard?mode=test#results");
   });
 
+  it("opens a Tailscale Serve URL directly for a remote environment", async () => {
+    readPreparedConnection.mockReturnValue({ httpBaseUrl: "http://100.65.180.100:3773" });
+    const { resolveDiscoveredServerUrl } = await import("./browserTargetResolver");
+    expect(
+      resolveDiscoveredServerUrl(
+        EnvironmentId.make("environment-1"),
+        "https://desktop.example-tailnet.ts.net/dashboard",
+        4058,
+      ),
+    ).toBe("https://desktop.example-tailnet.ts.net/dashboard");
+  });
+
   it("normalizes public URLs without treating them as environment ports", async () => {
     const { resolveDiscoveredServerUrl } = await import("./browserTargetResolver");
     expect(resolveDiscoveredServerUrl(EnvironmentId.make("environment-1"), "example.com/app")).toBe(

--- a/apps/web/src/browser/browserTargetResolver.test.ts
+++ b/apps/web/src/browser/browserTargetResolver.test.ts
@@ -168,6 +168,30 @@ describe("browser target resolver", () => {
     ).toBe("http://localhost:5173/app?x=1#top");
   });
 
+  it("opens a Portless URL directly for a local environment", async () => {
+    readPreparedConnection.mockReturnValue({ httpBaseUrl: "http://127.0.0.1:3773" });
+    const { resolveDiscoveredServerUrl } = await import("./browserTargetResolver");
+    expect(
+      resolveDiscoveredServerUrl(
+        EnvironmentId.make("environment-1"),
+        "https://feature.artelo.localhost/dashboard",
+        4058,
+      ),
+    ).toBe("https://feature.artelo.localhost/dashboard");
+  });
+
+  it("preserves the target-port fallback for a remote Portless server", async () => {
+    readPreparedConnection.mockReturnValue({ httpBaseUrl: "http://100.65.180.100:3773" });
+    const { resolveDiscoveredServerUrl } = await import("./browserTargetResolver");
+    expect(
+      resolveDiscoveredServerUrl(
+        EnvironmentId.make("environment-1"),
+        "https://feature.artelo.localhost/dashboard?mode=test#results",
+        4058,
+      ),
+    ).toBe("http://100.65.180.100:4058/dashboard?mode=test#results");
+  });
+
   it("normalizes public URLs without treating them as environment ports", async () => {
     const { resolveDiscoveredServerUrl } = await import("./browserTargetResolver");
     expect(resolveDiscoveredServerUrl(EnvironmentId.make("environment-1"), "example.com/app")).toBe(

--- a/apps/web/src/browser/browserTargetResolver.test.ts
+++ b/apps/web/src/browser/browserTargetResolver.test.ts
@@ -186,8 +186,9 @@ describe("browser target resolver", () => {
     expect(
       resolveDiscoveredServerUrl(
         EnvironmentId.make("environment-1"),
-        "https://feature.artelo.localhost/dashboard?mode=test#results",
+        "https://current.test/dashboard?mode=test#results",
         4058,
+        "local-proxy",
       ),
     ).toBe("http://100.65.180.100:4058/dashboard?mode=test#results");
   });
@@ -200,6 +201,7 @@ describe("browser target resolver", () => {
         EnvironmentId.make("environment-1"),
         "https://feature.ngrok-free.app/dashboard?mode=test#results",
         4058,
+        "public-tunnel",
       ),
     ).toBe("https://feature.ngrok-free.app/dashboard?mode=test#results");
   });

--- a/apps/web/src/browser/browserTargetResolver.test.ts
+++ b/apps/web/src/browser/browserTargetResolver.test.ts
@@ -192,6 +192,18 @@ describe("browser target resolver", () => {
     ).toBe("http://100.65.180.100:4058/dashboard?mode=test#results");
   });
 
+  it("opens an ngrok URL directly for a remote environment", async () => {
+    readPreparedConnection.mockReturnValue({ httpBaseUrl: "http://100.65.180.100:3773" });
+    const { resolveDiscoveredServerUrl } = await import("./browserTargetResolver");
+    expect(
+      resolveDiscoveredServerUrl(
+        EnvironmentId.make("environment-1"),
+        "https://feature.ngrok-free.app/dashboard?mode=test#results",
+        4058,
+      ),
+    ).toBe("https://feature.ngrok-free.app/dashboard?mode=test#results");
+  });
+
   it("normalizes public URLs without treating them as environment ports", async () => {
     const { resolveDiscoveredServerUrl } = await import("./browserTargetResolver");
     expect(resolveDiscoveredServerUrl(EnvironmentId.make("environment-1"), "example.com/app")).toBe(

--- a/apps/web/src/browser/browserTargetResolver.ts
+++ b/apps/web/src/browser/browserTargetResolver.ts
@@ -105,11 +105,21 @@ export function resolveDiscoveredServerUrl(
           normalizedUrl,
         ).resolvedUrl;
       }
+      return normalizedUrl;
     }
-    return resolveBrowserNavigationTarget(environmentId, {
-      kind: "url",
-      url: normalizedUrl,
-    }).resolvedUrl;
+    if (!isLoopbackHost(parsed.hostname)) return normalizedUrl;
+    return resolveEnvironmentPortTarget(
+      environmentId,
+      {
+        kind: "environment-port",
+        port: Number(parsed.port || (parsed.protocol === "https:" ? 443 : 80)),
+        protocol: parsed.protocol === "https:" ? "https" : "http",
+        path: `${parsed.pathname}${parsed.search}${parsed.hash}`,
+      },
+      readEnvironmentUrl(environmentId),
+      rawUrl,
+      parsed,
+    ).resolvedUrl;
   } catch {
     return rawUrl;
   }

--- a/apps/web/src/browser/browserTargetResolver.ts
+++ b/apps/web/src/browser/browserTargetResolver.ts
@@ -1,5 +1,6 @@
 import type {
   BrowserNavigationTarget,
+  DiscoveredLocalServerUrlKind,
   EnvironmentId,
   PreviewUrlResolution,
 } from "@t3tools/contracts";
@@ -75,23 +76,40 @@ export function resolveBrowserNavigationTarget(
   return resolveEnvironmentPortTarget(environmentId, target, readEnvironmentUrl(environmentId));
 }
 
-export function resolveDiscoveredServerUrl(environmentId: EnvironmentId, rawUrl: string): string {
+export function resolveDiscoveredServerUrl(
+  environmentId: EnvironmentId,
+  rawUrl: string,
+  targetPort?: number,
+  urlKind?: DiscoveredLocalServerUrlKind,
+): string {
   try {
     const normalizedUrl = normalizePreviewUrl(rawUrl);
     const parsed = new URL(normalizedUrl);
-    if (!isLoopbackHost(parsed.hostname)) return normalizedUrl;
-    return resolveEnvironmentPortTarget(
-      environmentId,
-      {
-        kind: "environment-port",
-        port: Number(parsed.port || (parsed.protocol === "https:" ? 443 : 80)),
-        protocol: parsed.protocol === "https:" ? "https" : "http",
-        path: `${parsed.pathname}${parsed.search}${parsed.hash}`,
-      },
-      readEnvironmentUrl(environmentId),
-      rawUrl,
-      parsed,
-    ).resolvedUrl;
+    const isLocalProxy =
+      urlKind === "local-proxy" ||
+      (urlKind === undefined &&
+        parsed.hostname !== "localhost" &&
+        parsed.hostname.endsWith(".localhost"));
+    if (targetPort !== undefined && isLocalProxy) {
+      const environmentUrl = readEnvironmentUrl(environmentId);
+      if (!isLocalLoopbackHost(environmentUrl.hostname)) {
+        return resolveEnvironmentPortTarget(
+          environmentId,
+          {
+            kind: "environment-port",
+            port: targetPort,
+            protocol: "http",
+            path: `${parsed.pathname}${parsed.search}${parsed.hash}`,
+          },
+          environmentUrl,
+          normalizedUrl,
+        ).resolvedUrl;
+      }
+    }
+    return resolveBrowserNavigationTarget(environmentId, {
+      kind: "url",
+      url: normalizedUrl,
+    }).resolvedUrl;
   } catch {
     return rawUrl;
   }

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -88,6 +88,10 @@ import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../termina
 import { useThreadRunningTerminalIds } from "../state/terminalSessions";
 import { useThreadDiscoveredPorts } from "../portDiscoveryState";
 import { openDiscoveredPort } from "./preview/openDiscoveredPort";
+import {
+  formatDiscoveredServerHost,
+  selectPreferredDiscoveredServer,
+} from "./preview/useDiscoveredLocalServers";
 import { useAtomCommand } from "../state/use-atom-command";
 import { previewEnvironment } from "../state/preview";
 import {
@@ -391,6 +395,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
   const openPreview = useAtomCommand(previewEnvironment.open, {
     reportFailure: false,
   });
+  const preferredDiscoveredPort = selectPreferredDiscoveredServer(discoveredPorts);
   const environment = useEnvironment(thread.environmentId);
   const primaryEnvironmentId = usePrimaryEnvironmentId();
   // No primary (the hosted app) means every thread is remote, and the machine
@@ -411,7 +416,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
   const isHighlighted = isActive || isSelected;
   const handleOpenDiscoveredPort = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
-      const port = discoveredPorts[0];
+      const port = preferredDiscoveredPort;
       if (!port) return;
       event.preventDefault();
       event.stopPropagation();
@@ -432,7 +437,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
         );
       })();
     },
-    [discoveredPorts, navigateToThread, openPreview, threadRef],
+    [navigateToThread, openPreview, preferredDiscoveredPort, threadRef],
   );
   const isThreadRunning =
     thread.session?.status === "running" && thread.session.activeTurnId != null;
@@ -738,13 +743,13 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
           )}
         </div>
         <div className="ml-auto flex shrink-0 items-center gap-1.5">
-          {discoveredPorts.length > 0 && (
+          {preferredDiscoveredPort && (
             <Tooltip>
               <TooltipTrigger
                 render={
                   <button
                     type="button"
-                    aria-label={`Open localhost:${discoveredPorts[0]?.port ?? ""}`}
+                    aria-label={`Open ${formatDiscoveredServerHost(preferredDiscoveredPort)}`}
                     className="inline-flex cursor-pointer items-center justify-center text-emerald-600 outline-hidden focus-visible:ring-1 focus-visible:ring-ring dark:text-emerald-400"
                     onClick={handleOpenDiscoveredPort}
                   />
@@ -753,8 +758,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
                 <Globe2Icon className="size-3" />
               </TooltipTrigger>
               <TooltipPopup side="top">
-                Open localhost:{discoveredPorts[0]?.port}
-                {discoveredPorts.length > 1 ? ` (+${discoveredPorts.length - 1})` : ""}
+                Open {formatDiscoveredServerHost(preferredDiscoveredPort)}
               </TooltipPopup>
             </Tooltip>
           )}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -45,6 +45,7 @@ import {
   FolderIcon,
   FolderPlusIcon,
   GitBranchIcon,
+  Globe2Icon,
   PinIcon,
   PinOffIcon,
   PlusIcon,
@@ -202,6 +203,13 @@ import {
   type ProviderInstanceEntry,
 } from "../providerInstances";
 import { useThreadRunningTerminalIds } from "../state/terminalSessions";
+import { useThreadDiscoveredPorts } from "../portDiscoveryState";
+import { previewEnvironment } from "../state/preview";
+import { openDiscoveredPort } from "./preview/openDiscoveredPort";
+import {
+  formatDiscoveredServerHost,
+  selectPreferredDiscoveredServer,
+} from "./preview/useDiscoveredLocalServers";
 import { stackedThreadToast, toastManager } from "./ui/toast";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
@@ -1046,6 +1054,14 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     environmentId: thread.environmentId,
     threadId: thread.id,
   });
+  const discoveredPorts = useThreadDiscoveredPorts({
+    environmentId: thread.environmentId,
+    threadId: thread.id,
+  });
+  const preferredDiscoveredPort = selectPreferredDiscoveredServer(discoveredPorts);
+  const openPreview = useAtomCommand(previewEnvironment.open, {
+    reportFailure: false,
+  });
   const terminalStatus = terminalStatusFromRunningIds(runningTerminalIds);
   const terminalProcessCount = runningTerminalIds.length;
   // Unsent composer text on this thread. The open thread shows its own
@@ -1351,6 +1367,32 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     },
     [onThreadActivate, openPrLink, openPullRequestsInRightPanel, pr, props.isActive, threadRef],
   );
+  const handleOpenDiscoveredPort = useCallback(
+    (event: ReactMouseEvent<HTMLButtonElement>) => {
+      if (!preferredDiscoveredPort) return;
+      event.preventDefault();
+      event.stopPropagation();
+      onThreadActivate(threadRef);
+      void (async () => {
+        const result = await openDiscoveredPort({
+          threadRef,
+          port: preferredDiscoveredPort,
+          openPreview,
+        });
+        if (result._tag === "Success" || isAtomCommandInterrupted(result)) return;
+        const error = squashAtomCommandFailure(result);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Unable to open preview",
+            description:
+              error instanceof Error ? error.message : "The preview could not be opened.",
+          }),
+        );
+      })();
+    },
+    [onThreadActivate, openPreview, preferredDiscoveredPort, threadRef],
+  );
 
   // All sidebar rows share one surface model. Live threads used to look
   // like elevated cards while settled threads were plain rows, leaving neither
@@ -1534,6 +1576,25 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
       />
     )
   ) : null;
+  const discoveredPortButton = preferredDiscoveredPort ? (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <button
+            type="button"
+            aria-label={`Open ${formatDiscoveredServerHost(preferredDiscoveredPort)}`}
+            onClick={handleOpenDiscoveredPort}
+            className="inline-flex shrink-0 cursor-pointer items-center justify-center rounded-sm text-emerald-600 outline-none hover:text-emerald-700 focus-visible:ring-2 focus-visible:ring-ring dark:text-emerald-400 dark:hover:text-emerald-300"
+          />
+        }
+      >
+        <Globe2Icon aria-hidden className="size-3.5" />
+      </TooltipTrigger>
+      <TooltipPopup side="top">
+        Open {formatDiscoveredServerHost(preferredDiscoveredPort)}
+      </TooltipPopup>
+    </Tooltip>
+  ) : null;
 
   if (variant === "slim") {
     return (
@@ -1583,6 +1644,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
             {draftIndicator}
             {title}
             {pinIndicator}
+            {discoveredPortButton}
             {terminalStatusIcon}
             {isRegeneratingTitle ? (
               <span role="status" className="sr-only">
@@ -1894,6 +1956,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
               ) : (
                 <span className="flex-1" />
               )}
+              {discoveredPortButton}
               {terminalStatusIcon}
               {prBadge}
               {diff ? (

--- a/apps/web/src/components/preview/PreviewEmptyState.test.tsx
+++ b/apps/web/src/components/preview/PreviewEmptyState.test.tsx
@@ -15,7 +15,8 @@ const mocks = vi.hoisted(() => ({
   }>,
 }));
 
-vi.mock("./useDiscoveredLocalServers", () => ({
+vi.mock("./useDiscoveredLocalServers", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./useDiscoveredLocalServers")>()),
   useDiscoveredLocalServers: () => mocks.servers,
 }));
 vi.mock("./PreviewFaviconIcon", () => ({

--- a/apps/web/src/components/preview/PreviewEmptyState.test.tsx
+++ b/apps/web/src/components/preview/PreviewEmptyState.test.tsx
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
     host: string;
     port: number;
     url: string;
+    urlKind?: "local-proxy" | "public-tunnel";
     requestedUrl: string;
     processName: string | null;
     pid: number | null;
@@ -73,6 +74,20 @@ describe("PreviewEmptyState", () => {
     const html = render([{ url: "https://myapp.test/", lastVisitedAt: 0 }]);
     expect(html).toContain("Recently used");
     expect(html).not.toContain("Local servers");
+  });
+
+  it("labels a remote proxy from its stable requested URL", () => {
+    mocks.servers = [
+      {
+        ...server(4058),
+        url: "http://100.65.180.100:4058/",
+        requestedUrl: "https://feature.artelo.localhost/",
+        urlKind: "local-proxy",
+      },
+    ];
+    const html = render([]);
+    expect(html).toContain("feature.artelo.localhost");
+    expect(html).not.toContain("100.65.180.100:4058");
   });
 
   it("keeps the original empty state when both groups are empty", () => {

--- a/apps/web/src/components/preview/PreviewEmptyState.tsx
+++ b/apps/web/src/components/preview/PreviewEmptyState.tsx
@@ -1,4 +1,8 @@
-import type { EnvironmentId, ScopedThreadRef } from "@t3tools/contracts";
+import type {
+  DiscoveredLocalServerUrlKind,
+  EnvironmentId,
+  ScopedThreadRef,
+} from "@t3tools/contracts";
 import { Globe, History, RadioTower } from "lucide-react";
 
 import type { BrowserHistoryEntry } from "~/browserHistoryStore";
@@ -6,7 +10,7 @@ import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from "~/components/ui
 
 import { PreviewLocalServerCard } from "./PreviewLocalServerCard";
 import { PreviewRecentUrlCard } from "./PreviewRecentUrlCard";
-import { findDiscoveredServerTargetPort } from "./previewEmptyStateLogic";
+import { findDiscoveredServerTarget } from "./previewEmptyStateLogic";
 import { useDiscoveredLocalServers } from "./useDiscoveredLocalServers";
 
 interface Props {
@@ -15,7 +19,7 @@ interface Props {
   configuredUrls?: ReadonlyArray<string> | undefined;
   recentEntries: ReadonlyArray<BrowserHistoryEntry>;
   onRemoveRecent: (url: string) => void;
-  onOpenUrl: (url: string, targetPort?: number) => void;
+  onOpenUrl: (url: string, targetPort?: number, urlKind?: DiscoveredLocalServerUrlKind) => void;
 }
 
 export function PreviewEmptyState({
@@ -62,9 +66,10 @@ export function PreviewEmptyState({
                   key={entry.url}
                   threadRef={threadRef}
                   entry={entry}
-                  onOpen={() =>
-                    onOpenUrl(entry.url, findDiscoveredServerTargetPort(entry.url, servers))
-                  }
+                  onOpen={() => {
+                    const target = findDiscoveredServerTarget(entry.url, servers);
+                    onOpenUrl(entry.url, target?.port, target?.urlKind);
+                  }}
                   onRemove={() => onRemoveRecent(entry.url)}
                 />
               ))}
@@ -83,7 +88,7 @@ export function PreviewEmptyState({
                   key={`${server.host}:${server.port}`}
                   threadRef={threadRef}
                   server={server}
-                  onOpen={() => onOpenUrl(server.requestedUrl, server.port)}
+                  onOpen={() => onOpenUrl(server.requestedUrl, server.port, server.urlKind)}
                 />
               ))}
             </div>

--- a/apps/web/src/components/preview/PreviewEmptyState.tsx
+++ b/apps/web/src/components/preview/PreviewEmptyState.tsx
@@ -6,6 +6,7 @@ import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from "~/components/ui
 
 import { PreviewLocalServerCard } from "./PreviewLocalServerCard";
 import { PreviewRecentUrlCard } from "./PreviewRecentUrlCard";
+import { findDiscoveredServerTargetPort } from "./previewEmptyStateLogic";
 import { useDiscoveredLocalServers } from "./useDiscoveredLocalServers";
 
 interface Props {
@@ -14,7 +15,7 @@ interface Props {
   configuredUrls?: ReadonlyArray<string> | undefined;
   recentEntries: ReadonlyArray<BrowserHistoryEntry>;
   onRemoveRecent: (url: string) => void;
-  onOpenUrl: (url: string) => void;
+  onOpenUrl: (url: string, targetPort?: number) => void;
 }
 
 export function PreviewEmptyState({
@@ -61,7 +62,9 @@ export function PreviewEmptyState({
                   key={entry.url}
                   threadRef={threadRef}
                   entry={entry}
-                  onOpen={() => onOpenUrl(entry.url)}
+                  onOpen={() =>
+                    onOpenUrl(entry.url, findDiscoveredServerTargetPort(entry.url, servers))
+                  }
                   onRemove={() => onRemoveRecent(entry.url)}
                 />
               ))}
@@ -80,7 +83,7 @@ export function PreviewEmptyState({
                   key={`${server.host}:${server.port}`}
                   threadRef={threadRef}
                   server={server}
-                  onOpen={() => onOpenUrl(server.requestedUrl)}
+                  onOpen={() => onOpenUrl(server.requestedUrl, server.port)}
                 />
               ))}
             </div>

--- a/apps/web/src/components/preview/PreviewLocalServerCard.tsx
+++ b/apps/web/src/components/preview/PreviewLocalServerCard.tsx
@@ -21,7 +21,7 @@ export function PreviewLocalServerCard({ threadRef, server, onOpen }: Props) {
       <div className="flex min-w-0 flex-1 flex-col">
         <span className="truncate text-sm font-medium text-foreground">{subtitle}</span>
         <span className="truncate text-xs text-muted-foreground">
-          {formatDiscoveredServerHost(server)}
+          {formatDiscoveredServerHost({ ...server, url: server.requestedUrl })}
         </span>
       </div>
     </button>

--- a/apps/web/src/components/preview/PreviewLocalServerCard.tsx
+++ b/apps/web/src/components/preview/PreviewLocalServerCard.tsx
@@ -1,7 +1,10 @@
 import type { ScopedThreadRef } from "@t3tools/contracts";
 
 import { PreviewFaviconIcon } from "./PreviewFaviconIcon";
-import type { PreviewableServer } from "./useDiscoveredLocalServers";
+import {
+  formatDiscoveredServerHost,
+  type PreviewableServer,
+} from "./useDiscoveredLocalServers";
 
 interface Props {
   threadRef: ScopedThreadRef;
@@ -20,9 +23,9 @@ export function PreviewLocalServerCard({ threadRef, server, onOpen }: Props) {
       <PreviewFaviconIcon threadRef={threadRef} url={server.requestedUrl} />
       <div className="flex min-w-0 flex-1 flex-col">
         <span className="truncate text-sm font-medium text-foreground">{subtitle}</span>
-        <span className="truncate text-xs text-muted-foreground">
-          {server.host}:{server.port}
-        </span>
+          <span className="truncate text-xs text-muted-foreground">
+            {formatDiscoveredServerHost(server)}
+          </span>
       </div>
     </button>
   );

--- a/apps/web/src/components/preview/PreviewLocalServerCard.tsx
+++ b/apps/web/src/components/preview/PreviewLocalServerCard.tsx
@@ -1,10 +1,7 @@
 import type { ScopedThreadRef } from "@t3tools/contracts";
 
 import { PreviewFaviconIcon } from "./PreviewFaviconIcon";
-import {
-  formatDiscoveredServerHost,
-  type PreviewableServer,
-} from "./useDiscoveredLocalServers";
+import { formatDiscoveredServerHost, type PreviewableServer } from "./useDiscoveredLocalServers";
 
 interface Props {
   threadRef: ScopedThreadRef;
@@ -23,9 +20,9 @@ export function PreviewLocalServerCard({ threadRef, server, onOpen }: Props) {
       <PreviewFaviconIcon threadRef={threadRef} url={server.requestedUrl} />
       <div className="flex min-w-0 flex-1 flex-col">
         <span className="truncate text-sm font-medium text-foreground">{subtitle}</span>
-          <span className="truncate text-xs text-muted-foreground">
-            {formatDiscoveredServerHost(server)}
-          </span>
+        <span className="truncate text-xs text-muted-foreground">
+          {formatDiscoveredServerHost(server)}
+        </span>
       </div>
     </button>
   );

--- a/apps/web/src/components/preview/PreviewView.test.tsx
+++ b/apps/web/src/components/preview/PreviewView.test.tsx
@@ -16,7 +16,7 @@ const mocks = vi.hoisted(() => ({
   rememberPreviewUrl: vi.fn(),
   readPreparedConnection: vi.fn(() => ({ httpBaseUrl: "http://172.25.85.75:3773" })),
   submittedUrl: null as ((url: string) => void) | null,
-  emptyStateUrl: null as ((url: string) => void) | null,
+  emptyStateUrl: null as ((url: string, targetPort?: number) => void) | null,
   togglePictureInPicture: null as (() => void) | null,
   toggleNativePictureInPicture: null as (() => void) | null,
   pictureInPicturePressed: false,
@@ -235,7 +235,7 @@ vi.mock("./PreviewChromeRow", () => ({
 }));
 
 vi.mock("./PreviewEmptyState", () => ({
-  PreviewEmptyState: (props: { onOpenUrl: (url: string) => void }) => {
+  PreviewEmptyState: (props: { onOpenUrl: (url: string, targetPort?: number) => void }) => {
     mocks.emptyStateUrl = props.onOpenUrl;
     return null;
   },
@@ -469,6 +469,18 @@ describe("PreviewView navigation", () => {
         expect.objectContaining({ threadId: expect.anything() }),
         "http://localhost:5173/app?mode=test#top",
       ),
+    );
+  });
+
+  it("maps an empty-state Portless server onto its remote listener port", async () => {
+    mocks.showEmptyState = true;
+    renderToStaticMarkup(<PreviewView threadRef={TEST_THREAD_REF} tabId="tab-1" visible />);
+
+    expect(mocks.emptyStateUrl).not.toBeNull();
+    mocks.emptyStateUrl?.("https://artelo.localhost/", 4058);
+
+    await vi.waitFor(() =>
+      expect(mocks.navigate).toHaveBeenCalledWith(TEST_RUNTIME_TAB_ID, "http://172.25.85.75:4058/"),
     );
   });
 

--- a/apps/web/src/components/preview/PreviewView.test.tsx
+++ b/apps/web/src/components/preview/PreviewView.test.tsx
@@ -3,6 +3,7 @@ import {
   DEFAULT_BROWSER_PROFILE_ID,
   DEFAULT_PREVIEW_APPEARANCE,
   DEFAULT_PREVIEW_ZOOM_FACTOR,
+  type DiscoveredLocalServerUrlKind,
   EnvironmentId,
   FILL_PREVIEW_VIEWPORT,
   ThreadId,
@@ -16,7 +17,9 @@ const mocks = vi.hoisted(() => ({
   rememberPreviewUrl: vi.fn(),
   readPreparedConnection: vi.fn(() => ({ httpBaseUrl: "http://172.25.85.75:3773" })),
   submittedUrl: null as ((url: string) => void) | null,
-  emptyStateUrl: null as ((url: string, targetPort?: number) => void) | null,
+  emptyStateUrl: null as
+    | ((url: string, targetPort?: number, urlKind?: DiscoveredLocalServerUrlKind) => void)
+    | null,
   togglePictureInPicture: null as (() => void) | null,
   toggleNativePictureInPicture: null as (() => void) | null,
   pictureInPicturePressed: false,
@@ -235,7 +238,9 @@ vi.mock("./PreviewChromeRow", () => ({
 }));
 
 vi.mock("./PreviewEmptyState", () => ({
-  PreviewEmptyState: (props: { onOpenUrl: (url: string, targetPort?: number) => void }) => {
+  PreviewEmptyState: (props: {
+    onOpenUrl: (url: string, targetPort?: number, urlKind?: DiscoveredLocalServerUrlKind) => void;
+  }) => {
     mocks.emptyStateUrl = props.onOpenUrl;
     return null;
   },
@@ -477,7 +482,7 @@ describe("PreviewView navigation", () => {
     renderToStaticMarkup(<PreviewView threadRef={TEST_THREAD_REF} tabId="tab-1" visible />);
 
     expect(mocks.emptyStateUrl).not.toBeNull();
-    mocks.emptyStateUrl?.("https://artelo.localhost/", 4058);
+    mocks.emptyStateUrl?.("https://current.test/", 4058, "local-proxy");
 
     await vi.waitFor(() =>
       expect(mocks.navigate).toHaveBeenCalledWith(TEST_RUNTIME_TAB_ID, "http://172.25.85.75:4058/"),

--- a/apps/web/src/components/preview/PreviewView.tsx
+++ b/apps/web/src/components/preview/PreviewView.tsx
@@ -8,6 +8,7 @@ import {
 import {
   DEFAULT_BROWSER_PROFILE_ID,
   FILL_PREVIEW_VIEWPORT,
+  type DiscoveredLocalServerUrlKind,
   type PreviewAnnotationPayload,
   type PreviewViewportSetting,
   type ScopedThreadRef,
@@ -220,9 +221,14 @@ export function PreviewView({
   );
 
   const handleOpenServerUrl = useCallback(
-    async (next: string, targetPort?: number) => {
+    async (next: string, targetPort?: number, urlKind?: DiscoveredLocalServerUrlKind) => {
       try {
-        const resolved = resolveDiscoveredServerUrl(threadRef.environmentId, next, targetPort);
+        const resolved = resolveDiscoveredServerUrl(
+          threadRef.environmentId,
+          next,
+          targetPort,
+          urlKind,
+        );
         if (await navigateToResolvedUrl(resolved)) {
           recordVisitForThread(threadRef, next);
         }
@@ -788,7 +794,9 @@ export function PreviewView({
             configuredUrls={configuredUrls}
             recentEntries={recentHistoryEntries}
             onRemoveRecent={(url) => removeUrlForThread(threadRef, url)}
-            onOpenUrl={(next, targetPort) => void handleOpenServerUrl(next, targetPort)}
+            onOpenUrl={(next, targetPort, urlKind) =>
+              void handleOpenServerUrl(next, targetPort, urlKind)
+            }
           />
         ) : null}
         {snapshot && desktopOverlay ? (

--- a/apps/web/src/components/preview/PreviewView.tsx
+++ b/apps/web/src/components/preview/PreviewView.tsx
@@ -220,9 +220,9 @@ export function PreviewView({
   );
 
   const handleOpenServerUrl = useCallback(
-    async (next: string) => {
+    async (next: string, targetPort?: number) => {
       try {
-        const resolved = resolveDiscoveredServerUrl(threadRef.environmentId, next);
+        const resolved = resolveDiscoveredServerUrl(threadRef.environmentId, next, targetPort);
         if (await navigateToResolvedUrl(resolved)) {
           recordVisitForThread(threadRef, next);
         }

--- a/apps/web/src/components/preview/PreviewView.tsx
+++ b/apps/web/src/components/preview/PreviewView.tsx
@@ -788,7 +788,7 @@ export function PreviewView({
             configuredUrls={configuredUrls}
             recentEntries={recentHistoryEntries}
             onRemoveRecent={(url) => removeUrlForThread(threadRef, url)}
-            onOpenUrl={(next) => void handleOpenServerUrl(next)}
+            onOpenUrl={(next, targetPort) => void handleOpenServerUrl(next, targetPort)}
           />
         ) : null}
         {snapshot && desktopOverlay ? (

--- a/apps/web/src/components/preview/openDiscoveredPort.ts
+++ b/apps/web/src/components/preview/openDiscoveredPort.ts
@@ -19,6 +19,7 @@ export async function openDiscoveredPort<E>(input: {
     input.threadRef.environmentId,
     input.port.url,
     input.port.port,
+    input.port.urlKind,
   );
   const result = await openPreviewSession({
     openPreview: input.openPreview,

--- a/apps/web/src/components/preview/openDiscoveredPort.ts
+++ b/apps/web/src/components/preview/openDiscoveredPort.ts
@@ -15,7 +15,11 @@ export async function openDiscoveredPort<E>(input: {
   readonly port: DiscoveredLocalServer;
   readonly openPreview: OpenPreviewMutation<E>;
 }): Promise<AtomCommandResult<void, E | BrowserSettingsReadError>> {
-  const resolvedUrl = resolveDiscoveredServerUrl(input.threadRef.environmentId, input.port.url);
+  const resolvedUrl = resolveDiscoveredServerUrl(
+    input.threadRef.environmentId,
+    input.port.url,
+    input.port.port,
+  );
   const result = await openPreviewSession({
     openPreview: input.openPreview,
     threadRef: input.threadRef,

--- a/apps/web/src/components/preview/previewEmptyStateLogic.test.ts
+++ b/apps/web/src/components/preview/previewEmptyStateLogic.test.ts
@@ -60,7 +60,11 @@ describe("findDiscoveredServerTargetPort", () => {
       listening: true,
     } satisfies PreviewableServer;
 
-    expect(findDiscoveredServerTargetPort("https://artelo.localhost/", [server])).toBe(4058);
+    expect(
+      findDiscoveredServerTargetPort("https://artelo.localhost/products?sort=new#featured", [
+        server,
+      ]),
+    ).toBe(4058);
     expect(findDiscoveredServerTargetPort("https://other.localhost/", [server])).toBeUndefined();
   });
 });

--- a/apps/web/src/components/preview/previewEmptyStateLogic.test.ts
+++ b/apps/web/src/components/preview/previewEmptyStateLogic.test.ts
@@ -52,7 +52,7 @@ describe("findDiscoveredServerTargetPort", () => {
       host: "localhost",
       port: 4058,
       url: "http://100.65.180.100:4058/",
-      requestedUrl: "https://artelo.localhost/",
+      requestedUrl: "https://artelo.localhost",
       processName: "node",
       pid: 123,
       terminal: null,

--- a/apps/web/src/components/preview/previewEmptyStateLogic.test.ts
+++ b/apps/web/src/components/preview/previewEmptyStateLogic.test.ts
@@ -1,7 +1,12 @@
 import type { PreviewSessionSnapshot, ProjectScript } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
-import { getConfiguredPreviewUrls, shouldShowPreviewEmptyState } from "./previewEmptyStateLogic";
+import {
+  findDiscoveredServerTargetPort,
+  getConfiguredPreviewUrls,
+  shouldShowPreviewEmptyState,
+} from "./previewEmptyStateLogic";
+import type { PreviewableServer } from "./useDiscoveredLocalServers";
 
 const snapshot = (navStatus: PreviewSessionSnapshot["navStatus"]): PreviewSessionSnapshot => ({
   threadId: "thread-1",
@@ -38,5 +43,24 @@ describe("getConfiguredPreviewUrls", () => {
       "http://localhost:5173",
       "http://localhost:3000",
     ]);
+  });
+});
+
+describe("findDiscoveredServerTargetPort", () => {
+  it("finds the listener port for a Portless history URL", () => {
+    const server = {
+      host: "localhost",
+      port: 4058,
+      url: "http://100.65.180.100:4058/",
+      requestedUrl: "https://artelo.localhost/",
+      processName: "node",
+      pid: 123,
+      terminal: null,
+      source: "scanner",
+      listening: true,
+    } satisfies PreviewableServer;
+
+    expect(findDiscoveredServerTargetPort("https://artelo.localhost/", [server])).toBe(4058);
+    expect(findDiscoveredServerTargetPort("https://other.localhost/", [server])).toBeUndefined();
   });
 });

--- a/apps/web/src/components/preview/previewEmptyStateLogic.test.ts
+++ b/apps/web/src/components/preview/previewEmptyStateLogic.test.ts
@@ -57,7 +57,6 @@ describe("findDiscoveredServerTargetPort", () => {
       pid: 123,
       terminal: null,
       source: "scanner",
-      listening: true,
     } satisfies PreviewableServer;
 
     expect(

--- a/apps/web/src/components/preview/previewEmptyStateLogic.test.ts
+++ b/apps/web/src/components/preview/previewEmptyStateLogic.test.ts
@@ -2,7 +2,7 @@ import type { PreviewSessionSnapshot, ProjectScript } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
 import {
-  findDiscoveredServerTargetPort,
+  findDiscoveredServerTarget,
   getConfiguredPreviewUrls,
   shouldShowPreviewEmptyState,
 } from "./previewEmptyStateLogic";
@@ -46,7 +46,7 @@ describe("getConfiguredPreviewUrls", () => {
   });
 });
 
-describe("findDiscoveredServerTargetPort", () => {
+describe("findDiscoveredServerTarget", () => {
   it("finds the listener port for a Portless history URL", () => {
     const server = {
       host: "localhost",
@@ -57,13 +57,12 @@ describe("findDiscoveredServerTargetPort", () => {
       pid: 123,
       terminal: null,
       source: "scanner",
+      urlKind: "local-proxy",
     } satisfies PreviewableServer;
 
     expect(
-      findDiscoveredServerTargetPort("https://artelo.localhost/products?sort=new#featured", [
-        server,
-      ]),
-    ).toBe(4058);
-    expect(findDiscoveredServerTargetPort("https://other.localhost/", [server])).toBeUndefined();
+      findDiscoveredServerTarget("https://artelo.localhost/products?sort=new#featured", [server]),
+    ).toEqual({ port: 4058, urlKind: "local-proxy" });
+    expect(findDiscoveredServerTarget("https://other.localhost/", [server])).toBeUndefined();
   });
 });

--- a/apps/web/src/components/preview/previewEmptyStateLogic.ts
+++ b/apps/web/src/components/preview/previewEmptyStateLogic.ts
@@ -1,5 +1,7 @@
 import type { PreviewSessionSnapshot, ProjectScript } from "@t3tools/contracts";
 
+import { normalizeHistoryUrl } from "~/browserHistoryStore";
+
 import type { PreviewableServer } from "./useDiscoveredLocalServers";
 
 export function shouldShowPreviewEmptyState(snapshot: PreviewSessionSnapshot | null): boolean {
@@ -16,5 +18,7 @@ export function findDiscoveredServerTargetPort(
   url: string,
   servers: ReadonlyArray<PreviewableServer>,
 ): number | undefined {
-  return servers.find((server) => server.requestedUrl === url)?.port;
+  const normalizedUrl = normalizeHistoryUrl(url);
+  if (normalizedUrl === null) return undefined;
+  return servers.find((server) => normalizeHistoryUrl(server.requestedUrl) === normalizedUrl)?.port;
 }

--- a/apps/web/src/components/preview/previewEmptyStateLogic.ts
+++ b/apps/web/src/components/preview/previewEmptyStateLogic.ts
@@ -1,5 +1,7 @@
 import type { PreviewSessionSnapshot, ProjectScript } from "@t3tools/contracts";
 
+import type { PreviewableServer } from "./useDiscoveredLocalServers";
+
 export function shouldShowPreviewEmptyState(snapshot: PreviewSessionSnapshot | null): boolean {
   return snapshot === null || snapshot.navStatus._tag === "Idle";
 }
@@ -8,4 +10,11 @@ export function getConfiguredPreviewUrls(
   scripts: ReadonlyArray<ProjectScript> | undefined,
 ): ReadonlyArray<string> {
   return scripts?.flatMap((script) => (script.previewUrl ? [script.previewUrl] : [])) ?? [];
+}
+
+export function findDiscoveredServerTargetPort(
+  url: string,
+  servers: ReadonlyArray<PreviewableServer>,
+): number | undefined {
+  return servers.find((server) => server.requestedUrl === url)?.port;
 }

--- a/apps/web/src/components/preview/previewEmptyStateLogic.ts
+++ b/apps/web/src/components/preview/previewEmptyStateLogic.ts
@@ -20,5 +20,9 @@ export function findDiscoveredServerTargetPort(
 ): number | undefined {
   const normalizedUrl = normalizeHistoryUrl(url);
   if (normalizedUrl === null) return undefined;
-  return servers.find((server) => normalizeHistoryUrl(server.requestedUrl) === normalizedUrl)?.port;
+  const origin = new URL(normalizedUrl).origin;
+  return servers.find((server) => {
+    const normalizedRequestedUrl = normalizeHistoryUrl(server.requestedUrl);
+    return normalizedRequestedUrl !== null && new URL(normalizedRequestedUrl).origin === origin;
+  })?.port;
 }

--- a/apps/web/src/components/preview/previewEmptyStateLogic.ts
+++ b/apps/web/src/components/preview/previewEmptyStateLogic.ts
@@ -14,15 +14,16 @@ export function getConfiguredPreviewUrls(
   return scripts?.flatMap((script) => (script.previewUrl ? [script.previewUrl] : [])) ?? [];
 }
 
-export function findDiscoveredServerTargetPort(
+export function findDiscoveredServerTarget(
   url: string,
   servers: ReadonlyArray<PreviewableServer>,
-): number | undefined {
+): { readonly port: number; readonly urlKind: PreviewableServer["urlKind"] } | undefined {
   const normalizedUrl = normalizeHistoryUrl(url);
   if (normalizedUrl === null) return undefined;
   const origin = new URL(normalizedUrl).origin;
-  return servers.find((server) => {
-    const normalizedRequestedUrl = normalizeHistoryUrl(server.requestedUrl);
+  const server = servers.find((candidate) => {
+    const normalizedRequestedUrl = normalizeHistoryUrl(candidate.requestedUrl);
     return normalizedRequestedUrl !== null && new URL(normalizedRequestedUrl).origin === origin;
-  })?.port;
+  });
+  return server ? { port: server.port, urlKind: server.urlKind } : undefined;
 }

--- a/apps/web/src/components/preview/useDiscoveredLocalServers.test.ts
+++ b/apps/web/src/components/preview/useDiscoveredLocalServers.test.ts
@@ -188,6 +188,20 @@ describe("selectPreferredDiscoveredServer", () => {
     expect(selectPreferredDiscoveredServer([scannerServer({ port: 4004 }), ngrok])).toBe(ngrok);
   });
 
+  it("prefers an ngrok tunnel over Portless regardless of scan order", () => {
+    const portless = scannerServer({
+      port: 4004,
+      url: "https://artelo.localhost",
+      urlKind: "local-proxy",
+    });
+    const ngrok = scannerServer({
+      port: 4314,
+      url: "https://feature.ngrok-free.app/",
+      urlKind: "public-tunnel",
+    });
+    expect(selectPreferredDiscoveredServer([portless, ngrok])).toBe(ngrok);
+  });
+
   it("falls back to the first listener when none has a named URL", () => {
     const first = scannerServer({ port: 3000, url: "http://localhost:3000" });
     expect(selectPreferredDiscoveredServer([first, scannerServer({ port: 5173 })])).toBe(first);

--- a/apps/web/src/components/preview/useDiscoveredLocalServers.test.ts
+++ b/apps/web/src/components/preview/useDiscoveredLocalServers.test.ts
@@ -202,6 +202,27 @@ describe("selectPreferredDiscoveredServer", () => {
     expect(selectPreferredDiscoveredServer([portless, ngrok])).toBe(ngrok);
   });
 
+  it("uses ngrok, Tailscale, Portless, localhost priority regardless of scan order", () => {
+    const localhost = scannerServer({ port: 3000, url: "http://localhost:3000" });
+    const portless = scannerServer({
+      port: 4004,
+      url: "https://artelo.localhost",
+      urlKind: "local-proxy",
+    });
+    const tailscale = scannerServer({
+      port: 4173,
+      url: "https://desktop.example-tailnet.ts.net/",
+    });
+    const ngrok = scannerServer({
+      port: 4314,
+      url: "https://feature.ngrok-free.app/",
+      urlKind: "public-tunnel",
+    });
+
+    expect(selectPreferredDiscoveredServer([localhost, portless, tailscale])).toBe(tailscale);
+    expect(selectPreferredDiscoveredServer([tailscale, portless, ngrok, localhost])).toBe(ngrok);
+  });
+
   it("falls back to the first listener when none has a named URL", () => {
     const first = scannerServer({ port: 3000, url: "http://localhost:3000" });
     expect(selectPreferredDiscoveredServer([first, scannerServer({ port: 5173 })])).toBe(first);

--- a/apps/web/src/components/preview/useDiscoveredLocalServers.test.ts
+++ b/apps/web/src/components/preview/useDiscoveredLocalServers.test.ts
@@ -169,14 +169,22 @@ describe("formatDiscoveredServerHost", () => {
 
 describe("selectPreferredDiscoveredServer", () => {
   it("prefers a named proxy over another listener from the same terminal", () => {
-    const portless = scannerServer({ port: 4314, url: "https://artelo.localhost" });
+    const portless = scannerServer({
+      port: 4314,
+      url: "https://artelo.localhost",
+      urlKind: "local-proxy",
+    });
     expect(selectPreferredDiscoveredServer([scannerServer({ port: 4004 }), portless])).toBe(
       portless,
     );
   });
 
   it("prefers an ngrok tunnel over a bare listener", () => {
-    const ngrok = scannerServer({ port: 4314, url: "https://feature.ngrok-free.app/" });
+    const ngrok = scannerServer({
+      port: 4314,
+      url: "https://feature.ngrok-free.app/",
+      urlKind: "public-tunnel",
+    });
     expect(selectPreferredDiscoveredServer([scannerServer({ port: 4004 }), ngrok])).toBe(ngrok);
   });
 

--- a/apps/web/src/components/preview/useDiscoveredLocalServers.test.ts
+++ b/apps/web/src/components/preview/useDiscoveredLocalServers.test.ts
@@ -156,6 +156,12 @@ describe("formatDiscoveredServerHost", () => {
     ).toBe("feature-branch.artelo.localhost");
   });
 
+  it("shows an ngrok host instead of its underlying listener", () => {
+    expect(
+      formatDiscoveredServerHost(scannerServer({ url: "https://feature.ngrok-free.app/" })),
+    ).toBe("feature.ngrok-free.app");
+  });
+
   it("falls back to the listener host and port for an invalid URL", () => {
     expect(formatDiscoveredServerHost(scannerServer({ url: "not a url" }))).toBe("localhost:5173");
   });
@@ -167,6 +173,11 @@ describe("selectPreferredDiscoveredServer", () => {
     expect(selectPreferredDiscoveredServer([scannerServer({ port: 4004 }), portless])).toBe(
       portless,
     );
+  });
+
+  it("prefers an ngrok tunnel over a bare listener", () => {
+    const ngrok = scannerServer({ port: 4314, url: "https://feature.ngrok-free.app/" });
+    expect(selectPreferredDiscoveredServer([scannerServer({ port: 4004 }), ngrok])).toBe(ngrok);
   });
 
   it("falls back to the first listener when none has a named URL", () => {

--- a/apps/web/src/components/preview/useDiscoveredLocalServers.test.ts
+++ b/apps/web/src/components/preview/useDiscoveredLocalServers.test.ts
@@ -1,7 +1,11 @@
 import type { DiscoveredLocalServer } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
-import { mergeServers } from "./useDiscoveredLocalServers";
+import {
+  formatDiscoveredServerHost,
+  mergeServers,
+  selectPreferredDiscoveredServer,
+} from "./useDiscoveredLocalServers";
 
 const scannerServer = (
   overrides: Partial<DiscoveredLocalServer & { requestedUrl: string }>,
@@ -142,5 +146,31 @@ describe("mergeServers", () => {
     });
     expect(result[0]?.url).toBe("https://env-42.example.dev:5173/");
     expect(result[0]?.requestedUrl).toBe("http://localhost:5173/");
+  });
+});
+
+describe("formatDiscoveredServerHost", () => {
+  it("shows a named proxy instead of its underlying listener", () => {
+    expect(
+      formatDiscoveredServerHost(scannerServer({ url: "https://feature-branch.artelo.localhost" })),
+    ).toBe("feature-branch.artelo.localhost");
+  });
+
+  it("falls back to the listener host and port for an invalid URL", () => {
+    expect(formatDiscoveredServerHost(scannerServer({ url: "not a url" }))).toBe("localhost:5173");
+  });
+});
+
+describe("selectPreferredDiscoveredServer", () => {
+  it("prefers a named proxy over another listener from the same terminal", () => {
+    const portless = scannerServer({ port: 4314, url: "https://artelo.localhost" });
+    expect(selectPreferredDiscoveredServer([scannerServer({ port: 4004 }), portless])).toBe(
+      portless,
+    );
+  });
+
+  it("falls back to the first listener when none has a named URL", () => {
+    const first = scannerServer({ port: 3000, url: "http://localhost:3000" });
+    expect(selectPreferredDiscoveredServer([first, scannerServer({ port: 5173 })])).toBe(first);
   });
 });

--- a/apps/web/src/components/preview/useDiscoveredLocalServers.test.ts
+++ b/apps/web/src/components/preview/useDiscoveredLocalServers.test.ts
@@ -223,6 +223,12 @@ describe("selectPreferredDiscoveredServer", () => {
     expect(selectPreferredDiscoveredServer([tailscale, portless, ngrok, localhost])).toBe(ngrok);
   });
 
+  it("does not prioritize a listener because of hostname casing", () => {
+    const first = scannerServer({ port: 3000, url: "http://localhost:3000" });
+    const second = scannerServer({ host: "LOCALHOST", port: 5173 });
+    expect(selectPreferredDiscoveredServer([first, second])).toBe(first);
+  });
+
   it("falls back to the first listener when none has a named URL", () => {
     const first = scannerServer({ port: 3000, url: "http://localhost:3000" });
     expect(selectPreferredDiscoveredServer([first, scannerServer({ port: 5173 })])).toBe(first);

--- a/apps/web/src/components/preview/useDiscoveredLocalServers.ts
+++ b/apps/web/src/components/preview/useDiscoveredLocalServers.ts
@@ -108,6 +108,15 @@ export function selectPreferredDiscoveredServer(
   const publicTunnel = servers.find((server) => server.urlKind === "public-tunnel");
   if (publicTunnel) return publicTunnel;
 
+  const tailnetTunnel = servers.find((server) => {
+    try {
+      return new URL(server.url).hostname.toLowerCase().endsWith(".ts.net");
+    } catch {
+      return false;
+    }
+  });
+  if (tailnetTunnel) return tailnetTunnel;
+
   const localProxy = servers.find((server) => server.urlKind === "local-proxy");
   if (localProxy) return localProxy;
 

--- a/apps/web/src/components/preview/useDiscoveredLocalServers.ts
+++ b/apps/web/src/components/preview/useDiscoveredLocalServers.ts
@@ -34,7 +34,12 @@ export function useDiscoveredLocalServers(
       mergeServers({
         scanner: scannerState.servers.map((server) => ({
           ...server,
-          url: resolveDiscoveredServerUrl(input.environmentId, server.url, server.port),
+          url: resolveDiscoveredServerUrl(
+            input.environmentId,
+            server.url,
+            server.port,
+            server.urlKind,
+          ),
           requestedUrl: server.url,
         })),
         configuredUrls: input.configuredUrls ?? [],
@@ -101,6 +106,7 @@ export function selectPreferredDiscoveredServer(
   servers: ReadonlyArray<DiscoveredLocalServer>,
 ): DiscoveredLocalServer | null {
   const namedServer = servers.find((server) => {
+    if (server.urlKind !== undefined) return true;
     try {
       return new URL(server.url).hostname !== server.host;
     } catch {

--- a/apps/web/src/components/preview/useDiscoveredLocalServers.ts
+++ b/apps/web/src/components/preview/useDiscoveredLocalServers.ts
@@ -105,15 +105,20 @@ export function formatDiscoveredServerHost(
 export function selectPreferredDiscoveredServer(
   servers: ReadonlyArray<DiscoveredLocalServer>,
 ): DiscoveredLocalServer | null {
-  const namedServer = servers.find((server) => {
-    if (server.urlKind !== undefined) return true;
+  const publicTunnel = servers.find((server) => server.urlKind === "public-tunnel");
+  if (publicTunnel) return publicTunnel;
+
+  const localProxy = servers.find((server) => server.urlKind === "local-proxy");
+  if (localProxy) return localProxy;
+
+  const legacyNamedServer = servers.find((server) => {
     try {
       return new URL(server.url).hostname !== server.host;
     } catch {
       return false;
     }
   });
-  return namedServer ?? servers[0] ?? null;
+  return legacyNamedServer ?? servers[0] ?? null;
 }
 
 function parseLocalUrl(raw: string): { host: string; port: number; url: string } | null {

--- a/apps/web/src/components/preview/useDiscoveredLocalServers.ts
+++ b/apps/web/src/components/preview/useDiscoveredLocalServers.ts
@@ -34,7 +34,7 @@ export function useDiscoveredLocalServers(
       mergeServers({
         scanner: scannerState.servers.map((server) => ({
           ...server,
-          url: resolveDiscoveredServerUrl(input.environmentId, server.url),
+          url: resolveDiscoveredServerUrl(input.environmentId, server.url, server.port),
           requestedUrl: server.url,
         })),
         configuredUrls: input.configuredUrls ?? [],
@@ -85,6 +85,29 @@ export function mergeServers(input: {
 function canonicalKey(host: string, port: number): string {
   const normalizedHost = host.toLowerCase();
   return `${isLoopbackHost(normalizedHost) ? "loopback" : normalizedHost}:${port}`;
+}
+
+export function formatDiscoveredServerHost(
+  server: Pick<DiscoveredLocalServer, "host" | "port" | "url">,
+): string {
+  try {
+    return new URL(server.url).host;
+  } catch {
+    return `${server.host}:${server.port}`;
+  }
+}
+
+export function selectPreferredDiscoveredServer(
+  servers: ReadonlyArray<DiscoveredLocalServer>,
+): DiscoveredLocalServer | null {
+  const namedServer = servers.find((server) => {
+    try {
+      return new URL(server.url).hostname !== server.host;
+    } catch {
+      return false;
+    }
+  });
+  return namedServer ?? servers[0] ?? null;
 }
 
 function parseLocalUrl(raw: string): { host: string; port: number; url: string } | null {

--- a/apps/web/src/components/preview/useDiscoveredLocalServers.ts
+++ b/apps/web/src/components/preview/useDiscoveredLocalServers.ts
@@ -1,4 +1,5 @@
 import type { DiscoveredLocalServer } from "@t3tools/contracts";
+import { normalizeHostname } from "@t3tools/shared/hostClassification";
 import { isLoopbackHost } from "@t3tools/shared/preview";
 import { useMemo } from "react";
 
@@ -122,7 +123,7 @@ export function selectPreferredDiscoveredServer(
 
   const legacyNamedServer = servers.find((server) => {
     try {
-      return new URL(server.url).hostname !== server.host;
+      return normalizeHostname(new URL(server.url).hostname) !== normalizeHostname(server.host);
     } catch {
       return false;
     }

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -116,6 +116,6 @@ finishes; the call's own result shows its status.
 
 When a terminal starts a local dev server, a globe appears on its thread. Select it to open the
 server in T3 Code's browser. T3 Code recognizes Portless routes, Tailscale Serve routes, and active
-ngrok HTTP tunnels, then opens their named or public URL instead of the underlying `localhost` port.
-When several are available, the shortcut prefers ngrok, then Tailscale Serve, then Portless, then
-the underlying local address.
+ngrok HTTP tunnels. It opens their named or public URL when supported; for Portless routes in remote
+environments, it opens the underlying listener's port instead. When several are available, the
+shortcut prefers ngrok, then Tailscale Serve, then Portless, then the underlying local address.

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -115,5 +115,5 @@ finishes; the call's own result shows its status.
 ## Dev server shortcuts
 
 When a terminal starts a local dev server, a globe appears on its thread. Select it to open the
-server in T3 Code's browser. T3 Code recognizes Portless routes and opens their stable named URL
-instead of the underlying `localhost` port.
+server in T3 Code's browser. T3 Code recognizes Portless routes and active ngrok HTTP tunnels, then
+opens their named or public URL instead of the underlying `localhost` port.

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -115,5 +115,7 @@ finishes; the call's own result shows its status.
 ## Dev server shortcuts
 
 When a terminal starts a local dev server, a globe appears on its thread. Select it to open the
-server in T3 Code's browser. T3 Code recognizes Portless routes and active ngrok HTTP tunnels, then
-opens their named or public URL instead of the underlying `localhost` port.
+server in T3 Code's browser. T3 Code recognizes Portless routes, Tailscale Serve routes, and active
+ngrok HTTP tunnels, then opens their named or public URL instead of the underlying `localhost` port.
+When several are available, the shortcut prefers ngrok, then Tailscale Serve, then Portless, then
+the underlying local address.

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -111,3 +111,9 @@ On web and desktop, use **Agents** to follow work delegated to subagents.
 Expand a tool call in the conversation to see its full command and output.
 Summaries shorten shell wrappers and can still describe the latest call after it
 finishes; the call's own result shows its status.
+
+## Dev server shortcuts
+
+When a terminal starts a local dev server, a globe appears on its thread. Select it to open the
+server in T3 Code's browser. T3 Code recognizes Portless routes and opens their stable named URL
+instead of the underlying `localhost` port.

--- a/packages/contracts/src/preview.test.ts
+++ b/packages/contracts/src/preview.test.ts
@@ -303,12 +303,14 @@ describe("DiscoveredLocalServer", () => {
       host: "localhost",
       port: 5173,
       url: "http://localhost:5173",
+      urlKind: "public-tunnel",
       processName: "node",
       pid: 12345,
       terminal: null,
     });
     expect(server.port).toBe(5173);
     expect(server.processName).toBe("node");
+    expect(server.urlKind).toBe("public-tunnel");
   });
 
   it("decodes a server without process metadata", () => {

--- a/packages/contracts/src/preview.ts
+++ b/packages/contracts/src/preview.ts
@@ -299,7 +299,7 @@ export type PreviewEvent = typeof PreviewEvent.Type;
 
 /**
  * A local server detected by the port scanner. `url` may be a named local
- * proxy URL while `host` and `port` identify the underlying listener.
+ * proxy or public tunnel URL while `host` and `port` identify the underlying listener.
  */
 export const DiscoveredLocalServer = Schema.Struct({
   host: TrimmedNonEmptyString,

--- a/packages/contracts/src/preview.ts
+++ b/packages/contracts/src/preview.ts
@@ -298,8 +298,8 @@ export const PreviewEvent = Schema.Union([
 export type PreviewEvent = typeof PreviewEvent.Type;
 
 /**
- * A localhost server detected by the port scanner. Used to populate the
- * "Local" recommendations in the empty-state of the preview panel.
+ * A local server detected by the port scanner. `url` may be a named local
+ * proxy URL while `host` and `port` identify the underlying listener.
  */
 export const DiscoveredLocalServer = Schema.Struct({
   host: TrimmedNonEmptyString,

--- a/packages/contracts/src/preview.ts
+++ b/packages/contracts/src/preview.ts
@@ -299,7 +299,7 @@ export type PreviewEvent = typeof PreviewEvent.Type;
 
 /**
  * A local server detected by the port scanner. `url` may be a named local
- * proxy or public tunnel URL while `host` and `port` identify the underlying listener.
+ * proxy or tunnel URL while `host` and `port` identify the underlying listener.
  */
 export const DiscoveredLocalServerUrlKind = Schema.Literals(["local-proxy", "public-tunnel"]);
 export type DiscoveredLocalServerUrlKind = typeof DiscoveredLocalServerUrlKind.Type;

--- a/packages/contracts/src/preview.ts
+++ b/packages/contracts/src/preview.ts
@@ -301,10 +301,14 @@ export type PreviewEvent = typeof PreviewEvent.Type;
  * A local server detected by the port scanner. `url` may be a named local
  * proxy or public tunnel URL while `host` and `port` identify the underlying listener.
  */
+export const DiscoveredLocalServerUrlKind = Schema.Literals(["local-proxy", "public-tunnel"]);
+export type DiscoveredLocalServerUrlKind = typeof DiscoveredLocalServerUrlKind.Type;
+
 export const DiscoveredLocalServer = Schema.Struct({
   host: TrimmedNonEmptyString,
   port: Schema.Int.check(Schema.isGreaterThan(0)).check(Schema.isLessThan(65536)),
   url: Url,
+  urlKind: Schema.optional(DiscoveredLocalServerUrlKind),
   processName: Schema.NullOr(TrimmedNonEmptyString),
   pid: Schema.NullOr(Schema.Int.check(Schema.isGreaterThan(0))),
   terminal: Schema.NullOr(


### PR DESCRIPTION
## Demo

<img width="265" height="107" alt="Portless route in the sidebar" src="https://github.com/user-attachments/assets/e6ce9c46-d106-4a13-9abd-87d1723873fe" />
<img width="332" height="105" alt="Portless route in the browser" src="https://github.com/user-attachments/assets/299648c9-1569-40ae-be12-226db42063da" />

## Problem

T3 Code exposed underlying localhost listeners for named dev-server routes and tunnels, so the sidebar and browser could open transient local ports instead of stable URLs.

## What changed

- discover and validate Portless route state, active ngrok HTTP tunnels, and Tailscale Serve status
- enrich localhost listeners with named URLs while preserving configured paths, Tailscale mounts, and app-terminal ownership
- prefer the current-worktree shortcut in this order: ngrok, Tailscale Serve, Portless, localhost
- open ngrok and Tailscale URLs directly in remote environments; remote Portless falls back to the underlying listener port
- apply the behavior across the current sidebar, legacy sidebar, browser empty state, and preview surfaces

## Validation

- `vp test run apps/server/src/preview/PortScanner.test.ts apps/web/src/browser/browserTargetResolver.test.ts apps/web/src/components/preview/PreviewEmptyState.test.tsx apps/web/src/components/preview/useDiscoveredLocalServers.test.ts packages/contracts/src/preview.test.ts` (104 tests passed)
- `vp run --filter t3 --filter @t3tools/web --filter @t3tools/contracts typecheck`
- focused lint on changed files
- integrated T3 Code desktop pass with isolated Portless, ngrok, and Tailscale fixtures; verified all named routes and ngrok shortcut priority

Built with GPT-5.6 in the Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add discovery for Portless, ngrok, and Tailscale Serve dev server URLs
> - Add schemas and parsers in [PortScanner.ts](https://github.com/pingdotgg/t3code/pull/6514/files#diff-0f6b3292e660acf982893ba130c26e1ffa8f91ff09032cce9b07d55074e296f4) to convert Portless, ngrok, and Tailscale Serve metadata into named routes keyed by the underlying listener port.
> - Add `DiscoveredLocalServerUrlKind` contract type in [preview.ts](https://github.com/pingdotgg/t3code/pull/6514/files#diff-77fe1c85162b7ba16ab070d87c12024e0eb68eeebd0b5272e481eec4ecf0bb39) to classify URLs as `local-proxy` or `public-tunnel`.
> - Update the browser target resolver and preview UI components (e.g. Sidebar, PreviewView) to resolve, display, and open named URLs directly.
> - Risk: `resolveDiscoveredServerUrl` in [browserTargetResolver.ts](https://github.com/pingdotgg/t3code/pull/6514/files#diff-d3c7988731a040ddf1171c7c3b826a4b211a89884507fdb562b4bb24fe5aba39) changes how local-proxy URLs resolve on remote environments; they now use the underlying target port instead of the proxy port.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a9b9834.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds filesystem reads, subprocess calls, and localhost HTTP to ngrok during every scan; URL rewriting and remote Portless fallback affect which address the embedded browser loads.
> 
> **Overview**
> **Port discovery** now enriches loopback listeners with stable URLs from **Portless** state files, the **ngrok** agent API, and **`tailscale serve status`**, tagging routes with optional `urlKind` (`local-proxy` | `public-tunnel`). Scans merge routes by target port (ngrok wins over Tailscale over Portless), skip HTTP probing on confirmed ngrok agent ports, and preserve configured paths and app-terminal ownership when rewriting URLs.
> 
> **Preview navigation** passes listener port and `urlKind` through `resolveDiscoveredServerUrl`: Portless names open as-is on local environments but map to the environment host + listener port when remote; ngrok and Tailscale URLs open directly. Sidebar and preview empty state use **`selectPreferredDiscoveredServer`** (ngrok → Tailscale → Portless → plain localhost) and show **`formatDiscoveredServerHost`** on the globe shortcut.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaf046b1cc772341e7d7fdeaf83ef410f471b734. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Discovered development servers now support Portless, ngrok, and Tailscale Serve routes.
  - Added sidebar shortcuts for opening preferred discovered servers directly in the preview.
  - Preview links preserve named routes and map remote proxy URLs to their listener ports.
  - Server labels show useful proxy, tunnel, or tailnet hostnames.
  - Added a preferred-server order for selecting the most relevant discovered endpoint.

- **Documentation**
  - Documented development-server shortcuts, supported route types, fallback behavior, and URL preference order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->