### PR TITLE
fix(web): remove the line across text at the bottom of the topbar scroll fade

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -519,7 +519,18 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
   }
 
   /* Fade rows themselves as they pass beneath the top chrome. A mask remains
-     visible even when the header and timeline share the same background. */
+     visible even when the header and timeline share the same background.
+
+     The fade band and the content below it are one full-height gradient, not a
+     band layer abutting a solid layer. Two layers meeting at
+     var(--topbar-scroll-fade-height) composite as `add`, so when that boundary
+     falls between two device pixels the straddled row resolves to
+     a1 + a2(1 - a1) < 1. It lands past the end of the gradient, where text is
+     back at full brightness, so it reads as a line struck across the message
+     rather than as part of the fade. Whether it falls badly depends on the
+     element's subpixel offset and the zoom level as well as the device pixel
+     ratio, so it shows on some displays and not others. Carrying the last stop
+     to the bottom leaves no interior edge to land off-grid. */
   .chat-timeline-scroll-fade,
   .settings-page-scroll-fade,
   .pull-requests-scroll-fade {
@@ -527,38 +538,36 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
     -webkit-mask-image:
       linear-gradient(
         to bottom,
-        transparent 0%,
-        rgb(0 0 0 / 10%) 10%,
-        rgb(0 0 0 / 30%) 24%,
-        rgb(0 0 0 / 58%) 42%,
-        rgb(0 0 0 / 82%) 62%,
-        rgb(0 0 0 / 96%) 82%,
-        black 100%
+        transparent 0,
+        rgb(0 0 0 / 10%) calc(var(--topbar-scroll-fade-height) * 0.1),
+        rgb(0 0 0 / 30%) calc(var(--topbar-scroll-fade-height) * 0.24),
+        rgb(0 0 0 / 58%) calc(var(--topbar-scroll-fade-height) * 0.42),
+        rgb(0 0 0 / 82%) calc(var(--topbar-scroll-fade-height) * 0.62),
+        rgb(0 0 0 / 96%) calc(var(--topbar-scroll-fade-height) * 0.82),
+        black var(--topbar-scroll-fade-height)
       ),
-      linear-gradient(black, black), linear-gradient(black, black);
-    -webkit-mask-position: top, bottom, right;
+      linear-gradient(black, black);
+    -webkit-mask-position: top, right;
     -webkit-mask-repeat: no-repeat;
     -webkit-mask-size:
-      100% var(--topbar-scroll-fade-height),
-      100% calc(100% - var(--topbar-scroll-fade-height)),
+      100% 100%,
       var(--app-scrollbar-width) 100%;
     mask-image:
       linear-gradient(
         to bottom,
-        transparent 0%,
-        rgb(0 0 0 / 10%) 10%,
-        rgb(0 0 0 / 30%) 24%,
-        rgb(0 0 0 / 58%) 42%,
-        rgb(0 0 0 / 82%) 62%,
-        rgb(0 0 0 / 96%) 82%,
-        black 100%
+        transparent 0,
+        rgb(0 0 0 / 10%) calc(var(--topbar-scroll-fade-height) * 0.1),
+        rgb(0 0 0 / 30%) calc(var(--topbar-scroll-fade-height) * 0.24),
+        rgb(0 0 0 / 58%) calc(var(--topbar-scroll-fade-height) * 0.42),
+        rgb(0 0 0 / 82%) calc(var(--topbar-scroll-fade-height) * 0.62),
+        rgb(0 0 0 / 96%) calc(var(--topbar-scroll-fade-height) * 0.82),
+        black var(--topbar-scroll-fade-height)
       ),
-      linear-gradient(black, black), linear-gradient(black, black);
-    mask-position: top, bottom, right;
+      linear-gradient(black, black);
+    mask-position: top, right;
     mask-repeat: no-repeat;
     mask-size:
-      100% var(--topbar-scroll-fade-height),
-      100% calc(100% - var(--topbar-scroll-fade-height)),
+      100% 100%,
       var(--app-scrollbar-width) 100%;
   }
 


### PR DESCRIPTION
## What Changed

The top scroll fade is now a single full-height mask gradient instead of a band layer abutting a solid layer.

`.chat-timeline-scroll-fade`, `.settings-page-scroll-fade`, and `.pull-requests-scroll-fade` share one rule, so all three change. The fade curve, the band height, and the scrollbar-gutter layer are the same as before; only the layer geometry differs. Stop positions are now fractions of `--topbar-scroll-fade-height` rather than percentages of the band, which is what lets the last stop carry to the bottom of the element.

## Why

The mask was three layers, the first two meeting edge to edge at the band boundary:

```css
mask-position: top, bottom, right;
mask-size:
  100% var(--topbar-scroll-fade-height),
  100% calc(100% - var(--topbar-scroll-fade-height)),
  var(--app-scrollbar-width) 100%;
```

Mask layers composite with `add`, so the shared edge resolves to `a1 + a2(1 - a1)`. When the boundary lands on a whole device pixel both layers reach full alpha there and nothing shows. When it falls between two, neither layer covers the straddled row fully and it lands under full opacity.

Where that boundary falls depends on the element's own subpixel offset and the zoom level as well as the device pixel ratio, not on any one of them alone. The scroller does not start on a round number to begin with, so the boundary is already fractional before the ratio is applied.

That row is at the band's lower boundary, past the end of the gradient, where the text above and below it is already back at full brightness. So it does not read as part of the fade. It is a hard line holding a fixed viewport position, and message text scrolls through it.

Worth knowing when reviewing: **it does not reproduce everywhere.** It has been seen on an external monitor but not on the same machine's internal Retina display, and in a browser but not in the desktop app. If you cannot see it, try another display or zoom level before concluding it is absent. The captures below are from a browser at `devicePixelRatio` 1.0954.

Carrying the gradient's last stop to the bottom of the element leaves no interior edge to land off-grid, so the defect is structurally gone rather than tuned away.

## UI Changes

Chat transcript, message text passing the fade's lower boundary.

**Before**

<img width="1069" height="129" alt="image" src="https://github.com/user-attachments/assets/a9d31a1b-8af1-48c3-8593-8ac9c395a80f" />

**After**

<img width="1103" height="137" alt="image" src="https://github.com/user-attachments/assets/e1041c96-b54e-41c5-a7a8-fce582b59223" />


Measured on those two captures: in the before image the glyph row peaks at 146/255 while the rows immediately above and below peak at 242 and 243. In the after image no row dips below its neighbours anywhere in the crop.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only visual mask change with no logic or data impact; slight risk of subtle fade appearance differences across viewports.
> 
> **Overview**
> Fixes a **horizontal dim line** on scrolling text at the bottom edge of the top scroll fade (chat, settings, pull requests) on some displays and zoom levels.
> 
> The shared scroll-fade classes in `index.css` no longer use **two stacked mask layers** (short fade band plus a solid band below). That seam composited with `add` and could leave a row at less than full opacity when the boundary fell between device pixels. The fade is now **one full-height gradient** sized to `100% 100%`, with stops expressed as fractions of `--topbar-scroll-fade-height` and the final stop carried through so there is no interior edge. The **right-hand scrollbar gutter mask** is unchanged.
> 
> Inline comments document the compositing failure mode for future reviewers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f9295a0ac8f7948658e908d4ab5c37e7e645d86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix line artifact at the bottom of the topbar scroll fade
> Reworks the CSS mask gradient in [index.css](https://github.com/pingdotgg/t3code/pull/6604/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) for `.chat-timeline-scroll-fade`, `.settings-page-scroll-fade`, and `.pull-requests-scroll-fade`. Replaces the two-layer content mask (split at `--topbar-scroll-fade-height`) with a single full-height gradient, eliminating a compositing seam that appeared as a visible line at certain zoom levels or device pixel ratios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f9295a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

