### PR TITLE
fix(desktop): open chat artifacts in native apps

### DIFF
--- a/apps/desktop/src/electron/ElectronShell.test.ts
+++ b/apps/desktop/src/electron/ElectronShell.test.ts
@@ -79,7 +79,23 @@ describe("ElectronShell", () => {
       const electronShell = yield* ElectronShell.ElectronShell;
       const error = yield* Effect.flip(electronShell.openPath("/tmp/product.bin"));
 
-      assert.include(error.message, "There is no application set to open the file.");
+      assert.equal(error.reason, "open-refused");
+      assert.equal(error.cause, undefined);
+      assert.equal(error.message, 'Unable to open "/tmp/product.bin" in its default application');
+    }).pipe(Effect.provide(ElectronShell.layer)),
+  );
+
+  it.effect("preserves Electron rejections as the underlying cause", () =>
+    Effect.gen(function* () {
+      const cause = new Error("open failed");
+      openPathMock.mockRejectedValue(cause);
+
+      const electronShell = yield* ElectronShell.ElectronShell;
+      const error = yield* Effect.flip(electronShell.openPath("/tmp/product.bin"));
+
+      assert.equal(error.reason, "shell-rejected");
+      assert.equal(error.cause, cause);
+      assert.equal(error.message, 'Unable to open "/tmp/product.bin" in its default application');
     }).pipe(Effect.provide(ElectronShell.layer)),
   );
 });

--- a/apps/desktop/src/electron/ElectronShell.test.ts
+++ b/apps/desktop/src/electron/ElectronShell.test.ts
@@ -2,14 +2,16 @@ import { assert, describe, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import { beforeEach, vi } from "vite-plus/test";
 
-const { openExternalMock, writeTextMock } = vi.hoisted(() => ({
+const { openExternalMock, openPathMock, writeTextMock } = vi.hoisted(() => ({
   openExternalMock: vi.fn(),
+  openPathMock: vi.fn(),
   writeTextMock: vi.fn(),
 }));
 
 vi.mock("electron", () => ({
   shell: {
     openExternal: openExternalMock,
+    openPath: openPathMock,
   },
   clipboard: {
     writeText: writeTextMock,
@@ -21,6 +23,7 @@ import * as ElectronShell from "./ElectronShell.ts";
 describe("ElectronShell", () => {
   beforeEach(() => {
     openExternalMock.mockReset();
+    openPathMock.mockReset();
     writeTextMock.mockReset();
   });
 
@@ -54,6 +57,29 @@ describe("ElectronShell", () => {
       const result = yield* electronShell.openExternal("https://example.com/path");
 
       assert.equal(result, false);
+    }).pipe(Effect.provide(ElectronShell.layer)),
+  );
+
+  it.effect("opens the exact local path in its default application", () =>
+    Effect.gen(function* () {
+      openPathMock.mockResolvedValue("");
+      const path = "/Users/toviastorres/Downloads/product image.png";
+
+      const electronShell = yield* ElectronShell.ElectronShell;
+      yield* electronShell.openPath(path);
+
+      assert.deepEqual(openPathMock.mock.calls, [[path]]);
+    }).pipe(Effect.provide(ElectronShell.layer)),
+  );
+
+  it.effect("fails observably when Electron cannot open a local path", () =>
+    Effect.gen(function* () {
+      openPathMock.mockResolvedValue("There is no application set to open the file.");
+
+      const electronShell = yield* ElectronShell.ElectronShell;
+      const error = yield* Effect.flip(electronShell.openPath("/tmp/product.bin"));
+
+      assert.include(error.message, "There is no application set to open the file.");
     }).pipe(Effect.provide(ElectronShell.layer)),
   );
 });

--- a/apps/desktop/src/electron/ElectronShell.ts
+++ b/apps/desktop/src/electron/ElectronShell.ts
@@ -12,12 +12,12 @@ export class ElectronShellOpenPathError extends Schema.TaggedErrorClass<Electron
   "ElectronShellOpenPathError",
   {
     path: Schema.String,
-    reason: Schema.String,
-    cause: Schema.Defect(),
+    reason: Schema.Literals(["shell-rejected", "open-refused"]),
+    cause: Schema.optional(Schema.Defect()),
   },
 ) {
   override get message(): string {
-    return `Unable to open ${JSON.stringify(this.path)} in its default application: ${this.reason}`;
+    return `Unable to open ${JSON.stringify(this.path)} in its default application`;
   }
 }
 
@@ -61,15 +61,14 @@ export const make = ElectronShell.of({
       catch: (cause) =>
         new ElectronShellOpenPathError({
           path,
-          reason: cause instanceof Error ? cause.message : String(cause),
+          reason: "shell-rejected",
           cause,
         }),
     });
     if (result !== "") {
       return yield* new ElectronShellOpenPathError({
         path,
-        reason: result,
-        cause: new Error(result),
+        reason: "open-refused",
       });
     }
   }),

--- a/apps/desktop/src/electron/ElectronShell.ts
+++ b/apps/desktop/src/electron/ElectronShell.ts
@@ -2,10 +2,24 @@ import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
 
 import * as Electron from "electron";
 
 const SAFE_EXTERNAL_PROTOCOLS = new Set(["http:", "https:"]);
+
+export class ElectronShellOpenPathError extends Schema.TaggedErrorClass<ElectronShellOpenPathError>()(
+  "ElectronShellOpenPathError",
+  {
+    path: Schema.String,
+    reason: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Unable to open ${JSON.stringify(this.path)} in its default application: ${this.reason}`;
+  }
+}
 
 export function parseSafeExternalUrl(rawUrl: unknown): Option.Option<string> {
   if (typeof rawUrl !== "string") {
@@ -24,6 +38,7 @@ export class ElectronShell extends Context.Service<
   ElectronShell,
   {
     readonly openExternal: (rawUrl: unknown) => Effect.Effect<boolean>;
+    readonly openPath: (path: string) => Effect.Effect<void, ElectronShellOpenPathError>;
     readonly copyText: (text: string) => Effect.Effect<void>;
   }
 >()("@t3tools/desktop/electron/ElectronShell") {}
@@ -40,6 +55,24 @@ export const make = ElectronShell.of({
           ),
         ),
     }),
+  openPath: Effect.fn("desktop.electron.shell.openPath")(function* (path) {
+    const result = yield* Effect.tryPromise({
+      try: () => Electron.shell.openPath(path),
+      catch: (cause) =>
+        new ElectronShellOpenPathError({
+          path,
+          reason: cause instanceof Error ? cause.message : String(cause),
+          cause,
+        }),
+    });
+    if (result !== "") {
+      return yield* new ElectronShellOpenPathError({
+        path,
+        reason: result,
+        cause: new Error(result),
+      });
+    }
+  }),
   copyText: (text) =>
     Effect.sync(() => {
       Electron.clipboard.writeText(text);

--- a/apps/desktop/src/ipc/DesktopIpcHandlers.ts
+++ b/apps/desktop/src/ipc/DesktopIpcHandlers.ts
@@ -36,6 +36,7 @@ import {
   getLocalEnvironmentBearerToken,
   getWindowFullscreenState,
   openExternal,
+  openPath,
   pickFolder,
   pickThemeFiles,
   setTheme,
@@ -83,6 +84,7 @@ export const installDesktopIpcHandlers = Effect.fn("desktop.ipc.installHandlers"
   yield* ipc.handle(setTheme);
   yield* ipc.handle(showContextMenu);
   yield* ipc.handle(openExternal);
+  yield* ipc.handle(openPath);
   yield* ipc.handle(getUpdateState);
   yield* ipc.handle(setUpdateChannel);
   yield* ipc.handle(downloadUpdate);

--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -3,6 +3,7 @@ export const PICK_THEME_FILES_CHANNEL = "desktop:pick-theme-files";
 export const SET_THEME_CHANNEL = "desktop:set-theme";
 export const CONTEXT_MENU_CHANNEL = "desktop:context-menu";
 export const OPEN_EXTERNAL_CHANNEL = "desktop:open-external";
+export const OPEN_PATH_CHANNEL = "desktop:open-path";
 export const MENU_ACTION_CHANNEL = "desktop:menu-action";
 export const GET_WINDOW_FULLSCREEN_STATE_CHANNEL = "desktop:get-window-fullscreen-state";
 export const WINDOW_FULLSCREEN_STATE_CHANNEL = "desktop:window-fullscreen-state";

--- a/apps/desktop/src/ipc/methods/window.test.ts
+++ b/apps/desktop/src/ipc/methods/window.test.ts
@@ -8,7 +8,8 @@ import type * as Electron from "electron";
 import * as DesktopBackendManager from "../../backend/DesktopBackendManager.ts";
 import * as DesktopBackendPool from "../../backend/DesktopBackendPool.ts";
 import * as ElectronWindow from "../../electron/ElectronWindow.ts";
-import { getLocalEnvironmentBootstraps, getWindowFullscreenState } from "./window.ts";
+import * as ElectronShell from "../../electron/ElectronShell.ts";
+import { getLocalEnvironmentBootstraps, getWindowFullscreenState, openPath } from "./window.ts";
 
 const readyWslConfig: DesktopBackendManager.DesktopBackendStartConfig = {
   executablePath: "wsl.exe",
@@ -141,6 +142,28 @@ describe("getWindowFullscreenState", () => {
       Effect.provide(
         Layer.mock(ElectronWindow.ElectronWindow)({
           currentMainOrFirst: Effect.succeed(Option.some(window)),
+        }),
+      ),
+    );
+  });
+});
+
+describe("openPath", () => {
+  it.effect("passes the exact renderer path to the Electron shell", () => {
+    let openedPath: string | null = null;
+    const shellOpenPath = (path: string) =>
+      Effect.sync(() => {
+        openedPath = path;
+      });
+    const path = "/Users/toviastorres/Downloads/product image.png";
+
+    return Effect.gen(function* () {
+      yield* openPath.handler(path);
+      assert.equal(openedPath, path);
+    }).pipe(
+      Effect.provide(
+        Layer.mock(ElectronShell.ElectronShell)({
+          openPath: shellOpenPath,
         }),
       ),
     );

--- a/apps/desktop/src/ipc/methods/window.ts
+++ b/apps/desktop/src/ipc/methods/window.ts
@@ -261,6 +261,16 @@ export const openExternal = DesktopIpc.makeIpcMethod({
   }),
 });
 
+export const openPath = DesktopIpc.makeIpcMethod({
+  channel: IpcChannels.OPEN_PATH_CHANNEL,
+  payload: Schema.String,
+  result: Schema.Void,
+  handler: Effect.fn("desktop.ipc.window.openPath")(function* (path) {
+    const shell = yield* ElectronShell.ElectronShell;
+    return yield* shell.openPath(path);
+  }),
+});
+
 /** Theme files are a few KB; anything larger returns empty text and lets the
  *  renderer reject it by size without the contents ever crossing the bridge. */
 const PICKED_THEME_FILE_MAX_BYTES = 256 * 1024;

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -105,6 +105,7 @@ contextBridge.exposeInMainWorld("desktopBridge", {
       ...(position === undefined ? {} : { position }),
     }),
   openExternal: (url: string) => ipcRenderer.invoke(IpcChannels.OPEN_EXTERNAL_CHANNEL, url),
+  openPath: (path: string) => ipcRenderer.invoke(IpcChannels.OPEN_PATH_CHANNEL, path),
   onMenuAction: (listener) => {
     const wrappedListener = (_event: Electron.IpcRendererEvent, action: unknown) => {
       if (typeof action !== "string") return;

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -255,6 +255,7 @@ function makeTestLayer(input: {
               input.openedExternalUrls?.push(url);
               return true;
             }),
+          openPath: () => Effect.void,
           copyText: () => Effect.void,
         } satisfies ElectronShell.ElectronShell["Service"]),
         electronThemeLayer,
@@ -349,6 +350,7 @@ const makeSplashScenario = (createOutcomes: readonly (Electron.BrowserWindow | n
           electronMenuLayer,
           Layer.succeed(ElectronShell.ElectronShell, {
             openExternal: () => Effect.succeed(true),
+            openPath: () => Effect.void,
             copyText: () => Effect.void,
           } satisfies ElectronShell.ElectronShell["Service"]),
           electronThemeLayer,

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -74,7 +74,8 @@ import {
 } from "../markdown-clipboard";
 import { remarkNormalizeListItemIndentation } from "../markdown-list-indentation";
 import {
-  normalizeMarkdownLinkDestination,
+  extractMarkdownLinkHrefs,
+  normalizeMarkdownLinkHrefKey,
   resolveInlineCodeFileLinkMeta,
   resolveMarkdownFileLinkMeta,
   rewriteMarkdownFileUriHref,
@@ -87,6 +88,7 @@ import { useActiveEnvironmentId } from "../state/entities";
 import { serverEnvironment } from "../state/server";
 import { assetEnvironment } from "../state/assets";
 import { usePreparedConnection } from "../state/session";
+import { useEnvironmentPresentation } from "../state/presentation";
 import { previewEnvironment } from "../state/preview";
 import { useAtomCommand } from "../state/use-atom-command";
 import { useAtomQueryRunner } from "../state/use-atom-query-runner";
@@ -99,6 +101,10 @@ import {
   openUrlInPreview,
   BrowserPreviewUnavailableError,
 } from "../browser/openFileInPreview";
+import {
+  isHostFilesystemConnectionTarget,
+  openChatMarkdownFile,
+} from "./ChatMarkdownDesktopBridge";
 
 interface ChatMarkdownProps {
   text: string;
@@ -792,10 +798,10 @@ interface MarkdownFileLinkProps {
   threadRef?: ScopedThreadRef | undefined;
   onOpen: (targetPath: string) => Promise<AtomCommandResult<unknown, unknown>>;
   onOpenInBrowser?: (() => Promise<AtomCommandResult<unknown, unknown>>) | undefined;
+  onOpenNative?: (() => Promise<void>) | undefined;
   className?: string | undefined;
 }
 
-const MARKDOWN_LINK_HREF_PATTERN = /\[[^\]]*]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g;
 const MARKDOWN_FILE_LINK_CLASS_NAME =
   "chat-markdown-file-link cursor-pointer transition-colors hover:bg-accent/70";
 
@@ -872,21 +878,6 @@ function extractInlineCodeSpans(text: string): string[] {
     }
   }
   return spans;
-}
-
-function extractMarkdownLinkHrefs(text: string): string[] {
-  const hrefs: string[] = [];
-  for (const match of text.matchAll(MARKDOWN_LINK_HREF_PATTERN)) {
-    const href = match[1]?.trim();
-    if (!href) continue;
-    hrefs.push(href);
-  }
-  return hrefs;
-}
-
-function normalizeMarkdownLinkHrefKey(href: string): string {
-  const normalizedHref = normalizeMarkdownLinkDestination(href);
-  return rewriteMarkdownFileUriHref(normalizedHref) ?? normalizedHref;
 }
 
 const MARKDOWN_LINK_FAVICON_CLASS_NAME = "block size-full shrink-0 select-none";
@@ -1094,88 +1085,65 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
   threadRef,
   onOpen,
   onOpenInBrowser,
+  onOpenNative,
   className,
 }: MarkdownFileLinkProps) {
-  const handleOpenInEditor = useCallback(() => {
-    void (async () => {
-      try {
-        const result = await onOpen(targetPath);
-        if (result._tag === "Success" || isAtomCommandInterrupted(result)) {
-          return;
-        }
-        reportMarkdownActionFailure(
-          { operation: "open-file-in-editor", target: targetPath },
-          result.cause,
-        );
-        const error = squashAtomCommandFailure(result);
-        toastManager.add(
-          stackedThreadToast({
-            type: "error",
-            title: "Unable to open file",
-            description: error instanceof Error ? error.message : "An error occurred.",
-          }),
-        );
-      } catch (cause) {
-        reportMarkdownActionFailure(
-          { operation: "open-file-in-editor", target: targetPath },
-          cause,
-        );
-        toastManager.add(
-          stackedThreadToast({
-            type: "error",
-            title: "Unable to open file",
-            description: cause instanceof Error ? cause.message : "An error occurred.",
-          }),
-        );
-      }
-    })();
+  const openInEditor = useCallback(async () => {
+    const result = await onOpen(targetPath);
+    if (result._tag === "Success" || isAtomCommandInterrupted(result)) return;
+    throw squashAtomCommandFailure(result);
   }, [onOpen, targetPath]);
 
-  const handleOpenInFilePreview = useCallback(() => {
+  const openInFilePreview = useCallback(async () => {
     if (!threadRef || !workspaceRelativePath) {
-      handleOpenInEditor();
+      await openInEditor();
       return;
     }
     useRightPanelStore.getState().openFile(threadRef, workspaceRelativePath, line);
-  }, [handleOpenInEditor, line, threadRef, workspaceRelativePath]);
+  }, [line, openInEditor, threadRef, workspaceRelativePath]);
 
-  const handleOpenInBrowser = useCallback(() => {
-    if (!onOpenInBrowser) {
-      return;
-    }
-    void (async () => {
-      try {
-        const result = await onOpenInBrowser();
-        if (result._tag === "Success" || isAtomCommandInterrupted(result)) {
-          return;
-        }
-        reportMarkdownActionFailure(
-          { operation: "open-file-in-browser", target: targetPath },
-          result.cause,
-        );
-        const error = squashAtomCommandFailure(result);
+  const openInBrowser = useCallback(async () => {
+    if (!onOpenInBrowser) return;
+    const result = await onOpenInBrowser();
+    if (result._tag === "Success" || isAtomCommandInterrupted(result)) return;
+    throw squashAtomCommandFailure(result);
+  }, [onOpenInBrowser]);
+
+  const runFileOpen = useCallback(
+    (operation: string, open: () => Promise<void>) => {
+      void open().catch((cause: unknown) => {
+        reportMarkdownActionFailure({ operation, target: targetPath }, cause);
         toastManager.add(
           stackedThreadToast({
             type: "error",
-            title: "Unable to open file in browser",
-            description: error instanceof Error ? error.message : "An error occurred.",
-          }),
-        );
-      } catch (cause) {
-        reportMarkdownActionFailure(
-          { operation: "open-file-in-browser", target: targetPath },
-          cause,
-        );
-        toastManager.add(
-          stackedThreadToast({
-            type: "error",
-            title: "Unable to open file in browser",
+            title: "Unable to open file",
             description: cause instanceof Error ? cause.message : "An error occurred.",
           }),
         );
-      }
-    })();
-  }, [onOpenInBrowser, targetPath]);
+      });
+    },
+    [targetPath],
+  );
+
+  const handleDefaultOpen = useCallback(() => {
+    runFileOpen("open-file", () =>
+      openChatMarkdownFile({
+        filePath: iconPath,
+        desktopBridge: onOpenNative ? { openPath: onOpenNative } : undefined,
+        openInEditor: openInFilePreview,
+        ...(onOpenInBrowser ? { openInBrowser } : {}),
+      }),
+    );
+  }, [iconPath, onOpenInBrowser, onOpenNative, openInBrowser, openInFilePreview, runFileOpen]);
+
+  const handleOpenInEditor = useCallback(() => {
+    runFileOpen("open-file-in-editor", openInEditor);
+  }, [openInEditor, runFileOpen]);
+
+  const handleOpenInBrowser = useCallback(() => {
+    if (!onOpenInBrowser) return;
+    runFileOpen("open-file-in-browser", openInBrowser);
+  }, [onOpenInBrowser, openInBrowser, runFileOpen]);
 
   const handleCopy = useCallback(
     (value: string, title: string) => {
@@ -1273,11 +1241,7 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
             onClick={(event) => {
               event.preventDefault();
               event.stopPropagation();
-              if (onOpenInBrowser) {
-                handleOpenInBrowser();
-                return;
-              }
-              handleOpenInFilePreview();
+              handleDefaultOpen();
             }}
             onContextMenu={handleContextMenu}
           >
@@ -1314,6 +1278,7 @@ function areMarkdownFileLinkPropsEqual(
     previous.threadRef === next.threadRef &&
     previous.onOpen === next.onOpen &&
     previous.onOpenInBrowser === next.onOpenInBrowser &&
+    previous.onOpenNative === next.onOpenNative &&
     previous.className === next.className
   );
 }
@@ -1336,7 +1301,15 @@ function ChatMarkdown({
     reportFailure: false,
   });
   const preparedConnection = usePreparedConnection(threadRef?.environmentId ?? null);
-  const environmentId = useActiveEnvironmentId();
+  const activeEnvironmentId = useActiveEnvironmentId();
+  const environmentId = threadRef?.environmentId ?? activeEnvironmentId;
+  const { presentation: threadEnvironment } = useEnvironmentPresentation(
+    threadRef?.environmentId ?? null,
+  );
+  const hostLocalDesktopBridge =
+    threadEnvironment && isHostFilesystemConnectionTarget(threadEnvironment.entry.target)
+      ? window.desktopBridge
+      : undefined;
   const serverConfig = useAtomValue(serverEnvironment.configValueAtom(environmentId));
   const openInPreferredEditor = useOpenInPreferredEditor(
     environmentId,
@@ -1351,7 +1324,7 @@ function ChatMarkdown({
     for (const href of extractMarkdownLinkHrefs(text)) {
       const normalizedHref = normalizeMarkdownLinkHrefKey(href);
       if (metaByHref.has(normalizedHref)) continue;
-      const meta = resolveMarkdownFileLinkMeta(normalizedHref, cwd);
+      const meta = resolveMarkdownFileLinkMeta(href, cwd);
       if (meta) {
         metaByHref.set(normalizedHref, meta);
       }
@@ -1467,6 +1440,11 @@ function ChatMarkdown({
           theme={resolvedTheme}
           threadRef={threadRef}
           onOpen={openInPreferredEditor}
+          onOpenNative={
+            hostLocalDesktopBridge
+              ? () => hostLocalDesktopBridge.openPath(fileLinkMeta.filePath)
+              : undefined
+          }
           onOpenInBrowser={
             threadRef &&
             isPreviewSupportedInRuntime() &&
@@ -1623,7 +1601,7 @@ function ChatMarkdown({
 
         return fileLinkChip(
           fileLinkMeta,
-          `[${fileLinkMeta.basename}](${normalizedHref})`,
+          `[${fileLinkMeta.basename}](${href ?? normalizedHref})`,
           props.className,
         );
       },
@@ -1682,6 +1660,7 @@ function ChatMarkdown({
     cwd,
     diffThemeName,
     fileLinkParentSuffixByPath,
+    hostLocalDesktopBridge,
     inlineCodeFileLinkMetaByText,
     isStreaming,
     markdownFileLinkMetaByHref,

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1307,7 +1307,9 @@ function ChatMarkdown({
     threadRef?.environmentId ?? null,
   );
   const hostLocalDesktopBridge =
-    threadEnvironment && isHostFilesystemConnectionTarget(threadEnvironment.entry.target)
+    typeof window !== "undefined" &&
+    threadEnvironment &&
+    isHostFilesystemConnectionTarget(threadEnvironment.entry.target)
       ? window.desktopBridge
       : undefined;
   const serverConfig = useAtomValue(serverEnvironment.configValueAtom(environmentId));

--- a/apps/web/src/components/ChatMarkdownDesktopBridge.test.ts
+++ b/apps/web/src/components/ChatMarkdownDesktopBridge.test.ts
@@ -1,0 +1,117 @@
+import {
+  BearerConnectionTarget,
+  PrimaryConnectionTarget,
+  RelayConnectionTarget,
+  SshConnectionTarget,
+} from "@t3tools/client-runtime/connection";
+import { EnvironmentId } from "@t3tools/contracts";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  isHostFilesystemConnectionTarget,
+  openChatMarkdownFile,
+} from "./ChatMarkdownDesktopBridge";
+
+function fileOpenHarness(options?: { readonly hostLocal?: boolean }) {
+  const openPath = vi.fn(async (_path: string) => undefined);
+  const openInEditor = vi.fn(async () => undefined);
+  const openInBrowser = vi.fn(async () => undefined);
+
+  return {
+    openPath,
+    openInEditor,
+    openInBrowser,
+    open: (filePath: string, browserPreviewAvailable = false) =>
+      openChatMarkdownFile({
+        filePath,
+        desktopBridge: options?.hostLocal === false ? undefined : { openPath },
+        openInEditor,
+        ...(browserPreviewAvailable ? { openInBrowser } : {}),
+      }),
+  };
+}
+
+describe("ChatMarkdownDesktopBridge", () => {
+  it.each([
+    "/Users/toviastorres/Downloads/product image.png",
+    "/Users/toviastorres/Downloads/product demo.html",
+    "/Users/toviastorres/Downloads/model.blend",
+    "/Users/toviastorres/Downloads/.hidden screenshot.png",
+  ])("opens a host-local desktop artifact in its native app: %s", async (filePath) => {
+    const harness = fileOpenHarness();
+
+    await harness.open(filePath, filePath.endsWith(".html"));
+
+    expect(harness.openPath).toHaveBeenCalledWith(filePath);
+    expect(harness.openInEditor).not.toHaveBeenCalled();
+    expect(harness.openInBrowser).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "/Users/toviastorres/Projects/t3code/src/example.ts",
+    "/Users/toviastorres/Projects/t3code/infra/main.tf",
+    "/Users/toviastorres/Projects/t3code/.gitignore",
+    "/Users/toviastorres/Projects/t3code/.env.local",
+    "/Users/toviastorres/Projects/t3code/Dockerfile.dev",
+    "/Users/toviastorres/Projects/t3code/go.mod",
+    "/Users/toviastorres/Projects/t3code/notebook.ipynb",
+  ])("keeps source and config files in the editor: %s", async (filePath) => {
+    const harness = fileOpenHarness();
+
+    await harness.open(filePath);
+
+    expect(harness.openPath).not.toHaveBeenCalled();
+    expect(harness.openInEditor).toHaveBeenCalledOnce();
+  });
+
+  it("never sends remote paths to the desktop shell", async () => {
+    const harness = fileOpenHarness({ hostLocal: false });
+
+    await harness.open("/remote/build/product image.png");
+
+    expect(harness.openPath).not.toHaveBeenCalled();
+    expect(harness.openInEditor).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the integrated-browser fallback for remote HTML", async () => {
+    const harness = fileOpenHarness({ hostLocal: false });
+
+    await harness.open("/remote/build/product demo.html", true);
+
+    expect(harness.openPath).not.toHaveBeenCalled();
+    expect(harness.openInBrowser).toHaveBeenCalledOnce();
+    expect(harness.openInEditor).not.toHaveBeenCalled();
+  });
+
+  it("propagates native open errors to the visible chat error handler", async () => {
+    const harness = fileOpenHarness();
+    const error = new Error("There is no application set to open the file.");
+    harness.openPath.mockRejectedValue(error);
+
+    await expect(harness.open("/Users/toviastorres/Downloads/product image.png")).rejects.toBe(
+      error,
+    );
+  });
+
+  it("only treats the primary desktop target as sharing the host filesystem", () => {
+    const environmentId = EnvironmentId.make("environment-1");
+    const common = { environmentId, label: "Test" };
+
+    expect(
+      isHostFilesystemConnectionTarget(
+        new PrimaryConnectionTarget({
+          ...common,
+          httpBaseUrl: "http://127.0.0.1:3773",
+          wsBaseUrl: "ws://127.0.0.1:3773",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      [
+        new BearerConnectionTarget({ ...common, connectionId: "local:wsl:Ubuntu" }),
+        new RelayConnectionTarget(common),
+        new SshConnectionTarget({ ...common, connectionId: "ssh:server" }),
+      ].every((target) => !isHostFilesystemConnectionTarget(target)),
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/components/ChatMarkdownDesktopBridge.ts
+++ b/apps/web/src/components/ChatMarkdownDesktopBridge.ts
@@ -1,0 +1,181 @@
+import type { ConnectionTarget } from "@t3tools/client-runtime/connection";
+
+interface ChatMarkdownDesktopBridge {
+  readonly openPath: (path: string) => Promise<void>;
+}
+
+interface OpenChatMarkdownFileInput {
+  readonly filePath: string;
+  readonly desktopBridge: ChatMarkdownDesktopBridge | undefined;
+  readonly openInEditor: () => Promise<void>;
+  readonly openInBrowser?: (() => Promise<void>) | undefined;
+}
+
+const EDITOR_FILE_EXTENSIONS = new Set([
+  "astro",
+  "bash",
+  "bat",
+  "c",
+  "cc",
+  "cfg",
+  "cjs",
+  "clj",
+  "cljs",
+  "cljc",
+  "cmake",
+  "cmd",
+  "conf",
+  "cpp",
+  "cs",
+  "css",
+  "cts",
+  "cxx",
+  "env",
+  "erl",
+  "ex",
+  "exs",
+  "fish",
+  "fs",
+  "fsx",
+  "go",
+  "gql",
+  "gradle",
+  "graphql",
+  "h",
+  "hcl",
+  "hh",
+  "hpp",
+  "hrl",
+  "hs",
+  "hxx",
+  "ini",
+  "inl",
+  "ipynb",
+  "java",
+  "js",
+  "json",
+  "json5",
+  "jsonc",
+  "jsx",
+  "kt",
+  "kts",
+  "less",
+  "lhs",
+  "lock",
+  "lua",
+  "m",
+  "md",
+  "mdx",
+  "mjs",
+  "mod",
+  "ml",
+  "mli",
+  "mm",
+  "mts",
+  "php",
+  "pl",
+  "pm",
+  "properties",
+  "proto",
+  "ps1",
+  "py",
+  "pyi",
+  "pyw",
+  "pyx",
+  "r",
+  "rb",
+  "rake",
+  "rs",
+  "rst",
+  "sass",
+  "scala",
+  "scss",
+  "sh",
+  "sql",
+  "styl",
+  "sum",
+  "svelte",
+  "swift",
+  "tex",
+  "tf",
+  "tfstate",
+  "tfvars",
+  "toml",
+  "ts",
+  "tsx",
+  "vue",
+  "work",
+  "xml",
+  "xsl",
+  "xslt",
+  "yaml",
+  "yml",
+  "zig",
+  "zsh",
+]);
+
+const EDITOR_FILE_NAMES = new Set([
+  ".babelrc",
+  ".bash_profile",
+  ".bashrc",
+  ".browserslistrc",
+  ".dockerignore",
+  ".eslintignore",
+  ".eslintrc",
+  ".gitattributes",
+  ".gitignore",
+  ".gitkeep",
+  ".gitmodules",
+  ".postcssrc",
+  ".prettierignore",
+  ".prettierrc",
+  ".stylelintignore",
+  ".stylelintrc",
+  ".zprofile",
+  ".zshenv",
+  ".zshrc",
+  "dockerfile",
+  "gemfile",
+  "makefile",
+  "procfile",
+  "rakefile",
+]);
+
+const EDITOR_FILE_PREFIXES = [".env.", ".eslintrc.", ".prettierrc.", ".stylelintrc."];
+
+function fileName(path: string): string {
+  return (path.replaceAll("\\", "/").split("/").pop() ?? "").toLowerCase();
+}
+
+export function shouldOpenChatFileNatively(path: string): boolean {
+  const name = fileName(path);
+  if (
+    EDITOR_FILE_NAMES.has(name) ||
+    EDITOR_FILE_PREFIXES.some((prefix) => name.startsWith(prefix)) ||
+    name.startsWith("dockerfile.")
+  ) {
+    return false;
+  }
+  const extensionIndex = name.lastIndexOf(".");
+  if (extensionIndex <= 0) return false;
+  return !EDITOR_FILE_EXTENSIONS.has(name.slice(extensionIndex + 1));
+}
+
+/** A primary target shares the Electron host filesystem; remote and WSL targets do not. */
+export function isHostFilesystemConnectionTarget(target: ConnectionTarget): boolean {
+  return target._tag === "PrimaryConnectionTarget";
+}
+
+export async function openChatMarkdownFile(input: OpenChatMarkdownFileInput): Promise<void> {
+  if (input.desktopBridge !== undefined && shouldOpenChatFileNatively(input.filePath)) {
+    await input.desktopBridge.openPath(input.filePath);
+    return;
+  }
+
+  if (input.openInBrowser !== undefined) {
+    await input.openInBrowser();
+    return;
+  }
+
+  await input.openInEditor();
+}

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -1,11 +1,68 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  extractMarkdownLinkHrefs,
+  normalizeMarkdownLinkHrefKey,
   resolveInlineCodeFileLinkMeta,
   resolveMarkdownFileLinkMeta,
   resolveMarkdownFileLinkTarget,
   rewriteMarkdownFileUriHref,
 } from "./markdown-links";
+
+describe("markdown file link destinations", () => {
+  it("matches an angle-bracket destination containing spaces to its rendered href", () => {
+    const [sourceHref] = extractMarkdownLinkHrefs(
+      "[product image](</Users/toviastorres/Downloads/product image.png>)",
+    );
+
+    expect(sourceHref).toBe("/Users/toviastorres/Downloads/product image.png");
+    expect(normalizeMarkdownLinkHrefKey(sourceHref ?? "")).toBe(
+      normalizeMarkdownLinkHrefKey("/Users/toviastorres/Downloads/product%20image.png"),
+    );
+  });
+
+  it("keeps balanced parentheses inside bare destinations", () => {
+    expect(extractMarkdownLinkHrefs("[download](/tmp/report(1).pdf)")).toEqual([
+      "/tmp/report(1).pdf",
+    ]);
+  });
+
+  it("ignores a trailing title after the destination", () => {
+    expect(extractMarkdownLinkHrefs('[report](/tmp/report.pdf "Latest report")')).toEqual([
+      "/tmp/report.pdf",
+    ]);
+  });
+
+  it("finds the label end across escaped and nested brackets", () => {
+    expect(
+      extractMarkdownLinkHrefs("[escaped \\] label](/tmp/a.txt) and [nested [label]](/tmp/b.txt)"),
+    ).toEqual(["/tmp/a.txt", "/tmp/b.txt"]);
+  });
+
+  it("does not extract link-looking text from a title", () => {
+    expect(
+      extractMarkdownLinkHrefs('[report](/tmp/a.txt "see [fake](/tmp/not-a-link.txt)")'),
+    ).toEqual(["/tmp/a.txt"]);
+  });
+
+  it("continues after malformed destinations", () => {
+    expect(
+      extractMarkdownLinkHrefs("[unclosed](</tmp/nope.txt) then [valid](/tmp/valid.txt)"),
+    ).toEqual(["/tmp/valid.txt"]);
+  });
+
+  it("matches file URI source and rewritten render keys without double-decoding", () => {
+    const source = normalizeMarkdownLinkHrefKey(
+      "file:///Users/toviastorres/Downloads/file%2520name.pdf",
+    );
+    const rendered = normalizeMarkdownLinkHrefKey(
+      "/Users/toviastorres/Downloads/file%2520name.pdf",
+    );
+
+    expect(source).toBe(rendered);
+    expect(source).toBe("/Users/toviastorres/Downloads/file%20name.pdf");
+  });
+});
 
 describe("rewriteMarkdownFileUriHref", () => {
   it("rewrites file uri hrefs into direct path hrefs", () => {

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -51,6 +51,18 @@ describe("markdown file link destinations", () => {
     ).toEqual(["/tmp/valid.txt"]);
   });
 
+  it("continues after an unmatched opening bracket", () => {
+    expect(extractMarkdownLinkHrefs("output [pending; see [report](/tmp/report.pdf)")).toEqual([
+      "/tmp/report.pdf",
+    ]);
+  });
+
+  it("preserves Windows separators that are not Markdown escapes", () => {
+    expect(extractMarkdownLinkHrefs(String.raw`[report](C:\Users\me\report.pdf)`)).toEqual([
+      String.raw`C:\Users\me\report.pdf`,
+    ]);
+  });
+
   it("matches file URI source and rewritten render keys without double-decoding", () => {
     const source = normalizeMarkdownLinkHrefKey(
       "file:///Users/toviastorres/Downloads/file%2520name.pdf",

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -9,6 +9,7 @@ const RELATIVE_FILE_PATH_PATTERN = /^[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)+(?::\d
 const RELATIVE_FILE_NAME_PATTERN = /^[A-Za-z0-9._-]+\.[A-Za-z0-9_-]+(?::\d+){0,2}$/;
 const POSITION_SUFFIX_PATTERN = /:\d+(?::\d+)?$/;
 const POSITION_ONLY_PATTERN = /^\d+(?::\d+)?$/;
+const MARKDOWN_ESCAPABLE_CHARACTER_PATTERN = /^[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]$/;
 // Standard OS and dev-container roots; deliberately excludes app-route-ish
 // prefixes like /app/ or /chat/ so SPA routes never read as files.
 const POSIX_FILE_ROOT_PREFIXES = [
@@ -58,6 +59,10 @@ function safeDecode(value: string): string {
 
 function unwrapMarkdownLinkDestination(value: string): string {
   return value.startsWith("<") && value.endsWith(">") ? value.slice(1, -1) : value;
+}
+
+function isMarkdownEscapableCharacter(character: string | undefined): boolean {
+  return character !== undefined && MARKDOWN_ESCAPABLE_CHARACTER_PATTERN.test(character);
 }
 
 export function normalizeMarkdownLinkDestination(value: string): string {
@@ -112,7 +117,7 @@ function findMarkdownLinkLabelEnd(text: string, labelStart: number): number {
   let depth = 0;
   for (let index = labelStart; index < text.length; index += 1) {
     const character = text[index];
-    if (character === "\\") {
+    if (character === "\\" && isMarkdownEscapableCharacter(text[index + 1])) {
       index += 1;
       continue;
     }
@@ -162,7 +167,10 @@ export function extractMarkdownLinkHrefs(text: string): string[] {
     const labelStart = text.indexOf("[", index);
     if (labelStart === -1) break;
     const labelEnd = findMarkdownLinkLabelEnd(text, labelStart);
-    if (labelEnd === -1) break;
+    if (labelEnd === -1) {
+      index = labelStart + 1;
+      continue;
+    }
     if (text[labelEnd + 1] !== "(") {
       index = labelEnd + 1;
       continue;
@@ -177,7 +185,7 @@ export function extractMarkdownLinkHrefs(text: string): string[] {
       let closed = false;
       while (position < text.length) {
         const character = text[position];
-        if (character === "\\" && position + 1 < text.length) {
+        if (character === "\\" && isMarkdownEscapableCharacter(text[position + 1])) {
           destination += text[position + 1];
           position += 2;
           continue;
@@ -199,7 +207,7 @@ export function extractMarkdownLinkHrefs(text: string): string[] {
       let depth = 0;
       while (position < text.length) {
         const character = text[position];
-        if (character === "\\" && position + 1 < text.length) {
+        if (character === "\\" && isMarkdownEscapableCharacter(text[position + 1])) {
           destination += text[position + 1];
           position += 2;
           continue;

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -108,6 +108,136 @@ export function rewriteMarkdownFileUriHref(href: string | undefined): string | n
   return `${target.path}${target.hash}`;
 }
 
+function findMarkdownLinkLabelEnd(text: string, labelStart: number): number {
+  let depth = 0;
+  for (let index = labelStart; index < text.length; index += 1) {
+    const character = text[index];
+    if (character === "\\") {
+      index += 1;
+      continue;
+    }
+    if (character === "[") {
+      depth += 1;
+      continue;
+    }
+    if (character === "]") {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+  }
+  return -1;
+}
+
+function skipMarkdownLinkTitleAndClose(text: string, start: number): number {
+  const isWhitespace = (character: string | undefined): boolean =>
+    character === " " || character === "\t" || character === "\n" || character === "\r";
+  let position = start;
+  while (position < text.length && isWhitespace(text[position])) position += 1;
+
+  const opener = text[position];
+  if (opener === '"' || opener === "'" || opener === "(") {
+    const closer = opener === "(" ? ")" : opener;
+    position += 1;
+    while (position < text.length) {
+      const character = text[position];
+      if (character === "\\" && position + 1 < text.length) {
+        position += 2;
+        continue;
+      }
+      position += 1;
+      if (character === closer) break;
+    }
+    while (position < text.length && isWhitespace(text[position])) position += 1;
+  }
+
+  return text[position] === ")" ? position + 1 : position;
+}
+
+/** Extract inline-link destinations using the forms accepted by CommonMark. */
+export function extractMarkdownLinkHrefs(text: string): string[] {
+  const hrefs: string[] = [];
+  let index = 0;
+
+  while (index < text.length) {
+    const labelStart = text.indexOf("[", index);
+    if (labelStart === -1) break;
+    const labelEnd = findMarkdownLinkLabelEnd(text, labelStart);
+    if (labelEnd === -1) break;
+    if (text[labelEnd + 1] !== "(") {
+      index = labelEnd + 1;
+      continue;
+    }
+
+    let position = labelEnd + 2;
+    while (text[position] === " " || text[position] === "\t") position += 1;
+    let destination = "";
+
+    if (text[position] === "<") {
+      position += 1;
+      let closed = false;
+      while (position < text.length) {
+        const character = text[position];
+        if (character === "\\" && position + 1 < text.length) {
+          destination += text[position + 1];
+          position += 2;
+          continue;
+        }
+        if (character === "\n") break;
+        if (character === ">") {
+          closed = true;
+          position += 1;
+          break;
+        }
+        destination += character;
+        position += 1;
+      }
+      if (!closed) {
+        index = labelEnd + 2;
+        continue;
+      }
+    } else {
+      let depth = 0;
+      while (position < text.length) {
+        const character = text[position];
+        if (character === "\\" && position + 1 < text.length) {
+          destination += text[position + 1];
+          position += 2;
+          continue;
+        }
+        if (
+          character === " " ||
+          character === "\t" ||
+          character === "\n" ||
+          character === undefined ||
+          character.charCodeAt(0) < 0x20
+        ) {
+          break;
+        }
+        if (character === "(") {
+          depth += 1;
+        } else if (character === ")") {
+          if (depth === 0) break;
+          depth -= 1;
+        }
+        destination += character;
+        position += 1;
+      }
+    }
+
+    const href = destination.trim();
+    if (href.length > 0) hrefs.push(href);
+    index = Math.max(skipMarkdownLinkTitleAndClose(text, position), labelEnd + 2);
+  }
+
+  return hrefs;
+}
+
+/** Canonical map key shared by authored destinations and rendered anchor hrefs. */
+export function normalizeMarkdownLinkHrefKey(href: string): string {
+  const normalizedHref = normalizeMarkdownLinkDestination(href);
+  return safeDecode(rewriteMarkdownFileUriHref(normalizedHref) ?? normalizedHref);
+}
+
 function looksLikePosixFilesystemPath(path: string): boolean {
   if (!path.startsWith("/")) return false;
   if (POSIX_FILE_ROOT_PREFIXES.some((prefix) => path.startsWith(prefix))) return true;

--- a/docs/user/chat-file-links.md
+++ b/docs/user/chat-file-links.md
@@ -1,0 +1,14 @@
+# Open files linked in chat
+
+File links in a conversation open according to the file and environment:
+
+- Workspace source files, such as TypeScript, open in T3 Code's file panel. If a source file is
+  outside the workspace, T3 Code uses your configured editor instead.
+- In the desktop app, documents and generated artifacts from the primary environment that shares
+  the desktop host's filesystem open in the operating system's default application. For example,
+  HTML opens in your default browser and images open in your default image viewer.
+- Files from remote environments stay in T3 Code: browser-previewable files open in the integrated
+  browser, while other files use the configured editor.
+
+If the operating system cannot open a local file, T3 Code shows the error in the conversation
+instead of ignoring the click.

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1048,6 +1048,7 @@ export interface DesktopBridge {
     position?: { x: number; y: number },
   ) => Promise<T | null>;
   openExternal: (url: string) => Promise<boolean>;
+  openPath: (path: string) => Promise<void>;
   onMenuAction: (listener: (action: string) => void) => () => void;
   getWindowFullscreenState: () => boolean;
   onWindowFullscreenStateChange: (listener: (fullscreen: boolean) => void) => () => void;


### PR DESCRIPTION
## What Changed

- add a typed Desktop IPC bridge for Electron `shell.openPath`
- open host-local, non-code chat file links in their OS-default application
- keep source and configuration files on the existing editor path
- preserve safe integrated preview/editor behavior for remote and WSL environments
- support Markdown destinations wrapped in angle brackets, including paths with spaces
- surface native-open failures through the existing visible chat error handling
- document the desktop and remote behavior

## Why

Chat Markdown already recognizes local file links, but Desktop only exposed `openExternal` for HTTP(S) URLs. Non-code files outside the workspace could therefore be routed to the configured code editor or integrated preview instead of the user's default desktop application.

The new bridge calls Electron at the adapter boundary and only for the primary environment that shares the desktop host filesystem. Remote and secondary filesystem environments never receive host path access.

Related: #5228, #6360, #5158, #5222, #5125, #5126.

## User Impact

On Desktop, local images, PDFs, HTML, and other non-code artifacts now open in their default OS application. Code and configuration files keep the normal editor flow. Invalid paths produce an observable error instead of failing silently.

## UI Changes

No visual layout, animation, or timing changes. This only changes the result of clicking supported chat file links, so screenshots and video are not applicable.

Manual verification on macOS covered PNG, HTML, a real PDF, paths with spaces, and the visible error for a missing PDF.

## Validation

- `pnpm exec vp test run apps/web/src/components/ChatMarkdownDesktopBridge.test.ts apps/web/src/markdown-links.test.ts apps/desktop/src/electron/ElectronShell.test.ts apps/desktop/src/ipc/methods/window.test.ts --reporter dot` — 68 passed
- `pnpm --filter @t3tools/web typecheck`
- `pnpm --filter @t3tools/desktop typecheck`
- `pnpm --filter @t3tools/contracts typecheck`
- targeted `vp lint --report-unused-disable-directives`
- targeted `vp fmt --check`
- `pnpm exec vp run --filter @t3tools/desktop build`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No visual changes; before/after screenshots are not applicable
- [x] No animation or timing changes; video is not applicable

Model: GPT-5.6. Harness: Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New IPC exposes host filesystem paths but is gated to `PrimaryConnectionTarget` and file-type heuristics; incorrect classification could send the wrong paths to the shell or skip native open.
> 
> **Overview**
> Adds a desktop **`openPath`** IPC path (Electron `shell.openPath` → preload `desktopBridge.openPath`) so chat file links can launch the OS default app for local artifacts.
> 
> **Chat file open behavior** is centralized in `openChatMarkdownFile`: on the **primary** desktop environment only, non–source/config files (images, PDFs, HTML, etc.) open natively; code/config still use the editor/preview flow; SSH/WSL/relay targets never get host paths. Failures surface in the existing chat toast path.
> 
> **Markdown link parsing** moves to CommonMark-style `extractMarkdownLinkHrefs` / `normalizeMarkdownLinkHrefKey` so paths with spaces, parentheses, and file URIs match between authored markdown and rendered hrefs. Default click on file chips uses the new routing instead of always preferring integrated browser when available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f37fcc550b1648df88ef852cf21b0ba4e5f4b28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Open chat artifact file links in native OS apps from the desktop client
> - Adds `openPath` to the `ElectronShell` service, IPC channel (`desktop:open-path`), preload bridge, and `DesktopBridge` contract so renderers can request the main process to open a local file with the OS default app.
> - Introduces [ChatMarkdownDesktopBridge.ts](https://github.com/pingdotgg/t3code/pull/6528/files#diff-f33caa77f2b71cc544aa15f67372978b2c104ee64f3e5f2aec43fc145c95337e) to route chat file-link clicks: opens natively via the desktop bridge for artifact files when the thread environment shares the host filesystem, falls back to the integrated browser or editor otherwise.
> - Source/config files (e.g. dotfiles, Dockerfiles, common code extensions) are excluded from native open and continue to open in the editor.
> - Replaces local regex link parsing in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/6528/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05) with a new robust `extractMarkdownLinkHrefs`/`normalizeMarkdownLinkHrefKey` utility in [markdown-links.ts](https://github.com/pingdotgg/t3code/pull/6528/files#diff-010f94b966be6604cb228ce225d1f3ce41b15470b641a970ec5ed07cd2ed2040) that handles edge cases like angle-bracket destinations, balanced parentheses, and Windows paths.
> - Risk: switching to the new markdown link parser may change which links are recognized or how they are keyed for existing chat messages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2f37fcc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

