### PR TITLE
fix(web): align pull request action menu rows

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -1033,6 +1033,18 @@ export function PullRequestDetailPanel({
             : allowedMergeMethods.length > 0
               ? "merge"
               : null;
+  // What the menu's action group holds. Named once so the separators around it are drawn from
+  // the same answer as its contents, rather than on the assumption that it has any.
+  const showsDraftToggle =
+    detail?.state === "open" &&
+    can(detail.isDraft ? "ready" : "draft") &&
+    !(detail.isDraft && primaryAction === "ready");
+  const showsMergeMethods =
+    detail?.state === "open" &&
+    can("merge") &&
+    !detail.isDraft &&
+    !conflicting &&
+    allowedMergeMethods.length > 1;
   // The pull request number carries this state in the overview and the right-panel tab mirrors
   // it. Conflicts keep their own row below: an open pull request remains green there.
   const statePresentation = detail
@@ -1185,8 +1197,7 @@ export function PullRequestDetailPanel({
                       {/* Only where the button row could not take it: "Ready for review" on a
                           draft is the primary header button, so offering it here as well would
                           show the same action twice. */}
-                      {can(detail.isDraft ? "ready" : "draft") &&
-                      !(detail.isDraft && primaryAction === "ready") ? (
+                      {showsDraftToggle ? (
                         <MenuItem
                           disabled={actionPending}
                           onClick={() => void perform(detail.isDraft ? "ready" : "draft")}
@@ -1230,12 +1241,12 @@ export function PullRequestDetailPanel({
                           Hidden while conflicting: every method would fail. */}
                       {/* Only where merging is on offer at all: a strategy to merge with is not
                           a choice for someone who may not merge. */}
-                      {can("merge") &&
-                      !detail.isDraft &&
-                      !conflicting &&
-                      allowedMergeMethods.length > 1 ? (
+                      {showsMergeMethods ? (
                         <>
-                          <MenuSeparator />
+                          {/* Only below the draft control. A host with no draft of its own, or
+                              a draft whose control is already the header button, would leave
+                              this against the separator that opened the group. */}
+                          {showsDraftToggle ? <MenuSeparator /> : null}
                           <MenuRadioGroup
                             value={selectedMergeMethod}
                             onValueChange={(method) =>
@@ -1255,7 +1266,7 @@ export function PullRequestDetailPanel({
                           </MenuRadioGroup>
                         </>
                       ) : null}
-                      <MenuSeparator />
+                      {showsDraftToggle || showsMergeMethods ? <MenuSeparator /> : null}
                     </>
                   ) : null}
                   <MenuItem onClick={() => void readLocalApi()?.shell.openExternal(detail.url)}>

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -103,6 +103,7 @@ import {
   handoffPrompt,
   handoffReviewComments,
   pullRequestActionNeedsHostRefresh,
+  pullRequestActionMenuHasGroup,
   pullRequestFindingKey,
   pullRequestHandoffLabels,
   readableFailure,
@@ -1039,6 +1040,14 @@ export function PullRequestDetailPanel({
     detail?.state === "open" &&
     can(detail.isDraft ? "ready" : "draft") &&
     !(detail.isDraft && primaryAction === "ready");
+  const showsAutoMerge =
+    detail?.state === "open" &&
+    ((autoMergeArmed && can("disable-auto-merge")) ||
+      (!autoMergeArmed &&
+        !detail.isDraft &&
+        !conflicting &&
+        can("enable-auto-merge") &&
+        allowedMergeMethods.length > 0));
   const showsMergeMethods =
     detail?.state === "open" &&
     can("merge") &&
@@ -1266,7 +1275,13 @@ export function PullRequestDetailPanel({
                           </MenuRadioGroup>
                         </>
                       ) : null}
-                      {showsDraftToggle || showsMergeMethods ? <MenuSeparator /> : null}
+                      {pullRequestActionMenuHasGroup(
+                        showsDraftToggle,
+                        showsAutoMerge,
+                        showsMergeMethods,
+                      ) ? (
+                        <MenuSeparator />
+                      ) : null}
                     </>
                   ) : null}
                   <MenuItem onClick={() => void readLocalApi()?.shell.openExternal(detail.url)}>

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
@@ -19,6 +19,7 @@ import {
   isThreadOwnPullRequest,
   orderPullRequestComments,
   pullRequestActionNeedsHostRefresh,
+  pullRequestActionMenuHasGroup,
   pullRequestFindingKey,
   pullRequestHandoffLabels,
   readableFailure,
@@ -52,6 +53,12 @@ const TIMELINE_SOURCE: Pick<
   mergedAt: null,
   closedAt: null,
 };
+
+describe("pull request action menu", () => {
+  it("keeps the group divider when auto-merge is the only action", () => {
+    expect(pullRequestActionMenuHasGroup(false, true, false)).toBe(true);
+  });
+});
 
 describe("pull request state description", () => {
   it("keeps draft and conflicts orthogonal to the terminal states", () => {

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
@@ -57,6 +57,15 @@ export function pullRequestHandoffLabels(inThisThread: boolean) {
       };
 }
 
+/** Whether the open pull-request action group contains at least one action. */
+export function pullRequestActionMenuHasGroup(
+  showsDraftToggle: boolean,
+  showsAutoMerge: boolean,
+  showsMergeMethods: boolean,
+): boolean {
+  return showsDraftToggle || showsAutoMerge || showsMergeMethods;
+}
+
 /** Plain-language state, shown beside the author. Conflicts are a merge signal, not a state. */
 export function describePullRequestState(state: PullRequestState, isDraft: boolean): string {
   if (state === "merged") return "Merged";

--- a/apps/web/src/components/ui/menu.test.tsx
+++ b/apps/web/src/components/ui/menu.test.tsx
@@ -1,0 +1,23 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import { Menu, MenuRadioGroup, MenuRadioItem } from "./menu";
+
+describe("menu radio item geometry", () => {
+  it("keeps radio-item icons on the same text grid as menu items", () => {
+    const html = renderToStaticMarkup(
+      <Menu>
+        <MenuRadioGroup value="merge">
+          <MenuRadioItem value="merge">
+            <span className="flex items-center gap-2">
+              <svg aria-hidden className="size-3.5" />
+              <span>Merge</span>
+            </span>
+          </MenuRadioItem>
+        </MenuRadioGroup>
+      </Menu>,
+    );
+
+    expect(html).toContain("-mx-0.5");
+  });
+});

--- a/apps/web/src/components/ui/menu.tsx
+++ b/apps/web/src/components/ui/menu.tsx
@@ -158,7 +158,7 @@ function MenuRadioItem({
   return (
     <MenuPrimitive.RadioItem
       className={cn(
-        "flex min-h-8 in-data-[side=none]:min-w-[calc(var(--anchor-width)+1.25rem)] cursor-pointer items-center rounded-sm px-2 py-1 text-base text-foreground outline-none data-checked:bg-foreground/[0.08] data-disabled:pointer-events-none data-disabled:cursor-not-allowed data-highlighted:bg-accent data-highlighted:text-accent-foreground data-disabled:opacity-64 sm:min-h-7 sm:text-sm [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "[&_svg]:-mx-0.5 flex min-h-8 in-data-[side=none]:min-w-[calc(var(--anchor-width)+1.25rem)] cursor-pointer items-center rounded-sm px-2 py-1 text-base text-foreground outline-none data-checked:bg-foreground/[0.08] data-disabled:pointer-events-none data-disabled:cursor-not-allowed data-highlighted:bg-accent data-highlighted:text-accent-foreground data-disabled:opacity-64 sm:min-h-7 sm:text-sm [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       data-slot="menu-radio-item"


### PR DESCRIPTION
## Problem

The pull request actions menu had two visual issues:

- Optional action separators could become adjacent or disappear when draft, auto-merge, or merge-method actions were unavailable.
- Merge-method radio rows started their labels farther right than the normal menu actions because radio-item icons did not use the shared icon margin.

## Fix

- Derive divider state from `showsDraftToggle`, `showsAutoMerge`, and `showsMergeMethods`.
- Keep the merge-method separator only when it follows the draft control.
- Keep the closing separator whenever any action group is visible.
- Apply the shared `-mx-0.5` icon alignment to `MenuRadioItem`, fixing the pull request merge rows and other icon radio menus.
- Add regression coverage for the auto-merge-only divider state and radio-item geometry.

## Before / after

| Before | After |
| --- | --- |
| ![The actions menu with a doubled divider above Merge](https://raw.githubusercontent.com/nkyryliuk/t3code/59cb3f26f1dff4f42a14815b052f192e538c2496/before.png) | ![The actions menu with a single divider above Merge](https://raw.githubusercontent.com/nkyryliuk/t3code/59cb3f26f1dff4f42a14815b052f192e538c2496/after.png) |

## Verification

- `pnpm exec vp test run src/components/ui/menu.test.tsx src/components/pullRequest/pullRequestDetail.logic.test.ts --project unit` — 63 passed
- `pnpm exec vp run typecheck` — passed
- Focused lint — passed
- Focused format check — passed
- `git diff --check` — passed

Co-authored-by: Nickolas Kyryliuk <nickolaskyryliuk@gmail.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix pull request action menu row alignment and separator logic
> - Adds `[&_svg]:-mx-0.5` to `MenuRadioItem` in [menu.tsx](https://github.com/pingdotgg/t3code/pull/6534/files#diff-e0c9f33f4f308eae4b7e310785187bc81767e547539de6fcd955fa42aaccc621) to correct horizontal icon alignment within radio menu items.
> - Introduces `pullRequestActionMenuHasGroup` in [pullRequestDetail.logic.ts](https://github.com/pingdotgg/t3code/pull/6534/files#diff-2c5f917dba9decc3bd48ec3231f7b0db073e8b642379cf000265960a03718c18) to centralize visibility logic for the open pull-request action group.
> - Updates [PullRequestDetailPanel](https://github.com/pingdotgg/t3code/pull/6534/files#diff-3c76d43f3539848054e21911e658895287b4fe9c387c3267c21684290baebd3a) to use named booleans for draft toggle, auto-merge, and merge methods, and omits group separators when no group items are present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8947aff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->