### PR TITLE
fix(web): restore selected themes in dark mode

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1169,7 +1169,8 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
    compatibility overrides so both navigation implementations receive the
    same palette. Success, info, provider, and channel identity colors remain
    independent; error, warning, and update roles are themeable below. */
-html[data-theme-id] {
+html[data-theme-id],
+html.dark[data-theme-id] {
   --background: var(--app-theme-canvas);
   --app-chrome-background: var(--app-theme-chrome);
   --toolbar-background: var(--app-theme-toolbar);


### PR DESCRIPTION
Selected themes stopped applying their main palette in dark mode after the global stylesheet cleanup. The generated root dark defaults had higher specificity than the theme-token bridge, leaving the workspace on the default neutral palette.

Restore the explicit dark selector alongside the mode-agnostic selector. Light mode keeps the existing theme bridge unchanged, while dark mode now has enough specificity to override the generated defaults without changing theme-id semantics.

## Playwright proof

Dark mode: Ember is selected, the root has `.dark`, and the computed `--background`, `--app-theme-canvas`, and body background all resolve to `oklch(0.245899 0.019144 42.044)`.

![Ember theme applied in dark mode](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/1a2e1621-e0b8-490f-baab-4807d6b962e9/t3code-ember-dark-theme-proof.png)

Light mode: Ember remains selected, the root does not have `.dark`, and the computed `--background`, `--app-theme-canvas`, and body background all resolve to `oklch(0.976527 0.002685 60.725)`.

![Ember theme applied in light mode](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/c6dd80d4-1bac-49f9-b4fb-ecbd1504278a/t3code-ember-light-theme-proof.png)

## Validation

- `pnpm exec vp fmt --check apps/web/src/index.css`
- `pnpm --dir apps/web run build`
- Playwright verification of Ember in dark and light modes
- Inspected emitted production CSS for both `html[data-theme-id]` and `html.dark[data-theme-id]`

No tests added per request.

Created by GPT-5.6-sol in T3 Code via the Codex harness.
