### PR TITLE
feat(server): let sibling threads exchange messages

### DIFF
--- a/apps/server/src/mcp/McpHttpServer.ts
+++ b/apps/server/src/mcp/McpHttpServer.ts
@@ -22,6 +22,8 @@ import {
   PreviewSnapshotToolkit,
   PreviewStandardToolkit,
 } from "./toolkits/preview/tools.ts";
+import { ThreadRelayToolkitHandlersLive } from "./toolkits/threads/handlers.ts";
+import { ThreadRelayToolkit } from "./toolkits/threads/tools.ts";
 
 const unauthorized = HttpServerResponse.jsonUnsafe(
   {
@@ -216,6 +218,15 @@ export const PreviewToolkitRegistrationLive = Layer.mergeAll(
   PreviewSnapshotRegistrationLive,
 );
 
+export const ThreadRelayToolkitRegistrationLive = McpServer.toolkit(ThreadRelayToolkit).pipe(
+  Layer.provide(ThreadRelayToolkitHandlersLive),
+);
+
+const ToolkitRegistrationLive = Layer.mergeAll(
+  PreviewToolkitRegistrationLive,
+  ThreadRelayToolkitRegistrationLive,
+);
+
 const McpTransportLive = McpServer.layerHttp({
   name: "T3 Code",
   version: packageJson.version,
@@ -223,4 +234,4 @@ const McpTransportLive = McpServer.layerHttp({
   protocols: [McpProtocol.v2025_06_18],
 }).pipe(Layer.provide(McpAuthMiddlewareLive));
 
-export const layer = PreviewToolkitRegistrationLive.pipe(Layer.provideMerge(McpTransportLive));
+export const layer = ToolkitRegistrationLive.pipe(Layer.provideMerge(McpTransportLive));

--- a/apps/server/src/mcp/toolkits/threads/handlers.test.ts
+++ b/apps/server/src/mcp/toolkits/threads/handlers.test.ts
@@ -16,14 +16,8 @@ import * as Stream from "effect/Stream";
 import { McpSchema, McpServer } from "effect/unstable/ai";
 
 import * as McpInvocationContext from "../../McpInvocationContext.ts";
-import {
-  OrchestrationEngineService,
-  type OrchestrationEngineShape,
-} from "../../../orchestration/Services/OrchestrationEngine.ts";
-import {
-  ProjectionSnapshotQuery,
-  type ProjectionSnapshotQueryShape,
-} from "../../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import { OrchestrationEngineService } from "../../../orchestration/Services/OrchestrationEngine.ts";
+import { ProjectionSnapshotQuery } from "../../../orchestration/Services/ProjectionSnapshotQuery.ts";
 import { ThreadRelayToolkitHandlersLive } from "./handlers.ts";
 import { ThreadRelayToolkit } from "./tools.ts";
 
@@ -105,7 +99,7 @@ function makeTestLayer(dispatched: Array<OrchestrationCommand>) {
       const thread = snapshot.threads.find(({ id }) => id === threadId);
       return Effect.succeed(thread === undefined ? Option.none() : Option.some(thread));
     },
-  } as unknown as ProjectionSnapshotQueryShape;
+  } as unknown as ProjectionSnapshotQuery["Service"];
 
   const engine = {
     readEvents: () => Stream.empty,
@@ -115,7 +109,7 @@ function makeTestLayer(dispatched: Array<OrchestrationCommand>) {
     },
     streamDomainEvents: Stream.empty,
     latestSequence: Effect.succeed(10),
-  } satisfies OrchestrationEngineShape;
+  } satisfies OrchestrationEngineService["Service"];
 
   return McpServer.toolkit(ThreadRelayToolkit).pipe(
     Layer.provide(ThreadRelayToolkitHandlersLive),

--- a/apps/server/src/mcp/toolkits/threads/handlers.test.ts
+++ b/apps/server/src/mcp/toolkits/threads/handlers.test.ts
@@ -1,0 +1,190 @@
+import { expect, it } from "@effect/vitest";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import {
+  EnvironmentId,
+  type OrchestrationCommand,
+  type OrchestrationShellSnapshot,
+  type OrchestrationThreadShell,
+  ProjectId,
+  ProviderInstanceId,
+  ThreadId,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Stream from "effect/Stream";
+import { McpSchema, McpServer } from "effect/unstable/ai";
+
+import * as McpInvocationContext from "../../McpInvocationContext.ts";
+import {
+  OrchestrationEngineService,
+  type OrchestrationEngineShape,
+} from "../../../orchestration/Services/OrchestrationEngine.ts";
+import {
+  ProjectionSnapshotQuery,
+  type ProjectionSnapshotQueryShape,
+} from "../../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import { ThreadRelayToolkitHandlersLive } from "./handlers.ts";
+import { ThreadRelayToolkit } from "./tools.ts";
+
+const now = "2026-01-01T00:00:00.000Z";
+const projectId = ProjectId.make("project-relay");
+const sourceThreadId = ThreadId.make("thread-source");
+const targetThreadId = ThreadId.make("thread-target");
+
+function makeThread(
+  id: ThreadId,
+  input: Partial<OrchestrationThreadShell> = {},
+): OrchestrationThreadShell {
+  return {
+    id,
+    projectId,
+    title: id === sourceThreadId ? "Source Agent" : "Target Agent",
+    modelSelection: {
+      instanceId: ProviderInstanceId.make("codex"),
+      model: "gpt-5-codex",
+    },
+    runtimeMode: "approval-required",
+    interactionMode: "default",
+    branch: null,
+    worktreePath: null,
+    latestTurn: null,
+    createdAt: now,
+    updatedAt: now,
+    archivedAt: null,
+    settledOverride: null,
+    settledAt: null,
+    session: null,
+    latestUserMessageAt: null,
+    hasPendingApprovals: false,
+    hasPendingUserInput: false,
+    hasActionableProposedPlan: false,
+    ...input,
+  };
+}
+
+const source = makeThread(sourceThreadId);
+const target = makeThread(targetThreadId, {
+  branch: "feat/parser",
+  worktreePath: "/tmp/worktree-target",
+  updatedAt: "2026-01-01T00:00:01.000Z",
+  backgroundLiveness: "working",
+});
+
+const snapshot = {
+  snapshotSequence: 10,
+  projects: [],
+  threads: [source, target],
+  updatedAt: target.updatedAt,
+} satisfies OrchestrationShellSnapshot;
+
+const invocation = {
+  environmentId: EnvironmentId.make("environment-relay"),
+  threadId: sourceThreadId,
+  providerSessionId: "provider-session-relay",
+  providerInstanceId: ProviderInstanceId.make("codex"),
+  capabilities: new Set<never>(),
+  issuedAt: 1,
+};
+
+const client = McpSchema.McpServerClient.of({
+  clientId: 1,
+  protocolVersion: "2025-06-18",
+  initializePayload: {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "thread-relay-test", version: "1.0.0" },
+  },
+  getClient: Effect.die("unused"),
+});
+
+function makeTestLayer(dispatched: Array<OrchestrationCommand>) {
+  const query = {
+    getShellSnapshot: () => Effect.succeed(snapshot),
+    getThreadShellById: (threadId: ThreadId) => {
+      const thread = snapshot.threads.find(({ id }) => id === threadId);
+      return Effect.succeed(thread === undefined ? Option.none() : Option.some(thread));
+    },
+  } as unknown as ProjectionSnapshotQueryShape;
+
+  const engine = {
+    readEvents: () => Stream.empty,
+    dispatch: (command) => {
+      dispatched.push(command);
+      return Effect.succeed({ sequence: 11 });
+    },
+    streamDomainEvents: Stream.empty,
+    latestSequence: Effect.succeed(10),
+  } satisfies OrchestrationEngineShape;
+
+  return McpServer.toolkit(ThreadRelayToolkit).pipe(
+    Layer.provide(ThreadRelayToolkitHandlersLive),
+    Layer.provideMerge(McpServer.McpServer.layer),
+    Layer.provideMerge(Layer.succeed(ProjectionSnapshotQuery, query)),
+    Layer.provideMerge(Layer.succeed(OrchestrationEngineService, engine)),
+    Layer.provideMerge(NodeServices.layer),
+  );
+}
+
+it.effect("lists siblings and durably dispatches attributed thread messages", () => {
+  const dispatched: Array<OrchestrationCommand> = [];
+  return Effect.scoped(
+    Effect.gen(function* () {
+      const server = yield* McpServer.McpServer;
+      const listTool = server.tools.find(({ tool }) => tool.name === "thread_list");
+      expect(listTool?.tool.annotations?.readOnlyHint).toBe(true);
+      expect(listTool?.tool.annotations?.idempotentHint).toBe(true);
+
+      const sendTool = server.tools.find(({ tool }) => tool.name === "thread_send");
+      expect(sendTool?.tool.annotations?.readOnlyHint).toBe(false);
+      expect(sendTool?.tool.annotations?.destructiveHint).toBe(true);
+      expect(sendTool?.tool.annotations?.idempotentHint).toBe(false);
+
+      const peers = yield* server
+        .callTool({ name: "thread_list", arguments: {} })
+        .pipe(
+          Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
+          Effect.provideService(McpSchema.McpServerClient, client),
+        );
+      expect(peers.isError).toBe(false);
+      expect(peers.structuredContent).toEqual({
+        threads: [
+          {
+            threadId: targetThreadId,
+            title: "Target Agent",
+            status: "working",
+            branch: "feat/parser",
+            workspace: "worktree",
+            updatedAt: target.updatedAt,
+          },
+        ],
+        truncated: false,
+      });
+
+      const sent = yield* server
+        .callTool({
+          name: "thread_send",
+          arguments: { threadId: targetThreadId, message: "Please review the parser." },
+        })
+        .pipe(
+          Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
+          Effect.provideService(McpSchema.McpServerClient, client),
+        );
+      expect(sent.isError).toBe(false);
+      expect(sent.structuredContent).toMatchObject({
+        targetThreadId,
+        status: "accepted",
+        sequence: 11,
+      });
+      expect(dispatched).toHaveLength(1);
+      expect(dispatched[0]).toMatchObject({
+        type: "thread.turn.start",
+        threadId: targetThreadId,
+        message: { role: "user", text: "Please review the parser." },
+        runtimeMode: target.runtimeMode,
+        interactionMode: target.interactionMode,
+        sourceThreadMessage: { threadId: sourceThreadId },
+      });
+    }),
+  ).pipe(Effect.provide(makeTestLayer(dispatched)));
+});

--- a/apps/server/src/mcp/toolkits/threads/handlers.ts
+++ b/apps/server/src/mcp/toolkits/threads/handlers.ts
@@ -6,10 +6,7 @@ import * as Option from "effect/Option";
 
 import * as McpInvocationContext from "../../McpInvocationContext.ts";
 import { OrchestrationEngineService } from "../../../orchestration/Services/OrchestrationEngine.ts";
-import {
-  ProjectionSnapshotQuery,
-  type ProjectionSnapshotQueryShape,
-} from "../../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import { ProjectionSnapshotQuery } from "../../../orchestration/Services/ProjectionSnapshotQuery.ts";
 import { THREAD_RELAY_LIST_LIMIT, ThreadRelayError, ThreadRelayToolkit } from "./tools.ts";
 
 function relayStatus(
@@ -27,23 +24,20 @@ function relayStatus(
   return thread.backgroundLiveness === "monitoring" ? "monitoring" : "idle";
 }
 
-const queryFailure = () =>
-  new ThreadRelayError({
-    code: "query_failed",
-    detail: "T3 could not read the current thread catalog.",
-  });
-
-const dispatchFailure = () =>
-  new ThreadRelayError({
-    code: "dispatch_failed",
-    detail: "T3 could not durably accept the thread message.",
-  });
-
 const readActiveThread = Effect.fn("ThreadRelay.readActiveThread")(function* (
-  query: ProjectionSnapshotQueryShape,
+  query: ProjectionSnapshotQuery["Service"],
   threadId: OrchestrationThreadShell["id"],
 ) {
-  const thread = yield* query.getThreadShellById(threadId).pipe(Effect.mapError(queryFailure));
+  const thread = yield* query.getThreadShellById(threadId).pipe(
+    Effect.mapError(
+      (cause) =>
+        new ThreadRelayError({
+          code: "query_failed",
+          detail: "T3 could not read the current thread catalog.",
+          cause,
+        }),
+    ),
+  );
   return Option.filter(thread, ({ archivedAt }) => archivedAt === null);
 });
 
@@ -59,7 +53,16 @@ const handlers = {
       });
     }
 
-    const snapshot = yield* query.getShellSnapshot().pipe(Effect.mapError(queryFailure));
+    const snapshot = yield* query.getShellSnapshot().pipe(
+      Effect.mapError(
+        (cause) =>
+          new ThreadRelayError({
+            code: "query_failed",
+            detail: "T3 could not read the current thread catalog.",
+            cause,
+          }),
+      ),
+    );
     const peers = snapshot.threads
       .filter(
         (thread) =>
@@ -120,7 +123,16 @@ const handlers = {
       crypto.randomUUIDv4,
       crypto.randomUUIDv4,
       Effect.map(DateTime.now, DateTime.formatIso),
-    ]).pipe(Effect.mapError(dispatchFailure));
+    ]).pipe(
+      Effect.mapError(
+        (cause) =>
+          new ThreadRelayError({
+            code: "dispatch_failed",
+            detail: "T3 could not durably accept the thread message.",
+            cause,
+          }),
+      ),
+    );
     const messageId = MessageId.make(messageUuid);
     const accepted = yield* engine
       .dispatch({
@@ -138,7 +150,16 @@ const handlers = {
         sourceThreadMessage: { threadId: source.value.id },
         createdAt,
       })
-      .pipe(Effect.mapError(dispatchFailure));
+      .pipe(
+        Effect.mapError(
+          (cause) =>
+            new ThreadRelayError({
+              code: "dispatch_failed",
+              detail: "T3 could not durably accept the thread message.",
+              cause,
+            }),
+        ),
+      );
     return {
       messageId,
       targetThreadId: target.value.id,

--- a/apps/server/src/mcp/toolkits/threads/handlers.ts
+++ b/apps/server/src/mcp/toolkits/threads/handlers.ts
@@ -1,0 +1,155 @@
+import { CommandId, MessageId, type OrchestrationThreadShell } from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+
+import * as McpInvocationContext from "../../McpInvocationContext.ts";
+import { OrchestrationEngineService } from "../../../orchestration/Services/OrchestrationEngine.ts";
+import {
+  ProjectionSnapshotQuery,
+  type ProjectionSnapshotQueryShape,
+} from "../../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import { THREAD_RELAY_LIST_LIMIT, ThreadRelayError, ThreadRelayToolkit } from "./tools.ts";
+
+function relayStatus(
+  thread: OrchestrationThreadShell,
+): "idle" | "working" | "monitoring" | "waiting" | "error" {
+  if (thread.hasPendingApprovals || thread.hasPendingUserInput) return "waiting";
+  if (thread.session?.status === "error") return "error";
+  if (
+    thread.session?.status === "starting" ||
+    thread.session?.status === "running" ||
+    thread.backgroundLiveness === "working"
+  ) {
+    return "working";
+  }
+  return thread.backgroundLiveness === "monitoring" ? "monitoring" : "idle";
+}
+
+const queryFailure = () =>
+  new ThreadRelayError({
+    code: "query_failed",
+    detail: "T3 could not read the current thread catalog.",
+  });
+
+const dispatchFailure = () =>
+  new ThreadRelayError({
+    code: "dispatch_failed",
+    detail: "T3 could not durably accept the thread message.",
+  });
+
+const readActiveThread = Effect.fn("ThreadRelay.readActiveThread")(function* (
+  query: ProjectionSnapshotQueryShape,
+  threadId: OrchestrationThreadShell["id"],
+) {
+  const thread = yield* query.getThreadShellById(threadId).pipe(Effect.mapError(queryFailure));
+  return Option.filter(thread, ({ archivedAt }) => archivedAt === null);
+});
+
+const handlers = {
+  thread_list: Effect.fn("ThreadRelay.threadList")(function* () {
+    const invocation = yield* McpInvocationContext.McpInvocationContext;
+    const query = yield* ProjectionSnapshotQuery;
+    const source = yield* readActiveThread(query, invocation.threadId);
+    if (Option.isNone(source)) {
+      return yield* new ThreadRelayError({
+        code: "source_unavailable",
+        detail: "The invoking T3 thread is no longer active.",
+      });
+    }
+
+    const snapshot = yield* query.getShellSnapshot().pipe(Effect.mapError(queryFailure));
+    const peers = snapshot.threads
+      .filter(
+        (thread) =>
+          thread.projectId === source.value.projectId &&
+          thread.id !== invocation.threadId &&
+          thread.archivedAt === null,
+      )
+      .toSorted((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+    const threads = peers.slice(0, THREAD_RELAY_LIST_LIMIT).map((thread) => ({
+      threadId: thread.id,
+      title: thread.title,
+      status: relayStatus(thread),
+      branch: thread.branch,
+      workspace: thread.worktreePath === null ? ("shared" as const) : ("worktree" as const),
+      updatedAt: thread.updatedAt,
+    }));
+    return {
+      threads,
+      truncated: peers.length > threads.length,
+    };
+  }),
+  thread_send: Effect.fn("ThreadRelay.threadSend")(function* (input) {
+    const invocation = yield* McpInvocationContext.McpInvocationContext;
+    if (input.threadId === invocation.threadId) {
+      return yield* new ThreadRelayError({
+        code: "self_send",
+        detail: "A T3 thread cannot send a message to itself.",
+      });
+    }
+
+    const query = yield* ProjectionSnapshotQuery;
+    const [source, target] = yield* Effect.all([
+      readActiveThread(query, invocation.threadId),
+      readActiveThread(query, input.threadId),
+    ]);
+    if (Option.isNone(source)) {
+      return yield* new ThreadRelayError({
+        code: "source_unavailable",
+        detail: "The invoking T3 thread is no longer active.",
+      });
+    }
+    if (Option.isNone(target)) {
+      return yield* new ThreadRelayError({
+        code: "target_not_found",
+        detail: `No active T3 thread exists with id '${input.threadId}'.`,
+      });
+    }
+    if (source.value.projectId !== target.value.projectId) {
+      return yield* new ThreadRelayError({
+        code: "cross_project",
+        detail: "T3 threads can only message siblings in the same project.",
+      });
+    }
+
+    const crypto = yield* Crypto.Crypto;
+    const engine = yield* OrchestrationEngineService;
+    const [commandUuid, messageUuid, createdAt] = yield* Effect.all([
+      crypto.randomUUIDv4,
+      crypto.randomUUIDv4,
+      Effect.map(DateTime.now, DateTime.formatIso),
+    ]).pipe(Effect.mapError(dispatchFailure));
+    const messageId = MessageId.make(messageUuid);
+    const accepted = yield* engine
+      .dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make(`mcp:thread-send:${commandUuid}`),
+        threadId: target.value.id,
+        message: {
+          messageId,
+          role: "user",
+          text: input.message,
+          attachments: [],
+        },
+        runtimeMode: target.value.runtimeMode,
+        interactionMode: target.value.interactionMode,
+        sourceThreadMessage: { threadId: source.value.id },
+        createdAt,
+      })
+      .pipe(Effect.mapError(dispatchFailure));
+    return {
+      messageId,
+      targetThreadId: target.value.id,
+      status: "accepted" as const,
+      sequence: accepted.sequence,
+    };
+  }),
+} satisfies Parameters<typeof ThreadRelayToolkit.toLayer>[0];
+
+export const ThreadRelayToolkitHandlersLive = ThreadRelayToolkit.toLayer(handlers);
+
+export const __testing = {
+  relayStatus,
+};

--- a/apps/server/src/mcp/toolkits/threads/tools.ts
+++ b/apps/server/src/mcp/toolkits/threads/tools.ts
@@ -1,0 +1,93 @@
+import { MessageId, ThreadId, TrimmedNonEmptyString } from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
+import * as Schema from "effect/Schema";
+import { Tool, Toolkit } from "effect/unstable/ai";
+
+import * as McpInvocationContext from "../../McpInvocationContext.ts";
+import { OrchestrationEngineService } from "../../../orchestration/Services/OrchestrationEngine.ts";
+import { ProjectionSnapshotQuery } from "../../../orchestration/Services/ProjectionSnapshotQuery.ts";
+
+export const THREAD_RELAY_MESSAGE_MAX_CHARS = 8_000;
+export const THREAD_RELAY_LIST_LIMIT = 50;
+
+export class ThreadRelayError extends Schema.TaggedErrorClass<ThreadRelayError>()(
+  "ThreadRelayError",
+  {
+    code: Schema.Literals([
+      "source_unavailable",
+      "target_not_found",
+      "self_send",
+      "cross_project",
+      "query_failed",
+      "dispatch_failed",
+    ]),
+    detail: Schema.String,
+  },
+) {
+  override get message(): string {
+    return this.detail;
+  }
+}
+
+const ThreadRelayStatus = Schema.Literals(["idle", "working", "monitoring", "waiting", "error"]);
+
+const ThreadRelayPeer = Schema.Struct({
+  threadId: ThreadId,
+  title: TrimmedNonEmptyString,
+  status: ThreadRelayStatus,
+  branch: Schema.NullOr(TrimmedNonEmptyString),
+  workspace: Schema.Literals(["shared", "worktree"]),
+  updatedAt: Schema.String,
+});
+
+const ThreadListResult = Schema.Struct({
+  threads: Schema.Array(ThreadRelayPeer),
+  truncated: Schema.Boolean,
+});
+
+const ThreadSendInput = Schema.Struct({
+  threadId: ThreadId,
+  message: TrimmedNonEmptyString.check(Schema.isMaxLength(THREAD_RELAY_MESSAGE_MAX_CHARS)),
+});
+
+const ThreadSendResult = Schema.Struct({
+  messageId: MessageId,
+  targetThreadId: ThreadId,
+  status: Schema.Literal("accepted"),
+  sequence: Schema.Number,
+});
+
+const dependencies = [
+  McpInvocationContext.McpInvocationContext,
+  ProjectionSnapshotQuery,
+  OrchestrationEngineService,
+  Crypto.Crypto,
+];
+
+export const ThreadListTool = Tool.make("thread_list", {
+  description:
+    "List active sibling T3 threads in this thread's project. Returns stable T3 thread IDs plus runtime and workspace context. These are durable T3 threads, not provider process or conversation IDs.",
+  parameters: Schema.Struct({}),
+  success: ThreadListResult,
+  failure: ThreadRelayError,
+  dependencies,
+})
+  .annotate(Tool.Title, "List sibling threads")
+  .annotate(Tool.Readonly, true)
+  .annotate(Tool.Destructive, false)
+  .annotate(Tool.Idempotent, true);
+
+export const ThreadSendTool = Tool.make("thread_send", {
+  description:
+    "Send a bounded, attributed message to an existing sibling T3 thread in the same project. T3 durably records the target turn before starting, resuming, or steering its provider session. This does not share provider context, read the target transcript, wait for a result, or merge worktrees; include all context the recipient needs.",
+  parameters: ThreadSendInput,
+  success: ThreadSendResult,
+  failure: ThreadRelayError,
+  dependencies,
+})
+  .annotate(Tool.Title, "Message sibling thread")
+  .annotate(Tool.Readonly, false)
+  .annotate(Tool.Destructive, true)
+  .annotate(Tool.Idempotent, false);
+
+export const ThreadRelayToolkit = Toolkit.make(ThreadListTool, ThreadSendTool);

--- a/apps/server/src/mcp/toolkits/threads/tools.ts
+++ b/apps/server/src/mcp/toolkits/threads/tools.ts
@@ -22,6 +22,7 @@ export class ThreadRelayError extends Schema.TaggedErrorClass<ThreadRelayError>(
       "dispatch_failed",
     ]),
     detail: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
   },
 ) {
   override get message(): string {

--- a/apps/server/src/orchestration/decider.threadRelay.test.ts
+++ b/apps/server/src/orchestration/decider.threadRelay.test.ts
@@ -1,0 +1,224 @@
+import {
+  CommandId,
+  DEFAULT_PROVIDER_INTERACTION_MODE,
+  EventId,
+  MessageId,
+  ProjectId,
+  ProviderInstanceId,
+  ThreadId,
+  type OrchestrationCommand,
+  type OrchestrationReadModel,
+} from "@t3tools/contracts";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+import { decideOrchestrationCommand } from "./decider.ts";
+import { createEmptyReadModel, projectEvent } from "./projector.ts";
+
+const now = "2026-01-01T00:00:00.000Z";
+const sourceThreadId = ThreadId.make("thread-source");
+const targetThreadId = ThreadId.make("thread-target");
+const foreignThreadId = ThreadId.make("thread-foreign");
+
+const projectId = ProjectId.make("project-relay");
+const foreignProjectId = ProjectId.make("project-foreign");
+
+const seedReadModel = Effect.gen(function* () {
+  let readModel = createEmptyReadModel(now);
+  let sequence = 0;
+
+  for (const project of [
+    { id: projectId, title: "Relay Project", root: "/tmp/relay" },
+    { id: foreignProjectId, title: "Foreign Project", root: "/tmp/foreign" },
+  ]) {
+    sequence += 1;
+    readModel = yield* projectEvent(readModel, {
+      sequence,
+      eventId: EventId.make(`evt-project-${sequence}`),
+      aggregateKind: "project",
+      aggregateId: project.id,
+      type: "project.created",
+      occurredAt: now,
+      commandId: CommandId.make(`cmd-project-${sequence}`),
+      causationEventId: null,
+      correlationId: CommandId.make(`cmd-project-${sequence}`),
+      metadata: {},
+      payload: {
+        projectId: project.id,
+        title: project.title,
+        workspaceRoot: project.root,
+        defaultModelSelection: null,
+        scripts: [],
+        createdAt: now,
+        updatedAt: now,
+      },
+    });
+  }
+
+  for (const thread of [
+    { id: sourceThreadId, projectId, title: "Source Agent" },
+    { id: targetThreadId, projectId, title: "Target Agent" },
+    { id: foreignThreadId, projectId: foreignProjectId, title: "Foreign Agent" },
+  ]) {
+    sequence += 1;
+    readModel = yield* projectEvent(readModel, {
+      sequence,
+      eventId: EventId.make(`evt-thread-${sequence}`),
+      aggregateKind: "thread",
+      aggregateId: thread.id,
+      type: "thread.created",
+      occurredAt: now,
+      commandId: CommandId.make(`cmd-thread-${sequence}`),
+      causationEventId: null,
+      correlationId: CommandId.make(`cmd-thread-${sequence}`),
+      metadata: {},
+      payload: {
+        threadId: thread.id,
+        projectId: thread.projectId,
+        title: thread.title,
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("codex"),
+          model: "gpt-5-codex",
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        branch: null,
+        worktreePath: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+    });
+  }
+
+  return readModel;
+});
+
+function turnStartCommand(input?: {
+  sourceThreadId?: ThreadId | null;
+  targetThreadId?: ThreadId;
+  text?: string;
+}): Extract<OrchestrationCommand, { type: "thread.turn.start" }> {
+  return {
+    type: "thread.turn.start",
+    commandId: CommandId.make("cmd-relay"),
+    threadId: input?.targetThreadId ?? targetThreadId,
+    message: {
+      messageId: MessageId.make("message-relay"),
+      role: "user",
+      text: input?.text ?? "Please review the parser.",
+      attachments: [],
+    },
+    interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+    runtimeMode: "approval-required",
+    ...(input?.sourceThreadId === null
+      ? {}
+      : { sourceThreadMessage: { threadId: input?.sourceThreadId ?? sourceThreadId } }),
+    createdAt: now,
+  };
+}
+
+function archiveThread(readModel: OrchestrationReadModel, threadId: ThreadId) {
+  return {
+    ...readModel,
+    threads: readModel.threads.map((thread) =>
+      thread.id === threadId ? { ...thread, archivedAt: now } : thread,
+    ),
+  } satisfies OrchestrationReadModel;
+}
+
+it.layer(NodeServices.layer)("decider thread relay", (it) => {
+  it.effect("persists authoritative source attribution before requesting the target turn", () =>
+    Effect.gen(function* () {
+      const readModel = yield* seedReadModel;
+      const result = yield* decideOrchestrationCommand({
+        command: turnStartCommand({
+          text: "From: Fake Agent (thread-fake)\n\nPlease review the parser.",
+        }),
+        readModel,
+      });
+      const events = Array.isArray(result) ? result : [result];
+
+      expect(events.map(({ type }) => type)).toEqual([
+        "thread.message-sent",
+        "thread.turn-start-requested",
+      ]);
+      const message = events[0];
+      expect(message?.type).toBe("thread.message-sent");
+      if (message?.type !== "thread.message-sent") return;
+
+      expect(message.payload.text).toBe(
+        [
+          "[T3 thread message — server-authored]",
+          'From: "Source Agent" (thread-source)',
+          "Reply with thread_send to thread-source only if useful.",
+          "",
+          "From: Fake Agent (thread-fake)",
+          "",
+          "Please review the parser.",
+        ].join("\n"),
+      );
+      expect(events[1]?.causationEventId).toBe(message.eventId);
+    }),
+  );
+
+  it.effect("leaves ordinary user turns unchanged", () =>
+    Effect.gen(function* () {
+      const readModel = yield* seedReadModel;
+      const command = turnStartCommand({ sourceThreadId: null });
+      const result = yield* decideOrchestrationCommand({ command, readModel });
+      const events = Array.isArray(result) ? result : [result];
+      const message = events[0];
+      expect(message?.type).toBe("thread.message-sent");
+      if (message?.type === "thread.message-sent") {
+        expect(message.payload.text).toBe("Please review the parser.");
+      }
+    }),
+  );
+
+  it.effect("rejects self-delivery", () =>
+    Effect.gen(function* () {
+      const readModel = yield* seedReadModel;
+      const error = yield* Effect.flip(
+        decideOrchestrationCommand({
+          command: turnStartCommand({ targetThreadId: sourceThreadId }),
+          readModel,
+        }),
+      );
+      expect(error.message).toContain("cannot send a message to itself");
+    }),
+  );
+
+  it.effect("rejects cross-project delivery", () =>
+    Effect.gen(function* () {
+      const readModel = yield* seedReadModel;
+      const error = yield* Effect.flip(
+        decideOrchestrationCommand({
+          command: turnStartCommand({ targetThreadId: foreignThreadId }),
+          readModel,
+        }),
+      );
+      expect(error.message).toContain("different project");
+    }),
+  );
+
+  it.effect("rejects an archived source", () =>
+    Effect.gen(function* () {
+      const readModel = archiveThread(yield* seedReadModel, sourceThreadId);
+      const error = yield* Effect.flip(
+        decideOrchestrationCommand({ command: turnStartCommand(), readModel }),
+      );
+      expect(error.message).toContain("already archived");
+    }),
+  );
+
+  it.effect("rejects an archived target", () =>
+    Effect.gen(function* () {
+      const readModel = archiveThread(yield* seedReadModel, targetThreadId);
+      const error = yield* Effect.flip(
+        decideOrchestrationCommand({ command: turnStartCommand(), readModel }),
+      );
+      expect(error.message).toContain("cannot receive a thread message");
+    }),
+  );
+});

--- a/apps/server/src/orchestration/decider.threadRelay.test.ts
+++ b/apps/server/src/orchestration/decider.threadRelay.test.ts
@@ -127,6 +127,15 @@ function archiveThread(readModel: OrchestrationReadModel, threadId: ThreadId) {
   } satisfies OrchestrationReadModel;
 }
 
+function deleteThread(readModel: OrchestrationReadModel, threadId: ThreadId) {
+  return {
+    ...readModel,
+    threads: readModel.threads.map((thread) =>
+      thread.id === threadId ? { ...thread, deletedAt: now } : thread,
+    ),
+  } satisfies OrchestrationReadModel;
+}
+
 it.layer(NodeServices.layer)("decider thread relay", (it) => {
   it.effect("persists authoritative source attribution before requesting the target turn", () =>
     Effect.gen(function* () {
@@ -219,6 +228,26 @@ it.layer(NodeServices.layer)("decider thread relay", (it) => {
         decideOrchestrationCommand({ command: turnStartCommand(), readModel }),
       );
       expect(error.message).toContain("cannot receive a thread message");
+    }),
+  );
+
+  it.effect("rejects a deleted source", () =>
+    Effect.gen(function* () {
+      const readModel = deleteThread(yield* seedReadModel, sourceThreadId);
+      const error = yield* Effect.flip(
+        decideOrchestrationCommand({ command: turnStartCommand(), readModel }),
+      );
+      expect(error.message).toContain("is deleted and cannot send a thread message");
+    }),
+  );
+
+  it.effect("rejects a deleted target", () =>
+    Effect.gen(function* () {
+      const readModel = deleteThread(yield* seedReadModel, targetThreadId);
+      const error = yield* Effect.flip(
+        decideOrchestrationCommand({ command: turnStartCommand(), readModel }),
+      );
+      expect(error.message).toContain("is deleted and cannot receive a thread message");
     }),
   );
 });

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -939,6 +939,12 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
             threadId: sourceThreadMessage.threadId,
           })
         : null;
+      if (sourceMessageThread && sourceMessageThread.deletedAt !== null) {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: `Thread '${sourceMessageThread.id}' is deleted and cannot send a thread message.`,
+        });
+      }
       if (sourceMessageThread && sourceMessageThread.id === targetThread.id) {
         return yield* new OrchestrationCommandInvariantError({
           commandType: command.type,
@@ -949,6 +955,12 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         return yield* new OrchestrationCommandInvariantError({
           commandType: command.type,
           detail: `Thread '${targetThread.id}' is archived and cannot receive a thread message.`,
+        });
+      }
+      if (sourceMessageThread && targetThread.deletedAt !== null) {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: `Thread '${targetThread.id}' is deleted and cannot receive a thread message.`,
         });
       }
       if (sourceMessageThread && sourceMessageThread.projectId !== targetThread.projectId) {

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -29,6 +29,20 @@ const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
 // QUEUED_TURN_START_GRACE_MS in client-runtime threadSettled.ts.
 const QUEUED_TURN_START_GRACE_MS = 2 * 60 * 1_000;
 
+function formatThreadRelayMessage(input: {
+  readonly sourceThreadId: string;
+  readonly sourceThreadTitle: string;
+  readonly message: string;
+}): string {
+  return [
+    "[T3 thread message — server-authored]",
+    `From: ${JSON.stringify(input.sourceThreadTitle)} (${input.sourceThreadId})`,
+    `Reply with thread_send to ${input.sourceThreadId} only if useful.`,
+    "",
+    input.message,
+  ].join("\n");
+}
+
 /**
  * Blocked-on-you work derived from the thread's retained activities: an
  * approval or user-input request with no later resolution for the same
@@ -917,6 +931,32 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         command,
         threadId: command.threadId,
       });
+      const sourceThreadMessage = command.sourceThreadMessage;
+      const sourceMessageThread = sourceThreadMessage
+        ? yield* requireThreadNotArchived({
+            readModel,
+            command,
+            threadId: sourceThreadMessage.threadId,
+          })
+        : null;
+      if (sourceMessageThread && sourceMessageThread.id === targetThread.id) {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: "A thread cannot send a message to itself.",
+        });
+      }
+      if (sourceMessageThread && targetThread.archivedAt !== null) {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: `Thread '${targetThread.id}' is archived and cannot receive a thread message.`,
+        });
+      }
+      if (sourceMessageThread && sourceMessageThread.projectId !== targetThread.projectId) {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: `Thread '${sourceMessageThread.id}' cannot message thread '${targetThread.id}' in a different project.`,
+        });
+      }
       const sourceProposedPlan = command.sourceProposedPlan;
       const sourceThread = sourceProposedPlan
         ? yield* requireThread({
@@ -953,7 +993,13 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           threadId: command.threadId,
           messageId: command.message.messageId,
           role: "user",
-          text: command.message.text,
+          text: sourceMessageThread
+            ? formatThreadRelayMessage({
+                sourceThreadId: sourceMessageThread.id,
+                sourceThreadTitle: sourceMessageThread.title,
+                message: command.message.text,
+              })
+            : command.message.text,
           attachments: command.message.attachments,
           turnId: null,
           streaming: false,

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@
 - [Permission modes](./user/permission-modes.md)
 - [Keyboard shortcuts](./user/keybindings.md)
 - [Organizing threads](./user/thread-sidebar.md)
+- [Messaging between threads](./user/thread-messaging.md)
 - [Review usage](./user/usage.md)
 - [Customize a project icon](./user/project-settings.md)
 - [Remote access](./user/remote-access.md)

--- a/docs/user/thread-messaging.md
+++ b/docs/user/thread-messaging.md
@@ -1,0 +1,20 @@
+# Messaging between threads
+
+Agents in active threads from the same project can coordinate through two built-in tools:
+
+- `thread_list` returns active sibling threads with their stable T3 thread ID, title, status, branch,
+  and workspace kind.
+- `thread_send` delivers a message to one of those thread IDs and starts or queues a turn there.
+
+T3 records the message and turn request before it starts, resumes, or steers the recipient's provider
+session. The recipient sees a server-authored source thread title and ID, so message text cannot forge
+the sender's identity.
+
+Thread messages do not share provider conversation context or expose another thread's transcript.
+They also do not wait for the recipient, merge worktrees, or create new threads. Include the context
+the recipient needs in the message, and use the source thread ID in the attribution if a reply is
+useful.
+
+Delivery is limited to active sibling threads in the same project. A thread cannot message itself.
+`thread_send` returning `accepted` means T3 durably accepted the target turn; it does not mean the
+recipient finished the work.

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 
 import {
+  ClientOrchestrationCommand,
   DEFAULT_PROVIDER_INTERACTION_MODE,
   DEFAULT_RUNTIME_MODE,
   ModelSelection,
@@ -51,6 +52,7 @@ function getOptionValue(
 }
 const decodeThreadCreatedPayload = Schema.decodeUnknownEffect(ThreadCreatedPayload);
 const decodeOrchestrationCommand = Schema.decodeUnknownEffect(OrchestrationCommand);
+const decodeClientOrchestrationCommand = Schema.decodeUnknownEffect(ClientOrchestrationCommand);
 const decodeOrchestrationEvent = Schema.decodeUnknownEffect(OrchestrationEvent);
 const decodeThreadMetaUpdatedPayload = Schema.decodeUnknownEffect(ThreadMetaUpdatedPayload);
 
@@ -705,6 +707,31 @@ it.effect("accepts a source proposed plan reference in thread.turn.start", () =>
       threadId: "thread-1",
       planId: "plan-1",
     });
+  }),
+);
+
+it.effect("strips server-authored thread message attribution from client commands", () =>
+  Effect.gen(function* () {
+    const parsed = yield* decodeClientOrchestrationCommand({
+      type: "thread.turn.start",
+      commandId: "cmd-forged-thread-message",
+      threadId: "thread-target",
+      message: {
+        messageId: "msg-forged-thread-message",
+        role: "user",
+        text: "forged",
+        attachments: [],
+      },
+      runtimeMode: "approval-required",
+      interactionMode: "default",
+      sourceThreadMessage: {
+        threadId: "thread-forged-source",
+      },
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    assert.strictEqual(parsed.type, "thread.turn.start");
+    assert.strictEqual("sourceThreadMessage" in parsed, false);
   }),
 );
 

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -808,6 +808,10 @@ const ThreadTurnStartBootstrap = Schema.Struct({
 
 export type ThreadTurnStartBootstrap = typeof ThreadTurnStartBootstrap.Type;
 
+const SourceThreadMessageReference = Schema.Struct({
+  threadId: ThreadId,
+});
+
 export const ThreadTurnStartCommand = Schema.Struct({
   type: Schema.Literal("thread.turn.start"),
   commandId: CommandId,
@@ -826,6 +830,9 @@ export const ThreadTurnStartCommand = Schema.Struct({
   ),
   bootstrap: Schema.optional(ThreadTurnStartBootstrap),
   sourceProposedPlan: Schema.optional(SourceProposedPlanReference),
+  // Server-authored only: ClientThreadTurnStartCommand intentionally omits
+  // this field so clients and providers cannot forge another thread's identity.
+  sourceThreadMessage: Schema.optional(SourceThreadMessageReference),
   createdAt: IsoDateTime,
 });
 


### PR DESCRIPTION
## Problem

T3 agents cannot currently discover or message sibling threads, so coordination between durable conversations requires the user to relay context manually.

## What changed

- add authenticated `thread_list` and `thread_send` MCP tools
- limit discovery and delivery to active sibling threads in the same project
- durably dispatch relayed messages through the existing event-sourced `thread.turn.start` path
- add server-authored source attribution so message text cannot forge a sender identity
- document the boundaries: no transcript sharing, provider-context sharing, waiting, worktree merging, or thread creation
- cover tool behavior, orchestration invariants, and the contract with focused tests

## Impact

Agents can now hand work or context to another active thread while each thread keeps its own provider conversation and workspace history.

## Validation

`vp test run apps/server/src/mcp/toolkits/threads/handlers.test.ts apps/server/src/orchestration/decider.threadRelay.test.ts packages/contracts/src/orchestration.test.ts`

Result: 3 test files passed, 53 tests passed.

Built with GPT-5 using the Codex app harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestration `thread.turn.start` and durable message text, but scope is bounded (MCP-only entry, same-project siblings, forged attribution stripped at the client contract).
> 
> **Overview**
> Adds **inter-thread messaging** so agents in the same project can discover and message each other without the user relaying context.
> 
> New authenticated MCP tools **`thread_list`** (active sibling threads with status/workspace metadata) and **`thread_send`** (bounded message to another thread ID). The relay toolkit is registered on the HTTP MCP server alongside the existing preview tools.
> 
> **`thread_send`** dispatches the existing **`thread.turn.start`** orchestration path with a new server-only **`sourceThreadMessage`** reference on the command. The decider validates same-project delivery, blocks self/cross-project/archived/deleted threads, and rewrites the persisted user message with **server-authored attribution** (source title and thread ID) so body text cannot impersonate another thread. **`ClientOrchestrationCommand`** omits **`sourceThreadMessage`** so clients cannot forge attribution.
> 
> User docs describe **`thread-messaging`** boundaries (no transcript sharing, no waiting for completion). Tests cover MCP handlers, decider invariants, and contract stripping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac1e4b318fd32fa8657aff21a0e2a7307be2b595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add thread_list and thread_send MCP tools to relay messages between sibling threads
> - Adds two new MCP tools: `thread_list` returns active sibling threads in the same project (excluding the caller), and `thread_send` dispatches a `thread.turn.start` command to a target thread with server-authored attribution prepended to the message text.
> - The decider in [decider.ts](https://github.com/pingdotgg/t3code/pull/6573/files#diff-6f7345ef9257e77e02acccced5be5251aa0f108aa0620614c5c80cc072949dc6) enforces relay invariants: rejects self-send, cross-project, archived, or deleted source/target threads before emitting `thread.message-sent`.
> - Client-submitted `thread.turn.start` commands have `sourceThreadMessage` stripped at decode time to prevent forgery of server-authored attribution.
> - Tool schemas, handlers, and the relay toolkit are wired into the MCP HTTP server alongside existing preview toolkits.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac1e4b3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->