### PR TITLE
fix(desktop): app zoom no longer zooms the preview browser

### DIFF
--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -979,7 +979,10 @@ describe("PreviewManager", () => {
     ),
   );
 
-  effectIt.effect("mirrors Electron's effective zoom across registration and navigation", () =>
+  // The guest reports whatever zoom level Chromium handed it from the app
+  // window, so the tab's own zoom is the source of truth in both directions:
+  // asserted onto every guest, never read back off one.
+  effectIt.effect("keeps the tab's own zoom instead of the guest's reported zoom", () =>
     withManager((manager) =>
       Effect.gen(function* () {
         let effectiveZoom = 0.9;
@@ -1025,18 +1028,13 @@ describe("PreviewManager", () => {
         yield* manager.createTab("tab_zoom");
         yield* manager.registerWebview("tab_zoom", 42);
 
-        expect(states.at(-1)?.zoomFactor).toBe(0.9);
-        expect(setZoomFactor).not.toHaveBeenCalled();
+        expect(states.at(-1)?.zoomFactor).toBe(1);
+        expect(setZoomFactor).toHaveBeenCalledWith(1);
 
-        effectiveZoom = 1.25;
-        listeners.get("did-navigate")?.();
-        yield* Effect.yieldNow;
-
-        expect(states.at(-1)?.zoomFactor).toBe(1.25);
-        expect(setZoomFactor).not.toHaveBeenCalled();
-
-        zoomReadable = false;
-        url = "https://example.com/after-zoom-read-failed";
+        // An app zoom leaves the guest reporting the inherited level. Navigating
+        // must not adopt it as the preview's zoom.
+        effectiveZoom = 0.8;
+        url = "https://example.com/after-app-zoom";
         listeners.get("did-navigate")?.();
         yield* Effect.yieldNow;
 
@@ -1045,7 +1043,18 @@ describe("PreviewManager", () => {
           url,
           title: "Example",
         });
-        expect(states.at(-1)?.zoomFactor).toBe(1.25);
+        expect(states.at(-1)?.zoomFactor).toBe(1);
+
+        // Only the preview's own zoom controls move it.
+        yield* manager.zoomIn("tab_zoom");
+        expect(setZoomFactor).toHaveBeenCalledWith(1.1);
+        expect(states.at(-1)?.zoomFactor).toBe(1.1);
+
+        zoomReadable = false;
+        listeners.get("did-navigate")?.();
+        yield* Effect.yieldNow;
+
+        expect(states.at(-1)?.zoomFactor).toBe(1.1);
 
         const replacementSetZoomFactor = vi.fn();
         fromId.mockReturnValue({
@@ -1074,8 +1083,51 @@ describe("PreviewManager", () => {
 
         yield* manager.registerWebview("tab_zoom", 43);
 
-        expect(replacementSetZoomFactor).toHaveBeenCalledWith(1.25);
-        expect(states.at(-1)?.zoomFactor).toBe(1.25);
+        expect(replacementSetZoomFactor).toHaveBeenCalledWith(1.1);
+        expect(states.at(-1)?.zoomFactor).toBe(1.1);
+      }),
+    ),
+  );
+
+  // Zooming the app UI pushes the window's zoom level onto every guest, so the
+  // preview has to be put back at the zoom the user gave it.
+  effectIt.effect("re-applies each tab's own zoom when the app window zooms", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const setZoomFactor = vi.fn();
+        fromId.mockReturnValue({
+          id: 42,
+          isDestroyed: () => false,
+          getType: () => "webview",
+          getURL: () => "https://example.com",
+          getTitle: () => "Example",
+          isLoading: () => false,
+          getZoomFactor: () => 1,
+          setZoomFactor,
+          on: vi.fn(),
+          off: vi.fn(),
+          ipc: { on: vi.fn(), off: vi.fn() },
+          send: webviewSend,
+          navigationHistory: { canGoBack: () => false, canGoForward: () => false },
+          setWindowOpenHandler: vi.fn(),
+          debugger: {
+            isAttached: () => false,
+            attach: vi.fn(),
+            sendCommand: vi.fn(async () => undefined),
+            on: vi.fn(),
+            off: vi.fn(),
+          },
+        } as never);
+
+        yield* manager.createTab("tab_reapply");
+        yield* manager.registerWebview("tab_reapply", 42);
+        yield* manager.zoomIn("tab_reapply");
+        setZoomFactor.mockClear();
+
+        yield* manager.reapplyZoom();
+
+        expect(setZoomFactor).toHaveBeenCalledTimes(1);
+        expect(setZoomFactor).toHaveBeenCalledWith(1.1);
       }),
     ),
   );

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -1132,6 +1132,58 @@ describe("PreviewManager", () => {
     ),
   );
 
+  // did-attach and dom-ready both re-register the guest that is already
+  // attached, and a guest that just inherited the app window's zoom needs its
+  // own back — without that round trip republishing tab state.
+  effectIt.effect("re-asserts the tab's zoom when the active guest registers again", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const setZoomFactor = vi.fn();
+        fromId.mockReturnValue({
+          id: 42,
+          isDestroyed: () => false,
+          getType: () => "webview",
+          getURL: () => "https://example.com",
+          getTitle: () => "Example",
+          isLoading: () => false,
+          getZoomFactor: () => 1,
+          setZoomFactor,
+          on: vi.fn(),
+          off: vi.fn(),
+          ipc: { on: vi.fn(), off: vi.fn() },
+          send: webviewSend,
+          navigationHistory: { canGoBack: () => false, canGoForward: () => false },
+          setWindowOpenHandler: vi.fn(),
+          debugger: {
+            isAttached: () => false,
+            attach: vi.fn(),
+            sendCommand: vi.fn(async () => undefined),
+            on: vi.fn(),
+            off: vi.fn(),
+          },
+        } as never);
+        const states: PreviewManager.PreviewTabState[] = [];
+        yield* manager.subscribeStateChanges((_tabId, state) =>
+          Effect.sync(() => {
+            states.push(state);
+          }),
+        );
+
+        yield* manager.createTab("tab_reregister_zoom");
+        yield* manager.registerWebview("tab_reregister_zoom", 42);
+        yield* manager.zoomIn("tab_reregister_zoom");
+        setZoomFactor.mockClear();
+        const publishedBefore = states.length;
+
+        yield* manager.registerWebview("tab_reregister_zoom", 42);
+
+        expect(setZoomFactor).toHaveBeenCalledWith(1.1);
+        expect(states.length).toBe(publishedBefore);
+        expect(states.at(-1)?.zoomFactor).toBe(1.1);
+      }),
+    ),
+  );
+
   effectIt.effect("emulates prefers-color-scheme and re-applies it across webview swaps", () =>
     withManager((manager) =>
       Effect.gen(function* () {

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -647,6 +647,22 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     if (Option.isSome(next)) yield* emit(tabId, next.value);
   });
 
+  /**
+   * Pushes a tab's zoom factor onto whichever guest it currently owns, reading
+   * both at call time. Anything that applies zoom after an await goes through
+   * here: a snapshot taken before the await can be older than a zoom action that
+   * landed in between, and re-applying it would roll that action back.
+   */
+  const assertTabZoom = Effect.fn("PreviewManager.assertTabZoom")(function* (tabId: string) {
+    const tab = (yield* SynchronizedRef.get(tabsRef)).get(tabId);
+    if (!tab || tab.webContentsId == null) return;
+    const wc = webContents.fromId(tab.webContentsId);
+    if (!wc || wc.isDestroyed()) return;
+    yield* attempt({ operation: "assertTabZoom", tabId, webContentsId: wc.id }, () =>
+      wc.setZoomFactor(tab.zoomFactor),
+    ).pipe(Effect.ignore);
+  });
+
   const requireWebContents = Effect.fn("PreviewManager.requireWebContents")(function* (
     tabId: string,
   ) {
@@ -1714,10 +1730,10 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     const annotationTheme = yield* Ref.get(annotationThemeRef);
     const currentAttachment = attached.get(webContentsId);
     if (tab.webContentsId === webContentsId && currentAttachment?.webContents === wc) {
-      yield* attempt({ operation: "registerWebview.restoreZoomFactor", tabId, webContentsId }, () =>
-        wc.setZoomFactor(tab.zoomFactor),
-      );
-      yield* update(tabId, { zoomFactor: tab.zoomFactor });
+      // The guest we already own re-announced itself, so nothing about the tab
+      // changed. Only push its zoom back down — Chromium may have just handed
+      // this guest the app window's zoom level.
+      yield* assertTabZoom(tabId);
       yield* attempt({ operation: "registerWebview.sendTheme", tabId, webContentsId }, () =>
         wc.send(ANNOTATION_THEME_CHANNEL, annotationTheme),
       );
@@ -1748,13 +1764,10 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     }
     // Always assert the tab's own zoom rather than reading the guest's: a guest
     // attaching while the app UI is zoomed starts at the embedder's inherited
-    // zoom level, which is not the preview's zoom.
-    const zoomFactor = yield* attempt(
-      { operation: "registerWebview.restoreZoomFactor", tabId, webContentsId },
-      () => {
-        wc.setZoomFactor(currentTab.zoomFactor);
-        return currentTab.zoomFactor;
-      },
+    // zoom level, which is not the preview's zoom. Done before the guest is
+    // published so it never paints a frame at the inherited zoom.
+    yield* attempt({ operation: "registerWebview.restoreZoomFactor", tabId, webContentsId }, () =>
+      wc.setZoomFactor(currentTab.zoomFactor),
     );
     yield* attachListeners(tabId, wc);
     const registeredAt = yield* currentIso;
@@ -1779,7 +1792,6 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           navStatus: pendingUrl === null ? computeNavStatus(wc) : current.navStatus,
           canGoBack: wc.navigationHistory.canGoBack(),
           canGoForward: wc.navigationHistory.canGoForward(),
-          zoomFactor,
           updatedAt: registeredAt,
         };
         return [
@@ -1801,6 +1813,9 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       return yield* new PreviewTabNotFoundError({ tabId });
     }
     const { state: registered, pendingUrl } = registration.value;
+    // A zoom action that landed while this attach was in flight addressed the
+    // guest this one replaced, so settle the new guest on the committed factor.
+    yield* assertTabZoom(tabId);
     runFork(restoreControlSession(tabId, wc));
     yield* emit(tabId, registered);
     yield* attempt({ operation: "registerWebview.sendTheme", tabId, webContentsId }, () =>
@@ -2101,19 +2116,8 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
    * window's zoom changes (see DesktopWindow.zoomMain).
    */
   const reapplyZoom = Effect.fn("PreviewManager.reapplyZoom")(function* () {
-    const tabs = yield* SynchronizedRef.get(tabsRef);
-    yield* Effect.forEach(
-      tabs.values(),
-      (tab) => {
-        if (tab.webContentsId === null) return Effect.void;
-        const wc = webContents.fromId(tab.webContentsId);
-        if (!wc || wc.isDestroyed()) return Effect.void;
-        return attempt({ operation: "reapplyZoom", tabId: tab.tabId, webContentsId: wc.id }, () =>
-          wc.setZoomFactor(tab.zoomFactor),
-        ).pipe(Effect.ignore);
-      },
-      { discard: true },
-    );
+    const tabIds = Array.from((yield* SynchronizedRef.get(tabsRef)).keys());
+    yield* Effect.forEach(tabIds, assertTabZoom, { discard: true });
   });
 
   const applyZoom = Effect.fn("PreviewManager.applyZoom")(function* (

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -1305,10 +1305,6 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       confirmedNavigation = false,
     ) {
       if (wc.isDestroyed()) return;
-      const zoomFactor = yield* attempt(
-        { operation: "syncWebContentsState.getZoomFactor", tabId, webContentsId: wc.id },
-        () => wc.getZoomFactor(),
-      ).pipe(Effect.option);
       const computedNavStatus = computeNavStatus(wc);
       const canGoBack = wc.navigationHistory.canGoBack();
       const canGoForward = wc.navigationHistory.canGoForward();
@@ -1338,7 +1334,9 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           navStatus,
           canGoBack,
           canGoForward,
-          ...(Option.isSome(zoomFactor) ? { zoomFactor: zoomFactor.value } : {}),
+          // zoomFactor is deliberately not read back from the guest: Chromium
+          // reports the level it inherited from the app window, so mirroring it
+          // would turn an app zoom into the preview's own zoom.
           updatedAt,
         };
         return [
@@ -1716,11 +1714,10 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     const annotationTheme = yield* Ref.get(annotationThemeRef);
     const currentAttachment = attached.get(webContentsId);
     if (tab.webContentsId === webContentsId && currentAttachment?.webContents === wc) {
-      const zoomFactor = yield* attempt(
-        { operation: "registerWebview.getZoomFactor", tabId, webContentsId },
-        () => wc.getZoomFactor(),
+      yield* attempt({ operation: "registerWebview.restoreZoomFactor", tabId, webContentsId }, () =>
+        wc.setZoomFactor(tab.zoomFactor),
       );
-      yield* update(tabId, { zoomFactor });
+      yield* update(tabId, { zoomFactor: tab.zoomFactor });
       yield* attempt({ operation: "registerWebview.sendTheme", tabId, webContentsId }, () =>
         wc.send(ANNOTATION_THEME_CHANNEL, annotationTheme),
       );
@@ -1749,18 +1746,16 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     ) {
       return yield* new PreviewTabNotFoundError({ tabId });
     }
-    const zoomFactor =
-      replacedWebContentsId !== null
-        ? yield* attempt(
-            { operation: "registerWebview.restoreZoomFactor", tabId, webContentsId },
-            () => {
-              wc.setZoomFactor(currentTab.zoomFactor);
-              return currentTab.zoomFactor;
-            },
-          )
-        : yield* attempt({ operation: "registerWebview.getZoomFactor", tabId, webContentsId }, () =>
-            wc.getZoomFactor(),
-          );
+    // Always assert the tab's own zoom rather than reading the guest's: a guest
+    // attaching while the app UI is zoomed starts at the embedder's inherited
+    // zoom level, which is not the preview's zoom.
+    const zoomFactor = yield* attempt(
+      { operation: "registerWebview.restoreZoomFactor", tabId, webContentsId },
+      () => {
+        wc.setZoomFactor(currentTab.zoomFactor);
+        return currentTab.zoomFactor;
+      },
+    );
     yield* attachListeners(tabId, wc);
     const registeredAt = yield* currentIso;
     const registration = yield* SynchronizedRef.modifyEffect(tabsRef, (tabs) =>
@@ -2096,6 +2091,28 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         );
         return cancel;
       },
+    );
+  });
+
+  /**
+   * Chromium hands every guest `<webview>` the embedder's zoom level, so zooming
+   * the app UI drags the previewed page along with it. The preview browser owns
+   * its own zoom factor, so re-assert it on each attached guest whenever the main
+   * window's zoom changes (see DesktopWindow.zoomMain).
+   */
+  const reapplyZoom = Effect.fn("PreviewManager.reapplyZoom")(function* () {
+    const tabs = yield* SynchronizedRef.get(tabsRef);
+    yield* Effect.forEach(
+      tabs.values(),
+      (tab) => {
+        if (tab.webContentsId === null) return Effect.void;
+        const wc = webContents.fromId(tab.webContentsId);
+        if (!wc || wc.isDestroyed()) return Effect.void;
+        return attempt({ operation: "reapplyZoom", tabId: tab.tabId, webContentsId: wc.id }, () =>
+          wc.setZoomFactor(tab.zoomFactor),
+        ).pipe(Effect.ignore);
+      },
+      { discard: true },
     );
   });
 
@@ -3476,6 +3493,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     openPictureInPicture,
     openDevTools,
     pickElement,
+    reapplyZoom,
     refresh,
     registerWebview,
     resetZoom: (tabId: string) => applyZoom(tabId, () => DEFAULT_ZOOM_FACTOR),
@@ -3774,6 +3792,9 @@ export class PreviewManager extends Context.Service<
     readonly zoomIn: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
     readonly zoomOut: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
     readonly resetZoom: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
+    // Re-applies every attached guest's own zoom factor, undoing the zoom level
+    // Chromium inherits from the embedder when the app UI zooms.
+    readonly reapplyZoom: () => Effect.Effect<void>;
     readonly hardReload: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
     readonly setColorScheme: (
       tabId: string,
@@ -3874,6 +3895,7 @@ export const make = Effect.gen(function* PreviewManagerMake() {
     zoomIn: operations.zoomIn,
     zoomOut: operations.zoomOut,
     resetZoom: operations.resetZoom,
+    reapplyZoom: operations.reapplyZoom,
     hardReload: operations.hardReload,
     setColorScheme: operations.setColorScheme,
     openDevTools: operations.openDevTools,

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -61,9 +61,14 @@ const environmentInput = {
 function makeFakeBrowserWindow() {
   const windowListeners = new Map<string, (...args: readonly unknown[]) => void>();
   const webContentsListeners = new Map<string, (...args: readonly unknown[]) => void>();
+  let zoomLevel = 0;
   const webContents = {
     copyImageAt: vi.fn(),
     getURL: vi.fn(() => "t3code-dev://app/"),
+    getZoomLevel: vi.fn(() => zoomLevel),
+    setZoomLevel: vi.fn((level: number) => {
+      zoomLevel = level;
+    }),
     isLoadingMainFrame: vi.fn(() => false),
     on: vi.fn((eventName: string, listener: (...args: readonly unknown[]) => void) => {
       webContentsListeners.set(eventName, listener);
@@ -116,6 +121,7 @@ function makeFakeBrowserWindow() {
     openDevTools: webContents.openDevTools,
     reload: webContents.reload,
     send: webContents.send,
+    setZoomLevel: webContents.setZoomLevel,
     setAutoHideCursor: window.setAutoHideCursor,
     webContentsListeners,
     windowListeners,
@@ -186,6 +192,7 @@ function makeTestLayer(input: {
     bounds: DesktopAppSettings.DesktopWindowBounds,
   ) => Effect.Effect<void>;
   readonly openedExternalUrls?: unknown[];
+  readonly previewZoomReapplies?: number[];
 }) {
   let desktopSettings = input.desktopSettings ?? DesktopAppSettings.DEFAULT_DESKTOP_SETTINGS;
   const desktopAppSettingsLayer = Layer.succeed(DesktopAppSettings.DesktopAppSettings, {
@@ -264,6 +271,10 @@ function makeTestLayer(input: {
           setMainWindow: () => Effect.void,
           isBrowserPartition: (partition) => partition.startsWith("persist:t3code-preview-"),
           getBrowserPartition: () => Effect.succeed("persist:t3code-preview-test"),
+          reapplyZoom: () =>
+            Effect.sync(() => {
+              input.previewZoomReapplies?.push(input.window.webContents.getZoomLevel());
+            }),
         }),
       ),
     ),
@@ -479,6 +490,42 @@ describe("DesktopWindow", () => {
         prevented = false;
         beforeInput(event, { ...input, meta: false });
         assert.isFalse(prevented);
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
+  // Chromium hands the main window's zoom level down to embedded preview
+  // guests, so every app zoom has to put the preview browser back at its own
+  // zoom or zooming the UI drags the previewed page with it.
+  it.effect("restores the preview browser's own zoom after zooming the app", () =>
+    Effect.gen(function* () {
+      const fakeWindow = makeFakeBrowserWindow();
+      const createCount = yield* Ref.make(0);
+      const mainWindow = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(Option.none());
+      const previewZoomReapplies: number[] = [];
+      const layer = makeTestLayer({
+        window: fakeWindow.window,
+        createCount,
+        mainWindow,
+        previewZoomReapplies,
+      });
+
+      yield* Effect.gen(function* () {
+        const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        yield* desktopWindow.handleBackendReady(new URL("http://127.0.0.1:3773"));
+
+        yield* desktopWindow.zoomMain("out");
+        yield* desktopWindow.zoomMain("out");
+        yield* desktopWindow.zoomMain("in");
+        yield* desktopWindow.zoomMain("reset");
+
+        assert.deepEqual(
+          fakeWindow.setZoomLevel.mock.calls.map(([level]) => level),
+          [-0.5, -1, -0.5, 0],
+        );
+        // Recorded after the window level moved, so the preview is put back at
+        // its own zoom on every step rather than left on the inherited one.
+        assert.deepEqual(previewZoomReapplies, [-0.5, -1, -0.5, 0]);
       }).pipe(Effect.provide(layer));
     }),
   );

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -855,6 +855,10 @@ export const make = Effect.gen(function* () {
       webContents.setZoomLevel(
         direction === "reset" ? 0 : webContents.getZoomLevel() + (direction === "in" ? 0.5 : -0.5),
       );
+      // Chromium pushes the new level down to embedded guests, which would zoom
+      // the previewed page along with the app UI. The preview browser keeps its
+      // own zoom, so put each guest back where the preview left it.
+      yield* previewManager.reapplyZoom();
     }),
     syncAppearance: Effect.gen(function* () {
       const shouldUseDarkColors = yield* electronTheme.shouldUseDarkColors;


### PR DESCRIPTION
Zooming the app UI (View → Zoom In/Out) also zoomed whatever the preview browser was showing, so there was no way to shrink T3's chrome without shrinking the previewed page with it — which is what Tanner asked for: "zoom T3's UI out, but not the browser".

Chromium hands every guest `<webview>` the embedder's zoom level, and `PreviewManager` then read that level back off the guest, so an app zoom silently became the preview's own zoom (and the zoom indicator reported it).

The tab's zoom factor is now the only source of truth: it is asserted onto the guest whenever a webview attaches, re-asserted after every app zoom, and never read back off the guest.

## Before / after

App zoomed out two steps, same window, same page. The readout is the previewed page's own `devicePixelRatio` and viewport.

**Before** — the page shrinks with the UI (`devicePixelRatio` drops to 1.67):

![before](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/01ff3f8e8fe00315/before-app-zoomed-out.png)

**After** — the UI shrinks, the page stays at true scale (`devicePixelRatio` stays 2.00; the guest just gets a narrower viewport as the panel gets physically smaller):

![after](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/53fc4d3f8ac63245/after-app-zoomed-out.png)

At 100% both builds are identical, and the preview's own zoom controls are unchanged:

![baseline](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/47367d10077927c1/baseline-app-at-100.png)

## Notes

- Desktop-only: the preview browser is an Electron `<webview>`, so web and mobile are unaffected.
- One behaviour change worth calling out: a zoom the user makes *inside* the guest (ctrl+wheel) is no longer mirrored into the tab state. That mirror was the leak — it could not tell an inherited app zoom from a real one — and T3's own zoom controls remain the way to zoom the preview.
- Verified in the desktop app (screenshots above) plus focused tests in `Manager.test.ts` and `DesktopWindow.test.ts`.

Model: Claude Opus 5 (1M context). Harness: Claude Code inside T3 Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desktop preview webview lifecycle and zoom synchronization; behavior change for guest-reported zoom, but scoped to Electron preview and covered by new tests.
> 
> **Overview**
> **App UI zoom no longer changes the previewed page’s scale.** Chromium was inheriting the main window zoom into guest `<webview>`s, and `PreviewManager` then mirrored `getZoomFactor()` back into tab state—so View → Zoom In/Out affected both chrome and the preview.
> 
> Tab **`zoomFactor` is now authoritative**: `syncWebContentsState` stops reading zoom from the guest; **`assertTabZoom`** pushes the stored factor onto the active webContents (including after async attach and on duplicate `registerWebview`); new **`reapplyZoom`** resets every tab’s guest after app zoom. **`DesktopWindow.zoomMain`** calls `reapplyZoom()` after each main-window zoom step.
> 
> **Behavior change:** in-guest zoom (e.g. ctrl+wheel) is no longer synced into tab state; preview zoom stays on T3’s own controls. Tests cover tab-owned zoom, `reapplyZoom`, re-register paths, and desktop window integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a46468dc59a53a30a595ea8cc942327c93711b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix app window zoom from affecting preview browser tab zoom
> - Embedded preview guests inherit the host window's zoom level, causing app zoom to unintentionally rescale preview content.
> - `PreviewManager` now tracks each tab's own zoom factor and asserts it onto the guest on registration, re-registration, and navigation, rather than reading the guest's zoom back into state.
> - A new `reapplyZoom()` method on `PreviewManager` iterates all tabs and pushes their zoom to attached guests; `DesktopWindow.zoomMain` calls this after each window zoom change.
> - Behavioral Change: the manager no longer adopts zoom from guests — guest zoom is always overwritten by the tab's stored value on attach.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a46468.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->