### PR TITLE
feat(mobile): add line wrapping to source files

### DIFF
--- a/apps/mobile/src/features/files/SourceFileSurface.tsx
+++ b/apps/mobile/src/features/files/SourceFileSurface.tsx
@@ -4,6 +4,7 @@ import type { ComponentType } from "react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   FlatList,
+  type LayoutChangeEvent,
   ScrollView,
   Text as NativeText,
   useColorScheme,
@@ -25,8 +26,11 @@ import type { ResolvedMobileCodeSurface } from "../../lib/appearancePreferences"
 import { useAppearanceCodeSurface } from "../settings/appearance/useAppearanceCodeSurface";
 import {
   buildNativeSourceTokens,
+  buildNativeSourceRows,
   NATIVE_SOURCE_CONTENT_WIDTH,
-  nativeSourceRowId,
+  nativeSourceRowIdsForLine,
+  nativeSourceRowIndexForLine,
+  nativeSourceWrapColumns,
 } from "./nativeSourceFileAdapter";
 import { prepareSourceFileDocument } from "./source-file-document";
 import { sourceHighlightAtom } from "./sourceHighlightingState";
@@ -159,9 +163,24 @@ function NativeSourceFileSurface(
 ) {
   const { NativeView, onRefresh } = props;
   const { codeSurface, codeWordBreak, nativeSourceStyle } = useAppearanceCodeSurface();
-  const { width: viewportWidth } = useWindowDimensions();
-  const { rowsJson, status, targetIndex, theme, tokens } = useSourceFileModel(props);
+  const { width: windowWidth } = useWindowDimensions();
+  const [surfaceWidth, setSurfaceWidth] = useState(windowWidth);
+  const {
+    lines,
+    rowsJson: unwrappedRowsJson,
+    status,
+    targetIndex,
+    theme,
+    tokens,
+  } = useSourceFileModel(props);
   const [isPullRefreshing, setIsPullRefreshing] = useState(false);
+  const handleLayout = useCallback((event: LayoutChangeEvent) => {
+    const nextWidth = Math.round(event.nativeEvent.layout.width);
+    if (nextWidth <= 0) {
+      return;
+    }
+    setSurfaceWidth((currentWidth) => (currentWidth === nextWidth ? currentWidth : nextWidth));
+  }, []);
   const handlePullToRefresh = useCallback(async () => {
     if (!onRefresh) {
       return;
@@ -173,19 +192,35 @@ function NativeSourceFileSurface(
       setIsPullRefreshing(false);
     }
   }, [onRefresh]);
-  const tokensJson = useMemo(() => JSON.stringify(buildNativeSourceTokens(tokens)), [tokens]);
+  const wrapColumns = codeWordBreak
+    ? nativeSourceWrapColumns(surfaceWidth, codeSurface)
+    : undefined;
+  const rowsJson = useMemo(
+    () =>
+      wrapColumns === undefined
+        ? unwrappedRowsJson
+        : JSON.stringify(buildNativeSourceRows(lines, wrapColumns)),
+    [lines, unwrappedRowsJson, wrapColumns],
+  );
+  const tokensJson = useMemo(
+    () => JSON.stringify(buildNativeSourceTokens(tokens, wrapColumns)),
+    [tokens, wrapColumns],
+  );
+  const initialRowIndex =
+    targetIndex === null ? -1 : nativeSourceRowIndexForLine(lines, targetIndex, wrapColumns);
   const selectedRowIdsJson = useMemo(
-    () => JSON.stringify(targetIndex === null ? [] : [nativeSourceRowId(targetIndex)]),
-    [targetIndex],
+    () =>
+      JSON.stringify(
+        targetIndex === null
+          ? []
+          : nativeSourceRowIdsForLine(lines[targetIndex] ?? "", targetIndex, wrapColumns),
+      ),
+    [lines, targetIndex, wrapColumns],
   );
   const themeJson = useMemo(() => JSON.stringify(createNativeReviewDiffTheme(theme)), [theme]);
   const styleJson = useMemo(() => JSON.stringify(nativeSourceStyle), [nativeSourceStyle]);
-  const contentWidth = codeWordBreak
-    ? Math.max(240, viewportWidth - codeSurface.gutterWidth - 24)
-    : NATIVE_SOURCE_CONTENT_WIDTH;
-
   return (
-    <View className="relative flex-1 bg-sheet">
+    <View className="relative flex-1 bg-sheet" onLayout={handleLayout}>
       <SourceHighlightStatusView status={status} />
       <NativeView
         collapsable={false}
@@ -193,8 +228,12 @@ function NativeSourceFileSurface(
         style={{ flex: 1 }}
         appearanceScheme={theme}
         contentResetKey={props.path}
-        contentWidth={contentWidth}
-        initialRowIndex={targetIndex ?? -1}
+        contentWidth={
+          codeWordBreak
+            ? Math.max(240, surfaceWidth - codeSurface.gutterWidth - 24)
+            : NATIVE_SOURCE_CONTENT_WIDTH
+        }
+        initialRowIndex={initialRowIndex}
         rowHeight={nativeSourceStyle.rowHeight ?? codeSurface.rowHeight}
         rowsJson={rowsJson}
         selectedRowIdsJson={selectedRowIdsJson}

--- a/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
+++ b/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
@@ -35,6 +35,7 @@ import {
 } from "../layout/native-mail-search-toolbar";
 import { WorkspaceSidebarToolbar } from "../layout/workspace-sidebar-toolbar";
 import { ReviewHighlighterProvider } from "../review/ReviewHighlighterProvider";
+import { useAppearancePreferences } from "../settings/appearance/AppearancePreferencesProvider";
 import { ThreadRouteScreen } from "../threads/ThreadRouteScreen";
 import { FileMarkdownPreview } from "./FileMarkdownPreview";
 import { FileTreeBrowser } from "./FileTreeBrowser";
@@ -463,6 +464,7 @@ export function ThreadFilesTreeScreen(props: ThreadFilesRouteScreenProps) {
 export function ThreadFileScreen(props: ThreadFileRouteScreenProps) {
   useAdaptiveWorkspacePaneRole("inspector");
   const navigation = useNavigation();
+  const { appearance, isReady: appearanceIsReady, setCodeWordBreak } = useAppearancePreferences();
   const { fileInspector, panes, toggleAuxiliaryPane } = useAdaptiveWorkspaceLayout();
   const iconColor = useThemeColor("--color-icon");
   const params = props.route.params;
@@ -626,6 +628,16 @@ export function ThreadFileScreen(props: ThreadFileRouteScreenProps) {
                   Source
                 </NativeHeaderToolbar.MenuAction>
               </NativeHeaderToolbar.Menu>
+            ) : null}
+            {resolvedActiveMode === "source" ? (
+              <NativeHeaderToolbar.MenuAction
+                disabled={!appearanceIsReady}
+                icon="text.word.spacing"
+                isOn={appearance.codeWordBreak}
+                onPress={() => setCodeWordBreak(!appearance.codeWordBreak)}
+              >
+                Line wrap
+              </NativeHeaderToolbar.MenuAction>
             ) : null}
             <NativeHeaderToolbar.MenuAction
               icon="doc.on.doc"

--- a/apps/mobile/src/features/files/nativeSourceFileAdapter.test.ts
+++ b/apps/mobile/src/features/files/nativeSourceFileAdapter.test.ts
@@ -6,7 +6,11 @@ import {
   NATIVE_SOURCE_ROW_HEIGHT,
   NATIVE_SOURCE_STYLE,
   nativeSourceRowId,
+  nativeSourceRowIdsForLine,
+  nativeSourceRowIndexForLine,
+  nativeSourceWrapColumns,
 } from "./nativeSourceFileAdapter";
+import { resolveMobileCodeSurface } from "../../lib/appearancePreferences";
 import {
   NATIVE_REVIEW_DIFF_ROW_HEIGHT,
   NATIVE_REVIEW_DIFF_STYLE,
@@ -58,6 +62,76 @@ describe("nativeSourceFileAdapter", () => {
       [nativeSourceRowId(0)]: [{ content: "const", color: "#ff0000", fontStyle: 2 }],
       [nativeSourceRowId(1)]: [{ content: "    value", color: null, fontStyle: null }],
     });
+  });
+
+  it("wraps source lines into native continuation rows", () => {
+    expect(buildNativeSourceRows(["abcdefg", "xy"], 3)).toEqual([
+      {
+        kind: "line",
+        id: nativeSourceRowId(0),
+        fileId: "source-file",
+        content: "abc",
+        change: "context",
+        newLineNumber: 1,
+      },
+      {
+        kind: "line",
+        id: nativeSourceRowId(0, 1),
+        fileId: "source-file",
+        content: "def",
+        change: "context",
+        newLineNumber: null,
+      },
+      {
+        kind: "line",
+        id: nativeSourceRowId(0, 2),
+        fileId: "source-file",
+        content: "g",
+        change: "context",
+        newLineNumber: null,
+      },
+      {
+        kind: "line",
+        id: nativeSourceRowId(1),
+        fileId: "source-file",
+        content: "xy",
+        change: "context",
+        newLineNumber: 2,
+      },
+    ]);
+  });
+
+  it("splits syntax tokens across the same native continuation rows", () => {
+    expect(
+      buildNativeSourceTokens(
+        [
+          [
+            { content: "abc", color: "#ff0000", fontStyle: 2 },
+            { content: "defg", color: "#00ff00", fontStyle: null },
+          ],
+        ],
+        4,
+      ),
+    ).toEqual({
+      [nativeSourceRowId(0)]: [
+        { content: "abc", color: "#ff0000", fontStyle: 2 },
+        { content: "d", color: "#00ff00", fontStyle: null },
+      ],
+      [nativeSourceRowId(0, 1)]: [{ content: "efg", color: "#00ff00", fontStyle: null }],
+    });
+  });
+
+  it("maps source-line navigation onto wrapped native rows", () => {
+    const lines = ["12345", "x", "abcdef"];
+    expect(nativeSourceRowIndexForLine(lines, 2, 3)).toBe(3);
+    expect(nativeSourceRowIdsForLine(lines[2] ?? "", 2, 3)).toEqual([
+      nativeSourceRowId(2),
+      nativeSourceRowId(2, 1),
+    ]);
+  });
+
+  it("derives conservative wrap columns from the native code geometry", () => {
+    expect(nativeSourceWrapColumns(390, resolveMobileCodeSurface(12))).toBe(44);
   });
 
   it("clears native tokens while highlighting is unavailable", () => {

--- a/apps/mobile/src/features/files/nativeSourceFileAdapter.ts
+++ b/apps/mobile/src/features/files/nativeSourceFileAdapter.ts
@@ -42,38 +42,146 @@ function expandTabs(value: string): string {
   return value.replace(/\t/g, "    ");
 }
 
-export function nativeSourceRowId(index: number): string {
-  return `source-line:${index}`;
+function expandedColumnCount(value: string): number {
+  let columns = 0;
+  for (const character of value) {
+    columns += character === "\t" ? 4 : 1;
+  }
+  return columns;
+}
+
+function splitAtColumns(value: string, columns: number | null): ReadonlyArray<string> {
+  const expanded = expandTabs(value);
+  if (columns === null) {
+    return [expanded];
+  }
+
+  const characters = Array.from(expanded);
+  if (characters.length === 0) {
+    return [""];
+  }
+
+  const segments: string[] = [];
+  for (let offset = 0; offset < characters.length; offset += columns) {
+    segments.push(characters.slice(offset, offset + columns).join(""));
+  }
+  return segments;
+}
+
+function normalizedWrapColumns(wrapColumns?: number): number | null {
+  return typeof wrapColumns === "number" && Number.isFinite(wrapColumns)
+    ? Math.max(1, Math.floor(wrapColumns))
+    : null;
+}
+
+export function nativeSourceRowId(index: number, segment = 0): string {
+  return segment === 0 ? `source-line:${index}` : `source-line:${index}:wrap:${segment}`;
+}
+
+export function nativeSourceRowCount(line: string, wrapColumns?: number): number {
+  const columns = normalizedWrapColumns(wrapColumns);
+  return columns === null ? 1 : Math.max(1, Math.ceil(expandedColumnCount(line) / columns));
+}
+
+export function nativeSourceRowIndexForLine(
+  lines: ReadonlyArray<string>,
+  lineIndex: number,
+  wrapColumns?: number,
+): number {
+  const target = Math.max(0, Math.min(Math.floor(lineIndex), lines.length));
+  let rowIndex = 0;
+  for (let index = 0; index < target; index += 1) {
+    rowIndex += nativeSourceRowCount(lines[index] ?? "", wrapColumns);
+  }
+  return rowIndex;
+}
+
+export function nativeSourceRowIdsForLine(
+  line: string,
+  lineIndex: number,
+  wrapColumns?: number,
+): ReadonlyArray<string> {
+  return Array.from({ length: nativeSourceRowCount(line, wrapColumns) }, (_, segment) =>
+    nativeSourceRowId(lineIndex, segment),
+  );
+}
+
+export function nativeSourceWrapColumns(
+  viewportWidth: number,
+  codeSurface: ResolvedMobileCodeSurface,
+): number {
+  const availableWidth = viewportWidth - codeSurface.gutterWidth - codeSurface.codePadding * 2;
+  // Both native canvases use the system monospace font. A conservative width
+  // estimate keeps the final glyph inside the viewport on iOS and Android.
+  return Math.max(1, Math.floor(availableWidth / (codeSurface.fontSize * 0.62)));
 }
 
 export function buildNativeSourceRows(
   lines: ReadonlyArray<string>,
+  wrapColumns?: number,
 ): ReadonlyArray<NativeReviewDiffRow> {
-  return lines.map((line, index) => ({
-    kind: "line",
-    id: nativeSourceRowId(index),
-    fileId: SOURCE_FILE_ID,
-    content: expandTabs(line),
-    change: "context",
-    newLineNumber: index + 1,
-  }));
+  const columns = normalizedWrapColumns(wrapColumns);
+  return lines.flatMap((line, index) =>
+    splitAtColumns(line, columns).map((content, segment) => ({
+      kind: "line" as const,
+      id: nativeSourceRowId(index, segment),
+      fileId: SOURCE_FILE_ID,
+      content,
+      change: "context" as const,
+      newLineNumber: segment === 0 ? index + 1 : null,
+    })),
+  );
+}
+
+function splitTokensAtColumns(
+  tokens: ReadonlyArray<NativeReviewDiffToken>,
+  columns: number | null,
+): ReadonlyArray<ReadonlyArray<NativeReviewDiffToken>> {
+  if (columns === null) {
+    return [tokens];
+  }
+
+  const segments: NativeReviewDiffToken[][] = [[]];
+  let currentColumn = 0;
+  for (const token of tokens) {
+    const characters = Array.from(token.content);
+    let offset = 0;
+    while (offset < characters.length) {
+      if (currentColumn === columns) {
+        segments.push([]);
+        currentColumn = 0;
+      }
+      const length = Math.min(columns - currentColumn, characters.length - offset);
+      segments.at(-1)?.push({
+        ...token,
+        content: characters.slice(offset, offset + length).join(""),
+      });
+      offset += length;
+      currentColumn += length;
+    }
+  }
+  return segments;
 }
 
 export function buildNativeSourceTokens(
   tokenLines: SourceHighlightTokens | null,
+  wrapColumns?: number,
 ): Readonly<Record<string, ReadonlyArray<NativeReviewDiffToken>>> {
   if (tokenLines === null) {
     return {};
   }
 
+  const columns = normalizedWrapColumns(wrapColumns);
   return Object.fromEntries(
-    tokenLines.map((tokens, index) => [
-      nativeSourceRowId(index),
-      tokens.map((token) => ({
-        content: expandTabs(token.content),
-        color: token.color,
-        fontStyle: token.fontStyle,
-      })),
-    ]),
+    tokenLines.flatMap((tokens, index) =>
+      splitTokensAtColumns(
+        tokens.map((token) => ({
+          content: expandTabs(token.content),
+          color: token.color,
+          fontStyle: token.fontStyle,
+        })),
+        columns,
+      ).map((segmentTokens, segment) => [nativeSourceRowId(index, segment), segmentTokens]),
+    ),
   );
 }

--- a/apps/mobile/src/features/settings/appearance/sections/CodeAppearanceSection.tsx
+++ b/apps/mobile/src/features/settings/appearance/sections/CodeAppearanceSection.tsx
@@ -55,7 +55,7 @@ export function CodeAppearanceSection() {
       <SettingsSwitchRow
         disabled={!isReady}
         icon="text.word.spacing"
-        label="Word break"
+        label="Line wrap"
         onValueChange={setCodeWordBreak}
         value={appearance.codeWordBreak}
       />

--- a/docs/user/mobile-source-files.md
+++ b/docs/user/mobile-source-files.md
@@ -1,0 +1,8 @@
+# Source files on mobile
+
+Open a source file's actions menu and select **Line wrap** to fit long lines within the phone's
+screen. Wrapped continuation rows keep their syntax highlighting and remain associated with the
+original source line.
+
+The choice is remembered for other source files. You can also change it under **Settings →
+Appearance → Code & Diffs → Line wrap**.


### PR DESCRIPTION
## What Changed

Adds a remembered **Line wrap** toggle to mobile source files. Wrapped lines remain on the native source canvas, including syntax highlighting and source-line navigation.

## Why

Long source lines force repeated horizontal panning on a phone and make it easy to lose reading context. Wrapping keeps the entire line within the handset width so files are practical to read and review one-handed.

## UI Changes

The supplied before image shows long lines extending beyond the phone viewport.

An after screenshot is not included yet because this Linux host has no Android SDK, emulator, connected device, or iOS tooling. The PR remains a draft until real-device UI evidence can be captured.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes (not applicable; no animation or timed interaction changed)

Model: GPT-5 · Harness: Codex