### PR TITLE
docs: document fork-to-upstream development workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,9 @@ If you open a 1,000+ line PR full of new features, we will probably close it qui
 
 ## If You Still Want To Open A PR
 
+If you work from a fork, follow the
+[fork-to-upstream development workflow](docs/internals/upstream-development.md).
+
 Keep it small.
 
 Explain exactly what changed.

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ policy in [CONTRIBUTING.md](../CONTRIBUTING.md); agent rules in [AGENTS.md](../A
 - [Environment auth](./internals/environment-auth.md)
 - [T3 Connect](./internals/t3-connect.md)
 - [CI gates](./internals/ci.md)
+- [Fork-to-upstream development](./internals/upstream-development.md)
 
 ### Runbooks
 

--- a/docs/internals/upstream-development.md
+++ b/docs/internals/upstream-development.md
@@ -1,0 +1,122 @@
+# Fork-to-upstream development
+
+Use a fork as a staging point for small, focused contributions to T3 Code. The
+fork is not a long-lived patch distribution: fixes should be proposed upstream,
+and local installations should return to an official release after the change
+ships.
+
+The examples below use these remotes:
+
+- `upstream`: [`pingdotgg/t3code`](https://github.com/pingdotgg/t3code), the
+  canonical repository and pull request target.
+- `origin`: [`clintebbesen/t3code`](https://github.com/clintebbesen/t3code), the
+  working fork used to publish feature branches.
+
+After cloning the working fork, add the canonical repository once, then confirm
+the mapping before doing any work. If either remote already exists with the
+wrong URL, correct it with `git remote set-url <name> <url>`.
+
+```sh
+git remote add upstream https://github.com/pingdotgg/t3code.git
+git remote -v
+git fetch --all --prune
+```
+
+Never put a token, key, password, `.env` value, or authenticated URL in a
+command that will be copied into an issue, commit, document, or transcript. Use
+GitHub CLI authentication or another approved credential store.
+
+## Check for existing work first
+
+Before opening an issue or writing code, search the upstream issues, pull
+requests, current source, and recent releases. Search both open and closed work
+and try the names of the visible symptom and the owning component.
+
+```sh
+gh issue list --repo pingdotgg/t3code --state all --search "search terms"
+gh pr list --repo pingdotgg/t3code --state all --search "search terms"
+gh release list --repo pingdotgg/t3code
+git fetch upstream main --prune
+git log --oneline upstream/main -- path/to/owner
+```
+
+Record the exact upstream commit inspected and links to matching issues, pull
+requests, and releases. If an upstream pull request already covers the defect,
+fetch and test its branch. Contribute only a missing regression, edge case, or
+other demonstrated gap; do not recreate the same fix on another branch.
+
+```sh
+gh pr checkout <pull-request-number> --repo pingdotgg/t3code --detach
+```
+
+## Start each fix from upstream
+
+The fork's `main` tracks upstream. Do not commit fixes to it or turn it into a
+permanent overlay branch. Create one short-lived branch per concern from the
+latest upstream `main`:
+
+```sh
+git fetch upstream main --prune
+git switch -c fix/short-description upstream/main
+git push -u origin fix/short-description
+```
+
+Keep the pull request narrow enough to describe without “also.” Before editing,
+reproduce the defect with a regression test, trace all callers, and identify the
+existing owner or layer to extend. Record the starting commit, reproduction,
+material decisions, and exact verification results. Run the focused tests,
+lint, type checks, and repository completion checks required by
+[`AGENTS.md`](../../AGENTS.md); do not replace a real entry-point check with a
+mock-only proof.
+
+Tests must use isolated state. Copy data into a disposable worktree environment
+when realistic data is needed. Never start a development server against the
+live T3 home, write to the live database, restart the live service, deploy, or
+mutate another environment without explicit authorization.
+
+## Open and maintain the upstream pull request
+
+Push only the feature branch to the fork. Then open a pull request from that
+branch to `pingdotgg/t3code:main`, with the source and target explicit:
+
+```sh
+git push origin fix/short-description
+gh pr create \
+  --repo pingdotgg/t3code \
+  --base main \
+  --head clintebbesen:fix/short-description
+```
+
+Link the upstream issue and any fork coordination issue, state what was
+reproduced, and include the exact checks run. Verify the pull request's base,
+head, and CI result after creation. Do not merge it automatically.
+
+While review is open, respond to current upstream source and maintainer
+feedback. Fetch `upstream/main` before each revision, keep new commits within
+the original purpose, and use the repository's normal review workflow to
+synchronize the branch when required. If upstream has independently fixed the
+defect, test that implementation and close or reduce the pull request instead
+of preserving duplicate code.
+
+After the change merges and appears in an official release, update the local
+installation to that release, confirm the supported behavior, and retire the
+fork build and short-lived branch. Do not accumulate merged fixes as permanent
+overlay patches.
+
+## Current reliability coordination
+
+These links are starting points, not a substitute for the duplicate and release
+search above:
+
+- Provider command lockout: upstream
+  [#6517](https://github.com/pingdotgg/t3code/issues/6517), coordinated in fork
+  [#1](https://github.com/clintebbesen/t3code/issues/1).
+- Quadratic Codex JSONL framing: upstream
+  [#5389](https://github.com/pingdotgg/t3code/issues/5389), coordinated in fork
+  [#2](https://github.com/clintebbesen/t3code/issues/2).
+- This workflow: fork
+  [#3](https://github.com/clintebbesen/t3code/issues/3).
+
+The provider lifecycle defect and JSONL framing defect have different owners,
+reproductions, and acceptance criteria. Keep their branches and pull requests
+separate unless a current reproduction proves that they share an owner.


### PR DESCRIPTION
Documents the fork-to-upstream lifecycle requested by the fork coordination issue https://github.com/clintebbesen/t3code/issues/3.

The new maintainer-facing guide explains:

- the `upstream` and `origin` remote roles and safe credential handling;
- duplicate/fix/release searches before issue creation or implementation;
- fresh short-lived branches from current upstream `main`;
- reproduction, existing-owner tracing, isolated state, and exact evidence;
- explicit fork-to-`pingdotgg/t3code:main` pull request creation and review synchronization;
- updating to an official release and retiring fork overlays;
- the separate scopes of upstream #6517 (provider lifecycle) and #5389 (Codex JSONL framing).

The guide is linked from `CONTRIBUTING.md` and `docs/README.md`. `done-check --base upstream/main --no-tests` passed; its mandated typecheck and lint passed with one pre-existing warning each, and no documentation-specific lint command is defined. Tests were not applicable to this documentation-only change.

Verification environment: Codex harness, gpt-5.6-sol.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, auth, or data-path impact.
> 
> **Overview**
> Adds maintainer-facing documentation for contributing from a fork without treating it as a long-lived patch overlay.
> 
> The new **`docs/internals/upstream-development.md`** guide covers `upstream` vs `origin` remotes, credential hygiene, duplicate/issue/PR/release search before coding, short-lived branches from current **`upstream/main`**, reproduction and isolated testing expectations (with pointers to **`AGENTS.md`**), explicit **`gh pr create`** targeting **`pingdotgg/t3code:main`**, review sync and post-merge release adoption, plus coordination links for related upstream/fork issues.
> 
> **`CONTRIBUTING.md`** now directs fork contributors to that guide, and **`docs/README.md`** lists it under internals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a872c67172e2d43b4b370e222e4cfa4f84ed86b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document fork-to-upstream development workflow in contributor docs
> Adds a new guide at [docs/internals/upstream-development.md](https://github.com/pingdotgg/t3code/pull/7069/files#diff-69aa46f6961deaa29df02c330496c48e506a5fd0f73cddb9f645328b65bd574e) covering the full fork-to-upstream workflow: remote setup, finding existing work, starting fixes from upstream, creating and maintaining PRs, and safety/testing guidance with example commands. Updates [CONTRIBUTING.md](https://github.com/pingdotgg/t3code/pull/7069/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055) and [docs/README.md](https://github.com/pingdotgg/t3code/pull/7069/files#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938) to link to the new document.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a872c67.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->