### PR TITLE
fix(web): reject oversized prompts before provider turn start

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4980,6 +4980,16 @@ function ChatViewContent(props: ChatViewProps) {
         draftText: trimmed,
         planMarkdown: activeProposedPlan.planMarkdown,
       });
+      const outgoingFollowUpText = formatOutgoingPrompt({
+        provider: ctxSelectedProvider,
+        model: ctxSelectedModel,
+        models: ctxSelectedProviderModels,
+        effort: ctxSelectedPromptEffort,
+        text: followUp.text.trim(),
+      });
+      if (composerRef.current?.validateProviderInput(outgoingFollowUpText) === false) {
+        return;
+      }
       promptRef.current = "";
       clearComposerDraftContent(composerDraftTarget);
       composerRef.current?.resetCursorState();
@@ -5049,6 +5059,34 @@ function ChatViewContent(props: ChatViewProps) {
       return;
     }
 
+    const composerImagesSnapshot = [...composerImages];
+    const composerTerminalContextsSnapshot = [...sendableComposerTerminalContexts];
+    const composerElementContextsSnapshot = [...composerElementContexts];
+    const composerPreviewAnnotationsSnapshot = [...composerPreviewAnnotations];
+    const composerReviewCommentsSnapshot: ReviewCommentContext[] = [...composerReviewComments];
+    const messageTextWithContexts = appendElementContextsToPrompt(
+      appendTerminalContextsToPrompt(promptForSend, composerTerminalContextsSnapshot),
+      composerElementContextsSnapshot,
+    );
+    const messageTextWithPreviewAnnotations = composerPreviewAnnotationsSnapshot.reduce(
+      (text, annotation) => appendPreviewAnnotationPrompt(text, annotation),
+      messageTextWithContexts,
+    );
+    const messageTextForSend = appendReviewCommentsToPrompt(
+      messageTextWithPreviewAnnotations,
+      composerReviewCommentsSnapshot,
+    );
+    const outgoingMessageText = formatOutgoingPrompt({
+      provider: ctxSelectedProvider,
+      model: ctxSelectedModel,
+      models: ctxSelectedProviderModels,
+      effort: ctxSelectedPromptEffort,
+      text: messageTextForSend || IMAGE_ONLY_BOOTSTRAP_PROMPT,
+    });
+    if (composerRef.current?.validateProviderInput(outgoingMessageText) === false) {
+      return;
+    }
+
     sendInFlightRef.current = true;
     if (isDraftHeroState && activeThreadKey) {
       let resolveDockStarted: (() => void) | undefined;
@@ -5067,32 +5105,8 @@ function ChatViewContent(props: ChatViewProps) {
     }
     beginLocalDispatch({ preparingWorktree: Boolean(baseBranchForWorktree) });
 
-    const composerImagesSnapshot = [...composerImages];
-    const composerTerminalContextsSnapshot = [...sendableComposerTerminalContexts];
-    const composerElementContextsSnapshot = [...composerElementContexts];
-    const composerPreviewAnnotationsSnapshot = [...composerPreviewAnnotations];
-    const composerReviewCommentsSnapshot: ReviewCommentContext[] = [...composerReviewComments];
-    const messageTextWithContexts = appendElementContextsToPrompt(
-      appendTerminalContextsToPrompt(promptForSend, composerTerminalContextsSnapshot),
-      composerElementContextsSnapshot,
-    );
-    const messageTextWithPreviewAnnotations = composerPreviewAnnotationsSnapshot.reduce(
-      (text, annotation) => appendPreviewAnnotationPrompt(text, annotation),
-      messageTextWithContexts,
-    );
-    const messageTextForSend = appendReviewCommentsToPrompt(
-      messageTextWithPreviewAnnotations,
-      composerReviewCommentsSnapshot,
-    );
     const messageIdForSend = newMessageId();
     const messageCreatedAt = new Date().toISOString();
-    const outgoingMessageText = formatOutgoingPrompt({
-      provider: ctxSelectedProvider,
-      model: ctxSelectedModel,
-      models: ctxSelectedProviderModels,
-      effort: ctxSelectedPromptEffort,
-      text: messageTextForSend || IMAGE_ONLY_BOOTSTRAP_PROMPT,
-    });
     const turnAttachmentsPromise = Promise.all(
       composerImagesSnapshot.map(async (image) => ({
         type: "image" as const,
@@ -5709,6 +5723,9 @@ function ChatViewContent(props: ChatViewProps) {
       effort: ctxSelectedPromptEffort,
       text: implementationPrompt,
     });
+    if (composerRef.current?.validateProviderInput(outgoingImplementationPrompt) === false) {
+      return;
+    }
     const nextThreadTitle = truncate(buildPlanImplementationThreadTitle(planMarkdown));
     const nextThreadModelSelection: ModelSelection = ctxSelectedModelSelection;
 

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -106,6 +106,11 @@ import { buildExpandedImagePreview, type ExpandedImagePreview } from "./Expanded
 import { basenameOfPath } from "../../pierre-icons";
 import { cn, randomUUID } from "~/lib/utils";
 import { Separator } from "../ui/separator";
+import {
+  getComposerPromptLengthValidationMessage,
+  submitComposerDraft,
+} from "./composerSubmission";
+import { ComposerPromptLengthValidation } from "./ComposerPromptLengthValidation";
 
 type ComposerCommandMenuPosition = {
   bottom: number;
@@ -947,6 +952,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const [isComposerPrimaryActionsCompact, setIsComposerPrimaryActionsCompact] = useState(false);
   const [isComposerModelPickerOpen, setIsComposerModelPickerOpen] = useState(false);
   const [isComposerFocused, setIsComposerFocused] = useState(false);
+  const [composerSubmissionError, setComposerSubmissionError] = useState<string | null>(null);
   const [composerMenuAnchor, setComposerMenuAnchor] = useState<HTMLDivElement | null>(null);
   const [isStashMenuOpen, setIsStashMenuOpen] = useState(false);
   const [stashPulse, setStashPulse] = useState<{ key: number; active: boolean }>({
@@ -1307,6 +1313,14 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   }, [prompt, promptRef]);
 
   useEffect(() => {
+    if (composerSubmissionError === null) return;
+    const nextError = getComposerPromptLengthValidationMessage(prompt);
+    if (nextError !== composerSubmissionError) {
+      setComposerSubmissionError(nextError);
+    }
+  }, [composerSubmissionError, prompt]);
+
+  useEffect(() => {
     composerImagesRef.current = composerImages;
   }, [composerImages, composerImagesRef]);
 
@@ -1397,6 +1411,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // ------------------------------------------------------------------
   useEffect(() => {
     setComposerHighlightedItemId(null);
+    setComposerSubmissionError(null);
     setComposerCursor(collapseExpandedComposerCursor(promptRef.current, promptRef.current.length));
     setComposerTrigger(detectComposerTrigger(promptRef.current, promptRef.current.length));
     dragDepthRef.current = 0;
@@ -1824,7 +1839,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         });
         return;
       }
-      onSend(event);
+      const submission = submitComposerDraft({
+        prompt: promptRef.current,
+        event,
+        onSend,
+      });
+      setComposerSubmissionError(submission.validationMessage);
+      if (!submission.didDispatch) return;
       if (shouldBlurMobileComposerOnSubmit()) {
         blurMobileComposerAfterSend();
       }
@@ -1835,6 +1856,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       isSendDisabled,
       noProviderAvailable,
       onSend,
+      promptRef,
       shouldBlurMobileComposerOnSubmit,
     ],
   );
@@ -3085,6 +3107,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
               ) : null}
             </div>
           </div>
+
+          <ComposerPromptLengthValidation message={composerSubmissionError} />
 
           {/* Bottom toolbar */}
           {isComposerCollapsedMobile ? null : activePendingApproval ? (

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -975,6 +975,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const composerEditorRef = useRef<ComposerPromptEditorHandle>(null);
   const composerFormRef = useRef<HTMLFormElement>(null);
   const composerSurfaceRef = useRef<HTMLDivElement>(null);
+  const providerInputRejectedRef = useRef(false);
   const composerSelectLockRef = useRef(false);
   const composerMenuOpenRef = useRef(false);
   const composerMenuItemsRef = useRef<ComposerCommandItem[]>([]);
@@ -1863,7 +1864,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         prompt: promptRef.current,
         submissionTarget: activePendingProgress ? "pending-user-input" : "provider-turn",
         event,
-        onSend,
+        onSend: (sendEvent) => {
+          // ChatView reports its final composed-input preflight through the
+          // composer handle before its first asynchronous send step.
+          providerInputRejectedRef.current = false;
+          onSend(sendEvent);
+          return !providerInputRejectedRef.current;
+        },
       });
       setComposerSubmissionError(submission.validationMessage);
       if (!submission.didDispatch) return;
@@ -2666,6 +2673,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
           providerInput,
           submissionTarget: "provider-turn",
         });
+        providerInputRejectedRef.current = validationMessage !== null;
         setProviderInputSubmissionError(validationMessage);
         return validationMessage === null;
       },

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -108,6 +108,7 @@ import { cn, randomUUID } from "~/lib/utils";
 import { Separator } from "../ui/separator";
 import {
   getComposerPromptLengthValidationMessage,
+  getComposerSubmissionValidationMessage,
   submitComposerDraft,
 } from "./composerSubmission";
 import { ComposerPromptLengthValidation } from "./ComposerPromptLengthValidation";
@@ -489,6 +490,8 @@ export interface ChatComposerHandle {
     selectedModel: string;
     selectedProviderModels: ReadonlyArray<ServerProvider["models"][number]>;
   };
+  /** Validate the fully composed text immediately before a provider turn starts. */
+  validateProviderInput: (providerInput: string) => boolean;
 }
 
 // --------------------------------------------------------------------------
@@ -953,6 +956,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const [isComposerModelPickerOpen, setIsComposerModelPickerOpen] = useState(false);
   const [isComposerFocused, setIsComposerFocused] = useState(false);
   const [composerSubmissionError, setComposerSubmissionError] = useState<string | null>(null);
+  const [providerInputSubmissionError, setProviderInputSubmissionError] = useState<string | null>(
+    null,
+  );
   const [composerMenuAnchor, setComposerMenuAnchor] = useState<HTMLDivElement | null>(null);
   const [isStashMenuOpen, setIsStashMenuOpen] = useState(false);
   const [stashPulse, setStashPulse] = useState<{ key: number; active: boolean }>({
@@ -1321,6 +1327,19 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   }, [composerSubmissionError, prompt]);
 
   useEffect(() => {
+    setProviderInputSubmissionError(null);
+  }, [
+    composerElementContexts,
+    composerPreviewAnnotations,
+    composerReviewComments,
+    composerTerminalContexts,
+    prompt,
+    selectedModel,
+    selectedPromptEffort,
+    selectedProvider,
+  ]);
+
+  useEffect(() => {
     composerImagesRef.current = composerImages;
   }, [composerImages, composerImagesRef]);
 
@@ -1412,6 +1431,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   useEffect(() => {
     setComposerHighlightedItemId(null);
     setComposerSubmissionError(null);
+    setProviderInputSubmissionError(null);
     setComposerCursor(collapseExpandedComposerCursor(promptRef.current, promptRef.current.length));
     setComposerTrigger(detectComposerTrigger(promptRef.current, promptRef.current.length));
     dragDepthRef.current = 0;
@@ -2640,6 +2660,15 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         selectedModel,
         selectedProviderModels,
       }),
+      validateProviderInput: (providerInput: string) => {
+        const validationMessage = getComposerSubmissionValidationMessage({
+          prompt: promptRef.current,
+          providerInput,
+          submissionTarget: "provider-turn",
+        });
+        setProviderInputSubmissionError(validationMessage);
+        return validationMessage === null;
+      },
     }),
     [
       activeThread,
@@ -3110,7 +3139,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
             </div>
           </div>
 
-          <ComposerPromptLengthValidation message={composerSubmissionError} />
+          <ComposerPromptLengthValidation
+            message={providerInputSubmissionError ?? composerSubmissionError}
+          />
 
           {/* Bottom toolbar */}
           {isComposerCollapsedMobile ? null : activePendingApproval ? (

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1841,6 +1841,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       }
       const submission = submitComposerDraft({
         prompt: promptRef.current,
+        submissionTarget: activePendingProgress ? "pending-user-input" : "provider-turn",
         event,
         onSend,
       });
@@ -1852,6 +1853,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     },
     [
       activeThreadId,
+      activePendingProgress,
       blurMobileComposerAfterSend,
       isSendDisabled,
       noProviderAvailable,

--- a/apps/web/src/components/chat/ComposerPromptLengthValidation.test.tsx
+++ b/apps/web/src/components/chat/ComposerPromptLengthValidation.test.tsx
@@ -1,0 +1,23 @@
+import { PROVIDER_SEND_TURN_MAX_INPUT_CHARS } from "@t3tools/contracts";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import { getComposerPromptLengthValidationMessage } from "./composerSubmission";
+import { ComposerPromptLengthValidation } from "./ComposerPromptLengthValidation";
+
+describe("ComposerPromptLengthValidation", () => {
+  it("renders oversized prompt feedback as an actionable composer alert", () => {
+    const message = getComposerPromptLengthValidationMessage(
+      "x".repeat(PROVIDER_SEND_TURN_MAX_INPUT_CHARS + 1),
+    );
+
+    const markup = renderToStaticMarkup(<ComposerPromptLengthValidation message={message} />);
+
+    expect(markup).toContain('role="alert"');
+    expect(markup).toContain('data-chat-composer-validation="prompt-length"');
+    expect(markup).toContain(
+      "Prompt is 1 character over the 120,000-character limit. Shorten or split it before sending.",
+    );
+    expect(markup).not.toContain("ProviderValidationError");
+  });
+});

--- a/apps/web/src/components/chat/ComposerPromptLengthValidation.tsx
+++ b/apps/web/src/components/chat/ComposerPromptLengthValidation.tsx
@@ -1,0 +1,13 @@
+export function ComposerPromptLengthValidation({ message }: { message: string | null }) {
+  if (!message) return null;
+
+  return (
+    <p
+      role="alert"
+      className="px-3 pb-2 text-xs text-destructive sm:px-4"
+      data-chat-composer-validation="prompt-length"
+    >
+      {message}
+    </p>
+  );
+}

--- a/apps/web/src/components/chat/composerSubmission.test.ts
+++ b/apps/web/src/components/chat/composerSubmission.test.ts
@@ -13,6 +13,7 @@ describe("submitComposerDraft", () => {
     const submit = () => {
       const result = submitComposerDraft({
         prompt: draft,
+        submissionTarget: "provider-turn",
         event: { preventDefault },
         onSend: () => dispatchedDrafts.push(draft),
       });
@@ -42,6 +43,41 @@ describe("submitComposerDraft", () => {
 
     const result = submitComposerDraft({
       prompt: draft,
+      submissionTarget: "provider-turn",
+      event: { preventDefault },
+      onSend,
+    });
+
+    expect(result).toEqual({ validationMessage: null, didDispatch: true });
+    expect(onSend).toHaveBeenCalledOnce();
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("allows surrounding whitespace that the provider turn contract trims", () => {
+    const draft = ` ${"x".repeat(PROVIDER_SEND_TURN_MAX_INPUT_CHARS)} `;
+    const onSend = vi.fn();
+    const preventDefault = vi.fn();
+
+    const result = submitComposerDraft({
+      prompt: draft,
+      submissionTarget: "provider-turn",
+      event: { preventDefault },
+      onSend,
+    });
+
+    expect(result).toEqual({ validationMessage: null, didDispatch: true });
+    expect(onSend).toHaveBeenCalledOnce();
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("dispatches pending user input answers on their separate response path", () => {
+    const answer = "x".repeat(PROVIDER_SEND_TURN_MAX_INPUT_CHARS + 1);
+    const onSend = vi.fn();
+    const preventDefault = vi.fn();
+
+    const result = submitComposerDraft({
+      prompt: answer,
+      submissionTarget: "pending-user-input",
       event: { preventDefault },
       onSend,
     });

--- a/apps/web/src/components/chat/composerSubmission.test.ts
+++ b/apps/web/src/components/chat/composerSubmission.test.ts
@@ -15,7 +15,9 @@ describe("submitComposerDraft", () => {
         prompt: draft,
         submissionTarget: "provider-turn",
         event: { preventDefault },
-        onSend: () => dispatchedDrafts.push(draft),
+        onSend: () => {
+          dispatchedDrafts.push(draft);
+        },
       });
       validationMessage = result.validationMessage;
     };
@@ -83,6 +85,20 @@ describe("submitComposerDraft", () => {
 
     expect(correctedResult).toEqual({ validationMessage: null, didDispatch: true });
     expect(onSend).toHaveBeenCalledOnce();
+  });
+
+  it("does not finish submission when the send boundary rejects composed provider input", () => {
+    const preventDefault = vi.fn();
+
+    const result = submitComposerDraft({
+      prompt: "Sendable raw draft",
+      submissionTarget: "provider-turn",
+      event: { preventDefault },
+      onSend: () => false,
+    });
+
+    expect(result).toEqual({ validationMessage: null, didDispatch: false });
+    expect(preventDefault).toHaveBeenCalledOnce();
   });
 
   it("allows fully composed provider input at the shared character limit", () => {

--- a/apps/web/src/components/chat/composerSubmission.test.ts
+++ b/apps/web/src/components/chat/composerSubmission.test.ts
@@ -1,0 +1,53 @@
+import { PROVIDER_SEND_TURN_MAX_INPUT_CHARS } from "@t3tools/contracts";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { submitComposerDraft } from "./composerSubmission";
+
+describe("submitComposerDraft", () => {
+  it("keeps an oversized draft editable and sends a corrected follow-up", () => {
+    let draft = "x".repeat(PROVIDER_SEND_TURN_MAX_INPUT_CHARS + 1);
+    let validationMessage: string | null = null;
+    const dispatchedDrafts: string[] = [];
+    const preventDefault = vi.fn();
+
+    const submit = () => {
+      const result = submitComposerDraft({
+        prompt: draft,
+        event: { preventDefault },
+        onSend: () => dispatchedDrafts.push(draft),
+      });
+      validationMessage = result.validationMessage;
+    };
+
+    submit();
+
+    expect(dispatchedDrafts).toEqual([]);
+    expect(draft).toHaveLength(PROVIDER_SEND_TURN_MAX_INPUT_CHARS + 1);
+    expect(validationMessage).toBe(
+      "Prompt is 1 character over the 120,000-character limit. Shorten or split it before sending.",
+    );
+    expect(preventDefault).toHaveBeenCalledOnce();
+
+    draft = "Corrected prompt";
+    submit();
+
+    expect(dispatchedDrafts).toEqual(["Corrected prompt"]);
+    expect(validationMessage).toBeNull();
+  });
+
+  it("allows a draft at the shared character limit through the normal send path", () => {
+    const draft = "x".repeat(PROVIDER_SEND_TURN_MAX_INPUT_CHARS);
+    const onSend = vi.fn();
+    const preventDefault = vi.fn();
+
+    const result = submitComposerDraft({
+      prompt: draft,
+      event: { preventDefault },
+      onSend,
+    });
+
+    expect(result).toEqual({ validationMessage: null, didDispatch: true });
+    expect(onSend).toHaveBeenCalledOnce();
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/chat/composerSubmission.test.ts
+++ b/apps/web/src/components/chat/composerSubmission.test.ts
@@ -53,6 +53,71 @@ describe("submitComposerDraft", () => {
     expect(preventDefault).not.toHaveBeenCalled();
   });
 
+  it("blocks when appended context pushes the provider input over the shared limit", () => {
+    const draft = "x".repeat(PROVIDER_SEND_TURN_MAX_INPUT_CHARS);
+    const onSend = vi.fn();
+
+    const result = submitComposerDraft({
+      prompt: draft,
+      providerInput: `${draft}\n\nTerminal context`,
+      submissionTarget: "provider-turn",
+      event: undefined,
+      onSend,
+    });
+
+    expect(result).toEqual({
+      validationMessage:
+        "Prompt is 18 characters over the 120,000-character limit. Shorten or split it before sending.",
+      didDispatch: false,
+    });
+    expect(draft).toHaveLength(PROVIDER_SEND_TURN_MAX_INPUT_CHARS);
+    expect(onSend).not.toHaveBeenCalled();
+
+    const correctedResult = submitComposerDraft({
+      prompt: "Corrected prompt",
+      providerInput: "Corrected prompt\n\nShort terminal context",
+      submissionTarget: "provider-turn",
+      event: undefined,
+      onSend,
+    });
+
+    expect(correctedResult).toEqual({ validationMessage: null, didDispatch: true });
+    expect(onSend).toHaveBeenCalledOnce();
+  });
+
+  it("allows fully composed provider input at the shared character limit", () => {
+    const onSend = vi.fn();
+
+    const result = submitComposerDraft({
+      prompt: "Short draft",
+      providerInput: "x".repeat(PROVIDER_SEND_TURN_MAX_INPUT_CHARS),
+      submissionTarget: "provider-turn",
+      event: undefined,
+      onSend,
+    });
+
+    expect(result).toEqual({ validationMessage: null, didDispatch: true });
+    expect(onSend).toHaveBeenCalledOnce();
+  });
+
+  it("blocks a generated plan follow-up that exceeds the shared limit", () => {
+    const onSend = vi.fn();
+
+    const result = submitComposerDraft({
+      prompt: "",
+      providerInput: `PLEASE IMPLEMENT THIS PLAN:\n${"x".repeat(
+        PROVIDER_SEND_TURN_MAX_INPUT_CHARS,
+      )}`,
+      submissionTarget: "provider-turn",
+      event: undefined,
+      onSend,
+    });
+
+    expect(result.didDispatch).toBe(false);
+    expect(result.validationMessage).toContain("over the 120,000-character limit");
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
   it("allows surrounding whitespace that the provider turn contract trims", () => {
     const draft = ` ${"x".repeat(PROVIDER_SEND_TURN_MAX_INPUT_CHARS)} `;
     const onSend = vi.fn();

--- a/apps/web/src/components/chat/composerSubmission.ts
+++ b/apps/web/src/components/chat/composerSubmission.ts
@@ -3,7 +3,7 @@ import { PROVIDER_SEND_TURN_MAX_INPUT_CHARS } from "@t3tools/contracts";
 type ComposerSubmitEvent = { preventDefault: () => void };
 
 export function getComposerPromptLengthValidationMessage(prompt: string): string | null {
-  const excessCharacters = prompt.length - PROVIDER_SEND_TURN_MAX_INPUT_CHARS;
+  const excessCharacters = prompt.trim().length - PROVIDER_SEND_TURN_MAX_INPUT_CHARS;
   if (excessCharacters <= 0) return null;
 
   const characterLabel = excessCharacters === 1 ? "character" : "characters";
@@ -12,10 +12,14 @@ export function getComposerPromptLengthValidationMessage(prompt: string): string
 
 export function submitComposerDraft(options: {
   prompt: string;
+  submissionTarget: "provider-turn" | "pending-user-input";
   event: ComposerSubmitEvent | undefined;
   onSend: (event?: ComposerSubmitEvent) => void;
 }): { validationMessage: string | null; didDispatch: boolean } {
-  const validationMessage = getComposerPromptLengthValidationMessage(options.prompt);
+  const validationMessage =
+    options.submissionTarget === "provider-turn"
+      ? getComposerPromptLengthValidationMessage(options.prompt)
+      : null;
   if (validationMessage) {
     options.event?.preventDefault();
     return { validationMessage, didDispatch: false };

--- a/apps/web/src/components/chat/composerSubmission.ts
+++ b/apps/web/src/components/chat/composerSubmission.ts
@@ -2,6 +2,12 @@ import { PROVIDER_SEND_TURN_MAX_INPUT_CHARS } from "@t3tools/contracts";
 
 type ComposerSubmitEvent = { preventDefault: () => void };
 
+type ComposerSubmissionInput = {
+  prompt: string;
+  providerInput?: string;
+  submissionTarget: "provider-turn" | "pending-user-input";
+};
+
 export function getComposerPromptLengthValidationMessage(prompt: string): string | null {
   const excessCharacters = prompt.trim().length - PROVIDER_SEND_TURN_MAX_INPUT_CHARS;
   if (excessCharacters <= 0) return null;
@@ -10,16 +16,21 @@ export function getComposerPromptLengthValidationMessage(prompt: string): string
   return `Prompt is ${excessCharacters.toLocaleString("en-US")} ${characterLabel} over the ${PROVIDER_SEND_TURN_MAX_INPUT_CHARS.toLocaleString("en-US")}-character limit. Shorten or split it before sending.`;
 }
 
-export function submitComposerDraft(options: {
-  prompt: string;
-  submissionTarget: "provider-turn" | "pending-user-input";
-  event: ComposerSubmitEvent | undefined;
-  onSend: (event?: ComposerSubmitEvent) => void;
-}): { validationMessage: string | null; didDispatch: boolean } {
-  const validationMessage =
-    options.submissionTarget === "provider-turn"
-      ? getComposerPromptLengthValidationMessage(options.prompt)
-      : null;
+export function getComposerSubmissionValidationMessage(
+  options: ComposerSubmissionInput,
+): string | null {
+  return options.submissionTarget === "provider-turn"
+    ? getComposerPromptLengthValidationMessage(options.providerInput ?? options.prompt)
+    : null;
+}
+
+export function submitComposerDraft(
+  options: ComposerSubmissionInput & {
+    event: ComposerSubmitEvent | undefined;
+    onSend: (event?: ComposerSubmitEvent) => void;
+  },
+): { validationMessage: string | null; didDispatch: boolean } {
+  const validationMessage = getComposerSubmissionValidationMessage(options);
   if (validationMessage) {
     options.event?.preventDefault();
     return { validationMessage, didDispatch: false };

--- a/apps/web/src/components/chat/composerSubmission.ts
+++ b/apps/web/src/components/chat/composerSubmission.ts
@@ -1,0 +1,26 @@
+import { PROVIDER_SEND_TURN_MAX_INPUT_CHARS } from "@t3tools/contracts";
+
+type ComposerSubmitEvent = { preventDefault: () => void };
+
+export function getComposerPromptLengthValidationMessage(prompt: string): string | null {
+  const excessCharacters = prompt.length - PROVIDER_SEND_TURN_MAX_INPUT_CHARS;
+  if (excessCharacters <= 0) return null;
+
+  const characterLabel = excessCharacters === 1 ? "character" : "characters";
+  return `Prompt is ${excessCharacters.toLocaleString("en-US")} ${characterLabel} over the ${PROVIDER_SEND_TURN_MAX_INPUT_CHARS.toLocaleString("en-US")}-character limit. Shorten or split it before sending.`;
+}
+
+export function submitComposerDraft(options: {
+  prompt: string;
+  event: ComposerSubmitEvent | undefined;
+  onSend: (event?: ComposerSubmitEvent) => void;
+}): { validationMessage: string | null; didDispatch: boolean } {
+  const validationMessage = getComposerPromptLengthValidationMessage(options.prompt);
+  if (validationMessage) {
+    options.event?.preventDefault();
+    return { validationMessage, didDispatch: false };
+  }
+
+  options.onSend(options.event);
+  return { validationMessage: null, didDispatch: true };
+}

--- a/apps/web/src/components/chat/composerSubmission.ts
+++ b/apps/web/src/components/chat/composerSubmission.ts
@@ -27,7 +27,7 @@ export function getComposerSubmissionValidationMessage(
 export function submitComposerDraft(
   options: ComposerSubmissionInput & {
     event: ComposerSubmitEvent | undefined;
-    onSend: (event?: ComposerSubmitEvent) => void;
+    onSend: (event?: ComposerSubmitEvent) => boolean | void;
   },
 ): { validationMessage: string | null; didDispatch: boolean } {
   const validationMessage = getComposerSubmissionValidationMessage(options);
@@ -36,6 +36,9 @@ export function submitComposerDraft(
     return { validationMessage, didDispatch: false };
   }
 
-  options.onSend(options.event);
+  if (options.onSend(options.event) === false) {
+    options.event?.preventDefault();
+    return { validationMessage: null, didDispatch: false };
+  }
   return { validationMessage: null, didDispatch: true };
 }

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -1,0 +1,5 @@
+# Message composer
+
+Messages can contain up to 120,000 characters. If a draft is longer, T3 Code keeps it in the
+composer and shows how many characters need to be removed. Shorten the draft or split it into
+multiple messages, then send again in the same thread.


### PR DESCRIPTION
## Problem

The web composer allowed drafts beyond the shared 120,000-character provider input limit to dispatch. The server then rejected the turn before the provider started, and the thread could expose an internal validation stack trace instead of an actionable correction.

## Fix

- Validate prompt length at the final `ChatComposer` submission boundary using the shared contract constant.
- Keep oversized drafts editable and show the exact overage with guidance to shorten or split the prompt.
- Allow drafts at exactly 120,000 characters and corrected follow-up submissions through the normal send path.
- Add behavior coverage, composer alert coverage, and user documentation.

## User impact

Oversized prompts now fail safely in the composer without starting a provider turn or making the thread appear broken.

## Validation

- `vp test run --project unit` in `apps/web`: 254 test files and 2,432 tests passed.
- `vp run typecheck` in `apps/web`: passed.
- Targeted lint and formatting checks: passed.
- Manual verification: the reporter confirmed the 120,001-character rejection, retained draft and actionable message, exact-boundary send, and corrected follow-up flow.

## Visual evidence

The interaction was manually verified, but before/after images were not captured in this draft. They remain a ready-for-review gate.

Closes #6105

Model: GPT-5
Harness: Codex desktop


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject oversized prompts before provider turn start in chat composer
> - Adds preflight validation in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/6602/files#diff-90b4b4dee89df040fe8cb45b1788c1d5876bd5092229a414007b0359c2142f4f) at all three send paths (plan follow-up, normal message, plan implementation) that formats the outgoing prompt and calls `validateProviderInput()` before dispatching, returning early on failure.
> - Adds `validateProviderInput(providerInput: string): boolean` to `ChatComposerHandle` in [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/6602/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a), which computes a validation message and updates inline error state.
> - Adds a `ComposerPromptLengthValidation` presentational component that renders an inline `role="alert"` when a validation message is present.
> - Centralizes validation logic in [composerSubmission.ts](https://github.com/pingdotgg/t3code/pull/6602/files#diff-a892194baad68d55a19db7bcc7e43219210ee701ca18529929bda2cef74641de) via `getComposerPromptLengthValidationMessage`, `getComposerSubmissionValidationMessage`, and `submitComposerDraft` utilities.
> - Behavioral Change: oversized messages (over 120,000 characters) are now blocked at the composer with an inline error rather than being sent to the provider.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8cc9ca3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only validation and send gating in the web composer; no server, auth, or data-model changes.
> 
> **Overview**
> **Oversized chat prompts are blocked in the composer** before any provider turn starts, using the shared **120,000-character** contract limit instead of failing on the server with an internal error.
> 
> Submission goes through new **`composerSubmission`** helpers: the form path validates trimmed draft length for provider turns, while **`ChatView`** calls **`validateProviderInput`** on the fully composed outgoing text (contexts, annotations, **`formatOutgoingPrompt`**) for normal sends, plan follow-ups, and plan implementation. Rejected sends keep the draft editable and show an inline **`ComposerPromptLengthValidation`** alert with how far over the limit the input is. **`sendInFlight`** and related UI only run after validation passes.
> 
> Pending user-input answers still use their own path and are not subject to this length gate. Tests and user docs cover the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cc9ca33be6bf3775201a4d93a907b6fe2abf3ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->