### PR TITLE
fix(server): bound OpenCode CLI health probes with timeouts

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
@@ -3,8 +3,10 @@ import * as NodeAssert from "node:assert/strict";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
+import * as TestClock from "effect/testing/TestClock";
 import { beforeEach } from "vite-plus/test";
 
 import { OpenCodeSettings } from "@t3tools/contracts";
@@ -35,6 +37,8 @@ const runtimeMock = {
     versionStdout: DEFAULT_VERSION_STDOUT,
     inventoryError: null as Error | null,
     inventoryCwd: null as string | null,
+    hangVersion: false,
+    hangInventory: false,
     closeCalls: 0,
     inventory: {
       providerList: { connected: [] as string[], all: [] as unknown[], default: {} },
@@ -47,6 +51,8 @@ const runtimeMock = {
     this.state.versionStdout = DEFAULT_VERSION_STDOUT;
     this.state.inventoryError = null;
     this.state.inventoryCwd = null;
+    this.state.hangVersion = false;
+    this.state.hangInventory = false;
     this.state.closeCalls = 0;
     this.state.inventory = {
       providerList: { connected: [], all: [] as unknown[], default: {} },
@@ -77,8 +83,11 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
         external: Boolean(serverUrl),
       };
     }),
-  runOpenCodeCommand: () =>
-    runtimeMock.state.runVersionError
+  runOpenCodeCommand: () => {
+    if (runtimeMock.state.hangVersion) {
+      return Effect.never;
+    }
+    return runtimeMock.state.runVersionError
       ? Effect.fail(
           new OpenCodeRuntimeError({
             operation: "runOpenCodeCommand",
@@ -86,7 +95,8 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
             cause: runtimeMock.state.runVersionError,
           }),
         )
-      : Effect.succeed({ stdout: runtimeMock.state.versionStdout, stderr: "", code: 0 }),
+      : Effect.succeed({ stdout: runtimeMock.state.versionStdout, stderr: "", code: 0 });
+  },
   createOpenCodeSdkClient: () =>
     ({}) as unknown as ReturnType<OpenCodeRuntimeShape["createOpenCodeSdkClient"]>,
   loadOpenCodeInventory: () =>
@@ -101,6 +111,9 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
       : Effect.succeed(runtimeMock.state.inventory as OpenCodeInventory),
   loadInventoryFromCli: ({ cwd }) => {
     runtimeMock.state.inventoryCwd = cwd;
+    if (runtimeMock.state.hangInventory) {
+      return Effect.never;
+    }
     return runtimeMock.state.inventoryError
       ? Effect.fail(
           new OpenCodeRuntimeError({
@@ -300,6 +313,42 @@ it.layer(testLayer)("checkOpenCodeProviderStatus", (it) => {
       NodeAssert.equal(
         snapshot.message,
         "Failed to execute OpenCode CLI health check: opencode models failed",
+      );
+    }),
+  );
+
+  it.effect("fails the health check when the version probe hangs", () =>
+    Effect.gen(function* () {
+      runtimeMock.state.hangVersion = true;
+      const fiber = yield* Effect.forkChild(
+        checkOpenCodeProviderStatus(makeOpenCodeSettings(), process.cwd()),
+      );
+      yield* TestClock.adjust("30 seconds");
+      const snapshot = yield* Fiber.join(fiber);
+
+      NodeAssert.equal(snapshot.status, "error");
+      NodeAssert.equal(snapshot.installed, true);
+      NodeAssert.equal(
+        snapshot.message,
+        "Failed to execute OpenCode CLI health check: Timed out while running `opencode --version`.",
+      );
+    }),
+  );
+
+  it.effect("fails the health check when the inventory probe hangs", () =>
+    Effect.gen(function* () {
+      runtimeMock.state.hangInventory = true;
+      const fiber = yield* Effect.forkChild(
+        checkOpenCodeProviderStatus(makeOpenCodeSettings(), process.cwd()),
+      );
+      yield* TestClock.adjust("30 seconds");
+      const snapshot = yield* Fiber.join(fiber);
+
+      NodeAssert.equal(snapshot.status, "error");
+      NodeAssert.equal(snapshot.installed, true);
+      NodeAssert.equal(
+        snapshot.message,
+        "Failed to execute OpenCode CLI health check: Timed out while loading the OpenCode model inventory.",
       );
     }),
   );

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -8,6 +8,7 @@ import * as Cause from "effect/Cause";
 import * as Data from "effect/Data";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 
 import { createModelCapabilities } from "@t3tools/shared/model";
 import { compareSemverVersions } from "@t3tools/shared/semver";
@@ -30,6 +31,11 @@ const OPENCODE_PRESENTATION = {
   showInteractionModeToggle: false,
 } as const;
 const MINIMUM_OPENCODE_VERSION = "1.14.19";
+// Peer providers bound their CLI probes (GrokProvider/CursorProvider); OpenCode
+// probes get the same bounds so a hung `opencode` binary cannot stall the
+// provider snapshot forever.
+const VERSION_PROBE_TIMEOUT_MS = 4_000;
+const INVENTORY_PROBE_TIMEOUT_MS = 15_000;
 
 class OpenCodeProbeError extends Data.TaggedError("OpenCodeProbeError")<{
   readonly cause: unknown;
@@ -382,6 +388,7 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
           environment: resolvedEnvironment,
         })
         .pipe(
+          Effect.timeoutOption(VERSION_PROBE_TIMEOUT_MS),
           Effect.mapError(
             (cause) => new OpenCodeProbeError({ cause, detail: openCodeRuntimeErrorDetail(cause) }),
           ),
@@ -390,7 +397,10 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
     if (versionExit._tag === "Failure") {
       return fallback(Cause.squash(versionExit.cause));
     }
-    version = parseGenericCliVersion(versionExit.value.stdout) ?? null;
+    if (Option.isNone(versionExit.value)) {
+      return fallback(new Error("Timed out while running `opencode --version`."));
+    }
+    version = parseGenericCliVersion(versionExit.value.value.stdout) ?? null;
 
     if (!version) {
       return fallback(
@@ -443,6 +453,7 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
           environment: resolvedEnvironment,
         })
     ).pipe(
+      Effect.timeoutOption(INVENTORY_PROBE_TIMEOUT_MS),
       Effect.mapError(
         (cause) => new OpenCodeProbeError({ cause, detail: openCodeRuntimeErrorDetail(cause) }),
       ),
@@ -451,14 +462,18 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
   if (inventoryExit._tag === "Failure") {
     return fallback(Cause.squash(inventoryExit.cause), version);
   }
+  if (Option.isNone(inventoryExit.value)) {
+    return fallback(new Error("Timed out while loading the OpenCode model inventory."), version);
+  }
+  const inventory = inventoryExit.value.value;
 
   const models = providerModelsFromSettings(
-    flattenOpenCodeModels(inventoryExit.value),
+    flattenOpenCodeModels(inventory),
     customModels,
     DEFAULT_OPENCODE_MODEL_CAPABILITIES,
   );
-  const skills = flattenOpenCodeSkills(inventoryExit.value);
-  const connectedCount = inventoryExit.value.providerList.connected.length;
+  const skills = flattenOpenCodeSkills(inventory);
+  const connectedCount = inventory.providerList.connected.length;
   return buildServerProvider({
     presentation: OPENCODE_PRESENTATION,
     enabled: true,


### PR DESCRIPTION
## What Changed

The OpenCode provider health probes (`opencode --version` and the model inventory commands via `loadInventoryFromCli`) awaited `child.exitCode` with no timeout, so a hung `opencode` binary (waiting on stdin, stuck on a lock, wedged build) stalled the provider snapshot indefinitely and leaked the spawned process. Every other provider adapter already bounds its probes — Codex (`CodexProvider.ts`), Claude, Cursor, and Grok all wrap probe commands in `Effect.timeoutOption`; OpenCode was the only one without.

This wraps both OpenCode probe call sites in `Effect.timeoutOption`:

- 4s for the version probe (matches `GrokProvider`'s version probe budget)
- 15s for the model inventory probe (matches the Grok/Cursor model-discovery budgets; the CLI path can run two subcommands with one 1s-spaced retry)

On timeout the snapshot now reports a clear error (`Failed to execute OpenCode CLI health check: Timed out while ...`, or the friendly "couldn't reach the configured server" message for external-server setups) instead of hanging. The spawned child is acquired under `Effect.scoped` in `runOpenCodeCommand`, so the timeout interrupts the effect and the scope finalizer kills the process — no zombie.

Adds two focused tests (hung version probe, hung inventory probe) using `TestClock`.

## Why

A hung OpenCode CLI leaves the provider stuck in a pending/probing state forever, which previously also surfaced as a cold-start blocker (#2248 — fixed once before, then reintroduced when the health check moved to CLI probes). Bounding the probes turns a silent permanent hang into a bounded, diagnosable failure.

Verified: `vp test run` on the OpenCode provider/adapter/text-generation test files (48 tests, all passing), targeted typecheck and lint clean.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (N/A — server-only, no UI changes)
- [x] I included a video for animation/interaction changes (N/A)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Server-only OpenCode health probing; bounded timeouts replace an indefinite hang and match patterns already used by other CLI providers.
> 
> **Overview**
> OpenCode’s CLI health check could hang forever when `opencode --version` or model inventory probes never finish, leaving the provider snapshot stuck probing. **This change caps those probes** with `Effect.timeoutOption`: **4s** for version (same as Grok) and **15s** for inventory.
> 
> When a probe exceeds its budget, `checkOpenCodeProviderStatus` returns an **error snapshot** with explicit timeout messages instead of blocking indefinitely. Tests extend the runtime mock with hang flags and use **TestClock** + forked fibers to assert both timeout paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6fcc788179b56645698fef465f1c4fb2f21bc87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound OpenCode CLI health probes in `checkOpenCodeProviderStatus` with 4s and 15s timeouts
> - Wraps the `--version` probe in `Effect.timeoutOption(VERSION_PROBE_TIMEOUT_MS)` (4000 ms) and the inventory load in `Effect.timeoutOption(INVENTORY_PROBE_TIMEOUT_MS)` (15000 ms) in [OpenCodeProvider.ts](https://github.com/pingdotgg/t3code/pull/6577/files#diff-4477b51690b8bf5db4f32c13ac9bb4ed2be7798d366111f84b38be236cc034bd).
> - On timeout, returns a fallback snapshot with a specific error message (`Timed out while running opencode --version` or `Timed out while loading the OpenCode model inventory`) instead of waiting indefinitely.
> - Adds tests in [OpenCodeProvider.test.ts](https://github.com/pingdotgg/t3code/pull/6577/files#diff-d2ce6bb456d8f9d5c84524ca4756f50478df4fd491ab0867f3f6e9ed657cbbda) that fork the health check and advance `TestClock` by 30s to assert the timeout error messages for both probes.
> - Behavioral Change: version and inventory probes that previously hung forever now fail after their respective timeouts; `Exit` values now wrap `Option` to account for `timeoutOption` results.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e6fcc78.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->