### PR TITLE
fix(mobile): steer active turns by default

### DIFF
--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -103,7 +103,6 @@ export interface ThreadComposerProps {
   readonly selectedThread: OrchestrationThreadShell;
   readonly serverConfig: T3ServerConfig | null;
   readonly queueCount: number;
-  readonly activeThreadBusy: boolean;
   readonly environmentId: EnvironmentId;
   readonly projectCwd: string | null;
   readonly editorRef?: RefObject<ComposerEditorHandle | null>;
@@ -329,9 +328,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     props.selectedThread.session?.status === "starting";
 
   const sendLabel =
-    props.connectionState !== "connected" || props.activeThreadBusy || props.queueCount > 0
-      ? "Queue"
-      : "Send";
+    props.connectionState !== "connected" || props.queueCount > 0 ? "Queue" : "Send";
   const currentModelSelection = props.selectedThread.modelSelection;
   const currentRuntimeMode = props.selectedThread.runtimeMode;
   const currentInteractionMode = props.selectedThread.interactionMode ?? "default";

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -100,7 +100,6 @@ export interface ThreadDetailScreenProps {
   readonly threadSyncStatus?: EnvironmentThreadStatus;
   /** Non-null when older turns exist beyond the loaded window. */
   readonly loadEarlier?: { readonly loading: boolean; readonly onLoadEarlier: () => void } | null;
-  readonly activeThreadBusy: boolean;
   readonly environmentId: EnvironmentId;
   readonly projectWorkspaceRoot: string | null;
   readonly threadCwd: string | null;
@@ -726,7 +725,6 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
                 selectedThread={props.selectedThread}
                 serverConfig={props.serverConfig}
                 queueCount={props.selectedThreadQueueCount}
-                activeThreadBusy={props.activeThreadBusy}
                 environmentId={props.environmentId}
                 projectCwd={props.projectWorkspaceRoot}
                 bottomInset={composerBottomInset}

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -785,7 +785,6 @@ function ThreadRouteContent(
           connectionStateLabel={routeConnectionState}
           threadSyncStatus={selectedThreadDetailState.status}
           loadEarlier={loadEarlierTurns}
-          activeThreadBusy={composer.activeThreadBusy}
           environmentId={selectedThread.environmentId}
           projectWorkspaceRoot={selectedThreadProject?.workspaceRoot ?? null}
           threadCwd={selectedThreadCwd}

--- a/apps/mobile/src/state/thread-outbox-model.ts
+++ b/apps/mobile/src/state/thread-outbox-model.ts
@@ -169,7 +169,7 @@ export function resolveThreadOutboxDeliveryAction(input: {
   if (!input.threadExists) {
     return input.shellStatus === "live" ? "remove" : "wait";
   }
-  return input.environmentConnected && !input.threadBusy ? "send" : "wait";
+  return input.environmentConnected ? "send" : "wait";
 }
 
 /**

--- a/apps/mobile/src/state/thread-outbox.test.ts
+++ b/apps/mobile/src/state/thread-outbox.test.ts
@@ -487,6 +487,27 @@ describe("thread outbox", () => {
     ).toBe("send");
   });
 
+  it("sends existing-thread messages whenever connected so queued messages can steer", () => {
+    expect(
+      resolveThreadOutboxDeliveryAction({
+        isCreation: false,
+        threadExists: true,
+        shellStatus: "live",
+        environmentConnected: true,
+        threadBusy: true,
+      }),
+    ).toBe("send");
+    expect(
+      resolveThreadOutboxDeliveryAction({
+        isCreation: false,
+        threadExists: true,
+        shellStatus: "live",
+        environmentConnected: false,
+        threadBusy: true,
+      }),
+    ).toBe("wait");
+  });
+
   it("sends queued creations once connected and live, removing already-created ones", () => {
     expect(
       resolveThreadOutboxDeliveryAction({

--- a/apps/mobile/src/state/use-thread-composer-state.ts
+++ b/apps/mobile/src/state/use-thread-composer-state.ts
@@ -129,10 +129,6 @@ export function useThreadComposerState() {
     );
   }, [selectedThreadDetail, selectedThreadSessionActivity, selectedThreadShell]);
 
-  const activeThreadBusy =
-    !!selectedThread &&
-    (selectedThread.session?.status === "running" || selectedThread.session?.status === "starting");
-
   const onSendMessage = useCallback(async () => {
     if (!selectedThreadShell) {
       return null;
@@ -308,7 +304,6 @@ export function useThreadComposerState() {
     modelSelection,
     runtimeMode,
     interactionMode,
-    activeThreadBusy,
     onChangeDraftMessage,
     onPickDraftImages,
     onPasteIntoDraft,

--- a/apps/mobile/src/state/use-thread-outbox-drain.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.ts
@@ -37,7 +37,7 @@ import {
   type QueuedThreadMessage,
   type ThreadOutboxCommandStage,
 } from "./thread-outbox-model";
-import { environmentThreadShells, threadEnvironment } from "./threads";
+import { threadEnvironment } from "./threads";
 import { useAtomCommand } from "./use-atom-command";
 import {
   editingQueuedMessageIdsAtom,
@@ -362,20 +362,10 @@ export function useThreadOutboxDrain(): void {
           return true;
         }
         // The guards evaluated before the confirmation await are stale by now:
-        // the thread may have gone busy, or the user may have opened this
-        // message in the editor. Re-read both and defer to the next drain pass
-        // (returning true skips the failure/backoff path) rather than sending
-        // a payload the user is editing or racing an active turn.
+        // the user may have opened this message in the editor. Re-read that
+        // guard and defer to the next drain pass (returning true skips the
+        // failure/backoff path) rather than sending a payload being edited.
         if (appAtomRegistry.get(editingQueuedMessageIdsAtom)[nextQueuedMessage.messageId]) {
-          return true;
-        }
-        const freshThread = findThread(
-          appAtomRegistry.get(environmentThreadShells.threadShellsAtom),
-          nextQueuedMessage,
-        );
-        const freshThreadBusy =
-          freshThread?.session?.status === "running" || freshThread?.session?.status === "starting";
-        if (deliveryAction === "send" && creation === undefined && freshThreadBusy) {
           return true;
         }
         return deliveryAction === "remove"


### PR DESCRIPTION
## What Changed

- Mobile messages now steer an active turn by default when the environment is connected.
- Messages continue to queue locally while the environment is offline.
- The local queue drains automatically after the environment reconnects, including into an active turn.

## Why

Mobile previously treated every message sent during an active turn as a local queued message. That differed from desktop steering, and a queued message could remain on the device until the thread became idle or the app was revisited.

The mobile outbox now treats connectivity as the delivery boundary: disconnected messages remain durable locally, while connected messages are delivered immediately. This keeps the existing offline safety and FIFO ordering without adding a user-facing queue/steer mode ahead of server-side orchestration queueing.

## UI Changes

### Turn starts when online

<img width="360" alt="image" src="https://github.com/user-attachments/assets/2284faf5-5464-448a-982f-ee62f34e5976" />

### Queueing a message while offline

<img width="360" alt="image" src="https://github.com/user-attachments/assets/9740ac6b-7234-4ef6-9bd2-be2ddcb9b27c" /> &nbsp; &nbsp;<img width="360" alt="image" src="https://github.com/user-attachments/assets/cb98dc3f-ce0b-44d6-b2de-dd02e7f46d8e" />

### Queue drains when back online

<img width="360" alt="image" src="https://github.com/user-attachments/assets/316a4ede-345f-4c3b-8472-3c71f65da57c" />

### Steering mid-turn 

<img width="360" alt="image" src="https://github.com/user-attachments/assets/5dc404c1-6258-4925-a4da-fc405371d34b" />


## Verification

- `vp test run apps/mobile/src/state/thread-outbox.test.ts` (20 tests)
- `vp run typecheck` from `apps/mobile`
- Targeted lint for the seven changed mobile files
- iOS Simulator: active-turn send steered immediately
- iOS Simulator: offline message persisted locally and drained automatically after reconnect

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] Interaction video not included

Authored with GPT-5.6-Sol via the Codex harness in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow active turns to send by default in mobile thread outbox
> - Removes the `threadBusy` guard from [`resolveThreadOutboxDeliveryAction`](https://github.com/pingdotgg/t3code/pull/6543/files#diff-70b765fdc85f11eba546273ca7f2459bb1a0ed084acdec2d67bce652f3cd7895) so existing-thread messages are eligible to send whenever the environment is connected, regardless of whether the thread is currently running.
> - Removes the post-confirmation busy check in [`useThreadOutboxDrain`](https://github.com/pingdotgg/t3code/pull/6543/files#diff-c6afd8ca1f9412d0350ad44712f269fd37ea380215bf974fa2fcead4352da5a3), so the drain proceeds after queue confirmation as long as the message is not being edited.
> - Removes the `activeThreadBusy` prop from `ThreadComposer` and related components, so the send button label no longer switches to 'Queue' when the thread is busy.
> - Behavioral Change: messages are now queued and sent during active AI turns instead of being held until the turn completes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 22160d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core message delivery timing during active orchestration turns; mis-handling could duplicate sends or break offline safety, though connectivity gating and tests limit scope.
> 
> **Overview**
> **Mobile thread messaging now matches desktop steering:** when the environment is connected, user messages are delivered immediately—even if a turn is already running—instead of sitting in the local outbox until the thread goes idle.
> 
> The outbox delivery rule in `resolveThreadOutboxDeliveryAction` no longer waits on `threadBusy` for existing threads; only connectivity (and the existing creation/shell rules) gates send vs wait. `useThreadOutboxDrain` drops the post-confirmation re-check that deferred delivery when the thread had become running/starting.
> 
> **Composer UI** removes `activeThreadBusy` end-to-end. The send button label shows **Queue** only when disconnected or when there are already queued messages—not merely because the agent is busy. Offline queuing and automatic drain on reconnect are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22160d9faae6d5d94a171e3cc836747cedc4d693. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->