### PR TITLE
feat(web): add turn completion sound with settings toggle

### DIFF
--- a/apps/web/src/audio/turnChime.test.ts
+++ b/apps/web/src/audio/turnChime.test.ts
@@ -46,16 +46,47 @@ describe("turnChime", () => {
   });
 
   it("plays a two-tone chime when called", () => {
-    playTurnCompletionSound();
+    playTurnCompletionSound("chime");
     expect(createdOscillators.length).toBe(2);
     expect(createdOscillators[0]?.start).toHaveBeenCalledWith(10);
     expect(createdOscillators[1]?.start).toHaveBeenCalledWith(10.08);
   });
 
-  it("plays an error sound when called", () => {
-    playTurnErrorSound();
+  it("plays bell sound preset", () => {
+    playTurnCompletionSound("bell");
+    expect(createdOscillators.length).toBe(1);
+    expect(createdOscillators[0]?.start).toHaveBeenCalledWith(10);
+  });
+
+  it("plays marimba sound preset", () => {
+    playTurnCompletionSound("marimba");
+    expect(createdOscillators.length).toBe(3);
+  });
+
+  it("plays pop sound preset", () => {
+    playTurnCompletionSound("pop");
+    expect(createdOscillators.length).toBe(1);
+  });
+
+  it("plays descending error sound", () => {
+    playTurnErrorSound("descending");
     expect(createdOscillators.length).toBe(2);
     expect(createdOscillators[0]?.start).toHaveBeenCalledWith(10);
     expect(createdOscillators[1]?.start).toHaveBeenCalledWith(10.09);
+  });
+
+  it("plays chord error sound preset", () => {
+    playTurnErrorSound("chord");
+    expect(createdOscillators.length).toBe(3);
+  });
+
+  it("plays subtle error sound preset", () => {
+    playTurnErrorSound("subtle");
+    expect(createdOscillators.length).toBe(1);
+  });
+
+  it("plays buzz error sound preset", () => {
+    playTurnErrorSound("buzz");
+    expect(createdOscillators.length).toBe(2);
   });
 });

--- a/apps/web/src/audio/turnChime.test.ts
+++ b/apps/web/src/audio/turnChime.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
-import { __resetAudioContextForTests, playTurnCompletionSound } from "./turnChime";
+import {
+  __resetAudioContextForTests,
+  playTurnCompletionSound,
+  playTurnErrorSound,
+} from "./turnChime";
 
 describe("turnChime", () => {
   let createdOscillators: Array<{
@@ -46,5 +50,12 @@ describe("turnChime", () => {
     expect(createdOscillators.length).toBe(2);
     expect(createdOscillators[0]?.start).toHaveBeenCalledWith(10);
     expect(createdOscillators[1]?.start).toHaveBeenCalledWith(10.08);
+  });
+
+  it("plays an error sound when called", () => {
+    playTurnErrorSound();
+    expect(createdOscillators.length).toBe(2);
+    expect(createdOscillators[0]?.start).toHaveBeenCalledWith(10);
+    expect(createdOscillators[1]?.start).toHaveBeenCalledWith(10.09);
   });
 });

--- a/apps/web/src/audio/turnChime.test.ts
+++ b/apps/web/src/audio/turnChime.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { __resetAudioContextForTests, playTurnCompletionSound } from "./turnChime";
+
+describe("turnChime", () => {
+  let createdOscillators: Array<{
+    frequency: { setValueAtTime: ReturnType<typeof vi.fn> };
+    start: ReturnType<typeof vi.fn>;
+    stop: ReturnType<typeof vi.fn>;
+  }> = [];
+
+  beforeEach(() => {
+    __resetAudioContextForTests();
+    createdOscillators = [];
+    const mockGainNode = {
+      gain: {
+        setValueAtTime: vi.fn(),
+        linearRampToValueAtTime: vi.fn(),
+        exponentialRampToValueAtTime: vi.fn(),
+      },
+      connect: vi.fn(),
+    };
+    class MockAudioContext {
+      state = "running";
+      currentTime = 10;
+      destination = {};
+      resume = vi.fn().mockResolvedValue(undefined);
+      createGain = vi.fn().mockReturnValue(mockGainNode);
+      createOscillator = vi.fn().mockImplementation(() => {
+        const osc = {
+          type: "sine",
+          frequency: { setValueAtTime: vi.fn() },
+          connect: vi.fn(),
+          start: vi.fn(),
+          stop: vi.fn(),
+        };
+        createdOscillators.push(osc);
+        return osc;
+      });
+    }
+
+    vi.stubGlobal("AudioContext", MockAudioContext);
+  });
+
+  it("plays a two-tone chime when called", () => {
+    playTurnCompletionSound();
+    expect(createdOscillators.length).toBe(2);
+    expect(createdOscillators[0]?.start).toHaveBeenCalledWith(10);
+    expect(createdOscillators[1]?.start).toHaveBeenCalledWith(10.08);
+  });
+});

--- a/apps/web/src/audio/turnChime.ts
+++ b/apps/web/src/audio/turnChime.ts
@@ -1,3 +1,5 @@
+import type { SoundCompletionKind, SoundErrorKind } from "@t3tools/contracts";
+
 let audioContextInstance: AudioContext | null = null;
 
 export function __resetAudioContextForTests(): void {
@@ -25,7 +27,7 @@ function getAudioContext(): AudioContext | null {
   return audioContextInstance;
 }
 
-export function playTurnCompletionSound(): void {
+export function playTurnCompletionSound(kind: SoundCompletionKind = "chime"): void {
   try {
     const ctx = getAudioContext();
     if (!ctx) return;
@@ -39,33 +41,76 @@ export function playTurnCompletionSound(): void {
     masterGain.gain.setValueAtTime(0.12, now);
     masterGain.connect(ctx.destination);
 
-    const osc1 = ctx.createOscillator();
-    const gain1 = ctx.createGain();
-    osc1.type = "sine";
-    osc1.frequency.setValueAtTime(587.33, now);
-    gain1.gain.setValueAtTime(0, now);
-    gain1.gain.linearRampToValueAtTime(1, now + 0.01);
-    gain1.gain.exponentialRampToValueAtTime(0.001, now + 0.09);
-    osc1.connect(gain1);
-    gain1.connect(masterGain);
-    osc1.start(now);
-    osc1.stop(now + 0.09);
+    if (kind === "bell") {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = "sine";
+      osc.frequency.setValueAtTime(1046.5, now);
+      gain.gain.setValueAtTime(0, now);
+      gain.gain.linearRampToValueAtTime(1, now + 0.005);
+      gain.gain.exponentialRampToValueAtTime(0.001, now + 0.35);
+      osc.connect(gain);
+      gain.connect(masterGain);
+      osc.start(now);
+      osc.stop(now + 0.35);
+    } else if (kind === "marimba") {
+      const notes = [523.25, 659.25, 783.99];
+      notes.forEach((freq, index) => {
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.type = "triangle";
+        const start = now + index * 0.05;
+        osc.frequency.setValueAtTime(freq, start);
+        gain.gain.setValueAtTime(0, start);
+        gain.gain.linearRampToValueAtTime(0.8, start + 0.005);
+        gain.gain.exponentialRampToValueAtTime(0.001, start + 0.12);
+        osc.connect(gain);
+        gain.connect(masterGain);
+        osc.start(start);
+        osc.stop(start + 0.12);
+      });
+    } else if (kind === "pop") {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = "sine";
+      osc.frequency.setValueAtTime(800, now);
+      osc.frequency.exponentialRampToValueAtTime(400, now + 0.06);
+      gain.gain.setValueAtTime(0, now);
+      gain.gain.linearRampToValueAtTime(1, now + 0.005);
+      gain.gain.exponentialRampToValueAtTime(0.001, now + 0.06);
+      osc.connect(gain);
+      gain.connect(masterGain);
+      osc.start(now);
+      osc.stop(now + 0.06);
+    } else {
+      const osc1 = ctx.createOscillator();
+      const gain1 = ctx.createGain();
+      osc1.type = "sine";
+      osc1.frequency.setValueAtTime(587.33, now);
+      gain1.gain.setValueAtTime(0, now);
+      gain1.gain.linearRampToValueAtTime(1, now + 0.01);
+      gain1.gain.exponentialRampToValueAtTime(0.001, now + 0.09);
+      osc1.connect(gain1);
+      gain1.connect(masterGain);
+      osc1.start(now);
+      osc1.stop(now + 0.09);
 
-    const osc2 = ctx.createOscillator();
-    const gain2 = ctx.createGain();
-    osc2.type = "sine";
-    osc2.frequency.setValueAtTime(880, now + 0.08);
-    gain2.gain.setValueAtTime(0, now + 0.08);
-    gain2.gain.linearRampToValueAtTime(1, now + 0.09);
-    gain2.gain.exponentialRampToValueAtTime(0.001, now + 0.22);
-    osc2.connect(gain2);
-    gain2.connect(masterGain);
-    osc2.start(now + 0.08);
-    osc2.stop(now + 0.22);
+      const osc2 = ctx.createOscillator();
+      const gain2 = ctx.createGain();
+      osc2.type = "sine";
+      osc2.frequency.setValueAtTime(880, now + 0.08);
+      gain2.gain.setValueAtTime(0, now + 0.08);
+      gain2.gain.linearRampToValueAtTime(1, now + 0.09);
+      gain2.gain.exponentialRampToValueAtTime(0.001, now + 0.22);
+      osc2.connect(gain2);
+      gain2.connect(masterGain);
+      osc2.start(now + 0.08);
+      osc2.stop(now + 0.22);
+    }
   } catch {}
 }
 
-export function playTurnErrorSound(): void {
+export function playTurnErrorSound(kind: SoundErrorKind = "descending"): void {
   try {
     const ctx = getAudioContext();
     if (!ctx) return;
@@ -79,28 +124,72 @@ export function playTurnErrorSound(): void {
     masterGain.gain.setValueAtTime(0.12, now);
     masterGain.connect(ctx.destination);
 
-    const osc1 = ctx.createOscillator();
-    const gain1 = ctx.createGain();
-    osc1.type = "sine";
-    osc1.frequency.setValueAtTime(440, now);
-    gain1.gain.setValueAtTime(0, now);
-    gain1.gain.linearRampToValueAtTime(1, now + 0.01);
-    gain1.gain.exponentialRampToValueAtTime(0.001, now + 0.1);
-    osc1.connect(gain1);
-    gain1.connect(masterGain);
-    osc1.start(now);
-    osc1.stop(now + 0.1);
+    if (kind === "chord") {
+      const notes = [311.13, 370.0, 440.0];
+      notes.forEach((freq) => {
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.type = "sine";
+        osc.frequency.setValueAtTime(freq, now);
+        gain.gain.setValueAtTime(0, now);
+        gain.gain.linearRampToValueAtTime(0.5, now + 0.01);
+        gain.gain.exponentialRampToValueAtTime(0.001, now + 0.22);
+        osc.connect(gain);
+        gain.connect(masterGain);
+        osc.start(now);
+        osc.stop(now + 0.22);
+      });
+    } else if (kind === "subtle") {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = "triangle";
+      osc.frequency.setValueAtTime(220, now);
+      gain.gain.setValueAtTime(0, now);
+      gain.gain.linearRampToValueAtTime(0.8, now + 0.01);
+      gain.gain.exponentialRampToValueAtTime(0.001, now + 0.18);
+      osc.connect(gain);
+      gain.connect(masterGain);
+      osc.start(now);
+      osc.stop(now + 0.18);
+    } else if (kind === "buzz") {
+      [0, 0.08].forEach((offset) => {
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.type = "sawtooth";
+        const start = now + offset;
+        osc.frequency.setValueAtTime(200, start);
+        gain.gain.setValueAtTime(0, start);
+        gain.gain.linearRampToValueAtTime(0.3, start + 0.005);
+        gain.gain.exponentialRampToValueAtTime(0.001, start + 0.05);
+        osc.connect(gain);
+        gain.connect(masterGain);
+        osc.start(start);
+        osc.stop(start + 0.05);
+      });
+    } else {
+      const osc1 = ctx.createOscillator();
+      const gain1 = ctx.createGain();
+      osc1.type = "sine";
+      osc1.frequency.setValueAtTime(440, now);
+      gain1.gain.setValueAtTime(0, now);
+      gain1.gain.linearRampToValueAtTime(1, now + 0.01);
+      gain1.gain.exponentialRampToValueAtTime(0.001, now + 0.1);
+      osc1.connect(gain1);
+      gain1.connect(masterGain);
+      osc1.start(now);
+      osc1.stop(now + 0.1);
 
-    const osc2 = ctx.createOscillator();
-    const gain2 = ctx.createGain();
-    osc2.type = "sine";
-    osc2.frequency.setValueAtTime(311.13, now + 0.09);
-    gain2.gain.setValueAtTime(0, now + 0.09);
-    gain2.gain.linearRampToValueAtTime(1, now + 0.1);
-    gain2.gain.exponentialRampToValueAtTime(0.001, now + 0.25);
-    osc2.connect(gain2);
-    gain2.connect(masterGain);
-    osc2.start(now + 0.09);
-    osc2.stop(now + 0.25);
+      const osc2 = ctx.createOscillator();
+      const gain2 = ctx.createGain();
+      osc2.type = "sine";
+      osc2.frequency.setValueAtTime(311.13, now + 0.09);
+      gain2.gain.setValueAtTime(0, now + 0.09);
+      gain2.gain.linearRampToValueAtTime(1, now + 0.1);
+      gain2.gain.exponentialRampToValueAtTime(0.001, now + 0.25);
+      osc2.connect(gain2);
+      gain2.connect(masterGain);
+      osc2.start(now + 0.09);
+      osc2.stop(now + 0.25);
+    }
   } catch {}
 }

--- a/apps/web/src/audio/turnChime.ts
+++ b/apps/web/src/audio/turnChime.ts
@@ -1,0 +1,66 @@
+let audioContextInstance: AudioContext | null = null;
+
+export function __resetAudioContextForTests(): void {
+  audioContextInstance = null;
+}
+
+function getAudioContext(): AudioContext | null {
+  const AudioContextClass =
+    (typeof window !== "undefined"
+      ? window.AudioContext ||
+        (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
+      : undefined) ??
+    (typeof globalThis !== "undefined"
+      ? (globalThis as unknown as { AudioContext?: typeof AudioContext }).AudioContext
+      : undefined);
+
+  if (!AudioContextClass) return null;
+  if (!audioContextInstance || audioContextInstance.state === "closed") {
+    try {
+      audioContextInstance = new AudioContextClass();
+    } catch {
+      return null;
+    }
+  }
+  return audioContextInstance;
+}
+
+export function playTurnCompletionSound(): void {
+  try {
+    const ctx = getAudioContext();
+    if (!ctx) return;
+
+    if (ctx.state === "suspended") {
+      void ctx.resume();
+    }
+
+    const now = ctx.currentTime;
+    const masterGain = ctx.createGain();
+    masterGain.gain.setValueAtTime(0.12, now);
+    masterGain.connect(ctx.destination);
+
+    const osc1 = ctx.createOscillator();
+    const gain1 = ctx.createGain();
+    osc1.type = "sine";
+    osc1.frequency.setValueAtTime(587.33, now);
+    gain1.gain.setValueAtTime(0, now);
+    gain1.gain.linearRampToValueAtTime(1, now + 0.01);
+    gain1.gain.exponentialRampToValueAtTime(0.001, now + 0.09);
+    osc1.connect(gain1);
+    gain1.connect(masterGain);
+    osc1.start(now);
+    osc1.stop(now + 0.09);
+
+    const osc2 = ctx.createOscillator();
+    const gain2 = ctx.createGain();
+    osc2.type = "sine";
+    osc2.frequency.setValueAtTime(880, now + 0.08);
+    gain2.gain.setValueAtTime(0, now + 0.08);
+    gain2.gain.linearRampToValueAtTime(1, now + 0.09);
+    gain2.gain.exponentialRampToValueAtTime(0.001, now + 0.22);
+    osc2.connect(gain2);
+    gain2.connect(masterGain);
+    osc2.start(now + 0.08);
+    osc2.stop(now + 0.22);
+  } catch {}
+}

--- a/apps/web/src/audio/turnChime.ts
+++ b/apps/web/src/audio/turnChime.ts
@@ -64,3 +64,43 @@ export function playTurnCompletionSound(): void {
     osc2.stop(now + 0.22);
   } catch {}
 }
+
+export function playTurnErrorSound(): void {
+  try {
+    const ctx = getAudioContext();
+    if (!ctx) return;
+
+    if (ctx.state === "suspended") {
+      void ctx.resume();
+    }
+
+    const now = ctx.currentTime;
+    const masterGain = ctx.createGain();
+    masterGain.gain.setValueAtTime(0.12, now);
+    masterGain.connect(ctx.destination);
+
+    const osc1 = ctx.createOscillator();
+    const gain1 = ctx.createGain();
+    osc1.type = "sine";
+    osc1.frequency.setValueAtTime(440, now);
+    gain1.gain.setValueAtTime(0, now);
+    gain1.gain.linearRampToValueAtTime(1, now + 0.01);
+    gain1.gain.exponentialRampToValueAtTime(0.001, now + 0.1);
+    osc1.connect(gain1);
+    gain1.connect(masterGain);
+    osc1.start(now);
+    osc1.stop(now + 0.1);
+
+    const osc2 = ctx.createOscillator();
+    const gain2 = ctx.createGain();
+    osc2.type = "sine";
+    osc2.frequency.setValueAtTime(311.13, now + 0.09);
+    gain2.gain.setValueAtTime(0, now + 0.09);
+    gain2.gain.linearRampToValueAtTime(1, now + 0.1);
+    gain2.gain.exponentialRampToValueAtTime(0.001, now + 0.25);
+    osc2.connect(gain2);
+    gain2.connect(masterGain);
+    osc2.start(now + 0.09);
+    osc2.stop(now + 0.25);
+  } catch {}
+}

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -526,6 +526,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.confirmThreadDelete !== DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete
         ? ["Delete confirmation"]
         : []),
+      ...(settings.soundNotificationsEnabled !== DEFAULT_UNIFIED_SETTINGS.soundNotificationsEnabled
+        ? ["Turn completion chime"]
+        : []),
       ...(isTextGenerationModelDirty ? ["Text generation model"] : []),
     ],
     [
@@ -533,6 +536,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       isBackgroundActivityDirty,
       settings.confirmThreadArchive,
       settings.confirmThreadDelete,
+      settings.soundNotificationsEnabled,
       settings.addProjectBaseDirectory,
       settings.defaultThreadEnvMode,
       settings.newWorktreesStartFromOrigin,
@@ -644,6 +648,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
       confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
       confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
+      soundNotificationsEnabled: DEFAULT_UNIFIED_SETTINGS.soundNotificationsEnabled,
       textGenerationModelSelection: DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
       fontFamilySans: DEFAULT_UNIFIED_SETTINGS.fontFamilySans,
       fontFamilyComposer: DEFAULT_UNIFIED_SETTINGS.fontFamilyComposer,
@@ -2230,6 +2235,33 @@ export function GeneralSettingsPanel() {
                 updateSettings({ confirmThreadDelete: Boolean(checked) })
               }
               aria-label="Confirm thread deletion"
+            />
+          }
+        />
+
+        <SettingsRow
+          {...searchableSetting("sound-notifications")}
+          description="Play a subtle sound when an agent completes a turn."
+          resetAction={
+            settings.soundNotificationsEnabled !==
+            DEFAULT_UNIFIED_SETTINGS.soundNotificationsEnabled ? (
+              <SettingResetButton
+                label="turn completion chime"
+                onClick={() =>
+                  updateSettings({
+                    soundNotificationsEnabled: DEFAULT_UNIFIED_SETTINGS.soundNotificationsEnabled,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.soundNotificationsEnabled}
+              onCheckedChange={(checked) =>
+                updateSettings({ soundNotificationsEnabled: Boolean(checked) })
+              }
+              aria-label="Play sound when agent completes a turn"
             />
           }
         />

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1,4 +1,11 @@
-import { ArchiveIcon, ArchiveX, ChevronRightIcon, LoaderIcon, SettingsIcon } from "lucide-react";
+import {
+  ArchiveIcon,
+  ArchiveX,
+  ChevronRightIcon,
+  LoaderIcon,
+  SettingsIcon,
+  Volume2,
+} from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import type { CSSProperties, ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -9,6 +16,8 @@ import {
   ProviderDriverKind,
   type ScopedThreadRef,
   type SidebarProjectGroupingMode,
+  type SoundCompletionKind,
+  type SoundErrorKind,
 } from "@t3tools/contracts";
 import { scopeThreadRef } from "@t3tools/client-runtime/environment";
 import {
@@ -76,6 +85,7 @@ import {
 } from "../../providerInstances";
 import { ensureLocalApi, readLocalApi } from "../../localApi";
 import { isMacPlatform } from "../../lib/utils";
+import { playTurnCompletionSound, playTurnErrorSound } from "../../audio/turnChime";
 import { primaryServerObservabilityAtom, primaryServerProvidersAtom } from "../../state/server";
 import { useProjects } from "../../state/entities";
 import { useArchivedThreadSnapshots } from "../../lib/archivedThreadsState";
@@ -154,6 +164,20 @@ const TIMESTAMP_FORMAT_LABELS = {
   "12-hour": "12-hour",
   "24-hour": "24-hour",
 } as const;
+
+const SOUND_COMPLETION_LABELS: Record<SoundCompletionKind, string> = {
+  chime: "Chime",
+  bell: "Bell",
+  marimba: "Marimba",
+  pop: "Pop",
+};
+
+const SOUND_ERROR_LABELS: Record<SoundErrorKind, string> = {
+  descending: "Descending",
+  chord: "Chord",
+  subtle: "Subtle",
+  buzz: "Double pulse",
+};
 
 const BACKGROUND_ACTIVITY_PROFILE_LABELS: Record<BackgroundActivityProfile, string> = {
   balanced: "Balanced",
@@ -526,8 +550,15 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.confirmThreadDelete !== DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete
         ? ["Delete confirmation"]
         : []),
-      ...(settings.soundNotificationsEnabled !== DEFAULT_UNIFIED_SETTINGS.soundNotificationsEnabled
+      ...(settings.soundNotificationsEnabled !==
+        DEFAULT_UNIFIED_SETTINGS.soundNotificationsEnabled ||
+      settings.soundCompletionKind !== DEFAULT_UNIFIED_SETTINGS.soundCompletionKind
         ? ["Turn completion chime"]
+        : []),
+      ...(settings.soundErrorNotificationsEnabled !==
+        DEFAULT_UNIFIED_SETTINGS.soundErrorNotificationsEnabled ||
+      settings.soundErrorKind !== DEFAULT_UNIFIED_SETTINGS.soundErrorKind
+        ? ["Turn error chime"]
         : []),
       ...(isTextGenerationModelDirty ? ["Text generation model"] : []),
     ],
@@ -537,6 +568,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.confirmThreadArchive,
       settings.confirmThreadDelete,
       settings.soundNotificationsEnabled,
+      settings.soundErrorNotificationsEnabled,
+      settings.soundCompletionKind,
+      settings.soundErrorKind,
       settings.addProjectBaseDirectory,
       settings.defaultThreadEnvMode,
       settings.newWorktreesStartFromOrigin,
@@ -576,24 +610,13 @@ export function useSettingsRestore(onRestored?: () => void) {
     );
     if (!confirmed) return;
 
-    // Only touch the theme keys that are actually dirty, so a theme-storage
-    // failure cannot block restoring unrelated settings. Preferences are
-    // re-read after the confirmation dialog: they may have changed (another
-    // tab, an OS flip) while it was open, and rollback must restore the live
-    // values rather than the ones captured at render time.
     let previousTheme = theme;
     try {
       previousTheme = readThemePreference();
-    } catch {
-      // Storage is unreadable; the render-time value is the best rollback.
-    }
-    // The mix may have changed while the confirmation dialog was open; both
-    // the dirty check and the rollback must see the live value.
+    } catch {}
     const liveHalves = readThemeHalves();
     const needsThemeReset = previousTheme !== "system";
     const needsMixReset = liveHalves !== null;
-    // Same for the appearance mode: trusting the render-time value would skip
-    // the reset and report success while a non-system mode stayed in storage.
     const needsFollowSystemReset = readAppearanceModePreference(previousTheme) !== "system";
     const notifyThemeRestoreFailure = () => {
       toastManager.add(
@@ -604,9 +627,6 @@ export function useSettingsRestore(onRestored?: () => void) {
         }),
       );
     };
-    // Rollback restores the base preference first (which clears any mix) and
-    // then re-applies the captured mix on top, so no failure path can leave
-    // the pair of keys half-restored.
     const previousHalves = liveHalves;
     const rollbackThemeState = () => {
       if (needsThemeReset) setTheme(previousTheme);
@@ -649,6 +669,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
       confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
       soundNotificationsEnabled: DEFAULT_UNIFIED_SETTINGS.soundNotificationsEnabled,
+      soundErrorNotificationsEnabled: DEFAULT_UNIFIED_SETTINGS.soundErrorNotificationsEnabled,
+      soundCompletionKind: DEFAULT_UNIFIED_SETTINGS.soundCompletionKind,
+      soundErrorKind: DEFAULT_UNIFIED_SETTINGS.soundErrorKind,
       textGenerationModelSelection: DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
       fontFamilySans: DEFAULT_UNIFIED_SETTINGS.fontFamilySans,
       fontFamilyComposer: DEFAULT_UNIFIED_SETTINGS.fontFamilyComposer,
@@ -2244,25 +2267,134 @@ export function GeneralSettingsPanel() {
           description="Play a subtle sound when an agent completes a turn."
           resetAction={
             settings.soundNotificationsEnabled !==
-            DEFAULT_UNIFIED_SETTINGS.soundNotificationsEnabled ? (
+              DEFAULT_UNIFIED_SETTINGS.soundNotificationsEnabled ||
+            settings.soundCompletionKind !== DEFAULT_UNIFIED_SETTINGS.soundCompletionKind ? (
               <SettingResetButton
                 label="turn completion chime"
                 onClick={() =>
                   updateSettings({
                     soundNotificationsEnabled: DEFAULT_UNIFIED_SETTINGS.soundNotificationsEnabled,
+                    soundCompletionKind: DEFAULT_UNIFIED_SETTINGS.soundCompletionKind,
                   })
                 }
               />
             ) : null
           }
           control={
-            <Switch
-              checked={settings.soundNotificationsEnabled}
-              onCheckedChange={(checked) =>
-                updateSettings({ soundNotificationsEnabled: Boolean(checked) })
-              }
-              aria-label="Play sound when agent completes a turn"
-            />
+            <div className="flex items-center gap-2">
+              <Select
+                value={settings.soundCompletionKind}
+                onValueChange={(val) => {
+                  if (!val) return;
+                  const kind = val as SoundCompletionKind;
+                  updateSettings({ soundCompletionKind: kind });
+                  playTurnCompletionSound(kind);
+                }}
+                disabled={!settings.soundNotificationsEnabled}
+              >
+                <SelectTrigger className="w-32" aria-label="Turn completion sound">
+                  <SelectValue>{SOUND_COMPLETION_LABELS[settings.soundCompletionKind]}</SelectValue>
+                </SelectTrigger>
+                <SelectPopup align="end" alignItemWithTrigger={false}>
+                  <SelectItem hideIndicator value="chime">
+                    Chime
+                  </SelectItem>
+                  <SelectItem hideIndicator value="bell">
+                    Bell
+                  </SelectItem>
+                  <SelectItem hideIndicator value="marimba">
+                    Marimba
+                  </SelectItem>
+                  <SelectItem hideIndicator value="pop">
+                    Pop
+                  </SelectItem>
+                </SelectPopup>
+              </Select>
+              <Button
+                size="icon-xs"
+                variant="ghost"
+                aria-label="Preview turn completion sound"
+                disabled={!settings.soundNotificationsEnabled}
+                onClick={() => playTurnCompletionSound(settings.soundCompletionKind)}
+              >
+                <Volume2 className="size-3.5" />
+              </Button>
+              <Switch
+                checked={settings.soundNotificationsEnabled}
+                onCheckedChange={(checked) =>
+                  updateSettings({ soundNotificationsEnabled: Boolean(checked) })
+                }
+                aria-label="Play sound when agent completes a turn"
+              />
+            </div>
+          }
+        />
+        <SettingsRow
+          {...searchableSetting("sound-error-notifications")}
+          description="Play a distinct alert sound when an agent turn ends in an error."
+          resetAction={
+            settings.soundErrorNotificationsEnabled !==
+              DEFAULT_UNIFIED_SETTINGS.soundErrorNotificationsEnabled ||
+            settings.soundErrorKind !== DEFAULT_UNIFIED_SETTINGS.soundErrorKind ? (
+              <SettingResetButton
+                label="turn error chime"
+                onClick={() =>
+                  updateSettings({
+                    soundErrorNotificationsEnabled:
+                      DEFAULT_UNIFIED_SETTINGS.soundErrorNotificationsEnabled,
+                    soundErrorKind: DEFAULT_UNIFIED_SETTINGS.soundErrorKind,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <div className="flex items-center gap-2">
+              <Select
+                value={settings.soundErrorKind}
+                onValueChange={(val) => {
+                  if (!val) return;
+                  const kind = val as SoundErrorKind;
+                  updateSettings({ soundErrorKind: kind });
+                  playTurnErrorSound(kind);
+                }}
+                disabled={!settings.soundErrorNotificationsEnabled}
+              >
+                <SelectTrigger className="w-32" aria-label="Turn error sound">
+                  <SelectValue>{SOUND_ERROR_LABELS[settings.soundErrorKind]}</SelectValue>
+                </SelectTrigger>
+                <SelectPopup align="end" alignItemWithTrigger={false}>
+                  <SelectItem hideIndicator value="descending">
+                    Descending
+                  </SelectItem>
+                  <SelectItem hideIndicator value="chord">
+                    Chord
+                  </SelectItem>
+                  <SelectItem hideIndicator value="subtle">
+                    Subtle
+                  </SelectItem>
+                  <SelectItem hideIndicator value="buzz">
+                    Double pulse
+                  </SelectItem>
+                </SelectPopup>
+              </Select>
+              <Button
+                size="icon-xs"
+                variant="ghost"
+                aria-label="Preview turn error sound"
+                disabled={!settings.soundErrorNotificationsEnabled}
+                onClick={() => playTurnErrorSound(settings.soundErrorKind)}
+              >
+                <Volume2 className="size-3.5" />
+              </Button>
+              <Switch
+                checked={settings.soundErrorNotificationsEnabled}
+                onCheckedChange={(checked) =>
+                  updateSettings({ soundErrorNotificationsEnabled: Boolean(checked) })
+                }
+                aria-label="Play sound when agent turn fails"
+              />
+            </div>
           }
         />
 

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -150,6 +150,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/general",
   },
   {
+    id: "sound-notifications",
+    title: "Turn completion chime",
+    to: "/settings/general",
+  },
+  {
     id: "text-generation-model",
     title: "Text generation model",
     to: "/settings/general",

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -155,6 +155,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/general",
   },
   {
+    id: "sound-error-notifications",
+    title: "Turn error chime",
+    to: "/settings/general",
+  },
+  {
     id: "text-generation-model",
     title: "Text generation model",
     to: "/settings/general",

--- a/apps/web/src/hooks/useTurnCompletionSound.test.ts
+++ b/apps/web/src/hooks/useTurnCompletionSound.test.ts
@@ -167,4 +167,52 @@ describe("detectNewTurnCompletions", () => {
     expect(unarchivedResult.hasNewCompletion).toBe(false);
     expect(unarchivedResult.nextCompletions[key]).toBe("2026-08-15T07:06:00.000Z");
   });
+
+  it("does not trigger chime when a turn is interrupted or stopped", () => {
+    const thread = createMockThread("thread-1", {
+      session: {
+        status: "interrupted",
+        activeTurnId: null,
+        updatedAt: "2026-08-15T07:02:00.000Z",
+      } as any,
+      latestTurn: {
+        turnId: TurnId.make("turn-1"),
+        state: "interrupted",
+        requestedAt: "2026-08-15T07:01:00.000Z",
+        startedAt: "2026-08-15T07:01:01.000Z",
+        completedAt: "2026-08-15T07:02:00.000Z",
+        assistantMessageId: null,
+      },
+    });
+    const key = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+    const previous = { [key]: "running" };
+
+    const result = detectNewTurnCompletions([thread], previous);
+    expect(result.hasNewCompletion).toBe(false);
+    expect(result.nextCompletions[key]).toBe("2026-08-15T07:02:00.000Z");
+  });
+
+  it("does not trigger chime when a turn ends in error", () => {
+    const thread = createMockThread("thread-1", {
+      session: {
+        status: "error",
+        activeTurnId: null,
+        updatedAt: "2026-08-15T07:02:00.000Z",
+      } as any,
+      latestTurn: {
+        turnId: TurnId.make("turn-1"),
+        state: "error",
+        requestedAt: "2026-08-15T07:01:00.000Z",
+        startedAt: "2026-08-15T07:01:01.000Z",
+        completedAt: "2026-08-15T07:02:00.000Z",
+        assistantMessageId: null,
+      },
+    });
+    const key = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+    const previous = { [key]: "running" };
+
+    const result = detectNewTurnCompletions([thread], previous);
+    expect(result.hasNewCompletion).toBe(false);
+    expect(result.nextCompletions[key]).toBe("2026-08-15T07:02:00.000Z");
+  });
 });

--- a/apps/web/src/hooks/useTurnCompletionSound.test.ts
+++ b/apps/web/src/hooks/useTurnCompletionSound.test.ts
@@ -42,10 +42,9 @@ function createMockThread(
 }
 
 describe("detectNewTurnCompletions", () => {
-  const sessionStart = Date.parse("2026-08-15T07:00:00.000Z");
-
-  it("returns hasNewCompletion false when completions are unchanged", () => {
+  it("does not trigger chime on initial snapshot or environment hydration of settled threads", () => {
     const thread = createMockThread("thread-1", {
+      session: { status: "idle", activeTurnId: null, updatedAt: "2026-08-15T07:02:00.000Z" },
       latestTurn: {
         turnId: TurnId.make("turn-1"),
         state: "completed",
@@ -56,14 +55,54 @@ describe("detectNewTurnCompletions", () => {
       },
     });
     const key = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
-    const previous = { [key]: "2026-08-15T07:02:00.000Z" };
 
-    const result = detectNewTurnCompletions([thread], previous, sessionStart);
+    const result = detectNewTurnCompletions([thread], {});
     expect(result.hasNewCompletion).toBe(false);
+    expect(result.nextCompletions[key]).toBe("2026-08-15T07:02:00.000Z");
   });
 
-  it("returns hasNewCompletion true when a thread receives a new completion timestamp", () => {
+  it("does not trigger chime during mid-turn checkpoints while state or session is running", () => {
     const thread = createMockThread("thread-1", {
+      session: { status: "running", activeTurnId: "turn-1", updatedAt: "2026-08-15T07:01:30.000Z" },
+      latestTurn: {
+        turnId: TurnId.make("turn-1"),
+        state: "running",
+        requestedAt: "2026-08-15T07:01:00.000Z",
+        startedAt: "2026-08-15T07:01:01.000Z",
+        completedAt: "2026-08-15T07:01:30.000Z",
+        assistantMessageId: null,
+      },
+    });
+    const key = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+
+    const result = detectNewTurnCompletions([thread], {});
+    expect(result.hasNewCompletion).toBe(false);
+    expect(result.nextCompletions[key]).toBe("running");
+  });
+
+  it("triggers chime when a running thread settles and completes", () => {
+    const thread = createMockThread("thread-1", {
+      session: { status: "idle", activeTurnId: null, updatedAt: "2026-08-15T07:02:00.000Z" },
+      latestTurn: {
+        turnId: TurnId.make("turn-1"),
+        state: "completed",
+        requestedAt: "2026-08-15T07:01:00.000Z",
+        startedAt: "2026-08-15T07:01:01.000Z",
+        completedAt: "2026-08-15T07:02:00.000Z",
+        assistantMessageId: null,
+      },
+    });
+    const key = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+    const previous = { [key]: "running" };
+
+    const result = detectNewTurnCompletions([thread], previous);
+    expect(result.hasNewCompletion).toBe(true);
+    expect(result.nextCompletions[key]).toBe("2026-08-15T07:02:00.000Z");
+  });
+
+  it("triggers chime when a previously completed thread completes a new turn", () => {
+    const thread = createMockThread("thread-1", {
+      session: { status: "idle", activeTurnId: null, updatedAt: "2026-08-15T07:06:00.000Z" },
       latestTurn: {
         turnId: TurnId.make("turn-2"),
         state: "completed",
@@ -76,14 +115,34 @@ describe("detectNewTurnCompletions", () => {
     const key = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
     const previous = { [key]: "2026-08-15T07:02:00.000Z" };
 
-    const result = detectNewTurnCompletions([thread], previous, sessionStart);
+    const result = detectNewTurnCompletions([thread], previous);
     expect(result.hasNewCompletion).toBe(true);
     expect(result.nextCompletions[key]).toBe("2026-08-15T07:06:00.000Z");
+  });
+
+  it("ignores unchanged completed threads on subsequent renders", () => {
+    const thread = createMockThread("thread-1", {
+      session: { status: "idle", activeTurnId: null, updatedAt: "2026-08-15T07:06:00.000Z" },
+      latestTurn: {
+        turnId: TurnId.make("turn-2"),
+        state: "completed",
+        requestedAt: "2026-08-15T07:05:00.000Z",
+        startedAt: "2026-08-15T07:05:01.000Z",
+        completedAt: "2026-08-15T07:06:00.000Z",
+        assistantMessageId: null,
+      },
+    });
+    const key = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+    const previous = { [key]: "2026-08-15T07:06:00.000Z" };
+
+    const result = detectNewTurnCompletions([thread], previous);
+    expect(result.hasNewCompletion).toBe(false);
   });
 
   it("ignores archived threads", () => {
     const thread = createMockThread("thread-1", {
       archivedAt: "2026-08-15T07:04:00.000Z",
+      session: { status: "idle", activeTurnId: null, updatedAt: "2026-08-15T07:06:00.000Z" },
       latestTurn: {
         turnId: TurnId.make("turn-2"),
         state: "completed",
@@ -94,9 +153,9 @@ describe("detectNewTurnCompletions", () => {
       },
     });
     const key = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
-    const previous = { [key]: "2026-08-15T07:02:00.000Z" };
+    const previous = { [key]: "running" };
 
-    const result = detectNewTurnCompletions([thread], previous, sessionStart);
+    const result = detectNewTurnCompletions([thread], previous);
     expect(result.hasNewCompletion).toBe(false);
   });
 });

--- a/apps/web/src/hooks/useTurnCompletionSound.test.ts
+++ b/apps/web/src/hooks/useTurnCompletionSound.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vite-plus/test";
+import { EnvironmentId, ProjectId, ProviderInstanceId, ThreadId, TurnId } from "@t3tools/contracts";
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/models";
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
+
+import { detectNewTurnCompletions } from "./useTurnCompletionSound";
+
+const envId = EnvironmentId.make("environment-local");
+const projId = ProjectId.make("project-1");
+const providerInstanceId = ProviderInstanceId.make("provider-1");
+
+function createMockThread(
+  id: string,
+  overrides?: Partial<EnvironmentThreadShell>,
+): EnvironmentThreadShell {
+  return {
+    environmentId: envId,
+    id: ThreadId.make(id),
+    projectId: projId,
+    title: `Thread ${id}`,
+    modelSelection: {
+      instanceId: providerInstanceId,
+      model: "test-model",
+    },
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    branch: null,
+    worktreePath: null,
+    latestTurn: null,
+    createdAt: "2026-08-15T07:00:00.000Z",
+    updatedAt: "2026-08-15T07:00:00.000Z",
+    archivedAt: null,
+    settledOverride: null,
+    settledAt: null,
+    session: null,
+    latestUserMessageAt: null,
+    hasPendingApprovals: false,
+    hasPendingUserInput: false,
+    hasActionableProposedPlan: false,
+    ...overrides,
+  };
+}
+
+describe("detectNewTurnCompletions", () => {
+  const sessionStart = Date.parse("2026-08-15T07:00:00.000Z");
+
+  it("returns hasNewCompletion false when completions are unchanged", () => {
+    const thread = createMockThread("thread-1", {
+      latestTurn: {
+        turnId: TurnId.make("turn-1"),
+        state: "completed",
+        requestedAt: "2026-08-15T07:01:00.000Z",
+        startedAt: "2026-08-15T07:01:01.000Z",
+        completedAt: "2026-08-15T07:02:00.000Z",
+        assistantMessageId: null,
+      },
+    });
+    const key = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+    const previous = { [key]: "2026-08-15T07:02:00.000Z" };
+
+    const result = detectNewTurnCompletions([thread], previous, sessionStart);
+    expect(result.hasNewCompletion).toBe(false);
+  });
+
+  it("returns hasNewCompletion true when a thread receives a new completion timestamp", () => {
+    const thread = createMockThread("thread-1", {
+      latestTurn: {
+        turnId: TurnId.make("turn-2"),
+        state: "completed",
+        requestedAt: "2026-08-15T07:05:00.000Z",
+        startedAt: "2026-08-15T07:05:01.000Z",
+        completedAt: "2026-08-15T07:06:00.000Z",
+        assistantMessageId: null,
+      },
+    });
+    const key = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+    const previous = { [key]: "2026-08-15T07:02:00.000Z" };
+
+    const result = detectNewTurnCompletions([thread], previous, sessionStart);
+    expect(result.hasNewCompletion).toBe(true);
+    expect(result.nextCompletions[key]).toBe("2026-08-15T07:06:00.000Z");
+  });
+
+  it("ignores archived threads", () => {
+    const thread = createMockThread("thread-1", {
+      archivedAt: "2026-08-15T07:04:00.000Z",
+      latestTurn: {
+        turnId: TurnId.make("turn-2"),
+        state: "completed",
+        requestedAt: "2026-08-15T07:05:00.000Z",
+        startedAt: "2026-08-15T07:05:01.000Z",
+        completedAt: "2026-08-15T07:06:00.000Z",
+        assistantMessageId: null,
+      },
+    });
+    const key = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+    const previous = { [key]: "2026-08-15T07:02:00.000Z" };
+
+    const result = detectNewTurnCompletions([thread], previous, sessionStart);
+    expect(result.hasNewCompletion).toBe(false);
+  });
+});

--- a/apps/web/src/hooks/useTurnCompletionSound.test.ts
+++ b/apps/web/src/hooks/useTurnCompletionSound.test.ts
@@ -189,10 +189,11 @@ describe("detectNewTurnCompletions", () => {
 
     const result = detectNewTurnCompletions([thread], previous);
     expect(result.hasNewCompletion).toBe(false);
+    expect(result.hasNewError).toBe(false);
     expect(result.nextCompletions[key]).toBe("2026-08-15T07:02:00.000Z");
   });
 
-  it("does not trigger chime when a turn ends in error", () => {
+  it("triggers error sound when a turn ends in error", () => {
     const thread = createMockThread("thread-1", {
       session: {
         status: "error",
@@ -213,6 +214,7 @@ describe("detectNewTurnCompletions", () => {
 
     const result = detectNewTurnCompletions([thread], previous);
     expect(result.hasNewCompletion).toBe(false);
+    expect(result.hasNewError).toBe(true);
     expect(result.nextCompletions[key]).toBe("2026-08-15T07:02:00.000Z");
   });
 });

--- a/apps/web/src/hooks/useTurnCompletionSound.test.ts
+++ b/apps/web/src/hooks/useTurnCompletionSound.test.ts
@@ -139,8 +139,8 @@ describe("detectNewTurnCompletions", () => {
     expect(result.hasNewCompletion).toBe(false);
   });
 
-  it("ignores archived threads", () => {
-    const thread = createMockThread("thread-1", {
+  it("clears tracked state when thread is archived and does not chime on unarchiving an already-settled thread", () => {
+    const archivedThread = createMockThread("thread-1", {
       archivedAt: "2026-08-15T07:04:00.000Z",
       session: { status: "idle", activeTurnId: null, updatedAt: "2026-08-15T07:06:00.000Z" },
       latestTurn: {
@@ -152,10 +152,19 @@ describe("detectNewTurnCompletions", () => {
         assistantMessageId: null,
       },
     });
-    const key = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+    const key = scopedThreadKey(scopeThreadRef(archivedThread.environmentId, archivedThread.id));
     const previous = { [key]: "running" };
 
-    const result = detectNewTurnCompletions([thread], previous);
-    expect(result.hasNewCompletion).toBe(false);
+    const archivedResult = detectNewTurnCompletions([archivedThread], previous);
+    expect(archivedResult.hasNewCompletion).toBe(false);
+    expect(archivedResult.nextCompletions[key]).toBeUndefined();
+
+    const unarchivedThread = { ...archivedThread, archivedAt: null };
+    const unarchivedResult = detectNewTurnCompletions(
+      [unarchivedThread],
+      archivedResult.nextCompletions,
+    );
+    expect(unarchivedResult.hasNewCompletion).toBe(false);
+    expect(unarchivedResult.nextCompletions[key]).toBe("2026-08-15T07:06:00.000Z");
   });
 });

--- a/apps/web/src/hooks/useTurnCompletionSound.ts
+++ b/apps/web/src/hooks/useTurnCompletionSound.ts
@@ -83,12 +83,16 @@ export function useTurnCompletionSound(): void {
     );
     knownCompletionsRef.current = nextCompletions;
 
-    if (settings.soundNotificationsEnabled) {
-      if (hasNewError) {
-        playTurnErrorSound();
-      } else if (hasNewCompletion) {
-        playTurnCompletionSound();
-      }
+    if (hasNewError && settings.soundErrorNotificationsEnabled) {
+      playTurnErrorSound(settings.soundErrorKind);
+    } else if (hasNewCompletion && settings.soundNotificationsEnabled) {
+      playTurnCompletionSound(settings.soundCompletionKind);
     }
-  }, [threads, settings.soundNotificationsEnabled]);
+  }, [
+    threads,
+    settings.soundNotificationsEnabled,
+    settings.soundErrorNotificationsEnabled,
+    settings.soundCompletionKind,
+    settings.soundErrorKind,
+  ]);
 }

--- a/apps/web/src/hooks/useTurnCompletionSound.ts
+++ b/apps/web/src/hooks/useTurnCompletionSound.ts
@@ -18,8 +18,11 @@ export function detectNewTurnCompletions(
   let hasNewCompletion = false;
 
   for (const thread of threads) {
-    if (thread.archivedAt !== null) continue;
     const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+    if (thread.archivedAt !== null) {
+      delete nextCompletions[threadKey];
+      continue;
+    }
     const previousState = previousCompletions[threadKey];
 
     const isSettled =

--- a/apps/web/src/hooks/useTurnCompletionSound.ts
+++ b/apps/web/src/hooks/useTurnCompletionSound.ts
@@ -2,7 +2,7 @@ import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environ
 import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/models";
 import { useEffect, useRef } from "react";
 
-import { playTurnCompletionSound } from "~/audio/turnChime";
+import { playTurnCompletionSound, playTurnErrorSound } from "~/audio/turnChime";
 import { useClientSettings } from "./useSettings";
 import { useThreadShells } from "~/state/entities";
 import { isLatestTurnSettled } from "~/session-logic";
@@ -12,10 +12,12 @@ export function detectNewTurnCompletions(
   previousCompletions: Readonly<Record<string, string>>,
 ): {
   readonly hasNewCompletion: boolean;
+  readonly hasNewError: boolean;
   readonly nextCompletions: Record<string, string>;
 } {
   const nextCompletions: Record<string, string> = { ...previousCompletions };
   let hasNewCompletion = false;
+  let hasNewError = false;
 
   for (const thread of threads) {
     const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
@@ -25,25 +27,31 @@ export function detectNewTurnCompletions(
     }
     const previousState = previousCompletions[threadKey];
 
-    const isSuccessfulCompletion =
+    const isSettled =
       isLatestTurnSettled(thread.latestTurn, thread.session) &&
-      thread.latestTurn?.state === "completed" &&
-      thread.session?.status !== "interrupted" &&
-      thread.session?.status !== "stopped" &&
-      thread.session?.status !== "error" &&
+      thread.latestTurn?.state !== "running" &&
       Boolean(thread.latestTurn?.completedAt);
 
-    if (!isSuccessfulCompletion) {
+    if (!isSettled) {
       if (thread.session?.status === "running" || thread.latestTurn?.state === "running") {
         nextCompletions[threadKey] = "running";
-      } else if (thread.latestTurn?.completedAt) {
-        nextCompletions[threadKey] = thread.latestTurn.completedAt;
       }
       continue;
     }
 
     const completedAt = thread.latestTurn?.completedAt;
     if (!completedAt) continue;
+
+    const isInterrupted =
+      thread.latestTurn?.state === "interrupted" ||
+      thread.session?.status === "interrupted" ||
+      thread.session?.status === "stopped";
+
+    const isError =
+      !isInterrupted &&
+      (thread.latestTurn?.state === "error" || thread.session?.status === "error");
+
+    const isSuccess = !isInterrupted && !isError && thread.latestTurn?.state === "completed";
 
     if (previousState === undefined) {
       nextCompletions[threadKey] = completedAt;
@@ -52,11 +60,15 @@ export function detectNewTurnCompletions(
 
     if (previousState !== completedAt) {
       nextCompletions[threadKey] = completedAt;
-      hasNewCompletion = true;
+      if (isSuccess) {
+        hasNewCompletion = true;
+      } else if (isError) {
+        hasNewError = true;
+      }
     }
   }
 
-  return { hasNewCompletion, nextCompletions };
+  return { hasNewCompletion, hasNewError, nextCompletions };
 }
 
 export function useTurnCompletionSound(): void {
@@ -65,14 +77,18 @@ export function useTurnCompletionSound(): void {
   const knownCompletionsRef = useRef<Record<string, string>>({});
 
   useEffect(() => {
-    const { hasNewCompletion, nextCompletions } = detectNewTurnCompletions(
+    const { hasNewCompletion, hasNewError, nextCompletions } = detectNewTurnCompletions(
       threads,
       knownCompletionsRef.current,
     );
     knownCompletionsRef.current = nextCompletions;
 
-    if (hasNewCompletion && settings.soundNotificationsEnabled) {
-      playTurnCompletionSound();
+    if (settings.soundNotificationsEnabled) {
+      if (hasNewError) {
+        playTurnErrorSound();
+      } else if (hasNewCompletion) {
+        playTurnCompletionSound();
+      }
     }
   }, [threads, settings.soundNotificationsEnabled]);
 }

--- a/apps/web/src/hooks/useTurnCompletionSound.ts
+++ b/apps/web/src/hooks/useTurnCompletionSound.ts
@@ -5,11 +5,11 @@ import { useEffect, useRef } from "react";
 import { playTurnCompletionSound } from "~/audio/turnChime";
 import { useClientSettings } from "./useSettings";
 import { useThreadShells } from "~/state/entities";
+import { isLatestTurnSettled } from "~/session-logic";
 
 export function detectNewTurnCompletions(
   threads: ReadonlyArray<EnvironmentThreadShell>,
   previousCompletions: Readonly<Record<string, string>>,
-  sessionStartedAtMs: number,
 ): {
   readonly hasNewCompletion: boolean;
   readonly nextCompletions: Record<string, string>;
@@ -19,18 +19,32 @@ export function detectNewTurnCompletions(
 
   for (const thread of threads) {
     if (thread.archivedAt !== null) continue;
+    const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+    const previousState = previousCompletions[threadKey];
+
+    const isSettled =
+      isLatestTurnSettled(thread.latestTurn, thread.session) &&
+      thread.latestTurn?.state !== "running" &&
+      Boolean(thread.latestTurn?.completedAt);
+
+    if (!isSettled) {
+      if (thread.session?.status === "running" || thread.latestTurn?.state === "running") {
+        nextCompletions[threadKey] = "running";
+      }
+      continue;
+    }
+
     const completedAt = thread.latestTurn?.completedAt;
     if (!completedAt) continue;
 
-    const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
-    const previousCompletedAt = previousCompletions[threadKey];
-
-    if (previousCompletedAt !== completedAt) {
+    if (previousState === undefined) {
       nextCompletions[threadKey] = completedAt;
-      const completedAtMs = Date.parse(completedAt);
-      if (!Number.isNaN(completedAtMs) && completedAtMs >= sessionStartedAtMs) {
-        hasNewCompletion = true;
-      }
+      continue;
+    }
+
+    if (previousState !== completedAt) {
+      nextCompletions[threadKey] = completedAt;
+      hasNewCompletion = true;
     }
   }
 
@@ -40,28 +54,12 @@ export function detectNewTurnCompletions(
 export function useTurnCompletionSound(): void {
   const settings = useClientSettings();
   const threads = useThreadShells();
-  const sessionStartedAtRef = useRef<number>(Date.now());
   const knownCompletionsRef = useRef<Record<string, string>>({});
-  const initializedRef = useRef(false);
 
   useEffect(() => {
-    if (!initializedRef.current) {
-      const initialMap: Record<string, string> = {};
-      for (const thread of threads) {
-        if (thread.latestTurn?.completedAt) {
-          const key = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
-          initialMap[key] = thread.latestTurn.completedAt;
-        }
-      }
-      knownCompletionsRef.current = initialMap;
-      initializedRef.current = true;
-      return;
-    }
-
     const { hasNewCompletion, nextCompletions } = detectNewTurnCompletions(
       threads,
       knownCompletionsRef.current,
-      sessionStartedAtRef.current,
     );
     knownCompletionsRef.current = nextCompletions;
 

--- a/apps/web/src/hooks/useTurnCompletionSound.ts
+++ b/apps/web/src/hooks/useTurnCompletionSound.ts
@@ -1,0 +1,72 @@
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/models";
+import { useEffect, useRef } from "react";
+
+import { playTurnCompletionSound } from "~/audio/turnChime";
+import { useClientSettings } from "./useSettings";
+import { useThreadShells } from "~/state/entities";
+
+export function detectNewTurnCompletions(
+  threads: ReadonlyArray<EnvironmentThreadShell>,
+  previousCompletions: Readonly<Record<string, string>>,
+  sessionStartedAtMs: number,
+): {
+  readonly hasNewCompletion: boolean;
+  readonly nextCompletions: Record<string, string>;
+} {
+  const nextCompletions: Record<string, string> = { ...previousCompletions };
+  let hasNewCompletion = false;
+
+  for (const thread of threads) {
+    if (thread.archivedAt !== null) continue;
+    const completedAt = thread.latestTurn?.completedAt;
+    if (!completedAt) continue;
+
+    const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+    const previousCompletedAt = previousCompletions[threadKey];
+
+    if (previousCompletedAt !== completedAt) {
+      nextCompletions[threadKey] = completedAt;
+      const completedAtMs = Date.parse(completedAt);
+      if (!Number.isNaN(completedAtMs) && completedAtMs >= sessionStartedAtMs) {
+        hasNewCompletion = true;
+      }
+    }
+  }
+
+  return { hasNewCompletion, nextCompletions };
+}
+
+export function useTurnCompletionSound(): void {
+  const settings = useClientSettings();
+  const threads = useThreadShells();
+  const sessionStartedAtRef = useRef<number>(Date.now());
+  const knownCompletionsRef = useRef<Record<string, string>>({});
+  const initializedRef = useRef(false);
+
+  useEffect(() => {
+    if (!initializedRef.current) {
+      const initialMap: Record<string, string> = {};
+      for (const thread of threads) {
+        if (thread.latestTurn?.completedAt) {
+          const key = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+          initialMap[key] = thread.latestTurn.completedAt;
+        }
+      }
+      knownCompletionsRef.current = initialMap;
+      initializedRef.current = true;
+      return;
+    }
+
+    const { hasNewCompletion, nextCompletions } = detectNewTurnCompletions(
+      threads,
+      knownCompletionsRef.current,
+      sessionStartedAtRef.current,
+    );
+    knownCompletionsRef.current = nextCompletions;
+
+    if (hasNewCompletion && settings.soundNotificationsEnabled) {
+      playTurnCompletionSound();
+    }
+  }, [threads, settings.soundNotificationsEnabled]);
+}

--- a/apps/web/src/hooks/useTurnCompletionSound.ts
+++ b/apps/web/src/hooks/useTurnCompletionSound.ts
@@ -25,14 +25,19 @@ export function detectNewTurnCompletions(
     }
     const previousState = previousCompletions[threadKey];
 
-    const isSettled =
+    const isSuccessfulCompletion =
       isLatestTurnSettled(thread.latestTurn, thread.session) &&
-      thread.latestTurn?.state !== "running" &&
+      thread.latestTurn?.state === "completed" &&
+      thread.session?.status !== "interrupted" &&
+      thread.session?.status !== "stopped" &&
+      thread.session?.status !== "error" &&
       Boolean(thread.latestTurn?.completedAt);
 
-    if (!isSettled) {
+    if (!isSuccessfulCompletion) {
       if (thread.session?.status === "running" || thread.latestTurn?.state === "running") {
         nextCompletions[threadKey] = "running";
+      } else if (thread.latestTurn?.completedAt) {
+        nextCompletions[threadKey] = thread.latestTurn.completedAt;
       }
       continue;
     }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -31,6 +31,7 @@ import {
 import { resolveAndPersistPreferredEditor } from "../editorPreferences";
 import { applyAppearanceFontVariables } from "~/appearanceFonts";
 import { useClientSettings } from "../hooks/useSettings";
+import { useTurnCompletionSound } from "../hooks/useTurnCompletionSound";
 import {
   deriveLogicalProjectKeyFromSettings,
   derivePhysicalProjectKeyFromPath,
@@ -132,6 +133,7 @@ function RootRouteView() {
         <DocumentTitleSync />
         <GlassAppearanceSync />
         <FontAppearanceSync />
+        <TurnCompletionSoundSync />
         {primaryEnvironmentAuthenticated ? <AuthenticatedTracingBootstrap /> : null}
         <RelayClientInstallDialog />
         <ConnectOnboardingDialog />
@@ -148,6 +150,11 @@ function RootRouteView() {
       </AnchoredToastProvider>
     </ToastProvider>
   );
+}
+
+function TurnCompletionSoundSync() {
+  useTurnCompletionSound();
+  return null;
 }
 
 function GlassAppearanceSync() {

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -33,6 +33,21 @@ describe("ClientSettings word wrap", () => {
   });
 });
 
+describe("ClientSettings sound notifications", () => {
+  it("defaults sound notifications on", () => {
+    expect(decodeClientSettings({}).soundNotificationsEnabled).toBe(true);
+  });
+
+  it("decodes explicit sound notifications setting", () => {
+    expect(
+      decodeClientSettings({ soundNotificationsEnabled: false }).soundNotificationsEnabled,
+    ).toBe(false);
+    expect(
+      decodeClientSettingsPatch({ soundNotificationsEnabled: false }).soundNotificationsEnabled,
+    ).toBe(false);
+  });
+});
+
 describe("ClientSettings glass opacity", () => {
   it("defaults to a readable translucent surface", () => {
     expect(decodeClientSettings({}).glassOpacity).toBe(80);

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -34,17 +34,41 @@ describe("ClientSettings word wrap", () => {
 });
 
 describe("ClientSettings sound notifications", () => {
-  it("defaults sound notifications on", () => {
-    expect(decodeClientSettings({}).soundNotificationsEnabled).toBe(true);
+  it("defaults sound notifications on and with standard presets", () => {
+    const settings = decodeClientSettings({});
+    expect(settings.soundNotificationsEnabled).toBe(true);
+    expect(settings.soundErrorNotificationsEnabled).toBe(true);
+    expect(settings.soundCompletionKind).toBe("chime");
+    expect(settings.soundErrorKind).toBe("descending");
   });
 
-  it("decodes explicit sound notifications setting", () => {
+  it("decodes explicit sound notifications settings", () => {
     expect(
-      decodeClientSettings({ soundNotificationsEnabled: false }).soundNotificationsEnabled,
-    ).toBe(false);
+      decodeClientSettings({
+        soundNotificationsEnabled: false,
+        soundErrorNotificationsEnabled: false,
+        soundCompletionKind: "bell",
+        soundErrorKind: "chord",
+      }),
+    ).toMatchObject({
+      soundNotificationsEnabled: false,
+      soundErrorNotificationsEnabled: false,
+      soundCompletionKind: "bell",
+      soundErrorKind: "chord",
+    });
     expect(
-      decodeClientSettingsPatch({ soundNotificationsEnabled: false }).soundNotificationsEnabled,
-    ).toBe(false);
+      decodeClientSettingsPatch({
+        soundNotificationsEnabled: false,
+        soundErrorNotificationsEnabled: false,
+        soundCompletionKind: "marimba",
+        soundErrorKind: "subtle",
+      }),
+    ).toMatchObject({
+      soundNotificationsEnabled: false,
+      soundErrorNotificationsEnabled: false,
+      soundCompletionKind: "marimba",
+      soundErrorKind: "subtle",
+    });
   });
 });
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -104,12 +104,16 @@ export const EnvironmentIdentificationMode = Schema.Literals(["artwork", "pill",
 export type EnvironmentIdentificationMode = typeof EnvironmentIdentificationMode.Type;
 export const DEFAULT_ENVIRONMENT_IDENTIFICATION_MODE: EnvironmentIdentificationMode = "artwork";
 
-/**
- * A user-chosen font family (a single name or a comma-separated list). Empty
- * means "use the app default"; clients compose their own fallback stacks.
- */
 export const FontFamilyPreference = Schema.String.check(Schema.isMaxLength(200));
 export type FontFamilyPreference = typeof FontFamilyPreference.Type;
+
+export const SoundCompletionKind = Schema.Literals(["chime", "bell", "marimba", "pop"]);
+export type SoundCompletionKind = typeof SoundCompletionKind.Type;
+export const DEFAULT_SOUND_COMPLETION_KIND: SoundCompletionKind = "chime";
+
+export const SoundErrorKind = Schema.Literals(["descending", "chord", "subtle", "buzz"]);
+export type SoundErrorKind = typeof SoundErrorKind.Type;
+export const DEFAULT_SOUND_ERROR_KIND: SoundErrorKind = "descending";
 
 export const ClientSettingsSchema = Schema.Struct({
   confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
@@ -201,6 +205,15 @@ export const ClientSettingsSchema = Schema.Struct({
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_TIMESTAMP_FORMAT)),
   ),
   soundNotificationsEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  soundErrorNotificationsEnabled: Schema.Boolean.pipe(
+    Schema.withDecodingDefault(Effect.succeed(true)),
+  ),
+  soundCompletionKind: SoundCompletionKind.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_SOUND_COMPLETION_KIND)),
+  ),
+  soundErrorKind: SoundErrorKind.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_SOUND_ERROR_KIND)),
+  ),
   wordWrap: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
 });
 export type ClientSettings = typeof ClientSettingsSchema.Type;
@@ -805,6 +818,9 @@ export const ClientSettingsPatch = Schema.Struct({
   sidebarThreadPreviewCount: Schema.optionalKey(SidebarThreadPreviewCount),
   timestampFormat: Schema.optionalKey(TimestampFormat),
   soundNotificationsEnabled: Schema.optionalKey(Schema.Boolean),
+  soundErrorNotificationsEnabled: Schema.optionalKey(Schema.Boolean),
+  soundCompletionKind: Schema.optionalKey(SoundCompletionKind),
+  soundErrorKind: Schema.optionalKey(SoundErrorKind),
   wordWrap: Schema.optionalKey(Schema.Boolean),
 });
 export type ClientSettingsPatch = typeof ClientSettingsPatch.Type;

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -200,6 +200,7 @@ export const ClientSettingsSchema = Schema.Struct({
   timestampFormat: TimestampFormat.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_TIMESTAMP_FORMAT)),
   ),
+  soundNotificationsEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   wordWrap: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
 });
 export type ClientSettings = typeof ClientSettingsSchema.Type;
@@ -803,6 +804,7 @@ export const ClientSettingsPatch = Schema.Struct({
   sidebarThreadSortOrder: Schema.optionalKey(SidebarThreadSortOrder),
   sidebarThreadPreviewCount: Schema.optionalKey(SidebarThreadPreviewCount),
   timestampFormat: Schema.optionalKey(TimestampFormat),
+  soundNotificationsEnabled: Schema.optionalKey(Schema.Boolean),
   wordWrap: Schema.optionalKey(Schema.Boolean),
 });
 export type ClientSettingsPatch = typeof ClientSettingsPatch.Type;


### PR DESCRIPTION
### Problem
When agents (Codex, Claude, etc.) complete long-running turns, users working across other windows or tasks don't receive an immediate auditory signal indicating that the response has finished and it's their turn to interact.

### Solution
- Implemented a subtle, synthetic two-tone chime via Web Audio API (`playTurnCompletionSound`) with no external audio file dependencies.
- Added `useTurnCompletionSound` hook to automatically play the chime when an agent turn completes.
- Added `soundNotificationsEnabled` setting to `ClientSettings` and a toggle in General Settings.

Gemini 3.7 Flash via Antigravity CLI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only UX with guarded audio playback and explicit detection rules; default-on chimes are a product change but not a security or data risk.
> 
> **Overview**
> Adds **audible notifications** when agent turns finish, using the Web Audio API (no bundled audio files).
> 
> **Runtime behavior:** A global `useTurnCompletionSound` hook watches all thread shells, tracks per-thread settlement via `detectNewTurnCompletions`, and plays a completion or error sound when a turn newly settles. It skips the first snapshot/hydration, mid-turn checkpoints, interrupted/stopped turns, and archived threads; **error sounds take priority** over completion when both could apply.
> 
> **Sounds:** `turnChime.ts` exposes multiple completion presets (chime, bell, marimba, pop) and error presets (descending, chord, subtle, buzz).
> 
> **Settings:** `ClientSettings` gains toggles and kind fields (both **default on**). General Settings adds two rows with preset selects, preview buttons, and reset-to-defaults; restore-defaults and settings search include the new options.
> 
> **Wiring:** `TurnCompletionSoundSync` in the app root mounts the hook app-wide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af50d4619a16c9a77cfef354694e50caf2681166. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add turn completion and error chime sounds with settings controls
> - Adds `playTurnCompletionSound` and `playTurnErrorSound` functions in [turnChime.ts](https://github.com/pingdotgg/t3code/pull/7066/files#diff-44dd39836b6311dd7be00e9c1ca331a8c7050d7c2affb840d04c1ff278c95244) that synthesize short tones via the Web Audio API with multiple selectable presets (chime, bell, marimba, pop / descending, chord, subtle, buzz).
> - Adds a `useTurnCompletionSound` hook that tracks per-thread turn state and plays the appropriate sound when a turn completes or errors, mounted globally via [__root.tsx](https://github.com/pingdotgg/t3code/pull/7066/files#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100).
> - Extends `ClientSettingsSchema` in [settings.ts](https://github.com/pingdotgg/t3code/pull/7066/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c) with four new keys: `soundNotificationsEnabled`, `soundErrorNotificationsEnabled`, `soundCompletionKind`, and `soundErrorKind`, all defaulting to enabled.
> - Adds UI controls to the General settings panel for enabling/disabling each sound, choosing a preset, and previewing it; both settings are also indexed in settings search.
> - Behavioral Change: sound notifications are on by default for all users after this change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized af50d46.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->