### PR TITLE
fix(usage): aggregate transcripts from every provider instance

### DIFF
--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -306,12 +306,9 @@ export const make = Effect.gen(function* () {
     yield* ensureScanCacheLoaded;
 
     const hostId = NodeOS.hostname();
-    // The source resolvers ask for filesystem services themselves; satisfy
-    // them from the instances we already hold so readSummary stays context-free.
-    const dirs = yield* resolveTranscriptDirs().pipe(
-      Effect.provideService(FileSystem.FileSystem, fileSystem),
-      Effect.provideService(Path.Path, path),
-    );
+    // The source resolvers ask for Path themselves; satisfy them from the
+    // instance we already hold so readSummary stays context-free.
+    const dirs = yield* resolveTranscriptDirs().pipe(Effect.provideService(Path.Path, path));
     const windowStart = DateTime.make(`${input.sinceDay}T00:00:00Z`);
     if (Option.isNone(windowStart)) {
       return yield* new UsageReadError({
@@ -326,18 +323,22 @@ export const make = Effect.gen(function* () {
     const buckets: UsageSummary["buckets"][number][] = [];
     const livePaths = new Set<string>();
     const walkedRoots: string[] = [];
+    const seenDedupeKeys = new Set<string>();
 
     for (const { provider, dir } of dirs) {
       const sourceIndex = sources.length;
-      const aggregator = new UsageAggregator({
-        sourceIndex,
-        timeZone: input.timeZone,
-        sinceDay: input.sinceDay,
-        untilDay: input.untilDay,
-        resolution: input.resolution ?? "day",
-        ...hourlyWindow,
-        rates,
-      });
+      const aggregator = new UsageAggregator(
+        {
+          sourceIndex,
+          timeZone: input.timeZone,
+          sinceDay: input.sinceDay,
+          untilDay: input.untilDay,
+          resolution: input.resolution ?? "day",
+          ...hourlyWindow,
+          rates,
+        },
+        seenDedupeKeys,
+      );
       const volumeId = yield* Effect.promise(() => readDirectoryVolumeId(dir));
       const exists = yield* fileSystem
         .exists(dir)

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -35,8 +35,6 @@ import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 
 import { ServerConfig } from "../config.ts";
 import * as ServerSettings from "../serverSettings.ts";
-import { resolveClaudeHomePath } from "../provider/Drivers/ClaudeHome.ts";
-import { resolveCodexHomeLayout } from "../provider/Drivers/CodexHomeLayout.ts";
 import { UsageAggregator } from "./usageAggregation.ts";
 import { parseRateTable, type RateTable } from "./usagePricing.ts";
 import {
@@ -52,6 +50,7 @@ import {
   type ScanCache,
 } from "./usageScanCache.ts";
 import type { UsageRecord } from "./usageTranscripts.ts";
+import { resolveUsageTranscriptSources } from "./usageTranscriptSources.ts";
 
 const LITELLM_RATES_URL =
   "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
@@ -184,19 +183,6 @@ export const make = Effect.gen(function* () {
     );
   });
 
-  /**
-   * Claude's config dir is the home itself when overridden, but a default
-   * install nests transcripts under `~/.claude/projects`. Probe both.
-   */
-  const resolveClaudeTranscriptDir = (homePath: string) =>
-    Effect.gen(function* () {
-      const nested = path.join(homePath, ".claude", "projects");
-      const nestedExists = yield* fileSystem
-        .exists(nested)
-        .pipe(Effect.catchCause(() => Effect.succeed(false)));
-      return nestedExists ? nested : path.join(homePath, "projects");
-    });
-
   /** Resolves the transcript directory for each provider. */
   const resolveTranscriptDirs = Effect.fn("UsageService.resolveTranscriptDirs")(function* () {
     // A settings failure must surface as an error: swallowing it here would
@@ -215,14 +201,7 @@ export const make = Effect.gen(function* () {
       ),
     );
 
-    const claudeHome = yield* resolveClaudeHomePath(settings.providers.claudeAgent);
-    const claudeDir = yield* resolveClaudeTranscriptDir(claudeHome);
-    const codexLayout = yield* resolveCodexHomeLayout(settings.providers.codex);
-
-    return [
-      { provider: "claude" as const, dir: claudeDir },
-      { provider: "codex" as const, dir: path.join(codexLayout.sharedHomePath, "sessions") },
-    ];
+    return yield* resolveUsageTranscriptSources(settings);
   });
 
   /**
@@ -327,9 +306,12 @@ export const make = Effect.gen(function* () {
     yield* ensureScanCacheLoaded;
 
     const hostId = NodeOS.hostname();
-    // The home resolvers ask for `Path` themselves; satisfy them from the
-    // instance we already hold so `readSummary` stays context-free.
-    const dirs = yield* resolveTranscriptDirs().pipe(Effect.provideService(Path.Path, path));
+    // The source resolvers ask for filesystem services themselves; satisfy
+    // them from the instances we already hold so readSummary stays context-free.
+    const dirs = yield* resolveTranscriptDirs().pipe(
+      Effect.provideService(FileSystem.FileSystem, fileSystem),
+      Effect.provideService(Path.Path, path),
+    );
     const windowStart = DateTime.make(`${input.sinceDay}T00:00:00Z`);
     if (Option.isNone(windowStart)) {
       return yield* new UsageReadError({
@@ -340,20 +322,22 @@ export const make = Effect.gen(function* () {
     const windowStartMs =
       (hourlyWindow?.sinceTimeMs ?? DateTime.toEpochMillis(windowStart.value)) - MTIME_SLACK_MS;
 
-    const aggregator = new UsageAggregator({
-      timeZone: input.timeZone,
-      sinceDay: input.sinceDay,
-      untilDay: input.untilDay,
-      resolution: input.resolution ?? "day",
-      ...hourlyWindow,
-      rates,
-    });
-
     const sources: UsageSource[] = [];
+    const buckets: UsageSummary["buckets"][number][] = [];
     const livePaths = new Set<string>();
     const walkedRoots: string[] = [];
 
     for (const { provider, dir } of dirs) {
+      const sourceIndex = sources.length;
+      const aggregator = new UsageAggregator({
+        sourceIndex,
+        timeZone: input.timeZone,
+        sinceDay: input.sinceDay,
+        untilDay: input.untilDay,
+        resolution: input.resolution ?? "day",
+        ...hourlyWindow,
+        rates,
+      });
       const volumeId = yield* Effect.promise(() => readDirectoryVolumeId(dir));
       const exists = yield* fileSystem
         .exists(dir)
@@ -406,6 +390,7 @@ export const make = Effect.gen(function* () {
         distinctSessions: sessionIds.size,
         message: null,
       });
+      buckets.push(...aggregator.finish().buckets);
     }
 
     const pruned = pruneScanCache(fileCache, {
@@ -417,7 +402,6 @@ export const make = Effect.gen(function* () {
     if (pruned > 0) cacheDirty = true;
     yield* persistScanCache();
 
-    const aggregated = aggregator.finish();
     const readAt = yield* DateTime.now;
     const finishedAtMs = yield* Clock.currentTimeMillis;
 
@@ -427,7 +411,14 @@ export const make = Effect.gen(function* () {
       timeZone: input.timeZone,
       sinceDay: input.sinceDay,
       untilDay: input.untilDay,
-      buckets: aggregated.buckets,
+      buckets: buckets.sort(
+        (a, b) =>
+          a.day.localeCompare(b.day) ||
+          (a.hourStart ?? "").localeCompare(b.hourStart ?? "") ||
+          a.provider.localeCompare(b.provider) ||
+          a.model.localeCompare(b.model) ||
+          a.sourceIndex - b.sourceIndex,
+      ),
       sources,
       pricing: {
         status: ratesStatus,

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -88,7 +88,10 @@ const encodeScanCacheFile = Schema.encodeEffect(ScanCacheJson);
 export class UsageService extends Context.Service<
   UsageService,
   {
-    readonly readSummary: (input: UsageSummaryInput) => Effect.Effect<UsageSummary, UsageReadError>;
+    readonly readSummary: (
+      input: UsageSummaryInput,
+      workspaceCwds?: readonly string[],
+    ) => Effect.Effect<UsageSummary, UsageReadError>;
   }
 >()("t3/usage/UsageService") {}
 
@@ -184,7 +187,9 @@ export const make = Effect.gen(function* () {
   });
 
   /** Resolves the transcript directory for each provider. */
-  const resolveTranscriptDirs = Effect.fn("UsageService.resolveTranscriptDirs")(function* () {
+  const resolveTranscriptDirs = Effect.fn("UsageService.resolveTranscriptDirs")(function* (
+    workspaceCwds: readonly string[],
+  ) {
     // A settings failure must surface as an error: swallowing it here would
     // present "zero usage from every provider" as a valid answer.
     const settings = yield* settingsService.getSettings.pipe(
@@ -201,7 +206,7 @@ export const make = Effect.gen(function* () {
       ),
     );
 
-    return yield* resolveUsageTranscriptSources(settings);
+    return yield* resolveUsageTranscriptSources(settings, process.env, workspaceCwds);
   });
 
   /**
@@ -269,7 +274,10 @@ export const make = Effect.gen(function* () {
       return records;
     });
 
-  const readSummary = Effect.fn("UsageService.readSummary")(function* (input: UsageSummaryInput) {
+  const readSummary = Effect.fn("UsageService.readSummary")(function* (
+    input: UsageSummaryInput,
+    workspaceCwds: readonly string[] = [config.cwd],
+  ) {
     if (input.sinceDay > input.untilDay) {
       return yield* new UsageReadError({
         reason: "invalidWindow",
@@ -308,7 +316,9 @@ export const make = Effect.gen(function* () {
     const hostId = NodeOS.hostname();
     // The source resolvers ask for Path themselves; satisfy them from the
     // instance we already hold so readSummary stays context-free.
-    const dirs = yield* resolveTranscriptDirs().pipe(Effect.provideService(Path.Path, path));
+    const dirs = yield* resolveTranscriptDirs(workspaceCwds).pipe(
+      Effect.provideService(Path.Path, path),
+    );
     const windowStart = DateTime.make(`${input.sinceDay}T00:00:00Z`);
     if (Option.isNone(windowStart)) {
       return yield* new UsageReadError({

--- a/apps/server/src/usage/usageAggregation.test.ts
+++ b/apps/server/src/usage/usageAggregation.test.ts
@@ -90,6 +90,23 @@ describe("UsageAggregator", () => {
     expect(result.buckets[0]?.totals.outputTokens).toBe(50);
   });
 
+  it("deduplicates records across transcript sources in the same scan", () => {
+    const seenDedupeKeys = new Set<string>();
+    const options = {
+      timeZone: "UTC",
+      sinceDay: "2026-08-01",
+      untilDay: "2026-08-31",
+      rates,
+    };
+    const first = new UsageAggregator({ ...options, sourceIndex: 0 }, seenDedupeKeys);
+    const second = new UsageAggregator({ ...options, sourceIndex: 1 }, seenDedupeKeys);
+
+    expect(first.add(record({ dedupeKey: "msg_1:" }))).toBe(true);
+    expect(second.add(record({ dedupeKey: "msg_1:" }))).toBe(false);
+    expect(first.finish().buckets[0]?.records).toBe(1);
+    expect(second.finish()).toMatchObject({ buckets: [], duplicatesDropped: 1 });
+  });
+
   it("still sums records that carry no dedupe key", () => {
     const result = aggregate([record(), record()]);
 

--- a/apps/server/src/usage/usageAggregation.test.ts
+++ b/apps/server/src/usage/usageAggregation.test.ts
@@ -49,6 +49,7 @@ function aggregate(
         }
       : {};
   const aggregator = new UsageAggregator({
+    sourceIndex: 0,
     timeZone,
     sinceDay: "2026-08-01",
     untilDay: "2026-08-31",
@@ -65,6 +66,7 @@ describe("UsageAggregator", () => {
     expect(
       () =>
         new UsageAggregator({
+          sourceIndex: 0,
           timeZone: "UTC",
           sinceDay: "2026-08-01",
           untilDay: "2026-08-31",
@@ -83,6 +85,7 @@ describe("UsageAggregator", () => {
 
     expect(result.duplicatesDropped).toBe(2);
     expect(result.buckets).toHaveLength(1);
+    expect(result.buckets[0]?.sourceIndex).toBe(0);
     expect(result.buckets[0]?.records).toBe(1);
     expect(result.buckets[0]?.totals.outputTokens).toBe(50);
   });
@@ -181,6 +184,7 @@ describe("UsageAggregator", () => {
 
   it("reports whether a record contributed", () => {
     const aggregator = new UsageAggregator({
+      sourceIndex: 0,
       timeZone: "UTC",
       sinceDay: "2026-08-01",
       untilDay: "2026-08-31",

--- a/apps/server/src/usage/usageAggregation.ts
+++ b/apps/server/src/usage/usageAggregation.ts
@@ -84,15 +84,16 @@ export interface AggregateResult {
  */
 export class UsageAggregator {
   readonly #buckets = new Map<string, MutableBucket>();
-  readonly #seen = new Set<string>();
+  readonly #seen: Set<string>;
   readonly #toDay: (timestampMs: number) => string;
   readonly #hourlyWindow: { readonly sinceTimeMs: number; readonly untilTimeMs: number } | null;
   readonly #options: AggregateOptions;
   #duplicatesDropped = 0;
   #outOfWindow = 0;
 
-  constructor(options: AggregateOptions) {
+  constructor(options: AggregateOptions, seenDedupeKeys: Set<string> = new Set()) {
     this.#options = options;
+    this.#seen = seenDedupeKeys;
     this.#toDay = makeDayFormatter(options.timeZone);
     if (options.resolution === "hour") {
       if (options.sinceTimeMs === undefined || options.untilTimeMs === undefined) {

--- a/apps/server/src/usage/usageAggregation.ts
+++ b/apps/server/src/usage/usageAggregation.ts
@@ -57,6 +57,7 @@ interface MutableBucket {
 }
 
 export interface AggregateOptions {
+  readonly sourceIndex: number;
   readonly timeZone: string;
   readonly sinceDay: string;
   readonly untilDay: string;
@@ -182,6 +183,7 @@ export class UsageAggregator {
     for (const [key, bucket] of this.#buckets) {
       const [day = "", hourStart = "", provider = "", model = ""] = key.split("\u0000");
       buckets.push({
+        sourceIndex: this.#options.sourceIndex,
         day: day as UsageDay,
         ...(hourStart === "" ? {} : { hourStart }),
         provider: provider as UsageBucket["provider"],

--- a/apps/server/src/usage/usageTranscriptSources.test.ts
+++ b/apps/server/src/usage/usageTranscriptSources.test.ts
@@ -1,0 +1,142 @@
+import * as NodeOS from "node:os";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { ServerSettings } from "@t3tools/contracts";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+
+import { resolveUsageTranscriptSources } from "./usageTranscriptSources.ts";
+
+const decodeSettings = Schema.decodeSync(ServerSettings);
+
+it.layer(NodeServices.layer)("resolveUsageTranscriptSources", (it) => {
+  it.effect("reads custom homes from every explicit Claude and Codex instance", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-usage-sources-",
+      });
+      const claudeDefault = path.join(tempDir, "claude-default");
+      const claudePersonal = path.join(tempDir, "claude-personal");
+      const codexDefault = path.join(tempDir, "codex-default");
+      const codexWork = path.join(tempDir, "codex-work");
+
+      const settings = decodeSettings({
+        providerInstances: {
+          claudeAgent: { driver: "claudeAgent", config: { homePath: claudeDefault } },
+          claude_personal: { driver: "claudeAgent", config: { homePath: claudePersonal } },
+          codex: { driver: "codex", config: { homePath: codexDefault } },
+          codex_work: { driver: "codex", config: { homePath: codexWork } },
+        },
+      });
+
+      const sources = yield* resolveUsageTranscriptSources(settings, {});
+
+      assert.deepEqual(sources, [
+        { provider: "claude", dir: path.join(claudeDefault, "projects") },
+        { provider: "claude", dir: path.join(claudePersonal, "projects") },
+        { provider: "codex", dir: path.join(codexDefault, "sessions") },
+        { provider: "codex", dir: path.join(codexWork, "sessions") },
+      ]);
+    }),
+  );
+
+  it.effect("keeps legacy defaults for built-in slots absent from providerInstances", () =>
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const settings = decodeSettings({
+        providerInstances: {
+          claude_personal: {
+            driver: "claudeAgent",
+            config: { homePath: "/tmp/claude-personal" },
+          },
+        },
+      });
+
+      const sources = yield* resolveUsageTranscriptSources(settings, {});
+
+      assert.equal(sources.filter((source) => source.provider === "claude").length, 2);
+      assert.ok(
+        sources.some(
+          (source) =>
+            source.provider === "codex" &&
+            source.dir === path.join(NodeOS.homedir(), ".codex", "sessions"),
+        ),
+      );
+    }),
+  );
+
+  it.effect("honors a per-instance CLAUDE_CONFIG_DIR when homePath is empty", () =>
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const settings = decodeSettings({
+        providerInstances: {
+          claudeAgent: {
+            driver: "claudeAgent",
+            config: {},
+            environment: [{ name: "CLAUDE_CONFIG_DIR", value: "/tmp/claude-from-environment" }],
+          },
+          codex: { driver: "codex", config: {} },
+        },
+      });
+
+      const sources = yield* resolveUsageTranscriptSources(settings, {});
+
+      assert.ok(
+        sources.some(
+          (source) =>
+            source.provider === "claude" &&
+            source.dir === path.resolve("/tmp/claude-from-environment/projects"),
+        ),
+      );
+    }),
+  );
+
+  it.effect("deduplicates instances that share a transcript directory", () =>
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const settings = decodeSettings({
+        providerInstances: {
+          claudeAgent: { driver: "claudeAgent", config: { homePath: "/tmp/shared-claude" } },
+          claude_work: { driver: "claudeAgent", config: { homePath: "/tmp/shared-claude" } },
+          codex: { driver: "codex", config: {} },
+        },
+      });
+
+      const sources = yield* resolveUsageTranscriptSources(settings, {});
+
+      assert.deepEqual(
+        sources.filter((source) => source.provider === "claude"),
+        [{ provider: "claude", dir: path.resolve("/tmp/shared-claude/projects") }],
+      );
+    }),
+  );
+
+  it.effect("preserves the nested legacy Claude transcript layout when it exists", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-usage-sources-",
+      });
+      const nestedProjects = path.join(tempDir, ".claude", "projects");
+      yield* fileSystem.makeDirectory(nestedProjects, { recursive: true });
+      const settings = decodeSettings({
+        providerInstances: {
+          claudeAgent: { driver: "claudeAgent", config: { homePath: tempDir } },
+          codex: { driver: "codex", config: {} },
+        },
+      });
+
+      const sources = yield* resolveUsageTranscriptSources(settings, {});
+
+      assert.ok(
+        sources.some((source) => source.provider === "claude" && source.dir === nestedProjects),
+      );
+    }),
+  );
+});

--- a/apps/server/src/usage/usageTranscriptSources.test.ts
+++ b/apps/server/src/usage/usageTranscriptSources.test.ts
@@ -63,6 +63,13 @@ it.layer(NodeServices.layer)("resolveUsageTranscriptSources", (it) => {
       assert.ok(
         sources.some(
           (source) =>
+            source.provider === "claude" &&
+            source.dir === path.join(NodeOS.homedir(), ".claude", "projects"),
+        ),
+      );
+      assert.ok(
+        sources.some(
+          (source) =>
             source.provider === "codex" &&
             source.dir === path.join(NodeOS.homedir(), ".codex", "sessions"),
         ),
@@ -96,6 +103,84 @@ it.layer(NodeServices.layer)("resolveUsageTranscriptSources", (it) => {
     }),
   );
 
+  it.effect("honors per-instance CODEX_HOME when homePath is empty", () =>
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const settings = decodeSettings({
+        providerInstances: {
+          claudeAgent: { driver: "claudeAgent", config: {} },
+          codex: {
+            driver: "codex",
+            config: {},
+            environment: [{ name: "CODEX_HOME", value: "/tmp/codex-from-instance" }],
+          },
+        },
+      });
+
+      const sources = yield* resolveUsageTranscriptSources(settings, {
+        CODEX_HOME: "/tmp/codex-from-process",
+      });
+
+      assert.ok(
+        sources.some(
+          (source) =>
+            source.provider === "codex" &&
+            source.dir === path.resolve("/tmp/codex-from-instance/sessions"),
+        ),
+      );
+    }),
+  );
+
+  it.effect("honors process CODEX_HOME when the instance does not override it", () =>
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const settings = decodeSettings({
+        providerInstances: {
+          claudeAgent: { driver: "claudeAgent", config: {} },
+          codex: { driver: "codex", config: {} },
+        },
+      });
+
+      const sources = yield* resolveUsageTranscriptSources(settings, {
+        CODEX_HOME: "/tmp/codex-from-process",
+      });
+
+      assert.ok(
+        sources.some(
+          (source) =>
+            source.provider === "codex" &&
+            source.dir === path.resolve("/tmp/codex-from-process/sessions"),
+        ),
+      );
+    }),
+  );
+
+  it.effect("keeps explicit Codex homePath ahead of CODEX_HOME", () =>
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const settings = decodeSettings({
+        providerInstances: {
+          claudeAgent: { driver: "claudeAgent", config: {} },
+          codex: {
+            driver: "codex",
+            config: { homePath: "/tmp/codex-explicit" },
+            environment: [{ name: "CODEX_HOME", value: "/tmp/codex-from-instance" }],
+          },
+        },
+      });
+
+      const sources = yield* resolveUsageTranscriptSources(settings, {});
+
+      assert.ok(
+        sources.some(
+          (source) =>
+            source.provider === "codex" &&
+            source.dir === path.resolve("/tmp/codex-explicit/sessions"),
+        ),
+      );
+    }),
+  );
+
   it.effect("deduplicates instances that share a transcript directory", () =>
     Effect.gen(function* () {
       const path = yield* Path.Path;
@@ -116,7 +201,7 @@ it.layer(NodeServices.layer)("resolveUsageTranscriptSources", (it) => {
     }),
   );
 
-  it.effect("preserves the nested legacy Claude transcript layout when it exists", () =>
+  it.effect("uses the explicit Claude config dir even when a nested path exists", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
@@ -134,8 +219,9 @@ it.layer(NodeServices.layer)("resolveUsageTranscriptSources", (it) => {
 
       const sources = yield* resolveUsageTranscriptSources(settings, {});
 
-      assert.ok(
-        sources.some((source) => source.provider === "claude" && source.dir === nestedProjects),
+      assert.deepEqual(
+        sources.filter((source) => source.provider === "claude"),
+        [{ provider: "claude", dir: path.join(tempDir, "projects") }],
       );
     }),
   );

--- a/apps/server/src/usage/usageTranscriptSources.test.ts
+++ b/apps/server/src/usage/usageTranscriptSources.test.ts
@@ -103,6 +103,35 @@ it.layer(NodeServices.layer)("resolveUsageTranscriptSources", (it) => {
     }),
   );
 
+  it.effect("resolves a relative CLAUDE_CONFIG_DIR from every workspace cwd", () =>
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const settings = decodeSettings({
+        providerInstances: {
+          claudeAgent: {
+            driver: "claudeAgent",
+            config: {},
+            environment: [{ name: "CLAUDE_CONFIG_DIR", value: "relative-config" }],
+          },
+          codex: { driver: "codex", config: {} },
+        },
+      });
+
+      const sources = yield* resolveUsageTranscriptSources(settings, {}, [
+        "/tmp/workspace-a",
+        "/tmp/workspace-b",
+      ]);
+
+      assert.deepEqual(
+        sources.filter((source) => source.provider === "claude"),
+        [
+          { provider: "claude", dir: path.resolve("/tmp/workspace-a/relative-config/projects") },
+          { provider: "claude", dir: path.resolve("/tmp/workspace-b/relative-config/projects") },
+        ],
+      );
+    }),
+  );
+
   it.effect("honors per-instance CODEX_HOME when homePath is empty", () =>
     Effect.gen(function* () {
       const path = yield* Path.Path;

--- a/apps/server/src/usage/usageTranscriptSources.ts
+++ b/apps/server/src/usage/usageTranscriptSources.ts
@@ -19,7 +19,6 @@ import {
   type UsageProviderKind,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
-import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
@@ -62,46 +61,58 @@ function configuredUsageInstances(settings: ServerSettings): readonly ProviderIn
 }
 
 /**
- * An explicit homePath wins because makeClaudeEnvironment exports it over any
- * existing CLAUDE_CONFIG_DIR. Otherwise use the merged per-instance/process
- * environment seen by the Claude subprocess, then the normal OS home.
+ * Match the config-dir precedence seen by the Claude subprocess. Explicit and
+ * environment config dirs store transcripts directly under `projects`; only
+ * the default installation nests them under `~/.claude/projects`.
  */
-const resolveClaudeInstanceHome = Effect.fn("UsageTranscriptSources.resolveClaudeInstanceHome")(
+const resolveClaudeInstanceTranscriptDir = Effect.fn(
+  "UsageTranscriptSources.resolveClaudeInstanceTranscriptDir",
+)(function* (
+  config: ClaudeSettings,
+  instance: ProviderInstanceConfig,
+  baseEnvironment: NodeJS.ProcessEnv,
+) {
+  const path = yield* Path.Path;
+  if (config.homePath.trim().length > 0) {
+    return path.join(yield* resolveClaudeHomePath(config), "projects");
+  }
+
+  const environment = mergeProviderInstanceEnvironment(instance.environment, baseEnvironment);
+  const environmentHome = environment.CLAUDE_CONFIG_DIR?.trim() ?? "";
+  if (environmentHome.length > 0) {
+    // Environment variables are passed directly to the subprocess and do
+    // not receive shell-style tilde expansion.
+    return path.join(path.resolve(environmentHome), "projects");
+  }
+
+  return path.join(NodeOS.homedir(), ".claude", "projects");
+});
+
+/**
+ * Match the direct-home precedence seen by the Codex subprocess: an explicit
+ * homePath wins, otherwise CODEX_HOME comes from the merged instance/process
+ * environment. A shadow home keeps the configured shared-home layout because
+ * CodexDriver materializes that layout and passes the shadow path explicitly.
+ */
+const resolveCodexInstanceLayout = Effect.fn("UsageTranscriptSources.resolveCodexInstanceLayout")(
   function* (
-    config: ClaudeSettings,
+    config: CodexSettings,
     instance: ProviderInstanceConfig,
     baseEnvironment: NodeJS.ProcessEnv,
   ) {
     const path = yield* Path.Path;
-    if (config.homePath.trim().length > 0) {
-      return yield* resolveClaudeHomePath(config);
+    if (config.homePath.trim().length > 0 || config.shadowHomePath.trim().length > 0) {
+      return yield* resolveCodexHomeLayout(config);
     }
 
     const environment = mergeProviderInstanceEnvironment(instance.environment, baseEnvironment);
-    const environmentHome = environment.CLAUDE_CONFIG_DIR?.trim() ?? "";
-    if (environmentHome.length > 0) {
-      // Environment variables are passed directly to the subprocess and do
-      // not receive shell-style tilde expansion.
-      return path.resolve(environmentHome);
-    }
-
-    return path.resolve(NodeOS.homedir());
-  },
-);
-
-/**
- * Claude's config dir is the home itself when overridden, but older/default
- * layouts nest transcripts under `<home>/.claude/projects`. Probe both.
- */
-const resolveClaudeTranscriptDir = Effect.fn("UsageTranscriptSources.resolveClaudeTranscriptDir")(
-  function* (homePath: string) {
-    const fileSystem = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    const nested = path.join(homePath, ".claude", "projects");
-    const nestedExists = yield* fileSystem
-      .exists(nested)
-      .pipe(Effect.catchCause(() => Effect.succeed(false)));
-    return nestedExists ? nested : path.join(homePath, "projects");
+    const environmentHome = environment.CODEX_HOME?.trim() ?? "";
+    return yield* resolveCodexHomeLayout({
+      ...config,
+      // Environment variables are not shell-expanded. Resolve the value first
+      // so resolveCodexHomeLayout does not treat a literal `~` as config syntax.
+      homePath: environmentHome.length > 0 ? path.resolve(environmentHome) : "",
+    });
   },
 );
 
@@ -124,10 +135,9 @@ export const resolveUsageTranscriptSources = Effect.fn(
     if (instance.driver === CLAUDE_DRIVER) {
       const decoded = decodeClaudeSettings(instance.config ?? {});
       if (Option.isNone(decoded)) continue;
-      const homePath = yield* resolveClaudeInstanceHome(decoded.value, instance, baseEnvironment);
       append({
         provider: "claude",
-        dir: yield* resolveClaudeTranscriptDir(homePath),
+        dir: yield* resolveClaudeInstanceTranscriptDir(decoded.value, instance, baseEnvironment),
       });
       continue;
     }
@@ -135,7 +145,7 @@ export const resolveUsageTranscriptSources = Effect.fn(
     if (instance.driver === CODEX_DRIVER) {
       const decoded = decodeCodexSettings(instance.config ?? {});
       if (Option.isNone(decoded)) continue;
-      const layout = yield* resolveCodexHomeLayout(decoded.value);
+      const layout = yield* resolveCodexInstanceLayout(decoded.value, instance, baseEnvironment);
       append({ provider: "codex", dir: path.join(layout.sharedHomePath, "sessions") });
     }
   }

--- a/apps/server/src/usage/usageTranscriptSources.ts
+++ b/apps/server/src/usage/usageTranscriptSources.ts
@@ -65,27 +65,32 @@ function configuredUsageInstances(settings: ServerSettings): readonly ProviderIn
  * environment config dirs store transcripts directly under `projects`; only
  * the default installation nests them under `~/.claude/projects`.
  */
-const resolveClaudeInstanceTranscriptDir = Effect.fn(
-  "UsageTranscriptSources.resolveClaudeInstanceTranscriptDir",
+const resolveClaudeInstanceTranscriptDirs = Effect.fn(
+  "UsageTranscriptSources.resolveClaudeInstanceTranscriptDirs",
 )(function* (
   config: ClaudeSettings,
   instance: ProviderInstanceConfig,
   baseEnvironment: NodeJS.ProcessEnv,
+  workspaceCwds: readonly string[],
 ) {
   const path = yield* Path.Path;
   if (config.homePath.trim().length > 0) {
-    return path.join(yield* resolveClaudeHomePath(config), "projects");
+    return [path.join(yield* resolveClaudeHomePath(config), "projects")];
   }
 
   const environment = mergeProviderInstanceEnvironment(instance.environment, baseEnvironment);
   const environmentHome = environment.CLAUDE_CONFIG_DIR?.trim() ?? "";
   if (environmentHome.length > 0) {
     // Environment variables are passed directly to the subprocess and do
-    // not receive shell-style tilde expansion.
-    return path.join(path.resolve(environmentHome), "projects");
+    // not receive shell-style tilde expansion. Relative values resolve from
+    // each workspace cwd used to launch Claude.
+    const configDirs = path.isAbsolute(environmentHome)
+      ? [path.resolve(environmentHome)]
+      : workspaceCwds.map((cwd) => path.resolve(cwd, environmentHome));
+    return configDirs.map((configDir) => path.join(configDir, "projects"));
   }
 
-  return path.join(NodeOS.homedir(), ".claude", "projects");
+  return [path.join(NodeOS.homedir(), ".claude", "projects")];
 });
 
 /**
@@ -119,7 +124,11 @@ const resolveCodexInstanceLayout = Effect.fn("UsageTranscriptSources.resolveCode
 /** Resolve unique transcript roots for every configured Claude/Codex instance. */
 export const resolveUsageTranscriptSources = Effect.fn(
   "UsageTranscriptSources.resolveUsageTranscriptSources",
-)(function* (settings: ServerSettings, baseEnvironment: NodeJS.ProcessEnv = process.env) {
+)(function* (
+  settings: ServerSettings,
+  baseEnvironment: NodeJS.ProcessEnv = process.env,
+  workspaceCwds: readonly string[] = [process.cwd()],
+) {
   const path = yield* Path.Path;
   const sources: UsageTranscriptSource[] = [];
   const seen = new Set<string>();
@@ -135,10 +144,13 @@ export const resolveUsageTranscriptSources = Effect.fn(
     if (instance.driver === CLAUDE_DRIVER) {
       const decoded = decodeClaudeSettings(instance.config ?? {});
       if (Option.isNone(decoded)) continue;
-      append({
-        provider: "claude",
-        dir: yield* resolveClaudeInstanceTranscriptDir(decoded.value, instance, baseEnvironment),
-      });
+      const dirs = yield* resolveClaudeInstanceTranscriptDirs(
+        decoded.value,
+        instance,
+        baseEnvironment,
+        workspaceCwds,
+      );
+      for (const dir of dirs) append({ provider: "claude", dir });
       continue;
     }
 

--- a/apps/server/src/usage/usageTranscriptSources.ts
+++ b/apps/server/src/usage/usageTranscriptSources.ts
@@ -1,0 +1,144 @@
+/**
+ * Resolves every configured Codex and Claude Code transcript directory.
+ *
+ * Provider instances are the runtime source of truth. Legacy provider settings
+ * remain a fallback for the built-in default slots, matching provider registry
+ * hydration during the settings migration.
+ *
+ * @module usageTranscriptSources
+ */
+import * as NodeOS from "node:os";
+
+import {
+  ClaudeSettings,
+  CodexSettings,
+  defaultInstanceIdForDriver,
+  ProviderDriverKind,
+  type ProviderInstanceConfig,
+  type ServerSettings,
+  type UsageProviderKind,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+
+import { resolveClaudeHomePath } from "../provider/Drivers/ClaudeHome.ts";
+import { resolveCodexHomeLayout } from "../provider/Drivers/CodexHomeLayout.ts";
+import { mergeProviderInstanceEnvironment } from "../provider/ProviderInstanceEnvironment.ts";
+
+const CLAUDE_DRIVER = ProviderDriverKind.make("claudeAgent");
+const CODEX_DRIVER = ProviderDriverKind.make("codex");
+
+const decodeClaudeSettings = Schema.decodeUnknownOption(ClaudeSettings);
+const decodeCodexSettings = Schema.decodeUnknownOption(CodexSettings);
+
+export interface UsageTranscriptSource {
+  readonly provider: UsageProviderKind;
+  readonly dir: string;
+}
+
+/**
+ * Builds the same relevant instance set as provider registry hydration:
+ * explicit entries win, while an absent built-in default slot is synthesized
+ * from its legacy provider settings.
+ */
+function configuredUsageInstances(settings: ServerSettings): readonly ProviderInstanceConfig[] {
+  const instances = Object.entries(settings.providerInstances).map(([, instance]) => instance);
+
+  const appendLegacyDefault = (
+    driver: typeof CLAUDE_DRIVER | typeof CODEX_DRIVER,
+    config: ServerSettings["providers"]["claudeAgent" | "codex"],
+  ) => {
+    const defaultInstanceId = defaultInstanceIdForDriver(driver);
+    if (Object.hasOwn(settings.providerInstances, defaultInstanceId)) return;
+    instances.push({ driver, config });
+  };
+
+  appendLegacyDefault(CLAUDE_DRIVER, settings.providers.claudeAgent);
+  appendLegacyDefault(CODEX_DRIVER, settings.providers.codex);
+  return instances;
+}
+
+/**
+ * An explicit homePath wins because makeClaudeEnvironment exports it over any
+ * existing CLAUDE_CONFIG_DIR. Otherwise use the merged per-instance/process
+ * environment seen by the Claude subprocess, then the normal OS home.
+ */
+const resolveClaudeInstanceHome = Effect.fn("UsageTranscriptSources.resolveClaudeInstanceHome")(
+  function* (
+    config: ClaudeSettings,
+    instance: ProviderInstanceConfig,
+    baseEnvironment: NodeJS.ProcessEnv,
+  ) {
+    const path = yield* Path.Path;
+    if (config.homePath.trim().length > 0) {
+      return yield* resolveClaudeHomePath(config);
+    }
+
+    const environment = mergeProviderInstanceEnvironment(instance.environment, baseEnvironment);
+    const environmentHome = environment.CLAUDE_CONFIG_DIR?.trim() ?? "";
+    if (environmentHome.length > 0) {
+      // Environment variables are passed directly to the subprocess and do
+      // not receive shell-style tilde expansion.
+      return path.resolve(environmentHome);
+    }
+
+    return path.resolve(NodeOS.homedir());
+  },
+);
+
+/**
+ * Claude's config dir is the home itself when overridden, but older/default
+ * layouts nest transcripts under `<home>/.claude/projects`. Probe both.
+ */
+const resolveClaudeTranscriptDir = Effect.fn("UsageTranscriptSources.resolveClaudeTranscriptDir")(
+  function* (homePath: string) {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const nested = path.join(homePath, ".claude", "projects");
+    const nestedExists = yield* fileSystem
+      .exists(nested)
+      .pipe(Effect.catchCause(() => Effect.succeed(false)));
+    return nestedExists ? nested : path.join(homePath, "projects");
+  },
+);
+
+/** Resolve unique transcript roots for every configured Claude/Codex instance. */
+export const resolveUsageTranscriptSources = Effect.fn(
+  "UsageTranscriptSources.resolveUsageTranscriptSources",
+)(function* (settings: ServerSettings, baseEnvironment: NodeJS.ProcessEnv = process.env) {
+  const path = yield* Path.Path;
+  const sources: UsageTranscriptSource[] = [];
+  const seen = new Set<string>();
+
+  const append = (source: UsageTranscriptSource) => {
+    const key = `${source.provider}\0${source.dir}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    sources.push(source);
+  };
+
+  for (const instance of configuredUsageInstances(settings)) {
+    if (instance.driver === CLAUDE_DRIVER) {
+      const decoded = decodeClaudeSettings(instance.config ?? {});
+      if (Option.isNone(decoded)) continue;
+      const homePath = yield* resolveClaudeInstanceHome(decoded.value, instance, baseEnvironment);
+      append({
+        provider: "claude",
+        dir: yield* resolveClaudeTranscriptDir(homePath),
+      });
+      continue;
+    }
+
+    if (instance.driver === CODEX_DRIVER) {
+      const decoded = decodeCodexSettings(instance.config ?? {});
+      if (Option.isNone(decoded)) continue;
+      const layout = yield* resolveCodexHomeLayout(decoded.value);
+      append({ provider: "codex", dir: path.join(layout.sharedHomePath, "sessions") });
+    }
+  }
+
+  return sources;
+});

--- a/apps/server/src/usage/usageWorkspaceCwds.test.ts
+++ b/apps/server/src/usage/usageWorkspaceCwds.test.ts
@@ -1,0 +1,38 @@
+import { assert, it } from "@effect/vitest";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+
+import { resolveUsageWorkspaceCwds } from "./usageWorkspaceCwds.ts";
+
+class ProjectionUnavailable extends Data.TaggedError("ProjectionUnavailable") {}
+
+it.effect("falls back to the server cwd when workspace projections fail", () =>
+  Effect.gen(function* () {
+    const workspaceCwds = yield* resolveUsageWorkspaceCwds(
+      "/server-cwd",
+      Effect.fail(new ProjectionUnavailable()),
+    );
+
+    assert.deepEqual(workspaceCwds, ["/server-cwd"]);
+  }),
+);
+
+it.effect("collects distinct project and worktree cwd values", () =>
+  Effect.gen(function* () {
+    const workspaceCwds = yield* resolveUsageWorkspaceCwds(
+      "/server-cwd",
+      Effect.succeed([
+        {
+          projects: [{ workspaceRoot: "/project-a" }, { workspaceRoot: "/server-cwd" }],
+          threads: [{ worktreePath: "/worktree-a" }, { worktreePath: null }],
+        },
+        {
+          projects: [{ workspaceRoot: "/project-a" }],
+          threads: [{ worktreePath: "/worktree-a" }],
+        },
+      ]),
+    );
+
+    assert.deepEqual(workspaceCwds, ["/server-cwd", "/project-a", "/worktree-a"]);
+  }),
+);

--- a/apps/server/src/usage/usageWorkspaceCwds.test.ts
+++ b/apps/server/src/usage/usageWorkspaceCwds.test.ts
@@ -8,10 +8,9 @@ class ProjectionUnavailable extends Data.TaggedError("ProjectionUnavailable") {}
 
 it.effect("falls back to the server cwd when workspace projections fail", () =>
   Effect.gen(function* () {
-    const workspaceCwds = yield* resolveUsageWorkspaceCwds(
-      "/server-cwd",
+    const workspaceCwds = yield* resolveUsageWorkspaceCwds("/server-cwd", [
       Effect.fail(new ProjectionUnavailable()),
-    );
+    ]);
 
     assert.deepEqual(workspaceCwds, ["/server-cwd"]);
   }),
@@ -19,19 +18,30 @@ it.effect("falls back to the server cwd when workspace projections fail", () =>
 
 it.effect("collects distinct project and worktree cwd values", () =>
   Effect.gen(function* () {
-    const workspaceCwds = yield* resolveUsageWorkspaceCwds(
-      "/server-cwd",
-      Effect.succeed([
-        {
-          projects: [{ workspaceRoot: "/project-a" }, { workspaceRoot: "/server-cwd" }],
-          threads: [{ worktreePath: "/worktree-a" }, { worktreePath: null }],
-        },
-        {
-          projects: [{ workspaceRoot: "/project-a" }],
-          threads: [{ worktreePath: "/worktree-a" }],
-        },
-      ]),
-    );
+    const workspaceCwds = yield* resolveUsageWorkspaceCwds("/server-cwd", [
+      Effect.succeed({
+        projects: [{ workspaceRoot: "/project-a" }, { workspaceRoot: "/server-cwd" }],
+        threads: [{ worktreePath: "/worktree-a" }, { worktreePath: null }],
+      }),
+      Effect.succeed({
+        projects: [{ workspaceRoot: "/project-a" }],
+        threads: [{ worktreePath: "/worktree-a" }],
+      }),
+    ]);
+
+    assert.deepEqual(workspaceCwds, ["/server-cwd", "/project-a", "/worktree-a"]);
+  }),
+);
+
+it.effect("keeps successful workspace projections when another fails", () =>
+  Effect.gen(function* () {
+    const workspaceCwds = yield* resolveUsageWorkspaceCwds("/server-cwd", [
+      Effect.succeed({
+        projects: [{ workspaceRoot: "/project-a" }],
+        threads: [{ worktreePath: "/worktree-a" }],
+      }),
+      Effect.fail(new ProjectionUnavailable()),
+    ]);
 
     assert.deepEqual(workspaceCwds, ["/server-cwd", "/project-a", "/worktree-a"]);
   }),

--- a/apps/server/src/usage/usageWorkspaceCwds.ts
+++ b/apps/server/src/usage/usageWorkspaceCwds.ts
@@ -12,17 +12,23 @@ interface UsageWorkspaceSnapshot {
  */
 export const resolveUsageWorkspaceCwds = Effect.fn("resolveUsageWorkspaceCwds")(function* <E, R>(
   serverCwd: string,
-  loadSnapshots: Effect.Effect<readonly UsageWorkspaceSnapshot[], E, R>,
+  loadSnapshots: readonly Effect.Effect<UsageWorkspaceSnapshot, E, R>[],
 ) {
-  const snapshots = yield* loadSnapshots.pipe(
-    Effect.catch((error) =>
-      Effect.logWarning("Failed to read project workspaces for usage", { error }).pipe(
-        Effect.as([] as readonly UsageWorkspaceSnapshot[]),
+  const snapshots = yield* Effect.all(
+    loadSnapshots.map((loadSnapshot) =>
+      loadSnapshot.pipe(
+        Effect.catch((error) =>
+          Effect.logWarning("Failed to read project workspaces for usage", { error }).pipe(
+            Effect.as(null as UsageWorkspaceSnapshot | null),
+          ),
+        ),
       ),
     ),
+    { concurrency: "unbounded" },
   );
   const workspaceCwds = new Set([serverCwd]);
   for (const snapshot of snapshots) {
+    if (snapshot === null) continue;
     for (const project of snapshot.projects) workspaceCwds.add(project.workspaceRoot);
     for (const thread of snapshot.threads) {
       if (thread.worktreePath !== null) workspaceCwds.add(thread.worktreePath);

--- a/apps/server/src/usage/usageWorkspaceCwds.ts
+++ b/apps/server/src/usage/usageWorkspaceCwds.ts
@@ -1,0 +1,32 @@
+import * as Effect from "effect/Effect";
+
+interface UsageWorkspaceSnapshot {
+  readonly projects: readonly { readonly workspaceRoot: string }[];
+  readonly threads: readonly { readonly worktreePath: string | null }[];
+}
+
+/**
+ * Load every cwd that may anchor a relative provider path. Projection data is
+ * enrichment: if it is temporarily unavailable, usage can still scan default
+ * and absolute homes using the server cwd as its only relative-path fallback.
+ */
+export const resolveUsageWorkspaceCwds = Effect.fn("resolveUsageWorkspaceCwds")(function* <E, R>(
+  serverCwd: string,
+  loadSnapshots: Effect.Effect<readonly UsageWorkspaceSnapshot[], E, R>,
+) {
+  const snapshots = yield* loadSnapshots.pipe(
+    Effect.catch((error) =>
+      Effect.logWarning("Failed to read project workspaces for usage", { error }).pipe(
+        Effect.as([] as readonly UsageWorkspaceSnapshot[]),
+      ),
+    ),
+  );
+  const workspaceCwds = new Set([serverCwd]);
+  for (const snapshot of snapshots) {
+    for (const project of snapshot.projects) workspaceCwds.add(project.workspaceRoot);
+    for (const thread of snapshot.threads) {
+      if (thread.worktreePath !== null) workspaceCwds.add(thread.worktreePath);
+    }
+  }
+  return [...workspaceCwds];
+});

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -44,7 +44,6 @@ import {
   type RelayClientInstallProgressEvent,
   type ServerSelfUpdateError,
   type ServerSelfUpdateProgressEvent,
-  UsageReadError,
   type FilesystemBrowseFailure,
   FilesystemBrowseError,
   AssetWorkspaceContextNotFoundError,
@@ -107,6 +106,7 @@ import * as ProcessDiagnostics from "./diagnostics/ProcessDiagnostics.ts";
 import * as ProcessResourceMonitor from "./diagnostics/ProcessResourceMonitor.ts";
 import * as ResourceTelemetry from "./resourceTelemetry/ResourceTelemetry.ts";
 import * as UsageService from "./usage/UsageService.ts";
+import { resolveUsageWorkspaceCwds } from "./usage/usageWorkspaceCwds.ts";
 import * as TraceDiagnostics from "./diagnostics/TraceDiagnostics.ts";
 import * as PullRequestService from "./pullRequest/PullRequestService.ts";
 import * as SourceControlDiscovery from "./sourceControl/SourceControlDiscovery.ts";
@@ -1568,32 +1568,17 @@ const makeWsRpcLayer = (
           observeRpcEffect(
             WS_METHODS.serverGetUsageSummary,
             Effect.gen(function* () {
-              const [active, archived] = yield* Effect.all(
-                [
-                  projectionSnapshotQuery.getShellSnapshot(),
-                  projectionSnapshotQuery.getArchivedShellSnapshot(),
-                ],
-                { concurrency: "unbounded" },
-              ).pipe(
-                Effect.mapError(
-                  (cause) =>
-                    new UsageReadError({
-                      reason: "scanFailed",
-                      detail: "Project workspaces could not be read.",
-                      cause,
-                    }),
+              const workspaceCwds = yield* resolveUsageWorkspaceCwds(
+                config.cwd,
+                Effect.all(
+                  [
+                    projectionSnapshotQuery.getShellSnapshot(),
+                    projectionSnapshotQuery.getArchivedShellSnapshot(),
+                  ],
+                  { concurrency: "unbounded" },
                 ),
               );
-              const workspaceCwds = new Set([config.cwd]);
-              for (const snapshot of [active, archived]) {
-                for (const project of snapshot.projects) {
-                  workspaceCwds.add(project.workspaceRoot);
-                }
-                for (const thread of snapshot.threads) {
-                  if (thread.worktreePath !== null) workspaceCwds.add(thread.worktreePath);
-                }
-              }
-              return yield* usage.readSummary(input, [...workspaceCwds]);
+              return yield* usage.readSummary(input, workspaceCwds);
             }),
             { "rpc.aggregate": "server" },
           ),

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -44,6 +44,7 @@ import {
   type RelayClientInstallProgressEvent,
   type ServerSelfUpdateError,
   type ServerSelfUpdateProgressEvent,
+  UsageReadError,
   type FilesystemBrowseFailure,
   FilesystemBrowseError,
   AssetWorkspaceContextNotFoundError,
@@ -1564,9 +1565,38 @@ const makeWsRpcLayer = (
             },
           ),
         [WS_METHODS.serverGetUsageSummary]: (input) =>
-          observeRpcEffect(WS_METHODS.serverGetUsageSummary, usage.readSummary(input), {
-            "rpc.aggregate": "server",
-          }),
+          observeRpcEffect(
+            WS_METHODS.serverGetUsageSummary,
+            Effect.gen(function* () {
+              const [active, archived] = yield* Effect.all(
+                [
+                  projectionSnapshotQuery.getShellSnapshot(),
+                  projectionSnapshotQuery.getArchivedShellSnapshot(),
+                ],
+                { concurrency: "unbounded" },
+              ).pipe(
+                Effect.mapError(
+                  (cause) =>
+                    new UsageReadError({
+                      reason: "scanFailed",
+                      detail: "Project workspaces could not be read.",
+                      cause,
+                    }),
+                ),
+              );
+              const workspaceCwds = new Set([config.cwd]);
+              for (const snapshot of [active, archived]) {
+                for (const project of snapshot.projects) {
+                  workspaceCwds.add(project.workspaceRoot);
+                }
+                for (const thread of snapshot.threads) {
+                  if (thread.worktreePath !== null) workspaceCwds.add(thread.worktreePath);
+                }
+              }
+              return yield* usage.readSummary(input, [...workspaceCwds]);
+            }),
+            { "rpc.aggregate": "server" },
+          ),
         [WS_METHODS.serverRetryResourceTelemetry]: (_input) =>
           observeRpcEffect(WS_METHODS.serverRetryResourceTelemetry, resourceTelemetry.retry, {
             "rpc.aggregate": "server",

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1568,16 +1568,10 @@ const makeWsRpcLayer = (
           observeRpcEffect(
             WS_METHODS.serverGetUsageSummary,
             Effect.gen(function* () {
-              const workspaceCwds = yield* resolveUsageWorkspaceCwds(
-                config.cwd,
-                Effect.all(
-                  [
-                    projectionSnapshotQuery.getShellSnapshot(),
-                    projectionSnapshotQuery.getArchivedShellSnapshot(),
-                  ],
-                  { concurrency: "unbounded" },
-                ),
-              );
+              const workspaceCwds = yield* resolveUsageWorkspaceCwds(config.cwd, [
+                projectionSnapshotQuery.getShellSnapshot(),
+                projectionSnapshotQuery.getArchivedShellSnapshot(),
+              ]);
               return yield* usage.readSummary(input, workspaceCwds);
             }),
             { "rpc.aggregate": "server" },

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -1,9 +1,10 @@
 # Review usage
 
 The Usage page combines Codex and Claude Code activity from your connected environments. It reads
-the providers' local session history and shows API-equivalent token cost, processed tokens, cache
-savings, provider shares, and model breakdowns. Subscription billing is separate from the raw token
-cost shown here.
+the local session history for every configured provider instance, including custom `CODEX_HOME` and
+`CLAUDE_CONFIG_DIR` paths, and shows API-equivalent token cost, processed tokens, cache savings,
+provider shares, and model breakdowns. Subscription billing is separate from the raw token cost
+shown here.
 
 Use **Past 24h** for an hourly chart covering the exact rolling 24-hour period. The **7 days**,
 **30 days**, and **90 days** ranges use daily resolution. Cost and token toggles update both the

--- a/packages/contracts/src/usage.test.ts
+++ b/packages/contracts/src/usage.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vite-plus/test";
+import * as Schema from "effect/Schema";
+
+import { UsageBucket } from "./usage.ts";
+
+const decodeUsageBucket = Schema.decodeUnknownSync(UsageBucket);
+
+describe("UsageBucket", () => {
+  it("defaults sourceIndex when decoding an older server bucket", () => {
+    const decoded = decodeUsageBucket({
+      day: "2026-08-14",
+      provider: "claude",
+      model: "claude-sonnet-4-6",
+      totals: {
+        uncachedInputTokens: 1,
+        cachedInputTokens: 2,
+        cacheCreationTokens: 3,
+        outputTokens: 4,
+        reasoningTokens: 0,
+      },
+      costUsd: 0.01,
+      cacheSavingsUsd: 0.02,
+      costSource: "modelPriced",
+      records: 1,
+      unpricedRecords: 0,
+      sessions: 1,
+    });
+
+    expect(decoded.sourceIndex).toBe(0);
+  });
+});

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -7,11 +7,13 @@
  * even for turns that were never driven through T3 Code. This mirrors the
  * approach `ccusage` takes.
  *
- * Environments return pre-aggregated `(day, hourStart?, provider, model)`
- * buckets. Raw transcript records never cross the wire.
+ * Environments return pre-aggregated
+ * `(sourceIndex, day, hourStart?, provider, model)` buckets. Raw transcript
+ * records never cross the wire.
  *
  * @module usage
  */
+import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 
 import { NonNegativeInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
@@ -21,7 +23,7 @@ import { NonNegativeInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
  * client renders partial coverage when an environment reports an older version
  * rather than failing the whole page.
  */
-export const USAGE_CONTRACT_VERSION = 4 as const;
+export const USAGE_CONTRACT_VERSION = 5 as const;
 
 export const UsageProviderKind = Schema.Literals(["claude", "codex"]);
 export type UsageProviderKind = typeof UsageProviderKind.Type;
@@ -71,8 +73,9 @@ export const UsageTokenTotals = Schema.Struct({
 export type UsageTokenTotals = typeof UsageTokenTotals.Type;
 
 /**
- * One `(day, hourStart?, provider, model)` cell. `hourStart` is the UTC start
- * instant of a rolling bucket and is present only for hourly requests.
+ * One `(sourceIndex, day, hourStart?, provider, model)` cell. `sourceIndex`
+ * points into the enclosing summary's `sources` array. `hourStart` is the UTC
+ * start instant of a rolling bucket and is present only for hourly requests.
  *
  * `costUsd` is the raw API-equivalent cost of these tokens. It is not money
  * spent: subscription plans bill separately. `unpricedRecords` counts records
@@ -80,6 +83,8 @@ export type UsageTokenTotals = typeof UsageTokenTotals.Type;
  * to `costUsd`.
  */
 export const UsageBucket = Schema.Struct({
+  /** Defaults only so an older summary can decode before its version is rejected. */
+  sourceIndex: NonNegativeInt.pipe(Schema.withDecodingDefault(Effect.succeed(0))),
   day: UsageDay,
   hourStart: Schema.optional(TrimmedNonEmptyString),
   provider: UsageProviderKind,

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -12,6 +12,7 @@ import { mergeUsage, type EnvironmentUsage } from "./usageMerge.ts";
 
 function bucket(overrides: Partial<UsageBucket> = {}): UsageBucket {
   return {
+    sourceIndex: 0,
     day: "2026-08-07" as UsageDay,
     provider: "claude",
     model: "claude-fable-5",
@@ -124,7 +125,10 @@ describe("mergeUsage", () => {
         environment(
           "env-b",
           summary(
-            [bucket(), bucket({ provider: "codex", model: "gpt-5.6-sol", costUsd: 4 })],
+            [
+              bucket(),
+              bucket({ sourceIndex: 1, provider: "codex", model: "gpt-5.6-sol", costUsd: 4 }),
+            ],
             [sharedClaude, { provider: "codex", hostId: "mac", homePath: "/home/theo/.codex" }],
           ),
         ),
@@ -222,6 +226,39 @@ describe("mergeUsage", () => {
 
     expect(merged.costUsd).toBe(10);
     expect(merged.duplicateSources).toHaveLength(1);
+  });
+
+  it("drops only overlapping roots when one environment scans multiple Claude homes", () => {
+    const shared = {
+      provider: "claude" as const,
+      hostId: "mac",
+      homePath: "/Users/theo/.claude",
+      volumeId: "16777220:1234",
+    };
+    const personal = {
+      provider: "claude" as const,
+      hostId: "mac",
+      homePath: "/Users/theo/.claude-personal",
+      volumeId: "16777220:5678",
+    };
+    const merged = mergeUsage(
+      [
+        environment("env-a", summary([bucket({ costUsd: 10 })], [shared])),
+        environment(
+          "env-b",
+          summary(
+            [bucket({ costUsd: 10 }), bucket({ sourceIndex: 1, costUsd: 7 })],
+            [shared, personal],
+          ),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(merged.costUsd).toBe(17);
+    expect(merged.records).toBe(10);
+    expect(merged.sessions).toBe(2);
+    expect(merged.duplicateSources).toEqual(["env-b: /Users/theo/.claude"]);
   });
 
   it("totals sessions from per-directory distinct counts, not per-bucket sums", () => {

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -136,20 +136,22 @@ function ownedContribution(
   environment: EnvironmentUsage,
   ownerByFingerprint: ReadonlyMap<string, EnvironmentId>,
 ): { readonly buckets: readonly UsageBucket[]; readonly sessions: number } {
-  const ownedProviders = new Set<UsageProviderKind>();
+  const ownedSourceIndexes = new Set<number>();
   let sessions = 0;
-  for (const source of environment.summary.sources) {
+  for (const [sourceIndex, source] of environment.summary.sources.entries()) {
     if (source.status === "missing") continue;
     const key = fingerprintKey(source.fingerprint);
     if (ownerByFingerprint.get(key) === environment.environmentId) {
-      ownedProviders.add(source.fingerprint.provider);
+      ownedSourceIndexes.add(sourceIndex);
       // Distinct within a directory. Summing per-bucket session counts instead
       // would count a session once per day and model it spans.
       sessions += source.distinctSessions;
     }
   }
   return {
-    buckets: environment.summary.buckets.filter((bucket) => ownedProviders.has(bucket.provider)),
+    buckets: environment.summary.buckets.filter((bucket) =>
+      ownedSourceIndexes.has(bucket.sourceIndex),
+    ),
     sessions,
   };
 }


### PR DESCRIPTION
## What Changed

The Usage page now aggregates transcript history from every configured Claude Code and Codex provider instance.

- Resolve each instance's explicit `homePath` or merged `CLAUDE_CONFIG_DIR`/`CODEX_HOME`, while retaining built-in defaults for legacy settings.
- Resolve relative `CLAUDE_CONFIG_DIR` values against every known active or archived project and worktree cwd, matching Claude's runtime behavior.
- Deduplicate identical transcript roots before scanning and share record-level deduplication across every source in one scan.
- Associate usage buckets with their exact transcript source via `sourceIndex`, so cross-environment merging removes only overlapping roots.
- Bump the usage contract to v5 while decoding older buckets with `sourceIndex: 0`, and document multi-instance collection.
- Add focused coverage for source resolution, cross-source aggregation, contract compatibility, and usage merging.

Tests: 4 files passed, 35 tests passed.

## Why

Previously, usage collection only scanned the default Claude Code and Codex homes, omitting activity from additional provider instances and workspace-relative Claude config directories. Cross-environment ownership also operated at the provider level, which could discard valid usage when two environments shared one transcript root but had other distinct roots.

Resolving the same provider instances and workspace-relative paths used at runtime, sharing record deduplication across roots, and tracking each bucket's exact source makes collection complete without double-counting copied records or dropping unrelated instance usage.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (not applicable)
- [x] I included a video for animation/interaction changes (not applicable)

Authored with `gpt-5.6-sol` through the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes usage collection, aggregation, and the v5 contract; wrong path resolution or merge logic could misreport totals, though behavior is covered by new tests and backward-compatible decoding.
> 
> **Overview**
> The Usage page now scans **every configured Claude and Codex provider instance** instead of only the default homes, using a new `resolveUsageTranscriptSources` path that honors explicit `homePath`, per-instance `CLAUDE_CONFIG_DIR` / `CODEX_HOME`, and legacy default slots.
> 
> **Relative `CLAUDE_CONFIG_DIR`** values resolve against all project and worktree cwds gathered via `resolveUsageWorkspaceCwds` (from active and archived shell projections, with server cwd fallback). Identical transcript roots are deduped before scanning, and **record dedupe runs once across all sources** in a scan via a shared `seenDedupeKeys` set.
> 
> Each **`UsageBucket` carries `sourceIndex`** (contract v5; older payloads decode as `0`), and cross-environment **`mergeUsage` keeps buckets by owned source index** rather than by provider alone, so overlapping roots drop without discarding other instances on the same machine.
> 
> `serverGetUsageSummary` passes workspace cwds into `readSummary`; aggregation uses one aggregator per transcript source and merges sorted buckets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1dbf038b32862b2f1286fdf1f697f219ee9884b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Aggregate usage transcripts from every configured provider instance
> - Introduces [`usageTranscriptSources.ts`](https://github.com/pingdotgg/t3code/pull/6603/files#diff-b80a76c927a0b04674cbfed1c447c65996c47fcbd558577c426221a08f1f15b4) to resolve transcript directories for all Claude and Codex provider instances, honoring explicit config, `CLAUDE_CONFIG_DIR`/`CODEX_HOME` env vars, and workspace-relative paths.
> - Adds [`usageWorkspaceCwds.ts`](https://github.com/pingdotgg/t3code/pull/6603/files#diff-e82b58d0df581823b65b0de1eeef02ec3a77a6488c159d4f84c5024187040d9b) to collect workspace root paths from active projections, passed to `readSummary` at request time to resolve relative provider paths.
> - `UsageAggregator` now accepts a shared `seenDedupeKeys` set so duplicate records across multiple transcript sources are dropped in a single scan; emitted `UsageBucket` entries carry a `sourceIndex`.
> - Ownership filtering in [`usageMerge.ts`](https://github.com/pingdotgg/t3code/pull/6603/files#diff-143d7ed21cccd3774754bd4f261d302d61b7997008db82ed56a3920e176a57b3) now tracks owned source indexes instead of provider names, preserving buckets from unowned sources of the same provider.
> - Behavioral Change: `USAGE_CONTRACT_VERSION` bumped from 4 to 5; older summaries decode with `sourceIndex` defaulting to 0.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e1dbf03.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->