### PR TITLE
fix(provider): deliver OpenCode steers at the next tool boundary

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -28,7 +28,7 @@
     "@effect/platform-node-shared": "catalog:",
     "@effect/sql-sqlite-bun": "catalog:",
     "@ff-labs/fff-node": "0.9.4",
-    "@opencode-ai/sdk": "^1.3.15",
+    "@opencode-ai/sdk": "^1.18.14",
     "@pierre/diffs": "catalog:",
     "effect": "catalog:",
     "node-pty": "^1.1.0",

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -183,6 +183,12 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
             throw runtimeMock.state.promptAsyncError;
           }
         },
+        prompt: async (input: unknown) => {
+          runtimeMock.state.promptCalls.push(input);
+          if (runtimeMock.state.promptAsyncError) {
+            throw runtimeMock.state.promptAsyncError;
+          }
+        },
         messages: async () => ({ data: runtimeMock.state.messages }),
         revert: async ({ sessionID, messageID }: { sessionID: string; messageID?: string }) => {
           runtimeMock.state.revertCalls.push({
@@ -211,6 +217,16 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
             }
           })(),
         }),
+      },
+      v2: {
+        session: {
+          prompt: async (input: unknown) => {
+            runtimeMock.state.promptCalls.push(input);
+            if (runtimeMock.state.promptAsyncError) {
+              throw runtimeMock.state.promptAsyncError;
+            }
+          },
+        },
       },
     }) as unknown as ReturnType<OpenCodeRuntimeShape["createOpenCodeSdkClient"]>,
   loadOpenCodeInventory: () =>
@@ -750,7 +766,9 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       });
 
       // Steer: OpenCode queues the prompt into the busy session, so the
-      // active turn id is reused instead of opening a new turn.
+      // active turn id is reused instead of opening a new turn. The steer is
+      // delivered via the v2 prompt endpoint with steer delivery so the
+      // message rides along with the next tool boundary.
       const steeredTurn = yield* adapter.sendTurn({
         threadId,
         input: "actually run 15",
@@ -766,6 +784,9 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       NodeAssert.equal(session?.status, "running");
       NodeAssert.equal(String(session?.activeTurnId), String(turn.turnId));
       NodeAssert.equal(runtimeMock.state.promptCalls.length, 2);
+      const steerCall = runtimeMock.state.promptCalls.at(-1) as Record<string, unknown>;
+      NodeAssert.equal(steerCall.delivery, "steer");
+      NodeAssert.deepEqual(steerCall.prompt, { text: "actually run 15" });
     }),
   );
 

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -1481,14 +1481,41 @@ export function makeOpenCodeAdapter(
         });
       }
 
-      yield* runOpenCodeSdk("session.promptAsync", () =>
-        context.client.session.promptAsync({
-          sessionID: context.openCodeSessionId,
-          model: parsedModel,
-          ...(context.activeAgent ? { agent: context.activeAgent } : {}),
-          ...(context.activeVariant ? { variant: context.activeVariant } : {}),
-          parts: [...(text ? [{ type: "text" as const, text }] : []), ...fileParts],
-        }),
+      // A steer sends into the busy session. Use the v2 prompt endpoint with
+      // `delivery: "steer"` so opencode promotes the message at the next safe
+      // provider-turn boundary (i.e. after the current tool call) instead of
+      // deferring it until the whole turn finishes — matching the behavior of
+      // typing into a native opencode session. Fresh turns keep the legacy
+      // async prompt since they start the agent loop themselves.
+      const sendPrompt =
+        steeringTurnId !== undefined
+          ? context.client.v2.session.prompt({
+              sessionID: context.openCodeSessionId,
+              prompt: {
+                text: text ?? "",
+                ...(fileParts.length > 0
+                  ? {
+                      files: fileParts.map((part) => ({
+                        uri: part.url,
+                        mime: part.mime,
+                        ...(part.filename !== undefined ? { name: part.filename } : {}),
+                      })),
+                    }
+                  : {}),
+              },
+              delivery: "steer",
+            })
+          : context.client.session.promptAsync({
+              sessionID: context.openCodeSessionId,
+              model: parsedModel,
+              ...(context.activeAgent ? { agent: context.activeAgent } : {}),
+              ...(context.activeVariant ? { variant: context.activeVariant } : {}),
+              parts: [...(text ? [{ type: "text" as const, text }] : []), ...fileParts],
+            });
+
+      yield* runOpenCodeSdk(
+        steeringTurnId !== undefined ? "session.prompt" : "session.promptAsync",
+        () => sendPrompt,
       ).pipe(
         Effect.mapError(toRequestError),
         // On failure of a fresh turn: clear active-turn state, flip the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -465,8 +465,8 @@ importers:
         specifier: 0.9.4
         version: 0.9.4(patch_hash=2b16019ce7ab61aec6478dd02f79ef468cc1d5c51e9d00764f7d2ab8167210c8)
       '@opencode-ai/sdk':
-        specifier: ^1.3.15
-        version: 1.15.13
+        specifier: ^1.18.14
+        version: 1.18.16
       '@pierre/diffs':
         specifier: 'catalog:'
         version: 1.3.0-beta.10(patch_hash=7ef7cb0cbabb17c15cdb137554068b36f15f6f5265e73fb51452aa3380db91aa)(@shikijs/themes@4.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -3279,8 +3279,8 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
-  '@opencode-ai/sdk@1.15.13':
-    resolution: {integrity: sha512-4TwojIoQ8EG6/mVBuUVYZXiFcwNmiiytEnjnvyuvSJjGwFIlw2YIBFxtSVC3FbwwbwHT63teh1RHiQUUC4U5xw==}
+  '@opencode-ai/sdk@1.18.16':
+    resolution: {integrity: sha512-UvaHyL93spLm7MttoprWTOBSYQN3aYWd7/3Ie5WNnG2pRAPq/U/d51qt0smYBTrkjxqlQmg+AJoGw8MEH6lGUg==}
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
@@ -13429,7 +13429,7 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@opencode-ai/sdk@1.15.13':
+  '@opencode-ai/sdk@1.18.16':
     dependencies:
       cross-spawn: 7.0.6
 


### PR DESCRIPTION
## What changed

Active OpenCode turns now send follow-up prompts through the v2 prompt endpoint with `delivery: "steer"`. Fresh turns continue using the async legacy prompt endpoint. The OpenCode SDK is updated to the first compatible v2 release line.

## Why

The legacy async prompt path can defer a follow-up until the current agent loop finishes. OpenCode v2 defines steer delivery to promote the input at the next safe provider-turn boundary, matching the native OpenCode client and making mid-turn corrections responsive.

This addresses the delayed steering behavior reported in #2573 without changing fresh-turn semantics.

## Testing

- `cd apps/server && bun run test -- OpenCodeAdapter.test.ts` (30 passed)
- The adapter test asserts that a busy-session follow-up uses `delivery: "steer"` and retains the active turn id.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live provider turn delivery for busy OpenCode sessions; behavior is narrow (steer vs fresh turn) and covered by adapter tests, but it affects when mid-turn corrections reach the agent.
> 
> **Overview**
> **Mid-turn OpenCode follow-ups** now call `client.v2.session.prompt` with `delivery: "steer"` instead of the legacy `session.promptAsync` path, so user input is applied at the next tool boundary rather than after the whole agent loop finishes. **New turns** are unchanged and still use `session.promptAsync` with model, agent, variant, and file parts.
> 
> The server bumps **`@opencode-ai/sdk`** to the v2-compatible line (^1.18.14). Tests extend the SDK double with `v2.session.prompt` and assert steers send `{ prompt: { text }, delivery: "steer" }` while reusing the active turn id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b49bea422ab23efc84c2ce7b6c9399322a26aa1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deliver OpenCode steers via `v2.session.prompt` with `delivery: "steer"` at the next tool boundary
> - Steering prompts in [`OpenCodeAdapter.ts`](https://github.com/pingdotgg/t3code/pull/6530/files#diff-a4267388b15e5043ae1899beded972cbee9e52533ca3d9d65d438a91a9f7fbe7) now dispatch via `client.v2.session.prompt` with `delivery: "steer"` and a structured prompt payload (text + mapped file parts), instead of using `session.promptAsync`.
> - Fresh (non-steer) turns continue to use `session.promptAsync` with the existing parts-based payload.
> - The `@opencode-ai/sdk` dependency is bumped from `^1.3.15` to `^1.18.14` to support the new v2 prompt API.
> - Tests in [`OpenCodeAdapter.test.ts`](https://github.com/pingdotgg/t3code/pull/6530/files#diff-2d1ef28752ab2f1ec0f021e6723508dc18e6a9294ebd20255ec3767afe34cf5f) are updated to assert that steers use the v2 endpoint with `delivery: "steer"` and the correct prompt payload.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b49bea4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->