### PR TITLE
feat(web): add unread notification badge to sidebar toggle button

### DIFF
--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -40,6 +40,7 @@ import {
   useSidebarVisibility,
 } from "./ui/sidebar";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
+import { useUnreadBackgroundThreadCount } from "../hooks/useUnreadBackgroundThreadCount";
 
 const MACOS_TRAFFIC_LIGHTS_LEFT_INSET = "90px";
 
@@ -73,6 +74,7 @@ function SidebarControl() {
     environmentIdentificationMode === "artwork",
   );
   const shortcutLabel = shortcutLabelForCommand(keybindings, "sidebar.toggle");
+  const unreadCount = useUnreadBackgroundThreadCount();
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -90,15 +92,11 @@ function SidebarControl() {
       toggleSidebar();
     };
 
-    // Capture before focused editors consume commands such as Mod+B for rich-text formatting.
     window.addEventListener("keydown", onKeyDown, true);
     return () => window.removeEventListener("keydown", onKeyDown, true);
   }, [keybindings, toggleSidebar]);
 
   return (
-    // The right-side layout controls carry mr-px (border compensation inside
-    // the panel), so the trigger mirrors it: both clusters sit one extra pixel
-    // off their edge and the titlebar reads symmetric.
     <div
       className="pointer-events-none fixed left-[var(--workspace-controls-left)] top-[var(--workspace-controls-top)] z-50 ml-px flex h-[var(--workspace-topbar-height)] items-center"
       data-sidebar-control=""
@@ -107,6 +105,7 @@ function SidebarControl() {
         <TooltipTrigger
           render={
             <SidebarTrigger
+              unreadCount={unreadCount}
               className={cn(
                 "pointer-events-auto",
                 isSidebarVisible &&

--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -92,11 +92,15 @@ function SidebarControl() {
       toggleSidebar();
     };
 
+    // Capture before focused editors consume commands such as Mod+B for rich-text formatting.
     window.addEventListener("keydown", onKeyDown, true);
     return () => window.removeEventListener("keydown", onKeyDown, true);
   }, [keybindings, toggleSidebar]);
 
   return (
+    // The right-side layout controls carry mr-px (border compensation inside
+    // the panel), so the trigger mirrors it: both clusters sit one extra pixel
+    // off their edge and the titlebar reads symmetric.
     <div
       className="pointer-events-none fixed left-[var(--workspace-controls-left)] top-[var(--workspace-controls-top)] z-50 ml-px flex h-[var(--workspace-topbar-height)] items-center"
       data-sidebar-control=""
@@ -115,12 +119,17 @@ function SidebarControl() {
                   stageBackdropVariant &&
                   resolveSidebarStageFocusRingOffsetClass(stageBackdropVariant),
               )}
-              aria-label="Toggle main sidebar"
+              aria-label={
+                unreadCount > 0
+                  ? `Toggle main sidebar (${unreadCount} unread)`
+                  : "Toggle main sidebar"
+              }
             />
           }
         />
         <TooltipPopup side="bottom">
           Toggle main sidebar{shortcutLabel ? ` (${shortcutLabel})` : ""}
+          {unreadCount > 0 ? ` · ${unreadCount} unread` : ""}
         </TooltipPopup>
       </Tooltip>
     </div>

--- a/apps/web/src/components/sidebar/SidebarChrome.tsx
+++ b/apps/web/src/components/sidebar/SidebarChrome.tsx
@@ -30,6 +30,7 @@ import {
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { SidebarProviderUpdatePill } from "./SidebarProviderUpdatePill";
 import { SidebarUpdateArchitectureWarning, SidebarUpdatePill } from "./SidebarUpdatePill";
+import { useUnreadBackgroundThreadCount } from "../../hooks/useUnreadBackgroundThreadCount";
 
 export const SidebarChromeHeader = memo(function SidebarChromeHeader({
   isElectron,
@@ -46,6 +47,7 @@ export const SidebarChromeHeader = memo(function SidebarChromeHeader({
     environmentIdentificationMode === "pill"
       ? resolveEnvironmentIdentificationPillLabel(stageLabel)
       : null;
+  const unreadCount = useUnreadBackgroundThreadCount();
 
   return (
     <SidebarHeader
@@ -56,6 +58,7 @@ export const SidebarChromeHeader = memo(function SidebarChromeHeader({
     >
       {backdropVariant ? <SidebarStageBackdrop variant={backdropVariant} /> : null}
       <SidebarTrigger
+        unreadCount={unreadCount}
         className={cn(
           "relative z-10 md:hidden",
           backdropVariant &&

--- a/apps/web/src/components/ui/sidebar.test.tsx
+++ b/apps/web/src/components/ui/sidebar.test.tsx
@@ -58,7 +58,18 @@ describe("sidebar interactive cursors", () => {
     );
 
     expect(html).toContain('data-testid="sidebar-unread-badge"');
-    expect(html).toContain("3");
+    expect(html).toContain(">3</span>");
+    expect(html).toContain('aria-label="Toggle Sidebar (3 unread)"');
+  });
+
+  it("preserves explicit aria-label when unreadCount is present", () => {
+    const html = renderToStaticMarkup(
+      <SidebarProvider>
+        <SidebarTrigger aria-label="Expand sidebar (3 unread)" unreadCount={3} />
+      </SidebarProvider>,
+    );
+
+    expect(html).toContain('aria-label="Expand sidebar (3 unread)"');
   });
 
   it("uses shared geometry and icon constraints for menu buttons by default", () => {

--- a/apps/web/src/components/ui/sidebar.test.tsx
+++ b/apps/web/src/components/ui/sidebar.test.tsx
@@ -50,6 +50,17 @@ describe("sidebar interactive cursors", () => {
     expect(html).toContain("size-[var(--workspace-titlebar-control-size)]!");
   });
 
+  it("renders unread badge when unreadCount is greater than zero", () => {
+    const html = renderToStaticMarkup(
+      <SidebarProvider>
+        <SidebarTrigger unreadCount={3} />
+      </SidebarProvider>,
+    );
+
+    expect(html).toContain('data-testid="sidebar-unread-badge"');
+    expect(html).toContain("3");
+  });
+
   it("uses shared geometry and icon constraints for menu buttons by default", () => {
     const html = renderSidebarButton();
 

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -355,7 +355,7 @@ function SidebarTrigger({
       {unreadCount !== undefined && unreadCount > 0 ? (
         <span
           aria-hidden
-          className="pointer-events-none absolute -top-0.5 -right-0.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-destructive px-1 text-[9px] font-semibold tabular-nums text-destructive-foreground shadow-xs"
+          className="pointer-events-none absolute -top-0.5 -right-0.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-destructive px-1 text-[9px] font-semibold tabular-nums text-white shadow-xs"
           data-testid="sidebar-unread-badge"
         >
           {unreadCount > 9 ? "9+" : unreadCount}

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -322,10 +322,16 @@ function SidebarTrigger({
   className,
   onClick,
   unreadCount,
+  "aria-label": ariaLabel,
   ...props
 }: React.ComponentProps<typeof Button> & { unreadCount?: number | undefined }) {
   const { toggleSidebar } = useSidebar();
   const isOpen = useSidebarVisibility();
+  const resolvedAriaLabel =
+    ariaLabel ??
+    (unreadCount !== undefined && unreadCount > 0
+      ? `Toggle Sidebar (${unreadCount} unread)`
+      : undefined);
 
   return (
     <Button
@@ -335,6 +341,7 @@ function SidebarTrigger({
       )}
       data-sidebar="trigger"
       data-slot="sidebar-trigger"
+      aria-label={resolvedAriaLabel}
       aria-pressed={isOpen}
       onClick={(event) => {
         onClick?.(event);
@@ -347,9 +354,9 @@ function SidebarTrigger({
       {isOpen ? <PanelLeftCloseIcon /> : <PanelLeftIcon />}
       {unreadCount !== undefined && unreadCount > 0 ? (
         <span
-          className="pointer-events-none absolute -right-0.5 -top-0.5 flex min-w-3.5 h-3.5 items-center justify-center rounded-full bg-red-600 px-1 text-[9px] font-bold leading-none text-white shadow-xs"
+          aria-hidden
+          className="pointer-events-none absolute -top-0.5 -right-0.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-destructive px-1 text-[9px] font-semibold tabular-nums text-destructive-foreground shadow-xs"
           data-testid="sidebar-unread-badge"
-          aria-label={`${unreadCount} unread`}
         >
           {unreadCount > 9 ? "9+" : unreadCount}
         </span>

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -318,14 +318,19 @@ function Sidebar({
   );
 }
 
-function SidebarTrigger({ className, onClick, ...props }: React.ComponentProps<typeof Button>) {
+function SidebarTrigger({
+  className,
+  onClick,
+  unreadCount,
+  ...props
+}: React.ComponentProps<typeof Button> & { unreadCount?: number | undefined }) {
   const { toggleSidebar } = useSidebar();
   const isOpen = useSidebarVisibility();
 
   return (
     <Button
       className={cn(
-        "size-[var(--workspace-titlebar-control-size)]! [-webkit-app-region:no-drag]",
+        "relative size-[var(--workspace-titlebar-control-size)]! [-webkit-app-region:no-drag]",
         className,
       )}
       data-sidebar="trigger"
@@ -340,6 +345,15 @@ function SidebarTrigger({ className, onClick, ...props }: React.ComponentProps<t
       {...props}
     >
       {isOpen ? <PanelLeftCloseIcon /> : <PanelLeftIcon />}
+      {unreadCount !== undefined && unreadCount > 0 ? (
+        <span
+          className="pointer-events-none absolute -right-0.5 -top-0.5 flex min-w-3.5 h-3.5 items-center justify-center rounded-full bg-red-600 px-1 text-[9px] font-bold leading-none text-white shadow-xs"
+          data-testid="sidebar-unread-badge"
+          aria-label={`${unreadCount} unread`}
+        >
+          {unreadCount > 9 ? "9+" : unreadCount}
+        </span>
+      ) : null}
       <span className="sr-only">Toggle Sidebar</span>
     </Button>
   );

--- a/apps/web/src/hooks/useUnreadBackgroundThreadCount.test.ts
+++ b/apps/web/src/hooks/useUnreadBackgroundThreadCount.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vite-plus/test";
+import { EnvironmentId, ProjectId, ProviderInstanceId, ThreadId, TurnId } from "@t3tools/contracts";
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/models";
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
+
+import {
+  countUnreadBackgroundThreads,
+  isThreadUnreadBackground,
+} from "./useUnreadBackgroundThreadCount";
+
+const envId = EnvironmentId.make("environment-local");
+const projId = ProjectId.make("project-1");
+const providerInstanceId = ProviderInstanceId.make("provider-1");
+
+function createMockThread(
+  id: string,
+  overrides?: Partial<EnvironmentThreadShell>,
+): EnvironmentThreadShell {
+  return {
+    environmentId: envId,
+    id: ThreadId.make(id),
+    projectId: projId,
+    title: `Thread ${id}`,
+    modelSelection: {
+      instanceId: providerInstanceId,
+      model: "test-model",
+    },
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    branch: null,
+    worktreePath: null,
+    latestTurn: null,
+    createdAt: "2026-08-14T20:00:00.000Z",
+    updatedAt: "2026-08-14T20:00:00.000Z",
+    archivedAt: null,
+    settledOverride: null,
+    settledAt: null,
+    session: null,
+    latestUserMessageAt: null,
+    hasPendingApprovals: false,
+    hasPendingUserInput: false,
+    hasActionableProposedPlan: false,
+    ...overrides,
+  };
+}
+
+describe("isThreadUnreadBackground", () => {
+  const sessionStart = Date.parse("2026-08-14T20:00:00.000Z");
+
+  it("returns false for archived threads", () => {
+    const thread = createMockThread("thread-1", {
+      archivedAt: "2026-08-14T20:10:00.000Z",
+      latestTurn: {
+        turnId: TurnId.make("turn-1"),
+        state: "completed",
+        requestedAt: "2026-08-14T20:05:00.000Z",
+        startedAt: "2026-08-14T20:05:01.000Z",
+        completedAt: "2026-08-14T20:06:00.000Z",
+        assistantMessageId: null,
+      },
+    });
+    expect(isThreadUnreadBackground(thread, undefined, null, sessionStart)).toBe(false);
+  });
+
+  it("returns false for the currently open route thread", () => {
+    const thread = createMockThread("thread-1", {
+      latestTurn: {
+        turnId: TurnId.make("turn-1"),
+        state: "completed",
+        requestedAt: "2026-08-14T20:05:00.000Z",
+        startedAt: "2026-08-14T20:05:01.000Z",
+        completedAt: "2026-08-14T20:06:00.000Z",
+        assistantMessageId: null,
+      },
+    });
+    const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+    expect(
+      isThreadUnreadBackground(thread, "2026-08-14T20:00:00.000Z", threadKey, sessionStart),
+    ).toBe(false);
+  });
+
+  it("returns true when turn completed after last visited timestamp", () => {
+    const thread = createMockThread("thread-1", {
+      latestTurn: {
+        turnId: TurnId.make("turn-1"),
+        state: "completed",
+        requestedAt: "2026-08-14T20:05:00.000Z",
+        startedAt: "2026-08-14T20:05:01.000Z",
+        completedAt: "2026-08-14T20:06:00.000Z",
+        assistantMessageId: null,
+      },
+    });
+    expect(
+      isThreadUnreadBackground(thread, "2026-08-14T20:05:00.000Z", "other-thread", sessionStart),
+    ).toBe(true);
+  });
+
+  it("returns false when last visited timestamp is newer than turn completion", () => {
+    const thread = createMockThread("thread-1", {
+      latestTurn: {
+        turnId: TurnId.make("turn-1"),
+        state: "completed",
+        requestedAt: "2026-08-14T20:05:00.000Z",
+        startedAt: "2026-08-14T20:05:01.000Z",
+        completedAt: "2026-08-14T20:06:00.000Z",
+        assistantMessageId: null,
+      },
+    });
+    expect(
+      isThreadUnreadBackground(thread, "2026-08-14T20:07:00.000Z", "other-thread", sessionStart),
+    ).toBe(false);
+  });
+
+  it("returns true when turn completed in current session and thread was never visited", () => {
+    const thread = createMockThread("thread-1", {
+      latestTurn: {
+        turnId: TurnId.make("turn-1"),
+        state: "completed",
+        requestedAt: "2026-08-14T20:05:00.000Z",
+        startedAt: "2026-08-14T20:05:01.000Z",
+        completedAt: "2026-08-14T20:06:00.000Z",
+        assistantMessageId: null,
+      },
+    });
+    expect(isThreadUnreadBackground(thread, undefined, "other-thread", sessionStart)).toBe(true);
+  });
+
+  it("returns false for historical turn completion before session started when unvisited", () => {
+    const thread = createMockThread("thread-1", {
+      latestTurn: {
+        turnId: TurnId.make("turn-1"),
+        state: "completed",
+        requestedAt: "2026-08-14T19:05:00.000Z",
+        startedAt: "2026-08-14T19:05:01.000Z",
+        completedAt: "2026-08-14T19:06:00.000Z",
+        assistantMessageId: null,
+      },
+    });
+    expect(isThreadUnreadBackground(thread, undefined, "other-thread", sessionStart)).toBe(false);
+  });
+});
+
+describe("countUnreadBackgroundThreads", () => {
+  const sessionStart = Date.parse("2026-08-14T20:00:00.000Z");
+
+  it("counts only unread background threads", () => {
+    const thread1 = createMockThread("thread-1", {
+      latestTurn: {
+        turnId: TurnId.make("turn-1"),
+        state: "completed",
+        requestedAt: "2026-08-14T20:05:00.000Z",
+        startedAt: "2026-08-14T20:05:01.000Z",
+        completedAt: "2026-08-14T20:06:00.000Z",
+        assistantMessageId: null,
+      },
+    });
+    const thread2 = createMockThread("thread-2", {
+      latestTurn: {
+        turnId: TurnId.make("turn-2"),
+        state: "completed",
+        requestedAt: "2026-08-14T20:10:00.000Z",
+        startedAt: "2026-08-14T20:10:01.000Z",
+        completedAt: "2026-08-14T20:11:00.000Z",
+        assistantMessageId: null,
+      },
+    });
+    const thread3 = createMockThread("thread-3");
+
+    const key1 = scopedThreadKey(scopeThreadRef(thread1.environmentId, thread1.id));
+    const key2 = scopedThreadKey(scopeThreadRef(thread2.environmentId, thread2.id));
+
+    const visits = {
+      [key1]: "2026-08-14T20:05:00.000Z",
+      [key2]: "2026-08-14T20:15:00.000Z",
+    };
+
+    expect(
+      countUnreadBackgroundThreads(
+        [thread1, thread2, thread3],
+        visits,
+        "active-thread",
+        sessionStart,
+      ),
+    ).toBe(1);
+    expect(
+      countUnreadBackgroundThreads([thread1, thread2, thread3], visits, key1, sessionStart),
+    ).toBe(0);
+  });
+});

--- a/apps/web/src/hooks/useUnreadBackgroundThreadCount.test.ts
+++ b/apps/web/src/hooks/useUnreadBackgroundThreadCount.test.ts
@@ -45,8 +45,6 @@ function createMockThread(
 }
 
 describe("isThreadUnreadBackground", () => {
-  const sessionStart = Date.parse("2026-08-14T20:00:00.000Z");
-
   it("returns false for archived threads", () => {
     const thread = createMockThread("thread-1", {
       archivedAt: "2026-08-14T20:10:00.000Z",
@@ -59,7 +57,7 @@ describe("isThreadUnreadBackground", () => {
         assistantMessageId: null,
       },
     });
-    expect(isThreadUnreadBackground(thread, undefined, null, sessionStart)).toBe(false);
+    expect(isThreadUnreadBackground(thread, undefined, null)).toBe(false);
   });
 
   it("returns false for the currently open route thread", () => {
@@ -74,9 +72,7 @@ describe("isThreadUnreadBackground", () => {
       },
     });
     const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
-    expect(
-      isThreadUnreadBackground(thread, "2026-08-14T20:00:00.000Z", threadKey, sessionStart),
-    ).toBe(false);
+    expect(isThreadUnreadBackground(thread, "2026-08-14T20:00:00.000Z", threadKey)).toBe(false);
   });
 
   it("returns true when turn completed after last visited timestamp", () => {
@@ -90,9 +86,7 @@ describe("isThreadUnreadBackground", () => {
         assistantMessageId: null,
       },
     });
-    expect(
-      isThreadUnreadBackground(thread, "2026-08-14T20:05:00.000Z", "other-thread", sessionStart),
-    ).toBe(true);
+    expect(isThreadUnreadBackground(thread, "2026-08-14T20:05:00.000Z", "other-thread")).toBe(true);
   });
 
   it("returns false when last visited timestamp is newer than turn completion", () => {
@@ -106,12 +100,12 @@ describe("isThreadUnreadBackground", () => {
         assistantMessageId: null,
       },
     });
-    expect(
-      isThreadUnreadBackground(thread, "2026-08-14T20:07:00.000Z", "other-thread", sessionStart),
-    ).toBe(false);
+    expect(isThreadUnreadBackground(thread, "2026-08-14T20:07:00.000Z", "other-thread")).toBe(
+      false,
+    );
   });
 
-  it("returns true when turn completed in current session and thread was never visited", () => {
+  it("returns false when thread was never visited", () => {
     const thread = createMockThread("thread-1", {
       latestTurn: {
         turnId: TurnId.make("turn-1"),
@@ -122,27 +116,11 @@ describe("isThreadUnreadBackground", () => {
         assistantMessageId: null,
       },
     });
-    expect(isThreadUnreadBackground(thread, undefined, "other-thread", sessionStart)).toBe(true);
-  });
-
-  it("returns false for historical turn completion before session started when unvisited", () => {
-    const thread = createMockThread("thread-1", {
-      latestTurn: {
-        turnId: TurnId.make("turn-1"),
-        state: "completed",
-        requestedAt: "2026-08-14T19:05:00.000Z",
-        startedAt: "2026-08-14T19:05:01.000Z",
-        completedAt: "2026-08-14T19:06:00.000Z",
-        assistantMessageId: null,
-      },
-    });
-    expect(isThreadUnreadBackground(thread, undefined, "other-thread", sessionStart)).toBe(false);
+    expect(isThreadUnreadBackground(thread, undefined, "other-thread")).toBe(false);
   });
 });
 
 describe("countUnreadBackgroundThreads", () => {
-  const sessionStart = Date.parse("2026-08-14T20:00:00.000Z");
-
   it("counts only unread background threads", () => {
     const thread1 = createMockThread("thread-1", {
       latestTurn: {
@@ -174,16 +152,9 @@ describe("countUnreadBackgroundThreads", () => {
       [key2]: "2026-08-14T20:15:00.000Z",
     };
 
-    expect(
-      countUnreadBackgroundThreads(
-        [thread1, thread2, thread3],
-        visits,
-        "active-thread",
-        sessionStart,
-      ),
-    ).toBe(1);
-    expect(
-      countUnreadBackgroundThreads([thread1, thread2, thread3], visits, key1, sessionStart),
-    ).toBe(0);
+    expect(countUnreadBackgroundThreads([thread1, thread2, thread3], visits, "active-thread")).toBe(
+      1,
+    );
+    expect(countUnreadBackgroundThreads([thread1, thread2, thread3], visits, key1)).toBe(0);
   });
 });

--- a/apps/web/src/hooks/useUnreadBackgroundThreadCount.ts
+++ b/apps/web/src/hooks/useUnreadBackgroundThreadCount.ts
@@ -1,0 +1,75 @@
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/models";
+import { useParams } from "@tanstack/react-router";
+import { useMemo } from "react";
+
+import { hasUnseenCompletion } from "~/components/Sidebar.logic";
+import { useThreadShells } from "~/state/entities";
+import { resolveThreadRouteTarget } from "~/threadRoutes";
+import { useUiStateStore } from "~/uiStateStore";
+
+const APP_SESSION_STARTED_AT_MS = Date.now();
+
+export function isThreadUnreadBackground(
+  thread: EnvironmentThreadShell,
+  lastVisitedAt: string | undefined,
+  currentRouteThreadKey: string | null,
+  sessionStartedAtMs: number = APP_SESSION_STARTED_AT_MS,
+): boolean {
+  if (thread.archivedAt !== null) return false;
+  const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+  if (threadKey === currentRouteThreadKey) return false;
+
+  if (hasUnseenCompletion({ ...thread, lastVisitedAt })) {
+    return true;
+  }
+
+  if (lastVisitedAt === undefined && thread.latestTurn?.completedAt) {
+    const completedAtMs = Date.parse(thread.latestTurn.completedAt);
+    if (!Number.isNaN(completedAtMs) && completedAtMs >= sessionStartedAtMs) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function countUnreadBackgroundThreads(
+  threads: ReadonlyArray<EnvironmentThreadShell>,
+  threadLastVisitedAtById: Readonly<Record<string, string>>,
+  currentRouteThreadKey: string | null,
+  sessionStartedAtMs: number = APP_SESSION_STARTED_AT_MS,
+): number {
+  let count = 0;
+  for (const thread of threads) {
+    const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+    const lastVisitedAt = threadLastVisitedAtById[threadKey];
+    if (
+      isThreadUnreadBackground(thread, lastVisitedAt, currentRouteThreadKey, sessionStartedAtMs)
+    ) {
+      count++;
+    }
+  }
+  return count;
+}
+
+export function useUnreadBackgroundThreadCount(): number {
+  const threads = useThreadShells();
+  const threadLastVisitedAtById = useUiStateStore((state) => state.threadLastVisitedAtById);
+  const routeTarget = useParams({
+    strict: false,
+    select: (params) => resolveThreadRouteTarget(params),
+  });
+
+  const currentRouteThreadKey = useMemo(() => {
+    if (routeTarget?.kind === "server") {
+      return scopedThreadKey(routeTarget.threadRef);
+    }
+    return null;
+  }, [routeTarget]);
+
+  return useMemo(
+    () => countUnreadBackgroundThreads(threads, threadLastVisitedAtById, currentRouteThreadKey),
+    [threads, threadLastVisitedAtById, currentRouteThreadKey],
+  );
+}

--- a/apps/web/src/hooks/useUnreadBackgroundThreadCount.ts
+++ b/apps/web/src/hooks/useUnreadBackgroundThreadCount.ts
@@ -8,45 +8,28 @@ import { useThreadShells } from "~/state/entities";
 import { resolveThreadRouteTarget } from "~/threadRoutes";
 import { useUiStateStore } from "~/uiStateStore";
 
-const APP_SESSION_STARTED_AT_MS = Date.now();
-
 export function isThreadUnreadBackground(
   thread: EnvironmentThreadShell,
   lastVisitedAt: string | undefined,
   currentRouteThreadKey: string | null,
-  sessionStartedAtMs: number = APP_SESSION_STARTED_AT_MS,
 ): boolean {
   if (thread.archivedAt !== null) return false;
   const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
   if (threadKey === currentRouteThreadKey) return false;
 
-  if (hasUnseenCompletion({ ...thread, lastVisitedAt })) {
-    return true;
-  }
-
-  if (lastVisitedAt === undefined && thread.latestTurn?.completedAt) {
-    const completedAtMs = Date.parse(thread.latestTurn.completedAt);
-    if (!Number.isNaN(completedAtMs) && completedAtMs >= sessionStartedAtMs) {
-      return true;
-    }
-  }
-
-  return false;
+  return hasUnseenCompletion({ ...thread, lastVisitedAt });
 }
 
 export function countUnreadBackgroundThreads(
   threads: ReadonlyArray<EnvironmentThreadShell>,
   threadLastVisitedAtById: Readonly<Record<string, string>>,
   currentRouteThreadKey: string | null,
-  sessionStartedAtMs: number = APP_SESSION_STARTED_AT_MS,
 ): number {
   let count = 0;
   for (const thread of threads) {
     const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
     const lastVisitedAt = threadLastVisitedAtById[threadKey];
-    if (
-      isThreadUnreadBackground(thread, lastVisitedAt, currentRouteThreadKey, sessionStartedAtMs)
-    ) {
+    if (isThreadUnreadBackground(thread, lastVisitedAt, currentRouteThreadKey)) {
       count++;
     }
   }


### PR DESCRIPTION
### Problem
When agents finish turns in other conversations running in the background, there is no direct visual cue on the top-left sidebar toggle button to notify the user of unread responses while working in another thread.

### Solution
- Added `useUnreadBackgroundThreadCount` hook to track unseen turn completions in background threads.
- Added unread badge rendering to `SidebarTrigger` in the top-left workspace control area.
- Excluded the active conversation from the background count, and automatically cleared the notification when opening/navigating into the thread.

Gemini 3.7 Flash via Antigravity CLI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only notification wiring reusing existing sidebar unread logic; no auth, data, or API changes.
> 
> **Overview**
> Surfaces **unread background thread** activity on the **sidebar toggle** so users see when other conversations finished while they work elsewhere.
> 
> Adds **`useUnreadBackgroundThreadCount`**, which counts non-archived threads with unseen turn completions (via existing **`hasUnseenCompletion`**), using **`threadLastVisitedAtById`** and excluding the **currently routed** thread. **`SidebarTrigger`** accepts optional **`unreadCount`**, shows a destructive badge (capped at **9+**), and sets **`aria-label`** / tooltip copy when count &gt; 0; explicit **`aria-label`** from callers is preserved. The count is passed from **desktop** (`AppSidebarLayout`) and **mobile** (`SidebarChrome`) triggers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bfef89bc1c43b1d8d7623d4aede89121ae3e583. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add unread notification badge to sidebar toggle button
> - Adds a new `useUnreadBackgroundThreadCount` hook in [`useUnreadBackgroundThreadCount.ts`](https://github.com/pingdotgg/t3code/pull/6652/files#diff-3e1648fa1699759f78d5c38b5d06e5e9ac08746ddbbd8a8ac3dd471c0d574207) that counts threads with unseen completions, excluding the active thread and archived threads.
> - Updates `SidebarTrigger` in [`sidebar.tsx`](https://github.com/pingdotgg/t3code/pull/6652/files#diff-224383fe35d78f69b89d11dbdf0c045779e7ba45ca023f26abc828cd88e309cd) to accept an `unreadCount` prop and render a badge (capped at `9+`) with an updated `aria-label` reflecting the count.
> - Passes the unread count into `SidebarTrigger` from both [`AppSidebarLayout.tsx`](https://github.com/pingdotgg/t3code/pull/6652/files#diff-b580a936d60a70bebcccf38ac9a82ca5f4440c99445dbccb0c176ebe5dc1d301) and [`SidebarChrome.tsx`](https://github.com/pingdotgg/t3code/pull/6652/files#diff-cbdc7d544762cec67fb7c23f9e66e80e1ca2158f0d100a878363a7ae01f77c11), also updating the tooltip text when count > 0.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3bfef89.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->