### PR TITLE
fix(desktop): exclude msgpackr-extract build artifacts on Windows ARM64

### DIFF
--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -389,10 +389,12 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
     );
   });
 
-  it("limits Electron locales and excludes the unused Claude SDK executable", () => {
+  it("limits Electron locales and excludes unused desktop payload files", () => {
     assert.deepStrictEqual(DESKTOP_ELECTRON_LANGUAGES, ["en-US"]);
     assert.deepStrictEqual(DESKTOP_FILE_EXCLUSIONS, [
       "!**/node_modules/@anthropic-ai/claude-agent-sdk-*/**/*",
+      "!**/node_modules/msgpackr-extract/build/!(Release){,/**/*}",
+      "!**/node_modules/msgpackr-extract/build/Release/!(extract.node){,/**/*}",
       "!apps/desktop/prod-resources/windows-server",
       "!apps/desktop/prod-resources/windows-server/**/*",
     ]);

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -453,8 +453,8 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
       ]);
       assert.deepStrictEqual(win.nsis, { differentialPackage: true });
       // Native binaries and helper executables cannot load from inside an
-      // asar; everything else stays packed. The Claude SDK platform packages
-      // and .bin shims never ship.
+      // asar; everything else stays packed. The Claude SDK platform packages,
+      // native compiler intermediates, and .bin shims never ship.
       assert.equal(
         WINDOWS_SERVER_ASAR_UNPACK_GLOB,
         "{**/*.node,**/*.dll,**/*.exe,**/*.so,**/*.so.*,**/*.dylib}",
@@ -462,6 +462,8 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
       assert.deepStrictEqual(WINDOWS_SERVER_ASAR_IGNORE_GLOBS, [
         "**/node_modules/@anthropic-ai/claude-agent-sdk-*",
         "**/node_modules/@anthropic-ai/claude-agent-sdk-*/**",
+        "**/node_modules/msgpackr-extract/build/!(Release){,/**/*}",
+        "**/node_modules/msgpackr-extract/build/Release/!(extract.node){,/**/*}",
         "**/node_modules/.bin",
         "**/node_modules/.bin/**",
       ]);

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -778,6 +778,10 @@ export const DESKTOP_FILE_EXCLUSIONS = [
   // so the SDK's optional platform packages (each a ~200MB bundled executable)
   // are dead weight. The trailing dash keeps the SDK's own JS package.
   "!**/node_modules/@anthropic-ai/claude-agent-sdk-*/**/*",
+  // Windows arm64 builds msgpackr-extract locally. Keep its runtime addon while
+  // excluding MSBuild intermediates that electron-builder would smart-unpack.
+  "!**/node_modules/msgpackr-extract/build/!(Release){,/**/*}",
+  "!**/node_modules/msgpackr-extract/build/Release/!(extract.node){,/**/*}",
   // Windows stages the server sidecar below prod-resources so electron-builder
   // can copy it using project-relative extraResources matchers. Keep those
   // staging inputs out of app.asar; they are emitted once at resources/.

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -802,12 +802,14 @@ export const WINDOWS_SERVER_ASAR_RESOURCE = "server.asar";
 export const WINDOWS_SERVER_ASAR_UNPACK_GLOB =
   "{**/*.node,**/*.dll,**/*.exe,**/*.so,**/*.so.*,**/*.dylib}";
 // Mirrors DESKTOP_FILE_EXCLUSIONS for the hand-packed sidecar: the Claude SDK
-// platform packages are dead weight (see above), and node_modules/.bin shims
-// are never spawned at runtime (and are symlinks on POSIX build hosts, which
-// the asar extraction path deliberately does not support).
+// platform packages and native compiler intermediates are dead weight (see
+// above), and node_modules/.bin shims are never spawned at runtime (and are
+// symlinks on POSIX build hosts, which the asar extraction path does not support).
 export const WINDOWS_SERVER_ASAR_IGNORE_GLOBS = [
   "**/node_modules/@anthropic-ai/claude-agent-sdk-*",
   "**/node_modules/@anthropic-ai/claude-agent-sdk-*/**",
+  "**/node_modules/msgpackr-extract/build/!(Release){,/**/*}",
+  "**/node_modules/msgpackr-extract/build/Release/!(extract.node){,/**/*}",
   "**/node_modules/.bin",
   "**/node_modules/.bin/**",
 ] as const;


### PR DESCRIPTION
## What Changed

Excluded locally generated `msgpackr-extract` compiler artifacts from both the Electron app and Windows server sidecar while preserving the required `extract.node` binary.

## Why

Windows ARM64 packaging fails because MSBuild intermediates increased the packaged payload to 84 files, exceeding the 80-file limit. After this change, packaging succeeds with 68 files. Equivalent sidecar exclusions also remove 21 unnecessary files and reduce `server.asar` by about 5.9 MB, lowering first-use WSL extraction work.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only glob changes with tests; runtime native addon is explicitly preserved.
> 
> **Overview**
> **Desktop packaging** now strips locally built `msgpackr-extract` MSBuild output while still shipping `extract.node`.
> 
> The same negated globs are applied in **`DESKTOP_FILE_EXCLUSIONS`** (electron-builder `files`) and **`WINDOWS_SERVER_ASAR_IGNORE_GLOBS`** (hand-packed `server.asar`), so compiler intermediates are not counted or smart-unpacked into the Windows payload. Tests assert the updated exclusion lists and sidecar ignore patterns.
> 
> This unblocks **Windows ARM64** builds that were failing the packaged payload file-count guard (84 vs 80 files).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97cd590b07577c1a10752f73a83e22a9225f91a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Exclude msgpackr-extract build artifacts from desktop app packaging
> Windows arm64 builds `msgpackr-extract` locally, producing MSBuild intermediates that were previously included in the packaged app. Two glob patterns are added to [`DESKTOP_FILE_EXCLUSIONS` and `WINDOWS_SERVER_ASAR_IGNORE_GLOBS`](https://github.com/pingdotgg/t3code/pull/6676/files#diff-384c39593c6da8887b4f03c00f763af0e3b689525d3555a9fe03fd05c808471d) to strip these intermediates while retaining the `extract.node` runtime addon.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 97cd590.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->