### PR TITLE
feat(web): accept file drops across the chat workspace

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -141,6 +141,7 @@ import { closePreviewSession } from "./preview/closePreviewSession";
 import { ThreadPreviewMiniPlayer } from "./preview/ThreadPreviewMiniPlayer";
 import { subscribePreviewAction } from "./preview/previewActionBus";
 import { getConfiguredPreviewUrls } from "./preview/previewEmptyStateLogic";
+import { makeWorkspaceFileDropHandlers } from "./chat/workspaceFileDrop";
 import {
   selectThreadPreviewMiniPlayer,
   usePreviewMiniPlayerStore,
@@ -164,6 +165,7 @@ import {
   CheckCircle2Icon,
   ChevronDownIcon,
   GitBranchIcon,
+  PaperclipIcon,
   WifiOffIcon,
 } from "lucide-react";
 import { cn, randomHex } from "~/lib/utils";
@@ -1336,6 +1338,7 @@ function ChatViewContent(props: ChatViewProps) {
   const composerElementContextsRef = useRef<ElementContextDraft[]>([]);
   const localComposerRef = useRef<ChatComposerHandle | null>(null);
   const composerRef = useComposerHandleContext() ?? localComposerRef;
+  const [isWorkspaceFileDragActive, setIsWorkspaceFileDragActive] = useState(false);
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
   const [expandedImage, setExpandedImage] = useState<ExpandedImagePreview | null>(null);
   const [optimisticUserMessages, setOptimisticUserMessages] = useState<ChatMessage[]>([]);
@@ -1356,6 +1359,17 @@ function ChatViewContent(props: ChatViewProps) {
   const [respondingUserInputRequestIds, setRespondingUserInputRequestIds] = useState<
     ApprovalRequestId[]
   >([]);
+
+  useEffect(() => {
+    setIsWorkspaceFileDragActive(false);
+  }, [draftId, routeThreadKey]);
+
+  useEffect(() => {
+    if (!isWorkspaceFileDragActive) return;
+    const clearWorkspaceFileDrag = () => setIsWorkspaceFileDragActive(false);
+    window.addEventListener("dragend", clearWorkspaceFileDrag);
+    return () => window.removeEventListener("dragend", clearWorkspaceFileDrag);
+  }, [isWorkspaceFileDragActive]);
   const [pendingUserInputAnswersByRequestId, setPendingUserInputAnswersByRequestId] = useState<
     Record<string, Record<string, PendingUserInputDraftAnswer>>
   >({});
@@ -6148,6 +6162,11 @@ function ChatViewContent(props: ChatViewProps) {
     ) : null
   ) : null;
 
+  const workspaceFileDropHandlers = makeWorkspaceFileDropHandlers({
+    setDragActive: setIsWorkspaceFileDragActive,
+    addFiles: (files) => composerRef.current?.addDroppedFiles(files),
+  });
+
   return (
     <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden bg-background">
       {rightPanelOpen && !shouldUseRightPanelSheet ? panelLayoutControls : null}
@@ -6216,7 +6235,28 @@ function ChatViewContent(props: ChatViewProps) {
         {/* Main content area with optional plan sidebar */}
         <div className="flex min-h-0 min-w-0 flex-1">
           {/* Chat column */}
-          <div className="relative flex min-h-0 min-w-0 flex-1 flex-col">
+          <div
+            className="relative flex min-h-0 min-w-0 flex-1 flex-col"
+            data-chat-workspace-drop-target="true"
+            onDragEnter={workspaceFileDropHandlers.onDragEnter}
+            onDragOver={workspaceFileDropHandlers.onDragOver}
+            onDragLeave={workspaceFileDropHandlers.onDragLeave}
+            onDrop={workspaceFileDropHandlers.onDrop}
+          >
+            {isWorkspaceFileDragActive ? (
+              <div
+                className="pointer-events-none absolute inset-2 z-40 flex items-center justify-center rounded-2xl border-2 border-dashed border-primary/60 bg-primary/[0.035]"
+                data-chat-workspace-drop-overlay="true"
+              >
+                <div
+                  role="status"
+                  className="flex items-center gap-2 rounded-full border border-primary/25 bg-background/95 px-4 py-2.5 text-sm font-medium text-foreground shadow-lg"
+                >
+                  <PaperclipIcon className="size-4 text-primary" aria-hidden="true" />
+                  Drop files to attach
+                </div>
+              </div>
+            ) : null}
             {/* Provider status overlays the timeline without changing its content height. */}
             <div className="pointer-events-none absolute inset-x-0 top-0 z-20">
               <ProviderStatusBanner

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -450,6 +450,7 @@ const ComposerFooterPrimaryActions = memo(function ComposerFooterPrimaryActions(
 export interface ChatComposerHandle {
   focusAtEnd: () => void;
   focusAt: (cursor: number) => void;
+  addDroppedFiles: (files: File[]) => void;
   insertTextAtEnd: (text: string, options?: { ensureLeadingBoundary?: boolean }) => boolean;
   openModelPicker: () => void;
   toggleModelPicker: () => void;
@@ -971,7 +972,6 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const mobileComposerExpandFrameRef = useRef<number | null>(null);
   const mobileComposerExpandReleaseFrameRef = useRef<number | null>(null);
   const mobileComposerExpandInFlightRef = useRef(false);
-  const dragDepthRef = useRef(0);
   const stashPulseKeyRef = useRef(0);
   const stashPulseTimeoutRef = useRef<number | null>(null);
   /**
@@ -1399,7 +1399,6 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     setComposerHighlightedItemId(null);
     setComposerCursor(collapseExpandedComposerCursor(promptRef.current, promptRef.current.length));
     setComposerTrigger(detectComposerTrigger(promptRef.current, promptRef.current.length));
-    dragDepthRef.current = 0;
     setIsDragOverComposer(false);
   }, [draftId, activeThreadId, promptRef]);
 
@@ -2380,41 +2379,6 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     void addComposerImages(imageFiles);
   };
 
-  const onComposerDragEnter = (event: React.DragEvent<HTMLDivElement>) => {
-    if (!event.dataTransfer.types.includes("Files")) return;
-    event.preventDefault();
-    dragDepthRef.current += 1;
-    setIsDragOverComposer(true);
-  };
-
-  const onComposerDragOver = (event: React.DragEvent<HTMLDivElement>) => {
-    if (!event.dataTransfer.types.includes("Files")) return;
-    event.preventDefault();
-    event.dataTransfer.dropEffect = "copy";
-    setIsDragOverComposer(true);
-  };
-
-  const onComposerDragLeave = (event: React.DragEvent<HTMLDivElement>) => {
-    if (!event.dataTransfer.types.includes("Files")) return;
-    event.preventDefault();
-    const nextTarget = event.relatedTarget;
-    if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) return;
-    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
-    if (dragDepthRef.current === 0) {
-      setIsDragOverComposer(false);
-    }
-  };
-
-  const onComposerDrop = (event: React.DragEvent<HTMLDivElement>) => {
-    if (!event.dataTransfer.types.includes("Files")) return;
-    event.preventDefault();
-    dragDepthRef.current = 0;
-    setIsDragOverComposer(false);
-    const files = Array.from(event.dataTransfer.files);
-    void addComposerImages(files);
-    focusComposer();
-  };
-
   const insertComposerTextAtEnd = (
     text: string,
     options?: { ensureLeadingBoundary?: boolean },
@@ -2468,7 +2432,6 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   useEffect(() => {
     if (!isDragOverComposer) return;
     const onWindowDragEnd = () => {
-      dragDepthRef.current = 0;
       setIsDragOverComposer(false);
     };
     window.addEventListener("dragend", onWindowDragEnd);
@@ -2536,6 +2499,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       },
       focusAt: (cursor: number) => {
         composerEditorRef.current?.focusAt(cursor);
+      },
+      addDroppedFiles: (files: File[]) => {
+        void addComposerImages(files);
+        focusComposer();
       },
       insertTextAtEnd: insertComposerTextAtEnd,
       openModelPicker: () => {
@@ -2619,6 +2586,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     }),
     [
       activeThread,
+      addComposerImages,
       composerDraftTarget,
       composerCursor,
       composerTerminalContexts,
@@ -2629,6 +2597,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       composerElementContextsRef,
       composerPreviewAnnotations,
       composerReviewComments,
+      focusComposer,
       isConnecting,
       isComposerApprovalState,
       pendingUserInputs.length,
@@ -2660,10 +2629,6 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
           "group rounded-[22px] p-px transition-colors duration-200",
           composerProviderState.composerFrameClassName,
         )}
-        onDragEnter={onComposerDragEnter}
-        onDragOver={onComposerDragOver}
-        onDragLeave={onComposerDragLeave}
-        onDrop={onComposerDrop}
         onDragEnterCapture={composerMentionDragHandlers.onDragEnter}
         onDragOverCapture={composerMentionDragHandlers.onDragOver}
         onDragLeaveCapture={onComposerMentionDragLeaveCapture}

--- a/apps/web/src/components/chat/workspaceFileDrop.test.ts
+++ b/apps/web/src/components/chat/workspaceFileDrop.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "@effect/vitest";
+import {
+  makeWorkspaceFileDropHandlers,
+  type WorkspaceFileDragEvent,
+  type WorkspaceFileDropHost,
+} from "./workspaceFileDrop";
+
+function makeDragEvent(options?: {
+  types?: string[];
+  files?: File[];
+  movedWithinTarget?: boolean;
+}) {
+  const preventDefault = vi.fn();
+  const event = {
+    dataTransfer: {
+      types: options?.types ?? ["Files"],
+      files: options?.files ?? [],
+      dropEffect: "none",
+    },
+    relatedTarget: options?.movedWithinTarget ? ({} as EventTarget) : null,
+    currentTarget: {
+      contains: () => options?.movedWithinTarget ?? false,
+    },
+    preventDefault,
+  } satisfies WorkspaceFileDragEvent;
+  return { event, preventDefault };
+}
+
+function makeHost() {
+  const setDragActive = vi.fn();
+  const addFiles = vi.fn();
+  const host = { setDragActive, addFiles } satisfies WorkspaceFileDropHost;
+  return { host, setDragActive, addFiles };
+}
+
+describe("makeWorkspaceFileDropHandlers", () => {
+  it("activates the target for an external file drag", () => {
+    const { host, setDragActive } = makeHost();
+    const { event, preventDefault } = makeDragEvent();
+
+    makeWorkspaceFileDropHandlers(host).onDragEnter(event);
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(setDragActive).toHaveBeenCalledWith(true);
+  });
+
+  it("ignores non-file drags", () => {
+    const { host, setDragActive } = makeHost();
+    const { event, preventDefault } = makeDragEvent({ types: ["text/plain"] });
+
+    makeWorkspaceFileDropHandlers(host).onDragOver(event);
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(setDragActive).not.toHaveBeenCalled();
+  });
+
+  it("does not flicker when the drag moves between children", () => {
+    const { host, setDragActive } = makeHost();
+    const { event } = makeDragEvent({ movedWithinTarget: true });
+
+    const handlers = makeWorkspaceFileDropHandlers(host);
+    handlers.onDragEnter(event);
+    handlers.onDragLeave(event);
+
+    expect(setDragActive).not.toHaveBeenCalled();
+  });
+
+  it("forwards dropped files and clears the active state", () => {
+    const file = new File(["contents"], "example.txt", { type: "text/plain" });
+    const { host, setDragActive, addFiles } = makeHost();
+    const { event } = makeDragEvent({ files: [file] });
+
+    makeWorkspaceFileDropHandlers(host).onDrop(event);
+
+    expect(setDragActive).toHaveBeenCalledWith(false);
+    expect(addFiles).toHaveBeenCalledWith([file]);
+  });
+});

--- a/apps/web/src/components/chat/workspaceFileDrop.ts
+++ b/apps/web/src/components/chat/workspaceFileDrop.ts
@@ -1,0 +1,54 @@
+export interface WorkspaceFileDragEvent {
+  readonly dataTransfer: {
+    readonly types: ReadonlyArray<string>;
+    readonly files: Iterable<File>;
+    dropEffect: string;
+  };
+  readonly relatedTarget: EventTarget | null;
+  readonly currentTarget: {
+    contains(target: Node | null): boolean;
+  };
+  preventDefault(): void;
+}
+
+export interface WorkspaceFileDropHost {
+  setDragActive(active: boolean): void;
+  addFiles(files: File[]): void;
+}
+
+function isFileDrag(event: WorkspaceFileDragEvent): boolean {
+  return event.dataTransfer.types.includes("Files");
+}
+
+function movedWithinDropTarget(event: WorkspaceFileDragEvent): boolean {
+  return event.relatedTarget !== null && event.currentTarget.contains(event.relatedTarget as Node);
+}
+
+export function makeWorkspaceFileDropHandlers(host: WorkspaceFileDropHost) {
+  return {
+    onDragEnter(event: WorkspaceFileDragEvent) {
+      if (!isFileDrag(event)) return;
+      event.preventDefault();
+      if (movedWithinDropTarget(event)) return;
+      host.setDragActive(true);
+    },
+    onDragOver(event: WorkspaceFileDragEvent) {
+      if (!isFileDrag(event)) return;
+      event.preventDefault();
+      event.dataTransfer.dropEffect = "copy";
+      host.setDragActive(true);
+    },
+    onDragLeave(event: WorkspaceFileDragEvent) {
+      if (!isFileDrag(event)) return;
+      event.preventDefault();
+      if (movedWithinDropTarget(event)) return;
+      host.setDragActive(false);
+    },
+    onDrop(event: WorkspaceFileDragEvent) {
+      if (!isFileDrag(event)) return;
+      event.preventDefault();
+      host.setDragActive(false);
+      host.addFiles(Array.from(event.dataTransfer.files));
+    },
+  };
+}


### PR DESCRIPTION
## Problem

Files only attach when they are dropped directly on the composer, so valid drops elsewhere in the active conversation area are easy to miss.

## Solution

Make the chat column one continuous file-drop target and show a clear “Drop files to attach” overlay while a file drag is active. Drops are forwarded to the existing composer attachment path, so its supported types, limits, validation errors, and focus behavior remain authoritative.

The target deliberately excludes the window chrome, left sidebar, and separate right panel so their existing drag behavior is unchanged. Text, link, and other non-file drags are ignored. Cancelled drags and thread changes clear the overlay.

This expands the drop target only; it does not add new attachment formats or overlap the separate non-image attachment work in #3927.

Fixes #6474

<img width="824" height="759" alt="Screenshot 2026-08-14 at 1 11 20 PM" src="https://github.com/user-attachments/assets/29b3f312-9038-40b4-9404-3ccdf3e29fa8" />
