### PR TITLE
fix(web): restore the Archive action in the default sidebar thread menu

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2964,6 +2964,8 @@ export default function Sidebar() {
               isSnoozed,
               canSnoozeNow: canSnooze(thread, { now: new Date().toISOString() }),
               isRegeneratingTitle,
+              isRunning:
+                thread.session?.status === "running" && thread.session.activeTurnId != null,
               supports: {
                 settlement: supportsSettlement,
                 snooze: supportsSnooze,
@@ -3074,13 +3076,20 @@ export default function Sidebar() {
               );
               if (confirmed._tag === "Failure" || !confirmed.value) return;
             }
-            const result = await archiveThread(threadRef);
+            let didArchive = false;
+            const result = await archiveThread(threadRef, {
+              onArchived: () => {
+                didArchive = true;
+              },
+            });
             if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
               const error = squashAtomCommandFailure(result);
               toastManager.add(
                 stackedThreadToast({
                   type: "error",
-                  title: "Failed to archive thread",
+                  title: didArchive
+                    ? "Thread archived, but navigation failed"
+                    : "Failed to archive thread",
                   description: error instanceof Error ? error.message : "An error occurred.",
                 }),
               );

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1600,6 +1600,7 @@ export default function Sidebar() {
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const autoSettleAfterDays = useClientSettings((s) => s.sidebarAutoSettleAfterDays);
   const confirmThreadDelete = useClientSettings((s) => s.confirmThreadDelete);
+  const confirmThreadArchive = useClientSettings((s) => s.confirmThreadArchive);
   const sidebarProjectSortOrder = useClientSettings((s) => s.sidebarProjectSortOrder);
   const timestampFormat = useClientSettings((s) => s.timestampFormat);
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
@@ -1611,6 +1612,7 @@ export default function Sidebar() {
     pinThread,
     unpinThread,
     reorderPinnedThread,
+    archiveThread,
     deleteThread,
   } = useThreadActions();
   const updateThreadMetadata = useAtomCommand(threadEnvironment.updateMetadata, {
@@ -3065,6 +3067,27 @@ export default function Sidebar() {
           case "copy-thread-id":
             copyThreadIdToClipboard(thread.id, { threadId: thread.id });
             return;
+          case "archive": {
+            if (confirmThreadArchive) {
+              const confirmed = await settlePromise(() =>
+                api.dialogs.confirm(`Archive thread "${thread.title}"?`),
+              );
+              if (confirmed._tag === "Failure" || !confirmed.value) return;
+            }
+            const result = await archiveThread(threadRef);
+            if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+              const error = squashAtomCommandFailure(result);
+              toastManager.add(
+                stackedThreadToast({
+                  type: "error",
+                  title: "Failed to archive thread",
+                  description: error instanceof Error ? error.message : "An error occurred.",
+                }),
+              );
+              return;
+            }
+            return;
+          }
           case "delete": {
             if (confirmThreadDelete) {
               const confirmed = await settlePromise(() =>
@@ -3098,12 +3121,14 @@ export default function Sidebar() {
       })();
     },
     [
+      archiveThread,
       attemptPin,
       attemptSettle,
       attemptSnooze,
       attemptUnpin,
       attemptUnsettle,
       attemptUnsnooze,
+      confirmThreadArchive,
       confirmThreadDelete,
       copyBranchToClipboard,
       copyPathToClipboard,

--- a/apps/web/src/components/threadActionMenu.logic.test.ts
+++ b/apps/web/src/components/threadActionMenu.logic.test.ts
@@ -26,7 +26,7 @@ describe("buildThreadActionMenuItems", () => {
         ...baseState,
         supports: { settlement: false, snooze: false, pinning: false, titleRegeneration: false },
       }),
-    ).toEqual(["rename", "mark-unread", "copy-path", "copy-thread-id", "delete"]);
+    ).toEqual(["rename", "mark-unread", "copy-path", "copy-thread-id", "archive", "delete"]);
   });
 
   it("includes branch items only for threads with a branch", () => {
@@ -62,5 +62,22 @@ describe("buildThreadActionMenuItems", () => {
   it("marks delete as destructive and keeps it last", () => {
     const items = buildThreadActionMenuItems({ ...baseState, branch: "main" });
     expect(items.at(-1)).toMatchObject({ id: "delete", destructive: true });
+  });
+
+  it("offers archive as a non-destructive action right before delete", () => {
+    const items = buildThreadActionMenuItems(baseState);
+    const archiveItem = items.at(-2);
+    expect(archiveItem?.id).toBe("archive");
+    expect(archiveItem?.destructive).toBeFalsy();
+    expect(items.at(-1)?.id).toBe("delete");
+  });
+
+  it("keeps archive available even when the environment lacks every other capability", () => {
+    expect(
+      ids({
+        ...baseState,
+        supports: { settlement: false, snooze: false, pinning: false, titleRegeneration: false },
+      }),
+    ).toContain("archive");
   });
 });

--- a/apps/web/src/components/threadActionMenu.logic.test.ts
+++ b/apps/web/src/components/threadActionMenu.logic.test.ts
@@ -9,6 +9,7 @@ const baseState: ThreadActionMenuState = {
   isSnoozed: false,
   canSnoozeNow: true,
   isRegeneratingTitle: false,
+  isRunning: false,
   supports: { settlement: true, snooze: true, pinning: true, titleRegeneration: true },
   snoozePresets: [
     { id: "hour", label: "In 1 hour", whenLabel: "3:00 PM", snoozedUntil: "2026-08-07T15:00:00Z" },
@@ -79,5 +80,12 @@ describe("buildThreadActionMenuItems", () => {
         supports: { settlement: false, snooze: false, pinning: false, titleRegeneration: false },
       }),
     ).toContain("archive");
+  });
+
+  it("disables archive while the thread is running", () => {
+    const archiveItem = buildThreadActionMenuItems({ ...baseState, isRunning: true }).find(
+      (item) => item.id === "archive",
+    );
+    expect(archiveItem?.disabled).toBe(true);
   });
 });

--- a/apps/web/src/components/threadActionMenu.logic.ts
+++ b/apps/web/src/components/threadActionMenu.logic.ts
@@ -21,6 +21,7 @@ export type ThreadActionMenuId =
   | "copy-path"
   | "copy-branch"
   | "copy-thread-id"
+  | "archive"
   | "delete";
 
 export interface ThreadActionMenuState {
@@ -102,6 +103,12 @@ export function buildThreadActionMenuItems(
     { id: "copy-path", label: "Copy path", icon: "copy" },
     ...(state.branch ? [{ id: "copy-branch" as const, label: "Copy branch", icon: "copy" }] : []),
     { id: "copy-thread-id", label: "Copy thread ID", icon: "copy" },
+    // Archive removes the thread from the sidebar while keeping its
+    // conversation under Settings > Archived threads — distinct from Settle
+    // (stays visible in the Settled shelf) and Delete (clears history for
+    // good), so it sits beside Delete without borrowing its destructive
+    // styling.
+    { id: "archive", label: "Archive thread" },
     { id: "delete", label: "Delete", destructive: true, icon: "trash" },
   ];
 }

--- a/apps/web/src/components/threadActionMenu.logic.ts
+++ b/apps/web/src/components/threadActionMenu.logic.ts
@@ -31,6 +31,8 @@ export interface ThreadActionMenuState {
   readonly isSnoozed: boolean;
   readonly canSnoozeNow: boolean;
   readonly isRegeneratingTitle: boolean;
+  /** Archive rejects a thread with an active turn, so disable it here rather than let the action fail. */
+  readonly isRunning: boolean;
   readonly supports: {
     readonly settlement: boolean;
     readonly snooze: boolean;
@@ -108,7 +110,7 @@ export function buildThreadActionMenuItems(
     // (stays visible in the Settled shelf) and Delete (clears history for
     // good), so it sits beside Delete without borrowing its destructive
     // styling.
-    { id: "archive", label: "Archive thread" },
+    { id: "archive", label: "Archive thread", disabled: state.isRunning },
     { id: "delete", label: "Delete", destructive: true, icon: "trash" },
   ];
 }

--- a/apps/web/src/hooks/useThreadActionMenu.ts
+++ b/apps/web/src/hooks/useThreadActionMenu.ts
@@ -139,6 +139,7 @@ export function useThreadActionMenu(input: {
           isSnoozed: supports.snooze && effectiveSnoozed(thread, { now: now.toISOString() }),
           canSnoozeNow: canSnooze(thread, { now: now.toISOString() }),
           isRegeneratingTitle,
+          isRunning: thread.session?.status === "running" && thread.session.activeTurnId != null,
           supports,
           snoozePresets,
         });
@@ -260,7 +261,18 @@ export function useThreadActionMenu(input: {
               );
               if (confirmed._tag === "Failure" || !confirmed.value) return;
             }
-            await reportFailure("Failed to archive thread", () => archiveThread(threadRef));
+            let didArchive = false;
+            const result = await archiveThread(threadRef, {
+              onArchived: () => {
+                didArchive = true;
+              },
+            });
+            if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+              failureToast(
+                didArchive ? "Thread archived, but navigation failed" : "Failed to archive thread",
+                squashAtomCommandFailure(result),
+              );
+            }
             return;
           }
           case "delete": {

--- a/apps/web/src/hooks/useThreadActionMenu.ts
+++ b/apps/web/src/hooks/useThreadActionMenu.ts
@@ -72,6 +72,7 @@ export function useThreadActionMenu(input: {
     unsnoozeThread,
     pinThread,
     unpinThread,
+    archiveThread,
     deleteThread,
   } = useThreadActions();
   const updateThreadMetadata = useAtomCommand(threadEnvironment.updateMetadata, {
@@ -81,6 +82,7 @@ export function useThreadActionMenu(input: {
   const markThreadUnread = useUiStateStore((s) => s.markThreadUnread);
   const autoSettleAfterDays = useClientSettings((s) => s.sidebarAutoSettleAfterDays);
   const confirmThreadDelete = useClientSettings((s) => s.confirmThreadDelete);
+  const confirmThreadArchive = useClientSettings((s) => s.confirmThreadArchive);
   const timestampFormat = useClientSettings((s) => s.timestampFormat);
   const { copyToClipboard: copyPathToClipboard } = useCopyToClipboard<{ path: string }>({
     onCopy: ({ path }) => {
@@ -251,6 +253,16 @@ export function useThreadActionMenu(input: {
           case "copy-thread-id":
             copyThreadIdToClipboard(thread.id, { threadId: thread.id });
             return;
+          case "archive": {
+            if (confirmThreadArchive) {
+              const confirmed = await settlePromise(() =>
+                api.dialogs.confirm(`Archive thread "${thread.title}"?`),
+              );
+              if (confirmed._tag === "Failure" || !confirmed.value) return;
+            }
+            await reportFailure("Failed to archive thread", () => archiveThread(threadRef));
+            return;
+          }
           case "delete": {
             if (confirmThreadDelete) {
               const confirmed = await settlePromise(() =>
@@ -283,8 +295,10 @@ export function useThreadActionMenu(input: {
       })();
     },
     [
+      archiveThread,
       autoSettleAfterDays,
       changeRequestState,
+      confirmThreadArchive,
       confirmThreadDelete,
       copyBranchToClipboard,
       copyPathToClipboard,


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️
Small, focused bug fix PR — see below.
-->

## What Changed

Adds an "Archive thread" item back to the per-thread action menu (`buildThreadActionMenuItems` in `apps/web/src/components/threadActionMenu.logic.ts`), which is the single source that both the default sidebar's right-click row menu (`Sidebar.tsx`) and the chat header menu (`useThreadActionMenu.ts`) render. Wired both surfaces to dispatch the new `"archive"` id to the existing `archiveThread` mutation from `useThreadActions`, reusing the same `confirmThreadArchive` client setting the legacy sidebar and the existing bulk-archive flow already use for an optional confirm dialog.

Archive sits directly before Delete in the list (after Copy thread ID), without the `destructive` styling Delete uses — archiving hides a thread from the sidebar but keeps it under Settings > Archived threads, so it isn't a destructive action.

No new capability gate was added: `archiveThread`/`unarchiveThread` are already dispatched unconditionally everywhere else in the codebase (the legacy sidebar's row button and bulk-select menu never check a `readEnvironmentSupports*` flag for archive), so gating it here would be inventing a capability the backend doesn't expose.

## Why

Closes #6511. PR #5672 made the new (non-legacy) sidebar the default and its per-thread menu never got an Archive item, even though:
- Settings > Archived threads still lists archived conversations.
- The legacy sidebar (still selectable via Settings > General > Legacy features) still exposes a dedicated Archive button per thread, using the same `archiveThread` mutation this PR now reuses.
- Delete is the only remaining way to remove a thread from the default sidebar, but Delete permanently clears history, and Settle isn't equivalent (the thread stays visible in the Settled shelf and can be settled automatically).

This restores parity with the legacy sidebar. If the removal was actually intentional, the maintainers may prefer to close #6511 instead of merging this — I'm not aware of any discussion establishing that, so I'm treating it as an unintentional regression per the issue.

## UI Changes

The menu renders through the native context-menu bridge (`api.contextMenu.show`), so on the desktop app it's an OS-native menu a browser screenshot can't capture. However, `apps/web/src/localApi.ts` falls back to a DOM-rendered menu (`showContextMenuFallback` in `apps/web/src/contextMenuFallback.ts`) whenever `window.desktopBridge` isn't present (i.e. the web app running in a plain browser). I exercised that real fallback renderer with the real `buildThreadActionMenuItems` output via a throwaway demo page served by the app's own Vite dev server (not committed — deleted after capturing evidence), and captured real screenshots with a headless Chromium:

**Before** (pre-fix code, reproduced verbatim from the prior `buildThreadActionMenuItems` output):
Settle thread → Snooze › → Rename thread → Mark unread → Copy path → Copy thread ID → Delete

**After** (current code):
Settle thread → Snooze › → Rename thread → Mark unread → Copy path → Copy thread ID → **Archive thread** → Delete

| Before | After |
| --- | --- |
| <img width="420" alt="Thread menu before: Copy thread ID then Delete, no Archive" src="https://raw.githubusercontent.com/lnieuwenhuis/t3code/assets/pr-6511-archive-menu/pr-assets/6511-before.png" /> | <img width="420" alt="Thread menu after: Archive thread between Copy thread ID and Delete" src="https://raw.githubusercontent.com/lnieuwenhuis/t3code/assets/pr-6511-archive-menu/pr-assets/6511-after.png" /> |

Please read these two images for what they are: the **DOM fallback** menu rendered by the real
`showContextMenuFallback` from the real `buildThreadActionMenuItems` output, in an isolated demo
page rather than inside the running app. They are evidence of **item presence and ordering**, not of
final visual styling — the icon sizing and label wrapping you see are artifacts of the bare demo
page's lack of app CSS, and are not introduced by this PR. On the desktop app this menu is an
OS-native menu, which no browser screenshot can capture; I could not produce a native-menu
screenshot and am not going to imply otherwise.

The before/after item ordering is additionally pinned by the two new tests in
`apps/web/src/components/threadActionMenu.logic.test.ts` ("offers archive as a non-destructive
action right before delete" and the updated capability-gating test), which fail if Archive's
presence or position regresses.

## Verification

- `cd apps/web && pnpm exec vp test run --passWithNoTests --project unit src/components/threadActionMenu.logic.test.ts` — 8 passed (6 pre-existing + 2 new).
- `cd apps/web && pnpm exec vp test run --passWithNoTests --project unit src/hooks/useThreadActions.test.ts` — 1 passed (unaffected, ran as a sanity check since `archiveThread` is reused here).
- `cd apps/web && pnpm exec tsgo --noEmit` — no errors.
- `pnpm exec vp lint --report-unused-disable-directives` on the changed files — no findings.
- `pnpm exec vp format --check` on the changed files — all correctly formatted.
- Manual: rendered the real DOM-fallback context menu with the actual builder/renderer code in a throwaway Vite-served demo page and confirmed the before/after item list and ordering by screenshot (see UI Changes).

I did not run the full test suite or a repo-wide typecheck, per the smallest-relevant-scope guidance.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (DOM-fallback renderer; see the caveat in UI Changes)
- [ ] I included a video for animation/interaction changes (not applicable — no animation)

Closes #6511

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only wiring to an existing `archiveThread` mutation and settings; no new server paths or auth changes.
> 
> **Overview**
> Restores **Archive thread** to the default sidebar and chat header per-thread menus, which regressed when the new sidebar became default (#6511).
> 
> `buildThreadActionMenuItems` now includes a non-destructive **Archive thread** item immediately before **Delete**, always shown (not capability-gated). Archive is **disabled** while a thread has an active running turn (`isRunning`), matching server rejection in `archiveThread`.
> 
> **Sidebar** and **`useThreadActionMenu`** both handle the `"archive"` action: optional confirm via `confirmThreadArchive`, then `archiveThread` with error toasts (including archive-succeeded-but-navigation-failed). Tests cover ordering, non-destructive styling, capability-off availability, and the running disable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1524c5e9b38698b7159b4664e3951264c98e6cb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore the Archive action in the sidebar and chat header thread menus
> - Adds an 'Archive thread' item to menus built by [`buildThreadActionMenuItems`](https://github.com/pingdotgg/t3code/pull/6526/files#diff-adb26427668f045711eaaf3119b9956a72193f99f3791157faa0e60353e09574), positioned just before 'Delete' with no destructive styling.
> - Wires up archive handling in both [`Sidebar.tsx`](https://github.com/pingdotgg/t3code/pull/6526/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) and [`useThreadActionMenu.ts`](https://github.com/pingdotgg/t3code/pull/6526/files#diff-d31aea23d18521fa1c03e05a4d3c2e45d0ca6fab34084d74f072cecc48d21e17), using `archiveThread` from `useThreadActions` and respecting the `confirmThreadArchive` setting.
> - The action is disabled while the thread is running (active turn); on failure, an error toast distinguishes between archive success with navigation failure and outright failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1524c5e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->