### PR TITLE
fix(server): subagent runs no longer delay replies

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.activity.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.activity.test.ts
@@ -129,6 +129,147 @@ describe("mergeBackgroundIngestion", () => {
     }
   });
 
+  it("preserves activity and max-merges a later sparse usage update", () => {
+    const taskId = RuntimeTaskId.make("agent-later-usage");
+    const activityUpdate = {
+      source: "runtime",
+      event: {
+        ...base,
+        type: "task.progress",
+        eventId: EventId.make("evt-earlier-activity"),
+        payload: {
+          taskId,
+          description: "Agent later usage",
+          summary: "Running tests",
+          lastToolName: "exec_command",
+          typedUsage: {
+            totalTokens: 100,
+            inputTokens: 80,
+            cachedInputTokens: 30,
+            outputTokens: 20,
+            reasoningOutputTokens: 10,
+            toolUses: 3,
+            durationMs: 1_000,
+          },
+        },
+      } satisfies ProviderRuntimeEvent,
+    } as const;
+    const usageUpdate = {
+      source: "runtime",
+      event: {
+        ...base,
+        type: "task.progress",
+        eventId: EventId.make("evt-later-usage"),
+        payload: {
+          taskId,
+          description: "Agent later usage",
+          typedUsage: {
+            totalTokens: 200,
+            inputTokens: 70,
+            outputTokens: 40,
+            durationMs: 900,
+          },
+        },
+      } satisfies ProviderRuntimeEvent,
+    } as const;
+
+    const merged = mergeBackgroundIngestion([activityUpdate], [usageUpdate]);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.event.type).toBe("task.progress");
+    if (merged[0]?.event.type === "task.progress") {
+      expect(merged[0].event.payload).toEqual({
+        taskId,
+        description: "Agent later usage",
+        summary: "Running tests",
+        lastToolName: "exec_command",
+        typedUsage: {
+          totalTokens: 200,
+          inputTokens: 80,
+          cachedInputTokens: 30,
+          outputTokens: 40,
+          reasoningOutputTokens: 10,
+          toolUses: 3,
+          durationMs: 1_000,
+        },
+      });
+    }
+  });
+
+  it("replaces stale activity fields while preserving the last usage snapshot", () => {
+    const taskId = RuntimeTaskId.make("agent-replaced-progress");
+    const previous = {
+      source: "runtime",
+      event: {
+        ...base,
+        type: "task.progress",
+        eventId: EventId.make("evt-previous-progress"),
+        payload: {
+          taskId,
+          description: "Agent replaced progress",
+          summary: "Old summary",
+          lastToolName: "old_tool",
+          error: "Old error",
+          phases: [{ index: 0, title: "Old phase" }],
+          typedUsage: { totalTokens: 4_200 },
+        },
+      } satisfies ProviderRuntimeEvent,
+    } as const;
+    const next = {
+      source: "runtime",
+      event: {
+        ...base,
+        type: "task.progress",
+        eventId: EventId.make("evt-next-progress"),
+        payload: {
+          taskId,
+          description: "Agent replaced progress",
+          phases: [{ index: 1, title: "New phase" }],
+          typedUsage: { totalTokens: 5_000 },
+        },
+      } satisfies ProviderRuntimeEvent,
+    } as const;
+
+    const merged = mergeBackgroundIngestion([previous], [next]);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.event.type).toBe("task.progress");
+    if (merged[0]?.event.type === "task.progress") {
+      expect(merged[0].event.payload).toEqual({
+        taskId,
+        description: "Agent replaced progress",
+        phases: [{ index: 1, title: "New phase" }],
+        typedUsage: { totalTokens: 5_000 },
+      });
+    }
+  });
+
+  it("preserves explicit task reactivation order", () => {
+    const taskId = RuntimeTaskId.make("agent-reactivated");
+    const completed = {
+      source: "runtime",
+      event: {
+        ...base,
+        type: "task.completed",
+        eventId: EventId.make("evt-task-completed"),
+        payload: { taskId, status: "completed" },
+      } satisfies ProviderRuntimeEvent,
+    } as const;
+    const reactivated = {
+      source: "runtime",
+      event: {
+        ...base,
+        type: "task.updated",
+        eventId: EventId.make("evt-task-reactivated"),
+        payload: { taskId, status: "running" },
+      } satisfies ProviderRuntimeEvent,
+    } as const;
+
+    const merged = mergeBackgroundIngestion([completed], [reactivated]);
+
+    expect(merged.map((input) => input.event.type)).toEqual(["task.completed", "task.updated"]);
+  });
+
   it("preserves fields from partial task status patches", () => {
     const taskId = RuntimeTaskId.make("agent-partial-update");
     const statusUpdate = {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.activity.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.activity.test.ts
@@ -84,6 +84,51 @@ describe("runtimeEventToActivities task progress", () => {
 });
 
 describe("mergeBackgroundIngestion", () => {
+  it("preserves usage when a later task progress tick only updates activity", () => {
+    const taskId = RuntimeTaskId.make("agent-partial-progress");
+    const usageUpdate = {
+      source: "runtime",
+      event: {
+        ...base,
+        type: "task.progress",
+        eventId: EventId.make("evt-task-usage"),
+        payload: {
+          taskId,
+          description: "Agent partial progress",
+          typedUsage: { totalTokens: 4_200 },
+        },
+      } satisfies ProviderRuntimeEvent,
+    } as const;
+    const activityUpdate = {
+      source: "runtime",
+      event: {
+        ...base,
+        type: "task.progress",
+        eventId: EventId.make("evt-task-activity"),
+        payload: {
+          taskId,
+          description: "Agent partial progress",
+          summary: "Running tests",
+          lastToolName: "exec_command",
+        },
+      } satisfies ProviderRuntimeEvent,
+    } as const;
+
+    const merged = mergeBackgroundIngestion([usageUpdate], [activityUpdate]);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.event.type).toBe("task.progress");
+    if (merged[0]?.event.type === "task.progress") {
+      expect(merged[0].event.payload).toEqual({
+        taskId,
+        description: "Agent partial progress",
+        typedUsage: { totalTokens: 4_200 },
+        summary: "Running tests",
+        lastToolName: "exec_command",
+      });
+    }
+  });
+
   it("preserves fields from partial task status patches", () => {
     const taskId = RuntimeTaskId.make("agent-partial-update");
     const statusUpdate = {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.activity.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.activity.test.ts
@@ -7,7 +7,7 @@ import {
 } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
-import { runtimeEventToActivities } from "./ProviderRuntimeIngestion.ts";
+import { mergeBackgroundIngestion, runtimeEventToActivities } from "./ProviderRuntimeIngestion.ts";
 
 const base = {
   provider: ProviderDriverKind.make("codex"),
@@ -80,5 +80,47 @@ describe("runtimeEventToActivities task progress", () => {
     expect(usagePayload.typedUsage).toEqual({ totalTokens: 4_200, toolUses: 7 });
     expect(usagePayload.usageSnapshot).toBe(true);
     expect(usagePayload).not.toHaveProperty("status");
+  });
+});
+
+describe("mergeBackgroundIngestion", () => {
+  it("preserves fields from partial task status patches", () => {
+    const taskId = RuntimeTaskId.make("agent-partial-update");
+    const statusUpdate = {
+      source: "runtime",
+      event: {
+        ...base,
+        type: "task.updated",
+        eventId: EventId.make("evt-task-status"),
+        payload: {
+          taskId,
+          status: "completed",
+        },
+      } satisfies ProviderRuntimeEvent,
+    } as const;
+    const completionTimeUpdate = {
+      source: "runtime",
+      event: {
+        ...base,
+        type: "task.updated",
+        eventId: EventId.make("evt-task-ended-at"),
+        payload: {
+          taskId,
+          endedAt: "2026-08-06T00:00:01.000Z",
+        },
+      } satisfies ProviderRuntimeEvent,
+    } as const;
+
+    const merged = mergeBackgroundIngestion([statusUpdate], [completionTimeUpdate]);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.event.type).toBe("task.updated");
+    if (merged[0]?.event.type === "task.updated") {
+      expect(merged[0].event.payload).toEqual({
+        taskId,
+        status: "completed",
+        endedAt: "2026-08-06T00:00:01.000Z",
+      });
+    }
   });
 });

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -225,6 +225,11 @@ describe("ProviderRuntimeIngestion", () => {
     const workspaceRoot = makeTempDir("t3-provider-project-");
     NodeFS.mkdirSync(NodePath.join(workspaceRoot, ".git"));
     const provider = createProviderServiceHarness();
+    const backgroundLiveness = ThreadBackgroundLiveness.make();
+    const backgroundLivenessLayer = Layer.succeed(
+      ThreadBackgroundLiveness.ThreadBackgroundLivenessService,
+      backgroundLiveness,
+    );
     const orchestrationLayer = OrchestrationEngineLive.pipe(
       Layer.provide(OrchestrationProjectionSnapshotQueryLive),
       Layer.provide(OrchestrationProjectionPipelineLive),
@@ -242,7 +247,7 @@ describe("ProviderRuntimeIngestion", () => {
       Layer.provideMerge(projectionSnapshotLayer),
       // Single shared liveness instance across ingestion (writer), the
       // engine, and the snapshot query (reader).
-      Layer.provideMerge(ThreadBackgroundLiveness.layer),
+      Layer.provideMerge(backgroundLivenessLayer),
       Layer.provideMerge(ThreadPlanProgress.layer),
       Layer.provideMerge(SqlitePersistenceMemory),
       Layer.provideMerge(Layer.succeed(ProviderService, provider.service)),
@@ -318,6 +323,8 @@ describe("ProviderRuntimeIngestion", () => {
       readModel: () => Effect.runPromise(snapshotQuery.getSnapshot()),
       emit: provider.emit,
       setProviderSession: provider.setSession,
+      getBackgroundLiveness: (threadId: ThreadId) =>
+        backgroundLiveness.getThreadBackgroundLiveness(threadId),
       drain,
     };
   }
@@ -3252,6 +3259,37 @@ describe("ProviderRuntimeIngestion", () => {
         (entry: ProviderRuntimeTestProposedPlan) => entry.id === "plan:thread-1:turn:turn-task-1",
       )?.planMarkdown,
     ).toBe("# Plan title");
+  });
+
+  it("does not revive background liveness after the provider session exits", async () => {
+    const harness = await createHarness();
+    const threadId = asThreadId("thread-1");
+
+    harness.emit({
+      type: "session.exited",
+      eventId: asEventId("evt-session-exited-before-stale-task"),
+      provider: ProviderDriverKind.make("claudeAgent"),
+      createdAt: "2026-01-01T00:00:01.000Z",
+      threadId,
+      payload: {},
+    });
+    await harness.drain();
+    expect(harness.getBackgroundLiveness(threadId)).toBeNull();
+
+    harness.emit({
+      type: "task.progress",
+      eventId: asEventId("evt-stale-task-after-session-exit"),
+      provider: ProviderDriverKind.make("claudeAgent"),
+      createdAt: "2026-01-01T00:00:02.000Z",
+      threadId,
+      payload: {
+        taskId: "stale-task-after-exit",
+        description: "This task belongs to the exited session",
+      },
+    });
+    await harness.drain();
+
+    expect(harness.getBackgroundLiveness(threadId)).toBeNull();
   });
 
   it("titles task activities with the task description, including on completion", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -135,7 +135,7 @@ function isTaskLifecycleInput(input: RuntimeIngestionInput): input is Extract<
   );
 }
 
-function mergeBackgroundIngestion(
+export function mergeBackgroundIngestion(
   current: RuntimeIngestionBatch,
   next: RuntimeIngestionBatch,
 ): RuntimeIngestionBatch {
@@ -146,6 +146,24 @@ function mergeBackgroundIngestion(
 
   const latestByType = new Map<(typeof TASK_LIFECYCLE_ORDER)[number], RuntimeIngestionInput>();
   for (const input of combined) {
+    const previous = latestByType.get(input.event.type);
+    if (
+      input.event.type === "task.updated" &&
+      previous?.source === "runtime" &&
+      previous.event.type === "task.updated"
+    ) {
+      latestByType.set(input.event.type, {
+        ...input,
+        event: {
+          ...input.event,
+          payload: {
+            ...previous.event.payload,
+            ...input.event.payload,
+          },
+        },
+      });
+      continue;
+    }
     latestByType.set(input.event.type, input);
   }
   return TASK_LIFECYCLE_ORDER.flatMap((eventType) => {
@@ -2031,6 +2049,11 @@ const make = Effect.gen(function* () {
         case "task.progress":
         case "task.updated":
         case "task.completed": {
+          // A realtime session exit can overtake queued background task
+          // telemetry. Never let those stale rows resurrect sidebar liveness.
+          if (thread.session?.status === "stopped") {
+            break;
+          }
           const payload = event.payload as {
             taskId: string;
             taskType?: string;

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -18,6 +18,8 @@ import {
   type OrchestrationThread,
   type OrchestrationThreadActivity,
   type ProviderRuntimeEvent,
+  type RuntimeTaskUsage,
+  type TaskProgressPayload,
 } from "@t3tools/contracts";
 import * as Cache from "effect/Cache";
 import * as Cause from "effect/Cause";
@@ -135,6 +137,52 @@ function isTaskLifecycleInput(input: RuntimeIngestionInput): input is Extract<
   );
 }
 
+function hasTaskProgressActivityState(payload: TaskProgressPayload): boolean {
+  return (
+    payload.typedUsage === undefined ||
+    payload.summary !== undefined ||
+    payload.lastToolName !== undefined ||
+    payload.status !== undefined ||
+    payload.error !== undefined ||
+    payload.phases !== undefined
+  );
+}
+
+function mergeTaskUsage(
+  previous: RuntimeTaskUsage | undefined,
+  next: RuntimeTaskUsage | undefined,
+): RuntimeTaskUsage | undefined {
+  if (!previous) return next;
+  if (!next) return previous;
+
+  const max = (a: number | undefined, b: number | undefined): number | undefined =>
+    a === undefined ? b : b === undefined ? a : Math.max(a, b);
+  const inputTokens = max(previous.inputTokens, next.inputTokens);
+  const cachedInputTokens = max(previous.cachedInputTokens, next.cachedInputTokens);
+  const outputTokens = max(previous.outputTokens, next.outputTokens);
+  const reasoningOutputTokens = max(previous.reasoningOutputTokens, next.reasoningOutputTokens);
+  const toolUses = max(previous.toolUses, next.toolUses);
+  const durationMs = max(previous.durationMs, next.durationMs);
+  return {
+    totalTokens: Math.max(previous.totalTokens, next.totalTokens),
+    ...(inputTokens === undefined ? {} : { inputTokens }),
+    ...(cachedInputTokens === undefined ? {} : { cachedInputTokens }),
+    ...(outputTokens === undefined ? {} : { outputTokens }),
+    ...(reasoningOutputTokens === undefined ? {} : { reasoningOutputTokens }),
+    ...(toolUses === undefined ? {} : { toolUses }),
+    ...(durationMs === undefined ? {} : { durationMs }),
+  };
+}
+
+function mergeTaskProgressPayload(
+  previous: TaskProgressPayload,
+  next: TaskProgressPayload,
+): TaskProgressPayload {
+  const payload = hasTaskProgressActivityState(next) ? next : { ...previous, ...next };
+  const typedUsage = mergeTaskUsage(previous.typedUsage, next.typedUsage);
+  return typedUsage === undefined ? payload : { ...payload, typedUsage };
+}
+
 export function mergeBackgroundIngestion(
   current: RuntimeIngestionBatch,
   next: RuntimeIngestionBatch,
@@ -145,6 +193,8 @@ export function mergeBackgroundIngestion(
   }
 
   const latestByType = new Map<(typeof TASK_LIFECYCLE_ORDER)[number], RuntimeIngestionInput>();
+  // Reinsert replacements so different lifecycle types keep their latest arrival order.
+  // Explicit running updates can reactivate a task after a completed attempt.
   for (const input of combined) {
     const previous = latestByType.get(input.event.type);
     if (
@@ -152,14 +202,12 @@ export function mergeBackgroundIngestion(
       previous?.source === "runtime" &&
       previous.event.type === "task.progress"
     ) {
+      latestByType.delete(input.event.type);
       latestByType.set(input.event.type, {
         ...input,
         event: {
           ...input.event,
-          payload: {
-            ...previous.event.payload,
-            ...input.event.payload,
-          },
+          payload: mergeTaskProgressPayload(previous.event.payload, input.event.payload),
         },
       });
       continue;
@@ -169,6 +217,7 @@ export function mergeBackgroundIngestion(
       previous?.source === "runtime" &&
       previous.event.type === "task.updated"
     ) {
+      latestByType.delete(input.event.type);
       latestByType.set(input.event.type, {
         ...input,
         event: {
@@ -181,12 +230,10 @@ export function mergeBackgroundIngestion(
       });
       continue;
     }
+    latestByType.delete(input.event.type);
     latestByType.set(input.event.type, input);
   }
-  return TASK_LIFECYCLE_ORDER.flatMap((eventType) => {
-    const input = latestByType.get(eventType);
-    return input === undefined ? [] : [input];
-  });
+  return Array.from(latestByType.values());
 }
 
 function backgroundIngestionKey(input: RuntimeIngestionInput): string | undefined {
@@ -678,12 +725,7 @@ export function runtimeEventToActivities(
         event.payload.description.trim().length > 0
           ? { title: truncateDetail(event.payload.description, 120) }
           : {};
-      const hasProgressState =
-        event.payload.typedUsage === undefined ||
-        event.payload.summary !== undefined ||
-        event.payload.lastToolName !== undefined ||
-        event.payload.status !== undefined ||
-        event.payload.error !== undefined;
+      const hasProgressState = hasTaskProgressActivityState(event.payload);
       return [
         ...(hasProgressState
           ? [

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -27,7 +27,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Stream from "effect/Stream";
-import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
+import { makePriorityCoalescingWorker } from "@t3tools/shared/PriorityCoalescingWorker";
 
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { ProjectionTurnRepository } from "../../persistence/Services/ProjectionTurns.ts";
@@ -113,6 +113,72 @@ type RuntimeIngestionInput =
       source: "domain";
       event: TurnStartRequestedDomainEvent;
     };
+
+type RuntimeIngestionBatch = ReadonlyArray<RuntimeIngestionInput>;
+
+const TASK_LIFECYCLE_ORDER = [
+  "task.started",
+  "task.progress",
+  "task.updated",
+  "task.completed",
+] as const;
+
+function isTaskLifecycleInput(input: RuntimeIngestionInput): input is Extract<
+  RuntimeIngestionInput,
+  { source: "runtime" }
+> & {
+  readonly event: Extract<ProviderRuntimeEvent, { type: (typeof TASK_LIFECYCLE_ORDER)[number] }>;
+} {
+  return (
+    input.source === "runtime" &&
+    TASK_LIFECYCLE_ORDER.some((eventType) => eventType === input.event.type)
+  );
+}
+
+function mergeBackgroundIngestion(
+  current: RuntimeIngestionBatch,
+  next: RuntimeIngestionBatch,
+): RuntimeIngestionBatch {
+  const combined = [...current, ...next];
+  if (!combined.every(isTaskLifecycleInput)) {
+    return next;
+  }
+
+  const latestByType = new Map<(typeof TASK_LIFECYCLE_ORDER)[number], RuntimeIngestionInput>();
+  for (const input of combined) {
+    latestByType.set(input.event.type, input);
+  }
+  return TASK_LIFECYCLE_ORDER.flatMap((eventType) => {
+    const input = latestByType.get(eventType);
+    return input === undefined ? [] : [input];
+  });
+}
+
+function backgroundIngestionKey(input: RuntimeIngestionInput): string | undefined {
+  if (input.source !== "runtime") {
+    return undefined;
+  }
+
+  const event = input.event;
+  switch (event.type) {
+    // These are latest-state telemetry streams. A large agent fleet can emit
+    // hundreds of ticks while one database write is in flight, so keeping
+    // every queued intermediate value only delays user-visible replies.
+    case "task.started":
+    case "task.progress":
+    case "task.updated":
+    case "task.completed":
+      return `task:${event.threadId}:${event.payload.taskId}`;
+    case "tool.progress":
+      return event.payload.taskId === undefined
+        ? undefined
+        : `tool-progress:${event.threadId}:${event.payload.taskId}`;
+    case "thread.token-usage.updated":
+      return `thread-token-usage:${event.threadId}`;
+    default:
+      return undefined;
+  }
+}
 
 function toTurnId(value: TurnId | string | undefined): TurnId | undefined {
   return value === undefined ? undefined : TurnId.make(String(value));
@@ -2040,13 +2106,24 @@ const make = Effect.gen(function* () {
       }),
     );
 
-  const worker = yield* makeDrainableWorker(processInputSafely);
+  const worker = yield* makePriorityCoalescingWorker({
+    mergeBackground: mergeBackgroundIngestion,
+    process: (batch) =>
+      Effect.forEach(batch, processInputSafely, { concurrency: 1 }).pipe(Effect.asVoid),
+  });
+
+  const enqueueInput = (input: RuntimeIngestionInput) => {
+    const backgroundKey = backgroundIngestionKey(input);
+    return backgroundKey === undefined
+      ? worker.enqueueRealtime([input])
+      : worker.enqueueBackground(backgroundKey, [input]);
+  };
 
   const start: ProviderRuntimeIngestionShape["start"] = () =>
     Effect.gen(function* () {
       yield* forkParked(
         Stream.runForEach(providerService.streamEvents, (event) =>
-          worker.enqueue({ source: "runtime", event }),
+          enqueueInput({ source: "runtime", event }),
         ),
       );
       yield* forkParked(
@@ -2054,7 +2131,7 @@ const make = Effect.gen(function* () {
           if (event.type !== "thread.turn-start-requested") {
             return Effect.void;
           }
-          return worker.enqueue({ source: "domain", event });
+          return enqueueInput({ source: "domain", event });
         }),
       );
     });

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -148,6 +148,23 @@ export function mergeBackgroundIngestion(
   for (const input of combined) {
     const previous = latestByType.get(input.event.type);
     if (
+      input.event.type === "task.progress" &&
+      previous?.source === "runtime" &&
+      previous.event.type === "task.progress"
+    ) {
+      latestByType.set(input.event.type, {
+        ...input,
+        event: {
+          ...input.event,
+          payload: {
+            ...previous.event.payload,
+            ...input.event.payload,
+          },
+        },
+      });
+      continue;
+    }
+    if (
       input.event.type === "task.updated" &&
       previous?.source === "runtime" &&
       previous.event.type === "task.updated"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -59,6 +59,10 @@
       "types": "./src/KeyedCoalescingWorker.ts",
       "import": "./src/KeyedCoalescingWorker.ts"
     },
+    "./PriorityCoalescingWorker": {
+      "types": "./src/PriorityCoalescingWorker.ts",
+      "import": "./src/PriorityCoalescingWorker.ts"
+    },
     "./schemaJson": {
       "types": "./src/schemaJson.ts",
       "import": "./src/schemaJson.ts"

--- a/packages/shared/src/PriorityCoalescingWorker.test.ts
+++ b/packages/shared/src/PriorityCoalescingWorker.test.ts
@@ -1,0 +1,41 @@
+import { it } from "@effect/vitest";
+import { describe, expect } from "vite-plus/test";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+
+import { makePriorityCoalescingWorker } from "./PriorityCoalescingWorker.ts";
+
+describe("makePriorityCoalescingWorker", () => {
+  it.live("runs realtime work before queued background updates and coalesces each key", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const processed: string[] = [];
+        const firstStarted = yield* Deferred.make<void>();
+        const releaseFirst = yield* Deferred.make<void>();
+
+        const worker = yield* makePriorityCoalescingWorker<string, string, never, never>({
+          mergeBackground: (_current, next) => next,
+          process: (value) =>
+            Effect.gen(function* () {
+              processed.push(value);
+              if (value === "background:first") {
+                yield* Deferred.succeed(firstStarted, undefined).pipe(Effect.orDie);
+                yield* Deferred.await(releaseFirst);
+              }
+            }),
+        });
+
+        yield* worker.enqueueBackground("task-1", "background:first");
+        yield* Deferred.await(firstStarted);
+
+        yield* worker.enqueueBackground("task-2", "background:stale");
+        yield* worker.enqueueBackground("task-2", "background:latest");
+        yield* worker.enqueueRealtime("assistant:reply");
+        yield* Deferred.succeed(releaseFirst, undefined);
+        yield* worker.drain;
+
+        expect(processed).toEqual(["background:first", "assistant:reply", "background:latest"]);
+      }),
+    ),
+  );
+});

--- a/packages/shared/src/PriorityCoalescingWorker.test.ts
+++ b/packages/shared/src/PriorityCoalescingWorker.test.ts
@@ -38,4 +38,53 @@ describe("makePriorityCoalescingWorker", () => {
       }),
     ),
   );
+
+  it.live("keeps processing realtime work after a processor failure", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const processed = yield* Deferred.make<void>();
+        const worker = yield* makePriorityCoalescingWorker<string, string, string, never>({
+          mergeBackground: (_current, next) => next,
+          process: (value) =>
+            value === "fail"
+              ? Effect.fail("expected failure")
+              : Deferred.succeed(processed, undefined).pipe(Effect.asVoid),
+        });
+
+        yield* worker.enqueueRealtime("fail");
+        yield* worker.enqueueRealtime("succeed");
+        yield* Deferred.await(processed);
+        yield* worker.drain;
+      }),
+    ),
+  );
+
+  it.live("processes the latest background update after a processor failure", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const firstStarted = yield* Deferred.make<void>();
+        const releaseFirst = yield* Deferred.make<void>();
+        const processedLatest = yield* Deferred.make<void>();
+        const worker = yield* makePriorityCoalescingWorker<string, string, string, never>({
+          mergeBackground: (_current, next) => next,
+          process: (value) =>
+            Effect.gen(function* () {
+              if (value === "first") {
+                yield* Deferred.succeed(firstStarted, undefined).pipe(Effect.orDie);
+                yield* Deferred.await(releaseFirst);
+                return yield* Effect.fail("expected failure");
+              }
+              yield* Deferred.succeed(processedLatest, undefined).pipe(Effect.orDie);
+            }),
+        });
+
+        yield* worker.enqueueBackground("task-1", "first");
+        yield* Deferred.await(firstStarted);
+        yield* worker.enqueueBackground("task-1", "latest");
+        yield* Deferred.succeed(releaseFirst, undefined);
+        yield* Deferred.await(processedLatest);
+        yield* worker.drain;
+      }),
+    ),
+  );
 });

--- a/packages/shared/src/PriorityCoalescingWorker.ts
+++ b/packages/shared/src/PriorityCoalescingWorker.ts
@@ -8,29 +8,32 @@
  *
  * @module PriorityCoalescingWorker
  */
-import * as Scope from "effect/Scope";
+import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
+import * as HashMap from "effect/HashMap";
+import * as HashSet from "effect/HashSet";
 import * as Option from "effect/Option";
+import * as Scope from "effect/Scope";
 import * as TxQueue from "effect/TxQueue";
 import * as TxRef from "effect/TxRef";
 
-export interface PriorityCoalescingWorker<K, V> {
+export interface PriorityCoalescingWorker<K extends string, V> {
   readonly enqueueRealtime: (value: V) => Effect.Effect<void>;
   readonly enqueueBackground: (key: K, value: V) => Effect.Effect<void>;
   readonly drain: Effect.Effect<void>;
 }
 
-interface BackgroundState<K, V> {
-  readonly latestByKey: Map<K, V>;
-  readonly queuedKeys: Set<K>;
-  readonly activeKeys: Set<K>;
+interface BackgroundState<K extends string, V> {
+  readonly latestByKey: HashMap.HashMap<K, V>;
+  readonly queuedKeys: HashSet.HashSet<K>;
+  readonly activeKeys: HashSet.HashSet<K>;
 }
 
-type WorkItem<K, V> =
+type WorkItem<K extends string, V> =
   | { readonly _tag: "Realtime"; readonly value: V }
   | { readonly _tag: "Background"; readonly key: K; readonly value: V };
 
-export const makePriorityCoalescingWorker = <K, V, E, R>(options: {
+export const makePriorityCoalescingWorker = <K extends string, V, E, R>(options: {
   readonly mergeBackground: (current: V, next: V) => V;
   readonly process: (value: V) => Effect.Effect<void, E, R>;
 }): Effect.Effect<PriorityCoalescingWorker<K, V>, never, Scope.Scope | R> =>
@@ -38,9 +41,9 @@ export const makePriorityCoalescingWorker = <K, V, E, R>(options: {
     const realtimeQueue = yield* Effect.acquireRelease(TxQueue.unbounded<V>(), TxQueue.shutdown);
     const backgroundQueue = yield* Effect.acquireRelease(TxQueue.unbounded<K>(), TxQueue.shutdown);
     const backgroundState = yield* TxRef.make<BackgroundState<K, V>>({
-      latestByKey: new Map(),
-      queuedKeys: new Set(),
-      activeKeys: new Set(),
+      latestByKey: HashMap.empty(),
+      queuedKeys: HashSet.empty(),
+      activeKeys: HashSet.empty(),
     });
     const outstanding = yield* TxRef.make(0);
 
@@ -52,49 +55,61 @@ export const makePriorityCoalescingWorker = <K, V, E, R>(options: {
 
       const key = yield* TxQueue.take(backgroundQueue);
       const state = yield* TxRef.get(backgroundState);
-      if (!state.latestByKey.has(key)) {
+      const value = HashMap.get(state.latestByKey, key);
+      if (Option.isNone(value)) {
         return yield* Effect.txRetry;
       }
-      const value = state.latestByKey.get(key) as V;
 
-      const latestByKey = new Map(state.latestByKey);
-      latestByKey.delete(key);
-      const queuedKeys = new Set(state.queuedKeys);
-      queuedKeys.delete(key);
-      const activeKeys = new Set(state.activeKeys);
-      activeKeys.add(key);
-      yield* TxRef.set(backgroundState, { latestByKey, queuedKeys, activeKeys });
+      yield* TxRef.set(backgroundState, {
+        latestByKey: HashMap.remove(state.latestByKey, key),
+        queuedKeys: HashSet.remove(state.queuedKeys, key),
+        activeKeys: HashSet.add(state.activeKeys, key),
+      });
 
-      return { _tag: "Background", key, value } as const;
+      return { _tag: "Background", key, value: value.value } as const;
     }).pipe(Effect.tx);
 
     const finishBackground = (key: K) =>
       Effect.gen(function* () {
         const state = yield* TxRef.get(backgroundState);
-        const activeKeys = new Set(state.activeKeys);
-        activeKeys.delete(key);
+        const activeKeys = HashSet.remove(state.activeKeys, key);
 
-        if (!state.latestByKey.has(key)) {
+        if (!HashMap.has(state.latestByKey, key)) {
           yield* TxRef.set(backgroundState, { ...state, activeKeys });
           yield* TxRef.update(outstanding, (count) => count - 1);
           return;
         }
 
-        const queuedKeys = new Set(state.queuedKeys);
-        queuedKeys.add(key);
-        yield* TxRef.set(backgroundState, { ...state, queuedKeys, activeKeys });
+        yield* TxRef.set(backgroundState, {
+          ...state,
+          queuedKeys: HashSet.add(state.queuedKeys, key),
+          activeKeys,
+        });
         yield* TxQueue.offer(backgroundQueue, key);
       }).pipe(Effect.tx);
+
+    // One malformed event must not terminate the worker and strand later work.
+    // Scoped interruption still propagates so shutdown remains prompt.
+    const keepWorkerAlive = <A, E>(effect: Effect.Effect<A, E, R>) =>
+      effect.pipe(
+        Effect.catchCause((cause) =>
+          Cause.hasInterruptsOnly(cause) ? Effect.failCause(cause) : Effect.void,
+        ),
+      );
 
     yield* takeNext.pipe(
       Effect.flatMap((item: WorkItem<K, V>) =>
         item._tag === "Realtime"
-          ? options
-              .process(item.value)
-              .pipe(
-                Effect.ensuring(TxRef.update(outstanding, (count) => count - 1).pipe(Effect.tx)),
-              )
-          : options.process(item.value).pipe(Effect.ensuring(finishBackground(item.key))),
+          ? keepWorkerAlive(
+              options
+                .process(item.value)
+                .pipe(
+                  Effect.ensuring(TxRef.update(outstanding, (count) => count - 1).pipe(Effect.tx)),
+                ),
+            )
+          : keepWorkerAlive(
+              options.process(item.value).pipe(Effect.ensuring(finishBackground(item.key))),
+            ),
       ),
       Effect.forever,
       Effect.forkScoped,
@@ -110,21 +125,26 @@ export const makePriorityCoalescingWorker = <K, V, E, R>(options: {
     const enqueueBackground: PriorityCoalescingWorker<K, V>["enqueueBackground"] = (key, value) =>
       Effect.gen(function* () {
         const state = yield* TxRef.get(backgroundState);
-        const latestByKey = new Map(state.latestByKey);
-        const existing = latestByKey.get(key);
-        latestByKey.set(
+        const existing = HashMap.get(state.latestByKey, key);
+        const latestByKey = HashMap.set(
+          state.latestByKey,
           key,
-          existing === undefined ? value : options.mergeBackground(existing, value),
+          Option.match(existing, {
+            onNone: () => value,
+            onSome: (current) => options.mergeBackground(current, value),
+          }),
         );
 
-        if (state.queuedKeys.has(key) || state.activeKeys.has(key)) {
+        if (HashSet.has(state.queuedKeys, key) || HashSet.has(state.activeKeys, key)) {
           yield* TxRef.set(backgroundState, { ...state, latestByKey });
           return;
         }
 
-        const queuedKeys = new Set(state.queuedKeys);
-        queuedKeys.add(key);
-        yield* TxRef.set(backgroundState, { ...state, latestByKey, queuedKeys });
+        yield* TxRef.set(backgroundState, {
+          ...state,
+          latestByKey,
+          queuedKeys: HashSet.add(state.queuedKeys, key),
+        });
         yield* TxRef.update(outstanding, (count) => count + 1);
         yield* TxQueue.offer(backgroundQueue, key);
       }).pipe(Effect.tx);

--- a/packages/shared/src/PriorityCoalescingWorker.ts
+++ b/packages/shared/src/PriorityCoalescingWorker.ts
@@ -1,0 +1,142 @@
+/**
+ * A single-lane worker that always drains realtime work before background
+ * work and keeps only the latest queued background value for each key.
+ *
+ * Realtime work cannot interrupt the item already being processed, but it is
+ * selected before any remaining background key. Background keys are requeued
+ * after one pass, so one hot key cannot starve the others.
+ *
+ * @module PriorityCoalescingWorker
+ */
+import * as Scope from "effect/Scope";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as TxQueue from "effect/TxQueue";
+import * as TxRef from "effect/TxRef";
+
+export interface PriorityCoalescingWorker<K, V> {
+  readonly enqueueRealtime: (value: V) => Effect.Effect<void>;
+  readonly enqueueBackground: (key: K, value: V) => Effect.Effect<void>;
+  readonly drain: Effect.Effect<void>;
+}
+
+interface BackgroundState<K, V> {
+  readonly latestByKey: Map<K, V>;
+  readonly queuedKeys: Set<K>;
+  readonly activeKeys: Set<K>;
+}
+
+type WorkItem<K, V> =
+  | { readonly _tag: "Realtime"; readonly value: V }
+  | { readonly _tag: "Background"; readonly key: K; readonly value: V };
+
+export const makePriorityCoalescingWorker = <K, V, E, R>(options: {
+  readonly mergeBackground: (current: V, next: V) => V;
+  readonly process: (value: V) => Effect.Effect<void, E, R>;
+}): Effect.Effect<PriorityCoalescingWorker<K, V>, never, Scope.Scope | R> =>
+  Effect.gen(function* () {
+    const realtimeQueue = yield* Effect.acquireRelease(TxQueue.unbounded<V>(), TxQueue.shutdown);
+    const backgroundQueue = yield* Effect.acquireRelease(TxQueue.unbounded<K>(), TxQueue.shutdown);
+    const backgroundState = yield* TxRef.make<BackgroundState<K, V>>({
+      latestByKey: new Map(),
+      queuedKeys: new Set(),
+      activeKeys: new Set(),
+    });
+    const outstanding = yield* TxRef.make(0);
+
+    const takeNext = Effect.gen(function* () {
+      const realtime = yield* TxQueue.poll(realtimeQueue);
+      if (Option.isSome(realtime)) {
+        return { _tag: "Realtime", value: realtime.value } as const;
+      }
+
+      const key = yield* TxQueue.take(backgroundQueue);
+      const state = yield* TxRef.get(backgroundState);
+      if (!state.latestByKey.has(key)) {
+        return yield* Effect.txRetry;
+      }
+      const value = state.latestByKey.get(key) as V;
+
+      const latestByKey = new Map(state.latestByKey);
+      latestByKey.delete(key);
+      const queuedKeys = new Set(state.queuedKeys);
+      queuedKeys.delete(key);
+      const activeKeys = new Set(state.activeKeys);
+      activeKeys.add(key);
+      yield* TxRef.set(backgroundState, { latestByKey, queuedKeys, activeKeys });
+
+      return { _tag: "Background", key, value } as const;
+    }).pipe(Effect.tx);
+
+    const finishBackground = (key: K) =>
+      Effect.gen(function* () {
+        const state = yield* TxRef.get(backgroundState);
+        const activeKeys = new Set(state.activeKeys);
+        activeKeys.delete(key);
+
+        if (!state.latestByKey.has(key)) {
+          yield* TxRef.set(backgroundState, { ...state, activeKeys });
+          yield* TxRef.update(outstanding, (count) => count - 1);
+          return;
+        }
+
+        const queuedKeys = new Set(state.queuedKeys);
+        queuedKeys.add(key);
+        yield* TxRef.set(backgroundState, { ...state, queuedKeys, activeKeys });
+        yield* TxQueue.offer(backgroundQueue, key);
+      }).pipe(Effect.tx);
+
+    yield* takeNext.pipe(
+      Effect.flatMap((item: WorkItem<K, V>) =>
+        item._tag === "Realtime"
+          ? options
+              .process(item.value)
+              .pipe(
+                Effect.ensuring(TxRef.update(outstanding, (count) => count - 1).pipe(Effect.tx)),
+              )
+          : options.process(item.value).pipe(Effect.ensuring(finishBackground(item.key))),
+      ),
+      Effect.forever,
+      Effect.forkScoped,
+    );
+
+    const enqueueRealtime: PriorityCoalescingWorker<K, V>["enqueueRealtime"] = (value) =>
+      TxQueue.offer(realtimeQueue, value).pipe(
+        Effect.tap(() => TxRef.update(outstanding, (count) => count + 1)),
+        Effect.tx,
+        Effect.asVoid,
+      );
+
+    const enqueueBackground: PriorityCoalescingWorker<K, V>["enqueueBackground"] = (key, value) =>
+      Effect.gen(function* () {
+        const state = yield* TxRef.get(backgroundState);
+        const latestByKey = new Map(state.latestByKey);
+        const existing = latestByKey.get(key);
+        latestByKey.set(
+          key,
+          existing === undefined ? value : options.mergeBackground(existing, value),
+        );
+
+        if (state.queuedKeys.has(key) || state.activeKeys.has(key)) {
+          yield* TxRef.set(backgroundState, { ...state, latestByKey });
+          return;
+        }
+
+        const queuedKeys = new Set(state.queuedKeys);
+        queuedKeys.add(key);
+        yield* TxRef.set(backgroundState, { ...state, latestByKey, queuedKeys });
+        yield* TxRef.update(outstanding, (count) => count + 1);
+        yield* TxQueue.offer(backgroundQueue, key);
+      }).pipe(Effect.tx);
+
+    const drain: PriorityCoalescingWorker<K, V>["drain"] = TxRef.get(outstanding).pipe(
+      Effect.tap((count) => (count > 0 ? Effect.txRetry : Effect.void)),
+      Effect.tx,
+    );
+
+    return {
+      enqueueRealtime,
+      enqueueBackground,
+      drain,
+    } satisfies PriorityCoalescingWorker<K, V>;
+  });


### PR DESCRIPTION
During large subagent runs, background progress events could pile up ahead of assistant events. The assistant had replied, but T3 Code was still processing old progress updates, so the reply looked missing.

Replies and other realtime events now move ahead of queued background telemetry. Replaceable progress updates are collapsed to their newest state instead of replaying every intermediate tick.

How it works:

- `ProviderRuntimeIngestion` routes task lifecycle events, task-owned tool progress, and thread usage updates through a background lane. Conversation events stay realtime.
- `PriorityCoalescingWorker` checks the realtime queue before each background item and keeps one queued value per task or telemetry key.
- Task lifecycle merges preserve started/progress/updated/completed order, and partial `task.updated` patches keep fields reported by earlier patches.
- One failed event no longer terminates the worker and strands everything behind it. A session exit also prevents overtaken task telemetry from restoring stale background activity.

Focused tests cover realtime priority, task coalescing, partial updates, processor failures, and session-exit ordering.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core orchestration ingestion ordering and merging for all provider runtime events; incorrect coalescing could drop or mis-order task state, though scope is limited to telemetry lanes with extensive tests.
> 
> **Overview**
> Fixes replies appearing stuck behind large subagent runs by **replacing** the single FIFO drain worker in `ProviderRuntimeIngestion` with **`makePriorityCoalescingWorker`**: conversation and other non-telemetry events stay on a **realtime** lane, while task lifecycle, task-scoped `tool.progress`, and `thread.token-usage.updated` go to **background** lanes keyed per thread/task and collapse to the latest tick instead of replaying every intermediate update.
> 
> Adds **`mergeBackgroundIngestion`** so coalesced `task.progress` / `task.updated` batches keep partial fields (usage max-merge, activity vs usage-only ticks, lifecycle order including reactivation after `task.completed`).
> 
> **Guards:** task liveness is not recorded when `session.status === "stopped"` (stale telemetry after `session.exited`); processor failures no longer kill the worker loop.
> 
> New **`packages/shared/PriorityCoalescingWorker`** is exported and covered by unit tests; ingestion behavior is covered by expanded activity/merge tests and an integration test for post-exit liveness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 053539b2c023b94052c09728699ed5fb16777639. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix subagent runs delaying replies by prioritizing realtime events over background ingestion
> - Replaces `makeDrainableWorker` with a new `makePriorityCoalescingWorker` in [ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/6584/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7) that processes realtime events before background ones, so subagent task telemetry no longer blocks reply delivery.
> - Background task lifecycle events (e.g. `task.progress`, `task.updated`) are coalesced per task key, merging usage metrics via max-merge and preserving the latest activity state, reducing redundant processing.
> - After a provider session exits, subsequent task lifecycle telemetry no longer updates background liveness for that thread.
> - The new [PriorityCoalescingWorker.ts](https://github.com/pingdotgg/t3code/pull/6584/files#diff-d99ff5c0390e72ecfcaa2d22384ffc9599f6dfde80c3b7aa58ad6f0bc6844efb) module exposes `enqueueRealtime`, `enqueueBackground(key, value)`, and `drain`, and survives processor failures by swallowing non-interrupt errors.
> - Behavioral Change: `task.progress` events that include phases are now treated as having activity state, replacing the previous per-task progress activity row rather than overlaying it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 053539b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->