### PR TITLE
fix(desktop): close the window before quit cleanup

### DIFF
--- a/apps/desktop/src/app/DesktopLifecycle.test.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.test.ts
@@ -76,17 +76,22 @@ function makeElectronWindowLayer(destroyAll: Effect.Effect<void> = Effect.void) 
   });
 }
 
-function makeDesktopWindowLayer(flushMainWindowBounds: Effect.Effect<void> = Effect.void) {
+function makeDesktopWindowLayer(
+  input: {
+    readonly activate?: Effect.Effect<void>;
+    readonly flushMainWindowBounds?: Effect.Effect<void>;
+  } = {},
+) {
   return Layer.succeed(DesktopWindow.DesktopWindow, {
     createMain: Effect.die("unexpected window creation"),
     ensureMain: Effect.die("unexpected window creation"),
     revealOrCreateMain: Effect.die("unexpected window creation"),
-    activate: Effect.void,
+    activate: input.activate ?? Effect.void,
     createMainIfBackendReady: Effect.void,
     showConnectingSplash: Effect.void,
     handleBackendReady: () => Effect.void,
     handleBackendNotReady: Effect.void,
-    flushMainWindowBounds,
+    flushMainWindowBounds: input.flushMainWindowBounds ?? Effect.void,
     dispatchMenuAction: () => Effect.void,
     zoomMain: () => Effect.void,
     syncAppearance: Effect.void,
@@ -176,7 +181,7 @@ describe("DesktopLifecycle", () => {
         Layer.provideMerge(makeElectronAppLayer(appListeners, quit)),
         Layer.provideMerge(electronThemeLayer),
         Layer.provideMerge(makeElectronWindowLayer(destroyAll)),
-        Layer.provideMerge(makeDesktopWindowLayer(flushMainWindowBounds)),
+        Layer.provideMerge(makeDesktopWindowLayer({ flushMainWindowBounds })),
         Layer.provideMerge(environmentLayer),
         Layer.provideMerge(desktopShutdownLayer),
         Layer.provideMerge(DesktopState.layer),
@@ -197,6 +202,42 @@ describe("DesktopLifecycle", () => {
 
           assert.deepEqual(eventsBeforeCleanup, ["flush", "destroy", "request"]);
           assert.deepEqual(events, ["flush", "destroy", "request", "quit"]);
+        }),
+      ).pipe(Effect.provide(layer));
+    }),
+  );
+
+  it.effect("ignores app activation while quitting", () =>
+    Effect.gen(function* () {
+      const appListeners = new Map<string, (...args: readonly unknown[]) => void>();
+      let activationCount = 0;
+      const activate = Effect.sync(() => {
+        activationCount += 1;
+      });
+      const environmentLayer = Layer.succeed(DesktopEnvironment.DesktopEnvironment, {
+        platform: "darwin",
+        isDevelopment: false,
+      } as DesktopEnvironment.DesktopEnvironment["Service"]);
+      const layer = DesktopLifecycle.layer.pipe(
+        Layer.provideMerge(makeElectronAppLayer(appListeners)),
+        Layer.provideMerge(electronThemeLayer),
+        Layer.provideMerge(makeElectronWindowLayer()),
+        Layer.provideMerge(makeDesktopWindowLayer({ activate })),
+        Layer.provideMerge(environmentLayer),
+        Layer.provideMerge(DesktopShutdown.layer),
+        Layer.provideMerge(DesktopState.layer),
+      );
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const lifecycle = yield* DesktopLifecycle.DesktopLifecycle;
+          const state = yield* DesktopState.DesktopState;
+          yield* lifecycle.register;
+          yield* Ref.set(state.quitting, true);
+
+          appListeners.get("activate")?.();
+
+          assert.equal(activationCount, 0);
         }),
       ).pipe(Effect.provide(layer));
     }),

--- a/apps/desktop/src/app/DesktopLifecycle.test.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.test.ts
@@ -1,4 +1,5 @@
 import { assert, describe, it } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Ref from "effect/Ref";
@@ -7,91 +8,105 @@ import type * as Electron from "electron";
 
 import * as ElectronApp from "../electron/ElectronApp.ts";
 import * as ElectronTheme from "../electron/ElectronTheme.ts";
+import * as ElectronWindow from "../electron/ElectronWindow.ts";
 import * as DesktopEnvironment from "./DesktopEnvironment.ts";
 import * as DesktopLifecycle from "./DesktopLifecycle.ts";
 import * as DesktopShutdown from "./DesktopShutdown.ts";
 import * as DesktopState from "./DesktopState.ts";
 import * as DesktopWindow from "../window/DesktopWindow.ts";
 
+function makeElectronAppLayer(
+  appListeners: Map<string, (...args: readonly unknown[]) => void>,
+  quit: Effect.Effect<void> = Effect.void,
+) {
+  const registerListener = (eventName: string, listener: (...args: readonly unknown[]) => void) =>
+    Effect.acquireRelease(
+      Effect.sync(() => {
+        appListeners.set(eventName, listener);
+      }),
+      () =>
+        Effect.sync(() => {
+          appListeners.delete(eventName);
+        }),
+    ).pipe(Effect.asVoid);
+
+  return Layer.succeed(ElectronApp.ElectronApp, {
+    metadata: Effect.die("unexpected metadata read"),
+    name: Effect.succeed("T3 Code"),
+    systemLocale: Effect.succeed("en-US"),
+    whenReady: Effect.void,
+    quit,
+    exit: () => Effect.void,
+    relaunch: () => Effect.void,
+    setPath: () => Effect.void,
+    setName: () => Effect.void,
+    setAboutPanelOptions: () => Effect.void,
+    setAppUserModelId: () => Effect.void,
+    getAppMetrics: Effect.succeed([]),
+    isDefaultProtocolClient: () => Effect.succeed(false),
+    setAsDefaultProtocolClient: () => Effect.succeed(true),
+    setDesktopName: () => Effect.void,
+    setDockIcon: () => Effect.void,
+    appendCommandLineSwitch: () => Effect.void,
+    removeCommandLineSwitch: () => Effect.void,
+    onBeforeQuitForUpdate: (listener) => registerListener("before-quit-for-update", listener),
+    on: (eventName, listener) =>
+      registerListener(eventName, listener as unknown as (...args: readonly unknown[]) => void),
+  } satisfies ElectronApp.ElectronApp["Service"]);
+}
+
+const electronThemeLayer = Layer.succeed(ElectronTheme.ElectronTheme, {
+  shouldUseDarkColors: Effect.succeed(false),
+  setSource: () => Effect.void,
+  onUpdated: () => Effect.void,
+});
+
+function makeElectronWindowLayer(destroyAll: Effect.Effect<void> = Effect.void) {
+  return Layer.succeed(ElectronWindow.ElectronWindow, {
+    create: () => Effect.die("unexpected window creation"),
+    main: Effect.die("unexpected main window read"),
+    currentMainOrFirst: Effect.die("unexpected current window read"),
+    focusedMainOrFirst: Effect.die("unexpected focused window read"),
+    setMain: () => Effect.void,
+    clearMain: () => Effect.void,
+    reveal: () => Effect.void,
+    sendAll: () => Effect.void,
+    destroyAll,
+    syncAllAppearance: () => Effect.void,
+  });
+}
+
+function makeDesktopWindowLayer(flushMainWindowBounds: Effect.Effect<void> = Effect.void) {
+  return Layer.succeed(DesktopWindow.DesktopWindow, {
+    createMain: Effect.die("unexpected window creation"),
+    ensureMain: Effect.die("unexpected window creation"),
+    revealOrCreateMain: Effect.die("unexpected window creation"),
+    activate: Effect.void,
+    createMainIfBackendReady: Effect.void,
+    showConnectingSplash: Effect.void,
+    handleBackendReady: () => Effect.void,
+    handleBackendNotReady: Effect.void,
+    flushMainWindowBounds,
+    dispatchMenuAction: () => Effect.void,
+    zoomMain: () => Effect.void,
+    syncAppearance: Effect.void,
+  });
+}
+
 describe("DesktopLifecycle", () => {
   for (const platform of ["darwin", "win32", "linux"] satisfies ReadonlyArray<NodeJS.Platform>) {
     it.effect(`lets the updater's quit event proceed on ${platform}`, () => {
       const appListeners = new Map<string, (...args: readonly unknown[]) => void>();
-
-      const electronAppLayer = Layer.succeed(ElectronApp.ElectronApp, {
-        metadata: Effect.die("unexpected metadata read"),
-        name: Effect.succeed("T3 Code"),
-        systemLocale: Effect.succeed("en-US"),
-        whenReady: Effect.void,
-        quit: Effect.void,
-        exit: () => Effect.void,
-        relaunch: () => Effect.void,
-        setPath: () => Effect.void,
-        setName: () => Effect.void,
-        setAboutPanelOptions: () => Effect.void,
-        setAppUserModelId: () => Effect.void,
-        getAppMetrics: Effect.succeed([]),
-        isDefaultProtocolClient: () => Effect.succeed(false),
-        setAsDefaultProtocolClient: () => Effect.succeed(true),
-        setDesktopName: () => Effect.void,
-        setDockIcon: () => Effect.void,
-        appendCommandLineSwitch: () => Effect.void,
-        removeCommandLineSwitch: () => Effect.void,
-        onBeforeQuitForUpdate: (listener) =>
-          Effect.acquireRelease(
-            Effect.sync(() => {
-              appListeners.set("before-quit-for-update", listener);
-            }),
-            () =>
-              Effect.sync(() => {
-                appListeners.delete("before-quit-for-update");
-              }),
-          ).pipe(Effect.asVoid),
-        on: (eventName, listener) =>
-          Effect.acquireRelease(
-            Effect.sync(() => {
-              appListeners.set(
-                eventName,
-                listener as unknown as (...args: readonly unknown[]) => void,
-              );
-            }),
-            () =>
-              Effect.sync(() => {
-                appListeners.delete(eventName);
-              }),
-          ).pipe(Effect.asVoid),
-      } satisfies ElectronApp.ElectronApp["Service"]);
-
-      const electronThemeLayer = Layer.succeed(ElectronTheme.ElectronTheme, {
-        shouldUseDarkColors: Effect.succeed(false),
-        setSource: () => Effect.void,
-        onUpdated: () => Effect.void,
-      });
-
-      const desktopWindowLayer = Layer.succeed(DesktopWindow.DesktopWindow, {
-        createMain: Effect.die("unexpected window creation"),
-        ensureMain: Effect.die("unexpected window creation"),
-        revealOrCreateMain: Effect.die("unexpected window creation"),
-        activate: Effect.void,
-        createMainIfBackendReady: Effect.void,
-        showConnectingSplash: Effect.void,
-        handleBackendReady: () => Effect.void,
-        handleBackendNotReady: Effect.void,
-        flushMainWindowBounds: Effect.void,
-        dispatchMenuAction: () => Effect.void,
-        zoomMain: () => Effect.void,
-        syncAppearance: Effect.void,
-      });
-
       const environmentLayer = Layer.succeed(DesktopEnvironment.DesktopEnvironment, {
         platform,
         isDevelopment: false,
       } as DesktopEnvironment.DesktopEnvironment["Service"]);
 
       const layer = DesktopLifecycle.layer.pipe(
-        Layer.provideMerge(electronAppLayer),
+        Layer.provideMerge(makeElectronAppLayer(appListeners)),
         Layer.provideMerge(electronThemeLayer),
-        Layer.provideMerge(desktopWindowLayer),
+        Layer.provideMerge(makeElectronWindowLayer()),
+        Layer.provideMerge(makeDesktopWindowLayer()),
         Layer.provideMerge(environmentLayer),
         Layer.provideMerge(DesktopShutdown.layer),
         Layer.provideMerge(DesktopState.layer),
@@ -123,4 +138,67 @@ describe("DesktopLifecycle", () => {
       ).pipe(Effect.provide(layer));
     });
   }
+
+  it.effect("destroys windows before waiting for backend shutdown", () =>
+    Effect.gen(function* () {
+      const appListeners = new Map<string, (...args: readonly unknown[]) => void>();
+      const shutdownRequested = yield* Deferred.make<void>();
+      const allowShutdown = yield* Deferred.make<void>();
+      const quitRequested = yield* Deferred.make<void>();
+      const events: string[] = [];
+
+      const quit = Effect.sync(() => {
+        events.push("quit");
+      }).pipe(Effect.andThen(Deferred.succeed(quitRequested, undefined)), Effect.asVoid);
+      const destroyAll = Effect.sync(() => {
+        events.push("destroy");
+      });
+      const flushMainWindowBounds = Effect.sync(() => {
+        events.push("flush");
+      });
+
+      const desktopShutdownLayer = Layer.succeed(DesktopShutdown.DesktopShutdown, {
+        request: Effect.sync(() => {
+          events.push("request");
+        }).pipe(Effect.andThen(Deferred.succeed(shutdownRequested, undefined)), Effect.asVoid),
+        awaitRequest: Deferred.await(shutdownRequested),
+        markComplete: Deferred.succeed(allowShutdown, undefined).pipe(Effect.asVoid),
+        awaitComplete: Deferred.await(allowShutdown),
+        isComplete: Deferred.isDone(allowShutdown),
+      });
+
+      const environmentLayer = Layer.succeed(DesktopEnvironment.DesktopEnvironment, {
+        platform: "darwin",
+        isDevelopment: false,
+      } as DesktopEnvironment.DesktopEnvironment["Service"]);
+
+      const layer = DesktopLifecycle.layer.pipe(
+        Layer.provideMerge(makeElectronAppLayer(appListeners, quit)),
+        Layer.provideMerge(electronThemeLayer),
+        Layer.provideMerge(makeElectronWindowLayer(destroyAll)),
+        Layer.provideMerge(makeDesktopWindowLayer(flushMainWindowBounds)),
+        Layer.provideMerge(environmentLayer),
+        Layer.provideMerge(desktopShutdownLayer),
+        Layer.provideMerge(DesktopState.layer),
+      );
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const lifecycle = yield* DesktopLifecycle.DesktopLifecycle;
+          yield* lifecycle.register;
+
+          const event = { preventDefault: () => undefined } as Electron.Event;
+          appListeners.get("before-quit")?.(event);
+
+          yield* Deferred.await(shutdownRequested);
+          const eventsBeforeCleanup = [...events];
+          yield* Deferred.succeed(allowShutdown, undefined);
+          yield* Deferred.await(quitRequested);
+
+          assert.deepEqual(eventsBeforeCleanup, ["flush", "destroy", "request"]);
+          assert.deepEqual(events, ["flush", "destroy", "request", "quit"]);
+        }),
+      ).pipe(Effect.provide(layer));
+    }),
+  );
 });

--- a/apps/desktop/src/app/DesktopLifecycle.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.ts
@@ -223,7 +223,13 @@ export const make = DesktopLifecycle.of({
       );
     });
     yield* electronApp.on("activate", () => {
-      void runEffect(desktopWindow.activate.pipe(Effect.withSpan("desktop.lifecycle.activate")));
+      void runEffect(
+        Effect.gen(function* () {
+          const state = yield* DesktopState.DesktopState;
+          if (yield* Ref.get(state.quitting)) return;
+          yield* desktopWindow.activate;
+        }).pipe(Effect.withSpan("desktop.lifecycle.activate")),
+      );
     });
     yield* electronApp.on("window-all-closed", () => {
       void runEffect(

--- a/apps/desktop/src/app/DesktopLifecycle.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.ts
@@ -12,6 +12,7 @@ import { makeComponentLogger } from "./DesktopObservability.ts";
 import * as DesktopShutdown from "./DesktopShutdown.ts";
 import * as ElectronApp from "../electron/ElectronApp.ts";
 import * as ElectronTheme from "../electron/ElectronTheme.ts";
+import * as ElectronWindow from "../electron/ElectronWindow.ts";
 import * as DesktopState from "./DesktopState.ts";
 import * as DesktopWindow from "../window/DesktopWindow.ts";
 
@@ -35,8 +36,12 @@ export type DesktopLifecycleRuntimeServices =
   | ElectronApp.ElectronApp
   | ElectronTheme.ElectronTheme;
 
+type DesktopLifecycleRegistrationServices =
+  | DesktopLifecycleRuntimeServices
+  | ElectronWindow.ElectronWindow;
+
 /**
- * @effect-expect-leaking DesktopEnvironment | DesktopShutdown | DesktopState | DesktopWindow | ElectronApp | ElectronTheme
+ * @effect-expect-leaking DesktopEnvironment | DesktopShutdown | DesktopState | DesktopWindow | ElectronApp | ElectronTheme | ElectronWindow
  */
 export class DesktopLifecycle extends Context.Service<
   DesktopLifecycle,
@@ -44,7 +49,11 @@ export class DesktopLifecycle extends Context.Service<
     readonly relaunch: (
       reason: string,
     ) => Effect.Effect<void, never, DesktopLifecycleRuntimeServices>;
-    readonly register: Effect.Effect<void, never, Scope.Scope | DesktopLifecycleRuntimeServices>;
+    readonly register: Effect.Effect<
+      void,
+      never,
+      Scope.Scope | DesktopLifecycleRegistrationServices
+    >;
   }
 >()("@t3tools/desktop/app/DesktopLifecycle") {}
 
@@ -73,14 +82,13 @@ function addScopedListener<Args extends ReadonlyArray<unknown>>(
 }
 
 const requestDesktopShutdownAndWait = Effect.fn("desktop.lifecycle.requestShutdownAndWait")(
-  function* (): Effect.fn.Return<
-    void,
-    never,
-    DesktopShutdown.DesktopShutdown | DesktopWindow.DesktopWindow
-  > {
+  function* (
+    afterBoundsFlush: Effect.Effect<void> = Effect.void,
+  ): Effect.fn.Return<void, never, DesktopShutdown.DesktopShutdown | DesktopWindow.DesktopWindow> {
     const shutdown = yield* DesktopShutdown.DesktopShutdown;
     const desktopWindow = yield* DesktopWindow.DesktopWindow;
     yield* desktopWindow.flushMainWindowBounds;
+    yield* afterBoundsFlush;
     yield* shutdown.request;
     yield* shutdown.awaitComplete;
   },
@@ -88,7 +96,9 @@ const requestDesktopShutdownAndWait = Effect.fn("desktop.lifecycle.requestShutdo
 
 function handleBeforeQuit(
   event: Electron.Event,
-  runEffect: <A, E>(effect: Effect.Effect<A, E, DesktopLifecycleRuntimeServices>) => Promise<A>,
+  runEffect: <A, E>(
+    effect: Effect.Effect<A, E, DesktopLifecycleRegistrationServices>,
+  ) => Promise<A>,
   allowQuit: () => boolean,
   markQuitAllowed: () => void,
 ): void {
@@ -107,9 +117,16 @@ function handleBeforeQuit(
   void runEffect(
     Effect.gen(function* () {
       const state = yield* DesktopState.DesktopState;
+      const electronWindow = yield* ElectronWindow.ElectronWindow;
       yield* Ref.set(state.quitting, true);
       yield* logLifecycleInfo("before-quit received");
-      yield* requestDesktopShutdownAndWait();
+      yield* requestDesktopShutdownAndWait(
+        electronWindow.destroyAll.pipe(
+          Effect.catchCause((cause) =>
+            logLifecycleError("failed to destroy windows before shutdown", { cause }),
+          ),
+        ),
+      );
     }).pipe(Effect.withSpan("desktop.lifecycle.beforeQuit")),
   ).finally(() => {
     markQuitAllowed();
@@ -124,7 +141,9 @@ function handleBeforeQuit(
 
 function quitFromSignal(
   signal: "SIGINT" | "SIGTERM",
-  runEffect: <A, E>(effect: Effect.Effect<A, E, DesktopLifecycleRuntimeServices>) => Promise<A>,
+  runEffect: <A, E>(
+    effect: Effect.Effect<A, E, DesktopLifecycleRegistrationServices>,
+  ) => Promise<A>,
 ): void {
   void runEffect(
     Effect.gen(function* () {
@@ -173,7 +192,7 @@ export const make = DesktopLifecycle.of({
     const electronApp = yield* ElectronApp.ElectronApp;
     const electronTheme = yield* ElectronTheme.ElectronTheme;
     const environment = yield* DesktopEnvironment.DesktopEnvironment;
-    const context = yield* Effect.context<DesktopLifecycleRuntimeServices>();
+    const context = yield* Effect.context<DesktopLifecycleRegistrationServices>();
     const runEffect = Effect.runPromiseWith(context);
     let quitAllowed = false;
     let updaterQuitAllowed = false;

--- a/apps/desktop/src/electron/ElectronWindow.test.ts
+++ b/apps/desktop/src/electron/ElectronWindow.test.ts
@@ -208,7 +208,7 @@ describe("ElectronWindow", () => {
     }).pipe(Effect.provide(TestLayer)),
   );
 
-  it.effect("preserves destroy failures with the target window", () =>
+  it.effect("preserves destroy failures and continues with later windows", () =>
     Effect.gen(function* () {
       const cause = new Error("window destroy failed");
       const window = {
@@ -217,7 +217,11 @@ describe("ElectronWindow", () => {
           throw cause;
         }),
       } as unknown as Electron.BrowserWindow;
-      getAllWindowsMock.mockReturnValueOnce([window]);
+      const laterWindow = {
+        id: 44,
+        destroy: vi.fn(),
+      } as unknown as Electron.BrowserWindow;
+      getAllWindowsMock.mockReturnValueOnce([window, laterWindow]);
 
       const electronWindow = yield* ElectronWindow.ElectronWindow;
       const exit = yield* Effect.exit(electronWindow.destroyAll);
@@ -231,6 +235,7 @@ describe("ElectronWindow", () => {
         assert.isNull(error.channel);
         assert.strictEqual(error.cause, cause);
       }
+      assert.equal(vi.mocked(laterWindow.destroy).mock.calls.length, 1);
     }).pipe(Effect.provide(TestLayer)),
   );
 });

--- a/apps/desktop/src/electron/ElectronWindow.ts
+++ b/apps/desktop/src/electron/ElectronWindow.ts
@@ -1,6 +1,8 @@
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import type * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
@@ -257,18 +259,27 @@ export const make = Effect.gen(function* () {
         }
       }),
     destroyAll: Effect.gen(function* () {
+      let firstFailure: Cause.Cause<never> | undefined;
       for (const window of yield* listWindows) {
-        yield* Effect.try({
-          try: () => window.destroy(),
-          catch: (cause) =>
-            new ElectronWindowOperationError({
-              operation: "destroy-window",
-              platform,
-              windowId: window.id,
-              channel: null,
-              cause,
-            }),
-        }).pipe(Effect.orDie);
+        const exit = yield* Effect.exit(
+          Effect.try({
+            try: () => window.destroy(),
+            catch: (cause) =>
+              new ElectronWindowOperationError({
+                operation: "destroy-window",
+                platform,
+                windowId: window.id,
+                channel: null,
+                cause,
+              }),
+          }).pipe(Effect.orDie),
+        );
+        if (Exit.isFailure(exit)) {
+          firstFailure ??= exit.cause;
+        }
+      }
+      if (firstFailure !== undefined) {
+        return yield* Effect.failCause(firstFailure);
       }
     }),
     syncAllAppearance: Effect.fn("desktop.electron.window.syncAllAppearance")(function* <E, R>(


### PR DESCRIPTION
Quitting T3 Code kept the desktop window visible while the local backend completed about two seconds of graceful cleanup. This made Cmd+Q feel unresponsive on macOS.

The desktop now saves window bounds and destroys all Electron windows before it starts backend cleanup. The Electron process remains alive until cleanup completes, then exits as before. Updater-controlled quits still use the updater path.

Tests:
- vp test run apps/desktop/src/app/DesktopLifecycle.test.ts apps/desktop/src/electron/ElectronWindow.test.ts
- vp run --filter @t3tools/desktop typecheck
- targeted lint and formatting checks

Made by GPT-5.6 using T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core quit/teardown ordering in the desktop lifecycle; behavior is well-tested but incorrect ordering could affect shutdown or updater paths.
> 
> **Overview**
> **Quit now hides the UI immediately** by flushing main window bounds, destroying all Electron windows, and only then requesting backend shutdown—the process still exits after cleanup finishes.
> 
> `ElectronWindow.destroyAll` **attempts every window** and surfaces the first destroy error instead of stopping at the first failure; lifecycle **logs destroy failures** but does not block shutdown. **macOS `activate` is ignored** while `DesktopState.quitting` is set so a window cannot reopen during teardown.
> 
> Tests add shared mock layers plus coverage for flush → destroy → shutdown ordering and suppressed activation while quitting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b146aa03b332141f76ae7b11da29aceda3516150. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Close all Electron windows before backend shutdown on quit
> - On `before-quit`, all Electron windows are now destroyed before requesting backend shutdown, ensuring windows close cleanly prior to teardown.
> - `destroyAll` in [`ElectronWindow.ts`](https://github.com/pingdotgg/t3code/pull/6562/files#diff-7136f1f9fe8074c62732d3926f8a6fabbd5e67cfca593644ce9870fce5f0dcee) now attempts to destroy every window even if earlier ones fail, reporting only the first failure cause.
> - App `activate` events are ignored once the quitting flag is set, preventing activation during shutdown.
> - Behavioral Change: `requestDesktopShutdownAndWait` now accepts an optional `afterBoundsFlush` effect, changing the quit sequence to: flush bounds → destroy windows → request shutdown → quit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b146aa0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->