### PR TITLE
fix(web): hide provider Update toast action while an update is running

### DIFF
--- a/apps/web/src/components/ProviderUpdatePrimaryNotification.tsx
+++ b/apps/web/src/components/ProviderUpdatePrimaryNotification.tsx
@@ -20,7 +20,7 @@ import {
   providerUpdateNotificationKey,
   type ProviderUpdateToastView,
 } from "./ProviderUpdateLaunchNotification.logic";
-import { stackedThreadToast, toastManager } from "./ui/toast";
+import { hiddenToastActionProps, stackedThreadToast, toastManager } from "./ui/toast";
 import { useAtomCommand } from "../state/use-atom-command";
 
 const seenProviderUpdateNotificationKeys = new Set<string>();
@@ -68,10 +68,10 @@ function updateProviderUpdateToast(input: {
       title: input.view.title,
       description: input.view.description,
       timeout: 0,
-      // Base UI merges toast updates with the existing toast. Explicitly clear
-      // the prompt action so its guarded Update handler cannot linger as a
-      // visible no-op while the update is running (or after it succeeds).
-      actionProps: undefined,
+      // Base UI merges toast updates and omits `undefined` keys, so `undefined`
+      // would leave the prompt's Update button in place. Replace it with a
+      // defined empty action so the CTA cannot linger while the update runs.
+      actionProps: hiddenToastActionProps,
       data: {
         hideCopyButton: true,
         ...(input.view.dismissAfterVisibleMs !== undefined

--- a/apps/web/src/components/ui/toast.logic.test.ts
+++ b/apps/web/src/components/ui/toast.logic.test.ts
@@ -2,9 +2,22 @@ import type { ScopedThreadRef } from "@t3tools/contracts";
 import { assert, describe, it } from "vite-plus/test";
 import {
   buildVisibleToastLayout,
+  hasVisibleToastAction,
   shouldHideCollapsedToastContent,
   shouldRenderThreadScopedToast,
 } from "./toast.logic";
+
+describe("hasVisibleToastAction", () => {
+  it("treats a labeled action as visible", () => {
+    assert.equal(hasVisibleToastAction({ children: "Update" }), true);
+  });
+
+  it("hides an explicit empty action used to clear a previous CTA", () => {
+    assert.equal(hasVisibleToastAction({ children: null }), false);
+    assert.equal(hasVisibleToastAction({ children: "" }), false);
+    assert.equal(hasVisibleToastAction(undefined), false);
+  });
+});
 
 describe("shouldHideCollapsedToastContent", () => {
   it("keeps a single visible toast readable", () => {

--- a/apps/web/src/components/ui/toast.logic.ts
+++ b/apps/web/src/components/ui/toast.logic.ts
@@ -1,5 +1,21 @@
 import type { ScopedThreadRef, ThreadId } from "@t3tools/contracts";
 
+/**
+ * Base UI toast updates omit `undefined` fields, so callers that need to remove
+ * an action must pass a defined `actionProps` whose `children` are empty.
+ * Treat that payload (and missing children) as "no visible action".
+ */
+export function hasVisibleToastAction(actionProps: unknown): boolean {
+  if (actionProps == null || typeof actionProps !== "object") {
+    return false;
+  }
+  if (!("children" in actionProps)) {
+    return false;
+  }
+  const children = actionProps.children;
+  return children != null && children !== false && children !== "";
+}
+
 export function shouldHideCollapsedToastContent(
   visibleToastIndex: number,
   visibleToastCount: number,

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -32,6 +32,7 @@ import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { resolveThreadRouteTarget } from "~/threadRoutes";
 import {
   buildVisibleToastLayout,
+  hasVisibleToastAction,
   shouldHideCollapsedToastContent,
   shouldRenderThreadScopedToast,
 } from "./toast.logic";
@@ -287,7 +288,7 @@ function deriveToastBodyDescriptor(toast: {
 }): ToastBodyDescriptor {
   const Icon = toast.type ? TOAST_ICONS[toast.type as keyof typeof TOAST_ICONS] : null;
   const stackedActionLayout =
-    toast.actionProps !== undefined && toast.data?.actionLayout === "stacked-end";
+    hasVisibleToastAction(toast.actionProps) && toast.data?.actionLayout === "stacked-end";
   const actionVariant: NonNullable<ThreadToastData["actionVariant"]> =
     toast.data?.actionVariant ?? "default";
   const secondaryActionVariant: NonNullable<ThreadToastData["secondaryActionVariant"]> =
@@ -300,7 +301,7 @@ function deriveToastBodyDescriptor(toast: {
   const hasSecondaryAction = toast.data?.secondaryActionProps !== undefined;
   const hasTrailingControls =
     copyErrorText !== null ||
-    toast.actionProps !== undefined ||
+    hasVisibleToastAction(toast.actionProps) ||
     hasAdditionalActions ||
     hasSecondaryAction;
   const inlineContentEndPad = hasTrailingControls ? "pr-6" : "pr-10";
@@ -401,12 +402,12 @@ function ToastBodyContent({
               type="button"
             />
           ) : null}
-          {actionProps ? (
+          {hasVisibleToastAction(actionProps) ? (
             <Toast.Action
               className={cn(buttonVariants({ size: "xs", variant: actionVariant }), "shrink-0")}
               data-slot="toast-action"
             >
-              {actionProps.children}
+              {actionProps?.children}
             </Toast.Action>
           ) : null}
         </div>
@@ -799,7 +800,7 @@ function AnchoredToasts() {
   );
 }
 
-export { stackedThreadToast } from "./toastHelpers";
+export { hiddenToastActionProps, stackedThreadToast } from "./toastHelpers";
 export type { StackedThreadToastOptions } from "./toastHelpers";
 
 export {

--- a/apps/web/src/components/ui/toastHelpers.test.ts
+++ b/apps/web/src/components/ui/toastHelpers.test.ts
@@ -1,0 +1,21 @@
+import { assert, describe, it } from "vite-plus/test";
+
+import { hiddenToastActionProps, stackedThreadToast } from "./toastHelpers";
+
+describe("hiddenToastActionProps", () => {
+  it("is a defined update payload so Base UI can replace a previous action", () => {
+    assert.equal(hiddenToastActionProps.children, null);
+    assert.equal(
+      "actionProps" in stackedThreadToast({ type: "loading", title: "Updating" }),
+      false,
+    );
+    assert.deepEqual(
+      stackedThreadToast({
+        type: "loading",
+        title: "Updating",
+        actionProps: hiddenToastActionProps,
+      }).actionProps,
+      hiddenToastActionProps,
+    );
+  });
+});

--- a/apps/web/src/components/ui/toastHelpers.ts
+++ b/apps/web/src/components/ui/toastHelpers.ts
@@ -18,6 +18,14 @@ export type StackedThreadToastOptions = {
 };
 
 /**
+ * Defined `actionProps` that hide a previous toast CTA on `toastManager.update`.
+ * Passing `actionProps: undefined` is a no-op because updates omit undefined keys.
+ */
+export const hiddenToastActionProps = {
+  children: null,
+} as const satisfies Pick<ComponentPropsWithoutRef<"button">, "children">;
+
+/**
  * Thread toast using the stacked body + bottom action row (copy for errors, CTA on its own row).
  */
 export function stackedThreadToast(


### PR DESCRIPTION
## Summary
- Clicking **Update** on the provider update toast left the same **Update** button visible and clickable while the command was already running (`#6277`).
- Toast updates omit `undefined` fields, so the earlier `actionProps: undefined` clear was a no-op. The progress toast now replaces the CTA with a defined empty action, and the toast UI treats that as “no button”.

## Test plan
- [ ] With an outdated one-click provider, click **Update** on the launch toast.
- [ ] Confirm the toast switches to “Updating provider” / a spinner and the **Update** button is gone.
- [ ] Confirm a later failure still shows **Settings**, and success auto-dismisses without a leftover CTA.

### Before
The toast title already says the update is running, but **Update** is still there:

<img width="640" alt="Before: Update still clickable on the updating toast" src="https://github.com/user-attachments/assets/93994232-06a9-4a55-81d8-0eb989e12990" />

### After
<img width="420" alt="After: updating toast with no Update button" src="https://files.catbox.moe/ewwb4w.png" />

Fixes #6277

Cursor Grok 4.6

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide stale action buttons on provider update toasts during loading and success states
> - Adds `hiddenToastActionProps` (children: null) to [toastHelpers.ts](https://github.com/pingdotgg/t3code/pull/6544/files#diff-a28594ecb84cd817404f08eb5979b295ba5b82812c054b4714fc57ff1ddda863) as a canonical way to explicitly clear a toast's CTA on update, since Base UI omits undefined fields during updates.
> - Adds `hasVisibleToastAction` to [toast.logic.ts](https://github.com/pingdotgg/t3code/pull/6544/files#diff-c3182d6685311defeefe9d1e131cb06f1f9a264fd0ef3528190accd7212a5e9f) to check whether a toast action has non-empty children, used to gate rendering and layout decisions.
> - Updates [toast.tsx](https://github.com/pingdotgg/t3code/pull/6544/files#diff-dbb38a4f02a67491223157a9f1aba388365f4cd55652e1f32847ffda53aee7f2) to use `hasVisibleToastAction` when determining stacked layout, trailing controls, and whether to render the action button at all.
> - Fixes [ProviderUpdatePrimaryNotification.tsx](https://github.com/pingdotgg/t3code/pull/6544/files#diff-d406ca641d650a2341fd7b4aa3ac1f6d980b270a7046f0f791dd54e39da147c9) to pass `hiddenToastActionProps` instead of `undefined` when updating toasts to loading or success state, preventing stale CTAs from persisting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d2a5b9a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->