### PR TITLE
fix(web): restore dark theme palette

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1169,7 +1169,9 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
    compatibility overrides so both navigation implementations receive the
    same palette. Success, info, provider, and channel identity colors remain
    independent; error, warning, and update roles are themeable below. */
-html[data-theme-id] {
+/* The non-empty marker adds enough specificity to outrank the generated root
+   dark variant without reintroducing raw `.dark` selectors. */
+html[data-theme-id]:not([data-theme-id=""]) {
   --background: var(--app-theme-canvas);
   --app-chrome-background: var(--app-theme-chrome);
   --toolbar-background: var(--app-theme-toolbar);


### PR DESCRIPTION
## What Changed

Raised the runtime theme-token bridge above the generated root dark-mode defaults by requiring a non-empty `data-theme-id`.

The selector stays mode-agnostic and avoids reintroducing raw `.dark` selectors.

## Why

The CSS cleanup in #6381 changed the bridge from `html[data-theme-id], html.dark[data-theme-id]` to `html[data-theme-id]`. In dark mode, Tailwind emits the default tokens under `:root:is(.dark, .dark *)`, which has higher specificity. The selected theme's artwork and sidebar still rendered, but the workspace inherited the neutral black default palette.

The extra non-empty attribute condition gives the theme bridge enough specificity for built-in, custom, and preview themes while leaving the default palette untouched when no valid theme id is present.

## UI Changes

Before: Ember is selected, but the main surface remains neutral black.

<img width="1084" height="768" alt="Before: Ember sidebar with a neutral black workspace" src="https://github.com/user-attachments/assets/3017b912-f023-4b3d-b956-71e2f66e6a46" />

After: Ember's dark canvas and derived surfaces apply across the workspace.

<img width="1084" height="768" alt="After: Ember palette applied across the workspace" src="https://github.com/user-attachments/assets/d3519db5-425c-4bed-bf36-87976c74f8d9" />

## Validation

- `pnpm exec vp fmt --check apps/web/src/index.css`
- `pnpm --dir apps/web run typecheck`
- `pnpm --dir apps/web run build`
- Inspected the emitted production CSS to confirm `html[data-theme-id]:not([data-theme-id=""])` is preserved and outranks `:root:is(.dark, .dark *)`.
- Verified the fix in the Nightly desktop client with Ember dark mode.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes (not applicable; this is a static CSS cascade fix)

Created with Codex (GPT-5) via the Codex desktop harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix dark theme palette by updating CSS selector in `index.css`
> Replaces the `html[data-theme-id], html.dark[data-theme-id]` selector with `html[data-theme-id]:not([data-theme-id=""])` in [index.css](https://github.com/pingdotgg/t3code/pull/6663/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd). The new selector removes the dependency on the `.dark` class and excludes empty `data-theme-id` values, which restores correct theme variable mapping for dark themes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 80fb733.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-selector cascade fix in global CSS with no runtime or auth changes; risk is limited to theme/default palette edge cases when `data-theme-id` is empty.
> 
> **Overview**
> Fixes **dark mode ignoring the selected appearance theme** for the main workspace: after a prior CSS cleanup, Tailwind’s generated `:root:is(.dark, .dark *)` defaults could beat the runtime theme-token bridge on `html[data-theme-id]`, so palettes like Ember kept themed sidebar art but the canvas stayed neutral black.
> 
> The bridge selector in `index.css` is tightened to **`html[data-theme-id]:not([data-theme-id=""])`**, adding specificity without bringing back a separate `html.dark[...]` rule. Theme CSS variables apply only when a real theme id is set; empty `data-theme-id` still uses the default palette.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80fb733c90c92b027f120ebae8db1f40afc9edfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->