### PR TITLE
fix(web): move settings back action to the top

### DIFF
--- a/apps/web/src/components/settings/SettingsSidebarNav.tsx
+++ b/apps/web/src/components/settings/SettingsSidebarNav.tsx
@@ -191,6 +191,14 @@ export function SettingsSidebarNav({ pathname }: { pathname: string }) {
     <>
       <SidebarContent className="overflow-x-hidden">
         <SidebarGroup className="gap-2 p-[var(--sidebar-content-inset)]">
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton onClick={handleBackClick}>
+                <ArrowLeftIcon />
+                <span>Back</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
           <div className="flex h-8 items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium text-sidebar-muted-foreground hover:bg-sidebar-row-hover hover:text-sidebar-foreground">
             <SearchIcon className="size-4 shrink-0 text-sidebar-muted-foreground/80" />
             <Input
@@ -296,14 +304,7 @@ export function SettingsSidebarNav({ pathname }: { pathname: string }) {
       <SidebarFooter className="p-[var(--sidebar-content-inset)]">
         <T3ConnectSidebarSignIn />
         <div className="flex items-center gap-1">
-          <SidebarMenu className="min-w-0 flex-1">
-            <SidebarMenuItem>
-              <SidebarMenuButton onClick={handleBackClick}>
-                <ArrowLeftIcon />
-                <span>Back</span>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          </SidebarMenu>
+          <SidebarMenu className="min-w-0 flex-1" />
           <T3ConnectSidebarAvatar />
         </div>
       </SidebarFooter>


### PR DESCRIPTION
## What Changed

Moved the existing Back action from the Settings footer to the top of the Settings sidebar, before search and section navigation.

The action keeps the same behavior. Secondary account actions remain in the footer, whose structure is unchanged.

Closes #4303.

## Why

Back is one of the main actions in Settings. After changing a setting, users often want to return to what they were doing.

Keeping Back in the footer makes it harder to find and requires moving the pointer away from the Settings navigation every time. Placing it at the top keeps navigation actions together and makes the exit visible without relying on the Escape shortcut.

## UI Changes

| Before | After |
| --- | --- |
| <img width="1040" height="1307" alt="Back action in the Settings footer" src="https://github.com/user-attachments/assets/6bebc4b8-ca62-47d3-8f51-c0844303d7f2" /> | <img width="1040" height="1307" alt="Back action at the top of the Settings sidebar" src="https://github.com/user-attachments/assets/9d0df459-a92d-412c-a8d7-73e5d13cb08a" /> |

## Validation

- Confirmed that Back returns to the previous page.
- Confirmed that the fallback navigation still returns to the main page.
- Confirmed that Escape navigation is unchanged.
- Confirmed that secondary footer actions remain in place.
- `pnpm --filter @t3tools/web exec tsgo --noEmit`
- `vp lint apps/web/src/components/settings/SettingsSidebarNav.tsx`
- `vp fmt --check apps/web/src/components/settings/SettingsSidebarNav.tsx`
- `git diff --check`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots
- [x] No video is needed because this change has no motion or timing changes

Created with GPT-5.6 Sol via the Codex harness.
