### PR TITLE
feat(web): collapse the question prompt from its header

### DIFF
--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.test.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.test.tsx
@@ -1,0 +1,61 @@
+import { ApprovalRequestId } from "@t3tools/contracts";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import { ComposerPendingUserInputPanel } from "./ComposerPendingUserInputPanel";
+import type { PendingUserInput } from "../../session-logic";
+
+const prompt: PendingUserInput = {
+  requestId: ApprovalRequestId.make("request-1"),
+  createdAt: "2026-08-15T00:00:00.000Z",
+  questions: [
+    {
+      id: "question-1",
+      header: "Approach",
+      question: "Which approach should the migration take?",
+      options: [
+        { label: "Incremental", description: "Move one module at a time" },
+        { label: "Big bang", description: "Move everything in one release" },
+      ],
+      multiSelect: false,
+    },
+  ],
+};
+
+function renderPanel() {
+  return renderToStaticMarkup(
+    <ComposerPendingUserInputPanel
+      pendingUserInputs={[prompt]}
+      respondingRequestIds={[]}
+      answers={{}}
+      questionIndex={0}
+      onToggleOption={() => {}}
+      onAdvance={() => {}}
+    />,
+  );
+}
+
+describe("ComposerPendingUserInputPanel", () => {
+  it("renders the header as a disclosure control for the question body", () => {
+    const markup = renderPanel();
+
+    const toggle = markup.match(/<button[^>]*data-pending-user-input-toggle="[^"]*"[^>]*>/)?.[0];
+    expect(toggle).toBeDefined();
+    expect(toggle).toContain('data-pending-user-input-toggle="expanded"');
+    expect(toggle).toContain('aria-expanded="true"');
+    expect(toggle).toContain('type="button"');
+
+    const controlledId = toggle?.match(/aria-controls="([^"]+)"/)?.[1];
+    expect(controlledId).toBeDefined();
+    expect(markup).toMatch(new RegExp(`<div[^>]*\\sid="${controlledId}"`));
+  });
+
+  it("starts expanded so the question and its options are visible", () => {
+    const markup = renderPanel();
+
+    expect(markup).toContain("Approach");
+    expect(markup).toContain("Which approach should the migration take?");
+    expect(markup).toContain("Incremental");
+    expect(markup).toContain("Big bang");
+  });
+});

--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
@@ -5,7 +5,8 @@ import {
   derivePendingUserInputProgress,
   type PendingUserInputDraftAnswer,
 } from "../../pendingUserInput";
-import { CheckIcon } from "lucide-react";
+import { CheckIcon, ChevronDownIcon } from "lucide-react";
+import { Collapsible, CollapsiblePanel, CollapsibleTrigger } from "../ui/collapsible";
 import { cn } from "~/lib/utils";
 
 interface PendingUserInputPanelProps {
@@ -65,6 +66,14 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
     questionId: string;
     optionLabel: string;
   } | null>(null);
+  // Collapsing hides everything but the header so a tall prompt stops covering
+  // the thread the user is trying to read. Scoped to a single question: the card
+  // is keyed by request id so the next prompt starts expanded, and storing the
+  // collapsed question's id (rather than a bare flag) reopens the card when the
+  // prompt advances to its next question, which can happen without a click —
+  // sending from the composer advances the active question.
+  const [collapsedQuestionId, setCollapsedQuestionId] = useState<string | null>(null);
+  const isCollapsed = collapsedQuestionId !== null && collapsedQuestionId === activeQuestion?.id;
 
   useEffect(() => {
     onAdvanceRef.current = onAdvance;
@@ -118,9 +127,10 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
 
   // Keyboard shortcut: number keys 1-9 select corresponding options when focus is
   // outside editable fields. Multi-select prompts toggle options in place; single-
-  // select prompts keep the existing auto-advance behavior.
+  // select prompts keep the existing auto-advance behavior. Collapsed prompts opt
+  // out, since the numbers they refer to are not on screen.
   useEffect(() => {
-    if (!activeQuestion || isResponding) return;
+    if (!activeQuestion || isResponding || isCollapsed) return;
     const handler = (event: globalThis.KeyboardEvent) => {
       if (event.metaKey || event.ctrlKey || event.altKey) return;
       const target = event.target;
@@ -144,7 +154,7 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
     };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
-  }, [activeQuestion, isResponding]);
+  }, [activeQuestion, isCollapsed, isResponding]);
 
   if (!activeQuestion) {
     return null;
@@ -153,75 +163,119 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
   const customAnswerActive = progress.customAnswer.trim().length > 0;
 
   return (
-    <div className="px-4 py-3 sm:px-5">
-      <div className="mb-2 flex items-center gap-3">
-        <span className="text-secondary-label text-[11px] font-semibold tracking-widest uppercase">
-          {activeQuestion.header}
-        </span>
-        {prompt.questions.length > 1 ? (
-          <span className="flex h-5 items-center rounded-md bg-muted/60 px-1.5 text-secondary-label text-[10px] font-medium tabular-nums">
-            {questionIndex + 1}/{prompt.questions.length}
+    <Collapsible
+      className="py-3"
+      open={!isCollapsed}
+      onOpenChange={(open) => {
+        setCollapsedQuestionId(open ? null : activeQuestion.id);
+      }}
+    >
+      {/* The trigger's wrapper is inset less than the card's text column, and
+          the trigger pays the difference back as padding: the hover background
+          and focus ring bleed 10px past that column on both sides, while the
+          header label and the chevron still line up with the left and right
+          edges of the question text below. The negative block margin keeps the
+          taller hit area from pushing the panel down. */}
+      <div className="px-1.5 sm:px-2.5">
+        <CollapsibleTrigger
+          title={
+            isCollapsed ? "Show the question and its options" : "Hide the question and its options"
+          }
+          data-pending-user-input-toggle={isCollapsed ? "collapsed" : "expanded"}
+          className="group -my-1 flex w-full items-center gap-3 rounded-md px-2.5 py-1.5 text-left outline-none transition-colors duration-150 hover:bg-muted/40 focus-visible:ring-1 focus-visible:ring-primary/25"
+        >
+          <span className="text-secondary-label text-[11px] font-semibold tracking-widest uppercase group-hover:text-foreground">
+            {activeQuestion.header}
           </span>
-        ) : null}
+          {prompt.questions.length > 1 ? (
+            <span className="flex h-5 items-center rounded-md bg-muted/60 px-1.5 text-secondary-label text-[10px] font-medium tabular-nums">
+              {questionIndex + 1}/{prompt.questions.length}
+            </span>
+          ) : null}
+          {/* Collapsed, the header is otherwise just a section label and a
+              counter, so the question itself is echoed here as a one-line
+              reminder of what is being asked. */}
+          {isCollapsed ? (
+            <span className="min-w-0 flex-1 truncate text-secondary-label text-xs">
+              {activeQuestion.question}
+            </span>
+          ) : null}
+          {/* The chevron points at the body: down while it is open below the
+              header, up while it is collapsed into it. */}
+          <ChevronDownIcon
+            aria-hidden="true"
+            className={cn(
+              "ml-auto size-3.5 shrink-0 text-secondary-label transition-transform duration-150 group-hover:text-foreground",
+              isCollapsed && "rotate-180",
+            )}
+          />
+        </CollapsibleTrigger>
       </div>
-      <p className="text-sm text-foreground/90">{activeQuestion.question}</p>
-      {activeQuestion.multiSelect ? (
-        <p className="mt-1 text-secondary-label text-xs">Select one or more options.</p>
-      ) : null}
-      <div className="mt-3 space-y-1.5">
-        {activeQuestion.options.map((option, index) => {
-          const isOptimisticallySelected =
-            optimisticSingleSelect?.questionId === activeQuestion.id &&
-            optimisticSingleSelect.optionLabel === option.label;
-          const isSelected =
-            isOptimisticallySelected ||
-            (!customAnswerActive && progress.selectedOptionLabels.includes(option.label));
-          const shortcutKey = index < 9 ? index + 1 : null;
-          const className = cn(
-            "group flex w-full items-center gap-3 rounded-lg border px-3 py-2 text-left outline-none transition-all duration-150 focus-visible:border-primary/40 focus-visible:ring-1 focus-visible:ring-primary/25",
-            isSelected
-              ? "border-primary/30 bg-primary/8 text-foreground"
-              : "border-transparent bg-muted/22 text-foreground/85 hover:border-border/45 hover:bg-muted/34",
-            isResponding && "opacity-50 cursor-not-allowed",
-            !isResponding && "cursor-pointer",
-          );
-          const content = (
-            <>
-              <div className="min-w-0 flex-1 flex flex-col gap-0.5">
-                <span className="text-sm font-medium">{option.label}</span>
-                {option.description && option.description !== option.label ? (
-                  <span className="text-secondary-label text-xs">{option.description}</span>
-                ) : null}
-              </div>
-              {isSelected ? (
-                <CheckIcon className="size-3.5 shrink-0 text-primary" />
-              ) : shortcutKey !== null ? (
-                <kbd
-                  className={cn(
-                    "flex size-5 shrink-0 items-center justify-center rounded border border-border/50 text-[11px] font-medium tabular-nums transition-colors duration-150",
-                    "bg-background/35 text-secondary-label group-hover:border-border/70 group-hover:text-foreground",
-                  )}
+      {/* The panel carries the horizontal padding itself: it clips its content
+          while the height animates, so the option buttons have to sit inside
+          that padding or their focus rings get shaved off at the edges. */}
+      <CollapsiblePanel className="px-4 sm:px-5">
+        <div className="pt-2 pb-0.5">
+          <p className="text-sm text-foreground/90">{activeQuestion.question}</p>
+          {activeQuestion.multiSelect ? (
+            <p className="mt-1 text-secondary-label text-xs">Select one or more options.</p>
+          ) : null}
+          <div className="mt-3 space-y-1.5">
+            {activeQuestion.options.map((option, index) => {
+              const isOptimisticallySelected =
+                optimisticSingleSelect?.questionId === activeQuestion.id &&
+                optimisticSingleSelect.optionLabel === option.label;
+              const isSelected =
+                isOptimisticallySelected ||
+                (!customAnswerActive && progress.selectedOptionLabels.includes(option.label));
+              const shortcutKey = index < 9 ? index + 1 : null;
+              const className = cn(
+                "group flex w-full items-center gap-3 rounded-lg border px-3 py-2 text-left outline-none transition-all duration-150 focus-visible:border-primary/40 focus-visible:ring-1 focus-visible:ring-primary/25",
+                isSelected
+                  ? "border-primary/30 bg-primary/8 text-foreground"
+                  : "border-transparent bg-muted/22 text-foreground/85 hover:border-border/45 hover:bg-muted/34",
+                isResponding && "opacity-50 cursor-not-allowed",
+                !isResponding && "cursor-pointer",
+              );
+              const content = (
+                <>
+                  <div className="min-w-0 flex-1 flex flex-col gap-0.5">
+                    <span className="text-sm font-medium">{option.label}</span>
+                    {option.description && option.description !== option.label ? (
+                      <span className="text-secondary-label text-xs">{option.description}</span>
+                    ) : null}
+                  </div>
+                  {isSelected ? (
+                    <CheckIcon className="size-3.5 shrink-0 text-primary" />
+                  ) : shortcutKey !== null ? (
+                    <kbd
+                      className={cn(
+                        "flex size-5 shrink-0 items-center justify-center rounded border border-border/50 text-[11px] font-medium tabular-nums transition-colors duration-150",
+                        "bg-background/35 text-secondary-label group-hover:border-border/70 group-hover:text-foreground",
+                      )}
+                    >
+                      {shortcutKey}
+                    </kbd>
+                  ) : null}
+                </>
+              );
+              return (
+                <button
+                  key={`${activeQuestion.id}:${option.label}`}
+                  type="button"
+                  disabled={isResponding}
+                  onClick={() => {
+                    handleOptionSelection(activeQuestion.id, option.label);
+                  }}
+                  className={className}
                 >
-                  {shortcutKey}
-                </kbd>
-              ) : null}
-            </>
-          );
-          return (
-            <button
-              key={`${activeQuestion.id}:${option.label}`}
-              type="button"
-              disabled={isResponding}
-              onClick={() => {
-                handleOptionSelection(activeQuestion.id, option.label);
-              }}
-              className={className}
-            >
-              {content}
-            </button>
-          );
-        })}
-      </div>
-    </div>
+                  {content}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </CollapsiblePanel>
+    </Collapsible>
   );
 });


### PR DESCRIPTION
## What Changed

The pending-question panel above the composer (`ComposerPendingUserInputPanel`) can now be collapsed from its header.

- The header row is a disclosure control, built on the existing `~/components/ui/collapsible` primitive. Clicking it hides the question, the multi-select hint and the option list; clicking it again restores them.
- Collapsed, the header keeps its section label and question counter and echoes the question itself on one truncated line, so the strip still says what is being asked.
- A chevron marks the affordance and points at the body: down while it is open, up while it is collapsed.
- Collapsed prompts stop listening for the `1`–`9` option shortcuts, since the numbers they refer to are off screen. The composer's custom-answer field keeps working, so a prompt can still be answered while collapsed.
- The collapsed *question's* id is stored rather than a bare flag, so a prompt that advances to its next question reopens. That matters because it happens without a click — sending from the composer advances the active question.

One file of behavior plus a test file. No contract, server or provider surface is touched.

## Why

Resolves #4431. When a question has a long body or many options, the panel grows tall enough to cover most of the thread, so the reasoning that led to the question is hard to read while answering it. On a laptop that is most of the window.

Collapsing to the header is the smallest thing that fixes it: the prompt stays visible and answerable, but it stops competing with the thread for space. Mobile already has an expand/collapse choreography for its own `PendingUserInputCard` (`pendingUserInputLayout.ts`); this closes the same gap on web.

## UI Changes

### Before

The question covers the entire thread:

<img width="1446" height="935" alt="Screenshot from 2026-08-15 11-49-24" src="https://github.com/user-attachments/assets/495e1743-e1f0-47aa-b7fc-ef2a31d14b56" />

### After

There is a chevron icon indicating that clicking the header will collapse the panel:

<img width="1458" height="932" alt="Screenshot from 2026-08-15 11-35-13" src="https://github.com/user-attachments/assets/2810726b-c401-45cc-ac48-08b873d3edd4" />

Collapsed panel after clicking the header:

<img width="1452" height="936" alt="Screenshot from 2026-08-15 11-36-13" src="https://github.com/user-attachments/assets/295a5ea4-b019-43a7-80d4-4e222a961b8c" />

### Video

https://github.com/user-attachments/assets/cae1e446-1372-42ba-90e8-199694b887bb

In words: expanded is unchanged from today. Collapsed, the panel is a single header row — uppercase section label, the `1/2` counter when a prompt has several questions, the question on one truncated line, and the chevron on the right — sitting on the composer's top edge where the full panel used to be. Open and close run through the collapsible's standard 200ms height transition; there is no continuous animation.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes — to follow, see above
- [x] I included a video for animation/interaction changes — the only motion is the shared collapsible's existing height transition

---

Two things worth flagging for review rather than leaving you to find them:

- **No test covers the collapsed branch.** `apps/web` tests run in the node environment with `renderToStaticMarkup` and no DOM, so nothing there can click the trigger. The alternative was a `defaultCollapsed` prop existing purely for the test, which seemed worse than the gap; since the disclosure is built on the shared primitive, the open/close mechanics and the ARIA wiring are covered by it rather than by this file. Happy to add the prop if you would rather have the assertion.
- **Crossing the mobile composer's collapsed/expanded boundary reopens the prompt.** `ChatComposer` renders this panel from two mutually exclusive branches, so focusing or blurring the mobile composer remounts the card and drops the collapsed state. Fixing it means lifting the state into `ChatComposer`, which widens the diff past the requested change, so I left it. Say the word if you want it in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI change in the composer pending-question panel; no API, auth, or data-path changes.
> 
> **Overview**
> The composer **pending user input** panel can be **collapsed from its header** so long questions and option lists stop covering the chat thread.
> 
> The section header becomes a **disclosure control** (shared `Collapsible` primitive): expanded behavior matches today; collapsed keeps the label, multi-question counter, a **one-line truncated question**, and a chevron. **Number-key (1–9) shortcuts** are disabled while collapsed because options are hidden; composer custom answers still work.
> 
> Collapse state is tracked by **active question id**, so when the prompt advances to the next question (including via composer send) the card **reopens** without a manual expand. New static markup tests assert the header is an accessible toggle (`aria-expanded`, `aria-controls`) and that the panel **starts expanded**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c26aed8d197ebd001aec1a386d87b59e2d77ab7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add collapsible toggle to question prompt header in chat composer
> - Each prompt card header in `ComposerPendingUserInputCard` is now a button that collapses or expands the question body, starting expanded by default.
> - When collapsed, a one-line truncated question is shown in the header and a chevron icon rotates to indicate state; a `data-pending-user-input-toggle` attribute reflects "collapsed" or "expanded".
> - Number-key selection shortcuts are disabled when the panel is collapsed to prevent selecting hidden options.
> - Adds a test in [ComposerPendingUserInputPanel.test.tsx](https://github.com/pingdotgg/t3code/pull/6773/files#diff-538b17807993832c5a7229ed1a4efb0f21080e3f331132071d2dee5d5d085589) asserting initial expanded state and correct ARIA attributes on the trigger.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c26aed8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->