### PR TITLE
fix(codex): frame large app-server records linearly

### DIFF
--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -32,6 +32,7 @@ import * as Stream from "effect/Stream";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import * as CodexClient from "effect-codex-app-server/client";
 import * as CodexErrors from "effect-codex-app-server/errors";
+import { makeLineFramer } from "effect-codex-app-server/lineFramer";
 import * as CodexRpc from "effect-codex-app-server/rpc";
 import * as EffectCodexSchema from "effect-codex-app-server/schema";
 
@@ -1621,34 +1622,25 @@ export const makeCodexSessionRuntime = (
       Effect.forkIn(runtimeScope),
     );
 
-    const stderrRemainderRef = yield* Ref.make("");
+    const stderrLineFramer = makeLineFramer();
     yield* child.stderr.pipe(
       Stream.decodeText(),
       Stream.runForEach((chunk) =>
-        Ref.modify(stderrRemainderRef, (current) => {
-          const combined = current + chunk;
-          const lines = combined.split("\n");
-          const remainder = lines.pop() ?? "";
-          return [lines.map((line) => line.replace(/\r$/, "")), remainder] as const;
-        }).pipe(
-          Effect.flatMap((lines) =>
-            Effect.forEach(
-              lines,
-              (line) => {
-                const classified = classifyCodexStderrLine(line);
-                if (!classified) {
-                  return Effect.void;
-                }
-                return emitEvent({
-                  kind: "notification",
-                  threadId: options.threadId,
-                  method: "process/stderr",
-                  message: classified.message,
-                });
-              },
-              { discard: true },
-            ),
-          ),
+        Effect.forEach(
+          stderrLineFramer.push(chunk),
+          (line) => {
+            const classified = classifyCodexStderrLine(line);
+            if (!classified) {
+              return Effect.void;
+            }
+            return emitEvent({
+              kind: "notification",
+              threadId: options.threadId,
+              method: "process/stderr",
+              message: classified.message,
+            });
+          },
+          { discard: true },
         ),
       ),
       Effect.forkIn(runtimeScope),

--- a/packages/effect-codex-app-server/package.json
+++ b/packages/effect-codex-app-server/package.json
@@ -19,6 +19,10 @@
       "types": "./src/protocol.ts",
       "import": "./src/protocol.ts"
     },
+    "./lineFramer": {
+      "types": "./src/lineFramer.ts",
+      "import": "./src/lineFramer.ts"
+    },
     "./errors": {
       "types": "./src/errors.ts",
       "import": "./src/errors.ts"

--- a/packages/effect-codex-app-server/src/lineFramer.test.ts
+++ b/packages/effect-codex-app-server/src/lineFramer.test.ts
@@ -1,0 +1,56 @@
+import { assert, it } from "@effect/vitest";
+
+import { makeLineFramer } from "./lineFramer.ts";
+
+const collectLines = (chunks: ReadonlyArray<string>) => {
+  const framer = makeLineFramer();
+  const lines = chunks.flatMap((chunk) => framer.push(chunk));
+  const finalLine = framer.finish();
+  return finalLine === undefined ? lines : [...lines, finalLine];
+};
+
+it("preserves LF, CRLF, empty-line, and unterminated-line semantics across chunks", () => {
+  assert.deepEqual(collectLines(["alpha\r", "\n", "\nb", "eta\n", "gamma", "\r", "\ndelta"]), [
+    "alpha",
+    "",
+    "beta",
+    "gamma",
+    "delta",
+  ]);
+});
+
+it("handles chunk boundaries immediately before, after, and within line endings", () => {
+  assert.deepEqual(collectLines(["one", "\n", "two\n", "\r", "\n", "three\r", "\nfour"]), [
+    "one",
+    "two",
+    "",
+    "three",
+    "four",
+  ]);
+});
+
+it("retains a large fragmented line without emitting partial records", () => {
+  const framer = makeLineFramer();
+  const recordSize = 20 * 1024 * 1024;
+  const record = "x".repeat(recordSize);
+  const chunkSizes = [4_093, 8_191, 16_381];
+  let offset = 0;
+  let chunkIndex = 0;
+
+  while (offset < record.length) {
+    const nextOffset = Math.min(
+      record.length,
+      offset + chunkSizes[chunkIndex % chunkSizes.length]!,
+    );
+    assert.deepEqual(framer.push(record.slice(offset, nextOffset)), []);
+    offset = nextOffset;
+    chunkIndex++;
+  }
+
+  const completed = framer.push("\n");
+  assert.lengthOf(completed, 1);
+  assert.lengthOf(completed[0]!, recordSize);
+  assert.equal(completed[0]![0], "x");
+  assert.equal(completed[0]!.at(-1), "x");
+  assert.isUndefined(framer.finish());
+});

--- a/packages/effect-codex-app-server/src/lineFramer.test.ts
+++ b/packages/effect-codex-app-server/src/lineFramer.test.ts
@@ -32,10 +32,11 @@ it("handles chunk boundaries immediately before, after, and within line endings"
 it("retains a large fragmented line without emitting partial records", () => {
   const framer = makeLineFramer();
   const recordSize = 20 * 1024 * 1024;
-  const record = "x".repeat(recordSize);
+  const record = "0123456789abcdef".repeat(recordSize / 16);
   const chunkSizes = [4_093, 8_191, 16_381];
   let offset = 0;
   let chunkIndex = 0;
+  const startedAt = performance.now();
 
   while (offset < record.length) {
     const nextOffset = Math.min(
@@ -49,8 +50,7 @@ it("retains a large fragmented line without emitting partial records", () => {
 
   const completed = framer.push("\n");
   assert.lengthOf(completed, 1);
-  assert.lengthOf(completed[0]!, recordSize);
-  assert.equal(completed[0]![0], "x");
-  assert.equal(completed[0]!.at(-1), "x");
+  assert.equal(completed[0], record);
   assert.isUndefined(framer.finish());
+  assert.isBelow(performance.now() - startedAt, 2_000);
 });

--- a/packages/effect-codex-app-server/src/lineFramer.ts
+++ b/packages/effect-codex-app-server/src/lineFramer.ts
@@ -1,0 +1,48 @@
+export interface LineFramer {
+  readonly push: (chunk: string) => ReadonlyArray<string>;
+  readonly finish: () => string | undefined;
+}
+
+export function makeLineFramer(): LineFramer {
+  // Keep incomplete lines fragmented so every incoming chunk is copied at most once.
+  let fragments: Array<string> = [];
+
+  const completeLine = (segment: string) => {
+    if (fragments.length === 0) {
+      return segment.endsWith("\r") ? segment.slice(0, -1) : segment;
+    }
+    if (segment.length > 0) {
+      fragments.push(segment);
+    }
+    const line = fragments.join("");
+    fragments = [];
+    return line.endsWith("\r") ? line.slice(0, -1) : line;
+  };
+
+  return {
+    push: (chunk) => {
+      const lines: Array<string> = [];
+      let segmentStart = 0;
+      let newlineIndex = chunk.indexOf("\n");
+
+      while (newlineIndex !== -1) {
+        lines.push(completeLine(chunk.slice(segmentStart, newlineIndex)));
+        segmentStart = newlineIndex + 1;
+        newlineIndex = chunk.indexOf("\n", segmentStart);
+      }
+
+      if (segmentStart < chunk.length) {
+        fragments.push(chunk.slice(segmentStart));
+      }
+      return lines;
+    },
+    finish: () => {
+      if (fragments.length === 0) {
+        return undefined;
+      }
+      const line = fragments.join("");
+      fragments = [];
+      return line;
+    },
+  };
+}

--- a/packages/effect-codex-app-server/src/protocol.test.ts
+++ b/packages/effect-codex-app-server/src/protocol.test.ts
@@ -290,6 +290,29 @@ it.layer(NodeServices.layer)("effect-codex-app-server protocol", (it) => {
       }),
   );
 
+  it.effect("routes a CRLF-framed message split across arbitrary input chunks", () =>
+    Effect.gen(function* () {
+      const { stdio, input } = yield* makeInMemoryStdio();
+      const transport = yield* CodexProtocol.makeCodexAppServerPatchedProtocol({ stdio });
+      const notification = yield* transport.incomingNotifications.pipe(
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkScoped,
+      );
+      const encoded = encoder.encode(
+        `${encodeUnknownJsonString({ method: "thread/started", params: { threadId: "thread-1" } })}\r\n`,
+      );
+
+      yield* Queue.offer(input, encoded.slice(0, 7));
+      yield* Queue.offer(input, encoded.slice(7, -1));
+      yield* Queue.offer(input, encoded.slice(-1));
+
+      assert.deepEqual(yield* Fiber.join(notification), [
+        { method: "thread/started", params: { threadId: "thread-1" } },
+      ]);
+    }),
+  );
+
   it.effect("surfaces JSON encoding failures as protocol parse errors", () =>
     Effect.gen(function* () {
       const { stdio } = yield* makeInMemoryStdio();

--- a/packages/effect-codex-app-server/src/protocol.test.ts
+++ b/packages/effect-codex-app-server/src/protocol.test.ts
@@ -313,6 +313,37 @@ it.layer(NodeServices.layer)("effect-codex-app-server protocol", (it) => {
     }),
   );
 
+  it.effect("routes a final unterminated message before handling input stream completion", () =>
+    Effect.gen(function* () {
+      const { stdio, input } = yield* makeInMemoryStdio();
+      const termination = yield* Deferred.make<CodexError.CodexAppServerError>();
+      const transport = yield* CodexProtocol.makeCodexAppServerPatchedProtocol({
+        stdio,
+        onTermination: (error) => Deferred.succeed(termination, error).pipe(Effect.asVoid),
+      });
+      const notification = yield* transport.incomingNotifications.pipe(
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkScoped,
+      );
+      const encoded = encoder.encode(
+        encodeUnknownJsonString({ method: "thread/started", params: { threadId: "thread-1" } }),
+      );
+
+      yield* Queue.offer(input, encoded.slice(0, 11));
+      yield* Queue.offer(input, encoded.slice(11));
+      yield* Queue.end(input);
+
+      assert.deepEqual(yield* Fiber.join(notification), [
+        { method: "thread/started", params: { threadId: "thread-1" } },
+      ]);
+      assert.instanceOf(
+        yield* Deferred.await(termination),
+        CodexError.CodexAppServerInputStreamEndedError,
+      );
+    }),
+  );
+
   it.effect("surfaces JSON encoding failures as protocol parse errors", () =>
     Effect.gen(function* () {
       const { stdio } = yield* makeInMemoryStdio();

--- a/packages/effect-codex-app-server/src/protocol.test.ts
+++ b/packages/effect-codex-app-server/src/protocol.test.ts
@@ -317,9 +317,17 @@ it.layer(NodeServices.layer)("effect-codex-app-server protocol", (it) => {
     Effect.gen(function* () {
       const { stdio, input } = yield* makeInMemoryStdio();
       const termination = yield* Deferred.make<CodexError.CodexAppServerError>();
+      const lifecycle: Array<"notification" | "termination"> = [];
       const transport = yield* CodexProtocol.makeCodexAppServerPatchedProtocol({
         stdio,
-        onTermination: (error) => Deferred.succeed(termination, error).pipe(Effect.asVoid),
+        onNotification: () =>
+          Effect.sync(() => {
+            lifecycle.push("notification");
+          }),
+        onTermination: (error) =>
+          Effect.sync(() => {
+            lifecycle.push("termination");
+          }).pipe(Effect.andThen(Deferred.succeed(termination, error)), Effect.asVoid),
       });
       const notification = yield* transport.incomingNotifications.pipe(
         Stream.take(1),
@@ -341,6 +349,7 @@ it.layer(NodeServices.layer)("effect-codex-app-server protocol", (it) => {
         yield* Deferred.await(termination),
         CodexError.CodexAppServerInputStreamEndedError,
       );
+      assert.deepEqual(lifecycle, ["notification", "termination"]);
     }),
   );
 

--- a/packages/effect-codex-app-server/src/protocol.ts
+++ b/packages/effect-codex-app-server/src/protocol.ts
@@ -9,6 +9,7 @@ import * as Stdio from "effect/Stdio";
 import * as Stream from "effect/Stream";
 
 import * as CodexError from "./errors.ts";
+import { makeLineFramer } from "./lineFramer.ts";
 import { JsonRpcId, JsonRpcResponseEnvelope } from "./_internal/shared.ts";
 const isJsonRpcId = Schema.is(JsonRpcId);
 const isJsonRpcResponseEnvelope = Schema.is(JsonRpcResponseEnvelope);
@@ -157,7 +158,7 @@ export const makeCodexAppServerPatchedProtocol = Effect.fn("makeCodexAppServerPa
     const incomingRequests = yield* Queue.unbounded<CodexAppServerIncomingRequest>();
     const pending = yield* Ref.make(new Map<string, CodexAppServerPendingRequest>());
     const nextRequestId = yield* Ref.make(1);
-    const remainder = yield* Ref.make("");
+    const lineFramer = makeLineFramer();
     const terminationHandled = yield* Ref.make(false);
 
     const logProtocol = (event: CodexAppServerProtocolLogEvent) => {
@@ -354,12 +355,7 @@ export const makeCodexAppServerPatchedProtocol = Effect.fn("makeCodexAppServerPa
     yield* options.stdio.stdin.pipe(
       Stream.decodeText(),
       Stream.runForEach((chunk) =>
-        Ref.modify(remainder, (current) => {
-          const combined = current + chunk;
-          const lines = combined.split("\n");
-          const nextRemainder = lines.pop() ?? "";
-          return [lines.map((line) => line.replace(/\r$/, "")), nextRemainder] as const;
-        }).pipe(Effect.flatMap((lines) => Effect.forEach(lines, handleLine, { discard: true }))),
+        Effect.forEach(lineFramer.push(chunk), handleLine, { discard: true }),
       ),
       Effect.matchEffect({
         onFailure: (error) =>
@@ -367,8 +363,10 @@ export const makeCodexAppServerPatchedProtocol = Effect.fn("makeCodexAppServerPa
             Effect.succeed(normalizeIncomingError(error, "read-input-stream")),
           ),
         onSuccess: () =>
-          Ref.get(remainder).pipe(
-            Effect.flatMap((line) => (line.trim().length === 0 ? Effect.void : handleLine(line))),
+          Effect.succeed(lineFramer.finish()).pipe(
+            Effect.flatMap((line) =>
+              line === undefined || line.trim().length === 0 ? Effect.void : handleLine(line),
+            ),
             Effect.matchEffect({
               onFailure: (error) => handleTermination(() => Effect.succeed(error)),
               onSuccess: () =>


### PR DESCRIPTION
Fixes #5389.

The Codex app-server protocol reader repeatedly concatenated and rescanned an unfinished JSONL record for every incoming chunk. Large records therefore incurred quadratic copying and could exhaust CPU and memory.

This change adds one incremental line-framing owner that retains unfinished records as fragments and joins them only at a newline or EOF. Both protocol stdin and Codex stderr now use it while preserving existing newline, CRLF, empty-line, parse-error, stream-failure, and EOF behavior.

Regression coverage includes a 20 MiB record split into irregular chunks, multiple records, CRLF, empty records, newline-boundary splits, final unterminated records, protocol EOF routing, and termination order. On the exact 20 MiB workload, the candidate completed in 7–13 ms versus 8,105 ms for the prior accumulator; the test rejects implementations exceeding 2,000 ms. Focused tests, package/server typechecks, targeted lint/formatting, and done-check passed.

Fork coordination: https://github.com/clintebbesen/t3code/issues/2

Verification environment: Codex harness, gpt-5.6-sol.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Codex app-server JSONL read path and stderr framing; behavior is intended to match prior semantics but mistakes could drop or mis-parse wire messages.
> 
> **Overview**
> Fixes pathological CPU/memory use when Codex sends **large JSONL records** split across many stdin chunks. The old reader kept **re-concatenating and re-scanning** the whole unfinished line on every chunk (quadratic work); very large lines could stall or exhaust resources.
> 
> This PR adds **`makeLineFramer`** in `effect-codex-app-server`, exported as `./lineFramer`. It buffers incomplete lines as **fragments**, emits only on `\n`, strips trailing `\r`, and exposes **`finish()`** for a final unterminated line at EOF. **Protocol stdin** and **Codex session stderr** both use it instead of local `remainder` + `split("\n")` logic.
> 
> Regression tests cover LF/CRLF, empty lines, arbitrary chunk boundaries, a **20 MiB** fragmented record (must complete under 2s), CRLF messages split across chunks, and routing the **last line without a trailing newline** before input stream end (notification before termination).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3de1fe92b989e804a540725222f9c32641943217. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace ad-hoc line buffering with `makeLineFramer` in codex app-server protocol and runtime
> - Introduces [`makeLineFramer`](https://github.com/pingdotgg/t3code/pull/7068/files#diff-e5e4811ebd80c4f45e1712c3557fae7c295dd5628a146ceffe48c8dd633b79e5), a reusable framer that incrementally buffers string chunks and emits complete lines split on `\n` with trailing `\r` trimmed.
> - Replaces `Ref`-based remainder accumulators in both [`protocol.ts`](https://github.com/pingdotgg/t3code/pull/7068/files#diff-c2eebe727f23e219c63497172bee07fd14e21634903ec9de0e7d63bfc80571fd) and [`CodexSessionRuntime.ts`](https://github.com/pingdotgg/t3code/pull/7068/files#diff-e29bf409c8e737a2d4e655f7e9e7def9c78c008d98a0a23575baa5e714c4e12c) with `lineFramer.push()` / `lineFramer.finish()` calls.
> - Exports the new module as the `effect-codex-app-server/lineFramer` subpath in [`package.json`](https://github.com/pingdotgg/t3code/pull/7068/files#diff-e02c7fc3e76b0053bbf910f67f429902bbcbaaaf7785daf78c787889f40a3172).
> - Adds tests covering LF, CRLF, empty lines, unterminated final lines, and large fragmented lines.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3de1fe9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->