### PR TITLE
feat(composer): add feedback command

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Report broken behavior, regressions, crashes, or reliability issues.
-title: "[Bug]: "
+title: "Bug: "
 labels:
   - bug
   - needs-triage

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Propose a scoped improvement or new capability.
-title: "[Feature]: "
+title: "Feature: "
 labels:
   - enhancement
   - needs-triage

--- a/apps/mobile/src/features/threads/ComposerCommandPopover.tsx
+++ b/apps/mobile/src/features/threads/ComposerCommandPopover.tsx
@@ -1,4 +1,5 @@
 import type { ComposerTriggerKind } from "@t3tools/shared/composerTrigger";
+import type { FeedbackType } from "@t3tools/shared/feedback";
 import type { ServerProviderSkill, ServerProviderSlashCommand } from "@t3tools/contracts";
 import { SymbolView } from "../../components/AppSymbol";
 import { memo } from "react";
@@ -20,6 +21,7 @@ export type ComposerCommandItem =
       readonly id: string;
       readonly type: "slash-command";
       readonly command: string;
+      readonly feedbackType?: FeedbackType;
       readonly label: string;
       readonly description: string;
     }

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -9,6 +9,7 @@ import type {
 } from "@t3tools/contracts";
 import {
   detectComposerTrigger,
+  parseStandaloneComposerSlashCommand,
   replaceTextRange,
   serializeComposerFileLink,
   type ComposerTrigger,
@@ -65,6 +66,7 @@ import {
 } from "@t3tools/shared/searchRanking";
 import { resolveProviderOptionDescriptors } from "../../lib/providerOptions";
 import { useComposerPathSearch } from "../../state/use-composer-path-search";
+import { openMobileFeedbackIssueForm } from "../../lib/feedback";
 import { ComposerCommandPopover, type ComposerCommandItem } from "./ComposerCommandPopover";
 import {
   type ExistingThreadSettingsRouteSession,
@@ -389,6 +391,13 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
       const q = composerTrigger.query.toLowerCase();
       const allBuiltIn = [
         {
+          id: "cmd:feedback",
+          type: "slash-command" as const,
+          command: "feedback",
+          label: "/feedback",
+          description: "Report a bug or suggest a feature",
+        },
+        {
           id: "cmd:model",
           type: "slash-command" as const,
           command: "model",
@@ -535,6 +544,12 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     if (inFlightThreadIdsRef.current.has(threadKey)) return;
     inFlightThreadIdsRef.current.add(threadKey);
     try {
+      if (parseStandaloneComposerSlashCommand(draftMessage) === "feedback") {
+        if (await openMobileFeedbackIssueForm()) {
+          onChangeDraftMessage("");
+        }
+        return;
+      }
       await onSendMessage();
       // Sending a prompt starts agent work: arm the lock-screen card while the
       // app is foregrounded and the activity token can be registered. Armed
@@ -549,6 +564,8 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     }
   }, [
     onSendMessage,
+    draftMessage,
+    onChangeDraftMessage,
     props.environmentId,
     props.environmentLabel,
     props.selectedThread.id,
@@ -571,6 +588,19 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
         setComposerSelection({ start: result.cursor, end: result.cursor });
         onChangeDraftMessage(result.text);
         onUpdateInteractionMode(item.command);
+        return;
+      }
+
+      if (item.type === "slash-command" && item.command === "feedback") {
+        const result = replaceTextRange(
+          draftMessage,
+          composerTrigger.rangeStart,
+          composerTrigger.rangeEnd,
+          "",
+        );
+        setComposerSelection({ start: result.cursor, end: result.cursor });
+        onChangeDraftMessage(result.text);
+        void openMobileFeedbackIssueForm();
         return;
       }
 

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -18,6 +18,7 @@ import { StackActions, useFocusEffect, useNavigation } from "@react-navigation/n
 import type { ReactNode } from "react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import {
+  Alert,
   ActivityIndicator,
   Image,
   Platform,
@@ -66,7 +67,7 @@ import {
 } from "@t3tools/shared/searchRanking";
 import { resolveProviderOptionDescriptors } from "../../lib/providerOptions";
 import { useComposerPathSearch } from "../../state/use-composer-path-search";
-import { openMobileFeedbackIssueForm } from "../../lib/feedback";
+import { openMobileFeedbackFromDraft } from "../../lib/feedback";
 import { ComposerCommandPopover, type ComposerCommandItem } from "./ComposerCommandPopover";
 import {
   type ExistingThreadSettingsRouteSession,
@@ -391,11 +392,20 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
       const q = composerTrigger.query.toLowerCase();
       const allBuiltIn = [
         {
-          id: "cmd:feedback",
+          id: "cmd:feedback:bug",
           type: "slash-command" as const,
           command: "feedback",
           label: "/feedback",
-          description: "Report a bug or suggest a feature",
+          description: "Report a bug",
+          feedbackType: "bug" as const,
+        },
+        {
+          id: "cmd:feedback:feature",
+          type: "slash-command" as const,
+          command: "feedback",
+          label: "/feedback",
+          description: "Suggest a feature",
+          feedbackType: "feature" as const,
         },
         {
           id: "cmd:model",
@@ -545,9 +555,21 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     inFlightThreadIdsRef.current.add(threadKey);
     try {
       if (parseStandaloneComposerSlashCommand(draftMessage) === "feedback") {
-        if (await openMobileFeedbackIssueForm()) {
-          onChangeDraftMessage("");
-        }
+        Alert.alert("Send feedback", "What would you like to share?", [
+          { text: "Cancel", style: "cancel" },
+          {
+            text: "Bug report",
+            onPress: () => {
+              void openMobileFeedbackFromDraft("bug", () => onChangeDraftMessage(""));
+            },
+          },
+          {
+            text: "Feature request",
+            onPress: () => {
+              void openMobileFeedbackFromDraft("feature", () => onChangeDraftMessage(""));
+            },
+          },
+        ]);
         return;
       }
       await onSendMessage();
@@ -598,9 +620,10 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
           composerTrigger.rangeEnd,
           "",
         );
-        setComposerSelection({ start: result.cursor, end: result.cursor });
-        onChangeDraftMessage(result.text);
-        void openMobileFeedbackIssueForm();
+        void openMobileFeedbackFromDraft(item.feedbackType ?? "bug", () => {
+          setComposerSelection({ start: result.cursor, end: result.cursor });
+          onChangeDraftMessage(result.text);
+        });
         return;
       }
 

--- a/apps/mobile/src/lib/feedback.test.ts
+++ b/apps/mobile/src/lib/feedback.test.ts
@@ -6,13 +6,37 @@ vi.mock("react-native", () => ({
   Platform: { OS: "ios", Version: "26.0" },
 }));
 
-import { buildMobileFeedbackIssueUrl } from "./feedback";
+import { buildMobileFeedbackIssueUrl, openMobileFeedbackFromDraft } from "./feedback";
 
 describe("buildMobileFeedbackIssueUrl", () => {
   it("includes the mobile app version and operating system", () => {
-    const url = new URL(buildMobileFeedbackIssueUrl({ appVersion: "3.2.1", platform: "iOS 26.0" }));
+    const url = new URL(
+      buildMobileFeedbackIssueUrl({
+        appVersion: "3.2.1",
+        platform: "iOS 26.0",
+        feedbackType: "bug",
+      }),
+    );
 
     expect(url.searchParams.get("version")).toBe("3.2.1");
     expect(url.searchParams.get("environment")).toBe("T3 Code Mobile; iOS 26.0");
+  });
+});
+
+describe("openMobileFeedbackFromDraft", () => {
+  it("retains the draft when opening the issue form fails", async () => {
+    const clearDraft = vi.fn();
+
+    await openMobileFeedbackFromDraft("bug", clearDraft, async () => false);
+
+    expect(clearDraft).not.toHaveBeenCalled();
+  });
+
+  it("clears the draft after the issue form opens", async () => {
+    const clearDraft = vi.fn();
+
+    await openMobileFeedbackFromDraft("feature", clearDraft, async () => true);
+
+    expect(clearDraft).toHaveBeenCalledOnce();
   });
 });

--- a/apps/mobile/src/lib/feedback.test.ts
+++ b/apps/mobile/src/lib/feedback.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+vi.mock("expo-constants", () => ({ default: { expoConfig: { version: "0.0.0" } } }));
+vi.mock("react-native", () => ({
+  Linking: { openURL: vi.fn() },
+  Platform: { OS: "ios", Version: "26.0" },
+}));
+
+import { buildMobileFeedbackIssueUrl } from "./feedback";
+
+describe("buildMobileFeedbackIssueUrl", () => {
+  it("includes the mobile app version and operating system", () => {
+    const url = new URL(buildMobileFeedbackIssueUrl({ appVersion: "3.2.1", platform: "iOS 26.0" }));
+
+    expect(url.searchParams.get("version")).toBe("3.2.1");
+    expect(url.searchParams.get("environment")).toBe("T3 Code Mobile; iOS 26.0");
+  });
+});

--- a/apps/mobile/src/lib/feedback.ts
+++ b/apps/mobile/src/lib/feedback.ts
@@ -1,4 +1,4 @@
-import { buildFeedbackIssueUrl } from "@t3tools/shared/feedback";
+import { buildFeedbackIssueUrl, type FeedbackType } from "@t3tools/shared/feedback";
 import Constants from "expo-constants";
 import { Platform } from "react-native";
 
@@ -7,12 +7,16 @@ import { tryOpenExternalUrl } from "./openExternalUrl";
 export function buildMobileFeedbackIssueUrl(input: {
   readonly appVersion: string;
   readonly platform: string;
+  readonly feedbackType: FeedbackType;
 }): string {
-  return buildFeedbackIssueUrl({
-    appVersion: input.appVersion,
-    surface: "T3 Code Mobile",
-    platform: input.platform,
-  });
+  return buildFeedbackIssueUrl(
+    {
+      appVersion: input.appVersion,
+      surface: "T3 Code Mobile",
+      platform: input.platform,
+    },
+    input.feedbackType,
+  );
 }
 
 function currentMobilePlatform(): string {
@@ -20,12 +24,25 @@ function currentMobilePlatform(): string {
   return `${os} ${String(Platform.Version)}`;
 }
 
-export function openMobileFeedbackIssueForm(): Promise<boolean> {
+export function openMobileFeedbackIssueForm(feedbackType: FeedbackType): Promise<boolean> {
   return tryOpenExternalUrl(
     buildMobileFeedbackIssueUrl({
       appVersion: Constants.expoConfig?.version ?? "0.0.0",
       platform: currentMobilePlatform(),
+      feedbackType,
     }),
     "feedback",
   );
+}
+
+export async function openMobileFeedbackFromDraft(
+  feedbackType: FeedbackType,
+  clearDraft: () => void,
+  openIssueForm: (type: FeedbackType) => Promise<boolean> = openMobileFeedbackIssueForm,
+): Promise<boolean> {
+  const opened = await openIssueForm(feedbackType);
+  if (opened) {
+    clearDraft();
+  }
+  return opened;
 }

--- a/apps/mobile/src/lib/feedback.ts
+++ b/apps/mobile/src/lib/feedback.ts
@@ -1,0 +1,31 @@
+import { buildFeedbackIssueUrl } from "@t3tools/shared/feedback";
+import Constants from "expo-constants";
+import { Platform } from "react-native";
+
+import { tryOpenExternalUrl } from "./openExternalUrl";
+
+export function buildMobileFeedbackIssueUrl(input: {
+  readonly appVersion: string;
+  readonly platform: string;
+}): string {
+  return buildFeedbackIssueUrl({
+    appVersion: input.appVersion,
+    surface: "T3 Code Mobile",
+    platform: input.platform,
+  });
+}
+
+function currentMobilePlatform(): string {
+  const os = Platform.OS === "ios" ? "iOS" : Platform.OS === "android" ? "Android" : Platform.OS;
+  return `${os} ${String(Platform.Version)}`;
+}
+
+export function openMobileFeedbackIssueForm(): Promise<boolean> {
+  return tryOpenExternalUrl(
+    buildMobileFeedbackIssueUrl({
+      appVersion: Constants.expoConfig?.version ?? "0.0.0",
+      platform: currentMobilePlatform(),
+    }),
+    "feedback",
+  );
+}

--- a/apps/mobile/src/lib/openExternalUrl.ts
+++ b/apps/mobile/src/lib/openExternalUrl.ts
@@ -1,7 +1,12 @@
 import * as Schema from "effect/Schema";
 import { Linking } from "react-native";
 
-const ExternalUrlTarget = Schema.Literals(["file-preview", "markdown-link", "pull-request"]);
+const ExternalUrlTarget = Schema.Literals([
+  "feedback",
+  "file-preview",
+  "markdown-link",
+  "pull-request",
+]);
 
 export type ExternalUrlTarget = typeof ExternalUrlTarget.Type;
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -74,6 +74,7 @@ import * as Cause from "effect/Cause";
 import { AsyncResult } from "effect/unstable/reactivity";
 import { isElectron } from "../env";
 import { readLocalApi } from "../localApi";
+import { openFeedbackIssueForm } from "../lib/feedback";
 import { useDiffPanelStore } from "../diffPanelStore";
 import {
   collapseExpandedComposerCursor,
@@ -4989,18 +4990,40 @@ function ChatViewContent(props: ChatViewProps) {
       });
       return;
     }
-    // Legacy plan mode: /plan and /default only act when the beta flag is on;
-    // otherwise they send as plain text like any other message.
-    const standaloneSlashCommand =
+    const parsedStandaloneSlashCommand = parseStandaloneComposerSlashCommand(trimmed);
+    // Legacy plan mode: /plan and /default only act when the beta flag is on
+    // and the draft has no attachments or context. /feedback is always a
+    // client command and leaves those draft items in place.
+    const canApplyLegacyModeCommand =
       settings.planModeEnabled &&
       composerImages.length === 0 &&
       sendableComposerTerminalContexts.length === 0 &&
       composerElementContexts.length === 0 &&
       composerPreviewAnnotations.length === 0 &&
-      composerReviewComments.length === 0
-        ? parseStandaloneComposerSlashCommand(trimmed)
+      composerReviewComments.length === 0;
+    const standaloneSlashCommand =
+      parsedStandaloneSlashCommand === "feedback" || canApplyLegacyModeCommand
+        ? parsedStandaloneSlashCommand
         : null;
     if (standaloneSlashCommand) {
+      if (standaloneSlashCommand === "feedback") {
+        try {
+          await openFeedbackIssueForm();
+        } catch (error) {
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Could not open feedback form",
+              description: error instanceof Error ? error.message : "Opening the form failed.",
+            }),
+          );
+          return;
+        }
+        promptRef.current = "";
+        setComposerDraftPrompt(composerDraftTarget, "");
+        composerRef.current?.resetCursorState();
+        return;
+      }
       handleInteractionModeChange(standaloneSlashCommand);
       promptRef.current = "";
       clearComposerDraftContent(composerDraftTarget);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -45,8 +45,10 @@ import {
 } from "@t3tools/shared/model";
 import { CHAT_LIST_ANCHOR_OFFSET } from "@t3tools/shared/chatList";
 import { projectScriptCwd, projectScriptRuntimeEnv } from "@t3tools/shared/projectScripts";
+import type { FeedbackType } from "@t3tools/shared/feedback";
 import { truncate } from "@t3tools/shared/String";
 import { nextTerminalId, resolveTerminalSessionLabel } from "@t3tools/shared/terminalLabels";
+import { isClientOnlyComposerCommand } from "@t3tools/shared/composerTrigger";
 import { Debouncer } from "@tanstack/react-pacer";
 import { useAtomValue } from "@effect/atom-react";
 import {
@@ -4259,6 +4261,7 @@ function ChatViewContent(props: ChatViewProps) {
   }, [activeThreadRef, unsnoozeThreadMutation]);
   const [isRestoringThreadBranch, setIsRestoringThreadBranch] = useState(false);
   const [branchRestoreConfirmOpen, setBranchRestoreConfirmOpen] = useState(false);
+  const [feedbackPickerOpen, setFeedbackPickerOpen] = useState(false);
   // Once revealed for a given mismatch, the banner stays mounted until the
   // mismatch changes or resolves, so clearing the draft doesn't flicker it.
   const [revealedBranchMismatchKey, setRevealedBranchMismatchKey] = useState<string | null>(null);
@@ -4878,6 +4881,25 @@ function ChatViewContent(props: ChatViewProps) {
     ],
   );
 
+  const openSelectedFeedbackForm = async (feedbackType: FeedbackType) => {
+    try {
+      await openFeedbackIssueForm(feedbackType);
+    } catch (error) {
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Could not open feedback form",
+          description: error instanceof Error ? error.message : "Opening the form failed.",
+        }),
+      );
+      return;
+    }
+    promptRef.current = "";
+    setComposerDraftPrompt(composerDraftTarget, "");
+    composerRef.current?.resetCursorState();
+    setFeedbackPickerOpen(false);
+  };
+
   const onSend = async (
     e?: { preventDefault: () => void },
     directAnnotation?: {
@@ -4896,6 +4918,10 @@ function ChatViewContent(props: ChatViewProps) {
         }),
       );
     };
+    if (!directAnnotation && isClientOnlyComposerCommand(promptRef.current)) {
+      setFeedbackPickerOpen(true);
+      return;
+    }
     if (
       !activeThread ||
       isSendBusy ||
@@ -4992,8 +5018,7 @@ function ChatViewContent(props: ChatViewProps) {
     }
     const parsedStandaloneSlashCommand = parseStandaloneComposerSlashCommand(trimmed);
     // Legacy plan mode: /plan and /default only act when the beta flag is on
-    // and the draft has no attachments or context. /feedback is always a
-    // client command and leaves those draft items in place.
+    // and the draft has no attachments or context.
     const canApplyLegacyModeCommand =
       settings.planModeEnabled &&
       composerImages.length === 0 &&
@@ -5002,28 +5027,10 @@ function ChatViewContent(props: ChatViewProps) {
       composerPreviewAnnotations.length === 0 &&
       composerReviewComments.length === 0;
     const standaloneSlashCommand =
-      parsedStandaloneSlashCommand === "feedback" || canApplyLegacyModeCommand
-        ? parsedStandaloneSlashCommand
-        : null;
+      parsedStandaloneSlashCommand === "feedback" || !canApplyLegacyModeCommand
+        ? null
+        : parsedStandaloneSlashCommand;
     if (standaloneSlashCommand) {
-      if (standaloneSlashCommand === "feedback") {
-        try {
-          await openFeedbackIssueForm();
-        } catch (error) {
-          toastManager.add(
-            stackedThreadToast({
-              type: "error",
-              title: "Could not open feedback form",
-              description: error instanceof Error ? error.message : "Opening the form failed.",
-            }),
-          );
-          return;
-        }
-        promptRef.current = "";
-        setComposerDraftPrompt(composerDraftTarget, "");
-        composerRef.current?.resetCursorState();
-        return;
-      }
       handleInteractionModeChange(standaloneSlashCommand);
       promptRef.current = "";
       clearComposerDraftContent(composerDraftTarget);
@@ -6522,6 +6529,26 @@ function ChatViewContent(props: ChatViewProps) {
                     }}
                   >
                     Switch branch
+                  </Button>
+                </AlertDialogFooter>
+              </AlertDialogPopup>
+            </AlertDialog>
+
+            <AlertDialog open={feedbackPickerOpen} onOpenChange={setFeedbackPickerOpen}>
+              <AlertDialogPopup>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Send feedback</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Choose the GitHub issue form that best matches your feedback.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogClose render={<Button variant="outline" />}>Cancel</AlertDialogClose>
+                  <Button variant="outline" onClick={() => void openSelectedFeedbackForm("bug")}>
+                    Bug report
+                  </Button>
+                  <Button onClick={() => void openSelectedFeedbackForm("feature")}>
+                    Feature request
                   </Button>
                 </AlertDialogFooter>
               </AlertDialogPopup>

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -18,7 +18,10 @@ import {
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
 } from "@t3tools/contracts";
 import type { EnvironmentConnectionPresentation } from "@t3tools/client-runtime/connection";
-import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
+import {
+  isClientOnlyComposerCommand,
+  serializeComposerFileLink,
+} from "@t3tools/shared/composerTrigger";
 import { createModelSelection, normalizeModelSlug } from "@t3tools/shared/model";
 import {
   memo,
@@ -407,6 +410,7 @@ const ComposerFooterPrimaryActions = memo(function ComposerFooterPrimaryActions(
   isConnecting: boolean;
   isEnvironmentUnavailable: boolean;
   hasSendableContent: boolean;
+  clientOnlyCommand: boolean;
   preserveComposerFocusOnPointerDown?: boolean;
   onPreviousPendingQuestion: () => void;
   onInterrupt: () => void;
@@ -435,6 +439,7 @@ const ComposerFooterPrimaryActions = memo(function ComposerFooterPrimaryActions(
         isEnvironmentUnavailable={props.isEnvironmentUnavailable}
         isPreparingWorktree={props.isPreparingWorktree}
         hasSendableContent={props.hasSendableContent}
+        clientOnlyCommand={props.clientOnlyCommand}
         preserveComposerFocusOnPointerDown={props.preserveComposerFocusOnPointerDown ?? false}
         onPreviousPendingQuestion={props.onPreviousPendingQuestion}
         onInterrupt={props.onInterrupt}
@@ -1012,6 +1017,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       prompt,
     ],
   );
+  const isClientOnlyCommand = useMemo(() => isClientOnlyComposerCommand(prompt), [prompt]);
 
   // ------------------------------------------------------------------
   // Derived: composer trigger / menu
@@ -1040,11 +1046,20 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     if (composerTrigger.kind === "slash-command") {
       const builtInSlashCommandItems = [
         {
-          id: "slash:feedback",
+          id: "slash:feedback:bug",
           type: "slash-command",
           command: "feedback",
           label: "/feedback",
-          description: "Report a bug or suggest a feature",
+          description: "Report a bug",
+          feedbackType: "bug",
+        },
+        {
+          id: "slash:feedback:feature",
+          type: "slash-command",
+          command: "feedback",
+          label: "/feedback",
+          description: "Suggest a feature",
+          feedbackType: "feature",
         },
         {
           id: "slash:model",
@@ -1240,15 +1255,18 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     [activePendingIsResponding, activePendingProgress, activePendingResolvedAnswers],
   );
   const collapsedComposerPrimaryActionDisabled =
-    phase === "running" ||
-    isSendBusy ||
-    isSendDisabled ||
-    isConnecting ||
-    noProviderAvailable ||
-    projectSelectionRequired ||
-    environmentUnavailable !== null ||
-    !composerSendState.hasSendableContent;
-  const collapsedComposerPrimaryActionLabel = "Send message";
+    !isClientOnlyCommand &&
+    (phase === "running" ||
+      isSendBusy ||
+      isSendDisabled ||
+      isConnecting ||
+      noProviderAvailable ||
+      projectSelectionRequired ||
+      environmentUnavailable !== null ||
+      !composerSendState.hasSendableContent);
+  const collapsedComposerPrimaryActionLabel = isClientOnlyCommand
+    ? "Open feedback form"
+    : "Send message";
   const showMobilePendingAnswerActions =
     isMobileViewport && !isComposerCollapsedMobile && pendingPrimaryAction !== null;
 
@@ -1686,20 +1704,23 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       }
       if (item.type === "slash-command") {
         if (item.command === "feedback") {
-          const applied = applyPromptReplacement(trigger.rangeStart, trigger.rangeEnd, "", {
-            expectedText: snapshot.value.slice(trigger.rangeStart, trigger.rangeEnd),
-            focusEditorAfterReplace: false,
-          });
-          if (applied) {
-            setComposerHighlightedItemId(null);
-            void openFeedbackIssueForm().catch((error: unknown) => {
+          void openFeedbackIssueForm(item.feedbackType ?? "bug")
+            .then(() => {
+              const applied = applyPromptReplacement(trigger.rangeStart, trigger.rangeEnd, "", {
+                expectedText: snapshot.value.slice(trigger.rangeStart, trigger.rangeEnd),
+                focusEditorAfterReplace: false,
+              });
+              if (applied) {
+                setComposerHighlightedItemId(null);
+              }
+            })
+            .catch((error: unknown) => {
               toastManager.add({
                 type: "error",
                 title: "Could not open feedback form",
                 description: error instanceof Error ? error.message : "Opening the form failed.",
               });
             });
-          }
           return;
         }
         if (item.command === "model") {
@@ -1832,7 +1853,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
 
   const submitComposer = useCallback(
     (event?: { preventDefault: () => void }) => {
-      if (noProviderAvailable || isSendDisabled) {
+      const isClientOnlyCommand = isClientOnlyComposerCommand(promptRef.current);
+      if (!isClientOnlyCommand && (noProviderAvailable || isSendDisabled)) {
         event?.preventDefault();
         return;
       }
@@ -1840,7 +1862,11 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       // image: the turn snapshot wouldn't include it, and it would surface
       // in the *next* draft instead. Only oversized images hit this — small
       // files clear the pending counter within a microtask.
-      if (activeThreadId && (pendingImageCompressionsRef.current.get(activeThreadId) ?? 0) > 0) {
+      if (
+        !isClientOnlyCommand &&
+        activeThreadId &&
+        (pendingImageCompressionsRef.current.get(activeThreadId) ?? 0) > 0
+      ) {
         event?.preventDefault();
         toastManager.add({
           type: "info",
@@ -1860,6 +1886,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       isSendDisabled,
       noProviderAvailable,
       onSend,
+      promptRef,
       shouldBlurMobileComposerOnSubmit,
     ],
   );
@@ -3225,6 +3252,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                   }
                   isPreparingWorktree={isPreparingWorktree}
                   hasSendableContent={composerSendState.hasSendableContent}
+                  clientOnlyCommand={isClientOnlyCommand}
                   preserveComposerFocusOnPointerDown={isMobileViewport}
                   onPreviousPendingQuestion={onPreviousActivePendingUserInputQuestion}
                   onInterrupt={handleInterruptPrimaryAction}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -75,6 +75,7 @@ import {
   removeInlineTerminalContextPlaceholder,
 } from "../../lib/terminalContext";
 import { useComposerPathSearch } from "../../lib/composerPathSearchState";
+import { openFeedbackIssueForm } from "../../lib/feedback";
 import { type ElementContextDraft } from "../../lib/elementContext";
 import { ComposerPendingElementContexts } from "./ComposerPendingElementContexts";
 import { ComposerPendingReviewComments } from "./ComposerPendingReviewComments";
@@ -1039,6 +1040,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     if (composerTrigger.kind === "slash-command") {
       const builtInSlashCommandItems = [
         {
+          id: "slash:feedback",
+          type: "slash-command",
+          command: "feedback",
+          label: "/feedback",
+          description: "Report a bug or suggest a feature",
+        },
+        {
           id: "slash:model",
           type: "slash-command",
           command: "model",
@@ -1677,6 +1685,23 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         return;
       }
       if (item.type === "slash-command") {
+        if (item.command === "feedback") {
+          const applied = applyPromptReplacement(trigger.rangeStart, trigger.rangeEnd, "", {
+            expectedText: snapshot.value.slice(trigger.rangeStart, trigger.rangeEnd),
+            focusEditorAfterReplace: false,
+          });
+          if (applied) {
+            setComposerHighlightedItemId(null);
+            void openFeedbackIssueForm().catch((error: unknown) => {
+              toastManager.add({
+                type: "error",
+                title: "Could not open feedback form",
+                description: error instanceof Error ? error.message : "Opening the form failed.",
+              });
+            });
+          }
+          return;
+        }
         if (item.command === "model") {
           const applied = applyPromptReplacement(trigger.rangeStart, trigger.rangeEnd, "", {
             expectedText: snapshot.value.slice(trigger.rangeStart, trigger.rangeEnd),

--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -5,6 +5,7 @@ import {
   type ServerProviderSlashCommand,
 } from "@t3tools/contracts";
 import { BotIcon } from "lucide-react";
+import type { FeedbackType } from "@t3tools/shared/feedback";
 import { memo, useLayoutEffect, useMemo, useRef } from "react";
 
 import { type ComposerSlashCommand, type ComposerTriggerKind } from "../../composer-logic";
@@ -33,6 +34,7 @@ export type ComposerCommandItem =
       id: string;
       type: "slash-command";
       command: ComposerSlashCommand;
+      feedbackType?: FeedbackType;
       label: string;
       description: string;
     }

--- a/apps/web/src/components/chat/ComposerPrimaryActions.test.ts
+++ b/apps/web/src/components/chat/ComposerPrimaryActions.test.ts
@@ -215,4 +215,36 @@ describe("ComposerPrimaryActions", () => {
     expect(markup).not.toContain("stage-nightly");
     expect(markup).toContain("bg-message-action text-message-action-foreground");
   });
+
+  it("keeps client-only feedback submission enabled ahead of send-state guards", () => {
+    const markup = renderToStaticMarkup(
+      createElement(ComposerPrimaryActions, {
+        compact: true,
+        pendingAction: {
+          questionIndex: 0,
+          isLastQuestion: false,
+          canAdvance: false,
+          isResponding: true,
+          isComplete: false,
+        },
+        isRunning: true,
+        showPlanFollowUpPrompt: true,
+        promptHasText: true,
+        isSendBusy: true,
+        sendDisabledReason: "Provider unavailable",
+        isConnecting: true,
+        isEnvironmentUnavailable: true,
+        isPreparingWorktree: false,
+        hasSendableContent: true,
+        clientOnlyCommand: true,
+        onPreviousPendingQuestion: () => {},
+        onInterrupt: () => {},
+        onImplementPlanInNewThread: () => {},
+      }),
+    );
+
+    expect(markup).toContain('aria-label="Open feedback form"');
+    expect(markup).not.toMatch(/\sdisabled(?:=|\s|>)/);
+    expect(markup).not.toContain("Submitting...");
+  });
 });

--- a/apps/web/src/components/chat/ComposerPrimaryActions.tsx
+++ b/apps/web/src/components/chat/ComposerPrimaryActions.tsx
@@ -27,6 +27,7 @@ interface ComposerPrimaryActionsProps {
   isEnvironmentUnavailable: boolean;
   isPreparingWorktree: boolean;
   hasSendableContent: boolean;
+  clientOnlyCommand?: boolean;
   preserveComposerFocusOnPointerDown?: boolean;
   onPreviousPendingQuestion: () => void;
   onInterrupt: () => void;
@@ -67,6 +68,7 @@ export const ComposerPrimaryActions = memo(function ComposerPrimaryActions({
   isEnvironmentUnavailable,
   isPreparingWorktree,
   hasSendableContent,
+  clientOnlyCommand = false,
   preserveComposerFocusOnPointerDown = false,
   onPreviousPendingQuestion,
   onInterrupt,
@@ -97,6 +99,28 @@ export const ComposerPrimaryActions = memo(function ComposerPrimaryActions({
       </svg>
     </button>
   );
+
+  if (clientOnlyCommand) {
+    return (
+      <Button
+        type="submit"
+        size="icon"
+        className="rounded-full bg-message-action text-message-action-foreground hover:bg-message-action-hover"
+        {...pointerFocusProps}
+        aria-label="Open feedback form"
+      >
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+          <path
+            d="M7 11.5V2.5M7 2.5L3 6.5M7 2.5L11 6.5"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </Button>
+    );
+  }
 
   if (pendingAction) {
     return (

--- a/apps/web/src/composer-logic.test.ts
+++ b/apps/web/src/composer-logic.test.ts
@@ -368,6 +368,10 @@ describe("parseStandaloneComposerSlashCommand", () => {
     expect(parseStandaloneComposerSlashCommand("/default")).toBe("default");
   });
 
+  it("parses standalone /feedback command", () => {
+    expect(parseStandaloneComposerSlashCommand(" /FeEdBaCk ")).toBe("feedback");
+  });
+
   it("ignores slash commands with extra message text", () => {
     expect(parseStandaloneComposerSlashCommand("/plan explain this")).toBeNull();
   });

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -2,7 +2,7 @@ import { splitPromptIntoComposerSegments } from "./composer-editor-mentions";
 import { INLINE_TERMINAL_CONTEXT_PLACEHOLDER } from "./lib/terminalContext";
 
 export type ComposerTriggerKind = "path" | "slash-command" | "skill";
-export type ComposerSlashCommand = "model" | "plan" | "default";
+export type ComposerSlashCommand = "model" | "plan" | "default" | "feedback";
 
 export interface ComposerTrigger {
   kind: ComposerTriggerKind;
@@ -265,12 +265,13 @@ export function detectComposerTrigger(text: string, cursorInput: number): Compos
 export function parseStandaloneComposerSlashCommand(
   text: string,
 ): Exclude<ComposerSlashCommand, "model"> | null {
-  const match = /^\/(plan|default)\s*$/i.exec(text.trim());
+  const match = /^\/(plan|default|feedback)\s*$/i.exec(text.trim());
   if (!match) {
     return null;
   }
   const command = match[1]?.toLowerCase();
   if (command === "plan") return "plan";
+  if (command === "feedback") return "feedback";
   return "default";
 }
 

--- a/apps/web/src/lib/feedback.test.ts
+++ b/apps/web/src/lib/feedback.test.ts
@@ -9,6 +9,7 @@ describe("buildWebFeedbackIssueUrl", () => {
         appVersion: "2.4.6",
         isDesktop: true,
         navigator: { platform: "MacIntel", userAgent: "Electron/39.0.0" },
+        feedbackType: "bug",
       }),
     );
 
@@ -21,6 +22,7 @@ describe("buildWebFeedbackIssueUrl", () => {
         appVersion: "2.4.6",
         isDesktop: false,
         navigator: { platform: "Linux x86_64", userAgent: "Firefox/141" },
+        feedbackType: "feature",
       }),
     );
 

--- a/apps/web/src/lib/feedback.test.ts
+++ b/apps/web/src/lib/feedback.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { buildWebFeedbackIssueUrl } from "./feedback";
+
+describe("buildWebFeedbackIssueUrl", () => {
+  it("identifies the desktop shell and includes browser runtime details", () => {
+    const url = new URL(
+      buildWebFeedbackIssueUrl({
+        appVersion: "2.4.6",
+        isDesktop: true,
+        navigator: { platform: "MacIntel", userAgent: "Electron/39.0.0" },
+      }),
+    );
+
+    expect(url.searchParams.get("environment")).toBe("T3 Code Desktop; MacIntel; Electron/39.0.0");
+  });
+
+  it("identifies the browser surface", () => {
+    const url = new URL(
+      buildWebFeedbackIssueUrl({
+        appVersion: "2.4.6",
+        isDesktop: false,
+        navigator: { platform: "Linux x86_64", userAgent: "Firefox/141" },
+      }),
+    );
+
+    expect(url.searchParams.get("environment")).toBe("T3 Code Web; Linux x86_64; Firefox/141");
+  });
+});

--- a/apps/web/src/lib/feedback.ts
+++ b/apps/web/src/lib/feedback.ts
@@ -1,5 +1,5 @@
 import type { LocalApi } from "@t3tools/contracts";
-import { buildFeedbackIssueUrl } from "@t3tools/shared/feedback";
+import { buildFeedbackIssueUrl, type FeedbackType } from "@t3tools/shared/feedback";
 
 import { APP_VERSION } from "../branding";
 import { isElectron } from "../env";
@@ -14,24 +14,30 @@ export function buildWebFeedbackIssueUrl(input: {
   readonly appVersion: string;
   readonly isDesktop: boolean;
   readonly navigator: FeedbackBrowserMetadata;
+  readonly feedbackType: FeedbackType;
 }): string {
-  return buildFeedbackIssueUrl({
-    appVersion: input.appVersion,
-    surface: input.isDesktop ? "T3 Code Desktop" : "T3 Code Web",
-    platform: [input.navigator.platform, input.navigator.userAgent]
-      .map((detail) => detail.trim())
-      .filter(Boolean)
-      .join("; "),
-  });
+  return buildFeedbackIssueUrl(
+    {
+      appVersion: input.appVersion,
+      surface: input.isDesktop ? "T3 Code Desktop" : "T3 Code Web",
+      platform: [input.navigator.platform, input.navigator.userAgent]
+        .map((detail) => detail.trim())
+        .filter(Boolean)
+        .join("; "),
+    },
+    input.feedbackType,
+  );
 }
 
 export function openFeedbackIssueForm(
+  feedbackType: FeedbackType,
   shell: Pick<LocalApi["shell"], "openExternal"> = ensureLocalApi().shell,
 ): Promise<void> {
   const url = buildWebFeedbackIssueUrl({
     appVersion: APP_VERSION,
     isDesktop: isElectron,
     navigator,
+    feedbackType,
   });
   return shell.openExternal(url);
 }

--- a/apps/web/src/lib/feedback.ts
+++ b/apps/web/src/lib/feedback.ts
@@ -1,0 +1,37 @@
+import type { LocalApi } from "@t3tools/contracts";
+import { buildFeedbackIssueUrl } from "@t3tools/shared/feedback";
+
+import { APP_VERSION } from "../branding";
+import { isElectron } from "../env";
+import { ensureLocalApi } from "../localApi";
+
+interface FeedbackBrowserMetadata {
+  readonly platform: string;
+  readonly userAgent: string;
+}
+
+export function buildWebFeedbackIssueUrl(input: {
+  readonly appVersion: string;
+  readonly isDesktop: boolean;
+  readonly navigator: FeedbackBrowserMetadata;
+}): string {
+  return buildFeedbackIssueUrl({
+    appVersion: input.appVersion,
+    surface: input.isDesktop ? "T3 Code Desktop" : "T3 Code Web",
+    platform: [input.navigator.platform, input.navigator.userAgent]
+      .map((detail) => detail.trim())
+      .filter(Boolean)
+      .join("; "),
+  });
+}
+
+export function openFeedbackIssueForm(
+  shell: Pick<LocalApi["shell"], "openExternal"> = ensureLocalApi().shell,
+): Promise<void> {
+  const url = buildWebFeedbackIssueUrl({
+    appVersion: APP_VERSION,
+    isDesktop: isElectron,
+    navigator,
+  });
+  return shell.openExternal(url);
+}

--- a/docs/user/feedback.md
+++ b/docs/user/feedback.md
@@ -1,6 +1,7 @@
 # Send feedback
 
-Type `/feedback` in a thread to report a bug or suggest a feature. T3 Code opens the GitHub issue
-form chooser and includes the app version, client surface, and platform details in the form you
-select. Bug reports start with `Bug: ` and feature requests start with `Feature: `. Review and edit
-the title and every field before submitting the issue on GitHub.
+Type `/feedback` in a thread to report a bug or suggest a feature. Choose **Bug report** or
+**Feature request** in T3 Code, and the matching GitHub form opens with the app version, client
+surface, and platform details already filled in. Bug reports start with `Bug: ` and feature requests
+start with `Feature: `. Review and edit the title and every field before submitting the issue on
+GitHub.

--- a/docs/user/feedback.md
+++ b/docs/user/feedback.md
@@ -1,0 +1,6 @@
+# Send feedback
+
+Type `/feedback` in a thread to report a bug or suggest a feature. T3 Code opens the GitHub issue
+form chooser and includes the app version, client surface, and platform details in the form you
+select. Bug reports start with `Bug: ` and feature requests start with `Feature: `. Review and edit
+the title and every field before submitting the issue on GitHub.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -163,6 +163,10 @@
       "types": "./src/composerTrigger.ts",
       "import": "./src/composerTrigger.ts"
     },
+    "./feedback": {
+      "types": "./src/feedback.ts",
+      "import": "./src/feedback.ts"
+    },
     "./composerInlineTokens": {
       "types": "./src/composerInlineTokens.ts",
       "import": "./src/composerInlineTokens.ts"

--- a/packages/shared/src/composerTrigger.test.ts
+++ b/packages/shared/src/composerTrigger.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { serializeComposerFileLink, serializeComposerMentionPath } from "./composerTrigger.ts";
+import {
+  parseStandaloneComposerSlashCommand,
+  serializeComposerFileLink,
+  serializeComposerMentionPath,
+} from "./composerTrigger.ts";
 
 describe("serializeComposerMentionPath", () => {
   it("keeps simple mention paths unquoted", () => {
@@ -39,5 +43,12 @@ describe("serializeComposerFileLink", () => {
     expect(serializeComposerFileLink("@scope/package.json")).toBe(
       "[package.json](@scope/package.json)",
     );
+  });
+});
+
+describe("parseStandaloneComposerSlashCommand", () => {
+  it("parses standalone feedback commands without swallowing message text", () => {
+    expect(parseStandaloneComposerSlashCommand(" /FeEdBaCk ")).toBe("feedback");
+    expect(parseStandaloneComposerSlashCommand("/feedback here are details")).toBeNull();
   });
 });

--- a/packages/shared/src/composerTrigger.test.ts
+++ b/packages/shared/src/composerTrigger.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  isClientOnlyComposerCommand,
   parseStandaloneComposerSlashCommand,
   serializeComposerFileLink,
   serializeComposerMentionPath,
@@ -50,5 +51,21 @@ describe("parseStandaloneComposerSlashCommand", () => {
   it("parses standalone feedback commands without swallowing message text", () => {
     expect(parseStandaloneComposerSlashCommand(" /FeEdBaCk ")).toBe("feedback");
     expect(parseStandaloneComposerSlashCommand("/feedback here are details")).toBeNull();
+  });
+});
+
+describe("isClientOnlyComposerCommand", () => {
+  it.each([
+    "provider unavailable",
+    "environment reconnecting",
+    "pending user input",
+    "plan follow-up",
+    "send disabled",
+  ])("routes /feedback before the %s guard", () => {
+    expect(isClientOnlyComposerCommand(" /FeEdBaCk ")).toBe(true);
+  });
+
+  it("does not intercept feedback text that should be sent to the provider", () => {
+    expect(isClientOnlyComposerCommand("/feedback please investigate this")).toBe(false);
   });
 });

--- a/packages/shared/src/composerTrigger.ts
+++ b/packages/shared/src/composerTrigger.ts
@@ -1,5 +1,5 @@
 export type ComposerTriggerKind = "path" | "slash-command" | "slash-model" | "skill";
-export type ComposerSlashCommand = "model" | "plan" | "default";
+export type ComposerSlashCommand = "model" | "plan" | "default" | "feedback";
 
 export interface ComposerTrigger {
   kind: ComposerTriggerKind;
@@ -127,12 +127,13 @@ export function detectComposerTrigger(
 export function parseStandaloneComposerSlashCommand(
   text: string,
 ): Exclude<ComposerSlashCommand, "model"> | null {
-  const match = /^\/(plan|default)\s*$/i.exec(text.trim());
+  const match = /^\/(plan|default|feedback)\s*$/i.exec(text.trim());
   if (!match) {
     return null;
   }
   const command = match[1]?.toLowerCase();
   if (command === "plan") return "plan";
+  if (command === "feedback") return "feedback";
   return "default";
 }
 

--- a/packages/shared/src/composerTrigger.ts
+++ b/packages/shared/src/composerTrigger.ts
@@ -137,6 +137,10 @@ export function parseStandaloneComposerSlashCommand(
   return "default";
 }
 
+export function isClientOnlyComposerCommand(text: string): boolean {
+  return parseStandaloneComposerSlashCommand(text) === "feedback";
+}
+
 export function replaceTextRange(
   text: string,
   rangeStart: number,

--- a/packages/shared/src/feedback.test.ts
+++ b/packages/shared/src/feedback.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { buildFeedbackIssueUrl } from "./feedback.ts";
+
+describe("buildFeedbackIssueUrl", () => {
+  it("opens the issue form chooser with editable app and platform details", () => {
+    const url = new URL(
+      buildFeedbackIssueUrl({
+        appVersion: "1.2.3",
+        surface: "T3 Code Desktop",
+        platform: "MacIntel; Electron 39",
+      }),
+    );
+
+    expect(url.origin + url.pathname).toBe("https://github.com/pingdotgg/t3code/issues/new/choose");
+    expect(url.searchParams.get("title")).toBeNull();
+    expect(url.searchParams.get("version")).toBe("1.2.3");
+    expect(url.searchParams.get("environment")).toBe("T3 Code Desktop; MacIntel; Electron 39");
+    expect(url.searchParams.get("body")).toContain("- Version: 1.2.3");
+    expect(url.searchParams.get("body")).toContain("- Surface: T3 Code Desktop");
+    expect(url.searchParams.get("references")).toBe(url.searchParams.get("body"));
+  });
+
+  it("uses readable fallbacks when metadata is unavailable", () => {
+    const url = new URL(buildFeedbackIssueUrl({ appVersion: " ", surface: "", platform: "\t" }));
+
+    expect(url.searchParams.get("version")).toBe("Unknown");
+    expect(url.searchParams.get("environment")).toBe("T3 Code; Unknown");
+  });
+});

--- a/packages/shared/src/feedback.test.ts
+++ b/packages/shared/src/feedback.test.ts
@@ -3,17 +3,24 @@ import { describe, expect, it } from "vite-plus/test";
 import { buildFeedbackIssueUrl } from "./feedback.ts";
 
 describe("buildFeedbackIssueUrl", () => {
-  it("opens the issue form chooser with editable app and platform details", () => {
+  it.each([
+    ["bug", "bug_report.yml", "Bug: "],
+    ["feature", "feature_request.yml", "Feature: "],
+  ] as const)("opens the %s issue form with its prefills", (type, template, title) => {
     const url = new URL(
-      buildFeedbackIssueUrl({
-        appVersion: "1.2.3",
-        surface: "T3 Code Desktop",
-        platform: "MacIntel; Electron 39",
-      }),
+      buildFeedbackIssueUrl(
+        {
+          appVersion: "1.2.3",
+          surface: "T3 Code Desktop",
+          platform: "MacIntel; Electron 39",
+        },
+        type,
+      ),
     );
 
-    expect(url.origin + url.pathname).toBe("https://github.com/pingdotgg/t3code/issues/new/choose");
-    expect(url.searchParams.get("title")).toBeNull();
+    expect(url.origin + url.pathname).toBe("https://github.com/pingdotgg/t3code/issues/new");
+    expect(url.searchParams.get("template")).toBe(template);
+    expect(url.searchParams.get("title")).toBe(title);
     expect(url.searchParams.get("version")).toBe("1.2.3");
     expect(url.searchParams.get("environment")).toBe("T3 Code Desktop; MacIntel; Electron 39");
     expect(url.searchParams.get("body")).toContain("- Version: 1.2.3");
@@ -22,7 +29,9 @@ describe("buildFeedbackIssueUrl", () => {
   });
 
   it("uses readable fallbacks when metadata is unavailable", () => {
-    const url = new URL(buildFeedbackIssueUrl({ appVersion: " ", surface: "", platform: "\t" }));
+    const url = new URL(
+      buildFeedbackIssueUrl({ appVersion: " ", surface: "", platform: "\t" }, "bug"),
+    );
 
     expect(url.searchParams.get("version")).toBe("Unknown");
     expect(url.searchParams.get("environment")).toBe("T3 Code; Unknown");

--- a/packages/shared/src/feedback.ts
+++ b/packages/shared/src/feedback.ts
@@ -1,0 +1,36 @@
+const FEEDBACK_ISSUE_CHOOSER_URL = "https://github.com/pingdotgg/t3code/issues/new/choose";
+
+export interface FeedbackEnvironment {
+  readonly appVersion: string;
+  readonly surface: string;
+  readonly platform: string;
+}
+
+function normalizedDetail(value: string, fallback: string): string {
+  return value.trim() || fallback;
+}
+
+export function buildFeedbackIssueUrl(environment: FeedbackEnvironment): string {
+  const appVersion = normalizedDetail(environment.appVersion, "Unknown");
+  const surface = normalizedDetail(environment.surface, "T3 Code");
+  const platform = normalizedDetail(environment.platform, "Unknown");
+  const environmentSummary = `${surface}; ${platform}`;
+  const body = [
+    "## T3 Code environment",
+    "",
+    `- Version: ${appVersion}`,
+    `- Surface: ${surface}`,
+    `- Platform: ${platform}`,
+    "",
+    "<!-- Add your feedback above, then review and edit all details before submitting. -->",
+  ].join("\n");
+
+  const url = new URL(FEEDBACK_ISSUE_CHOOSER_URL);
+  url.searchParams.set("body", body);
+  // GitHub issue forms accept field ids as query parameters. These cover the
+  // bug form's environment fields and the feature form's references field.
+  url.searchParams.set("version", appVersion);
+  url.searchParams.set("environment", environmentSummary);
+  url.searchParams.set("references", body);
+  return url.toString();
+}

--- a/packages/shared/src/feedback.ts
+++ b/packages/shared/src/feedback.ts
@@ -1,4 +1,11 @@
-const FEEDBACK_ISSUE_CHOOSER_URL = "https://github.com/pingdotgg/t3code/issues/new/choose";
+const FEEDBACK_ISSUE_URL = "https://github.com/pingdotgg/t3code/issues/new";
+
+export type FeedbackType = "bug" | "feature";
+
+const FEEDBACK_TEMPLATE_BY_TYPE = {
+  bug: { template: "bug_report.yml", title: "Bug: " },
+  feature: { template: "feature_request.yml", title: "Feature: " },
+} as const satisfies Record<FeedbackType, { readonly template: string; readonly title: string }>;
 
 export interface FeedbackEnvironment {
   readonly appVersion: string;
@@ -10,7 +17,10 @@ function normalizedDetail(value: string, fallback: string): string {
   return value.trim() || fallback;
 }
 
-export function buildFeedbackIssueUrl(environment: FeedbackEnvironment): string {
+export function buildFeedbackIssueUrl(
+  environment: FeedbackEnvironment,
+  feedbackType: FeedbackType,
+): string {
   const appVersion = normalizedDetail(environment.appVersion, "Unknown");
   const surface = normalizedDetail(environment.surface, "T3 Code");
   const platform = normalizedDetail(environment.platform, "Unknown");
@@ -25,7 +35,10 @@ export function buildFeedbackIssueUrl(environment: FeedbackEnvironment): string 
     "<!-- Add your feedback above, then review and edit all details before submitting. -->",
   ].join("\n");
 
-  const url = new URL(FEEDBACK_ISSUE_CHOOSER_URL);
+  const url = new URL(FEEDBACK_ISSUE_URL);
+  const issueTemplate = FEEDBACK_TEMPLATE_BY_TYPE[feedbackType];
+  url.searchParams.set("template", issueTemplate.template);
+  url.searchParams.set("title", issueTemplate.title);
   url.searchParams.set("body", body);
   // GitHub issue forms accept field ids as query parameters. These cover the
   // bug form's environment fields and the feature form's references field.


### PR DESCRIPTION
## What Changed

- Adds a `/feedback` composer command on web, desktop, and mobile.
- Opens the T3 Code GitHub issue-form chooser with version, client-surface, and platform details prepared for review.
- Sets form title defaults to `Bug: ` and `Feature: `.
- Adds focused unit coverage and user documentation.

## Why

Issue #6565 asks for an in-app way to report bugs or propose features without requiring users to first find the repository and issue forms. The command keeps submission in GitHub, where users can review and edit every field.

## UI Changes

Manually exercised the web composer: `/feedback` appears in slash-command suggestions and submitting it opens GitHub in the browser.

## Validation

- `pnpm --filter @t3tools/shared exec vp test run src/feedback.test.ts src/composerTrigger.test.ts`
- `pnpm --filter @t3tools/web exec vp test run --project unit src/lib/feedback.test.ts src/composer-logic.test.ts`
- `pnpm --filter @t3tools/mobile exec vp test run src/lib/feedback.test.ts`
- Targeted type checks for shared, web, and mobile
- Targeted format check and `git diff --check`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I manually verified the UI behavior

Closes #6565

Built with GPT-5.6-terra via Hermes Agent and Codex CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Composer-only UX and external URL opening; no auth, server, or message pipeline changes beyond intercepting a standalone slash command.
> 
> **Overview**
> Adds a **`/feedback`** client-only composer command on web, desktop, and mobile so users can open prefilled GitHub bug or feature issue forms instead of sending a thread message.
> 
> A shared **`buildFeedbackIssueUrl`** helper constructs the issue URL with version, surface, and platform metadata; web/desktop use **`openFeedbackIssueForm`** (external shell) and mobile uses **`openMobileFeedbackFromDraft`**, which only clears the draft after the browser opens successfully. Standalone **`/feedback`** bypasses normal send guards via **`isClientOnlyComposerCommand`**; the slash menu offers separate bug vs feature entries, and submit shows a chooser (Alert on mobile, dialog on web). GitHub issue template default titles change from **`[Bug]: `** / **`[Feature]: `** to **`Bug: `** / **`Feature: `**, with user docs and unit tests added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2390606bedadd590c17d71ac831c56d59a209292. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `/feedback` slash command to open prefilled GitHub issue forms on web and mobile
> - Adds `/feedback` as a new slash command in the composer on both web and mobile, with sub-options for bug reports and feature requests.
> - Builds prefilled GitHub issue URLs via a new shared `buildFeedbackIssueUrl` utility in [`packages/shared/src/feedback.ts`](https://github.com/pingdotgg/t3code/pull/6570/files#diff-71881e72db5360ad2f73ffa8da899011abae21e704f603352f28c015ec401952), including app version, platform, and environment metadata.
> - On web, intercepting `/feedback` bypasses normal send guards and shows an `AlertDialog` picker; the primary action button relabels to "Open feedback form" when a client-only command is detected.
> - On mobile, `/feedback` is intercepted in [`ThreadComposer`](https://github.com/pingdotgg/t3code/pull/6570/files#diff-4c62d895b68dd46f4d2858321c8942fde0d3ddd37c5e4253cba04c18c21a6024) to show a native `Alert` picker and open the external URL via `tryOpenExternalUrl`.
> - The draft is cleared only after the external form opens successfully; on failure (web), a toast is shown instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2390606.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->