### PR TITLE
feat(mobile): let Android collapse the thread sidebar

### DIFF
--- a/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
+++ b/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
@@ -11,7 +11,7 @@ import {
   ThreadId,
 } from "@t3tools/contracts";
 
-import { AndroidScreenHeader } from "../../components/AndroidScreenHeader";
+import { AndroidHeaderIconButton, AndroidScreenHeader } from "../../components/AndroidScreenHeader";
 import { SymbolView } from "../../components/AppSymbol";
 import { AppText as Text, AppTextInput as TextInput } from "../../components/AppText";
 import { EmptyState } from "../../components/EmptyState";
@@ -408,6 +408,21 @@ export function ThreadFilesTreeScreen(props: ThreadFilesRouteScreenProps) {
                 onPress: entriesQuery.refresh,
               },
             ]}
+            trailing={
+              layout.usesSplitView ? (
+                <AndroidHeaderIconButton
+                  accessibilityLabel={
+                    panes.primarySidebarVisible ? "Maximize files" : "Show threads"
+                  }
+                  icon={
+                    panes.primarySidebarVisible
+                      ? "arrow.up.left.and.arrow.down.right"
+                      : "sidebar.left"
+                  }
+                  onPress={togglePrimarySidebar}
+                />
+              ) : null
+            }
           />
           <View className="flex-row items-center gap-2 border-b border-border px-3 py-2">
             <SymbolView name="magnifyingglass" size={17} tintColor={iconColor} type="monochrome" />

--- a/apps/mobile/src/features/home/HomeRouteScreen.tsx
+++ b/apps/mobile/src/features/home/HomeRouteScreen.tsx
@@ -2,12 +2,14 @@ import * as Arr from "effect/Array";
 import * as Order from "effect/Order";
 import { useNavigation } from "@react-navigation/native";
 import { useEffect, useMemo, useState } from "react";
+import { Platform } from "react-native";
 
 import { NativeHeaderToolbar, NativeStackScreenOptions } from "../../native/StackHeader";
 import { useProjects, useThreadShells } from "../../state/entities";
 import { usePendingNewTasks } from "../../state/use-pending-new-tasks";
 import { useWorkspaceState } from "../../state/workspace";
 import { useSavedRemoteConnections } from "../../state/use-remote-environment-registry";
+import { shouldOfferSidebarReveal } from "../../lib/layout";
 import { useAdaptiveWorkspaceLayout } from "../layout/AdaptiveWorkspaceLayout";
 import { WorkspaceEmptyDetail } from "../layout/WorkspaceEmptyDetail";
 import { WorkspaceSidebarToolbar } from "../layout/workspace-sidebar-toolbar";
@@ -24,7 +26,7 @@ import { getConnectionAwareBrandHeaderOptions } from "./WorkspaceConnectionTitle
 /* ─── Route screen ───────────────────────────────────────────────────── */
 
 export function HomeRouteScreen() {
-  const { layout } = useAdaptiveWorkspaceLayout();
+  const { layout, panes, togglePrimarySidebar } = useAdaptiveWorkspaceLayout();
   const projects = useProjects();
   const threads = useThreadShells();
   const { environments: workspaceEnvironments, state: catalogState } = useWorkspaceState();
@@ -118,6 +120,18 @@ export function HomeRouteScreen() {
           }
         />
         <WorkspaceEmptyDetail
+          // Android draws no header on this route, so the pane itself has to
+          // offer the sidebar back. iOS gets it from WorkspaceSidebarToolbar.
+          onShowSidebar={
+            shouldOfferSidebarReveal({
+              primarySidebarVisible: panes.primarySidebarVisible,
+              // iOS carries it in this route's navigation bar; Android draws
+              // no header here at all.
+              hasHeaderSidebarToggle: Platform.OS !== "android",
+            })
+              ? togglePrimarySidebar
+              : undefined
+          }
           onStartNewTask={() => navigation.navigate("NewTaskSheet", { screen: "NewTask" })}
         />
       </>

--- a/apps/mobile/src/features/layout/WorkspaceEmptyDetail.tsx
+++ b/apps/mobile/src/features/layout/WorkspaceEmptyDetail.tsx
@@ -4,7 +4,15 @@ import { Pressable, View } from "react-native";
 import { AppText as Text } from "../../components/AppText";
 import { useThemeColor } from "../../lib/useThemeColor";
 
-export function WorkspaceEmptyDetail(props: { readonly onStartNewTask?: () => void }) {
+export function WorkspaceEmptyDetail(props: {
+  readonly onStartNewTask?: () => void;
+  /**
+   * Passed only while the sidebar is hidden and this route's header has no
+   * toggle of its own — otherwise the pane points at a sidebar that is not on
+   * screen and cannot be brought back.
+   */
+  readonly onShowSidebar?: () => void;
+}) {
   const iconColor = useThemeColor("--color-icon-subtle");
 
   return (
@@ -12,18 +20,31 @@ export function WorkspaceEmptyDetail(props: { readonly onStartNewTask?: () => vo
       <View className="max-w-[360px] items-center gap-3">
         <SymbolView name="sidebar.left" size={34} tintColor={iconColor} type="hierarchical" />
         <Text className="text-center text-xl font-t3-bold">Select a thread</Text>
+        {/* Deliberately does not name the sidebar: this pane also renders when
+            the sidebar is hidden. Mirrors the web empty state. */}
         <Text className="text-center text-base text-foreground-muted">
-          Choose a thread from the sidebar or start a new task.
+          Select an existing thread or start a new task.
         </Text>
-        {props.onStartNewTask ? (
-          <Pressable
-            accessibilityRole="button"
-            className="mt-2 flex-row items-center gap-2 rounded-full bg-primary px-5 py-3 active:opacity-70"
-            onPress={props.onStartNewTask}
-          >
-            <Text className="text-base font-t3-bold text-primary-foreground">New Task</Text>
-          </Pressable>
-        ) : null}
+        <View className="mt-2 flex-row flex-wrap items-center justify-center gap-2">
+          {props.onShowSidebar ? (
+            <Pressable
+              accessibilityRole="button"
+              className="flex-row items-center gap-2 rounded-full bg-subtle px-5 py-3 active:opacity-70"
+              onPress={props.onShowSidebar}
+            >
+              <Text className="text-base font-t3-bold text-foreground">Show sidebar</Text>
+            </Pressable>
+          ) : null}
+          {props.onStartNewTask ? (
+            <Pressable
+              accessibilityRole="button"
+              className="flex-row items-center gap-2 rounded-full bg-primary px-5 py-3 active:opacity-70"
+              onPress={props.onStartNewTask}
+            >
+              <Text className="text-base font-t3-bold text-primary-foreground">New Task</Text>
+            </Pressable>
+          ) : null}
+        </View>
       </View>
     </View>
   );

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -22,6 +22,7 @@ import { vcsEnvironment } from "../../state/vcs";
 
 import { EmptyState } from "../../components/EmptyState";
 import {
+  AndroidHeaderIconButton,
   AndroidScreenHeader,
   type AndroidHeaderAction,
 } from "../../components/AndroidScreenHeader";
@@ -858,6 +859,21 @@ function ThreadRouteContent(
           subtitle={headerSubtitle}
           onBack={layout.usesSplitView ? undefined : () => navigation.goBack()}
           actions={androidHeaderActions}
+          trailing={
+            layout.usesSplitView ? (
+              <AndroidHeaderIconButton
+                accessibilityLabel={
+                  panes.primarySidebarVisible ? "Maximize content" : "Show thread sidebar"
+                }
+                icon={
+                  panes.primarySidebarVisible
+                    ? "arrow.up.left.and.arrow.down.right"
+                    : "sidebar.left"
+                }
+                onPress={togglePrimarySidebar}
+              />
+            ) : null
+          }
         />
       ) : null}
 

--- a/apps/mobile/src/lib/layout.test.ts
+++ b/apps/mobile/src/lib/layout.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   constrainAuxiliaryPaneWidth,
+  shouldOfferSidebarReveal,
   constrainPrimarySidebarWidth,
   deriveCenteredContentHorizontalPadding,
   deriveFileInspectorPaneLayout,
@@ -339,5 +340,25 @@ describe("deriveStableFormSheetDetent", () => {
     { height: 0, expected: 0.92 },
   ])("derives a stable sheet detent for height $height", ({ height, expected }) => {
     expect(deriveStableFormSheetDetent(height)).toBe(expected);
+  });
+});
+
+describe("shouldOfferSidebarReveal", () => {
+  it("offers the sidebar back when it is hidden and the header has no toggle", () => {
+    expect(
+      shouldOfferSidebarReveal({ primarySidebarVisible: false, hasHeaderSidebarToggle: false }),
+    ).toBe(true);
+  });
+
+  it("stays quiet while the sidebar is on screen", () => {
+    expect(
+      shouldOfferSidebarReveal({ primarySidebarVisible: true, hasHeaderSidebarToggle: false }),
+    ).toBe(false);
+  });
+
+  it("defers to a header that already carries the toggle", () => {
+    expect(
+      shouldOfferSidebarReveal({ primarySidebarVisible: false, hasHeaderSidebarToggle: true }),
+    ).toBe(false);
   });
 });

--- a/apps/mobile/src/lib/layout.ts
+++ b/apps/mobile/src/lib/layout.ts
@@ -254,3 +254,17 @@ export function deriveStableFormSheetDetent(containerHeight: number): number {
   );
   return Math.round(detent * 1_000) / 1_000;
 }
+
+/**
+ * Whether a detail pane has to offer the sidebar back itself.
+ *
+ * True only when the sidebar is hidden AND this surface's header has no toggle
+ * of its own — Android's split-view Home draws no header at all, so without
+ * this the sidebar can be hidden there and never recovered.
+ */
+export function shouldOfferSidebarReveal(input: {
+  readonly primarySidebarVisible: boolean;
+  readonly hasHeaderSidebarToggle: boolean;
+}): boolean {
+  return !input.primarySidebarVisible && !input.hasHeaderSidebarToggle;
+}


### PR DESCRIPTION
On Android split view the thread list was permanent: iOS reaches `togglePrimarySidebar` from its navigation-bar items, but Android's in-flow headers never offered it, so on an unfolded foldable the sidebar ate ~360dp of the widest screen the app runs on. (The terminal header was the one exception — it already had the toggle.)

Adds the toggle to the Android thread and file-tree headers the same way `ThreadTerminalRouteScreen` already does it — `trailing` + `AndroidHeaderIconButton`, same icon pair, same `layout.usesSplitView` guard, labels matching each surface's iOS counterpart. No new abstractions, no shared components touched.

It also closes a reverse-state hole that hiding the sidebar would otherwise open. `AGENTS.md`: *"If you added a way in, add the way out and the way to see it… A one-way door is a bug."* Android's split-view Home draws no header at all, so collapsing the sidebar and pressing back stranded you on an empty pane with no affordance to bring it back. `WorkspaceEmptyDetail` now offers it whenever the sidebar is hidden and the surface's header has no toggle of its own. That pane's copy no longer names the sidebar either, since it renders in both states — matching the web empty state, which says "Select an existing thread…" rather than pointing at chrome that may not be there.

## Test plan

- `tsc --noEmit` clean; `pnpm lint` clean; mobile suite passing, +3 tests covering `shouldOfferSidebarReveal` (inverting it is what recreates the one-way door)
- Verified on a Pixel 9 Pro Fold emulator (inner display, 852dp × 883dp):
  - Thread header: collapse → chat spans full width, icon flips to `sidebar.left`; reveal restores
  - Collapse → hardware back to Home → **Show sidebar** is offered and restores the sidebar
  - Re-run at **779dp** to exercise the file-tree header, which only renders between 720–819dp (above that the inspector path takes over): "Maximize files" appears, collapses, and stays recoverable

## Known gap

The file *viewer* route (`ThreadFilesRouteScreen.tsx`, `ThreadFileScreen`) still has no toggle on Android — it renders `WorkspaceSidebarToolbar`, which is `null` there. It is recoverable in one tap via the native back button to the tree, which does have the toggle. Closing it means adding a second header to a screen that already shows a native one, so I left it out of this PR.

---
Claude Opus 5 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mobile layout and header UI only; no auth, data, or API changes. Risk is limited to split-view navigation affordances on Android.
> 
> **Overview**
> **Android split view** can now hide and restore the thread list via `togglePrimarySidebar`, matching iOS and the existing terminal header pattern. **Thread** and **Files** tree routes get a trailing `AndroidHeaderIconButton` (maximize / show threads icons) when `layout.usesSplitView` is true.
> 
> Collapsing the sidebar no longer strands users on split-view **Home**, which has no Android header. `shouldOfferSidebarReveal` drives when the empty detail must offer recovery; `WorkspaceEmptyDetail` adds an optional **Show sidebar** action and copy that no longer assumes the sidebar is visible.
> 
> Unit tests cover `shouldOfferSidebarReveal` (hidden sidebar + no header toggle → offer reveal).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e300e46e13bfef3fd4bfebddd19b177a643f56e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add sidebar toggle button to Android split-view screens
> - Adds a toggle button to the `AndroidScreenHeader` in the thread and files detail screens, allowing users to show or hide the primary sidebar in split-view mode on Android.
> - Adds a `shouldOfferSidebarReveal` utility in [layout.ts](https://github.com/pingdotgg/t3code/pull/6521/files#diff-3ec9d5e0285c42e8cc3bb4d432f83eb9ebfe2be1f270c01367d25528afc76cac) that returns true when the sidebar is hidden and the current screen header has no toggle of its own.
> - Uses this utility in `HomeRouteScreen` to conditionally render a "Show sidebar" button in the empty detail pane (via `WorkspaceEmptyDetail`), covering the Android home screen which has no header toggle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6e300e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->