### PR TITLE
fix(server): keep turn interrupts responsive

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -2486,6 +2486,82 @@ describe("ProviderCommandReactor", () => {
     });
   });
 
+  it("interrupts an active turn while the general provider worker is blocked", async () => {
+    const blockedStart = await Effect.runPromise(Deferred.make<ProviderSession>());
+    const harness = await createHarness({
+      startSessionEffect: (session) =>
+        session.threadId === ThreadId.make("thread-2")
+          ? Deferred.await(blockedStart)
+          : Effect.succeed(session),
+    });
+    const now = "2026-01-01T00:00:00.000Z";
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-running-turn-start"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("running-user-message"),
+          role: "user",
+          text: "keep working",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        createdAt: now,
+      }),
+    );
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.create",
+        commandId: CommandId.make("cmd-blocked-thread-create"),
+        threadId: ThreadId.make("thread-2"),
+        projectId: asProjectId("project-1"),
+        title: "Blocked thread",
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("codex"),
+          model: "gpt-5-codex",
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        branch: null,
+        worktreePath: null,
+        createdAt: now,
+      }),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-blocked-turn-start"),
+        threadId: ThreadId.make("thread-2"),
+        message: {
+          messageId: asMessageId("blocked-user-message"),
+          role: "user",
+          text: "block the general worker",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        createdAt: now,
+      }),
+    );
+    await waitFor(() => harness.startSession.mock.calls.length === 2);
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.interrupt",
+        commandId: CommandId.make("cmd-urgent-turn-interrupt"),
+        threadId: ThreadId.make("thread-1"),
+        turnId: asTurnId("turn-1"),
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.interruptTurn.mock.calls.length === 1);
+    expect(harness.interruptTurn.mock.calls[0]?.[0]).toEqual({ threadId: "thread-1" });
+  });
+
   it("starts a fresh session when only projected session state exists", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -1386,6 +1386,11 @@ const make = Effect.gen(function* () {
     );
 
   const worker = yield* makeDrainableWorker(processDomainEventSafely);
+  // Interrupts are latency-sensitive and must not wait behind provider
+  // lifecycle work on the general worker. A session start/stop or recovery can
+  // block on an unhealthy provider indefinitely; serializing Stop behind it
+  // leaves the active turn running even though the command was accepted.
+  const interruptWorker = yield* makeDrainableWorker(processDomainEventSafely);
 
   const start: ProviderCommandReactorShape["start"] = Effect.fn("start")(function* () {
     const interruptedTitleRegenerations = yield* findInterruptedThreadTitleRegenerations().pipe(
@@ -1409,7 +1414,9 @@ const make = Effect.gen(function* () {
         event.type === "thread.user-input-response-requested" ||
         event.type === "thread.session-stop-requested"
       ) {
-        return yield* worker.enqueue(event);
+        return yield* event.type === "thread.turn-interrupt-requested"
+          ? interruptWorker.enqueue(event)
+          : worker.enqueue(event);
       }
     });
 
@@ -1445,6 +1452,7 @@ const make = Effect.gen(function* () {
     start,
     drain: Effect.gen(function* () {
       yield* worker.drain;
+      yield* interruptWorker.drain;
       yield* threadTitleRegenerationWorker.drain;
     }),
   } satisfies ProviderCommandReactorShape;

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -497,6 +497,42 @@ describe("ProviderRuntimeIngestion", () => {
     expect(thread.session?.lastError).toBeNull();
   });
 
+  it("settles the active turn when the provider reports it was aborted", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+    const turnId = asTurnId("turn-aborted");
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-aborted"),
+      provider: ProviderDriverKind.make("opencode"),
+      threadId: asThreadId("thread-1"),
+      turnId,
+      createdAt: now,
+    });
+
+    await waitForThread(
+      harness.readModel,
+      (thread) => thread.session?.status === "running" && thread.session?.activeTurnId === turnId,
+    );
+
+    harness.emit({
+      type: "turn.aborted",
+      eventId: asEventId("evt-turn-aborted"),
+      provider: ProviderDriverKind.make("opencode"),
+      threadId: asThreadId("thread-1"),
+      turnId,
+      createdAt: "2026-01-01T00:00:01.000Z",
+      payload: { reason: "Interrupted by user." },
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) => entry.session?.status === "ready" && entry.session?.activeTurnId === null,
+    );
+    expect(thread.session?.lastError).toBeNull();
+  });
+
   effectIt.effect(
     "keeps a reconnecting pending turn starting while ready clears stale active state",
     () =>

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1525,6 +1525,7 @@ const make = Effect.gen(function* () {
           case "turn.started":
             return !conflictsWithActiveTurn || conflictingTurnStartIsPendingTurnStart;
           case "turn.completed":
+          case "turn.aborted":
             if (conflictsWithActiveTurn || missingTurnForActiveTurn) {
               return false;
             }
@@ -1555,7 +1556,8 @@ const make = Effect.gen(function* () {
         event.type === "session.exited" ||
         event.type === "thread.started" ||
         event.type === "turn.started" ||
-        event.type === "turn.completed"
+        event.type === "turn.completed" ||
+        event.type === "turn.aborted"
       ) {
         const status = (() => {
           switch (event.type) {
@@ -1571,6 +1573,8 @@ const make = Effect.gen(function* () {
               return normalizeRuntimeTurnState(event.payload.state) === "failed"
                 ? "error"
                 : "ready";
+            case "turn.aborted":
+              return "ready";
             case "session.started":
             case "thread.started":
               // Provider thread/session start notifications can arrive during an
@@ -1581,7 +1585,9 @@ const make = Effect.gen(function* () {
         const nextActiveTurnId =
           event.type === "turn.started"
             ? (eventTurnId ?? null)
-            : event.type === "turn.completed" || event.type === "session.exited"
+            : event.type === "turn.completed" ||
+                event.type === "turn.aborted" ||
+                event.type === "session.exited"
               ? null
               : event.type === "session.state.changed" &&
                   !sessionStatusAllowsActiveTurn(
@@ -1822,7 +1828,7 @@ const make = Effect.gen(function* () {
         });
       }
 
-      if (event.type === "turn.completed") {
+      if (event.type === "turn.completed" || event.type === "turn.aborted") {
         const detailedThread = yield* getLoadedThreadDetail();
         const messages = detailedThread?.messages ?? [];
         const proposedPlans = detailedThread?.proposedPlans ?? [];

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -65,6 +65,7 @@ const runtimeMock = {
     revertCalls: [] as Array<{ sessionID: string; messageID?: string }>,
     promptCalls: [] as Array<unknown>,
     promptAsyncError: null as Error | null,
+    abortError: null as Error | null,
     closeError: null as Error | null,
     messages: [] as MessageEntry[],
     subscribedEvents: [] as unknown[],
@@ -85,6 +86,7 @@ const runtimeMock = {
     this.state.revertCalls.length = 0;
     this.state.promptCalls.length = 0;
     this.state.promptAsyncError = null;
+    this.state.abortError = null;
     this.state.closeError = null;
     this.state.messages = [];
     this.state.subscribedEvents = [];
@@ -176,6 +178,9 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
         },
         abort: async ({ sessionID }: { sessionID: string }) => {
           runtimeMock.state.abortCalls.push(sessionID);
+          if (runtimeMock.state.abortError) {
+            throw runtimeMock.state.abortError;
+          }
         },
         promptAsync: async (input: unknown) => {
           runtimeMock.state.promptCalls.push(input);
@@ -806,6 +811,64 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       const session = sessions.find((entry) => entry.threadId === threadId);
       NodeAssert.equal(session?.status, "running");
       NodeAssert.equal(String(session?.activeTurnId), String(turn.turnId));
+    }),
+  );
+
+  it.effect("settles an interrupt before a remote abort failure can block it", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-interrupt-failure");
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+
+      const turn = yield* adapter.sendTurn({
+        threadId,
+        input: "stop this turn",
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("opencode"),
+          model: "openai/gpt-5",
+        },
+      });
+
+      runtimeMock.state.abortError = new Error("abort request failed");
+      yield* adapter.interruptTurn(threadId, turn.turnId);
+
+      const session = (yield* adapter.listSessions()).find((entry) => entry.threadId === threadId);
+      NodeAssert.equal(session?.status, "ready");
+      NodeAssert.equal(session?.activeTurnId, undefined);
+    }),
+  );
+
+  it.effect("keeps an interrupted OpenCode session ready after its abort event", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-interrupt-abort-event");
+      runtimeMock.state.subscribedEvents = [
+        {
+          type: "session.error",
+          properties: {
+            sessionID: "http://127.0.0.1:9999/session",
+            error: {
+              name: "MessageAbortedError",
+              data: { message: "Aborted" },
+            },
+          },
+        },
+      ];
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* advanceTestClock(10);
+
+      const session = (yield* adapter.listSessions()).find((entry) => entry.threadId === threadId);
+      NodeAssert.equal(session?.status, "ready");
+      NodeAssert.equal(session?.lastError, undefined);
     }),
   );
 

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -511,6 +511,12 @@ function sessionErrorMessage(error: unknown): string {
     : "OpenCode session failed.";
 }
 
+function isSessionAbortError(error: unknown): boolean {
+  return Boolean(
+    error && typeof error === "object" && "name" in error && error.name === "MessageAbortedError",
+  );
+}
+
 function updateProviderSession(
   context: OpenCodeSessionContext,
   patch: Partial<ProviderSession>,
@@ -1075,9 +1081,35 @@ export function makeOpenCodeAdapter(
         }
 
         case "session.error": {
-          const message = sessionErrorMessage(event.properties.error);
+          const error = event.properties.error;
           const activeTurnId = context.activeTurnId;
           context.activeTurnId = undefined;
+          context.activeAgent = undefined;
+          context.activeVariant = undefined;
+
+          if (isSessionAbortError(error)) {
+            yield* updateProviderSession(
+              context,
+              { status: "ready" },
+              { clearActiveTurnId: true, clearLastError: true },
+            );
+            if (activeTurnId) {
+              yield* emit({
+                ...(yield* buildEventBase({
+                  threadId: context.session.threadId,
+                  turnId: activeTurnId,
+                  raw: event,
+                })),
+                type: "turn.aborted",
+                payload: {
+                  reason: "Interrupted by user.",
+                },
+              });
+            }
+            break;
+          }
+
+          const message = sessionErrorMessage(error);
           yield* updateProviderSession(
             context,
             {
@@ -1109,7 +1141,7 @@ export function makeOpenCodeAdapter(
             payload: {
               message,
               class: "provider_error",
-              detail: event.properties.error,
+              detail: error,
             },
           });
           break;
@@ -1540,14 +1572,12 @@ export function makeOpenCodeAdapter(
     const interruptTurn: OpenCodeAdapterShape["interruptTurn"] = Effect.fn("interruptTurn")(
       function* (threadId, turnId) {
         const context = yield* ensureSessionContext(sessions, threadId);
-        yield* runOpenCodeSdk("session.abort", () =>
-          context.client.session.abort({ sessionID: context.openCodeSessionId }),
-        ).pipe(Effect.mapError(toRequestError));
-        if (turnId ?? context.activeTurnId) {
+        const targetTurnId = turnId ?? context.activeTurnId;
+        if (targetTurnId) {
           yield* emit({
             ...(yield* buildEventBase({
               threadId,
-              turnId: turnId ?? context.activeTurnId,
+              turnId: targetTurnId,
             })),
             type: "turn.aborted",
             payload: {
@@ -1555,6 +1585,26 @@ export function makeOpenCodeAdapter(
             },
           });
         }
+        // Publish the local lifecycle transition before waiting on the remote
+        // abort. OpenCode can sit in a provider retry (for example after a
+        // monthly usage limit) long enough for session.abort to hang, but the
+        // user must still be able to stop the turn immediately.
+        context.activeTurnId = undefined;
+        context.activeAgent = undefined;
+        context.activeVariant = undefined;
+        yield* updateProviderSession(context, { status: "ready" }, { clearActiveTurnId: true });
+
+        // Best effort: the lifecycle event above is the authoritative UI
+        // transition, while this request stops the provider's in-flight work
+        // when the OpenCode server is responsive. Run it in the session scope
+        // so a later session stop also cancels a hung abort request.
+        yield* runOpenCodeSdk("session.abort", () =>
+          context.client.session.abort({ sessionID: context.openCodeSessionId }),
+        ).pipe(
+          Effect.mapError(toRequestError),
+          Effect.ignore({ log: true }),
+          Effect.forkIn(context.sessionScope),
+        );
       },
     );
 


### PR DESCRIPTION
## Summary

- settle OpenCode interrupts locally before waiting for the provider abort request
- process interrupt commands on a dedicated worker so unrelated long-running commands cannot block Stop
- treat OpenCode MessageAbortedError events as expected cancellation and keep the session ready
- settle turn.aborted events in runtime ingestion

## Validation

- Live reproduction: Stop terminated a running test:ci command and settled backend state in under 100 ms
- Focused server tests: 126 passed
- Repository build: passed
- Full server suite: 2,481 passed; 13 unrelated baseline failures (11 GitManager worktree tests, one newline-worktree-path test, and the existing ProviderRegistry reprobe test)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration turn lifecycle and OpenCode interrupt ordering; behavior is covered by new reactor, ingestion, and adapter tests but affects user-visible Stop semantics.
> 
> **Overview**
> **Stop** no longer waits behind long-running provider work on the general command reactor queue: `thread.turn-interrupt-requested` events go to a **dedicated interrupt worker**, so a blocked session start on another thread cannot delay interrupt handling.
> 
> For **OpenCode**, `interruptTurn` now **publishes `turn.aborted` and marks the session ready locally before** calling `session.abort`. The remote abort runs **best-effort in the background** (errors ignored), so hung provider retries cannot block the UI transition. **`MessageAbortedError`** from `session.error` is treated as expected user cancellation (ready session, `turn.aborted`) instead of a provider error.
> 
> **Runtime ingestion** applies **`turn.aborted`** like a turn end: session returns to **ready**, **active turn is cleared**, and assistant messages are finalized the same path as completion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9d0bcb410d7f5901ebcbd2a6a7bbf3df8b86b09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix turn interrupts to process on a dedicated worker independently of blocked provider operations
> - Routes `thread.turn-interrupt-requested` events to a new dedicated `interruptWorker` in [`ProviderCommandReactor`](https://github.com/pingdotgg/t3code/pull/6531/files#diff-0630e9ad70d5dcd1c8586d29297f9b7d5f5436cc8e10fc88dc22acc511f1450d), preventing interrupts from queuing behind long-running start/stop/recovery tasks.
> - Reworks `interruptTurn` in [`OpenCodeAdapter`](https://github.com/pingdotgg/t3code/pull/6531/files#diff-a4267388b15e5043ae1899beded972cbee9e52533ca3d9d65d438a91a9f7fbe7) to immediately settle the local session and emit `turn.aborted` before calling the remote abort, so the interrupt is responsive regardless of remote failures.
> - Treats `session.error` with `MessageAbortedError` as a successful interrupt: sets session status to `ready`, clears `lastError`, and emits `turn.aborted` instead of transitioning to an error state.
> - Handles `turn.aborted` in [`ProviderRuntimeIngestion`](https://github.com/pingdotgg/t3code/pull/6531/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7) by clearing `activeTurnId`, setting thread session to `ready`, and finalizing any assistant messages for the turn.
> - Behavioral Change: remote abort failures are now silently logged and ignored; callers of `interruptTurn` no longer receive abort errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c9d0bcb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->