### PR TITLE
fix(server): ignore Claude command lifecycle messages

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -2287,6 +2287,77 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("consumes Claude command lifecycle notifications silently", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const sessionId = "6e81554e-5cff-4b37-8a39-f3a9051ac234";
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      const readyMessage = "command lifecycle test ready";
+      const readyFiber = yield* Stream.takeUntil(
+        adapter.streamEvents,
+        (event) => event.type === "runtime.warning" && event.payload.message === readyMessage,
+      ).pipe(Stream.runDrain, Effect.forkChild);
+      harness.query.emit({
+        type: "system",
+        subtype: "notification",
+        key: "command-lifecycle-ready",
+        text: readyMessage,
+        priority: "high",
+        session_id: sessionId,
+        uuid: "command-lifecycle-ready",
+      } as unknown as SDKMessage);
+      yield* Fiber.join(readyFiber);
+
+      const processedMessage = "command lifecycle messages processed";
+      const runtimeEventsFiber = yield* Stream.takeUntil(
+        adapter.streamEvents,
+        (event) => event.type === "runtime.warning" && event.payload.message === processedMessage,
+      ).pipe(Stream.runCollect, Effect.forkChild);
+      for (const [state, uuid] of [
+        ["started", "command-started"],
+        ["completed", "command-completed"],
+      ]) {
+        harness.query.emit({
+          type: "command_lifecycle",
+          command_uuid: "4cd8e8a3-df7a-425d-b6c9-4053abc0b8fd",
+          state,
+          session_id: sessionId,
+          uuid,
+        } as unknown as SDKMessage);
+      }
+      harness.query.emit({
+        type: "system",
+        subtype: "notification",
+        key: "command-lifecycle-processed",
+        text: processedMessage,
+        priority: "high",
+        session_id: sessionId,
+        uuid: "command-lifecycle-processed",
+      } as unknown as SDKMessage);
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      assert.deepEqual(
+        runtimeEvents.map((event) => event.type),
+        ["runtime.warning"],
+      );
+      const warning = runtimeEvents[0];
+      assert.equal(warning?.type, "runtime.warning");
+      if (warning?.type === "runtime.warning") {
+        assert.equal(warning.payload.message, processedMessage);
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("emits thread token usage updates from Claude task progress", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -3490,6 +3490,11 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     yield* logNativeSdkMessage(context, message);
     yield* ensureThreadId(context, message);
 
+    // Wire-only command bookkeeping has no user-facing T3 lifecycle.
+    if (sdkMessageType(message) === "command_lifecycle") {
+      return;
+    }
+
     switch (message.type) {
       case "stream_event":
         yield* handleStreamEvent(context, message);


### PR DESCRIPTION
## What Changed

- Ignore Claude SDK `command_lifecycle` wire messages at the adapter boundary.
- Add focused regression coverage for both `started` and `completed` lifecycle notifications.
- Preserve the existing warning path for genuinely unknown or high-priority SDK messages.

## Why

Claude Code emits `command_lifecycle` messages as routine command bookkeeping. The adapter previously treated these unrecognized wire messages as `runtime.warning` events, which made healthy turns appear as red failures in the Work Log. Consuming them silently at the provider boundary keeps the canonical runtime model and clients free of provider-only bookkeeping.

Closes #6093.

## Validation

- `vp test run apps/server/src/provider/Layers/ClaudeAdapter.test.ts` — 68 passed.
- Server test suite — 230 test files passed, 2 skipped; 2,507 tests passed, 7 skipped.
- Focused formatting, lint, and server typechecking passed.
- One code-review pass completed against `038560e58036d51b2576b3c2cd9170a194cefe9e` on both Standards and Spec axes; valid findings were fixed and focused tests rerun.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes; screenshots are not applicable
- [x] No animation or interaction changes; video is not applicable


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ignore `command_lifecycle` SDK messages in `handleSdkMessage`
> Adds an early return in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/6606/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc) to drop SDK messages of type `command_lifecycle` before they reach the main switch, preventing any runtime events or lifecycle actions from being emitted. A test in [ClaudeAdapter.test.ts](https://github.com/pingdotgg/t3code/pull/6606/files#diff-1657a55ebc1e3682293aa20a7f71a55adf8de546f36af50f289dca9da45b0b6f) verifies that only a `runtime.warning` for the processed system notification is observed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec0126c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, provider-boundary change with regression tests; no auth, data, or API contract changes.
> 
> **Overview**
> Stops routine Claude SDK **`command_lifecycle`** wire messages (`started` / `completed`) from surfacing as **`runtime.warning`** events in the Work Log.
> 
> **`handleSdkMessage`** in `ClaudeAdapter` now returns early for that message type after logging and thread binding, so provider-only bookkeeping never reaches the main switch or unknown-message warning path. A focused adapter test asserts that **`started`** and **`completed`** lifecycle notifications produce no runtime events while high-priority system notifications still emit warnings as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec0126c149741245335af0fdecee8aa82b43d20f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->