### PR TITLE
fix(web): stop clipping the changed-files expand hover on Windows

### DIFF
--- a/apps/web/src/components/chat/ChangedFilesTree.test.tsx
+++ b/apps/web/src/components/chat/ChangedFilesTree.test.tsx
@@ -23,14 +23,14 @@ describe("ChangedFilesCard", () => {
     expect(markup).toContain('data-changed-files-state="expanded"');
     expect(markup).toContain('aria-expanded="true"');
     expect(markup).toContain("whitespace-nowrap");
-    expect(markup).toContain(
-      'class="group flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden',
-    );
+    expect(markup).toContain('class="group flex min-w-0 flex-1 items-center rounded-xl');
+    expect(markup).not.toMatch(/class="group flex min-w-0 flex-1 items-center[^"]*overflow-hidden/);
+    expect(markup).toContain('class="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden"');
     expect(markup).toContain('class="flex shrink-0 items-center gap-1 whitespace-nowrap');
     expect(markup).toContain('class="ml-1 hidden min-w-0 flex-1 truncate');
     expect(markup).toContain("@[24rem]/changed-files:inline");
     expect(markup).not.toContain("sm:inline");
-    expect(markup).toContain('class="flex shrink-0 items-center gap-1.5"');
+    expect(markup).toContain('class="flex shrink-0 items-center gap-1.5 pr-1"');
     expect(markup).toContain("!size-[22px]");
     expect(markup).toContain("size-3");
     expect(markup).toContain('aria-label="Collapse all folders"');

--- a/apps/web/src/components/chat/ChangedFilesTree.tsx
+++ b/apps/web/src/components/chat/ChangedFilesTree.tsx
@@ -64,7 +64,7 @@ export const ChangedFilesCard = memo(function ChangedFilesCard(props: {
       <div
         data-changed-files-header=""
         className={cn(
-          "flex items-center justify-between gap-2 rounded-xl px-1",
+          "flex items-center justify-between gap-2 rounded-xl",
           expanded &&
             "sticky top-2 z-10 mb-2 bg-secondary dark:bg-[color-mix(in_srgb,var(--foreground)_2.5%,var(--background))]",
         )}
@@ -73,34 +73,36 @@ export const ChangedFilesCard = memo(function ChangedFilesCard(props: {
           type="button"
           aria-expanded={expanded}
           data-scroll-anchor-ignore
-          className="group flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden rounded-lg px-1 py-1.5 text-left transition-colors hover:bg-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="group flex min-w-0 flex-1 items-center rounded-xl px-2 py-1.5 text-left transition-colors hover:bg-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           onClick={() => onExpandedChange(!expanded)}
         >
-          <ChevronRightIcon
-            aria-hidden="true"
-            className={cn(
-              "size-3.5 shrink-0 text-muted-foreground transition-transform",
-              expanded && "rotate-90",
-            )}
-          />
-          <span className="flex shrink-0 items-center gap-1 whitespace-nowrap font-medium text-foreground text-xs leading-4">
-            <span>
-              {files.length} changed file{files.length === 1 ? "" : "s"}
+          <span className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
+            <ChevronRightIcon
+              aria-hidden="true"
+              className={cn(
+                "size-3.5 shrink-0 text-muted-foreground transition-transform",
+                expanded && "rotate-90",
+              )}
+            />
+            <span className="flex shrink-0 items-center gap-1 whitespace-nowrap font-medium text-foreground text-xs leading-4">
+              <span>
+                {files.length} changed file{files.length === 1 ? "" : "s"}
+              </span>
+              {hasNonZeroStat(summaryStat) && (
+                <DiffStatLabel
+                  additions={summaryStat.additions}
+                  className="text-xs leading-4"
+                  deletions={summaryStat.deletions}
+                  layout="inline"
+                />
+              )}
             </span>
-            {hasNonZeroStat(summaryStat) && (
-              <DiffStatLabel
-                additions={summaryStat.additions}
-                className="text-xs leading-4"
-                deletions={summaryStat.deletions}
-                layout="inline"
-              />
-            )}
-          </span>
-          <span className="ml-1 hidden min-w-0 flex-1 truncate text-[11px] text-muted-foreground group-hover:text-foreground/80 @[24rem]/changed-files:inline">
-            {expanded ? "Hide files" : "Show files"}
+            <span className="ml-1 hidden min-w-0 flex-1 truncate text-[11px] text-muted-foreground group-hover:text-foreground/80 @[24rem]/changed-files:inline">
+              {expanded ? "Hide files" : "Show files"}
+            </span>
           </span>
         </button>
-        <div className="flex shrink-0 items-center gap-1.5">
+        <div className="flex shrink-0 items-center gap-1.5 pr-1">
           {expanded ? (
             <Tooltip>
               <TooltipTrigger


### PR DESCRIPTION
## Summary
- Hovering the inline changed-files expand bar clipped the highlight on the left on Windows (`#6430`).
- `#6314` put `overflow-hidden` on the header button to truncate “Hide files”, which also squared off the hover fill. Truncation now lives on an inner row so the highlight can follow the bar’s left edge.

## Test plan
- [ ] Expand the changed-files card in a thread with several edits.
- [ ] Hover the expand/collapse bar and confirm the highlight meets the left rounded edge instead of cutting off.
- [ ] Shrink the pane until “Hide files” / “Show files” truncates and confirm it still does not overlap **Open diff**.

### Before
<img width="960" alt="Before: hover fill clipped on the left" src="https://github.com/user-attachments/assets/b333ed5b-b961-4fc3-9429-b0bc502e0f45" />

### After
<img width="800" alt="After: hover fill follows the left rounded edge" src="https://files.catbox.moe/sv4qpd.png" />

Fixes #6430

Cursor Grok 4.6

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix clipping of the changed-files expand hover state on Windows
> Restructures the header layout in [`ChangedFilesTree.tsx`](https://github.com/pingdotgg/t3code/pull/6545/files#diff-6864e7755be29c811b2329bf788d411fda278c8f9a22f4ec373e82a9acc03f0c) to stop `overflow-hidden` from clipping the hover ring on the expand button. The chevron and labels move into an inner `flex min-w-0 flex-1` span, and `overflow-hidden` is scoped there instead of on the button itself. The button border radius changes from `rounded-lg` to `rounded-xl` and right-side controls gain `pr-1` padding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 269c0c2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->