### PR TITLE
fix(web): improve Codex usage graph contrast

### DIFF
--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -25,7 +25,7 @@ import { SidebarInset } from "../ui/sidebar";
 import { WorkspaceBreadcrumb, WorkspaceBreadcrumbItem } from "../WorkspaceBreadcrumb";
 import { COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS } from "../../workspaceTitlebar";
 import { UsageChartLegend, UsageProviderChart, type UsageChartMetric } from "./UsageProviderChart";
-import { PROVIDER_COLOR, PROVIDER_LABEL, PROVIDER_MARK, PROVIDER_ORDER } from "./usageProviders";
+import { PROVIDER_ORDER, PROVIDER_PRESENTATION } from "./usageProviders";
 
 const WINDOW_OPTIONS = [
   { days: 1, label: "Past 24h" },
@@ -209,7 +209,7 @@ export function UsagePage() {
                           <div className="flex items-baseline justify-between">
                             <span className="flex items-center gap-2 text-sm text-foreground">
                               <ProviderMark provider={provider.provider} className="size-4" />
-                              {PROVIDER_LABEL[provider.provider]}
+                              {PROVIDER_PRESENTATION[provider.provider].label}
                             </span>
                             <span className="text-sm text-foreground tabular-nums">
                               {metric === "cost"
@@ -222,7 +222,7 @@ export function UsagePage() {
                               className="h-full"
                               style={{
                                 width: `${(share * 100).toFixed(1)}%`,
-                                backgroundColor: PROVIDER_COLOR[provider.provider],
+                                backgroundColor: PROVIDER_PRESENTATION[provider.provider].color,
                               }}
                             />
                           </div>
@@ -385,7 +385,7 @@ export function UsagePage() {
                           <th className="py-2 font-normal">{isPast24Hours ? "Hour" : "Day"}</th>
                           {PROVIDER_ORDER.map((provider) => (
                             <th key={provider} className="py-2 text-right font-normal">
-                              {PROVIDER_LABEL[provider]}
+                              {PROVIDER_PRESENTATION[provider].label}
                             </th>
                           ))}
                           <th className="py-2 text-right font-normal">Total</th>
@@ -448,7 +448,7 @@ function ProviderMark({
   readonly provider: UsageProviderKind;
   readonly className: string;
 }) {
-  const Mark = PROVIDER_MARK[provider];
+  const Mark = PROVIDER_PRESENTATION[provider].mark;
   return <Mark className={cn("shrink-0", className)} aria-hidden />;
 }
 
@@ -595,7 +595,7 @@ function UsageSkeleton({ resolution }: { readonly resolution: "day" | "hour" }) 
               <div className="flex items-center justify-between">
                 <span className="flex items-center gap-2 text-sm text-foreground">
                   <ProviderMark provider={provider} className="size-4" />
-                  {PROVIDER_LABEL[provider]}
+                  {PROVIDER_PRESENTATION[provider].label}
                 </span>
                 <div className="h-3.5 w-14 rounded-sm bg-muted" />
               </div>

--- a/apps/web/src/components/usage/UsageProviderChart.tsx
+++ b/apps/web/src/components/usage/UsageProviderChart.tsx
@@ -9,7 +9,7 @@ import {
   formatTokens,
   formatUsd,
 } from "@t3tools/shared/usageFormat";
-import { PROVIDER_COLOR, PROVIDER_LABEL, PROVIDER_MARK, PROVIDER_ORDER } from "./usageProviders";
+import { PROVIDER_ORDER, PROVIDER_PRESENTATION } from "./usageProviders";
 
 const VIEW_WIDTH = 960;
 const VIEW_HEIGHT = 260;
@@ -339,14 +339,19 @@ export function UsageProviderChart({
 
             {/* Fills first, then every stroke, so no series covers another's line. */}
             {paths.map(({ provider, area }) => (
-              <path key={provider} d={area} fill={PROVIDER_COLOR[provider]} fillOpacity={0.12} />
+              <path
+                key={provider}
+                d={area}
+                fill={PROVIDER_PRESENTATION[provider].color}
+                fillOpacity={0.12}
+              />
             ))}
             {paths.map(({ provider, line }) => (
               <path
                 key={provider}
                 d={line}
                 fill="none"
-                stroke={PROVIDER_COLOR[provider]}
+                stroke={PROVIDER_PRESENTATION[provider].color}
                 strokeWidth={2}
                 vectorEffect="non-scaling-stroke"
               />
@@ -376,12 +381,12 @@ export function UsageProviderChart({
             >
               <div className="mb-1 text-muted-foreground">{formatTooltipPeriod(hoveredPeriod)}</div>
               {PROVIDER_ORDER.map((provider) => {
-                const Mark = PROVIDER_MARK[provider];
+                const { label, mark: Mark } = PROVIDER_PRESENTATION[provider];
                 return (
                   <div key={provider} className="flex items-center justify-between gap-3">
                     <span className="flex items-center gap-1.5 text-muted-foreground">
                       <Mark className="size-3 shrink-0" aria-hidden />
-                      {PROVIDER_LABEL[provider]}
+                      {label}
                     </span>
                     <span className="text-foreground tabular-nums">
                       {format(
@@ -423,13 +428,13 @@ export function UsageChartLegend() {
   return (
     <div className="flex items-center gap-4">
       {PROVIDER_ORDER.map((provider) => {
-        // The marks carry the same fills as the bands, so they key the chart
-        // just as a colour swatch would.
-        const Mark = PROVIDER_MARK[provider];
+        // Brand marks keep monochrome providers identifiable even when their
+        // chart series use distinct colors.
+        const { label, mark: Mark } = PROVIDER_PRESENTATION[provider];
         return (
           <span key={provider} className="flex items-center gap-1.5 text-xs text-muted-foreground">
             <Mark className="size-3.5 shrink-0" aria-hidden />
-            {PROVIDER_LABEL[provider]}
+            {label}
           </span>
         );
       })}

--- a/apps/web/src/components/usage/usageProviders.ts
+++ b/apps/web/src/components/usage/usageProviders.ts
@@ -1,8 +1,6 @@
 import type { UsageProviderKind } from "@t3tools/contracts";
 
-import { ClaudeAI, CursorIcon, GrokIcon, type Icon, OpenAI } from "../Icons";
-
-type UsageProviderPresentationKind = UsageProviderKind | "cursor" | "grok";
+import { ClaudeAI, type Icon, OpenAI } from "../Icons";
 
 type UsageProviderPresentation = {
   readonly label: string;
@@ -11,36 +9,22 @@ type UsageProviderPresentation = {
 };
 
 /**
- * Series and table order. The chart layers both providers from a shared zero
- * baseline, so this only fixes the reading order of legends, tables and hover
- * rows; it does not decide which series sits above the other.
- */
-export const PROVIDER_ORDER: readonly UsageProviderKind[] = ["codex", "claude"];
-
-/**
- * Usage-series presentation, including planned Cursor and Grok support. Their
- * monochrome marks stay on-brand while distinct mode-aware series colors keep
- * a future four-provider chart readable.
+ * Exhaustive presentation for providers supported by the usage contract.
+ * Declaration order is reused by every chart, table, legend, and skeleton, so
+ * adding a provider only requires its contract support and one entry here.
  */
 export const PROVIDER_PRESENTATION = {
-  claude: {
-    label: "Claude Code",
-    color: "#d97757",
-    mark: ClaudeAI,
-  },
   codex: {
     label: "Codex",
     color: "var(--foreground)",
     mark: OpenAI,
   },
-  cursor: {
-    label: "Cursor",
-    color: "light-dark(var(--color-blue-700), var(--color-blue-300))",
-    mark: CursorIcon,
+  claude: {
+    label: "Claude Code",
+    color: "#d97757",
+    mark: ClaudeAI,
   },
-  grok: {
-    label: "Grok",
-    color: "light-dark(var(--color-violet-700), var(--color-violet-300))",
-    mark: GrokIcon,
-  },
-} satisfies Record<UsageProviderPresentationKind, UsageProviderPresentation>;
+} satisfies Record<UsageProviderKind, UsageProviderPresentation>;
+
+/** The chart layers every series from zero, so order only controls how it is read. */
+export const PROVIDER_ORDER = Object.keys(PROVIDER_PRESENTATION) as UsageProviderKind[];

--- a/apps/web/src/components/usage/usageProviders.ts
+++ b/apps/web/src/components/usage/usageProviders.ts
@@ -14,18 +14,18 @@ export const PROVIDER_LABEL: Record<UsageProviderKind, string> = {
   codex: "Codex",
 };
 
-/** Claude's brand orange against a neutral white for Codex. */
+/** Claude keeps its brand orange; Codex follows the theme's neutral foreground. */
 export const PROVIDER_COLOR: Record<UsageProviderKind, string> = {
   claude: "#d97757",
-  codex: "#e6e6e6",
+  codex: "var(--foreground)",
 };
 
 /**
  * Brand marks, reused from the provider picker.
  *
- * These ship their own fills (`#d97757` for Claude, white on dark for OpenAI),
- * which are the same colours as the chart bands, so swapping a colour dot for a
- * mark keeps the series association intact rather than trading it away.
+ * These ship their own fills (`#d97757` for Claude, neutral for OpenAI), which
+ * match the chart bands, so swapping a colour dot for a mark keeps the series
+ * association intact rather than trading it away.
  */
 export const PROVIDER_MARK: Record<UsageProviderKind, Icon> = {
   claude: ClaudeAI,

--- a/apps/web/src/components/usage/usageProviders.ts
+++ b/apps/web/src/components/usage/usageProviders.ts
@@ -1,6 +1,14 @@
 import type { UsageProviderKind } from "@t3tools/contracts";
 
-import { ClaudeAI, type Icon, OpenAI } from "../Icons";
+import { ClaudeAI, CursorIcon, GrokIcon, type Icon, OpenAI } from "../Icons";
+
+type UsageProviderPresentationKind = UsageProviderKind | "cursor" | "grok";
+
+type UsageProviderPresentation = {
+  readonly label: string;
+  readonly color: string;
+  readonly mark: Icon;
+};
 
 /**
  * Series and table order. The chart layers both providers from a shared zero
@@ -9,25 +17,30 @@ import { ClaudeAI, type Icon, OpenAI } from "../Icons";
  */
 export const PROVIDER_ORDER: readonly UsageProviderKind[] = ["codex", "claude"];
 
-export const PROVIDER_LABEL: Record<UsageProviderKind, string> = {
-  claude: "Claude Code",
-  codex: "Codex",
-};
-
-/** Claude keeps its brand orange; Codex follows the theme's neutral foreground. */
-export const PROVIDER_COLOR: Record<UsageProviderKind, string> = {
-  claude: "#d97757",
-  codex: "var(--foreground)",
-};
-
 /**
- * Brand marks, reused from the provider picker.
- *
- * These ship their own fills (`#d97757` for Claude, neutral for OpenAI), which
- * match the chart bands, so swapping a colour dot for a mark keeps the series
- * association intact rather than trading it away.
+ * Usage-series presentation, including planned Cursor and Grok support. Their
+ * monochrome marks stay on-brand while distinct mode-aware series colors keep
+ * a future four-provider chart readable.
  */
-export const PROVIDER_MARK: Record<UsageProviderKind, Icon> = {
-  claude: ClaudeAI,
-  codex: OpenAI,
-};
+export const PROVIDER_PRESENTATION = {
+  claude: {
+    label: "Claude Code",
+    color: "#d97757",
+    mark: ClaudeAI,
+  },
+  codex: {
+    label: "Codex",
+    color: "var(--foreground)",
+    mark: OpenAI,
+  },
+  cursor: {
+    label: "Cursor",
+    color: "light-dark(var(--color-blue-700), var(--color-blue-300))",
+    mark: CursorIcon,
+  },
+  grok: {
+    label: "Grok",
+    color: "light-dark(var(--color-violet-700), var(--color-violet-300))",
+    mark: GrokIcon,
+  },
+} satisfies Record<UsageProviderPresentationKind, UsageProviderPresentation>;


### PR DESCRIPTION
The Codex usage series used a fixed near-white color, which made its line and fill almost disappear on light themes.

Use the theme foreground for Codex instead. The series now has strong contrast in light mode, stays light in dark mode, and follows custom theme palettes while Claude keeps its brand orange.

Provider presentation now lives in one exhaustive typed registry. Its declaration order drives every usage chart, table, legend, tooltip, and skeleton, so future tracked providers can be added alongside contract support with one presentation entry.

## Screenshots

These Playwright captures force synthetic Cursor and Grok series into the graph for visual comparison only. They do not add either provider to production tracking or rendering. The before and after light images use identical data and colors except that the before image applies the previous `#e6e6e6` Codex color.

| Before, light | After, light |
| --- | --- |
| ![Before: four-provider graph with the Codex line washed out in light mode](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/f84a8489-d4ab-4af4-bdef-70ee7d0593d1/codex-usage-four-providers-before-light.png) | ![After: four-provider graph with a high-contrast Codex line in light mode](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/d181c63e-62fa-4542-9814-c3b2ef7cc026/codex-usage-four-providers-after-light.png) |

Dark mode remains high contrast across the same four synthetic series:

![After: four-provider graph retaining contrast in dark mode](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/bdc8aaec-67a5-4051-9b87-e03704158847/codex-usage-four-providers-after-dark.png)

## Validation

- `pnpm exec vp fmt --check apps/web/src/components/usage/usageProviders.ts apps/web/src/components/usage/UsageProviderChart.tsx apps/web/src/components/usage/UsagePage.tsx`
- `pnpm --dir apps/web run typecheck`
- Playwright light-mode before/after captures with four forced synthetic provider series
- Playwright dark-mode capture with the same four forced synthetic provider series

No tests added per request.

Created by GPT-5.6-sol in T3 Code via the Codex harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Codex usage graph contrast by updating its color to `var(--foreground)`
> Consolidates provider presentation metadata (label, color, mark) into a single `PROVIDER_PRESENTATION` object in [usageProviders.ts](https://github.com/pingdotgg/t3code/pull/6669/files#diff-1239d4db3da7697f4049ced6bc9ed40ea2896435b8994e4558f10ac229c8bfdc), replacing the separate `PROVIDER_LABEL`, `PROVIDER_COLOR`, and `PROVIDER_MARK` maps. The Codex provider color changes from `#e6e6e6` (near-white) to `var(--foreground)`, fixing low-contrast rendering in the usage chart, legend, and table.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 302b106.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->