### PR TITLE
fix(web): keep theme specificity variant-safe

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1168,9 +1168,9 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
    semantic surface tokens here. Keep this block after the sidebar-version
    compatibility overrides so both navigation implementations receive the
    same palette. Success, info, provider, and channel identity colors remain
-   independent; error, warning, and update roles are themeable below. */
-html[data-theme-id],
-html.dark[data-theme-id] {
+   independent; error, warning, and update roles are themeable below. The root
+   qualifier keeps these tokens above the generated dark-variant defaults. */
+html[data-theme-id]:root {
   --background: var(--app-theme-canvas);
   --app-chrome-background: var(--app-theme-chrome);
   --toolbar-background: var(--app-theme-toolbar);


### PR DESCRIPTION
Follow-up to #6665. The dark-theme fix restored the selected palette, but hard-coded the `.dark` class in the theme bridge and made that selector depend on the current custom-variant implementation.

Use `html[data-theme-id]:root` instead. It has enough specificity to outrank the generated dark defaults in both appearances without naming `.dark`, and the nearby comment documents why the extra qualifier exists.

## Playwright proof

Dark mode: Ember is selected, and the computed `--background`, `--app-theme-canvas`, and body background all resolve to `oklch(0.245899 0.019144 42.044)`.

![Ember theme applied in dark mode](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/1a2e1621-e0b8-490f-baab-4807d6b962e9/t3code-ember-dark-theme-proof.png)

Light mode: Ember remains selected, and the computed `--background`, `--app-theme-canvas`, and body background all resolve to `oklch(0.976527 0.002685 60.725)`.

![Ember theme applied in light mode](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/c6dd80d4-1bac-49f9-b4fb-ecbd1504278a/t3code-ember-light-theme-proof.png)

## Validation

- `pnpm exec vp fmt --check apps/web/src/index.css`
- `pnpm --dir apps/web run build`
- Playwright verification of Ember in dark and light modes after the selector change

No tests added per request.

Created by GPT-5.6-sol in T3 Code via the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS selector change in the theme token bridge; styling-only with no auth, data, or runtime logic impact.
> 
> **Overview**
> Follow-up to the dark-theme palette fix: the theme-to-semantic token bridge no longer uses **`html[data-theme-id]`** paired with **`html.dark[data-theme-id]`**.
> 
> It now targets **`html[data-theme-id]:root`**, which keeps custom palette variables above Tailwind’s generated **`@variant dark`** defaults in **both** light and dark appearance without hard-coding the **`.dark`** class or tying behavior to the current **`@custom-variant dark`** definition. The adjacent comment explains that the **`:root`** qualifier is intentional for specificity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaec26fcc9fd525faff0bde3c4a6b535addb3553. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CSS theme token selector specificity in `index.css`
> Replaces the dual selectors `html[data-theme-id], html.dark[data-theme-id]` with a single `html[data-theme-id]:root` selector in [index.css](https://github.com/pingdotgg/t3code/pull/6667/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd). This increases specificity via the `:root` pseudo-class and removes the `.dark` variant from the selector, making theme token mapping variant-safe.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aaec26f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->