### PR TITLE
fix(web): preserve custom chat backgrounds in dark themes

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1169,7 +1169,8 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
    compatibility overrides so both navigation implementations receive the
    same palette. Success, info, provider, and channel identity colors remain
    independent; error, warning, and update roles are themeable below. */
-html[data-theme-id] {
+/* Tie the base dark root's specificity so this later theme bridge wins. */
+:root[data-theme-id] {
   --background: var(--app-theme-canvas);
   --app-chrome-background: var(--app-theme-chrome);
   --toolbar-background: var(--app-theme-toolbar);


### PR DESCRIPTION
Custom dark themes could not change the main chat canvas because the simplified theme selector lost to the higher-specificity base dark selector.

This restores the dark theme selector so `--app-theme-canvas` wins and continues to drive `--background`.

Verification: `pnpm --dir apps/web exec vp build`

Created with GPT-5.6 Sol using pi.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS selector change in the theme bridge with no logic or data-path changes; risk is limited to appearance/cascade ordering.
> 
> **Overview**
> **Fixes custom dark theme chat canvas colors** by changing the theme-token bridge selector in `index.css` from `html[data-theme-id]` to `:root[data-theme-id]`.
> 
> That bridge maps `--app-theme-canvas` (and other app theme roles) onto semantic tokens like `--background`. In dark mode, the default `:root` dark block was winning the cascade over the old `html[...]` rule, so custom palettes never applied to the main chat background. Anchoring the bridge on `:root` with the same specificity intent lets those mappings apply after the base dark root tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9db540dd589a6682977e84db46e62ab6ab73d588. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix custom chat backgrounds being overridden in dark themes
> Changes the CSS selector for the theme variable bridge block from `html[data-theme-id]` to `:root[data-theme-id]` in [index.css](https://github.com/pingdotgg/t3code/pull/6655/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd). This increases specificity so custom theme properties correctly override lower-specificity root definitions when a theme ID is present, preserving custom chat backgrounds in dark themes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9db540d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->