### PR TITLE
perf(server): persist the wire projection for streaming tool.updated data

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.activity.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.activity.test.ts
@@ -82,3 +82,63 @@ describe("runtimeEventToActivities task progress", () => {
     expect(usagePayload).not.toHaveProperty("status");
   });
 });
+describe("runtimeEventToActivities tool streaming persistence", () => {
+  const accumulatedStdout = [
+    "first line of output",
+    ...Array.from({ length: 500 }, (_, index) => `Capturing frame ${index}/9028`),
+  ].join("\n");
+  const streamingData = {
+    toolCallId: "tool-call-1",
+    kind: "execute",
+    command: "blender --render",
+    rawOutput: { stdout: accumulatedStdout },
+    content: [{ type: "content", content: { type: "text", text: accumulatedStdout } }],
+  };
+
+  it("persists tool.updated with the wire projection of data, not the accumulated stream", () => {
+    const event = {
+      ...base,
+      type: "item.updated",
+      eventId: EventId.make("evt-tool-streaming-updated"),
+      payload: {
+        itemType: "command_execution",
+        status: "inProgress",
+        title: "Render",
+        detail: accumulatedStdout,
+        data: streamingData,
+      },
+    } satisfies ProviderRuntimeEvent;
+
+    const activities = runtimeEventToActivities(event);
+
+    expect(activities).toHaveLength(1);
+    const payload = activities[0]?.payload as Record<string, unknown>;
+    const data = payload.data as Record<string, unknown>;
+    expect(payload.status).toBe("inProgress");
+    expect(data.toolCallId).toBe("tool-call-1");
+    expect(data.command).toBe("blender --render");
+    expect(data.rawOutput).toEqual({ content: "first line of output" });
+    expect(data.content).toBeUndefined();
+    expect(JSON.stringify(data).length).toBeLessThan(1_000);
+  });
+
+  it("persists the full terminal payload on tool.completed", () => {
+    const event = {
+      ...base,
+      type: "item.completed",
+      eventId: EventId.make("evt-tool-streaming-completed"),
+      payload: {
+        itemType: "command_execution",
+        status: "completed",
+        title: "Render",
+        data: streamingData,
+      },
+    } satisfies ProviderRuntimeEvent;
+
+    const activities = runtimeEventToActivities(event);
+
+    expect(activities).toHaveLength(1);
+    const payload = activities[0]?.payload as Record<string, unknown>;
+    expect(payload.data).toEqual(streamingData);
+  });
+});

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -41,6 +41,7 @@ import {
   ProviderRuntimeIngestionService,
   type ProviderRuntimeIngestionShape,
 } from "../Services/ProviderRuntimeIngestion.ts";
+import { projectActivityPayload } from "../ActivityPayloadProjection.ts";
 import { forkParked } from "../../serverActivation.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 
@@ -785,8 +786,15 @@ export function runtimeEventToActivities(
       if (!isToolLifecycleItemType(event.payload.itemType)) {
         return [];
       }
+      // A streaming update's `data` carries the full tool output accumulated
+      // so far (adapters merge state forward), and a new activity is emitted
+      // per chunk, so persisting `data` verbatim writes O(N²) bytes per tool
+      // call into both the event store and the projection table. No reader
+      // needs it: ws.ts and http.ts apply `projectActivityPayload` before any
+      // payload reaches a client. Persist the projected form for non-terminal
+      // updates; `item.completed` below still persists the full payload.
       return [
-        {
+        projectActivityPayload({
           id: event.eventId,
           createdAt: event.createdAt,
           tone: "tool",
@@ -804,7 +812,7 @@ export function runtimeEventToActivities(
           },
           turnId: toTurnId(event.turnId) ?? null,
           ...maybeSequence,
-        },
+        }),
       ];
     }
 


### PR DESCRIPTION
Fixes #6673. Related: #6608 / #5855 (read side of the same event flood), #5550 (retention), #5651 (assistant message write path). Decision date: 2026-08-15.

## Outcome

Non-terminal `tool.updated` activities now persist the same projected `data` that clients receive on the wire. `projectActivityPayload` already runs in `ws.ts` and in `http.ts`, so no client can receive the full `data` of any activity today. This PR applies the same projection at ingestion time, before the payload reaches `orchestration_events` and `projection_thread_activities`.

This PR does not change: terminal `tool.completed` payloads (still persisted in full), the event count per tool call, any schema, any existing rows, or any client-visible payload.

## Before and after

| Failure mode before | Mechanism after |
| --- | --- |
| A streaming update persists the full accumulated `rawOutput`/`content`, so one tool call with N updates writes O(N²) bytes, twice. Measured: one 65 KB tool result persisted 238.7 MB across 2,226 updates (3,772×); one tool call produced 357 MB of payload. | A non-terminal update persists the projected form: `toolCallId`, `kind`, `command`, changed files, and a one-line `rawOutput` summary. Bytes per update are bounded (~1 KB), so a tool call writes O(N) bytes. |
| The event store grows without bound from streaming payloads (~235 MB/day measured on one instance), which multiplies the full-thread rescan cost fixed by #6608. | Streaming updates no longer carry payload bulk into the event store. Terminal payloads remain the only large rows. |

## Decisions taken

- **Reuse `projectActivityPayload` instead of adding a size cap.** A cap needs a constant and keeps a second copy of the slimming rules. Reuse keeps one invariant: for streaming updates, persistence stores what clients can receive. The projection's own doc comment ("full payloads remain in persistence") described the pre-#6673 intent; this PR revises that intent for non-terminal updates only.
- **`item.completed` stays untouched.** The terminal payload is the record of what the tool produced. It is one row per call, so it does not amplify.
- **Event count is not reduced.** Debouncing emissions or reusing a stable `activity_id` per `toolCallId` changes what clients observe and belongs in a separate change. Deferred; noted in #6673 as a follow-up.
- **Interrupted tool calls keep only projected data for their last update.** Accepted: clients could never render more than the projected form anyway.

## Finding disposition (#6673)

- O(N²) bytes per tool call, stored twice → fixed here, regression-tested.
- One activity row per update (O(N) rows) → deferred; requires an id-semantics change (see #6673 suggested follow-up).
- `shouldEmitToolCallUpdate` gates only on `detail` → not changed; with bounded payloads the extra emissions cost little, and fewer emissions would change client behavior.

## Verification

Ran on Linux, Node v24.18.1, pnpm 11.10.0:

- `pnpm exec vp test run src/orchestration/Layers/ProviderRuntimeIngestion.activity.test.ts` — 4 passed (2 new: projected persistence for `tool.updated`; full payload kept for `tool.completed`).
- `pnpm exec vp test run src/orchestration/Layers/ProviderRuntimeIngestion.test.ts src/orchestration/Layers/ProviderRuntimeIngestion.approval.test.ts src/orchestration/ActivityPayloadProjection.test.ts` — 52 passed.
- `pnpm exec tsgo --noEmit` in `apps/server` — no errors (pre-existing suggestions in unrelated files only).

Not run: the full monorepo suite (left to CI) and a production soak (moves to the rollout gate below).

## Rollout and proof gates

We run t3 on self-hosted instances with the exact workload from #6673 (render jobs with progress-bar output). Ordered steps to produce production proof:

1. Deploy a build of this branch to an idle instance.
2. Run a chatty render job to completion.
3. Compare `SELECT count(*), sum(length(payload_json)) FROM projection_thread_activities WHERE thread_id = ?` against an unpatched run of the same job. Expected: similar row count, payload bytes down by >100×.
4. Report the numbers on this PR.

Rollback: reinstall the released npm build. The change is write-path only; there is no schema change and old rows are untouched, so nothing durable is lost by rolling back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Write-path change to persisted activity payloads for streaming tool updates; behavior aligns with existing ws/http projection but could affect any internal reader that expected full in-progress data in the DB.
> 
> **Overview**
> Fixes **O(N²) storage** from streaming tool runs by persisting the same slim **`data`** clients already get on the wire for non-terminal **`tool.updated`** activities, instead of the full accumulated stdout/content on every chunk.
> 
> **`runtimeEventToActivities`** now runs **`projectActivityPayload`** on **`item.updated`** tool lifecycle events before rows hit the event store and **`projection_thread_activities`**. **`item.completed`** is unchanged and still stores the full terminal payload. Event count and client-visible payloads are unchanged; only what gets written on the ingestion path for in-progress updates.
> 
> Regression tests assert projected **`tool.updated`** **`data`** (bounded size, one-line **`rawOutput`**) and full **`streamingData`** on **`tool.completed`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66d0ce4d898989977dfad94b855eddd6e90ff0f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Project wire payload for streaming `tool.updated` activities to avoid quadratic growth
> Streaming tool output accumulates over time, so persisting the full `data` payload on every `item.updated` event causes storage to grow quadratically with stream length. `runtimeEventToActivities` in [ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/6675/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7) now wraps `item.updated` tool activities with `projectActivityPayload`, which truncates raw output and omits content fields. Terminal `item.completed` events are unaffected and still persist the full payload.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 66d0ce4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->