### PR TITLE
fix(claude): surface usage-limit pauses

### DIFF
--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -37,6 +37,7 @@ import Animated, {
 import { useThemeColor } from "../../lib/useThemeColor";
 import { armAgentAwarenessLiveActivityForLocalWork } from "../agent-awareness/remoteRegistration";
 import { scopedThreadKey } from "../../lib/scopedEntities";
+import { readUsageLimit, usageLimitPresentation } from "./usageLimitPresentation";
 
 import { AppText as Text } from "../../components/AppText";
 import { ComposerAttachmentStrip } from "../../components/ComposerAttachmentStrip";
@@ -288,6 +289,10 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
   // while focus moves between its native editor and the settings picker.
   const isExpanded = isFocused || settingsSheetPresentation.isActive;
   const canSend = hasContent;
+  const usageLimit = readUsageLimit(
+    (props.selectedThread.session as { usageLimit?: unknown } | null | undefined)?.usageLimit,
+  );
+  const usageLimitCopy = usageLimit ? usageLimitPresentation(usageLimit) : null;
 
   // Notify the parent from the derived value, not focus events: the parent
   // sizes the feed inset from this, and blur-during-sheet would otherwise
@@ -715,6 +720,22 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
         layout={COMPOSER_LAYOUT_TRANSITION}
         style={{ maxWidth: props.contentMaxWidth }}
       >
+        {usageLimitCopy ? (
+          <View
+            accessibilityRole="alert"
+            className="mb-2 flex-row items-start gap-2 rounded-2xl border border-red-500/30 bg-red-500/10 px-3 py-2"
+          >
+            <Text className="text-sm font-t3-bold text-red-600 dark:text-red-300">!</Text>
+            <View className="min-w-0 flex-1">
+              <Text className="text-sm font-t3-bold text-red-700 dark:text-red-200">
+                {usageLimitCopy.title}
+              </Text>
+              <Text className="text-xs leading-snug text-red-700/80 dark:text-red-200/80">
+                {usageLimitCopy.detail}
+              </Text>
+            </View>
+          </View>
+        ) : null}
         {composerTrigger && composerMenuItems.length > 0 ? (
           <View className="absolute inset-x-0 bottom-full z-10 mb-2">
             <ComposerCommandPopover

--- a/apps/mobile/src/features/threads/usageLimitPresentation.test.ts
+++ b/apps/mobile/src/features/threads/usageLimitPresentation.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vite-plus/test";
+import { formatUsageLimitReset, usageLimitPresentation } from "./usageLimitPresentation";
+
+describe("usage limit presentation", () => {
+  it("includes provider message and localized reset", () => {
+    const notice = {
+      occurrenceId: "abc",
+      provider: "claudeAgent",
+      message: "Your plan is at its limit.",
+      resetsAt: Date.UTC(2026, 0, 2, 15, 30),
+    };
+    expect(usageLimitPresentation(notice)).toEqual({
+      title: "Claude usage limit reached",
+      detail: `Your plan is at its limit. Resets ${formatUsageLimitReset(notice.resetsAt)}.`,
+    });
+  });
+});

--- a/apps/mobile/src/features/threads/usageLimitPresentation.ts
+++ b/apps/mobile/src/features/threads/usageLimitPresentation.ts
@@ -1,0 +1,52 @@
+export interface UsageLimitNotice {
+  readonly occurrenceId: string;
+  readonly provider: string;
+  readonly resetsAt?: number;
+  readonly message: string;
+}
+
+export interface UsageLimitPresentation {
+  readonly title: string;
+  readonly detail: string;
+}
+
+function providerLabel(provider: string): string {
+  return provider === "claudeAgent" ? "Claude" : provider;
+}
+
+export function usageLimitPresentation(notice: UsageLimitNotice): UsageLimitPresentation {
+  const reset =
+    typeof notice.resetsAt === "number" && Number.isFinite(notice.resetsAt)
+      ? formatUsageLimitReset(notice.resetsAt)
+      : null;
+  return {
+    title: `${providerLabel(notice.provider)} usage limit reached`,
+    detail: reset ? `${notice.message} Resets ${reset}.` : notice.message,
+  };
+}
+
+export function formatUsageLimitReset(timestamp: number, locale?: string): string {
+  return new Intl.DateTimeFormat(locale, { dateStyle: "medium", timeStyle: "short" }).format(
+    new Date(timestamp),
+  );
+}
+
+export function readUsageLimit(value: unknown): UsageLimitNotice | null {
+  if (!value || typeof value !== "object") return null;
+  const notice = value as Partial<UsageLimitNotice>;
+  if (
+    typeof notice.occurrenceId !== "string" ||
+    typeof notice.provider !== "string" ||
+    typeof notice.message !== "string"
+  ) {
+    return null;
+  }
+  return {
+    occurrenceId: notice.occurrenceId,
+    provider: notice.provider,
+    message: notice.message,
+    ...(typeof notice.resetsAt === "number" && Number.isFinite(notice.resetsAt)
+      ? { resetsAt: notice.resetsAt }
+      : {}),
+  };
+}

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -1141,6 +1141,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
         runtimeMode: event.payload.session.runtimeMode,
         activeTurnId: event.payload.session.activeTurnId,
         lastError: event.payload.session.lastError,
+        usageLimit: event.payload.session.usageLimit ?? null,
         updatedAt: event.payload.session.updatedAt,
       });
     });

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -7,6 +7,7 @@ import {
   OrchestrationCheckpointFile,
   OrchestrationProposedPlanId,
   OrchestrationReadModel,
+  OrchestrationSessionUsageLimit,
   OrchestrationThreadSearchSource,
   OrchestrationShellSnapshot,
   OrchestrationThread,
@@ -93,7 +94,11 @@ const ProjectionThreadActivityDbRowSchema = ProjectionThreadActivity.mapFields(
     sequence: Schema.NullOr(NonNegativeInt),
   }),
 );
-const ProjectionThreadSessionDbRowSchema = ProjectionThreadSession;
+const ProjectionThreadSessionDbRowSchema = ProjectionThreadSession.mapFields(
+  Struct.assign({
+    usageLimit: Schema.NullOr(Schema.fromJsonString(OrchestrationSessionUsageLimit)),
+  }),
+);
 const ProjectionCheckpointDbRowSchema = ProjectionCheckpoint.mapFields(
   Struct.assign({
     files: Schema.fromJsonString(Schema.Array(OrchestrationCheckpointFile)),
@@ -302,6 +307,7 @@ function mapSessionRow(
     runtimeMode: row.runtimeMode,
     activeTurnId: row.activeTurnId,
     lastError: row.lastError,
+    ...(row.usageLimit !== null ? { usageLimit: row.usageLimit } : {}),
     updatedAt: row.updatedAt,
   };
 }
@@ -594,6 +600,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           runtime_mode AS "runtimeMode",
           active_turn_id AS "activeTurnId",
           last_error AS "lastError",
+          usage_limit AS "usageLimit",
           updated_at AS "updatedAt"
         FROM projection_thread_sessions
         ORDER BY thread_id ASC
@@ -615,6 +622,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           sessions.runtime_mode AS "runtimeMode",
           sessions.active_turn_id AS "activeTurnId",
           sessions.last_error AS "lastError",
+          sessions.usage_limit AS "usageLimit",
           sessions.updated_at AS "updatedAt"
         FROM projection_thread_sessions sessions
         INNER JOIN projection_threads threads
@@ -640,6 +648,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           sessions.runtime_mode AS "runtimeMode",
           sessions.active_turn_id AS "activeTurnId",
           sessions.last_error AS "lastError",
+          sessions.usage_limit AS "usageLimit",
           sessions.updated_at AS "updatedAt"
         FROM projection_thread_sessions sessions
         INNER JOIN projection_threads threads
@@ -678,7 +687,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         SELECT
           turns.thread_id AS "threadId",
           turns.turn_id AS "turnId",
-          turns.state,
+          CASE WHEN sessions.status = 'interrupted' THEN 'interrupted' ELSE turns.state END AS state,
           turns.requested_at AS "requestedAt",
           turns.started_at AS "startedAt",
           turns.completed_at AS "completedAt",
@@ -689,6 +698,8 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         JOIN projection_turns turns
           ON turns.thread_id = threads.thread_id
           AND turns.turn_id = threads.latest_turn_id
+        LEFT JOIN projection_thread_sessions sessions
+          ON sessions.thread_id = threads.thread_id
         WHERE threads.latest_turn_id IS NOT NULL
         ORDER BY turns.thread_id ASC
       `,
@@ -702,7 +713,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         SELECT
           turns.thread_id AS "threadId",
           turns.turn_id AS "turnId",
-          turns.state,
+          CASE WHEN sessions.status = 'interrupted' THEN 'interrupted' ELSE turns.state END AS state,
           turns.requested_at AS "requestedAt",
           turns.started_at AS "startedAt",
           turns.completed_at AS "completedAt",
@@ -713,6 +724,8 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         JOIN projection_turns turns
           ON turns.thread_id = threads.thread_id
           AND turns.turn_id = threads.latest_turn_id
+        LEFT JOIN projection_thread_sessions sessions
+          ON sessions.thread_id = threads.thread_id
         WHERE threads.deleted_at IS NULL
           AND threads.archived_at IS NULL
           AND threads.latest_turn_id IS NOT NULL
@@ -728,7 +741,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         SELECT
           turns.thread_id AS "threadId",
           turns.turn_id AS "turnId",
-          turns.state,
+          CASE WHEN sessions.status = 'interrupted' THEN 'interrupted' ELSE turns.state END AS state,
           turns.requested_at AS "requestedAt",
           turns.started_at AS "startedAt",
           turns.completed_at AS "completedAt",
@@ -739,6 +752,8 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         JOIN projection_turns turns
           ON turns.thread_id = threads.thread_id
           AND turns.turn_id = threads.latest_turn_id
+        LEFT JOIN projection_thread_sessions sessions
+          ON sessions.thread_id = threads.thread_id
         WHERE threads.deleted_at IS NULL
           AND threads.archived_at IS NOT NULL
           AND threads.latest_turn_id IS NOT NULL
@@ -1037,6 +1052,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           runtime_mode AS "runtimeMode",
           active_turn_id AS "activeTurnId",
           last_error AS "lastError",
+          usage_limit AS "usageLimit",
           updated_at AS "updatedAt"
         FROM projection_thread_sessions
         WHERE thread_id = ${threadId}
@@ -1052,7 +1068,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         SELECT
           turns.thread_id AS "threadId",
           turns.turn_id AS "turnId",
-          turns.state,
+          CASE WHEN sessions.status = 'interrupted' THEN 'interrupted' ELSE turns.state END AS state,
           turns.requested_at AS "requestedAt",
           turns.started_at AS "startedAt",
           turns.completed_at AS "completedAt",
@@ -1063,6 +1079,8 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         JOIN projection_turns turns
           ON turns.thread_id = threads.thread_id
           AND turns.turn_id = threads.latest_turn_id
+        LEFT JOIN projection_thread_sessions sessions
+          ON sessions.thread_id = threads.thread_id
         WHERE threads.thread_id = ${threadId}
           AND threads.deleted_at IS NULL
           AND threads.archived_at IS NULL
@@ -1535,6 +1553,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                   runtimeMode: row.runtimeMode,
                   activeTurnId: row.activeTurnId,
                   lastError: row.lastError,
+                  ...(row.usageLimit !== null ? { usageLimit: row.usageLimit } : {}),
                   updatedAt: row.updatedAt,
                 });
               }

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -364,6 +364,93 @@ describe("ProviderRuntimeIngestion", () => {
     expect(thread.session?.lastError).toBe("turn failed");
   });
 
+  it("projects a Claude usage-limit stop as an interrupted, non-error session", async () => {
+    const harness = await createHarness();
+    const startedAt = "2026-01-01T00:00:00.000Z";
+    const completedAt = "2026-01-01T00:00:05.000Z";
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-claude-limit-started"),
+      provider: ProviderDriverKind.make("claudeAgent"),
+      threadId: asThreadId("thread-1"),
+      createdAt: startedAt,
+      turnId: asTurnId("turn-claude-limit"),
+    });
+
+    await waitForThread(
+      harness.readModel,
+      (thread) =>
+        thread.session?.status === "running" && thread.session.activeTurnId === "turn-claude-limit",
+    );
+
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-claude-limit-completed"),
+      provider: ProviderDriverKind.make("claudeAgent"),
+      threadId: asThreadId("thread-1"),
+      createdAt: completedAt,
+      turnId: asTurnId("turn-claude-limit"),
+      payload: {
+        state: "interrupted",
+        errorMessage: "5-hour Claude usage limit reached.",
+        usageLimit: {
+          windowType: "five_hour",
+          resetsAt: 1_800_000_000_000,
+          message: "5-hour Claude usage limit reached.",
+        },
+      },
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) => entry.session?.usageLimit?.occurrenceId === "evt-claude-limit-completed",
+    );
+
+    expect(thread.session).toMatchObject({
+      status: "interrupted",
+      activeTurnId: null,
+      lastError: null,
+      usageLimit: {
+        occurrenceId: "evt-claude-limit-completed",
+        provider: "claudeAgent",
+        windowType: "five_hour",
+        resetsAt: 1_800_000_000_000,
+        message: "5-hour Claude usage limit reached.",
+      },
+    });
+    expect(thread.latestTurn).toMatchObject({
+      turnId: "turn-claude-limit",
+      state: "interrupted",
+      completedAt,
+    });
+    expect(thread.activities).toContainEqual(
+      expect.objectContaining({
+        kind: "usage-limit.reached",
+        tone: "info",
+        turnId: "turn-claude-limit",
+      }),
+    );
+
+    harness.emit({
+      type: "session.exited",
+      eventId: asEventId("evt-claude-limit-exited"),
+      provider: ProviderDriverKind.make("claudeAgent"),
+      threadId: asThreadId("thread-1"),
+      createdAt: "2026-01-01T00:00:06.000Z",
+      payload: {},
+    });
+
+    const exitedThread = await waitForThread(
+      harness.readModel,
+      (entry) => entry.session?.updatedAt === "2026-01-01T00:00:06.000Z",
+    );
+    expect(exitedThread.session).toMatchObject({
+      status: "interrupted",
+      usageLimit: { occurrenceId: "evt-claude-limit-completed" },
+    });
+  });
+
   it("applies provider session.state.changed transitions directly", async () => {
     const harness = await createHarness();
     const waitingAt = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -368,6 +368,37 @@ export function runtimeEventToActivities(
       : {};
   })();
   switch (event.type) {
+    case "turn.completed": {
+      if (event.payload.usageLimit === undefined) {
+        return [];
+      }
+      const message =
+        event.payload.usageLimit.message ??
+        event.payload.errorMessage ??
+        "Claude usage limit reached.";
+      return [
+        {
+          id: event.eventId,
+          createdAt: event.createdAt,
+          tone: "info",
+          kind: "usage-limit.reached",
+          summary: message,
+          payload: {
+            provider: event.provider,
+            message,
+            ...(event.payload.usageLimit.windowType !== undefined
+              ? { windowType: event.payload.usageLimit.windowType }
+              : {}),
+            ...(event.payload.usageLimit.resetsAt !== undefined
+              ? { resetsAt: event.payload.usageLimit.resetsAt }
+              : {}),
+          },
+          turnId: toTurnId(event.turnId) ?? null,
+          ...maybeSequence,
+        },
+      ];
+    }
+
     case "request.opened": {
       if (event.payload.requestType === "tool_user_input") {
         return [];
@@ -1566,11 +1597,13 @@ const make = Effect.gen(function* () {
             case "turn.started":
               return "running";
             case "session.exited":
-              return "stopped";
+              return thread.session?.usageLimit ? "interrupted" : "stopped";
             case "turn.completed":
-              return normalizeRuntimeTurnState(event.payload.state) === "failed"
-                ? "error"
-                : "ready";
+              return event.payload.usageLimit !== undefined
+                ? "interrupted"
+                : normalizeRuntimeTurnState(event.payload.state) === "failed"
+                  ? "error"
+                  : "ready";
             case "session.started":
             case "thread.started":
               // Provider thread/session start notifications can arrive during an
@@ -1592,12 +1625,33 @@ const make = Effect.gen(function* () {
         const lastError =
           event.type === "session.state.changed" && event.payload.state === "error"
             ? (event.payload.reason ?? thread.session?.lastError ?? "Provider session error")
-            : event.type === "turn.completed" &&
-                normalizeRuntimeTurnState(event.payload.state) === "failed"
-              ? (event.payload.errorMessage ?? thread.session?.lastError ?? "Turn failed")
-              : status === "ready"
-                ? null
-                : (thread.session?.lastError ?? null);
+            : event.type === "turn.completed" && event.payload.usageLimit !== undefined
+              ? null
+              : event.type === "turn.completed" &&
+                  normalizeRuntimeTurnState(event.payload.state) === "failed"
+                ? (event.payload.errorMessage ?? thread.session?.lastError ?? "Turn failed")
+                : status === "ready"
+                  ? null
+                  : (thread.session?.lastError ?? null);
+        const usageLimit =
+          event.type === "turn.started"
+            ? null
+            : event.type === "turn.completed" && event.payload.usageLimit !== undefined
+              ? {
+                  occurrenceId: event.eventId,
+                  provider: event.provider,
+                  ...(event.payload.usageLimit.windowType !== undefined
+                    ? { windowType: event.payload.usageLimit.windowType }
+                    : {}),
+                  ...(event.payload.usageLimit.resetsAt !== undefined
+                    ? { resetsAt: event.payload.usageLimit.resetsAt }
+                    : {}),
+                  message:
+                    event.payload.usageLimit.message ??
+                    event.payload.errorMessage ??
+                    "Claude usage limit reached.",
+                }
+              : (thread.session?.usageLimit ?? null);
 
         if (shouldApplyThreadLifecycle) {
           if (event.type === "turn.started" && acceptedTurnStartedSourcePlan !== null) {
@@ -1634,6 +1688,7 @@ const make = Effect.gen(function* () {
               runtimeMode: thread.session?.runtimeMode ?? "full-access",
               activeTurnId: nextActiveTurnId,
               lastError,
+              usageLimit,
               updatedAt: now,
             },
             createdAt: now,
@@ -1884,6 +1939,7 @@ const make = Effect.gen(function* () {
               runtimeMode: thread.session?.runtimeMode ?? "full-access",
               activeTurnId: eventTurnId ?? null,
               lastError: runtimeErrorMessage,
+              usageLimit: thread.session?.usageLimit ?? null,
               updatedAt: now,
             },
             createdAt: now,

--- a/apps/server/src/persistence/Layers/ProjectionRepositories.test.ts
+++ b/apps/server/src/persistence/Layers/ProjectionRepositories.test.ts
@@ -1,4 +1,10 @@
-import { ProjectId, ThreadId, ProviderInstanceId } from "@t3tools/contracts";
+import {
+  EventId,
+  ProjectId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  ThreadId,
+} from "@t3tools/contracts";
 import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -8,18 +14,63 @@ import * as SqlClient from "effect/unstable/sql/SqlClient";
 import { SqlitePersistenceMemory } from "./Sqlite.ts";
 import { ProjectionProjectRepositoryLive } from "./ProjectionProjects.ts";
 import { ProjectionThreadRepositoryLive } from "./ProjectionThreads.ts";
+import { ProjectionThreadSessionRepositoryLive } from "./ProjectionThreadSessions.ts";
 import { ProjectionProjectRepository } from "../Services/ProjectionProjects.ts";
 import { ProjectionThreadRepository } from "../Services/ProjectionThreads.ts";
+import { ProjectionThreadSessionRepository } from "../Services/ProjectionThreadSessions.ts";
 
 const projectionRepositoriesLayer = it.layer(
   Layer.mergeAll(
     ProjectionProjectRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
     ProjectionThreadRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
+    ProjectionThreadSessionRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
     SqlitePersistenceMemory,
   ),
 );
 
 projectionRepositoriesLayer("Projection repositories", (it) => {
+  it.effect("round-trips structured thread-session usage limits as JSON", () =>
+    Effect.gen(function* () {
+      const sessions = yield* ProjectionThreadSessionRepository;
+      const sql = yield* SqlClient.SqlClient;
+      const usageLimit = {
+        occurrenceId: EventId.make("usage-limit-1"),
+        provider: ProviderDriverKind.make("claudeAgent"),
+        windowType: "five_hour",
+        resetsAt: 1_800_000_000_000,
+        message: "Claude usage limit reached.",
+      };
+
+      yield* sessions.upsert({
+        threadId: ThreadId.make("thread-usage-limit"),
+        status: "interrupted",
+        providerName: "claudeAgent",
+        providerInstanceId: null,
+        runtimeMode: "full-access",
+        activeTurnId: null,
+        lastError: null,
+        usageLimit,
+        updatedAt: "2026-03-24T00:00:00.000Z",
+      });
+
+      const rows = yield* sql<{ readonly usageLimit: string | null }>`
+        SELECT usage_limit AS "usageLimit"
+        FROM projection_thread_sessions
+        WHERE thread_id = 'thread-usage-limit'
+      `;
+      assert.strictEqual(
+        rows[0]?.usageLimit,
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
+        JSON.stringify(usageLimit),
+      );
+
+      const persisted = yield* sessions.getByThreadId({
+        threadId: ThreadId.make("thread-usage-limit"),
+      });
+      assert.deepStrictEqual(Option.getOrNull(persisted)?.usageLimit, usageLimit);
+    }),
+  );
+
   it.effect("stores SQL NULL for missing project model options", () =>
     Effect.gen(function* () {
       const projects = yield* ProjectionProjectRepository;

--- a/apps/server/src/persistence/Layers/ProjectionThreadSessions.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadSessions.ts
@@ -2,6 +2,9 @@ import * as SqlClient from "effect/unstable/sql/SqlClient";
 import * as SqlSchema from "effect/unstable/sql/SqlSchema";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+import * as Struct from "effect/Struct";
+import { OrchestrationSessionUsageLimit } from "@t3tools/contracts";
 
 import { toPersistenceSqlError } from "../Errors.ts";
 
@@ -12,6 +15,12 @@ import {
   DeleteProjectionThreadSessionInput,
   GetProjectionThreadSessionInput,
 } from "../Services/ProjectionThreadSessions.ts";
+
+const ProjectionThreadSessionDbRow = ProjectionThreadSession.mapFields(
+  Struct.assign({
+    usageLimit: Schema.NullOr(Schema.fromJsonString(OrchestrationSessionUsageLimit)),
+  }),
+);
 
 const makeProjectionThreadSessionRepository = Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient;
@@ -28,6 +37,7 @@ const makeProjectionThreadSessionRepository = Effect.gen(function* () {
           runtime_mode,
           active_turn_id,
           last_error,
+          usage_limit,
           updated_at
         )
         VALUES (
@@ -38,6 +48,7 @@ const makeProjectionThreadSessionRepository = Effect.gen(function* () {
           ${row.runtimeMode},
           ${row.activeTurnId},
           ${row.lastError},
+          ${row.usageLimit === null ? null : JSON.stringify(row.usageLimit)},
           ${row.updatedAt}
         )
         ON CONFLICT (thread_id)
@@ -48,13 +59,14 @@ const makeProjectionThreadSessionRepository = Effect.gen(function* () {
           runtime_mode = excluded.runtime_mode,
           active_turn_id = excluded.active_turn_id,
           last_error = excluded.last_error,
+          usage_limit = excluded.usage_limit,
           updated_at = excluded.updated_at
       `,
   });
 
   const getProjectionThreadSessionRow = SqlSchema.findOneOption({
     Request: GetProjectionThreadSessionInput,
-    Result: ProjectionThreadSession,
+    Result: ProjectionThreadSessionDbRow,
     execute: ({ threadId }) =>
       sql`
         SELECT
@@ -65,6 +77,7 @@ const makeProjectionThreadSessionRepository = Effect.gen(function* () {
           runtime_mode AS "runtimeMode",
           active_turn_id AS "activeTurnId",
           last_error AS "lastError",
+          usage_limit AS "usageLimit",
           updated_at AS "updatedAt"
         FROM projection_thread_sessions
         WHERE thread_id = ${threadId}

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -53,6 +53,7 @@ import Migration0037 from "./Migrations/037_ProjectionTurnsKeysetIndex.ts";
 import Migration0038 from "./Migrations/038_ProjectionThreadsPinOrderKey.ts";
 import Migration0039 from "./Migrations/039_ProjectionProjectsDefaultThreadEnvMode.ts";
 import Migration0040 from "./Migrations/040_ProjectionProjectFaviconPath.ts";
+import Migration0041 from "./Migrations/041_ProjectionThreadSessionUsageLimit.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -105,6 +106,7 @@ export const migrationEntries = [
   [38, "ProjectionThreadsPinOrderKey", Migration0038],
   [39, "ProjectionProjectsDefaultThreadEnvMode", Migration0039],
   [40, "ProjectionProjectFaviconPath", Migration0040],
+  [41, "ProjectionThreadSessionUsageLimit", Migration0041],
 ] as const;
 
 export const migrationManifest = migrationEntries.map(([id, name]) => [id, name] as const);

--- a/apps/server/src/persistence/Migrations/041_ProjectionThreadSessionUsageLimit.test.ts
+++ b/apps/server/src/persistence/Migrations/041_ProjectionThreadSessionUsageLimit.test.ts
@@ -1,0 +1,28 @@
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { runMigrations } from "../Migrations.ts";
+import * as NodeSqliteClient from "../NodeSqliteClient.ts";
+
+const layer = it.layer(Layer.mergeAll(NodeSqliteClient.layerMemory()));
+
+layer("041_ProjectionThreadSessionUsageLimit", (it) => {
+  it.effect("adds a nullable usage limit column", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* runMigrations({ toMigrationInclusive: 40 });
+      yield* runMigrations({ toMigrationInclusive: 41 });
+
+      const columns = yield* sql<{ readonly name: string; readonly notnull: number }>`
+        PRAGMA table_info(projection_thread_sessions)
+      `;
+      const usageLimit = columns.find((column) => column.name === "usage_limit");
+
+      assert.equal(usageLimit?.name, "usage_limit");
+      assert.equal(usageLimit?.notnull, 0);
+    }),
+  );
+});

--- a/apps/server/src/persistence/Migrations/041_ProjectionThreadSessionUsageLimit.ts
+++ b/apps/server/src/persistence/Migrations/041_ProjectionThreadSessionUsageLimit.ts
@@ -1,0 +1,16 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  const columns = yield* sql<{ readonly name: string }>`
+    PRAGMA table_info(projection_thread_sessions)
+  `;
+
+  if (!columns.some((column) => column.name === "usage_limit")) {
+    yield* sql`
+      ALTER TABLE projection_thread_sessions
+      ADD COLUMN usage_limit TEXT
+    `;
+  }
+});

--- a/apps/server/src/persistence/Services/ProjectionThreadSessions.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreadSessions.ts
@@ -10,6 +10,7 @@ import {
   RuntimeMode,
   IsoDateTime,
   OrchestrationSessionStatus,
+  OrchestrationSessionUsageLimit,
   ProviderInstanceId,
   ThreadId,
   TurnId,
@@ -29,6 +30,7 @@ export const ProjectionThreadSession = Schema.Struct({
   runtimeMode: RuntimeMode,
   activeTurnId: Schema.NullOr(TurnId),
   lastError: Schema.NullOr(Schema.String),
+  usageLimit: Schema.NullOr(OrchestrationSessionUsageLimit),
   updatedAt: IsoDateTime,
 });
 export type ProjectionThreadSession = typeof ProjectionThreadSession.Type;

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1580,6 +1580,150 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("turns Claude usage-limit results into an interrupted completion", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 7).pipe(
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      const turn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "rate_limit_event",
+        rate_limit_info: {
+          status: "rejected",
+          rateLimitType: "five_hour",
+          resetsAt: 1_800_000_000_000,
+        },
+        session_id: "sdk-session-limit",
+        uuid: "rate-limit",
+      } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "result",
+        subtype: "error_during_execution",
+        is_error: true,
+        errors: ["[ede_diagnostic] rate limit"],
+        terminal_reason: "blocking_limit",
+        session_id: "sdk-session-limit",
+        uuid: "result-limit",
+      } as unknown as SDKMessage);
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      assert.equal(runtimeEvents.filter((event) => event.type === "runtime.error").length, 0);
+      const completed = runtimeEvents.find((event) => event.type === "turn.completed");
+      assert.equal(completed?.type, "turn.completed");
+      if (completed?.type === "turn.completed") {
+        assert.equal(String(completed.turnId), String(turn.turnId));
+        assert.equal(completed.payload.state, "interrupted");
+        assert.deepEqual(completed.payload.usageLimit, {
+          windowType: "five_hour",
+          resetsAt: 1_800_000_000_000,
+          message: "Claude usage limit reached.",
+        });
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("clears a rejected usage-limit marker on a later allowed event", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 8).pipe(
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({ threadId: session.threadId, input: "hello", attachments: [] });
+      harness.query.emit({
+        type: "rate_limit_event",
+        rate_limit_info: { status: "rejected", rateLimitType: "five_hour" },
+        session_id: "sdk-session-limit-clear",
+        uuid: "rate-limit-rejected",
+      } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "rate_limit_event",
+        rate_limit_info: { status: "allowed" },
+        session_id: "sdk-session-limit-clear",
+        uuid: "rate-limit-allowed",
+      } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "result",
+        subtype: "error_during_execution",
+        is_error: true,
+        errors: ["[ede_diagnostic] rate limit"],
+        terminal_reason: "rapid_refill_breaker",
+        session_id: "sdk-session-limit-clear",
+        uuid: "result-limit-clear",
+      } as unknown as SDKMessage);
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      const completed = runtimeEvents.find((event) => event.type === "turn.completed");
+      assert.equal(completed?.type, "turn.completed");
+      if (completed?.type === "turn.completed") {
+        assert.equal(completed.payload.state, "interrupted");
+        assert.equal(completed.payload.usageLimit, undefined);
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("completes a silently ended limited stream once without a runtime error", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 7).pipe(
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({ threadId: session.threadId, input: "hello", attachments: [] });
+      harness.query.emit({
+        type: "rate_limit_event",
+        rate_limit_info: { status: "rejected", rateLimitType: "seven_day" },
+        session_id: "sdk-session-silent-limit",
+        uuid: "rate-limit-silent",
+      } as unknown as SDKMessage);
+      harness.query.finish();
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      assert.equal(runtimeEvents.filter((event) => event.type === "runtime.error").length, 0);
+      const completions = runtimeEvents.filter((event) => event.type === "turn.completed");
+      assert.equal(completions.length, 1);
+      const completed = completions[0];
+      if (completed?.type === "turn.completed") {
+        assert.equal(completed.payload.state, "interrupted");
+        assert.equal(completed.payload.usageLimit?.windowType, "seven_day");
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("interruptTurn settles every acknowledged live task before interrupting", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -245,7 +245,14 @@ interface ClaudeSessionContext {
   lastKnownTotalProcessedTokens: number | undefined;
   lastAssistantUuid: string | undefined;
   lastThreadStartedId: string | undefined;
+  usageLimit: ClaudeUsageLimit | undefined;
   stopped: boolean;
+}
+
+interface ClaudeUsageLimit {
+  readonly windowType?: string;
+  readonly resetsAt?: number;
+  readonly message?: string;
 }
 
 interface ClaudeQueryRuntime extends AsyncIterable<SDKMessage> {
@@ -367,7 +374,9 @@ function isInterruptedResult(result: SDKResultMessage): boolean {
   // is_error: true), interrupting mid-stream yields "aborted_streaming".
   if (
     result.terminal_reason === "aborted_tools" ||
-    result.terminal_reason === "aborted_streaming"
+    result.terminal_reason === "aborted_streaming" ||
+    result.terminal_reason === "blocking_limit" ||
+    result.terminal_reason === "rapid_refill_breaker"
   ) {
     return true;
   }
@@ -2170,6 +2179,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     status: ProviderRuntimeTurnStatus,
     errorMessage?: string,
     result?: SDKResultMessage,
+    usageLimit?: ClaudeUsageLimit,
   ) {
     const resultContextWindow = maxClaudeContextWindowFromModelUsage(result?.modelUsage);
     if (resultContextWindow !== undefined) {
@@ -2339,6 +2349,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           ? { totalCostUsd: result.total_cost_usd }
           : {}),
         ...(errorMessage ? { errorMessage } : {}),
+        ...(usageLimit ? { usageLimit } : {}),
       },
       providerRefs: nativeProviderRefs(context),
     });
@@ -2943,12 +2954,17 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
     const status = turnStatusFromResult(message);
     const errorMessage = resultUserFacingError(message);
+    const usageLimit =
+      message.terminal_reason === "blocking_limit" ||
+      message.terminal_reason === "rapid_refill_breaker"
+        ? context.usageLimit
+        : undefined;
 
     if (status === "failed") {
       yield* emitRuntimeError(context, errorMessage ?? "Claude turn failed.");
     }
 
-    yield* completeTurn(context, status, errorMessage, message);
+    yield* completeTurn(context, status, errorMessage, message, usageLimit);
   });
 
   /**
@@ -3472,6 +3488,18 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     }
 
     if (message.type === "rate_limit_event") {
+      const rateLimitInfo = message.rate_limit_info;
+      if (rateLimitInfo.status === "rejected") {
+        context.usageLimit = {
+          ...(rateLimitInfo.rateLimitType ? { windowType: rateLimitInfo.rateLimitType } : {}),
+          ...(typeof rateLimitInfo.resetsAt === "number" && Number.isFinite(rateLimitInfo.resetsAt)
+            ? { resetsAt: rateLimitInfo.resetsAt }
+            : {}),
+          message: "Claude usage limit reached.",
+        };
+      } else if (rateLimitInfo.status === "allowed") {
+        context.usageLimit = undefined;
+      }
       yield* offerRuntimeEvent({
         ...base,
         type: "account.rate-limits.updated",
@@ -3584,7 +3612,13 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         yield* completeTurn(context, "failed", message);
       }
     } else if (context.turnState) {
-      yield* completeTurn(context, "interrupted", "Claude runtime stream ended.");
+      yield* completeTurn(
+        context,
+        "interrupted",
+        "Claude runtime stream ended.",
+        undefined,
+        context.usageLimit,
+      );
     }
 
     yield* stopSessionInternal(context, {
@@ -4221,6 +4255,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         lastKnownTotalProcessedTokens: undefined,
         lastAssistantUuid: resumeState?.resumeSessionAt,
         lastThreadStartedId: undefined,
+        usageLimit: undefined,
         stopped: false,
       };
       yield* Ref.set(contextRef, context);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -276,6 +276,7 @@ import {
 } from "./chat/ThreadErrorBanner";
 import { resolveThreadPr } from "./ThreadStatusIndicators";
 import { ComposerBannerStack, type ComposerBannerStackItem } from "./chat/ComposerBannerStack";
+import { readUsageLimit, usageLimitBannerItem } from "./chat/usageLimitBanner";
 import { ThreadSyncStatusPill } from "./chat/ThreadSyncStatusPill";
 import {
   DRAFT_HERO_TRANSITION_ANIMATION_ID,
@@ -4442,6 +4443,11 @@ function ChatViewContent(props: ChatViewProps) {
     handleStopBackgroundWork,
     isStoppingBackgroundWork,
   ]);
+  const usageLimitBanner = useMemo<ComposerBannerStackItem | null>(() => {
+    const session = activeThread?.session as { usageLimit?: unknown } | null | undefined;
+    const notice = readUsageLimit(session?.usageLimit);
+    return notice ? usageLimitBannerItem(notice) : null;
+  }, [activeThread?.session]);
   // A woken thread announces itself in the open view, not just the sidebar
   // pill. Dismissing marks the wake as seen (same acknowledgment as the
   // pill); sending a message clears it as a side effect of the send path.
@@ -4521,11 +4527,13 @@ function ChatViewContent(props: ChatViewProps) {
     const calmSystemItems = systemComposerBannerItems.filter((item) => !isUrgentSystemItem(item));
     const backgroundLivenessItems =
       backgroundLivenessBannerItem === null ? [] : [backgroundLivenessBannerItem];
+    const usageLimitItems = usageLimitBanner === null ? [] : [usageLimitBanner];
     const wokeThreadItems = wokeThreadBannerItem === null ? [] : [wokeThreadBannerItem];
     const parkedThreadItems = parkedThreadBannerItem === null ? [] : [parkedThreadBannerItem];
     if (!localCheckoutBranchMismatch || !showBranchMismatchBanner || !activeBranchMismatchKey) {
       return [
         ...urgentSystemItems,
+        ...usageLimitItems,
         ...backgroundLivenessItems,
         ...calmSystemItems,
         ...wokeThreadItems,
@@ -4534,6 +4542,7 @@ function ChatViewContent(props: ChatViewProps) {
     }
     return [
       ...urgentSystemItems,
+      ...usageLimitItems,
       ...backgroundLivenessItems,
       ...calmSystemItems,
       ...wokeThreadItems,
@@ -4587,6 +4596,7 @@ function ChatViewContent(props: ChatViewProps) {
     parkedThreadBannerItem,
     showBranchMismatchBanner,
     systemComposerBannerItems,
+    usageLimitBanner,
     wokeThreadBannerItem,
   ]);
 

--- a/apps/web/src/components/chat/usageLimitBanner.test.ts
+++ b/apps/web/src/components/chat/usageLimitBanner.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vite-plus/test";
+import { formatUsageLimitReset, readUsageLimit, usageLimitBannerItem } from "./usageLimitBanner";
+
+describe("usage limit banner", () => {
+  it("shows provider, supplied message, and localized reset time", () => {
+    const notice = {
+      occurrenceId: "abc",
+      provider: "claudeAgent",
+      message: "Try again later.",
+      resetsAt: Date.UTC(2026, 0, 2, 15, 30),
+    };
+    const item = usageLimitBannerItem(notice);
+
+    expect(item.title).toBe("Claude usage limit reached");
+    expect(item.description).toBe(
+      `Try again later. Resets ${formatUsageLimitReset(notice.resetsAt)}.`,
+    );
+    expect(item.id).toBe("usage-limit:abc");
+  });
+
+  it("accepts notices without a reset and rejects malformed values", () => {
+    expect(
+      usageLimitBannerItem({ occurrenceId: "abc", provider: "Codex", message: "Limit hit." })
+        .description,
+    ).toBe("Limit hit.");
+    expect(readUsageLimit(null)).toBeNull();
+    expect(readUsageLimit({ provider: "Codex" })).toBeNull();
+  });
+});

--- a/apps/web/src/components/chat/usageLimitBanner.ts
+++ b/apps/web/src/components/chat/usageLimitBanner.ts
@@ -1,0 +1,54 @@
+import type { ComposerBannerStackItem } from "./ComposerBannerStack";
+
+export interface UsageLimitNotice {
+  readonly occurrenceId: string;
+  readonly provider: string;
+  readonly windowType?: string;
+  readonly resetsAt?: number;
+  readonly message: string;
+}
+
+function providerLabel(provider: string): string {
+  return provider === "claudeAgent" ? "Claude" : provider;
+}
+
+export function usageLimitBannerItem(notice: UsageLimitNotice): ComposerBannerStackItem {
+  const reset =
+    typeof notice.resetsAt === "number" && Number.isFinite(notice.resetsAt)
+      ? formatUsageLimitReset(notice.resetsAt)
+      : null;
+  return {
+    id: `usage-limit:${notice.occurrenceId}`,
+    variant: "warning",
+    icon: "!",
+    title: `${providerLabel(notice.provider)} usage limit reached`,
+    description: reset ? `${notice.message} Resets ${reset}.` : notice.message,
+  };
+}
+
+export function formatUsageLimitReset(timestamp: number, locale?: string): string {
+  return new Intl.DateTimeFormat(locale, { dateStyle: "medium", timeStyle: "short" }).format(
+    new Date(timestamp),
+  );
+}
+
+export function readUsageLimit(value: unknown): UsageLimitNotice | null {
+  if (!value || typeof value !== "object") return null;
+  const notice = value as Partial<UsageLimitNotice>;
+  if (
+    typeof notice.occurrenceId !== "string" ||
+    typeof notice.provider !== "string" ||
+    typeof notice.message !== "string"
+  ) {
+    return null;
+  }
+  return {
+    occurrenceId: notice.occurrenceId,
+    provider: notice.provider,
+    message: notice.message,
+    ...(notice.windowType === undefined ? {} : { windowType: notice.windowType }),
+    ...(typeof notice.resetsAt === "number" && Number.isFinite(notice.resetsAt)
+      ? { resetsAt: notice.resetsAt }
+      : {}),
+  };
+}

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -21,7 +21,7 @@ import {
   TrimmedString,
   TurnId,
 } from "./baseSchemas.ts";
-import { ProviderInstanceId } from "./providerInstance.ts";
+import { ProviderDriverKind, ProviderInstanceId } from "./providerInstance.ts";
 
 export const ORCHESTRATION_WS_METHODS = {
   dispatchCommand: "orchestration.dispatchCommand",
@@ -282,6 +282,20 @@ export const OrchestrationSessionStatus = Schema.Literals([
 ]);
 export type OrchestrationSessionStatus = typeof OrchestrationSessionStatus.Type;
 
+/**
+ * Durable attribution for a provider turn that paused because its account
+ * usage window closed. Reset timestamps are epoch milliseconds so every
+ * client can format them in the viewer's locale.
+ */
+export const OrchestrationSessionUsageLimit = Schema.Struct({
+  occurrenceId: EventId,
+  provider: ProviderDriverKind,
+  windowType: Schema.optional(TrimmedNonEmptyString),
+  resetsAt: Schema.optional(Schema.Number),
+  message: TrimmedNonEmptyString,
+});
+export type OrchestrationSessionUsageLimit = typeof OrchestrationSessionUsageLimit.Type;
+
 export const OrchestrationSession = Schema.Struct({
   threadId: ThreadId,
   status: OrchestrationSessionStatus,
@@ -290,6 +304,7 @@ export const OrchestrationSession = Schema.Struct({
   runtimeMode: RuntimeMode.pipe(Schema.withDecodingDefault(Effect.succeed(DEFAULT_RUNTIME_MODE))),
   activeTurnId: Schema.NullOr(TurnId),
   lastError: Schema.NullOr(TrimmedNonEmptyString),
+  usageLimit: Schema.optional(Schema.NullOr(OrchestrationSessionUsageLimit)),
   updatedAt: IsoDateTime,
 });
 export type OrchestrationSession = typeof OrchestrationSession.Type;

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -368,6 +368,13 @@ const TurnCompletedPayload = Schema.Struct({
   modelUsage: Schema.optional(UnknownRecordSchema),
   totalCostUsd: Schema.optional(Schema.Number),
   errorMessage: Schema.optional(TrimmedNonEmptyStringSchema),
+  usageLimit: Schema.optional(
+    Schema.Struct({
+      windowType: Schema.optional(TrimmedNonEmptyStringSchema),
+      resetsAt: Schema.optional(Schema.Number),
+      message: Schema.optional(TrimmedNonEmptyStringSchema),
+    }),
+  ),
 });
 export type TurnCompletedPayload = typeof TurnCompletedPayload.Type;
 


### PR DESCRIPTION
Claude usage-limit exits currently look like silent turn failures: the adapter discards the rejected rate-limit payload, and the interruption is not represented durably for clients.

This normalizes Claude's rejected rate-limit events and blocking-limit exits into a structured usage-limit marker, persists it with the orchestration session, and renders the reset state in web and mobile without treating it as a runtime error.

Closes #6513.

Tests: focused Claude adapter, runtime ingestion, projection/persistence, web, and mobile tests; targeted server/contracts/client-runtime/web/mobile typechecks.

Built with GPT-5.6 in the Codex harness through T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface Claude usage-limit pauses as warning banners in web and mobile chat
> - Adds `OrchestrationSessionUsageLimit` to contracts and persists it via a new `usage_limit` column (migration 041) in `projection_thread_sessions`.
> - The Claude adapter classifies `blocking_limit` and `rapid_refill_breaker` terminal reasons as interrupted, tracks usage-limit state in session context, and propagates it through `turn.completed` payloads instead of emitting runtime errors.
> - `ProviderRuntimeIngestion` sets session status to `interrupted` and stores `usageLimit` metadata on the session when a usage-limit turn completion is received; `lastError` is suppressed in this case.
> - Web ([ChatView.tsx](https://github.com/pingdotgg/t3code/pull/6639/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e)) and mobile ([ThreadComposer.tsx](https://github.com/pingdotgg/t3code/pull/6639/files#diff-4c62d895b68dd46f4d2858321c8942fde0d3ddd37c5e4253cba04c18c21a6024)) display a warning banner with provider label and localized reset time when the active session carries a usage limit.
> - Behavioral Change: sessions paused by Claude usage limits now report status `interrupted` rather than `failed`, and `lastError` is cleared for these cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 928c931. 14 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->