### PR TITLE
fix(server): treat removed Bitbucket permissions endpoint as unknown, not blocking

### DIFF
--- a/apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts
@@ -867,6 +867,46 @@ layer("BitbucketPullRequestApi.layer", (it) => {
     }),
   );
 
+  it.effect(
+    "reads a removed permissions endpoint as granted rather than failing the merge on it",
+    () =>
+      Effect.gen(function* () {
+        // Bitbucket retired /user/permissions/repositories under CHANGE-2770: every account now
+        // gets HTTP 410 here, whatever it may do.
+        mockedRequest.mockReturnValue(
+          Effect.fail(
+            new BitbucketApi.BitbucketResponseError({
+              operation: "request",
+              status: 410,
+              responseBodyLength: 0,
+            }),
+          ),
+        );
+        const api = yield* BitbucketPullRequestApi.BitbucketPullRequestApi;
+
+        assert.isTrue(yield* api.getRepositoryPermission({ repository: "acme/web" }));
+      }),
+  );
+
+  it.effect("still fails the permission read on a failure that is not the removed endpoint", () =>
+    Effect.gen(function* () {
+      mockedRequest.mockReturnValue(
+        Effect.fail(
+          new BitbucketApi.BitbucketResponseError({
+            operation: "request",
+            status: 401,
+            responseBodyLength: 0,
+          }),
+        ),
+      );
+      const api = yield* BitbucketPullRequestApi.BitbucketPullRequestApi;
+
+      const error = yield* Effect.flip(api.getRepositoryPermission({ repository: "acme/web" }));
+
+      assert.strictEqual(error._tag, "BitbucketResponseError");
+    }),
+  );
+
   it.effect("reads the workspace's people and marks whoever is already a reviewer", () =>
     Effect.gen(function* () {
       mockedRequest

--- a/apps/server/src/pullRequest/BitbucketPullRequestApi.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestApi.ts
@@ -108,6 +108,16 @@ export type BitbucketPullRequestApiError =
   | BitbucketDiffCommitError;
 
 /**
+ * `/user/permissions/repositories` answering CHANGE-2770's removal notice rather than a
+ * permission — Bitbucket sends this for every account now, not only ones it would have refused.
+ */
+function isRepositoryPermissionRemovedError(
+  error: BitbucketPullRequestApiError,
+): error is BitbucketApi.BitbucketResponseError {
+  return error._tag === "BitbucketResponseError" && error.status === 410;
+}
+
+/**
  * Bitbucket's own ceiling. Asking for more does not fail — it answers with an empty page and no
  * error at all, so this is a number to respect rather than to push against.
  */
@@ -553,6 +563,13 @@ export const make = Effect.gen(function* () {
     // Nothing on the repository, the pull request or the workspace states what the credentials
     // may do, so this endpoint is the one request Bitbucket makes unavoidable. It is asked
     // alongside the reads the detail was already making, so it costs no round trip of its own.
+    //
+    // Bitbucket permanently removed this endpoint (CHANGE-2770): every account now gets HTTP 410
+    // in place of an answer, whatever it may do. That is the deprecated-endpoint signal, not a
+    // permission being refused, so it is read the same way an unreachable read already is
+    // elsewhere — as a permission that could not be learned, which grants rather than blocks, and
+    // leaves the actual merge or write to say why if the account may not do it. Any other failure
+    // (a bad token, a network fault, an unreadable body) still fails as it did before.
     getRepositoryPermission: (input) =>
       withRepository(input.repository, () =>
         readPage({
@@ -562,7 +579,7 @@ export const make = Effect.gen(function* () {
           )}`,
           decode: decodeRepositoryPermissionJson,
         }),
-      ),
+      ).pipe(Effect.catchIf(isRepositoryPermissionRemovedError, () => Effect.succeed(true))),
 
     getPullRequestDiff: (input) =>
       input.commit !== undefined && !isCommitSha(input.commit)


### PR DESCRIPTION
## What Changed

`BitbucketPullRequestApi.getRepositoryPermission` now treats an HTTP 410 from
`GET /2.0/user/permissions/repositories` as a permission that could not be learned
(granted) instead of a hard failure. Any other failure (401, 500, network fault,
unreadable body, etc.) still fails exactly as before.

## Why

Bitbucket permanently removed `/2.0/user/permissions/repositories` under CHANGE-2770;
it now returns HTTP 410 for every account, not only ones that would have been refused.

`getRepositoryPermission` feeds two call sites in `BitbucketPullRequestProvider`:
- `getChangeRequest` already swallows *any* failure here via
  `Effect.orElseSucceed(() => true)` (a permission that can't be read is treated as
  unknown and granted) — so the change request detail view already tolerated this.
- `getViewerPermissions` had no such fallback, and `PullRequestService.viewerPermissionsOf`
  gates every write action — including merge — through `getViewerPermissions`. A 410
  there fails that gate outright, so the merge request is never sent, even though the
  merge endpoint itself would have authorized or refused it correctly.

I fixed this at the source (`getRepositoryPermission`) rather than widening
`getViewerPermissions`'s error handling in general, so the fix is specific to the
documented deprecated-endpoint signal (HTTP 410) and doesn't also swallow real
authorization/network failures at the one call site that gates writes.

No live Bitbucket account was exercised against the real API for this change — I
could not verify against production Bitbucket. The fix is verified against the
documented CHANGE-2770 response (HTTP 410) via unit tests and against the existing
test suite's mocked Bitbucket client.

Closes #6341

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (not applicable — no UI change)
- [ ] I included a video for animation/interaction changes (not applicable)

## Verification

Run from `apps/server`:

- `pnpm exec vp test run src/pullRequest/BitbucketPullRequestApi.test.ts src/pullRequest/BitbucketPullRequestProvider.test.ts`
  → `Test Files 2 passed (2)`, `Tests 47 passed (47)`
- `pnpm exec tsgo --noEmit` → no errors in the changed file (pre-existing suggestions
  elsewhere in the codebase, unrelated to this change)
- `pnpm exec vp lint` on the two changed files → clean, no findings

Not verified: an actual merge against a live Bitbucket Cloud repository (no account
available in this environment). The fix targets the documented HTTP 410 response
from CHANGE-2770 exactly as reported in the issue's logs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow, Bitbucket-specific handling of documented HTTP 410; other auth and API errors are unchanged, with tests locking the behavior.
> 
> **Overview**
> Bitbucket retired `GET /user/permissions/repositories` (CHANGE-2770) and now returns **HTTP 410** for every account. **`getRepositoryPermission`** used to surface that as a hard error, which blocked **`getViewerPermissions`** and stopped merge (and other write actions) even when Bitbucket would have allowed the operation.
> 
> The API layer now treats **410 only** as “permission could not be learned” and returns **granted** (`true`), matching how unreachable permission reads are handled elsewhere; **401**, network, and other failures still propagate unchanged. A small **`isRepositoryPermissionRemovedError`** guard plus unit tests cover the 410 and non-410 paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f70f770f2dc840c880f81e581f7211c7fe2c73f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Treat Bitbucket's removed permissions endpoint (HTTP 410) as granted rather than blocking
> Bitbucket removed the `/user/permissions/repositories` endpoint, causing `getRepositoryPermission` to fail on 410 responses and block merges. A new `isRepositoryPermissionRemovedError` type guard catches 410 errors in [`BitbucketPullRequestApi.ts`](https://github.com/pingdotgg/t3code/pull/6525/files#diff-b8db316b58d8493059f93e4d1bec9cbf008091ccb14abcf8a88defe4de2fc842) and maps them to `true` (permission granted), matching the intent described in CHANGE-2770. Non-410 errors continue to propagate as before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f70f77.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->