### PR TITLE
fix(files): rescan workspace on explicit refresh

### DIFF
--- a/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
+++ b/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
@@ -24,6 +24,7 @@ import { useThreadSelection } from "../../state/use-thread-selection";
 import { useSelectedThreadWorktree } from "../../state/use-selected-thread-worktree";
 import { useEnvironmentQuery } from "../../state/query";
 import { projectEnvironment } from "../../state/projects";
+import { useAtomCommand } from "../../state/use-atom-command";
 import {
   useAdaptiveWorkspaceLayout,
   useAdaptiveWorkspacePaneRole,
@@ -259,6 +260,17 @@ export function ThreadFilesTreeScreen(props: ThreadFilesRouteScreenProps) {
       : null,
   );
   const entriesData = entriesQuery.data as ProjectListEntriesResult | null;
+  const [isRefreshingEntries, setIsRefreshingEntries] = useState(false);
+  const refreshEntries = useAtomCommand(projectEnvironment.refreshEntries, {
+    reportFailure: false,
+  });
+  const handleRefreshEntries = useCallback(() => {
+    if (environmentId === null || cwd === null || isRefreshingEntries) return;
+    setIsRefreshingEntries(true);
+    void refreshEntries({ environmentId, input: { cwd } }).finally(() => {
+      setIsRefreshingEntries(false);
+    });
+  }, [cwd, environmentId, isRefreshingEntries, refreshEntries]);
   const handleReturnToThread = useCallback(() => {
     if (navigation.canGoBack()) {
       navigation.goBack();
@@ -405,7 +417,7 @@ export function ThreadFilesTreeScreen(props: ThreadFilesRouteScreenProps) {
               {
                 accessibilityLabel: "Refresh files",
                 icon: "arrow.clockwise",
-                onPress: entriesQuery.refresh,
+                onPress: handleRefreshEntries,
               },
             ]}
           />
@@ -448,11 +460,11 @@ export function ThreadFilesTreeScreen(props: ThreadFilesRouteScreenProps) {
       <FileTreeBrowser
         entries={entriesData?.entries ?? []}
         error={entriesQuery.error}
-        isPending={entriesQuery.isPending}
+        isPending={entriesQuery.isPending || isRefreshingEntries}
         searchQuery={searchQuery}
         selectedPath={null}
         onPreviewFile={handlePreviewFile}
-        onRefresh={entriesQuery.refresh}
+        onRefresh={handleRefreshEntries}
         onSelectFile={handleSelectFile}
       />
       <FilesToolbarBottomFade />

--- a/apps/mobile/src/features/files/thread-file-navigator-pane.tsx
+++ b/apps/mobile/src/features/files/thread-file-navigator-pane.tsx
@@ -15,6 +15,7 @@ import { nativeHeaderScrollEdgeEffects } from "../../native/StackHeader";
 import { useThemeColor } from "../../lib/useThemeColor";
 import { projectEnvironment } from "../../state/projects";
 import { useEnvironmentQuery } from "../../state/query";
+import { useAtomCommand } from "../../state/use-atom-command";
 import { FileTreeBrowser } from "./FileTreeBrowser";
 import { preloadWorkspaceFileContents } from "./preload-workspace-file";
 
@@ -40,6 +41,19 @@ export function ThreadFileNavigatorPane(props: {
     }),
   );
   const entriesData = entriesQuery.data as ProjectListEntriesResult | null;
+  const [isRefreshingEntries, setIsRefreshingEntries] = useState(false);
+  const refreshEntries = useAtomCommand(projectEnvironment.refreshEntries, {
+    reportFailure: false,
+  });
+  const handleRefreshEntries = useCallback(() => {
+    if (isRefreshingEntries) return;
+    setIsRefreshingEntries(true);
+    void refreshEntries({ environmentId: props.environmentId, input: { cwd: props.cwd } }).finally(
+      () => {
+        setIsRefreshingEntries(false);
+      },
+    );
+  }, [isRefreshingEntries, props.cwd, props.environmentId, refreshEntries]);
   const handlePreviewFile = useCallback(
     (relativePath: string) => {
       preloadWorkspaceFileContents({
@@ -58,25 +72,25 @@ export function ThreadFileNavigatorPane(props: {
           accessibilityLabel: "Refresh files",
           icon: { name: "arrow.clockwise", type: "sfSymbol" as const },
           identifier: "thread-file-navigator-refresh",
-          onPress: entriesQuery.refresh,
+          onPress: handleRefreshEntries,
           sharesBackground: false,
           tintColor: foregroundColor,
           type: "button" as const,
           width: 44,
         },
       ] as ComponentProps<typeof ScreenStackHeaderConfig>["headerRightBarButtonItems"],
-    [entriesQuery.refresh, foregroundColor],
+    [foregroundColor, handleRefreshEntries],
   );
 
   const fileTree = (
     <FileTreeBrowser
       entries={entriesData?.entries ?? []}
       error={entriesQuery.error}
-      isPending={entriesQuery.isPending}
+      isPending={entriesQuery.isPending || isRefreshingEntries}
       searchQuery={searchQuery}
       selectedPath={props.selectedPath}
       onPreviewFile={handlePreviewFile}
-      onRefresh={entriesQuery.refresh}
+      onRefresh={handleRefreshEntries}
       onSelectFile={props.onSelectFile}
     />
   );
@@ -150,7 +164,7 @@ export function ThreadFileNavigatorPane(props: {
             accessibilityLabel="Refresh files"
             hitSlop={8}
             className="h-8 w-8 items-center justify-center rounded-full active:bg-subtle"
-            onPress={entriesQuery.refresh}
+            onPress={handleRefreshEntries}
           >
             <SymbolView name="arrow.clockwise" size={14} tintColor={iconColor} type="monochrome" />
           </Pressable>

--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -76,6 +76,7 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.sourceControlCloneRepository]: AuthOrchestrationOperateScope,
   [WS_METHODS.sourceControlPublishRepository]: AuthOrchestrationOperateScope,
   [WS_METHODS.projectsListEntries]: AuthOrchestrationReadScope,
+  [WS_METHODS.projectsRefreshEntries]: AuthOrchestrationReadScope,
   [WS_METHODS.projectsReadFile]: AuthOrchestrationReadScope,
   [WS_METHODS.projectsSearchContents]: AuthOrchestrationReadScope,
   [WS_METHODS.projectsSearchEntries]: AuthOrchestrationReadScope,

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -4769,6 +4769,67 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
     }).pipe(Effect.provide(NodeHttpServer.layerTest), TestClock.withLive),
   );
 
+  it.effect("refreshes external workspace creates, moves, and deletes before re-listing", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const workspaceDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-ws-project-refresh-" });
+      yield* fs.writeFileString(path.join(workspaceDir, "existing.ts"), "export {}\n");
+      yield* fs.writeFileString(path.join(workspaceDir, "move-before-refresh.ts"), "export {}\n");
+      yield* fs.writeFileString(path.join(workspaceDir, "delete-before-refresh.ts"), "export {}\n");
+
+      yield* buildAppUnderTest();
+
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const response = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          Effect.gen(function* () {
+            yield* client[WS_METHODS.projectsListEntries]({ cwd: workspaceDir });
+            yield* fs.writeFileString(
+              path.join(workspaceDir, "created-outside-t3.ts"),
+              "export {}\n",
+            );
+            yield* fs.rename(
+              path.join(workspaceDir, "move-before-refresh.ts"),
+              path.join(workspaceDir, "moved-outside-t3.ts"),
+            );
+            yield* fs.remove(path.join(workspaceDir, "delete-before-refresh.ts"));
+            const beforeRefresh = yield* client[WS_METHODS.projectsListEntries]({
+              cwd: workspaceDir,
+            });
+            yield* client[WS_METHODS.projectsRefreshEntries]({ cwd: workspaceDir });
+            const afterRefresh = yield* client[WS_METHODS.projectsListEntries]({
+              cwd: workspaceDir,
+            });
+            return { beforeRefresh, afterRefresh };
+          }),
+        ),
+      );
+
+      assert.isFalse(
+        response.beforeRefresh.entries.some((entry) => entry.path === "created-outside-t3.ts"),
+      );
+      assert.isTrue(
+        response.beforeRefresh.entries.some((entry) => entry.path === "move-before-refresh.ts"),
+      );
+      assert.isTrue(
+        response.beforeRefresh.entries.some((entry) => entry.path === "delete-before-refresh.ts"),
+      );
+      assert.isTrue(
+        response.afterRefresh.entries.some((entry) => entry.path === "created-outside-t3.ts"),
+      );
+      assert.isFalse(
+        response.afterRefresh.entries.some((entry) => entry.path === "move-before-refresh.ts"),
+      );
+      assert.isTrue(
+        response.afterRefresh.entries.some((entry) => entry.path === "moved-outside-t3.ts"),
+      );
+      assert.isFalse(
+        response.afterRefresh.entries.some((entry) => entry.path === "delete-before-refresh.ts"),
+      );
+    }).pipe(Effect.provide(NodeHttpServer.layerTest), TestClock.withLive),
+  );
+
   it.effect("routes websocket rpc projects.searchEntries excludes gitignored files", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1789,6 +1789,10 @@ const makeWsRpcLayer = (
             ),
             { "rpc.aggregate": "workspace" },
           ),
+        [WS_METHODS.projectsRefreshEntries]: (input) =>
+          observeRpcEffect(WS_METHODS.projectsRefreshEntries, workspaceEntries.refresh(input.cwd), {
+            "rpc.aggregate": "workspace",
+          }),
         [WS_METHODS.projectsReadFile]: (input) =>
           observeRpcEffect(
             WS_METHODS.projectsReadFile,

--- a/apps/web/src/components/files/projectFilesQueryState.ts
+++ b/apps/web/src/components/files/projectFilesQueryState.ts
@@ -7,11 +7,12 @@ import type {
 import * as Cause from "effect/Cause";
 import * as Option from "effect/Option";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 
 import { appAtomRegistry } from "~/rpc/atomRegistry";
 import { projectEnvironment } from "~/state/projects";
 import { useProjectPathSearch } from "~/state/queries";
+import { useAtomCommand } from "~/state/use-atom-command";
 import { executeAtomQuery } from "@t3tools/client-runtime/state/runtime";
 
 const EMPTY_PROJECT_FILE_PATH = "";
@@ -127,12 +128,21 @@ export function useProjectEntriesQuery(
 ): ProjectQueryState<ProjectListEntriesResult> {
   const atom = getProjectEntriesQueryAtom(environmentId, cwd);
   const result = useAtomValue(atom);
-  const refreshAtom = useAtomRefresh(atom);
-  const refresh = useCallback(() => refreshAtom(), [refreshAtom]);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const refreshEntries = useAtomCommand(projectEnvironment.refreshEntries, {
+    reportFailure: false,
+  });
+  const refresh = useCallback(() => {
+    if (isRefreshing) return;
+    setIsRefreshing(true);
+    void refreshEntries({ environmentId, input: { cwd } }).finally(() => {
+      setIsRefreshing(false);
+    });
+  }, [cwd, environmentId, isRefreshing, refreshEntries]);
   return {
     data: Option.getOrNull(AsyncResult.value(result)),
     error: errorMessage(result),
-    isPending: result.waiting,
+    isPending: result.waiting || isRefreshing,
     refresh,
   };
 }

--- a/packages/client-runtime/src/state/projectCommands.ts
+++ b/packages/client-runtime/src/state/projectCommands.ts
@@ -1,5 +1,6 @@
 import { type EnvironmentId, type ProjectReadFileResult, WS_METHODS } from "@t3tools/contracts";
 import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
 import { Atom } from "effect/unstable/reactivity";
 
 import {
@@ -54,17 +55,26 @@ export function createProjectEnvironmentAtoms<R, E>(
     key: ({ environmentId, input }: { environmentId: string; input: { projectId: string } }) =>
       JSON.stringify([environmentId, input.projectId]),
   };
+  const listEntries = createEnvironmentRpcQueryAtomFamily(runtime, {
+    label: "environment-data:projects:list-entries",
+    tag: WS_METHODS.projectsListEntries,
+    staleTimeMs: 30_000,
+    idleTtlMs: 5 * 60_000,
+  });
   return {
     searchEntries: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:projects:search-entries",
       tag: WS_METHODS.projectsSearchEntries,
       staleTimeMs: 15_000,
     }),
-    listEntries: createEnvironmentRpcQueryAtomFamily(runtime, {
-      label: "environment-data:projects:list-entries",
-      tag: WS_METHODS.projectsListEntries,
-      staleTimeMs: 30_000,
-      idleTtlMs: 5 * 60_000,
+    listEntries,
+    refreshEntries: createEnvironmentRpcCommand(runtime, {
+      label: "environment-data:projects:refresh-entries",
+      tag: WS_METHODS.projectsRefreshEntries,
+      onSettled: (target, registry) =>
+        Effect.sync(() => {
+          registry.refresh(listEntries(target));
+        }),
     }),
     readFile: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:projects:read-file",

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1205,6 +1205,7 @@ export interface EnvironmentApi {
   };
   projects: {
     listEntries: (input: ProjectListEntriesInput) => Promise<ProjectListEntriesResult>;
+    refreshEntries: (input: ProjectListEntriesInput) => Promise<void>;
     readFile: (input: ProjectReadFileInput) => Promise<ProjectReadFileResult>;
     searchEntries: (input: ProjectSearchEntriesInput) => Promise<ProjectSearchEntriesResult>;
     writeFile: (input: ProjectWriteFileInput) => Promise<ProjectWriteFileResult>;

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -196,6 +196,7 @@ export const WS_METHODS = {
   projectsAdd: "projects.add",
   projectsRemove: "projects.remove",
   projectsListEntries: "projects.listEntries",
+  projectsRefreshEntries: "projects.refreshEntries",
   projectsReadFile: "projects.readFile",
   projectsSearchContents: "projects.searchContents",
   projectsSearchEntries: "projects.searchEntries",
@@ -626,6 +627,11 @@ export const WsProjectsListEntriesRpc = Rpc.make(WS_METHODS.projectsListEntries,
   error: Schema.Union([ProjectListEntriesError, EnvironmentAuthorizationError]),
 });
 
+export const WsProjectsRefreshEntriesRpc = Rpc.make(WS_METHODS.projectsRefreshEntries, {
+  payload: ProjectListEntriesInput,
+  error: EnvironmentAuthorizationError,
+});
+
 export const WsProjectsReadFileRpc = Rpc.make(WS_METHODS.projectsReadFile, {
   payload: ProjectReadFileInput,
   success: ProjectReadFileResult,
@@ -1014,6 +1020,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsSourceControlCloneRepositoryRpc,
   WsSourceControlPublishRepositoryRpc,
   WsProjectsListEntriesRpc,
+  WsProjectsRefreshEntriesRpc,
   WsProjectsReadFileRpc,
   WsProjectsSearchContentsRpc,
   WsProjectsSearchEntriesRpc,


### PR DESCRIPTION
## What Changed

The Files panel's explicit refresh action now performs a real server-side workspace rescan before reloading the existing file-list query.

A new `projects.refreshEntries` command reuses `WorkspaceEntries.refresh(cwd)`, then revalidates the normal `projects.listEntries` query. Web/desktop and mobile refresh controls use the same environment-routed path.

## Why

`projects.listEntries` intentionally reads from a cached `WorkspaceSearchIndex`. The existing Refresh button only re-ran that query, so files created, moved, or deleted outside T3 remained stale until the server-side index was rebuilt.

The existing `WorkspaceEntries.refresh(cwd)` already performs the correct `FileFinder.scanFiles()` rescan; it just was not exposed through the client refresh path.

Normal reads remain cached. This change only performs the rescan when the user explicitly requests a file refresh.

## Validation

- deterministic WebSocket regression covers external create, move/rename, and delete;
- verifies normal `listEntries` remains stale before explicit refresh and becomes fresh afterward;
- focused server/workspace/contracts/web tests pass;
- contracts, client-runtime, server, web, and mobile typechecks pass;
- targeted lint and format checks pass;
- `git diff --check` passes.

This intentionally keeps F5/live filesystem invalidation out of scope; the PR fixes the explicit Files refresh contract without adding a watcher, changing cache TTLs, or making normal reads scan the filesystem.

Addresses #6452

Created with **gpt-5.6-sol** using **T3 Code (Codex harness)**.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to explicit refresh and read authorization; normal list reads stay cached, with regression coverage for the new RPC path.
> 
> **Overview**
> **Explicit Files refresh now triggers a real workspace rescan** instead of only re-running the cached `projects.listEntries` query.
> 
> A new **`projects.refreshEntries`** WebSocket RPC calls **`WorkspaceEntries.refresh(cwd)`** (filesystem scan / index rebuild), then clients revalidate the normal list query via **`projectEnvironment.refreshEntries`** with **`onSettled`** refreshing **`listEntries`**. Web (`useProjectEntriesQuery`) and mobile file trees (thread files screen and navigator pane) wire refresh buttons and pull-to-refresh to this command and show pending state while it runs.
> 
> **`projectsRefreshEntries`** is registered in contracts, IPC, server **`ws`**, and **`RpcAuthorization`** as **read** scope (same idea as invalidate-on-read). A server integration test asserts external create, rename, and delete stay stale on **`listEntries`** until refresh, then match disk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e127a51b7bfa303dcc929d5fd7176028f4a9796d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `projects.refreshEntries` RPC to rescan workspace on explicit refresh
> - Adds a new `projects.refreshEntries` WebSocket RPC that triggers a server-side workspace directory rescan for a given `cwd`, separate from the existing `listEntries` query.
> - Previously, pull-to-refresh and header refresh actions re-used the query's cached data; now they invoke the new command, which on completion invalidates and re-fetches the `listEntries` cache.
> - Wires the new refresh command into the mobile file navigator ([ThreadFilesRouteScreen](https://github.com/pingdotgg/t3code/pull/6522/files#diff-9d701f672b12c7184cdf9b51e0e5b5417c35e688fe894ee38e91017bf15aea6a), [ThreadFileNavigatorPane](https://github.com/pingdotgg/t3code/pull/6522/files#diff-5c60d47be8b47d98c17ff476fc2bd41a9d1cdda24c7a0dda7fba4732add69b72)) and web ([useProjectEntriesQuery](https://github.com/pingdotgg/t3code/pull/6522/files#diff-806be0160895303d53e1626c9f2ae08183713de619da98a4d058c0eec96c622c)), with a local `isRefreshingEntries` flag driving pending UI state.
> - Registers the new RPC in [RpcAuthorization.ts](https://github.com/pingdotgg/t3code/pull/6522/files#diff-ef8e11f5d03122896863286f476eac62b31a12ed508924c3af039ec784a3a4d4) under `AuthOrchestrationReadScope`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e127a51. 8 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->