### PR TITLE
perf(server): stop reading a thread's whole activity timeline per event

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -2086,6 +2086,125 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
     }),
   );
 
+  it.effect("counts an unresolved user-input request on the thread shell", () =>
+    Effect.gen(function* () {
+      const projectionPipeline = yield* OrchestrationProjectionPipeline;
+      const eventStore = yield* OrchestrationEventStore;
+      const sql = yield* SqlClient.SqlClient;
+      const appendAndProject = (event: Parameters<typeof eventStore.append>[0]) =>
+        eventStore
+          .append(event)
+          .pipe(Effect.flatMap((savedEvent) => projectionPipeline.projectEvent(savedEvent)));
+
+      yield* appendAndProject({
+        type: "project.created",
+        eventId: EventId.make("evt-open-user-input-1"),
+        aggregateKind: "project",
+        aggregateId: ProjectId.make("project-open-user-input"),
+        occurredAt: "2026-02-26T13:00:00.000Z",
+        commandId: CommandId.make("cmd-open-user-input-1"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-open-user-input-1"),
+        metadata: {},
+        payload: {
+          projectId: ProjectId.make("project-open-user-input"),
+          title: "Project Open User Input",
+          workspaceRoot: "/tmp/project-open-user-input",
+          defaultModelSelection: null,
+          scripts: [],
+          createdAt: "2026-02-26T13:00:00.000Z",
+          updatedAt: "2026-02-26T13:00:00.000Z",
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.created",
+        eventId: EventId.make("evt-open-user-input-2"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-open-user-input"),
+        occurredAt: "2026-02-26T13:00:01.000Z",
+        commandId: CommandId.make("cmd-open-user-input-2"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-open-user-input-2"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-open-user-input"),
+          projectId: ProjectId.make("project-open-user-input"),
+          title: "Thread Open User Input",
+          modelSelection: {
+            instanceId: ProviderInstanceId.make("codex"),
+            model: "gpt-5-codex",
+          },
+          runtimeMode: "approval-required",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          createdAt: "2026-02-26T13:00:01.000Z",
+          updatedAt: "2026-02-26T13:00:01.000Z",
+        },
+      });
+
+      // Noise the summary must read past: the request it counts is a handful of
+      // rows among a thread's whole tool timeline.
+      yield* appendAndProject({
+        type: "thread.activity-appended",
+        eventId: EventId.make("evt-open-user-input-3"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-open-user-input"),
+        occurredAt: "2026-02-26T13:00:02.000Z",
+        commandId: CommandId.make("cmd-open-user-input-3"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-open-user-input-3"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-open-user-input"),
+          activity: {
+            id: EventId.make("activity-open-user-input-tool"),
+            tone: "tool",
+            kind: "tool.updated",
+            summary: "Tool progress",
+            payload: { requestId: "not-a-user-input-request" },
+            turnId: null,
+            createdAt: "2026-02-26T13:00:02.000Z",
+          },
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.activity-appended",
+        eventId: EventId.make("evt-open-user-input-4"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-open-user-input"),
+        occurredAt: "2026-02-26T13:00:03.000Z",
+        commandId: CommandId.make("cmd-open-user-input-4"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-open-user-input-4"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-open-user-input"),
+          activity: {
+            id: EventId.make("activity-open-user-input-requested"),
+            tone: "info",
+            kind: "user-input.requested",
+            summary: "User input requested",
+            payload: { requestId: "user-input-request-open-1" },
+            turnId: null,
+            createdAt: "2026-02-26T13:00:03.000Z",
+          },
+        },
+      });
+
+      const threadRows = yield* sql<{
+        readonly pendingUserInputCount: number;
+      }>`
+        SELECT pending_user_input_count AS "pendingUserInputCount"
+        FROM projection_threads
+        WHERE thread_id = 'thread-open-user-input'
+      `;
+      assert.deepEqual(threadRows, [{ pendingUserInputCount: 1 }]);
+    }),
+  );
+
   it.effect("ignores non-stale provider approval response failures", () =>
     Effect.gen(function* () {
       const projectionPipeline = yield* OrchestrationProjectionPipeline;

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -130,6 +130,17 @@ function isStalePendingApprovalFailureDetail(detail: string | null): boolean {
   );
 }
 
+/**
+ * The only activity kinds `derivePendingUserInputCountFromActivities` reacts to.
+ * Every other kind is skipped, so the query feeding it filters on these — keep
+ * the two in step.
+ */
+const PENDING_USER_INPUT_ACTIVITY_KINDS = [
+  "user-input.requested",
+  "user-input.resolved",
+  "provider.user-input.respond.failed",
+] as const;
+
 function derivePendingUserInputCountFromActivities(
   activities: ReadonlyArray<ProjectionThreadActivity>,
 ): number {
@@ -562,10 +573,18 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
         return;
       }
 
+      // Only the user-input activity kinds, not the whole timeline: the single
+      // consumer below reduces them to one integer, while a thread's activity
+      // rows carry every tool payload it has produced. This runs on every event
+      // in the thread, so reading them in full makes each event cost the
+      // thread's entire history.
       const [messages, proposedPlans, activities, pendingApprovals] = yield* Effect.all([
         projectionThreadMessageRepository.listByThreadId({ threadId }),
         projectionThreadProposedPlanRepository.listByThreadId({ threadId }),
-        projectionThreadActivityRepository.listByThreadId({ threadId }),
+        projectionThreadActivityRepository.listByThreadIdAndKinds({
+          threadId,
+          kinds: PENDING_USER_INPUT_ACTIVITY_KINDS,
+        }),
         projectionPendingApprovalRepository.listByThreadId({ threadId }),
       ]);
 

--- a/apps/server/src/persistence/Layers/ProjectionThreadActivities.test.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadActivities.test.ts
@@ -1,0 +1,126 @@
+import { EventId, ThreadId } from "@t3tools/contracts";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import { SqlitePersistenceMemory } from "./Sqlite.ts";
+import { ProjectionThreadActivityRepositoryLive } from "./ProjectionThreadActivities.ts";
+import { ProjectionThreadActivityRepository } from "../Services/ProjectionThreadActivities.ts";
+import type { ProjectionThreadActivity } from "../Services/ProjectionThreadActivities.ts";
+
+const threadId = ThreadId.make("thread-activity-kinds");
+const otherThreadId = ThreadId.make("thread-activity-kinds-other");
+
+const activity = (
+  id: string,
+  kind: string,
+  createdAt: string,
+  overrides: Partial<ProjectionThreadActivity> = {},
+): ProjectionThreadActivity => ({
+  activityId: EventId.make(id),
+  threadId,
+  turnId: null,
+  tone: "info",
+  kind,
+  summary: `${kind} ${id}`,
+  payload: { requestId: `request-${id}` },
+  createdAt,
+  ...overrides,
+});
+
+const layer = it.layer(
+  Layer.mergeAll(
+    ProjectionThreadActivityRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
+    SqlitePersistenceMemory,
+  ),
+);
+
+layer("ProjectionThreadActivityRepository.listByThreadIdAndKinds", (it) => {
+  const seed = Effect.fn("seed")(function* () {
+    const activities = yield* ProjectionThreadActivityRepository;
+    yield* activities.upsert(activity("a1", "user-input.requested", "2026-03-24T00:00:01.000Z"));
+    yield* activities.upsert(activity("a2", "tool.updated", "2026-03-24T00:00:02.000Z"));
+    yield* activities.upsert(activity("a3", "user-input.resolved", "2026-03-24T00:00:03.000Z"));
+    yield* activities.upsert(activity("a4", "tool.completed", "2026-03-24T00:00:04.000Z"));
+    yield* activities.upsert(
+      activity("a5", "user-input.requested", "2026-03-24T00:00:05.000Z", {
+        threadId: otherThreadId,
+      }),
+    );
+    return activities;
+  });
+
+  it.effect("returns only the requested kinds", () =>
+    Effect.gen(function* () {
+      const activities = yield* seed();
+
+      const rows = yield* activities.listByThreadIdAndKinds({
+        threadId,
+        kinds: ["user-input.requested", "user-input.resolved"],
+      });
+
+      assert.deepStrictEqual(
+        rows.map((row) => row.activityId),
+        ["a1", "a3"],
+      );
+    }),
+  );
+
+  it.effect("keeps the same ordering as the unfiltered list", () =>
+    Effect.gen(function* () {
+      const activities = yield* seed();
+
+      const all = yield* activities.listByThreadId({ threadId });
+      const filtered = yield* activities.listByThreadIdAndKinds({
+        threadId,
+        kinds: ["user-input.requested", "user-input.resolved", "tool.updated", "tool.completed"],
+      });
+
+      assert.deepStrictEqual(
+        filtered.map((row) => row.activityId),
+        all.map((row) => row.activityId),
+      );
+    }),
+  );
+
+  it.effect("decodes the payload the same way the unfiltered list does", () =>
+    Effect.gen(function* () {
+      const activities = yield* seed();
+
+      const [filtered] = yield* activities.listByThreadIdAndKinds({
+        threadId,
+        kinds: ["user-input.requested"],
+      });
+      const all = yield* activities.listByThreadId({ threadId });
+      const unfiltered = all.find((row) => row.activityId === "a1");
+
+      assert.deepStrictEqual(filtered, unfiltered);
+    }),
+  );
+
+  it.effect("does not reach across threads", () =>
+    Effect.gen(function* () {
+      const activities = yield* seed();
+
+      const rows = yield* activities.listByThreadIdAndKinds({
+        threadId: otherThreadId,
+        kinds: ["user-input.requested"],
+      });
+
+      assert.deepStrictEqual(
+        rows.map((row) => row.activityId),
+        ["a5"],
+      );
+    }),
+  );
+
+  it.effect("returns nothing for an empty kind list without querying", () =>
+    Effect.gen(function* () {
+      const activities = yield* seed();
+
+      const rows = yield* activities.listByThreadIdAndKinds({ threadId, kinds: [] });
+
+      assert.deepStrictEqual(rows, []);
+    }),
+  );
+});

--- a/apps/server/src/persistence/Layers/ProjectionThreadActivities.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadActivities.ts
@@ -10,6 +10,7 @@ import { toPersistenceDecodeError, toPersistenceSqlError } from "../Errors.ts";
 
 import {
   DeleteProjectionThreadActivitiesInput,
+  ListProjectionThreadActivitiesByKindInput,
   ListProjectionThreadActivitiesInput,
   ProjectionThreadActivity,
   ProjectionThreadActivityRepository,
@@ -29,6 +30,20 @@ function toPersistenceSqlOrDecodeError(sqlOperation: string, decodeOperation: st
       ? toPersistenceDecodeError(decodeOperation)(cause)
       : toPersistenceSqlError(sqlOperation)(cause);
 }
+
+const toProjectionThreadActivity = (
+  row: typeof ProjectionThreadActivityDbRowSchema.Type,
+): ProjectionThreadActivity => ({
+  activityId: row.activityId,
+  threadId: row.threadId,
+  turnId: row.turnId,
+  tone: row.tone,
+  kind: row.kind,
+  summary: row.summary,
+  payload: row.payload,
+  ...(row.sequence !== null ? { sequence: row.sequence } : {}),
+  createdAt: row.createdAt,
+});
 
 const makeProjectionThreadActivityRepository = Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient;
@@ -97,6 +112,32 @@ const makeProjectionThreadActivityRepository = Effect.gen(function* () {
       `,
   });
 
+  const listProjectionThreadActivityRowsByKind = SqlSchema.findAll({
+    Request: ListProjectionThreadActivitiesByKindInput,
+    Result: ProjectionThreadActivityDbRowSchema,
+    execute: ({ threadId, kinds }) =>
+      sql`
+        SELECT
+          activity_id AS "activityId",
+          thread_id AS "threadId",
+          turn_id AS "turnId",
+          tone,
+          kind,
+          summary,
+          payload_json AS "payload",
+          sequence,
+          created_at AS "createdAt"
+        FROM projection_thread_activities
+        WHERE thread_id = ${threadId}
+          AND kind IN ${sql.in(kinds)}
+        ORDER BY
+          CASE WHEN sequence IS NULL THEN 0 ELSE 1 END ASC,
+          sequence ASC,
+          created_at ASC,
+          activity_id ASC
+      `,
+  });
+
   const deleteProjectionThreadActivityRows = SqlSchema.void({
     Request: DeleteProjectionThreadActivitiesInput,
     execute: ({ threadId }) =>
@@ -124,20 +165,22 @@ const makeProjectionThreadActivityRepository = Effect.gen(function* () {
           "ProjectionThreadActivityRepository.listByThreadId:decodeRows",
         ),
       ),
-      Effect.map((rows) =>
-        rows.map((row) => ({
-          activityId: row.activityId,
-          threadId: row.threadId,
-          turnId: row.turnId,
-          tone: row.tone,
-          kind: row.kind,
-          summary: row.summary,
-          payload: row.payload,
-          ...(row.sequence !== null ? { sequence: row.sequence } : {}),
-          createdAt: row.createdAt,
-        })),
-      ),
+      Effect.map((rows) => rows.map(toProjectionThreadActivity)),
     );
+
+  const listByThreadIdAndKinds: ProjectionThreadActivityRepositoryShape["listByThreadIdAndKinds"] =
+    (input) =>
+      input.kinds.length === 0
+        ? Effect.succeed([])
+        : listProjectionThreadActivityRowsByKind(input).pipe(
+            Effect.mapError(
+              toPersistenceSqlOrDecodeError(
+                "ProjectionThreadActivityRepository.listByThreadIdAndKinds:query",
+                "ProjectionThreadActivityRepository.listByThreadIdAndKinds:decodeRows",
+              ),
+            ),
+            Effect.map((rows) => rows.map(toProjectionThreadActivity)),
+          );
 
   const deleteByThreadId: ProjectionThreadActivityRepositoryShape["deleteByThreadId"] = (input) =>
     deleteProjectionThreadActivityRows(input).pipe(
@@ -149,6 +192,7 @@ const makeProjectionThreadActivityRepository = Effect.gen(function* () {
   return {
     upsert,
     listByThreadId,
+    listByThreadIdAndKinds,
     deleteByThreadId,
   } satisfies ProjectionThreadActivityRepositoryShape;
 });

--- a/apps/server/src/persistence/Services/ProjectionThreadActivities.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreadActivities.ts
@@ -38,6 +38,13 @@ export const ListProjectionThreadActivitiesInput = Schema.Struct({
 });
 export type ListProjectionThreadActivitiesInput = typeof ListProjectionThreadActivitiesInput.Type;
 
+export const ListProjectionThreadActivitiesByKindInput = Schema.Struct({
+  threadId: ThreadId,
+  kinds: Schema.Array(Schema.String),
+});
+export type ListProjectionThreadActivitiesByKindInput =
+  typeof ListProjectionThreadActivitiesByKindInput.Type;
+
 export const DeleteProjectionThreadActivitiesInput = Schema.Struct({
   threadId: ThreadId,
 });
@@ -65,6 +72,18 @@ export interface ProjectionThreadActivityRepositoryShape {
    */
   readonly listByThreadId: (
     input: ListProjectionThreadActivitiesInput,
+  ) => Effect.Effect<ReadonlyArray<ProjectionThreadActivity>, ProjectionRepositoryError>;
+
+  /**
+   * List projected thread activity rows for a thread, restricted to `kinds`.
+   *
+   * Same ordering as {@link listByThreadId}. Callers deriving a fact from a few
+   * activity kinds should use this: a thread's activity rows carry every tool
+   * payload it has produced, so reading them all to answer a narrow question
+   * scales with the thread's whole history.
+   */
+  readonly listByThreadIdAndKinds: (
+    input: ListProjectionThreadActivitiesByKindInput,
   ) => Effect.Effect<ReadonlyArray<ProjectionThreadActivity>, ProjectionRepositoryError>;
 
   /**


### PR DESCRIPTION
## The problem

`refreshThreadShellSummary` loads every activity row a thread has ever produced — payloads included — to compute a single integer, `pendingUserInputCount`.

Activity payloads are the tool timeline, so the cost of one refresh scales with the thread's entire history. Across the 402 threads on a heavily-used instance, comparing what the refresh reads against what the derivation needs:

| thread | rows read | of which needed | bytes read | of which needed |
|---|---|---|---|---|
| median | 277 | 0 | 2.8 MB | 0 |
| p95 | 1,190 | 0 | 60.4 MB | 0 |
| p99 | 4,279 | 0 | 123.0 MB | 0 |
| max | 11,137 | 0 | 493.3 MB | 0 |

The "needed" column is zero for 397 of 402 threads, and that is not a quirk of this dataset: `pendingUserInputCount` derives only from `user-input.requested`, `user-input.resolved` and `provider.user-input.respond.failed`, which exist only when a provider stops mid-turn to ask the user something. Even on the 5 threads here that *have* had one, they account for **2–4 rows out of thousands** — 1.3 KB out of 3.5 MB on the largest.

So the read is not merely oversized on one unusual thread; it is reading the whole timeline to find a handful of rows that are usually not there at all.

## This is already reported

- **#5719** — *Assistant streaming causes full-thread projection scans for every text delta* — names `refreshThreadShellSummary` and this exact reload.
- **#4597** — *Headless nightly server crashes with JavaScript heap out of memory after ~23.5 hours* — the symptom. That report died at ~23.5 h; on the instance measured here, systemd recorded a 25 h run peaking at **31.8 G** with **28.8 G read from disk**, and shorter runs at 32.4 G and 36.8 G against a raised `--max-old-space-size`. At the cap the process sits in back-to-back full GCs and every connected client stalls until it is restarted.
- On #5719, `dain` also observed cross-thread head-of-line blocking: one busy thread delaying unrelated turns for minutes. That matches what this looks like from a client — everything slow, not one screen.

## How this relates to #5855 and #6608

Both of those reduce **how often** the refresh runs. This PR reduces **what it costs when it runs**. They compose; none of them replaces another:

| | #5855 | #6608 | this PR |
|---|---|---|---|
| Skip refresh for assistant deltas | ✅ | ✅ | — |
| Skip refresh for streaming activity kinds | — | ✅ | — |
| Make the remaining refreshes cheap | — | — | ✅ |

Neither #5855 nor #6608 changes the read itself — both still call `projectionThreadActivityRepository.listByThreadId({ threadId })` and pull the full payload set. With either merged, every *lifecycle* event (`user-input.requested/resolved`, approval events, proposed-plan upserts, `thread.session-set`, `thread.turn-diff-completed`) still pays the whole-thread read. On the instance above that is up to 467 MB per event, for one integer.

Merging this alongside them means the refreshes that remain are also cheap. If the maintainers prefer #6608's shape, this still applies unchanged on top of it — the two touch different lines.

## The change

`derivePendingUserInputCountFromActivities` only reacts to three kinds — `user-input.requested`, `user-input.resolved` and `provider.user-input.respond.failed` — and `continue`s past everything else. The read now filters on exactly those three, with the kinds declared next to the deriver so the two stay in step.

Measured against the same database. The busiest thread, warm, before schema decode and the sort that follows:

```
before:  10,652 rows      467.4 MB     348.8 ms
after :       0 rows        0.000 MB       6.9 ms
```

And on the threads where the filtered read is *not* empty — the fix's worst case:

```
3,778 rows / 3.5 MB → 2 rows / 1.3 KB     7.3 ms → 1.9 ms
1,576 rows / 1.8 MB → 3 rows / 1.3 KB     2.3 ms → 0.8 ms
1,226 rows / 1.6 MB → 2 rows / 1.4 KB     1.9 ms → 0.6 ms
```

Deployed, the traced projection step moved:

```
applyThreadsProjection   p50 1,707 ms → 1.5 ms     p95 4,814 ms → 17.4 ms     max 15,010 ms → 35.1 ms
```

94% of orchestration events there reach this path (`thread.activity-appended` alone), averaging ~356/hour and peaking at 2,613 in one hour.

`ProjectionThreadActivityRepository` gains `listByThreadIdAndKinds`, which reuses the row decoding of `listByThreadId`, keeps its exact ordering, and short-circuits an empty kind list without issuing a query. `listByThreadId` is unchanged and still used everywhere else.

No behaviour change: the rows removed from the read are ones the deriver already skipped.

## Why it went unnoticed for so long

The code landed in #1973 (2026-04-13) and has not been touched in the 1,239 commits since. It only bites at the tail — on the instance measured, the median thread holds 306 activity rows (~2.8 MB), which is unnoticeable; the p99 holds 4,279 rows / 123 MB. It needs long-lived threads *and* a server process that stays up for days, which is not the common desktop profile.

Adjacent fixes have repeatedly addressed the same underlying volume on the **serve** path — #4622 pruning activity payloads over the wire, #4788 gzipping snapshots, #5482 dropping MCP tool results from thread payloads, #5147 bounding catch-up replay. This is the same volume problem on the **projection** path.

## Tests

Five repository tests cover kind filtering, ordering parity with the unfiltered list, payload-decoding parity, thread isolation, and the empty-kinds short circuit.

One `ProjectionPipeline` test is added, because the existing suite could not catch the failure mode this change introduces. The suite asserted `pendingUserInputCount` only where it settles back to `0`, so a filter that dropped every row would still have passed. The new test appends a `user-input.requested` activity alongside unrelated tool noise and asserts the count is **1**.

Verified by mutation: renaming the filtered kinds makes only the new test fail — the other 22 in that file still pass.

Equivalence was also checked against real data. Replaying the deriver over all 402 threads on the instance above, once from the full activity list and once from the filtered list, produced identical counts for every thread.

Not a UI change, so no screenshots.