### PR TITLE
feat(claude): auto-continue after usage limits

### DIFF
--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -7,6 +7,7 @@ import type {
   RuntimeMode,
   ServerConfig as T3ServerConfig,
 } from "@t3tools/contracts";
+import { EventId } from "@t3tools/contracts";
 import {
   detectComposerTrigger,
   replaceTextRange,
@@ -35,6 +36,8 @@ import Animated, {
   LinearTransition,
 } from "react-native-reanimated";
 import { useThemeColor } from "../../lib/useThemeColor";
+import { useAtomCommand } from "../../state/use-atom-command";
+import { threadEnvironment } from "../../state/threads";
 import { armAgentAwarenessLiveActivityForLocalWork } from "../agent-awareness/remoteRegistration";
 import { scopedThreadKey } from "../../lib/scopedEntities";
 import { readUsageLimit, usageLimitPresentation } from "./usageLimitPresentation";
@@ -289,10 +292,30 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
   // while focus moves between its native editor and the settings picker.
   const isExpanded = isFocused || settingsSheetPresentation.isActive;
   const canSend = hasContent;
-  const usageLimit = readUsageLimit(
-    (props.selectedThread.session as { usageLimit?: unknown } | null | undefined)?.usageLimit,
-  );
+  const usageLimit = readUsageLimit(props.selectedThread.session?.usageLimit);
   const usageLimitCopy = usageLimit ? usageLimitPresentation(usageLimit) : null;
+  const setUsageLimitAutoContinue = useAtomCommand(threadEnvironment.setUsageLimitAutoContinue, {
+    reportFailure: false,
+  });
+  const isClaudeUsageLimit = usageLimit?.provider === "claudeAgent";
+  const handleUsageLimitAutoContinue = useCallback(() => {
+    if (!usageLimit || !isClaudeUsageLimit) return;
+    void setUsageLimitAutoContinue({
+      environmentId: props.environmentId,
+      input: {
+        threadId: props.selectedThread.id,
+        expectedOccurrenceId: EventId.make(usageLimit.occurrenceId),
+        enabled: !usageLimitCopy?.autoContinueEnabled,
+      },
+    });
+  }, [
+    isClaudeUsageLimit,
+    props.environmentId,
+    props.selectedThread.id,
+    setUsageLimitAutoContinue,
+    usageLimit,
+    usageLimitCopy?.autoContinueEnabled,
+  ]);
 
   // Notify the parent from the derived value, not focus events: the parent
   // sizes the feed inset from this, and blur-during-sheet would otherwise
@@ -733,6 +756,18 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
               <Text className="text-xs leading-snug text-red-700/80 dark:text-red-200/80">
                 {usageLimitCopy.detail}
               </Text>
+              {isClaudeUsageLimit ? (
+                <Pressable
+                  accessibilityLabel={usageLimitCopy.autoContinueLabel}
+                  accessibilityRole="button"
+                  className="mt-1 self-start"
+                  onPress={handleUsageLimitAutoContinue}
+                >
+                  <Text className="text-xs font-t3-bold text-red-700 underline dark:text-red-200">
+                    {usageLimitCopy.autoContinueLabel}
+                  </Text>
+                </Pressable>
+              ) : null}
             </View>
           </View>
         ) : null}

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -37,6 +37,7 @@ import Animated, {
 import { useThemeColor } from "../../lib/useThemeColor";
 import { armAgentAwarenessLiveActivityForLocalWork } from "../agent-awareness/remoteRegistration";
 import { scopedThreadKey } from "../../lib/scopedEntities";
+import { readUsageLimit, usageLimitPresentation } from "./usageLimitPresentation";
 
 import { AppText as Text } from "../../components/AppText";
 import { ComposerAttachmentStrip } from "../../components/ComposerAttachmentStrip";
@@ -288,6 +289,10 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
   // while focus moves between its native editor and the settings picker.
   const isExpanded = isFocused || settingsSheetPresentation.isActive;
   const canSend = hasContent;
+  const usageLimit = readUsageLimit(
+    (props.selectedThread.session as { usageLimit?: unknown } | null | undefined)?.usageLimit,
+  );
+  const usageLimitCopy = usageLimit ? usageLimitPresentation(usageLimit) : null;
 
   // Notify the parent from the derived value, not focus events: the parent
   // sizes the feed inset from this, and blur-during-sheet would otherwise
@@ -715,6 +720,22 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
         layout={COMPOSER_LAYOUT_TRANSITION}
         style={{ maxWidth: props.contentMaxWidth }}
       >
+        {usageLimitCopy ? (
+          <View
+            accessibilityRole="alert"
+            className="mb-2 flex-row items-start gap-2 rounded-2xl border border-red-500/30 bg-red-500/10 px-3 py-2"
+          >
+            <Text className="text-sm font-t3-bold text-red-600 dark:text-red-300">!</Text>
+            <View className="min-w-0 flex-1">
+              <Text className="text-sm font-t3-bold text-red-700 dark:text-red-200">
+                {usageLimitCopy.title}
+              </Text>
+              <Text className="text-xs leading-snug text-red-700/80 dark:text-red-200/80">
+                {usageLimitCopy.detail}
+              </Text>
+            </View>
+          </View>
+        ) : null}
         {composerTrigger && composerMenuItems.length > 0 ? (
           <View className="absolute inset-x-0 bottom-full z-10 mb-2">
             <ComposerCommandPopover

--- a/apps/mobile/src/features/threads/usageLimitPresentation.test.ts
+++ b/apps/mobile/src/features/threads/usageLimitPresentation.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vite-plus/test";
+import { formatUsageLimitReset, usageLimitPresentation } from "./usageLimitPresentation";
+
+describe("usage limit presentation", () => {
+  it("includes provider message and localized reset", () => {
+    const notice = {
+      occurrenceId: "abc",
+      provider: "claudeAgent",
+      message: "Your plan is at its limit.",
+      resetsAt: Date.UTC(2026, 0, 2, 15, 30),
+    };
+    expect(usageLimitPresentation(notice)).toEqual({
+      title: "Claude usage limit reached",
+      detail: `Your plan is at its limit. Resets ${formatUsageLimitReset(notice.resetsAt)}.`,
+    });
+  });
+});

--- a/apps/mobile/src/features/threads/usageLimitPresentation.test.ts
+++ b/apps/mobile/src/features/threads/usageLimitPresentation.test.ts
@@ -12,6 +12,8 @@ describe("usage limit presentation", () => {
     expect(usageLimitPresentation(notice)).toEqual({
       title: "Claude usage limit reached",
       detail: `Your plan is at its limit. Resets ${formatUsageLimitReset(notice.resetsAt)}.`,
+      autoContinueEnabled: false,
+      autoContinueLabel: "Enable auto-continue",
     });
   });
 });

--- a/apps/mobile/src/features/threads/usageLimitPresentation.ts
+++ b/apps/mobile/src/features/threads/usageLimitPresentation.ts
@@ -3,11 +3,18 @@ export interface UsageLimitNotice {
   readonly provider: string;
   readonly resetsAt?: number;
   readonly message: string;
+  readonly autoContinue?: boolean;
 }
 
 export interface UsageLimitPresentation {
   readonly title: string;
   readonly detail: string;
+  readonly autoContinueEnabled: boolean;
+  readonly autoContinueLabel: string;
+}
+
+export function usageLimitAutoContinueEnabled(notice: UsageLimitNotice): boolean {
+  return notice.autoContinue === true;
 }
 
 function providerLabel(provider: string): string {
@@ -22,6 +29,10 @@ export function usageLimitPresentation(notice: UsageLimitNotice): UsageLimitPres
   return {
     title: `${providerLabel(notice.provider)} usage limit reached`,
     detail: reset ? `${notice.message} Resets ${reset}.` : notice.message,
+    autoContinueEnabled: usageLimitAutoContinueEnabled(notice),
+    autoContinueLabel: usageLimitAutoContinueEnabled(notice)
+      ? "Disable auto-continue"
+      : "Enable auto-continue",
   };
 }
 
@@ -48,5 +59,6 @@ export function readUsageLimit(value: unknown): UsageLimitNotice | null {
     ...(typeof notice.resetsAt === "number" && Number.isFinite(notice.resetsAt)
       ? { resetsAt: notice.resetsAt }
       : {}),
+    ...(typeof notice.autoContinue === "boolean" ? { autoContinue: notice.autoContinue } : {}),
   };
 }

--- a/apps/mobile/src/features/threads/usageLimitPresentation.ts
+++ b/apps/mobile/src/features/threads/usageLimitPresentation.ts
@@ -1,0 +1,52 @@
+export interface UsageLimitNotice {
+  readonly occurrenceId: string;
+  readonly provider: string;
+  readonly resetsAt?: number;
+  readonly message: string;
+}
+
+export interface UsageLimitPresentation {
+  readonly title: string;
+  readonly detail: string;
+}
+
+function providerLabel(provider: string): string {
+  return provider === "claudeAgent" ? "Claude" : provider;
+}
+
+export function usageLimitPresentation(notice: UsageLimitNotice): UsageLimitPresentation {
+  const reset =
+    typeof notice.resetsAt === "number" && Number.isFinite(notice.resetsAt)
+      ? formatUsageLimitReset(notice.resetsAt)
+      : null;
+  return {
+    title: `${providerLabel(notice.provider)} usage limit reached`,
+    detail: reset ? `${notice.message} Resets ${reset}.` : notice.message,
+  };
+}
+
+export function formatUsageLimitReset(timestamp: number, locale?: string): string {
+  return new Intl.DateTimeFormat(locale, { dateStyle: "medium", timeStyle: "short" }).format(
+    new Date(timestamp),
+  );
+}
+
+export function readUsageLimit(value: unknown): UsageLimitNotice | null {
+  if (!value || typeof value !== "object") return null;
+  const notice = value as Partial<UsageLimitNotice>;
+  if (
+    typeof notice.occurrenceId !== "string" ||
+    typeof notice.provider !== "string" ||
+    typeof notice.message !== "string"
+  ) {
+    return null;
+  }
+  return {
+    occurrenceId: notice.occurrenceId,
+    provider: notice.provider,
+    message: notice.message,
+    ...(typeof notice.resetsAt === "number" && Number.isFinite(notice.resetsAt)
+      ? { resetsAt: notice.resetsAt }
+      : {}),
+  };
+}

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -1130,6 +1130,29 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
     const applyThreadSessionsProjection: ProjectorDefinition["apply"] = Effect.fn(
       "applyThreadSessionsProjection",
     )(function* (event, _attachmentSideEffects) {
+      if (event.type === "thread.usage-limit-auto-continue-set") {
+        const existingRow = yield* projectionThreadSessionRepository.getByThreadId({
+          threadId: event.payload.threadId,
+        });
+        if (Option.isNone(existingRow)) {
+          return;
+        }
+        if (
+          existingRow.value.usageLimit === null ||
+          existingRow.value.usageLimit.occurrenceId !== event.payload.expectedOccurrenceId
+        ) {
+          return;
+        }
+        yield* projectionThreadSessionRepository.upsert({
+          ...existingRow.value,
+          usageLimit: {
+            ...existingRow.value.usageLimit,
+            autoContinue: event.payload.enabled,
+          },
+          updatedAt: event.occurredAt,
+        });
+        return;
+      }
       if (event.type !== "thread.session-set") {
         return;
       }

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -1141,6 +1141,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
         runtimeMode: event.payload.session.runtimeMode,
         activeTurnId: event.payload.session.activeTurnId,
         lastError: event.payload.session.lastError,
+        usageLimit: event.payload.session.usageLimit ?? null,
         updatedAt: event.payload.session.updatedAt,
       });
     });

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -7,6 +7,7 @@ import {
   OrchestrationCheckpointFile,
   OrchestrationProposedPlanId,
   OrchestrationReadModel,
+  OrchestrationSessionUsageLimit,
   OrchestrationThreadSearchSource,
   OrchestrationShellSnapshot,
   OrchestrationThread,
@@ -93,7 +94,11 @@ const ProjectionThreadActivityDbRowSchema = ProjectionThreadActivity.mapFields(
     sequence: Schema.NullOr(NonNegativeInt),
   }),
 );
-const ProjectionThreadSessionDbRowSchema = ProjectionThreadSession;
+const ProjectionThreadSessionDbRowSchema = ProjectionThreadSession.mapFields(
+  Struct.assign({
+    usageLimit: Schema.NullOr(Schema.fromJsonString(OrchestrationSessionUsageLimit)),
+  }),
+);
 const ProjectionCheckpointDbRowSchema = ProjectionCheckpoint.mapFields(
   Struct.assign({
     files: Schema.fromJsonString(Schema.Array(OrchestrationCheckpointFile)),
@@ -302,6 +307,7 @@ function mapSessionRow(
     runtimeMode: row.runtimeMode,
     activeTurnId: row.activeTurnId,
     lastError: row.lastError,
+    ...(row.usageLimit !== null ? { usageLimit: row.usageLimit } : {}),
     updatedAt: row.updatedAt,
   };
 }
@@ -594,6 +600,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           runtime_mode AS "runtimeMode",
           active_turn_id AS "activeTurnId",
           last_error AS "lastError",
+          usage_limit AS "usageLimit",
           updated_at AS "updatedAt"
         FROM projection_thread_sessions
         ORDER BY thread_id ASC
@@ -615,6 +622,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           sessions.runtime_mode AS "runtimeMode",
           sessions.active_turn_id AS "activeTurnId",
           sessions.last_error AS "lastError",
+          sessions.usage_limit AS "usageLimit",
           sessions.updated_at AS "updatedAt"
         FROM projection_thread_sessions sessions
         INNER JOIN projection_threads threads
@@ -640,6 +648,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           sessions.runtime_mode AS "runtimeMode",
           sessions.active_turn_id AS "activeTurnId",
           sessions.last_error AS "lastError",
+          sessions.usage_limit AS "usageLimit",
           sessions.updated_at AS "updatedAt"
         FROM projection_thread_sessions sessions
         INNER JOIN projection_threads threads
@@ -678,7 +687,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         SELECT
           turns.thread_id AS "threadId",
           turns.turn_id AS "turnId",
-          turns.state,
+          CASE WHEN sessions.status = 'interrupted' THEN 'interrupted' ELSE turns.state END AS state,
           turns.requested_at AS "requestedAt",
           turns.started_at AS "startedAt",
           turns.completed_at AS "completedAt",
@@ -689,6 +698,8 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         JOIN projection_turns turns
           ON turns.thread_id = threads.thread_id
           AND turns.turn_id = threads.latest_turn_id
+        LEFT JOIN projection_thread_sessions sessions
+          ON sessions.thread_id = threads.thread_id
         WHERE threads.latest_turn_id IS NOT NULL
         ORDER BY turns.thread_id ASC
       `,
@@ -702,7 +713,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         SELECT
           turns.thread_id AS "threadId",
           turns.turn_id AS "turnId",
-          turns.state,
+          CASE WHEN sessions.status = 'interrupted' THEN 'interrupted' ELSE turns.state END AS state,
           turns.requested_at AS "requestedAt",
           turns.started_at AS "startedAt",
           turns.completed_at AS "completedAt",
@@ -713,6 +724,8 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         JOIN projection_turns turns
           ON turns.thread_id = threads.thread_id
           AND turns.turn_id = threads.latest_turn_id
+        LEFT JOIN projection_thread_sessions sessions
+          ON sessions.thread_id = threads.thread_id
         WHERE threads.deleted_at IS NULL
           AND threads.archived_at IS NULL
           AND threads.latest_turn_id IS NOT NULL
@@ -728,7 +741,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         SELECT
           turns.thread_id AS "threadId",
           turns.turn_id AS "turnId",
-          turns.state,
+          CASE WHEN sessions.status = 'interrupted' THEN 'interrupted' ELSE turns.state END AS state,
           turns.requested_at AS "requestedAt",
           turns.started_at AS "startedAt",
           turns.completed_at AS "completedAt",
@@ -739,6 +752,8 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         JOIN projection_turns turns
           ON turns.thread_id = threads.thread_id
           AND turns.turn_id = threads.latest_turn_id
+        LEFT JOIN projection_thread_sessions sessions
+          ON sessions.thread_id = threads.thread_id
         WHERE threads.deleted_at IS NULL
           AND threads.archived_at IS NOT NULL
           AND threads.latest_turn_id IS NOT NULL
@@ -1037,6 +1052,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           runtime_mode AS "runtimeMode",
           active_turn_id AS "activeTurnId",
           last_error AS "lastError",
+          usage_limit AS "usageLimit",
           updated_at AS "updatedAt"
         FROM projection_thread_sessions
         WHERE thread_id = ${threadId}
@@ -1052,7 +1068,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         SELECT
           turns.thread_id AS "threadId",
           turns.turn_id AS "turnId",
-          turns.state,
+          CASE WHEN sessions.status = 'interrupted' THEN 'interrupted' ELSE turns.state END AS state,
           turns.requested_at AS "requestedAt",
           turns.started_at AS "startedAt",
           turns.completed_at AS "completedAt",
@@ -1063,6 +1079,8 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         JOIN projection_turns turns
           ON turns.thread_id = threads.thread_id
           AND turns.turn_id = threads.latest_turn_id
+        LEFT JOIN projection_thread_sessions sessions
+          ON sessions.thread_id = threads.thread_id
         WHERE threads.thread_id = ${threadId}
           AND threads.deleted_at IS NULL
           AND threads.archived_at IS NULL
@@ -1535,6 +1553,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                   runtimeMode: row.runtimeMode,
                   activeTurnId: row.activeTurnId,
                   lastError: row.lastError,
+                  ...(row.usageLimit !== null ? { usageLimit: row.usageLimit } : {}),
                   updatedAt: row.updatedAt,
                 });
               }

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -143,6 +143,117 @@ describe("ProviderCommandReactor", () => {
     });
   });
 
+  it("restarts a Claude query for native usage-limit auto-continue without sending a turn", async () => {
+    const harness = await createHarness({
+      threadModelSelection: {
+        instanceId: ProviderInstanceId.make("claudeAgent"),
+        model: "claude-sonnet-4-6",
+      },
+    });
+    const threadId = ThreadId.make("thread-1");
+    const occurrenceId = EventId.make("usage-limit-1");
+    harness.runtimeSessions.push({
+      threadId,
+      provider: ProviderDriverKind.make("claudeAgent"),
+      providerInstanceId: ProviderInstanceId.make("claudeAgent"),
+      status: "ready",
+      runtimeMode: "approval-required",
+      model: "claude-sonnet-4-6",
+      resumeCursor: { resume: "claude-session-1", resumeSessionAt: "assistant-1" },
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("cmd-usage-limit-session"),
+        threadId,
+        session: {
+          threadId,
+          status: "interrupted",
+          providerName: "claudeAgent",
+          providerInstanceId: ProviderInstanceId.make("claudeAgent"),
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          usageLimit: {
+            occurrenceId,
+            provider: ProviderDriverKind.make("claudeAgent"),
+            resetsAt: 1_800_000_000_000,
+            message: "Claude usage limit reached.",
+          },
+          updatedAt: "2026-01-01T00:00:01.000Z",
+        },
+        createdAt: "2026-01-01T00:00:01.000Z",
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.usage-limit.auto-continue.set",
+        commandId: CommandId.make("cmd-enable-usage-limit-auto-continue"),
+        threadId,
+        expectedOccurrenceId: occurrenceId,
+        enabled: true,
+        createdAt: "2026-01-01T00:00:02.000Z",
+      }),
+    );
+
+    await waitFor(() => harness.startSession.mock.calls.length === 1);
+    expect(harness.startSession.mock.calls[0]?.[1]).toMatchObject({
+      threadId,
+      provider: ProviderDriverKind.make("claudeAgent"),
+      providerInstanceId: ProviderInstanceId.make("claudeAgent"),
+      resumeCursor: { resume: "claude-session-1", resumeSessionAt: "assistant-1" },
+      resumeInterruptedTurn: true,
+    });
+    expect(harness.sendTurn).not.toHaveBeenCalled();
+
+    const readModel = await harness.readModel();
+    const thread = readModel.threads.find((entry) => entry.id === threadId);
+    expect(thread?.session).toMatchObject({
+      status: "starting",
+      usageLimit: { occurrenceId, autoContinue: true },
+    });
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.usage-limit.auto-continue.set",
+        commandId: CommandId.make("cmd-disable-usage-limit-auto-continue"),
+        threadId,
+        expectedOccurrenceId: occurrenceId,
+        enabled: false,
+        createdAt: "2026-01-01T00:00:03.000Z",
+      }),
+    );
+
+    await waitFor(() => harness.stopSession.mock.calls.length === 1);
+    await harness.drain();
+    const disabledReadModel = await harness.readModel();
+    const disabledThread = disabledReadModel.threads.find((entry) => entry.id === threadId);
+    expect(disabledThread?.session).toMatchObject({
+      status: "interrupted",
+      usageLimit: { occurrenceId, autoContinue: false },
+    });
+  });
+
+  it("restores an opted-in Claude watchdog query when the reactor starts", async () => {
+    const harness = await createHarness({
+      threadModelSelection: {
+        instanceId: ProviderInstanceId.make("claudeAgent"),
+        model: "claude-sonnet-4-6",
+      },
+      usageLimitAutoContinueBeforeStart: true,
+    });
+
+    expect(harness.startSession).toHaveBeenCalledTimes(1);
+    expect(harness.startSession.mock.calls[0]?.[1]).toMatchObject({
+      resumeCursor: { resume: "claude-session-before-reactor-start" },
+      resumeInterruptedTurn: true,
+    });
+    expect(harness.sendTurn).not.toHaveBeenCalled();
+  });
+
   async function createHarness(input?: {
     readonly baseDir?: string;
     readonly threadModelSelection?: ModelSelection;
@@ -150,6 +261,7 @@ describe("ProviderCommandReactor", () => {
     readonly requiresNewThreadForModelChange?: boolean;
     readonly titleRegenerationCompletionDispatchFailures?: number;
     readonly titleRegenerationBeforeStart?: "one" | "two";
+    readonly usageLimitAutoContinueBeforeStart?: boolean;
     readonly startSessionEffect?: (
       session: ProviderSession,
     ) => Effect.Effect<ProviderSession, ProviderAdapterRequestError>;
@@ -481,6 +593,42 @@ describe("ProviderCommandReactor", () => {
           ),
           threadId,
           regenerateTitle: true,
+        }),
+      );
+    }
+    if (input?.usageLimitAutoContinueBeforeStart === true) {
+      runtimeSessions.push({
+        threadId: ThreadId.make("thread-1"),
+        provider: ProviderDriverKind.make("claudeAgent"),
+        providerInstanceId: modelSelection.instanceId,
+        status: "ready",
+        runtimeMode: "approval-required",
+        resumeCursor: { resume: "claude-session-before-reactor-start" },
+        createdAt: now,
+        updatedAt: now,
+      });
+      await Effect.runPromise(
+        engine.dispatch({
+          type: "thread.session.set",
+          commandId: CommandId.make("cmd-usage-limit-before-reactor-start"),
+          threadId: ThreadId.make("thread-1"),
+          session: {
+            threadId: ThreadId.make("thread-1"),
+            status: "interrupted",
+            providerName: "claudeAgent",
+            providerInstanceId: modelSelection.instanceId,
+            runtimeMode: "approval-required",
+            activeTurnId: null,
+            lastError: null,
+            usageLimit: {
+              occurrenceId: EventId.make("usage-limit-before-reactor-start"),
+              provider: ProviderDriverKind.make("claudeAgent"),
+              message: "Claude usage limit reached.",
+              autoContinue: true,
+            },
+            updatedAt: now,
+          },
+          createdAt: now,
         }),
       );
     }

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -58,7 +58,8 @@ type ProviderIntentEvent = Extract<
       | "thread.turn-interrupt-requested"
       | "thread.approval-response-requested"
       | "thread.user-input-response-requested"
-      | "thread.session-stop-requested";
+      | "thread.session-stop-requested"
+      | "thread.usage-limit-auto-continue-set";
   }
 >;
 
@@ -328,6 +329,7 @@ const make = Effect.gen(function* () {
     timeToLive: HANDLED_TURN_START_KEY_TTL,
     lookup: () => Effect.succeed(true),
   });
+  const autoContinuingUsageLimitOccurrences = new Map<ThreadId, EventId>();
 
   const hasHandledTurnStartRecently = (key: string) =>
     Cache.getOption(handledTurnStartKeys, key).pipe(
@@ -484,6 +486,7 @@ const make = Effect.gen(function* () {
     options?: {
       readonly modelSelection?: ModelSelection;
       readonly pendingTurnStart?: boolean;
+      readonly resumeInterruptedTurn?: boolean;
     },
   ) {
     const thread = yield* resolveThread(threadId);
@@ -558,7 +561,10 @@ const make = Effect.gen(function* () {
       });
     }
     const preferredProvider: ProviderDriverKind = desiredDriverKind;
-    if (options?.pendingTurnStart === true && thread.session?.status !== "running") {
+    if (
+      (options?.pendingTurnStart === true || options?.resumeInterruptedTurn === true) &&
+      thread.session?.status !== "running"
+    ) {
       yield* setThreadSession({
         threadId,
         session: {
@@ -569,6 +575,9 @@ const make = Effect.gen(function* () {
           runtimeMode: desiredRuntimeMode,
           activeTurnId: null,
           lastError: null,
+          ...(options?.resumeInterruptedTurn === true
+            ? { usageLimit: thread.session?.usageLimit ?? null }
+            : {}),
           updatedAt: createdAt,
         },
         createdAt,
@@ -620,6 +629,7 @@ const make = Effect.gen(function* () {
     const startProviderSession = (input?: {
       readonly resumeCursor?: unknown;
       readonly provider?: ProviderDriverKind;
+      readonly resumeInterruptedTurn?: boolean;
     }) =>
       providerService.startSession(threadId, {
         threadId,
@@ -628,6 +638,7 @@ const make = Effect.gen(function* () {
         ...(effectiveCwd ? { cwd: effectiveCwd } : {}),
         modelSelection: desiredModelSelection,
         ...(input?.resumeCursor !== undefined ? { resumeCursor: input.resumeCursor } : {}),
+        ...(input?.resumeInterruptedTurn === true ? { resumeInterruptedTurn: true } : {}),
         runtimeMode: desiredRuntimeMode,
       });
 
@@ -645,7 +656,8 @@ const make = Effect.gen(function* () {
           session: {
             threadId,
             status:
-              options?.pendingTurnStart === true && session.status === "ready"
+              (options?.pendingTurnStart === true || options?.resumeInterruptedTurn === true) &&
+              session.status === "ready"
                 ? "starting"
                 : mapProviderSessionStatusToOrchestrationStatus(session.status),
             providerName: session.provider,
@@ -654,6 +666,9 @@ const make = Effect.gen(function* () {
             // Provider turn ids are not orchestration turn ids.
             activeTurnId: null,
             lastError: session.lastError ?? null,
+            ...(options?.resumeInterruptedTurn === true
+              ? { usageLimit: thread.session?.usageLimit ?? null }
+              : {}),
             updatedAt: session.updatedAt,
           },
           createdAt,
@@ -685,7 +700,8 @@ const make = Effect.gen(function* () {
         !cwdChanged &&
         !instanceChanged &&
         !shouldRestartForModelChange &&
-        !shouldRestartForModelSelectionChange
+        !shouldRestartForModelSelectionChange &&
+        options?.resumeInterruptedTurn !== true
       ) {
         return existingSessionThreadId;
       }
@@ -710,10 +726,16 @@ const make = Effect.gen(function* () {
         instanceChanged,
         shouldRestartForModelChange,
         shouldRestartForModelSelectionChange,
+        resumeInterruptedTurn: options?.resumeInterruptedTurn === true,
         hasResumeCursor: resumeCursor !== undefined,
       });
       const restartedSession = yield* startProviderSession(
-        resumeCursor !== undefined ? { resumeCursor } : undefined,
+        resumeCursor !== undefined || options?.resumeInterruptedTurn === true
+          ? {
+              ...(resumeCursor !== undefined ? { resumeCursor } : {}),
+              ...(options?.resumeInterruptedTurn === true ? { resumeInterruptedTurn: true } : {}),
+            }
+          : undefined,
       );
       yield* Effect.logInfo("provider command reactor restarted provider session", {
         threadId,
@@ -727,7 +749,9 @@ const make = Effect.gen(function* () {
       return restartedSession.threadId;
     }
 
-    const startedSession = yield* startProviderSession(undefined);
+    const startedSession = yield* startProviderSession(
+      options?.resumeInterruptedTurn === true ? { resumeInterruptedTurn: true } : undefined,
+    );
     yield* bindSessionToThread(startedSession);
     return startedSession.threadId;
   });
@@ -1326,6 +1350,87 @@ const make = Effect.gen(function* () {
     });
   });
 
+  const resumeUsageLimitedThread = Effect.fn("resumeUsageLimitedThread")(function* (input: {
+    readonly threadId: ThreadId;
+    readonly expectedOccurrenceId: EventId;
+    readonly createdAt: string;
+  }) {
+    const thread = yield* resolveThread(input.threadId);
+    const usageLimit = thread?.session?.usageLimit;
+    if (
+      usageLimit?.occurrenceId !== input.expectedOccurrenceId ||
+      usageLimit.autoContinue !== true ||
+      usageLimit.provider !== "claudeAgent"
+    ) {
+      return;
+    }
+
+    if (autoContinuingUsageLimitOccurrences.get(input.threadId) === input.expectedOccurrenceId) {
+      return;
+    }
+    autoContinuingUsageLimitOccurrences.set(input.threadId, input.expectedOccurrenceId);
+    yield* ensureSessionForThread(input.threadId, input.createdAt, {
+      resumeInterruptedTurn: true,
+    }).pipe(
+      Effect.onError(() =>
+        Effect.sync(() => {
+          if (
+            autoContinuingUsageLimitOccurrences.get(input.threadId) === input.expectedOccurrenceId
+          ) {
+            autoContinuingUsageLimitOccurrences.delete(input.threadId);
+          }
+        }),
+      ),
+    );
+  });
+
+  const processUsageLimitAutoContinueSet = Effect.fn("processUsageLimitAutoContinueSet")(function* (
+    event: Extract<ProviderIntentEvent, { type: "thread.usage-limit-auto-continue-set" }>,
+  ) {
+    const input = {
+      threadId: event.payload.threadId,
+      expectedOccurrenceId: event.payload.expectedOccurrenceId,
+      createdAt: event.payload.createdAt,
+    };
+    if (event.payload.enabled) {
+      yield* resumeUsageLimitedThread(input);
+      return;
+    }
+
+    if (autoContinuingUsageLimitOccurrences.get(input.threadId) === input.expectedOccurrenceId) {
+      autoContinuingUsageLimitOccurrences.delete(input.threadId);
+    }
+    const limitedThread = yield* resolveThread(input.threadId);
+    if (
+      limitedThread?.session?.usageLimit?.occurrenceId !== input.expectedOccurrenceId ||
+      limitedThread.session.usageLimit.autoContinue !== false
+    ) {
+      return;
+    }
+    const activeSession = (yield* providerService.listSessions()).find(
+      (session) => session.threadId === input.threadId,
+    );
+    if (activeSession) {
+      yield* providerService.stopSession({ threadId: input.threadId });
+    }
+
+    const thread = yield* resolveThread(input.threadId);
+    if (thread?.session?.usageLimit?.occurrenceId !== input.expectedOccurrenceId) {
+      return;
+    }
+    yield* setThreadSession({
+      threadId: input.threadId,
+      session: {
+        ...thread.session,
+        status: "interrupted",
+        activeTurnId: null,
+        lastError: null,
+        updatedAt: input.createdAt,
+      },
+      createdAt: input.createdAt,
+    });
+  });
+
   const processDomainEvent = Effect.fn("processDomainEvent")(function* (
     event: ProviderIntentEvent,
   ) {
@@ -1369,6 +1474,9 @@ const make = Effect.gen(function* () {
       case "thread.session-stop-requested":
         yield* processSessionStopRequested(event);
         return;
+      case "thread.usage-limit-auto-continue-set":
+        yield* processUsageLimitAutoContinueSet(event);
+        return;
     }
   });
 
@@ -1407,13 +1515,45 @@ const make = Effect.gen(function* () {
         event.type === "thread.turn-interrupt-requested" ||
         event.type === "thread.approval-response-requested" ||
         event.type === "thread.user-input-response-requested" ||
-        event.type === "thread.session-stop-requested"
+        event.type === "thread.session-stop-requested" ||
+        event.type === "thread.usage-limit-auto-continue-set"
       ) {
         return yield* worker.enqueue(event);
       }
     });
 
     yield* forkParked(Stream.runForEach(orchestrationEngine.streamDomainEvents, processEvent));
+
+    // The event stream is hot. Restore opted-in watchdog queries from the
+    // durable projection after subscribing so a concurrent disable cannot be
+    // missed between the snapshot read and stream attachment.
+    yield* Effect.gen(function* () {
+      const snapshot = yield* projectionSnapshotQuery.getSnapshot();
+      yield* Effect.forEach(
+        snapshot.threads,
+        (thread) => {
+          const usageLimit = thread.session?.usageLimit;
+          return usageLimit?.autoContinue === true && usageLimit.provider === "claudeAgent"
+            ? resumeUsageLimitedThread({
+                threadId: thread.id,
+                expectedOccurrenceId: usageLimit.occurrenceId,
+                createdAt: thread.session?.updatedAt ?? thread.updatedAt,
+              })
+            : Effect.void;
+        },
+        { discard: true },
+      );
+    }).pipe(
+      Effect.catchCause((cause) => {
+        if (Cause.hasInterruptsOnly(cause)) {
+          return Effect.interrupt;
+        }
+        return Effect.logWarning(
+          "provider command reactor failed to restore usage-limit auto-continue",
+          { cause: Cause.pretty(cause) },
+        );
+      }),
+    );
 
     // The domain event stream is hot, so work pending before this reactor
     // starts cannot be resumed. Correlated completions only clear the request

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -364,6 +364,93 @@ describe("ProviderRuntimeIngestion", () => {
     expect(thread.session?.lastError).toBe("turn failed");
   });
 
+  it("projects a Claude usage-limit stop as an interrupted, non-error session", async () => {
+    const harness = await createHarness();
+    const startedAt = "2026-01-01T00:00:00.000Z";
+    const completedAt = "2026-01-01T00:00:05.000Z";
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-claude-limit-started"),
+      provider: ProviderDriverKind.make("claudeAgent"),
+      threadId: asThreadId("thread-1"),
+      createdAt: startedAt,
+      turnId: asTurnId("turn-claude-limit"),
+    });
+
+    await waitForThread(
+      harness.readModel,
+      (thread) =>
+        thread.session?.status === "running" && thread.session.activeTurnId === "turn-claude-limit",
+    );
+
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-claude-limit-completed"),
+      provider: ProviderDriverKind.make("claudeAgent"),
+      threadId: asThreadId("thread-1"),
+      createdAt: completedAt,
+      turnId: asTurnId("turn-claude-limit"),
+      payload: {
+        state: "interrupted",
+        errorMessage: "5-hour Claude usage limit reached.",
+        usageLimit: {
+          windowType: "five_hour",
+          resetsAt: 1_800_000_000_000,
+          message: "5-hour Claude usage limit reached.",
+        },
+      },
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) => entry.session?.usageLimit?.occurrenceId === "evt-claude-limit-completed",
+    );
+
+    expect(thread.session).toMatchObject({
+      status: "interrupted",
+      activeTurnId: null,
+      lastError: null,
+      usageLimit: {
+        occurrenceId: "evt-claude-limit-completed",
+        provider: "claudeAgent",
+        windowType: "five_hour",
+        resetsAt: 1_800_000_000_000,
+        message: "5-hour Claude usage limit reached.",
+      },
+    });
+    expect(thread.latestTurn).toMatchObject({
+      turnId: "turn-claude-limit",
+      state: "interrupted",
+      completedAt,
+    });
+    expect(thread.activities).toContainEqual(
+      expect.objectContaining({
+        kind: "usage-limit.reached",
+        tone: "info",
+        turnId: "turn-claude-limit",
+      }),
+    );
+
+    harness.emit({
+      type: "session.exited",
+      eventId: asEventId("evt-claude-limit-exited"),
+      provider: ProviderDriverKind.make("claudeAgent"),
+      threadId: asThreadId("thread-1"),
+      createdAt: "2026-01-01T00:00:06.000Z",
+      payload: {},
+    });
+
+    const exitedThread = await waitForThread(
+      harness.readModel,
+      (entry) => entry.session?.updatedAt === "2026-01-01T00:00:06.000Z",
+    );
+    expect(exitedThread.session).toMatchObject({
+      status: "interrupted",
+      usageLimit: { occurrenceId: "evt-claude-limit-completed" },
+    });
+  });
+
   it("applies provider session.state.changed transitions directly", async () => {
     const harness = await createHarness();
     const waitingAt = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -368,6 +368,37 @@ export function runtimeEventToActivities(
       : {};
   })();
   switch (event.type) {
+    case "turn.completed": {
+      if (event.payload.usageLimit === undefined) {
+        return [];
+      }
+      const message =
+        event.payload.usageLimit.message ??
+        event.payload.errorMessage ??
+        "Claude usage limit reached.";
+      return [
+        {
+          id: event.eventId,
+          createdAt: event.createdAt,
+          tone: "info",
+          kind: "usage-limit.reached",
+          summary: message,
+          payload: {
+            provider: event.provider,
+            message,
+            ...(event.payload.usageLimit.windowType !== undefined
+              ? { windowType: event.payload.usageLimit.windowType }
+              : {}),
+            ...(event.payload.usageLimit.resetsAt !== undefined
+              ? { resetsAt: event.payload.usageLimit.resetsAt }
+              : {}),
+          },
+          turnId: toTurnId(event.turnId) ?? null,
+          ...maybeSequence,
+        },
+      ];
+    }
+
     case "request.opened": {
       if (event.payload.requestType === "tool_user_input") {
         return [];
@@ -1566,11 +1597,13 @@ const make = Effect.gen(function* () {
             case "turn.started":
               return "running";
             case "session.exited":
-              return "stopped";
+              return thread.session?.usageLimit ? "interrupted" : "stopped";
             case "turn.completed":
-              return normalizeRuntimeTurnState(event.payload.state) === "failed"
-                ? "error"
-                : "ready";
+              return event.payload.usageLimit !== undefined
+                ? "interrupted"
+                : normalizeRuntimeTurnState(event.payload.state) === "failed"
+                  ? "error"
+                  : "ready";
             case "session.started":
             case "thread.started":
               // Provider thread/session start notifications can arrive during an
@@ -1592,12 +1625,33 @@ const make = Effect.gen(function* () {
         const lastError =
           event.type === "session.state.changed" && event.payload.state === "error"
             ? (event.payload.reason ?? thread.session?.lastError ?? "Provider session error")
-            : event.type === "turn.completed" &&
-                normalizeRuntimeTurnState(event.payload.state) === "failed"
-              ? (event.payload.errorMessage ?? thread.session?.lastError ?? "Turn failed")
-              : status === "ready"
-                ? null
-                : (thread.session?.lastError ?? null);
+            : event.type === "turn.completed" && event.payload.usageLimit !== undefined
+              ? null
+              : event.type === "turn.completed" &&
+                  normalizeRuntimeTurnState(event.payload.state) === "failed"
+                ? (event.payload.errorMessage ?? thread.session?.lastError ?? "Turn failed")
+                : status === "ready"
+                  ? null
+                  : (thread.session?.lastError ?? null);
+        const usageLimit =
+          event.type === "turn.started"
+            ? null
+            : event.type === "turn.completed" && event.payload.usageLimit !== undefined
+              ? {
+                  occurrenceId: event.eventId,
+                  provider: event.provider,
+                  ...(event.payload.usageLimit.windowType !== undefined
+                    ? { windowType: event.payload.usageLimit.windowType }
+                    : {}),
+                  ...(event.payload.usageLimit.resetsAt !== undefined
+                    ? { resetsAt: event.payload.usageLimit.resetsAt }
+                    : {}),
+                  message:
+                    event.payload.usageLimit.message ??
+                    event.payload.errorMessage ??
+                    "Claude usage limit reached.",
+                }
+              : (thread.session?.usageLimit ?? null);
 
         if (shouldApplyThreadLifecycle) {
           if (event.type === "turn.started" && acceptedTurnStartedSourcePlan !== null) {
@@ -1634,6 +1688,7 @@ const make = Effect.gen(function* () {
               runtimeMode: thread.session?.runtimeMode ?? "full-access",
               activeTurnId: nextActiveTurnId,
               lastError,
+              usageLimit,
               updatedAt: now,
             },
             createdAt: now,
@@ -1884,6 +1939,7 @@ const make = Effect.gen(function* () {
               runtimeMode: thread.session?.runtimeMode ?? "full-access",
               activeTurnId: eventTurnId ?? null,
               lastError: runtimeErrorMessage,
+              usageLimit: thread.session?.usageLimit ?? null,
               updatedAt: now,
             },
             createdAt: now,

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1213,6 +1213,48 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
       return [unsettledEvent, sessionSetEvent];
     }
 
+    case "thread.usage-limit.auto-continue.set": {
+      const thread = yield* requireThread({
+        readModel,
+        command,
+        threadId: command.threadId,
+      });
+      const usageLimit = thread.session?.usageLimit;
+      if (usageLimit === undefined || usageLimit === null) {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: `thread ${command.threadId} has no usage-limit marker`,
+        });
+      }
+      if (usageLimit.occurrenceId !== command.expectedOccurrenceId) {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: `thread ${command.threadId} usage-limit marker does not match expected occurrence`,
+        });
+      }
+      if (usageLimit.provider !== "claudeAgent") {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: `thread ${command.threadId} usage-limit auto-continue is not supported for ${usageLimit.provider}`,
+        });
+      }
+      return {
+        ...(yield* withEventBase({
+          aggregateKind: "thread",
+          aggregateId: command.threadId,
+          occurredAt: command.createdAt,
+          commandId: command.commandId,
+        })),
+        type: "thread.usage-limit-auto-continue-set",
+        payload: {
+          threadId: command.threadId,
+          expectedOccurrenceId: command.expectedOccurrenceId,
+          enabled: command.enabled,
+          createdAt: command.createdAt,
+        },
+      };
+    }
+
     case "thread.message.assistant.delta": {
       yield* requireThread({
         readModel,

--- a/apps/server/src/orchestration/decider.usageLimit.test.ts
+++ b/apps/server/src/orchestration/decider.usageLimit.test.ts
@@ -1,0 +1,106 @@
+import {
+  CommandId,
+  EventId,
+  ProjectId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  ThreadId,
+  type OrchestrationReadModel,
+} from "@t3tools/contracts";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+import { decideOrchestrationCommand } from "./decider.ts";
+
+const NOW = "2026-01-01T00:00:00.000Z";
+const OCCURRENCE = EventId.make("usage-occurrence");
+
+function makeReadModel(usageLimit: OrchestrationReadModel["threads"][number]["session"] = null) {
+  return {
+    snapshotSequence: 0,
+    projects: [],
+    threads: [
+      {
+        id: ThreadId.make("thread-1"),
+        projectId: ProjectId.make("project-1"),
+        title: "Thread",
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("claudeAgent"),
+          model: "claude-sonnet-4-6",
+        },
+        runtimeMode: "full-access" as const,
+        interactionMode: "default" as const,
+        branch: null,
+        worktreePath: null,
+        latestTurn: null,
+        createdAt: NOW,
+        updatedAt: NOW,
+        archivedAt: null,
+        settledOverride: null,
+        settledAt: null,
+        snoozedUntil: null,
+        snoozedAt: null,
+        deletedAt: null,
+        messages: [],
+        proposedPlans: [],
+        activities: [],
+        checkpoints: [],
+        session: usageLimit,
+      },
+    ],
+    updatedAt: NOW,
+  } satisfies OrchestrationReadModel;
+}
+
+const session = {
+  threadId: ThreadId.make("thread-1"),
+  status: "interrupted" as const,
+  providerName: "claudeAgent",
+  runtimeMode: "full-access" as const,
+  activeTurnId: null,
+  lastError: null,
+  usageLimit: {
+    occurrenceId: OCCURRENCE,
+    provider: ProviderDriverKind.make("claudeAgent"),
+    message: "rate limited",
+  },
+  updatedAt: NOW,
+};
+
+it.layer(NodeServices.layer)("usage-limit auto-continue decider", (it) => {
+  it.effect("emits a reversible event only for the matching marker", () =>
+    Effect.gen(function* () {
+      const result = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.usage-limit.auto-continue.set",
+          commandId: CommandId.make("command-1"),
+          threadId: ThreadId.make("thread-1"),
+          expectedOccurrenceId: OCCURRENCE,
+          enabled: true,
+          createdAt: NOW,
+        },
+        readModel: makeReadModel(session),
+      });
+      const event = Array.isArray(result) ? result[0] : result;
+      expect(event?.type).toBe("thread.usage-limit-auto-continue-set");
+    }),
+  );
+
+  it.effect("rejects missing or stale markers", () =>
+    Effect.gen(function* () {
+      const error = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.usage-limit.auto-continue.set",
+          commandId: CommandId.make("command-2"),
+          threadId: ThreadId.make("thread-1"),
+          expectedOccurrenceId: EventId.make("stale"),
+          enabled: false,
+          createdAt: NOW,
+        },
+        readModel: makeReadModel(session),
+      }).pipe(Effect.flip);
+      expect(error._tag).toBe("OrchestrationCommandInvariantError");
+    }),
+  );
+});

--- a/apps/server/src/orchestration/projector.test.ts
+++ b/apps/server/src/orchestration/projector.test.ts
@@ -343,6 +343,108 @@ describe("orchestration projector", () => {
     expect(settledThread?.latestTurn?.completedAt).toBe(settledAt);
   });
 
+  it("updates auto-continue only for the matching usage-limit occurrence", async () => {
+    const now = "2026-02-23T08:00:00.000Z";
+    const afterCreate = await Effect.runPromise(
+      projectEvent(
+        createEmptyReadModel(now),
+        makeEvent({
+          sequence: 1,
+          type: "thread.created",
+          aggregateKind: "thread",
+          aggregateId: "thread-usage-limit",
+          occurredAt: now,
+          commandId: "cmd-create-usage-limit",
+          payload: {
+            threadId: "thread-usage-limit",
+            projectId: "project-1",
+            title: "usage limit",
+            modelSelection: {
+              provider: ProviderDriverKind.make("claudeAgent"),
+              model: "claude-sonnet-4-6",
+            },
+            runtimeMode: "full-access",
+            branch: null,
+            worktreePath: null,
+            createdAt: now,
+            updatedAt: now,
+          },
+        }),
+      ),
+    );
+    const afterSession = await Effect.runPromise(
+      projectEvent(
+        afterCreate,
+        makeEvent({
+          sequence: 2,
+          type: "thread.session-set",
+          aggregateKind: "thread",
+          aggregateId: "thread-usage-limit",
+          occurredAt: now,
+          commandId: "cmd-set-usage-limit",
+          payload: {
+            threadId: "thread-usage-limit",
+            session: {
+              threadId: "thread-usage-limit",
+              status: "interrupted",
+              providerName: "claudeAgent",
+              runtimeMode: "full-access",
+              activeTurnId: null,
+              lastError: null,
+              usageLimit: {
+                occurrenceId: "usage-limit-current",
+                provider: "claudeAgent",
+                message: "Claude usage limit reached.",
+              },
+              updatedAt: now,
+            },
+          },
+        }),
+      ),
+    );
+    const afterMatching = await Effect.runPromise(
+      projectEvent(
+        afterSession,
+        makeEvent({
+          sequence: 3,
+          type: "thread.usage-limit-auto-continue-set",
+          aggregateKind: "thread",
+          aggregateId: "thread-usage-limit",
+          occurredAt: now,
+          commandId: "cmd-enable-auto-continue",
+          payload: {
+            threadId: "thread-usage-limit",
+            expectedOccurrenceId: "usage-limit-current",
+            enabled: true,
+            createdAt: now,
+          },
+        }),
+      ),
+    );
+    const afterStale = await Effect.runPromise(
+      projectEvent(
+        afterMatching,
+        makeEvent({
+          sequence: 4,
+          type: "thread.usage-limit-auto-continue-set",
+          aggregateKind: "thread",
+          aggregateId: "thread-usage-limit",
+          occurredAt: now,
+          commandId: "cmd-stale-auto-continue",
+          payload: {
+            threadId: "thread-usage-limit",
+            expectedOccurrenceId: "usage-limit-stale",
+            enabled: false,
+            createdAt: now,
+          },
+        }),
+      ),
+    );
+
+    expect(afterMatching.threads[0]?.session?.usageLimit?.autoContinue).toBe(true);
+    expect(afterStale.threads[0]?.session?.usageLimit?.autoContinue).toBe(true);
+  });
+
   it("updates canonical thread runtime mode from thread.runtime-mode-set", async () => {
     const createdAt = "2026-02-23T08:00:00.000Z";
     const updatedAt = "2026-02-23T08:00:05.000Z";

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -1,4 +1,9 @@
-import type { OrchestrationEvent, OrchestrationReadModel, ThreadId } from "@t3tools/contracts";
+import {
+  ThreadUsageLimitAutoContinueSetPayload,
+  type OrchestrationEvent,
+  type OrchestrationReadModel,
+  type ThreadId,
+} from "@t3tools/contracts";
 import {
   OrchestrationCheckpointSummary,
   OrchestrationMessage,
@@ -607,6 +612,33 @@ export function projectEvent(
                       completedAt: session.updatedAt,
                     }
                   : thread.latestTurn,
+            updatedAt: event.occurredAt,
+          }),
+        };
+      });
+
+    case "thread.usage-limit-auto-continue-set":
+      return Effect.gen(function* () {
+        const payload = yield* decodeForEvent(
+          ThreadUsageLimitAutoContinueSetPayload,
+          event.payload,
+          event.type,
+          "payload",
+        );
+        const thread = nextBase.threads.find((entry) => entry.id === payload.threadId);
+        if (!thread || thread.session?.usageLimit?.occurrenceId !== payload.expectedOccurrenceId) {
+          return nextBase;
+        }
+        return {
+          ...nextBase,
+          threads: updateThread(nextBase.threads, payload.threadId, {
+            session: {
+              ...thread.session,
+              usageLimit: {
+                ...thread.session.usageLimit,
+                autoContinue: payload.enabled,
+              },
+            },
             updatedAt: event.occurredAt,
           }),
         };

--- a/apps/server/src/persistence/Layers/ProjectionRepositories.test.ts
+++ b/apps/server/src/persistence/Layers/ProjectionRepositories.test.ts
@@ -1,4 +1,10 @@
-import { ProjectId, ThreadId, ProviderInstanceId } from "@t3tools/contracts";
+import {
+  EventId,
+  ProjectId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  ThreadId,
+} from "@t3tools/contracts";
 import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -8,18 +14,63 @@ import * as SqlClient from "effect/unstable/sql/SqlClient";
 import { SqlitePersistenceMemory } from "./Sqlite.ts";
 import { ProjectionProjectRepositoryLive } from "./ProjectionProjects.ts";
 import { ProjectionThreadRepositoryLive } from "./ProjectionThreads.ts";
+import { ProjectionThreadSessionRepositoryLive } from "./ProjectionThreadSessions.ts";
 import { ProjectionProjectRepository } from "../Services/ProjectionProjects.ts";
 import { ProjectionThreadRepository } from "../Services/ProjectionThreads.ts";
+import { ProjectionThreadSessionRepository } from "../Services/ProjectionThreadSessions.ts";
 
 const projectionRepositoriesLayer = it.layer(
   Layer.mergeAll(
     ProjectionProjectRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
     ProjectionThreadRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
+    ProjectionThreadSessionRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
     SqlitePersistenceMemory,
   ),
 );
 
 projectionRepositoriesLayer("Projection repositories", (it) => {
+  it.effect("round-trips structured thread-session usage limits as JSON", () =>
+    Effect.gen(function* () {
+      const sessions = yield* ProjectionThreadSessionRepository;
+      const sql = yield* SqlClient.SqlClient;
+      const usageLimit = {
+        occurrenceId: EventId.make("usage-limit-1"),
+        provider: ProviderDriverKind.make("claudeAgent"),
+        windowType: "five_hour",
+        resetsAt: 1_800_000_000_000,
+        message: "Claude usage limit reached.",
+      };
+
+      yield* sessions.upsert({
+        threadId: ThreadId.make("thread-usage-limit"),
+        status: "interrupted",
+        providerName: "claudeAgent",
+        providerInstanceId: null,
+        runtimeMode: "full-access",
+        activeTurnId: null,
+        lastError: null,
+        usageLimit,
+        updatedAt: "2026-03-24T00:00:00.000Z",
+      });
+
+      const rows = yield* sql<{ readonly usageLimit: string | null }>`
+        SELECT usage_limit AS "usageLimit"
+        FROM projection_thread_sessions
+        WHERE thread_id = 'thread-usage-limit'
+      `;
+      assert.strictEqual(
+        rows[0]?.usageLimit,
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
+        JSON.stringify(usageLimit),
+      );
+
+      const persisted = yield* sessions.getByThreadId({
+        threadId: ThreadId.make("thread-usage-limit"),
+      });
+      assert.deepStrictEqual(Option.getOrNull(persisted)?.usageLimit, usageLimit);
+    }),
+  );
+
   it.effect("stores SQL NULL for missing project model options", () =>
     Effect.gen(function* () {
       const projects = yield* ProjectionProjectRepository;

--- a/apps/server/src/persistence/Layers/ProjectionThreadSessions.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadSessions.ts
@@ -2,6 +2,9 @@ import * as SqlClient from "effect/unstable/sql/SqlClient";
 import * as SqlSchema from "effect/unstable/sql/SqlSchema";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+import * as Struct from "effect/Struct";
+import { OrchestrationSessionUsageLimit } from "@t3tools/contracts";
 
 import { toPersistenceSqlError } from "../Errors.ts";
 
@@ -12,6 +15,12 @@ import {
   DeleteProjectionThreadSessionInput,
   GetProjectionThreadSessionInput,
 } from "../Services/ProjectionThreadSessions.ts";
+
+const ProjectionThreadSessionDbRow = ProjectionThreadSession.mapFields(
+  Struct.assign({
+    usageLimit: Schema.NullOr(Schema.fromJsonString(OrchestrationSessionUsageLimit)),
+  }),
+);
 
 const makeProjectionThreadSessionRepository = Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient;
@@ -28,6 +37,7 @@ const makeProjectionThreadSessionRepository = Effect.gen(function* () {
           runtime_mode,
           active_turn_id,
           last_error,
+          usage_limit,
           updated_at
         )
         VALUES (
@@ -38,6 +48,7 @@ const makeProjectionThreadSessionRepository = Effect.gen(function* () {
           ${row.runtimeMode},
           ${row.activeTurnId},
           ${row.lastError},
+          ${row.usageLimit === null ? null : JSON.stringify(row.usageLimit)},
           ${row.updatedAt}
         )
         ON CONFLICT (thread_id)
@@ -48,13 +59,14 @@ const makeProjectionThreadSessionRepository = Effect.gen(function* () {
           runtime_mode = excluded.runtime_mode,
           active_turn_id = excluded.active_turn_id,
           last_error = excluded.last_error,
+          usage_limit = excluded.usage_limit,
           updated_at = excluded.updated_at
       `,
   });
 
   const getProjectionThreadSessionRow = SqlSchema.findOneOption({
     Request: GetProjectionThreadSessionInput,
-    Result: ProjectionThreadSession,
+    Result: ProjectionThreadSessionDbRow,
     execute: ({ threadId }) =>
       sql`
         SELECT
@@ -65,6 +77,7 @@ const makeProjectionThreadSessionRepository = Effect.gen(function* () {
           runtime_mode AS "runtimeMode",
           active_turn_id AS "activeTurnId",
           last_error AS "lastError",
+          usage_limit AS "usageLimit",
           updated_at AS "updatedAt"
         FROM projection_thread_sessions
         WHERE thread_id = ${threadId}

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -53,6 +53,7 @@ import Migration0037 from "./Migrations/037_ProjectionTurnsKeysetIndex.ts";
 import Migration0038 from "./Migrations/038_ProjectionThreadsPinOrderKey.ts";
 import Migration0039 from "./Migrations/039_ProjectionProjectsDefaultThreadEnvMode.ts";
 import Migration0040 from "./Migrations/040_ProjectionProjectFaviconPath.ts";
+import Migration0041 from "./Migrations/041_ProjectionThreadSessionUsageLimit.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -105,6 +106,7 @@ export const migrationEntries = [
   [38, "ProjectionThreadsPinOrderKey", Migration0038],
   [39, "ProjectionProjectsDefaultThreadEnvMode", Migration0039],
   [40, "ProjectionProjectFaviconPath", Migration0040],
+  [41, "ProjectionThreadSessionUsageLimit", Migration0041],
 ] as const;
 
 export const migrationManifest = migrationEntries.map(([id, name]) => [id, name] as const);

--- a/apps/server/src/persistence/Migrations/041_ProjectionThreadSessionUsageLimit.test.ts
+++ b/apps/server/src/persistence/Migrations/041_ProjectionThreadSessionUsageLimit.test.ts
@@ -1,0 +1,28 @@
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { runMigrations } from "../Migrations.ts";
+import * as NodeSqliteClient from "../NodeSqliteClient.ts";
+
+const layer = it.layer(Layer.mergeAll(NodeSqliteClient.layerMemory()));
+
+layer("041_ProjectionThreadSessionUsageLimit", (it) => {
+  it.effect("adds a nullable usage limit column", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* runMigrations({ toMigrationInclusive: 40 });
+      yield* runMigrations({ toMigrationInclusive: 41 });
+
+      const columns = yield* sql<{ readonly name: string; readonly notnull: number }>`
+        PRAGMA table_info(projection_thread_sessions)
+      `;
+      const usageLimit = columns.find((column) => column.name === "usage_limit");
+
+      assert.equal(usageLimit?.name, "usage_limit");
+      assert.equal(usageLimit?.notnull, 0);
+    }),
+  );
+});

--- a/apps/server/src/persistence/Migrations/041_ProjectionThreadSessionUsageLimit.ts
+++ b/apps/server/src/persistence/Migrations/041_ProjectionThreadSessionUsageLimit.ts
@@ -1,0 +1,16 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  const columns = yield* sql<{ readonly name: string }>`
+    PRAGMA table_info(projection_thread_sessions)
+  `;
+
+  if (!columns.some((column) => column.name === "usage_limit")) {
+    yield* sql`
+      ALTER TABLE projection_thread_sessions
+      ADD COLUMN usage_limit TEXT
+    `;
+  }
+});

--- a/apps/server/src/persistence/Services/ProjectionThreadSessions.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreadSessions.ts
@@ -10,6 +10,7 @@ import {
   RuntimeMode,
   IsoDateTime,
   OrchestrationSessionStatus,
+  OrchestrationSessionUsageLimit,
   ProviderInstanceId,
   ThreadId,
   TurnId,
@@ -29,6 +30,7 @@ export const ProjectionThreadSession = Schema.Struct({
   runtimeMode: RuntimeMode,
   activeTurnId: Schema.NullOr(TurnId),
   lastError: Schema.NullOr(Schema.String),
+  usageLimit: Schema.NullOr(OrchestrationSessionUsageLimit),
   updatedAt: IsoDateTime,
 });
 export type ProjectionThreadSession = typeof ProjectionThreadSession.Type;

--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -24,11 +24,13 @@ import { HttpClient } from "effect/unstable/http";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
 import { makeClaudeTextGeneration } from "../../textGeneration/ClaudeTextGeneration.ts";
+import { TextGeneration } from "../../textGeneration/TextGeneration.ts";
 import * as BackgroundPolicy from "../../background/BackgroundPolicy.ts";
 import { ServerConfig } from "../../config.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import { ProviderDriverError } from "../Errors.ts";
 import { makeClaudeAdapter } from "../Layers/ClaudeAdapter.ts";
+import { makeClaudeUsageLimitQueryFactory } from "../testFixtures/claudeUsageLimitQuery.ts";
 import {
   checkClaudeProviderStatus,
   makePendingClaudeProvider,
@@ -59,6 +61,18 @@ const decodeClaudeSettings = Schema.decodeSync(ClaudeSettings);
 
 const DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
 const CAPABILITIES_PROBE_TTL = Duration.minutes(5);
+
+const claudeUsageLimitFixtureTextGeneration = TextGeneration.of({
+  generateCommitMessage: () =>
+    Effect.succeed({ subject: "test: exercise Claude usage-limit fixture", body: "" }),
+  generatePrContent: () =>
+    Effect.succeed({
+      title: "Test Claude usage-limit auto-continue",
+      body: "Exercises the local Claude usage-limit fixture.",
+    }),
+  generateBranchName: () => Effect.succeed({ branch: "t3code/claude-usage-limit-fixture" }),
+  generateThreadTitle: () => Effect.succeed({ title: "Claude usage-limit fixture" }),
+});
 
 function isClaudeNativeCommandPath(commandPath: string): boolean {
   const normalized = normalizeCommandPath(commandPath);
@@ -126,6 +140,11 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
       const processEnv = mergeProviderInstanceEnvironment(environment);
+      const usageLimitFixtureEnabled = processEnv.T3CODE_CLAUDE_USAGE_LIMIT_FIXTURE === "1";
+      const fixtureResetDelayMs = Number.parseInt(
+        processEnv.T3CODE_CLAUDE_USAGE_LIMIT_FIXTURE_RESET_MS ?? "",
+        10,
+      );
       const fallbackContinuationIdentity = defaultProviderContinuationIdentity({
         driverKind: DRIVER_KIND,
         instanceId,
@@ -146,10 +165,21 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
       const adapterOptions = {
         instanceId,
         environment: processEnv,
+        ...(usageLimitFixtureEnabled
+          ? {
+              createQuery: makeClaudeUsageLimitQueryFactory({
+                ...(Number.isFinite(fixtureResetDelayMs) && fixtureResetDelayMs >= 0
+                  ? { resetDelayMs: fixtureResetDelayMs }
+                  : {}),
+              }),
+            }
+          : {}),
         ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
       };
       const adapter = yield* makeClaudeAdapter(effectiveConfig, adapterOptions);
-      const textGeneration = yield* makeClaudeTextGeneration(effectiveConfig, processEnv);
+      const textGeneration = usageLimitFixtureEnabled
+        ? claudeUsageLimitFixtureTextGeneration
+        : yield* makeClaudeTextGeneration(effectiveConfig, processEnv);
 
       // Per-instance capabilities cache: keyed on binary + resolved HOME so
       // account-specific probes never share auth metadata across instances.
@@ -163,17 +193,32 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
       });
       const capabilitiesCacheKey = yield* makeClaudeCapabilitiesCacheKey(effectiveConfig, cwd);
 
-      const checkProvider = checkClaudeProviderStatus(
-        effectiveConfig,
-        () => Cache.get(capabilitiesProbeCache, capabilitiesCacheKey),
-        processEnv,
-        cwd,
-      ).pipe(
-        Effect.map(stampIdentity),
-        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
-        Effect.provideService(FileSystem.FileSystem, fileSystem),
-        Effect.provideService(Path.Path, path),
-      );
+      const checkProviderDraft = usageLimitFixtureEnabled
+        ? makePendingClaudeProvider(effectiveConfig).pipe(
+            Effect.map(({ message: _message, ...provider }) => ({
+              ...provider,
+              installed: true,
+              version: "usage-limit-fixture",
+              status: "ready" as const,
+              auth: {
+                status: "authenticated" as const,
+                type: "fixture",
+                label: "Claude usage-limit fixture",
+              },
+              message: "Using the local Claude usage-limit fixture.",
+            })),
+          )
+        : checkClaudeProviderStatus(
+            effectiveConfig,
+            () => Cache.get(capabilitiesProbeCache, capabilitiesCacheKey),
+            processEnv,
+            cwd,
+          ).pipe(
+            Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+            Effect.provideService(FileSystem.FileSystem, fileSystem),
+            Effect.provideService(Path.Path, path),
+          );
+      const checkProvider = checkProviderDraft.pipe(Effect.map(stampIdentity));
 
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
       const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<ClaudeSettings>>({

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1580,6 +1580,150 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("turns Claude usage-limit results into an interrupted completion", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 7).pipe(
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      const turn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "rate_limit_event",
+        rate_limit_info: {
+          status: "rejected",
+          rateLimitType: "five_hour",
+          resetsAt: 1_800_000_000_000,
+        },
+        session_id: "sdk-session-limit",
+        uuid: "rate-limit",
+      } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "result",
+        subtype: "error_during_execution",
+        is_error: true,
+        errors: ["[ede_diagnostic] rate limit"],
+        terminal_reason: "blocking_limit",
+        session_id: "sdk-session-limit",
+        uuid: "result-limit",
+      } as unknown as SDKMessage);
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      assert.equal(runtimeEvents.filter((event) => event.type === "runtime.error").length, 0);
+      const completed = runtimeEvents.find((event) => event.type === "turn.completed");
+      assert.equal(completed?.type, "turn.completed");
+      if (completed?.type === "turn.completed") {
+        assert.equal(String(completed.turnId), String(turn.turnId));
+        assert.equal(completed.payload.state, "interrupted");
+        assert.deepEqual(completed.payload.usageLimit, {
+          windowType: "five_hour",
+          resetsAt: 1_800_000_000_000,
+          message: "Claude usage limit reached.",
+        });
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("clears a rejected usage-limit marker on a later allowed event", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 8).pipe(
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({ threadId: session.threadId, input: "hello", attachments: [] });
+      harness.query.emit({
+        type: "rate_limit_event",
+        rate_limit_info: { status: "rejected", rateLimitType: "five_hour" },
+        session_id: "sdk-session-limit-clear",
+        uuid: "rate-limit-rejected",
+      } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "rate_limit_event",
+        rate_limit_info: { status: "allowed" },
+        session_id: "sdk-session-limit-clear",
+        uuid: "rate-limit-allowed",
+      } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "result",
+        subtype: "error_during_execution",
+        is_error: true,
+        errors: ["[ede_diagnostic] rate limit"],
+        terminal_reason: "rapid_refill_breaker",
+        session_id: "sdk-session-limit-clear",
+        uuid: "result-limit-clear",
+      } as unknown as SDKMessage);
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      const completed = runtimeEvents.find((event) => event.type === "turn.completed");
+      assert.equal(completed?.type, "turn.completed");
+      if (completed?.type === "turn.completed") {
+        assert.equal(completed.payload.state, "interrupted");
+        assert.equal(completed.payload.usageLimit, undefined);
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("completes a silently ended limited stream once without a runtime error", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 7).pipe(
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({ threadId: session.threadId, input: "hello", attachments: [] });
+      harness.query.emit({
+        type: "rate_limit_event",
+        rate_limit_info: { status: "rejected", rateLimitType: "seven_day" },
+        session_id: "sdk-session-silent-limit",
+        uuid: "rate-limit-silent",
+      } as unknown as SDKMessage);
+      harness.query.finish();
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      assert.equal(runtimeEvents.filter((event) => event.type === "runtime.error").length, 0);
+      const completions = runtimeEvents.filter((event) => event.type === "turn.completed");
+      assert.equal(completions.length, 1);
+      const completed = completions[0];
+      if (completed?.type === "turn.completed") {
+        assert.equal(completed.payload.state, "interrupted");
+        assert.equal(completed.payload.usageLimit?.windowType, "seven_day");
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("interruptTurn settles every acknowledged live task before interrupting", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -161,6 +161,7 @@ function makeHarness(config?: {
   readonly baseDir?: string;
   readonly claudeConfig?: Partial<ClaudeSettings>;
   readonly instanceId?: ProviderInstanceId;
+  readonly environment?: NodeJS.ProcessEnv;
 }) {
   const query = new FakeClaudeQuery();
   let createInput:
@@ -172,6 +173,7 @@ function makeHarness(config?: {
 
   const adapterOptions: ClaudeAdapterLiveOptions = {
     ...(config?.instanceId ? { instanceId: config.instanceId } : {}),
+    ...(config?.environment ? { environment: config.environment } : {}),
     createQuery: (input) => {
       createInput = input;
       return query;
@@ -355,6 +357,44 @@ describe("ClaudeAdapterLive", () => {
       assert.deepEqual(createInput?.options.settingSources, ["user", "project", "local"]);
       assert.equal(createInput?.options.permissionMode, "bypassPermissions");
       assert.equal(createInput?.options.allowDangerouslySkipPermissions, true);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("enables interrupted-turn watchdog only for native resume", () => {
+    const harness = makeHarness({
+      environment: {
+        CLAUDE_CODE_RETRY_WATCHDOG: "preserve-me",
+        CUSTOM_CLAUDE_ENV: "preserve-me-too",
+      },
+    });
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const nativeResume = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+        resumeCursor: { resume: "123e4567-e89b-12d3-a456-426614174000" },
+        resumeInterruptedTurn: true,
+      });
+
+      const nativeEnv = harness.getLastCreateQueryInput()?.options.env;
+      assert.equal(nativeEnv?.CLAUDE_CODE_RETRY_WATCHDOG, "1");
+      assert.equal(nativeEnv?.CLAUDE_CODE_RESUME_INTERRUPTED_TURN, "1");
+      assert.equal(nativeEnv?.CUSTOM_CLAUDE_ENV, "preserve-me-too");
+
+      yield* adapter.startSession({
+        threadId: nativeResume.threadId,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+        resumeInterruptedTurn: true,
+      });
+      const freshEnv = harness.getLastCreateQueryInput()?.options.env;
+      assert.equal(freshEnv?.CLAUDE_CODE_RETRY_WATCHDOG, "preserve-me");
+      assert.equal(freshEnv?.CLAUDE_CODE_RESUME_INTERRUPTED_TURN, undefined);
+      assert.equal(freshEnv?.CUSTOM_CLAUDE_ENV, "preserve-me-too");
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -4154,7 +4154,15 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         ...(newSessionId ? { sessionId: newSessionId } : {}),
         includePartialMessages: true,
         canUseTool,
-        env: claudeEnvironment,
+        env: {
+          ...claudeEnvironment,
+          ...(input.resumeInterruptedTurn && existingResumeSessionId
+            ? {
+                CLAUDE_CODE_RETRY_WATCHDOG: "1",
+                CLAUDE_CODE_RESUME_INTERRUPTED_TURN: "1",
+              }
+            : {}),
+        },
         additionalDirectories,
         ...(Object.keys(extraArgs).length > 0 ? { extraArgs } : {}),
         ...(mcpSession

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -245,7 +245,14 @@ interface ClaudeSessionContext {
   lastKnownTotalProcessedTokens: number | undefined;
   lastAssistantUuid: string | undefined;
   lastThreadStartedId: string | undefined;
+  usageLimit: ClaudeUsageLimit | undefined;
   stopped: boolean;
+}
+
+interface ClaudeUsageLimit {
+  readonly windowType?: string;
+  readonly resetsAt?: number;
+  readonly message?: string;
 }
 
 interface ClaudeQueryRuntime extends AsyncIterable<SDKMessage> {
@@ -367,7 +374,9 @@ function isInterruptedResult(result: SDKResultMessage): boolean {
   // is_error: true), interrupting mid-stream yields "aborted_streaming".
   if (
     result.terminal_reason === "aborted_tools" ||
-    result.terminal_reason === "aborted_streaming"
+    result.terminal_reason === "aborted_streaming" ||
+    result.terminal_reason === "blocking_limit" ||
+    result.terminal_reason === "rapid_refill_breaker"
   ) {
     return true;
   }
@@ -2170,6 +2179,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     status: ProviderRuntimeTurnStatus,
     errorMessage?: string,
     result?: SDKResultMessage,
+    usageLimit?: ClaudeUsageLimit,
   ) {
     const resultContextWindow = maxClaudeContextWindowFromModelUsage(result?.modelUsage);
     if (resultContextWindow !== undefined) {
@@ -2339,6 +2349,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           ? { totalCostUsd: result.total_cost_usd }
           : {}),
         ...(errorMessage ? { errorMessage } : {}),
+        ...(usageLimit ? { usageLimit } : {}),
       },
       providerRefs: nativeProviderRefs(context),
     });
@@ -2943,12 +2954,17 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
     const status = turnStatusFromResult(message);
     const errorMessage = resultUserFacingError(message);
+    const usageLimit =
+      message.terminal_reason === "blocking_limit" ||
+      message.terminal_reason === "rapid_refill_breaker"
+        ? context.usageLimit
+        : undefined;
 
     if (status === "failed") {
       yield* emitRuntimeError(context, errorMessage ?? "Claude turn failed.");
     }
 
-    yield* completeTurn(context, status, errorMessage, message);
+    yield* completeTurn(context, status, errorMessage, message, usageLimit);
   });
 
   /**
@@ -3472,6 +3488,18 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     }
 
     if (message.type === "rate_limit_event") {
+      const rateLimitInfo = message.rate_limit_info;
+      if (rateLimitInfo.status === "rejected") {
+        context.usageLimit = {
+          ...(rateLimitInfo.rateLimitType ? { windowType: rateLimitInfo.rateLimitType } : {}),
+          ...(typeof rateLimitInfo.resetsAt === "number" && Number.isFinite(rateLimitInfo.resetsAt)
+            ? { resetsAt: rateLimitInfo.resetsAt }
+            : {}),
+          message: "Claude usage limit reached.",
+        };
+      } else if (rateLimitInfo.status === "allowed") {
+        context.usageLimit = undefined;
+      }
       yield* offerRuntimeEvent({
         ...base,
         type: "account.rate-limits.updated",
@@ -3584,7 +3612,13 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         yield* completeTurn(context, "failed", message);
       }
     } else if (context.turnState) {
-      yield* completeTurn(context, "interrupted", "Claude runtime stream ended.");
+      yield* completeTurn(
+        context,
+        "interrupted",
+        "Claude runtime stream ended.",
+        undefined,
+        context.usageLimit,
+      );
     }
 
     yield* stopSessionInternal(context, {
@@ -4221,6 +4255,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         lastKnownTotalProcessedTokens: undefined,
         lastAssistantUuid: resumeState?.resumeSessionAt,
         lastThreadStartedId: undefined,
+        usageLimit: undefined,
         stopped: false,
       };
       yield* Ref.set(contextRef, context);

--- a/apps/server/src/provider/testFixtures/claudeUsageLimitQuery.test.ts
+++ b/apps/server/src/provider/testFixtures/claudeUsageLimitQuery.test.ts
@@ -1,0 +1,59 @@
+import type { Options, SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
+import { describe, expect, it } from "vite-plus/test";
+
+import { makeClaudeUsageLimitQueryFactory } from "./claudeUsageLimitQuery.ts";
+
+async function* onePrompt(): AsyncIterable<SDKUserMessage> {
+  yield {
+    type: "user",
+    session_id: "fixture-session",
+    parent_tool_use_id: null,
+    message: { role: "user", content: "trigger the fixture" },
+  } as SDKUserMessage;
+}
+
+describe("Claude usage-limit dev query", () => {
+  it("rejects the first turn and resumes natively without another prompt", async () => {
+    const createQuery = makeClaudeUsageLimitQueryFactory({ resetDelayMs: 0 });
+    const first = createQuery({
+      prompt: onePrompt(),
+      options: { sessionId: "fixture-session" } as Options,
+    });
+    const firstMessages = [];
+    for await (const message of first) firstMessages.push(message);
+
+    expect(firstMessages.map((message) => message.type)).toEqual([
+      "system",
+      "rate_limit_event",
+      "result",
+    ]);
+    expect(firstMessages[1]).toMatchObject({
+      rate_limit_info: { status: "rejected", rateLimitType: "five_hour" },
+    });
+
+    const resumed = createQuery({
+      prompt: {
+        [Symbol.asyncIterator]: () => ({
+          next: () => new Promise<IteratorResult<SDKUserMessage>>(() => undefined),
+        }),
+      },
+      options: {
+        resume: "fixture-session",
+        env: {
+          CLAUDE_CODE_RETRY_WATCHDOG: "1",
+          CLAUDE_CODE_RESUME_INTERRUPTED_TURN: "1",
+        },
+      } as Options,
+    });
+    const resumedMessages = [];
+    for await (const message of resumed) resumedMessages.push(message);
+
+    expect(resumedMessages.map((message) => message.type)).toEqual([
+      "system",
+      "rate_limit_event",
+      "assistant",
+      "result",
+    ]);
+    expect(resumedMessages[1]).toMatchObject({ rate_limit_info: { status: "allowed" } });
+  });
+});

--- a/apps/server/src/provider/testFixtures/claudeUsageLimitQuery.ts
+++ b/apps/server/src/provider/testFixtures/claudeUsageLimitQuery.ts
@@ -1,0 +1,192 @@
+// @effect-diagnostics globalDate:off -- This dev fixture simulates the external Claude harness clock.
+// @effect-diagnostics globalTimers:off -- Only the fixture simulates Claude's wait; production uses the native watchdog.
+import type {
+  Options,
+  PermissionMode,
+  SDKMessage,
+  SDKUserMessage,
+} from "@anthropic-ai/claude-agent-sdk";
+
+interface FixtureQueryInput {
+  readonly prompt: AsyncIterable<SDKUserMessage>;
+  readonly options: Options;
+}
+
+interface FixtureQuery extends AsyncIterable<SDKMessage> {
+  readonly interrupt: () => Promise<void>;
+  readonly setModel: (model?: string) => Promise<void>;
+  readonly setPermissionMode: (mode: PermissionMode) => Promise<void>;
+  readonly setMaxThinkingTokens: (maxThinkingTokens: number | null) => Promise<void>;
+  readonly close: () => void;
+}
+
+interface UsageLimitFixtureState {
+  readonly resetsAt: number;
+}
+
+function initMessage(sessionId: string, model: string | undefined): SDKMessage {
+  return {
+    type: "system",
+    subtype: "init",
+    apiKeySource: "none",
+    claude_code_version: "usage-limit-fixture",
+    cwd: process.cwd(),
+    tools: [],
+    mcp_servers: [],
+    model: model ?? "claude-sonnet-4-6",
+    permissionMode: "bypassPermissions",
+    slash_commands: [],
+    output_style: "default",
+    skills: [],
+    plugins: [],
+    session_id: sessionId,
+    uuid: `fixture-init-${sessionId}`,
+  } as unknown as SDKMessage;
+}
+
+class ClaudeUsageLimitFixtureQuery implements FixtureQuery {
+  readonly #input: FixtureQueryInput;
+  readonly #sessionId: string;
+  readonly #state: Map<string, UsageLimitFixtureState>;
+  readonly #resetDelayMs: number;
+  readonly #closedListeners = new Set<() => void>();
+  #closed = false;
+
+  constructor(input: {
+    readonly query: FixtureQueryInput;
+    readonly sessionId: string;
+    readonly state: Map<string, UsageLimitFixtureState>;
+    readonly resetDelayMs: number;
+  }) {
+    this.#input = input.query;
+    this.#sessionId = input.sessionId;
+    this.#state = input.state;
+    this.#resetDelayMs = input.resetDelayMs;
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterator<SDKMessage> {
+    yield initMessage(this.#sessionId, this.#input.options.model);
+
+    const nativeResume =
+      this.#input.options.resume === this.#sessionId &&
+      this.#input.options.env?.CLAUDE_CODE_RETRY_WATCHDOG === "1" &&
+      this.#input.options.env?.CLAUDE_CODE_RESUME_INTERRUPTED_TURN === "1";
+    if (!nativeResume) {
+      const prompt = await this.#input.prompt[Symbol.asyncIterator]().next();
+      if (prompt.done || this.#closed) return;
+
+      const resetsAt = Date.now() + this.#resetDelayMs;
+      this.#state.set(this.#sessionId, { resetsAt });
+      yield {
+        type: "rate_limit_event",
+        rate_limit_info: {
+          status: "rejected",
+          rateLimitType: "five_hour",
+          resetsAt,
+        },
+        session_id: this.#sessionId,
+        uuid: `fixture-rate-limit-${this.#sessionId}`,
+      } as unknown as SDKMessage;
+      yield {
+        type: "result",
+        subtype: "error_during_execution",
+        is_error: true,
+        errors: ["[ede_diagnostic] simulated Claude usage limit"],
+        terminal_reason: "blocking_limit",
+        session_id: this.#sessionId,
+        uuid: `fixture-limited-result-${this.#sessionId}`,
+      } as unknown as SDKMessage;
+      return;
+    }
+
+    const stored = this.#state.get(this.#sessionId);
+    await this.#waitUntil(stored?.resetsAt ?? Date.now() + this.#resetDelayMs);
+    if (this.#closed) return;
+
+    this.#state.delete(this.#sessionId);
+    yield {
+      type: "rate_limit_event",
+      rate_limit_info: { status: "allowed", rateLimitType: "five_hour", utilization: 0 },
+      session_id: this.#sessionId,
+      uuid: `fixture-rate-limit-allowed-${this.#sessionId}`,
+    } as unknown as SDKMessage;
+    yield {
+      type: "assistant",
+      session_id: this.#sessionId,
+      uuid: `fixture-assistant-${this.#sessionId}`,
+      parent_tool_use_id: null,
+      message: {
+        id: `fixture-message-${this.#sessionId}`,
+        type: "message",
+        role: "assistant",
+        model: this.#input.options.model ?? "claude-sonnet-4-6",
+        content: [
+          {
+            type: "text",
+            text: "Mock Claude resumed automatically through the native watchdog.",
+          },
+        ],
+        stop_reason: "end_turn",
+        stop_sequence: null,
+        usage: {},
+      },
+    } as unknown as SDKMessage;
+    yield {
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      errors: [],
+      session_id: this.#sessionId,
+      uuid: `fixture-success-${this.#sessionId}`,
+    } as unknown as SDKMessage;
+  }
+
+  async #waitUntil(timestamp: number): Promise<void> {
+    const delayMs = Math.max(0, timestamp - Date.now());
+    if (delayMs === 0 || this.#closed) return;
+    await new Promise<void>((resolve) => {
+      const finish = () => {
+        clearTimeout(timer);
+        this.#closedListeners.delete(finish);
+        resolve();
+      };
+      const timer = setTimeout(finish, delayMs);
+      this.#closedListeners.add(finish);
+    });
+  }
+
+  async interrupt(): Promise<void> {
+    this.close();
+  }
+
+  async setModel(_model?: string): Promise<void> {}
+  async setPermissionMode(_mode: PermissionMode): Promise<void> {}
+  async setMaxThinkingTokens(_maxThinkingTokens: number | null): Promise<void> {}
+
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    for (const listener of this.#closedListeners) listener();
+    this.#closedListeners.clear();
+  }
+}
+
+/**
+ * Dev-only Claude query stand-in. The delay simulates Claude Code's native
+ * retry watchdog; production auto-continue never schedules a T3 timer.
+ */
+export function makeClaudeUsageLimitQueryFactory(input?: {
+  readonly resetDelayMs?: number;
+}): (query: FixtureQueryInput) => FixtureQuery {
+  const state = new Map<string, UsageLimitFixtureState>();
+  const resetDelayMs = input?.resetDelayMs ?? 45_000;
+  let fallbackSessionIndex = 0;
+
+  return (query) => {
+    const sessionId =
+      query.options.resume ??
+      query.options.sessionId ??
+      `fixture-session-${fallbackSessionIndex++}`;
+    return new ClaudeUsageLimitFixtureQuery({ query, sessionId, state, resetDelayMs });
+  };
+}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3,6 +3,7 @@ import {
   DEFAULT_MODEL,
   defaultInstanceIdForDriver,
   type EnvironmentId,
+  EventId,
   type MessageId,
   type ModelSelection,
   type ProjectScript,
@@ -276,7 +277,12 @@ import {
 } from "./chat/ThreadErrorBanner";
 import { resolveThreadPr } from "./ThreadStatusIndicators";
 import { ComposerBannerStack, type ComposerBannerStackItem } from "./chat/ComposerBannerStack";
-import { readUsageLimit, usageLimitBannerItem } from "./chat/usageLimitBanner";
+import {
+  readUsageLimit,
+  usageLimitAutoContinueEnabled,
+  usageLimitAutoContinueLabel,
+  usageLimitBannerItem,
+} from "./chat/usageLimitBanner";
 import { ThreadSyncStatusPill } from "./chat/ThreadSyncStatusPill";
 import {
   DRAFT_HERO_TRANSITION_ANIMATION_ID,
@@ -1227,6 +1233,9 @@ function ChatViewContent(props: ChatViewProps) {
   });
   const startThreadTurn = useAtomCommand(threadEnvironment.startTurn, { reportFailure: false });
   const interruptThreadTurn = useAtomCommand(threadEnvironment.interruptTurn, {
+    reportFailure: false,
+  });
+  const setUsageLimitAutoContinue = useAtomCommand(threadEnvironment.setUsageLimitAutoContinue, {
     reportFailure: false,
   });
   const respondToThreadApproval = useAtomCommand(threadEnvironment.respondToApproval, {
@@ -4444,10 +4453,34 @@ function ChatViewContent(props: ChatViewProps) {
     isStoppingBackgroundWork,
   ]);
   const usageLimitBanner = useMemo<ComposerBannerStackItem | null>(() => {
-    const session = activeThread?.session as { usageLimit?: unknown } | null | undefined;
-    const notice = readUsageLimit(session?.usageLimit);
-    return notice ? usageLimitBannerItem(notice) : null;
-  }, [activeThread?.session]);
+    const notice = readUsageLimit(activeThread?.session?.usageLimit);
+    if (!notice) return null;
+    if (notice.provider !== "claudeAgent" || !activeThreadRef) {
+      return usageLimitBannerItem(notice);
+    }
+    const enabled = usageLimitAutoContinueEnabled(notice);
+    return {
+      ...usageLimitBannerItem(notice),
+      actions: (
+        <Button
+          size="xs"
+          variant="outline"
+          onClick={() => {
+            void setUsageLimitAutoContinue({
+              environmentId: activeThreadRef.environmentId,
+              input: {
+                threadId: activeThreadRef.threadId,
+                expectedOccurrenceId: EventId.make(notice.occurrenceId),
+                enabled: !enabled,
+              },
+            });
+          }}
+        >
+          {usageLimitAutoContinueLabel(notice)}
+        </Button>
+      ),
+    };
+  }, [activeThread?.session, activeThreadRef, setUsageLimitAutoContinue]);
   // A woken thread announces itself in the open view, not just the sidebar
   // pill. Dismissing marks the wake as seen (same acknowledgment as the
   // pill); sending a message clears it as a side effect of the send path.

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -276,6 +276,7 @@ import {
 } from "./chat/ThreadErrorBanner";
 import { resolveThreadPr } from "./ThreadStatusIndicators";
 import { ComposerBannerStack, type ComposerBannerStackItem } from "./chat/ComposerBannerStack";
+import { readUsageLimit, usageLimitBannerItem } from "./chat/usageLimitBanner";
 import { ThreadSyncStatusPill } from "./chat/ThreadSyncStatusPill";
 import {
   DRAFT_HERO_TRANSITION_ANIMATION_ID,
@@ -4442,6 +4443,11 @@ function ChatViewContent(props: ChatViewProps) {
     handleStopBackgroundWork,
     isStoppingBackgroundWork,
   ]);
+  const usageLimitBanner = useMemo<ComposerBannerStackItem | null>(() => {
+    const session = activeThread?.session as { usageLimit?: unknown } | null | undefined;
+    const notice = readUsageLimit(session?.usageLimit);
+    return notice ? usageLimitBannerItem(notice) : null;
+  }, [activeThread?.session]);
   // A woken thread announces itself in the open view, not just the sidebar
   // pill. Dismissing marks the wake as seen (same acknowledgment as the
   // pill); sending a message clears it as a side effect of the send path.
@@ -4521,11 +4527,13 @@ function ChatViewContent(props: ChatViewProps) {
     const calmSystemItems = systemComposerBannerItems.filter((item) => !isUrgentSystemItem(item));
     const backgroundLivenessItems =
       backgroundLivenessBannerItem === null ? [] : [backgroundLivenessBannerItem];
+    const usageLimitItems = usageLimitBanner === null ? [] : [usageLimitBanner];
     const wokeThreadItems = wokeThreadBannerItem === null ? [] : [wokeThreadBannerItem];
     const parkedThreadItems = parkedThreadBannerItem === null ? [] : [parkedThreadBannerItem];
     if (!localCheckoutBranchMismatch || !showBranchMismatchBanner || !activeBranchMismatchKey) {
       return [
         ...urgentSystemItems,
+        ...usageLimitItems,
         ...backgroundLivenessItems,
         ...calmSystemItems,
         ...wokeThreadItems,
@@ -4534,6 +4542,7 @@ function ChatViewContent(props: ChatViewProps) {
     }
     return [
       ...urgentSystemItems,
+      ...usageLimitItems,
       ...backgroundLivenessItems,
       ...calmSystemItems,
       ...wokeThreadItems,
@@ -4587,6 +4596,7 @@ function ChatViewContent(props: ChatViewProps) {
     parkedThreadBannerItem,
     showBranchMismatchBanner,
     systemComposerBannerItems,
+    usageLimitBanner,
     wokeThreadBannerItem,
   ]);
 

--- a/apps/web/src/components/chat/usageLimitBanner.test.ts
+++ b/apps/web/src/components/chat/usageLimitBanner.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vite-plus/test";
+import { formatUsageLimitReset, readUsageLimit, usageLimitBannerItem } from "./usageLimitBanner";
+
+describe("usage limit banner", () => {
+  it("shows provider, supplied message, and localized reset time", () => {
+    const notice = {
+      occurrenceId: "abc",
+      provider: "claudeAgent",
+      message: "Try again later.",
+      resetsAt: Date.UTC(2026, 0, 2, 15, 30),
+    };
+    const item = usageLimitBannerItem(notice);
+
+    expect(item.title).toBe("Claude usage limit reached");
+    expect(item.description).toBe(
+      `Try again later. Resets ${formatUsageLimitReset(notice.resetsAt)}.`,
+    );
+    expect(item.id).toBe("usage-limit:abc");
+  });
+
+  it("accepts notices without a reset and rejects malformed values", () => {
+    expect(
+      usageLimitBannerItem({ occurrenceId: "abc", provider: "Codex", message: "Limit hit." })
+        .description,
+    ).toBe("Limit hit.");
+    expect(readUsageLimit(null)).toBeNull();
+    expect(readUsageLimit({ provider: "Codex" })).toBeNull();
+  });
+});

--- a/apps/web/src/components/chat/usageLimitBanner.test.ts
+++ b/apps/web/src/components/chat/usageLimitBanner.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vite-plus/test";
-import { formatUsageLimitReset, readUsageLimit, usageLimitBannerItem } from "./usageLimitBanner";
+import {
+  formatUsageLimitReset,
+  readUsageLimit,
+  usageLimitAutoContinueLabel,
+  usageLimitBannerItem,
+} from "./usageLimitBanner";
 
 describe("usage limit banner", () => {
   it("shows provider, supplied message, and localized reset time", () => {
@@ -25,5 +30,16 @@ describe("usage limit banner", () => {
     ).toBe("Limit hit.");
     expect(readUsageLimit(null)).toBeNull();
     expect(readUsageLimit({ provider: "Codex" })).toBeNull();
+  });
+
+  it("exposes a reversible auto-continue label from the server marker", () => {
+    expect(
+      usageLimitAutoContinueLabel({
+        occurrenceId: "abc",
+        provider: "claudeAgent",
+        message: "Limit hit.",
+        autoContinue: true,
+      }),
+    ).toBe("Disable auto-continue");
   });
 });

--- a/apps/web/src/components/chat/usageLimitBanner.ts
+++ b/apps/web/src/components/chat/usageLimitBanner.ts
@@ -6,6 +6,15 @@ export interface UsageLimitNotice {
   readonly windowType?: string;
   readonly resetsAt?: number;
   readonly message: string;
+  readonly autoContinue?: boolean;
+}
+
+export function usageLimitAutoContinueEnabled(notice: UsageLimitNotice): boolean {
+  return notice.autoContinue === true;
+}
+
+export function usageLimitAutoContinueLabel(notice: UsageLimitNotice): string {
+  return usageLimitAutoContinueEnabled(notice) ? "Disable auto-continue" : "Enable auto-continue";
 }
 
 function providerLabel(provider: string): string {
@@ -50,5 +59,6 @@ export function readUsageLimit(value: unknown): UsageLimitNotice | null {
     ...(typeof notice.resetsAt === "number" && Number.isFinite(notice.resetsAt)
       ? { resetsAt: notice.resetsAt }
       : {}),
+    ...(typeof notice.autoContinue === "boolean" ? { autoContinue: notice.autoContinue } : {}),
   };
 }

--- a/apps/web/src/components/chat/usageLimitBanner.ts
+++ b/apps/web/src/components/chat/usageLimitBanner.ts
@@ -1,0 +1,54 @@
+import type { ComposerBannerStackItem } from "./ComposerBannerStack";
+
+export interface UsageLimitNotice {
+  readonly occurrenceId: string;
+  readonly provider: string;
+  readonly windowType?: string;
+  readonly resetsAt?: number;
+  readonly message: string;
+}
+
+function providerLabel(provider: string): string {
+  return provider === "claudeAgent" ? "Claude" : provider;
+}
+
+export function usageLimitBannerItem(notice: UsageLimitNotice): ComposerBannerStackItem {
+  const reset =
+    typeof notice.resetsAt === "number" && Number.isFinite(notice.resetsAt)
+      ? formatUsageLimitReset(notice.resetsAt)
+      : null;
+  return {
+    id: `usage-limit:${notice.occurrenceId}`,
+    variant: "warning",
+    icon: "!",
+    title: `${providerLabel(notice.provider)} usage limit reached`,
+    description: reset ? `${notice.message} Resets ${reset}.` : notice.message,
+  };
+}
+
+export function formatUsageLimitReset(timestamp: number, locale?: string): string {
+  return new Intl.DateTimeFormat(locale, { dateStyle: "medium", timeStyle: "short" }).format(
+    new Date(timestamp),
+  );
+}
+
+export function readUsageLimit(value: unknown): UsageLimitNotice | null {
+  if (!value || typeof value !== "object") return null;
+  const notice = value as Partial<UsageLimitNotice>;
+  if (
+    typeof notice.occurrenceId !== "string" ||
+    typeof notice.provider !== "string" ||
+    typeof notice.message !== "string"
+  ) {
+    return null;
+  }
+  return {
+    occurrenceId: notice.occurrenceId,
+    provider: notice.provider,
+    message: notice.message,
+    ...(notice.windowType === undefined ? {} : { windowType: notice.windowType }),
+    ...(typeof notice.resetsAt === "number" && Number.isFinite(notice.resetsAt)
+      ? { resetsAt: notice.resetsAt }
+      : {}),
+  };
+}

--- a/docs/internals/claude-usage-limit-fixture.md
+++ b/docs/internals/claude-usage-limit-fixture.md
@@ -1,0 +1,21 @@
+# Claude usage-limit fixture
+
+Use the dev-only Claude query fixture to exercise usage-limit presentation and
+native auto-continue without using a real Claude account:
+
+```sh
+T3CODE_CLAUDE_USAGE_LIMIT_FIXTURE=1 \
+T3CODE_CLAUDE_USAGE_LIMIT_FIXTURE_RESET_MS=45000 \
+vp run dev
+```
+
+Create a Claude thread and send any prompt. The fixture rejects that turn with
+a five-hour usage-limit event and displays a reset time. Enable auto-continue
+from the composer banner. T3 restarts the Claude query with the persisted resume
+cursor and Claude's native watchdog flags; the fixture then waits until its
+simulated reset and emits an assistant response without receiving another user
+message.
+
+Disabling auto-continue stops the waiting query. The reset delay is only part of
+the fixture: production auto-continue delegates waiting and interrupted-turn
+resume to Claude Code.

--- a/packages/client-runtime/src/operations/commands.test.ts
+++ b/packages/client-runtime/src/operations/commands.test.ts
@@ -1,6 +1,7 @@
 import {
   CommandId,
   EnvironmentId,
+  EventId,
   ORCHESTRATION_WS_METHODS,
   ProjectId,
   ThreadId,
@@ -25,6 +26,7 @@ import {
   archiveThread,
   createProject,
   settleThread,
+  setThreadUsageLimitAutoContinue,
   stopThreadSession,
   unsettleThread,
 } from "./commands.ts";
@@ -116,6 +118,32 @@ describe("environment commands", () => {
           commandId: "queued-command",
           threadId: "thread-1",
           createdAt: "2026-06-06T00:01:00.000Z",
+        },
+      ]);
+    }).pipe(Effect.provide(TEST_CRYPTO_LAYER)),
+  );
+
+  it.effect("dispatches a usage-limit auto-continue preference with typed metadata", () =>
+    Effect.gen(function* () {
+      const dispatched: ClientOrchestrationCommand[] = [];
+      const supervisor = yield* makeSupervisor(dispatched);
+
+      yield* setThreadUsageLimitAutoContinue({
+        commandId: CommandId.make("usage-limit-command"),
+        threadId: ThreadId.make("thread-1"),
+        expectedOccurrenceId: EventId.make("usage-limit-1"),
+        enabled: true,
+        createdAt: "2026-06-06T00:02:00.000Z",
+      }).pipe(Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor));
+
+      expect(dispatched).toEqual([
+        {
+          type: "thread.usage-limit.auto-continue.set",
+          commandId: "usage-limit-command",
+          threadId: "thread-1",
+          expectedOccurrenceId: "usage-limit-1",
+          enabled: true,
+          createdAt: "2026-06-06T00:02:00.000Z",
         },
       ]);
     }).pipe(Effect.provide(TEST_CRYPTO_LAYER)),

--- a/packages/client-runtime/src/operations/commands.ts
+++ b/packages/client-runtime/src/operations/commands.ts
@@ -51,6 +51,8 @@ export type RespondToThreadApprovalInput = CommandInput<"thread.approval.respond
 export type RespondToThreadUserInputInput = CommandInput<"thread.user-input.respond">;
 export type RevertThreadCheckpointInput = CommandInput<"thread.checkpoint.revert">;
 export type StopThreadSessionInput = CommandInput<"thread.session.stop">;
+export type SetThreadUsageLimitAutoContinueInput =
+  CommandInput<"thread.usage-limit.auto-continue.set">;
 
 type DispatchTag = typeof ORCHESTRATION_WS_METHODS.dispatchCommand;
 type CommandEffect = Effect.Effect<
@@ -331,3 +333,17 @@ export const stopThreadSession: (input: StopThreadSessionInput) => CommandEffect
     createdAt: metadata.createdAt,
   });
 });
+
+export const setThreadUsageLimitAutoContinue: (
+  input: SetThreadUsageLimitAutoContinueInput,
+) => CommandEffect = Effect.fn("EnvironmentCommands.setThreadUsageLimitAutoContinue")(
+  function* (input) {
+    const metadata = yield* timestampedCommandMetadata(input);
+    return yield* dispatch({
+      ...input,
+      type: "thread.usage-limit.auto-continue.set",
+      commandId: metadata.commandId,
+      createdAt: metadata.createdAt,
+    });
+  },
+);

--- a/packages/client-runtime/src/state/threadCommands.ts
+++ b/packages/client-runtime/src/state/threadCommands.ts
@@ -18,6 +18,7 @@ import {
   type SnoozeThreadInput,
   type StartThreadTurnInput,
   type StopThreadSessionInput,
+  type SetThreadUsageLimitAutoContinueInput,
   type UnarchiveThreadInput,
   type UnpinThreadInput,
   type UnsettleThreadInput,
@@ -38,6 +39,7 @@ import {
   snoozeThread,
   startThreadTurn,
   stopThreadSession,
+  setThreadUsageLimitAutoContinue,
   unarchiveThread,
   unpinThread,
   unsettleThread,
@@ -62,6 +64,7 @@ export type {
   SnoozeThreadInput,
   StartThreadTurnInput,
   StopThreadSessionInput,
+  SetThreadUsageLimitAutoContinueInput,
   UnarchiveThreadInput,
   UnpinThreadInput,
   UnsettleThreadInput,
@@ -196,6 +199,13 @@ export function createThreadEnvironmentAtoms<R, E>(
     stopSession: createEnvironmentCommand(runtime, {
       label: "environment-data:commands:thread:stop-session",
       execute: (input: StopThreadSessionInput) => stopThreadSession(input),
+      scheduler,
+      concurrency,
+    }),
+    setUsageLimitAutoContinue: createEnvironmentCommand(runtime, {
+      label: "environment-data:commands:thread:set-usage-limit-auto-continue",
+      execute: (input: SetThreadUsageLimitAutoContinueInput) =>
+        setThreadUsageLimitAutoContinue(input),
       scheduler,
       concurrency,
     }),

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -21,7 +21,7 @@ import {
   TrimmedString,
   TurnId,
 } from "./baseSchemas.ts";
-import { ProviderInstanceId } from "./providerInstance.ts";
+import { ProviderDriverKind, ProviderInstanceId } from "./providerInstance.ts";
 
 export const ORCHESTRATION_WS_METHODS = {
   dispatchCommand: "orchestration.dispatchCommand",
@@ -282,6 +282,20 @@ export const OrchestrationSessionStatus = Schema.Literals([
 ]);
 export type OrchestrationSessionStatus = typeof OrchestrationSessionStatus.Type;
 
+/**
+ * Durable attribution for a provider turn that paused because its account
+ * usage window closed. Reset timestamps are epoch milliseconds so every
+ * client can format them in the viewer's locale.
+ */
+export const OrchestrationSessionUsageLimit = Schema.Struct({
+  occurrenceId: EventId,
+  provider: ProviderDriverKind,
+  windowType: Schema.optional(TrimmedNonEmptyString),
+  resetsAt: Schema.optional(Schema.Number),
+  message: TrimmedNonEmptyString,
+});
+export type OrchestrationSessionUsageLimit = typeof OrchestrationSessionUsageLimit.Type;
+
 export const OrchestrationSession = Schema.Struct({
   threadId: ThreadId,
   status: OrchestrationSessionStatus,
@@ -290,6 +304,7 @@ export const OrchestrationSession = Schema.Struct({
   runtimeMode: RuntimeMode.pipe(Schema.withDecodingDefault(Effect.succeed(DEFAULT_RUNTIME_MODE))),
   activeTurnId: Schema.NullOr(TurnId),
   lastError: Schema.NullOr(TrimmedNonEmptyString),
+  usageLimit: Schema.optional(Schema.NullOr(OrchestrationSessionUsageLimit)),
   updatedAt: IsoDateTime,
 });
 export type OrchestrationSession = typeof OrchestrationSession.Type;

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -293,6 +293,7 @@ export const OrchestrationSessionUsageLimit = Schema.Struct({
   windowType: Schema.optional(TrimmedNonEmptyString),
   resetsAt: Schema.optional(Schema.Number),
   message: TrimmedNonEmptyString,
+  autoContinue: Schema.optional(Schema.Boolean),
 });
 export type OrchestrationSessionUsageLimit = typeof OrchestrationSessionUsageLimit.Type;
 
@@ -910,6 +911,15 @@ const ThreadSessionStopCommand = Schema.Struct({
   onlyIfSettled: Schema.optional(Schema.Boolean),
 });
 
+export const ThreadUsageLimitAutoContinueSetCommand = Schema.Struct({
+  type: Schema.Literal("thread.usage-limit.auto-continue.set"),
+  commandId: CommandId,
+  threadId: ThreadId,
+  expectedOccurrenceId: EventId,
+  enabled: Schema.Boolean,
+  createdAt: IsoDateTime,
+});
+
 const DispatchableClientOrchestrationCommand = Schema.Union([
   ProjectCreateCommand,
   ProjectMetaUpdateCommand,
@@ -934,6 +944,7 @@ const DispatchableClientOrchestrationCommand = Schema.Union([
   ThreadUserInputRespondCommand,
   ThreadCheckpointRevertCommand,
   ThreadSessionStopCommand,
+  ThreadUsageLimitAutoContinueSetCommand,
 ]);
 export type DispatchableClientOrchestrationCommand =
   typeof DispatchableClientOrchestrationCommand.Type;
@@ -962,6 +973,7 @@ export const ClientOrchestrationCommand = Schema.Union([
   ThreadUserInputRespondCommand,
   ThreadCheckpointRevertCommand,
   ThreadSessionStopCommand,
+  ThreadUsageLimitAutoContinueSetCommand,
 ]);
 export type ClientOrchestrationCommand = typeof ClientOrchestrationCommand.Type;
 
@@ -970,6 +982,13 @@ const ThreadSessionSetCommand = Schema.Struct({
   commandId: CommandId,
   threadId: ThreadId,
   session: OrchestrationSession,
+  createdAt: IsoDateTime,
+});
+
+export const ThreadUsageLimitAutoContinueSetPayload = Schema.Struct({
+  threadId: ThreadId,
+  expectedOccurrenceId: EventId,
+  enabled: Schema.Boolean,
   createdAt: IsoDateTime,
 });
 
@@ -1083,6 +1102,7 @@ export const OrchestrationEventType = Schema.Literals([
   "thread.reverted",
   "thread.session-stop-requested",
   "thread.session-set",
+  "thread.usage-limit-auto-continue-set",
   "thread.proposed-plan-upserted",
   "thread.turn-diff-completed",
   "thread.activity-appended",
@@ -1471,6 +1491,11 @@ export const OrchestrationEvent = Schema.Union([
     ...EventBaseFields,
     type: Schema.Literal("thread.session-set"),
     payload: ThreadSessionSetPayload,
+  }),
+  Schema.Struct({
+    ...EventBaseFields,
+    type: Schema.Literal("thread.usage-limit-auto-continue-set"),
+    payload: ThreadUsageLimitAutoContinueSetPayload,
   }),
   Schema.Struct({
     ...EventBaseFields,

--- a/packages/contracts/src/provider.ts
+++ b/packages/contracts/src/provider.ts
@@ -58,6 +58,7 @@ export const ProviderSessionStartInput = Schema.Struct({
   cwd: Schema.optional(TrimmedNonEmptyString),
   modelSelection: Schema.optional(ModelSelection),
   resumeCursor: Schema.optional(Schema.Unknown),
+  resumeInterruptedTurn: Schema.optional(Schema.Boolean),
   approvalPolicy: Schema.optional(ProviderApprovalPolicy),
   sandboxMode: Schema.optional(ProviderSandboxMode),
   runtimeMode: RuntimeMode,

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -368,6 +368,13 @@ const TurnCompletedPayload = Schema.Struct({
   modelUsage: Schema.optional(UnknownRecordSchema),
   totalCostUsd: Schema.optional(Schema.Number),
   errorMessage: Schema.optional(TrimmedNonEmptyStringSchema),
+  usageLimit: Schema.optional(
+    Schema.Struct({
+      windowType: Schema.optional(TrimmedNonEmptyStringSchema),
+      resetsAt: Schema.optional(Schema.Number),
+      message: Schema.optional(TrimmedNonEmptyStringSchema),
+    }),
+  ),
 });
 export type TurnCompletedPayload = typeof TurnCompletedPayload.Type;
 


### PR DESCRIPTION
Depends on #6639.

Claude Code now exposes native retry-watchdog behavior for interrupted usage-limit turns, but T3 Code has no durable way for users to opt into it.

This adds a reversible, occurrence-guarded auto-continue preference to the usage-limit banner, persists it in the orchestration projection, and resumes the existing Claude session with `CLAUDE_CODE_RETRY_WATCHDOG` and `CLAUDE_CODE_RESUME_INTERRUPTED_TURN`. T3 does not schedule a production timer or synthesize a user message.

A dev-only Claude query fixture makes the rejected → waiting → native resume flow testable without consuming a Claude account.

Tests: 211 focused adapter, fixture, decider, projection, reactor, ingestion, client-runtime, web, and mobile tests; targeted server/contracts/client-runtime/web/mobile typechecks.

Built with GPT-5.6 in the Codex harness through T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Claude usage limit detection and auto-continue to thread sessions
> - Detects Claude provider usage limits (`blocking_limit`, `rapid_refill_breaker`) in `ClaudeAdapter`, emits a `turn.completed` with `state='interrupted'` and a `usageLimit` payload, and sets session status to `interrupted`.
> - Adds a `usage_limit` column to `projection_thread_sessions` (migration 041) and propagates the `usageLimit` field through projection queries, snapshot assembly, and the in-memory session model.
> - Introduces a `thread.usage-limit.auto-continue.set` command and matching event; the decider validates occurrenceId and provider before emitting, and the projector toggles `session.usageLimit.autoContinue`.
> - `ProviderCommandReactor` resumes interrupted Claude sessions when auto-continue is enabled, deduplicates restarts per thread, and restores opted-in sessions on reactor startup.
> - Web and mobile composer UIs display a warning banner when a session has a `usageLimit`, with a toggle to enable/disable auto-continue for Claude threads.
> - Adds a local dev fixture (`T3CODE_CLAUDE_USAGE_LIMIT_FIXTURE=1`) in `ClaudeDriver` to exercise usage-limit and native resume flows without hitting the real API.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 612d2c4. 23 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->