### PR TITLE
fix(web): simplify the desktop-managed server update banner copy

### DIFF
--- a/apps/web/src/versionSkew.test.ts
+++ b/apps/web/src/versionSkew.test.ts
@@ -101,7 +101,7 @@ describe("versionSkew", () => {
       "Update the Remote server so they stay in sync.",
     );
     expect(serverUpdateGuidance("desktop-managed", "Desktop server")).toBe(
-      "The Desktop server is run by the T3 Code desktop app on its machine — update the desktop app there to sync them.",
+      "Update the desktop app that runs the Desktop server.",
     );
     expect(serverUpdateGuidance(null, "Local server")).toBe(
       "Relaunch the Local server with the copied command to sync them.",

--- a/apps/web/src/versionSkew.ts
+++ b/apps/web/src/versionSkew.ts
@@ -73,7 +73,7 @@ export function serverUpdateGuidance(
     case "respawn":
       return `Update the ${serverLabel} so they stay in sync.`;
     case "desktop-managed":
-      return `The ${serverLabel} is run by the T3 Code desktop app on its machine — update the desktop app there to sync them.`;
+      return `Update the desktop app that runs the ${serverLabel}.`;
     default:
       return `Relaunch the ${serverLabel} with the copied command to sync them.`;
   }


### PR DESCRIPTION
The version-skew banner for desktop-managed servers was a mouthful: "The leftbook server is run by the T3 Code desktop app on its machine — update the desktop app there to sync them."

Now it is one plain line that matches the other guidance cases: "Update the desktop app that runs the leftbook server."

---
Change made by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing copy only; no logic or capability handling changes.
> 
> **Overview**
> Shortens the version-skew banner text when the server reports **`desktop-managed`** self-update capability.
> 
> **`serverUpdateGuidance`** now returns `Update the desktop app that runs the ${serverLabel}.` instead of the longer line about the T3 Code desktop app on its machine. Respawn/boot-service and manual-relaunch guidance are unchanged.
> 
> The unit test expectation for the desktop-managed case is updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66d2c26f57b37521a05380601b42e98ff4415b4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Simplify the desktop-managed server update banner copy
> Shortens the guidance message returned by `serverUpdateGuidance` for the `desktop-managed` capability in [versionSkew.ts](https://github.com/pingdotgg/t3code/pull/6549/files#diff-783a2e421405ef3af3e1f17f70b8b5d18abf1081be90640034de054f22e85caa). The new copy reads "Update the desktop app that runs the ${serverLabel}." instead of the previous longer sentence.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 66d2c26.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->