### PR TITLE
feat(web): let users choose where links open

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -49,6 +49,7 @@ import { CHAT_FILE_TAG_CHIP_CLASS_NAME, FileTagChipContent } from "./chat/FileTa
 import { PierreEntryIcon } from "./chat/PierreEntryIcon";
 import {
   resolveExternalWebLinkHost,
+  shouldOpenExternalLinkInPreview,
   showExternalLinkContextMenu,
 } from "./chat/externalLinkContextMenu";
 import { hasSpecificPierreIconForFileName, syntheticFileNameForLanguageId } from "../pierre-icons";
@@ -1558,15 +1559,42 @@ function ChatMarkdown({
               rel={isSameDocumentLink ? undefined : "noopener noreferrer"}
               onClick={(event) => {
                 onClick?.(event);
+                if (event.defaultPrevented) return;
                 if (isSameDocumentLink && href) {
                   handleMarkdownFragmentClick(event, href);
                   return;
                 }
                 // A link to a change request in a workspace project opens beside the
                 // conversation instead of in a browser: it is the thing being talked about, and
-                // the panel it opens offers the browser as one of its actions. Anything else is
-                // an ordinary link and keeps the `_blank` the shell already handles.
-                if (href) openChangeRequestLink(event, href);
+                // the panel it opens offers the browser as one of its actions. Other links honor
+                // the client-local destination preference, with `_blank` as the external path.
+                if (!href || openChangeRequestLink(event, href)) return;
+                if (
+                  shouldOpenExternalLinkInPreview({
+                    mode: getClientSettings().externalLinkOpenMode,
+                    canOpenInPreview,
+                    event,
+                  })
+                ) {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  void openExternalLinkInPreview(href).then(
+                    (result) => {
+                      if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+                        reportMarkdownActionFailure(
+                          { operation: "open-link-in-preview", target: href },
+                          result.cause,
+                        );
+                      }
+                    },
+                    (cause) => {
+                      reportMarkdownActionFailure(
+                        { operation: "open-link-in-preview", target: href },
+                        cause,
+                      );
+                    },
+                  );
+                }
               }}
               onContextMenu={(event) => {
                 if (!href || !faviconHost) return;

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1579,6 +1579,16 @@ function ChatMarkdown({
                 ) {
                   event.preventDefault();
                   event.stopPropagation();
+                  const openInSystemBrowser = () => {
+                    void readLocalApi()
+                      ?.shell.openExternal(href)
+                      .catch((cause) => {
+                        reportMarkdownActionFailure(
+                          { operation: "open-link-external", target: href },
+                          cause,
+                        );
+                      });
+                  };
                   void openExternalLinkInPreview(href).then(
                     (result) => {
                       if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
@@ -1586,6 +1596,7 @@ function ChatMarkdown({
                           { operation: "open-link-in-preview", target: href },
                           result.cause,
                         );
+                        openInSystemBrowser();
                       }
                     },
                     (cause) => {
@@ -1593,6 +1604,7 @@ function ChatMarkdown({
                         { operation: "open-link-in-preview", target: href },
                         cause,
                       );
+                      openInSystemBrowser();
                     },
                   );
                 }

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1571,6 +1571,7 @@ function ChatMarkdown({
                 if (!href || openChangeRequestLink(event, href)) return;
                 if (
                   shouldOpenExternalLinkInPreview({
+                    href,
                     mode: getClientSettings().externalLinkOpenMode,
                     canOpenInPreview,
                     event,

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1604,7 +1604,6 @@ function ChatMarkdown({
                         { operation: "open-link-in-preview", target: href },
                         cause,
                       );
-                      openInSystemBrowser();
                     },
                   );
                 }

--- a/apps/web/src/components/chat/externalLinkContextMenu.test.ts
+++ b/apps/web/src/components/chat/externalLinkContextMenu.test.ts
@@ -156,6 +156,7 @@ describe("preferred external link destination", () => {
   it("uses the integrated browser only for an available, unmodified preferred click", () => {
     expect(
       shouldOpenExternalLinkInPreview({
+        href: "https://example.com/docs",
         mode: "integrated",
         canOpenInPreview: true,
         event: plainClick,
@@ -163,6 +164,7 @@ describe("preferred external link destination", () => {
     ).toBe(true);
     expect(
       shouldOpenExternalLinkInPreview({
+        href: "https://example.com/docs",
         mode: "external",
         canOpenInPreview: true,
         event: plainClick,
@@ -170,6 +172,7 @@ describe("preferred external link destination", () => {
     ).toBe(false);
     expect(
       shouldOpenExternalLinkInPreview({
+        href: "https://example.com/docs",
         mode: "integrated",
         canOpenInPreview: false,
         event: plainClick,
@@ -177,9 +180,18 @@ describe("preferred external link destination", () => {
     ).toBe(false);
     expect(
       shouldOpenExternalLinkInPreview({
+        href: "https://example.com/docs",
         mode: "integrated",
         canOpenInPreview: true,
         event: { ...plainClick, metaKey: true },
+      }),
+    ).toBe(false);
+    expect(
+      shouldOpenExternalLinkInPreview({
+        href: "mailto:hello@example.com",
+        mode: "integrated",
+        canOpenInPreview: true,
+        event: plainClick,
       }),
     ).toBe(false);
   });

--- a/apps/web/src/components/chat/externalLinkContextMenu.test.ts
+++ b/apps/web/src/components/chat/externalLinkContextMenu.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 
-import { resolveExternalWebLinkHost, showExternalLinkContextMenu } from "./externalLinkContextMenu";
+import {
+  resolveExternalWebLinkHost,
+  shouldOpenExternalLinkInPreview,
+  showExternalLinkContextMenu,
+} from "./externalLinkContextMenu";
 
 function createHarness(selection: "open-in-preview" | "open-external" | "copy-link" | null) {
   const showContextMenu = vi.fn().mockResolvedValue(selection);
@@ -143,5 +147,40 @@ describe("external chat link context menu", () => {
     [undefined, null],
   ])("resolves the external web-link host for %s as %s", (href, expected) => {
     expect(resolveExternalWebLinkHost(href)).toBe(expected);
+  });
+});
+
+describe("preferred external link destination", () => {
+  const plainClick = { altKey: false, ctrlKey: false, metaKey: false, shiftKey: false };
+
+  it("uses the integrated browser only for an available, unmodified preferred click", () => {
+    expect(
+      shouldOpenExternalLinkInPreview({
+        mode: "integrated",
+        canOpenInPreview: true,
+        event: plainClick,
+      }),
+    ).toBe(true);
+    expect(
+      shouldOpenExternalLinkInPreview({
+        mode: "external",
+        canOpenInPreview: true,
+        event: plainClick,
+      }),
+    ).toBe(false);
+    expect(
+      shouldOpenExternalLinkInPreview({
+        mode: "integrated",
+        canOpenInPreview: false,
+        event: plainClick,
+      }),
+    ).toBe(false);
+    expect(
+      shouldOpenExternalLinkInPreview({
+        mode: "integrated",
+        canOpenInPreview: true,
+        event: { ...plainClick, metaKey: true },
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/web/src/components/chat/externalLinkContextMenu.ts
+++ b/apps/web/src/components/chat/externalLinkContextMenu.ts
@@ -64,6 +64,7 @@ export function resolveExternalWebLinkHost(href: string | undefined): string | n
 }
 
 export function shouldOpenExternalLinkInPreview(options: {
+  readonly href: string;
   readonly mode: ExternalLinkOpenMode;
   readonly canOpenInPreview: boolean;
   readonly event: {
@@ -73,10 +74,11 @@ export function shouldOpenExternalLinkInPreview(options: {
     readonly shiftKey: boolean;
   };
 }): boolean {
-  const { mode, canOpenInPreview, event } = options;
+  const { href, mode, canOpenInPreview, event } = options;
   return (
     mode === "integrated" &&
     canOpenInPreview &&
+    resolveExternalWebLinkHost(href) !== null &&
     !event.altKey &&
     !event.ctrlKey &&
     !event.metaKey &&

--- a/apps/web/src/components/chat/externalLinkContextMenu.ts
+++ b/apps/web/src/components/chat/externalLinkContextMenu.ts
@@ -1,4 +1,4 @@
-import type { ContextMenuItem } from "@t3tools/contracts";
+import type { ContextMenuItem, ExternalLinkOpenMode } from "@t3tools/contracts";
 
 export type ExternalLinkContextMenuAction = "open-in-preview" | "open-external" | "copy-link";
 
@@ -61,6 +61,27 @@ export function resolveExternalWebLinkHost(href: string | undefined): string | n
   } catch {
     return null;
   }
+}
+
+export function shouldOpenExternalLinkInPreview(options: {
+  readonly mode: ExternalLinkOpenMode;
+  readonly canOpenInPreview: boolean;
+  readonly event: {
+    readonly altKey: boolean;
+    readonly ctrlKey: boolean;
+    readonly metaKey: boolean;
+    readonly shiftKey: boolean;
+  };
+}): boolean {
+  const { mode, canOpenInPreview, event } = options;
+  return (
+    mode === "integrated" &&
+    canOpenInPreview &&
+    !event.altKey &&
+    !event.ctrlKey &&
+    !event.metaKey &&
+    !event.shiftKey
+  );
 }
 
 export async function showExternalLinkContextMenu({

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -20,6 +20,7 @@ import {
   DEFAULT_ENVIRONMENT_IDENTIFICATION_MODE,
   DEFAULT_UNIFIED_SETTINGS,
   type EnvironmentIdentificationMode,
+  type ExternalLinkOpenMode,
   MAX_CODE_FONT_SIZE,
   MAX_GLASS_OPACITY,
   MAX_INTERFACE_FONT_SIZE,
@@ -154,6 +155,11 @@ const TIMESTAMP_FORMAT_LABELS = {
   "12-hour": "12-hour",
   "24-hour": "24-hour",
 } as const;
+
+const EXTERNAL_LINK_OPEN_MODE_LABELS: Record<ExternalLinkOpenMode, string> = {
+  external: "System browser",
+  integrated: "Integrated browser",
+};
 
 const BACKGROUND_ACTIVITY_PROFILE_LABELS: Record<BackgroundActivityProfile, string> = {
   balanced: "Balanced",
@@ -482,6 +488,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.timestampFormat !== DEFAULT_UNIFIED_SETTINGS.timestampFormat
         ? ["Time format"]
         : []),
+      ...(settings.externalLinkOpenMode !== DEFAULT_UNIFIED_SETTINGS.externalLinkOpenMode
+        ? ["Open web links"]
+        : []),
       ...(settings.sidebarThreadPreviewCount !== DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount
         ? ["Visible threads"]
         : []),
@@ -535,6 +544,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.newWorktreesStartFromOrigin,
       settings.diffIgnoreWhitespace,
       settings.environmentIdentificationMode,
+      settings.externalLinkOpenMode,
       settings.fontFamilyCode,
       settings.fontFamilyComposer,
       settings.fontFamilySans,
@@ -621,6 +631,7 @@ export function useSettingsRestore(onRestored?: () => void) {
     }
     updateSettings({
       timestampFormat: DEFAULT_UNIFIED_SETTINGS.timestampFormat,
+      externalLinkOpenMode: DEFAULT_UNIFIED_SETTINGS.externalLinkOpenMode,
       wordWrap: DEFAULT_UNIFIED_SETTINGS.wordWrap,
       diffIgnoreWhitespace: DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
       environmentIdentificationMode: DEFAULT_UNIFIED_SETTINGS.environmentIdentificationMode,
@@ -1905,6 +1916,47 @@ export function GeneralSettingsPanel() {
                 </SelectItem>
                 <SelectItem hideIndicator value="24-hour">
                   {TIMESTAMP_FORMAT_LABELS["24-hour"]}
+                </SelectItem>
+              </SelectPopup>
+            </Select>
+          }
+        />
+
+        <SettingsRow
+          {...searchableSetting("open-web-links")}
+          description="Choose where links in conversations open by default. When the integrated browser is unavailable, links open in the system browser."
+          resetAction={
+            settings.externalLinkOpenMode !== DEFAULT_UNIFIED_SETTINGS.externalLinkOpenMode ? (
+              <SettingResetButton
+                label="web link destination"
+                onClick={() =>
+                  updateSettings({
+                    externalLinkOpenMode: DEFAULT_UNIFIED_SETTINGS.externalLinkOpenMode,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Select
+              value={settings.externalLinkOpenMode}
+              onValueChange={(value) => {
+                if (value === "external" || value === "integrated") {
+                  updateSettings({ externalLinkOpenMode: value });
+                }
+              }}
+            >
+              <SelectTrigger className="w-full sm:w-44" aria-label="Default web link destination">
+                <SelectValue>
+                  {EXTERNAL_LINK_OPEN_MODE_LABELS[settings.externalLinkOpenMode]}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                <SelectItem hideIndicator value="external">
+                  {EXTERNAL_LINK_OPEN_MODE_LABELS.external}
+                </SelectItem>
+                <SelectItem hideIndicator value="integrated">
+                  {EXTERNAL_LINK_OPEN_MODE_LABELS.integrated}
                 </SelectItem>
               </SelectPopup>
             </Select>

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -109,6 +109,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/general",
   },
   {
+    id: "open-web-links",
+    title: "Open web links",
+    to: "/settings/general",
+  },
+  {
     id: "hide-whitespace-changes",
     title: "Hide whitespace changes",
     to: "/settings/general",

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 - [Install and first run](./user/install.md)
 - [Permission modes](./user/permission-modes.md)
 - [Keyboard shortcuts](./user/keybindings.md)
+- [Choose where web links open](./user/link-opening.md)
 - [Organizing threads](./user/thread-sidebar.md)
 - [Review usage](./user/usage.md)
 - [Customize a project icon](./user/project-settings.md)

--- a/docs/user/link-opening.md
+++ b/docs/user/link-opening.md
@@ -1,0 +1,9 @@
+# Opening web links
+
+Choose **Settings** → **General** → **Open web links** to open links from conversations in either
+the system browser or T3 Code's integrated browser. This preference is stored on the current
+device, so each client can use the destination that fits it best.
+
+The integrated-browser choice falls back to the system browser when a conversation cannot show a
+browser panel. Command-click, Control-click, and the link context menu keep their explicit browser
+actions regardless of the default.

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -33,6 +33,19 @@ describe("ClientSettings word wrap", () => {
   });
 });
 
+describe("ClientSettings external link opening", () => {
+  it("defaults to the system browser and accepts either destination", () => {
+    expect(decodeClientSettings({}).externalLinkOpenMode).toBe("external");
+    expect(decodeClientSettingsPatch({ externalLinkOpenMode: "integrated" })).toEqual({
+      externalLinkOpenMode: "integrated",
+    });
+  });
+
+  it("rejects unsupported destinations", () => {
+    expect(() => decodeClientSettings({ externalLinkOpenMode: "new-tab" })).toThrow();
+  });
+});
+
 describe("ClientSettings glass opacity", () => {
   it("defaults to a readable translucent surface", () => {
     expect(decodeClientSettings({}).glassOpacity).toBe(80);

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -18,6 +18,10 @@ export const TimestampFormat = Schema.Literals(["locale", "12-hour", "24-hour"])
 export type TimestampFormat = typeof TimestampFormat.Type;
 export const DEFAULT_TIMESTAMP_FORMAT: TimestampFormat = "locale";
 
+export const ExternalLinkOpenMode = Schema.Literals(["external", "integrated"]);
+export type ExternalLinkOpenMode = typeof ExternalLinkOpenMode.Type;
+export const DEFAULT_EXTERNAL_LINK_OPEN_MODE: ExternalLinkOpenMode = "external";
+
 export const SidebarProjectSortOrder = Schema.Literals(["updated_at", "created_at", "manual"]);
 export type SidebarProjectSortOrder = typeof SidebarProjectSortOrder.Type;
 export const DEFAULT_SIDEBAR_PROJECT_SORT_ORDER: SidebarProjectSortOrder = "updated_at";
@@ -120,6 +124,9 @@ export const ClientSettingsSchema = Schema.Struct({
   diffIgnoreWhitespace: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   environmentIdentificationMode: EnvironmentIdentificationMode.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_ENVIRONMENT_IDENTIFICATION_MODE)),
+  ),
+  externalLinkOpenMode: ExternalLinkOpenMode.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_EXTERNAL_LINK_OPEN_MODE)),
   ),
   glassOpacity: GlassOpacity.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_GLASS_OPACITY)),
@@ -759,6 +766,7 @@ export const ClientSettingsPatch = Schema.Struct({
   confirmThreadDelete: Schema.optionalKey(Schema.Boolean),
   diffIgnoreWhitespace: Schema.optionalKey(Schema.Boolean),
   environmentIdentificationMode: Schema.optionalKey(EnvironmentIdentificationMode),
+  externalLinkOpenMode: Schema.optionalKey(ExternalLinkOpenMode),
   glassOpacity: Schema.optionalKey(GlassOpacity),
   fontSizeInterface: Schema.optionalKey(InterfaceFontSize),
   fontSizePrompt: Schema.optionalKey(PromptFontSize),


### PR DESCRIPTION
External links in rendered conversations always followed the platform default, so users who prefer T3 Code's integrated browser had to use the context menu for every link.

This adds a per-client **Open web links** preference under Settings → General. Unmodified web-link clicks now honor the selected destination, while pull request links, modified clicks, explicit context-menu actions, and the system-browser fallback keep their existing behavior. The preference is documented and defaults to the current system-browser behavior.

Validation:
- `vp run --filter @t3tools/contracts typecheck`
- `vp run --filter @t3tools/web typecheck`
- Focused Vite+ tests were attempted, but this fresh worktree's test runtime failed before test collection with `Cannot read properties of undefined (reading 'config')`, including untouched suites.

Model: GPT-5.6-sol
Harness: Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing navigation preference with safe defaults and fallbacks; no auth, data, or server contract changes beyond a new optional client setting field.
> 
> **Overview**
> Adds a per-device **Open web links** preference (system browser vs integrated browser) under Settings → General, backed by a new `externalLinkOpenMode` client setting that defaults to the system browser.
> 
> **Chat markdown** now routes unmodified http(s) link clicks through that preference: integrated mode opens the in-app preview when available, with fallback to the system browser on failure. Change-request links, modifier clicks, non-web URLs, and the link context menu are unchanged.
> 
> Includes `shouldOpenExternalLinkInPreview` helper, settings search/reset wiring, contract tests, and user docs for link-opening behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fc57767e557b91a67d0d0be8f4bc41a2ba5af80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add user setting to choose where web links open (system or integrated browser)
> - Adds an `externalLinkOpenMode` setting (`'external'` | `'integrated'`, default `'external'`) to `ClientSettings` in [settings.ts](https://github.com/pingdotgg/t3code/pull/6540/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c).
> - Adds a UI row in the General settings panel ([SettingsPanels.tsx](https://github.com/pingdotgg/t3code/pull/6540/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18)) with a dropdown to choose between system browser and integrated browser.
> - Clicking links in chat ([ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/6540/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05)) now respects this preference via the new `shouldOpenExternalLinkInPreview` helper; modifier keys (alt/ctrl/meta/shift) always bypass the integrated browser and open externally.
> - Adds documentation at [docs/user/link-opening.md](https://github.com/pingdotgg/t3code/pull/6540/files#diff-b0b7fe495b128e563b5d8fbe49500013c72501ab3c61285b0df55a90aec37996) describing the setting and fallback behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8fc5776.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a searchable **Open web links** setting with integrated-browser and external-browser options.
  * External links can open in an integrated preview when configured and supported.
  * Added fallback behavior and modifier-key overrides for link opening.
  * External-link preferences are saved locally and can be reset.
  * Same-document and change-request links continue to use their existing behavior.

* **Documentation**
  * Added guidance for configuring web-link destinations, fallback behavior, and link-action overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->