### PR TITLE
fix(web): load pull request images from private repositories

### DIFF
--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -1,5 +1,9 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { AssetPreviewTypeValidationError, ThreadId } from "@t3tools/contracts";
+import {
+  AssetGitHubAttachmentUrlValidationError,
+  AssetPreviewTypeValidationError,
+  ThreadId,
+} from "@t3tools/contracts";
 import { PROJECT_FAVICON_FALLBACK_MARKER } from "@t3tools/shared/projectFavicon";
 import { describe, expect, it } from "@effect/vitest";
 import * as Crypto from "effect/Crypto";
@@ -31,6 +35,31 @@ const testLayer = Layer.mergeAll(
 ).pipe(Layer.provideMerge(NodeServices.layer));
 
 describe("AssetAccess", () => {
+  it.effect("signs only GitHub user attachment URLs", () =>
+    Effect.gen(function* () {
+      const url = "https://github.com/user-attachments/assets/dec6b30a-7724-4590-802a-af5586a2724d";
+      const result = yield* issueAssetUrl({
+        resource: { _tag: "github-user-attachment", url },
+      });
+      const suffix = result.relativeUrl.slice(`${ASSET_ROUTE_PREFIX}/`.length);
+      const separatorIndex = suffix.indexOf("/");
+      expect(
+        yield* resolveAsset(suffix.slice(0, separatorIndex), suffix.slice(separatorIndex + 1)),
+      ).toEqual({
+        kind: "github-user-attachment",
+        url,
+      });
+
+      const error = yield* issueAssetUrl({
+        resource: {
+          _tag: "github-user-attachment",
+          url: "https://example.com/user-attachments/assets/dec6b30a-7724-4590-802a-af5586a2724d",
+        },
+      }).pipe(Effect.flip);
+      expect(error).toBeInstanceOf(AssetGitHubAttachmentUrlValidationError);
+    }).pipe(Effect.provide(testLayer)),
+  );
+
   it.effect("issues workspace URLs that resolve the entry file and sibling assets", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
@@ -191,7 +220,9 @@ describe("AssetAccess", () => {
       const path = yield* Path.Path;
       const attachmentId = "thread-1-00000000-0000-4000-8000-000000000001";
       const attachmentPath = path.join(config.attachmentsDir, `${attachmentId}.png`);
-      yield* fileSystem.makeDirectory(config.attachmentsDir, { recursive: true });
+      yield* fileSystem.makeDirectory(config.attachmentsDir, {
+        recursive: true,
+      });
       yield* fileSystem.writeFile(attachmentPath, new Uint8Array([1, 2, 3]));
 
       const result = yield* issueAssetUrl({
@@ -299,7 +330,11 @@ describe("AssetAccess", () => {
       yield* fileSystem.writeFileString(path.join(root, "brand", "saved.svg"), "<svg>saved</svg>");
 
       const result = yield* issueAssetUrl({
-        resource: { _tag: "project-favicon", cwd: root, path: "brand/hint.svg" },
+        resource: {
+          _tag: "project-favicon",
+          cwd: root,
+          path: "brand/hint.svg",
+        },
         projectFaviconPath: "brand/saved.svg",
       });
 

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -2,6 +2,7 @@ import type { AssetResource } from "@t3tools/contracts";
 import {
   AssetAttachmentNotFoundError,
   AssetPreviewTypeValidationError,
+  AssetGitHubAttachmentUrlValidationError,
   AssetProjectFaviconInspectionError,
   AssetProjectFaviconNotFoundError,
   AssetProjectFaviconResolutionError,
@@ -88,6 +89,12 @@ const AssetClaimsSchema = Schema.Union([
     relativePath: Schema.NullOr(Schema.String),
     expiresAt: Schema.Number,
   }),
+  Schema.Struct({
+    version: Schema.Literal(1),
+    kind: Schema.Literal("github-user-attachment"),
+    url: Schema.String,
+    expiresAt: Schema.Number,
+  }),
 ]);
 type AssetClaims = typeof AssetClaimsSchema.Type;
 
@@ -95,7 +102,27 @@ const AssetClaimsJson = Schema.fromJsonString(AssetClaimsSchema);
 const decodeAssetClaims = Schema.decodeUnknownOption(AssetClaimsJson);
 const encodeAssetClaims = Schema.encodeSync(AssetClaimsJson);
 
-export type ResolvedAsset = { readonly kind: "file"; readonly path: string };
+export type ResolvedAsset =
+  | { readonly kind: "file"; readonly path: string }
+  | { readonly kind: "github-user-attachment"; readonly url: string };
+
+export function isGitHubUserAttachmentUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === "https:" &&
+      url.hostname === "github.com" &&
+      url.port === "" &&
+      url.username === "" &&
+      url.password === "" &&
+      url.search === "" &&
+      url.hash === "" &&
+      /^\/user-attachments\/assets\/[0-9a-f-]+$/i.test(url.pathname)
+    );
+  } catch {
+    return false;
+  }
+}
 
 function decodeClaims(encodedPayload: string): AssetClaims | null {
   try {
@@ -302,11 +329,16 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
         );
       const relativePath = faviconPath ? path.relative(workspaceRoot, faviconPath) : null;
       if (relativePath && !isWorkspaceImagePreviewPath(relativePath)) {
-        return yield* new AssetPreviewTypeValidationError({ resource: input.resource });
+        return yield* new AssetPreviewTypeValidationError({
+          resource: input.resource,
+        });
       }
       sourcePath = relativePath ?? undefined;
       const canonicalFaviconPath = relativePath
-        ? yield* resolveCanonicalWorkspaceFile({ workspaceRoot, relativePath }).pipe(
+        ? yield* resolveCanonicalWorkspaceFile({
+            workspaceRoot,
+            relativePath,
+          }).pipe(
             Effect.mapError(
               (cause) =>
                 new AssetProjectFaviconInspectionError({
@@ -363,6 +395,21 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
       }
       break;
     }
+    case "github-user-attachment": {
+      if (!isGitHubUserAttachmentUrl(input.resource.url)) {
+        return yield* new AssetGitHubAttachmentUrlValidationError({
+          resource: input.resource,
+        });
+      }
+      claims = {
+        version: 1,
+        kind: "github-user-attachment",
+        url: input.resource.url,
+        expiresAt,
+      };
+      fileName = path.basename(new URL(input.resource.url).pathname);
+      break;
+    }
   }
 
   const secretStore = yield* ServerSecretStore.ServerSecretStore;
@@ -408,6 +455,15 @@ export const resolveAsset = Effect.fn("AssetAccess.resolveAsset")(function* (
 
   const claims = decodeClaims(encodedPayload);
   if (!claims || claims.expiresAt <= (yield* Clock.currentTimeMillis)) return null;
+
+  if (claims.kind === "github-user-attachment") {
+    return isGitHubUserAttachmentUrl(claims.url)
+      ? ({
+          kind: "github-user-attachment",
+          url: claims.url,
+        } satisfies ResolvedAsset)
+      : null;
+  }
 
   if (claims.kind === "attachment") {
     const config = yield* ServerConfig.ServerConfig;

--- a/apps/server/src/http.test.ts
+++ b/apps/server/src/http.test.ts
@@ -1,7 +1,27 @@
 import { expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 import { describe } from "vite-plus/test";
 
-import { assetResponseHeaders, isLoopbackHostname, resolveDevRedirectUrl } from "./http.ts";
+import * as ProcessRunner from "./processRunner.ts";
+import {
+  assetResponseHeaders,
+  isLoopbackHostname,
+  proxyGitHubUserAttachment,
+  resolveDevRedirectUrl,
+} from "./http.ts";
+
+const processResult = (stdout: string): ProcessRunner.ProcessRunOutput => ({
+  stdout,
+  stderr: "",
+  code: 0 as ProcessRunner.ProcessRunOutput["code"],
+  timedOut: false,
+  stdoutTruncated: false,
+  stderrTruncated: false,
+  stdoutInvalidUtf8: false,
+  stderrInvalidUtf8: false,
+});
 
 describe("http dev routing", () => {
   it("treats localhost and loopback addresses as local", () => {
@@ -36,6 +56,12 @@ describe("assetResponseHeaders", () => {
     expect(assetResponseHeaders("/attachments/user-image.SVG")).toHaveProperty(
       "Content-Security-Policy",
     );
+    expect(
+      assetResponseHeaders(
+        "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000000",
+        "image/svg+xml",
+      ),
+    ).toHaveProperty("Content-Security-Policy");
   });
 
   it("does not apply document policy to raster images", () => {
@@ -43,5 +69,53 @@ describe("assetResponseHeaders", () => {
       "Cache-Control": "private, max-age=3600",
       "X-Content-Type-Options": "nosniff",
     });
+  });
+});
+
+describe("GitHub attachment proxy", () => {
+  it.effect("returns 404 without a GitHub token", () =>
+    proxyGitHubUserAttachment("https://github.com/user-attachments/assets/id").pipe(
+      Effect.provide(
+        Layer.merge(
+          Layer.succeed(ProcessRunner.ProcessRunner, {
+            run: () => Effect.succeed(processResult("")),
+          }),
+          Layer.succeed(
+            HttpClient.HttpClient,
+            HttpClient.make(() => Effect.die("unexpected fetch")),
+          ),
+        ),
+      ),
+      Effect.tap((response) => Effect.sync(() => expect(response.status).toBe(404))),
+    ),
+  );
+
+  it.effect("streams authenticated images with safe headers", () => {
+    const httpClient = HttpClient.make((request) =>
+      Effect.succeed(
+        HttpClientResponse.fromWeb(
+          request,
+          new Response("<svg/>", { headers: { "content-type": "image/svg+xml" } }),
+        ),
+      ),
+    );
+    return proxyGitHubUserAttachment("https://github.com/user-attachments/assets/id").pipe(
+      Effect.provide(
+        Layer.merge(
+          Layer.succeed(ProcessRunner.ProcessRunner, {
+            run: () => Effect.succeed(processResult("token\n")),
+          }),
+          Layer.succeed(HttpClient.HttpClient, httpClient),
+        ),
+      ),
+      Effect.tap((response) =>
+        Effect.sync(() => {
+          expect(response.status).toBe(200);
+          expect(response.headers["content-type"]).toBe("image/svg+xml");
+          expect(response.headers["content-security-policy"]).toContain("sandbox");
+          expect(response.body._tag).toBe("Stream");
+        }),
+      ),
+    );
   });
 });

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -16,6 +16,7 @@ import { cast } from "effect/Function";
 import {
   HttpBody,
   HttpClient,
+  HttpClientRequest,
   HttpClientResponse,
   HttpMiddleware,
   HttpRouter,
@@ -38,6 +39,7 @@ import {
   failEnvironmentInternal,
 } from "./auth/http.ts";
 import * as ServerEnvironment from "./environment/ServerEnvironment.ts";
+import * as ProcessRunner from "./processRunner.ts";
 import { browserApiCorsAllowedHeaders, browserApiCorsAllowedMethods } from "./httpCors.ts";
 
 const OTLP_TRACES_PROXY_PATH = "/api/observability/v1/traces";
@@ -45,15 +47,60 @@ const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "::1", "localhost"]);
 const DESKTOP_RENDERER_ORIGINS = ["t3code://app", "t3code-dev://app"];
 const SVG_CONTENT_SECURITY_POLICY = "default-src 'none'; style-src 'unsafe-inline'; sandbox";
 
-export function assetResponseHeaders(filePath: string): Record<string, string> {
+export function assetResponseHeaders(
+  filePath: string,
+  contentType?: string,
+): Record<string, string> {
   return {
     "Cache-Control": "private, max-age=3600",
     "X-Content-Type-Options": "nosniff",
-    ...(filePath.toLowerCase().endsWith(".svg")
+    ...(contentType === "image/svg+xml" || filePath.toLowerCase().endsWith(".svg")
       ? { "Content-Security-Policy": SVG_CONTENT_SECURITY_POLICY }
       : {}),
   };
 }
+
+export const proxyGitHubUserAttachment = Effect.fn("proxyGitHubUserAttachment")(function* (
+  url: string,
+) {
+  const processRunner = yield* ProcessRunner.ProcessRunner;
+  const token = yield* processRunner
+    .run({
+      command: "gh",
+      args: ["auth", "token", "--hostname", "github.com"],
+      timeout: "10 seconds",
+      maxOutputBytes: 4096,
+    })
+    .pipe(
+      Effect.map((result) => (result.code === 0 ? result.stdout.trim() : "")),
+      Effect.orElseSucceed(() => ""),
+    );
+  if (token.length === 0) return HttpServerResponse.text("Not Found", { status: 404 });
+
+  const httpClient = yield* HttpClient.HttpClient;
+  const response = yield* httpClient
+    .execute(
+      HttpClientRequest.get(url).pipe(
+        HttpClientRequest.setHeader("accept", "image/*"),
+        HttpClientRequest.bearerToken(token),
+      ),
+    )
+    .pipe(Effect.orElseSucceed(() => null));
+  if (!response || response.status < 200 || response.status >= 300) {
+    return HttpServerResponse.text("Not Found", { status: 404 });
+  }
+  const contentType = response.headers["content-type"]?.split(";", 1)[0] ?? "";
+  if (!contentType.startsWith("image/")) {
+    return HttpServerResponse.text("Not Found", { status: 404 });
+  }
+  return HttpServerResponse.stream(response.stream, {
+    status: 200,
+    headers: {
+      ...assetResponseHeaders(url, contentType),
+      "Content-Type": contentType,
+    },
+  });
+});
 
 export const httpCompressionLayer = HttpRouter.middleware(HttpMiddleware.compression(), {
   global: true,
@@ -217,6 +264,9 @@ export const assetRouteLayer = HttpRouter.add(
     if (!asset) {
       return HttpServerResponse.text("Not Found", { status: 404 });
     }
+    if (asset.kind === "github-user-attachment") {
+      return yield* proxyGitHubUserAttachment(asset.url).pipe(Effect.provide(ProcessRunner.layer));
+    }
     return yield* HttpServerResponse.file(asset.path, {
       status: 200,
       headers: assetResponseHeaders(asset.path),
@@ -270,7 +320,9 @@ export const staticAndDevRouteLayer = HttpRouter.add(
       hasPathTraversalSegment ||
       staticRelativePath.includes("\0")
     ) {
-      return HttpServerResponse.text("Invalid static file path", { status: 400 });
+      return HttpServerResponse.text("Invalid static file path", {
+        status: 400,
+      });
     }
 
     const isWithinStaticRoot = (candidate: string) =>
@@ -279,14 +331,18 @@ export const staticAndDevRouteLayer = HttpRouter.add(
 
     let filePath = path.resolve(staticRoot, staticRelativePath);
     if (!isWithinStaticRoot(filePath)) {
-      return HttpServerResponse.text("Invalid static file path", { status: 400 });
+      return HttpServerResponse.text("Invalid static file path", {
+        status: 400,
+      });
     }
 
     const ext = path.extname(filePath);
     if (!ext) {
       filePath = path.resolve(filePath, "index.html");
       if (!isWithinStaticRoot(filePath)) {
-        return HttpServerResponse.text("Invalid static file path", { status: 400 });
+        return HttpServerResponse.text("Invalid static file path", {
+          status: 400,
+        });
       }
     }
 

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1223,7 +1223,9 @@ const makeWsRpcLayer = (
                 input.requestCompletionMarker === true
                   ? Stream.concat(
                       Stream.fromEffect(
-                        Queue.offer(liveBuffer, { kind: "synchronized" as const }).pipe(
+                        Queue.offer(liveBuffer, {
+                          kind: "synchronized" as const,
+                        }).pipe(
                           Effect.andThen(Queue.takeAll(liveBuffer)),
                           Effect.flatMap(coalesceShellLiveInputs),
                         ),
@@ -1373,7 +1375,9 @@ const makeWsRpcLayer = (
                     input.requestCompletionMarker === true
                       ? Stream.concat(
                           Stream.fromEffect(
-                            Queue.offer(liveBuffer, { kind: "synchronized" as const }),
+                            Queue.offer(liveBuffer, {
+                              kind: "synchronized" as const,
+                            }),
                           ).pipe(Stream.drain),
                           bufferedLiveStream,
                         )
@@ -1415,7 +1419,9 @@ const makeWsRpcLayer = (
                 input.requestCompletionMarker === true
                   ? Stream.concat(
                       Stream.fromEffect(
-                        Queue.offer(liveBuffer, { kind: "synchronized" as const }),
+                        Queue.offer(liveBuffer, {
+                          kind: "synchronized" as const,
+                        }),
                       ).pipe(Stream.drain),
                       bufferedLiveStream,
                     )
@@ -1869,6 +1875,9 @@ const makeWsRpcLayer = (
                     ? { projectFaviconPath: project.value.faviconPath }
                     : {}),
                 });
+              }
+              if (input.resource._tag === "github-user-attachment") {
+                return yield* issueAssetUrl({ resource: input.resource });
               }
               const thread = yield* projectionSnapshotQuery
                 .getThreadShellById(input.resource.threadId)

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -110,6 +110,7 @@ interface ChatMarkdownProps {
   className?: string;
   /** Treat single newlines as hard breaks — chat-style user input. */
   lineBreaks?: boolean;
+  imageComponent?: Components["img"];
 }
 
 const EMPTY_MARKDOWN_SKILLS: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">> = [];
@@ -185,7 +186,12 @@ const CHAT_MARKDOWN_REHYPE_PLUGINS = [
 /** GitHub's own five alert kinds, in its colors: the glyph names the urgency, the title says it. */
 const GITHUB_ALERT_PRESENTATIONS: Record<
   string,
-  { label: string; Icon: typeof InfoIcon; borderClassName: string; titleClassName: string }
+  {
+    label: string;
+    Icon: typeof InfoIcon;
+    borderClassName: string;
+    titleClassName: string;
+  }
 > = {
   note: {
     label: "Note",
@@ -334,9 +340,11 @@ function extractCodeBlock(
 
   const onlyChild = childNodes[0];
   if (
-    !isValidElement<{ className?: string; children?: ReactNode; node?: { tagName?: string } }>(
-      onlyChild,
-    )
+    !isValidElement<{
+      className?: string;
+      children?: ReactNode;
+      node?: { tagName?: string };
+    }>(onlyChild)
   ) {
     return null;
   }
@@ -1200,7 +1208,11 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
         },
         (error) => {
           reportMarkdownActionFailure(
-            { operation: "copy-file-path", target: targetPath, copyTarget: title },
+            {
+              operation: "copy-file-path",
+              target: targetPath,
+              copyTarget: title,
+            },
             error,
           );
           toastManager.add(
@@ -1229,7 +1241,12 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
           [
             { id: "open", label: "Open in editor" },
             ...(onOpenInBrowser
-              ? ([{ id: "open-in-browser", label: "Open in integrated browser" }] as const)
+              ? ([
+                  {
+                    id: "open-in-browser",
+                    label: "Open in integrated browser",
+                  },
+                ] as const)
               : []),
             { id: "copy-relative", label: "Copy relative path" },
             { id: "copy-full", label: "Copy full path" },
@@ -1327,6 +1344,7 @@ function ChatMarkdown({
   skills = EMPTY_MARKDOWN_SKILLS,
   className,
   lineBreaks = false,
+  imageComponent,
 }: ChatMarkdownProps) {
   const { resolvedTheme } = useTheme();
   const createAssetUrl = useAtomQueryRunner(assetEnvironment.createUrl, {
@@ -1480,6 +1498,7 @@ function ChatMarkdown({
     };
 
     return {
+      ...(imageComponent ? { img: imageComponent } : {}),
       p({ node: _node, children, ...props }) {
         return <p {...props}>{renderSkillInlineMarkdownChildren(children, skills)}</p>;
       },
@@ -1537,7 +1556,10 @@ function ChatMarkdown({
                 event.currentTarget.closest("li")?.dataset.taskMarkerOffset,
               );
               if (!Number.isSafeInteger(markerOffset)) return;
-              onTaskListChange({ markerOffset, checked: event.currentTarget.checked });
+              onTaskListChange({
+                markerOffset,
+                checked: event.currentTarget.checked,
+              });
             }}
           />
         );
@@ -1683,6 +1705,7 @@ function ChatMarkdown({
     diffThemeName,
     fileLinkParentSuffixByPath,
     inlineCodeFileLinkMetaByText,
+    imageComponent,
     isStreaming,
     markdownFileLinkMetaByHref,
     onTaskListChange,

--- a/apps/web/src/components/pullRequest/PullRequestMarkdown.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestMarkdown.tsx
@@ -1,9 +1,27 @@
 import { ExternalLinkIcon, PaperclipIcon, PlayIcon } from "lucide-react";
+import type { EnvironmentId } from "@t3tools/contracts";
+import { useMemo, type ComponentProps } from "react";
 
+import { useAssetUrl } from "~/assets/assetUrls";
 import { cn } from "~/lib/utils";
 
 import ChatMarkdown from "../ChatMarkdown";
 import { splitPullRequestBody } from "./pullRequestMarkdown.logic";
+
+const GITHUB_USER_ATTACHMENT_PREFIX = "https://github.com/user-attachments/assets/";
+
+function PullRequestImage({
+  environmentId,
+  src,
+  ...props
+}: ComponentProps<"img"> & { environmentId: EnvironmentId }) {
+  const resource = useMemo(
+    () => ({ _tag: "github-user-attachment" as const, url: src ?? "" }),
+    [src],
+  );
+  const authenticatedSrc = useAssetUrl(environmentId, resource);
+  return <img {...props} src={authenticatedSrc ?? src} />;
+}
 
 /**
  * A pull request body, rendered with the app's markdown renderer plus a card for each upload
@@ -19,18 +37,33 @@ import { splitPullRequestBody } from "./pullRequestMarkdown.logic";
 export function PullRequestMarkdown({
   text,
   cwd,
+  environmentId,
   className,
 }: {
   text: string;
   cwd: string;
+  environmentId: EnvironmentId;
   className?: string;
 }) {
   const segments = splitPullRequestBody(text);
+  const Image = useMemo(
+    () =>
+      function PullRequestMarkdownImage({ src, ...props }: ComponentProps<"img">) {
+        return src?.startsWith(GITHUB_USER_ATTACHMENT_PREFIX) ? (
+          <PullRequestImage {...props} src={src} environmentId={environmentId} />
+        ) : (
+          <img {...props} src={src} />
+        );
+      },
+    [environmentId],
+  );
   return (
     <div className={cn("space-y-3", className)}>
       {segments.map((segment) => {
         if (segment.kind === "markdown") {
-          return <ChatMarkdown key={segment.id} text={segment.text} cwd={cwd} />;
+          return (
+            <ChatMarkdown key={segment.id} text={segment.text} cwd={cwd} imageComponent={Image} />
+          );
         }
         const isVideo = segment.media === "video";
         const Icon = isVideo ? PlayIcon : PaperclipIcon;

--- a/apps/web/src/components/pullRequest/PullRequestMarkdownEditor.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestMarkdownEditor.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import type { EnvironmentId } from "@t3tools/contracts";
 
 import { cn } from "~/lib/utils";
 
@@ -17,6 +18,7 @@ import { PullRequestMarkdown } from "./PullRequestMarkdown";
 export function PullRequestMarkdownEditor({
   value,
   cwd,
+  environmentId,
   placeholder,
   label,
   saving,
@@ -27,6 +29,7 @@ export function PullRequestMarkdownEditor({
 }: {
   readonly value: string;
   readonly cwd: string;
+  readonly environmentId: EnvironmentId;
   readonly placeholder?: string | undefined;
   readonly label: string;
   readonly saving: boolean;
@@ -81,7 +84,7 @@ export function PullRequestMarkdownEditor({
           {empty ? (
             <p className="text-xs text-muted-foreground">Nothing to preview.</p>
           ) : (
-            <PullRequestMarkdown text={draft} cwd={cwd} />
+            <PullRequestMarkdown text={draft} cwd={cwd} environmentId={environmentId} />
           )}
         </div>
       ) : (

--- a/apps/web/src/components/pullRequest/PullRequestReviewAnnotation.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestReviewAnnotation.tsx
@@ -218,6 +218,7 @@ export function ReviewThreadCard({
                     className="mt-1"
                     value={comment.body}
                     cwd={workspaceRoot}
+                    environmentId={environmentId}
                     label="Edit comment"
                     saving={savingEdit}
                     onSave={(body) => void saveEdit(comment.id, body)}
@@ -229,6 +230,7 @@ export function ReviewThreadCard({
                       className="min-w-0 flex-1 text-sm"
                       text={comment.body}
                       cwd={workspaceRoot}
+                      environmentId={environmentId}
                     />
                     {canEditComment(comment) ? (
                       <Button

--- a/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
@@ -81,6 +81,7 @@ function reviewStateLabel(state: string): string {
 
 /** What every remark in the conversation needs to be rewritten where it sits. */
 interface CommentEditing {
+  readonly environmentId: EnvironmentId;
   readonly cwd: string;
   readonly canEdit: (comment: PullRequestComment) => boolean;
   readonly editingId: string | null;
@@ -107,6 +108,7 @@ function CommentBody({
       <PullRequestMarkdownEditor
         className={className}
         value={comment.body}
+        environmentId={editing.environmentId}
         cwd={editing.cwd}
         label="Edit comment"
         saving={editing.saving}
@@ -117,7 +119,12 @@ function CommentBody({
   }
   return (
     <div className={cn("flex items-start gap-1", className)}>
-      <PullRequestMarkdown className="min-w-0 flex-1" text={comment.body} cwd={editing.cwd} />
+      <PullRequestMarkdown
+        className="min-w-0 flex-1"
+        text={comment.body}
+        cwd={editing.cwd}
+        environmentId={editing.environmentId}
+      />
       {editing.canEdit(comment) ? (
         <Button
           size="icon-xs"
@@ -290,7 +297,9 @@ function CommentComposer({
 }) {
   const [body, setBody] = useState("");
   const [posting, setPosting] = useState(false);
-  const postComment = useAtomCommand(pullRequestEnvironment.comment, { reportFailure: false });
+  const postComment = useAtomCommand(pullRequestEnvironment.comment, {
+    reportFailure: false,
+  });
 
   const submit = async () => {
     const trimmed = body.trim();
@@ -395,7 +404,9 @@ export function PullRequestSummaryTab({
     void readLocalApi()?.shell.openExternal(url);
   };
 
-  const update = useAtomCommand(pullRequestEnvironment.update, { reportFailure: false });
+  const update = useAtomCommand(pullRequestEnvironment.update, {
+    reportFailure: false,
+  });
   const updateComment = useAtomCommand(pullRequestEnvironment.updateComment, {
     reportFailure: false,
   });
@@ -417,10 +428,16 @@ export function PullRequestSummaryTab({
   const saveBody = async (body: string) => {
     if (bodySaving) return;
     setBodySaving(true);
-    const result = await update({ environmentId, input: { ...reference, body } });
+    const result = await update({
+      environmentId,
+      input: { ...reference, body },
+    });
     setBodySaving(false);
     if (result._tag === "Failure") {
-      toastManager.add({ type: "error", title: "Could not save the description" });
+      toastManager.add({
+        type: "error",
+        title: "Could not save the description",
+      });
       return;
     }
     setBodyScope(null);
@@ -428,6 +445,7 @@ export function PullRequestSummaryTab({
   };
 
   const commentEditing: CommentEditing = {
+    environmentId,
     cwd: detail.workspaceRoot,
     canEdit: (comment) => canEditPullRequestComment(detail, comment),
     editingId: editingCommentId,
@@ -441,11 +459,19 @@ export function PullRequestSummaryTab({
       setCommentSaving(true);
       const result = await updateComment({
         environmentId,
-        input: { ...reference, commentId: comment.id, kind: comment.kind, body },
+        input: {
+          ...reference,
+          commentId: comment.id,
+          kind: comment.kind,
+          body,
+        },
       });
       setCommentSaving(false);
       if (result._tag === "Failure") {
-        toastManager.add({ type: "error", title: "Could not save the comment" });
+        toastManager.add({
+          type: "error",
+          title: "Could not save the comment",
+        });
         return;
       }
       setCommentScope(null);
@@ -544,6 +570,7 @@ export function PullRequestSummaryTab({
               // Empty is a real answer here: saving nothing is how a description is cleared.
               allowEmpty
               value={detail.body}
+              environmentId={environmentId}
               cwd={detail.workspaceRoot}
               label="Pull request description"
               placeholder="Describe this pull request"
@@ -557,6 +584,7 @@ export function PullRequestSummaryTab({
                 className="min-w-0 flex-1"
                 text={detail.body.trim().length > 0 ? detail.body : "_No description provided._"}
                 cwd={detail.workspaceRoot}
+                environmentId={environmentId}
               />
               {canEditPullRequestChangeRequest(detail) ? (
                 <Button
@@ -682,7 +710,10 @@ export function PullRequestSummaryTab({
                     variant="outline"
                     className="w-full"
                     onClick={() =>
-                      setShown({ url: detail.url, count: shownComments + COMMENT_PAGE })
+                      setShown({
+                        url: detail.url,
+                        count: shownComments + COMMENT_PAGE,
+                      })
                     }
                   >
                     Show {Math.min(hiddenCommentCount, COMMENT_PAGE)} earlier{" "}

--- a/apps/web/src/components/pullRequest/PullRequestTimelineTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestTimelineTab.tsx
@@ -50,11 +50,21 @@ interface ReactionSurface {
   readonly onRefresh: () => void;
 }
 
-function TimelineBody({ body, markdown, cwd }: { body: string; markdown: boolean; cwd: string }) {
+function TimelineBody({
+  body,
+  markdown,
+  cwd,
+  environmentId,
+}: {
+  body: string;
+  markdown: boolean;
+  cwd: string;
+  environmentId: EnvironmentId;
+}) {
   return (
     <div className="mt-3">
       {markdown ? (
-        <PullRequestMarkdown text={body} cwd={cwd} />
+        <PullRequestMarkdown text={body} cwd={cwd} environmentId={environmentId} />
       ) : (
         <p className="whitespace-pre-wrap text-xs text-muted-foreground">{body}</p>
       )}
@@ -176,7 +186,12 @@ function ConversationCard({
     setSaving(true);
     const result = await updateComment({
       environmentId: reactions.environmentId,
-      input: { ...reactions.reference, commentId: editable.id, kind: editable.kind, body },
+      input: {
+        ...reactions.reference,
+        commentId: editable.id,
+        kind: editable.kind,
+        body,
+      },
     });
     setSaving(false);
     if (result._tag === "Failure") {
@@ -226,6 +241,7 @@ function ConversationCard({
           <PullRequestMarkdownEditor
             value={editable.body}
             cwd={cwd}
+            environmentId={reactions.environmentId}
             label="Edit comment"
             saving={saving}
             onSave={(body) => void save(body)}
@@ -234,7 +250,12 @@ function ConversationCard({
         </div>
       ) : event.body ? (
         <div className="px-2 pb-2">
-          <TimelineBody body={event.body} markdown={event.markdown} cwd={cwd} />
+          <TimelineBody
+            body={event.body}
+            markdown={event.markdown}
+            cwd={cwd}
+            environmentId={reactions.environmentId}
+          />
         </div>
       ) : null}
       {reactions.canReact || event.reactions.length > 0 ? (

--- a/packages/contracts/src/assets.ts
+++ b/packages/contracts/src/assets.ts
@@ -19,6 +19,9 @@ export const AssetResource = Schema.Union([
     // project projection before it issues the signed URL.
     path: Schema.optional(ProjectFaviconPath),
   }),
+  Schema.TaggedStruct("github-user-attachment", {
+    url: TrimmedNonEmptyString.check(Schema.isMaxLength(4096)),
+  }),
 ]);
 export type AssetResource = typeof AssetResource.Type;
 
@@ -91,6 +94,15 @@ export class AssetPreviewTypeValidationError extends Schema.TaggedErrorClass<Ass
 ) {
   override get message(): string {
     return "Only browser documents and images can be previewed.";
+  }
+}
+
+export class AssetGitHubAttachmentUrlValidationError extends Schema.TaggedErrorClass<AssetGitHubAttachmentUrlValidationError>()(
+  "AssetGitHubAttachmentUrlValidationError",
+  { resource: AssetResource },
+) {
+  override get message(): string {
+    return "GitHub attachment URL is invalid.";
   }
 }
 
@@ -193,6 +205,7 @@ export const AssetAccessError = Schema.Union([
   AssetWorkspaceRootNormalizationError,
   AssetWorkspacePathValidationError,
   AssetPreviewTypeValidationError,
+  AssetGitHubAttachmentUrlValidationError,
   AssetWorkspaceAssetInspectionError,
   AssetWorkspaceAssetNotFoundError,
   AssetWorkspaceResolutionError,


### PR DESCRIPTION
Closes #6600.

Images embedded in pull requests from private repositories are fetched anonymously by the renderer, so GitHub answers with `404` even when the environment’s GitHub CLI is authenticated.

This adds a signed asset resource for GitHub user attachments. Pull request markdown requests that URL from the environment server, which validates the attachment host and path, retrieves the existing `gh` credential, and returns the authenticated image bytes. This keeps credentials out of the client and works for remote environments as well as desktop.

## Before

Seeded from public PR #6594 with an unreferenced private test attachment substituted at render time. No private pull request content is shown.

![Private pull request images fail to load](https://github.com/user-attachments/assets/5804c0f6-6b94-4802-a4c9-b60d93bd7b55)

## After

![Private pull request images load through the authenticated asset route](https://github.com/user-attachments/assets/81a6fe60-4a5f-4966-97d1-4cefeeb4a4d0)

## Testing

- `pnpm --filter ./apps/server test --run src/assets/AssetAccess.test.ts`
- `pnpm --filter @t3tools/web typecheck`
- `pnpm --filter @t3tools/contracts typecheck`
- `pnpm --filter ./apps/server typecheck`
- Desktop before/after verification with the seeded reproduction

Built with GPT-5.6-sol using the Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Proxy GitHub user attachment images in pull requests through authenticated server endpoint
> - Adds a `github-user-attachment` asset resource kind to the contracts and asset access layer, with URL validation enforcing strict `github.com/user-attachments/assets/<uuid>` paths.
> - Adds `proxyGitHubUserAttachment` in [http.ts](https://github.com/pingdotgg/t3code/pull/6601/files#diff-55fb49cf72ecef123d8f2fa7061526dadb37cf93f8e9dd9e7f0d4f8cd4ff9f6d) that fetches a token via `gh auth token`, performs an authenticated GET, validates the response is an image, and streams it with safe headers.
> - Extends `PullRequestMarkdown` to detect GitHub attachment URLs in markdown images and rewrite them through the authenticated asset proxy.
> - Propagates `environmentId` through pull request summary, timeline, review annotation, and editor components to enable proxying in all PR markdown contexts.
> - Risk: proxying requires a locally authenticated GitHub CLI (`gh`); requests return 404 if no token is available.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e014682.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces authenticated outbound proxying tied to `gh` CLI availability and token state; URL validation limits scope but misconfiguration yields silent 404s for images.
> 
> **Overview**
> Fixes **private-repo PR images** that 404 when the client loads `github.com/user-attachments/assets/…` without credentials.
> 
> Adds a **`github-user-attachment` signed asset** in contracts and the server asset pipeline: only strict `https://github.com/user-attachments/assets/{uuid}` URLs are accepted; invalid hosts/paths fail with `AssetGitHubAttachmentUrlValidationError`. The asset route resolves signed tokens to a **server-side proxy** that reads a GitHub token via `gh auth token`, fetches the image with `Authorization: Bearer`, streams **image/** responses only, and applies SVG sandbox CSP via an optional `contentType` on `assetResponseHeaders`. Missing or bad auth/upstream responses return **404** so tokens never reach the renderer.
> 
> **Web:** `PullRequestMarkdown` takes `environmentId`, swaps GitHub user-attachment `<img>` sources through `useAssetUrl`, and passes a custom renderer into `ChatMarkdown` via new **`imageComponent`**. PR summary, timeline, review annotation, and markdown editor pass `environmentId` through. **RPC** `assetsCreateUrl` issues URLs for this resource without workspace context.
> 
> Tests cover signing/validation in `AssetAccess` and proxy behavior in `http.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e01468213f820a327bcfde17ae2cae99e4307def. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->