### PR TITLE
feat(server): make the worktree branch prefix configurable

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -145,6 +145,7 @@ describe("ProviderCommandReactor", () => {
 
   async function createHarness(input?: {
     readonly baseDir?: string;
+    readonly worktreeBranchPrefix?: string;
     readonly threadModelSelection?: ModelSelection;
     readonly sessionModelSwitch?: "unsupported" | "in-session";
     readonly requiresNewThreadForModelChange?: boolean;
@@ -412,7 +413,13 @@ describe("ProviderCommandReactor", () => {
           generateThreadTitle,
         }),
       ),
-      Layer.provideMerge(ServerSettingsService.layerTest()),
+      Layer.provideMerge(
+        ServerSettingsService.layerTest(
+          input?.worktreeBranchPrefix === undefined
+            ? {}
+            : { worktreeBranchPrefix: input.worktreeBranchPrefix },
+        ),
+      ),
       Layer.provideMerge(ServerConfig.layerTest(process.cwd(), baseDir)),
       Layer.provideMerge(NodeServices.layer),
     );
@@ -1456,8 +1463,8 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.title).toBe("Reconnect spinner resume bug");
   });
 
-  it("generates a worktree branch name for the first turn", async () => {
-    const harness = await createHarness();
+  it("generates a worktree branch name for the first turn using the configured prefix", async () => {
+    const harness = await createHarness({ worktreeBranchPrefix: "feat/" });
     const now = "2026-01-01T00:00:00.000Z";
 
     await Effect.runPromise(
@@ -1470,19 +1477,8 @@ describe("ProviderCommandReactor", () => {
       }),
     );
 
-    harness.generateBranchName.mockImplementation((input: unknown) =>
-      Effect.succeed({
-        branch:
-          typeof input === "object" &&
-          input !== null &&
-          "modelSelection" in input &&
-          typeof input.modelSelection === "object" &&
-          input.modelSelection !== null &&
-          "model" in input.modelSelection &&
-          typeof input.modelSelection.model === "string"
-            ? `feature/${input.modelSelection.model}`
-            : "feature/generated",
-      }),
+    harness.generateBranchName.mockImplementation(() =>
+      Effect.succeed({ branch: "Safer reconnect backoff" }),
     );
 
     await Effect.runPromise(
@@ -1506,6 +1502,10 @@ describe("ProviderCommandReactor", () => {
     await waitFor(() => harness.refreshStatus.mock.calls.length === 1);
     expect(harness.generateBranchName.mock.calls[0]?.[0]).toMatchObject({
       message: "Add a safer reconnect backoff.",
+    });
+    expect(harness.renameBranch.mock.calls[0]?.[0]).toMatchObject({
+      oldBranch: "t3code/1234abcd",
+      newBranch: "feat/safer-reconnect-backoff",
     });
     expect(harness.refreshStatus.mock.calls[0]?.[0]).toBe("/tmp/provider-project-worktree");
   });

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -12,7 +12,7 @@ import {
   type RuntimeMode,
   type TurnId,
 } from "@t3tools/contracts";
-import { isTemporaryWorktreeBranch, WORKTREE_BRANCH_PREFIX } from "@t3tools/shared/git";
+import { buildGeneratedWorktreeBranchName, isTemporaryWorktreeBranch } from "@t3tools/shared/git";
 import * as Cache from "effect/Cache";
 import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
@@ -273,29 +273,6 @@ function stalePendingRequestDetail(
   requestId: string,
 ): string {
   return `Stale pending ${requestKind} request: ${requestId}. Provider callback state does not survive app restarts or recovered sessions. Restart the turn to continue.`;
-}
-
-function buildGeneratedWorktreeBranchName(raw: string): string {
-  const normalized = raw
-    .trim()
-    .toLowerCase()
-    .replace(/^refs\/heads\//, "")
-    .replace(/['"`]/g, "");
-
-  const withoutPrefix = normalized.startsWith(`${WORKTREE_BRANCH_PREFIX}/`)
-    ? normalized.slice(`${WORKTREE_BRANCH_PREFIX}/`.length)
-    : normalized;
-
-  const branchFragment = withoutPrefix
-    .replace(/[^a-z0-9/_-]+/g, "-")
-    .replace(/\/+/g, "/")
-    .replace(/-+/g, "-")
-    .replace(/^[./_-]+|[./_-]+$/g, "")
-    .slice(0, 64)
-    .replace(/[./_-]+$/g, "");
-
-  const safeFragment = branchFragment.length > 0 ? branchFragment : "update";
-  return `${WORKTREE_BRANCH_PREFIX}/${safeFragment}`;
 }
 
 const make = Effect.gen(function* () {
@@ -818,7 +795,10 @@ const make = Effect.gen(function* () {
       });
       if (!generated) return;
 
-      const targetBranch = buildGeneratedWorktreeBranchName(generated.branch);
+      const targetBranch = buildGeneratedWorktreeBranchName(
+        settings.worktreeBranchPrefix,
+        generated.branch,
+      );
       if (targetBranch === oldBranch) return;
 
       const renamed = yield* gitWorkflow.renameBranch({ cwd, oldBranch, newBranch: targetBranch });

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -34,6 +34,7 @@ import {
   MIN_TERMINAL_FONT_SIZE,
 } from "@t3tools/contracts/settings";
 import { resolveServerBackgroundActivitySettings } from "@t3tools/shared/backgroundActivitySettings";
+import { sanitizeBranchPrefix } from "@t3tools/shared/git";
 import { createModelSelection } from "@t3tools/shared/model";
 import * as Duration from "effect/Duration";
 import * as Equal from "effect/Equal";
@@ -517,6 +518,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin
         ? ["New worktrees start from origin"]
         : []),
+      ...(settings.worktreeBranchPrefix !== DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix
+        ? ["Worktree branch prefix"]
+        : []),
       ...(settings.addProjectBaseDirectory !== DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory
         ? ["Add project base directory"]
         : []),
@@ -540,6 +544,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.addProjectBaseDirectory,
       settings.defaultThreadEnvMode,
       settings.newWorktreesStartFromOrigin,
+      settings.worktreeBranchPrefix,
       settings.diffIgnoreWhitespace,
       settings.environmentIdentificationMode,
       settings.fontFamilyCode,
@@ -645,6 +650,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       providerHealthRefreshInterval: DEFAULT_UNIFIED_SETTINGS.providerHealthRefreshInterval,
       defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
       newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
+      worktreeBranchPrefix: DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix,
       addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
       confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
       confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
@@ -2158,6 +2164,35 @@ export function GeneralSettingsPanel() {
             }
           />
         ) : null}
+
+        <SettingsRow
+          {...searchableSetting("worktree-branch-prefix")}
+          description="Prefixes generated worktree branch names. Empty for none."
+          resetAction={
+            settings.worktreeBranchPrefix !== DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix ? (
+              <SettingResetButton
+                label="worktree branch prefix"
+                onClick={() =>
+                  updateSettings({
+                    worktreeBranchPrefix: DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <DraftInput
+              className="w-full sm:w-72"
+              value={settings.worktreeBranchPrefix}
+              onCommit={(next) =>
+                updateSettings({ worktreeBranchPrefix: sanitizeBranchPrefix(next) })
+              }
+              placeholder="t3code/"
+              spellCheck={false}
+              aria-label="Worktree branch prefix"
+            />
+          }
+        />
 
         <SettingsRow
           {...searchableSetting("add-project-starts-in")}

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -140,6 +140,12 @@ export const SETTINGS_SEARCH_ITEMS = [
     targetId: "new-threads",
   },
   {
+    id: "worktree-branch-prefix",
+    title: "Worktree branch prefix",
+    to: "/settings/general",
+    targetId: "new-threads",
+  },
+  {
     id: "add-project-starts-in",
     title: "Add project starts in",
     to: "/settings/general",

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -143,7 +143,6 @@ export const SETTINGS_SEARCH_ITEMS = [
     id: "worktree-branch-prefix",
     title: "Worktree branch prefix",
     to: "/settings/general",
-    targetId: "new-threads",
   },
   {
     id: "add-project-starts-in",

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -187,6 +187,17 @@ describe("ServerSettings worktree defaults", () => {
       decodeServerSettingsPatch({ newWorktreesStartFromOrigin: false }).newWorktreesStartFromOrigin,
     ).toBe(false);
   });
+
+  it("defaults the branch prefix to the built-in namespace for legacy configs", () => {
+    expect(decodeServerSettings({}).worktreeBranchPrefix).toBe("t3code/");
+  });
+
+  it("accepts a custom branch prefix, including an empty one", () => {
+    expect(decodeServerSettingsPatch({ worktreeBranchPrefix: "feat/" }).worktreeBranchPrefix).toBe(
+      "feat/",
+    );
+    expect(decodeServerSettingsPatch({ worktreeBranchPrefix: "" }).worktreeBranchPrefix).toBe("");
+  });
 });
 
 describe("ServerSettings.sourceControlWritingStyle", () => {

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -571,6 +571,7 @@ export const ServerSettings = Schema.Struct({
   newWorktreesStartFromOrigin: Schema.Boolean.pipe(
     Schema.withDecodingDefault(Effect.succeed(true)),
   ),
+  worktreeBranchPrefix: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed("t3code/"))),
   addProjectBaseDirectory: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   textGenerationModelSelection: ModelSelection.pipe(
     Schema.withDecodingDefault(
@@ -725,6 +726,7 @@ export const ServerSettingsPatch = Schema.Struct({
   backgroundActivityProfile: Schema.optionalKey(BackgroundActivityProfile),
   defaultThreadEnvMode: Schema.optionalKey(ThreadEnvMode),
   newWorktreesStartFromOrigin: Schema.optionalKey(Schema.Boolean),
+  worktreeBranchPrefix: Schema.optionalKey(TrimmedString),
   addProjectBaseDirectory: Schema.optionalKey(TrimmedString),
   textGenerationModelSelection: Schema.optionalKey(ModelSelectionPatch),
   sourceControlWritingStyle: Schema.optionalKey(

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -146,11 +146,18 @@ describe("buildGeneratedWorktreeBranchName", () => {
     );
   });
 
+  it("keeps a name that merely starts with a separator-less prefix", () => {
+    expect(buildGeneratedWorktreeBranchName("feat", "feature-x")).toBe("featfeature-x");
+  });
+
   it("filters characters git rejects in a prefix", () => {
     expect(buildGeneratedWorktreeBranchName("feat branch/", "multiselect toggle")).toBe(
       "feat-branch/multiselect-toggle",
     );
     expect(buildGeneratedWorktreeBranchName("//feat//", "multiselect toggle")).toBe(
+      "feat/multiselect-toggle",
+    );
+    expect(buildGeneratedWorktreeBranchName("-feat/", "multiselect toggle")).toBe(
       "feat/multiselect-toggle",
     );
   });

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   applyGitStatusStreamEvent,
+  buildGeneratedWorktreeBranchName,
   buildTemporaryWorktreeBranchName,
   isTemporaryWorktreeBranch,
   normalizeGitRemoteUrl,
@@ -107,6 +108,55 @@ describe("isTemporaryWorktreeBranch", () => {
     expect(isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/feature/demo`)).toBe(false);
     expect(isTemporaryWorktreeBranch("main")).toBe(false);
     expect(isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/deadbeef-extra`)).toBe(false);
+  });
+});
+
+describe("buildGeneratedWorktreeBranchName", () => {
+  it("applies the default prefix", () => {
+    expect(buildGeneratedWorktreeBranchName("t3code/", "Multiselect Toggle")).toBe(
+      "t3code/multiselect-toggle",
+    );
+  });
+
+  it("applies a custom prefix verbatim", () => {
+    expect(buildGeneratedWorktreeBranchName("feat/", "Multiselect Toggle")).toBe(
+      "feat/multiselect-toggle",
+    );
+    expect(buildGeneratedWorktreeBranchName("wip-", "Multiselect Toggle")).toBe(
+      "wip-multiselect-toggle",
+    );
+  });
+
+  it("produces a bare name for an empty prefix", () => {
+    expect(buildGeneratedWorktreeBranchName("", "Multiselect Toggle")).toBe("multiselect-toggle");
+  });
+
+  it("strips a temporary-branch namespace the model echoed back", () => {
+    expect(buildGeneratedWorktreeBranchName("feat/", "t3code/multiselect-toggle")).toBe(
+      "feat/multiselect-toggle",
+    );
+  });
+
+  it("strips the configured prefix the model echoed back", () => {
+    expect(buildGeneratedWorktreeBranchName("feat/", "feat/multiselect-toggle")).toBe(
+      "feat/multiselect-toggle",
+    );
+    expect(buildGeneratedWorktreeBranchName("feat/", "refs/heads/feat/multiselect-toggle")).toBe(
+      "feat/multiselect-toggle",
+    );
+  });
+
+  it("filters characters git rejects in a prefix", () => {
+    expect(buildGeneratedWorktreeBranchName("feat branch/", "multiselect toggle")).toBe(
+      "feat-branch/multiselect-toggle",
+    );
+    expect(buildGeneratedWorktreeBranchName("//feat//", "multiselect toggle")).toBe(
+      "feat/multiselect-toggle",
+    );
+  });
+
+  it("falls back to update when the generated name sanitizes to nothing", () => {
+    expect(buildGeneratedWorktreeBranchName("feat/", "!!!")).toBe("feat/update");
   });
 });
 

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -108,6 +108,37 @@ export function isTemporaryWorktreeBranch(refName: string): boolean {
   return TEMP_WORKTREE_BRANCH_PATTERN.test(refName.trim().toLowerCase());
 }
 
+export function sanitizeBranchPrefix(raw: string): string {
+  return raw
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9/_-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/\/+/g, "/")
+    .replace(/^\/+/, "")
+    .slice(0, 64);
+}
+
+function stripLeadingNamespace(value: string, namespace: string): string {
+  return namespace.length > 0 && value.startsWith(namespace)
+    ? value.slice(namespace.length)
+    : value;
+}
+
+export function buildGeneratedWorktreeBranchName(prefix: string, raw: string): string {
+  const normalized = raw
+    .trim()
+    .toLowerCase()
+    .replace(/^refs\/heads\//, "")
+    .replace(/['"`]/g, "");
+  const safePrefix = sanitizeBranchPrefix(prefix);
+  const withoutEcho = stripLeadingNamespace(
+    stripLeadingNamespace(normalized, `${WORKTREE_BRANCH_PREFIX}/`),
+    safePrefix,
+  );
+  return `${safePrefix}${sanitizeBranchFragment(withoutEcho)}`;
+}
+
 /**
  * Normalize a git remote URL into a stable comparison key.
  */

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -115,12 +115,12 @@ export function sanitizeBranchPrefix(raw: string): string {
     .replace(/[^a-z0-9/_-]+/g, "-")
     .replace(/-+/g, "-")
     .replace(/\/+/g, "/")
-    .replace(/^\/+/, "")
+    .replace(/^[-/]+/, "")
     .slice(0, 64);
 }
 
 function stripLeadingNamespace(value: string, namespace: string): string {
-  return namespace.length > 0 && value.startsWith(namespace)
+  return /[/_-]$/.test(namespace) && value.startsWith(namespace)
     ? value.slice(namespace.length)
     : value;
 }


### PR DESCRIPTION
## What Changed

- Added a global setting, `worktreeBranchPrefix`, default `t3code/`. It is applied when the first turn renames a worktree thread's branch.
- Moved `buildGeneratedWorktreeBranchName` into `packages/shared/src/git.ts`, which deletes a verbatim copy of `sanitizeBranchFragment` in `ProviderCommandReactor.ts`.
- Added a "Worktree branch prefix" row to Settings → General.

## Why

Every generated worktree branch is forced under a hard-coded `t3code/` prefix. A team whose repository requires `feat/` or `fix/` cannot follow its own convention.

The configured value goes in front of the generated name verbatim, so `feat/`, `rait-`, and an empty string all work without a special case. The default does not change, so no branch name changes until a user opts in.

The temporary `t3code/<8 hex>` branch keeps its fixed name on purpose: the clients build that name, including the mobile offline outbox drain, and four call sites match on its shape.

Deliberately out of scope: a project-scoped prefix in `t3.json`, the separate `feature/` auto-branch, and the pre-existing silent rename failure when an existing branch shadows the prefix.

Related: #272. #3954 proposes the same setting and has been open longer — close this one if that lands first.

## UI Changes

The new row in Settings → General. Same window, viewport, theme, and settings state in both captures; only the checkout differs.

**Before**
<img width="1848" height="332" alt="t3code-branch-prefix-before" src="https://github.com/user-attachments/assets/cb2a723c-cb22-4e11-8aae-cb9702f0b32a" />

**After**
<img width="1848" height="474" alt="t3code-branch-prefix-after" src="https://github.com/user-attachments/assets/30ebbab3-6202-422c-8484-b849f6092896" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] Not applicable — the change has no animation or interaction

Written by Claude Opus 5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default prefix is unchanged; impact is limited to optional git branch naming on first turn plus settings UI, with sanitization and tests.
> 
> **Overview**
> Adds **`worktreeBranchPrefix`** to server settings (default **`t3code/`**, patchable including empty string) and wires it into first-turn worktree renames from temporary **`t3code/<hex>`** branches.
> 
> **`buildGeneratedWorktreeBranchName`** and **`sanitizeBranchPrefix`** move to **`@t3tools/shared/git`**, replacing the reactor’s local builder so names use the configured prefix, strip echoed **`t3code/`** or prefix namespaces, and sanitize fragments. **`ProviderCommandReactor`** passes **`settings.worktreeBranchPrefix`** when renaming after branch-name generation.
> 
> Settings → General gets a **Worktree branch prefix** field (commit sanitizes input), reset/dirty tracking, and search entry. Contract and shared git tests cover defaults and naming edge cases; the reactor test asserts **`feat/safer-reconnect-backoff`** when prefix is **`feat/`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28986112aa9e8ec65de8c1b4c0e6e0f4b6c9c64a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make the worktree branch prefix configurable via server settings
> - Adds `worktreeBranchPrefix` to the `ServerSettings` schema (defaulting to `"t3code/"`) and `ServerSettingsPatch`, allowing users to override the prefix used for generated worktree branch names.
> - Introduces `sanitizeBranchPrefix` and `buildGeneratedWorktreeBranchName` in [`packages/shared/src/git.ts`](https://github.com/pingdotgg/t3code/pull/6651/files#diff-e52ee60f55e13d4ce4a00279168044882e11385edf15a01ad8073cd1442f5785); the builder normalizes the prefix, strips echoed namespaces, sanitizes the fragment, and falls back to `"update"` when the sanitized fragment is empty.
> - Adds a UI control in General Settings ([`SettingsPanels.tsx`](https://github.com/pingdotgg/t3code/pull/6651/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18)) to view, edit, and reset the prefix, with input sanitized via `sanitizeBranchPrefix` before saving.
> - Makes the prefix discoverable via settings search under the id `"worktree-branch-prefix"`.
> - Behavioral Change: `ProviderCommandReactor` now calls the shared `buildGeneratedWorktreeBranchName` instead of a local implementation, applying the user-configured prefix and additional sanitization rules.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2898611.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->