### PR TITLE
fix(web): keep settled shelf collapsed when closed

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2092,14 +2092,9 @@ export default function Sidebar() {
     [setSettledShelfExpanded],
   );
   const renderedSettledThreads = useMemo(() => {
-    if (settledShelfExpanded) return visibleSettledThreads;
-    if (routeThreadKey === null) return [];
-    const routeThread = visibleSettledThreads.find(
-      (thread) =>
-        scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)) === routeThreadKey,
-    );
-    return routeThread === undefined ? [] : [routeThread];
-  }, [routeThreadKey, settledShelfExpanded, visibleSettledThreads]);
+    if (!settledShelfExpanded) return [];
+    return visibleSettledThreads;
+  }, [settledShelfExpanded, visibleSettledThreads]);
 
   // The snoozed shelf is collapsed by default: out of the way, never gone.
   // Collapsed threads don't render (and so don't participate in jump


### PR DESCRIPTION
When the Settled shelf is collapsed (`settledShelfExpanded === false`), `renderedSettledThreads` previously retained an exception to keep rendering the active `routeThread`. This caused the shelf to appear open with the current thread still showing below the collapsed header.

Render an empty array when the shelf is collapsed so it remains cleanly closed until explicitly expanded.

*Crafted with Antigravity.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single UI conditional in the sidebar with no API or data changes; only affects how settled threads render when the shelf is collapsed.
> 
> **Overview**
> **Fixes settled shelf collapse** so a collapsed Settled section no longer shows thread rows under the header.
> 
> `renderedSettledThreads` used to keep rendering the **active route thread** when `settledShelfExpanded` was false, which made the shelf look half-open. It now returns **no rows** while collapsed and only shows `visibleSettledThreads` when expanded.
> 
> Paging behavior is unchanged: `visibleSettledThreads` still pulls the routed settled thread into the visible tail when it would otherwise sit behind **Show more**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 470d5ed7c337350542a07a5d29e2635a8c4ec7bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep settled shelf collapsed when navigating to a settled thread
> Previously, the currently routed settled thread would still render in the sidebar even when the settled shelf was collapsed. The `renderedSettledThreads` memo in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/6630/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) now returns an empty array when `settledShelfExpanded` is false, removing the special-case logic that surfaced the active thread.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 470d5ed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->