### PR TITLE
feat(web): older chat timestamps show the date, not just the time

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -105,7 +105,7 @@ import {
 import { cn } from "~/lib/utils";
 import { useUiStateStore } from "~/uiStateStore";
 import { type TimestampFormat } from "@t3tools/contracts/settings";
-import { formatChatTimestampTooltip, formatShortTimestamp } from "../../timestampFormat";
+import { formatChatTimestampTooltip, formatDayAwareTimestamp } from "../../timestampFormat";
 
 import {
   buildInlineTerminalContextText,
@@ -1038,7 +1038,7 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
         <div className="flex shrink-0 items-center gap-2">
           <Tooltip>
             <TooltipTrigger render={<p className="text-muted-foreground text-xs tabular-nums" />}>
-              {formatShortTimestamp(row.message.createdAt, ctx.timestampFormat)}
+              {formatDayAwareTimestamp(row.message.createdAt, ctx.timestampFormat)}
             </TooltipTrigger>
             <TooltipPopup>
               {formatChatTimestampTooltip(row.message.createdAt, ctx.timestampFormat)}
@@ -1129,7 +1129,7 @@ function AssistantTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "mess
                 <TooltipTrigger
                   render={<p className="text-muted-foreground text-xs tabular-nums" />}
                 >
-                  {formatShortTimestamp(row.message.updatedAt, ctx.timestampFormat)}
+                  {formatDayAwareTimestamp(row.message.updatedAt, ctx.timestampFormat)}
                 </TooltipTrigger>
                 <TooltipPopup>
                   {formatChatTimestampTooltip(row.message.updatedAt, ctx.timestampFormat)}

--- a/apps/web/src/timestampFormat.test.ts
+++ b/apps/web/src/timestampFormat.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import {
+  formatDayAwareTimestamp,
   formatElapsedDurationLabel,
   formatExpiresInLabel,
   formatRelativeTime,
@@ -93,6 +94,55 @@ describe("formatExpiresInLabel", () => {
   it("uses hours with minute and second remainder", () => {
     expect(formatExpiresInLabel("2026-04-07T14:02:03.000Z")).toBe("Expires in 2h 2m 3s");
     expect(formatExpiresInLabel("2026-04-07T18:00:00.000Z")).toBe("Expires in 6h");
+  });
+});
+
+describe("formatDayAwareTimestamp", () => {
+  // Instants are built with the local-time Date constructor so the
+  // calendar-day boundaries hold in any test timezone or locale.
+  const iso = (y: number, monthIndex: number, d: number, h: number, mi: number) =>
+    new Date(y, monthIndex, d, h, mi).toISOString();
+  const now = new Date(2026, 7, 14, 12, 0).getTime();
+  const time = (isoDate: string) => formatShortTimestamp(isoDate, "12-hour");
+
+  it("shows time only for today", () => {
+    const messageAt = iso(2026, 7, 14, 9, 30);
+    expect(formatDayAwareTimestamp(messageAt, "12-hour", now)).toBe(time(messageAt));
+  });
+
+  it("labels the previous calendar day as yesterday even when under 24h old", () => {
+    const messageAt = iso(2026, 7, 13, 23, 30);
+    const justPastMidnight = new Date(2026, 7, 14, 0, 30).getTime();
+    expect(formatDayAwareTimestamp(messageAt, "12-hour", justPastMidnight)).toBe(
+      `yesterday at ${time(messageAt)}`,
+    );
+  });
+
+  it("prefixes older same-year messages with the numeric date", () => {
+    const messageAt = iso(2026, 7, 12, 12, 34);
+    const datePart = new Intl.DateTimeFormat(undefined, {
+      month: "numeric",
+      day: "numeric",
+    }).format(new Date(messageAt));
+    expect(formatDayAwareTimestamp(messageAt, "12-hour", now)).toBe(
+      `${datePart} ${time(messageAt)}`,
+    );
+  });
+
+  it("includes the year once the calendar year differs", () => {
+    const messageAt = iso(2025, 11, 31, 18, 0);
+    const datePart = new Intl.DateTimeFormat(undefined, {
+      month: "numeric",
+      day: "numeric",
+      year: "numeric",
+    }).format(new Date(messageAt));
+    expect(formatDayAwareTimestamp(messageAt, "12-hour", now)).toBe(
+      `${datePart} ${time(messageAt)}`,
+    );
+  });
+
+  it("returns an empty string for invalid input", () => {
+    expect(formatDayAwareTimestamp("not-a-date", "12-hour", now)).toBe("");
   });
 });
 

--- a/apps/web/src/timestampFormat.ts
+++ b/apps/web/src/timestampFormat.ts
@@ -91,6 +91,44 @@ export function formatShortTimestamp(isoDate: string, timestampFormat: Timestamp
   return getTimestampFormatter(timestampFormat, false).format(date);
 }
 
+const numericDateFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "numeric",
+  day: "numeric",
+});
+const numericDateWithYearFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "numeric",
+  day: "numeric",
+  year: "numeric",
+});
+
+/**
+ * Chat timestamp that adds the date once the message is no longer from today:
+ * today `12:34 PM`, yesterday `yesterday at 12:34 PM`, older `8/13 12:34 PM`
+ * (locale digit order), with the year included once the calendar year differs.
+ * Boundaries are local calendar days, not 24-hour windows.
+ */
+export function formatDayAwareTimestamp(
+  isoDate: string,
+  timestampFormat: TimestampFormat,
+  nowMs: number = Date.now(),
+): string {
+  const date = parseTimestampDate(isoDate);
+  if (!date) return "";
+  const time = getTimestampFormatter(timestampFormat, false).format(date);
+
+  const now = new Date(nowMs);
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  const startOfMessageDay = new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+  // Round so DST-shifted 23/25 hour days still count as whole days.
+  const dayDiff = Math.round((startOfToday - startOfMessageDay) / 86_400_000);
+
+  if (dayDiff <= 0) return time;
+  if (dayDiff === 1) return `yesterday at ${time}`;
+  const dateFormatter =
+    date.getFullYear() === now.getFullYear() ? numericDateFormatter : numericDateWithYearFormatter;
+  return `${dateFormatter.format(date)} ${time}`;
+}
+
 /**
  * Format a relative time string from an ISO date.
  * Returns `{ value: "20s", suffix: "ago" }` or `{ value: "just now", suffix: null }`


### PR DESCRIPTION
Message timestamps in a thread only ever showed the wall-clock time. A message from last week said "12:34 PM" with no hint that it was days old. The date only lived in the hover tooltip.

Now the timestamp adds context as the message ages:

- Today: `12:34 PM` (unchanged)
- Yesterday: `yesterday at 12:34 PM`
- Older: `8/13 12:34 PM`, plus the year once the calendar year differs

Boundaries are local calendar days, not 24-hour windows, so a message from 11pm reads "yesterday" at 1am. Date digit order follows the user's locale via `Intl`. Labels can go stale if a thread sits open across midnight; that staleness is accepted rather than adding a ticking re-render.

Written by Claude Fable 5 running in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change in chat timestamps with tests; no auth, data, or API impact. Labels may be stale until re-render if a thread stays open across midnight.
> 
> **Overview**
> Chat thread **inline timestamps** now show age context instead of wall-clock time only. **Today** stays time-only; **yesterday** uses `yesterday at …`; older messages get a locale numeric date (and year when needed), still respecting 12/24-hour settings.
> 
> Adds **`formatDayAwareTimestamp`** in `timestampFormat.ts` using **local calendar-day** boundaries (not 24h windows), with DST-safe day math. **`MessagesTimeline`** uses it for user and assistant row labels; full date detail remains in the hover tooltip. Unit tests cover today, yesterday-after-midnight, same-year, cross-year, and invalid input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 457d433504b50667b6ba6e1e99b21e3c787bc72a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show date in chat message timestamps when messages are from a previous day
> Adds `formatDayAwareTimestamp` in [timestampFormat.ts](https://github.com/pingdotgg/t3code/pull/6654/files#diff-3c87b91789abf1f3644a1a66f0da1d791ac92e439c18f8a651d177cd2ed1601b) and replaces `formatShortTimestamp` in [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/6654/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) for both user and assistant messages. The new formatter shows time-only for today, 'yesterday at …' for the previous calendar day, and a numeric date plus time (with year when needed) for older messages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 457d433.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->