### PR TITLE
fix(mobile): wrap source files when Word break is on

### DIFF
--- a/apps/mobile/src/features/files/SourceFileSurface.tsx
+++ b/apps/mobile/src/features/files/SourceFileSurface.tsx
@@ -45,7 +45,7 @@ const HighlightedSourceLine = memo(function HighlightedSourceLine(props: {
 }) {
   return (
     <View
-      className={cn("flex-row", props.highlighted && "bg-primary/10")}
+      className={cn("flex-row items-start", props.highlighted && "bg-primary/10")}
       style={{ minHeight: props.codeSurface.rowHeight }}
     >
       <NativeText
@@ -59,51 +59,55 @@ const HighlightedSourceLine = memo(function HighlightedSourceLine(props: {
       >
         {props.index + 1}
       </NativeText>
-      <NativeText
-        selectable
-        numberOfLines={props.wordBreak ? undefined : 1}
-        className="flex-1 font-normal text-foreground"
-        style={{
-          fontFamily: REVIEW_MONO_FONT_FAMILY,
-          fontSize: props.codeSurface.fontSize,
-          lineHeight: props.codeSurface.rowHeight,
-          minWidth: props.wordBreak ? undefined : 320,
-        }}
+      <View
+        className={props.wordBreak ? "min-w-0 flex-1" : undefined}
+        style={props.wordBreak ? undefined : { minWidth: 320 }}
       >
-        {props.tokens && props.tokens.length > 0
-          ? (() => {
-              let offset = 0;
-              return props.tokens.map((token) => {
-                const start = offset;
-                offset += token.content.length;
+        <NativeText
+          selectable
+          numberOfLines={props.wordBreak ? undefined : 1}
+          className="font-normal text-foreground"
+          style={{
+            fontFamily: REVIEW_MONO_FONT_FAMILY,
+            fontSize: props.codeSurface.fontSize,
+            lineHeight: props.codeSurface.rowHeight,
+          }}
+        >
+          {props.tokens && props.tokens.length > 0
+            ? (() => {
+                let offset = 0;
+                return props.tokens.map((token) => {
+                  const start = offset;
+                  offset += token.content.length;
 
-                const fontWeight =
-                  token.fontStyle !== null && (token.fontStyle & 2) === 2
-                    ? ("700" as const)
-                    : ("400" as const);
-                const fontStyle =
-                  token.fontStyle !== null && (token.fontStyle & 1) === 1
-                    ? ("italic" as const)
-                    : ("normal" as const);
+                  const fontWeight =
+                    token.fontStyle !== null && (token.fontStyle & 2) === 2
+                      ? ("700" as const)
+                      : ("400" as const);
+                  const fontStyle =
+                    token.fontStyle !== null && (token.fontStyle & 1) === 1
+                      ? ("italic" as const)
+                      : ("normal" as const);
 
-                return (
-                  <NativeText
-                    key={`${start}:${token.content.length}:${token.color ?? ""}`}
-                    selectable
-                    style={{
-                      color: token.color ?? undefined,
-                      fontFamily: REVIEW_MONO_FONT_FAMILY,
-                      fontWeight,
-                      fontStyle,
-                    }}
-                  >
-                    {token.content.length > 0 ? renderVisibleWhitespace(token.content) : " "}
-                  </NativeText>
-                );
-              });
-            })()
-          : renderVisibleWhitespace(props.line || " ")}
-      </NativeText>
+                  return (
+                    <NativeText
+                      key={`${start}:${token.content.length}:${token.color ?? ""}`}
+                      selectable
+                      style={{
+                        color: token.color ?? undefined,
+                        fontFamily: REVIEW_MONO_FONT_FAMILY,
+                        fontWeight,
+                        fontStyle,
+                      }}
+                    >
+                      {token.content.length > 0 ? renderVisibleWhitespace(token.content) : " "}
+                    </NativeText>
+                  );
+                });
+              })()
+            : renderVisibleWhitespace(props.line || " ")}
+        </NativeText>
+      </View>
     </View>
   );
 });

--- a/apps/mobile/src/features/files/SourceFileSurface.tsx
+++ b/apps/mobile/src/features/files/SourceFileSurface.tsx
@@ -2,14 +2,7 @@ import { useAtomValue } from "@effect/atom-react";
 import { AsyncResult } from "effect/unstable/reactivity";
 import type { ComponentType } from "react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-  FlatList,
-  ScrollView,
-  Text as NativeText,
-  useColorScheme,
-  useWindowDimensions,
-  View,
-} from "react-native";
+import { FlatList, ScrollView, Text as NativeText, useColorScheme, View } from "react-native";
 
 import { AppText as Text } from "../../components/AppText";
 import { LoadingStrip } from "../../components/LoadingStrip";
@@ -27,6 +20,7 @@ import {
   buildNativeSourceTokens,
   NATIVE_SOURCE_CONTENT_WIDTH,
   nativeSourceRowId,
+  shouldUseNativeSourceFileRenderer,
 } from "./nativeSourceFileAdapter";
 import { prepareSourceFileDocument } from "./source-file-document";
 import { sourceHighlightAtom } from "./sourceHighlightingState";
@@ -158,8 +152,7 @@ function NativeSourceFileSurface(
   },
 ) {
   const { NativeView, onRefresh } = props;
-  const { codeSurface, codeWordBreak, nativeSourceStyle } = useAppearanceCodeSurface();
-  const { width: viewportWidth } = useWindowDimensions();
+  const { codeSurface, nativeSourceStyle } = useAppearanceCodeSurface();
   const { rowsJson, status, targetIndex, theme, tokens } = useSourceFileModel(props);
   const [isPullRefreshing, setIsPullRefreshing] = useState(false);
   const handlePullToRefresh = useCallback(async () => {
@@ -180,9 +173,6 @@ function NativeSourceFileSurface(
   );
   const themeJson = useMemo(() => JSON.stringify(createNativeReviewDiffTheme(theme)), [theme]);
   const styleJson = useMemo(() => JSON.stringify(nativeSourceStyle), [nativeSourceStyle]);
-  const contentWidth = codeWordBreak
-    ? Math.max(240, viewportWidth - codeSurface.gutterWidth - 24)
-    : NATIVE_SOURCE_CONTENT_WIDTH;
 
   return (
     <View className="relative flex-1 bg-sheet">
@@ -193,7 +183,7 @@ function NativeSourceFileSurface(
         style={{ flex: 1 }}
         appearanceScheme={theme}
         contentResetKey={props.path}
-        contentWidth={contentWidth}
+        contentWidth={NATIVE_SOURCE_CONTENT_WIDTH}
         initialRowIndex={targetIndex ?? -1}
         rowHeight={nativeSourceStyle.rowHeight ?? codeSurface.rowHeight}
         rowsJson={rowsJson}
@@ -283,9 +273,15 @@ function JavaScriptSourceFileSurface(props: SourceFileSurfaceProps) {
 
 export function SourceFileSurface(props: SourceFileSurfaceProps) {
   const NativeView = resolveNativeReviewDiffView();
-  return NativeView ? (
-    <NativeSourceFileSurface {...props} NativeView={NativeView} />
-  ) : (
-    <JavaScriptSourceFileSurface {...props} />
-  );
+  const { codeWordBreak } = useAppearanceCodeSurface();
+  if (
+    shouldUseNativeSourceFileRenderer({
+      nativeViewAvailable: NativeView !== null,
+      codeWordBreak,
+    }) &&
+    NativeView
+  ) {
+    return <NativeSourceFileSurface {...props} NativeView={NativeView} />;
+  }
+  return <JavaScriptSourceFileSurface {...props} />;
 }

--- a/apps/mobile/src/features/files/nativeSourceFileAdapter.test.ts
+++ b/apps/mobile/src/features/files/nativeSourceFileAdapter.test.ts
@@ -6,6 +6,7 @@ import {
   NATIVE_SOURCE_ROW_HEIGHT,
   NATIVE_SOURCE_STYLE,
   nativeSourceRowId,
+  shouldUseNativeSourceFileRenderer,
 } from "./nativeSourceFileAdapter";
 import {
   NATIVE_REVIEW_DIFF_ROW_HEIGHT,
@@ -62,5 +63,20 @@ describe("nativeSourceFileAdapter", () => {
 
   it("clears native tokens while highlighting is unavailable", () => {
     expect(buildNativeSourceTokens(null)).toEqual({});
+  });
+
+  it("uses the JS source renderer when word break is enabled", () => {
+    expect(
+      shouldUseNativeSourceFileRenderer({ nativeViewAvailable: true, codeWordBreak: false }),
+    ).toBe(true);
+    expect(
+      shouldUseNativeSourceFileRenderer({ nativeViewAvailable: true, codeWordBreak: true }),
+    ).toBe(false);
+    expect(
+      shouldUseNativeSourceFileRenderer({ nativeViewAvailable: false, codeWordBreak: false }),
+    ).toBe(false);
+    expect(
+      shouldUseNativeSourceFileRenderer({ nativeViewAvailable: false, codeWordBreak: true }),
+    ).toBe(false);
   });
 });

--- a/apps/mobile/src/features/files/nativeSourceFileAdapter.ts
+++ b/apps/mobile/src/features/files/nativeSourceFileAdapter.ts
@@ -11,6 +11,14 @@ import type { SourceHighlightTokens } from "./sourceHighlightingState";
 export const NATIVE_SOURCE_ROW_HEIGHT = MOBILE_CODE_SURFACE.rowHeight;
 export const NATIVE_SOURCE_CONTENT_WIDTH = 32_000;
 
+/** Native canvas drawing cannot wrap; the JS source renderer owns word break. */
+export function shouldUseNativeSourceFileRenderer(options: {
+  readonly nativeViewAvailable: boolean;
+  readonly codeWordBreak: boolean;
+}): boolean {
+  return options.nativeViewAvailable && !options.codeWordBreak;
+}
+
 export const NATIVE_SOURCE_STYLE: NativeReviewDiffStyle = createNativeSourceStyle(
   resolveMobileCodeSurface(MOBILE_CODE_SURFACE.fontSize),
 );


### PR DESCRIPTION
## Summary
- Enabling Word break on Android clipped long source lines at the viewport instead of wrapping.
- The JS file renderer already wraps, but Android always used the native canvas when it was available, and that canvas draws each line with one unwrapped `drawText()` call.
- Switching to the JS renderer when Word break is on was not enough: `flex-1` on `Text` still clips on Android. The line now sits in a `min-w-0 flex-1` view, matching the Appearance preview.

## Test plan
- [ ] Android: Settings → Appearance → Word break **on**, open a source file with long lines, confirm they wrap to the next row
- [ ] Android: Word break **off**, confirm horizontal scrolling still works (native renderer)
- [ ] iOS: Word break on/off still behaves correctly in the file viewer

Cursor Grok 4.6

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fall back to JavaScript source renderer when word break is enabled on mobile
> - Adds `shouldUseNativeSourceFileRenderer` in [nativeSourceFileAdapter.ts](https://github.com/pingdotgg/t3code/pull/6645/files#diff-fbd74d72dc5cf4821bda1fece2c39a0d1bb55bf593f05db5ceb8ab5bbe5823ac) that returns `true` only when a native view is available and `codeWordBreak` is `false`, since the native canvas renderer cannot wrap text.
> - Updates `SourceFileSurface` to use this function for renderer selection, falling back to `JavaScriptSourceFileSurface` when word break is on.
> - Fixes `HighlightedSourceLine` to wrap the code token `NativeText` in a width-controlling `View` (using `min-w-0 flex-1` when word break is active, fixed `minWidth: 320` otherwise), and sets `items-start` on the outer row so wrapped lines align correctly.
> - Simplifies `NativeSourceFileSurface` to always pass `NATIVE_SOURCE_CONTENT_WIDTH` as `contentWidth`, removing the previous viewport-and-word-break-dependent calculation.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3655c05. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->