### PR TITLE
fix(grok): show reasoning and context usage in the composer

### DIFF
--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -279,8 +279,32 @@ function modeState(): AcpSchema.SessionModeState {
 }
 
 const grokAcpModels: ReadonlyArray<AcpSchema.ModelInfo> = [
-  { modelId: "grok-build", name: "Grok Build" },
-  { modelId: "grok-mock-alt", name: "Grok Mock Alt" },
+  {
+    modelId: "grok-build",
+    name: "Grok Build",
+    _meta: {
+      supportsReasoningEffort: true,
+      reasoningEffort: "low",
+      reasoningEfforts: [
+        { id: "low", label: "Low", default: true },
+        { id: "high", label: "High", description: "Think more" },
+      ],
+      totalContextTokens: 256000,
+    },
+  },
+  {
+    modelId: "grok-mock-alt",
+    name: "Grok Mock Alt",
+    _meta: {
+      supportsReasoningEffort: true,
+      reasoningEffort: "high",
+      reasoningEfforts: [
+        { id: "low", label: "Low" },
+        { id: "high", label: "High", isDefault: true },
+      ],
+      totalContextTokens: 128000,
+    },
+  },
 ];
 
 function modelState(): AcpSchema.SessionModelState {
@@ -873,7 +897,27 @@ const program = Effect.gen(function* () {
         },
       });
 
-      return { stopReason: "end_turn" };
+      yield* agent.client.sessionUpdate({
+        sessionId: requestedSessionId,
+        _meta: {
+          totalTokens: 1234,
+          totalContextTokens: 256000,
+        },
+        update: {
+          sessionUpdate: "usage_update",
+          used: 1234,
+          size: 256000,
+        },
+      });
+
+      return {
+        stopReason: "end_turn",
+        _meta: {
+          totalTokens: 1234,
+          totalContextTokens: 256000,
+          usage: { totalTokens: 1234 },
+        },
+      };
     }),
   );
 

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -175,6 +175,7 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
         "turn.started",
         "item.started",
         "content.delta",
+        "thread.token-usage.updated",
         "turn.completed",
       ] as const);
 
@@ -182,6 +183,16 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
       assert.isDefined(delta);
       if (delta?.type === "content.delta") {
         assert.equal(delta.payload.delta, "hello from mock");
+      }
+
+      const usage = runtimeEvents.find((e) => e.type === "thread.token-usage.updated");
+      assert.isDefined(usage);
+      if (usage?.type === "thread.token-usage.updated") {
+        assert.deepStrictEqual(usage.payload.usage, {
+          usedTokens: 1234,
+          maxTokens: 256000,
+          compactsAutomatically: true,
+        });
       }
 
       yield* adapter.stopSession(threadId);
@@ -1040,6 +1051,114 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
 
       assert.equal(error._tag, "ProviderAdapterValidationError");
 
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("does not call set_model when prompt preparation fails", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-empty-turn-no-set-model");
+      const tempDir = yield* Effect.promise(() =>
+        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-acp-")),
+      );
+      const requestLogPath = NodePath.join(tempDir, "requests.ndjson");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({
+          T3_ACP_REQUEST_LOG_PATH: requestLogPath,
+        }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath);
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("grok"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+        modelSelection: { instanceId: ProviderInstanceId.make("grok"), model: "grok-build" },
+      });
+
+      const error = yield* Effect.flip(
+        adapter.sendTurn({
+          threadId,
+          input: "   ",
+          attachments: [],
+          modelSelection: {
+            instanceId: ProviderInstanceId.make("grok"),
+            model: "grok-build",
+            options: [{ id: "reasoningEffort", value: "high" }],
+          },
+        }),
+      );
+
+      assert.equal(error._tag, "ProviderAdapterValidationError");
+      const requests = yield* Effect.promise(() => readJsonLines(requestLogPath));
+      assert.isFalse(requests.some((entry) => entry.method === "session/set_model"));
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("applies same-model reasoning effort through session/set_model _meta", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-same-model-effort");
+      const tempDir = yield* Effect.promise(() =>
+        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-acp-")),
+      );
+      const requestLogPath = NodePath.join(tempDir, "requests.ndjson");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({
+          T3_ACP_REQUEST_LOG_PATH: requestLogPath,
+        }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath);
+      const turnCompleted = yield* Deferred.make<void>();
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        event.type === "turn.completed"
+          ? Deferred.succeed(turnCompleted, undefined).pipe(Effect.asVoid)
+          : Effect.void,
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("grok"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+        modelSelection: { instanceId: ProviderInstanceId.make("grok"), model: "grok-build" },
+      });
+
+      yield* adapter.sendTurn({
+        threadId,
+        input: "think harder",
+        attachments: [],
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("grok"),
+          model: "grok-build",
+          options: [{ id: "reasoningEffort", value: "high" }],
+        },
+      });
+
+      yield* Deferred.await(turnCompleted);
+      const requests = yield* Effect.promise(() => readJsonLines(requestLogPath));
+      assert.isTrue(
+        requests.some((entry) => {
+          const params = entry.params;
+          const meta =
+            params && typeof params === "object" && "_meta" in params ? params._meta : undefined;
+          return (
+            entry.method === "session/set_model" &&
+            params !== null &&
+            typeof params === "object" &&
+            "modelId" in params &&
+            params.modelId === "grok-build" &&
+            meta !== null &&
+            typeof meta === "object" &&
+            "reasoningEffort" in meta &&
+            meta.reasoningEffort === "high"
+          );
+        }),
+      );
+
+      yield* Fiber.interrupt(runtimeEventsFiber);
       yield* adapter.stopSession(threadId);
     }),
   );

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -125,6 +125,7 @@ interface GrokSessionContext {
   promptsInFlight: number;
   currentModelId: string | undefined;
   currentReasoningEffort: string | undefined;
+  availableModels: ReadonlyArray<EffectAcpSchema.ModelInfo> | undefined;
   contextWindowTokens: number | undefined;
   lastEmittedUsage: { usedTokens: number; maxTokens: number | undefined } | undefined;
   stopped: boolean;
@@ -835,6 +836,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
             promptsInFlight: 0,
             currentModelId: boundModelId,
             currentReasoningEffort: boundSelection.reasoningEffort,
+            availableModels: started.sessionSetupResult.models?.availableModels,
             contextWindowTokens: grokContextWindowFromAvailableModels(
               started.sessionSetupResult.models?.availableModels,
               boundModelId,
@@ -1078,6 +1080,12 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                   mapAcpToAdapterError(PROVIDER, input.threadId, "session/set_model", cause),
               });
               const currentModelId = boundSelection.modelId;
+              if (currentModelId !== ctx.currentModelId) {
+                ctx.contextWindowTokens = grokContextWindowFromAvailableModels(
+                  ctx.availableModels,
+                  currentModelId,
+                );
+              }
               ctx.currentModelId = currentModelId;
               ctx.currentReasoningEffort = boundSelection.reasoningEffort;
               const displayModel = currentModelId

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -126,6 +126,7 @@ interface GrokSessionContext {
   currentModelId: string | undefined;
   currentReasoningEffort: string | undefined;
   contextWindowTokens: number | undefined;
+  lastEmittedUsage: { usedTokens: number; maxTokens: number | undefined } | undefined;
   stopped: boolean;
 }
 
@@ -299,6 +300,18 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
         if (usage.maxTokens !== undefined) {
           ctx.contextWindowTokens = usage.maxTokens;
         }
+        const last = ctx.lastEmittedUsage;
+        if (
+          last !== undefined &&
+          last.usedTokens === usage.usedTokens &&
+          last.maxTokens === usage.maxTokens
+        ) {
+          return;
+        }
+        ctx.lastEmittedUsage = {
+          usedTokens: usage.usedTokens,
+          maxTokens: usage.maxTokens,
+        };
         yield* offerRuntimeEvent(
           makeAcpTokenUsageUpdatedEvent({
             stamp: yield* makeEventStamp(),
@@ -826,6 +839,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
               started.sessionSetupResult.models?.availableModels,
               boundModelId,
             ),
+            lastEmittedUsage: undefined,
             stopped: false,
           };
 

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -31,6 +31,7 @@ import * as SynchronizedRef from "effect/SynchronizedRef";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import * as EffectAcpErrors from "effect-acp/errors";
 import type * as EffectAcpSchema from "effect-acp/schema";
+import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
 
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
@@ -49,15 +50,21 @@ import {
   makeAcpPlanUpdatedEvent,
   makeAcpRequestOpenedEvent,
   makeAcpRequestResolvedEvent,
+  makeAcpTokenUsageUpdatedEvent,
   makeAcpToolCallEvent,
 } from "../acp/AcpCoreRuntimeEvents.ts";
 import { parsePermissionRequest } from "../acp/AcpRuntimeModel.ts";
 import { makeAcpNativeLoggerFactory } from "../acp/AcpNativeLogging.ts";
 import {
   applyGrokAcpModelSelection,
+  buildGrokTokenUsageSnapshot,
   currentGrokModelIdFromSessionSetup,
+  GROK_REASONING_EFFORT_OPTION_ID,
+  grokContextWindowFromAvailableModels,
   makeGrokAcpRuntime,
+  parseGrokPromptResponseUsage,
   resolveGrokAcpBaseModelId,
+  type GrokTokenUsageReading,
 } from "../acp/GrokAcpSupport.ts";
 import {
   extractXAiAskUserQuestions,
@@ -117,6 +124,8 @@ interface GrokSessionContext {
    * continues it, and only the last remaining prompt settles the turn. */
   promptsInFlight: number;
   currentModelId: string | undefined;
+  currentReasoningEffort: string | undefined;
+  contextWindowTokens: number | undefined;
   stopped: boolean;
 }
 
@@ -272,6 +281,35 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
 
     const offerRuntimeEvent = (event: ProviderRuntimeEvent) =>
       PubSub.publish(runtimeEventPubSub, event).pipe(Effect.asVoid);
+
+    const emitGrokTokenUsage = (
+      ctx: GrokSessionContext,
+      turnId: TurnId | undefined,
+      reading: GrokTokenUsageReading,
+      rawPayload?: unknown,
+    ) =>
+      Effect.gen(function* () {
+        const usage = buildGrokTokenUsageSnapshot({
+          usedTokens: reading.usedTokens,
+          maxTokens: reading.maxTokens ?? ctx.contextWindowTokens,
+        });
+        if (!usage) {
+          return;
+        }
+        if (usage.maxTokens !== undefined) {
+          ctx.contextWindowTokens = usage.maxTokens;
+        }
+        yield* offerRuntimeEvent(
+          makeAcpTokenUsageUpdatedEvent({
+            stamp: yield* makeEventStamp(),
+            provider: PROVIDER,
+            threadId: ctx.threadId,
+            turnId,
+            usage,
+            ...(rawPayload !== undefined ? { rawPayload } : {}),
+          }),
+        );
+      });
 
     const getThreadSemaphore = (threadId: string) =>
       SynchronizedRef.modifyEffect(threadLocksRef, (current) => {
@@ -738,13 +776,18 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
           const requestedStartModelId = grokModelSelection?.model
             ? resolveGrokAcpBaseModelId(grokModelSelection.model)
             : undefined;
-          const boundModelId = yield* applyGrokAcpModelSelection({
+          const boundSelection = yield* applyGrokAcpModelSelection({
             runtime: acp,
             currentModelId: currentGrokModelIdFromSessionSetup(started.sessionSetupResult),
             requestedModelId: requestedStartModelId,
+            requestedReasoningEffort: getModelSelectionStringOptionValue(
+              grokModelSelection,
+              GROK_REASONING_EFFORT_OPTION_ID,
+            ),
             mapError: (cause) =>
               mapAcpToAdapterError(PROVIDER, input.threadId, "session/set_model", cause),
           });
+          const boundModelId = boundSelection.modelId;
 
           const now = yield* nowIso;
           const session: ProviderSession = {
@@ -778,6 +821,11 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
             interruptedTurnIds: new Set(),
             promptsInFlight: 0,
             currentModelId: boundModelId,
+            currentReasoningEffort: boundSelection.reasoningEffort,
+            contextWindowTokens: grokContextWindowFromAvailableModels(
+              started.sessionSetupResult.models?.availableModels,
+              boundModelId,
+            ),
             stopped: false,
           };
 
@@ -797,6 +845,19 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 }
 
                 if (event._tag === "ModeChanged") {
+                  return;
+                }
+
+                if (event._tag === "TokenUsageUpdated") {
+                  yield* emitGrokTokenUsage(
+                    ctx,
+                    resolveNotificationTurnId(ctx),
+                    {
+                      usedTokens: event.usedTokens,
+                      ...(event.maxTokens !== undefined ? { maxTokens: event.maxTokens } : {}),
+                    },
+                    event.rawPayload,
+                  );
                   return;
                 }
 
@@ -942,13 +1003,6 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
               const requestedTurnModelId = turnModelSelection?.model
                 ? resolveGrokAcpBaseModelId(turnModelSelection.model)
                 : undefined;
-              const currentModelId = yield* applyGrokAcpModelSelection({
-                runtime: ctx.acp,
-                currentModelId: ctx.currentModelId,
-                requestedModelId: requestedTurnModelId,
-                mapError: (cause) =>
-                  mapAcpToAdapterError(PROVIDER, input.threadId, "session/set_model", cause),
-              });
 
               const text = input.input?.trim();
               const imagePromptParts = yield* Effect.forEach(
@@ -997,7 +1051,21 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 });
               }
 
+              const boundSelection = yield* applyGrokAcpModelSelection({
+                runtime: ctx.acp,
+                currentModelId: ctx.currentModelId,
+                requestedModelId: requestedTurnModelId,
+                currentReasoningEffort: ctx.currentReasoningEffort,
+                requestedReasoningEffort: getModelSelectionStringOptionValue(
+                  turnModelSelection,
+                  GROK_REASONING_EFFORT_OPTION_ID,
+                ),
+                mapError: (cause) =>
+                  mapAcpToAdapterError(PROVIDER, input.threadId, "session/set_model", cause),
+              });
+              const currentModelId = boundSelection.modelId;
               ctx.currentModelId = currentModelId;
+              ctx.currentReasoningEffort = boundSelection.reasoningEffort;
               const displayModel = currentModelId
                 ? resolveGrokAcpBaseModelId(currentModelId)
                 : undefined;
@@ -1143,6 +1211,10 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
               }
 
               appendPromptResultToTurn(ctx, prepared.turnId, prepared.promptParts, result);
+              const promptUsage = parseGrokPromptResponseUsage(result);
+              if (promptUsage) {
+                yield* emitGrokTokenUsage(ctx, prepared.turnId, promptUsage, result);
+              }
               ctx.session = {
                 ...ctx.session,
                 status: "running",

--- a/apps/server/src/provider/Layers/GrokProvider.test.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.test.ts
@@ -6,7 +6,12 @@ import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import { GrokSettings } from "@t3tools/contracts";
 
-import { buildInitialGrokProviderSnapshot, checkGrokProviderStatus } from "./GrokProvider.ts";
+import {
+  buildGrokDiscoveredModelsFromSessionModelState,
+  buildGrokModelCapabilities,
+  buildInitialGrokProviderSnapshot,
+  checkGrokProviderStatus,
+} from "./GrokProvider.ts";
 
 const decodeGrokSettings = Schema.decodeSync(GrokSettings);
 
@@ -107,4 +112,84 @@ it.layer(NodeServices.layer)("checkGrokProviderStatus", (it) => {
       expect(snapshot.message).toContain("ACP startup failed");
     }),
   );
+});
+
+describe("buildGrokModelCapabilities", () => {
+  it("exposes a reasoningEffort select from ACP model _meta", () => {
+    expect(
+      buildGrokModelCapabilities({
+        modelId: "grok-4.6",
+        name: "Grok 4.6",
+        _meta: {
+          reasoningEffort: "low",
+          reasoningEfforts: [
+            { id: "low", label: "Low", default: true },
+            { id: "high", label: "High", description: "Think more" },
+          ],
+        },
+      }),
+    ).toEqual({
+      optionDescriptors: [
+        {
+          id: "reasoningEffort",
+          label: "Reasoning",
+          type: "select",
+          currentValue: "low",
+          options: [
+            { id: "low", label: "Low", isDefault: true },
+            { id: "high", label: "High", description: "Think more" },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("keeps empty capabilities when _meta is missing or invalid", () => {
+    expect(buildGrokModelCapabilities({ modelId: "grok-build", name: "Grok Build" })).toEqual({
+      optionDescriptors: [],
+    });
+    expect(
+      buildGrokModelCapabilities({
+        modelId: "grok-build",
+        name: "Grok Build",
+        _meta: {
+          supportsReasoningEffort: false,
+          reasoningEfforts: [{ id: "low", label: "Low" }],
+        },
+      }),
+    ).toEqual({ optionDescriptors: [] });
+  });
+});
+
+describe("buildGrokDiscoveredModelsFromSessionModelState", () => {
+  it("attaches per-model reasoning capabilities from ACP _meta", () => {
+    const models = buildGrokDiscoveredModelsFromSessionModelState({
+      currentModelId: "grok-4.6",
+      availableModels: [
+        {
+          modelId: "grok-4.6",
+          name: "Grok 4.6",
+          _meta: {
+            reasoningEfforts: [{ id: "low", label: "Low", isDefault: true }],
+          },
+        },
+        {
+          modelId: "grok-4.5",
+          name: "Grok 4.5",
+        },
+      ],
+    });
+
+    expect(models).toHaveLength(2);
+    expect(models[0]?.capabilities.optionDescriptors).toEqual([
+      {
+        id: "reasoningEffort",
+        label: "Reasoning",
+        type: "select",
+        currentValue: "low",
+        options: [{ id: "low", label: "Low", isDefault: true }],
+      },
+    ]);
+    expect(models[1]?.capabilities.optionDescriptors).toEqual([]);
+  });
 });

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -29,7 +29,12 @@ import {
   enrichProviderSnapshotWithVersionAdvisory,
   type ProviderMaintenanceCapabilities,
 } from "../providerMaintenance.ts";
-import { makeGrokAcpRuntime, resolveGrokAcpBaseModelId } from "../acp/GrokAcpSupport.ts";
+import {
+  GROK_REASONING_EFFORT_OPTION_ID,
+  makeGrokAcpRuntime,
+  parseGrokReasoningEffortMenu,
+  resolveGrokAcpBaseModelId,
+} from "../acp/GrokAcpSupport.ts";
 
 const GROK_PRESENTATION = {
   displayName: "Grok",
@@ -99,7 +104,30 @@ function grokModelsFromSettings(
   return providerModelsFromSettings(builtInModels, customModels ?? [], EMPTY_CAPABILITIES);
 }
 
-function buildGrokDiscoveredModelsFromSessionModelState(
+export function buildGrokModelCapabilities(model: EffectAcpSchema.ModelInfo): ModelCapabilities {
+  const menu = parseGrokReasoningEffortMenu(model._meta);
+  if (!menu) {
+    return EMPTY_CAPABILITIES;
+  }
+  return createModelCapabilities({
+    optionDescriptors: [
+      {
+        id: GROK_REASONING_EFFORT_OPTION_ID,
+        label: "Reasoning",
+        type: "select",
+        options: menu.options.map((option) => ({
+          id: option.id,
+          label: option.label,
+          ...(option.description ? { description: option.description } : {}),
+          ...(option.isDefault ? { isDefault: true } : {}),
+        })),
+        ...(menu.currentValue ? { currentValue: menu.currentValue } : {}),
+      },
+    ],
+  });
+}
+
+export function buildGrokDiscoveredModelsFromSessionModelState(
   modelState: EffectAcpSchema.SessionModelState | null | undefined,
 ): ReadonlyArray<ServerProviderModel> {
   if (!modelState || modelState.availableModels.length === 0) {
@@ -117,7 +145,7 @@ function buildGrokDiscoveredModelsFromSessionModelState(
         slug,
         name: model.name.trim() || slug,
         isCustom: false,
-        capabilities: EMPTY_CAPABILITIES,
+        capabilities: buildGrokModelCapabilities(model),
       };
     })
     .filter((model): model is ServerProviderModel => model !== undefined);

--- a/apps/server/src/provider/acp/AcpCoreRuntimeEvents.test.ts
+++ b/apps/server/src/provider/acp/AcpCoreRuntimeEvents.test.ts
@@ -7,6 +7,7 @@ import {
   makeAcpPlanUpdatedEvent,
   makeAcpRequestOpenedEvent,
   makeAcpRequestResolvedEvent,
+  makeAcpTokenUsageUpdatedEvent,
   makeAcpToolCallEvent,
 } from "./AcpCoreRuntimeEvents.ts";
 
@@ -189,6 +190,30 @@ describe("AcpCoreRuntimeEvents", () => {
       payload: {
         itemType: "assistant_message",
         status: "inProgress",
+      },
+    });
+
+    expect(
+      makeAcpTokenUsageUpdatedEvent({
+        stamp,
+        provider: ProviderDriverKind.make("grok"),
+        threadId: "thread-1" as never,
+        turnId,
+        usage: {
+          usedTokens: 1234,
+          maxTokens: 256000,
+          compactsAutomatically: true,
+        },
+        rawPayload: { sessionId: "session-1" },
+      }),
+    ).toMatchObject({
+      type: "thread.token-usage.updated",
+      payload: {
+        usage: {
+          usedTokens: 1234,
+          maxTokens: 256000,
+          compactsAutomatically: true,
+        },
       },
     });
   });

--- a/apps/server/src/provider/acp/AcpCoreRuntimeEvents.ts
+++ b/apps/server/src/provider/acp/AcpCoreRuntimeEvents.ts
@@ -8,6 +8,7 @@ import {
   type ProviderRuntimeEvent,
   type RuntimeRequestId,
   type ThreadId,
+  type ThreadTokenUsageSnapshot,
   type ToolLifecycleItemType,
   type TurnId,
 } from "@t3tools/contracts";
@@ -238,5 +239,34 @@ export function makeAcpContentDeltaEvent(input: {
       method: "session/update",
       payload: input.rawPayload,
     },
+  };
+}
+
+export function makeAcpTokenUsageUpdatedEvent(input: {
+  readonly stamp: AcpEventStamp;
+  readonly provider: ProviderDriverKind;
+  readonly threadId: ThreadId;
+  readonly turnId: TurnId | undefined;
+  readonly usage: ThreadTokenUsageSnapshot;
+  readonly rawPayload?: unknown;
+}): ProviderRuntimeEvent {
+  return {
+    type: "thread.token-usage.updated",
+    ...input.stamp,
+    provider: input.provider,
+    threadId: input.threadId,
+    turnId: input.turnId,
+    payload: {
+      usage: input.usage,
+    },
+    ...(input.rawPayload !== undefined
+      ? {
+          raw: {
+            source: "acp.jsonrpc" as const,
+            method: "session/update",
+            payload: input.rawPayload,
+          },
+        }
+      : {}),
   };
 }

--- a/apps/server/src/provider/acp/AcpRuntimeModel.test.ts
+++ b/apps/server/src/provider/acp/AcpRuntimeModel.test.ts
@@ -374,4 +374,77 @@ describe("AcpRuntimeModel", () => {
       },
     });
   });
+
+  it("maps usage_update and notification _meta into TokenUsageUpdated", () => {
+    const usageUpdate = parseSessionUpdateEvent({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "usage_update",
+        used: 1234,
+        size: 256000,
+      },
+    } satisfies EffectAcpSchema.SessionNotification);
+
+    expect(usageUpdate.events).toEqual([
+      {
+        _tag: "TokenUsageUpdated",
+        usedTokens: 1234,
+        maxTokens: 256000,
+        rawPayload: {
+          sessionId: "session-1",
+          update: {
+            sessionUpdate: "usage_update",
+            used: 1234,
+            size: 256000,
+          },
+        },
+      },
+    ]);
+
+    const metaUsage = parseSessionUpdateEvent({
+      sessionId: "session-1",
+      _meta: {
+        totalTokens: 80,
+        totalContextTokens: 128000,
+      },
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "hello" },
+      },
+    } satisfies EffectAcpSchema.SessionNotification);
+
+    expect(metaUsage.events).toEqual([
+      {
+        _tag: "ContentDelta",
+        text: "hello",
+        rawPayload: {
+          sessionId: "session-1",
+          _meta: {
+            totalTokens: 80,
+            totalContextTokens: 128000,
+          },
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "hello" },
+          },
+        },
+      },
+      {
+        _tag: "TokenUsageUpdated",
+        usedTokens: 80,
+        maxTokens: 128000,
+        rawPayload: {
+          sessionId: "session-1",
+          _meta: {
+            totalTokens: 80,
+            totalContextTokens: 128000,
+          },
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "hello" },
+          },
+        },
+      },
+    ]);
+  });
 });

--- a/apps/server/src/provider/acp/AcpRuntimeModel.ts
+++ b/apps/server/src/provider/acp/AcpRuntimeModel.ts
@@ -11,6 +11,51 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function readNonNegativeInt(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isInteger(value) && value >= 0) {
+    return value;
+  }
+  return undefined;
+}
+
+function readPositiveInt(value: unknown): number | undefined {
+  const parsed = readNonNegativeInt(value);
+  return parsed !== undefined && parsed > 0 ? parsed : undefined;
+}
+
+function parseSessionNotificationTokenUsage(
+  params: EffectAcpSchema.SessionNotification,
+): { readonly usedTokens: number; readonly maxTokens?: number } | undefined {
+  const update = params.update;
+  if (update.sessionUpdate === "usage_update") {
+    const usedTokens = readNonNegativeInt(update.used);
+    if (usedTokens === undefined) {
+      return undefined;
+    }
+    const maxTokens = readPositiveInt(update.size);
+    return {
+      usedTokens,
+      ...(maxTokens !== undefined ? { maxTokens } : {}),
+    };
+  }
+  const meta = params._meta;
+  if (!isRecord(meta)) {
+    return undefined;
+  }
+  const usedTokens = readNonNegativeInt(meta.totalTokens);
+  if (usedTokens === undefined) {
+    return undefined;
+  }
+  const maxTokens =
+    readPositiveInt(meta.totalContextTokens) ??
+    readPositiveInt(meta.contextWindow) ??
+    readPositiveInt(meta.size);
+  return {
+    usedTokens,
+    ...(maxTokens !== undefined ? { maxTokens } : {}),
+  };
+}
+
 function isSessionModelState(value: unknown): value is EffectAcpSchema.SessionModelState {
   if (!isRecord(value) || typeof value.currentModelId !== "string") {
     return false;
@@ -107,6 +152,12 @@ export type AcpParsedSessionEvent =
       readonly _tag: "ContentDelta";
       readonly itemId?: string;
       readonly text: string;
+      readonly rawPayload: unknown;
+    }
+  | {
+      readonly _tag: "TokenUsageUpdated";
+      readonly usedTokens: number;
+      readonly maxTokens?: number;
       readonly rawPayload: unknown;
     };
 
@@ -576,6 +627,16 @@ export function parseSessionUpdateEvent(params: EffectAcpSchema.SessionNotificat
     }
     default:
       break;
+  }
+
+  const usage = parseSessionNotificationTokenUsage(params);
+  if (usage) {
+    events.push({
+      _tag: "TokenUsageUpdated",
+      usedTokens: usage.usedTokens,
+      ...(usage.maxTokens !== undefined ? { maxTokens: usage.maxTokens } : {}),
+      rawPayload: params,
+    });
   }
 
   return { ...(modeId !== undefined ? { modeId } : {}), events };

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -226,6 +226,7 @@ export class AcpSessionRuntime extends Context.Service<
      */
     readonly setSessionModel: (
       modelId: string,
+      meta?: EffectAcpSchema.SetSessionModelRequest["_meta"],
     ) => Effect.Effect<EffectAcpSchema.SetSessionModelResponse, EffectAcpErrors.AcpError>;
     /**
      * Sends a generic ACP extension request and records it through the request logger.
@@ -789,12 +790,13 @@ export const make = (
           Effect.flatMap((started) => setConfigOption(started.modelConfigId ?? "model", model)),
           Effect.asVoid,
         ),
-      setSessionModel: (modelId) =>
+      setSessionModel: (modelId, meta) =>
         getStartedState.pipe(
           Effect.flatMap((started) => {
             const requestPayload = {
               sessionId: started.sessionId,
               modelId,
+              ...(meta != null ? { _meta: meta } : {}),
             } satisfies EffectAcpSchema.SetSessionModelRequest;
             return runLoggedRequest(
               "session/set_model",

--- a/apps/server/src/provider/acp/GrokAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.test.ts
@@ -213,6 +213,21 @@ describe("applyGrokAcpModelSelection", () => {
     }),
   );
 
+  it.effect("does not clear effort when no model or effort is requested", () =>
+    Effect.gen(function* () {
+      const { runtime, modelCalls } = makeRecordingRuntime();
+      const result = yield* applyGrokAcpModelSelection({
+        runtime,
+        currentModelId: "grok-build",
+        requestedModelId: undefined,
+        currentReasoningEffort: "high",
+        mapError: (cause) => cause.message,
+      });
+      expect(modelCalls).toEqual([]);
+      expect(result).toEqual({ modelId: "grok-build", reasoningEffort: "high" });
+    }),
+  );
+
   it.effect("propagates session/set_model failures via mapError", () =>
     Effect.gen(function* () {
       const failure = EffectAcpErrors.AcpRequestError.invalidParams("session id not known");

--- a/apps/server/src/provider/acp/GrokAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.test.ts
@@ -119,6 +119,24 @@ describe("Grok token usage parsers", () => {
         "grok-mock-alt",
       ),
     ).toBe(128000);
+    expect(
+      grokContextWindowFromAvailableModels(
+        [
+          { modelId: "grok-build", name: "Grok Build", _meta: { totalContextTokens: 256000 } },
+          { modelId: "grok-mock-alt", name: "Alt", _meta: { totalContextTokens: 128000 } },
+        ],
+        "grok-unknown",
+      ),
+    ).toBeUndefined();
+    expect(
+      grokContextWindowFromAvailableModels(
+        [
+          { modelId: "grok-build", name: "Grok Build", _meta: { totalContextTokens: 256000 } },
+          { modelId: "grok-mock-alt", name: "Alt", _meta: { totalContextTokens: 128000 } },
+        ],
+        undefined,
+      ),
+    ).toBe(256000);
   });
 });
 
@@ -197,7 +215,7 @@ describe("applyGrokAcpModelSelection", () => {
     }),
   );
 
-  it.effect("omits _meta when clearing effort on the same model", () =>
+  it.effect("does not clear effort when the same model is repeated without effort", () =>
     Effect.gen(function* () {
       const { runtime, modelCalls } = makeRecordingRuntime();
       const result = yield* applyGrokAcpModelSelection({
@@ -208,8 +226,8 @@ describe("applyGrokAcpModelSelection", () => {
         requestedReasoningEffort: undefined,
         mapError: (cause) => cause.message,
       });
-      expect(modelCalls).toEqual([{ modelId: "grok-build" }]);
-      expect(result).toEqual({ modelId: "grok-build", reasoningEffort: undefined });
+      expect(modelCalls).toEqual([]);
+      expect(result).toEqual({ modelId: "grok-build", reasoningEffort: "high" });
     }),
   );
 

--- a/apps/server/src/provider/acp/GrokAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.test.ts
@@ -5,6 +5,13 @@ import * as EffectAcpErrors from "effect-acp/errors";
 import {
   applyGrokAcpModelSelection,
   buildGrokAcpSpawnInput,
+  buildGrokTokenUsageSnapshot,
+  grokContextWindowFromAvailableModels,
+  normalizeGrokReasoningEffortToken,
+  parseGrokAcpMetaTokenUsage,
+  parseGrokAcpUsageUpdate,
+  parseGrokPromptResponseUsage,
+  parseGrokReasoningEffortMenu,
   resolveGrokAcpBaseModelId,
 } from "./GrokAcpSupport.ts";
 
@@ -35,13 +42,96 @@ describe("buildGrokAcpSpawnInput", () => {
   });
 });
 
+describe("normalizeGrokReasoningEffortToken", () => {
+  it("accepts compact ACP effort tokens and rejects invalid ones", () => {
+    expect(normalizeGrokReasoningEffortToken(" high ")).toBe("high");
+    expect(normalizeGrokReasoningEffortToken("xhigh")).toBe("xhigh");
+    expect(normalizeGrokReasoningEffortToken("extra-high")).toBe("extra-high");
+    expect(normalizeGrokReasoningEffortToken("")).toBeUndefined();
+    expect(normalizeGrokReasoningEffortToken("has space")).toBeUndefined();
+    expect(normalizeGrokReasoningEffortToken("a".repeat(33))).toBeUndefined();
+  });
+});
+
+describe("parseGrokReasoningEffortMenu", () => {
+  it("parses id/value tokens, current effort, and default flags", () => {
+    expect(
+      parseGrokReasoningEffortMenu({
+        reasoningEffort: "high",
+        reasoningEfforts: [
+          { value: "low", label: "Low" },
+          { id: "high", label: "High", description: "Think more", isDefault: true },
+          { id: "bad token", label: "Nope" },
+        ],
+      }),
+    ).toEqual({
+      currentValue: "high",
+      options: [
+        { id: "low", label: "Low" },
+        { id: "high", label: "High", description: "Think more", isDefault: true },
+      ],
+    });
+  });
+
+  it("skips the menu when reasoning is unsupported or tokens are invalid", () => {
+    expect(
+      parseGrokReasoningEffortMenu({
+        supportsReasoningEffort: false,
+        reasoningEfforts: [{ id: "low", label: "Low" }],
+      }),
+    ).toBeUndefined();
+    expect(parseGrokReasoningEffortMenu({ reasoningEfforts: [{ id: "???" }] })).toBeUndefined();
+    expect(parseGrokReasoningEffortMenu({})).toBeUndefined();
+  });
+});
+
+describe("Grok token usage parsers", () => {
+  it("reads usage_update, notification _meta, and prompt _meta", () => {
+    expect(parseGrokAcpUsageUpdate({ used: 1234, size: 256000 })).toEqual({
+      usedTokens: 1234,
+      maxTokens: 256000,
+    });
+    expect(
+      parseGrokAcpMetaTokenUsage({
+        totalTokens: 80,
+        contextWindow: 128000,
+      }),
+    ).toEqual({ usedTokens: 80, maxTokens: 128000 });
+    expect(
+      parseGrokPromptResponseUsage({
+        _meta: { usage: { totalTokens: 42, size: 64000 } },
+      }),
+    ).toEqual({ usedTokens: 42, maxTokens: 64000 });
+  });
+
+  it("builds a Grok usage snapshot with automatic compaction", () => {
+    expect(buildGrokTokenUsageSnapshot({ usedTokens: 10, maxTokens: 100 })).toEqual({
+      usedTokens: 10,
+      maxTokens: 100,
+      compactsAutomatically: true,
+    });
+    expect(
+      grokContextWindowFromAvailableModels(
+        [
+          { modelId: "grok-build", name: "Grok Build", _meta: { totalContextTokens: 256000 } },
+          { modelId: "grok-mock-alt", name: "Alt", _meta: { totalContextTokens: 128000 } },
+        ],
+        "grok-mock-alt",
+      ),
+    ).toBe(128000);
+  });
+});
+
 describe("applyGrokAcpModelSelection", () => {
   const makeRecordingRuntime = (failure?: EffectAcpErrors.AcpError) => {
-    const modelCalls: Array<string> = [];
+    const modelCalls: Array<{
+      readonly modelId: string;
+      readonly meta?: { readonly [x: string]: unknown } | null;
+    }> = [];
     const runtime = {
-      setSessionModel: (modelId: string) =>
+      setSessionModel: (modelId: string, meta?: { readonly [x: string]: unknown } | null) =>
         Effect.gen(function* () {
-          modelCalls.push(modelId);
+          modelCalls.push({ modelId, ...(meta !== undefined ? { meta } : {}) });
           if (failure) return yield* failure;
           return {};
         }),
@@ -58,8 +148,8 @@ describe("applyGrokAcpModelSelection", () => {
         requestedModelId: "grok-mock-alt",
         mapError: (cause) => cause.message,
       });
-      expect(modelCalls).toEqual(["grok-mock-alt"]);
-      expect(result).toBe("grok-mock-alt");
+      expect(modelCalls).toEqual([{ modelId: "grok-mock-alt" }]);
+      expect(result).toEqual({ modelId: "grok-mock-alt", reasoningEffort: undefined });
     }),
   );
 
@@ -73,7 +163,7 @@ describe("applyGrokAcpModelSelection", () => {
         mapError: (cause) => cause.message,
       });
       expect(modelCalls).toEqual([]);
-      expect(result).toBe("grok-build");
+      expect(result).toEqual({ modelId: "grok-build", reasoningEffort: undefined });
     }),
   );
 
@@ -87,7 +177,39 @@ describe("applyGrokAcpModelSelection", () => {
         mapError: (cause) => cause.message,
       });
       expect(modelCalls).toEqual([]);
-      expect(result).toBe("grok-build");
+      expect(result).toEqual({ modelId: "grok-build", reasoningEffort: undefined });
+    }),
+  );
+
+  it.effect("calls set_model with reasoningEffort _meta for same-model effort changes", () =>
+    Effect.gen(function* () {
+      const { runtime, modelCalls } = makeRecordingRuntime();
+      const result = yield* applyGrokAcpModelSelection({
+        runtime,
+        currentModelId: "grok-build",
+        requestedModelId: "grok-build",
+        currentReasoningEffort: "low",
+        requestedReasoningEffort: "high",
+        mapError: (cause) => cause.message,
+      });
+      expect(modelCalls).toEqual([{ modelId: "grok-build", meta: { reasoningEffort: "high" } }]);
+      expect(result).toEqual({ modelId: "grok-build", reasoningEffort: "high" });
+    }),
+  );
+
+  it.effect("omits _meta when clearing effort on the same model", () =>
+    Effect.gen(function* () {
+      const { runtime, modelCalls } = makeRecordingRuntime();
+      const result = yield* applyGrokAcpModelSelection({
+        runtime,
+        currentModelId: "grok-build",
+        requestedModelId: "grok-build",
+        currentReasoningEffort: "high",
+        requestedReasoningEffort: undefined,
+        mapError: (cause) => cause.message,
+      });
+      expect(modelCalls).toEqual([{ modelId: "grok-build" }]);
+      expect(result).toEqual({ modelId: "grok-build", reasoningEffort: undefined });
     }),
   );
 

--- a/apps/server/src/provider/acp/GrokAcpSupport.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.ts
@@ -281,7 +281,8 @@ export function grokContextWindowFromAvailableModels(
   const current = resolvedCurrent
     ? models.find((model) => resolveGrokAcpBaseModelId(model.modelId) === resolvedCurrent)
     : undefined;
-  const candidate = current ?? models[0];
+  // A known but unmatched model must not inherit another model's window.
+  const candidate = resolvedCurrent ? current : models[0];
   if (!candidate || !isRecord(candidate._meta)) {
     return undefined;
   }
@@ -327,10 +328,9 @@ export function applyGrokAcpModelSelection<E>(input: {
   );
   const modelChanged =
     input.requestedModelId !== undefined && input.requestedModelId !== input.currentModelId;
-  // A missing model selection is not a clear. Only treat effort as changed when
-  // the caller actually sent a model or an effort value.
-  const effortSpecified =
-    input.requestedModelId !== undefined || input.requestedReasoningEffort !== undefined;
+  // Repeating the current model is not an effort change. Only an explicit
+  // requestedReasoningEffort counts as specified.
+  const effortSpecified = input.requestedReasoningEffort !== undefined;
   const effortChanged = effortSpecified && requestedReasoningEffort !== currentReasoningEffort;
   const targetModelId = modelChanged ? input.requestedModelId : input.currentModelId;
 

--- a/apps/server/src/provider/acp/GrokAcpSupport.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.ts
@@ -1,4 +1,8 @@
-import { type GrokSettings, ProviderDriverKind } from "@t3tools/contracts";
+import {
+  type GrokSettings,
+  ProviderDriverKind,
+  type ThreadTokenUsageSnapshot,
+} from "@t3tools/contracts";
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -82,6 +86,224 @@ export function resolveGrokAcpBaseModelId(model: string | null | undefined): str
   return normalizeModelSlug(base, GROK_DRIVER_KIND) ?? "grok-build";
 }
 
+export const GROK_REASONING_EFFORT_OPTION_ID = "reasoningEffort";
+const GROK_REASONING_EFFORT_TOKEN = /^[a-z0-9][a-z0-9._-]{0,31}$/i;
+
+export interface GrokReasoningEffortChoice {
+  readonly id: string;
+  readonly label: string;
+  readonly description?: string;
+  readonly isDefault?: boolean;
+}
+
+export interface GrokReasoningEffortMenu {
+  readonly currentValue?: string;
+  readonly options: ReadonlyArray<GrokReasoningEffortChoice>;
+}
+
+export interface GrokAcpAppliedModelSelection {
+  readonly modelId: string | undefined;
+  readonly reasoningEffort: string | undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function normalizeGrokReasoningEffortToken(
+  value: string | null | undefined,
+): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || !GROK_REASONING_EFFORT_TOKEN.test(trimmed)) {
+    return undefined;
+  }
+  return trimmed;
+}
+
+function parseGrokReasoningEffortChoice(entry: unknown): GrokReasoningEffortChoice | undefined {
+  if (!isRecord(entry)) {
+    return undefined;
+  }
+  const rawId =
+    typeof entry.id === "string"
+      ? entry.id
+      : typeof entry.value === "string"
+        ? entry.value
+        : undefined;
+  const id = normalizeGrokReasoningEffortToken(rawId);
+  if (!id) {
+    return undefined;
+  }
+  const label =
+    typeof entry.label === "string" && entry.label.trim().length > 0 ? entry.label.trim() : id;
+  const description =
+    typeof entry.description === "string" && entry.description.trim().length > 0
+      ? entry.description.trim()
+      : undefined;
+  const isDefault = entry.default === true || entry.isDefault === true;
+  return {
+    id,
+    label,
+    ...(description ? { description } : {}),
+    ...(isDefault ? { isDefault: true } : {}),
+  };
+}
+
+export function parseGrokReasoningEffortMenu(meta: unknown): GrokReasoningEffortMenu | undefined {
+  if (!isRecord(meta) || meta.supportsReasoningEffort === false) {
+    return undefined;
+  }
+  if (!Array.isArray(meta.reasoningEfforts)) {
+    return undefined;
+  }
+  const options: Array<GrokReasoningEffortChoice> = [];
+  const seen = new Set<string>();
+  for (const entry of meta.reasoningEfforts) {
+    const option = parseGrokReasoningEffortChoice(entry);
+    if (!option || seen.has(option.id)) {
+      continue;
+    }
+    seen.add(option.id);
+    options.push(option);
+  }
+  if (options.length === 0) {
+    return undefined;
+  }
+  const advertisedCurrent = normalizeGrokReasoningEffortToken(
+    typeof meta.reasoningEffort === "string" ? meta.reasoningEffort : undefined,
+  );
+  const currentValue =
+    advertisedCurrent && seen.has(advertisedCurrent)
+      ? advertisedCurrent
+      : options.find((option) => option.isDefault)?.id;
+  return {
+    options,
+    ...(currentValue ? { currentValue } : {}),
+  };
+}
+
+export interface GrokTokenUsageReading {
+  readonly usedTokens: number;
+  readonly maxTokens?: number;
+}
+
+function readFiniteNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
+
+function readNonNegativeInt(value: unknown): number | undefined {
+  const parsed = readFiniteNumber(value);
+  if (parsed === undefined || !Number.isInteger(parsed) || parsed < 0) {
+    return undefined;
+  }
+  return parsed;
+}
+
+function readPositiveInt(value: unknown): number | undefined {
+  const parsed = readNonNegativeInt(value);
+  return parsed !== undefined && parsed > 0 ? parsed : undefined;
+}
+
+export function parseGrokAcpMetaTokenUsage(meta: unknown): GrokTokenUsageReading | undefined {
+  if (!isRecord(meta)) {
+    return undefined;
+  }
+  const usedTokens = readNonNegativeInt(meta.totalTokens);
+  if (usedTokens === undefined) {
+    return undefined;
+  }
+  const maxTokens =
+    readPositiveInt(meta.totalContextTokens) ??
+    readPositiveInt(meta.contextWindow) ??
+    readPositiveInt(meta.size);
+  return {
+    usedTokens,
+    ...(maxTokens !== undefined ? { maxTokens } : {}),
+  };
+}
+
+export function parseGrokAcpUsageUpdate(update: {
+  readonly used: number;
+  readonly size: number;
+}): GrokTokenUsageReading | undefined {
+  const usedTokens = readNonNegativeInt(update.used);
+  if (usedTokens === undefined) {
+    return undefined;
+  }
+  const maxTokens = readPositiveInt(update.size);
+  return {
+    usedTokens,
+    ...(maxTokens !== undefined ? { maxTokens } : {}),
+  };
+}
+
+export function parseGrokPromptResponseUsage(
+  response: Pick<EffectAcpSchema.PromptResponse, "_meta">,
+): GrokTokenUsageReading | undefined {
+  const direct = parseGrokAcpMetaTokenUsage(response._meta);
+  if (direct) {
+    return direct;
+  }
+  if (!isRecord(response._meta) || !isRecord(response._meta.usage)) {
+    return undefined;
+  }
+  const usedTokens = readNonNegativeInt(response._meta.usage.totalTokens);
+  if (usedTokens === undefined) {
+    return undefined;
+  }
+  const maxTokens =
+    readPositiveInt(response._meta.usage.totalContextTokens) ??
+    readPositiveInt(response._meta.usage.contextWindow) ??
+    readPositiveInt(response._meta.usage.size);
+  return {
+    usedTokens,
+    ...(maxTokens !== undefined ? { maxTokens } : {}),
+  };
+}
+
+export function grokContextWindowFromAvailableModels(
+  models: ReadonlyArray<EffectAcpSchema.ModelInfo> | undefined,
+  currentModelId?: string,
+): number | undefined {
+  if (!models || models.length === 0) {
+    return undefined;
+  }
+  const resolvedCurrent = currentModelId ? resolveGrokAcpBaseModelId(currentModelId) : undefined;
+  const current = resolvedCurrent
+    ? models.find((model) => resolveGrokAcpBaseModelId(model.modelId) === resolvedCurrent)
+    : undefined;
+  const candidate = current ?? models[0];
+  if (!candidate || !isRecord(candidate._meta)) {
+    return undefined;
+  }
+  return readPositiveInt(candidate._meta.totalContextTokens);
+}
+
+export function buildGrokTokenUsageSnapshot(input: {
+  readonly usedTokens: number;
+  readonly maxTokens?: number;
+}): ThreadTokenUsageSnapshot | undefined {
+  const usedTokens = readNonNegativeInt(input.usedTokens);
+  if (usedTokens === undefined) {
+    return undefined;
+  }
+  const maxTokens = readPositiveInt(input.maxTokens);
+  return {
+    usedTokens,
+    ...(maxTokens !== undefined ? { maxTokens } : {}),
+    compactsAutomatically: true,
+  };
+}
+
 export function currentGrokModelIdFromSessionSetup(
   sessionSetupResult:
     | EffectAcpSchema.LoadSessionResponse
@@ -95,14 +317,41 @@ export function applyGrokAcpModelSelection<E>(input: {
   readonly runtime: Pick<AcpSessionRuntime.AcpSessionRuntime["Service"], "setSessionModel">;
   readonly currentModelId: string | undefined;
   readonly requestedModelId: string | undefined;
+  readonly currentReasoningEffort?: string;
+  readonly requestedReasoningEffort?: string;
   readonly mapError: (cause: EffectAcpErrors.AcpError) => E;
-}): Effect.Effect<string | undefined, E> {
-  const shouldSwitchModel =
+}): Effect.Effect<GrokAcpAppliedModelSelection, E> {
+  const currentReasoningEffort = normalizeGrokReasoningEffortToken(input.currentReasoningEffort);
+  const requestedReasoningEffort = normalizeGrokReasoningEffortToken(
+    input.requestedReasoningEffort,
+  );
+  const modelChanged =
     input.requestedModelId !== undefined && input.requestedModelId !== input.currentModelId;
-  if (!shouldSwitchModel) {
-    return Effect.succeed(input.currentModelId);
+  const effortChanged = requestedReasoningEffort !== currentReasoningEffort;
+  const targetModelId = modelChanged ? input.requestedModelId : input.currentModelId;
+
+  if (!modelChanged && !effortChanged) {
+    return Effect.succeed({
+      modelId: input.currentModelId,
+      reasoningEffort: currentReasoningEffort,
+    });
   }
-  return input.runtime
-    .setSessionModel(input.requestedModelId)
-    .pipe(Effect.mapError(input.mapError), Effect.as(input.requestedModelId));
+  if (!targetModelId) {
+    return Effect.succeed({
+      modelId: input.currentModelId,
+      reasoningEffort: currentReasoningEffort,
+    });
+  }
+
+  const meta =
+    requestedReasoningEffort !== undefined
+      ? { reasoningEffort: requestedReasoningEffort }
+      : undefined;
+  return input.runtime.setSessionModel(targetModelId, meta).pipe(
+    Effect.mapError(input.mapError),
+    Effect.as({
+      modelId: targetModelId,
+      reasoningEffort: requestedReasoningEffort,
+    }),
+  );
 }

--- a/apps/server/src/provider/acp/GrokAcpSupport.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.ts
@@ -327,7 +327,11 @@ export function applyGrokAcpModelSelection<E>(input: {
   );
   const modelChanged =
     input.requestedModelId !== undefined && input.requestedModelId !== input.currentModelId;
-  const effortChanged = requestedReasoningEffort !== currentReasoningEffort;
+  // A missing model selection is not a clear. Only treat effort as changed when
+  // the caller actually sent a model or an effort value.
+  const effortSpecified =
+    input.requestedModelId !== undefined || input.requestedReasoningEffort !== undefined;
+  const effortChanged = effortSpecified && requestedReasoningEffort !== currentReasoningEffort;
   const targetModelId = modelChanged ? input.requestedModelId : input.currentModelId;
 
   if (!modelChanged && !effortChanged) {

--- a/apps/server/src/textGeneration/GrokTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/GrokTextGeneration.test.ts
@@ -125,6 +125,50 @@ it.layer(GrokTextGenerationTestLayer)("GrokTextGeneration", (it) => {
     );
   });
 
+  it.effect("forwards reasoning effort through session/set_model _meta", () => {
+    const requestLogDir = NodeFS.mkdtempSync(
+      NodePath.join(NodeOS.tmpdir(), "t3code-grok-text-effort-log-"),
+    );
+    const requestLogPath = NodePath.join(requestLogDir, "requests.ndjson");
+
+    return withFakeAcpGrok(
+      {
+        T3_ACP_REQUEST_LOG_PATH: requestLogPath,
+        T3_ACP_PROMPT_RESPONSE_TEXT: JSON.stringify({
+          subject: "Tune Grok reasoning",
+          body: "Forward the composer effort selection.",
+        }),
+      },
+      (textGeneration) =>
+        Effect.gen(function* () {
+          yield* textGeneration.generateCommitMessage({
+            cwd: process.cwd(),
+            branch: "feature/grok",
+            stagedSummary: "M apps/server/src/provider/Drivers/GrokDriver.ts",
+            stagedPatch: "diff --git a/.../GrokDriver.ts b/.../GrokDriver.ts",
+            modelSelection: createModelSelection(ProviderInstanceId.make("grok"), "grok-build", [
+              { id: "reasoningEffort", value: "high" },
+            ]),
+          });
+
+          const requests = readJsonRpcRequests(requestLogPath);
+          expect(
+            requests.some((request) => {
+              const meta = request.params?._meta;
+              return (
+                request.method === "session/set_model" &&
+                request.params?.modelId === "grok-build" &&
+                typeof meta === "object" &&
+                meta !== null &&
+                "reasoningEffort" in meta &&
+                meta.reasoningEffort === "high"
+              );
+            }),
+          ).toBe(true);
+        }),
+    );
+  });
+
   it.effect("extracts the JSON object when Grok wraps it in conversational text", () =>
     withFakeAcpGrok(
       {

--- a/apps/server/src/textGeneration/GrokTextGeneration.ts
+++ b/apps/server/src/textGeneration/GrokTextGeneration.ts
@@ -7,6 +7,7 @@ import { ChildProcessSpawner } from "effect/unstable/process";
 import type * as EffectAcpErrors from "effect-acp/errors";
 
 import { type GrokSettings, type ModelSelection } from "@t3tools/contracts";
+import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
 import { sanitizeBranchFragment, sanitizeFeatureBranchName } from "@t3tools/shared/git";
 import { extractJsonObject } from "@t3tools/shared/schemaJson";
 
@@ -26,6 +27,7 @@ import {
 import {
   applyGrokAcpModelSelection,
   currentGrokModelIdFromSessionSetup,
+  GROK_REASONING_EFFORT_OPTION_ID,
   makeGrokAcpRuntime,
   resolveGrokAcpBaseModelId,
 } from "../provider/acp/GrokAcpSupport.ts";
@@ -87,6 +89,10 @@ export const makeGrokTextGeneration = Effect.fn("makeGrokTextGeneration")(functi
           runtime,
           currentModelId: currentGrokModelIdFromSessionSetup(started.sessionSetupResult),
           requestedModelId: resolvedModel,
+          requestedReasoningEffort: getModelSelectionStringOptionValue(
+            modelSelection,
+            GROK_REASONING_EFFORT_OPTION_ID,
+          ),
           mapError: (cause) =>
             new TextGenerationError({
               operation,

--- a/apps/web/src/lib/contextWindow.test.ts
+++ b/apps/web/src/lib/contextWindow.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vite-plus/test";
 import { EventId, type OrchestrationThreadActivity, TurnId } from "@t3tools/contracts";
 
-import { deriveLatestContextWindowSnapshot, formatContextWindowTokens } from "./contextWindow";
+import {
+  deriveLatestContextWindowSnapshot,
+  formatContextWindowTokens,
+  formatProviderDisplayName,
+} from "./contextWindow";
 
 function makeActivity(id: string, kind: string, payload: unknown): OrchestrationThreadActivity {
   return {
@@ -16,6 +20,12 @@ function makeActivity(id: string, kind: string, payload: unknown): Orchestration
 }
 
 describe("contextWindow", () => {
+  it("names known providers for the context meter", () => {
+    expect(formatProviderDisplayName("grok")).toBe("Grok");
+    expect(formatProviderDisplayName("claude")).toBe("Claude");
+    expect(formatProviderDisplayName("codex")).toBe("Codex");
+  });
+
   it("derives the latest valid context window snapshot", () => {
     const snapshot = deriveLatestContextWindowSnapshot([
       makeActivity("activity-1", "context-window.updated", {

--- a/apps/web/src/lib/contextWindow.ts
+++ b/apps/web/src/lib/contextWindow.ts
@@ -34,6 +34,8 @@ export function formatProviderDisplayName(provider: string | null | undefined): 
       return "Claude";
     case "codex":
       return "Codex";
+    case "grok":
+      return "Grok";
     case "cursor":
       return "Cursor";
     case "opencode":

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -54,6 +54,8 @@ to use, then authenticate it.
 | Grok Build | [Grok Build CLI](https://x.ai/cli)                    | `grok`         | `grok login`          |
 | OpenCode   | [OpenCode](https://opencode.ai)                       | `opencode`     | `opencode auth login` |
 
+Supported Grok models expose a Reasoning control in the composer.
+
 Cursor is the one to watch: install Cursor CLI, which provides the `cursor-agent` binary that
 T3 Code looks for, but authenticate with `agent login`, not `cursor-agent login`.
 


### PR DESCRIPTION
## What Changed

Grok threads now show a Reasoning menu and a filling context meter. Those controls already existed for Claude and Codex. Grok discarded the data.

Discovered Grok models that advertise ACP `_meta.reasoningEfforts` get a `reasoningEffort` select. Changing the level on the same model calls `session/set_model` with `_meta.reasoningEffort`. A turn with no selection no longer clears the current level.

ACP `usage_update`, notification `_meta`, and prompt `_meta` become `thread.token-usage.updated`. Duplicate ticks are dropped. The existing composer meter can fill. `formatProviderDisplayName("grok")` is now `Grok`.

This is not Fast Mode. Grok has no Fast Mode. Low reasoning is the faster setting. Skills stay on #6518.

## Why

Grok 4.6 advertises Extra High, High, Medium, and Low. T3 assigned empty capabilities and never emitted token usage. The composer hid both controls.

The composer already knows how to render `optionDescriptors` and `context-window.updated`. This PR fills those contracts from live ACP metadata instead of adding Grok-only UI.

## UI Changes

No new chrome. The existing composer Reasoning control and context meter now populate on Grok.

No screenshots in this PR. The change is wiring, not new layout. I will add before/after shots if review wants them.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes (not applicable)

Related: #6518, #6386, #5405

Implemented with Grok 4.6 through T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Grok turn preparation order, in-session `session/set_model` behavior, and runtime event emission; well-covered by tests but affects live ACP session state on every turn.
> 
> **Overview**
> Grok threads now populate the **existing** composer Reasoning control and context meter by wiring live ACP metadata into the same contracts Claude/Codex already use.
> 
> **Reasoning:** Discovered models read `_meta.reasoningEfforts` into a `reasoningEffort` select. `applyGrokAcpModelSelection` tracks effort and calls `session/set_model` with `_meta.reasoningEffort` when only the level changes on the same model; repeating a turn without an effort option does **not** clear the current level. `sendTurn` applies model/effort **after** prompt validation so empty turns never hit `set_model`. Text generation forwards effort the same way.
> 
> **Context usage:** ACP `usage_update`, notification `_meta`, and prompt response `_meta` are parsed into `TokenUsageUpdated` / Grok helpers and emitted as `thread.token-usage.updated` (with dedupe). Context window size comes from model `_meta.totalContextTokens`. The web layer labels the meter **Grok** via `formatProviderDisplayName`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a4ec099255808b5ea02d6f1a869f699b98454db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show reasoning effort controls and context window usage for Grok models in the composer
> - Grok models now advertise reasoning effort options (low/medium/high) and context window size via ACP `_meta`, surfaced as a Reasoning select in the composer.
> - `applyGrokAcpModelSelection` now triggers a `session/set_model` call (with `_meta.reasoningEffort`) even when the model itself does not change, to apply effort changes.
> - The adapter emits `thread.token-usage.updated` events from both ACP `usage_update` notifications and prompt response metadata, powering the context meter in the UI.
> - `formatProviderDisplayName` in [contextWindow.ts](https://github.com/pingdotgg/t3code/pull/6578/files#diff-7ca184c32d7cf96da57c102485f859064626dd9d63fabdf57a5e1d465b121c99) maps `'grok'` to `'Grok'` so the context meter labels the provider correctly.
> - Behavioral Change: `setSessionModel` in [AcpSessionRuntime.ts](https://github.com/pingdotgg/t3code/pull/6578/files#diff-947405407dc15b91fd18625aab3132939b58753dce5a014fe17c590f2abfa5d6) now accepts and forwards an optional `_meta` field; callers relying on exact JSON-RPC payloads will see the additional field when reasoning effort is set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a4ec09.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->