### PR TITLE
fix(web): keep following the stream after scrolling back to the live edge

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1185,6 +1185,20 @@ function chatActionErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "An error occurred.";
 }
 
+/**
+ * Drops the send-time anchored end space. That space is what holds a sent
+ * message near the top while its turn streams, and it keeps LegendList's
+ * maintainScrollAtEnd switched off for as long as it is installed — ChatView
+ * drives the streaming scrolls itself, but only in "anchoring-new-turn" mode.
+ * So every return to the live edge has to release the anchor too, otherwise the
+ * timeline settles into "following-end" with nothing following anything.
+ */
+function releaseChatTimelineAnchor<T extends { readonly messageId: MessageId | null }>(
+  current: T,
+): T {
+  return current.messageId === null ? current : { ...current, messageId: null };
+}
+
 function ChatViewContent(props: ChatViewProps) {
   const {
     environmentId,
@@ -3744,9 +3758,7 @@ function ChatViewContent(props: ChatViewProps) {
     activeTimelineAnchorIndexRef.current = null;
     showScrollDebouncer.current.cancel();
     setShowScrollToBottom(false);
-    setTimelineAnchor((current) =>
-      current.messageId === null ? current : { ...current, messageId: null },
-    );
+    setTimelineAnchor(releaseChatTimelineAnchor);
     requestAnimationFrame(() => {
       void legendListRef.current?.scrollToEnd?.({ animated });
     });
@@ -3921,6 +3933,11 @@ function ChatViewContent(props: ChatViewProps) {
       timelineScrollModeRef.current = "following-end";
       liveFollowUserScrollGenerationRef.current = anchorUserScrollGenerationRef.current;
       setTimelineLiveFollowEnabled(true);
+      // Reachable only once manual navigation has already broken follow, so
+      // the anchored turn framing is over: the user scrolled back to the live
+      // edge and expects the stream to stick to it again, exactly like the
+      // scroll-to-bottom pill.
+      setTimelineAnchor(releaseChatTimelineAnchor);
       showScrollDebouncer.current.cancel();
       setShowScrollToBottom(false);
     } else {

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -432,6 +432,56 @@ describe("MessagesTimeline", () => {
     expect(onAnchorReady).toHaveBeenCalledWith(secondEntry.message.id, 1);
   });
 
+  it("hands end-following back to the list once the send anchor is released", () => {
+    const firstEntry = buildUserTimelineEntry("First prompt.");
+    const secondEntry = {
+      ...buildUserTimelineEntry("Newest prompt."),
+      id: "entry-2",
+      message: {
+        ...buildUserTimelineEntry("Newest prompt.").message,
+        id: MessageId.make("message-2"),
+      },
+    };
+    const timelineEntries = [firstEntry, secondEntry];
+
+    // While the send anchor holds the end space open, ChatView owns streaming
+    // scrolls and LegendList must not re-pin behind it.
+    expect(
+      renderToStaticMarkup(
+        <MessagesTimeline
+          {...buildProps()}
+          anchorMessageId={secondEntry.message.id}
+          timelineEntries={timelineEntries}
+        />,
+      ),
+    ).not.toContain('data-maintain-scroll-at-end="enabled"');
+
+    // Dropping the anchor is what actually gives end-following back, so
+    // returning to the live edge has to release it — re-enabling live follow
+    // alone leaves nothing pinned to the stream.
+    expect(
+      renderToStaticMarkup(
+        <MessagesTimeline
+          {...buildProps()}
+          anchorMessageId={null}
+          timelineEntries={timelineEntries}
+        />,
+      ),
+    ).toContain('data-maintain-scroll-at-end="enabled"');
+
+    // Reading history still wins over both.
+    expect(
+      renderToStaticMarkup(
+        <MessagesTimeline
+          {...buildProps()}
+          anchorMessageId={null}
+          liveFollowEnabled={false}
+          timelineEntries={timelineEntries}
+        />,
+      ),
+    ).not.toContain('data-maintain-scroll-at-end="enabled"');
+  });
+
   it("renders collapse controls for long user messages", () => {
     const markup = renderToStaticMarkup(
       <MessagesTimeline


### PR DESCRIPTION
## What Changed

Releases the send-time anchored end space when the chat timeline re-arms live follow, so scrolling back down to the live edge during a streaming turn actually resumes following it.

One call site changed: the `isAtEnd` branch of `onIsAtEndChange` in `ChatView.tsx` now drops the timeline anchor, the same way `scrollToEnd` already did for the scroll-to-bottom pill. The shared updater is named `releaseChatTimelineAnchor` so the reason lives in one place.

## Why

While the anchored end space is installed (it holds a sent message near the top while its turn streams), `MessagesTimeline` deliberately passes `maintainScrollAtEnd={false}`, and ChatView drives the streaming scrolls itself — but only while `timelineScrollModeRef` is `"anchoring-new-turn"`.

Scrolling up mid-turn switches the mode to `"free-scrolling"` and intentionally keeps the anchor installed (collapsing it mid-gesture would clamp the viewport back to the end). Scrolling back down then re-armed follow — mode `"following-end"`, `liveFollowEnabled` true — but left the anchor in place. Neither mechanism was pinning the list any more:

- LegendList's `maintainScrollAtEnd` stayed off, because the anchor was still there.
- The anchoring effect no longer ran, because the mode was no longer `"anchoring-new-turn"`.

So further output kept appending below the viewport, and the scroll-to-bottom pill stayed hidden because the list *did* consider itself at the end. Reopening the thread (which clears the anchor) was the only way to recover.

The re-arm branch is only reachable once manual navigation has already broken follow, so the send-time "keep the sent message at the top" framing during normal streaming is unaffected.

## UI Changes

Interaction-only; no static visual difference, so no before/after screenshots apply.

Reproduction: send a prompt whose response fills more than a screen; while it is streaming, scroll up, then scroll back to the bottom. Before this change, subsequent output ran off the bottom of the viewport with no pill and no way back except switching threads. After it, the timeline sticks to the live edge again.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes — not applicable, nothing static changes
- [ ] I included a video for animation/interaction changes — not applicable, didn't change visuals, only fixed a behaviour issue


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to chat scroll/anchor state in ChatView with a regression test; no auth, data, or API changes.
> 
> **Overview**
> Fixes chat **live-edge follow** after you scroll up during a streaming turn and then scroll back down.
> 
> The send-time **timeline anchor** keeps LegendList’s `maintainScrollAtEnd` off while ChatView drives scroll in anchoring mode. Re-arming follow (mode + `liveFollowEnabled`) used to leave that anchor in place, so new output could grow below the viewport with no scroll-to-bottom affordance. **`releaseChatTimelineAnchor`** centralizes clearing the anchor; it’s now invoked when the user returns to the end (same as the scroll-to-bottom path), not only from `scrollToEnd`.
> 
> Adds a **MessagesTimeline** test that `data-maintain-scroll-at-end="enabled"` returns once `anchorMessageId` is null while live follow is on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a02177d20f2ced7bf411c3e54cfc37d02a81b73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->