### PR TITLE
feat(web): pick reasoning effort with a colored slider

### DIFF
--- a/apps/web/src/components/chat/ReasoningSlider.test.ts
+++ b/apps/web/src/components/chat/ReasoningSlider.test.ts
@@ -117,9 +117,9 @@ describe("ReasoningSlider", () => {
   });
 
   it("paints the thumb in the level colour and parks it at the level offset", () => {
-    expect(render("low")).toContain("left:calc(0.5rem + (100% - 0.5rem * 2) * 0)");
+    expect(render("low")).toContain("left:calc(0.625rem + (100% - 0.625rem * 2) * 0)");
     const max = render("max");
-    expect(max).toContain("left:calc(0.5rem + (100% - 0.5rem * 2) * 1)");
+    expect(max).toContain("left:calc(0.625rem + (100% - 0.625rem * 2) * 1)");
     expect(max).toContain("background-color:var(--reasoning-6)");
   });
 

--- a/apps/web/src/components/chat/ReasoningSlider.test.ts
+++ b/apps/web/src/components/chat/ReasoningSlider.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vite-plus/test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { ProviderOptionDescriptor } from "@t3tools/contracts";
+import {
+  getReasoningLevelColor,
+  getReasoningRampIndex,
+  isReasoningDescriptor,
+  ReasoningSlider,
+} from "./ReasoningSlider";
+
+function selectDescriptor(
+  id: string,
+  label: string,
+  optionIds: ReadonlyArray<string>,
+): Extract<ProviderOptionDescriptor, { type: "select" }> {
+  return {
+    id,
+    label,
+    type: "select",
+    options: optionIds.map((optionId) => ({ id: optionId, label: optionId })),
+  };
+}
+
+describe("isReasoningDescriptor", () => {
+  it("matches the reasoning descriptor id of every harness", () => {
+    for (const id of ["effort", "reasoningEffort", "reasoning"]) {
+      expect(isReasoningDescriptor(selectDescriptor(id, "Reasoning", ["low", "high"]))).toBe(true);
+    }
+  });
+
+  it("matches harness-provided labels when the id is unknown", () => {
+    expect(isReasoningDescriptor(selectDescriptor("mystery", "Thinking Level", ["a", "b"]))).toBe(
+      true,
+    );
+  });
+
+  it("leaves other selects as menu lists", () => {
+    expect(isReasoningDescriptor(selectDescriptor("serviceTier", "Service Tier", ["a", "b"]))).toBe(
+      false,
+    );
+    expect(isReasoningDescriptor(selectDescriptor("agent", "Agent", ["build", "plan"]))).toBe(
+      false,
+    );
+  });
+
+  it("needs at least two stops to be a slider", () => {
+    expect(isReasoningDescriptor(selectDescriptor("effort", "Reasoning", ["high"]))).toBe(false);
+  });
+});
+
+describe("getReasoningRampIndex", () => {
+  it("keeps known levels on the same colour across harnesses", () => {
+    const claude = ["low", "medium", "high", "xhigh", "max", "ultracode", "ultrathink"];
+    const codex = ["minimal", "low", "medium", "high", "xhigh", "max", "ultra"];
+    const claudeMax = getReasoningRampIndex("max", claude.indexOf("max"), claude.length);
+    const codexMax = getReasoningRampIndex("max", codex.indexOf("max"), codex.length);
+    expect(claudeMax).toBe(codexMax);
+  });
+
+  it("ramps unknown levels by position", () => {
+    expect(getReasoningRampIndex("turbo", 0, 3)).toBe(0);
+    expect(getReasoningRampIndex("turbo", 2, 3)).toBe(7);
+    expect(getReasoningRampIndex("turbo", 0, 1)).toBe(0);
+  });
+
+  it("stays inside the declared ramp", () => {
+    for (let index = 0; index < 12; index += 1) {
+      const ramp = getReasoningRampIndex(`level-${index}`, index, 12);
+      expect(ramp).toBeGreaterThanOrEqual(0);
+      expect(ramp).toBeLessThanOrEqual(7);
+    }
+  });
+
+  it("rises with effort", () => {
+    const levels = ["minimal", "low", "medium", "high", "xhigh", "max", "ultra"];
+    const ramps = levels.map((level, index) => getReasoningRampIndex(level, index, levels.length));
+    for (let index = 1; index < ramps.length; index += 1) {
+      expect(ramps[index]).toBeGreaterThan(ramps[index - 1] as number);
+    }
+  });
+});
+
+describe("getReasoningLevelColor", () => {
+  it("resolves to a declared ramp token", () => {
+    expect(getReasoningLevelColor("low", 0, 5)).toBe("var(--reasoning-2)");
+    expect(getReasoningLevelColor("ultrathink", 6, 7)).toBe("var(--reasoning-8)");
+  });
+});
+
+describe("ReasoningSlider", () => {
+  const CLAUDE_EFFORT = selectDescriptor("effort", "Reasoning", [
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+  ]);
+
+  function render(value: string, disabled = false) {
+    return renderToStaticMarkup(
+      createElement(ReasoningSlider, {
+        descriptor: CLAUDE_EFFORT,
+        value,
+        disabled,
+        onValueChange: () => {},
+      }),
+    );
+  }
+
+  it("drives a native range input over the option list", () => {
+    const markup = render("high");
+    expect(markup).toContain('type="range"');
+    expect(markup).toContain('max="4"');
+    expect(markup).toContain('value="2"');
+    expect(markup).toContain('aria-valuetext="high"');
+  });
+
+  it("paints the thumb in the level colour and parks it at the level offset", () => {
+    expect(render("low")).toContain("left:calc(0.5rem + (100% - 0.5rem * 2) * 0)");
+    const max = render("max");
+    expect(max).toContain("left:calc(0.5rem + (100% - 0.5rem * 2) * 1)");
+    expect(max).toContain("background-color:var(--reasoning-6)");
+  });
+
+  it("falls back to the first level when the value is unknown", () => {
+    expect(render("nonsense")).toContain('value="0"');
+  });
+
+  it("disables the input when the prompt owns the effort", () => {
+    expect(render("high", true)).toContain("disabled");
+  });
+});

--- a/apps/web/src/components/chat/ReasoningSlider.test.ts
+++ b/apps/web/src/components/chat/ReasoningSlider.test.ts
@@ -116,10 +116,10 @@ describe("ReasoningSlider", () => {
     expect(markup).toContain('aria-valuetext="high"');
   });
 
-  it("paints the thumb in the level colour and parks it at the level offset", () => {
-    expect(render("low")).toContain("left:calc(0.625rem + (100% - 0.625rem * 2) * 0)");
+  it("fills the capsule in the level colour and parks the thumb at the level offset", () => {
+    expect(render("low")).toContain("left:calc(1rem + (100% - 1rem * 2) * 0)");
     const max = render("max");
-    expect(max).toContain("left:calc(0.625rem + (100% - 0.625rem * 2) * 1)");
+    expect(max).toContain("left:calc(1rem + (100% - 1rem * 2) * 1)");
     expect(max).toContain("background-color:var(--reasoning-6)");
   });
 

--- a/apps/web/src/components/chat/ReasoningSlider.tsx
+++ b/apps/web/src/components/chat/ReasoningSlider.tsx
@@ -1,0 +1,159 @@
+import type { ProviderOptionDescriptor } from "@t3tools/contracts";
+import type { ReactNode } from "react";
+import { cn } from "~/lib/utils";
+
+type SelectDescriptor = Extract<ProviderOptionDescriptor, { type: "select" }>;
+
+/**
+ * Reasoning selects are named differently per harness: Claude ships `effort`,
+ * Codex `reasoningEffort`, Cursor `reasoning` (whose label comes from the CLI,
+ * so it can read "Thinking Level" instead).
+ */
+const REASONING_DESCRIPTOR_IDS = new Set(["effort", "reasoning", "reasoningEffort"]);
+
+export function isReasoningDescriptor(descriptor: SelectDescriptor): boolean {
+  return (
+    descriptor.options.length > 1 &&
+    (REASONING_DESCRIPTOR_IDS.has(descriptor.id) ||
+      /reasoning|effort|thinking/i.test(descriptor.label))
+  );
+}
+
+/** Number of `--reasoning-N` stops declared in index.css, calmest first. */
+const RAMP_STOPS = 8;
+
+/**
+ * Known level ids keep the same colour whatever the harness calls the model, so
+ * "Max" reads the same red on Claude and Codex even though their option lists
+ * differ in length. Unknown ids fall back to their position in the ramp.
+ */
+const LEVEL_RAMP_INDEX: Record<string, number> = {
+  none: 0,
+  minimal: 0,
+  low: 1,
+  medium: 2,
+  high: 3,
+  xhigh: 4,
+  max: 5,
+  ultra: 6,
+  ultracode: 6,
+  ultrathink: 7,
+};
+
+export function getReasoningRampIndex(optionId: string, index: number, total: number): number {
+  const known = LEVEL_RAMP_INDEX[optionId.toLowerCase()];
+  if (known !== undefined) {
+    return known;
+  }
+  if (total <= 1) {
+    return 0;
+  }
+  return Math.round((index / (total - 1)) * (RAMP_STOPS - 1));
+}
+
+export function getReasoningLevelColor(optionId: string, index: number, total: number): string {
+  return `var(--reasoning-${getReasoningRampIndex(optionId, index, total) + 1})`;
+}
+
+/** Half the slider thumb, so the painted track lines up with the native value mapping. */
+const TRACK_INSET = "0.5rem";
+
+function stopOffset(index: number, total: number): string {
+  const ratio = total > 1 ? index / (total - 1) : 0;
+  return `calc(${TRACK_INSET} + (100% - ${TRACK_INSET} * 2) * ${ratio})`;
+}
+
+export interface ReasoningSliderProps {
+  descriptor: SelectDescriptor;
+  value: string;
+  disabled?: boolean;
+  badge?: ReactNode;
+  onValueChange: (value: string) => void;
+}
+
+/**
+ * Horizontal effort picker: drag, click, or arrow-key through the harness's
+ * reasoning levels. A transparent native range input sits on top of the painted
+ * track so pointer, touch, keyboard, and screen-reader support come for free.
+ */
+export function ReasoningSlider({
+  descriptor,
+  value,
+  disabled = false,
+  badge,
+  onValueChange,
+}: ReasoningSliderProps) {
+  const options = descriptor.options;
+  const total = options.length;
+  const foundIndex = options.findIndex((option) => option.id === value);
+  const selectedIndex = foundIndex >= 0 ? foundIndex : 0;
+  const selected = options[selectedIndex];
+  if (!selected) {
+    return null;
+  }
+  const color = getReasoningLevelColor(selected.id, selectedIndex, total);
+  const offset = stopOffset(selectedIndex, total);
+
+  return (
+    <div className="min-w-52 px-2 pt-1.5 pb-1" data-slot="reasoning-slider">
+      <div className="flex items-center justify-between gap-3 pb-1.5">
+        <span className="font-medium text-muted-foreground text-xs">{descriptor.label}</span>
+        <span className="flex items-center gap-1.5">
+          <span className="font-medium text-xs" style={{ color }}>
+            {selected.label}
+          </span>
+          {selected.isDefault ? badge : null}
+        </span>
+      </div>
+      <div className={cn("relative flex h-5 items-center", disabled && "opacity-50")}>
+        <div className="absolute right-2 left-2 h-1 rounded-full bg-foreground/15" />
+        <div
+          className="absolute left-2 h-1 rounded-full transition-[width] duration-100"
+          style={{
+            width: `calc((100% - ${TRACK_INSET} * 2) * ${total > 1 ? selectedIndex / (total - 1) : 1})`,
+            background: `linear-gradient(90deg, var(--reasoning-1), ${color})`,
+          }}
+        />
+        {options.map((option, index) => (
+          <span
+            key={option.id}
+            className="-translate-x-1/2 absolute size-1 rounded-full bg-foreground/30"
+            style={{ left: stopOffset(index, total) }}
+          />
+        ))}
+        <span
+          className="-translate-x-1/2 pointer-events-none absolute size-4 rounded-full border-2 border-popover shadow-sm transition-[left,background-color] duration-100"
+          style={{ left: offset, backgroundColor: color }}
+        />
+        <input
+          aria-label={descriptor.label}
+          aria-valuetext={selected.label}
+          className="absolute inset-0 h-full w-full cursor-pointer appearance-none bg-transparent opacity-0 disabled:cursor-not-allowed [&::-moz-range-thumb]:size-4 [&::-moz-range-thumb]:border-0 [&::-webkit-slider-thumb]:size-4 [&::-webkit-slider-thumb]:appearance-none"
+          disabled={disabled}
+          max={total - 1}
+          min={0}
+          onChange={(event) => {
+            const next = options[Number(event.target.value)];
+            if (next && next.id !== selected.id) {
+              onValueChange(next.id);
+            }
+          }}
+          // Base UI's menu owns arrow keys for item navigation; the slider needs
+          // them for its own steps while it is focused.
+          onKeyDown={(event) => {
+            if (event.key.startsWith("Arrow") || event.key === "Home" || event.key === "End") {
+              event.stopPropagation();
+            }
+          }}
+          step={1}
+          type="range"
+          value={selectedIndex}
+        />
+      </div>
+      <div className="flex items-center justify-between pt-0.5 text-[10px] text-muted-foreground/80">
+        <span>{options[0]?.label}</span>
+        <span>{options[total - 1]?.label}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/ReasoningSlider.tsx
+++ b/apps/web/src/components/chat/ReasoningSlider.tsx
@@ -55,8 +55,11 @@ export function getReasoningLevelColor(optionId: string, index: number, total: n
   return `var(--reasoning-${getReasoningRampIndex(optionId, index, total) + 1})`;
 }
 
-/** Half the slider thumb, so the painted track lines up with the native value mapping. */
-const TRACK_INSET = "0.625rem";
+/**
+ * Half the native thumb (pinned to the capsule height below), so the painted
+ * stops line up with the browser's own value mapping.
+ */
+const TRACK_INSET = "1rem";
 
 function stopOffset(index: number, total: number): string {
   const ratio = total > 1 ? index / (total - 1) : 0;
@@ -93,59 +96,50 @@ export function ReasoningSlider({
   }
   const color = getReasoningLevelColor(selected.id, selectedIndex, total);
   const offset = stopOffset(selectedIndex, total);
-  // The track paints the whole ramp and dims everything past the thumb, so the
-  // levels ahead stay visible as a preview instead of reading as empty space.
-  const rampGradient = `linear-gradient(90deg, ${options
-    .map((option, index) => getReasoningLevelColor(option.id, index, total))
-    .join(", ")})`;
 
   return (
     <div className="min-w-72 px-3 pt-2.5 pb-2" data-slot="reasoning-slider">
-      <div className="flex items-center justify-between gap-3 pb-2.5">
+      <div className="flex items-center justify-between gap-3 pb-2">
         <span className="font-medium text-muted-foreground text-xs">{descriptor.label}</span>
         <span className="flex items-center gap-2">
-          <span className="flex items-center gap-1.5 font-semibold text-sm" style={{ color }}>
-            <span
-              className="size-2 rounded-full transition-colors duration-150"
-              style={{ backgroundColor: color }}
-            />
+          <span className="font-semibold text-sm" style={{ color }}>
             {selected.label}
           </span>
           {selected.isDefault ? badge : null}
         </span>
       </div>
-      <div className={cn("group relative flex h-7 items-center", disabled && "opacity-50")}>
+      <div
+        className={cn(
+          "group relative flex h-8 items-center rounded-full bg-foreground/10 inset-shadow-[0_1px_2px_rgb(0_0_0/0.12)]",
+          disabled && "opacity-50",
+        )}
+      >
+        {/* Filled capsule ends under the thumb, so the two read as one shape. */}
         <div
-          className="absolute right-2.5 left-2.5 h-2 overflow-hidden rounded-full"
-          style={{ backgroundImage: rampGradient }}
-        >
-          <div
-            className="absolute inset-y-0 right-0 bg-popover/80 transition-[left] duration-150"
-            style={{ left: `${total > 1 ? (selectedIndex / (total - 1)) * 100 : 100}%` }}
-          />
-        </div>
+          className="absolute left-1 h-6 rounded-full transition-[width,background-color] duration-150"
+          style={{
+            width: `calc(${offset} + 0.5rem)`,
+            backgroundColor: color,
+          }}
+        />
         {options.map((option, index) => (
           <span
             key={option.id}
             className={cn(
-              "-translate-x-1/2 absolute size-1.5 rounded-full transition-colors duration-150",
-              index <= selectedIndex ? "bg-popover/70" : "bg-foreground/25",
+              "-translate-x-1/2 absolute size-1 rounded-full transition-colors duration-150",
+              index <= selectedIndex ? "bg-black/30" : "bg-foreground/25",
             )}
             style={{ left: stopOffset(index, total) }}
           />
         ))}
         <span
-          className="-translate-x-1/2 pointer-events-none absolute size-5 rounded-full border-2 border-popover transition-[left,background-color,box-shadow] duration-150 group-active:scale-105"
-          style={{
-            left: offset,
-            backgroundColor: color,
-            boxShadow: `0 1px 3px rgb(0 0 0 / 0.25), 0 0 0 4px color-mix(in oklab, ${color} 22%, transparent)`,
-          }}
+          className="-translate-x-1/2 pointer-events-none absolute size-6 rounded-full bg-white shadow-[0_1px_3px_rgb(0_0_0/0.3)] transition-[left] duration-150 group-active:scale-105"
+          style={{ left: offset }}
         />
         <input
           aria-label={descriptor.label}
           aria-valuetext={selected.label}
-          className="absolute inset-0 h-full w-full cursor-pointer appearance-none bg-transparent opacity-0 disabled:cursor-not-allowed [&::-moz-range-thumb]:size-5 [&::-moz-range-thumb]:border-0 [&::-webkit-slider-thumb]:size-5 [&::-webkit-slider-thumb]:appearance-none"
+          className="absolute inset-0 h-full w-full cursor-pointer appearance-none bg-transparent opacity-0 disabled:cursor-not-allowed [&::-moz-range-thumb]:size-8 [&::-moz-range-thumb]:border-0 [&::-webkit-slider-thumb]:size-8 [&::-webkit-slider-thumb]:appearance-none"
           disabled={disabled}
           max={total - 1}
           min={0}

--- a/apps/web/src/components/chat/ReasoningSlider.tsx
+++ b/apps/web/src/components/chat/ReasoningSlider.tsx
@@ -56,7 +56,7 @@ export function getReasoningLevelColor(optionId: string, index: number, total: n
 }
 
 /** Half the slider thumb, so the painted track lines up with the native value mapping. */
-const TRACK_INSET = "0.5rem";
+const TRACK_INSET = "0.625rem";
 
 function stopOffset(index: number, total: number): string {
   const ratio = total > 1 ? index / (total - 1) : 0;
@@ -93,42 +93,59 @@ export function ReasoningSlider({
   }
   const color = getReasoningLevelColor(selected.id, selectedIndex, total);
   const offset = stopOffset(selectedIndex, total);
+  // The track paints the whole ramp and dims everything past the thumb, so the
+  // levels ahead stay visible as a preview instead of reading as empty space.
+  const rampGradient = `linear-gradient(90deg, ${options
+    .map((option, index) => getReasoningLevelColor(option.id, index, total))
+    .join(", ")})`;
 
   return (
-    <div className="min-w-52 px-2 pt-1.5 pb-1" data-slot="reasoning-slider">
-      <div className="flex items-center justify-between gap-3 pb-1.5">
+    <div className="min-w-72 px-3 pt-2.5 pb-2" data-slot="reasoning-slider">
+      <div className="flex items-center justify-between gap-3 pb-2.5">
         <span className="font-medium text-muted-foreground text-xs">{descriptor.label}</span>
-        <span className="flex items-center gap-1.5">
-          <span className="font-medium text-xs" style={{ color }}>
+        <span className="flex items-center gap-2">
+          <span className="flex items-center gap-1.5 font-semibold text-sm" style={{ color }}>
+            <span
+              className="size-2 rounded-full transition-colors duration-150"
+              style={{ backgroundColor: color }}
+            />
             {selected.label}
           </span>
           {selected.isDefault ? badge : null}
         </span>
       </div>
-      <div className={cn("relative flex h-5 items-center", disabled && "opacity-50")}>
-        <div className="absolute right-2 left-2 h-1 rounded-full bg-foreground/15" />
+      <div className={cn("group relative flex h-7 items-center", disabled && "opacity-50")}>
         <div
-          className="absolute left-2 h-1 rounded-full transition-[width] duration-100"
-          style={{
-            width: `calc((100% - ${TRACK_INSET} * 2) * ${total > 1 ? selectedIndex / (total - 1) : 1})`,
-            background: `linear-gradient(90deg, var(--reasoning-1), ${color})`,
-          }}
-        />
+          className="absolute right-2.5 left-2.5 h-2 overflow-hidden rounded-full"
+          style={{ backgroundImage: rampGradient }}
+        >
+          <div
+            className="absolute inset-y-0 right-0 bg-popover/80 transition-[left] duration-150"
+            style={{ left: `${total > 1 ? (selectedIndex / (total - 1)) * 100 : 100}%` }}
+          />
+        </div>
         {options.map((option, index) => (
           <span
             key={option.id}
-            className="-translate-x-1/2 absolute size-1 rounded-full bg-foreground/30"
+            className={cn(
+              "-translate-x-1/2 absolute size-1.5 rounded-full transition-colors duration-150",
+              index <= selectedIndex ? "bg-popover/70" : "bg-foreground/25",
+            )}
             style={{ left: stopOffset(index, total) }}
           />
         ))}
         <span
-          className="-translate-x-1/2 pointer-events-none absolute size-4 rounded-full border-2 border-popover shadow-sm transition-[left,background-color] duration-100"
-          style={{ left: offset, backgroundColor: color }}
+          className="-translate-x-1/2 pointer-events-none absolute size-5 rounded-full border-2 border-popover transition-[left,background-color,box-shadow] duration-150 group-active:scale-105"
+          style={{
+            left: offset,
+            backgroundColor: color,
+            boxShadow: `0 1px 3px rgb(0 0 0 / 0.25), 0 0 0 4px color-mix(in oklab, ${color} 22%, transparent)`,
+          }}
         />
         <input
           aria-label={descriptor.label}
           aria-valuetext={selected.label}
-          className="absolute inset-0 h-full w-full cursor-pointer appearance-none bg-transparent opacity-0 disabled:cursor-not-allowed [&::-moz-range-thumb]:size-4 [&::-moz-range-thumb]:border-0 [&::-webkit-slider-thumb]:size-4 [&::-webkit-slider-thumb]:appearance-none"
+          className="absolute inset-0 h-full w-full cursor-pointer appearance-none bg-transparent opacity-0 disabled:cursor-not-allowed [&::-moz-range-thumb]:size-5 [&::-moz-range-thumb]:border-0 [&::-webkit-slider-thumb]:size-5 [&::-webkit-slider-thumb]:appearance-none"
           disabled={disabled}
           max={total - 1}
           min={0}
@@ -150,7 +167,7 @@ export function ReasoningSlider({
           value={selectedIndex}
         />
       </div>
-      <div className="flex items-center justify-between pt-0.5 text-[10px] text-muted-foreground/80">
+      <div className="flex items-center justify-between pt-1.5 text-[11px] text-muted-foreground">
         <span>{options[0]?.label}</span>
         <span>{options[total - 1]?.label}</span>
       </div>

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -27,6 +27,7 @@ import {
   MenuSeparator as MenuDivider,
   MenuTrigger,
 } from "../ui/menu";
+import { isReasoningDescriptor, ReasoningSlider } from "./ReasoningSlider";
 import { useComposerDraftStore, DraftId } from "../../composerDraftStore";
 import { getProviderModelCapabilities } from "../../providerModels";
 import { cn } from "~/lib/utils";
@@ -301,47 +302,63 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
             ? "ultrathink"
             : (getDescriptorStringValue(descriptor) ?? "");
 
+        const isLocked = ultrathinkInBodyText && descriptor.id === primarySelectDescriptor?.id;
+
         return (
           <div key={descriptor.id}>
             {index > 0 ? <MenuDivider /> : null}
             <MenuGroup>
-              <div className="px-2 pt-1.5 pb-1 font-medium text-muted-foreground text-xs">
-                {descriptor.label}
-              </div>
-              {ultrathinkInBodyText && descriptor.id === primarySelectDescriptor?.id ? (
-                <div className="px-2 pb-1.5 text-muted-foreground/80 text-xs">
-                  Your prompt contains &quot;ultrathink&quot; in the text. Remove it to change this
-                  option.
-                </div>
-              ) : null}
-              <MenuRadioGroup
-                value={selectedValue}
-                onValueChange={(value) => handleSelectChange(descriptor, value)}
-              >
-                {descriptor.options.map((option) => (
-                  <MenuRadioItem
-                    key={option.id}
-                    value={option.id}
-                    hideIndicator
-                    // Base UI keeps radio menus open by default. Close on pick so
-                    // the traits menu behaves like the model picker.
-                    closeOnClick
-                    disabled={ultrathinkInBodyText && descriptor.id === primarySelectDescriptor?.id}
+              {isReasoningDescriptor(descriptor) ? (
+                <>
+                  {isLocked ? (
+                    <div className="px-2 pt-1.5 text-muted-foreground/80 text-xs">
+                      Your prompt contains &quot;ultrathink&quot; in the text. Remove it to change
+                      this option.
+                    </div>
+                  ) : null}
+                  <ReasoningSlider
+                    badge={<DefaultBadge />}
+                    descriptor={descriptor}
+                    disabled={isLocked}
+                    onValueChange={(nextValue) => handleSelectChange(descriptor, nextValue)}
+                    value={selectedValue}
+                  />
+                </>
+              ) : (
+                <>
+                  <div className="px-2 pt-1.5 pb-1 font-medium text-muted-foreground text-xs">
+                    {descriptor.label}
+                  </div>
+                  <MenuRadioGroup
+                    value={selectedValue}
+                    onValueChange={(value) => handleSelectChange(descriptor, value)}
                   >
-                    <span className="flex w-full min-w-0 items-center justify-between gap-3">
-                      <span className="min-w-0 truncate">
-                        {option.label}
-                        {option.isDefault ? (
-                          <>
-                            {" "}
-                            <DefaultBadge />
-                          </>
-                        ) : null}
-                      </span>
-                    </span>
-                  </MenuRadioItem>
-                ))}
-              </MenuRadioGroup>
+                    {descriptor.options.map((option) => (
+                      <MenuRadioItem
+                        key={option.id}
+                        value={option.id}
+                        hideIndicator
+                        // Base UI keeps radio menus open by default. Close on pick so
+                        // the traits menu behaves like the model picker.
+                        closeOnClick
+                        disabled={isLocked}
+                      >
+                        <span className="flex w-full min-w-0 items-center justify-between gap-3">
+                          <span className="min-w-0 truncate">
+                            {option.label}
+                            {option.isDefault ? (
+                              <>
+                                {" "}
+                                <DefaultBadge />
+                              </>
+                            ) : null}
+                          </span>
+                        </span>
+                      </MenuRadioItem>
+                    ))}
+                  </MenuRadioGroup>
+                </>
+              )}
             </MenuGroup>
           </div>
         );

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1135,6 +1135,16 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
   --update: var(--primary);
   --update-foreground: var(--primary);
   --update-surface: color-mix(in srgb, var(--update) 12%, transparent);
+  /* Reasoning-effort ramp, calmest to hottest. Literal values (not palette vars)
+     so the ramp survives Tailwind dropping unreferenced theme colours. */
+  --reasoning-1: oklch(55.4% 0.046 257.417);
+  --reasoning-2: oklch(58.8% 0.158 241.966);
+  --reasoning-3: oklch(59.6% 0.145 163.225);
+  --reasoning-4: oklch(66.6% 0.179 58.318);
+  --reasoning-5: oklch(64.6% 0.222 41.116);
+  --reasoning-6: oklch(57.7% 0.245 27.325);
+  --reasoning-7: oklch(59.1% 0.293 322.896);
+  --reasoning-8: oklch(54.1% 0.281 293.009);
   /* Keep every sidebar primitive on the same light surface hierarchy, including
      portaled mobile sheets and settings navigation outside the app sidebar. */
   --sidebar: var(--color-zinc-50);
@@ -1201,6 +1211,15 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
     --update: var(--primary);
     --update-foreground: var(--color-blue-400);
     --update-surface: color-mix(in srgb, var(--update) 18%, transparent);
+    /* Same ramp, lifted to the 400 shades so it stays legible on dark surfaces. */
+    --reasoning-1: oklch(70.4% 0.04 256.788);
+    --reasoning-2: oklch(74.6% 0.16 232.661);
+    --reasoning-3: oklch(76.5% 0.177 163.223);
+    --reasoning-4: oklch(82.8% 0.189 84.429);
+    --reasoning-5: oklch(75% 0.183 55.934);
+    --reasoning-6: oklch(70.4% 0.191 22.216);
+    --reasoning-7: oklch(74% 0.238 322.16);
+    --reasoning-8: oklch(70.2% 0.183 293.541);
     --sidebar: var(--card);
     --sidebar-foreground: var(--foreground);
     --sidebar-muted-foreground: var(--muted-foreground);


### PR DESCRIPTION
## What

The traits menu rendered every reasoning level as its own radio row. On Claude Opus 5 that is a seven-row list — Low, Medium, High, Extra High, Max, Ultracode, Ultrathink — where each row looks the same as the one above it, so choosing an effort means reading the whole list every time.

This replaces that list with a slider: drag it, click a stop, or arrow-key it left and right. The fill, the thumb, and the value label all carry a per-level color, so the current effort is readable at a glance without reading any text. Everything else in the menu is untouched and stays underneath the slider — Codex keeps its **Service Tier** rows, Claude and Cursor keep **Fast Mode**. Slider on top for effort, rows below for speed.

| Before | After |
| --- | --- |
| Seven identical radio rows | One slider + color per level |
| Menu closes on every pick | Menu stays open; pick effort, then speed |

## Works across every harness

The slider is driven by the option descriptor, never by a provider branch, so it lights up wherever a harness advertises a reasoning select:

| Harness | Descriptor id | Levels |
| --- | --- | --- |
| Claude | `effort` | Low → Ultrathink (7) |
| Codex | `reasoningEffort` | Minimal → Ultra (up to 7) |
| Cursor | `reasoning` | CLI-supplied, variable |
| anything else | id or label matching reasoning/effort/thinking | any length ≥ 2 |

Non-reasoning selects (`serviceTier`, `contextWindow`, `agent`, `variant`) keep the existing radio rows, and a single-option reasoning select stays a row too — there is nothing to slide.

Known level ids share a slot on the color ramp, so `max` is the same red on Claude as it is on Codex even though their level lists differ in length. Unknown ids from a CLI we have never seen ramp by position instead, so a custom harness still gets a sensible cold-to-hot gradient.

## Implementation notes

- **Native range input, painted skin.** A transparent `<input type="range">` sits on top of the drawn track, so pointer, touch, keyboard, and screen-reader behaviour come from the platform rather than from hand-rolled drag math. The thumb is pinned to `1rem` in both engines and the visuals are inset by half of that, so the painted track lines up with the browser's own value mapping.
- **Arrow keys.** Base UI's menu owns arrow keys for item navigation, so the slider stops their propagation while focused.
- **Colors are theme tokens.** `--reasoning-1` … `--reasoning-8` are declared in `index.css` with a lighter set under the dark variant, as literal `oklch` values so the ramp cannot be dropped by Tailwind's unused-theme-color pruning.
- **Ultrathink still works.** Sliding to a prompt-injected level (Claude's `ultrathink`) prefixes the composer as before, sliding away strips it, and a prompt that already contains "ultrathink" in its body locks the slider with the same explanation as before.

## Testing

- `pnpm test` in `apps/web` — 235 files / 2170 tests pass, including 13 new ones covering harness detection, ramp stability across harnesses, ramp bounds, monotonicity, and a server-rendered slider (input range, offsets, thumb color, unknown-value fallback, disabled state).
- `pnpm typecheck`, `pnpm lint`, `pnpm fmt` clean.
- Not yet verified in a running browser — this box could not expose a dev server to a browser, so the layout, the drag feel, and the color ramp in each built-in theme still want a human look. That is the main thing to check before this leaves draft.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add a colored reasoning effort slider to the chat traits picker
> - Replaces the radio menu for reasoning-effort select descriptors with a horizontal range slider (`ReasoningSlider`) that maps effort levels to a visual color ramp (`--reasoning-1` through `--reasoning-8`).
> - Adds `isReasoningDescriptor` to detect select descriptors representing reasoning effort by known ids (`effort`, `reasoning`, `reasoningEffort`) or label pattern.
> - The slider uses a native `<input type="range">` under the hood for full keyboard and assistive-technology support, and emits discrete option ids via `onValueChange`.
> - When `ultrathink` appears in the prompt body and the primary descriptor is selected, the slider is disabled with an explanatory message.
> - Eight `oklch`-based CSS variables are added to [index.css](https://github.com/pingdotgg/t3code/pull/6615/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) for both light and dark themes.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 32a0d63. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->