### PR TITLE
fix(web): hide the server update banner when this app is older

### DIFF
--- a/apps/web/src/versionSkew.test.ts
+++ b/apps/web/src/versionSkew.test.ts
@@ -7,6 +7,7 @@ import {
   buildVersionMismatchDismissalKey,
   dismissVersionMismatch,
   isVersionMismatchDismissed,
+  isClientBehindServer,
   resolveServerConfigVersionMismatch,
   resolveServerSelfUpdateCapability,
   resolveVersionMismatch,
@@ -26,7 +27,10 @@ describe("versionSkew", () => {
     });
   });
 
-  it("reads the server version from config descriptors", () => {
+  it("does not offer a server update when this client is older than the server", () => {
+    expect(
+      isClientBehindServer("0.0.34-nightly.20260814.1090", "0.0.34-nightly.20260814.1092"),
+    ).toBe(true);
     expect(
       resolveServerConfigVersionMismatch({
         environment: {
@@ -42,8 +46,27 @@ describe("versionSkew", () => {
           },
         },
       }),
+    ).toBeNull();
+  });
+
+  it("reads an older server version from config descriptors", () => {
+    expect(
+      resolveServerConfigVersionMismatch({
+        environment: {
+          environmentId: EnvironmentId.make("environment-1"),
+          label: "Remote",
+          platform: {
+            os: "darwin",
+            arch: "arm64",
+          },
+          serverVersion: "0.0.0-old",
+          capabilities: {
+            repositoryIdentity: true,
+          },
+        },
+      }),
     ).toMatchObject({
-      serverVersion: "9.9.9",
+      serverVersion: "0.0.0-old",
     });
   });
 

--- a/apps/web/src/versionSkew.ts
+++ b/apps/web/src/versionSkew.ts
@@ -1,4 +1,5 @@
 import type { EnvironmentId, ServerConfig, ServerSelfUpdateCapability } from "@t3tools/contracts";
+import { compareSemverVersions } from "@t3tools/shared/semver";
 import * as Schema from "effect/Schema";
 
 import { APP_VERSION } from "./branding";
@@ -43,10 +44,20 @@ export function resolveVersionMismatch(
   };
 }
 
+export function isClientBehindServer(clientVersion: string, serverVersion: string): boolean {
+  return compareSemverVersions(clientVersion, serverVersion) < 0;
+}
+
 export function resolveServerConfigVersionMismatch(
   serverConfig: Pick<ServerConfig, "environment"> | null | undefined,
 ): VersionMismatch | null {
-  return resolveVersionMismatch(serverConfig?.environment.serverVersion);
+  const mismatch = resolveVersionMismatch(serverConfig?.environment.serverVersion);
+  // The desktop app already surfaces its own update in the sidebar. A newer
+  // server should not look like a server update, or offer a downgrade.
+  if (!mismatch || isClientBehindServer(mismatch.clientVersion, mismatch.serverVersion)) {
+    return null;
+  }
+  return mismatch;
 }
 
 /** The update path the connected server offers, or null when it only

--- a/docs/user/updating.md
+++ b/docs/user/updating.md
@@ -1,7 +1,9 @@
 # Keeping T3 Code in Sync
 
 The T3 Code web or desktop app and the server it connects to work best when they use the same
-version. If they do not match, T3 Code shows a warning with the right update option for that server.
+version. If the server is older, T3 Code shows a warning with the right update option for that
+server. If this app is older, the desktop update indicator in the sidebar is the place to update;
+T3 Code does not offer to move the server backward.
 
 ## Where to Find the Update
 


### PR DESCRIPTION
## What Changed

If this app is older than the connected server, T3 Code no longer shows the version-skew **Server update available** banner. The desktop sidebar already has the app update indicator. The previous banner offered a command that would downgrade the newer server.

If the server is older, the existing **Server update available** flow is unchanged.

## Why

Connecting a slightly older desktop app to an already-updated remote server showed **Server update available** and a downgrade command. The server was fine; the client update belongs in the sidebar updater.

Replaces #6605, which grew a different (and then reverted) approach.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Made with Grok 4.6 in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted UX fix in version-skew resolution with tests; no auth, data, or server API changes.
> 
> **Overview**
> **Version skew handling** now treats “client behind server” differently from “server behind client.” When the connected server is **newer** than this app, `resolveServerConfigVersionMismatch` returns no mismatch, so the **Server update available** banner and related connection warnings do not appear in chat or **Settings → Connections**.
> 
> A new **`isClientBehindServer`** helper compares versions with `compareSemverVersions`. The **server-older-than-client** path is unchanged: users still get the existing server-update guidance and actions.
> 
> User docs in **`updating.md`** describe that an older app should use the desktop sidebar updater and that T3 Code will not suggest downgrading the server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1ba51846cf7e64c93f8a713bd2af3b1aa6ae3bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide server update banner when the client app is older than the server
> - Adds `isClientBehindServer` in [versionSkew.ts](https://github.com/pingdotgg/t3code/pull/6637/files#diff-783a2e421405ef3af3e1f17f70b8b5d18abf1081be90640034de054f22e85caa) to detect when the client version is behind the server using semantic version comparison.
> - `resolveServerConfigVersionMismatch` now returns `null` when the client is older than the server, suppressing any prompt to downgrade the server.
> - Updates [updating.md](https://github.com/pingdotgg/t3code/pull/6637/files#diff-346e6eee50c69757c87a85fb4c1982569f3a2ad9c76d019f9d3f5d8fb61e427a) to clarify that the warning only appears when the server is older, and that users should update via the desktop sidebar when the app is behind.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a1ba518.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->