### PR TITLE
fix(mobile): add breathing room between the git progress overlay and the app bar

### DIFF
--- a/apps/mobile/src/features/threads/GitActionProgressOverlay.tsx
+++ b/apps/mobile/src/features/threads/GitActionProgressOverlay.tsx
@@ -12,6 +12,8 @@ import { useThemeColor } from "../../lib/useThemeColor";
 import type { GitActionProgress } from "../../state/use-vcs-action-state";
 
 const OVERLAY_LAYOUT_TRANSITION = LinearTransition.duration(220);
+const APP_BAR_HEIGHT = 48;
+const OVERLAY_TOP_GAP = 8;
 const AnimatedLiquidGlassView = Animated.createAnimatedComponent(LiquidGlassView);
 
 export function GitActionProgressOverlay(props: {
@@ -52,7 +54,7 @@ export function GitActionProgressOverlay(props: {
       entering={isLiquidGlassSupported ? undefined : FadeIn.duration(200)}
       exiting={FadeOut.duration(150)}
       className="absolute inset-x-3 z-[100]"
-      style={{ top: insets.top + 48 }}
+      style={{ top: insets.top + APP_BAR_HEIGHT + OVERLAY_TOP_GAP }}
       pointerEvents="box-none"
     >
       <Pressable onPress={handlePress}>

--- a/apps/mobile/src/features/threads/GitActionProgressOverlay.tsx
+++ b/apps/mobile/src/features/threads/GitActionProgressOverlay.tsx
@@ -7,12 +7,12 @@ import Animated, { FadeIn, FadeOut, LinearTransition } from "react-native-reanim
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { AppText as Text } from "../../components/AppText";
+import { APP_BAR_HEIGHT } from "../../lib/layoutMetrics";
 import { tryOpenExternalUrl } from "../../lib/openExternalUrl";
 import { useThemeColor } from "../../lib/useThemeColor";
 import type { GitActionProgress } from "../../state/use-vcs-action-state";
 
 const OVERLAY_LAYOUT_TRANSITION = LinearTransition.duration(220);
-const APP_BAR_HEIGHT = 48;
 const OVERLAY_TOP_GAP = 8;
 const AnimatedLiquidGlassView = Animated.createAnimatedComponent(LiquidGlassView);
 

--- a/apps/mobile/src/lib/layoutMetrics.ts
+++ b/apps/mobile/src/lib/layoutMetrics.ts
@@ -3,3 +3,10 @@ export const HOME_HORIZONTAL_INSET = 20;
 
 /** Compensates for the tighter native sidebar title margin on iPad. */
 export const IPAD_HOME_TITLE_OFFSET = 10;
+
+/**
+ * Height of the app's own header chrome below the safe-area inset, on every
+ * platform (matches the `min-h-12` AndroidScreenHeader). Distinct from the
+ * 44pt native iOS navigation bar.
+ */
+export const APP_BAR_HEIGHT = 48;


### PR DESCRIPTION
## Summary
- The `GitActionProgressOverlay` banner ("Pushing…") was positioned at `insets.top + 48`, sitting flush against the app bar on the session screen.
- Extracted the magic `48` into an `APP_BAR_HEIGHT` constant and added an 8px `OVERLAY_TOP_GAP` (the `mt-2` step of the default 4px spacing scale, consistent with the existing 12px `inset-x-3` side margins). The gap lives in the inline `top` calculation because the overlay is absolutely positioned against the safe-area insets.

## Before / after

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/PollyGlot/t3code/assets/overlay-gap-screens/overlay-before.png) | ![after](https://raw.githubusercontent.com/PollyGlot/t3code/assets/overlay-gap-screens/overlay-after.png) |

(Dev-client builds on iOS simulators; the floating gear bubble is the Expo dev menu, not part of the UI.)

## Test plan
- [x] `vp run -r typecheck` passes (exit 0)
- [x] `vp test run src/features/threads` in `apps/mobile`: 85 tests pass
- [x] `vp fmt --check` clean
- [x] Verified visually on iPhone 17 / iPhone 17 Pro simulators (screenshots above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual layout tweak only; no auth, data, or business-logic changes.
> 
> **Overview**
> Adds **8px** breathing room between the session **git progress** banner and the app bar by changing its absolute `top` from `insets.top + 48` to `insets.top + APP_BAR_HEIGHT + OVERLAY_TOP_GAP`.
> 
> The inline `48` is pulled into shared **`APP_BAR_HEIGHT`** in `layoutMetrics.ts` (documented as matching `min-h-12` header chrome), with **`OVERLAY_TOP_GAP`** kept next to the overlay positioning logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 136cacf2e9670a1bdee9d8c5da9687577492b28f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add spacing between the git progress overlay and the app bar on mobile
> The overlay's top offset now uses the safe-area inset plus `APP_BAR_HEIGHT` (exported from [layoutMetrics.ts](https://github.com/pingdotgg/t3code/pull/6587/files#diff-1220797f14b1d97d8302a3fea13727ac81828a304ac5d44d4aed4335671d1d37)) and a new `OVERLAY_TOP_GAP` constant, replacing a hardcoded numeric offset in [GitActionProgressOverlay.tsx](https://github.com/pingdotgg/t3code/pull/6587/files#diff-676fe607184008943cedbcbd21f43bbf678b3617b5934ad9c366823c90e4e2f4).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 136cacf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->