### PR TITLE
fix(mobile): connect saved addresses independently

### DIFF
--- a/apps/mobile/src/connection/onboarding.ts
+++ b/apps/mobile/src/connection/onboarding.ts
@@ -3,7 +3,6 @@ import {
   createAtomCommandScheduler,
   createRuntimeCommand,
 } from "@t3tools/client-runtime/state/runtime";
-import type { EnvironmentId } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 
 import { connectionAtomRuntime } from "./runtime";
@@ -25,10 +24,10 @@ export const updateBearerConnection = createRuntimeCommand(connectionAtomRuntime
   scheduler: onboardingScheduler,
   concurrency: {
     mode: "serial",
-    key: (input: { readonly environmentId: EnvironmentId }) => input.environmentId,
+    key: (input: { readonly connectionId: string }) => input.connectionId,
   },
   execute: (input: {
-    readonly environmentId: EnvironmentId;
+    readonly connectionId: string;
     readonly label: string;
     readonly httpBaseUrl: string;
   }) => ConnectionOnboarding.pipe(Effect.flatMap((onboarding) => onboarding.updateBearer(input))),

--- a/apps/mobile/src/connection/storage.ts
+++ b/apps/mobile/src/connection/storage.ts
@@ -2,7 +2,6 @@ import {
   ConnectionPersistenceError,
   ConnectionRegistrationStore,
   ConnectionTargetStore,
-  activateConnectionInCatalog,
   registerConnectionInCatalog,
   removeConnectionFromCatalog,
   removeCatalogValue,
@@ -21,7 +20,7 @@ import * as Option from "effect/Option";
 import * as CatalogStore from "./catalog-store";
 
 function targetPersistenceError(
-  operation: "list-targets" | "register-connection" | "activate-connection" | "remove-connection",
+  operation: "list-targets" | "register-connection" | "remove-connection",
   error: ConnectionTransientError,
 ) {
   return new ConnectionPersistenceError({
@@ -46,27 +45,13 @@ export const connectionStorageLayer = Layer.effectContext(
         catalog
           .update((document) => registerConnectionInCatalog(document, registration))
           .pipe(Effect.mapError((error) => targetPersistenceError("register-connection", error))),
-      update: (registration, activeTarget) =>
+      update: (registration) =>
         catalog
-          .update((document) => {
-            const updated = registerConnectionInCatalog(document, registration);
-            return activeTarget === undefined
-              ? updated
-              : activateConnectionInCatalog(updated, activeTarget);
-          })
+          .update((document) => registerConnectionInCatalog(document, registration))
           .pipe(Effect.mapError((error) => targetPersistenceError("register-connection", error))),
-      activate: (target) =>
+      remove: (target) =>
         catalog
-          .update((document) => activateConnectionInCatalog(document, target))
-          .pipe(Effect.mapError((error) => targetPersistenceError("activate-connection", error))),
-      remove: (target, nextActiveTarget) =>
-        catalog
-          .update((document) => {
-            const removed = removeConnectionFromCatalog(document, target);
-            return nextActiveTarget === undefined
-              ? removed
-              : activateConnectionInCatalog(removed, nextActiveTarget);
-          })
+          .update((document) => removeConnectionFromCatalog(document, target))
           .pipe(Effect.mapError((error) => targetPersistenceError("remove-connection", error))),
     });
     const profileStore = ProfileStore.make({

--- a/apps/mobile/src/connection/storage.ts
+++ b/apps/mobile/src/connection/storage.ts
@@ -21,7 +21,7 @@ import * as Option from "effect/Option";
 import * as CatalogStore from "./catalog-store";
 
 function targetPersistenceError(
-  operation: "list-targets" | "register-connection" | "remove-connection",
+  operation: "list-targets" | "register-connection" | "activate-connection" | "remove-connection",
   error: ConnectionTransientError,
 ) {
   return new ConnectionPersistenceError({
@@ -46,13 +46,27 @@ export const connectionStorageLayer = Layer.effectContext(
         catalog
           .update((document) => registerConnectionInCatalog(document, registration))
           .pipe(Effect.mapError((error) => targetPersistenceError("register-connection", error))),
+      update: (registration, activeTarget) =>
+        catalog
+          .update((document) => {
+            const updated = registerConnectionInCatalog(document, registration);
+            return activeTarget === undefined
+              ? updated
+              : activateConnectionInCatalog(updated, activeTarget);
+          })
+          .pipe(Effect.mapError((error) => targetPersistenceError("register-connection", error))),
       activate: (target) =>
         catalog
           .update((document) => activateConnectionInCatalog(document, target))
-          .pipe(Effect.mapError((error) => targetPersistenceError("register-connection", error))),
-      remove: (target) =>
+          .pipe(Effect.mapError((error) => targetPersistenceError("activate-connection", error))),
+      remove: (target, nextActiveTarget) =>
         catalog
-          .update((document) => removeConnectionFromCatalog(document, target))
+          .update((document) => {
+            const removed = removeConnectionFromCatalog(document, target);
+            return nextActiveTarget === undefined
+              ? removed
+              : activateConnectionInCatalog(removed, nextActiveTarget);
+          })
           .pipe(Effect.mapError((error) => targetPersistenceError("remove-connection", error))),
     });
     const profileStore = ProfileStore.make({

--- a/apps/mobile/src/connection/storage.ts
+++ b/apps/mobile/src/connection/storage.ts
@@ -2,6 +2,7 @@ import {
   ConnectionPersistenceError,
   ConnectionRegistrationStore,
   ConnectionTargetStore,
+  activateConnectionInCatalog,
   registerConnectionInCatalog,
   removeConnectionFromCatalog,
   removeCatalogValue,
@@ -40,9 +41,14 @@ export const connectionStorageLayer = Layer.effectContext(
       ),
     });
     const registrationStore = ConnectionRegistrationStore.of({
+      retainsSiblingRoutes: true,
       register: (registration) =>
         catalog
           .update((document) => registerConnectionInCatalog(document, registration))
+          .pipe(Effect.mapError((error) => targetPersistenceError("register-connection", error))),
+      activate: (target) =>
+        catalog
+          .update((document) => activateConnectionInCatalog(document, target))
           .pipe(Effect.mapError((error) => targetPersistenceError("register-connection", error))),
       remove: (target) =>
         catalog

--- a/apps/mobile/src/features/cloud/ConnectOnboardingRouteScreen.tsx
+++ b/apps/mobile/src/features/cloud/ConnectOnboardingRouteScreen.tsx
@@ -45,7 +45,7 @@ function ConfiguredConnectOnboardingRouteScreen() {
   const navigation = useNavigation();
   const insets = useSafeAreaInsets();
   const { isSignedIn, userId } = useAuth({ treatPendingAsSignedOut: false });
-  const { connectedEnvironments, onReconnectEnvironment } = useRemoteConnections();
+  const { connectedEnvironments, onReconnectConnection } = useRemoteConnections();
   const { refreshRelayEnvironments } = useConnectionController();
   const { connectedCloudEnvironments } = splitEnvironmentSections({
     connectedEnvironments,
@@ -110,7 +110,7 @@ function ConfiguredConnectOnboardingRouteScreen() {
         {isSignedIn ? (
           <CloudEnvironmentRows
             connectedCloudEnvironments={connectedCloudEnvironments}
-            onReconnectEnvironment={onReconnectEnvironment}
+            onReconnectConnection={onReconnectConnection}
             showHeader={false}
           />
         ) : (

--- a/apps/mobile/src/features/connection/CloudEnvironmentRows.tsx
+++ b/apps/mobile/src/features/connection/CloudEnvironmentRows.tsx
@@ -96,8 +96,8 @@ function CloudEnvironmentRowsContent(
     [controller],
   );
 
-  const handleToggleCloudError = useCallback((environmentId: string) => {
-    setExpandedErrorId((current) => (current === environmentId ? null : environmentId));
+  const handleToggleCloudError = useCallback((rowId: string) => {
+    setExpandedErrorId((current) => (current === rowId ? null : rowId));
   }, []);
 
   const showHeader = props.showHeader ?? true;
@@ -140,8 +140,8 @@ function CloudEnvironmentRowsContent(
               borderTop={index !== 0}
               onConnect={() => props.onReconnectConnection(environment.connectionId)}
               onDisconnect={() => handleDisconnectCloudEnvironment(environment.connectionId)}
-              errorExpanded={expandedErrorId === environment.environmentId}
-              onToggleError={() => handleToggleCloudError(environment.environmentId)}
+              errorExpanded={expandedErrorId === environment.connectionId}
+              onToggleError={() => handleToggleCloudError(environment.connectionId)}
             />
           ))}
           {availableCloudEnvironments.map((environment, index) => (

--- a/apps/mobile/src/features/connection/CloudEnvironmentRows.tsx
+++ b/apps/mobile/src/features/connection/CloudEnvironmentRows.tsx
@@ -4,7 +4,6 @@ import {
   connectionStatusText,
   type EnvironmentConnectionPhase,
 } from "@t3tools/client-runtime/connection";
-import type { EnvironmentId } from "@t3tools/contracts";
 import { useCallback, useState } from "react";
 import {
   ActivityIndicator,
@@ -27,7 +26,7 @@ import { type RelayEnvironmentView, useConnectionController } from "./useConnect
 
 interface CloudEnvironmentRowsProps {
   readonly connectedCloudEnvironments: ReadonlyArray<ConnectedEnvironmentSummary>;
-  readonly onReconnectEnvironment: (environmentId: EnvironmentId) => void;
+  readonly onReconnectConnection: (connectionId: string) => void;
   readonly showcaseAvailableEnvironments?: ReadonlyArray<RelayEnvironmentView>;
   readonly showcaseSignedIn?: boolean;
   /**
@@ -93,7 +92,7 @@ function CloudEnvironmentRowsContent(
   );
 
   const handleDisconnectCloudEnvironment = useCallback(
-    (environmentId: EnvironmentId) => controller.removeEnvironment(environmentId),
+    (connectionId: string) => controller.removeConnection(connectionId),
     [controller],
   );
 
@@ -136,11 +135,11 @@ function CloudEnvironmentRowsContent(
         <View collapsable={false} className="overflow-hidden rounded-[24px] bg-card">
           {props.connectedCloudEnvironments.map((environment, index) => (
             <ConnectedCloudEnvironmentRow
-              key={environment.environmentId}
+              key={environment.connectionId}
               environment={environment}
               borderTop={index !== 0}
-              onConnect={() => props.onReconnectEnvironment(environment.environmentId)}
-              onDisconnect={() => handleDisconnectCloudEnvironment(environment.environmentId)}
+              onConnect={() => props.onReconnectConnection(environment.connectionId)}
+              onDisconnect={() => handleDisconnectCloudEnvironment(environment.connectionId)}
               errorExpanded={expandedErrorId === environment.environmentId}
               onToggleError={() => handleToggleCloudError(environment.environmentId)}
             />

--- a/apps/mobile/src/features/connection/ConnectionEnvironmentRow.tsx
+++ b/apps/mobile/src/features/connection/ConnectionEnvironmentRow.tsx
@@ -15,7 +15,6 @@ import type { ConnectedEnvironmentSummary } from "../../state/remote-runtime-typ
 import { ConnectionStatusDot } from "./ConnectionStatusDot";
 
 function connectionStatusLabel(environment: ConnectedEnvironmentSummary): string | null {
-  if (!environment.isActive) return "Saved route";
   return connectionStatusText({
     phase: environment.connectionState,
     error: environment.connectionError,

--- a/apps/mobile/src/features/connection/ConnectionEnvironmentRow.tsx
+++ b/apps/mobile/src/features/connection/ConnectionEnvironmentRow.tsx
@@ -1,7 +1,6 @@
 import { SymbolView } from "../../components/AppSymbol";
 import { connectionStatusText } from "@t3tools/client-runtime/connection";
 import type { AtomCommandResult } from "@t3tools/client-runtime/state/runtime";
-import type { EnvironmentId } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
 import { AsyncResult } from "effect/unstable/reactivity";
 import { useCallback, useState } from "react";
@@ -16,6 +15,7 @@ import type { ConnectedEnvironmentSummary } from "../../state/remote-runtime-typ
 import { ConnectionStatusDot } from "./ConnectionStatusDot";
 
 function connectionStatusLabel(environment: ConnectedEnvironmentSummary): string | null {
+  if (!environment.isActive) return "Saved route";
   return connectionStatusText({
     phase: environment.connectionState,
     error: environment.connectionError,
@@ -27,10 +27,10 @@ export function ConnectionEnvironmentRow(props: {
   readonly environment: ConnectedEnvironmentSummary;
   readonly expanded: boolean;
   readonly onToggle: () => void;
-  readonly onReconnect: (environmentId: EnvironmentId) => void;
-  readonly onRemove: (environmentId: EnvironmentId) => void;
+  readonly onReconnect: (connectionId: string) => void;
+  readonly onRemove: (connectionId: string) => void;
   readonly onUpdate: (
-    environmentId: EnvironmentId,
+    connectionId: string,
     updates: { readonly label: string; readonly displayUrl: string },
   ) => Promise<AtomCommandResult<unknown, unknown>>;
 }) {
@@ -47,7 +47,7 @@ export function ConnectionEnvironmentRow(props: {
     props.environment.connectionState === "connecting" ||
     props.environment.connectionState === "reconnecting";
   const handleSave = useCallback(async () => {
-    const result = await props.onUpdate(props.environment.environmentId, {
+    const result = await props.onUpdate(props.environment.connectionId, {
       label: label.trim(),
       displayUrl: url.trim(),
     });
@@ -183,7 +183,7 @@ export function ConnectionEnvironmentRow(props: {
 
             <Pressable
               className="h-[42px] w-[42px] items-center justify-center rounded-[14px] border border-input-border bg-input active:opacity-70"
-              onPress={() => props.onReconnect(props.environment.environmentId)}
+              onPress={() => props.onReconnect(props.environment.connectionId)}
             >
               <SymbolView
                 name="arrow.clockwise"
@@ -195,7 +195,7 @@ export function ConnectionEnvironmentRow(props: {
 
             <Pressable
               className="h-[42px] w-[42px] items-center justify-center rounded-[14px] border border-danger-border bg-danger active:opacity-70"
-              onPress={() => props.onRemove(props.environment.environmentId)}
+              onPress={() => props.onRemove(props.environment.connectionId)}
             >
               <SymbolView name="trash" size={14} tintColor={dangerFg} type="monochrome" />
             </Pressable>

--- a/apps/mobile/src/features/connection/ConnectionsRouteScreen.tsx
+++ b/apps/mobile/src/features/connection/ConnectionsRouteScreen.tsx
@@ -1,7 +1,6 @@
 import { NativeHeaderToolbar } from "../../native/StackHeader";
 import { useNavigation } from "@react-navigation/native";
 import { SymbolView } from "../../components/AppSymbol";
-import type { EnvironmentId } from "@t3tools/contracts";
 import { useCallback, useState } from "react";
 import { Platform, ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -16,19 +15,19 @@ import { ConnectionEnvironmentRow } from "./ConnectionEnvironmentRow";
 export function ConnectionsRouteScreen() {
   const {
     connectedEnvironments,
-    onReconnectEnvironment,
+    onReconnectConnection,
     onRemoveEnvironmentPress,
     onUpdateEnvironment,
   } = useRemoteConnections();
   const navigation = useNavigation();
   const insets = useSafeAreaInsets();
   const hasEnvironments = connectedEnvironments.length > 0;
-  const [expandedId, setExpandedId] = useState<EnvironmentId | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
 
   const accentColor = useThemeColor("--color-icon-muted");
 
-  const handleToggle = useCallback((environmentId: EnvironmentId) => {
-    setExpandedId((prev) => (prev === environmentId ? null : environmentId));
+  const handleToggle = useCallback((connectionId: string) => {
+    setExpandedId((prev) => (prev === connectionId ? null : connectionId));
   }, []);
 
   return (
@@ -68,15 +67,15 @@ export function ConnectionsRouteScreen() {
           <View collapsable={false} className="overflow-hidden rounded-[24px] bg-card">
             {connectedEnvironments.map((environment, index) => (
               <View
-                key={environment.environmentId}
+                key={environment.connectionId}
                 collapsable={false}
                 className={cn(index !== 0 && "border-t border-border")}
               >
                 <ConnectionEnvironmentRow
                   environment={environment}
-                  expanded={expandedId === environment.environmentId}
-                  onToggle={() => handleToggle(environment.environmentId)}
-                  onReconnect={onReconnectEnvironment}
+                  expanded={expandedId === environment.connectionId}
+                  onToggle={() => handleToggle(environment.connectionId)}
+                  onReconnect={onReconnectConnection}
                   onRemove={onRemoveEnvironmentPress}
                   onUpdate={onUpdateEnvironment}
                 />

--- a/apps/mobile/src/features/connection/environmentSections.test.ts
+++ b/apps/mobile/src/features/connection/environmentSections.test.ts
@@ -11,6 +11,8 @@ function connectedEnvironment(
   },
 ): ConnectedEnvironmentSummary {
   return {
+    connectionId: input.connectionId ?? `connection:${input.environmentId}`,
+    isActive: input.isActive ?? true,
     environmentId: EnvironmentId.make(input.environmentId),
     environmentLabel: input.environmentLabel ?? input.environmentId,
     displayUrl: input.displayUrl ?? `https://${input.environmentId}.example.test/`,

--- a/apps/mobile/src/features/connection/environmentSections.test.ts
+++ b/apps/mobile/src/features/connection/environmentSections.test.ts
@@ -12,7 +12,6 @@ function connectedEnvironment(
 ): ConnectedEnvironmentSummary {
   return {
     connectionId: input.connectionId ?? `connection:${input.environmentId}`,
-    isActive: input.isActive ?? true,
     environmentId: EnvironmentId.make(input.environmentId),
     environmentLabel: input.environmentLabel ?? input.environmentId,
     displayUrl: input.displayUrl ?? `https://${input.environmentId}.example.test/`,
@@ -111,6 +110,22 @@ describe("mobile environment settings sections", () => {
 
     expect(sections.connectedCloudEnvironments).toEqual([cloud]);
     expect(sections.availableCloudEnvironments).toEqual([]);
+  });
+
+  it("keeps a relay route available when only a direct sibling is saved", () => {
+    const local = connectedEnvironment({
+      environmentId: "environment-shared",
+      isRelayManaged: false,
+    });
+    const listedCloud = cloudEnvironment("environment-shared");
+
+    const sections = splitEnvironmentSections({
+      connectedEnvironments: [local],
+      cloudEnvironments: [listedCloud],
+    });
+
+    expect(sections.localEnvironments).toEqual([local]);
+    expect(sections.availableCloudEnvironments).toEqual([listedCloud]);
   });
 
   it("keeps failed relay environments in the local connection row", () => {

--- a/apps/mobile/src/features/connection/environmentSections.ts
+++ b/apps/mobile/src/features/connection/environmentSections.ts
@@ -12,10 +12,18 @@ export interface EnvironmentSections {
   readonly availableCloudEnvironments: ReadonlyArray<RelayClientEnvironmentRecord>;
 }
 
-export function splitEnvironmentSections(input: EnvironmentSectionsInput): EnvironmentSections {
-  const savedEnvironmentIds = new Set(
-    input.connectedEnvironments.map((environment) => environment.environmentId),
+export function connectedRelayEnvironmentIds(
+  environments: ReadonlyArray<ConnectedEnvironmentSummary>,
+) {
+  return new Set(
+    environments
+      .filter((environment) => environment.isRelayManaged)
+      .map((environment) => environment.environmentId),
   );
+}
+
+export function splitEnvironmentSections(input: EnvironmentSectionsInput): EnvironmentSections {
+  const savedRelayEnvironmentIds = connectedRelayEnvironmentIds(input.connectedEnvironments);
 
   return {
     localEnvironments: input.connectedEnvironments.filter(
@@ -25,7 +33,7 @@ export function splitEnvironmentSections(input: EnvironmentSectionsInput): Envir
       (environment) => environment.isRelayManaged,
     ),
     availableCloudEnvironments: (input.cloudEnvironments ?? []).filter(
-      (environment) => !savedEnvironmentIds.has(environment.environmentId),
+      (environment) => !savedRelayEnvironmentIds.has(environment.environmentId),
     ),
   };
 }

--- a/apps/mobile/src/features/connection/useConnectionController.ts
+++ b/apps/mobile/src/features/connection/useConnectionController.ts
@@ -16,10 +16,10 @@ import {
   connectPairingUrl as connectPairingUrlAtom,
   updateBearerConnection,
 } from "../../connection/onboarding";
-import { useEnvironments } from "../../state/environments";
+import { useEnvironmentConnections } from "../../state/environments";
 import { relayEnvironmentDiscovery } from "../../state/relay";
 import { useAtomCommand } from "../../state/use-atom-command";
-import { projectWorkspaceEnvironment, type WorkspaceEnvironment } from "../../state/workspaceModel";
+import type { ConnectedEnvironmentSummary } from "../../state/remote-runtime-types";
 
 export interface RelayEnvironmentView {
   readonly environment: RelayClientEnvironmentRecord;
@@ -30,7 +30,7 @@ export interface RelayEnvironmentView {
 }
 
 export function useConnectionController() {
-  const { environments } = useEnvironments();
+  const { environments } = useEnvironmentConnections();
   const discovery = useAtomValue(relayEnvironmentDiscovery.stateValueAtom);
   const connectPairingUrlMutation = useAtomCommand(connectPairingUrlAtom, {
     reportFailure: false,
@@ -38,14 +38,33 @@ export function useConnectionController() {
   const updateBearer = useAtomCommand(updateBearerConnection, { reportFailure: false });
   const registerEnvironment = useAtomCommand(environmentCatalog.register, "environment register");
   const removeEnvironmentMutation = useAtomCommand(environmentCatalog.remove, "environment remove");
+  const removeConnectionMutation = useAtomCommand(
+    environmentCatalog.removeConnection,
+    "connection remove",
+  );
   const retryEnvironmentMutation = useAtomCommand(environmentCatalog.retryNow, "environment retry");
+  const retryConnectionMutation = useAtomCommand(
+    environmentCatalog.retryConnection,
+    "connection retry",
+  );
   const refreshRelayEnvironments = useAtomCommand(
     relayEnvironmentDiscovery.refresh,
     "relay environment refresh",
   );
 
-  const connectedEnvironments = useMemo<ReadonlyArray<WorkspaceEnvironment>>(
-    () => environments.map(projectWorkspaceEnvironment),
+  const connectedEnvironments = useMemo<ReadonlyArray<ConnectedEnvironmentSummary>>(
+    () =>
+      environments.map((environment) => ({
+        connectionId: environment.connectionId,
+        isActive: environment.isActive,
+        environmentId: environment.environmentId,
+        environmentLabel: environment.label,
+        displayUrl: environment.displayUrl ?? "",
+        isRelayManaged: environment.relayManaged,
+        connectionState: environment.isActive ? environment.connection.phase : "available",
+        connectionError: environment.isActive ? environment.connection.error : null,
+        connectionErrorTraceId: environment.isActive ? environment.connection.traceId : null,
+      })),
     [environments],
   );
   const registeredIds = useMemo(
@@ -88,17 +107,22 @@ export function useConnectionController() {
     (environmentId: EnvironmentId) => removeEnvironmentMutation(environmentId),
     [removeEnvironmentMutation],
   );
+  const removeConnection = useCallback(
+    (connectionId: string) => removeConnectionMutation(connectionId),
+    [removeConnectionMutation],
+  );
   const retryEnvironment = useCallback(
     (environmentId: EnvironmentId) => retryEnvironmentMutation(environmentId),
     [retryEnvironmentMutation],
   );
+  const retryConnection = useCallback(
+    (connectionId: string) => retryConnectionMutation(connectionId),
+    [retryConnectionMutation],
+  );
   const updateEnvironment = useCallback(
-    (
-      environmentId: EnvironmentId,
-      updates: { readonly label: string; readonly displayUrl: string },
-    ) =>
+    (connectionId: string, updates: { readonly label: string; readonly displayUrl: string }) =>
       updateBearer({
-        environmentId,
+        connectionId,
         label: updates.label,
         httpBaseUrl: updates.displayUrl,
       }),
@@ -118,7 +142,9 @@ export function useConnectionController() {
     connectPairingUrl,
     connectRelayEnvironment,
     removeEnvironment,
+    removeConnection,
     retryEnvironment,
+    retryConnection,
     updateEnvironment,
     refreshRelayEnvironments,
   };

--- a/apps/mobile/src/features/connection/useConnectionController.ts
+++ b/apps/mobile/src/features/connection/useConnectionController.ts
@@ -20,6 +20,7 @@ import { useEnvironmentConnections } from "../../state/environments";
 import { relayEnvironmentDiscovery } from "../../state/relay";
 import { useAtomCommand } from "../../state/use-atom-command";
 import type { ConnectedEnvironmentSummary } from "../../state/remote-runtime-types";
+import { connectedRelayEnvironmentIds } from "./environmentSections";
 
 export interface RelayEnvironmentView {
   readonly environment: RelayClientEnvironmentRecord;
@@ -37,7 +38,6 @@ export function useConnectionController() {
   });
   const updateBearer = useAtomCommand(updateBearerConnection, { reportFailure: false });
   const registerEnvironment = useAtomCommand(environmentCatalog.register, "environment register");
-  const removeEnvironmentMutation = useAtomCommand(environmentCatalog.remove, "environment remove");
   const removeConnectionMutation = useAtomCommand(
     environmentCatalog.removeConnection,
     "connection remove",
@@ -56,19 +56,18 @@ export function useConnectionController() {
     () =>
       environments.map((environment) => ({
         connectionId: environment.connectionId,
-        isActive: environment.isActive,
         environmentId: environment.environmentId,
         environmentLabel: environment.label,
         displayUrl: environment.displayUrl ?? "",
         isRelayManaged: environment.relayManaged,
-        connectionState: environment.isActive ? environment.connection.phase : "available",
-        connectionError: environment.isActive ? environment.connection.error : null,
-        connectionErrorTraceId: environment.isActive ? environment.connection.traceId : null,
+        connectionState: environment.connection.phase,
+        connectionError: environment.connection.error,
+        connectionErrorTraceId: environment.connection.traceId,
       })),
     [environments],
   );
   const registeredIds = useMemo(
-    () => new Set(connectedEnvironments.map((environment) => environment.environmentId)),
+    () => connectedRelayEnvironmentIds(connectedEnvironments),
     [connectedEnvironments],
   );
   const relayEnvironments = useMemo<ReadonlyArray<RelayEnvironmentView>>(
@@ -102,10 +101,6 @@ export function useConnectionController() {
         }),
       ),
     [registerEnvironment],
-  );
-  const removeEnvironment = useCallback(
-    (environmentId: EnvironmentId) => removeEnvironmentMutation(environmentId),
-    [removeEnvironmentMutation],
   );
   const removeConnection = useCallback(
     (connectionId: string) => removeConnectionMutation(connectionId),
@@ -141,7 +136,6 @@ export function useConnectionController() {
     },
     connectPairingUrl,
     connectRelayEnvironment,
-    removeEnvironment,
     removeConnection,
     retryEnvironment,
     retryConnection,

--- a/apps/mobile/src/features/settings/SettingsEnvironmentsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsEnvironmentsRouteScreen.tsx
@@ -27,7 +27,6 @@ export function SettingsEnvironmentsRouteScreen() {
   const {
     connectedEnvironments,
     onReconnectConnection,
-    onReconnectEnvironment,
     onRemoveEnvironmentPress,
     onUpdateEnvironment,
   } = useRemoteConnections();
@@ -168,7 +167,7 @@ export function SettingsEnvironmentsRouteScreen() {
             user is signed out — the component gates discovery itself. */}
         <CloudEnvironmentRows
           connectedCloudEnvironments={connectedCloudEnvironments}
-          onReconnectEnvironment={onReconnectEnvironment}
+          onReconnectConnection={onReconnectConnection}
           {...(SHOWCASE_ENABLED
             ? {
                 showcaseAvailableEnvironments: SHOWCASE_AVAILABLE_CLOUD_ENVIRONMENTS,

--- a/apps/mobile/src/features/settings/SettingsEnvironmentsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsEnvironmentsRouteScreen.tsx
@@ -1,7 +1,6 @@
 import { NativeHeaderToolbar, NativeStackScreenOptions } from "../../native/StackHeader";
 import { useNavigation } from "@react-navigation/native";
 import { SymbolView } from "../../components/AppSymbol";
-import type { EnvironmentId } from "@t3tools/contracts";
 import { useCallback, useEffect, useState } from "react";
 import { Platform, ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -27,6 +26,7 @@ const SHOWCASE_ENABLED = process.env.EXPO_PUBLIC_SHOWCASE === "1";
 export function SettingsEnvironmentsRouteScreen() {
   const {
     connectedEnvironments,
+    onReconnectConnection,
     onReconnectEnvironment,
     onRemoveEnvironmentPress,
     onUpdateEnvironment,
@@ -44,7 +44,7 @@ export function SettingsEnvironmentsRouteScreen() {
     ? SHOWCASE_CONNECTED_CLOUD_ENVIRONMENTS
     : environmentSections.connectedCloudEnvironments;
   const hasLocalEnvironments = localEnvironments.length > 0;
-  const [expandedId, setExpandedId] = useState<EnvironmentId | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
   const accentColor = useThemeColor("--color-icon-muted");
   const headerIconColor = useThemeColor("--color-icon");
 
@@ -54,22 +54,19 @@ export function SettingsEnvironmentsRouteScreen() {
     return () => clearTimeout(timer);
   }, []);
 
-  const handleToggle = useCallback((environmentId: EnvironmentId) => {
-    setExpandedId((prev) => (prev === environmentId ? null : environmentId));
+  const handleToggle = useCallback((connectionId: string) => {
+    setExpandedId((prev) => (prev === connectionId ? null : connectionId));
   }, []);
   const handleUpdateEnvironment = useCallback(
-    (
-      environmentId: EnvironmentId,
-      updates: { readonly label: string; readonly displayUrl: string },
-    ) => {
-      if (!SHOWCASE_ENABLED) return onUpdateEnvironment(environmentId, updates);
+    (connectionId: string, updates: { readonly label: string; readonly displayUrl: string }) => {
+      if (!SHOWCASE_ENABLED) return onUpdateEnvironment(connectionId, updates);
       const actualEnvironment = environmentSections.localEnvironments.find(
-        (environment) => environment.environmentId === environmentId,
+        (environment) => environment.connectionId === connectionId,
       );
       const presentedEnvironment = localEnvironments.find(
-        (environment) => environment.environmentId === environmentId,
+        (environment) => environment.connectionId === connectionId,
       );
-      return onUpdateEnvironment(environmentId, {
+      return onUpdateEnvironment(connectionId, {
         ...updates,
         displayUrl:
           actualEnvironment && presentedEnvironment
@@ -134,15 +131,15 @@ export function SettingsEnvironmentsRouteScreen() {
           <View collapsable={false} className="overflow-hidden rounded-[24px] bg-card">
             {localEnvironments.map((environment, index) => (
               <View
-                key={environment.environmentId}
+                key={environment.connectionId}
                 collapsable={false}
                 className={cn(index !== 0 && "border-t border-border")}
               >
                 <ConnectionEnvironmentRow
                   environment={environment}
-                  expanded={expandedId === environment.environmentId}
-                  onToggle={() => handleToggle(environment.environmentId)}
-                  onReconnect={onReconnectEnvironment}
+                  expanded={expandedId === environment.connectionId}
+                  onToggle={() => handleToggle(environment.connectionId)}
+                  onReconnect={onReconnectConnection}
                   onRemove={onRemoveEnvironmentPress}
                   onUpdate={handleUpdateEnvironment}
                 />

--- a/apps/mobile/src/features/showcase/showcaseEnvironmentRows.test.ts
+++ b/apps/mobile/src/features/showcase/showcaseEnvironmentRows.test.ts
@@ -13,6 +13,8 @@ function environment(
   displayUrl = "http://127.0.0.1:3773/",
 ): ConnectedEnvironmentSummary {
   return {
+    connectionId: `bearer:${environmentId}`,
+    isActive: true,
     environmentId: EnvironmentId.make(environmentId),
     environmentLabel,
     displayUrl,

--- a/apps/mobile/src/features/showcase/showcaseEnvironmentRows.test.ts
+++ b/apps/mobile/src/features/showcase/showcaseEnvironmentRows.test.ts
@@ -14,7 +14,6 @@ function environment(
 ): ConnectedEnvironmentSummary {
   return {
     connectionId: `bearer:${environmentId}`,
-    isActive: true,
     environmentId: EnvironmentId.make(environmentId),
     environmentLabel,
     displayUrl,

--- a/apps/mobile/src/features/showcase/showcaseEnvironmentRows.ts
+++ b/apps/mobile/src/features/showcase/showcaseEnvironmentRows.ts
@@ -40,7 +40,6 @@ const pocketPiEndpoint = {
 export const SHOWCASE_CONNECTED_CLOUD_ENVIRONMENTS: ReadonlyArray<ConnectedEnvironmentSummary> = [
   {
     connectionId: "relay:showcase-aurora-gpu",
-    isActive: true,
     environmentId: EnvironmentId.make("showcase-aurora-gpu"),
     environmentLabel: "Aurora GPU Pod",
     displayUrl: "https://aurora-gpu.t3.sh",

--- a/apps/mobile/src/features/showcase/showcaseEnvironmentRows.ts
+++ b/apps/mobile/src/features/showcase/showcaseEnvironmentRows.ts
@@ -39,6 +39,8 @@ const pocketPiEndpoint = {
 
 export const SHOWCASE_CONNECTED_CLOUD_ENVIRONMENTS: ReadonlyArray<ConnectedEnvironmentSummary> = [
   {
+    connectionId: "relay:showcase-aurora-gpu",
+    isActive: true,
     environmentId: EnvironmentId.make("showcase-aurora-gpu"),
     environmentLabel: "Aurora GPU Pod",
     displayUrl: "https://aurora-gpu.t3.sh",

--- a/apps/mobile/src/state/environmentConnections.ts
+++ b/apps/mobile/src/state/environmentConnections.ts
@@ -1,0 +1,50 @@
+import {
+  AVAILABLE_CONNECTION_STATE,
+  connectionCatalogDisplayUrl,
+  type ConnectionCatalogEntry,
+  type EnvironmentPresentation as BaseEnvironmentPresentation,
+  presentEnvironmentConnection,
+  type SupervisorConnectionState,
+} from "@t3tools/client-runtime/connection";
+import type { EnvironmentId } from "@t3tools/contracts";
+
+export interface EnvironmentPresentation extends BaseEnvironmentPresentation {
+  readonly environmentId: EnvironmentId;
+  readonly label: string;
+  readonly displayUrl: string | null;
+  readonly relayManaged: boolean;
+}
+
+export interface EnvironmentConnectionPresentation extends EnvironmentPresentation {
+  readonly connectionId: string;
+}
+
+export function projectEnvironmentPresentation(
+  environmentId: EnvironmentId,
+  presentation: BaseEnvironmentPresentation,
+): EnvironmentPresentation {
+  return {
+    ...presentation,
+    environmentId,
+    label: presentation.entry.target.label,
+    displayUrl: connectionCatalogDisplayUrl(presentation.entry),
+    relayManaged: presentation.entry.target._tag === "RelayConnectionTarget",
+  };
+}
+
+export function projectEnvironmentConnections(
+  connections: ReadonlyMap<string, ConnectionCatalogEntry>,
+  connectionStates: ReadonlyMap<string, SupervisorConnectionState>,
+  presentationById: ReadonlyMap<EnvironmentId, BaseEnvironmentPresentation>,
+): ReadonlyArray<EnvironmentConnectionPresentation> {
+  return [...connections.entries()].map(([connectionId, entry]) => ({
+    ...projectEnvironmentPresentation(entry.target.environmentId, {
+      entry,
+      connection: presentEnvironmentConnection(
+        connectionStates.get(connectionId) ?? AVAILABLE_CONNECTION_STATE,
+      ),
+      serverConfig: presentationById.get(entry.target.environmentId)?.serverConfig ?? null,
+    }),
+    connectionId,
+  }));
+}

--- a/apps/mobile/src/state/environments.test.ts
+++ b/apps/mobile/src/state/environments.test.ts
@@ -1,0 +1,69 @@
+import {
+  AVAILABLE_CONNECTION_STATE,
+  BearerConnectionProfile,
+  BearerConnectionTarget,
+  type ConnectionCatalogEntry,
+  type SupervisorConnectionState,
+} from "@t3tools/client-runtime/connection";
+import { EnvironmentId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+import * as Option from "effect/Option";
+
+import { projectEnvironmentConnections } from "./environmentConnections";
+
+describe("projectEnvironmentConnections", () => {
+  it("keeps same-environment connections as independent rows with independent states", () => {
+    const environmentId = EnvironmentId.make("same-machine");
+    const entries = [
+      ["home", "Home network", "http://192.168.1.20:3773"],
+      ["office", "Office network", "http://10.0.0.20:3773"],
+    ].map(([connectionId, label, httpBaseUrl]) => {
+      const target = new BearerConnectionTarget({ environmentId, connectionId, label });
+      return [
+        connectionId,
+        {
+          target,
+          profile: Option.some(
+            new BearerConnectionProfile({
+              connectionId,
+              environmentId,
+              label,
+              httpBaseUrl,
+              wsBaseUrl: httpBaseUrl.replace("http://", "ws://"),
+            }),
+          ),
+        } satisfies ConnectionCatalogEntry,
+      ] as const;
+    });
+    const connected: SupervisorConnectionState = {
+      ...AVAILABLE_CONNECTION_STATE,
+      desired: true,
+      network: "online",
+      phase: "connected",
+      generation: 1,
+    };
+    const connecting: SupervisorConnectionState = {
+      ...AVAILABLE_CONNECTION_STATE,
+      desired: true,
+      network: "online",
+      phase: "connecting",
+      stage: "opening",
+      attempt: 1,
+    };
+
+    const rows = projectEnvironmentConnections(
+      new Map(entries),
+      new Map([
+        ["home", connected],
+        ["office", connecting],
+      ]),
+      new Map(),
+    );
+
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => [row.connectionId, row.displayUrl, row.connection.phase])).toEqual([
+      ["home", "http://192.168.1.20:3773", "connected"],
+      ["office", "http://10.0.0.20:3773", "connecting"],
+    ]);
+  });
+});

--- a/apps/mobile/src/state/environments.ts
+++ b/apps/mobile/src/state/environments.ts
@@ -1,40 +1,19 @@
 import { useAtomValue } from "@effect/atom-react";
-import {
-  connectionCatalogDisplayUrl,
-  connectionTargetId,
-  type EnvironmentPresentation as BaseEnvironmentPresentation,
-} from "@t3tools/client-runtime/connection";
 import type { EnvironmentId } from "@t3tools/contracts";
 import { useMemo } from "react";
 
 import { environmentCatalog } from "../connection/catalog";
+import {
+  projectEnvironmentConnections,
+  projectEnvironmentPresentation,
+  type EnvironmentConnectionPresentation,
+  type EnvironmentPresentation,
+} from "./environmentConnections";
 import { environmentPresentations } from "./presentation";
 import { useEnvironmentQuery } from "./query";
 
-export interface EnvironmentPresentation extends BaseEnvironmentPresentation {
-  readonly environmentId: EnvironmentId;
-  readonly label: string;
-  readonly displayUrl: string | null;
-  readonly relayManaged: boolean;
-}
-
-export interface EnvironmentConnectionPresentation extends EnvironmentPresentation {
-  readonly connectionId: string;
-  readonly isActive: boolean;
-}
-
-export function projectEnvironmentPresentation(
-  environmentId: EnvironmentId,
-  presentation: BaseEnvironmentPresentation,
-): EnvironmentPresentation {
-  return {
-    ...presentation,
-    environmentId,
-    label: presentation.entry.target.label,
-    displayUrl: connectionCatalogDisplayUrl(presentation.entry),
-    relayManaged: presentation.entry.target._tag === "RelayConnectionTarget",
-  };
-}
+export type { EnvironmentConnectionPresentation, EnvironmentPresentation };
+export { projectEnvironmentPresentation };
 
 export function useEnvironments() {
   const catalog = useAtomValue(environmentCatalog.catalogValueAtom);
@@ -60,25 +39,12 @@ export function useEnvironments() {
 export function useEnvironmentConnections() {
   const catalog = useAtomValue(environmentCatalog.catalogValueAtom);
   const connections = useAtomValue(environmentCatalog.connectionsValueAtom);
+  const connectionStates = useAtomValue(environmentCatalog.connectionStatesValueAtom);
   const presentationById = useAtomValue(environmentPresentations.presentationsAtom);
 
   const environments = useMemo(
-    () =>
-      [...connections.entries()].flatMap(([connectionId, entry]) => {
-        const active = presentationById.get(entry.target.environmentId);
-        if (active === undefined) return [];
-        return [
-          {
-            ...projectEnvironmentPresentation(entry.target.environmentId, {
-              ...active,
-              entry,
-            }),
-            connectionId,
-            isActive: connectionTargetId(active.entry.target) === connectionId,
-          } satisfies EnvironmentConnectionPresentation,
-        ];
-      }),
-    [connections, presentationById],
+    () => projectEnvironmentConnections(connections, connectionStates, presentationById),
+    [connectionStates, connections, presentationById],
   );
 
   return { isReady: catalog.isReady, environments };

--- a/apps/mobile/src/state/environments.ts
+++ b/apps/mobile/src/state/environments.ts
@@ -1,6 +1,7 @@
 import { useAtomValue } from "@effect/atom-react";
 import {
   connectionCatalogDisplayUrl,
+  connectionTargetId,
   type EnvironmentPresentation as BaseEnvironmentPresentation,
 } from "@t3tools/client-runtime/connection";
 import type { EnvironmentId } from "@t3tools/contracts";
@@ -15,6 +16,11 @@ export interface EnvironmentPresentation extends BaseEnvironmentPresentation {
   readonly label: string;
   readonly displayUrl: string | null;
   readonly relayManaged: boolean;
+}
+
+export interface EnvironmentConnectionPresentation extends EnvironmentPresentation {
+  readonly connectionId: string;
+  readonly isActive: boolean;
 }
 
 export function projectEnvironmentPresentation(
@@ -49,6 +55,33 @@ export function useEnvironments() {
     environments,
     presentationById,
   };
+}
+
+export function useEnvironmentConnections() {
+  const catalog = useAtomValue(environmentCatalog.catalogValueAtom);
+  const connections = useAtomValue(environmentCatalog.connectionsValueAtom);
+  const presentationById = useAtomValue(environmentPresentations.presentationsAtom);
+
+  const environments = useMemo(
+    () =>
+      [...connections.entries()].flatMap(([connectionId, entry]) => {
+        const active = presentationById.get(entry.target.environmentId);
+        if (active === undefined) return [];
+        return [
+          {
+            ...projectEnvironmentPresentation(entry.target.environmentId, {
+              ...active,
+              entry,
+            }),
+            connectionId,
+            isActive: connectionTargetId(active.entry.target) === connectionId,
+          } satisfies EnvironmentConnectionPresentation,
+        ];
+      }),
+    [connections, presentationById],
+  );
+
+  return { isReady: catalog.isReady, environments };
 }
 
 export function useEnvironmentConnectionState(environmentId: EnvironmentId) {

--- a/apps/mobile/src/state/remote-runtime-types.ts
+++ b/apps/mobile/src/state/remote-runtime-types.ts
@@ -9,6 +9,8 @@ export interface EnvironmentRuntimeState {
 }
 
 export interface ConnectedEnvironmentSummary {
+  readonly connectionId: string;
+  readonly isActive: boolean;
   readonly environmentId: EnvironmentId;
   readonly environmentLabel: string;
   readonly displayUrl: string;

--- a/apps/mobile/src/state/remote-runtime-types.ts
+++ b/apps/mobile/src/state/remote-runtime-types.ts
@@ -10,7 +10,6 @@ export interface EnvironmentRuntimeState {
 
 export interface ConnectedEnvironmentSummary {
   readonly connectionId: string;
-  readonly isActive: boolean;
   readonly environmentId: EnvironmentId;
   readonly environmentLabel: string;
   readonly displayUrl: string;

--- a/apps/mobile/src/state/use-remote-environment-registry.ts
+++ b/apps/mobile/src/state/use-remote-environment-registry.ts
@@ -133,6 +133,8 @@ export function useRemoteConnectionStatus() {
   const connectedEnvironments = useMemo<ReadonlyArray<ConnectedEnvironmentSummary>>(
     () =>
       workspace.environments.map((environment) => ({
+        connectionId: `environment:${environment.environmentId}`,
+        isActive: true,
         environmentId: environment.environmentId,
         environmentLabel: environment.environmentLabel,
         displayUrl: environment.displayUrl,
@@ -155,7 +157,8 @@ export function useRemoteConnections() {
   const controller = useConnectionController();
   const connectionPairingUrl = useAtomValue(connectionPairingUrlAtom);
   const pendingConnectionError = useAtomValue(pendingConnectionErrorAtom);
-  const { connectedEnvironments, connectionError, connectionState } = useRemoteConnectionStatus();
+  const { connectionError, connectionState } = useRemoteConnectionStatus();
+  const connectedEnvironments = controller.connectedEnvironments;
 
   const onChangeConnectionPairingUrl = useCallback((pairingUrl: string) => {
     appAtomRegistry.set(connectionPairingUrlAtom, pairingUrl);
@@ -179,36 +182,38 @@ export function useRemoteConnections() {
     [connectionPairingUrl, controller],
   );
 
+  const onReconnectConnection = useCallback(
+    (connectionId: string) => controller.retryConnection(connectionId),
+    [controller],
+  );
   const onReconnectEnvironment = useCallback(
     (environmentId: EnvironmentId) => controller.retryEnvironment(environmentId),
     [controller],
   );
   const onUpdateEnvironment = useCallback(
-    (
-      environmentId: EnvironmentId,
-      updates: { readonly label: string; readonly displayUrl: string },
-    ) => controller.updateEnvironment(environmentId, updates),
+    (connectionId: string, updates: { readonly label: string; readonly displayUrl: string }) =>
+      controller.updateEnvironment(connectionId, updates),
     [controller],
   );
 
   const onRemoveEnvironmentPress = useCallback(
-    (environmentId: EnvironmentId) => {
+    (connectionId: string) => {
       const environment = connectedEnvironments.find(
-        (candidate) => candidate.environmentId === environmentId,
+        (candidate) => candidate.connectionId === connectionId,
       );
       if (!environment) {
         return;
       }
       Alert.alert(
-        "Remove environment?",
-        `Disconnect and forget ${environment.environmentLabel} on this device.`,
+        "Remove saved address?",
+        `Forget ${environment.displayUrl || environment.environmentLabel} on this device.`,
         [
           { text: "Cancel", style: "cancel" },
           {
             text: "Remove",
             style: "destructive",
             onPress: () => {
-              void controller.removeEnvironment(environmentId);
+              void controller.removeConnection(connectionId);
             },
           },
         ],
@@ -226,6 +231,7 @@ export function useRemoteConnections() {
     connectedEnvironmentCount: connectedEnvironments.length,
     onChangeConnectionPairingUrl,
     onConnectPress,
+    onReconnectConnection,
     onReconnectEnvironment,
     onUpdateEnvironment,
     onRemoveEnvironmentPress,

--- a/apps/mobile/src/state/use-remote-environment-registry.ts
+++ b/apps/mobile/src/state/use-remote-environment-registry.ts
@@ -134,7 +134,6 @@ export function useRemoteConnectionStatus() {
     () =>
       workspace.environments.map((environment) => ({
         connectionId: `environment:${environment.environmentId}`,
-        isActive: true,
         environmentId: environment.environmentId,
         environmentLabel: environment.environmentLabel,
         displayUrl: environment.displayUrl,

--- a/apps/web/src/connection/storage.ts
+++ b/apps/web/src/connection/storage.ts
@@ -99,6 +99,7 @@ function persistenceError(
   operation:
     | "list-targets"
     | "register-connection"
+    | "activate-connection"
     | "remove-connection"
     | "load-shell"
     | "save-shell"
@@ -383,13 +384,27 @@ export const connectionStorageLayer = Layer.effectContext(
         catalog
           .update((document) => replaceEnvironmentConnectionInCatalog(document, registration))
           .pipe(Effect.mapError((cause) => persistenceError("register-connection", cause))),
+      update: (registration, activeTarget) =>
+        catalog
+          .update((document) => {
+            const updated = replaceEnvironmentConnectionInCatalog(document, registration);
+            return activeTarget === undefined
+              ? updated
+              : activateConnectionInCatalog(updated, activeTarget);
+          })
+          .pipe(Effect.mapError((cause) => persistenceError("register-connection", cause))),
       activate: (target) =>
         catalog
           .update((document) => activateConnectionInCatalog(document, target))
-          .pipe(Effect.mapError((cause) => persistenceError("register-connection", cause))),
-      remove: (target) =>
+          .pipe(Effect.mapError((cause) => persistenceError("activate-connection", cause))),
+      remove: (target, nextActiveTarget) =>
         catalog
-          .update((document) => removeConnectionFromCatalog(document, target))
+          .update((document) => {
+            const removed = removeConnectionFromCatalog(document, target);
+            return nextActiveTarget === undefined
+              ? removed
+              : activateConnectionInCatalog(removed, nextActiveTarget);
+          })
           .pipe(Effect.mapError((cause) => persistenceError("remove-connection", cause))),
     });
     const profileStore = ProfileStore.make({

--- a/apps/web/src/connection/storage.ts
+++ b/apps/web/src/connection/storage.ts
@@ -4,7 +4,6 @@ import {
   ConnectionPersistenceError,
   ConnectionRegistrationStore,
   ConnectionTargetStore,
-  activateConnectionInCatalog,
   EMPTY_CONNECTION_CATALOG_DOCUMENT,
   EnvironmentCacheStore,
   replaceEnvironmentConnectionInCatalog,
@@ -99,7 +98,6 @@ function persistenceError(
   operation:
     | "list-targets"
     | "register-connection"
-    | "activate-connection"
     | "remove-connection"
     | "load-shell"
     | "save-shell"
@@ -384,27 +382,13 @@ export const connectionStorageLayer = Layer.effectContext(
         catalog
           .update((document) => replaceEnvironmentConnectionInCatalog(document, registration))
           .pipe(Effect.mapError((cause) => persistenceError("register-connection", cause))),
-      update: (registration, activeTarget) =>
+      update: (registration) =>
         catalog
-          .update((document) => {
-            const updated = replaceEnvironmentConnectionInCatalog(document, registration);
-            return activeTarget === undefined
-              ? updated
-              : activateConnectionInCatalog(updated, activeTarget);
-          })
+          .update((document) => replaceEnvironmentConnectionInCatalog(document, registration))
           .pipe(Effect.mapError((cause) => persistenceError("register-connection", cause))),
-      activate: (target) =>
+      remove: (target) =>
         catalog
-          .update((document) => activateConnectionInCatalog(document, target))
-          .pipe(Effect.mapError((cause) => persistenceError("activate-connection", cause))),
-      remove: (target, nextActiveTarget) =>
-        catalog
-          .update((document) => {
-            const removed = removeConnectionFromCatalog(document, target);
-            return nextActiveTarget === undefined
-              ? removed
-              : activateConnectionInCatalog(removed, nextActiveTarget);
-          })
+          .update((document) => removeConnectionFromCatalog(document, target))
           .pipe(Effect.mapError((cause) => persistenceError("remove-connection", cause))),
     });
     const profileStore = ProfileStore.make({

--- a/apps/web/src/connection/storage.ts
+++ b/apps/web/src/connection/storage.ts
@@ -4,9 +4,10 @@ import {
   ConnectionPersistenceError,
   ConnectionRegistrationStore,
   ConnectionTargetStore,
+  activateConnectionInCatalog,
   EMPTY_CONNECTION_CATALOG_DOCUMENT,
   EnvironmentCacheStore,
-  registerConnectionInCatalog,
+  replaceEnvironmentConnectionInCatalog,
   removeCatalogValue,
   removeConnectionFromCatalog,
   replaceCatalogValue,
@@ -377,9 +378,14 @@ export const connectionStorageLayer = Layer.effectContext(
       ),
     });
     const registrationStore = ConnectionRegistrationStore.of({
+      retainsSiblingRoutes: false,
       register: (registration) =>
         catalog
-          .update((document) => registerConnectionInCatalog(document, registration))
+          .update((document) => replaceEnvironmentConnectionInCatalog(document, registration))
+          .pipe(Effect.mapError((cause) => persistenceError("register-connection", cause))),
+      activate: (target) =>
+        catalog
+          .update((document) => activateConnectionInCatalog(document, target))
           .pipe(Effect.mapError((cause) => persistenceError("register-connection", cause))),
       remove: (target) =>
         catalog

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -60,6 +60,8 @@ If the copied link points directly at `http://192.168.x.y:3773`, open it from a 
 
 In the mobile app's **Add Environment** form, a numeric IP address without a scheme uses HTTP. Include `https://` explicitly when the backend is served over HTTPS.
 
+You can save more than one address for the same environment. This is useful when a laptop has different LAN addresses at home and at work. Each address stays available in **Settings → Environments**; reconnecting one makes it the active route without duplicating the laptop's projects or threads.
+
 ### Tailscale Endpoints
 
 When the desktop app can detect Tailscale, it adds Tailnet endpoints to the reachable endpoint list.

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -60,7 +60,7 @@ If the copied link points directly at `http://192.168.x.y:3773`, open it from a 
 
 In the mobile app's **Add Environment** form, a numeric IP address without a scheme uses HTTP. Include `https://` explicitly when the backend is served over HTTPS.
 
-You can save more than one address for the same environment. This is useful when a laptop has different LAN addresses at home and at work. Each address stays available in **Settings → Environments**; reconnecting one makes it the active route without duplicating the laptop's projects or threads.
+You can save more than one address for the same environment. This is useful when a laptop has different LAN addresses at home and at work. Each address connects and retries independently in **Settings → Environments**, while the app transparently uses any connected address for the laptop's projects and threads.
 
 ### Tailscale Endpoints
 

--- a/packages/client-runtime/src/connection/catalog.ts
+++ b/packages/client-runtime/src/connection/catalog.ts
@@ -128,3 +128,33 @@ export function connectionRegistrationCatalogEntry(
       };
   }
 }
+
+export function reuseSavedBearerRoute(
+  registration: BearerConnectionRegistration,
+  connections: ReadonlyMap<string, ConnectionCatalogEntry>,
+): BearerConnectionRegistration {
+  const existing = [...connections.values()].find(
+    (entry) =>
+      entry.target._tag === "BearerConnectionTarget" &&
+      entry.target.environmentId === registration.target.environmentId &&
+      Option.isSome(entry.profile) &&
+      entry.profile.value._tag === "BearerConnectionProfile" &&
+      entry.profile.value.httpBaseUrl === registration.profile.httpBaseUrl,
+  );
+  if (existing?.target._tag !== "BearerConnectionTarget") return registration;
+  return new BearerConnectionRegistration({
+    target: new BearerConnectionTarget({
+      environmentId: registration.target.environmentId,
+      label: registration.target.label,
+      connectionId: existing.target.connectionId,
+    }),
+    profile: new BearerConnectionProfile({
+      connectionId: existing.target.connectionId,
+      environmentId: registration.profile.environmentId,
+      label: registration.profile.label,
+      httpBaseUrl: registration.profile.httpBaseUrl,
+      wsBaseUrl: registration.profile.wsBaseUrl,
+    }),
+    credential: registration.credential,
+  });
+}

--- a/packages/client-runtime/src/connection/index.ts
+++ b/packages/client-runtime/src/connection/index.ts
@@ -24,6 +24,7 @@ export {
 export * from "./presentation.ts";
 export * as ProfileStore from "./profileStore.ts";
 export {
+  ConnectionNotRegisteredError,
   EnvironmentNotRegisteredError,
   EnvironmentRegistry,
   PlatformEnvironmentRemovalError,

--- a/packages/client-runtime/src/connection/model.ts
+++ b/packages/client-runtime/src/connection/model.ts
@@ -55,6 +55,24 @@ export type PersistedConnectionTarget = typeof PersistedConnectionTarget.Type;
 
 export type ConnectionTargetKind = ConnectionTarget["_tag"];
 
+/**
+ * Stable client-side identity for one saved route to an environment. An
+ * environment may be reachable through several bearer routes (for example,
+ * the same laptop on home and office LANs), while relay and primary targets
+ * have one implicit route each.
+ */
+export function connectionTargetId(target: ConnectionTarget): string {
+  switch (target._tag) {
+    case "PrimaryConnectionTarget":
+      return `primary:${target.environmentId}`;
+    case "RelayConnectionTarget":
+      return `relay:${target.environmentId}`;
+    case "BearerConnectionTarget":
+    case "SshConnectionTarget":
+      return target.connectionId;
+  }
+}
+
 export type NetworkStatus = "unknown" | "offline" | "online";
 
 export const ConnectionTransientReason = Schema.Literals([

--- a/packages/client-runtime/src/connection/onboarding.test.ts
+++ b/packages/client-runtime/src/connection/onboarding.test.ts
@@ -1,29 +1,46 @@
 import { AuthStandardClientScopes, EnvironmentId } from "@t3tools/contracts";
 import { describe, expect, it } from "@effect/vitest";
+import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 
 import { remoteHttpClientLayer } from "../rpc/http.ts";
 import { ClientPresentation, SshEnvironmentGateway } from "../platform/capabilities.ts";
-import { BearerConnectionCredential, BearerConnectionProfile } from "./catalog.ts";
+import {
+  BearerConnectionCredential,
+  BearerConnectionProfile,
+  BearerConnectionRegistration,
+} from "./catalog.ts";
 import { BearerConnectionTarget } from "./model.ts";
 import {
   prepareBearerConnectionUpdate,
   preparePairingRegistration,
   prepareSshRegistration,
+  reuseSavedPairingRoute,
 } from "./onboarding.ts";
 
-const CLIENT_PRESENTATION_LAYER = Layer.succeed(
-  ClientPresentation,
-  ClientPresentation.of({
-    metadata: {
-      label: "T3 Code Test",
-      deviceType: "desktop",
-      os: "Test OS",
-    },
-    scopes: AuthStandardClientScopes,
-  }),
+let nextCryptoByte = 0;
+
+const CLIENT_PRESENTATION_LAYER = Layer.merge(
+  Layer.succeed(
+    ClientPresentation,
+    ClientPresentation.of({
+      metadata: {
+        label: "T3 Code Test",
+        deviceType: "desktop",
+        os: "Test OS",
+      },
+      scopes: AuthStandardClientScopes,
+    }),
+  ),
+  Layer.succeed(
+    Crypto.Crypto,
+    Crypto.make({
+      randomBytes: (size) => new Uint8Array(size).fill((nextCryptoByte += 1) % 256),
+      digest: (_algorithm, data) => Effect.succeed(data),
+    }),
+  ),
 );
 
 function pairingHttpLayer(
@@ -88,12 +105,12 @@ describe("connection onboarding", () => {
         target: {
           environmentId: "environment-paired",
           label: "Paired environment",
-          connectionId: "bearer:environment-paired",
+          connectionId: expect.stringMatching(/^bearer:environment-paired:/),
         },
         profile: {
           environmentId: "environment-paired",
           label: "Paired environment",
-          connectionId: "bearer:environment-paired",
+          connectionId: expect.stringMatching(/^bearer:environment-paired:/),
           httpBaseUrl: "https://remote.example.test/",
           wsBaseUrl: "wss://remote.example.test/",
         },
@@ -141,6 +158,102 @@ describe("connection onboarding", () => {
     }),
   );
 
+  it.effect("uses distinct route identities for different addresses of one environment", () =>
+    Effect.gen(function* () {
+      const home = yield* preparePairingRegistration({
+        host: "http://192.168.1.10:3773",
+        pairingCode: "home-token",
+      }).pipe(Effect.provide(Layer.mergeAll(CLIENT_PRESENTATION_LAYER, pairingHttpLayer([]))));
+      const office = yield* preparePairingRegistration({
+        host: "http://192.168.50.10:3773",
+        pairingCode: "office-token",
+      }).pipe(Effect.provide(Layer.mergeAll(CLIENT_PRESENTATION_LAYER, pairingHttpLayer([]))));
+
+      expect(home.target.environmentId).toBe(office.target.environmentId);
+      expect(home.target.connectionId).not.toBe(office.target.connectionId);
+      expect(home.profile.httpBaseUrl).toBe("http://192.168.1.10:3773/");
+      expect(office.profile.httpBaseUrl).toBe("http://192.168.50.10:3773/");
+    }),
+  );
+
+  it.effect("does not reuse a route identity derived from its previous address", () =>
+    Effect.gen(function* () {
+      const first = yield* preparePairingRegistration({
+        host: "http://192.168.1.10:3773",
+        pairingCode: "first-token",
+      }).pipe(Effect.provide(Layer.mergeAll(CLIENT_PRESENTATION_LAYER, pairingHttpLayer([]))));
+      const edited = {
+        target: first.target,
+        profile: Option.some(
+          new BearerConnectionProfile({
+            ...first.profile,
+            httpBaseUrl: "http://192.168.50.10:3773/",
+            wsBaseUrl: "ws://192.168.50.10:3773/",
+          }),
+        ),
+      };
+      const pairedAgain = yield* preparePairingRegistration({
+        host: "http://192.168.1.10:3773",
+        pairingCode: "second-token",
+      }).pipe(Effect.provide(Layer.mergeAll(CLIENT_PRESENTATION_LAYER, pairingHttpLayer([]))));
+      const resolved = reuseSavedPairingRoute(
+        pairedAgain,
+        new Map([[first.target.connectionId, edited]]),
+      );
+
+      expect(resolved.target.connectionId).not.toBe(first.target.connectionId);
+      expect(resolved.profile.httpBaseUrl).toBe(first.profile.httpBaseUrl);
+    }),
+  );
+
+  it("reuses a legacy route identity when re-pairing the same address", () => {
+    const environmentId = EnvironmentId.make("environment-paired");
+    const target = new BearerConnectionTarget({
+      environmentId,
+      label: "Paired environment",
+      connectionId: "bearer:environment-paired:new-route",
+    });
+    const registration = new BearerConnectionRegistration({
+      target,
+      profile: new BearerConnectionProfile({
+        connectionId: target.connectionId,
+        environmentId,
+        label: target.label,
+        httpBaseUrl: "http://192.168.1.10:3773/",
+        wsBaseUrl: "ws://192.168.1.10:3773/",
+      }),
+      credential: new BearerConnectionCredential({ token: "new-token" }),
+    });
+    const legacyConnectionId = "bearer:environment-paired";
+    const resolved = reuseSavedPairingRoute(
+      registration,
+      new Map([
+        [
+          legacyConnectionId,
+          {
+            target: new BearerConnectionTarget({
+              environmentId,
+              label: target.label,
+              connectionId: legacyConnectionId,
+            }),
+            profile: Option.some(
+              new BearerConnectionProfile({
+                connectionId: legacyConnectionId,
+                environmentId,
+                label: target.label,
+                httpBaseUrl: registration.profile.httpBaseUrl,
+                wsBaseUrl: registration.profile.wsBaseUrl,
+              }),
+            ),
+          },
+        ],
+      ]),
+    );
+
+    expect(resolved.target.connectionId).toBe(legacyConnectionId);
+    expect(resolved.credential.token).toBe("new-token");
+  });
+
   it.effect("rejects invalid pairing details before making a request", () =>
     Effect.gen(function* () {
       const calls: Array<{ readonly url: string; readonly init: RequestInit }> = [];
@@ -166,7 +279,7 @@ describe("connection onboarding", () => {
       const environmentId = EnvironmentId.make("environment-paired");
       const registration = yield* prepareBearerConnectionUpdate({
         input: {
-          environmentId,
+          connectionId: "bearer:environment-paired",
           label: "  Renamed environment  ",
           httpBaseUrl: "http://100.65.180.100:3773/path",
         },

--- a/packages/client-runtime/src/connection/onboarding.ts
+++ b/packages/client-runtime/src/connection/onboarding.ts
@@ -68,7 +68,12 @@ export class ConnectionOnboarding extends Context.Service<
     >;
     readonly updateBearer: (
       input: BearerConnectionUpdateInput,
-    ) => Effect.Effect<void, ConnectionAttemptError | Persistence.ConnectionPersistenceError>;
+    ) => Effect.Effect<
+      void,
+      | ConnectionAttemptError
+      | Persistence.ConnectionPersistenceError
+      | EnvironmentRegistry.ConnectionNotRegisteredError
+    >;
   }
 >()("@t3tools/client-runtime/connection/onboarding/ConnectionOnboarding") {}
 

--- a/packages/client-runtime/src/connection/onboarding.ts
+++ b/packages/client-runtime/src/connection/onboarding.ts
@@ -21,6 +21,7 @@ import {
   type ConnectionCredential,
   SshConnectionProfile,
   SshConnectionRegistration,
+  reuseSavedBearerRoute,
 } from "./catalog.ts";
 import * as ConnectionCredentialStore from "./credentialStore.ts";
 import { mapRemoteEnvironmentError } from "./errors.ts";
@@ -121,47 +122,15 @@ export const preparePairingRegistration = Effect.fn(
   });
 });
 
-export function reuseSavedPairingRoute(
-  registration: BearerConnectionRegistration,
-  connections: ReadonlyMap<string, ConnectionCatalogEntry>,
-): BearerConnectionRegistration {
-  const existing = [...connections.values()].find(
-    (entry) =>
-      entry.target._tag === "BearerConnectionTarget" &&
-      entry.target.environmentId === registration.target.environmentId &&
-      Option.isSome(entry.profile) &&
-      entry.profile.value._tag === "BearerConnectionProfile" &&
-      entry.profile.value.httpBaseUrl === registration.profile.httpBaseUrl,
-  );
-  if (existing?.target._tag !== "BearerConnectionTarget") return registration;
-  return new BearerConnectionRegistration({
-    target: new BearerConnectionTarget({
-      environmentId: registration.target.environmentId,
-      label: registration.target.label,
-      connectionId: existing.target.connectionId,
-    }),
-    profile: new BearerConnectionProfile({
-      connectionId: existing.target.connectionId,
-      environmentId: registration.profile.environmentId,
-      label: registration.profile.label,
-      httpBaseUrl: registration.profile.httpBaseUrl,
-      wsBaseUrl: registration.profile.wsBaseUrl,
-    }),
-    credential: registration.credential,
-  });
-}
+export const reuseSavedPairingRoute = reuseSavedBearerRoute;
 
 export const registerPairingConnection = Effect.fn(
   "clientRuntime.connection.onboarding.registerPairingConnection",
 )(function* (input: PairingConnectionInput) {
   const registration = yield* preparePairingRegistration(input);
   const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
-  const resolved = reuseSavedPairingRoute(
-    registration,
-    yield* SubscriptionRef.get(registry.connections),
-  );
-  yield* registry.register(resolved);
-  return resolved.target.environmentId;
+  yield* registry.register(registration);
+  return registration.target.environmentId;
 });
 
 const isBearerCredential = Schema.is(BearerConnectionCredential);

--- a/packages/client-runtime/src/connection/onboarding.ts
+++ b/packages/client-runtime/src/connection/onboarding.ts
@@ -1,6 +1,7 @@
 import type { DesktopSshEnvironmentTarget, EnvironmentId } from "@t3tools/contracts";
 import { resolveRemotePairingTarget } from "@t3tools/shared/remote";
 import * as Context from "effect/Context";
+import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
@@ -44,7 +45,7 @@ export interface SshConnectionInput {
 }
 
 export interface BearerConnectionUpdateInput {
-  readonly environmentId: EnvironmentId;
+  readonly connectionId: string;
   readonly label: string;
   readonly httpBaseUrl: string;
 }
@@ -97,7 +98,9 @@ export const preparePairingRegistration = Effect.fn(
     scopes: presentation.scopes,
     clientMetadata: presentation.metadata,
   }).pipe(Effect.mapError(mapRemoteEnvironmentError));
-  const connectionId = `bearer:${descriptor.environmentId}`;
+  const crypto = yield* Crypto.Crypto;
+  const routeId = yield* crypto.randomUUIDv4.pipe(Effect.orDie);
+  const connectionId = `bearer:${descriptor.environmentId}:${routeId}`;
 
   return new BearerConnectionRegistration({
     target: new BearerConnectionTarget({
@@ -118,13 +121,47 @@ export const preparePairingRegistration = Effect.fn(
   });
 });
 
+export function reuseSavedPairingRoute(
+  registration: BearerConnectionRegistration,
+  connections: ReadonlyMap<string, ConnectionCatalogEntry>,
+): BearerConnectionRegistration {
+  const existing = [...connections.values()].find(
+    (entry) =>
+      entry.target._tag === "BearerConnectionTarget" &&
+      entry.target.environmentId === registration.target.environmentId &&
+      Option.isSome(entry.profile) &&
+      entry.profile.value._tag === "BearerConnectionProfile" &&
+      entry.profile.value.httpBaseUrl === registration.profile.httpBaseUrl,
+  );
+  if (existing?.target._tag !== "BearerConnectionTarget") return registration;
+  return new BearerConnectionRegistration({
+    target: new BearerConnectionTarget({
+      environmentId: registration.target.environmentId,
+      label: registration.target.label,
+      connectionId: existing.target.connectionId,
+    }),
+    profile: new BearerConnectionProfile({
+      connectionId: existing.target.connectionId,
+      environmentId: registration.profile.environmentId,
+      label: registration.profile.label,
+      httpBaseUrl: registration.profile.httpBaseUrl,
+      wsBaseUrl: registration.profile.wsBaseUrl,
+    }),
+    credential: registration.credential,
+  });
+}
+
 export const registerPairingConnection = Effect.fn(
   "clientRuntime.connection.onboarding.registerPairingConnection",
 )(function* (input: PairingConnectionInput) {
   const registration = yield* preparePairingRegistration(input);
   const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
-  yield* registry.register(registration);
-  return registration.target.environmentId;
+  const resolved = reuseSavedPairingRoute(
+    registration,
+    yield* SubscriptionRef.get(registry.connections),
+  );
+  yield* registry.register(resolved);
+  return resolved.target.environmentId;
 });
 
 const isBearerCredential = Schema.is(BearerConnectionCredential);
@@ -135,7 +172,7 @@ export const updateBearerConnection = Effect.fn(
 )(function* (input: BearerConnectionUpdateInput) {
   const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
   const credentials = yield* ConnectionCredentialStore.ConnectionCredentialStore;
-  const entry = (yield* SubscriptionRef.get(registry.entries)).get(input.environmentId);
+  const entry = (yield* SubscriptionRef.get(registry.connections)).get(input.connectionId);
   const credential =
     entry?.target._tag === "BearerConnectionTarget"
       ? yield* credentials.get(entry.target.connectionId)
@@ -145,7 +182,7 @@ export const updateBearerConnection = Effect.fn(
     entry: Option.fromUndefinedOr(entry),
     credential,
   });
-  yield* registry.register(registration);
+  yield* registry.update(registration);
 });
 
 export const prepareBearerConnectionUpdate = Effect.fn(
@@ -195,13 +232,13 @@ export const prepareBearerConnectionUpdate = Effect.fn(
   const connectionId = entry.target.connectionId;
   return new BearerConnectionRegistration({
     target: new BearerConnectionTarget({
-      environmentId: options.input.environmentId,
+      environmentId: entry.target.environmentId,
       label,
       connectionId,
     }),
     profile: new BearerConnectionProfile({
       connectionId,
-      environmentId: options.input.environmentId,
+      environmentId: entry.target.environmentId,
       label,
       httpBaseUrl,
       wsBaseUrl: deriveWsBaseUrl(httpBaseUrl),
@@ -248,6 +285,7 @@ export const make = Effect.gen(function* () {
   const httpClient = yield* HttpClient.HttpClient;
   const ssh = yield* ClientCapabilities.SshEnvironmentGateway;
   const credentials = yield* ConnectionCredentialStore.ConnectionCredentialStore;
+  const crypto = yield* Crypto.Crypto;
 
   return ConnectionOnboarding.of({
     registerPairing: (input) =>
@@ -255,6 +293,7 @@ export const make = Effect.gen(function* () {
         Effect.provideService(EnvironmentRegistry.EnvironmentRegistry, registry),
         Effect.provideService(ClientCapabilities.ClientPresentation, presentation),
         Effect.provideService(HttpClient.HttpClient, httpClient),
+        Effect.provideService(Crypto.Crypto, crypto),
       ),
     registerSsh: (input) =>
       registerSshConnection(input).pipe(

--- a/packages/client-runtime/src/connection/registry.test.ts
+++ b/packages/client-runtime/src/connection/registry.test.ts
@@ -133,6 +133,9 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
     readonly beforeRegistrationRegister?: (
       registration: ConnectionRegistration,
     ) => Effect.Effect<void, Persistence.ConnectionPersistenceError>;
+    readonly beforeRegistrationActivate?: (
+      target: ConnectionTarget,
+    ) => Effect.Effect<void, Persistence.ConnectionPersistenceError>;
     readonly beforeRegistrationRemove?: (
       target: ConnectionTarget,
     ) => Effect.Effect<void, Persistence.ConnectionPersistenceError>;
@@ -175,50 +178,70 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
   const targetStore = Persistence.ConnectionTargetStore.of({
     list: Ref.get(storedTargets).pipe(Effect.map((targets) => [...targets.values()])),
   });
+  const persistRegistration = (registration: ConnectionRegistration) =>
+    Effect.gen(function* () {
+      yield* Ref.update(storedTargets, (current) => {
+        const next = new Map(current);
+        next.delete(connectionTargetId(registration.target));
+        next.set(connectionTargetId(registration.target), registration.target);
+        return next;
+      });
+      switch (registration._tag) {
+        case "RelayConnectionRegistration":
+          return;
+        case "BearerConnectionRegistration":
+          yield* Ref.update(storedProfiles, (current) => {
+            const next = new Map(current);
+            next.set(registration.profile.connectionId, registration.profile);
+            return next;
+          });
+          yield* Ref.update(storedCredentials, (current) => {
+            const next = new Map(current);
+            next.set(registration.target.connectionId, registration.credential);
+            return next;
+          });
+          return;
+        case "SshConnectionRegistration":
+          yield* Ref.update(storedProfiles, (current) => {
+            const next = new Map(current);
+            next.set(registration.profile.connectionId, registration.profile);
+            return next;
+          });
+      }
+    });
+  const persistActivation = (target: ConnectionTarget) =>
+    Ref.update(storedTargets, (current) => {
+      const next = new Map(current);
+      next.delete(connectionTargetId(target));
+      next.set(connectionTargetId(target), target);
+      return next;
+    });
   const registrationStore = Persistence.ConnectionRegistrationStore.of({
     retainsSiblingRoutes: true,
     register: (registration) =>
       Effect.gen(function* () {
         yield* options?.beforeRegistrationRegister?.(registration) ?? Effect.void;
-        yield* Ref.update(storedTargets, (current) => {
-          const next = new Map(current);
-          next.delete(connectionTargetId(registration.target));
-          next.set(connectionTargetId(registration.target), registration.target);
-          return next;
-        });
-        switch (registration._tag) {
-          case "RelayConnectionRegistration":
-            return;
-          case "BearerConnectionRegistration":
-            yield* Ref.update(storedProfiles, (current) => {
-              const next = new Map(current);
-              next.set(registration.profile.connectionId, registration.profile);
-              return next;
-            });
-            yield* Ref.update(storedCredentials, (current) => {
-              const next = new Map(current);
-              next.set(registration.target.connectionId, registration.credential);
-              return next;
-            });
-            return;
-          case "SshConnectionRegistration":
-            yield* Ref.update(storedProfiles, (current) => {
-              const next = new Map(current);
-              next.set(registration.profile.connectionId, registration.profile);
-              return next;
-            });
+        yield* persistRegistration(registration);
+      }),
+    update: (registration, activeTarget) =>
+      Effect.gen(function* () {
+        if (activeTarget !== undefined) {
+          yield* options?.beforeRegistrationActivate?.(activeTarget) ?? Effect.void;
         }
+        yield* persistRegistration(registration);
+        if (activeTarget !== undefined) yield* persistActivation(activeTarget);
       }),
     activate: (target) =>
-      Ref.update(storedTargets, (current) => {
-        const next = new Map(current);
-        next.delete(connectionTargetId(target));
-        next.set(connectionTargetId(target), target);
-        return next;
+      Effect.gen(function* () {
+        yield* options?.beforeRegistrationActivate?.(target) ?? Effect.void;
+        yield* persistActivation(target);
       }),
-    remove: (target) =>
+    remove: (target, nextActiveTarget) =>
       Effect.gen(function* () {
         yield* options?.beforeRegistrationRemove?.(target) ?? Effect.void;
+        if (nextActiveTarget !== undefined) {
+          yield* options?.beforeRegistrationActivate?.(nextActiveTarget) ?? Effect.void;
+        }
         yield* Ref.update(storedTargets, (current) => {
           const next = new Map(current);
           next.delete(connectionTargetId(target));
@@ -246,6 +269,7 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
             return next;
           });
         }
+        if (nextActiveTarget !== undefined) yield* persistActivation(nextActiveTarget);
       }),
   });
   const cacheStore = Persistence.EnvironmentCacheStore.of({
@@ -727,6 +751,159 @@ describe("EnvironmentRegistry", () => {
           (yield* SubscriptionRef.get(registry.entries)).has(BEARER_TARGET.environmentId),
         ).toBe(false);
         expect(yield* Ref.get(harness.cacheClears)).toEqual([BEARER_TARGET.environmentId]);
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+    }),
+  );
+
+  it.effect("leaves an inactive route unchanged when its durable update fails", () =>
+    Effect.gen(function* () {
+      const secondTarget = new BearerConnectionTarget({
+        environmentId: BEARER_TARGET.environmentId,
+        label: "Office route",
+        connectionId: "bearer-connection-office",
+      });
+      const secondProfile = new BearerConnectionProfile({
+        connectionId: secondTarget.connectionId,
+        environmentId: secondTarget.environmentId,
+        label: secondTarget.label,
+        httpBaseUrl: "http://192.168.50.10:3773",
+        wsBaseUrl: "ws://192.168.50.10:3773",
+      });
+      const officeCredential = new BearerConnectionCredential({ token: "office-token" });
+      const persistenceError = new Persistence.ConnectionPersistenceError({
+        operation: "register-connection",
+        message: "Could not preserve the active route.",
+      });
+      const harness = yield* makeHarness(
+        [secondTarget, BEARER_TARGET],
+        [secondProfile, BEARER_PROFILE],
+        [
+          [secondTarget.connectionId, officeCredential],
+          [BEARER_TARGET.connectionId, BEARER_CREDENTIAL],
+        ],
+        { beforeRegistrationActivate: () => Effect.fail(persistenceError) },
+      );
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        const updatedTarget = new BearerConnectionTarget({
+          ...secondTarget,
+          label: "Renamed office route",
+        });
+        const error = yield* registry
+          .update(
+            new BearerConnectionRegistration({
+              target: updatedTarget,
+              profile: new BearerConnectionProfile({
+                ...secondProfile,
+                label: updatedTarget.label,
+              }),
+              credential: new BearerConnectionCredential({ token: "updated-office-token" }),
+            }),
+          )
+          .pipe(Effect.flip);
+
+        expect(error).toEqual(persistenceError);
+        expect((yield* Ref.get(harness.storedTargets)).get(secondTarget.connectionId)).toEqual(
+          secondTarget,
+        );
+        expect((yield* Ref.get(harness.storedProfiles)).get(secondTarget.connectionId)).toEqual(
+          secondProfile,
+        );
+        expect((yield* Ref.get(harness.storedCredentials)).get(secondTarget.connectionId)).toEqual(
+          officeCredential,
+        );
+        expect(
+          (yield* SubscriptionRef.get(registry.connections)).get(secondTarget.connectionId)?.target,
+        ).toEqual(secondTarget);
+        expect(
+          (yield* SubscriptionRef.get(registry.entries)).get(BEARER_TARGET.environmentId)?.target,
+        ).toEqual(BEARER_TARGET);
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+    }),
+  );
+
+  it.effect("leaves an active route installed when durable failover removal fails", () =>
+    Effect.gen(function* () {
+      const secondTarget = new BearerConnectionTarget({
+        environmentId: BEARER_TARGET.environmentId,
+        label: "Office route",
+        connectionId: "bearer-connection-office",
+      });
+      const secondProfile = new BearerConnectionProfile({
+        connectionId: secondTarget.connectionId,
+        environmentId: secondTarget.environmentId,
+        label: secondTarget.label,
+        httpBaseUrl: "http://192.168.50.10:3773",
+        wsBaseUrl: "ws://192.168.50.10:3773",
+      });
+      const persistenceError = new Persistence.ConnectionPersistenceError({
+        operation: "register-connection",
+        message: "Could not persist the replacement route.",
+      });
+      const harness = yield* makeHarness(
+        [secondTarget, BEARER_TARGET],
+        [secondProfile, BEARER_PROFILE],
+        [
+          [secondTarget.connectionId, new BearerConnectionCredential({ token: "office-token" })],
+          [BEARER_TARGET.connectionId, BEARER_CREDENTIAL],
+        ],
+        { beforeRegistrationActivate: () => Effect.fail(persistenceError) },
+      );
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        const error = yield* registry
+          .removeConnection(BEARER_TARGET.connectionId)
+          .pipe(Effect.flip);
+
+        expect(error).toEqual(persistenceError);
+        expect([...(yield* Ref.get(harness.storedTargets)).values()]).toEqual([
+          secondTarget,
+          BEARER_TARGET,
+        ]);
+        expect([...(yield* SubscriptionRef.get(registry.connections)).keys()]).toEqual([
+          secondTarget.connectionId,
+          BEARER_TARGET.connectionId,
+        ]);
+        expect(
+          (yield* SubscriptionRef.get(registry.entries)).get(BEARER_TARGET.environmentId)?.target,
+        ).toEqual(BEARER_TARGET);
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+    }),
+  );
+
+  it.effect("deduplicates concurrent bearer registrations for the same address", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness([]);
+      const registrations = ["first", "second"].map((suffix) => {
+        const target = new BearerConnectionTarget({
+          environmentId: BEARER_TARGET.environmentId,
+          label: `Bearer route ${suffix}`,
+          connectionId: `bearer-connection-${suffix}`,
+        });
+        return new BearerConnectionRegistration({
+          target,
+          profile: new BearerConnectionProfile({
+            connectionId: target.connectionId,
+            environmentId: target.environmentId,
+            label: target.label,
+            httpBaseUrl: BEARER_PROFILE.httpBaseUrl,
+            wsBaseUrl: BEARER_PROFILE.wsBaseUrl,
+          }),
+          credential: new BearerConnectionCredential({ token: `${suffix}-token` }),
+        });
+      });
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        yield* Effect.forEach(registrations, registry.register, {
+          concurrency: "unbounded",
+          discard: true,
+        });
+
+        expect(yield* SubscriptionRef.get(registry.connections)).toHaveLength(1);
+        expect(yield* Ref.get(harness.storedTargets)).toHaveLength(1);
       }).pipe(Effect.provide(harness.layer), Effect.scoped);
     }),
   );

--- a/packages/client-runtime/src/connection/registry.test.ts
+++ b/packages/client-runtime/src/connection/registry.test.ts
@@ -36,6 +36,7 @@ import {
   PrimaryConnectionTarget,
   RelayConnectionTarget,
   SshConnectionTarget,
+  connectionTargetId,
   type ConnectionTarget,
   type PreparedConnection,
   type SupervisorConnectionState,
@@ -138,7 +139,7 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
   },
 ) {
   const storedTargets = yield* Ref.make(
-    new Map(initialTargets.map((target) => [target.environmentId, target])),
+    new Map(initialTargets.map((target) => [connectionTargetId(target), target])),
   );
   const shellCache = yield* Ref.make(new Map([[TARGET.environmentId, CACHED_SNAPSHOT]]));
   const cacheClears = yield* Ref.make<ReadonlyArray<EnvironmentId>>([]);
@@ -175,12 +176,14 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
     list: Ref.get(storedTargets).pipe(Effect.map((targets) => [...targets.values()])),
   });
   const registrationStore = Persistence.ConnectionRegistrationStore.of({
+    retainsSiblingRoutes: true,
     register: (registration) =>
       Effect.gen(function* () {
         yield* options?.beforeRegistrationRegister?.(registration) ?? Effect.void;
         yield* Ref.update(storedTargets, (current) => {
           const next = new Map(current);
-          next.set(registration.target.environmentId, registration.target);
+          next.delete(connectionTargetId(registration.target));
+          next.set(connectionTargetId(registration.target), registration.target);
           return next;
         });
         switch (registration._tag) {
@@ -206,12 +209,19 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
             });
         }
       }),
+    activate: (target) =>
+      Ref.update(storedTargets, (current) => {
+        const next = new Map(current);
+        next.delete(connectionTargetId(target));
+        next.set(connectionTargetId(target), target);
+        return next;
+      }),
     remove: (target) =>
       Effect.gen(function* () {
         yield* options?.beforeRegistrationRemove?.(target) ?? Effect.void;
         yield* Ref.update(storedTargets, (current) => {
           const next = new Map(current);
-          next.delete(target.environmentId);
+          next.delete(connectionTargetId(target));
           return next;
         });
         if (target._tag === "BearerConnectionTarget" || target._tag === "SshConnectionTarget") {
@@ -226,11 +236,16 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
             return next;
           });
         }
-        yield* Ref.update(storedRemoteTokens, (current) => {
-          const next = new Map(current);
-          next.delete(target.environmentId);
-          return next;
-        });
+        const hasSiblingRoute = [...(yield* Ref.get(storedTargets)).values()].some(
+          (candidate) => candidate.environmentId === target.environmentId,
+        );
+        if (!hasSiblingRoute) {
+          yield* Ref.update(storedRemoteTokens, (current) => {
+            const next = new Map(current);
+            next.delete(target.environmentId);
+            return next;
+          });
+        }
       }),
   });
   const cacheStore = Persistence.EnvironmentCacheStore.of({
@@ -566,7 +581,7 @@ describe("EnvironmentRegistry", () => {
         );
 
         yield* registry.remove(TARGET.environmentId);
-        expect((yield* Ref.get(harness.storedTargets)).has(TARGET.environmentId)).toBe(false);
+        expect((yield* Ref.get(harness.storedTargets)).has(connectionTargetId(TARGET))).toBe(false);
         expect((yield* Ref.get(harness.shellCache)).has(TARGET.environmentId)).toBe(false);
         expect(yield* Ref.get(harness.cacheClears)).toEqual([TARGET.environmentId]);
         expect((yield* SubscriptionRef.get(registry.entries)).has(TARGET.environmentId)).toBe(
@@ -589,11 +604,180 @@ describe("EnvironmentRegistry", () => {
           (state) => state.phase === "connected",
         );
 
-        expect((yield* Ref.get(harness.storedTargets)).get(RELAY_TARGET.environmentId)).toEqual(
-          RELAY_TARGET,
-        );
+        expect(
+          (yield* Ref.get(harness.storedTargets)).get(connectionTargetId(RELAY_TARGET)),
+        ).toEqual(RELAY_TARGET);
         expect(yield* Ref.get(harness.sessions)).toHaveLength(1);
       }).pipe(Effect.provide(harness.layer));
+    }),
+  );
+
+  it.effect("keeps multiple saved routes while running one active environment", () =>
+    Effect.gen(function* () {
+      const secondTarget = new BearerConnectionTarget({
+        environmentId: BEARER_TARGET.environmentId,
+        label: "Bearer environment on office Wi-Fi",
+        connectionId: "bearer-connection-office",
+      });
+      const secondProfile = new BearerConnectionProfile({
+        connectionId: secondTarget.connectionId,
+        environmentId: secondTarget.environmentId,
+        label: secondTarget.label,
+        httpBaseUrl: "http://192.168.50.10:3773",
+        wsBaseUrl: "ws://192.168.50.10:3773",
+      });
+      const harness = yield* makeHarness(
+        [BEARER_TARGET],
+        [BEARER_PROFILE],
+        [[BEARER_TARGET.connectionId, BEARER_CREDENTIAL]],
+      );
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        yield* registry.register(
+          new BearerConnectionRegistration({
+            target: secondTarget,
+            profile: secondProfile,
+            credential: new BearerConnectionCredential({ token: "office-token" }),
+          }),
+        );
+
+        expect([...(yield* SubscriptionRef.get(registry.connections)).keys()]).toEqual([
+          BEARER_TARGET.connectionId,
+          secondTarget.connectionId,
+        ]);
+        expect(
+          (yield* SubscriptionRef.get(registry.entries)).get(BEARER_TARGET.environmentId)?.target,
+        ).toEqual(secondTarget);
+        expect([...(yield* Ref.get(harness.storedTargets)).values()]).toEqual([
+          BEARER_TARGET,
+          secondTarget,
+        ]);
+
+        yield* registry.activate(BEARER_TARGET.connectionId);
+        expect(
+          (yield* SubscriptionRef.get(registry.entries)).get(BEARER_TARGET.environmentId)?.target,
+        ).toEqual(BEARER_TARGET);
+        expect([...(yield* Ref.get(harness.storedTargets)).values()]).toEqual([
+          secondTarget,
+          BEARER_TARGET,
+        ]);
+
+        const updatedSecondTarget = new BearerConnectionTarget({
+          ...secondTarget,
+          label: "Renamed office route",
+        });
+        yield* registry.update(
+          new BearerConnectionRegistration({
+            target: updatedSecondTarget,
+            profile: new BearerConnectionProfile({
+              ...secondProfile,
+              label: updatedSecondTarget.label,
+            }),
+            credential: new BearerConnectionCredential({ token: "updated-office-token" }),
+          }),
+        );
+        expect([...(yield* SubscriptionRef.get(registry.connections)).keys()]).toEqual([
+          secondTarget.connectionId,
+          BEARER_TARGET.connectionId,
+        ]);
+        expect([...(yield* Ref.get(harness.storedTargets)).values()]).toEqual([
+          updatedSecondTarget,
+          BEARER_TARGET,
+        ]);
+        expect(
+          (yield* SubscriptionRef.get(registry.entries)).get(BEARER_TARGET.environmentId)?.target,
+        ).toEqual(BEARER_TARGET);
+
+        const updatedHomeTarget = new BearerConnectionTarget({
+          ...BEARER_TARGET,
+          label: "Renamed home route",
+        });
+        yield* registry.update(
+          new BearerConnectionRegistration({
+            target: updatedHomeTarget,
+            profile: new BearerConnectionProfile({
+              ...BEARER_PROFILE,
+              label: updatedHomeTarget.label,
+            }),
+            credential: BEARER_CREDENTIAL,
+          }),
+        );
+        expect([...(yield* SubscriptionRef.get(registry.connections)).keys()]).toEqual([
+          secondTarget.connectionId,
+          BEARER_TARGET.connectionId,
+        ]);
+        expect([...(yield* Ref.get(harness.storedTargets)).values()]).toEqual([
+          updatedSecondTarget,
+          updatedHomeTarget,
+        ]);
+        expect(
+          (yield* SubscriptionRef.get(registry.entries)).get(BEARER_TARGET.environmentId)?.target,
+        ).toEqual(updatedHomeTarget);
+
+        yield* registry.removeConnection(secondTarget.connectionId);
+        expect(
+          (yield* SubscriptionRef.get(registry.connections)).has(secondTarget.connectionId),
+        ).toBe(false);
+        expect([...(yield* Ref.get(harness.storedTargets)).values()]).toEqual([updatedHomeTarget]);
+        expect(yield* Ref.get(harness.cacheClears)).toEqual([]);
+
+        yield* registry.removeConnection(BEARER_TARGET.connectionId);
+        expect(
+          (yield* SubscriptionRef.get(registry.entries)).has(BEARER_TARGET.environmentId),
+        ).toBe(false);
+        expect(yield* Ref.get(harness.cacheClears)).toEqual([BEARER_TARGET.environmentId]);
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+    }),
+  );
+
+  it.effect("removes every route without connecting to an intermediate failover", () =>
+    Effect.gen(function* () {
+      const secondTarget = new BearerConnectionTarget({
+        environmentId: BEARER_TARGET.environmentId,
+        label: "Second bearer route",
+        connectionId: "bearer-connection-second",
+      });
+      const secondProfile = new BearerConnectionProfile({
+        connectionId: secondTarget.connectionId,
+        environmentId: secondTarget.environmentId,
+        label: secondTarget.label,
+        httpBaseUrl: "http://192.168.50.10:3773",
+        wsBaseUrl: "ws://192.168.50.10:3773",
+      });
+      const harness = yield* makeHarness(
+        [BEARER_TARGET, secondTarget],
+        [BEARER_PROFILE, secondProfile],
+        [
+          [BEARER_TARGET.connectionId, BEARER_CREDENTIAL],
+          [secondTarget.connectionId, new BearerConnectionCredential({ token: "second-token" })],
+        ],
+      );
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        yield* registry.activate(BEARER_TARGET.connectionId);
+        const sessionsBeforeRemoval = (yield* Ref.get(harness.sessions)).length;
+
+        yield* Effect.acquireUseRelease(
+          Effect.sync(() => {
+            const descriptor = Object.getOwnPropertyDescriptor(Array.prototype, "toSorted");
+            Reflect.deleteProperty(Array.prototype, "toSorted");
+            return descriptor;
+          }),
+          () => registry.remove(BEARER_TARGET.environmentId),
+          (descriptor) =>
+            Effect.sync(() => {
+              if (descriptor !== undefined) {
+                Reflect.defineProperty(Array.prototype, "toSorted", descriptor);
+              }
+            }),
+        );
+
+        expect(yield* Ref.get(harness.sessions)).toHaveLength(sessionsBeforeRemoval);
+        expect((yield* Ref.get(harness.storedTargets)).size).toBe(0);
+        expect(yield* Ref.get(harness.cacheClears)).toEqual([BEARER_TARGET.environmentId]);
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
     }),
   );
 
@@ -677,9 +861,9 @@ describe("EnvironmentRegistry", () => {
         yield* registry.removeRelayEnvironments();
 
         const targets = yield* Ref.get(harness.storedTargets);
-        expect(targets.has(RELAY_TARGET.environmentId)).toBe(false);
-        expect(targets.has(SECOND_RELAY_TARGET.environmentId)).toBe(false);
-        expect(targets.get(BEARER_TARGET.environmentId)).toEqual(BEARER_TARGET);
+        expect(targets.has(connectionTargetId(RELAY_TARGET))).toBe(false);
+        expect(targets.has(connectionTargetId(SECOND_RELAY_TARGET))).toBe(false);
+        expect(targets.get(connectionTargetId(BEARER_TARGET))).toEqual(BEARER_TARGET);
         expect(yield* Ref.get(harness.cacheClears)).toEqual(
           expect.arrayContaining([RELAY_TARGET.environmentId, SECOND_RELAY_TARGET.environmentId]),
         );
@@ -721,7 +905,9 @@ describe("EnvironmentRegistry", () => {
         expect((yield* SubscriptionRef.get(registry.entries)).has(RELAY_TARGET.environmentId)).toBe(
           true,
         );
-        expect((yield* Ref.get(harness.storedTargets)).has(RELAY_TARGET.environmentId)).toBe(true);
+        expect((yield* Ref.get(harness.storedTargets)).has(connectionTargetId(RELAY_TARGET))).toBe(
+          true,
+        );
         expect(yield* Ref.get(harness.cacheClears)).toEqual([]);
         expect(yield* Ref.get(harness.ownedDataClears)).toEqual([]);
       }).pipe(Effect.provide(harness.layer), Effect.scoped);
@@ -771,7 +957,7 @@ describe("EnvironmentRegistry", () => {
           (state) => state.phase === "connected",
         );
 
-        expect((yield* Ref.get(harness.storedTargets)).has(TARGET.environmentId)).toBe(false);
+        expect((yield* Ref.get(harness.storedTargets)).has(connectionTargetId(TARGET))).toBe(false);
         expect(
           (yield* SubscriptionRef.get(registry.entries)).get(TARGET.environmentId)?.target,
         ).toEqual(TARGET);
@@ -800,14 +986,14 @@ describe("EnvironmentRegistry", () => {
         expect(
           (yield* SubscriptionRef.get(registry.entries)).get(TARGET.environmentId)?.target,
         ).toEqual(TARGET);
-        expect((yield* Ref.get(harness.storedTargets)).has(TARGET.environmentId)).toBe(false);
+        expect((yield* Ref.get(harness.storedTargets)).has(connectionTargetId(TARGET))).toBe(false);
 
         yield* registry.register(new RelayConnectionRegistration({ target: shadowedTarget }));
 
         expect(
           (yield* SubscriptionRef.get(registry.entries)).get(TARGET.environmentId)?.target,
         ).toEqual(TARGET);
-        expect((yield* Ref.get(harness.storedTargets)).has(TARGET.environmentId)).toBe(false);
+        expect((yield* Ref.get(harness.storedTargets)).has(connectionTargetId(TARGET))).toBe(false);
       }).pipe(Effect.provide(harness.layer), Effect.scoped);
     }),
   );

--- a/packages/client-runtime/src/connection/registry.test.ts
+++ b/packages/client-runtime/src/connection/registry.test.ts
@@ -121,6 +121,7 @@ const CACHED_SNAPSHOT: OrchestrationShellSnapshot = {
 };
 
 interface SessionControl {
+  readonly connectionId: string;
   readonly closed: Deferred.Deferred<never, ConnectionTransientError>;
 }
 
@@ -129,12 +130,10 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
   initialProfiles: ReadonlyArray<ConnectionProfile> = [],
   initialCredentials: ReadonlyArray<readonly [string, ConnectionCredential]> = [],
   options?: {
+    readonly retainsSiblingRoutes?: boolean;
     readonly beforeSessionConnect?: (environmentId: EnvironmentId) => Effect.Effect<void>;
     readonly beforeRegistrationRegister?: (
       registration: ConnectionRegistration,
-    ) => Effect.Effect<void, Persistence.ConnectionPersistenceError>;
-    readonly beforeRegistrationActivate?: (
-      target: ConnectionTarget,
     ) => Effect.Effect<void, Persistence.ConnectionPersistenceError>;
     readonly beforeRegistrationRemove?: (
       target: ConnectionTarget,
@@ -209,39 +208,21 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
           });
       }
     });
-  const persistActivation = (target: ConnectionTarget) =>
-    Ref.update(storedTargets, (current) => {
-      const next = new Map(current);
-      next.delete(connectionTargetId(target));
-      next.set(connectionTargetId(target), target);
-      return next;
-    });
   const registrationStore = Persistence.ConnectionRegistrationStore.of({
-    retainsSiblingRoutes: true,
+    retainsSiblingRoutes: options?.retainsSiblingRoutes ?? true,
     register: (registration) =>
       Effect.gen(function* () {
         yield* options?.beforeRegistrationRegister?.(registration) ?? Effect.void;
         yield* persistRegistration(registration);
       }),
-    update: (registration, activeTarget) =>
+    update: (registration) =>
       Effect.gen(function* () {
-        if (activeTarget !== undefined) {
-          yield* options?.beforeRegistrationActivate?.(activeTarget) ?? Effect.void;
-        }
+        yield* options?.beforeRegistrationRegister?.(registration) ?? Effect.void;
         yield* persistRegistration(registration);
-        if (activeTarget !== undefined) yield* persistActivation(activeTarget);
       }),
-    activate: (target) =>
-      Effect.gen(function* () {
-        yield* options?.beforeRegistrationActivate?.(target) ?? Effect.void;
-        yield* persistActivation(target);
-      }),
-    remove: (target, nextActiveTarget) =>
+    remove: (target) =>
       Effect.gen(function* () {
         yield* options?.beforeRegistrationRemove?.(target) ?? Effect.void;
-        if (nextActiveTarget !== undefined) {
-          yield* options?.beforeRegistrationActivate?.(nextActiveTarget) ?? Effect.void;
-        }
         yield* Ref.update(storedTargets, (current) => {
           const next = new Map(current);
           next.delete(connectionTargetId(target));
@@ -269,7 +250,6 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
             return next;
           });
         }
-        if (nextActiveTarget !== undefined) yield* persistActivation(nextActiveTarget);
       }),
   });
   const cacheStore = Persistence.EnvironmentCacheStore.of({
@@ -386,7 +366,10 @@ const makeHarness = Effect.fn("TestEnvironmentRegistry.makeHarness")(function* (
         yield* reportProgress({ stage: "opening", prepared });
         yield* options?.beforeSessionConnect?.(target.environmentId) ?? Effect.void;
         const closed = yield* Deferred.make<never, ConnectionTransientError>();
-        yield* Ref.update(sessions, (current) => [...current, { closed }]);
+        yield* Ref.update(sessions, (current) => [
+          ...current,
+          { connectionId: connectionTargetId(target), closed },
+        ]);
         const session = yield* Effect.acquireRelease(
           Effect.succeed({
             client: {} as RpcSession.RpcSession["client"],
@@ -454,6 +437,22 @@ function awaitConnectionState(
     }
     return yield* registry
       .stateChanges(environmentId)
+      .pipe(Stream.filter(predicate), Stream.runHead, Effect.map(Option.getOrThrow));
+  });
+}
+
+function awaitSavedConnectionState(
+  registry: EnvironmentRegistry.EnvironmentRegistry["Service"],
+  connectionId: string,
+  predicate: (state: SupervisorConnectionState) => boolean,
+) {
+  return Effect.gen(function* () {
+    const current = yield* registry.connectionState(connectionId);
+    if (predicate(current)) {
+      return current;
+    }
+    return yield* registry
+      .connectionStateChanges(connectionId)
       .pipe(Stream.filter(predicate), Stream.runHead, Effect.map(Option.getOrThrow));
   });
 }
@@ -636,7 +635,7 @@ describe("EnvironmentRegistry", () => {
     }),
   );
 
-  it.effect("keeps multiple saved routes while running one active environment", () =>
+  it.effect("updates and removes same-environment connections independently", () =>
     Effect.gen(function* () {
       const secondTarget = new BearerConnectionTarget({
         environmentId: BEARER_TARGET.environmentId,
@@ -658,6 +657,7 @@ describe("EnvironmentRegistry", () => {
 
       yield* Effect.gen(function* () {
         const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        yield* registry.start;
         yield* registry.register(
           new BearerConnectionRegistration({
             target: secondTarget,
@@ -665,26 +665,25 @@ describe("EnvironmentRegistry", () => {
             credential: new BearerConnectionCredential({ token: "office-token" }),
           }),
         );
+        yield* Effect.all(
+          [BEARER_TARGET.connectionId, secondTarget.connectionId].map((connectionId) =>
+            awaitSavedConnectionState(
+              registry,
+              connectionId,
+              (state) => state.phase === "connected",
+            ),
+          ),
+          { concurrency: "unbounded" },
+        );
 
         expect([...(yield* SubscriptionRef.get(registry.connections)).keys()]).toEqual([
           BEARER_TARGET.connectionId,
           secondTarget.connectionId,
         ]);
-        expect(
-          (yield* SubscriptionRef.get(registry.entries)).get(BEARER_TARGET.environmentId)?.target,
-        ).toEqual(secondTarget);
+        expect(yield* Ref.get(harness.sessions)).toHaveLength(2);
         expect([...(yield* Ref.get(harness.storedTargets)).values()]).toEqual([
           BEARER_TARGET,
           secondTarget,
-        ]);
-
-        yield* registry.activate(BEARER_TARGET.connectionId);
-        expect(
-          (yield* SubscriptionRef.get(registry.entries)).get(BEARER_TARGET.environmentId)?.target,
-        ).toEqual(BEARER_TARGET);
-        expect([...(yield* Ref.get(harness.storedTargets)).values()]).toEqual([
-          secondTarget,
-          BEARER_TARGET,
         ]);
 
         const updatedSecondTarget = new BearerConnectionTarget({
@@ -701,17 +700,12 @@ describe("EnvironmentRegistry", () => {
             credential: new BearerConnectionCredential({ token: "updated-office-token" }),
           }),
         );
-        expect([...(yield* SubscriptionRef.get(registry.connections)).keys()]).toEqual([
-          secondTarget.connectionId,
-          BEARER_TARGET.connectionId,
-        ]);
-        expect([...(yield* Ref.get(harness.storedTargets)).values()]).toEqual([
-          updatedSecondTarget,
-          BEARER_TARGET,
-        ]);
         expect(
-          (yield* SubscriptionRef.get(registry.entries)).get(BEARER_TARGET.environmentId)?.target,
-        ).toEqual(BEARER_TARGET);
+          (yield* SubscriptionRef.get(registry.connections)).get(secondTarget.connectionId)?.target,
+        ).toEqual(updatedSecondTarget);
+        expect((yield* Ref.get(harness.storedTargets)).get(secondTarget.connectionId)).toEqual(
+          updatedSecondTarget,
+        );
 
         const updatedHomeTarget = new BearerConnectionTarget({
           ...BEARER_TARGET,
@@ -727,17 +721,13 @@ describe("EnvironmentRegistry", () => {
             credential: BEARER_CREDENTIAL,
           }),
         );
-        expect([...(yield* SubscriptionRef.get(registry.connections)).keys()]).toEqual([
-          secondTarget.connectionId,
-          BEARER_TARGET.connectionId,
-        ]);
-        expect([...(yield* Ref.get(harness.storedTargets)).values()]).toEqual([
-          updatedSecondTarget,
-          updatedHomeTarget,
-        ]);
         expect(
-          (yield* SubscriptionRef.get(registry.entries)).get(BEARER_TARGET.environmentId)?.target,
+          (yield* SubscriptionRef.get(registry.connections)).get(BEARER_TARGET.connectionId)
+            ?.target,
         ).toEqual(updatedHomeTarget);
+        expect((yield* Ref.get(harness.storedTargets)).get(BEARER_TARGET.connectionId)).toEqual(
+          updatedHomeTarget,
+        );
 
         yield* registry.removeConnection(secondTarget.connectionId);
         expect(
@@ -755,7 +745,284 @@ describe("EnvironmentRegistry", () => {
     }),
   );
 
-  it.effect("leaves an inactive route unchanged when its durable update fails", () =>
+  it.effect("starts same-environment connections independently", () =>
+    Effect.gen(function* () {
+      const secondTarget = new BearerConnectionTarget({
+        environmentId: BEARER_TARGET.environmentId,
+        label: "Bearer environment on office Wi-Fi",
+        connectionId: "bearer-connection-office",
+      });
+      const secondProfile = new BearerConnectionProfile({
+        connectionId: secondTarget.connectionId,
+        environmentId: secondTarget.environmentId,
+        label: secondTarget.label,
+        httpBaseUrl: "http://192.168.50.10:3773",
+        wsBaseUrl: "ws://192.168.50.10:3773",
+      });
+      const harness = yield* makeHarness(
+        [BEARER_TARGET, secondTarget],
+        [BEARER_PROFILE, secondProfile],
+        [
+          [BEARER_TARGET.connectionId, BEARER_CREDENTIAL],
+          [secondTarget.connectionId, new BearerConnectionCredential({ token: "office-token" })],
+        ],
+      );
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        yield* registry.start;
+        yield* Effect.all(
+          [BEARER_TARGET.connectionId, secondTarget.connectionId].map((connectionId) =>
+            awaitSavedConnectionState(
+              registry,
+              connectionId,
+              (state) => state.phase === "connected",
+            ),
+          ),
+          { concurrency: "unbounded" },
+        );
+
+        expect(yield* Ref.get(harness.sessions)).toHaveLength(2);
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+    }),
+  );
+
+  it.effect("moves a connection state stream to the supervisor created by an update", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness(
+        [BEARER_TARGET],
+        [BEARER_PROFILE],
+        [[BEARER_TARGET.connectionId, BEARER_CREDENTIAL]],
+      );
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        const firstConnected = yield* Deferred.make<void>();
+        const secondConnected = yield* Deferred.make<void>();
+        const connectedCount = yield* Ref.make(0);
+        const subscription = yield* registry
+          .connectionStateChanges(BEARER_TARGET.connectionId)
+          .pipe(
+            Stream.filter((state) => state.phase === "connected"),
+            Stream.runForEach(() =>
+              Ref.updateAndGet(connectedCount, (count) => count + 1).pipe(
+                Effect.flatMap((count) =>
+                  count === 1
+                    ? Deferred.succeed(firstConnected, undefined)
+                    : Deferred.succeed(secondConnected, undefined),
+                ),
+              ),
+            ),
+            Effect.forkChild,
+          );
+
+        yield* Deferred.await(firstConnected);
+        yield* registry.update(
+          new BearerConnectionRegistration({
+            target: new BearerConnectionTarget({
+              ...BEARER_TARGET,
+              label: "Updated bearer environment",
+            }),
+            profile: new BearerConnectionProfile({
+              ...BEARER_PROFILE,
+              label: "Updated bearer environment",
+              httpBaseUrl: "https://updated-bearer.example.test",
+              wsBaseUrl: "wss://updated-bearer.example.test",
+            }),
+            credential: BEARER_CREDENTIAL,
+          }),
+        );
+        yield* Deferred.await(secondConnected);
+        yield* Fiber.interrupt(subscription);
+
+        expect(yield* Ref.get(connectedCount)).toBe(2);
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+    }),
+  );
+
+  it.effect("closes a replaced connection for single-route clients", () =>
+    Effect.gen(function* () {
+      const replacementTarget = new BearerConnectionTarget({
+        environmentId: BEARER_TARGET.environmentId,
+        label: "Replacement bearer environment",
+        connectionId: "bearer-connection-replacement",
+      });
+      const replacementProfile = new BearerConnectionProfile({
+        connectionId: replacementTarget.connectionId,
+        environmentId: replacementTarget.environmentId,
+        label: replacementTarget.label,
+        httpBaseUrl: "http://192.168.50.10:3773",
+        wsBaseUrl: "ws://192.168.50.10:3773",
+      });
+      const harness = yield* makeHarness(
+        [BEARER_TARGET],
+        [BEARER_PROFILE],
+        [[BEARER_TARGET.connectionId, BEARER_CREDENTIAL]],
+        { retainsSiblingRoutes: false },
+      );
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        yield* registry.start;
+        yield* awaitSavedConnectionState(
+          registry,
+          BEARER_TARGET.connectionId,
+          (state) => state.phase === "connected",
+        );
+        yield* registry.register(
+          new BearerConnectionRegistration({
+            target: replacementTarget,
+            profile: replacementProfile,
+            credential: new BearerConnectionCredential({ token: "replacement-token" }),
+          }),
+        );
+        yield* awaitSavedConnectionState(
+          registry,
+          replacementTarget.connectionId,
+          (state) => state.phase === "connected",
+        );
+
+        expect([...(yield* SubscriptionRef.get(registry.connections)).keys()]).toEqual([
+          replacementTarget.connectionId,
+        ]);
+        expect(yield* Ref.get(harness.releasedSessions)).toBe(1);
+        expect(
+          (yield* SubscriptionRef.get(registry.entries)).get(BEARER_TARGET.environmentId)?.target,
+        ).toEqual(replacementTarget);
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+    }),
+  );
+
+  it.effect("keeps an environment connected through a healthy sibling connection", () =>
+    Effect.gen(function* () {
+      const secondTarget = new BearerConnectionTarget({
+        environmentId: BEARER_TARGET.environmentId,
+        label: "Bearer environment on office Wi-Fi",
+        connectionId: "bearer-connection-office",
+      });
+      const secondProfile = new BearerConnectionProfile({
+        connectionId: secondTarget.connectionId,
+        environmentId: secondTarget.environmentId,
+        label: secondTarget.label,
+        httpBaseUrl: "http://192.168.50.10:3773",
+        wsBaseUrl: "ws://192.168.50.10:3773",
+      });
+      const harness = yield* makeHarness(
+        [BEARER_TARGET, secondTarget],
+        [BEARER_PROFILE, secondProfile],
+        [
+          [BEARER_TARGET.connectionId, BEARER_CREDENTIAL],
+          [secondTarget.connectionId, new BearerConnectionCredential({ token: "office-token" })],
+        ],
+      );
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        yield* registry.start;
+        yield* Effect.all(
+          [BEARER_TARGET.connectionId, secondTarget.connectionId].map((connectionId) =>
+            awaitSavedConnectionState(
+              registry,
+              connectionId,
+              (state) => state.phase === "connected",
+            ),
+          ),
+          { concurrency: "unbounded" },
+        );
+        const selectedTarget = (yield* SubscriptionRef.get(registry.entries)).get(
+          BEARER_TARGET.environmentId,
+        )?.target;
+        expect(selectedTarget).toBeDefined();
+        const selectedConnectionId = connectionTargetId(selectedTarget!);
+        const siblingTarget =
+          selectedConnectionId === BEARER_TARGET.connectionId ? secondTarget : BEARER_TARGET;
+        const sessions = yield* Ref.get(harness.sessions);
+        const selectedSession = sessions.find(
+          (session) => session.connectionId === selectedConnectionId,
+        );
+        expect(selectedSession).toBeDefined();
+        yield* Deferred.fail(
+          selectedSession!.closed,
+          new ConnectionTransientError({
+            reason: "transport",
+            detail: "Selected network disconnected.",
+          }),
+        );
+        yield* awaitSavedConnectionState(
+          registry,
+          selectedConnectionId,
+          (state) => state.phase === "backoff",
+        );
+        const environmentState = yield* awaitConnectionState(
+          registry,
+          BEARER_TARGET.environmentId,
+          (state) => state.phase === "connected",
+        );
+
+        expect(environmentState.phase).toBe("connected");
+        expect(
+          (yield* SubscriptionRef.get(registry.entries)).get(BEARER_TARGET.environmentId)?.target,
+        ).toEqual(siblingTarget);
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+    }),
+  );
+
+  it.effect("retries only the requested same-environment connection", () =>
+    Effect.gen(function* () {
+      const secondTarget = new BearerConnectionTarget({
+        environmentId: BEARER_TARGET.environmentId,
+        label: "Bearer environment on office Wi-Fi",
+        connectionId: "bearer-connection-office",
+      });
+      const secondProfile = new BearerConnectionProfile({
+        connectionId: secondTarget.connectionId,
+        environmentId: secondTarget.environmentId,
+        label: secondTarget.label,
+        httpBaseUrl: "http://192.168.50.10:3773",
+        wsBaseUrl: "ws://192.168.50.10:3773",
+      });
+      const harness = yield* makeHarness(
+        [BEARER_TARGET, secondTarget],
+        [BEARER_PROFILE, secondProfile],
+        [
+          [BEARER_TARGET.connectionId, BEARER_CREDENTIAL],
+          [secondTarget.connectionId, new BearerConnectionCredential({ token: "office-token" })],
+        ],
+      );
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        yield* registry.start;
+        yield* Effect.all(
+          [BEARER_TARGET.connectionId, secondTarget.connectionId].map((connectionId) =>
+            awaitSavedConnectionState(
+              registry,
+              connectionId,
+              (state) => state.phase === "connected",
+            ),
+          ),
+          { concurrency: "unbounded" },
+        );
+
+        yield* registry.retryConnection(secondTarget.connectionId);
+        yield* awaitSavedConnectionState(
+          registry,
+          secondTarget.connectionId,
+          (state) => state.phase === "connected" && state.generation === 2,
+        );
+
+        const sessions = yield* Ref.get(harness.sessions);
+        expect(
+          sessions.filter((session) => session.connectionId === BEARER_TARGET.connectionId),
+        ).toHaveLength(1);
+        expect(
+          sessions.filter((session) => session.connectionId === secondTarget.connectionId),
+        ).toHaveLength(2);
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+    }),
+  );
+
+  it.effect("leaves a connection unchanged when its durable update fails", () =>
     Effect.gen(function* () {
       const secondTarget = new BearerConnectionTarget({
         environmentId: BEARER_TARGET.environmentId,
@@ -772,7 +1039,7 @@ describe("EnvironmentRegistry", () => {
       const officeCredential = new BearerConnectionCredential({ token: "office-token" });
       const persistenceError = new Persistence.ConnectionPersistenceError({
         operation: "register-connection",
-        message: "Could not preserve the active route.",
+        message: "Could not update the connection.",
       });
       const harness = yield* makeHarness(
         [secondTarget, BEARER_TARGET],
@@ -781,7 +1048,7 @@ describe("EnvironmentRegistry", () => {
           [secondTarget.connectionId, officeCredential],
           [BEARER_TARGET.connectionId, BEARER_CREDENTIAL],
         ],
-        { beforeRegistrationActivate: () => Effect.fail(persistenceError) },
+        { beforeRegistrationRegister: () => Effect.fail(persistenceError) },
       );
 
       yield* Effect.gen(function* () {
@@ -823,7 +1090,7 @@ describe("EnvironmentRegistry", () => {
     }),
   );
 
-  it.effect("leaves an active route installed when durable failover removal fails", () =>
+  it.effect("leaves a connection installed when durable removal fails", () =>
     Effect.gen(function* () {
       const secondTarget = new BearerConnectionTarget({
         environmentId: BEARER_TARGET.environmentId,
@@ -838,8 +1105,8 @@ describe("EnvironmentRegistry", () => {
         wsBaseUrl: "ws://192.168.50.10:3773",
       });
       const persistenceError = new Persistence.ConnectionPersistenceError({
-        operation: "register-connection",
-        message: "Could not persist the replacement route.",
+        operation: "remove-connection",
+        message: "Could not remove the connection.",
       });
       const harness = yield* makeHarness(
         [secondTarget, BEARER_TARGET],
@@ -848,7 +1115,7 @@ describe("EnvironmentRegistry", () => {
           [secondTarget.connectionId, new BearerConnectionCredential({ token: "office-token" })],
           [BEARER_TARGET.connectionId, BEARER_CREDENTIAL],
         ],
-        { beforeRegistrationActivate: () => Effect.fail(persistenceError) },
+        { beforeRegistrationRemove: () => Effect.fail(persistenceError) },
       );
 
       yield* Effect.gen(function* () {
@@ -908,6 +1175,58 @@ describe("EnvironmentRegistry", () => {
     }),
   );
 
+  it.effect("preserves concurrent registrations for different environments", () =>
+    Effect.gen(function* () {
+      const bothRegistrationsStarted = yield* Deferred.make<void>();
+      const startedCount = yield* Ref.make(0);
+      const targets = ["first", "second"].map(
+        (suffix) =>
+          new BearerConnectionTarget({
+            environmentId: EnvironmentId.make(`environment-${suffix}`),
+            label: `${suffix} environment`,
+            connectionId: `connection-${suffix}`,
+          }),
+      );
+      const harness = yield* makeHarness([], [], [], {
+        beforeRegistrationRegister: () =>
+          Ref.updateAndGet(startedCount, (count) => count + 1).pipe(
+            Effect.tap((count) =>
+              count === 2 ? Deferred.succeed(bothRegistrationsStarted, undefined) : Effect.void,
+            ),
+            Effect.andThen(Deferred.await(bothRegistrationsStarted)),
+          ),
+      });
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        yield* Effect.forEach(
+          targets,
+          (target) =>
+            registry.register(
+              new BearerConnectionRegistration({
+                target,
+                profile: new BearerConnectionProfile({
+                  connectionId: target.connectionId,
+                  environmentId: target.environmentId,
+                  label: target.label,
+                  httpBaseUrl: `http://${target.connectionId}.example.test:3773`,
+                  wsBaseUrl: `ws://${target.connectionId}.example.test:3773`,
+                }),
+                credential: new BearerConnectionCredential({
+                  token: `${target.connectionId}-token`,
+                }),
+              }),
+            ),
+          { concurrency: "unbounded", discard: true },
+        );
+
+        expect([...(yield* SubscriptionRef.get(registry.connections)).keys()].toSorted()).toEqual(
+          targets.map((target) => target.connectionId).toSorted(),
+        );
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+    }),
+  );
+
   it.effect("removes every route without connecting to an intermediate failover", () =>
     Effect.gen(function* () {
       const secondTarget = new BearerConnectionTarget({
@@ -933,7 +1252,6 @@ describe("EnvironmentRegistry", () => {
 
       yield* Effect.gen(function* () {
         const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
-        yield* registry.activate(BEARER_TARGET.connectionId);
         const sessionsBeforeRemoval = (yield* Ref.get(harness.sessions)).length;
 
         yield* Effect.acquireUseRelease(
@@ -1027,8 +1345,12 @@ describe("EnvironmentRegistry", () => {
 
   it.effect("removes all relay-owned data without touching non-cloud connections", () =>
     Effect.gen(function* () {
+      const siblingRelayTarget = new RelayConnectionTarget({
+        environmentId: BEARER_TARGET.environmentId,
+        label: "Bearer environment through T3 Connect",
+      });
       const harness = yield* makeHarness(
-        [RELAY_TARGET, SECOND_RELAY_TARGET, BEARER_TARGET],
+        [RELAY_TARGET, SECOND_RELAY_TARGET, siblingRelayTarget, BEARER_TARGET],
         [BEARER_PROFILE],
         [[BEARER_TARGET.connectionId, BEARER_CREDENTIAL]],
       );
@@ -1040,6 +1362,7 @@ describe("EnvironmentRegistry", () => {
         const targets = yield* Ref.get(harness.storedTargets);
         expect(targets.has(connectionTargetId(RELAY_TARGET))).toBe(false);
         expect(targets.has(connectionTargetId(SECOND_RELAY_TARGET))).toBe(false);
+        expect(targets.has(connectionTargetId(siblingRelayTarget))).toBe(false);
         expect(targets.get(connectionTargetId(BEARER_TARGET))).toEqual(BEARER_TARGET);
         expect(yield* Ref.get(harness.cacheClears)).toEqual(
           expect.arrayContaining([RELAY_TARGET.environmentId, SECOND_RELAY_TARGET.environmentId]),
@@ -1047,6 +1370,8 @@ describe("EnvironmentRegistry", () => {
         expect(yield* Ref.get(harness.ownedDataClears)).toEqual(
           expect.arrayContaining([RELAY_TARGET.environmentId, SECOND_RELAY_TARGET.environmentId]),
         );
+        expect(yield* Ref.get(harness.cacheClears)).not.toContain(BEARER_TARGET.environmentId);
+        expect(yield* Ref.get(harness.ownedDataClears)).not.toContain(BEARER_TARGET.environmentId);
         expect(
           (yield* SubscriptionRef.get(registry.entries)).has(BEARER_TARGET.environmentId),
         ).toBe(true);
@@ -1251,6 +1576,56 @@ describe("EnvironmentRegistry", () => {
         yield* Fiber.join(removal);
         const error = yield* Fiber.join(stateLookup);
         expect(error._tag).toBe("EnvironmentNotRegisteredError");
+      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+    }),
+  );
+
+  it.effect("does not resurrect a connection when an update loses a removal race", () =>
+    Effect.gen(function* () {
+      const removalStarted = yield* Deferred.make<void>();
+      const continueRemoval = yield* Deferred.make<void>();
+      const harness = yield* makeHarness(
+        [BEARER_TARGET],
+        [BEARER_PROFILE],
+        [[BEARER_TARGET.connectionId, BEARER_CREDENTIAL]],
+        {
+          beforeRegistrationRemove: () =>
+            Deferred.succeed(removalStarted, undefined).pipe(
+              Effect.andThen(Deferred.await(continueRemoval)),
+            ),
+        },
+      );
+
+      yield* Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        const removal = yield* Effect.forkChild(
+          registry.removeConnection(BEARER_TARGET.connectionId),
+        );
+        yield* Deferred.await(removalStarted);
+
+        const update = yield* Effect.flip(
+          registry.update(
+            new BearerConnectionRegistration({
+              target: new BearerConnectionTarget({
+                ...BEARER_TARGET,
+                label: "Updated after removal",
+              }),
+              profile: new BearerConnectionProfile({
+                ...BEARER_PROFILE,
+                label: "Updated after removal",
+              }),
+              credential: BEARER_CREDENTIAL,
+            }),
+          ),
+        ).pipe(Effect.forkChild);
+        yield* Effect.yieldNow;
+        yield* Deferred.succeed(continueRemoval, undefined);
+        yield* Fiber.join(removal);
+        const error = yield* Fiber.join(update);
+
+        expect(error._tag).toBe("ConnectionNotRegisteredError");
+        expect((yield* SubscriptionRef.get(registry.connections)).size).toBe(0);
+        expect((yield* Ref.get(harness.storedTargets)).size).toBe(0);
       }).pipe(Effect.provide(harness.layer), Effect.scoped);
     }),
   );

--- a/packages/client-runtime/src/connection/registry.ts
+++ b/packages/client-runtime/src/connection/registry.ts
@@ -485,7 +485,7 @@ export const make = Effect.gen(function* () {
       initialConnections.keys(),
       (connectionId) =>
         acquireConnectionSupervisor(connectionId).pipe(
-          Effect.catchTag("ConnectionNotRegisteredError", () => Effect.void),
+          Effect.catchTags({ ConnectionNotRegisteredError: () => Effect.void }),
         ),
       {
         concurrency: "unbounded",
@@ -853,7 +853,7 @@ export const make = Effect.gen(function* () {
         relayConnectionIds,
         (connectionId) =>
           removeConnection(connectionId).pipe(
-            Effect.catchTag("ConnectionNotRegisteredError", () => Effect.void),
+            Effect.catchTags({ ConnectionNotRegisteredError: () => Effect.void }),
           ),
         {
           concurrency: "unbounded",
@@ -873,7 +873,7 @@ export const make = Effect.gen(function* () {
           if (matching.length === 0) {
             yield* acquireSupervisor(environmentId).pipe(
               Effect.flatMap((supervisor) => supervisor.retryNow),
-              Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
+              Effect.catchTags({ EnvironmentNotRegisteredError: () => Effect.void }),
             );
             return;
           }
@@ -888,7 +888,7 @@ export const make = Effect.gen(function* () {
   const retryConnection = (connectionId: string) =>
     acquireConnectionSupervisor(connectionId).pipe(
       Effect.flatMap((supervisor) => supervisor.retryNow),
-      Effect.catchTag("ConnectionNotRegisteredError", () => Effect.void),
+      Effect.catchTags({ ConnectionNotRegisteredError: () => Effect.void }),
       Effect.withSpan("EnvironmentRegistry.retryConnection"),
     );
   const state = Effect.fn("EnvironmentRegistry.state")(function* (environmentId: EnvironmentId) {

--- a/packages/client-runtime/src/connection/registry.ts
+++ b/packages/client-runtime/src/connection/registry.ts
@@ -20,6 +20,7 @@ import {
   type PrimaryConnectionRegistration,
   SshConnectionProfile,
   connectionRegistrationCatalogEntry,
+  reuseSavedBearerRoute,
 } from "./catalog.ts";
 import * as ConnectionCredentialStore from "./credentialStore.ts";
 import * as ConnectionProfileStore from "./profileStore.ts";
@@ -442,15 +443,19 @@ export const make = Effect.gen(function* () {
   const register = Effect.fn("EnvironmentRegistry.register")(function* (
     registration: ConnectionRegistration,
   ) {
-    const entry = connectionRegistrationCatalogEntry(registration);
-    const environmentId = entry.target.environmentId;
+    const environmentId = registration.target.environmentId;
     yield* withLeaseLock(
       environmentId,
       Effect.gen(function* () {
         if ((yield* Ref.get(platformEnvironmentIds)).has(environmentId)) {
           return;
         }
-        yield* registrations.register(registration);
+        const resolved =
+          registrations.retainsSiblingRoutes && registration._tag === "BearerConnectionRegistration"
+            ? reuseSavedBearerRoute(registration, yield* SubscriptionRef.get(connections))
+            : registration;
+        const entry = connectionRegistrationCatalogEntry(resolved);
+        yield* registrations.register(resolved);
         yield* SubscriptionRef.update(connections, (current) =>
           installSavedConnection(current, entry, registrations.retainsSiblingRoutes),
         );
@@ -470,13 +475,14 @@ export const make = Effect.gen(function* () {
       Effect.gen(function* () {
         if ((yield* Ref.get(platformEnvironmentIds)).has(environmentId)) return;
         const active = (yield* SubscriptionRef.get(entries)).get(environmentId);
-        yield* registrations.register(registration);
+        const activeTarget =
+          active !== undefined && connectionTargetId(active.target) !== connectionId
+            ? active.target
+            : undefined;
+        yield* registrations.update(registration, activeTarget);
         yield* SubscriptionRef.update(connections, (current) =>
           updateSavedConnection(current, entry),
         );
-        if (active !== undefined && connectionTargetId(active.target) !== connectionId) {
-          yield* registrations.activate(active.target);
-        }
         if (active !== undefined && connectionTargetId(active.target) === connectionId) {
           yield* installEntryLocked(entry);
         }
@@ -678,9 +684,8 @@ export const make = Effect.gen(function* () {
   ) {
     const target = entry.target;
     if (target._tag !== "SshConnectionTarget") return;
-    const profile = yield* profiles.get(target.connectionId);
-    if (Option.isNone(profile) || !isSshConnectionProfile(profile.value)) return;
-    yield* ssh.disconnect(profile.value.target).pipe(
+    if (Option.isNone(entry.profile) || !isSshConnectionProfile(entry.profile.value)) return;
+    yield* ssh.disconnect(entry.profile.value.target).pipe(
       Effect.tapError((error) =>
         Effect.logWarning("Could not disconnect the managed SSH environment.", {
           environmentId: target.environmentId,
@@ -697,21 +702,25 @@ export const make = Effect.gen(function* () {
   ) {
     const environmentId = entry.target.environmentId;
     const active = (yield* SubscriptionRef.get(entries)).get(environmentId);
+    const isActive = active !== undefined && connectionTargetId(active.target) === connectionId;
+    const remaining = isActive
+      ? [...(yield* SubscriptionRef.get(connections)).values()].findLast(
+          (candidate) =>
+            candidate.target.environmentId === environmentId &&
+            connectionTargetId(candidate.target) !== connectionId,
+        )
+      : undefined;
+    yield* registrations.remove(entry.target, remaining?.target);
     yield* disconnectSsh(entry);
-    yield* registrations.remove(entry.target);
     yield* SubscriptionRef.update(connections, (current) => {
       const next = new Map(current);
       next.delete(connectionId);
       return next;
     });
 
-    if (active === undefined || connectionTargetId(active.target) !== connectionId) return;
+    if (!isActive) return;
     yield* closeServiceScope(environmentId);
-    const remaining = [...(yield* SubscriptionRef.get(connections)).values()].findLast(
-      (candidate) => candidate.target.environmentId === environmentId,
-    );
     if (remaining !== undefined) {
-      yield* registrations.activate(remaining.target);
       yield* installEntryLocked(remaining);
       return;
     }

--- a/packages/client-runtime/src/connection/registry.ts
+++ b/packages/client-runtime/src/connection/registry.ts
@@ -81,9 +81,6 @@ export class EnvironmentRegistry extends Context.Service<
     ) => Effect.Effect<void, Persistence.ConnectionPersistenceError>;
     readonly update: (
       registration: ConnectionRegistration,
-    ) => Effect.Effect<void, Persistence.ConnectionPersistenceError>;
-    readonly activate: (
-      connectionId: string,
     ) => Effect.Effect<void, Persistence.ConnectionPersistenceError | ConnectionNotRegisteredError>;
     readonly removeConnection: (
       connectionId: string,
@@ -106,17 +103,22 @@ export class EnvironmentRegistry extends Context.Service<
     >;
     readonly removeRelayEnvironments: () => Effect.Effect<
       void,
-      | Persistence.ConnectionPersistenceError
-      | ConnectionAttemptError
-      | PlatformEnvironmentRemovalError
+      Persistence.ConnectionPersistenceError | ConnectionAttemptError
     >;
     readonly retryNow: (environmentId: EnvironmentId) => Effect.Effect<void>;
+    readonly retryConnection: (connectionId: string) => Effect.Effect<void>;
     readonly state: (
       environmentId: EnvironmentId,
     ) => Effect.Effect<SupervisorConnectionState, EnvironmentNotRegisteredError>;
     readonly stateChanges: (
       environmentId: EnvironmentId,
     ) => Stream.Stream<SupervisorConnectionState, EnvironmentNotRegisteredError>;
+    readonly connectionState: (
+      connectionId: string,
+    ) => Effect.Effect<SupervisorConnectionState, ConnectionNotRegisteredError>;
+    readonly connectionStateChanges: (
+      connectionId: string,
+    ) => Stream.Stream<SupervisorConnectionState, ConnectionNotRegisteredError>;
     readonly run: <A, E, R>(
       environmentId: EnvironmentId,
       effect: Effect.Effect<A, E, R>,
@@ -156,10 +158,7 @@ function installSavedConnection(
   for (const [candidateId, candidate] of next) {
     if (
       candidateId === connectionId ||
-      (candidate.target.environmentId === entry.target.environmentId &&
-        (!retainsSiblingRoutes ||
-          candidate.target._tag === "RelayConnectionTarget" ||
-          entry.target._tag === "RelayConnectionTarget"))
+      (candidate.target.environmentId === entry.target.environmentId && !retainsSiblingRoutes)
     ) {
       next.delete(candidateId);
     }
@@ -203,8 +202,9 @@ export const make = Effect.gen(function* () {
   const initialConnections = new Map(
     persistedEntries.map((entry) => [connectionTargetId(entry.target), entry]),
   );
-  // Catalog order records the preferred route. Map replacement means the last
-  // saved route for an environment becomes its active runtime entry.
+  // Environment-owned data remains keyed by EnvironmentId, so bootstrap it with
+  // one representative entry. Runtime reconciliation moves it to a connected
+  // sibling without changing the independently supervised saved connections.
   const initialEntries = new Map(
     persistedEntries.map((entry) => [entry.target.environmentId, entry]),
   );
@@ -213,9 +213,9 @@ export const make = Effect.gen(function* () {
   const connections =
     yield* SubscriptionRef.make<ReadonlyMap<string, ConnectionCatalogEntry>>(initialConnections);
   const networkStatus = yield* SubscriptionRef.make(yield* connectivity.status);
-  const serviceScopes = yield* SubscriptionRef.make<
-    ReadonlyMap<EnvironmentId, EnvironmentServiceScope>
-  >(new Map());
+  const serviceScopes = yield* SubscriptionRef.make<ReadonlyMap<string, EnvironmentServiceScope>>(
+    new Map(),
+  );
   const platformEnvironmentIds = yield* Ref.make<ReadonlySet<EnvironmentId>>(new Set());
   interface LeaseLock {
     readonly semaphore: Semaphore.Semaphore;
@@ -285,24 +285,74 @@ export const make = Effect.gen(function* () {
   });
 
   const closeServiceScope = Effect.fn("EnvironmentRegistry.closeServiceScope")(function* (
-    environmentId: EnvironmentId,
+    connectionId: string,
   ) {
     const current = yield* SubscriptionRef.get(serviceScopes);
-    const lease = current.get(environmentId);
+    const lease = current.get(connectionId);
     if (lease === undefined) {
       return;
     }
-    const next = new Map(current);
-    next.delete(environmentId);
-    yield* SubscriptionRef.set(serviceScopes, next);
+    yield* SubscriptionRef.update(serviceScopes, (latest) => {
+      const next = new Map(latest);
+      next.delete(connectionId);
+      return next;
+    });
     yield* Scope.close(lease.scope, Exit.void);
   });
+
+  const reconcileEnvironmentEntryLocked = Effect.fn(
+    "EnvironmentRegistry.reconcileEnvironmentEntryLocked",
+  )(function* (environmentId: EnvironmentId) {
+    const currentEntry = (yield* SubscriptionRef.get(entries)).get(environmentId);
+    const currentConnectionId =
+      currentEntry === undefined ? undefined : connectionTargetId(currentEntry.target);
+    const savedConnections = yield* SubscriptionRef.get(connections);
+    const scopes = [...(yield* SubscriptionRef.get(serviceScopes)).entries()].filter(
+      ([, lease]) => lease.entry.target.environmentId === environmentId,
+    );
+    const currentScope =
+      currentConnectionId === undefined
+        ? undefined
+        : scopes.find(([connectionId]) => connectionId === currentConnectionId)?.[1];
+    if (
+      currentConnectionId !== undefined &&
+      savedConnections.has(currentConnectionId) &&
+      currentScope !== undefined
+    ) {
+      const currentState = yield* SubscriptionRef.get(currentScope.supervisor.state);
+      if (currentState.phase === "connected" && Equal.equals(currentEntry, currentScope.entry)) {
+        return;
+      }
+    }
+    const connected = yield* Effect.findFirst(scopes, ([, lease]) =>
+      SubscriptionRef.get(lease.supervisor.state).pipe(
+        Effect.map((state) => state.phase === "connected"),
+      ),
+    );
+    const replacement = Option.match(connected, {
+      onNone: () =>
+        scopes[0]?.[1].entry ??
+        [...savedConnections.values()].find(
+          (entry) => entry.target.environmentId === environmentId,
+        ),
+      onSome: ([, lease]) => lease.entry,
+    });
+    if (replacement === undefined || Equal.equals(currentEntry, replacement)) return;
+    yield* SubscriptionRef.update(entries, (current) => {
+      const next = new Map(current);
+      next.set(environmentId, replacement);
+      return next;
+    });
+  });
+
+  const reconcileEnvironmentEntry = (environmentId: EnvironmentId) =>
+    withLeaseLock(environmentId, reconcileEnvironmentEntryLocked(environmentId));
 
   const createServiceScope = Effect.fn("EnvironmentRegistry.createServiceScope")(
     (entry: ConnectionCatalogEntry) =>
       Effect.uninterruptible(
         Effect.gen(function* () {
-          const environmentId = entry.target.environmentId;
+          const connectionId = connectionTargetId(entry.target);
           const scope = yield* Scope.make();
           const supervisor = yield* EnvironmentSupervisor.make(entry, {
             initiallyDesired: false,
@@ -313,15 +363,52 @@ export const make = Effect.gen(function* () {
             Scope.provide(scope),
             Effect.onError(() => Scope.close(scope, Exit.void)),
           );
-          yield* supervisor.connect;
           yield* SubscriptionRef.update(serviceScopes, (current) => {
             const next = new Map(current);
-            next.set(environmentId, { entry, supervisor, scope });
+            next.set(connectionId, { entry, supervisor, scope });
             return next;
           });
+          yield* SubscriptionRef.changes(supervisor.state).pipe(
+            Stream.runForEach(() => reconcileEnvironmentEntry(entry.target.environmentId)),
+            Effect.forkIn(scope, { startImmediately: true, uninterruptible: false }),
+          );
+          yield* supervisor.connect;
           return supervisor;
         }),
       ),
+  );
+
+  const acquireEntrySupervisorLocked = Effect.fn(
+    "EnvironmentRegistry.acquireEntrySupervisorLocked",
+  )(function* (entry: ConnectionCatalogEntry) {
+    const connectionId = connectionTargetId(entry.target);
+    const existing = (yield* SubscriptionRef.get(serviceScopes)).get(connectionId);
+    if (existing !== undefined) {
+      if (Equal.equals(existing.entry, entry)) {
+        return existing.supervisor;
+      }
+      yield* closeServiceScope(connectionId);
+    }
+    return yield* createServiceScope(entry);
+  });
+
+  const acquireConnectionSupervisor = Effect.fn("EnvironmentRegistry.acquireConnectionSupervisor")(
+    function* (connectionId: string) {
+      const candidate = (yield* SubscriptionRef.get(connections)).get(connectionId);
+      if (candidate === undefined) {
+        return yield* new ConnectionNotRegisteredError({ connectionId });
+      }
+      return yield* withLeaseLock(
+        candidate.target.environmentId,
+        Effect.gen(function* () {
+          const entry = (yield* SubscriptionRef.get(connections)).get(connectionId);
+          if (entry === undefined) {
+            return yield* new ConnectionNotRegisteredError({ connectionId });
+          }
+          return yield* acquireEntrySupervisorLocked(entry);
+        }),
+      );
+    },
   );
 
   const acquireSupervisor = Effect.fn("EnvironmentRegistry.acquireSupervisor")(function* (
@@ -331,14 +418,7 @@ export const make = Effect.gen(function* () {
       environmentId,
       Effect.gen(function* () {
         const entry = yield* getEntry(environmentId);
-        const existing = (yield* SubscriptionRef.get(serviceScopes)).get(environmentId);
-        if (existing !== undefined) {
-          if (Equal.equals(existing.entry, entry)) {
-            return existing.supervisor;
-          }
-          yield* closeServiceScope(environmentId);
-        }
-        return yield* createServiceScope(entry);
+        return yield* acquireEntrySupervisorLocked(entry);
       }),
     );
   });
@@ -402,10 +482,10 @@ export const make = Effect.gen(function* () {
       return;
     }
     yield* Effect.forEach(
-      initialEntries.keys(),
-      (environmentId) =>
-        acquireSupervisor(environmentId).pipe(
-          Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
+      initialConnections.keys(),
+      (connectionId) =>
+        acquireConnectionSupervisor(connectionId).pipe(
+          Effect.catchTag("ConnectionNotRegisteredError", () => Effect.void),
         ),
       {
         concurrency: "unbounded",
@@ -419,8 +499,9 @@ export const make = Effect.gen(function* () {
     options?: { readonly retainEquivalentRuntime?: boolean },
   ) {
     const target = entry.target;
+    const connectionId = connectionTargetId(target);
     const previous = (yield* SubscriptionRef.get(entries)).get(target.environmentId);
-    const existingScope = (yield* SubscriptionRef.get(serviceScopes)).get(target.environmentId);
+    const existingScope = (yield* SubscriptionRef.get(serviceScopes)).get(connectionId);
     if (
       options?.retainEquivalentRuntime === true &&
       previous !== undefined &&
@@ -431,13 +512,12 @@ export const make = Effect.gen(function* () {
       return;
     }
 
-    yield* closeServiceScope(target.environmentId);
     yield* SubscriptionRef.update(entries, (current) => {
       const next = new Map(current);
       next.set(target.environmentId, entry);
       return next;
     });
-    yield* createServiceScope(entry);
+    yield* acquireEntrySupervisorLocked(entry);
   });
 
   const register = Effect.fn("EnvironmentRegistry.register")(function* (
@@ -456,10 +536,27 @@ export const make = Effect.gen(function* () {
             : registration;
         const entry = connectionRegistrationCatalogEntry(resolved);
         yield* registrations.register(resolved);
-        yield* SubscriptionRef.update(connections, (current) =>
-          installSavedConnection(current, entry, registrations.retainsSiblingRoutes),
+        const { previousConnections, nextConnections } = yield* SubscriptionRef.modify(
+          connections,
+          (current) => {
+            const next = installSavedConnection(current, entry, registrations.retainsSiblingRoutes);
+            return [{ previousConnections: current, nextConnections: next }, next];
+          },
         );
-        yield* installEntryLocked(entry);
+        yield* Effect.forEach(
+          previousConnections.keys(),
+          (connectionId) =>
+            nextConnections.has(connectionId) ? Effect.void : closeServiceScope(connectionId),
+          { discard: true },
+        );
+        const selected = (yield* SubscriptionRef.get(entries)).get(environmentId);
+        const selectedWasReplaced =
+          selected !== undefined && !nextConnections.has(connectionTargetId(selected.target));
+        if (selected !== undefined && !selectedWasReplaced) {
+          yield* acquireEntrySupervisorLocked(entry);
+        } else {
+          yield* installEntryLocked(entry);
+        }
       }),
     );
   });
@@ -474,45 +571,23 @@ export const make = Effect.gen(function* () {
       environmentId,
       Effect.gen(function* () {
         if ((yield* Ref.get(platformEnvironmentIds)).has(environmentId)) return;
-        const active = (yield* SubscriptionRef.get(entries)).get(environmentId);
-        const activeTarget =
-          active !== undefined && connectionTargetId(active.target) !== connectionId
-            ? active.target
-            : undefined;
-        yield* registrations.update(registration, activeTarget);
+        const saved = (yield* SubscriptionRef.get(connections)).get(connectionId);
+        if (saved === undefined || saved.target.environmentId !== environmentId) {
+          return yield* new ConnectionNotRegisteredError({ connectionId });
+        }
+        const selected = (yield* SubscriptionRef.get(entries)).get(environmentId);
+        yield* registrations.update(registration);
         yield* SubscriptionRef.update(connections, (current) =>
           updateSavedConnection(current, entry),
         );
-        if (active !== undefined && connectionTargetId(active.target) === connectionId) {
-          yield* installEntryLocked(entry);
+        if (selected !== undefined && connectionTargetId(selected.target) === connectionId) {
+          yield* SubscriptionRef.update(entries, (current) => {
+            const next = new Map(current);
+            next.set(environmentId, entry);
+            return next;
+          });
         }
-      }),
-    );
-  });
-
-  const activate = Effect.fn("EnvironmentRegistry.activate")(function* (connectionId: string) {
-    const candidate = (yield* SubscriptionRef.get(connections)).get(connectionId);
-    if (candidate === undefined) {
-      return yield* new ConnectionNotRegisteredError({ connectionId });
-    }
-    const environmentId = candidate.target.environmentId;
-    yield* withLeaseLock(
-      environmentId,
-      Effect.gen(function* () {
-        const entry = (yield* SubscriptionRef.get(connections)).get(connectionId);
-        if (entry === undefined || entry.target.environmentId !== environmentId) {
-          return yield* new ConnectionNotRegisteredError({ connectionId });
-        }
-        yield* registrations.activate(entry.target);
-        yield* SubscriptionRef.update(connections, (current) => {
-          const next = new Map(current);
-          next.delete(connectionId);
-          next.set(connectionId, entry);
-          return next;
-        });
-        if (!(yield* Ref.get(platformEnvironmentIds)).has(environmentId)) {
-          yield* installEntryLocked(entry, { retainEquivalentRuntime: true });
-        }
+        yield* acquireEntrySupervisorLocked(entry);
       }),
     );
   });
@@ -559,7 +634,7 @@ export const make = Effect.gen(function* () {
                     const next = new Map(current);
                     next.delete(connectionId);
                     return next;
-                  }),
+                  }).pipe(Effect.andThen(closeServiceScope(connectionId))),
                 ),
                 Effect.catch((error) =>
                   Effect.logWarning(
@@ -591,7 +666,9 @@ export const make = Effect.gen(function* () {
             next.delete(environmentId);
             return next;
           });
-          yield* closeServiceScope(environmentId);
+          if (entry !== undefined) {
+            yield* closeServiceScope(connectionTargetId(entry.target));
+          }
           yield* SubscriptionRef.update(entries, (current) => {
             const next = new Map(current);
             next.delete(environmentId);
@@ -613,11 +690,6 @@ export const make = Effect.gen(function* () {
           if (saved !== undefined) {
             yield* installEntryLocked(saved);
           } else {
-            yield* SubscriptionRef.update(entries, (current) => {
-              const next = new Map(current);
-              next.delete(environmentId);
-              return next;
-            });
             yield* Effect.all(
               [
                 cache.clear(environmentId).pipe(
@@ -701,16 +773,15 @@ export const make = Effect.gen(function* () {
     entry: ConnectionCatalogEntry,
   ) {
     const environmentId = entry.target.environmentId;
-    const active = (yield* SubscriptionRef.get(entries)).get(environmentId);
-    const isActive = active !== undefined && connectionTargetId(active.target) === connectionId;
-    const remaining = isActive
-      ? [...(yield* SubscriptionRef.get(connections)).values()].findLast(
-          (candidate) =>
-            candidate.target.environmentId === environmentId &&
-            connectionTargetId(candidate.target) !== connectionId,
-        )
-      : undefined;
-    yield* registrations.remove(entry.target, remaining?.target);
+    const selected = (yield* SubscriptionRef.get(entries)).get(environmentId);
+    const isSelected =
+      selected !== undefined && connectionTargetId(selected.target) === connectionId;
+    const remaining = [...(yield* SubscriptionRef.get(connections)).values()].filter(
+      (candidate) =>
+        candidate.target.environmentId === environmentId &&
+        connectionTargetId(candidate.target) !== connectionId,
+    );
+    yield* registrations.remove(entry.target);
     yield* disconnectSsh(entry);
     yield* SubscriptionRef.update(connections, (current) => {
       const next = new Map(current);
@@ -718,10 +789,10 @@ export const make = Effect.gen(function* () {
       return next;
     });
 
-    if (!isActive) return;
-    yield* closeServiceScope(environmentId);
-    if (remaining !== undefined) {
-      yield* installEntryLocked(remaining);
+    yield* closeServiceScope(connectionId);
+    if (!isSelected) return;
+    if (remaining.length > 0) {
+      yield* reconcileEnvironmentEntryLocked(environmentId);
       return;
     }
     yield* SubscriptionRef.update(entries, (current) => {
@@ -763,19 +834,8 @@ export const make = Effect.gen(function* () {
         if (saved.length === 0) {
           return yield* new EnvironmentNotRegisteredError({ environmentId });
         }
-        const activeConnectionId = Option.fromUndefinedOr(
-          (yield* SubscriptionRef.get(entries)).get(environmentId),
-        ).pipe(
-          Option.map((entry) => connectionTargetId(entry.target)),
-          Option.getOrNull,
-        );
-        // .sort() on a copy, not .toSorted(): Hermes doesn't ship the ES2023 method.
-        const removalOrder = [...saved].sort(
-          ([leftId], [rightId]) =>
-            Number(leftId === activeConnectionId) - Number(rightId === activeConnectionId),
-        );
         yield* Effect.forEach(
-          removalOrder,
+          saved,
           ([connectionId, entry]) => removeConnectionLocked(connectionId, entry),
           { discard: true },
         );
@@ -785,15 +845,15 @@ export const make = Effect.gen(function* () {
 
   const removeRelayEnvironments = Effect.fn("EnvironmentRegistry.removeRelayEnvironments")(
     function* () {
-      const relayEnvironmentIds = [...(yield* SubscriptionRef.get(entries)).values()]
-        .filter((entry) => entry.target._tag === "RelayConnectionTarget")
-        .map((entry) => entry.target.environmentId);
+      const relayConnectionIds = [...(yield* SubscriptionRef.get(connections)).entries()]
+        .filter(([, entry]) => entry.target._tag === "RelayConnectionTarget")
+        .map(([connectionId]) => connectionId);
 
       yield* Effect.forEach(
-        relayEnvironmentIds,
-        (environmentId) =>
-          remove(environmentId).pipe(
-            Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
+        relayConnectionIds,
+        (connectionId) =>
+          removeConnection(connectionId).pipe(
+            Effect.catchTag("ConnectionNotRegisteredError", () => Effect.void),
           ),
         {
           concurrency: "unbounded",
@@ -804,10 +864,32 @@ export const make = Effect.gen(function* () {
   );
 
   const retryNow = (environmentId: EnvironmentId) =>
-    acquireSupervisor(environmentId).pipe(
-      Effect.flatMap((supervisor) => supervisor.retryNow),
-      Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
+    SubscriptionRef.get(serviceScopes).pipe(
+      Effect.flatMap((current) =>
+        Effect.gen(function* () {
+          const matching = [...current.values()].filter(
+            (lease) => lease.entry.target.environmentId === environmentId,
+          );
+          if (matching.length === 0) {
+            yield* acquireSupervisor(environmentId).pipe(
+              Effect.flatMap((supervisor) => supervisor.retryNow),
+              Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
+            );
+            return;
+          }
+          yield* Effect.forEach(matching, (lease) => lease.supervisor.retryNow, {
+            concurrency: "unbounded",
+            discard: true,
+          });
+        }),
+      ),
       Effect.withSpan("EnvironmentRegistry.retryNow"),
+    );
+  const retryConnection = (connectionId: string) =>
+    acquireConnectionSupervisor(connectionId).pipe(
+      Effect.flatMap((supervisor) => supervisor.retryNow),
+      Effect.catchTag("ConnectionNotRegisteredError", () => Effect.void),
+      Effect.withSpan("EnvironmentRegistry.retryConnection"),
     );
   const state = Effect.fn("EnvironmentRegistry.state")(function* (environmentId: EnvironmentId) {
     const supervisor = yield* acquireSupervisor(environmentId);
@@ -822,7 +904,34 @@ export const make = Effect.gen(function* () {
         ),
       ),
     );
-
+  const connectionState = Effect.fn("EnvironmentRegistry.connectionState")(function* (
+    connectionId: string,
+  ) {
+    const supervisor = yield* acquireConnectionSupervisor(connectionId);
+    return yield* SubscriptionRef.get(supervisor.state);
+  });
+  const connectionStateChanges = (connectionId: string) =>
+    Stream.concat(
+      Stream.fromEffect(SubscriptionRef.get(connections)),
+      SubscriptionRef.changes(connections),
+    ).pipe(
+      Stream.map((current) => Option.fromUndefinedOr(current.get(connectionId))),
+      Stream.changes,
+      Stream.switchMap(
+        Option.match({
+          onNone: () => Stream.empty,
+          onSome: () =>
+            Stream.unwrap(
+              acquireConnectionSupervisor(connectionId).pipe(
+                Effect.match({
+                  onFailure: () => Stream.empty,
+                  onSuccess: (supervisor) => SubscriptionRef.changes(supervisor.state),
+                }),
+              ),
+            ),
+        }),
+      ),
+    );
   yield* Effect.addFinalizer(() =>
     SubscriptionRef.get(serviceScopes).pipe(
       Effect.flatMap((current) =>
@@ -845,15 +954,17 @@ export const make = Effect.gen(function* () {
     start,
     register,
     update,
-    activate,
     removeConnection,
     registerPlatform,
     reconcilePlatform,
     remove,
     removeRelayEnvironments,
     retryNow,
+    retryConnection,
     state,
     stateChanges,
+    connectionState,
+    connectionStateChanges,
     run,
     runStream,
     followStream,

--- a/packages/client-runtime/src/connection/registry.ts
+++ b/packages/client-runtime/src/connection/registry.ts
@@ -24,12 +24,8 @@ import {
 import * as ConnectionCredentialStore from "./credentialStore.ts";
 import * as ConnectionProfileStore from "./profileStore.ts";
 import * as Connectivity from "./connectivity.ts";
-import type {
-  ConnectionAttemptError,
-  ConnectionTarget,
-  NetworkStatus,
-  SupervisorConnectionState,
-} from "./model.ts";
+import type { ConnectionAttemptError, NetworkStatus, SupervisorConnectionState } from "./model.ts";
+import { connectionTargetId } from "./model.ts";
 import * as Persistence from "../platform/persistence.ts";
 import * as EnvironmentSupervisor from "./supervisor.ts";
 import * as ConnectionDriver from "./driver.ts";
@@ -59,17 +55,41 @@ export class PlatformEnvironmentRemovalError extends Schema.TaggedErrorClass<Pla
   }
 }
 
+export class ConnectionNotRegisteredError extends Schema.TaggedErrorClass<ConnectionNotRegisteredError>()(
+  "ConnectionNotRegisteredError",
+  { connectionId: Schema.String },
+) {
+  override get message(): string {
+    return `Connection ${this.connectionId} is not registered.`;
+  }
+}
+
 export class EnvironmentRegistry extends Context.Service<
   EnvironmentRegistry,
   {
     readonly entries: SubscriptionRef.SubscriptionRef<
       ReadonlyMap<EnvironmentId, ConnectionCatalogEntry>
     >;
+    readonly connections: SubscriptionRef.SubscriptionRef<
+      ReadonlyMap<string, ConnectionCatalogEntry>
+    >;
     readonly networkStatus: SubscriptionRef.SubscriptionRef<NetworkStatus>;
     readonly start: Effect.Effect<void>;
     readonly register: (
       registration: ConnectionRegistration,
     ) => Effect.Effect<void, Persistence.ConnectionPersistenceError>;
+    readonly update: (
+      registration: ConnectionRegistration,
+    ) => Effect.Effect<void, Persistence.ConnectionPersistenceError>;
+    readonly activate: (
+      connectionId: string,
+    ) => Effect.Effect<void, Persistence.ConnectionPersistenceError | ConnectionNotRegisteredError>;
+    readonly removeConnection: (
+      connectionId: string,
+    ) => Effect.Effect<
+      void,
+      Persistence.ConnectionPersistenceError | ConnectionAttemptError | ConnectionNotRegisteredError
+    >;
     readonly registerPlatform: (registration: PrimaryConnectionRegistration) => Effect.Effect<void>;
     readonly reconcilePlatform: (
       registrations: ReadonlyArray<PlatformConnectionRegistration>,
@@ -125,6 +145,37 @@ interface EnvironmentServiceScope {
   readonly scope: Scope.Closeable;
 }
 
+function installSavedConnection(
+  current: ReadonlyMap<string, ConnectionCatalogEntry>,
+  entry: ConnectionCatalogEntry,
+  retainsSiblingRoutes: boolean,
+): ReadonlyMap<string, ConnectionCatalogEntry> {
+  const connectionId = connectionTargetId(entry.target);
+  const next = new Map(current);
+  for (const [candidateId, candidate] of next) {
+    if (
+      candidateId === connectionId ||
+      (candidate.target.environmentId === entry.target.environmentId &&
+        (!retainsSiblingRoutes ||
+          candidate.target._tag === "RelayConnectionTarget" ||
+          entry.target._tag === "RelayConnectionTarget"))
+    ) {
+      next.delete(candidateId);
+    }
+  }
+  next.set(connectionId, entry);
+  return next;
+}
+
+function updateSavedConnection(
+  current: ReadonlyMap<string, ConnectionCatalogEntry>,
+  entry: ConnectionCatalogEntry,
+): ReadonlyMap<string, ConnectionCatalogEntry> {
+  const next = new Map(current);
+  next.set(connectionTargetId(entry.target), entry);
+  return next;
+}
+
 export const make = Effect.gen(function* () {
   const storage = yield* Persistence.ConnectionTargetStore;
   const registrations = yield* Persistence.ConnectionRegistrationStore;
@@ -137,32 +188,34 @@ export const make = Effect.gen(function* () {
   const wakeups = yield* ConnectionWakeups.ConnectionWakeups;
   const ssh = yield* ClientCapabilities.SshEnvironmentGateway;
   const persistedTargets = yield* storage.list;
+  const persistedEntries = yield* Effect.forEach(
+    persistedTargets,
+    Effect.fn("EnvironmentRegistry.loadCatalogEntry")(function* (target) {
+      const profile =
+        target._tag === "BearerConnectionTarget" || target._tag === "SshConnectionTarget"
+          ? yield* profiles.get(target.connectionId)
+          : Option.none();
+      return { target, profile } satisfies ConnectionCatalogEntry;
+    }),
+    { concurrency: "unbounded" },
+  );
+  const initialConnections = new Map(
+    persistedEntries.map((entry) => [connectionTargetId(entry.target), entry]),
+  );
+  // Catalog order records the preferred route. Map replacement means the last
+  // saved route for an environment becomes its active runtime entry.
   const initialEntries = new Map(
-    yield* Effect.forEach(
-      persistedTargets,
-      Effect.fn("EnvironmentRegistry.loadCatalogEntry")(function* (target) {
-        const profile =
-          target._tag === "BearerConnectionTarget" || target._tag === "SshConnectionTarget"
-            ? yield* profiles.get(target.connectionId)
-            : Option.none();
-        return [
-          target.environmentId,
-          { target, profile } satisfies ConnectionCatalogEntry,
-        ] as const;
-      }),
-      { concurrency: "unbounded" },
-    ),
+    persistedEntries.map((entry) => [entry.target.environmentId, entry]),
   );
   const entries =
     yield* SubscriptionRef.make<ReadonlyMap<EnvironmentId, ConnectionCatalogEntry>>(initialEntries);
+  const connections =
+    yield* SubscriptionRef.make<ReadonlyMap<string, ConnectionCatalogEntry>>(initialConnections);
   const networkStatus = yield* SubscriptionRef.make(yield* connectivity.status);
   const serviceScopes = yield* SubscriptionRef.make<
     ReadonlyMap<EnvironmentId, EnvironmentServiceScope>
   >(new Map());
   const platformEnvironmentIds = yield* Ref.make<ReadonlySet<EnvironmentId>>(new Set());
-  const persistedTargetsByEnvironment = yield* Ref.make<
-    ReadonlyMap<EnvironmentId, ConnectionTarget>
-  >(new Map(persistedTargets.map((target) => [target.environmentId, target])));
   interface LeaseLock {
     readonly semaphore: Semaphore.Semaphore;
     readonly users: number;
@@ -348,9 +401,9 @@ export const make = Effect.gen(function* () {
       return;
     }
     yield* Effect.forEach(
-      persistedTargets,
-      (target) =>
-        acquireSupervisor(target.environmentId).pipe(
+      initialEntries.keys(),
+      (environmentId) =>
+        acquireSupervisor(environmentId).pipe(
           Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
         ),
       {
@@ -398,12 +451,62 @@ export const make = Effect.gen(function* () {
           return;
         }
         yield* registrations.register(registration);
-        yield* Ref.update(persistedTargetsByEnvironment, (current) => {
+        yield* SubscriptionRef.update(connections, (current) =>
+          installSavedConnection(current, entry, registrations.retainsSiblingRoutes),
+        );
+        yield* installEntryLocked(entry);
+      }),
+    );
+  });
+
+  const update = Effect.fn("EnvironmentRegistry.update")(function* (
+    registration: ConnectionRegistration,
+  ) {
+    const entry = connectionRegistrationCatalogEntry(registration);
+    const environmentId = entry.target.environmentId;
+    const connectionId = connectionTargetId(entry.target);
+    yield* withLeaseLock(
+      environmentId,
+      Effect.gen(function* () {
+        if ((yield* Ref.get(platformEnvironmentIds)).has(environmentId)) return;
+        const active = (yield* SubscriptionRef.get(entries)).get(environmentId);
+        yield* registrations.register(registration);
+        yield* SubscriptionRef.update(connections, (current) =>
+          updateSavedConnection(current, entry),
+        );
+        if (active !== undefined && connectionTargetId(active.target) !== connectionId) {
+          yield* registrations.activate(active.target);
+        }
+        if (active !== undefined && connectionTargetId(active.target) === connectionId) {
+          yield* installEntryLocked(entry);
+        }
+      }),
+    );
+  });
+
+  const activate = Effect.fn("EnvironmentRegistry.activate")(function* (connectionId: string) {
+    const candidate = (yield* SubscriptionRef.get(connections)).get(connectionId);
+    if (candidate === undefined) {
+      return yield* new ConnectionNotRegisteredError({ connectionId });
+    }
+    const environmentId = candidate.target.environmentId;
+    yield* withLeaseLock(
+      environmentId,
+      Effect.gen(function* () {
+        const entry = (yield* SubscriptionRef.get(connections)).get(connectionId);
+        if (entry === undefined || entry.target.environmentId !== environmentId) {
+          return yield* new ConnectionNotRegisteredError({ connectionId });
+        }
+        yield* registrations.activate(entry.target);
+        yield* SubscriptionRef.update(connections, (current) => {
           const next = new Map(current);
-          next.set(environmentId, registration.target);
+          next.delete(connectionId);
+          next.set(connectionId, entry);
           return next;
         });
-        yield* installEntryLocked(entry);
+        if (!(yield* Ref.get(platformEnvironmentIds)).has(environmentId)) {
+          yield* installEntryLocked(entry, { retainEquivalentRuntime: true });
+        }
       }),
     );
   });
@@ -436,30 +539,31 @@ export const make = Effect.gen(function* () {
             );
           }
 
-          const persistedTarget = (yield* Ref.get(persistedTargetsByEnvironment)).get(
-            target.environmentId,
+          // Desktop-managed environments retain their existing ownership
+          // semantics and remove persisted routes that they shadow.
+          const shadowed = [...(yield* SubscriptionRef.get(connections)).entries()].filter(
+            ([, candidate]) => candidate.target.environmentId === target.environmentId,
           );
-          if (persistedTarget !== undefined) {
-            yield* registrations.remove(persistedTarget).pipe(
-              Effect.tap(() =>
-                Ref.update(persistedTargetsByEnvironment, (current) => {
-                  const next = new Map(current);
-                  next.delete(target.environmentId);
-                  return next;
-                }),
-              ),
-              Effect.catch((error) =>
-                Effect.logWarning(
-                  "Could not remove a persisted registration shadowed by a platform environment.",
-                  {
-                    environmentId: target.environmentId,
-                    error,
-                  },
+          yield* Effect.forEach(
+            shadowed,
+            ([connectionId, candidate]) =>
+              registrations.remove(candidate.target).pipe(
+                Effect.tap(() =>
+                  SubscriptionRef.update(connections, (current) => {
+                    const next = new Map(current);
+                    next.delete(connectionId);
+                    return next;
+                  }),
+                ),
+                Effect.catch((error) =>
+                  Effect.logWarning(
+                    "Could not remove a persisted registration shadowed by a platform environment.",
+                    { environmentId: target.environmentId, error },
+                  ),
                 ),
               ),
-            );
-          }
-
+            { discard: true },
+          );
           yield* installEntryLocked(entry, { retainEquivalentRuntime: true });
         }),
       );
@@ -497,20 +601,32 @@ export const make = Effect.gen(function* () {
               ),
             );
           }
-          yield* Effect.all(
-            [
-              cache.clear(environmentId).pipe(
-                Effect.catch((error) =>
-                  Effect.logWarning("Could not clear cached environment data after removal.", {
-                    environmentId,
-                    error,
-                  }),
-                ),
-              ),
-              ownedDataCleanup.clear(environmentId),
-            ],
-            { concurrency: "unbounded", discard: true },
+          const saved = [...(yield* SubscriptionRef.get(connections)).values()].findLast(
+            (candidate) => candidate.target.environmentId === environmentId,
           );
+          if (saved !== undefined) {
+            yield* installEntryLocked(saved);
+          } else {
+            yield* SubscriptionRef.update(entries, (current) => {
+              const next = new Map(current);
+              next.delete(environmentId);
+              return next;
+            });
+            yield* Effect.all(
+              [
+                cache.clear(environmentId).pipe(
+                  Effect.catch((error) =>
+                    Effect.logWarning("Could not clear cached environment data after removal.", {
+                      environmentId,
+                      error,
+                    }),
+                  ),
+                ),
+                ownedDataCleanup.clear(environmentId),
+              ],
+              { concurrency: "unbounded", discard: true },
+            );
+          }
         }),
       );
     },
@@ -541,63 +657,119 @@ export const make = Effect.gen(function* () {
     yield* Effect.forEach(platformRegistrations, installPlatformRegistration, { discard: true });
   });
 
+  const clearEnvironmentData = (environmentId: EnvironmentId) =>
+    Effect.all(
+      [
+        cache.clear(environmentId).pipe(
+          Effect.catch((error) =>
+            Effect.logWarning("Could not clear cached environment data after removal.", {
+              environmentId,
+              error,
+            }),
+          ),
+        ),
+        ownedDataCleanup.clear(environmentId),
+      ],
+      { concurrency: "unbounded", discard: true },
+    );
+
+  const disconnectSsh = Effect.fn("EnvironmentRegistry.disconnectSsh")(function* (
+    entry: ConnectionCatalogEntry,
+  ) {
+    const target = entry.target;
+    if (target._tag !== "SshConnectionTarget") return;
+    const profile = yield* profiles.get(target.connectionId);
+    if (Option.isNone(profile) || !isSshConnectionProfile(profile.value)) return;
+    yield* ssh.disconnect(profile.value.target).pipe(
+      Effect.tapError((error) =>
+        Effect.logWarning("Could not disconnect the managed SSH environment.", {
+          environmentId: target.environmentId,
+          error,
+        }),
+      ),
+      Effect.ignore,
+    );
+  });
+
+  const removeConnectionLocked = Effect.fn("EnvironmentRegistry.removeConnectionLocked")(function* (
+    connectionId: string,
+    entry: ConnectionCatalogEntry,
+  ) {
+    const environmentId = entry.target.environmentId;
+    const active = (yield* SubscriptionRef.get(entries)).get(environmentId);
+    yield* disconnectSsh(entry);
+    yield* registrations.remove(entry.target);
+    yield* SubscriptionRef.update(connections, (current) => {
+      const next = new Map(current);
+      next.delete(connectionId);
+      return next;
+    });
+
+    if (active === undefined || connectionTargetId(active.target) !== connectionId) return;
+    yield* closeServiceScope(environmentId);
+    const remaining = [...(yield* SubscriptionRef.get(connections)).values()].findLast(
+      (candidate) => candidate.target.environmentId === environmentId,
+    );
+    if (remaining !== undefined) {
+      yield* registrations.activate(remaining.target);
+      yield* installEntryLocked(remaining);
+      return;
+    }
+    yield* SubscriptionRef.update(entries, (current) => {
+      const next = new Map(current);
+      next.delete(environmentId);
+      return next;
+    });
+    yield* clearEnvironmentData(environmentId);
+  });
+
+  const removeConnection = Effect.fn("EnvironmentRegistry.removeConnection")(function* (
+    connectionId: string,
+  ) {
+    const candidate = (yield* SubscriptionRef.get(connections)).get(connectionId);
+    if (candidate === undefined) return yield* new ConnectionNotRegisteredError({ connectionId });
+    const environmentId = candidate.target.environmentId;
+    yield* withLeaseLock(
+      environmentId,
+      Effect.gen(function* () {
+        const entry = (yield* SubscriptionRef.get(connections)).get(connectionId);
+        if (entry === undefined || entry.target.environmentId !== environmentId) {
+          return yield* new ConnectionNotRegisteredError({ connectionId });
+        }
+        yield* removeConnectionLocked(connectionId, entry);
+      }),
+    );
+  });
+
   const remove = Effect.fn("EnvironmentRegistry.remove")(function* (environmentId: EnvironmentId) {
-    return yield* withLeaseLock(
+    yield* withLeaseLock(
       environmentId,
       Effect.gen(function* () {
         if ((yield* Ref.get(platformEnvironmentIds)).has(environmentId)) {
-          return yield* new PlatformEnvironmentRemovalError({
-            environmentId,
-          });
+          return yield* new PlatformEnvironmentRemovalError({ environmentId });
         }
-        const target = (yield* getEntry(environmentId)).target;
-        const profile =
-          target._tag === "BearerConnectionTarget" || target._tag === "SshConnectionTarget"
-            ? yield* profiles.get(target.connectionId)
-            : Option.none();
-
-        yield* registrations.remove(target);
-        yield* Ref.update(persistedTargetsByEnvironment, (current) => {
-          const next = new Map(current);
-          next.delete(environmentId);
-          return next;
-        });
-        yield* closeServiceScope(environmentId);
-        yield* SubscriptionRef.update(entries, (current) => {
-          const next = new Map(current);
-          next.delete(environmentId);
-          return next;
-        });
-        yield* Effect.all(
-          [
-            cache.clear(environmentId).pipe(
-              Effect.catch((error) =>
-                Effect.logWarning("Could not clear cached environment data after removal.", {
-                  environmentId,
-                  error,
-                }),
-              ),
-            ),
-            ownedDataCleanup.clear(environmentId),
-          ],
-          { concurrency: "unbounded", discard: true },
+        const saved = [...(yield* SubscriptionRef.get(connections)).entries()].filter(
+          ([, entry]) => entry.target.environmentId === environmentId,
         );
-
-        if (
-          target._tag === "SshConnectionTarget" &&
-          Option.isSome(profile) &&
-          isSshConnectionProfile(profile.value)
-        ) {
-          yield* ssh.disconnect(profile.value.target).pipe(
-            Effect.tapError((error) =>
-              Effect.logWarning("Could not disconnect the managed SSH environment.", {
-                environmentId,
-                error,
-              }),
-            ),
-            Effect.ignore,
-          );
+        if (saved.length === 0) {
+          return yield* new EnvironmentNotRegisteredError({ environmentId });
         }
+        const activeConnectionId = Option.fromUndefinedOr(
+          (yield* SubscriptionRef.get(entries)).get(environmentId),
+        ).pipe(
+          Option.map((entry) => connectionTargetId(entry.target)),
+          Option.getOrNull,
+        );
+        // .sort() on a copy, not .toSorted(): Hermes doesn't ship the ES2023 method.
+        const removalOrder = [...saved].sort(
+          ([leftId], [rightId]) =>
+            Number(leftId === activeConnectionId) - Number(rightId === activeConnectionId),
+        );
+        yield* Effect.forEach(
+          removalOrder,
+          ([connectionId, entry]) => removeConnectionLocked(connectionId, entry),
+          { discard: true },
+        );
       }),
     );
   });
@@ -659,9 +831,13 @@ export const make = Effect.gen(function* () {
 
   return EnvironmentRegistry.of({
     entries,
+    connections,
     networkStatus,
     start,
     register,
+    update,
+    activate,
+    removeConnection,
     registerPlatform,
     reconcilePlatform,
     remove,

--- a/packages/client-runtime/src/platform/persistence.ts
+++ b/packages/client-runtime/src/platform/persistence.ts
@@ -20,7 +20,6 @@ export class ConnectionPersistenceError extends Schema.TaggedErrorClass<Connecti
     operation: Schema.Literals([
       "list-targets",
       "register-connection",
-      "activate-connection",
       "remove-connection",
       "load-shell",
       "save-shell",
@@ -55,15 +54,8 @@ export class ConnectionRegistrationStore extends Context.Service<
     ) => Effect.Effect<void, ConnectionPersistenceError>;
     readonly update: (
       registration: ConnectionRegistration,
-      activeTarget: ConnectionTarget | undefined,
     ) => Effect.Effect<void, ConnectionPersistenceError>;
-    readonly activate: (
-      target: ConnectionTarget,
-    ) => Effect.Effect<void, ConnectionPersistenceError>;
-    readonly remove: (
-      target: ConnectionTarget,
-      nextActiveTarget?: ConnectionTarget,
-    ) => Effect.Effect<void, ConnectionPersistenceError>;
+    readonly remove: (target: ConnectionTarget) => Effect.Effect<void, ConnectionPersistenceError>;
   }
 >()("@t3tools/client-runtime/platform/persistence/ConnectionRegistrationStore") {}
 

--- a/packages/client-runtime/src/platform/persistence.ts
+++ b/packages/client-runtime/src/platform/persistence.ts
@@ -20,6 +20,7 @@ export class ConnectionPersistenceError extends Schema.TaggedErrorClass<Connecti
     operation: Schema.Literals([
       "list-targets",
       "register-connection",
+      "activate-connection",
       "remove-connection",
       "load-shell",
       "save-shell",
@@ -52,10 +53,17 @@ export class ConnectionRegistrationStore extends Context.Service<
     readonly register: (
       registration: ConnectionRegistration,
     ) => Effect.Effect<void, ConnectionPersistenceError>;
+    readonly update: (
+      registration: ConnectionRegistration,
+      activeTarget: ConnectionTarget | undefined,
+    ) => Effect.Effect<void, ConnectionPersistenceError>;
     readonly activate: (
       target: ConnectionTarget,
     ) => Effect.Effect<void, ConnectionPersistenceError>;
-    readonly remove: (target: ConnectionTarget) => Effect.Effect<void, ConnectionPersistenceError>;
+    readonly remove: (
+      target: ConnectionTarget,
+      nextActiveTarget?: ConnectionTarget,
+    ) => Effect.Effect<void, ConnectionPersistenceError>;
   }
 >()("@t3tools/client-runtime/platform/persistence/ConnectionRegistrationStore") {}
 

--- a/packages/client-runtime/src/platform/persistence.ts
+++ b/packages/client-runtime/src/platform/persistence.ts
@@ -48,8 +48,12 @@ export class ConnectionTargetStore extends Context.Service<
 export class ConnectionRegistrationStore extends Context.Service<
   ConnectionRegistrationStore,
   {
+    readonly retainsSiblingRoutes: boolean;
     readonly register: (
       registration: ConnectionRegistration,
+    ) => Effect.Effect<void, ConnectionPersistenceError>;
+    readonly activate: (
+      target: ConnectionTarget,
     ) => Effect.Effect<void, ConnectionPersistenceError>;
     readonly remove: (target: ConnectionTarget) => Effect.Effect<void, ConnectionPersistenceError>;
   }

--- a/packages/client-runtime/src/platform/storageDocument.test.ts
+++ b/packages/client-runtime/src/platform/storageDocument.test.ts
@@ -17,7 +17,9 @@ import {
 } from "../connection/model.ts";
 import {
   EMPTY_CONNECTION_CATALOG_DOCUMENT,
+  activateConnectionInCatalog,
   registerConnectionInCatalog,
+  replaceEnvironmentConnectionInCatalog,
   removeConnectionFromCatalog,
 } from "./storageDocument.ts";
 
@@ -70,6 +72,96 @@ describe("ConnectionCatalogDocument", () => {
         credential: BEARER_CREDENTIAL,
       },
     ]);
+  });
+
+  it("retains multiple bearer routes to the same environment", () => {
+    const secondTarget = new BearerConnectionTarget({
+      environmentId: ENVIRONMENT_ID,
+      label: "Remote on office Wi-Fi",
+      connectionId: "bearer-2",
+    });
+    const secondProfile = new BearerConnectionProfile({
+      connectionId: secondTarget.connectionId,
+      environmentId: ENVIRONMENT_ID,
+      label: secondTarget.label,
+      httpBaseUrl: "http://192.168.50.10:3773",
+      wsBaseUrl: "ws://192.168.50.10:3773",
+    });
+    const secondCredential = new BearerConnectionCredential({ token: "bearer-token-2" });
+    const first = registerConnectionInCatalog(
+      { ...EMPTY_CONNECTION_CATALOG_DOCUMENT, remoteDpopTokens: [REMOTE_TOKEN] },
+      new BearerConnectionRegistration({
+        target: BEARER_TARGET,
+        profile: BEARER_PROFILE,
+        credential: BEARER_CREDENTIAL,
+      }),
+    );
+    const both = registerConnectionInCatalog(
+      first,
+      new BearerConnectionRegistration({
+        target: secondTarget,
+        profile: secondProfile,
+        credential: secondCredential,
+      }),
+    );
+
+    expect(both.targets).toEqual([BEARER_TARGET, secondTarget]);
+    expect(both.profiles).toEqual([BEARER_PROFILE, secondProfile]);
+    expect(both.credentials).toEqual([
+      { connectionId: BEARER_TARGET.connectionId, credential: BEARER_CREDENTIAL },
+      { connectionId: secondTarget.connectionId, credential: secondCredential },
+    ]);
+
+    const firstActive = activateConnectionInCatalog(both, BEARER_TARGET);
+    expect(firstActive.targets).toEqual([secondTarget, BEARER_TARGET]);
+
+    const remaining = removeConnectionFromCatalog(firstActive, BEARER_TARGET);
+    expect(remaining.targets).toEqual([secondTarget]);
+    expect(remaining.profiles).toEqual([secondProfile]);
+    expect(remaining.credentials).toEqual([
+      { connectionId: secondTarget.connectionId, credential: secondCredential },
+    ]);
+    expect(remaining.remoteDpopTokens).toEqual([REMOTE_TOKEN]);
+
+    expect(removeConnectionFromCatalog(remaining, secondTarget)).toEqual(
+      EMPTY_CONNECTION_CATALOG_DOCUMENT,
+    );
+  });
+
+  it("supports clients that retain one route per environment", () => {
+    const replacementTarget = new BearerConnectionTarget({
+      environmentId: ENVIRONMENT_ID,
+      label: "Remote on another network",
+      connectionId: "bearer-replacement",
+    });
+    const replacementProfile = new BearerConnectionProfile({
+      connectionId: replacementTarget.connectionId,
+      environmentId: ENVIRONMENT_ID,
+      label: replacementTarget.label,
+      httpBaseUrl: "http://192.168.50.10:3773",
+      wsBaseUrl: "ws://192.168.50.10:3773",
+    });
+    const first = registerConnectionInCatalog(
+      { ...EMPTY_CONNECTION_CATALOG_DOCUMENT, remoteDpopTokens: [REMOTE_TOKEN] },
+      new BearerConnectionRegistration({
+        target: BEARER_TARGET,
+        profile: BEARER_PROFILE,
+        credential: BEARER_CREDENTIAL,
+      }),
+    );
+    const replaced = replaceEnvironmentConnectionInCatalog(
+      first,
+      new BearerConnectionRegistration({
+        target: replacementTarget,
+        profile: replacementProfile,
+        credential: new BearerConnectionCredential({ token: "replacement-token" }),
+      }),
+    );
+
+    expect(replaced.targets).toEqual([replacementTarget]);
+    expect(replaced.profiles).toEqual([replacementProfile]);
+    expect(replaced.credentials).toHaveLength(1);
+    expect(replaced.remoteDpopTokens).toEqual([REMOTE_TOKEN]);
   });
 
   it("replaces obsolete connection metadata without discarding a reusable DPoP token", () => {

--- a/packages/client-runtime/src/platform/storageDocument.test.ts
+++ b/packages/client-runtime/src/platform/storageDocument.test.ts
@@ -17,7 +17,6 @@ import {
 } from "../connection/model.ts";
 import {
   EMPTY_CONNECTION_CATALOG_DOCUMENT,
-  activateConnectionInCatalog,
   registerConnectionInCatalog,
   replaceEnvironmentConnectionInCatalog,
   removeConnectionFromCatalog,
@@ -112,10 +111,7 @@ describe("ConnectionCatalogDocument", () => {
       { connectionId: secondTarget.connectionId, credential: secondCredential },
     ]);
 
-    const firstActive = activateConnectionInCatalog(both, BEARER_TARGET);
-    expect(firstActive.targets).toEqual([secondTarget, BEARER_TARGET]);
-
-    const remaining = removeConnectionFromCatalog(firstActive, BEARER_TARGET);
+    const remaining = removeConnectionFromCatalog(both, BEARER_TARGET);
     expect(remaining.targets).toEqual([secondTarget]);
     expect(remaining.profiles).toEqual([secondProfile]);
     expect(remaining.credentials).toEqual([
@@ -126,6 +122,53 @@ describe("ConnectionCatalogDocument", () => {
     expect(removeConnectionFromCatalog(remaining, secondTarget)).toEqual(
       EMPTY_CONNECTION_CATALOG_DOCUMENT,
     );
+  });
+
+  it("retains relay and bearer routes to the same environment", () => {
+    const relayTarget = new RelayConnectionTarget({
+      environmentId: ENVIRONMENT_ID,
+      label: "Remote through T3 Connect",
+    });
+    const withRelay = registerConnectionInCatalog(
+      { ...EMPTY_CONNECTION_CATALOG_DOCUMENT, remoteDpopTokens: [REMOTE_TOKEN] },
+      new RelayConnectionRegistration({ target: relayTarget }),
+    );
+    const withBoth = registerConnectionInCatalog(
+      withRelay,
+      new BearerConnectionRegistration({
+        target: BEARER_TARGET,
+        profile: BEARER_PROFILE,
+        credential: BEARER_CREDENTIAL,
+      }),
+    );
+
+    expect(withBoth.targets).toEqual([relayTarget, BEARER_TARGET]);
+    expect(withBoth.profiles).toEqual([BEARER_PROFILE]);
+    expect(withBoth.credentials).toEqual([
+      { connectionId: BEARER_TARGET.connectionId, credential: BEARER_CREDENTIAL },
+    ]);
+    expect(removeConnectionFromCatalog(withBoth, BEARER_TARGET)).toEqual({
+      ...withRelay,
+      remoteDpopTokens: [REMOTE_TOKEN],
+    });
+    const withBearerFirst = registerConnectionInCatalog(
+      { ...EMPTY_CONNECTION_CATALOG_DOCUMENT, remoteDpopTokens: [REMOTE_TOKEN] },
+      new BearerConnectionRegistration({
+        target: BEARER_TARGET,
+        profile: BEARER_PROFILE,
+        credential: BEARER_CREDENTIAL,
+      }),
+    );
+    expect(removeConnectionFromCatalog(withBoth, relayTarget)).toEqual({
+      ...withBearerFirst,
+      remoteDpopTokens: [],
+    });
+    expect(
+      registerConnectionInCatalog(
+        withBearerFirst,
+        new RelayConnectionRegistration({ target: relayTarget }),
+      ).targets,
+    ).toEqual([BEARER_TARGET, relayTarget]);
   });
 
   it("supports clients that retain one route per environment", () => {
@@ -164,7 +207,7 @@ describe("ConnectionCatalogDocument", () => {
     expect(replaced.remoteDpopTokens).toEqual([REMOTE_TOKEN]);
   });
 
-  it("replaces obsolete connection metadata without discarding a reusable DPoP token", () => {
+  it("retains sibling connection metadata and its reusable DPoP token", () => {
     const bearer = registerConnectionInCatalog(
       {
         ...EMPTY_CONNECTION_CATALOG_DOCUMENT,
@@ -185,9 +228,11 @@ describe("ConnectionCatalogDocument", () => {
       new RelayConnectionRegistration({ target: relayTarget }),
     );
 
-    expect(relay.targets).toEqual([relayTarget]);
-    expect(relay.profiles).toEqual([]);
-    expect(relay.credentials).toEqual([]);
+    expect(relay.targets).toEqual([BEARER_TARGET, relayTarget]);
+    expect(relay.profiles).toEqual([BEARER_PROFILE]);
+    expect(relay.credentials).toEqual([
+      { connectionId: BEARER_TARGET.connectionId, credential: BEARER_CREDENTIAL },
+    ]);
     expect(relay.remoteDpopTokens).toEqual([REMOTE_TOKEN]);
   });
 

--- a/packages/client-runtime/src/platform/storageDocument.ts
+++ b/packages/client-runtime/src/platform/storageDocument.ts
@@ -5,7 +5,11 @@ import {
   ConnectionCredential,
   ConnectionProfile,
 } from "../connection/catalog.ts";
-import { type ConnectionTarget, PersistedConnectionTarget } from "../connection/model.ts";
+import {
+  type ConnectionTarget,
+  PersistedConnectionTarget,
+  connectionTargetId,
+} from "../connection/model.ts";
 import * as TokenStore from "../authorization/tokenStore.ts";
 
 export const StoredConnectionCredential = Schema.Struct({
@@ -65,13 +69,17 @@ function removeConnectionMetadata(
   removeRemoteToken: boolean,
 ): ConnectionCatalogDocument {
   const connectionId = connectionIdOf(target);
+  const targets = removeCatalogValue(
+    document.targets,
+    connectionTargetId,
+    connectionTargetId(target),
+  );
+  const hasSiblingRoute = targets.some(
+    (candidate) => candidate.environmentId === target.environmentId,
+  );
   return {
     ...document,
-    targets: removeCatalogValue(
-      document.targets,
-      (value) => value.environmentId,
-      target.environmentId,
-    ),
+    targets,
     profiles:
       connectionId === null
         ? document.profiles
@@ -80,13 +88,14 @@ function removeConnectionMetadata(
       connectionId === null
         ? document.credentials
         : removeCatalogValue(document.credentials, (value) => value.connectionId, connectionId),
-    remoteDpopTokens: removeRemoteToken
-      ? removeCatalogValue(
-          document.remoteDpopTokens,
-          (value) => value.environmentId,
-          target.environmentId,
-        )
-      : document.remoteDpopTokens,
+    remoteDpopTokens:
+      removeRemoteToken && !hasSiblingRoute
+        ? removeCatalogValue(
+            document.remoteDpopTokens,
+            (value) => value.environmentId,
+            target.environmentId,
+          )
+        : document.remoteDpopTokens,
   };
 }
 
@@ -95,14 +104,19 @@ export function registerConnectionInCatalog(
   registration: ConnectionRegistration,
 ): ConnectionCatalogDocument {
   const target = registration.target;
-  const previous = document.targets.find(
-    (candidate) => candidate.environmentId === target.environmentId,
+  const replaced = document.targets.filter(
+    (candidate) =>
+      connectionTargetId(candidate) === connectionTargetId(target) ||
+      (candidate.environmentId === target.environmentId &&
+        (candidate._tag === "RelayConnectionTarget" || target._tag === "RelayConnectionTarget")),
   );
-  const cleaned =
-    previous === undefined ? document : removeConnectionMetadata(document, previous, false);
+  const cleaned = replaced.reduce(
+    (current, previous) => removeConnectionMetadata(current, previous, false),
+    document,
+  );
   const next: ConnectionCatalogDocument = {
     ...cleaned,
-    targets: replaceCatalogValue(cleaned.targets, (value) => value.environmentId, target),
+    targets: replaceCatalogValue(cleaned.targets, connectionTargetId, target),
   };
 
   switch (registration._tag) {
@@ -131,6 +145,38 @@ export function registerConnectionInCatalog(
         ),
       };
   }
+}
+
+/**
+ * Register one route while retaining the legacy single-route-per-environment
+ * policy used by clients that do not expose route management UI.
+ */
+export function replaceEnvironmentConnectionInCatalog(
+  document: ConnectionCatalogDocument,
+  registration: ConnectionRegistration,
+): ConnectionCatalogDocument {
+  const cleaned = document.targets
+    .filter((target) => target.environmentId === registration.target.environmentId)
+    .reduce((current, target) => removeConnectionMetadata(current, target, false), document);
+  return registerConnectionInCatalog(cleaned, registration);
+}
+
+export function activateConnectionInCatalog(
+  document: ConnectionCatalogDocument,
+  target: ConnectionTarget,
+): ConnectionCatalogDocument {
+  const targetId = connectionTargetId(target);
+  const saved = document.targets.find((candidate) => connectionTargetId(candidate) === targetId);
+  if (saved === undefined) {
+    return document;
+  }
+  return {
+    ...document,
+    targets: [
+      ...document.targets.filter((candidate) => connectionTargetId(candidate) !== targetId),
+      saved,
+    ],
+  };
 }
 
 export function removeConnectionFromCatalog(

--- a/packages/client-runtime/src/platform/storageDocument.ts
+++ b/packages/client-runtime/src/platform/storageDocument.ts
@@ -89,7 +89,7 @@ function removeConnectionMetadata(
         ? document.credentials
         : removeCatalogValue(document.credentials, (value) => value.connectionId, connectionId),
     remoteDpopTokens:
-      removeRemoteToken && !hasSiblingRoute
+      removeRemoteToken && (target._tag === "RelayConnectionTarget" || !hasSiblingRoute)
         ? removeCatalogValue(
             document.remoteDpopTokens,
             (value) => value.environmentId,
@@ -105,10 +105,7 @@ export function registerConnectionInCatalog(
 ): ConnectionCatalogDocument {
   const target = registration.target;
   const replaced = document.targets.filter(
-    (candidate) =>
-      connectionTargetId(candidate) === connectionTargetId(target) ||
-      (candidate.environmentId === target.environmentId &&
-        (candidate._tag === "RelayConnectionTarget" || target._tag === "RelayConnectionTarget")),
+    (candidate) => connectionTargetId(candidate) === connectionTargetId(target),
   );
   const cleaned = replaced.reduce(
     (current, previous) => removeConnectionMetadata(current, previous, false),
@@ -159,24 +156,6 @@ export function replaceEnvironmentConnectionInCatalog(
     .filter((target) => target.environmentId === registration.target.environmentId)
     .reduce((current, target) => removeConnectionMetadata(current, target, false), document);
   return registerConnectionInCatalog(cleaned, registration);
-}
-
-export function activateConnectionInCatalog(
-  document: ConnectionCatalogDocument,
-  target: ConnectionTarget,
-): ConnectionCatalogDocument {
-  const targetId = connectionTargetId(target);
-  const saved = document.targets.find((candidate) => connectionTargetId(candidate) === targetId);
-  if (saved === undefined) {
-    return document;
-  }
-  return {
-    ...document,
-    targets: [
-      ...document.targets.filter((candidate) => connectionTargetId(candidate) !== targetId),
-      saved,
-    ],
-  };
 }
 
 export function removeConnectionFromCatalog(

--- a/packages/client-runtime/src/state/connections.ts
+++ b/packages/client-runtime/src/state/connections.ts
@@ -50,6 +50,27 @@ export function createEnvironmentCatalogAtoms<R, E>(
     Option.getOrElse(AsyncResult.value(get(catalogAtom)), () => EMPTY_ENVIRONMENT_CATALOG_STATE),
   ).pipe(Atom.withLabel("environment-catalog-value"));
 
+  const connectionsAtom = runtime.atom(
+    Stream.unwrap(
+      EnvironmentRegistry.EnvironmentRegistry.pipe(
+        Effect.map((registry) => SubscriptionRef.changes(registry.connections)),
+      ),
+    ),
+    {
+      initialValue: new Map<string, ConnectionCatalogEntry>() as ReadonlyMap<
+        string,
+        ConnectionCatalogEntry
+      >,
+    },
+  );
+
+  const connectionsValueAtom = Atom.make((get) =>
+    Option.getOrElse(
+      AsyncResult.value(get(connectionsAtom)),
+      () => new Map<string, ConnectionCatalogEntry>(),
+    ),
+  ).pipe(Atom.withLabel("environment-connections-value"));
+
   const networkStatusAtom = runtime.atom(
     Stream.unwrap(
       EnvironmentRegistry.EnvironmentRegistry.pipe(
@@ -97,6 +118,24 @@ export function createEnvironmentCatalogAtoms<R, E>(
         Effect.flatMap((registry) => registry.remove(environmentId)),
       ),
   });
+  const activate = createRuntimeCommand(runtime, {
+    label: "environment-catalog:activate",
+    scheduler: commandScheduler,
+    concurrency: serial,
+    execute: (connectionId: string) =>
+      EnvironmentRegistry.EnvironmentRegistry.pipe(
+        Effect.flatMap((registry) => registry.activate(connectionId)),
+      ),
+  });
+  const removeConnection = createRuntimeCommand(runtime, {
+    label: "environment-catalog:remove-connection",
+    scheduler: commandScheduler,
+    concurrency: serial,
+    execute: (connectionId: string) =>
+      EnvironmentRegistry.EnvironmentRegistry.pipe(
+        Effect.flatMap((registry) => registry.removeConnection(connectionId)),
+      ),
+  });
   const removeRelayEnvironments = createRuntimeCommand(runtime, {
     label: "environment-catalog:remove-relay-environments",
     scheduler: commandScheduler,
@@ -115,16 +154,33 @@ export function createEnvironmentCatalogAtoms<R, E>(
         Effect.flatMap((registry) => registry.retryNow(environmentId)),
       ),
   });
+  const retryConnection = createRuntimeCommand(runtime, {
+    label: "environment-catalog:retry-connection",
+    scheduler: commandScheduler,
+    concurrency: serial,
+    execute: (connectionId: string) =>
+      Effect.gen(function* () {
+        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+        yield* registry.activate(connectionId);
+        const entry = (yield* SubscriptionRef.get(registry.connections)).get(connectionId);
+        if (entry !== undefined) yield* registry.retryNow(entry.target.environmentId);
+      }),
+  });
 
   return {
     catalogAtom,
     catalogValueAtom,
+    connectionsAtom,
+    connectionsValueAtom,
     networkStatusAtom,
     networkStatusValueAtom,
     stateAtom,
     register,
     remove,
+    activate,
+    removeConnection,
     removeRelayEnvironments,
     retryNow,
+    retryConnection,
   };
 }

--- a/packages/client-runtime/src/state/connections.ts
+++ b/packages/client-runtime/src/state/connections.ts
@@ -7,7 +7,7 @@ import { AsyncResult, Atom } from "effect/unstable/reactivity";
 
 import * as EnvironmentRegistry from "../connection/registry.ts";
 import type { ConnectionCatalogEntry } from "../connection/catalog.ts";
-import { AVAILABLE_CONNECTION_STATE } from "../connection/model.ts";
+import { AVAILABLE_CONNECTION_STATE, type SupervisorConnectionState } from "../connection/model.ts";
 import * as EnvironmentSupervisor from "../connection/supervisor.ts";
 import {
   createAtomCommandScheduler,
@@ -71,6 +71,31 @@ export function createEnvironmentCatalogAtoms<R, E>(
     ),
   ).pipe(Atom.withLabel("environment-connections-value"));
 
+  const connectionStateAtom = Atom.family((connectionId: string) =>
+    runtime.atom(
+      Stream.unwrap(
+        EnvironmentRegistry.EnvironmentRegistry.pipe(
+          Effect.map((registry) => registry.connectionStateChanges(connectionId)),
+        ),
+      ),
+      { initialValue: AVAILABLE_CONNECTION_STATE },
+    ),
+  );
+
+  const connectionStatesValueAtom = Atom.make((get) => {
+    const states = new Map<string, SupervisorConnectionState>();
+    for (const connectionId of get(connectionsValueAtom).keys()) {
+      states.set(
+        connectionId,
+        Option.getOrElse(
+          AsyncResult.value(get(connectionStateAtom(connectionId))),
+          () => AVAILABLE_CONNECTION_STATE,
+        ),
+      );
+    }
+    return states;
+  }).pipe(Atom.withLabel("environment-connection-states-value"));
+
   const networkStatusAtom = runtime.atom(
     Stream.unwrap(
       EnvironmentRegistry.EnvironmentRegistry.pipe(
@@ -118,15 +143,6 @@ export function createEnvironmentCatalogAtoms<R, E>(
         Effect.flatMap((registry) => registry.remove(environmentId)),
       ),
   });
-  const activate = createRuntimeCommand(runtime, {
-    label: "environment-catalog:activate",
-    scheduler: commandScheduler,
-    concurrency: serial,
-    execute: (connectionId: string) =>
-      EnvironmentRegistry.EnvironmentRegistry.pipe(
-        Effect.flatMap((registry) => registry.activate(connectionId)),
-      ),
-  });
   const removeConnection = createRuntimeCommand(runtime, {
     label: "environment-catalog:remove-connection",
     scheduler: commandScheduler,
@@ -159,12 +175,9 @@ export function createEnvironmentCatalogAtoms<R, E>(
     scheduler: commandScheduler,
     concurrency: serial,
     execute: (connectionId: string) =>
-      Effect.gen(function* () {
-        const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
-        yield* registry.activate(connectionId);
-        const entry = (yield* SubscriptionRef.get(registry.connections)).get(connectionId);
-        if (entry !== undefined) yield* registry.retryNow(entry.target.environmentId);
-      }),
+      EnvironmentRegistry.EnvironmentRegistry.pipe(
+        Effect.flatMap((registry) => registry.retryConnection(connectionId)),
+      ),
   });
 
   return {
@@ -172,12 +185,13 @@ export function createEnvironmentCatalogAtoms<R, E>(
     catalogValueAtom,
     connectionsAtom,
     connectionsValueAtom,
+    connectionStateAtom,
+    connectionStatesValueAtom,
     networkStatusAtom,
     networkStatusValueAtom,
     stateAtom,
     register,
     remove,
-    activate,
     removeConnection,
     removeRelayEnvironments,
     retryNow,


### PR DESCRIPTION
The mobile connection catalog treated an environment ID as both the machine identity and the saved connection identity. Pairing the same laptop through another LAN, VPN, or Tailscale address therefore replaced its existing address.

This keeps one logical environment for server-owned data while giving every saved address its own connection supervisor, status, retry, update, and removal lifecycle. Mobile starts and retries all saved addresses automatically, just like connections to different machines, and transparently uses a healthy sibling when another address cannot connect. Web explicitly retains its existing single-address behavior.

Verification:
- 66 focused client-runtime, mobile, and web tests
- client-runtime, mobile, and web typechecks
- targeted lint and formatting checks
- iOS Simulator pass against a disposable backend: paired the same environment at `127.0.0.1` and `localhost`, confirmed both connected automatically, retried one independently, removed it without affecting its sibling, then cleaned up the last address

| Before: one saved address | After: two independently connected addresses |
| --- | --- |
| ![Mobile connection screen with one saved address](https://raw.githubusercontent.com/ipanasenko/t3code/pr-assets/6653/.github/pr-assets/6653/before.png) | ![Mobile connection screen with two connected addresses for one environment](https://raw.githubusercontent.com/ipanasenko/t3code/pr-assets/6653/.github/pr-assets/6653/after.png?v=bf98a8c03) |

Built with GPT-5.6 Sol in the Codex harness through T3 Code; reviewed and approved through iterative Claude Opus review.
