### PR TITLE
feat(web): create new experiment projects from the add-project flow

### DIFF
--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -81,6 +81,7 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.projectsSearchContents]: AuthOrchestrationReadScope,
   [WS_METHODS.projectsSearchEntries]: AuthOrchestrationReadScope,
   [WS_METHODS.projectsWriteFile]: AuthOrchestrationOperateScope,
+  [WS_METHODS.projectsScaffold]: AuthOrchestrationOperateScope,
   [WS_METHODS.shellOpenInEditor]: AuthOrchestrationOperateScope,
   [WS_METHODS.filesystemBrowse]: AuthOrchestrationReadScope,
   [WS_METHODS.assetsCreateUrl]: AuthOrchestrationReadScope,

--- a/apps/server/src/project/ProjectScaffoldService.test.ts
+++ b/apps/server/src/project/ProjectScaffoldService.test.ts
@@ -1,0 +1,124 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import { GitCommandError } from "@t3tools/contracts";
+
+import * as ServerConfig from "../config.ts";
+import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
+import * as VcsProcess from "../vcs/VcsProcess.ts";
+import * as ProjectScaffoldService from "./ProjectScaffoldService.ts";
+
+const RealGitLayer = ProjectScaffoldService.layer.pipe(
+  Layer.provideMerge(GitVcsDriver.layer),
+  Layer.provide(ServerConfig.layerTest(process.cwd(), { prefix: "t3-project-scaffold-" })),
+  Layer.provideMerge(VcsProcess.layer),
+  Layer.provideMerge(NodeServices.layer),
+);
+
+const runGit = (cwd: string, args: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const driver = yield* GitVcsDriver.GitVcsDriver;
+    return yield* driver.execute({
+      operation: "ProjectScaffoldService.test.git",
+      cwd,
+      args,
+      timeoutMs: 10_000,
+    });
+  });
+
+it.effect("scaffolds a committed repo on main with README and favicon", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const service = yield* ProjectScaffoldService.ProjectScaffoldService;
+      const tempDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-scaffold-" });
+      const destination = path.join(tempDir, "cool-idea");
+
+      const result = yield* service.scaffold({ name: "Cool Idea", destinationPath: destination });
+      assert.equal(result.cwd, destination);
+
+      const readme = yield* fileSystem.readFileString(path.join(destination, "README.md"));
+      assert.equal(readme, "# Cool Idea\n\nInitialized with T3 Code.\n");
+      const favicon = yield* fileSystem.readFileString(path.join(destination, "favicon.svg"));
+      assert.include(favicon, "<svg");
+
+      // The initial commit is the point of the scaffold: worktree creation
+      // fails on an unborn HEAD, so HEAD must resolve and the tree be clean.
+      const branch = yield* runGit(destination, ["symbolic-ref", "--short", "HEAD"]);
+      assert.equal(branch.stdout.trim(), "main");
+      yield* runGit(destination, ["rev-parse", "--verify", "HEAD"]);
+      const status = yield* runGit(destination, ["status", "--porcelain"]);
+      assert.equal(status.stdout.trim(), "");
+    }),
+  ).pipe(Effect.provide(RealGitLayer)),
+);
+
+it.effect("refuses an existing destination folder", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const service = yield* ProjectScaffoldService.ProjectScaffoldService;
+      const tempDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-scaffold-" });
+      const destination = path.join(tempDir, "taken");
+      yield* fileSystem.makeDirectory(destination);
+
+      const error = yield* Effect.flip(
+        service.scaffold({ name: "Taken", destinationPath: destination }),
+      );
+      assert.include(error.detail, "already exists");
+    }),
+  ).pipe(Effect.provide(RealGitLayer)),
+);
+
+it.effect("removes the created folder when a git step fails", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-scaffold-" });
+      const destination = path.join(tempDir, "doomed");
+
+      const failingGitLayer = ProjectScaffoldService.layer.pipe(
+        Layer.provide(
+          Layer.mock(GitVcsDriver.GitVcsDriver)({
+            execute: (input) =>
+              input.args.includes("commit")
+                ? Effect.fail(
+                    new GitCommandError({
+                      operation: input.operation,
+                      command: "git",
+                      cwd: input.cwd,
+                      detail: "boom",
+                    }),
+                  )
+                : Effect.succeed({
+                    exitCode: ChildProcessSpawner.ExitCode(0),
+                    stdout: "",
+                    stderr: "",
+                    stdoutTruncated: false,
+                    stderrTruncated: false,
+                  }),
+          }),
+        ),
+        Layer.provideMerge(NodeServices.layer),
+      );
+
+      const error = yield* Effect.gen(function* () {
+        const service = yield* ProjectScaffoldService.ProjectScaffoldService;
+        return yield* Effect.flip(
+          service.scaffold({ name: "Doomed", destinationPath: destination }),
+        );
+      }).pipe(Effect.provide(failingGitLayer));
+
+      assert.isNotNull(error);
+      assert.isFalse(yield* fileSystem.exists(destination));
+    }),
+  ).pipe(Effect.provide(NodeServices.layer)),
+);

--- a/apps/server/src/project/ProjectScaffoldService.ts
+++ b/apps/server/src/project/ProjectScaffoldService.ts
@@ -1,0 +1,153 @@
+import * as NodeOS from "node:os";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+
+import {
+  ProjectScaffoldError,
+  type ProjectScaffoldInput,
+  type ProjectScaffoldResult,
+} from "@t3tools/contracts";
+import { generateProjectFaviconSvg, generateProjectReadme } from "@t3tools/shared/projectScaffold";
+
+import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
+
+const isProjectScaffoldError = Schema.is(ProjectScaffoldError);
+
+// Fallback identity for the initial commit when the machine has no git
+// user.name/user.email configured. The commit genuinely comes from the tool,
+// and a first-run user should not hit a git config error here.
+const FALLBACK_COMMIT_IDENTITY = {
+  name: "T3 Code",
+  email: "noreply@t3.gg",
+} as const;
+
+/**
+ * Creates a brand-new project folder: mkdir, `git init -b main`, README.md and
+ * a generated favicon.svg, then one initial commit. The initial commit is
+ * mandatory — thread start creates a worktree from the base branch, and
+ * `git worktree add` fails on a repo with an unborn HEAD.
+ */
+export class ProjectScaffoldService extends Context.Service<
+  ProjectScaffoldService,
+  {
+    readonly scaffold: (
+      input: ProjectScaffoldInput,
+    ) => Effect.Effect<ProjectScaffoldResult, ProjectScaffoldError>;
+  }
+>()("t3/project/ProjectScaffoldService") {}
+
+function expandHomePath(input: string, path: Path.Path): string {
+  if (input === "~") {
+    return NodeOS.homedir();
+  }
+  if (input.startsWith("~/") || input.startsWith("~\\")) {
+    return path.join(NodeOS.homedir(), input.slice(2));
+  }
+  return input;
+}
+
+function mapScaffoldError(operation: string) {
+  return Effect.mapError((cause: unknown) =>
+    isProjectScaffoldError(cause)
+      ? cause
+      : new ProjectScaffoldError({
+          operation,
+          detail: cause instanceof Error ? cause.message : "The project could not be created.",
+          cause,
+        }),
+  );
+}
+
+export const make = Effect.gen(function* () {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const git = yield* GitVcsDriver.GitVcsDriver;
+  const path = yield* Path.Path;
+
+  const gitConfigValue = (cwd: string, key: string) =>
+    git
+      .execute({
+        operation: "ProjectScaffoldService.readGitConfig",
+        cwd,
+        args: ["config", "--get", key],
+        allowNonZeroExit: true,
+      })
+      .pipe(Effect.map((result) => (result.exitCode === 0 ? result.stdout.trim() : "")));
+
+  const populateRepository = Effect.fn("ProjectScaffoldService.populateRepository")(function* (
+    destination: string,
+    name: string,
+  ) {
+    yield* git.execute({
+      operation: "ProjectScaffoldService.gitInit",
+      cwd: destination,
+      args: ["init", "-b", "main"],
+    });
+
+    yield* fileSystem.writeFileString(
+      path.join(destination, "README.md"),
+      generateProjectReadme(name),
+    );
+    yield* fileSystem.writeFileString(
+      path.join(destination, "favicon.svg"),
+      generateProjectFaviconSvg(name),
+    );
+
+    yield* git.execute({
+      operation: "ProjectScaffoldService.gitAdd",
+      cwd: destination,
+      args: ["add", "README.md", "favicon.svg"],
+    });
+
+    const userName = yield* gitConfigValue(destination, "user.name");
+    const userEmail = yield* gitConfigValue(destination, "user.email");
+    const identityArgs =
+      userName.length > 0 && userEmail.length > 0
+        ? []
+        : [
+            "-c",
+            `user.name=${FALLBACK_COMMIT_IDENTITY.name}`,
+            "-c",
+            `user.email=${FALLBACK_COMMIT_IDENTITY.email}`,
+          ];
+
+    yield* git.execute({
+      operation: "ProjectScaffoldService.gitCommit",
+      cwd: destination,
+      args: [...identityArgs, "commit", "-m", "Initial commit"],
+    });
+  });
+
+  const scaffold = Effect.fn("ProjectScaffoldService.scaffold")(function* (
+    input: ProjectScaffoldInput,
+  ) {
+    const destination = path.resolve(expandHomePath(input.destinationPath.trim(), path));
+
+    if (yield* fileSystem.exists(destination).pipe(Effect.orElseSucceed(() => false))) {
+      return yield* new ProjectScaffoldError({
+        operation: "prepareDestination",
+        detail: `A folder already exists at ${destination}.`,
+      });
+    }
+
+    yield* fileSystem.makeDirectory(destination, { recursive: true });
+
+    // Remove the folder this call created when any later step fails, so a
+    // retry with the same name starts clean. Parents created by the recursive
+    // mkdir are left in place; they are the stable projects root.
+    yield* populateRepository(destination, input.name).pipe(
+      Effect.onError(() => fileSystem.remove(destination, { recursive: true }).pipe(Effect.ignore)),
+    );
+
+    return { cwd: destination };
+  });
+
+  return ProjectScaffoldService.of({
+    scaffold: (input) => scaffold(input).pipe(mapScaffoldError("scaffold")),
+  });
+});
+
+export const layer = Layer.effect(ProjectScaffoldService, make);

--- a/apps/server/src/project/ProjectScaffoldService.ts
+++ b/apps/server/src/project/ProjectScaffoldService.ts
@@ -56,7 +56,7 @@ function mapScaffoldError(operation: string) {
       ? cause
       : new ProjectScaffoldError({
           operation,
-          detail: cause instanceof Error ? cause.message : "The project could not be created.",
+          detail: "The project could not be created.",
           cause,
         }),
   );
@@ -125,15 +125,27 @@ export const make = Effect.gen(function* () {
     input: ProjectScaffoldInput,
   ) {
     const destination = path.resolve(expandHomePath(input.destinationPath.trim(), path));
+    const alreadyExists = new ProjectScaffoldError({
+      operation: "prepareDestination",
+      detail: `A folder already exists at ${destination}.`,
+    });
 
     if (yield* fileSystem.exists(destination).pipe(Effect.orElseSucceed(() => false))) {
-      return yield* new ProjectScaffoldError({
-        operation: "prepareDestination",
-        detail: `A folder already exists at ${destination}.`,
-      });
+      return yield* alreadyExists;
     }
 
-    yield* fileSystem.makeDirectory(destination, { recursive: true });
+    yield* fileSystem.makeDirectory(path.dirname(destination), { recursive: true });
+    // Non-recursive mkdir is the exclusive ownership claim: if a concurrent
+    // scaffold created the folder between the check above and here, this fails
+    // instead of silently adopting (and later deleting) the other call's repo.
+    yield* fileSystem.makeDirectory(destination).pipe(
+      Effect.catch((cause) =>
+        fileSystem.exists(destination).pipe(
+          Effect.orElseSucceed(() => false),
+          Effect.flatMap((nowExists) => Effect.fail(nowExists ? alreadyExists : cause)),
+        ),
+      ),
+    );
 
     // Remove the folder this call created when any later step fails, so a
     // retry with the same name starts clean. Parents created by the recursive

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -138,6 +138,7 @@ import * as VcsDriverRegistry from "./vcs/VcsDriverRegistry.ts";
 import * as VcsProvisioningService from "./vcs/VcsProvisioningService.ts";
 import * as GitWorkflowService from "./git/GitWorkflowService.ts";
 import * as ReviewService from "./review/ReviewService.ts";
+import * as ProjectScaffoldService from "./project/ProjectScaffoldService.ts";
 import * as SourceControlRepositoryService from "./sourceControl/SourceControlRepositoryService.ts";
 import * as ServerSecretStore from "./auth/ServerSecretStore.ts";
 import * as EnvironmentAuth from "./auth/EnvironmentAuth.ts";
@@ -395,6 +396,7 @@ const buildAppUnderTest = (options?: {
     sourceControlRepositoryService?: Partial<
       SourceControlRepositoryService.SourceControlRepositoryService["Service"]
     >;
+    projectScaffoldService?: Partial<ProjectScaffoldService.ProjectScaffoldService["Service"]>;
     reviewService?: Partial<ReviewService.ReviewService["Service"]>;
     vcsStatusBroadcaster?: Partial<VcsStatusBroadcaster.VcsStatusBroadcaster["Service"]>;
     projectSetupScriptRunner?: Partial<
@@ -729,9 +731,14 @@ const buildAppUnderTest = (options?: {
       Layer.provide(reviewLayer),
       Layer.provide(vcsProvisioningLayer),
       Layer.provide(
-        Layer.mock(SourceControlRepositoryService.SourceControlRepositoryService)({
-          ...options?.layers?.sourceControlRepositoryService,
-        }),
+        Layer.mergeAll(
+          Layer.mock(SourceControlRepositoryService.SourceControlRepositoryService)({
+            ...options?.layers?.sourceControlRepositoryService,
+          }),
+          Layer.mock(ProjectScaffoldService.ProjectScaffoldService)({
+            ...options?.layers?.projectScaffoldService,
+          }),
+        ),
       ),
       Layer.provideMerge(vcsStatusBroadcasterLayer),
       Layer.provide(

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -64,6 +64,7 @@ import { hasCloudPublicConfig } from "./cloud/publicConfig.ts";
 import { ProviderRegistryLive } from "./provider/Layers/ProviderRegistry.ts";
 import * as ServerSettings from "./serverSettings.ts";
 import * as ProjectFaviconResolver from "./project/ProjectFaviconResolver.ts";
+import * as ProjectScaffoldService from "./project/ProjectScaffoldService.ts";
 import * as T3ProjectFileLoader from "./project/T3ProjectFileLoader.ts";
 import * as RepositoryIdentityResolver from "./project/RepositoryIdentityResolver.ts";
 import * as WorkspaceEntries from "./workspace/WorkspaceEntries.ts";
@@ -300,6 +301,10 @@ const SourceControlRepositoryServiceLayerLive = SourceControlRepositoryService.l
   Layer.provideMerge(SourceControlProviderRegistryLayerLive),
 );
 
+const ProjectScaffoldServiceLayerLive = ProjectScaffoldService.layer.pipe(
+  Layer.provideMerge(GitVcsDriver.layer),
+);
+
 const ReviewLayerLive = ReviewService.layer.pipe(
   Layer.provideMerge(GitVcsDriver.layer),
   Layer.provideMerge(VcsDriverRegistryLayerLive),
@@ -312,6 +317,7 @@ const VcsLayerLive = Layer.empty.pipe(
   Layer.provideMerge(GitWorkflowLayerLive),
   Layer.provideMerge(ReviewLayerLive),
   Layer.provideMerge(SourceControlRepositoryServiceLayerLive),
+  Layer.provideMerge(ProjectScaffoldServiceLayerLive),
   Layer.provideMerge(VcsStatusBroadcaster.layer.pipe(Layer.provide(GitWorkflowLayerLive))),
 );
 

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -110,6 +110,7 @@ import * as UsageService from "./usage/UsageService.ts";
 import * as TraceDiagnostics from "./diagnostics/TraceDiagnostics.ts";
 import * as PullRequestService from "./pullRequest/PullRequestService.ts";
 import * as SourceControlDiscovery from "./sourceControl/SourceControlDiscovery.ts";
+import * as ProjectScaffoldService from "./project/ProjectScaffoldService.ts";
 import * as SourceControlRepositoryService from "./sourceControl/SourceControlRepositoryService.ts";
 import * as AzureDevOpsCli from "./sourceControl/AzureDevOpsCli.ts";
 import * as BitbucketApi from "./sourceControl/BitbucketApi.ts";
@@ -411,6 +412,7 @@ const makeWsRpcLayer = (
       );
       const sourceControlRepositories =
         yield* SourceControlRepositoryService.SourceControlRepositoryService;
+      const projectScaffold = yield* ProjectScaffoldService.ProjectScaffoldService;
       const pullRequests = yield* PullRequestService.PullRequestService;
       const bootstrapCredentials = yield* PairingGrantStore.PairingGrantStore;
       const sessions = yield* SessionStore.SessionStore;
@@ -1835,6 +1837,10 @@ const makeWsRpcLayer = (
             ),
             { "rpc.aggregate": "workspace" },
           ),
+        [WS_METHODS.projectsScaffold]: (input) =>
+          observeRpcEffect(WS_METHODS.projectsScaffold, projectScaffold.scaffold(input), {
+            "rpc.aggregate": "workspace",
+          }),
         [WS_METHODS.shellOpenInEditor]: (input) =>
           observeRpcEffect(WS_METHODS.shellOpenInEditor, externalLauncher.launchEditor(input), {
             "rpc.aggregate": "workspace",

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -858,9 +858,12 @@ function OpenCommandPaletteDialog(props: {
           addProjectCloneFlow.repository?.nameWithOwner ?? addProjectCloneFlow.remoteUrl,
         )
       : "";
+  // Free-text steps (clone repository input, create-project name) must never
+  // flip the palette into path-browse mode when the text looks like a path.
+  const isFreeTextAddProjectStep = isRemoteProjectRepositoryStep || addProjectCreateFlow !== null;
   const browsePath = useMemo(
-    () => getFilesystemBrowsePath(query, browseEnvironmentPlatform, !isRemoteProjectRepositoryStep),
-    [browseEnvironmentPlatform, isRemoteProjectRepositoryStep, query],
+    () => getFilesystemBrowsePath(query, browseEnvironmentPlatform, !isFreeTextAddProjectStep),
+    [browseEnvironmentPlatform, isFreeTextAddProjectStep, query],
   );
   const isBrowsing = browsePath.isBrowsing;
   const browseDirectoryPath = browsePath.directoryPath;

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -2197,8 +2197,10 @@ function OpenCommandPaletteDialog(props: {
     !createProjectCollision &&
     canCreateProjectInEnvironment(browseEnvironment?.connection.phase) &&
     !isCreatingProject;
+  // A typed name with no usable slug (e.g. all-symbol or non-Latin input)
+  // must not leave the view silently dead; explain why Create is unavailable.
   const createProjectGroups: CommandPaletteView["groups"] =
-    addProjectCreateFlow && createProjectPlan
+    addProjectCreateFlow && trimmedCreateProjectName.length > 0 && createProjectPlan === null
       ? [
           {
             value: "create-project",
@@ -2206,23 +2208,43 @@ function OpenCommandPaletteDialog(props: {
             items: [
               {
                 kind: "action",
-                value: "action:create-project:confirm",
+                value: "action:create-project:invalid-name",
                 searchTerms: [],
-                title: `Create "${trimmedCreateProjectName}"`,
-                description: createProjectCollision
-                  ? `Folder already exists: ${createProjectPlan.destinationPath}`
-                  : createProjectPlan.destinationPath,
+                title: "Name needs a letter or number",
+                description: "The folder name is built from a-z and 0-9 characters in the name",
                 icon: <SquarePlusIcon className={ITEM_ICON_CLASS} />,
-                disabled: !canSubmitCreateProjectFlow,
+                disabled: true,
                 keepOpen: true,
-                run: async () => {
-                  await submitAddProjectCreateFlow();
-                },
+                run: async () => {},
               },
             ],
           },
         ]
-      : [];
+      : addProjectCreateFlow && createProjectPlan
+        ? [
+            {
+              value: "create-project",
+              label: "Create project",
+              items: [
+                {
+                  kind: "action",
+                  value: "action:create-project:confirm",
+                  searchTerms: [],
+                  title: `Create "${trimmedCreateProjectName}"`,
+                  description: createProjectCollision
+                    ? `Folder already exists: ${createProjectPlan.destinationPath}`
+                    : createProjectPlan.destinationPath,
+                  icon: <SquarePlusIcon className={ITEM_ICON_CLASS} />,
+                  disabled: !canSubmitCreateProjectFlow,
+                  keepOpen: true,
+                  run: async () => {
+                    await submitAddProjectCreateFlow();
+                  },
+                },
+              ],
+            },
+          ]
+        : [];
 
   let displayedGroups: CommandPaletteView["groups"] = filteredGroups;
   if (addProjectCreateFlow) {

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -2663,7 +2663,7 @@ function OpenCommandPaletteDialog(props: {
         // inner input must reserve enough room for the full action label.
         className:
           addProjectCreateFlow !== null
-            ? "*:data-[slot=autocomplete-input]:pe-28!"
+            ? "*:data-[slot=autocomplete-input]:pe-32!"
             : addProjectCloneFlow?.step === "repository"
               ? "*:data-[slot=autocomplete-input]:pe-32!"
               : isBrowsing
@@ -2723,24 +2723,27 @@ function OpenCommandPaletteDialog(props: {
         isActionsOnly={isActionsOnly}
         keybindings={keybindings}
         onExecuteItem={executeItem}
-        {...(addProjectCloneFlow?.step === "repository"
-          ? {
-              emptyStateMessage:
-                addProjectCloneFlow.source === "url"
-                  ? "Enter a Git clone URL and press Enter to continue."
-                  : "Enter a repository path and press Enter to look it up.",
-            }
-          : addProjectCloneFlow?.step === "confirm"
-            ? { emptyStateMessage: "Choose a destination path and press Enter to clone." }
-            : relativePathNeedsActiveProject
-              ? { emptyStateMessage: "Relative paths require an active project." }
-              : willCreateProjectPath
-                ? {
-                    emptyStateMessage: "Press Enter to create this folder and add it as a project.",
-                  }
-                : threadSearch.isPending
-                  ? { emptyStateMessage: "Searching thread messages…" }
-                  : {})}
+        {...(addProjectCreateFlow
+          ? { emptyStateMessage: "Enter a project name and press Enter to create it." }
+          : addProjectCloneFlow?.step === "repository"
+            ? {
+                emptyStateMessage:
+                  addProjectCloneFlow.source === "url"
+                    ? "Enter a Git clone URL and press Enter to continue."
+                    : "Enter a repository path and press Enter to look it up.",
+              }
+            : addProjectCloneFlow?.step === "confirm"
+              ? { emptyStateMessage: "Choose a destination path and press Enter to clone." }
+              : relativePathNeedsActiveProject
+                ? { emptyStateMessage: "Relative paths require an active project." }
+                : willCreateProjectPath
+                  ? {
+                      emptyStateMessage:
+                        "Press Enter to create this folder and add it as a project.",
+                    }
+                  : threadSearch.isPending
+                    ? { emptyStateMessage: "Searching thread messages…" }
+                    : {})}
       />
     </CommandPaletteContent>
   );

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -2184,10 +2184,12 @@ function OpenCommandPaletteDialog(props: {
         })
       : null,
   );
+  // Exact-name compare: correct on case-sensitive filesystems, and the server's
+  // own exists check backstops case-insensitive ones at submit time.
   const createProjectCollision =
     createProjectPlan !== null &&
     (createProjectParentQuery.data?.entries ?? EMPTY_BROWSE_ENTRIES).some(
-      (entry) => entry.name.toLowerCase() === createProjectPlan.slug,
+      (entry) => entry.name === createProjectPlan.slug,
     );
   const canSubmitCreateProjectFlow =
     addProjectCreateFlow !== null &&

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -2,6 +2,7 @@
 
 import { scopeProjectRef, scopeThreadRef } from "@t3tools/client-runtime/environment";
 import {
+  buildCreateProjectDestination,
   canCreateProjectInEnvironment,
   getCloneDestinationBrowsePath,
   getCloneDestinationPath,
@@ -44,6 +45,7 @@ import {
   ServerIcon,
   SettingsIcon,
   SquarePenIcon,
+  SquarePlusIcon,
   TextSearchIcon,
 } from "lucide-react";
 import {
@@ -590,6 +592,9 @@ function OpenCommandPaletteDialog(props: {
   const cloneRepository = useAtomCommand(sourceControlEnvironment.cloneRepository, {
     reportFailure: false,
   });
+  const scaffoldProject = useAtomCommand(projectEnvironment.scaffold, {
+    reportFailure: false,
+  });
   const { environments } = useEnvironments();
   const desktopLocalBootstraps = useDesktopLocalBootstraps();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
@@ -648,8 +653,12 @@ function OpenCommandPaletteDialog(props: {
   );
   const [isPickingProjectFolder, setIsPickingProjectFolder] = useState(false);
   const [addProjectCloneFlow, setAddProjectCloneFlow] = useState<AddProjectCloneFlow | null>(null);
+  const [addProjectCreateFlow, setAddProjectCreateFlow] = useState<{
+    readonly environmentId: EnvironmentId;
+  } | null>(null);
   const [isRemoteProjectLookingUp, setIsRemoteProjectLookingUp] = useState(false);
   const [isRemoteProjectCloning, setIsRemoteProjectCloning] = useState(false);
+  const [isCreatingProject, setIsCreatingProject] = useState(false);
   const projectGroupingSettings = useMemo(
     () => selectProjectGroupingSettings(clientSettings),
     [clientSettings],
@@ -1187,6 +1196,7 @@ function OpenCommandPaletteDialog(props: {
   function popView(): void {
     browseNavigation.invalidate();
     setAddProjectCloneFlow(null);
+    setAddProjectCreateFlow(null);
     if (viewStack.length <= 1) {
       setAddProjectEnvironmentId(null);
     }
@@ -1223,6 +1233,7 @@ function OpenCommandPaletteDialog(props: {
         () => {
           setAddProjectEnvironmentId(environmentId);
           setAddProjectCloneFlow(null);
+          setAddProjectCreateFlow(null);
           pushPaletteView(view);
         },
       );
@@ -1240,10 +1251,24 @@ function OpenCommandPaletteDialog(props: {
     (environmentId: EnvironmentId, source: AddProjectRemoteSource): void => {
       setAddProjectEnvironmentId(environmentId);
       setAddProjectCloneFlow({ step: "repository", environmentId, source });
+      setAddProjectCreateFlow(null);
       pushPaletteView({
         addonIcon: remoteProjectSourceIcon(source, ADDON_ICON_CLASS),
         groups: [],
         initialQuery: "",
+      });
+    },
+    [pushPaletteView],
+  );
+
+  const startAddProjectCreate = useCallback(
+    (environmentId: EnvironmentId): void => {
+      setAddProjectEnvironmentId(environmentId);
+      setAddProjectCloneFlow(null);
+      setAddProjectCreateFlow({ environmentId });
+      pushPaletteView({
+        addonIcon: <SquarePlusIcon className={ADDON_ICON_CLASS} />,
+        groups: [],
       });
     },
     [pushPaletteView],
@@ -1270,6 +1295,18 @@ function OpenCommandPaletteDialog(props: {
           keepOpen: true,
           run: async () => {
             await startAddProjectBrowse(environmentId);
+          },
+        },
+        {
+          kind: "action",
+          value: `action:add-project:${environmentId}:create`,
+          searchTerms: ["create", "new", "empty", "init", "scaffold", "start"],
+          title: "Create new project",
+          description: "Start an empty repo in t3-projects",
+          icon: <SquarePlusIcon className={ITEM_ICON_CLASS} />,
+          keepOpen: true,
+          run: async () => {
+            startAddProjectCreate(environmentId);
           },
         },
       ];
@@ -1345,7 +1382,7 @@ function OpenCommandPaletteDialog(props: {
 
       return [{ value: `sources:${environmentId}`, label: "Sources", items: sourceItems }];
     },
-    [openSourceControlSettings, startAddProjectBrowse, startAddProjectClone],
+    [openSourceControlSettings, startAddProjectBrowse, startAddProjectClone, startAddProjectCreate],
   );
 
   const startAddProjectSourceSelection = useCallback(
@@ -1365,6 +1402,7 @@ function OpenCommandPaletteDialog(props: {
       }
       setAddProjectEnvironmentId(environmentId);
       setAddProjectCloneFlow(null);
+      setAddProjectCreateFlow(null);
       pushPaletteView({
         addonIcon: <FolderPlusIcon className={ADDON_ICON_CLASS} />,
         groups: buildAddProjectSourceGroups(
@@ -1460,6 +1498,7 @@ function OpenCommandPaletteDialog(props: {
     clearOpenIntent();
     browseNavigation.invalidate();
     setAddProjectCloneFlow(null);
+    setAddProjectCreateFlow(null);
     setViewStack([]);
     setQuery("");
     const currentPrefix =
@@ -1685,6 +1724,8 @@ function OpenCommandPaletteDialog(props: {
       readonly rawCwd: string;
       readonly platform: string;
       readonly currentProjectCwd: string | null;
+      /** Overrides the title inferred from the path (create-project keeps the typed name). */
+      readonly title?: string;
     }) => {
       const environment = environments.find(
         (candidate) => candidate.environmentId === input.environmentId,
@@ -1772,7 +1813,7 @@ function OpenCommandPaletteDialog(props: {
         environmentId: input.environmentId,
         input: {
           projectId,
-          title: inferProjectTitleFromPath(cwd),
+          title: input.title ?? inferProjectTitleFromPath(cwd),
           workspaceRoot: cwd,
           createWorkspaceRootIfMissing: true,
           defaultModelSelection: resolveDefaultProviderModelSelection(
@@ -1987,6 +2028,54 @@ function OpenCommandPaletteDialog(props: {
     await handleAddProject(cloneResult.value.cwd);
   }
 
+  async function submitAddProjectCreateFlow(): Promise<void> {
+    if (!addProjectCreateFlow || isCreatingProject) {
+      return;
+    }
+    if (!canCreateProjectInEnvironment(browseEnvironment?.connection.phase)) {
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Environment unavailable",
+          description: `${browseEnvironment?.label ?? "The selected environment"} is not connected.`,
+        }),
+      );
+      return;
+    }
+    if (createProjectPlan === null || createProjectCollision) {
+      return;
+    }
+
+    setIsCreatingProject(true);
+    const scaffoldResult = await scaffoldProject({
+      environmentId: addProjectCreateFlow.environmentId,
+      input: {
+        name: trimmedCreateProjectName,
+        destinationPath: createProjectPlan.destinationPath,
+      },
+    });
+    setIsCreatingProject(false);
+    if (scaffoldResult._tag === "Failure") {
+      if (!isAtomCommandInterrupted(scaffoldResult)) {
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Failed to create project",
+            description: errorMessage(squashAtomCommandFailure(scaffoldResult)),
+          }),
+        );
+      }
+      return;
+    }
+    await handleAddProjectForEnvironment({
+      environmentId: addProjectCreateFlow.environmentId,
+      rawCwd: scaffoldResult.value.cwd,
+      platform: browseEnvironmentPlatform,
+      currentProjectCwd: null,
+      title: trimmedCreateProjectName,
+    });
+  }
+
   const browseTo = useCallback(
     async (name: string): Promise<void> => {
       const nextQuery = pinnedCloneDirectoryName
@@ -2072,8 +2161,71 @@ function OpenCommandPaletteDialog(props: {
     };
   }, [addProjectCloneFlow]);
 
+  const trimmedCreateProjectName = addProjectCreateFlow ? query.trim() : "";
+  const createProjectPlan = useMemo(
+    () =>
+      addProjectCreateFlow && trimmedCreateProjectName.length > 0
+        ? buildCreateProjectDestination({
+            baseBrowsePath: getAddProjectInitialQueryForEnvironment(
+              addProjectCreateFlow.environmentId,
+            ),
+            name: trimmedCreateProjectName,
+          })
+        : null,
+    [addProjectCreateFlow, getAddProjectInitialQueryForEnvironment, trimmedCreateProjectName],
+  );
+  // Live collision check against the create parent directory. A failed browse
+  // (parent does not exist yet) means no collision is possible.
+  const createProjectParentQuery = useEnvironmentQuery(
+    addProjectCreateFlow && createProjectPlan
+      ? filesystemEnvironment.browse({
+          environmentId: addProjectCreateFlow.environmentId,
+          input: { partialPath: createProjectPlan.parentPath },
+        })
+      : null,
+  );
+  const createProjectCollision =
+    createProjectPlan !== null &&
+    (createProjectParentQuery.data?.entries ?? EMPTY_BROWSE_ENTRIES).some(
+      (entry) => entry.name.toLowerCase() === createProjectPlan.slug,
+    );
+  const canSubmitCreateProjectFlow =
+    addProjectCreateFlow !== null &&
+    createProjectPlan !== null &&
+    !createProjectCollision &&
+    canCreateProjectInEnvironment(browseEnvironment?.connection.phase) &&
+    !isCreatingProject;
+  const createProjectGroups: CommandPaletteView["groups"] =
+    addProjectCreateFlow && createProjectPlan
+      ? [
+          {
+            value: "create-project",
+            label: "Create project",
+            items: [
+              {
+                kind: "action",
+                value: "action:create-project:confirm",
+                searchTerms: [],
+                title: `Create "${trimmedCreateProjectName}"`,
+                description: createProjectCollision
+                  ? `Folder already exists: ${createProjectPlan.destinationPath}`
+                  : createProjectPlan.destinationPath,
+                icon: <SquarePlusIcon className={ITEM_ICON_CLASS} />,
+                disabled: !canSubmitCreateProjectFlow,
+                keepOpen: true,
+                run: async () => {
+                  await submitAddProjectCreateFlow();
+                },
+              },
+            ],
+          },
+        ]
+      : [];
+
   let displayedGroups: CommandPaletteView["groups"] = filteredGroups;
-  if (addProjectCloneFlow?.step === "repository") {
+  if (addProjectCreateFlow) {
+    displayedGroups = createProjectGroups;
+  } else if (addProjectCloneFlow?.step === "repository") {
     displayedGroups = [];
   } else if (addProjectCloneFlow?.step === "confirm") {
     displayedGroups = relativePathNeedsActiveProject ? [] : cloneDestinationBrowseGroups;
@@ -2081,9 +2233,10 @@ function OpenCommandPaletteDialog(props: {
     displayedGroups = relativePathNeedsActiveProject ? [] : browseGroups;
   }
 
-  const inputPlaceholder =
-    remoteProjectInputPlaceholder(addProjectCloneFlow) ??
-    getCommandPaletteInputPlaceholder(paletteMode);
+  const inputPlaceholder = addProjectCreateFlow
+    ? "Enter project name"
+    : (remoteProjectInputPlaceholder(addProjectCloneFlow) ??
+      getCommandPaletteInputPlaceholder(paletteMode));
   const isSubmenu = paletteMode === "submenu" || paletteMode === "submenu-browse";
   const hasHighlightedBrowseItem = highlightedItemValue?.startsWith("browse:") ?? false;
   const canSubmitBrowsePath =
@@ -2179,6 +2332,12 @@ function OpenCommandPaletteDialog(props: {
     if (addProjectCloneFlow?.step === "repository" && event.key === "Enter") {
       event.preventDefault();
       void submitAddProjectCloneFlow();
+      return;
+    }
+
+    if (addProjectCreateFlow && event.key === "Enter") {
+      event.preventDefault();
+      void submitAddProjectCreateFlow();
       return;
     }
 
@@ -2339,83 +2498,110 @@ function OpenCommandPaletteDialog(props: {
     primaryEnvironmentId,
   ]);
 
-  const inputAccessory =
-    addProjectCloneFlow?.step === "repository" ? (
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <Button
-              variant="outline"
-              size="xs"
-              tabIndex={-1}
-              className="absolute inset-e-2.5 top-1/2 gap-1.5 pe-1 ps-2 -translate-y-1/2"
-              aria-label={`${remoteProjectButtonLabel ?? "Continue"} (Enter)`}
-              disabled={!canSubmitRemoteProjectFlow}
-              onMouseDown={(event) => {
-                event.preventDefault();
-              }}
-              onClick={() => {
-                void submitAddProjectCloneFlow();
-              }}
-            />
-          }
-        >
-          <span>{isRemoteProjectPending ? "Working" : remoteProjectButtonLabel}</span>
-          <KbdGroup className="pointer-events-none -me-0.5 items-center gap-1">
-            <Kbd>Enter</Kbd>
-          </KbdGroup>
-        </TooltipTrigger>
-        <TooltipPopup side="top">{remoteProjectButtonLabel ?? "Continue"} (Enter)</TooltipPopup>
-      </Tooltip>
-    ) : isBrowsing ? (
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <Button
-              variant="outline"
-              size="xs"
-              tabIndex={-1}
-              className={cn(
-                "absolute inset-e-2.5 top-1/2 pe-1 ps-2 -translate-y-1/2",
-                hasHighlightedBrowseItem ? "gap-1" : "gap-1.5",
-              )}
-              aria-label={`${submitActionLabel} (${addShortcutLabel})`}
-              disabled={
-                !canCreateProjectInEnvironment(browseEnvironment?.connection.phase) ||
-                relativePathNeedsActiveProject ||
-                (isCloneDestinationStep && isRemoteProjectPending)
+  const inputAccessory = addProjectCreateFlow ? (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            variant="outline"
+            size="xs"
+            tabIndex={-1}
+            className="absolute inset-e-2.5 top-1/2 gap-1.5 pe-1 ps-2 -translate-y-1/2"
+            aria-label="Create project (Enter)"
+            disabled={!canSubmitCreateProjectFlow}
+            onMouseDown={(event) => {
+              event.preventDefault();
+            }}
+            onClick={() => {
+              void submitAddProjectCreateFlow();
+            }}
+          />
+        }
+      >
+        <span>{isCreatingProject ? "Creating" : "Create"}</span>
+        <KbdGroup className="pointer-events-none -me-0.5 items-center gap-1">
+          <Kbd>Enter</Kbd>
+        </KbdGroup>
+      </TooltipTrigger>
+      <TooltipPopup side="top">Create project (Enter)</TooltipPopup>
+    </Tooltip>
+  ) : addProjectCloneFlow?.step === "repository" ? (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            variant="outline"
+            size="xs"
+            tabIndex={-1}
+            className="absolute inset-e-2.5 top-1/2 gap-1.5 pe-1 ps-2 -translate-y-1/2"
+            aria-label={`${remoteProjectButtonLabel ?? "Continue"} (Enter)`}
+            disabled={!canSubmitRemoteProjectFlow}
+            onMouseDown={(event) => {
+              event.preventDefault();
+            }}
+            onClick={() => {
+              void submitAddProjectCloneFlow();
+            }}
+          />
+        }
+      >
+        <span>{isRemoteProjectPending ? "Working" : remoteProjectButtonLabel}</span>
+        <KbdGroup className="pointer-events-none -me-0.5 items-center gap-1">
+          <Kbd>Enter</Kbd>
+        </KbdGroup>
+      </TooltipTrigger>
+      <TooltipPopup side="top">{remoteProjectButtonLabel ?? "Continue"} (Enter)</TooltipPopup>
+    </Tooltip>
+  ) : isBrowsing ? (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            variant="outline"
+            size="xs"
+            tabIndex={-1}
+            className={cn(
+              "absolute inset-e-2.5 top-1/2 pe-1 ps-2 -translate-y-1/2",
+              hasHighlightedBrowseItem ? "gap-1" : "gap-1.5",
+            )}
+            aria-label={`${submitActionLabel} (${addShortcutLabel})`}
+            disabled={
+              !canCreateProjectInEnvironment(browseEnvironment?.connection.phase) ||
+              relativePathNeedsActiveProject ||
+              (isCloneDestinationStep && isRemoteProjectPending)
+            }
+            onMouseDown={(event) => {
+              event.preventDefault();
+            }}
+            onClick={() => {
+              if (relativePathNeedsActiveProject) {
+                return;
               }
-              onMouseDown={(event) => {
-                event.preventDefault();
-              }}
-              onClick={() => {
-                if (relativePathNeedsActiveProject) {
-                  return;
-                }
-                if (isCloneDestinationStep) {
-                  void submitAddProjectCloneFlow(resolvedAddProjectPath);
-                } else {
-                  void handleAddProject(resolvedAddProjectPath);
-                }
-              }}
-            />
-          }
-        >
-          <span>
-            {isCloneDestinationStep && isRemoteProjectPending ? "Cloning" : submitActionLabel}
-          </span>
-          <KbdGroup className="pointer-events-none -me-0.5 items-center gap-1">
-            <Kbd>{hasHighlightedBrowseItem ? `${submitModifierLabel} Enter` : "Enter"}</Kbd>
-          </KbdGroup>
-        </TooltipTrigger>
-        <TooltipPopup side="top">
-          {submitActionLabel} ({addShortcutLabel})
-        </TooltipPopup>
-      </Tooltip>
-    ) : null;
+              if (isCloneDestinationStep) {
+                void submitAddProjectCloneFlow(resolvedAddProjectPath);
+              } else {
+                void handleAddProject(resolvedAddProjectPath);
+              }
+            }}
+          />
+        }
+      >
+        <span>
+          {isCloneDestinationStep && isRemoteProjectPending ? "Cloning" : submitActionLabel}
+        </span>
+        <KbdGroup className="pointer-events-none -me-0.5 items-center gap-1">
+          <Kbd>{hasHighlightedBrowseItem ? `${submitModifierLabel} Enter` : "Enter"}</Kbd>
+        </KbdGroup>
+      </TooltipTrigger>
+      <TooltipPopup side="top">
+        {submitActionLabel} ({addShortcutLabel})
+      </TooltipPopup>
+    </Tooltip>
+  ) : null;
 
-  const footerActionLabel =
-    addProjectCloneFlow?.step === "repository"
+  const footerActionLabel = addProjectCreateFlow
+    ? "Create"
+    : addProjectCloneFlow?.step === "repository"
       ? (remoteProjectButtonLabel ?? "Continue")
       : !canSubmitBrowsePath || hasHighlightedBrowseItem
         ? "Select"
@@ -2437,9 +2623,11 @@ function OpenCommandPaletteDialog(props: {
 
   return (
     <CommandPaletteContent
-      key={`${viewStack.length}-${browseGeneration}-${isBrowsing}-${addProjectCloneFlow?.step ?? "none"}`}
+      key={`${viewStack.length}-${browseGeneration}-${isBrowsing}-${addProjectCloneFlow?.step ?? "none"}-${addProjectCreateFlow ? "create" : "none"}`}
       aria-label="Command palette"
-      autoHighlight={isBrowsing || isRemoteProjectCloneFlow ? false : "always"}
+      autoHighlight={
+        isBrowsing || isRemoteProjectCloneFlow || addProjectCreateFlow !== null ? false : "always"
+      }
       footerActionLabel={footerActionLabel}
       footerTrailing={footerTrailing}
       inputAccessory={inputAccessory}
@@ -2447,14 +2635,16 @@ function OpenCommandPaletteDialog(props: {
         // The submit button is absolutely positioned over the field, so the
         // inner input must reserve enough room for the full action label.
         className:
-          addProjectCloneFlow?.step === "repository"
-            ? "*:data-[slot=autocomplete-input]:pe-32!"
-            : isBrowsing
-              ? browseInputEndPaddingClass({
-                  willCreateProjectPath,
-                  hasHighlightedBrowseItem,
-                })
-              : undefined,
+          addProjectCreateFlow !== null
+            ? "*:data-[slot=autocomplete-input]:pe-28!"
+            : addProjectCloneFlow?.step === "repository"
+              ? "*:data-[slot=autocomplete-input]:pe-32!"
+              : isBrowsing
+                ? browseInputEndPaddingClass({
+                    willCreateProjectPath,
+                    hasHighlightedBrowseItem,
+                  })
+                : undefined,
         placeholder: inputPlaceholder,
         wrapperClassName: isSubmenu
           ? "[&_[data-slot=autocomplete-start-addon]]:pointer-events-auto"

--- a/packages/client-runtime/src/operations/projects.test.ts
+++ b/packages/client-runtime/src/operations/projects.test.ts
@@ -9,6 +9,7 @@ import * as Option from "effect/Option";
 
 import {
   buildAddProjectRemoteSourceReadiness,
+  buildCreateProjectDestination,
   buildProjectCreateCommand,
   canCreateProjectInEnvironment,
   findExistingAddProject,
@@ -225,5 +226,36 @@ describe("add project shared logic", () => {
       createWorkspaceRootIfMissing: true,
       defaultModelSelection: null,
     });
+  });
+});
+
+describe("buildCreateProjectDestination", () => {
+  it("nests the slug under t3-projects in the base browse path", () => {
+    expect(buildCreateProjectDestination({ baseBrowsePath: "~/", name: "Cool Idea 3" })).toEqual({
+      slug: "cool-idea-3",
+      parentPath: "~/t3-projects/",
+      destinationPath: "~/t3-projects/cool-idea-3",
+    });
+  });
+
+  it("respects a configured base directory", () => {
+    expect(buildCreateProjectDestination({ baseBrowsePath: "/work/", name: "demo" })).toEqual({
+      slug: "demo",
+      parentPath: "/work/t3-projects/",
+      destinationPath: "/work/t3-projects/demo",
+    });
+  });
+
+  it("uses windows separators for windows base paths", () => {
+    expect(buildCreateProjectDestination({ baseBrowsePath: "C:\\work\\", name: "demo" })).toEqual({
+      slug: "demo",
+      parentPath: "C:\\work\\t3-projects\\",
+      destinationPath: "C:\\work\\t3-projects\\demo",
+    });
+  });
+
+  it("returns null while the name has no usable slug", () => {
+    expect(buildCreateProjectDestination({ baseBrowsePath: "~/", name: "!!!" })).toBeNull();
+    expect(buildCreateProjectDestination({ baseBrowsePath: "~/", name: "  " })).toBeNull();
   });
 });

--- a/packages/client-runtime/src/operations/projects.ts
+++ b/packages/client-runtime/src/operations/projects.ts
@@ -8,6 +8,10 @@ import type {
   SourceControlProviderKind,
   SourceControlRepositoryInfo,
 } from "@t3tools/contracts";
+import {
+  CREATED_PROJECTS_DIRECTORY_NAME,
+  slugifyProjectName,
+} from "@t3tools/shared/projectScaffold";
 import * as Arr from "effect/Array";
 import * as Option from "effect/Option";
 import * as Order from "effect/Order";
@@ -245,6 +249,32 @@ export function getCloneDestinationBrowsePath(input: {
   return selectedDirectoryMatches
     ? selectedDirectoryPath
     : getCloneDestinationPath(selectedDirectoryPath, input.cloneDirectoryName);
+}
+
+export interface CreateProjectDestination {
+  readonly slug: string;
+  /** Browse-ready parent directory (trailing separator), e.g. "~/t3-projects/". */
+  readonly parentPath: string;
+  /** Full target folder for the new project, e.g. "~/t3-projects/cool-idea". */
+  readonly destinationPath: string;
+}
+
+/**
+ * Maps a typed project name to its create-project target under
+ * `[addProjectBaseDirectory or ~]/t3-projects/[slug]`. Returns null while the
+ * name has no usable slug yet. `baseBrowsePath` comes from
+ * getAddProjectInitialQuery.
+ */
+export function buildCreateProjectDestination(input: {
+  readonly baseBrowsePath: string;
+  readonly name: string;
+}): CreateProjectDestination | null {
+  const slug = slugifyProjectName(input.name);
+  if (slug.length === 0) {
+    return null;
+  }
+  const parentPath = appendBrowsePathSegment(input.baseBrowsePath, CREATED_PROJECTS_DIRECTORY_NAME);
+  return { slug, parentPath, destinationPath: `${parentPath}${slug}` };
 }
 
 export function resolveAddProjectPath(input: {

--- a/packages/client-runtime/src/state/projectCommands.ts
+++ b/packages/client-runtime/src/state/projectCommands.ts
@@ -92,6 +92,15 @@ export function createProjectEnvironmentAtoms<R, E>(
       scheduler: projectScheduler,
       concurrency: projectConcurrency,
     }),
+    scaffold: createEnvironmentRpcCommand(runtime, {
+      label: "environment-data:projects:scaffold",
+      tag: WS_METHODS.projectsScaffold,
+      scheduler: projectScheduler,
+      concurrency: {
+        mode: "serial",
+        key: ({ environmentId }) => environmentId,
+      },
+    }),
     writeFile: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:projects:write-file",
       tag: WS_METHODS.projectsWriteFile,

--- a/packages/contracts/src/project.ts
+++ b/packages/contracts/src/project.ts
@@ -298,3 +298,29 @@ export class ProjectWriteFileError extends Schema.TaggedErrorClass<ProjectWriteF
     } as any);
   }
 }
+
+export const ProjectScaffoldInput = Schema.Struct({
+  // Human-readable project name; the server derives the README heading and
+  // favicon letter from it. The folder name comes from destinationPath.
+  name: TrimmedNonEmptyString.check(Schema.isMaxLength(128)),
+  destinationPath: TrimmedNonEmptyString,
+});
+export type ProjectScaffoldInput = typeof ProjectScaffoldInput.Type;
+
+export const ProjectScaffoldResult = Schema.Struct({
+  cwd: TrimmedNonEmptyString,
+});
+export type ProjectScaffoldResult = typeof ProjectScaffoldResult.Type;
+
+export class ProjectScaffoldError extends Schema.TaggedErrorClass<ProjectScaffoldError>()(
+  "ProjectScaffoldError",
+  {
+    operation: Schema.String,
+    detail: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {
+  override get message(): string {
+    return this.detail;
+  }
+}

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -108,6 +108,9 @@ import {
   ProjectSearchContentsError,
   ProjectSearchContentsInput,
   ProjectSearchContentsResult,
+  ProjectScaffoldError,
+  ProjectScaffoldInput,
+  ProjectScaffoldResult,
   ProjectSearchEntriesError,
   ProjectSearchEntriesInput,
   ProjectSearchEntriesResult,
@@ -203,6 +206,7 @@ export const WS_METHODS = {
   projectsSearchContents: "projects.searchContents",
   projectsSearchEntries: "projects.searchEntries",
   projectsWriteFile: "projects.writeFile",
+  projectsScaffold: "projects.scaffold",
 
   // Shell methods
   shellOpenInEditor: "shell.openInEditor",
@@ -648,6 +652,12 @@ export const WsProjectsWriteFileRpc = Rpc.make(WS_METHODS.projectsWriteFile, {
   error: Schema.Union([ProjectWriteFileError, EnvironmentAuthorizationError]),
 });
 
+export const WsProjectsScaffoldRpc = Rpc.make(WS_METHODS.projectsScaffold, {
+  payload: ProjectScaffoldInput,
+  success: ProjectScaffoldResult,
+  error: Schema.Union([ProjectScaffoldError, EnvironmentAuthorizationError]),
+});
+
 export const WsShellOpenInEditorRpc = Rpc.make(WS_METHODS.shellOpenInEditor, {
   payload: LaunchEditorInput,
   error: Schema.Union([ExternalLauncherError, EnvironmentAuthorizationError]),
@@ -1031,6 +1041,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsProjectsSearchContentsRpc,
   WsProjectsSearchEntriesRpc,
   WsProjectsWriteFileRpc,
+  WsProjectsScaffoldRpc,
   WsShellOpenInEditorRpc,
   WsFilesystemBrowseRpc,
   WsAssetsCreateUrlRpc,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -15,6 +15,10 @@
       "types": "./src/projectFavicon.ts",
       "import": "./src/projectFavicon.ts"
     },
+    "./projectScaffold": {
+      "types": "./src/projectScaffold.ts",
+      "import": "./src/projectScaffold.ts"
+    },
     "./model": {
       "types": "./src/model.ts",
       "import": "./src/model.ts"

--- a/packages/shared/src/projectScaffold.test.ts
+++ b/packages/shared/src/projectScaffold.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  generateProjectFaviconSvg,
+  generateProjectReadme,
+  slugifyProjectName,
+} from "./projectScaffold.ts";
+
+describe("slugifyProjectName", () => {
+  it("lowercases and dashes word boundaries", () => {
+    expect(slugifyProjectName("Cool Idea 3")).toBe("cool-idea-3");
+    expect(slugifyProjectName("  spaced   out  ")).toBe("spaced-out");
+  });
+
+  it("collapses symbol runs into single dashes", () => {
+    expect(slugifyProjectName("t3.chat // clone!")).toBe("t3-chat-clone");
+  });
+
+  it("strips leading and trailing separators", () => {
+    expect(slugifyProjectName("--edgy--")).toBe("edgy");
+  });
+
+  it("returns empty when nothing survives", () => {
+    expect(slugifyProjectName("!!!")).toBe("");
+    expect(slugifyProjectName("   ")).toBe("");
+  });
+
+  it("caps length without a dangling dash", () => {
+    const slug = slugifyProjectName(`${"a".repeat(63)} tail`);
+    expect(slug.length).toBeLessThanOrEqual(64);
+    expect(slug.endsWith("-")).toBe(false);
+  });
+});
+
+describe("generateProjectFaviconSvg", () => {
+  it("is deterministic for the same name", () => {
+    expect(generateProjectFaviconSvg("Cool Idea")).toBe(generateProjectFaviconSvg("Cool Idea"));
+  });
+
+  it("uses the first alphanumeric character uppercased", () => {
+    expect(generateProjectFaviconSvg("cool idea")).toContain(">C</text>");
+    expect(generateProjectFaviconSvg("~scratch")).toContain(">S</text>");
+  });
+
+  it("escapes names with no alphanumeric characters", () => {
+    expect(generateProjectFaviconSvg("<>")).toContain(">&lt;</text>");
+  });
+
+  it("keeps hue inside the hsl wheel", () => {
+    const hue = Number(/hsl\((\d+) /.exec(generateProjectFaviconSvg("anything"))?.[1]);
+    expect(hue).toBeGreaterThanOrEqual(0);
+    expect(hue).toBeLessThan(360);
+  });
+});
+
+describe("generateProjectReadme", () => {
+  it("contains the name and the T3 Code line", () => {
+    expect(generateProjectReadme("Cool Idea")).toBe("# Cool Idea\n\nInitialized with T3 Code.\n");
+  });
+});

--- a/packages/shared/src/projectScaffold.ts
+++ b/packages/shared/src/projectScaffold.ts
@@ -1,0 +1,67 @@
+// Helpers for the "create project" flow: a project name maps deterministically
+// to a folder slug and a generated favicon, shared by the web client (path
+// preview, collision check) and the server (scaffold service).
+
+/** Folder that groups created projects under the add-project base directory. */
+export const CREATED_PROJECTS_DIRECTORY_NAME = "t3-projects";
+
+const MAX_PROJECT_SLUG_LENGTH = 64;
+
+/**
+ * Maps a human project name to a filesystem-safe folder name: lowercase,
+ * alphanumeric runs joined by single dashes. Returns "" when nothing survives
+ * (callers treat that as "no valid name yet").
+ */
+export function slugifyProjectName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, MAX_PROJECT_SLUG_LENGTH)
+    .replace(/-+$/g, "");
+}
+
+/** FNV-1a, used to derive a stable hue from the project name. */
+function hashProjectName(name: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < name.length; index += 1) {
+    hash ^= name.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function projectFaviconLetter(name: string): string {
+  const alphanumeric = /[\p{L}\p{N}]/u.exec(name);
+  const letter = alphanumeric?.[0] ?? name.trim().at(0) ?? "?";
+  return letter.toUpperCase();
+}
+
+/**
+ * Deterministic project favicon: the first letter of the name in white on a
+ * rounded square whose hue hashes from the name. Saturation/lightness are
+ * fixed so every icon reads on the true-black sidebar at 16px.
+ */
+export function generateProjectFaviconSvg(name: string): string {
+  const hue = hashProjectName(name) % 360;
+  const letter = escapeXml(projectFaviconLetter(name));
+  return [
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">`,
+    `<rect width="128" height="128" rx="24" fill="hsl(${hue} 65% 45%)"/>`,
+    `<text x="64" y="64" font-family="system-ui, sans-serif" font-size="72" font-weight="700" fill="#ffffff" text-anchor="middle" dominant-baseline="central">${letter}</text>`,
+    `</svg>`,
+    ``,
+  ].join("\n");
+}
+
+export function generateProjectReadme(name: string): string {
+  return `# ${name}\n\nInitialized with T3 Code.\n`;
+}


### PR DESCRIPTION
Starting a throwaway experiment meant leaving T3 Code: make a folder, git init, come back, add it. Enough friction that quick ideas didn't get captured.

Now the add-project flow has a third option next to local browse and clone: **Create new project**. Type a name and T3 Code scaffolds `[addProjectBaseDirectory or ~]/t3-projects/[slug]` with `git init -b main`, a README, a generated favicon, and one initial commit, then registers the project and drops you straight into a new thread.

Details:

- The initial commit is mandatory, not cosmetic: `git worktree add` fails on a repo with an unborn HEAD, so a fresh repo without it can't start threads.
- The favicon is a deterministic SVG (letter on a hue hashed from the name) written as `favicon.svg`, which the existing favicon resolver already picks up.
- The typed name stays as the project title; the slug is only the folder name.
- Live path preview while typing; an existing folder warns and blocks submit.
- If the scaffold fails midway the created folder is removed, and the commit falls back to a "T3 Code" identity when git identity is unset.
- Web only; mobile is a fast follow.

Server side is one new `projects.scaffold` RPC (`ProjectScaffoldService`), integration-tested against real git (committed on main, clean tree, refuses existing dirs, cleans up on failure). Also verified end to end in a live dev instance.

Built by Claude Fable 5 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New filesystem and git RPC with operate scope; failure cleanup and concurrent mkdir guards reduce risk, but wrong paths or races on the same destination remain possible.
> 
> **Overview**
> Adds **Create new project** to the command palette add-project flow so users can scaffold an empty repo without leaving T3 Code.
> 
> A new **`projects.scaffold`** RPC (`ProjectScaffoldService`) creates `[base]/t3-projects/[slug]` with `git init -b main`, README, generated `favicon.svg`, and a required initial commit (so worktrees can start). Shared **`projectScaffold`** helpers handle slugify, README, and favicon for client preview and server. The palette shows live destination paths, blocks name collisions, then registers the project with the typed title and opens a new thread. Failed scaffolds remove the created folder; commits use a T3 Code git identity when `user.name`/`user.email` are unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58f964b1cfd4f981d207bfc4d457d5e3944619ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'Create new project' flow to the command palette add-project dialog
> - Adds a `projects.scaffold` WebSocket RPC that creates a directory, initializes a git repo on `main`, writes a `README.md` and `favicon.svg`, and commits them, cleaning up on failure.
> - The command palette add-project flow gains a "Create new project" option where users type a project name, see a preview destination under a `t3-projects` directory, and submit to invoke the scaffold RPC.
> - Collision detection warns when the target directory already exists; the name input is validated via `slugifyProjectName` and the UI reflects disabled/progress states.
> - New shared helpers in [`packages/shared/src/projectScaffold.ts`](https://github.com/pingdotgg/t3code/pull/6638/files#diff-c5a1e69a966575610ad609dcc6c8d78b4adfb33bf7a52c767e5a99789e8f1a66) provide deterministic slug generation, favicon SVG, and README content used by both client and server.
> - New contract types in [`packages/contracts/src/project.ts`](https://github.com/pingdotgg/t3code/pull/6638/files#diff-8884ce1953b4cd4c0485483959ee19cfc087d42ff24c02d5f59af5957d80ec5f) define `ProjectScaffoldInput`, `ProjectScaffoldResult`, and `ProjectScaffoldError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 58f964b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->