### PR TITLE
fix(web): sidebar open state survives refresh

### DIFF
--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -216,7 +216,6 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
     <SidebarProvider
       className="h-dvh! min-h-0!"
       data-panel-animations={panelAnimationsActive ? "true" : "false"}
-      defaultOpen
       style={sidebarProviderStyle}
     >
       <ProjectProjectionRetention />

--- a/apps/web/src/components/ui/sidebar.test.tsx
+++ b/apps/web/src/components/ui/sidebar.test.tsx
@@ -1,5 +1,7 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vite-plus/test";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+
+import { removeLocalStorageItem } from "~/hooks/useLocalStorage";
 
 import {
   SidebarMenuAction,
@@ -8,7 +10,12 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from "./sidebar";
-import { resolveSidebarState } from "./sidebarState";
+import {
+  readPersistedSidebarOpen,
+  resolveSidebarState,
+  SIDEBAR_OPEN_STORAGE_KEY,
+  writePersistedSidebarOpen,
+} from "./sidebarState";
 
 function renderSidebarButton(className?: string) {
   return renderToStaticMarkup(
@@ -19,6 +26,10 @@ function renderSidebarButton(className?: string) {
 }
 
 describe("sidebar interactive cursors", () => {
+  afterEach(() => {
+    removeLocalStorageItem(SIDEBAR_OPEN_STORAGE_KEY);
+  });
+
   it("uses mobile sheet visibility for the shared responsive state", () => {
     expect(resolveSidebarState({ isMobile: true, open: true, openMobile: false })).toBe(
       "collapsed",
@@ -27,6 +38,18 @@ describe("sidebar interactive cursors", () => {
     expect(resolveSidebarState({ isMobile: false, open: true, openMobile: false })).toBe(
       "expanded",
     );
+  });
+
+  it("persists and restores desktop open state", () => {
+    writePersistedSidebarOpen(false);
+    expect(readPersistedSidebarOpen()).toBe(false);
+
+    const html = renderToStaticMarkup(
+      <SidebarProvider>
+        <div />
+      </SidebarProvider>,
+    );
+    expect(html).toContain('data-sidebar-state="collapsed"');
   });
 
   it("exposes collapsed state for shared titlebar inset styling", () => {

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -19,11 +19,14 @@ import { Skeleton } from "~/components/ui/skeleton";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
 import { useIsMobile } from "~/hooks/useMediaQuery";
 import { getLocalStorageItem, setLocalStorageItem } from "~/hooks/useLocalStorage";
-import { resolveSidebarState, type ResponsiveSidebarState } from "./sidebarState";
+import {
+  readPersistedSidebarOpen,
+  resolveSidebarState,
+  writePersistedSidebarOpen,
+  type ResponsiveSidebarState,
+} from "./sidebarState";
 import * as Schema from "effect/Schema";
 
-const SIDEBAR_COOKIE_NAME = "sidebar_state";
-const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 const SIDEBAR_WIDTH = "16rem";
 const SIDEBAR_WIDTH_MOBILE = "calc(100vw - var(--spacing(3)))";
 const SIDEBAR_WIDTH_ICON = "3rem";
@@ -109,10 +112,10 @@ function SidebarProvider({
 
   // This is the internal state of the sidebar.
   // We use openProp and setOpenProp for control from outside the component.
-  const [_open, _setOpen] = React.useState(defaultOpen);
+  const [_open, _setOpen] = React.useState(() => readPersistedSidebarOpen(defaultOpen));
   const open = openProp ?? _open;
   const setOpen = React.useCallback(
-    async (value: boolean | ((value: boolean) => boolean)) => {
+    (value: boolean | ((value: boolean) => boolean)) => {
       const openState = typeof value === "function" ? value(open) : value;
       if (setOpenProp) {
         setOpenProp(openState);
@@ -120,13 +123,7 @@ function SidebarProvider({
         _setOpen(openState);
       }
 
-      // This sets the cookie to keep the sidebar state.
-      await cookieStore.set({
-        expires: Date.now() + SIDEBAR_COOKIE_MAX_AGE * 1000,
-        name: SIDEBAR_COOKIE_NAME,
-        path: "/",
-        value: String(openState),
-      });
+      writePersistedSidebarOpen(openState);
     },
     [setOpenProp, open],
   );

--- a/apps/web/src/components/ui/sidebarState.ts
+++ b/apps/web/src/components/ui/sidebarState.ts
@@ -1,4 +1,10 @@
+import * as Schema from "effect/Schema";
+
+import { getLocalStorageItem, setLocalStorageItem } from "~/hooks/useLocalStorage";
+
 export type ResponsiveSidebarState = "expanded" | "collapsed";
+
+export const SIDEBAR_OPEN_STORAGE_KEY = "t3code:sidebar-open";
 
 export function resolveSidebarState(input: {
   isMobile: boolean;
@@ -6,4 +12,20 @@ export function resolveSidebarState(input: {
   openMobile: boolean;
 }): ResponsiveSidebarState {
   return (input.isMobile ? input.openMobile : input.open) ? "expanded" : "collapsed";
+}
+
+export function readPersistedSidebarOpen(fallback = true): boolean {
+  try {
+    return getLocalStorageItem(SIDEBAR_OPEN_STORAGE_KEY, Schema.Boolean) ?? fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function writePersistedSidebarOpen(open: boolean): void {
+  try {
+    setLocalStorageItem(SIDEBAR_OPEN_STORAGE_KEY, open, Schema.Boolean);
+  } catch {
+    // Preference persistence is best-effort.
+  }
 }


### PR DESCRIPTION
## Problem
Right panel open state already survived refresh. Sidebar only wrote a cookie and never read it, and the layout forced `defaultOpen`, so collapse/expand always reset.

## Fix
Persist desktop sidebar open state in localStorage and restore it on mount. Drop the write-only cookie path.

## Test plan
- [x] `vp test run apps/web/src/components/ui/sidebar.test.tsx`
- [ ] Collapse sidebar, refresh, confirm it stays collapsed
- [ ] Expand sidebar, refresh, confirm it stays expanded

Made with [opencode](https://opencode.ai) (grok-4.5)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI preference persistence only; best-effort localStorage with fallbacks and no auth or data-path changes.
> 
> **Overview**
> Fixes desktop sidebar collapse/expand resetting on refresh by **reading and writing** open state instead of only writing a cookie that was never read, and by stopping `AppSidebarLayout` from forcing `defaultOpen`.
> 
> **`SidebarProvider`** now seeds internal state from `readPersistedSidebarOpen` and calls `writePersistedSidebarOpen` on every toggle; the async `cookieStore` path is removed. Helpers live in `sidebarState.ts` under key `t3code:sidebar-open`, using the same localStorage hooks as other UI prefs.
> 
> **Note:** Existing cookie-stored sidebar state is not migrated—users may see one refresh with the default until they toggle again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10823c028d6520de76b301840d1867ef794789b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist desktop sidebar open state via `localStorage`
> - Moves sidebar state persistence from the `sidebar_state` cookie to the `t3code:sidebar-open` `localStorage` key using new helpers in [sidebarState.ts](https://github.com/pingdotgg/t3code/pull/6643/files#diff-78e2793d4fe576cb4bd349882f8237055d840d03f90dcd04458637c575f0986f)
> - `SidebarProvider` now lazily initializes its desktop open state from storage, falling back to `defaultOpen` when no preference exists
> - `AppSidebarLayout` removes its hardcoded `defaultOpen` prop so the persisted preference can take effect
> - Behavioral Change: the `sidebar_state` cookie is no longer written or read; storage errors during read or write are caught and silently ignored
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10823c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->