### PR TITLE
fix(web): align every titlebar control cluster on one shared inset

### DIFF
--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -96,8 +96,11 @@ function SidebarControl() {
   }, [keybindings, toggleSidebar]);
 
   return (
+    // The right-side layout controls carry mr-px (border compensation inside
+    // the panel), so the trigger mirrors it: both clusters sit one extra pixel
+    // off their edge and the titlebar reads symmetric.
     <div
-      className="pointer-events-none fixed left-[var(--workspace-controls-left)] top-[var(--workspace-controls-top)] z-50 flex h-[var(--workspace-topbar-height)] items-center"
+      className="pointer-events-none fixed left-[var(--workspace-controls-left)] top-[var(--workspace-controls-top)] z-50 ml-px flex h-[var(--workspace-topbar-height)] items-center"
       data-sidebar-control=""
     >
       <Tooltip>

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6583,7 +6583,11 @@ function ChatViewContent(props: ChatViewProps) {
         <RightPanelSheet open onClose={closePreviewPanel}>
           <RightPanelTabs
             mode="sheet"
-            layoutControls={panelToggleControls}
+            // Same effective inset as the closed-state titlebar controls
+            // (pr-3 in the tab bar plus this pixel equals the absolute
+            // right inset plus mr-px), so the cluster does not creep when
+            // the sheet opens.
+            layoutControls={<div className="mr-px flex items-center">{panelToggleControls}</div>}
             surfaces={rightPanelState.surfaces}
             activeSurfaceId={activeRightPanelSurface?.id ?? null}
             pendingSurfaceIds={pendingFileSurfaceIds}

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -604,7 +604,9 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
       <div
         className={cn(
           "workspace-topbar gap-1 pl-2",
-          props.mode !== "inline" && "[--workspace-topbar-height:--spacing(11)]",
+          // The sheet overlays from the viewport top, so its tab bar keeps
+          // the titlebar's height: a compact row re-centers the layout
+          // controls a few pixels higher and the cluster jumps on open.
           props.mode === "inline" && !props.layoutControls ? "pr-28" : "pr-3",
           ownsDesktopTitleBar && "wco:pr-[calc(var(--workspace-native-controls-inset)+6rem)]",
           props.mode === "inline" && props.maximized && COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS,

--- a/apps/web/src/components/chat/PanelLayoutControls.tsx
+++ b/apps/web/src/components/chat/PanelLayoutControls.tsx
@@ -48,7 +48,7 @@ export const PanelLayoutControls = memo(function PanelLayoutControls({
                 size="sm"
                 disabled={!terminalAvailable}
               >
-                <PanelBottomIcon className="size-3.5" />
+                <PanelBottomIcon className="size-4" />
               </Toggle>
             }
           />
@@ -75,7 +75,7 @@ export const PanelLayoutControls = memo(function PanelLayoutControls({
               size="sm"
               disabled={!rightPanelAvailable}
             >
-              <PanelRightIcon className="size-3.5" />
+              <PanelRightIcon className="size-4" />
               {liveAgentCount > 0 ? (
                 <span
                   aria-hidden
@@ -122,9 +122,9 @@ export const RightPanelMaximizeControl = memo(function RightPanelMaximizeControl
             size="sm"
           >
             {maximized ? (
-              <Minimize2Icon className="size-3.5" />
+              <Minimize2Icon className="size-4" />
             ) : (
-              <Maximize2Icon className="size-3.5" />
+              <Maximize2Icon className="size-4" />
             )}
           </Toggle>
         }

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1303,7 +1303,13 @@ function PullRequestsRouteView() {
     />
   );
   const openPanelControls = (
-    <div className="workspace-titlebar-controls right-2 z-50 gap-1 [-webkit-app-region:no-drag] wco:right-[var(--workspace-controls-right)]">
+    <div
+      // The bare workspace-titlebar-controls inset plus mr-px: the same
+      // anchor the thread view's controls and the sidebar trigger use, so
+      // every titlebar cluster in the app sits one shared inset from its
+      // edge.
+      className="workspace-titlebar-controls z-50 mr-px gap-1 [-webkit-app-region:no-drag]"
+    >
       {panelToggleControls}
     </div>
   );
@@ -1484,7 +1490,13 @@ function PullRequestsRouteView() {
     searchInput,
     filtersMenu,
     rightPanelControl:
-      !pullRequestsSupported || rightPanelState.isOpen ? null : panelToggleControls,
+      // Footprint reserve while the panel is closed: the toggle itself stays
+      // mounted at the fixed titlebar inset in both states so it cannot move
+      // on toggle, and this spacer keeps refresh from sliding underneath it
+      // (sized per header padding so refresh ends a normal gap short of it).
+      !pullRequestsSupported || rightPanelState.isOpen ? null : (
+        <span aria-hidden className="w-7 shrink-0 sm:w-5" />
+      ),
     rightPanelOpen: rightPanelState.isOpen,
     listBody,
   };
@@ -1526,7 +1538,7 @@ function PullRequestsRouteView() {
   return (
     <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
       <div className="relative flex min-h-0 flex-1">
-        {pullRequestsSupported && rightPanelState.isOpen ? openPanelControls : null}
+        {pullRequestsSupported ? openPanelControls : null}
         <PullRequestsColumn {...columnProps} />
 
         {rightPanelState.isOpen && activePullRequestSurface && panelEnvironmentId !== null ? (


### PR DESCRIPTION
Titlebar geometry polish so the sidebar trigger, the thread view's layout controls, and the pull requests page's panel toggle all read as one family. Found while dogfooding on the orchestrator branch (#2829); ported here so both lineages agree.

## What changed

- **Icon size**: the layout-control icons were hard-coded `size-3.5` while the sidebar trigger (Button `size="icon"` default) and the PR page refresh icon render `size-4` — the two ends of the titlebar sat a pixel apart on every edge. All layout-control icons now use `size-4`.
- **Trigger inset symmetry**: the right cluster carries `mr-px` (border compensation for anchoring inside the panel frame); the sidebar trigger now mirrors it with `ml-px` so both clusters sit one shared inset off their edges.
- **Sheet-mode jump**: the sheet overlays from the viewport top, but its tab bar used the compact `spacing(11)` row, re-centering the controls 4px higher than their closed-state titlebar position on every open. The sheet tab bar now keeps `--workspace-topbar-height`, and its layout-controls slot carries the `mr-px` so the horizontal inset matches too.
- **PR page toggle**: the panel toggle previously moved between an in-flow header slot (closed) and an absolute corner anchor (open). It now stays mounted at the fixed `workspace-titlebar-controls` inset in both states — the same anchor as the thread view — with a per-breakpoint footprint reserve in the list header so refresh never slides underneath it.

## Verification

- `pnpm --filter @t3tools/web typecheck` clean
- Web suite: 2429/2429 passing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS and layout-only changes to titlebar positioning and icon sizing; no auth, data, or API behavior.
> 
> **Overview**
> **Titlebar geometry** is unified so sidebar trigger, thread layout controls, and PR page panel toggle read as one family and stop jumping on panel open/close.
> 
> Layout-control icons move from `size-3.5` to **`size-4`** to match the sidebar trigger and PR refresh. The sidebar trigger wrapper gains **`ml-px`** to mirror the right cluster’s **`mr-px`**. In **sheet** mode, the right-panel tab bar no longer forces a shorter topbar height (removed compact `spacing(11)` override), and sheet layout controls are wrapped with **`mr-px`** so horizontal inset matches the closed titlebar. On **pull requests**, panel toggles stay on the fixed **`workspace-titlebar-controls`** anchor whenever PRs are supported (not only when the panel is open); the list header uses a footprint **spacer** instead of in-flow toggle controls when the panel is closed so refresh doesn’t slide under the fixed toggle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62badc9ec42a9cefdaf8a3cc77892dc719be810c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align titlebar control clusters on a shared 1px inset across all views
> - Wraps right panel controls in sheet mode with a `mr-px` flex container in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/6592/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to match the shared inset.
> - Updates [PullRequestsRouteView](https://github.com/pingdotgg/t3code/pull/6592/files#diff-514a5b26d9687035b089d834742d874da174aa0a8a0c7c2fd47c61d11795afa5) to always render the titlebar control cluster when pull requests are supported, and inserts a fixed-width spacer when the right panel is closed to prevent header controls from shifting.
> - Removes the conditional `--workspace-topbar-height` CSS variable override from [RightPanelTabs](https://github.com/pingdotgg/t3code/pull/6592/files#diff-1580fd0e52935869fd626dd71bcb2484b765e9b216e92c55d09960e870986b91) in non-inline mode.
> - Increases panel toggle and maximize/restore icon sizes from `size-3.5` to `size-4` in [PanelLayoutControls.tsx](https://github.com/pingdotgg/t3code/pull/6592/files#diff-4a8fd1569788ea7247bd600d44295eca372aea32c2d56bd144a3841b07dff51f).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 62badc9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->