### PR TITLE
fix(chat): render assistant-generated images inline

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -9,6 +9,7 @@
     "start": "node scripts/start-electron.mjs",
     "typecheck": "tsgo --noEmit",
     "test": "vp test run --passWithNoTests",
+    "test:assistant-image-e2e": "node scripts/assistant-image-e2e.mjs",
     "smoke-test": "node scripts/smoke-test.mjs"
   },
   "dependencies": {

--- a/apps/desktop/scripts/assistant-image-e2e.mjs
+++ b/apps/desktop/scripts/assistant-image-e2e.mjs
@@ -1,0 +1,264 @@
+import * as NodeChildProcess from "node:child_process";
+import * as NodeFS from "node:fs";
+import * as NodeNet from "node:net";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import * as NodeSqlite from "node:sqlite";
+import * as NodeURL from "node:url";
+
+import { chromium } from "playwright-core";
+
+import { resolveElectronLaunchCommand } from "./electron-launcher.mjs";
+
+const __dirname = NodePath.dirname(NodeURL.fileURLToPath(import.meta.url));
+const desktopDir = NodePath.resolve(__dirname, "..");
+const repoRoot = NodePath.resolve(desktopDir, "..", "..");
+const mainJs = NodePath.join(desktopDir, "dist-electron", "main.cjs");
+const serverBundle = NodePath.join(repoRoot, "apps", "server", "dist", "bin.mjs");
+const sourcePng = NodePath.join(repoRoot, "assets", "dev", "blueprint-universal-1024.png");
+const testHome = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-assistant-image-e2e-"));
+const attachmentId = "thread-inline-image-11111111-1111-4111-8111-111111111111";
+// oxlint-disable-next-line t3code/no-global-process-runtime -- Standalone E2E runner has no Effect runtime.
+const hostPlatform = NodeOS.platform();
+
+function reservePort() {
+  return new Promise((resolve, reject) => {
+    const server = NodeNet.createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("Could not reserve a desktop test port."));
+        return;
+      }
+      server.close((error) => (error ? reject(error) : resolve(address.port)));
+    });
+  });
+}
+
+function seedGeneratedImageProjection() {
+  const userdataDir = NodePath.join(testHome, "userdata");
+  const attachmentsDir = NodePath.join(userdataDir, "attachments");
+  const database = new NodeSqlite.DatabaseSync(NodePath.join(userdataDir, "state.sqlite"));
+  const modelSelection = JSON.stringify({ instanceId: "codex", model: "gpt-5.4" });
+  const attachment = JSON.stringify([
+    {
+      type: "image",
+      id: attachmentId,
+      name: "generated-blueprint.png",
+      mimeType: "image/png",
+      sizeBytes: NodeFS.statSync(sourcePng).size,
+    },
+  ]);
+  try {
+    database.exec("BEGIN IMMEDIATE");
+    database
+      .prepare(
+        `INSERT INTO projection_projects (
+          project_id, title, workspace_root, default_model_selection_json, scripts_json,
+          created_at, updated_at
+        ) VALUES (?, ?, ?, ?, '[]', ?, ?)`,
+      )
+      .run(
+        "project-inline-image",
+        "Inline image verification",
+        repoRoot,
+        modelSelection,
+        "2026-08-11T06:55:00.000Z",
+        "2026-08-11T06:55:02.000Z",
+      );
+    database
+      .prepare(
+        `INSERT INTO projection_threads (
+          thread_id, project_id, title, model_selection_json, runtime_mode, interaction_mode,
+          branch, worktree_path, latest_user_message_at, created_at, updated_at, settled_at
+        ) VALUES (?, ?, ?, ?, 'full-access', 'default', ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "thread-inline-image",
+        "project-inline-image",
+        "Generated PNG renders inline",
+        modelSelection,
+        "worktree",
+        repoRoot,
+        "2026-08-11T06:55:00.000Z",
+        "2026-08-11T06:55:00.000Z",
+        "2026-08-11T06:55:02.000Z",
+        "2026-08-11T06:55:02.000Z",
+      );
+    database
+      .prepare(
+        `INSERT INTO projection_thread_messages (
+          message_id, thread_id, turn_id, role, text, is_streaming, created_at, updated_at,
+          attachments_json
+        ) VALUES (?, ?, ?, 'assistant', ?, 0, ?, ?, ?)`,
+      )
+      .run(
+        "message-inline-image-assistant",
+        "thread-inline-image",
+        "turn-inline-image",
+        "",
+        "2026-08-11T06:55:02.000Z",
+        "2026-08-11T06:55:02.000Z",
+        attachment,
+      );
+    database
+      .prepare(
+        `INSERT INTO projection_thread_messages (
+          message_id, thread_id, turn_id, role, text, is_streaming, created_at, updated_at,
+          attachments_json
+        ) VALUES (?, ?, ?, 'assistant', ?, 0, ?, ?, '[]')`,
+      )
+      .run(
+        "message-inline-image-final",
+        "thread-inline-image",
+        "turn-inline-image",
+        "Here is the generated PNG.",
+        "2026-08-11T06:55:03.000Z",
+        "2026-08-11T06:55:03.000Z",
+      );
+    database.exec("COMMIT");
+  } catch (error) {
+    database.exec("ROLLBACK");
+    throw error;
+  } finally {
+    database.close();
+  }
+  NodeFS.mkdirSync(attachmentsDir, { recursive: true });
+  NodeFS.copyFileSync(sourcePng, NodePath.join(attachmentsDir, `${attachmentId}.png`));
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function launchDesktop(backendPort, debugPort) {
+  const launchCommand = resolveElectronLaunchCommand([
+    `--remote-debugging-port=${debugPort}`,
+    mainJs,
+  ]);
+  const childEnv = {
+    ...process.env,
+    APPDATA: NodePath.join(testHome, "appdata"),
+    ELECTRON_ENABLE_LOGGING: "1",
+    T3CODE_DESKTOP_APP_USER_MODEL_ID: `com.t3tools.t3code.e2e.${NodePath.basename(testHome)}`,
+    T3CODE_HOME: testHome,
+    T3CODE_PORT: String(backendPort),
+    VITE_DEV_SERVER_URL: "",
+  };
+  delete childEnv.ELECTRON_RUN_AS_NODE;
+  const child = NodeChildProcess.spawn(launchCommand.electronPath, launchCommand.args, {
+    cwd: desktopDir,
+    env: childEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let output = "";
+  const appendOutput = (chunk) => {
+    output = `${output}${chunk.toString()}`.slice(-20_000);
+  };
+  child.stdout.on("data", appendOutput);
+  child.stderr.on("data", appendOutput);
+  return { child, getOutput: () => output };
+}
+
+async function connectToDesktop(run, debugPort) {
+  const deadline = Date.now() + 45_000;
+  let lastError;
+  while (Date.now() < deadline) {
+    if (run.child.exitCode !== null) {
+      throw new Error(
+        `Desktop exited before CDP became available (${run.child.exitCode}).\n${run.getOutput()}`,
+      );
+    }
+    try {
+      const browser = await chromium.connectOverCDP(`http://127.0.0.1:${debugPort}`);
+      const context = browser.contexts()[0];
+      if (context) return { browser, context };
+      await browser.close();
+    } catch (error) {
+      lastError = error;
+    }
+    await delay(100);
+  }
+  throw new Error(`Timed out connecting to desktop CDP: ${String(lastError)}\n${run.getOutput()}`);
+}
+
+async function waitForAppWindow(context) {
+  const deadline = Date.now() + 45_000;
+  while (Date.now() < deadline) {
+    const page = context.pages().find((candidate) => !candidate.url().startsWith("devtools://"));
+    if (page) {
+      await page.locator("body").waitFor({ state: "visible", timeout: 45_000 });
+      return page;
+    }
+    await delay(100);
+  }
+  throw new Error("Timed out waiting for the T3 Code desktop window.");
+}
+
+async function stopDesktop(run, browser) {
+  await browser?.close().catch(() => undefined);
+  if (run.child.exitCode !== null) return;
+
+  if (hostPlatform === "win32") {
+    NodeChildProcess.spawnSync("taskkill", ["/PID", String(run.child.pid), "/T", "/F"], {
+      stdio: "ignore",
+    });
+  } else {
+    run.child.kill("SIGTERM");
+  }
+
+  const exited = new Promise((resolve) => run.child.once("exit", resolve));
+  await Promise.race([exited, delay(5_000)]);
+  if (run.child.exitCode === null) run.child.kill("SIGKILL");
+}
+
+if (!NodeFS.existsSync(mainJs) || !NodeFS.existsSync(serverBundle)) {
+  throw new Error("Build the desktop and server bundles before running the assistant image E2E.");
+}
+
+let run;
+let browser;
+try {
+  let backendPort = await reservePort();
+  let debugPort = await reservePort();
+  run = launchDesktop(backendPort, debugPort);
+  ({ browser } = await connectToDesktop(run, debugPort));
+  await waitForAppWindow(browser.contexts()[0]);
+  await stopDesktop(run, browser);
+  run = undefined;
+  browser = undefined;
+
+  seedGeneratedImageProjection();
+  backendPort = await reservePort();
+  debugPort = await reservePort();
+  run = launchDesktop(backendPort, debugPort);
+  let context;
+  ({ browser, context } = await connectToDesktop(run, debugPort));
+  const window = await waitForAppWindow(context);
+  await window
+    .getByTestId("sidebar-row-card")
+    .filter({ hasText: "Generated PNG renders inline" })
+    .click();
+  const image = window.getByRole("img", { name: "generated-blueprint.png" });
+  await image.waitFor({ state: "visible", timeout: 30_000 });
+  const imageState = await image.evaluate((element) => ({
+    src: element.currentSrc || element.src,
+    naturalWidth: element.naturalWidth,
+    naturalHeight: element.naturalHeight,
+  }));
+  if (
+    !imageState.src.includes("/api/assets/") ||
+    imageState.naturalWidth <= 0 ||
+    imageState.naturalHeight <= 0
+  ) {
+    throw new Error(
+      `Assistant image did not render through the asset endpoint: ${JSON.stringify(imageState)}`,
+    );
+  }
+  process.stdout.write(`Assistant image E2E passed: ${JSON.stringify(imageState)}\n`);
+} finally {
+  if (run) await stopDesktop(run, browser);
+  NodeFS.rmSync(testHome, { recursive: true, force: true });
+}

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -440,6 +440,78 @@ describe("buildThreadFeed", () => {
     ]);
   });
 
+  it("keeps generated image messages visible before the terminal answer", () => {
+    const turnId = TurnId.make("turn-image");
+    const thread = makeThread({
+      id: ThreadId.make("thread-image"),
+      projectId: ProjectId.make("project-1"),
+      title: "Generated image",
+      latestTurn: {
+        turnId,
+        state: "completed",
+        requestedAt: "2026-04-01T00:00:00.000Z",
+        startedAt: "2026-04-01T00:00:01.000Z",
+        completedAt: "2026-04-01T00:00:12.000Z",
+        assistantMessageId: MessageId.make("assistant-final"),
+      },
+      messages: [
+        {
+          id: MessageId.make("assistant-image"),
+          role: "assistant",
+          text: "",
+          attachments: [
+            {
+              type: "image",
+              id: "generated-image-1" as never,
+              name: "generated.png",
+              mimeType: "image/png",
+              sizeBytes: 67,
+            },
+          ],
+          turnId,
+          streaming: false,
+          createdAt: "2026-04-01T00:00:08.000Z",
+          updatedAt: "2026-04-01T00:00:08.000Z",
+        },
+        {
+          id: MessageId.make("assistant-final"),
+          role: "assistant",
+          text: "Here is the generated image.",
+          turnId,
+          streaming: false,
+          createdAt: "2026-04-01T00:00:11.000Z",
+          updatedAt: "2026-04-01T00:00:12.000Z",
+        },
+      ],
+      activities: [
+        makeActivity({
+          id: EventId.make("tool-completed"),
+          kind: "tool.completed",
+          tone: "tool",
+          summary: "Generated image",
+          createdAt: "2026-04-01T00:00:05.000Z",
+          turnId,
+          payload: {
+            title: "Generated image",
+            itemType: "dynamic_tool_call",
+            status: "completed",
+          },
+        }),
+      ],
+    });
+
+    const collapsed = deriveThreadFeedPresentation(
+      buildThreadFeed(thread),
+      thread.latestTurn,
+      new Set(),
+    );
+    expect(collapsed.map((entry) => entry.id)).toEqual([
+      "turn-fold:turn-image",
+      "assistant-image",
+      "assistant-final",
+    ]);
+  });
+
   it("measures a steer-superseded turn from its user boundary through trailing work", () => {
     const firstTurnId = TurnId.make("turn-1");
     const secondTurnId = TurnId.make("turn-2");

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -1196,7 +1196,17 @@ function deriveThreadFeedTurnFolds(
 
     const terminalAssistantMessageId = terminalAssistantMessageIdByTurn.get(turnId);
     const hiddenEntryIds = new Set(
-      entries.filter((entry) => entry.id !== terminalAssistantMessageId).map((entry) => entry.id),
+      entries
+        .filter(
+          (entry) =>
+            entry.id !== terminalAssistantMessageId &&
+            !(
+              entry.type === "message" &&
+              entry.message.role === "assistant" &&
+              (entry.message.attachments?.length ?? 0) > 0
+            ),
+        )
+        .map((entry) => entry.id),
     );
     if (hiddenEntryIds.size === 0) {
       continue;

--- a/apps/server/src/orchestration/AssistantImageAttachments.test.ts
+++ b/apps/server/src/orchestration/AssistantImageAttachments.test.ts
@@ -1,0 +1,195 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { PROVIDER_SEND_TURN_MAX_IMAGE_BYTES, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+
+import { resolveAttachmentPath } from "../attachmentStore.ts";
+import * as ServerConfig from "../config.ts";
+import {
+  extractAssistantImageInputs,
+  persistAssistantImageInputs,
+} from "./AssistantImageAttachments.ts";
+
+const ONE_PIXEL_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2ZQAAAABJRU5ErkJggg==";
+const testLayer = ServerConfig.layerTest(process.cwd(), {
+  prefix: "t3-assistant-image-test-",
+}).pipe(Layer.provideMerge(NodeServices.layer));
+
+describe("extractAssistantImageInputs", () => {
+  it("extracts MCP image blocks with raw base64 bytes", () => {
+    expect(
+      extractAssistantImageInputs({
+        item: {
+          type: "mcpToolCall",
+          result: {
+            content: [{ type: "image", data: "aGVsbG8=", mimeType: "image/png" }],
+          },
+        },
+      }),
+    ).toEqual([
+      {
+        _tag: "base64",
+        base64: "aGVsbG8=",
+        mimeType: "image/png",
+        name: "generated-image.png",
+      },
+    ]);
+  });
+
+  it("extracts generated-image result objects containing data URLs", () => {
+    expect(
+      extractAssistantImageInputs({
+        result: {
+          content: [
+            {
+              type: "generated_image",
+              image_url: "data:image/webp;base64,aGVsbG8=",
+              output_hint: "concept.webp",
+            },
+          ],
+        },
+      }),
+    ).toEqual([
+      {
+        _tag: "data-url",
+        dataUrl: "data:image/webp;base64,aGVsbG8=",
+        name: "concept.webp",
+      },
+    ]);
+  });
+
+  it("extracts Claude image blocks with nested base64 sources", () => {
+    expect(
+      extractAssistantImageInputs({
+        type: "tool_result",
+        content: [
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: ONE_PIXEL_PNG_BASE64,
+            },
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        _tag: "base64",
+        base64: ONE_PIXEL_PNG_BASE64,
+        mimeType: "image/png",
+        name: "generated-image.png",
+      },
+    ]);
+  });
+
+  it.effect("rejects oversized base64 before decoding", () =>
+    Effect.gen(function* () {
+      const oversizedBase64 = "A".repeat(Math.ceil(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES / 3) * 4 + 4);
+      expect(
+        extractAssistantImageInputs({
+          type: "image",
+          mimeType: "image/png",
+          data: oversizedBase64,
+        }),
+      ).toEqual([]);
+      expect(
+        yield* persistAssistantImageInputs({
+          threadId: ThreadId.make("thread-oversized-image"),
+          inputs: [
+            {
+              _tag: "base64",
+              base64: oversizedBase64,
+              mimeType: "image/png",
+              name: "oversized.png",
+            },
+          ],
+        }),
+      ).toEqual([]);
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it("extracts only the explicit saved path from native image-generation items", () => {
+    expect(
+      extractAssistantImageInputs({
+        item: {
+          type: "imageGeneration",
+          savedPath: "C:\\temp\\codex-generated.png",
+          result: "completed",
+        },
+        path: "C:\\private\\not-an-image.txt",
+      }),
+    ).toEqual([
+      {
+        _tag: "local-file",
+        path: "C:\\temp\\codex-generated.png",
+        name: "codex-generated.png",
+      },
+    ]);
+  });
+
+  it("ignores arbitrary filesystem paths and unsafe image URLs", () => {
+    expect(
+      extractAssistantImageInputs({
+        path: "C:\\Users\\me\\secret.png",
+        image_url: "file:///C:/Users/me/secret.png",
+        nested: { savedPath: "C:\\Users\\me\\also-secret.png" },
+      }),
+    ).toEqual([]);
+  });
+
+  it.effect("copies native generated files into the attachment store", () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const config = yield* ServerConfig.ServerConfig;
+          const sourcePath = yield* fs.makeTempFileScoped({
+            prefix: "codex-generated-",
+            suffix: ".png",
+          });
+          const sourceBytes = Buffer.from(ONE_PIXEL_PNG_BASE64, "base64");
+          yield* fs.writeFile(sourcePath, sourceBytes);
+
+          const [attachment] = yield* persistAssistantImageInputs({
+            threadId: ThreadId.make("thread-native-image"),
+            inputs: [
+              {
+                _tag: "local-file",
+                path: sourcePath,
+                name: "codex-generated.png",
+              },
+            ],
+          });
+          if (!attachment) return null;
+          const storedPath = resolveAttachmentPath({
+            attachmentsDir: config.attachmentsDir,
+            attachment,
+          });
+          if (!storedPath) return null;
+          return {
+            attachment,
+            storedBytes: yield* fs.readFile(storedPath),
+            sourcePath,
+            storedPath,
+          };
+        }).pipe(Effect.provide(testLayer)),
+      );
+
+      expect(result?.attachment).toEqual(
+        expect.objectContaining({
+          type: "image",
+          name: "codex-generated.png",
+          mimeType: "image/png",
+          sizeBytes: 67,
+        }),
+      );
+      expect(result?.storedBytes).toEqual(Buffer.from(ONE_PIXEL_PNG_BASE64, "base64"));
+      expect(result?.storedPath).not.toBe(result?.sourcePath);
+      expect(result?.attachment).not.toHaveProperty("path");
+    }),
+  );
+});

--- a/apps/server/src/orchestration/AssistantImageAttachments.test.ts
+++ b/apps/server/src/orchestration/AssistantImageAttachments.test.ts
@@ -1,5 +1,9 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { PROVIDER_SEND_TURN_MAX_IMAGE_BYTES, ThreadId } from "@t3tools/contracts";
+import {
+  PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
+  ProviderDriverKind,
+  ThreadId,
+} from "@t3tools/contracts";
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -61,6 +65,36 @@ describe("extractAssistantImageInputs", () => {
     ]);
   });
 
+  it("ignores image-looking values outside explicit provider output fields", () => {
+    expect(
+      extractAssistantImageInputs({
+        item: {
+          type: "mcpToolCall",
+          arguments: {
+            type: "generated_image",
+            image_url: "data:image/png;base64,aGVsbG8=",
+          },
+          result: { content: [{ type: "text", text: "done" }] },
+        },
+        rawInput: {
+          type: "image",
+          data: "aGVsbG8=",
+          mimeType: "image/png",
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it("requires a generated-image type before accepting image_url fields", () => {
+    expect(
+      extractAssistantImageInputs({
+        result: {
+          content: [{ image_url: "data:image/png;base64,aGVsbG8=" }],
+        },
+      }),
+    ).toEqual([]);
+  });
+
   it("extracts Claude image blocks with nested base64 sources", () => {
     expect(
       extractAssistantImageInputs({
@@ -112,21 +146,70 @@ describe("extractAssistantImageInputs", () => {
     }).pipe(Effect.provide(testLayer)),
   );
 
-  it("extracts only the explicit saved path from native image-generation items", () => {
+  it("prefers native Codex image bytes over its saved path", () => {
     expect(
-      extractAssistantImageInputs({
-        item: {
-          type: "imageGeneration",
-          savedPath: "C:\\temp\\codex-generated.png",
-          result: "completed",
+      extractAssistantImageInputs(
+        {
+          item: {
+            type: "imageGeneration",
+            savedPath: "C:\\temp\\codex-generated.png",
+            result: ONE_PIXEL_PNG_BASE64,
+          },
+          path: "C:\\private\\not-an-image.txt",
         },
-        path: "C:\\private\\not-an-image.txt",
-      }),
+        { provider: ProviderDriverKind.make("codex") },
+      ),
+    ).toEqual([
+      {
+        _tag: "base64",
+        base64: ONE_PIXEL_PNG_BASE64,
+        mimeType: "image/png",
+        name: "codex-generated.png",
+      },
+    ]);
+  });
+
+  it("accepts native saved paths only from Codex lifecycle items", () => {
+    const payload = {
+      item: {
+        type: "imageGeneration",
+        savedPath: "C:\\temp\\codex-generated.png",
+        result: "completed",
+      },
+    };
+
+    expect(
+      extractAssistantImageInputs(payload, { provider: ProviderDriverKind.make("claudeAgent") }),
+    ).toEqual([]);
+    expect(
+      extractAssistantImageInputs(payload, { provider: ProviderDriverKind.make("codex") }),
     ).toEqual([
       {
         _tag: "local-file",
         path: "C:\\temp\\codex-generated.png",
         name: "codex-generated.png",
+      },
+    ]);
+  });
+
+  it("uses an extension matching the actual generated image MIME type", () => {
+    expect(
+      extractAssistantImageInputs({
+        result: {
+          content: [
+            {
+              type: "generated_image",
+              image_url: "data:image/png;base64,aGVsbG8=",
+              output_hint: "concept.jpg",
+            },
+          ],
+        },
+      }),
+    ).toEqual([
+      {
+        _tag: "data-url",
+        dataUrl: "data:image/png;base64,aGVsbG8=",
+        name: "concept.png",
       },
     ]);
   });
@@ -191,5 +274,32 @@ describe("extractAssistantImageInputs", () => {
       expect(result?.storedPath).not.toBe(result?.sourcePath);
       expect(result?.attachment).not.toHaveProperty("path");
     }),
+  );
+
+  it.effect("rechecks local image size after reading the file", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const sourcePath = yield* fs.makeTempFileScoped({ suffix: ".png" });
+      yield* fs.writeFile(sourcePath, Buffer.from(ONE_PIXEL_PNG_BASE64, "base64"));
+      const oversizedBytes = new Uint8Array(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES + 1);
+      const guardedFs: FileSystem.FileSystem = {
+        ...fs,
+        readFile: (path) =>
+          path === sourcePath ? Effect.succeed(oversizedBytes) : fs.readFile(path),
+      };
+
+      const attachments = yield* persistAssistantImageInputs({
+        threadId: ThreadId.make("thread-raced-image"),
+        inputs: [
+          {
+            _tag: "local-file",
+            path: sourcePath,
+            name: "generated.png",
+          },
+        ],
+      }).pipe(Effect.provideService(FileSystem.FileSystem, guardedFs));
+
+      expect(attachments).toEqual([]);
+    }).pipe(Effect.scoped, Effect.provide(testLayer)),
   );
 });

--- a/apps/server/src/orchestration/AssistantImageAttachments.ts
+++ b/apps/server/src/orchestration/AssistantImageAttachments.ts
@@ -1,0 +1,310 @@
+import Mime from "@effect/platform-node/Mime";
+import {
+  PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
+  PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
+  type ChatAttachment,
+  type ThreadId,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Predicate from "effect/Predicate";
+
+import { createAttachmentId, resolveAttachmentPath } from "../attachmentStore.ts";
+import * as ServerConfig from "../config.ts";
+import {
+  inferImageExtension,
+  parseBase64DataUrl,
+  SAFE_IMAGE_FILE_EXTENSIONS,
+} from "../imageMime.ts";
+
+export type AssistantImageInput =
+  | {
+      readonly _tag: "base64";
+      readonly base64: string;
+      readonly mimeType: string;
+      readonly name: string;
+    }
+  | {
+      readonly _tag: "data-url";
+      readonly dataUrl: string;
+      readonly name: string;
+    }
+  | {
+      readonly _tag: "local-file";
+      readonly path: string;
+      readonly name: string;
+    };
+
+const MAX_TRAVERSAL_DEPTH = 8;
+const MAX_BASE64_IMAGE_CHARS = Math.ceil(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES / 3) * 4;
+const MAX_IMAGE_DATA_URL_CHARS = MAX_BASE64_IMAGE_CHARS + 1_024;
+
+function stringProperty(record: { [x: PropertyKey]: unknown }, key: string): string | undefined {
+  const value = record[key];
+  return Predicate.isString(value) && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function basename(value: string): string {
+  return value.replaceAll("\\", "/").split("/").at(-1)?.trim() ?? "";
+}
+
+function safeImageName(value: string | undefined, mimeType: string): string {
+  const candidate = basename(value ?? "").slice(0, 255);
+  const inferredExtension = inferImageExtension({ mimeType, fileName: candidate });
+  const extension = /\.[a-z0-9]{1,8}$/i.exec(candidate)?.[0]?.toLowerCase();
+  if (candidate.length > 0 && extension && SAFE_IMAGE_FILE_EXTENSIONS.has(extension)) {
+    return candidate;
+  }
+  return `generated-image${inferredExtension === ".bin" ? ".png" : inferredExtension}`;
+}
+
+function dataUrlInput(
+  dataUrl: string,
+  suggestedName: string | undefined,
+): AssistantImageInput | null {
+  if (dataUrl.length > MAX_IMAGE_DATA_URL_CHARS) {
+    return null;
+  }
+  const parsed = parseBase64DataUrl(dataUrl);
+  if (!parsed?.mimeType.startsWith("image/")) {
+    return null;
+  }
+  return {
+    _tag: "data-url",
+    dataUrl,
+    name: safeImageName(suggestedName, parsed.mimeType),
+  };
+}
+
+function rawBase64Input(
+  base64: string,
+  mimeType: string | undefined,
+  suggestedName: string | undefined,
+): AssistantImageInput | null {
+  if (base64.length > MAX_BASE64_IMAGE_CHARS || !mimeType?.toLowerCase().startsWith("image/")) {
+    return null;
+  }
+  const normalizedMimeType = mimeType.toLowerCase();
+  const parsed = parseBase64DataUrl(`data:${normalizedMimeType};base64,${base64}`);
+  if (!parsed) {
+    return null;
+  }
+  return {
+    _tag: "base64",
+    base64: parsed.base64,
+    mimeType: normalizedMimeType,
+    name: safeImageName(suggestedName, normalizedMimeType),
+  };
+}
+
+/**
+ * Extracts only explicit image-bearing provider result shapes. In particular,
+ * filesystem paths are accepted solely from Codex's native imageGeneration
+ * item so arbitrary tool output can never become a client-visible file URL.
+ */
+export function extractAssistantImageInputs(payload: unknown): ReadonlyArray<AssistantImageInput> {
+  const inputs: Array<AssistantImageInput> = [];
+  const seenObjects = new WeakSet<object>();
+  const seenSources = new Set<string>();
+
+  const add = (input: AssistantImageInput | null) => {
+    if (!input || inputs.length >= PROVIDER_SEND_TURN_MAX_ATTACHMENTS) {
+      return;
+    }
+    const source =
+      input._tag === "data-url"
+        ? input.dataUrl
+        : input._tag === "base64"
+          ? `${input.mimeType}:${input.base64}`
+          : input.path;
+    if (!seenSources.has(source)) {
+      seenSources.add(source);
+      inputs.push(input);
+    }
+  };
+
+  const visit = (value: unknown, depth: number): void => {
+    if (depth > MAX_TRAVERSAL_DEPTH || inputs.length >= PROVIDER_SEND_TURN_MAX_ATTACHMENTS) {
+      return;
+    }
+    if (Array.isArray(value)) {
+      for (const entry of value) visit(entry, depth + 1);
+      return;
+    }
+    if (!Predicate.isObject(value) || seenObjects.has(value)) {
+      return;
+    }
+    seenObjects.add(value);
+
+    const type = stringProperty(value, "type");
+    const suggestedName =
+      stringProperty(value, "output_hint") ??
+      stringProperty(value, "outputHint") ??
+      stringProperty(value, "fileName") ??
+      stringProperty(value, "name");
+
+    if (type === "imageGeneration") {
+      const savedPath = stringProperty(value, "savedPath");
+      if (savedPath) {
+        const name = basename(savedPath).slice(0, 255);
+        if (name.length > 0) {
+          add({ _tag: "local-file", path: savedPath, name });
+        }
+        return;
+      }
+      const result = stringProperty(value, "result");
+      if (result) {
+        add(dataUrlInput(result, suggestedName));
+      }
+      return;
+    }
+
+    const imageUrl = stringProperty(value, "image_url") ?? stringProperty(value, "imageUrl");
+    if (imageUrl) {
+      add(dataUrlInput(imageUrl, suggestedName));
+      if (type === "generated_image" || type === "generatedImage") {
+        return;
+      }
+    }
+
+    if (type === "image") {
+      const data = stringProperty(value, "data");
+      const mimeType = stringProperty(value, "mimeType") ?? stringProperty(value, "mime_type");
+      if (data) {
+        add(dataUrlInput(data, suggestedName) ?? rawBase64Input(data, mimeType, suggestedName));
+        return;
+      }
+
+      const source = value["source"];
+      if (Predicate.isObject(source) && stringProperty(source, "type") === "base64") {
+        const sourceData = stringProperty(source, "data");
+        const sourceMimeType = stringProperty(source, "media_type");
+        if (sourceData) {
+          add(rawBase64Input(sourceData, sourceMimeType, suggestedName));
+          return;
+        }
+      }
+    }
+
+    for (const nested of Object.values(value)) {
+      visit(nested, depth + 1);
+    }
+  };
+
+  visit(payload, 0);
+  return inputs;
+}
+
+function bytesFromInput(input: Exclude<AssistantImageInput, { _tag: "local-file" }>): {
+  readonly bytes: Uint8Array;
+  readonly mimeType: string;
+  readonly name: string;
+} | null {
+  const parsed =
+    input._tag === "data-url"
+      ? parseBase64DataUrl(input.dataUrl)
+      : parseBase64DataUrl(`data:${input.mimeType};base64,${input.base64}`);
+  if (!parsed?.mimeType.startsWith("image/")) {
+    return null;
+  }
+  const padding = parsed.base64.endsWith("==") ? 2 : parsed.base64.endsWith("=") ? 1 : 0;
+  const decodedByteLength = (parsed.base64.length / 4) * 3 - padding;
+  if (
+    parsed.base64.length > MAX_BASE64_IMAGE_CHARS ||
+    decodedByteLength <= 0 ||
+    decodedByteLength > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES
+  ) {
+    return null;
+  }
+  const bytes = Buffer.from(parsed.base64, "base64");
+  if (bytes.byteLength === 0 || bytes.byteLength > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES) {
+    return null;
+  }
+  return { bytes, mimeType: parsed.mimeType, name: input.name };
+}
+
+export const persistAssistantImageInputs = Effect.fn("persistAssistantImageInputs")(
+  function* (input: {
+    readonly threadId: ThreadId;
+    readonly inputs: ReadonlyArray<AssistantImageInput>;
+  }) {
+    const fs = yield* FileSystem.FileSystem;
+    const config = yield* ServerConfig.ServerConfig;
+
+    const persistOne = Effect.fn("persistAssistantImageInputs.persistOne")(function* (
+      imageInput: AssistantImageInput,
+    ) {
+      let image: {
+        readonly bytes: Uint8Array;
+        readonly mimeType: string;
+        readonly name: string;
+      } | null;
+
+      if (imageInput._tag === "local-file") {
+        const mimeType = Mime.getType(imageInput.name)?.toLowerCase();
+        const extension = /\.[a-z0-9]{1,8}$/i.exec(imageInput.name)?.[0]?.toLowerCase();
+        if (
+          !mimeType?.startsWith("image/") ||
+          !extension ||
+          !SAFE_IMAGE_FILE_EXTENSIONS.has(extension)
+        ) {
+          return null;
+        }
+        const stat = yield* fs.stat(imageInput.path);
+        if (
+          stat.type !== "File" ||
+          stat.size <= 0n ||
+          stat.size > BigInt(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES)
+        ) {
+          return null;
+        }
+        image = {
+          bytes: yield* fs.readFile(imageInput.path),
+          mimeType,
+          name: safeImageName(imageInput.name, mimeType),
+        };
+      } else {
+        image = bytesFromInput(imageInput);
+      }
+      if (!image) {
+        return null;
+      }
+
+      const attachmentId = createAttachmentId(input.threadId);
+      if (!attachmentId) {
+        return null;
+      }
+      const attachment: ChatAttachment = {
+        type: "image",
+        id: attachmentId,
+        name: image.name,
+        mimeType: image.mimeType,
+        sizeBytes: image.bytes.byteLength,
+      };
+      const attachmentPath = resolveAttachmentPath({
+        attachmentsDir: config.attachmentsDir,
+        attachment,
+      });
+      if (!attachmentPath) {
+        return null;
+      }
+      yield* fs.makeDirectory(config.attachmentsDir, { recursive: true });
+      yield* fs.writeFile(attachmentPath, image.bytes);
+      return attachment;
+    });
+
+    const attachments = yield* Effect.forEach(
+      input.inputs.slice(0, PROVIDER_SEND_TURN_MAX_ATTACHMENTS),
+      (imageInput) =>
+        persistOne(imageInput).pipe(
+          Effect.catchCause((cause) =>
+            Effect.logWarning("Failed to persist an assistant-generated image", { cause }).pipe(
+              Effect.as(null),
+            ),
+          ),
+        ),
+      { concurrency: 1 },
+    );
+    return attachments.filter((attachment): attachment is ChatAttachment => attachment !== null);
+  },
+);

--- a/apps/server/src/orchestration/AssistantImageAttachments.ts
+++ b/apps/server/src/orchestration/AssistantImageAttachments.ts
@@ -3,6 +3,7 @@ import {
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
   type ChatAttachment,
+  type ProviderDriverKind,
   type ThreadId,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
@@ -52,10 +53,19 @@ function safeImageName(value: string | undefined, mimeType: string): string {
   const candidate = basename(value ?? "").slice(0, 255);
   const inferredExtension = inferImageExtension({ mimeType, fileName: candidate });
   const extension = /\.[a-z0-9]{1,8}$/i.exec(candidate)?.[0]?.toLowerCase();
-  if (candidate.length > 0 && extension && SAFE_IMAGE_FILE_EXTENSIONS.has(extension)) {
+  const extensionMatchesMime =
+    extension === inferredExtension ||
+    (inferredExtension === ".jpg" && (extension === ".jpg" || extension === ".jpeg"));
+  if (
+    candidate.length > 0 &&
+    extension &&
+    SAFE_IMAGE_FILE_EXTENSIONS.has(extension) &&
+    (inferredExtension === ".bin" || extensionMatchesMime)
+  ) {
     return candidate;
   }
-  return `generated-image${inferredExtension === ".bin" ? ".png" : inferredExtension}`;
+  const stem = candidate.replace(/\.[a-z0-9]{1,8}$/i, "").trim() || "generated-image";
+  return `${stem}${inferredExtension === ".bin" ? ".png" : inferredExtension}`;
 }
 
 function dataUrlInput(
@@ -102,7 +112,10 @@ function rawBase64Input(
  * filesystem paths are accepted solely from Codex's native imageGeneration
  * item so arbitrary tool output can never become a client-visible file URL.
  */
-export function extractAssistantImageInputs(payload: unknown): ReadonlyArray<AssistantImageInput> {
+export function extractAssistantImageInputs(
+  payload: unknown,
+  context?: { readonly provider?: ProviderDriverKind },
+): ReadonlyArray<AssistantImageInput> {
   const inputs: Array<AssistantImageInput> = [];
   const seenObjects = new WeakSet<object>();
   const seenSources = new Set<string>();
@@ -123,12 +136,12 @@ export function extractAssistantImageInputs(payload: unknown): ReadonlyArray<Ass
     }
   };
 
-  const visit = (value: unknown, depth: number): void => {
+  const visitOutput = (value: unknown, depth: number, nativeCodexItem = false): void => {
     if (depth > MAX_TRAVERSAL_DEPTH || inputs.length >= PROVIDER_SEND_TURN_MAX_ATTACHMENTS) {
       return;
     }
     if (Array.isArray(value)) {
-      for (const entry of value) visit(entry, depth + 1);
+      for (const entry of value) visitOutput(entry, depth + 1);
       return;
     }
     if (!Predicate.isObject(value) || seenObjects.has(value)) {
@@ -144,27 +157,32 @@ export function extractAssistantImageInputs(payload: unknown): ReadonlyArray<Ass
       stringProperty(value, "name");
 
     if (type === "imageGeneration") {
-      const savedPath = stringProperty(value, "savedPath");
-      if (savedPath) {
-        const name = basename(savedPath).slice(0, 255);
-        if (name.length > 0) {
-          add({ _tag: "local-file", path: savedPath, name });
-        }
+      if (!nativeCodexItem) {
         return;
       }
       const result = stringProperty(value, "result");
       if (result) {
-        add(dataUrlInput(result, suggestedName));
+        const savedPath = stringProperty(value, "savedPath");
+        const embedded =
+          dataUrlInput(result, savedPath ?? suggestedName) ??
+          rawBase64Input(result, "image/png", savedPath ?? suggestedName);
+        if (embedded) {
+          add(embedded);
+          return;
+        }
+      }
+      const savedPath = stringProperty(value, "savedPath");
+      if (savedPath) {
+        const name = basename(savedPath).slice(0, 255);
+        if (name.length > 0) add({ _tag: "local-file", path: savedPath, name });
       }
       return;
     }
 
-    const imageUrl = stringProperty(value, "image_url") ?? stringProperty(value, "imageUrl");
-    if (imageUrl) {
-      add(dataUrlInput(imageUrl, suggestedName));
-      if (type === "generated_image" || type === "generatedImage") {
-        return;
-      }
+    if (type === "generated_image" || type === "generatedImage") {
+      const imageUrl = stringProperty(value, "image_url") ?? stringProperty(value, "imageUrl");
+      if (imageUrl) add(dataUrlInput(imageUrl, suggestedName));
+      return;
     }
 
     if (type === "image") {
@@ -186,12 +204,26 @@ export function extractAssistantImageInputs(payload: unknown): ReadonlyArray<Ass
       }
     }
 
-    for (const nested of Object.values(value)) {
-      visit(nested, depth + 1);
+    for (const key of ["content", "result", "output"] as const) {
+      if (key in value) visitOutput(value[key], depth + 1);
     }
   };
 
-  visit(payload, 0);
+  if (!Predicate.isObject(payload)) return inputs;
+  const item = payload["item"];
+  if (Predicate.isObject(item)) {
+    const itemType = stringProperty(item, "type");
+    if (itemType === "imageGeneration") {
+      visitOutput(item, 0, String(context?.provider) === "codex");
+    } else if (itemType === "mcpToolCall") {
+      visitOutput(item["result"], 0);
+    }
+  }
+  if (stringProperty(payload, "type") === "tool_result") {
+    visitOutput(payload["content"], 0);
+  }
+  visitOutput(payload["result"], 0);
+  visitOutput(payload["content"], 0);
   return inputs;
 }
 
@@ -267,6 +299,12 @@ export const persistAssistantImageInputs = Effect.fn("persistAssistantImageInput
         image = bytesFromInput(imageInput);
       }
       if (!image) {
+        return null;
+      }
+      if (
+        image.bytes.byteLength === 0 ||
+        image.bytes.byteLength > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES
+      ) {
         return null;
       }
 

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -65,6 +65,8 @@ const asEventId = (value: string): EventId => EventId.make(value);
 const asMessageId = (value: string): MessageId => MessageId.make(value);
 const asThreadId = (value: string): ThreadId => ThreadId.make(value);
 const asTurnId = (value: string): TurnId => TurnId.make(value);
+const ONE_PIXEL_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2ZQAAAABJRU5ErkJggg==";
 
 type LegacyProviderRuntimeEvent = {
   readonly type: string;
@@ -247,7 +249,9 @@ describe("ProviderRuntimeIngestion", () => {
       Layer.provideMerge(SqlitePersistenceMemory),
       Layer.provideMerge(Layer.succeed(ProviderService, provider.service)),
       Layer.provideMerge(makeTestServerSettingsLayer(options?.serverSettings)),
-      Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
+      Layer.provideMerge(
+        ServerConfig.layerTest(process.cwd(), { prefix: "t3-provider-ingestion-test-" }),
+      ),
       Layer.provideMerge(NodeServices.layer),
     );
     runtime = ManagedRuntime.make(layer);
@@ -1055,6 +1059,138 @@ describe("ProviderRuntimeIngestion", () => {
     );
     expect(message?.text).toBe("assistant-only final text");
     expect(message?.streaming).toBe(false);
+  });
+
+  it("copies a generated image result into assistant message attachments", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-generated-image-completed"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-generated-image"),
+      itemId: asItemId("item-generated-image"),
+      payload: {
+        itemType: "mcp_tool_call",
+        status: "completed",
+        title: "image_gen · imagegen",
+        data: {
+          item: {
+            type: "mcpToolCall",
+            id: "item-generated-image",
+            result: {
+              content: [
+                {
+                  type: "generated_image",
+                  image_url: `data:image/png;base64,${ONE_PIXEL_PNG_BASE64}`,
+                  output_hint: "generated-sunset.png",
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-generated-image-assistant-completed"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-generated-image"),
+      itemId: asItemId("item-generated-image-message"),
+      payload: {
+        itemType: "assistant_message",
+        status: "completed",
+        detail: "Here is the generated image.",
+      },
+    });
+
+    const thread = await waitForThread(harness.readModel, (entry) =>
+      entry.messages.some(
+        (message: ProviderRuntimeTestMessage) =>
+          message.turnId === "turn-generated-image" &&
+          !message.streaming &&
+          (message.attachments?.length ?? 0) === 1,
+      ),
+    );
+    const imageMessage = thread.messages.find(
+      (entry: ProviderRuntimeTestMessage) =>
+        entry.turnId === "turn-generated-image" && (entry.attachments?.length ?? 0) === 1,
+    );
+    const textMessage = thread.messages.find(
+      (entry: ProviderRuntimeTestMessage) =>
+        entry.turnId === "turn-generated-image" && entry.text === "Here is the generated image.",
+    );
+
+    expect(textMessage?.text).toBe("Here is the generated image.");
+    expect(imageMessage?.attachments).toEqual([
+      expect.objectContaining({
+        type: "image",
+        name: "generated-sunset.png",
+        mimeType: "image/png",
+        sizeBytes: 67,
+      }),
+    ]);
+    expect(JSON.stringify(imageMessage)).not.toContain("data:image/png");
+  });
+
+  it("copies Claude tool-result images with nested base64 sources", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-claude-image-completed"),
+      provider: ProviderDriverKind.make("claudeAgent"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-claude-image"),
+      itemId: asItemId("item-claude-image"),
+      payload: {
+        itemType: "dynamic_tool_call",
+        status: "completed",
+        title: "Generated image",
+        data: {
+          type: "tool_result",
+          tool_use_id: "tool-image-1",
+          content: [
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/png",
+                data: ONE_PIXEL_PNG_BASE64,
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    const thread = await waitForThread(harness.readModel, (entry) =>
+      entry.messages.some(
+        (message: ProviderRuntimeTestMessage) =>
+          message.turnId === "turn-claude-image" && (message.attachments?.length ?? 0) === 1,
+      ),
+    );
+    const imageMessage = thread.messages.find(
+      (entry: ProviderRuntimeTestMessage) =>
+        entry.turnId === "turn-claude-image" && (entry.attachments?.length ?? 0) === 1,
+    );
+
+    expect(imageMessage?.attachments).toEqual([
+      expect.objectContaining({
+        type: "image",
+        name: "generated-image.png",
+        mimeType: "image/png",
+        sizeBytes: 67,
+      }),
+    ]);
+    expect(JSON.stringify(imageMessage)).not.toContain(ONE_PIXEL_PNG_BASE64);
   });
 
   it("preserves completed tool metadata on projected tool activities", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -43,6 +43,10 @@ import {
 } from "../Services/ProviderRuntimeIngestion.ts";
 import { forkParked } from "../../serverActivation.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
+import {
+  extractAssistantImageInputs,
+  persistAssistantImageInputs,
+} from "../AssistantImageAttachments.ts";
 
 const providerTurnKey = (threadId: ThreadId, turnId: TurnId) => `${threadId}:${turnId}`;
 const providerTaskKey = (threadId: ThreadId, taskId: string) => `${threadId}:${taskId}`;
@@ -1737,6 +1741,32 @@ const make = Effect.gen(function* () {
       if (proposedPlanDelta && proposedPlanDelta.length > 0) {
         const planId = proposedPlanIdFromEvent(event, thread.id);
         yield* appendBufferedProposedPlan(planId, proposedPlanDelta, now);
+      }
+
+      if (event.type === "item.completed") {
+        const imageInputs = extractAssistantImageInputs(event.payload.data);
+        if (imageInputs.length > 0) {
+          const imageMessageId = MessageId.make(`assistant-image:${event.itemId ?? event.eventId}`);
+          const detailedThread = yield* getLoadedThreadDetail();
+          if (!findMessageById(detailedThread?.messages ?? [], imageMessageId)) {
+            const attachments = yield* persistAssistantImageInputs({
+              threadId: thread.id,
+              inputs: imageInputs,
+            });
+            if (attachments.length > 0) {
+              const turnId = toTurnId(event.turnId);
+              yield* orchestrationEngine.dispatch({
+                type: "thread.message.assistant.complete",
+                commandId: yield* providerCommandId(event, "assistant-image-complete"),
+                threadId: thread.id,
+                messageId: imageMessageId,
+                attachments,
+                ...(turnId ? { turnId } : {}),
+                createdAt: now,
+              });
+            }
+          }
+        }
       }
 
       const assistantCompletion =

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1744,7 +1744,9 @@ const make = Effect.gen(function* () {
       }
 
       if (event.type === "item.completed") {
-        const imageInputs = extractAssistantImageInputs(event.payload.data);
+        const imageInputs = extractAssistantImageInputs(event.payload.data, {
+          provider: event.provider,
+        });
         if (imageInputs.length > 0) {
           const imageMessageId = MessageId.make(`assistant-image:${event.itemId ?? event.eventId}`);
           const detailedThread = yield* getLoadedThreadDetail();

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1259,6 +1259,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           messageId: command.messageId,
           role: "assistant",
           text: "",
+          ...(command.attachments !== undefined ? { attachments: command.attachments } : {}),
           turnId: command.turnId ?? null,
           streaming: false,
           createdAt: command.createdAt,

--- a/apps/web/src/assets/assetUrls.ts
+++ b/apps/web/src/assets/assetUrls.ts
@@ -72,3 +72,36 @@ export function useAssetUrls(
     [preparedConnection, resources, results],
   );
 }
+
+export function useAssetUrlStates(
+  environmentId: EnvironmentId,
+  resources: ReadonlyArray<AssetResource>,
+): ReadonlyArray<AssetUrlState> {
+  const preparedConnection = usePreparedConnection(environmentId);
+  const results = useAtomValue(
+    assetEnvironment.createUrls({
+      environmentId,
+      resources,
+    }),
+  );
+  return useMemo(
+    () =>
+      results.map((result) => {
+        if (AsyncResult.isFailure(result)) return { _tag: "Failure" } as const;
+        if (preparedConnection._tag === "None" || !AsyncResult.isSuccess(result)) {
+          return { _tag: "Loading" } as const;
+        }
+        const url = resolveAssetUrl(preparedConnection.value.httpBaseUrl, result.value.relativeUrl);
+        return url === null
+          ? ({ _tag: "Failure" } as const)
+          : ({
+              _tag: "Success",
+              url,
+              ...(result.value.sourcePath !== undefined
+                ? { sourcePath: result.value.sourcePath }
+                : {}),
+            } as const);
+      }),
+    [preparedConnection, results],
+  );
+}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2518,13 +2518,17 @@ function ChatViewContent(props: ChatViewProps) {
               }
               const handoffPreviewUrl = handoffPreviewUrls[imageIndex];
               imageIndex += 1;
-              if (!handoffPreviewUrl || attachment.previewUrl === handoffPreviewUrl) {
+              if (
+                !handoffPreviewUrl ||
+                (attachment.previewUrl === handoffPreviewUrl && !attachment.previewError)
+              ) {
                 return attachment;
               }
               changed = true;
               return {
                 ...attachment,
                 previewUrl: handoffPreviewUrl,
+                previewError: false,
               };
             });
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -344,7 +344,7 @@ import {
   resolveServerSelfUpdateCapability,
   serverUpdateGuidance,
 } from "../versionSkew";
-import { useAssetUrls } from "../assets/assetUrls";
+import { useAssetUrlStates } from "../assets/assetUrls";
 
 const IMAGE_ONLY_BOOTSTRAP_PROMPT =
   "[User attached one or more images without additional text. Respond using the conversation context and the attached image(s).]";
@@ -2377,16 +2377,15 @@ function ChatViewContent(props: ChatViewProps) {
       })),
     [serverAttachmentIds],
   );
-  const serverAttachmentUrls = useAssetUrls(environmentId, serverAttachmentResources);
-  const serverAttachmentUrlById = useMemo(
+  const serverAttachmentUrlStates = useAssetUrlStates(environmentId, serverAttachmentResources);
+  const serverAttachmentUrlStateById = useMemo(
     () =>
       new Map(
-        serverAttachmentIds.flatMap((attachmentId, index) => {
-          const url = serverAttachmentUrls[index];
-          return url ? [[attachmentId, url] as const] : [];
-        }),
+        serverAttachmentIds.map(
+          (attachmentId, index) => [attachmentId, serverAttachmentUrlStates[index]] as const,
+        ),
       ),
-    [serverAttachmentIds, serverAttachmentUrls],
+    [serverAttachmentIds, serverAttachmentUrlStates],
   );
   const displayServerMessages = useMemo<ReadonlyArray<ChatMessage>>(() => {
     if (!serverMessages) return [];
@@ -2397,12 +2396,15 @@ function ChatViewContent(props: ChatViewProps) {
       return {
         ...message,
         attachments: message.attachments.map((attachment) => {
-          const previewUrl = serverAttachmentUrlById.get(attachment.id);
-          return previewUrl ? { ...attachment, previewUrl } : attachment;
+          const preview = serverAttachmentUrlStateById.get(attachment.id);
+          if (preview?._tag === "Success") {
+            return { ...attachment, previewUrl: preview.url, previewUrlKind: "asset" as const };
+          }
+          return preview?._tag === "Failure" ? { ...attachment, previewError: true } : attachment;
         }),
       };
     });
-  }, [serverAttachmentUrlById, serverMessages]);
+  }, [serverAttachmentUrlStateById, serverMessages]);
   useEffect(() => {
     if (typeof Image === "undefined" || displayServerMessages.length === 0) {
       return;

--- a/apps/web/src/components/chat/AssistantMessageImages.test.ts
+++ b/apps/web/src/components/chat/AssistantMessageImages.test.ts
@@ -50,4 +50,23 @@ describe("isSafeAssistantImagePreviewUrl", () => {
     expect(markup).toContain("Image unavailable");
     expect(markup).not.toContain("Loading image");
   });
+
+  it("renders downloads as real links so fallback navigation keeps the click gesture", () => {
+    const markup = renderToStaticMarkup(
+      createElement(AssistantMessageImages, {
+        images: [
+          {
+            id: "generated-image-1",
+            name: "generated.png",
+            previewUrl: "/api/assets/signed-token/generated.png",
+          },
+        ],
+        onExpand: () => {},
+      }),
+    );
+
+    expect(markup).toContain('href="/api/assets/signed-token/generated.png"');
+    expect(markup).toContain('download="generated.png"');
+    expect(markup).toContain('target="_blank"');
+  });
 });

--- a/apps/web/src/components/chat/AssistantMessageImages.test.ts
+++ b/apps/web/src/components/chat/AssistantMessageImages.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it } from "vite-plus/test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 
-import { isSafeAssistantImagePreviewUrl } from "./AssistantMessageImages.tsx";
+import {
+  AssistantMessageImages,
+  isSafeAssistantImagePreviewUrl,
+} from "./AssistantMessageImages.tsx";
 
 describe("isSafeAssistantImagePreviewUrl", () => {
   it.each([
     "data:image/png;base64,aGVsbG8=",
     "blob:https://app.t3.codes/generated-image-1",
     "/api/assets/signed-token/generated.png",
-    "https://environment.test/api/assets/signed-token/generated.png",
   ])("accepts renderable image source %s", (url) => {
     expect(isSafeAssistantImagePreviewUrl(url)).toBe(true);
   });
@@ -16,9 +20,34 @@ describe("isSafeAssistantImagePreviewUrl", () => {
     "file:///C:/Users/me/private.png",
     "C:\\Users\\me\\private.png",
     "https://example.com/untrusted.png",
+    "https://environment.test/api/assets/signed-token/generated.png",
     "javascript:alert(1)",
     "data:text/html;base64,aGVsbG8=",
   ])("rejects unsafe image source %s", (url) => {
     expect(isSafeAssistantImagePreviewUrl(url)).toBe(false);
+  });
+
+  it("accepts a remote environment asset only with trusted asset provenance", () => {
+    const url = "https://environment.test/api/assets/signed-token/generated.png";
+    expect(isSafeAssistantImagePreviewUrl(url)).toBe(false);
+    expect(isSafeAssistantImagePreviewUrl(url, { trustedAsset: true })).toBe(true);
+  });
+
+  it("renders a terminal unavailable state when asset URL creation fails", () => {
+    const markup = renderToStaticMarkup(
+      createElement(AssistantMessageImages, {
+        images: [
+          {
+            id: "generated-image-1",
+            name: "generated.png",
+            previewError: true,
+          },
+        ],
+        onExpand: () => {},
+      }),
+    );
+
+    expect(markup).toContain("Image unavailable");
+    expect(markup).not.toContain("Loading image");
   });
 });

--- a/apps/web/src/components/chat/AssistantMessageImages.test.ts
+++ b/apps/web/src/components/chat/AssistantMessageImages.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { isSafeAssistantImagePreviewUrl } from "./AssistantMessageImages.tsx";
+
+describe("isSafeAssistantImagePreviewUrl", () => {
+  it.each([
+    "data:image/png;base64,aGVsbG8=",
+    "blob:https://app.t3.codes/generated-image-1",
+    "/api/assets/signed-token/generated.png",
+    "https://environment.test/api/assets/signed-token/generated.png",
+  ])("accepts renderable image source %s", (url) => {
+    expect(isSafeAssistantImagePreviewUrl(url)).toBe(true);
+  });
+
+  it.each([
+    "file:///C:/Users/me/private.png",
+    "C:\\Users\\me\\private.png",
+    "https://example.com/untrusted.png",
+    "javascript:alert(1)",
+    "data:text/html;base64,aGVsbG8=",
+  ])("rejects unsafe image source %s", (url) => {
+    expect(isSafeAssistantImagePreviewUrl(url)).toBe(false);
+  });
+});

--- a/apps/web/src/components/chat/AssistantMessageImages.tsx
+++ b/apps/web/src/components/chat/AssistantMessageImages.tsx
@@ -42,21 +42,6 @@ export function isSafeAssistantImagePreviewUrl(
   }
 }
 
-async function downloadImage(url: string, name: string): Promise<void> {
-  try {
-    const response = await fetch(url);
-    if (!response.ok) throw new Error(`Image download failed with ${response.status}`);
-    const objectUrl = URL.createObjectURL(await response.blob());
-    const anchor = document.createElement("a");
-    anchor.href = objectUrl;
-    anchor.download = name;
-    anchor.click();
-    URL.revokeObjectURL(objectUrl);
-  } catch {
-    window.open(url, "_blank", "noopener,noreferrer");
-  }
-}
-
 const AssistantMessageImageCard = memo(function AssistantMessageImageCard({
   image,
   onExpand,
@@ -130,12 +115,19 @@ const AssistantMessageImageCard = memo(function AssistantMessageImageCard({
         </div>
       ) : null}
       <Button
-        type="button"
+        render={
+          <a
+            href={safePreviewUrl}
+            download={image.name}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(event) => event.stopPropagation()}
+          />
+        }
         size="icon-sm"
         variant="secondary"
         className="absolute bottom-2 right-2 z-10 opacity-100 shadow-sm transition-opacity pointer-fine:opacity-0 pointer-fine:focus-visible:opacity-100 pointer-fine:group-focus-within/image:opacity-100 pointer-fine:group-hover/image:opacity-100"
         aria-label={`Download ${image.name}`}
-        onClick={() => void downloadImage(safePreviewUrl, image.name)}
       >
         <DownloadIcon aria-hidden="true" />
       </Button>

--- a/apps/web/src/components/chat/AssistantMessageImages.tsx
+++ b/apps/web/src/components/chat/AssistantMessageImages.tsx
@@ -7,6 +7,8 @@ interface AssistantMessageImage {
   readonly id: string;
   readonly name: string;
   readonly previewUrl?: string;
+  readonly previewUrlKind?: "asset";
+  readonly previewError?: boolean;
 }
 
 interface AssistantMessageImagesProps {
@@ -14,7 +16,10 @@ interface AssistantMessageImagesProps {
   readonly onExpand: (imageId: string) => void;
 }
 
-export function isSafeAssistantImagePreviewUrl(value: string): boolean {
+export function isSafeAssistantImagePreviewUrl(
+  value: string,
+  options?: { readonly trustedAsset?: boolean },
+): boolean {
   const trimmed = value.trim();
   if (/^data:image\/[a-z0-9.+-]+(?:;[a-z0-9.+-]+=[^;,]+)*;base64,/i.test(trimmed)) {
     return true;
@@ -27,9 +32,10 @@ export function isSafeAssistantImagePreviewUrl(value: string): boolean {
     if (url.protocol === "blob:") {
       return true;
     }
-    return (
+    return Boolean(
       (url.protocol === "https:" || url.protocol === "http:") &&
-      url.pathname.startsWith("/api/assets/")
+      url.pathname.startsWith("/api/assets/") &&
+      options?.trustedAsset === true,
     );
   } catch {
     return false;
@@ -61,9 +67,12 @@ const AssistantMessageImageCard = memo(function AssistantMessageImageCard({
   const [loadState, setLoadState] = useState<"loading" | "loaded" | "error">("loading");
   const previewUrl = image.previewUrl?.trim();
   const safePreviewUrl =
-    previewUrl && isSafeAssistantImagePreviewUrl(previewUrl) ? previewUrl : undefined;
+    previewUrl &&
+    isSafeAssistantImagePreviewUrl(previewUrl, { trustedAsset: image.previewUrlKind === "asset" })
+      ? previewUrl
+      : undefined;
 
-  if (previewUrl && !safePreviewUrl) {
+  if (image.previewError || (previewUrl && !safePreviewUrl)) {
     return (
       <div
         className="flex min-h-28 w-full max-w-xl items-center justify-center gap-2 rounded-xl border border-border/70 bg-muted/30 px-4 py-8 text-sm text-muted-foreground"
@@ -124,7 +133,7 @@ const AssistantMessageImageCard = memo(function AssistantMessageImageCard({
         type="button"
         size="icon-sm"
         variant="secondary"
-        className="absolute bottom-2 right-2 z-10 opacity-0 shadow-sm transition-opacity focus-visible:opacity-100 group-focus-within/image:opacity-100 group-hover/image:opacity-100"
+        className="absolute bottom-2 right-2 z-10 opacity-100 shadow-sm transition-opacity pointer-fine:opacity-0 pointer-fine:focus-visible:opacity-100 pointer-fine:group-focus-within/image:opacity-100 pointer-fine:group-hover/image:opacity-100"
         aria-label={`Download ${image.name}`}
         onClick={() => void downloadImage(safePreviewUrl, image.name)}
       >

--- a/apps/web/src/components/chat/AssistantMessageImages.tsx
+++ b/apps/web/src/components/chat/AssistantMessageImages.tsx
@@ -1,0 +1,151 @@
+import { memo, useState } from "react";
+import { DownloadIcon, ImageOffIcon } from "lucide-react";
+
+import { Button } from "../ui/button";
+
+interface AssistantMessageImage {
+  readonly id: string;
+  readonly name: string;
+  readonly previewUrl?: string;
+}
+
+interface AssistantMessageImagesProps {
+  readonly images: ReadonlyArray<AssistantMessageImage>;
+  readonly onExpand: (imageId: string) => void;
+}
+
+export function isSafeAssistantImagePreviewUrl(value: string): boolean {
+  const trimmed = value.trim();
+  if (/^data:image\/[a-z0-9.+-]+(?:;[a-z0-9.+-]+=[^;,]+)*;base64,/i.test(trimmed)) {
+    return true;
+  }
+  if (trimmed.startsWith("/api/assets/")) {
+    return true;
+  }
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol === "blob:") {
+      return true;
+    }
+    return (
+      (url.protocol === "https:" || url.protocol === "http:") &&
+      url.pathname.startsWith("/api/assets/")
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function downloadImage(url: string, name: string): Promise<void> {
+  try {
+    const response = await fetch(url);
+    if (!response.ok) throw new Error(`Image download failed with ${response.status}`);
+    const objectUrl = URL.createObjectURL(await response.blob());
+    const anchor = document.createElement("a");
+    anchor.href = objectUrl;
+    anchor.download = name;
+    anchor.click();
+    URL.revokeObjectURL(objectUrl);
+  } catch {
+    window.open(url, "_blank", "noopener,noreferrer");
+  }
+}
+
+const AssistantMessageImageCard = memo(function AssistantMessageImageCard({
+  image,
+  onExpand,
+}: {
+  readonly image: AssistantMessageImage;
+  readonly onExpand: (imageId: string) => void;
+}) {
+  const [loadState, setLoadState] = useState<"loading" | "loaded" | "error">("loading");
+  const previewUrl = image.previewUrl?.trim();
+  const safePreviewUrl =
+    previewUrl && isSafeAssistantImagePreviewUrl(previewUrl) ? previewUrl : undefined;
+
+  if (previewUrl && !safePreviewUrl) {
+    return (
+      <div
+        className="flex min-h-28 w-full max-w-xl items-center justify-center gap-2 rounded-xl border border-border/70 bg-muted/30 px-4 py-8 text-sm text-muted-foreground"
+        role="alert"
+      >
+        <ImageOffIcon className="size-4" aria-hidden="true" />
+        Image unavailable
+      </div>
+    );
+  }
+
+  if (!safePreviewUrl) {
+    return (
+      <div
+        className="flex min-h-28 w-full max-w-xl items-center justify-center rounded-xl border border-border/70 bg-muted/30 px-4 py-8 text-sm text-muted-foreground"
+        role="status"
+      >
+        Loading image…
+      </div>
+    );
+  }
+
+  return (
+    <figure className="group/image relative w-fit max-w-full overflow-hidden rounded-xl border border-border/70 bg-muted/30">
+      <button
+        type="button"
+        className="block max-w-full cursor-zoom-in"
+        aria-label={`Expand ${image.name}`}
+        onClick={() => onExpand(image.id)}
+      >
+        <img
+          src={safePreviewUrl}
+          alt={image.name}
+          loading="lazy"
+          className={`block h-auto max-h-[70vh] max-w-full object-contain ${loadState === "error" ? "hidden" : ""}`}
+          onLoad={() => setLoadState("loaded")}
+          onError={() => setLoadState("error")}
+        />
+      </button>
+      {loadState === "loading" ? (
+        <div
+          className="pointer-events-none absolute inset-0 flex min-h-28 items-center justify-center bg-muted/80 px-4 py-8 text-sm text-muted-foreground"
+          role="status"
+        >
+          Loading image…
+        </div>
+      ) : null}
+      {loadState === "error" ? (
+        <div
+          className="flex min-h-28 items-center justify-center gap-2 px-4 py-8 text-sm text-muted-foreground"
+          role="alert"
+        >
+          <ImageOffIcon className="size-4" aria-hidden="true" />
+          Image failed to load
+        </div>
+      ) : null}
+      <Button
+        type="button"
+        size="icon-sm"
+        variant="secondary"
+        className="absolute bottom-2 right-2 z-10 opacity-0 shadow-sm transition-opacity focus-visible:opacity-100 group-focus-within/image:opacity-100 group-hover/image:opacity-100"
+        aria-label={`Download ${image.name}`}
+        onClick={() => void downloadImage(safePreviewUrl, image.name)}
+      >
+        <DownloadIcon aria-hidden="true" />
+      </Button>
+    </figure>
+  );
+});
+
+export const AssistantMessageImages = memo(function AssistantMessageImages({
+  images,
+  onExpand,
+}: AssistantMessageImagesProps) {
+  if (images.length === 0) {
+    return null;
+  }
+  return (
+    <div className="mt-2 flex max-w-full flex-col items-start gap-2">
+      {images.map((image) => (
+        <AssistantMessageImageCard key={image.id} image={image} onExpand={onExpand} />
+      ))}
+    </div>
+  );
+});

--- a/apps/web/src/components/chat/ExpandedImagePreview.test.ts
+++ b/apps/web/src/components/chat/ExpandedImagePreview.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { buildExpandedImagePreview } from "./ExpandedImagePreview";
+
+describe("buildExpandedImagePreview", () => {
+  it("excludes unsafe URLs from the expanded gallery", () => {
+    expect(
+      buildExpandedImagePreview(
+        [
+          { id: "safe", name: "safe.png", previewUrl: "blob:https://app.t3.codes/safe" },
+          {
+            id: "unsafe",
+            name: "unsafe.png",
+            previewUrl: "https://example.com/api/assets/stolen.png",
+          },
+        ],
+        "safe",
+      ),
+    ).toEqual({
+      images: [{ src: "blob:https://app.t3.codes/safe", name: "safe.png" }],
+      index: 0,
+    });
+  });
+});

--- a/apps/web/src/components/chat/ExpandedImagePreview.tsx
+++ b/apps/web/src/components/chat/ExpandedImagePreview.tsx
@@ -9,11 +9,21 @@ export interface ExpandedImagePreview {
 }
 
 export function buildExpandedImagePreview(
-  images: ReadonlyArray<{ id: string; name: string; previewUrl?: string }>,
+  images: ReadonlyArray<{
+    id: string;
+    name: string;
+    previewUrl?: string;
+    previewUrlKind?: "asset";
+  }>,
   selectedImageId: string,
 ): ExpandedImagePreview | null {
   const previewableImages = images.flatMap((image) =>
-    image.previewUrl ? [{ id: image.id, src: image.previewUrl, name: image.name }] : [],
+    image.previewUrl &&
+    isSafeAssistantImagePreviewUrl(image.previewUrl, {
+      trustedAsset: image.previewUrlKind === "asset",
+    })
+      ? [{ id: image.id, src: image.previewUrl, name: image.name }]
+      : [],
   );
   if (previewableImages.length === 0) {
     return null;
@@ -30,3 +40,4 @@ export function buildExpandedImagePreview(
     index: selectedIndex,
   };
 }
+import { isSafeAssistantImagePreviewUrl } from "./AssistantMessageImages";

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -541,6 +541,72 @@ describe("deriveMessagesTimelineRows", () => {
     ).toBeDefined();
   });
 
+  it("keeps generated image messages visible when a later assistant response is terminal", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [
+        {
+          id: "work-entry",
+          kind: "work",
+          createdAt: "2026-01-01T00:00:05Z",
+          entry: {
+            id: "work-1",
+            createdAt: "2026-01-01T00:00:05Z",
+            turnId: "turn-image" as never,
+            label: "Generated image",
+            tone: "tool",
+          },
+        },
+        {
+          id: "assistant-image-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:00:08Z",
+          message: {
+            id: "assistant-image" as never,
+            role: "assistant",
+            text: "",
+            attachments: [
+              {
+                type: "image",
+                id: "generated-image-1" as never,
+                name: "generated.png",
+                mimeType: "image/png",
+                sizeBytes: 67,
+              },
+            ],
+            turnId: "turn-image" as never,
+            createdAt: "2026-01-01T00:00:08Z",
+            updatedAt: "2026-01-01T00:00:08Z",
+            streaming: false,
+          },
+        },
+        {
+          id: "assistant-final-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:00:10Z",
+          message: {
+            id: "assistant-final" as never,
+            role: "assistant",
+            text: "Here is the generated image.",
+            turnId: "turn-image" as never,
+            createdAt: "2026-01-01T00:00:10Z",
+            updatedAt: "2026-01-01T00:00:11Z",
+            streaming: false,
+          },
+        },
+      ],
+      isWorking: false,
+      activeTurnStartedAt: null,
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.map((row) => row.id)).toEqual([
+      "turn-fold:turn-image",
+      "assistant-image-entry",
+      "assistant-final-entry",
+    ]);
+  });
+
   it("derives a sane duration for a steer-superseded turn with one instant commentary message", () => {
     // A steer ends the previous turn early: its only message completes the
     // instant it is created, and trailing work entries land after it. The

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -388,6 +388,11 @@ function deriveTurnFolds(input: {
       if (entry.id === group.terminalEntry?.id) {
         continue;
       }
+      // Generated images remain part of the visible answer even when a later
+      // text-only assistant message becomes the turn's terminal response.
+      if (entry.kind === "message" && (entry.message.attachments?.length ?? 0) > 0) {
+        continue;
+      }
       // Agent-spawn CTA rows never fold: workflows outlive their launching
       // turn (dynamic spawns, background execution), and folding the CTA
       // when the turn settles makes a still-running fleet invisible.

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -432,6 +432,46 @@ describe("MessagesTimeline", () => {
     expect(onAnchorReady).toHaveBeenCalledWith(secondEntry.message.id, 1);
   });
 
+  it("renders an assistant image attachment as an inline image with actions", () => {
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-assistant-generated-image",
+            kind: "message",
+            createdAt: MESSAGE_CREATED_AT,
+            message: {
+              id: MessageId.make("message-assistant-generated-image"),
+              role: "assistant",
+              text: "Here is the generated image.",
+              attachments: [
+                {
+                  type: "image",
+                  id: "generated-image-attachment-1",
+                  name: "generated-sunset.png",
+                  mimeType: "image/png",
+                  sizeBytes: 67,
+                  previewUrl: "blob:https://app.t3.codes/generated-image-1",
+                },
+              ],
+              turnId: TurnId.make("turn-generated-image"),
+              createdAt: MESSAGE_CREATED_AT,
+              updatedAt: MESSAGE_CREATED_AT,
+              streaming: false,
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain('<img src="blob:https://app.t3.codes/generated-image-1"');
+    expect(markup).toContain('alt="generated-sunset.png"');
+    expect(markup).toContain('aria-label="Expand generated-sunset.png"');
+    expect(markup).toContain('aria-label="Download generated-sunset.png"');
+    expect(markup).toContain("Loading image…");
+  });
+
   it("renders collapse controls for long user messages", () => {
     const markup = renderToStaticMarkup(
       <MessagesTimeline

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -71,6 +71,7 @@ import { ProposedPlanCard } from "./ProposedPlanCard";
 import { ChangedFilesCard } from "./ChangedFilesTree";
 import { shouldAutoExpandChangedFiles } from "./changedFilesPresentation";
 import { MessageCopyButton } from "./MessageCopyButton";
+import { AssistantMessageImages } from "./AssistantMessageImages";
 import {
   computeStableMessagesTimelineRows,
   deriveMessagesTimelineRows,
@@ -1103,17 +1104,29 @@ function TurnFoldTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "turn-
 
 function AssistantTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" }> }) {
   const ctx = use(TimelineRowCtx);
-  const messageText = row.message.text || (row.message.streaming ? "" : "(empty response)");
+  const assistantImages = row.message.attachments ?? [];
+  const messageText =
+    row.message.text ||
+    (row.message.streaming || assistantImages.length > 0 ? "" : "(empty response)");
 
   return (
     <>
       <div className="relative min-w-0 px-1 py-0.5">
-        <ChatMarkdown
-          text={messageText}
-          cwd={ctx.markdownCwd}
-          threadRef={ctx.threadRef ?? undefined}
-          isStreaming={Boolean(row.message.streaming)}
-          skills={ctx.skills}
+        {messageText ? (
+          <ChatMarkdown
+            text={messageText}
+            cwd={ctx.markdownCwd}
+            threadRef={ctx.threadRef ?? undefined}
+            isStreaming={Boolean(row.message.streaming)}
+            skills={ctx.skills}
+          />
+        ) : null}
+        <AssistantMessageImages
+          images={assistantImages}
+          onExpand={(imageId) => {
+            const preview = buildExpandedImagePreview(assistantImages, imageId);
+            if (preview) ctx.onImageExpand(preview);
+          }}
         />
         <AssistantChangedFilesSection
           turnSummary={row.assistantTurnDiffSummary}

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -33,6 +33,8 @@ export interface ThreadTerminalGroup {
 
 export interface ChatImageAttachment extends ContractChatImageAttachment {
   readonly previewUrl?: string;
+  readonly previewUrlKind?: "asset";
+  readonly previewError?: boolean;
 }
 
 export type ChatAttachment = ChatImageAttachment;

--- a/docs/user/generated-images.md
+++ b/docs/user/generated-images.md
@@ -1,0 +1,12 @@
+# Generated Images
+
+When an agent returns an image through a supported image-generation tool, T3 Code shows it directly
+in the assistant message. Select the image to open the full-size viewer, or use its download button
+to save a copy.
+
+Generated images are copied into T3 Code's attachment storage before they are shown. If the original
+provider output is unavailable or invalid, the message displays an unavailable state instead of
+loading forever.
+
+Inline rendering currently supports Codex image-generation results and image result blocks returned
+by supported provider tools.

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -973,6 +973,7 @@ const ThreadMessageAssistantCompleteCommand = Schema.Struct({
   commandId: CommandId,
   threadId: ThreadId,
   messageId: MessageId,
+  attachments: Schema.optional(Schema.Array(ChatAttachment)),
   turnId: Schema.optional(TurnId),
   createdAt: IsoDateTime,
 });


### PR DESCRIPTION
Assistant-generated images are not currently preserved and rendered as first-class chat output across the T3 Code surfaces, so generated artifacts can disappear into tool activity or fail to survive settled turn folding.

This persists approved provider image output through the attachment store, carries it through provider ingestion and orchestration, and renders it inline in assistant messages on web and mobile. Image messages remain visible after settled-turn folding, and the desktop package includes a focused end-to-end fixture for the attachment flow.

Related: #6441, #6029

Validation:

- 124 focused tests passed across server, web, and mobile
- scoped server, web, mobile, and contracts typechecks passed
- all 16 changed files passed formatting and changed-source lint checks

Implemented with GPT-5.6 Sol in T3 Code through the Codex harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render assistant-generated images inline in chat with safe URL validation
> - Adds a new ingestion path in `ProviderRuntimeIngestion` that extracts images from Codex `generated_image` and Claude `tool_result` provider payloads, persists them to the attachment store, and emits a completed assistant message with image attachments.
> - Adds `AssistantMessageImages` and `AssistantMessageImageCard` components that render image attachments inline with loading/error states, a download button, and an expand-to-gallery action.
> - Constrains renderable URLs via `isSafeAssistantImagePreviewUrl`, allowing only data URLs, blob URLs, and `/api/assets/` paths (remote only when explicitly trusted).
> - Keeps image-bearing assistant messages visible in collapsed turn folds on both web (`deriveTurnFolds`) and mobile (`deriveThreadFeedTurnFolds`), even when a later terminal message exists.
> - Adds an end-to-end Playwright/Electron test in [assistant-image-e2e.mjs](https://github.com/pingdotgg/t3code/pull/6558/files#diff-f5e9913a23a4bff948226fa0d4d397a0bbb4ea1655aaa5d6596095c5e341d435) that seeds a SQLite projection and validates the image renders via the asset endpoint.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2cd94e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->