### PR TITLE
fix(web): reject unsupported composer image types at attach time

### DIFF
--- a/apps/mobile/src/features/sharing/incoming-share-model.ts
+++ b/apps/mobile/src/features/sharing/incoming-share-model.ts
@@ -1,4 +1,5 @@
 import {
+  isProviderSendTurnSupportedImageMimeType,
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
 } from "@t3tools/contracts";
@@ -159,6 +160,13 @@ export async function buildIncomingShareDraft(input: {
     const mimeType = (resolved?.contentMimeType ?? payload.mimeType ?? "image/png").toLowerCase();
     if (!uri || !mimeType.startsWith("image/")) {
       warnings.push("One shared item was not a supported image.");
+      await releaseOwnedFiles(input.fileReader, [uri, payload.value]);
+      continue;
+    }
+    if (!isProviderSendTurnSupportedImageMimeType(mimeType)) {
+      warnings.push(
+        `'${resolved?.originalName ?? fallbackName(uri, index, mimeType)}' is not a supported image type.`,
+      );
       await releaseOwnedFiles(input.fileReader, [uri, payload.value]);
       continue;
     }

--- a/apps/mobile/src/lib/composerImages.ts
+++ b/apps/mobile/src/lib/composerImages.ts
@@ -1,4 +1,5 @@
 import {
+  isProviderSendTurnSupportedImageMimeType,
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
   type UploadChatImageAttachment,
@@ -96,6 +97,10 @@ export async function pickComposerImages(input: { readonly existingCount: number
     const mimeType = asset.mimeType?.toLowerCase();
     if (!mimeType?.startsWith("image/")) {
       error = `Unsupported file type for '${asset.fileName ?? "image"}'.`;
+      continue;
+    }
+    if (!isProviderSendTurnSupportedImageMimeType(mimeType)) {
+      error = `'${asset.fileName ?? "image"}' is not a supported image type. Attach GIF, JPEG, PNG, or WebP images.`;
       continue;
     }
 

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -12,6 +12,7 @@ import type {
   ThreadId,
 } from "@t3tools/contracts";
 import {
+  isProviderSendTurnSupportedImageMimeType,
   ProviderDriverKind,
   ProviderInstanceId,
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
@@ -2301,6 +2302,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     for (const file of files) {
       if (!file.type.startsWith("image/")) {
         error = `Unsupported file type for '${file.name}'. Please attach image files only.`;
+        continue;
+      }
+      if (!isProviderSendTurnSupportedImageMimeType(file.type)) {
+        error = `'${file.name}' is not a supported image type. Attach GIF, JPEG, PNG, or WebP images.`;
         continue;
       }
       if (reservedCount >= PROVIDER_SEND_TURN_MAX_ATTACHMENTS) {

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -23,6 +23,7 @@ import {
   ThreadCreatedPayload,
   ThreadTurnDiff,
   ThreadTurnStartRequestedPayload,
+  isProviderSendTurnSupportedImageMimeType,
 } from "./orchestration.ts";
 import { ProviderInstanceId } from "./providerInstance.ts";
 
@@ -935,3 +936,9 @@ it.effect("project favicon overrides accept only supported image files", () =>
     assert.strictEqual(invalid._tag, "Failure");
   }),
 );
+
+it("isProviderSendTurnSupportedImageMimeType accepts raster formats and rejects svg", () => {
+  assert.strictEqual(isProviderSendTurnSupportedImageMimeType("image/png"), true);
+  assert.strictEqual(isProviderSendTurnSupportedImageMimeType("IMAGE/JPEG"), true);
+  assert.strictEqual(isProviderSendTurnSupportedImageMimeType("image/svg+xml"), false);
+});

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -144,6 +144,20 @@ export type ProviderUserInputAnswers = typeof ProviderUserInputAnswers.Type;
 export const PROVIDER_SEND_TURN_MAX_INPUT_CHARS = 120_000;
 export const PROVIDER_SEND_TURN_MAX_ATTACHMENTS = 8;
 export const PROVIDER_SEND_TURN_MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+export const PROVIDER_SEND_TURN_SUPPORTED_IMAGE_MIME_TYPES = [
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+] as const;
+const PROVIDER_SEND_TURN_SUPPORTED_IMAGE_MIME_TYPE_SET = new Set<string>(
+  PROVIDER_SEND_TURN_SUPPORTED_IMAGE_MIME_TYPES,
+);
+
+/** Whether a pasted or picked image mime type can be sent on a provider turn. */
+export function isProviderSendTurnSupportedImageMimeType(mimeType: string): boolean {
+  return PROVIDER_SEND_TURN_SUPPORTED_IMAGE_MIME_TYPE_SET.has(mimeType.toLowerCase());
+}
 const PROVIDER_SEND_TURN_MAX_IMAGE_DATA_URL_CHARS = 14_000_000;
 const CHAT_ATTACHMENT_ID_MAX_CHARS = 128;
 // Correlation id is command id by design in this model.


### PR DESCRIPTION
## Summary

Pasting or dropping an SVG (or other non-raster image) into the composer looked like it worked — the preview showed up — but sending the message failed with `Unsupported Claude image attachment type 'image/svg+xml'`.

This adds a shared supported-mime check in contracts and uses it when images are attached on web and mobile, so unsupported types are rejected immediately with a clear error instead of failing mid-turn.

## What changed

- `packages/contracts`: exported the supported turn image mime list and a small helper
- `apps/web`: `ChatComposer` rejects unsupported types before compression/preview
- `apps/mobile`: same validation in the image picker and incoming share flow

## Why

Fixes #6020. Matches the issue reporter’s acceptable outcome: fail at paste/drop time like other unsupported file types, rather than after the image is already in the thread.

## Test plan

- [x] `vp test run packages/contracts/src/orchestration.test.ts`
- [x] `vp run --filter @t3tools/contracts typecheck`
- [x] `vp run --filter @t3tools/web typecheck`
- [ ] Paste/drop an SVG in the web composer → inline error, no preview chip
- [ ] Paste/drop PNG/JPEG/WebP/GIF → still works

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side validation only; tightens attach UX to match existing server/provider rules with no auth or data-path changes.
> 
> **Overview**
> Composer image attach paths now reject types the provider cannot send on a turn (e.g. **SVG**), instead of showing a preview and failing when the message is sent.
> 
> **Contracts** export `PROVIDER_SEND_TURN_SUPPORTED_IMAGE_MIME_TYPES` (GIF, JPEG, PNG, WebP) and `isProviderSendTurnSupportedImageMimeType`, with a small unit test.
> 
> **Web** `ChatComposer` runs that check after the generic `image/*` gate and before compression, surfacing an inline error that names the allowed formats.
> 
> **Mobile** applies the same rule in the image library picker and when building drafts from the **incoming share** flow, skipping bad items with a warning or error as appropriate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93376e451b586068ba73b64ea991f586e5af51b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject unsupported image mime types at composer attach time
> - Adds `isProviderSendTurnSupportedImageMimeType` to [`packages/contracts/src/orchestration.ts`](https://github.com/pingdotgg/t3code/pull/6574/files#diff-eb3f1de358c2fd7cec5950215e475b915ad3dca9e4f3f7305e46c3277630d2af), which checks a normalized mime type against a supported set (GIF, JPEG, PNG, WebP).
> - The web [`ChatComposer`](https://github.com/pingdotgg/t3code/pull/6574/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a), mobile [`pickComposerImages`](https://github.com/pingdotgg/t3code/pull/6574/files#diff-8723c2d87dbdbb196075db6f79088889d3a7f72c0b472d71bc669adc4b533e51), and incoming share draft builder each call this guard and skip unsupported files (e.g. SVG) with a user-facing error naming acceptable formats.
> - Behavioral Change: files with unsupported mime types that were previously accepted silently are now rejected with an error message at attach time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93376e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->