### PR TITLE
fix(desktop): support OAuth popups in browser previews

### DIFF
--- a/apps/desktop/src/ipc/methods/preview.test.ts
+++ b/apps/desktop/src/ipc/methods/preview.test.ts
@@ -40,7 +40,7 @@ describe("preview IPC methods", () => {
   effectIt.effect("rejects invalid webContents ids before resolving the preview service", () =>
     Effect.map(
       PreviewIpc.registerWebview
-        .handler({ tabId: "tab-1", webContentsId: 0 })
+        .handler({ tabId: "tab-1", webContentsId: 0, initialUrl: null })
         .pipe(Effect.provideService(PreviewManager.PreviewManager, null as never), Effect.exit),
       (exit) => {
         expect(Exit.isFailure(exit)).toBe(true);

--- a/apps/desktop/src/ipc/methods/preview.ts
+++ b/apps/desktop/src/ipc/methods/preview.ts
@@ -70,9 +70,13 @@ export const registerWebview = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_REGISTER_WEBVIEW_CHANNEL,
   payload: DesktopPreviewRegisterWebviewInputSchema,
   result: Schema.Void,
-  handler: Effect.fn("desktop.ipc.preview.registerWebview")(function* ({ tabId, webContentsId }) {
+  handler: Effect.fn("desktop.ipc.preview.registerWebview")(function* ({
+    tabId,
+    webContentsId,
+    initialUrl,
+  }) {
     const manager = yield* PreviewManager.PreviewManager;
-    yield* manager.registerWebview(tabId, webContentsId);
+    yield* manager.registerWebview(tabId, webContentsId, initialUrl);
   }),
 });
 

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -149,8 +149,12 @@ contextBridge.exposeInMainWorld("desktopBridge", {
   preview: {
     createTab: (tabId) => ipcRenderer.invoke(IpcChannels.PREVIEW_CREATE_TAB_CHANNEL, { tabId }),
     closeTab: (tabId) => ipcRenderer.invoke(IpcChannels.PREVIEW_CLOSE_TAB_CHANNEL, { tabId }),
-    registerWebview: (tabId, webContentsId) =>
-      ipcRenderer.invoke(IpcChannels.PREVIEW_REGISTER_WEBVIEW_CHANNEL, { tabId, webContentsId }),
+    registerWebview: (tabId, webContentsId, initialUrl) =>
+      ipcRenderer.invoke(IpcChannels.PREVIEW_REGISTER_WEBVIEW_CHANNEL, {
+        tabId,
+        webContentsId,
+        initialUrl,
+      }),
     navigate: (tabId, url) =>
       ipcRenderer.invoke(IpcChannels.PREVIEW_NAVIGATE_CHANNEL, { tabId, url }),
     goBack: (tabId) => ipcRenderer.invoke(IpcChannels.PREVIEW_GO_BACK_CHANNEL, { tabId }),

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -640,7 +640,6 @@ describe("PreviewManager", () => {
         expect(preview.loadURL).toHaveBeenCalledWith("https://example.com/start");
         expect(yield* manager.automationStatus("tab_bootstrap")).toMatchObject({
           url: "https://example.com/start",
-          loading: true,
         });
       }),
     ),

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -60,6 +60,7 @@ describe("isPreviewRefreshShortcut", () => {
 
 const {
   browserWindowConstructor,
+  browserWindowFromWebContents,
   createFromPath,
   fromId,
   getFocusedWebContents,
@@ -70,6 +71,9 @@ const {
   writeImage,
 } = vi.hoisted(() => ({
   browserWindowConstructor: vi.fn(),
+  browserWindowFromWebContents: vi.fn<
+    (webContents: Electron.WebContents) => Electron.BrowserWindow | null
+  >(() => null),
   createFromPath: vi.fn((): { readonly isEmpty: () => boolean } => ({ isEmpty: () => false })),
   fromId: vi.fn((_id?: number) => null),
   getFocusedWebContents: vi.fn(() => null),
@@ -81,7 +85,9 @@ const {
 }));
 
 vi.mock("electron", () => ({
-  BrowserWindow: browserWindowConstructor,
+  BrowserWindow: Object.assign(browserWindowConstructor, {
+    fromWebContents: browserWindowFromWebContents,
+  }),
   clipboard: {
     writeImage,
   },
@@ -198,6 +204,7 @@ const makeSourcePng = (width = 1, height = 1): Buffer => {
 
 const makeFaviconWebContents = (options?: {
   readonly fetch?: (url: string, init?: RequestInit) => Promise<Response>;
+  readonly hostWebContents?: Electron.WebContents | null;
   readonly id?: number;
   readonly rasterize?: (code: string) => Promise<unknown>;
   readonly url?: string;
@@ -224,6 +231,11 @@ const makeFaviconWebContents = (options?: {
   });
   const off = vi.fn();
   const debuggerOff = vi.fn();
+  const session = { fetch };
+  const setWindowOpenHandler =
+    vi.fn<
+      (handler: (details: Electron.HandlerDetails) => Electron.WindowOpenHandlerResponse) => void
+    >();
   const webContents = {
     id: options?.id ?? 42,
     isDestroyed: () => destroyed,
@@ -233,6 +245,7 @@ const makeFaviconWebContents = (options?: {
     isLoading: () => loading,
     isDevToolsOpened: () => false,
     getZoomFactor: () => 1,
+    hostWebContents: options?.hostWebContents ?? null,
     setZoomFactor: vi.fn(),
     reload,
     reloadIgnoringCache: vi.fn(),
@@ -243,9 +256,9 @@ const makeFaviconWebContents = (options?: {
     off,
     ipc: { on: vi.fn(), off: vi.fn() },
     send: webviewSend,
-    session: { fetch },
+    session,
     navigationHistory: { canGoBack: () => false, canGoForward: () => false },
-    setWindowOpenHandler: vi.fn(),
+    setWindowOpenHandler,
     executeJavaScriptInIsolatedWorld,
     debugger: {
       isAttached: () => false,
@@ -263,6 +276,8 @@ const makeFaviconWebContents = (options?: {
     loadURL,
     off,
     reload,
+    session,
+    setWindowOpenHandler,
     setDestroyed: (value: boolean) => {
       destroyed = value;
     },
@@ -281,6 +296,14 @@ const settle = function* (until: () => boolean) {
     yield* Effect.promise(() => Promise.resolve());
   }
 };
+
+const windowOpenDetails = (url: string): Electron.HandlerDetails => ({
+  url,
+  frameName: "oauth",
+  features: "width=500,height=600",
+  disposition: "new-window",
+  referrer: { url: "http://localhost:3200/", policy: "strict-origin-when-cross-origin" },
+});
 
 const makeTestPictureInPictureWindow = (loadURL: () => Promise<void> = async () => undefined) => {
   const listeners = new Map<string, () => void>();
@@ -315,6 +338,8 @@ const makeTestPictureInPictureWindow = (loadURL: () => Promise<void> = async () 
 describe("PreviewManager", () => {
   beforeEach(() => {
     browserWindowConstructor.mockReset();
+    browserWindowFromWebContents.mockReset();
+    browserWindowFromWebContents.mockReturnValue(null);
     fromId.mockClear();
     getFocusedWebContents.mockReset();
     getFocusedWebContents.mockReturnValue(null);
@@ -375,6 +400,106 @@ describe("PreviewManager", () => {
           });
         }
         expect(getType).not.toHaveBeenCalled();
+      }),
+    ),
+  );
+
+  effectIt.effect("allows safe preview popups without navigating the opener", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const hostWebContents = {} as Electron.WebContents;
+        const parent = { isDestroyed: () => false } as Electron.BrowserWindow;
+        const preview = makeFaviconWebContents({ hostWebContents });
+        browserWindowFromWebContents.mockReturnValue(parent);
+        fromId.mockReturnValue(preview.webContents);
+
+        yield* manager.createTab("tab_popup");
+        yield* manager.registerWebview("tab_popup", 42);
+
+        const handler = preview.setWindowOpenHandler.mock.calls[0]?.[0];
+        expect(handler).toBeDefined();
+        if (!handler) return;
+
+        for (const url of [
+          "https://accounts.google.com/",
+          "http://localhost:3200/auth",
+          "about:blank",
+        ]) {
+          expect(handler(windowOpenDetails(url))).toEqual({
+            action: "allow",
+            outlivesOpener: false,
+            overrideBrowserWindowOptions: {
+              parent,
+              autoHideMenuBar: true,
+              webPreferences: {
+                session: preview.session,
+                sandbox: true,
+                contextIsolation: true,
+                nodeIntegration: false,
+                nodeIntegrationInSubFrames: false,
+                webviewTag: false,
+              },
+            },
+          });
+        }
+        expect(browserWindowFromWebContents).toHaveBeenCalledWith(hostWebContents);
+        expect(preview.loadURL).not.toHaveBeenCalled();
+      }),
+    ),
+  );
+
+  effectIt.effect("denies unsafe and nested preview popups", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const preview = makeFaviconWebContents();
+        fromId.mockReturnValue(preview.webContents);
+
+        yield* manager.createTab("tab_popup_policy");
+        yield* manager.registerWebview("tab_popup_policy", 42);
+
+        const handler = preview.setWindowOpenHandler.mock.calls[0]?.[0];
+        expect(handler).toBeDefined();
+        if (!handler) return;
+        for (const url of [
+          "file:///tmp/secret",
+          "data:text/html,hello",
+          "mailto:test@example.com",
+          "about:blank?unexpected",
+        ]) {
+          expect(handler(windowOpenDetails(url))).toEqual({ action: "deny" });
+        }
+
+        const setMenuBarVisibility = vi.fn();
+        const setChildWindowOpenHandler =
+          vi.fn<
+            (
+              handler: (details: Electron.HandlerDetails) => Electron.WindowOpenHandlerResponse,
+            ) => void
+          >();
+        const popupWindow = {
+          isDestroyed: () => false,
+          setMenuBarVisibility,
+          webContents: {
+            id: 84,
+            isDestroyed: () => false,
+            setWindowOpenHandler: setChildWindowOpenHandler,
+          },
+        } as never;
+        const didCreateWindow = preview.listeners.get("did-create-window") as unknown as (
+          popupWindow: Electron.BrowserWindow,
+        ) => void;
+        didCreateWindow(popupWindow);
+
+        expect(setMenuBarVisibility).toHaveBeenCalledWith(false);
+        const childHandler = setChildWindowOpenHandler.mock.calls[0]?.[0];
+        expect(childHandler).toBeDefined();
+        expect(childHandler?.(windowOpenDetails("https://example.com"))).toEqual({
+          action: "deny",
+        });
+
+        yield* manager.closeTab("tab_popup_policy");
+        expect(preview.off).toHaveBeenCalledWith("did-create-window", didCreateWindow);
+        expect(preview.loadURL).not.toHaveBeenCalled();
       }),
     ),
   );

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -499,6 +499,10 @@ describe("PreviewManager", () => {
 
         yield* manager.closeTab("tab_popup_policy");
         expect(preview.off).toHaveBeenCalledWith("did-create-window", didCreateWindow);
+        const detachedHandler = preview.setWindowOpenHandler.mock.calls.at(-1)?.[0];
+        expect(detachedHandler?.(windowOpenDetails("https://example.com"))).toEqual({
+          action: "deny",
+        });
         expect(preview.loadURL).not.toHaveBeenCalled();
       }),
     ),

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -617,11 +617,31 @@ describe("PreviewManager", () => {
           loading: true,
         });
 
-        yield* manager.registerWebview("tab_pending", 42);
+        yield* manager.registerWebview("tab_pending", 42, "https://stale.example/");
         yield* Effect.yieldNow;
 
         expect(loadURL).toHaveBeenCalledOnce();
         expect(loadURL).toHaveBeenCalledWith("http://localhost:3200/");
+      }),
+    ),
+  );
+
+  effectIt.effect("starts the renderer bootstrap URL from the registered main process", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const preview = makeFaviconWebContents({ url: "about:blank" });
+        fromId.mockReturnValue(preview.webContents);
+
+        yield* manager.createTab("tab_bootstrap");
+        yield* manager.registerWebview("tab_bootstrap", 42, "https://example.com/start");
+        yield* Effect.yieldNow;
+
+        expect(preview.loadURL).toHaveBeenCalledOnce();
+        expect(preview.loadURL).toHaveBeenCalledWith("https://example.com/start");
+        expect(yield* manager.automationStatus("tab_bootstrap")).toMatchObject({
+          url: "https://example.com/start",
+          loading: true,
+        });
       }),
     ),
   );

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -1728,6 +1728,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     tabId: string,
     webContentsId: number,
     expectedGeneration: number | undefined,
+    initialUrl: string | null,
   ) {
     const tab = (yield* SynchronizedRef.get(tabsRef)).get(tabId);
     if (
@@ -1811,12 +1812,20 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
             tabs,
           ] as const;
         }
-        const pendingUrl = current.navStatus.kind === "Loading" ? current.navStatus.url : null;
+        const currentUrl = current.navStatus.kind === "Idle" ? null : current.navStatus.url;
+        const pendingUrl = currentUrl ?? initialUrl;
         const { favicon: _favicon, ...currentWithoutFavicon } = current;
         const next: PreviewTabState = {
           ...currentWithoutFavicon,
           webContentsId,
-          navStatus: pendingUrl === null ? computeNavStatus(wc) : current.navStatus,
+          navStatus:
+            pendingUrl === null
+              ? computeNavStatus(wc)
+              : {
+                  kind: "Loading",
+                  url: pendingUrl,
+                  title: current.navStatus.kind === "Idle" ? "" : current.navStatus.title,
+                },
           canGoBack: wc.navigationHistory.canGoBack(),
           canGoForward: wc.navigationHistory.canGoForward(),
           zoomFactor,
@@ -1864,11 +1873,18 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   const registerWebview = Effect.fn("PreviewManager.registerWebview")(function* (
     tabId: string,
     webContentsId: number,
+    rawInitialUrl: string | null = null,
   ) {
+    const initialUrl =
+      rawInitialUrl === null
+        ? null
+        : yield* attempt({ operation: "registerWebview.normalizeInitialUrl", tabId }, () =>
+            normalizePreviewUrl(rawInitialUrl),
+          );
     const expectedGeneration = tabLifecycleGenerations.get(tabId);
     return yield* withTabLifecycleLock(
       tabId,
-      registerWebviewUnlocked(tabId, webContentsId, expectedGeneration),
+      registerWebviewUnlocked(tabId, webContentsId, expectedGeneration, initialUrl),
     );
   });
 
@@ -3801,6 +3817,7 @@ export class PreviewManager extends Context.Service<
     readonly registerWebview: (
       tabId: string,
       webContentsId: number,
+      initialUrl?: string | null,
     ) => Effect.Effect<void, PreviewManagerError>;
     readonly navigate: (tabId: string, url: string) => Effect.Effect<void, PreviewManagerError>;
     readonly goBack: (tabId: string) => Effect.Effect<void, PreviewManagerError>;

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -1544,6 +1544,9 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     yield* Scope.addFinalizer(
       scope,
       attempt({ operation: "detachListeners", tabId, webContentsId: wc.id }, () => {
+        if (!wc.isDestroyed()) {
+          wc.setWindowOpenHandler(() => ({ action: "deny" }));
+        }
         cancelFaviconCapture();
         wc.off("did-start-navigation", navigationStarted);
         wc.off("did-navigate", syncNavigation);

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -197,6 +197,16 @@ const artifactSiteSlug = (rawUrl: string): string => {
   }
 };
 
+const isAllowedPreviewPopupUrl = (rawUrl: string): boolean => {
+  if (rawUrl === "about:blank") return true;
+  try {
+    const url = new URL(rawUrl);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
 interface CdpEvaluationResult {
   readonly result?: {
     readonly value?: unknown;
@@ -1524,6 +1534,13 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       }
       runFork(forwardShortcut(event, input));
     };
+    const didCreateWindow = (popupWindow: BrowserWindow): void => {
+      if (popupWindow.isDestroyed() || popupWindow.webContents.isDestroyed()) return;
+      popupWindow.setMenuBarVisibility(false);
+      // Popup WebContents are intentionally human-only. Preview automation has one
+      // registered target per tab, and authentication windows may contain credentials.
+      popupWindow.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+    };
     yield* Scope.addFinalizer(
       scope,
       attempt({ operation: "detachListeners", tabId, webContentsId: wc.id }, () => {
@@ -1536,6 +1553,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         wc.off("did-start-loading", sync);
         wc.off("did-stop-loading", sync);
         wc.off("did-fail-load", failed as never);
+        wc.off("did-create-window", didCreateWindow);
         wc.off("before-input-event", beforeInput);
         wc.ipc.off(HUMAN_INPUT_CHANNEL, humanInput);
       }).pipe(Effect.ignore),
@@ -1551,13 +1569,27 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         wc.on("did-stop-loading", sync);
         wc.on("did-fail-load", failed as never);
         wc.ipc.on(HUMAN_INPUT_CHANNEL, humanInput);
+        wc.on("did-create-window", didCreateWindow);
         wc.setWindowOpenHandler(({ url }) => {
-          runFork(
-            attemptPromise({ operation: "openPreviewWindow", tabId, webContentsId: wc.id }, () =>
-              wc.loadURL(url),
-            ).pipe(Effect.ignore),
-          );
-          return { action: "deny" };
+          if (!isAllowedPreviewPopupUrl(url)) return { action: "deny" };
+          const hostWebContents = wc.hostWebContents;
+          const parent = hostWebContents ? BrowserWindow.fromWebContents(hostWebContents) : null;
+          return {
+            action: "allow",
+            outlivesOpener: false,
+            overrideBrowserWindowOptions: {
+              ...(parent && !parent.isDestroyed() ? { parent } : {}),
+              autoHideMenuBar: true,
+              webPreferences: {
+                session: wc.session,
+                sandbox: true,
+                contextIsolation: true,
+                nodeIntegration: false,
+                nodeIntegrationInSubFrames: false,
+                webviewTag: false,
+              },
+            },
+          };
         });
         wc.on("before-input-event", beforeInput);
       });

--- a/apps/web/src/browser/HostedBrowserWebview.tsx
+++ b/apps/web/src/browser/HostedBrowserWebview.tsx
@@ -70,7 +70,6 @@ export function HostedBrowserWebview(props: {
   const tabLeaseRef = useRef<AcquiredDesktopTab | null>(null);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const webviewRef = useRef<ElectronWebview | null>(null);
-  const bootstrappedWebviewRef = useRef<ElectronWebview | null>(null);
   const crashRecoveryRef = useRef<WebviewCrashRecoveryState>(INITIAL_WEBVIEW_CRASH_RECOVERY_STATE);
   const [aspectRatioLocked, setAspectRatioLocked] = useState(false);
   const presentation = useBrowserSurfaceStore(
@@ -129,13 +128,11 @@ export function HostedBrowserWebview(props: {
           if (disposed || webviewRef.current !== webview) return;
           const webContentsId = webview.getWebContentsId();
           if (Number.isInteger(webContentsId) && webContentsId > 0) {
-            await bridge.registerWebview(runtimeTabId, webContentsId);
-            if (disposed || webviewRef.current !== webview) return;
-            // Navigation starts only after the main process installs the popup policy.
-            if (bootstrappedWebviewRef.current !== webview) {
-              bootstrappedWebviewRef.current = webview;
-              if (webview.src !== targetSrc) webview.src = targetSrc;
-            }
+            await bridge.registerWebview(
+              runtimeTabId,
+              webContentsId,
+              targetSrc === "about:blank" ? null : targetSrc,
+            );
           }
         } catch {
           // did-attach/dom-ready will retry if the guest was not ready yet.

--- a/apps/web/src/browser/HostedBrowserWebview.tsx
+++ b/apps/web/src/browser/HostedBrowserWebview.tsx
@@ -70,6 +70,7 @@ export function HostedBrowserWebview(props: {
   const tabLeaseRef = useRef<AcquiredDesktopTab | null>(null);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const webviewRef = useRef<ElectronWebview | null>(null);
+  const bootstrappedWebviewRef = useRef<ElectronWebview | null>(null);
   const crashRecoveryRef = useRef<WebviewCrashRecoveryState>(INITIAL_WEBVIEW_CRASH_RECOVERY_STATE);
   const [aspectRatioLocked, setAspectRatioLocked] = useState(false);
   const presentation = useBrowserSurfaceStore(
@@ -99,6 +100,7 @@ export function HostedBrowserWebview(props: {
 
   const [webviewGeneration, setWebviewGeneration] = useState(0);
   const [recoverySrc, setRecoverySrc] = useState(initialSrc);
+  const targetSrc = webviewGeneration === 0 ? initialSrc : recoverySrc;
   const latestUrlRef = useRef(initialUrl);
 
   useEffect(() => {
@@ -128,6 +130,12 @@ export function HostedBrowserWebview(props: {
           const webContentsId = webview.getWebContentsId();
           if (Number.isInteger(webContentsId) && webContentsId > 0) {
             await bridge.registerWebview(runtimeTabId, webContentsId);
+            if (disposed || webviewRef.current !== webview) return;
+            // Navigation starts only after the main process installs the popup policy.
+            if (bootstrappedWebviewRef.current !== webview) {
+              bootstrappedWebviewRef.current = webview;
+              if (webview.src !== targetSrc) webview.src = targetSrc;
+            }
           }
         } catch {
           // did-attach/dom-ready will retry if the guest was not ready yet.
@@ -158,7 +166,7 @@ export function HostedBrowserWebview(props: {
       webview.removeEventListener("dom-ready", register);
       webview.removeEventListener("render-process-gone", recoverGuest);
     };
-  }, [config, initialSrc, runtimeTabId, webviewGeneration]);
+  }, [config, initialSrc, runtimeTabId, targetSrc, webviewGeneration]);
 
   const active = presentation.visible && presentation.rect !== null;
   const lastRect = presentation.rect;
@@ -273,7 +281,7 @@ export function HostedBrowserWebview(props: {
         <PreviewWebview
           key={webviewGeneration}
           ref={setWebviewRef}
-          src={webviewGeneration === 0 ? initialSrc : recoverySrc}
+          src="about:blank"
           partition={config.partition}
           webpreferences={config.webPreferences}
           allowpopups="true"

--- a/apps/web/src/browser/HostedBrowserWebview.tsx
+++ b/apps/web/src/browser/HostedBrowserWebview.tsx
@@ -2,7 +2,14 @@
 
 import type { PreviewViewportSetting, ScopedThreadRef } from "@t3tools/contracts";
 import { useShallow } from "zustand/react/shallow";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  type ComponentProps,
+  type ComponentType,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
 import { previewBridge } from "~/components/preview/previewBridge";
 import { usePreviewBridge } from "~/components/preview/usePreviewBridge";
@@ -34,6 +41,14 @@ interface ElectronWebview extends HTMLElement {
   getWebContentsId: () => number;
   executeJavaScript: (code: string, userGesture?: boolean) => Promise<unknown>;
 }
+
+type PreviewWebviewProps = Omit<ComponentProps<"webview">, "allowpopups"> & {
+  readonly allowpopups: "true";
+};
+
+// React's Electron typing says this is boolean, but React omits unknown boolean
+// attributes. Electron needs the string attribute present before guest attach.
+const PreviewWebview = "webview" as unknown as ComponentType<PreviewWebviewProps>;
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -92,7 +107,6 @@ export function HostedBrowserWebview(props: {
 
   const setWebviewRef = useCallback((node: HTMLElement | null) => {
     webviewRef.current = node as ElectronWebview | null;
-    if (node && !node.hasAttribute("allowpopups")) node.setAttribute("allowpopups", "true");
   }, []);
 
   useEffect(() => {
@@ -256,12 +270,13 @@ export function HostedBrowserWebview(props: {
             onChange={commitViewportChange}
           />
         ) : null}
-        <webview
+        <PreviewWebview
           key={webviewGeneration}
           ref={setWebviewRef}
           src={webviewGeneration === 0 ? initialSrc : recoverySrc}
           partition={config.partition}
           webpreferences={config.webPreferences}
+          allowpopups="true"
           {...(config.preloadUrl ? { preload: config.preloadUrl } : {})}
           data-preview-tab={runtimeTabId}
           data-preview-server-tab={tabId}

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -958,6 +958,7 @@ export const DesktopPreviewTabInputSchema = Schema.Struct({
 export const DesktopPreviewRegisterWebviewInputSchema = Schema.Struct({
   tabId: DesktopPreviewTabIdSchema,
   webContentsId: Schema.Int.check(Schema.isGreaterThan(0)),
+  initialUrl: Schema.NullOr(Schema.String),
 });
 
 export const DesktopPreviewNavigateInputSchema = Schema.Struct({
@@ -1091,7 +1092,11 @@ export interface DesktopBridge {
 export interface DesktopPreviewBridge {
   createTab: (tabId: string) => Promise<void>;
   closeTab: (tabId: string) => Promise<void>;
-  registerWebview: (tabId: string, webContentsId: number) => Promise<void>;
+  registerWebview: (
+    tabId: string,
+    webContentsId: number,
+    initialUrl: string | null,
+  ) => Promise<void>;
   navigate: (tabId: string, url: string) => Promise<void>;
   goBack: (tabId: string) => Promise<void>;
   goForward: (tabId: string) => Promise<void>;


### PR DESCRIPTION
Fixes #6561.

OAuth helpers such as Firebase depend on `window.open()` returning a child window and preserving its opener. Browser previews were denying that request and navigating the preview itself, so popup sign-in failed as blocked.

Preview webviews now opt into popups before Electron attaches them. The desktop host allows only HTTP(S) and exact `about:blank` children, reuses the preview session for cookies, hardens the child renderer, ties it to the opener, and denies nested popups. Child windows stay human-only and are never registered with preview automation.

### Evidence

![OAuth popup handshake completes without navigating or exposing the child window](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/daf35ccb-a3cc-44c8-8591-1ea7eb132033/t3code-issue-6561-oauth-popup.gif)

A Playwright-driven Electron run confirmed the opener URL stayed unchanged, `window.open()` returned a child handle, the child sent its completion message, and the opener observed the child close. The recording is deliberately limited to the opener UI.

### Verification

- `vp run --filter @t3tools/desktop typecheck`
- `vp run --filter @t3tools/web typecheck`
- `vp lint apps/desktop/src/preview/Manager.ts apps/desktop/src/preview/Manager.test.ts apps/web/src/browser/HostedBrowserWebview.tsx`
- `vp pack --no-dts` in `apps/desktop`
- Playwright-driven Electron integration against an isolated local fixture

Focused unit coverage is included. The local direct Vitest invocation is currently blocked before collection by the existing Vite+ test bootstrap error (`Cannot read properties of undefined (reading config)`).

Made with GPT-5.6 Sol in T3 Code using the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Electron window-open policy and how preview URLs load (renderer vs main process), which affects auth popups and session sharing; mitigations include URL allowlisting, sandboxed children, and no automation on popups.
> 
> **Overview**
> Fixes OAuth flows that rely on `window.open()` by **allowing real popup windows** in desktop browser previews instead of denying them and navigating the preview webview.
> 
> **Preview webviews** now mount as `about:blank` with `allowpopups="true"` at attach time; the intended URL is sent as nullable `initialUrl` on `registerWebview` and loaded from the main process after registration (queued navigation still wins over a stale bootstrap URL).
> 
> **`PreviewManager`** replaces the old deny-and-`loadURL` opener behavior with a `setWindowOpenHandler` that allows only `http`/`https` and exact `about:blank`, parents popups to the host window, reuses the preview session, uses hardened child `webPreferences`, hides the menu bar on created windows, and denies nested popups and unsafe schemes. Popup webContents are not registered for automation; handlers revert to deny-all on detach.
> 
> Contracts, preload, IPC, renderer bridge, and unit tests are updated for `initialUrl` and the new popup policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 318020b2b01403db0230d74460dfb28b9a5da7bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support OAuth popups in desktop browser previews by allowing safe popup windows
> - Adds `allowpopups` to the webview element and configures `setWindowOpenHandler` in `PreviewManager` to allow popups for `http`, `https`, and `about:blank` URLs with sandboxed, menu-bar-hidden `BrowserWindow` options; unsafe URLs and nested popup opens are denied.
> - Shifts initial navigation responsibility to the main process: the webview DOM `src` is set to `about:blank` and `registerWebview` now accepts an `initialUrl` that drives the first `loadURL` call.
> - Updates the IPC schema, preload bridge, and `DesktopPreviewBridge` interface to include the new `initialUrl` parameter.
> - Behavioral Change: popup windows are no longer blocked and redirected into the opener; they now open as separate native windows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 318020b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->