### PR TITLE
fix(web): keep multi-select questions open after the first click

### DIFF
--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
@@ -1,5 +1,5 @@
 import { type ApprovalRequestId } from "@t3tools/contracts";
-import { memo, useEffect, useEffectEvent, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { type PendingUserInput } from "../../session-logic";
 import {
   derivePendingUserInputProgress,
@@ -109,21 +109,24 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
     };
   }, []);
 
-  const handleOptionSelection = useEffectEvent((questionId: string, optionLabel: string) => {
-    if (activeQuestion?.multiSelect) {
+  const handleOptionSelection = useCallback(
+    (questionId: string, optionLabel: string) => {
+      if (activeQuestion?.multiSelect) {
+        onToggleOption(questionId, optionLabel);
+        return;
+      }
+      setOptimisticSingleSelect({ questionId, optionLabel });
       onToggleOption(questionId, optionLabel);
-      return;
-    }
-    setOptimisticSingleSelect({ questionId, optionLabel });
-    onToggleOption(questionId, optionLabel);
-    if (autoAdvanceTimerRef.current !== null) {
-      window.clearTimeout(autoAdvanceTimerRef.current);
-    }
-    autoAdvanceTimerRef.current = window.setTimeout(() => {
-      autoAdvanceTimerRef.current = null;
-      onAdvanceRef.current();
-    }, 200);
-  });
+      if (autoAdvanceTimerRef.current !== null) {
+        window.clearTimeout(autoAdvanceTimerRef.current);
+      }
+      autoAdvanceTimerRef.current = window.setTimeout(() => {
+        autoAdvanceTimerRef.current = null;
+        onAdvanceRef.current();
+      }, 200);
+    },
+    [activeQuestion, onToggleOption],
+  );
 
   // Keyboard shortcut: number keys 1-9 select corresponding options when focus is
   // outside editable fields. Multi-select prompts toggle options in place; single-
@@ -154,7 +157,7 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
     };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
-  }, [activeQuestion, isCollapsed, isResponding]);
+  }, [activeQuestion, handleOptionSelection, isCollapsed, isResponding]);
 
   if (!activeQuestion) {
     return null;


### PR DESCRIPTION
## What Changed

`apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx`: `handleOptionSelection` is a plain `useCallback` with `[activeQuestion, onToggleOption]` instead of `useEffectEvent`, and the number-key effect lists it as a dependency.

Fixes #6344 (re-file of #6027 and #2707).

## Why

A question with `multiSelect: true` commits and advances on the first click whenever it is
**not** the first question of the prompt, so multi-select degrades to single-select and the
model receives one answer where several were intended.

The multi-select branch already exists. It never runs, because the guard reads a stale
question. `ComposerPendingUserInputCard` is wrapped in `memo`, and React applies effect-event
implementations only for plain function-component fibers: in `commitBeforeMutationEffects`,
tag `0` assigns `ref.impl = nextImpl`, while `15` (`SimpleMemoComponent`) and `11`
(`ForwardRef`) fall through to `break`. The `useEffectEvent` closure therefore freezes at the
first render, and the `multiSelect` check keeps reading question 1 for the whole prompt.

The click passes `activeQuestion.id` from the *render* closure, which is current, so the
answer is still stored against the right question. Only the guard is stale, so a later
multi-select question takes the single-select path and arms the 200 ms auto-advance timer.
Mirror case: put a multi-select question first, and later single-select questions never advance.

Reproduces on `upstream/main` at 9885a845c. macOS, desktop app, Claude provider. No test
accompanies the fix — the `apps/web` unit project renders with `renderToStaticMarkup` and has
no DOM environment, so a click cannot be simulated.

## UI Changes

Same window, theme, viewport, and question set in both clips. The only difference is this commit.

**Before** — one click on the multi-select step commits the whole prompt:

https://github.com/user-attachments/assets/b417a53c-bed5-489a-a4d5-8d8fc5712d3b

**After** — the multi-select step holds every pick and waits:

https://github.com/user-attachments/assets/41f2fa16-2e03-4a7f-80b4-ef9eef84cd1d

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

---

Written with Claude Opus 5 (1M context) in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized chat composer interaction fix with no auth, data, or API surface changes.
> 
> **Overview**
> Fixes pending user-input prompts where **multi-select** questions behaved like single-select (auto-advancing after one pick) whenever they were not the first question in the flow.
> 
> In `ComposerPendingUserInputPanel`, **`handleOptionSelection`** is switched from **`useEffectEvent`** to **`useCallback`** with `[activeQuestion, onToggleOption]` so the handler always sees the current question’s `multiSelect` flag. The number-key shortcut **`useEffect`** now depends on **`handleOptionSelection`** so keyboard and click paths stay aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a051e4e1a4c7c9fa47ac783ac24092661e49b5d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix multi-select questions staying open after first click in chat composer
> Replaces `useEffectEvent` with `useCallback` for `handleOptionSelection` in [ComposerPendingUserInputPanel.tsx](https://github.com/pingdotgg/t3code/pull/6646/files#diff-4d79f14a0bb3d90ecac6af885c54e9a485bcd9510c4a339f6bfdbcde568a0b0e), adding `[activeQuestion, onToggleOption]` as dependencies. The previous implementation caused multi-select dropdowns to close after a single selection because the stale handler reference wasn't triggering a re-bind of the keyboard shortcut effect.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a051e4e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->