### PR TITLE
fix(web): stop counting a workflow coordinator as a working agent

### DIFF
--- a/packages/client-runtime/src/state/subagentRuntime.test.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.test.ts
@@ -383,11 +383,47 @@ describe("deriveAgentPanelModel", () => {
   it("counts idle deliberately and waiting as active", () => {
     const model = deriveAgentPanelModel({ agents: roster });
     expect(model.idleCount).toBe(1);
-    // wf-1 coordinator + member 1 running.
-    expect(model.runningCount).toBeGreaterThanOrEqual(1);
+    // Member 1 is running; the wf-1 coordinator is a container, not a worker.
+    expect(model.runningCount).toBe(1);
+    // Every agent lands in exactly one bucket, except coordinators that stand
+    // in for their members.
     expect(model.idleCount + model.runningCount + model.waitingCount + model.settledCount).toBe(
-      roster.length,
+      roster.length - 1,
     );
+  });
+
+  it("omits a workflow coordinator from the working-agent count", () => {
+    const model = deriveAgentPanelModel({ agents: roster });
+    // One member still running plus one idle direct spawn. The coordinator
+    // reports running for the whole workflow and must not inflate the banner.
+    expect(model.liveCount).toBe(1);
+  });
+
+  it("omits a finished workflow coordinator from the settled count", () => {
+    const finished = fold([
+      activity("task.started", { taskId: "wf-2", taskType: "local_workflow", title: "sweep" }),
+      activity("task.progress", {
+        taskId: "wf-2:wf:0",
+        title: "sweep:a",
+        status: "completed",
+        parentAgentId: "wf-2",
+        agentIndex: 0,
+        phaseIndex: 0,
+      }),
+      activity("task.completed", {
+        taskId: "wf-2:wf:0",
+        status: "completed",
+        parentAgentId: "wf-2",
+      }),
+      activity("task.completed", { taskId: "wf-2", status: "completed" }),
+    ]);
+
+    const model = deriveAgentPanelModel({ agents: finished });
+
+    // Only the member settled. The coordinator stands in for it, so counting
+    // both would report two finished agents where one ran.
+    expect(model.settledCount).toBe(1);
+    expect(model.liveCount).toBe(0);
   });
 
   it("keeps direct spawns in first-seen order as their activity changes", () => {

--- a/packages/client-runtime/src/state/subagentRuntime.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.ts
@@ -826,15 +826,16 @@ export function deriveAgentPanelModel({
   let settledCount = 0;
   let totalTokens = 0;
   for (const agent of source) {
+    // A workflow coordinator with members is a container for those members, not
+    // work of its own: it reports running for the whole run and aggregates their
+    // usage upstream in some providers. Counting it would report one more agent
+    // working than there are, and double count tokens.
+    if (agent.kind === "workflow" && (members.get(agent.id) ?? []).length > 0) continue;
     if (agent.status === "running" || agent.status === "pending") runningCount += 1;
     else if (agent.status === "waiting") waitingCount += 1;
     else if (agent.status === "idle") idleCount += 1;
     else settledCount += 1;
-    // Workflow coordinators aggregate member usage upstream in some providers;
-    // avoid double counting by only summing leaf agents when members exist.
-    if (agent.kind !== "workflow" || (members.get(agent.id) ?? []).length === 0) {
-      totalTokens += agent.usage?.totalTokens ?? 0;
-    }
+    totalTokens += agent.usage?.totalTokens ?? 0;
   }
 
   return {


### PR DESCRIPTION
## What Changed

Running a workflow made the background-work banner claim one more agent was working than actually was. With a workflow that had two members and one of them finished, the banner still read "2 agents working in the background" while only one was. The "N working" count in the Agents panel footer was off by the same one.

The extra agent was the workflow coordinator. It is the row that represents the workflow itself, and it stays `running` for as long as the workflow runs, so it was tallied alongside the members it stands for.

The coordinator is now skipped when counting agents by status, so the banner reports the members that are actually doing work.

## Why

`deriveAgentPanelModel` was already skipping these coordinators when summing token usage, with the comment "Workflow coordinators aggregate member usage upstream in some providers; avoid double counting by only summing leaf agents when members exist." The same reasoning applies to the status tally, it just was not applied there.

Rather than repeat that condition, this hoists it to the top of the loop as a single `continue`, so a coordinator that stands in for members is left out of both the counts and the token sum. The net effect on tokens is unchanged.

A coordinator with no members yet is still counted, as before. It is not standing in for anything at that point.

## Note on an existing test

One assertion had to change. It checked that the four status counts add up to the number of agents in the roster, and its comment read "wf-1 coordinator + member 1 running", so it was asserting the behaviour this fixes. It now expects the coordinator to be excluded.

Two tests were added: one for the reported case (the banner count), and one for a finished workflow, so the matching change to the "N settled" footer is covered rather than assumed.

## UI Changes

n/a - no layout or styling change. Only the number in the banner and the panel footer differ, and only when a workflow is running.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (n/a)
- [x] I included a video for animation/interaction changes (n/a)

## Verification

```
vp test run packages/client-runtime/src/state/subagentRuntime.test.ts   # 48 passed
vp run --filter @t3tools/client-runtime typecheck                       # exit 0, no errors
vp lint packages/client-runtime/src/state/subagentRuntime.ts packages/client-runtime/src/state/subagentRuntime.test.ts
vp fmt --check <same two files>
```

Removing the new `continue` makes both new tests fail with `expected 2 to be 1`, which is the inflated count from the report.

Consumers checked: `ChatView` (banner) and `AgentsPanel` (footer) read these counts for display only. The per-phase `activeCount` / `settledCount` in `AgentsPanel` come from a different object and are untouched. `apps/mobile` does not use `deriveAgentPanelModel`; its Live Activity count comes from a server-side aggregate, which is worth a separate look and is not changed here.

Fixes #5807

Implemented with Claude Opus 5 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small display-only logic change in `deriveAgentPanelModel`; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes inflated **“N agents working”** banner and Agents panel footer counts when a workflow is active.
> 
> `deriveAgentPanelModel` now **skips workflow coordinators that have members** in the status tally loop—the coordinator stays `running` for the whole workflow but is a container, not an extra worker. The same early `continue` replaces the separate token-sum guard; **token totals are unchanged**.
> 
> Coordinators **with no members** are still counted. Tests lock in `liveCount`, `settledCount`, and the bucket-sum invariant (`roster.length - 1` when a memberful coordinator is present).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b38f9d044912365a7bb1aa40add976698a3aadb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop counting workflow coordinators as working agents in `deriveAgentPanelModel`
> Workflow coordinator agents that have members act as containers, not workers, and were incorrectly included in running/waiting/idle/settled tallies and `liveCount`. The aggregation loop in [`subagentRuntime.ts`](https://github.com/pingdotgg/t3code/pull/6672/files#diff-b28278fe62e259afab164f07d2e56800ca49f60942f6b12da5f748e9415c8259) now skips coordinators with members when computing status buckets and usage totals, so counts reflect only leaf agents and memberless coordinators.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b38f9d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->