### PR TITLE
fix(web): keep floating preview anchored after panel closes

### DIFF
--- a/apps/web/src/components/preview/ThreadPreviewMiniPlayer.tsx
+++ b/apps/web/src/components/preview/ThreadPreviewMiniPlayer.tsx
@@ -17,6 +17,7 @@ import {
   clampPreviewMiniPlayerPosition,
   clampPreviewMiniPlayerSize,
   PREVIEW_MINI_PLAYER_DEFAULT_SIZE,
+  PREVIEW_MINI_PLAYER_EDGE_GAP,
 } from "./previewMiniPlayerLayout";
 
 interface DragState {
@@ -91,8 +92,9 @@ export function ThreadPreviewMiniPlayer({ threadRef, tabId, bottomInset }: Props
         bottomInset,
       );
       usePreviewMiniPlayerStore.getState().resize(threadRef, tabId, nextSize);
+      if (!position) return;
       const next = clampPreviewMiniPlayerPosition(
-        position ?? { x: root.offsetLeft, y: root.offsetTop },
+        position,
         { width: parent.clientWidth, height: parent.clientHeight },
         nextSize,
         bottomInset,
@@ -193,8 +195,9 @@ export function ThreadPreviewMiniPlayer({ threadRef, tabId, bottomInset }: Props
       bottomInset,
     );
     usePreviewMiniPlayerStore.getState().resize(threadRef, tabId, nextSize);
+    if (!position) return;
     const nextPosition = clampPreviewMiniPlayerPosition(
-      position ?? { x: root.offsetLeft, y: root.offsetTop },
+      position,
       { width: parent.clientWidth, height: parent.clientHeight },
       nextSize,
       bottomInset,
@@ -222,8 +225,8 @@ export function ThreadPreviewMiniPlayer({ threadRef, tabId, bottomInset }: Props
         position
           ? { left: position.x, top: position.y, width: size.width, height: size.height }
           : {
-              right: 16,
-              top: 16,
+              right: PREVIEW_MINI_PLAYER_EDGE_GAP,
+              top: PREVIEW_MINI_PLAYER_EDGE_GAP,
               width: size.width,
               height: size.height,
             }

--- a/apps/web/src/components/preview/ThreadPreviewMiniPlayer.tsx
+++ b/apps/web/src/components/preview/ThreadPreviewMiniPlayer.tsx
@@ -2,7 +2,7 @@
 
 import type { ScopedThreadRef } from "@t3tools/contracts";
 import { PanelRightIcon, PictureInPicture2, XIcon } from "lucide-react";
-import { type PointerEvent as ReactPointerEvent, useLayoutEffect, useRef } from "react";
+import { type PointerEvent as ReactPointerEvent, useLayoutEffect, useRef, useState } from "react";
 
 import { BrowserSurfaceSlot } from "~/browser/BrowserSurfaceSlot";
 import { previewRuntimeTabId } from "~/browser/previewRuntimeTabId";
@@ -32,6 +32,8 @@ interface ResizeState {
   readonly pointerId: number;
   readonly pointerX: number;
   readonly pointerY: number;
+  readonly playerX: number;
+  readonly playerY: number;
   readonly width: number;
   readonly height: number;
 }
@@ -46,6 +48,7 @@ export function ThreadPreviewMiniPlayer({ threadRef, tabId, bottomInset }: Props
   const rootRef = useRef<HTMLElement | null>(null);
   const dragRef = useRef<DragState | null>(null);
   const resizeRef = useRef<ResizeState | null>(null);
+  const [defaultLayoutVersion, setDefaultLayoutVersion] = useState("");
   const miniPlayer = usePreviewMiniPlayerStore((state) =>
     selectThreadPreviewMiniPlayer(state.byThreadKey, threadRef),
   );
@@ -92,7 +95,10 @@ export function ThreadPreviewMiniPlayer({ threadRef, tabId, bottomInset }: Props
         bottomInset,
       );
       usePreviewMiniPlayerStore.getState().resize(threadRef, tabId, nextSize);
-      if (!position) return;
+      if (!position) {
+        setDefaultLayoutVersion(`${parent.clientWidth}:${parent.clientHeight}`);
+        return;
+      }
       const next = clampPreviewMiniPlayerPosition(
         position,
         { width: parent.clientWidth, height: parent.clientHeight },
@@ -161,11 +167,16 @@ export function ThreadPreviewMiniPlayer({ threadRef, tabId, bottomInset }: Props
   const handleResizePointerDown = (event: ReactPointerEvent<HTMLButtonElement>) => {
     if (event.button !== 0) return;
     const root = rootRef.current;
-    if (!root) return;
+    const parent = root?.offsetParent;
+    if (!root || !(parent instanceof HTMLElement)) return;
+    const rootRect = root.getBoundingClientRect();
+    const parentRect = parent.getBoundingClientRect();
     resizeRef.current = {
       pointerId: event.pointerId,
       pointerX: event.clientX,
       pointerY: event.clientY,
+      playerX: rootRect.left - parentRect.left,
+      playerY: rootRect.top - parentRect.top,
       width: root.offsetWidth,
       height: root.offsetHeight,
     };
@@ -195,9 +206,8 @@ export function ThreadPreviewMiniPlayer({ threadRef, tabId, bottomInset }: Props
       bottomInset,
     );
     usePreviewMiniPlayerStore.getState().resize(threadRef, tabId, nextSize);
-    if (!position) return;
     const nextPosition = clampPreviewMiniPlayerPosition(
-      position,
+      { x: resize.playerX, y: resize.playerY },
       { width: parent.clientWidth, height: parent.clientHeight },
       nextSize,
       bottomInset,
@@ -293,7 +303,11 @@ export function ThreadPreviewMiniPlayer({ threadRef, tabId, bottomInset }: Props
           visible={Boolean(desktopOverlay?.hasWebContents)}
           cornerRadius={12}
           fitSourceContent
-          layoutVersion={position ? `${position.x}:${position.y}` : `initial:${bottomInset}`}
+          layoutVersion={
+            position
+              ? `${position.x}:${position.y}`
+              : `initial:${bottomInset}:${defaultLayoutVersion}`
+          }
           className="absolute inset-0"
         />
         <div className="pointer-events-none absolute inset-0 z-[31] rounded-xl ring-1 ring-inset ring-border/80" />


### PR DESCRIPTION
## What Changed

Closing the side panel no longer leaves an untouched floating preview near the middle of the chat. It stays anchored to the top-right corner. Previews that the user moved still keep their explicit position.

Validated with the focused preview-layout tests, the web typecheck, targeted lint, and an integrated before/after pass.

## Why

When the side panel narrows the chat, the layout observer converts the preview's default right-anchored position into an explicit left coordinate. Closing the panel then reuses that coordinate in the wider layout.

The default position now stays responsive until the user moves the preview. The initial placement also uses the existing shared edge-gap value.

Fixes #6546

## UI Changes

### Before

<img width="1916" height="872" alt="Floating preview left near the middle after closing the side panel" src="https://github.com/user-attachments/assets/e332cf5c-6fdb-4ced-8a41-d5c7c3ef564f" />

https://github.com/user-attachments/assets/fcd7a698-23d9-47b0-a9de-9d6297ee0ab4

### After

<img width="1916" height="872" alt="Floating preview anchored to the top-right after closing the side panel" src="https://github.com/user-attachments/assets/01d0d4b7-571e-4f7d-ade5-bcef861f739a" />

https://github.com/user-attachments/assets/60f2d1ea-27b2-4196-a1b9-63f949008f84

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Built with GPT-5.6-Sol via the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI behavior in the preview mini player; no auth, data, or API changes.
> 
> **Overview**
> Fixes the floating thread preview drifting away from the top-right when the right panel closes after layout changes.
> 
> The **resize observer** no longer calls `move` when there is no stored user position—it only clamps size and bumps a `defaultLayoutVersion` keyed on parent dimensions so `BrowserSurfaceSlot` still relayouts. **User-moved** previews still get position clamping on resize.
> 
> Default placement now uses **`PREVIEW_MINI_PLAYER_EDGE_GAP`** instead of hardcoded `16px`. **Resize drag** seeds position from the player’s offset at pointer-down (`playerX`/`playerY`) rather than `position ?? offsetLeft`, avoiding accidental persistence of layout-derived coordinates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a356052c9fb4dfc5b9c457ebea3718e76e7c8bc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix floating preview mini-player anchor position after panel closes
> - When no saved position exists, `ThreadPreviewMiniPlayer` now records the offset parent's dimensions and skips moving based on DOM offsets, preventing positional jumps when a panel closes.
> - On resize start, the handler captures the player's coordinates relative to its offset parent and uses those for position clamping during the drag, rather than potentially stale DOM offsets.
> - The default top/right inset now uses `PREVIEW_MINI_PLAYER_EDGE_GAP` instead of a hardcoded `16`.
> - `BrowserSurfaceSlot` `layoutVersion` now includes parent dimensions when position is unset, so a relayout triggers when container size changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a356052.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->