### PR TITLE
fix(ssh): isolate managed tunnel forwards

### DIFF
--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -4,6 +4,7 @@ import * as NetService from "@t3tools/shared/Net";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Result from "effect/Result";
 import * as Sink from "effect/Sink";
@@ -346,6 +347,26 @@ describe("ssh tunnel scripts", () => {
       Effect.sync(() => {
         const args = commandArgs(command);
         spawnedCommands.push(args);
+        if (args.includes("-G")) {
+          return makeSuccessfulProcess(
+            [
+              "host devbox",
+              "hostname devbox.example.com",
+              "user julius",
+              "port 2222",
+              "identityfile /tmp/key with spaces",
+              "identityfile ~/.ssh/id-%n-%h-%r",
+              "certificatefile /tmp/cert #1.pub",
+              "proxyjump bastion",
+              "userknownhostsfile ~/.ssh/known_hosts_t3",
+              "localforward 127.0.0.1:41000 127.0.0.1:41001",
+              "remoteforward /home/david/.local/state/fleet-open/client.sock 127.0.0.1:48991",
+              "dynamicforward 127.0.0.1:41002",
+              "clearallforwardings no",
+              "",
+            ].join("\n"),
+          );
+        }
         if (args.includes("-N")) {
           return makeRunningProcess(() => {
             tunnelKillCount += 1;
@@ -378,18 +399,46 @@ describe("ssh tunnel scripts", () => {
 
     return Effect.gen(function* () {
       const manager = yield* SshEnvironmentManager;
+      const fs = yield* FileSystem.FileSystem;
 
       const first = yield* manager.ensureEnvironment(target);
       assert.equal(first.httpBaseUrl, "http://127.0.0.1:41773/");
       const firstTunnelArgs = spawnedCommands.find((args) => args.includes("-N"));
       assert.isDefined(firstTunnelArgs);
+      const configResolveArgs = spawnedCommands.findLast((args) => args.includes("-G"));
+      assert.isDefined(configResolveArgs);
+      assert.equal(configResolveArgs.at(-1), "julius@devbox");
       assert.include(firstTunnelArgs, "ControlMaster=no");
       assert.include(firstTunnelArgs, "ControlPath=none");
       assert.include(firstTunnelArgs, "ControlPersist=no");
+      assert.include(firstTunnelArgs, "-L");
+      assert.include(firstTunnelArgs, "41773:127.0.0.1:3773");
+      assert.equal(firstTunnelArgs.filter((arg) => arg === "-L").length, 1);
+      assert.notInclude(firstTunnelArgs, "-R");
+      assert.notInclude(firstTunnelArgs, "-D");
+      assert.notInclude(firstTunnelArgs, "ClearAllForwardings=yes");
+      assert.equal(firstTunnelArgs.at(-1), "julius@devbox");
+      const configFlagIndex = firstTunnelArgs.indexOf("-F");
+      assert.isAtLeast(configFlagIndex, 0);
+      const tunnelConfigPath = firstTunnelArgs[configFlagIndex + 1];
+      assert.isDefined(tunnelConfigPath);
+      const tunnelConfig = yield* fs.readFileString(tunnelConfigPath);
+      assert.notMatch(tunnelConfig, /^\s*(?:local|remote|dynamic)forward\b/imu);
+      assert.match(tunnelConfig, /^\s*hostname devbox\.example\.com$/imu);
+      assert.match(tunnelConfig, /^\s*user julius$/imu);
+      assert.match(tunnelConfig, /^\s*port 2222$/imu);
+      assert.match(tunnelConfig, /^\s*identityfile "\/tmp\/key with spaces"$/imu);
+      assert.match(tunnelConfig, /^\s*identityfile "~\/\.ssh\/id-%n-%h-%r"$/imu);
+      assert.match(tunnelConfig, /^\s*certificatefile "\/tmp\/cert #1\.pub"$/imu);
+      assert.match(tunnelConfig, /^\s*proxyjump "bastion"$/imu);
+      assert.match(tunnelConfig, /^\s*userknownhostsfile ~\/\.ssh\/known_hosts_t3$/imu);
+      assert.include(tunnelConfig, 'Host "devbox"');
+      assert.include(tunnelConfig, 'Host !"devbox" *');
 
       yield* manager.disconnectEnvironment(target);
       assert.equal(tunnelKillCount, 1);
       assert.equal(stopCommandCount, 1);
+      assert.isFalse(yield* fs.exists(tunnelConfigPath));
 
       yield* manager.ensureEnvironment(target);
 

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -6,6 +6,7 @@ import {
   describeReadinessCause,
   waitForHttpReady as waitForHttpReadyShared,
 } from "@t3tools/shared/httpReadiness";
+import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as NetService from "@t3tools/shared/Net";
 import { extractJsonObject, fromLenientJson } from "@t3tools/shared/schemaJson";
 import { satisfiesSemverRange } from "@t3tools/shared/semver";
@@ -56,6 +57,38 @@ const SSH_READY_PROBE_TIMEOUT_MS = 1_000;
 const TUNNEL_SHUTDOWN_TIMEOUT_MS = 2_000;
 const REMOTE_READY_TIMEOUT_MS = 15_000;
 const REMOTE_REUSE_READY_TIMEOUT_MS = 2_000;
+const FORWARDING_CONFIG_KEYS = new Set([
+  "clearallforwardings",
+  "dynamicforward",
+  "localforward",
+  "remoteforward",
+]);
+const SINGLE_ARGUMENT_CONFIG_KEYS = new Set([
+  "bindaddress",
+  "bindinterface",
+  "certificatefile",
+  "controlpath",
+  "forwardagent",
+  "hostkeyalias",
+  "identityagent",
+  "identityfile",
+  "knownhostscommand",
+  "localcommand",
+  "pkcs11provider",
+  "proxycommand",
+  "proxyjump",
+  "remotecommand",
+  "securitykeyprovider",
+  "sendenv",
+  "setenv",
+  "tag",
+  "versionaddendum",
+  "xauthlocation",
+]);
+
+function quoteSshConfigArgument(value: string): string {
+  return `"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
+}
 
 export interface RemoteT3RunnerOptions {
   readonly packageSpec?: string;
@@ -917,6 +950,103 @@ const reserveLocalTunnelPort = Effect.fn("ssh/tunnel.reserveLocalTunnelPort")(fu
   return yield* net.reserveLoopbackPort();
 });
 
+function buildManagedTunnelSshConfig(
+  resolvedConfig: string,
+  platform: NodeJS.Platform,
+  originalHost: string,
+  environment: NodeJS.ProcessEnv,
+): string {
+  const resolvedOptions = resolvedConfig
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => {
+      const key = line.split(/\s+/u, 1)[0]?.toLowerCase();
+      return (
+        key !== undefined && key.length > 0 && key !== "host" && !FORWARDING_CONFIG_KEYS.has(key)
+      );
+    })
+    .map((line) => {
+      const separatorIndex = line.search(/\s/u);
+      if (separatorIndex < 0) {
+        return `  ${line}`;
+      }
+      const key = line.slice(0, separatorIndex);
+      const value = line.slice(separatorIndex + 1).trim();
+      if (!SINGLE_ARGUMENT_CONFIG_KEYS.has(key.toLowerCase())) {
+        return `  ${line}`;
+      }
+      return `  ${key} ${quoteSshConfigArgument(value)}`;
+    });
+  const systemConfig =
+    platform === "win32"
+      ? `${(environment.PROGRAMDATA ?? "C:/ProgramData").replaceAll("\\", "/")}/ssh/ssh_config`
+      : "/etc/ssh/ssh_config";
+  const quotedHost = quoteSshConfigArgument(originalHost);
+
+  // ProxyJump re-invokes ssh with this -F file. Non-managed hosts fall back to
+  // normal config so jump aliases and authentication keep working; its -W mode
+  // clears forwarding requests on the proxy connection.
+  return [
+    `Host ${quotedHost}`,
+    "  ClearAllForwardings no",
+    ...resolvedOptions,
+    `Host !${quotedHost} *`,
+    "  Include ~/.ssh/config",
+    `  Include "${systemConfig.replaceAll('"', '\\"')}"`,
+    "",
+  ].join("\n");
+}
+
+const makeManagedTunnelSshConfig = Effect.fn("ssh/tunnel.makeManagedTunnelSshConfig")(function* (
+  target: DesktopSshEnvironmentTarget,
+): Effect.fn.Return<
+  string,
+  SshCommandError | SshInvalidTargetError,
+  ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path | Scope.Scope
+> {
+  const resolved = yield* runSshCommand(target, { preHostArgs: ["-G"] });
+  const fs = yield* FileSystem.FileSystem;
+  const platform = yield* HostProcessPlatform;
+  const environment = yield* HostProcessEnvironment;
+  const configPath = yield* fs
+    .makeTempFileScoped({ prefix: "t3-ssh-tunnel-", suffix: ".conf" })
+    .pipe(
+      Effect.mapError(
+        (cause) =>
+          new SshCommandError({
+            command: ["ssh", "-G", target.alias],
+            exitCode: null,
+            stderr: "",
+            message: "Failed to create isolated SSH tunnel configuration.",
+            cause,
+          }),
+      ),
+    );
+  yield* fs
+    .writeFileString(
+      configPath,
+      buildManagedTunnelSshConfig(
+        resolved.stdout,
+        platform,
+        target.alias.trim() || target.hostname.trim(),
+        environment,
+      ),
+    )
+    .pipe(
+      Effect.mapError(
+        (cause) =>
+          new SshCommandError({
+            command: ["ssh", "-G", target.alias],
+            exitCode: null,
+            stderr: "",
+            message: "Failed to write isolated SSH tunnel configuration.",
+            cause,
+          }),
+      ),
+    );
+  return configPath;
+});
+
 const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: {
   readonly key: string;
   readonly resolvedTarget: DesktopSshEnvironmentTarget;
@@ -936,6 +1066,7 @@ const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: 
   | NetService.NetService
   | Scope.Scope
 > {
+  const tunnelConfigPath = yield* makeManagedTunnelSshConfig(input.resolvedTarget);
   const hostSpec = yield* buildSshHostSpecEffect(input.resolvedTarget);
   const childEnvironment = yield* buildSshChildEnvironment({
     ...(input.authOptions.authSecret === undefined
@@ -957,6 +1088,8 @@ const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: 
     ),
   );
   const args = [
+    "-F",
+    tunnelConfigPath,
     ...baseSshArgs(input.resolvedTarget, {
       batchMode: input.authOptions.batchMode ?? "no",
     }),


### PR DESCRIPTION
## Problem

T3 starts its managed SSH tunnel as an independent connection with `ExitOnForwardFailure=yes` and its own command-line `-L`. It disables connection sharing, but still reads the user's SSH configuration. If that configuration contains a `RemoteForward` whose remote Unix socket is already owned by a normal multiplexed session, the managed connection fails before pairing:

```
remote port forwarding failed for listen path /home/david/.local/state/fleet-open/client-....sock
```

The same issue applies to inherited `LocalForward` and `DynamicForward` directives.

`ClearAllForwardings=yes` is not sufficient: OpenSSH documents and implements it as clearing forwards from both configuration files and the command line, so it also removes T3's required `-L`.

## Fix

Before starting the managed tunnel, resolve the target's effective configuration with `ssh -G`. T3 writes that resolved configuration to a scoped temporary file while filtering only `LocalForward`, `RemoteForward`, `DynamicForward`, and `ClearAllForwardings`. The tunnel still targets the original SSH alias—preserving `%n` expansion and canonicalization identity—and adds only T3's required command-line `-L`.

All other resolved options remain intact, including aliases/HostName, user and port, identities and certificates, agents and authentication helpers, ProxyJump/ProxyCommand, and host-key policy. ProxyJump subprocesses fall back to the normal user and system configuration so jump-host aliases and authentication continue to resolve. The temporary config follows the existing tunnel scope and is removed during disconnect or cleanup.

## Reproduction

1. Configure a Unix-socket `RemoteForward` for an SSH host.
2. Open a normal multiplexed session so that forward owns the remote socket.
3. Connect the same host as a T3 SSH environment.
4. The independent managed tunnel inherits the forward, cannot bind the socket, and exits because `ExitOnForwardFailure=yes`.

## Validation

- `pnpm exec vp test run packages/ssh/src` — 25 tests passed
- `pnpm exec vp run --filter @t3tools/ssh typecheck`
- Targeted lint and formatting checks
- `git diff --check`
- Local OpenSSH 10.2 `ssh -G` check: the isolated config retained alias/auth/ProxyJump/host-key settings, emitted T3's local forward, and emitted no inherited local, remote, or dynamic forwards

The regression test also verifies the existing disconnect/reconnect behavior, process cleanup, and scoped temporary-config deletion.

Model: GPT-5.6 Sol · Harness: Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core SSH tunnel startup and config generation; incorrect filtering or quoting could break connections or ProxyJump, but scope is limited to managed tunnels with added test coverage.
> 
> **Overview**
> Fixes managed SSH tunnels failing when user `~/.ssh/config` defines inherited `LocalForward`, `RemoteForward`, or `DynamicForward` directives that conflict with T3’s own `-L` (e.g. a `RemoteForward` Unix socket already bound by another session). `ClearAllForwardings=yes` was not viable because it also strips T3’s command-line forward.
> 
> Before spawning the `-N` tunnel, T3 now runs **`ssh -G`** to resolve the target’s effective config, writes a **scoped temporary `-F` file** that keeps auth, host, identity, and `ProxyJump` settings but **drops forwarding-related lines**, sets **`ClearAllForwardings no`** for the managed host, and routes other hosts through normal user/system includes so jump hosts still resolve. The tunnel process is started with **`-F <temp>`** plus only T3’s required **`-L`**; the temp file is removed when the tunnel scope closes.
> 
> The disconnect/reconnect regression test now mocks `-G` output and asserts the generated config contents, single `-L`, absence of inherited forwards, and temp file cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fec7569f1fdf4765f3fbeb0fc99aa493a5abeb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Isolate SSH tunnel forwards using a per-connection managed config file
> - Before starting a tunnel, runs `ssh -G` against the target to resolve the effective SSH config, then writes a filtered per-connection config file via `makeManagedTunnelSshConfig` in [tunnel.ts](https://github.com/pingdotgg/t3code/pull/6610/files#diff-7338be65675ab0699d0c8c6426e54f3421747885231f9bbb0ace4ec129cb2072).
> - The generated config strips all forwarding-related keys and Host lines from the resolved config, sets `ClearAllForwardings no` for the target host, and adds fallback includes for `~/.ssh/config` and the system `ssh_config`.
> - The tunnel process is launched with `-F <configPath>` prepended to its arguments; the temp config file is deleted when the tunnel scope closes.
> - Behavioral Change: SSH tunnels now always use a scoped config file rather than the user's default SSH config directly, which changes option resolution order for any host-level overrides.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5fec756.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->