### PR TITLE
fix(web): opening the sidebar no longer scrolls the thread away from the end

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2294,6 +2294,11 @@ function ChatViewContent(props: ChatViewProps) {
     threadError,
   });
   const isWorking = phase === "running" || isSendBusy || isConnecting || isRevertingCheckpoint;
+  const activeTurnInProgress = isWorking || !latestTurnSettled;
+  const activeTurnInProgressRef = useRef(activeTurnInProgress);
+  useEffect(() => {
+    activeTurnInProgressRef.current = activeTurnInProgress;
+  }, [activeTurnInProgress]);
   const activeWorkStartedAt = deriveActiveWorkStartedAt(
     activeLatestTurn,
     activeThread?.session ?? null,
@@ -3666,6 +3671,10 @@ function ChatViewContent(props: ChatViewProps) {
   const positionedTimelineAnchorRef = useRef<MessageId | null>(null);
   const settledTimelineAnchorRef = useRef<MessageId | null>(null);
   const activeTimelineAnchorIndexRef = useRef<number | null>(null);
+  // True once the armed anchor's end space has shrunk to zero — the response
+  // outgrew the reserved blank space, so the anchored view is identical to
+  // ordinary end-following and the anchor can be released.
+  const timelineAnchorEndSpaceCollapsedRef = useRef(false);
   const anchorUserScrollGenerationRef = useRef(0);
   const liveFollowUserScrollGenerationRef = useRef<number | null>(0);
   // Manual navigation stops live-follow without removing anchored end space.
@@ -3861,75 +3870,125 @@ function ChatViewContent(props: ChatViewProps) {
     };
   }, [activeThread?.id, composerOverlayHeight, timelineRealContentOverflowsViewport]);
 
-  const onTimelineAnchorReady = useCallback((messageId: MessageId, anchorIndex: number) => {
-    // Anchored-end space can be remeasured when the turn completes. Once the
-    // user has scrolled away (or returned to ordinary end-following), that
-    // remeasurement must not restart the send-time anchor positioning.
-    if (timelineScrollModeRef.current !== "anchoring-new-turn") {
-      return;
+  // A stale armed anchor keeps LegendList's maintainScrollAtEnd disabled for
+  // the rest of the thread session, so any layout resize (sidebar or right
+  // panel toggles) strands the viewport short of the live edge. Once the end
+  // space has collapsed, releasing the anchor is visually a no-op and hands
+  // ordinary end-follow back to LegendList.
+  const releaseCollapsedTimelineAnchor = useCallback(() => {
+    if (timelineScrollModeRef.current === "anchoring-new-turn") {
+      timelineScrollModeRef.current = "following-end";
     }
-    if (pendingTimelineAnchorRef.current === messageId) {
-      pendingTimelineAnchorRef.current = null;
-    }
-    activeTimelineAnchorIndexRef.current = anchorIndex;
-    if (positionedTimelineAnchorRef.current === messageId) {
-      return;
-    }
-    positionedTimelineAnchorRef.current = messageId;
+    pendingTimelineAnchorRef.current = null;
+    positionedTimelineAnchorRef.current = null;
     settledTimelineAnchorRef.current = null;
-    const positionAnchor = (remainingAttempts: number) => {
-      requestAnimationFrame(() => {
-        if (positionedTimelineAnchorRef.current !== messageId) {
-          return;
-        }
-        const list = legendListRef.current;
-        if (!list) {
-          if (remainingAttempts > 0) {
-            positionAnchor(remainingAttempts - 1);
-          }
-          return;
-        }
-        void list
-          .scrollToIndex({
-            index: anchorIndex,
-            animated: true,
-            viewPosition: 0,
-            viewOffset: CHAT_LIST_ANCHOR_OFFSET,
-          })
-          .then(() => {
-            if (positionedTimelineAnchorRef.current !== messageId) {
-              return;
-            }
-            settledTimelineAnchorRef.current = messageId;
-          });
-      });
-    };
-    requestAnimationFrame(() => positionAnchor(12));
+    activeTimelineAnchorIndexRef.current = null;
+    setTimelineAnchor((current) =>
+      current.messageId === null ? current : { ...current, messageId: null },
+    );
   }, []);
 
-  const onIsAtEndChange = useCallback((isAtEnd: boolean) => {
-    if (
-      !isAtEnd &&
-      liveFollowUserScrollGenerationRef.current === anchorUserScrollGenerationRef.current
-    ) {
-      showScrollDebouncer.current.cancel();
-      setShowScrollToBottom(false);
+  // The anchored reveal effect below owns end-following while the turn is
+  // still streaming, so release only after the turn settles; a size-0 report
+  // often arrives mid-stream, the moment the response outgrows the space.
+  useEffect(() => {
+    if (activeTurnInProgress) {
       return;
     }
-    if (isAtEndRef.current === isAtEnd) return;
-    isAtEndRef.current = isAtEnd;
-    if (isAtEnd) {
-      timelineScrollModeRef.current = "following-end";
-      liveFollowUserScrollGenerationRef.current = anchorUserScrollGenerationRef.current;
-      setTimelineLiveFollowEnabled(true);
-      showScrollDebouncer.current.cancel();
-      setShowScrollToBottom(false);
-    } else {
-      timelineScrollModeRef.current = "free-scrolling";
-      liveFollowUserScrollGenerationRef.current = null;
-      showScrollDebouncer.current.maybeExecute();
+    if (timelineAnchorEndSpaceCollapsedRef.current) {
+      releaseCollapsedTimelineAnchor();
     }
-  }, []);
+  }, [activeTurnInProgress, releaseCollapsedTimelineAnchor]);
+
+  const onTimelineAnchorReady = useCallback(
+    (messageId: MessageId, anchorIndex: number, endSpaceSize: number) => {
+      timelineAnchorEndSpaceCollapsedRef.current = endSpaceSize === 0;
+      if (
+        endSpaceSize === 0 &&
+        settledTimelineAnchorRef.current === messageId &&
+        !activeTurnInProgressRef.current
+      ) {
+        releaseCollapsedTimelineAnchor();
+        return;
+      }
+      // Anchored-end space can be remeasured when the turn completes. Once the
+      // user has scrolled away (or returned to ordinary end-following), that
+      // remeasurement must not restart the send-time anchor positioning.
+      if (timelineScrollModeRef.current !== "anchoring-new-turn") {
+        return;
+      }
+      if (pendingTimelineAnchorRef.current === messageId) {
+        pendingTimelineAnchorRef.current = null;
+      }
+      activeTimelineAnchorIndexRef.current = anchorIndex;
+      if (positionedTimelineAnchorRef.current === messageId) {
+        return;
+      }
+      positionedTimelineAnchorRef.current = messageId;
+      settledTimelineAnchorRef.current = null;
+      const positionAnchor = (remainingAttempts: number) => {
+        requestAnimationFrame(() => {
+          if (positionedTimelineAnchorRef.current !== messageId) {
+            return;
+          }
+          const list = legendListRef.current;
+          if (!list) {
+            if (remainingAttempts > 0) {
+              positionAnchor(remainingAttempts - 1);
+            }
+            return;
+          }
+          void list
+            .scrollToIndex({
+              index: anchorIndex,
+              animated: true,
+              viewPosition: 0,
+              viewOffset: CHAT_LIST_ANCHOR_OFFSET,
+            })
+            .then(() => {
+              if (positionedTimelineAnchorRef.current !== messageId) {
+                return;
+              }
+              settledTimelineAnchorRef.current = messageId;
+            });
+        });
+      };
+      requestAnimationFrame(() => positionAnchor(12));
+    },
+    [releaseCollapsedTimelineAnchor],
+  );
+
+  const onIsAtEndChange = useCallback(
+    (isAtEnd: boolean) => {
+      if (
+        !isAtEnd &&
+        liveFollowUserScrollGenerationRef.current === anchorUserScrollGenerationRef.current
+      ) {
+        showScrollDebouncer.current.cancel();
+        setShowScrollToBottom(false);
+        return;
+      }
+      if (isAtEndRef.current === isAtEnd) return;
+      isAtEndRef.current = isAtEnd;
+      if (isAtEnd) {
+        timelineScrollModeRef.current = "following-end";
+        liveFollowUserScrollGenerationRef.current = anchorUserScrollGenerationRef.current;
+        setTimelineLiveFollowEnabled(true);
+        showScrollDebouncer.current.cancel();
+        setShowScrollToBottom(false);
+        // Covers anchors whose end space collapsed while the user was away from
+        // the end: no further onAnchorReady will fire, so release on return.
+        if (timelineAnchorEndSpaceCollapsedRef.current && !activeTurnInProgressRef.current) {
+          releaseCollapsedTimelineAnchor();
+        }
+      } else {
+        timelineScrollModeRef.current = "free-scrolling";
+        liveFollowUserScrollGenerationRef.current = null;
+        showScrollDebouncer.current.maybeExecute();
+      }
+    },
+    [releaseCollapsedTimelineAnchor],
+  );
 
   // Anchored end space intentionally disables LegendList's normal end-follow so
   // the sent message can stay near the top. T3 only owns streaming adjustments
@@ -3993,6 +4052,7 @@ function ChatViewContent(props: ChatViewProps) {
     positionedTimelineAnchorRef.current = null;
     settledTimelineAnchorRef.current = null;
     activeTimelineAnchorIndexRef.current = null;
+    timelineAnchorEndSpaceCollapsedRef.current = false;
     showScrollDebouncer.current.cancel();
     setShowScrollToBottom(false);
     // activeThreadRef resets transitively with the active thread.
@@ -5112,6 +5172,7 @@ function ChatViewContent(props: ChatViewProps) {
     setTimelineLiveFollowEnabled(true);
     pendingTimelineAnchorRef.current = messageIdForSend;
     activeTimelineAnchorIndexRef.current = null;
+    timelineAnchorEndSpaceCollapsedRef.current = false;
     showScrollDebouncer.current.cancel();
     setShowScrollToBottom(false);
     setTimelineAnchor({
@@ -5557,6 +5618,7 @@ function ChatViewContent(props: ChatViewProps) {
       setTimelineLiveFollowEnabled(true);
       pendingTimelineAnchorRef.current = messageIdForSend;
       activeTimelineAnchorIndexRef.current = null;
+      timelineAnchorEndSpaceCollapsedRef.current = false;
       showScrollDebouncer.current.cancel();
       setShowScrollToBottom(false);
       setTimelineAnchor({
@@ -6226,7 +6288,7 @@ function ChatViewContent(props: ChatViewProps) {
                 key={activeThread.id}
                 isWorking={isWorking}
                 workingStepLabel={workingStepLabel}
-                activeTurnInProgress={isWorking || !latestTurnSettled}
+                activeTurnInProgress={activeTurnInProgress}
                 activeTurnStartedAt={activeWorkStartedAt}
                 listRef={legendListRef}
                 timelineEntries={timelineEntries}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3888,27 +3888,43 @@ function ChatViewContent(props: ChatViewProps) {
     );
   }, []);
 
-  // The anchored reveal effect below owns end-following while the turn is
-  // still streaming, so release only after the turn settles; a size-0 report
-  // often arrives mid-stream, the moment the response outgrows the space.
+  // Release preconditions, re-checked at every quiescent point: the anchored
+  // reveal effect below owns end-following while the turn is still streaming
+  // (a size-0 report often arrives mid-stream, the moment the response
+  // outgrows the space), and an in-flight anchored positioning must finish
+  // before the anchor state is torn down. Returns true when it released.
+  const maybeReleaseCollapsedTimelineAnchor = useCallback(() => {
+    if (!timelineAnchorEndSpaceCollapsedRef.current) {
+      return false;
+    }
+    if (activeTurnInProgressRef.current) {
+      return false;
+    }
+    const positioningInFlight =
+      pendingTimelineAnchorRef.current !== null ||
+      (positionedTimelineAnchorRef.current !== null &&
+        settledTimelineAnchorRef.current !== positionedTimelineAnchorRef.current);
+    if (positioningInFlight) {
+      return false;
+    }
+    releaseCollapsedTimelineAnchor();
+    return true;
+  }, [releaseCollapsedTimelineAnchor]);
+  const maybeReleaseCollapsedTimelineAnchorRef = useRef(maybeReleaseCollapsedTimelineAnchor);
   useEffect(() => {
-    if (activeTurnInProgress) {
-      return;
+    maybeReleaseCollapsedTimelineAnchorRef.current = maybeReleaseCollapsedTimelineAnchor;
+  }, [maybeReleaseCollapsedTimelineAnchor]);
+
+  useEffect(() => {
+    if (!activeTurnInProgress) {
+      maybeReleaseCollapsedTimelineAnchor();
     }
-    if (timelineAnchorEndSpaceCollapsedRef.current) {
-      releaseCollapsedTimelineAnchor();
-    }
-  }, [activeTurnInProgress, releaseCollapsedTimelineAnchor]);
+  }, [activeTurnInProgress, maybeReleaseCollapsedTimelineAnchor]);
 
   const onTimelineAnchorReady = useCallback(
     (messageId: MessageId, anchorIndex: number, endSpaceSize: number) => {
       timelineAnchorEndSpaceCollapsedRef.current = endSpaceSize === 0;
-      if (
-        endSpaceSize === 0 &&
-        settledTimelineAnchorRef.current === messageId &&
-        !activeTurnInProgressRef.current
-      ) {
-        releaseCollapsedTimelineAnchor();
+      if (maybeReleaseCollapsedTimelineAnchor()) {
         return;
       }
       // Anchored-end space can be remeasured when the turn completes. Once the
@@ -3950,12 +3966,14 @@ function ChatViewContent(props: ChatViewProps) {
                 return;
               }
               settledTimelineAnchorRef.current = messageId;
+              // The space may have collapsed while positioning was in flight.
+              maybeReleaseCollapsedTimelineAnchorRef.current();
             });
         });
       };
       requestAnimationFrame(() => positionAnchor(12));
     },
-    [releaseCollapsedTimelineAnchor],
+    [maybeReleaseCollapsedTimelineAnchor],
   );
 
   const onIsAtEndChange = useCallback(
@@ -3978,16 +3996,14 @@ function ChatViewContent(props: ChatViewProps) {
         setShowScrollToBottom(false);
         // Covers anchors whose end space collapsed while the user was away from
         // the end: no further onAnchorReady will fire, so release on return.
-        if (timelineAnchorEndSpaceCollapsedRef.current && !activeTurnInProgressRef.current) {
-          releaseCollapsedTimelineAnchor();
-        }
+        maybeReleaseCollapsedTimelineAnchor();
       } else {
         timelineScrollModeRef.current = "free-scrolling";
         liveFollowUserScrollGenerationRef.current = null;
         showScrollDebouncer.current.maybeExecute();
       }
     },
-    [releaseCollapsedTimelineAnchor],
+    [maybeReleaseCollapsedTimelineAnchor],
   );
 
   // Anchored end space intentionally disables LegendList's normal end-follow so

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -17,7 +17,7 @@ vi.mock("@legendapp/list/react", async () => {
       anchorIndex: number;
       anchorMaxSize?: number;
       anchorOffset?: number;
-      onReady?: (info: { anchorIndex: number }) => void;
+      onReady?: (info: { anchorIndex: number; size: number }) => void;
     };
     contentInsetEndAdjustment?: number;
     className?: string;
@@ -41,7 +41,10 @@ vi.mock("@legendapp/list/react", async () => {
     ref?: Ref<LegendListRef>;
   }) => {
     if (props.anchoredEndSpace) {
-      props.anchoredEndSpace.onReady?.({ anchorIndex: props.anchoredEndSpace.anchorIndex });
+      props.anchoredEndSpace.onReady?.({
+        anchorIndex: props.anchoredEndSpace.anchorIndex,
+        size: 120,
+      });
     }
     return (
       <div
@@ -429,7 +432,7 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain('data-maintain-visible-content-position-size="true"');
     expect(markup).toContain('data-maintain-visible-content-position-restore="true"');
     expect(onAnchorReady).toHaveBeenCalledOnce();
-    expect(onAnchorReady).toHaveBeenCalledWith(secondEntry.message.id, 1);
+    expect(onAnchorReady).toHaveBeenCalledWith(secondEntry.message.id, 1, 120);
   });
 
   it("renders collapse controls for long user messages", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -196,6 +196,14 @@ const TIMELINE_MAINTAIN_SCROLL_AT_END = {
     layout: true,
   },
 } as const;
+// LegendList abandons end maintenance once the viewport drifts further from
+// the end than this fraction of the viewport (library default 0.1). Container
+// width changes (sidebar/right-panel toggles) remeasure rows progressively
+// while maintainVisibleContentPosition holds the top visible row steady, which
+// walks the end away in steps larger than that window and strands the timeline
+// short of the live edge. One full viewport keeps maintenance active through a
+// remeasure; ChatView's scroll-mode refs still gate when maintenance runs.
+const TIMELINE_MAINTAIN_SCROLL_AT_END_THRESHOLD = 1;
 
 // ---------------------------------------------------------------------------
 // Props (public API)
@@ -226,7 +234,7 @@ interface MessagesTimelineProps {
   workspaceRoot: string | undefined;
   skills?: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">>;
   anchorMessageId: MessageId | null;
-  onAnchorReady: (messageId: MessageId, anchorIndex: number) => void;
+  onAnchorReady: (messageId: MessageId, anchorIndex: number, endSpaceSize: number) => void;
   contentInsetEndAdjustment: number;
   /**
    * Whether the timeline should keep pinning to the live edge as content
@@ -426,9 +434,9 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   const [minimapHasPersistentGutter, setMinimapHasPersistentGutter] = useState(false);
   const [minimapHitStripWidth, setMinimapHitStripWidth] = useState(0);
   const handleAnchorReady = useCallback(
-    (info: { anchorIndex: number | undefined }) => {
+    (info: { anchorIndex: number | undefined; size: number }) => {
       if (anchorMessageId !== null && info.anchorIndex !== undefined) {
-        onAnchorReady(anchorMessageId, info.anchorIndex);
+        onAnchorReady(anchorMessageId, info.anchorIndex, info.size);
       }
     },
     [anchorMessageId, onAnchorReady],
@@ -587,6 +595,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                 ? false
                 : TIMELINE_MAINTAIN_SCROLL_AT_END
             }
+            maintainScrollAtEndThreshold={TIMELINE_MAINTAIN_SCROLL_AT_END_THRESHOLD}
             maintainVisibleContentPosition={maintainVisibleContentPosition}
             onScroll={handleScroll}
             className={cn(


### PR DESCRIPTION
Toggling the main sidebar (or the right panel) in a thread made the chat content jump away from the live edge, looking like the blank space we reserve when sending a new message. Closing the sidebar landed back in the right place, but the extra space below the content stuck around and every toggle drifted further.

Two things compounded:

1. A width change remeasures timeline rows progressively while `maintainVisibleContentPosition` holds the top visible row steady. That walks the viewport outside LegendList's end-maintenance window (default 0.1 viewports), after which it stops re-pinning forever. Reproduced deterministically: every sidebar open stranded the viewport a few hundred px short of the end, scaling with thread size.
2. The send-time anchored end space (the reserved blank that puts your sent message near the top) stayed armed for the rest of the thread session. An armed anchor disables LegendList's end maintenance entirely, so even the small post-turn drift never corrected (threads settled 45-115px above the bottom after every turn).

The fix:

- Pass `maintainScrollAtEndThreshold={1}` so end maintenance survives a full remeasure. ChatView's scroll-mode refs still gate *when* maintenance runs, so readers scrolled up in history are untouched (verified with real wheel gestures: toggles preserve the visible paragraph exactly).
- Release the anchor once its reserved space has collapsed to zero and the turn has settled. At that point the anchored view is identical to ordinary end-following, so the release is visually a no-op and hands the end back to LegendList. Release explicitly waits for turn completion: the anchored reveal machinery owns following while streaming, and releasing early broke follow (caught during verification).

Verified in a paired dev environment with headless Chromium against real cloned thread data: at-end toggles stay pinned (`distanceFromEnd` 0 across repeated open/close, previously 341px and ratcheting), streaming follow lands at 0 after turn completion, and mid-history reading position survives toggles.

---
�okay module: written by Claude Fable 5 via Claude Code (harness), verified against a live dev environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches scroll anchoring, live-follow, and LegendList integration in the main chat view; behavior is timing-sensitive but scoped to timeline scroll UX with test updates for the new callback shape.
> 
> **Overview**
> Fixes chat threads drifting away from the live edge when the main sidebar or right panel toggles, and leftover send-time anchor state blocking end-follow for the rest of the session.
> 
> **MessagesTimeline** passes `maintainScrollAtEndThreshold={1}` (full viewport) so LegendList keeps end maintenance through progressive row remeasure during width changes; ChatView still gates when maintenance runs via `liveFollowEnabled` and anchor state.
> 
> **ChatView** tracks when send-time anchored end space collapses to zero (`endSpaceSize` on `onAnchorReady`), then **releases** the anchor after the turn settles and any in-flight scroll-to-anchor finishes—restoring ordinary end-follow without a visible jump. Release also runs when the user scrolls back to the end. `activeTurnInProgress` is hoisted for consistent turn-in-progress checks across timeline props and anchor release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88187c6e7e859b294b48fb59a69a5632cd734738. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sidebar opening scrolling the thread away from the end in ChatView
> - When the sidebar opens, `LegendList` remeasures the container width, causing the anchored end space to collapse; the previous code left a stale anchor that disabled end-following.
> - Introduces `maybeReleaseCollapsedTimelineAnchor` in [ChatViewContent](https://github.com/pingdotgg/t3code/pull/6564/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e): when the end space size reports as zero and no active turn is in progress, the anchor is released and normal end-following resumes.
> - Adds a `TIMELINE_MAINTAIN_SCROLL_AT_END_THRESHOLD` constant (value `1`) in [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/6564/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) so LegendList maintains end-follow through remeasure cycles triggered by layout changes.
> - Forwards the anchored end-space measured size from `LegendList` up to the parent via an updated `onAnchorReady(messageId, anchorIndex, endSpaceSize)` signature.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 88187c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->