### PR TITLE
fix(search): oversized thread queries no longer crash clients

### DIFF
--- a/packages/client-runtime/src/state/threadSearch.test.ts
+++ b/packages/client-runtime/src/state/threadSearch.test.ts
@@ -49,6 +49,51 @@ it("encodes scoped thread keys without delimiter collisions", () => {
   expect(first).not.toBe(second);
 });
 
+it("accepts search keys at the maximum decoded query length", () => {
+  const queries: string[] = [];
+  const searchAtom = createThreadSearchResultsAtomFamily<Error>({
+    getSearchAtom: (_environmentId, query) => {
+      queries.push(query);
+      return Atom.make(AsyncResult.success({ matches: [] }));
+    },
+    labelPrefix: "test:thread-search",
+  });
+  const registry = AtomRegistry.make();
+  const query = "a".repeat(200);
+
+  try {
+    registry.get(searchAtom(makeThreadSearchKey([envA], query)));
+    registry.get(searchAtom(makeThreadSearchKey([envA], ` ${query} `)));
+
+    expect(queries).toEqual([query, query]);
+  } finally {
+    registry.dispose();
+  }
+});
+
+it("ignores invalid search keys", () => {
+  let searchCount = 0;
+  const searchAtom = createThreadSearchResultsAtomFamily<Error>({
+    getSearchAtom: () => {
+      searchCount += 1;
+      return Atom.make(AsyncResult.success({ matches: [] }));
+    },
+    labelPrefix: "test:thread-search",
+  });
+  const registry = AtomRegistry.make();
+
+  try {
+    const state = registry.get(searchAtom(makeThreadSearchKey([envA], "a".repeat(201))));
+    const malformedState = registry.get(searchAtom("not json{{"));
+
+    expect(state).toEqual({ matches: [], isLoading: false });
+    expect(malformedState).toEqual({ matches: [], isLoading: false });
+    expect(searchCount).toBe(0);
+  } finally {
+    registry.dispose();
+  }
+});
+
 it("merges successful environments and silently ignores failures", () => {
   const result: OrchestrationSearchThreadsResult = {
     matches: [

--- a/packages/client-runtime/src/state/threadSearch.ts
+++ b/packages/client-runtime/src/state/threadSearch.ts
@@ -17,11 +17,10 @@ export interface ThreadSearchResultsState {
   readonly isLoading: boolean;
 }
 
-const ThreadSearchKey = Schema.Tuple([
-  Schema.Array(EnvironmentId),
-  OrchestrationSearchThreadsInput.fields.query,
-]);
-const decodeThreadSearchKey = Schema.decodeUnknownSync(ThreadSearchKey);
+const ThreadSearchKey = Schema.fromJsonString(
+  Schema.Tuple([Schema.Array(EnvironmentId), OrchestrationSearchThreadsInput.fields.query]),
+);
+const decodeThreadSearchKey = Schema.decodeUnknownOption(ThreadSearchKey);
 
 export function makeThreadSearchKey(
   environmentIds: ReadonlyArray<EnvironmentId>,
@@ -34,7 +33,7 @@ export function makeThreadSearchKey(
 }
 
 function parseThreadSearchKey(key: string) {
-  return decodeThreadSearchKey(JSON.parse(key));
+  return decodeThreadSearchKey(key);
 }
 
 export function threadSearchMatchKey(
@@ -44,9 +43,9 @@ export function threadSearchMatchKey(
 }
 
 /**
- * Combines one search query atom per environment. Failed and disconnected
- * environments contribute no content matches, preserving local title search
- * as the compatibility fallback.
+ * Combines one search query atom per environment. Invalid search keys, failed
+ * requests, and disconnected environments contribute no content matches,
+ * preserving local title search as the compatibility fallback.
  */
 export function createThreadSearchResultsAtomFamily<E>(options: {
   readonly getSearchAtom: (
@@ -57,7 +56,12 @@ export function createThreadSearchResultsAtomFamily<E>(options: {
 }) {
   return Atom.family((key: string) =>
     Atom.make((get): ThreadSearchResultsState => {
-      const [environmentIds, query] = parseThreadSearchKey(key);
+      const parsedKey = parseThreadSearchKey(key);
+      if (Option.isNone(parsedKey)) {
+        return { matches: [], isLoading: false };
+      }
+
+      const [environmentIds, query] = parsedKey.value;
       const matches: EnvironmentThreadSearchMatch[] = [];
       let isLoading = false;
 


### PR DESCRIPTION
## What Changed

Thread content search could throw in web and mobile when a query exceeded the 200-character contract limit because the shared atom decoded its cache key synchronously.

Search keys are now decoded safely from JSON at the shared client-runtime boundary. Out-of-contract or malformed keys return an empty content-search state without issuing environment requests, while valid queries and local title matching continue unchanged. Boundary tests cover maximum-length normalization, oversized queries, and malformed JSON.

## Why

A long query typed into the command palette or mobile thread search could abort client rendering. Treating out-of-contract content searches as empty keeps both clients usable and preserves the server's existing bounded-query contract.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (not applicable; no UI changes)
- [x] I included a video for animation/interaction changes (not applicable; no animation or interaction changes)

Created with **gpt-5.6-sol** using the Codex harness in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix oversized or malformed thread search keys to return empty state instead of crashing
> - `ThreadSearchKey` schema in [threadSearch.ts](https://github.com/pingdotgg/t3code/pull/6633/files#diff-4057f08c1bb8dbe59eef65c3a080d3b9440ae057fb668391059aac96aeb65657) now decodes via `Schema.decodeUnknownOption`, returning `None` on invalid input instead of throwing.
> - `createThreadSearchResultsAtomFamily` returns `{ matches: [], isLoading: false }` immediately when the key parses to `None`, skipping any search invocation.
> - Tests added in [threadSearch.test.ts](https://github.com/pingdotgg/t3code/pull/6633/files#diff-2a44f6fcdbcd267df26e8c74865c92593f5e14560cb4258c345e27daebab5e5d) covering boundary-length valid keys and over-length/malformed keys.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 12faef0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized defensive change in shared search state with tests; no auth, data, or API contract changes beyond avoiding client crashes.
> 
> **Overview**
> Thread content search in **client-runtime** no longer throws when a cache key is out of contract or malformed.
> 
> **`threadSearch.ts`** decodes search keys with `Schema.fromJsonString` and `decodeUnknownOption` instead of `JSON.parse` plus synchronous decode. Keys that fail validation (e.g. query over the **200**-character limit) or invalid JSON yield `{ matches: [], isLoading: false }` and **do not** call per-environment search atoms.
> 
> **`threadSearch.test.ts`** adds coverage for max-length valid keys (including trimmed whitespace) and for over-length and malformed keys asserting zero search invocations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12faef07a5fce902f5459add7ea0e72ad734f43e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->