### PR TITLE
fix(server): treat a missing Codex rollout as a recoverable resume error

### DIFF
--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -358,6 +358,18 @@ describe("isRecoverableThreadResumeError", () => {
     );
   });
 
+  it("matches a missing rollout for a known thread id", () => {
+    NodeAssert.equal(
+      isRecoverableThreadResumeError(
+        new CodexErrors.CodexAppServerRequestError({
+          code: -32603,
+          errorMessage: "no rollout found for thread id 019fdf74-aaa9-7950-b252-7cc7a8650470",
+        }),
+      ),
+      true,
+    );
+  });
+
   it("ignores non-recoverable resume errors", () => {
     NodeAssert.equal(
       isRecoverableThreadResumeError(

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -58,6 +58,7 @@ const RECOVERABLE_THREAD_RESUME_ERROR_SNIPPETS = [
   "no such thread",
   "unknown thread",
   "does not exist",
+  "no rollout found",
 ];
 
 export function hasConfiguredMcpServer(appServerArgs: ReadonlyArray<string> | undefined): boolean {


### PR DESCRIPTION
## What Changed

If the Codex rollout behind a thread went missing, that thread became permanently unusable. Sending a message failed with a provider error, the thread kept showing as needing attention, and retrying produced the same failure every time. There was no way to recover it from the UI.

T3 already knows how to handle this class of problem: when it cannot resume a Codex thread, it starts a fresh one instead of giving up. It decides whether an error is recoverable by looking at the message Codex sends back. When the rollout is gone, that message is:

```
no rollout found for thread id 019fdf74-aaa9-7950-b252-7cc7a8650470
```

The recoverable list held `not found`, `missing thread`, `no such thread`, `unknown thread` and `does not exist`. The phrase above contains the word "found", but not the substring `not found`, and matches none of the others. So a recoverable situation was read as fatal and the fallback never ran.

Added `no rollout found` to that list.

## Why

A missing rollout is precisely what the fallback is for. There is no transcript left to resume, so starting a fresh thread is the only sensible outcome, and it is already what happens for `missing thread` and `does not exist`. This adds one more wording to an existing behaviour rather than introducing new handling.

The check still requires the message to mention a thread before any snippet is considered, so this cannot widen matching to unrelated failures.

One correction to the report: it points at Settle, but `thread.settle` refuses a thread that still has an active session and never reaches this code. The stack trace in the issue runs through turn start (`processTurnStartRequested` -> `ensureSessionForThread` -> `startSession`), which is the path this fixes.

## UI Changes

n/a - nothing looks different. The thread recovers instead of staying stuck.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (n/a)
- [x] I included a video for animation/interaction changes (n/a)

## Verification

```
vp test run apps/server/src/provider/Layers/CodexSessionRuntime.test.ts   # 21 passed
vp run --filter t3 typecheck                                             # exit 0, no errors
vp lint  apps/server/src/provider/Layers/CodexSessionRuntime.ts apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
vp fmt --check <same two files>
```

Removing the new entry makes the added test fail, so it exercises the changed line rather than passing incidentally.

Fixes #5680

Implemented with Claude Opus 5 via Claude Code.
