### PR TITLE
fix(server): isolate provider command lanes by thread

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -23,7 +23,7 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
-import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
+import { makeDrainableWorker, makeKeyedDrainableWorker } from "@t3tools/shared/DrainableWorker";
 
 import { resolveThreadWorkspaceCwd } from "../../checkpointing/Utils.ts";
 import { increment, orchestrationEventsProcessedTotal } from "../../observability/Metrics.ts";
@@ -1325,7 +1325,6 @@ const make = Effect.gen(function* () {
       createdAt: now,
     });
   });
-
   const processDomainEvent = Effect.fn("processDomainEvent")(function* (
     event: ProviderIntentEvent,
   ) {
@@ -1371,7 +1370,6 @@ const make = Effect.gen(function* () {
         return;
     }
   });
-
   const processDomainEventSafely = (event: ProviderIntentEvent) =>
     processDomainEvent(event).pipe(
       Effect.catchCause((cause) => {
@@ -1385,8 +1383,10 @@ const make = Effect.gen(function* () {
       }),
     );
 
-  const worker = yield* makeDrainableWorker(processDomainEventSafely);
-
+  const worker = yield* makeKeyedDrainableWorker(
+    (event: ProviderIntentEvent) => event.payload.threadId,
+    processDomainEventSafely,
+  );
   const start: ProviderCommandReactorShape["start"] = Effect.fn("start")(function* () {
     const interruptedTitleRegenerations = yield* findInterruptedThreadTitleRegenerations().pipe(
       Effect.catchCause((cause) => {

--- a/packages/shared/src/DrainableWorker.test.ts
+++ b/packages/shared/src/DrainableWorker.test.ts
@@ -3,7 +3,7 @@ import { describe, expect } from "vite-plus/test";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 
-import { makeDrainableWorker } from "./DrainableWorker.ts";
+import { makeDrainableWorker, makeKeyedDrainableWorker } from "./DrainableWorker.ts";
 
 describe("makeDrainableWorker", () => {
   it.live("waits for work enqueued during active processing before draining", () =>
@@ -51,6 +51,44 @@ describe("makeDrainableWorker", () => {
         yield* Deferred.await(drained);
 
         expect(processed).toEqual(["first", "second"]);
+      }),
+    ),
+  );
+});
+
+describe("makeKeyedDrainableWorker", () => {
+  it.live("runs different keys independently while preserving each key's FIFO", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const processed: string[] = [];
+        const firstStarted = yield* Deferred.make<void>();
+        const secondStarted = yield* Deferred.make<void>();
+        const releaseFirst = yield* Deferred.make<void>();
+        const worker = yield* makeKeyedDrainableWorker(
+          (item: { readonly key: string; readonly value: string }) => item.key,
+          (item) =>
+            Effect.gen(function* () {
+              if (item.value === "a1") {
+                yield* Deferred.succeed(firstStarted, undefined);
+                yield* Deferred.await(releaseFirst);
+              }
+              processed.push(item.value);
+              if (item.value === "b1") {
+                yield* Deferred.succeed(secondStarted, undefined);
+              }
+            }),
+        );
+
+        yield* worker.enqueue({ key: "a", value: "a1" });
+        yield* Deferred.await(firstStarted);
+        yield* worker.enqueue({ key: "a", value: "a2" });
+        yield* worker.enqueue({ key: "b", value: "b1" });
+        yield* Deferred.await(secondStarted);
+        expect(processed).toEqual(["b1"]);
+
+        yield* Deferred.succeed(releaseFirst, undefined);
+        yield* worker.drain;
+        expect(processed).toEqual(["b1", "a1", "a2"]);
       }),
     ),
   );

--- a/packages/shared/src/DrainableWorker.ts
+++ b/packages/shared/src/DrainableWorker.ts
@@ -28,6 +28,59 @@ export interface DrainableWorker<A> {
   readonly drain: Effect.Effect<void>;
 }
 
+/** Create drainable FIFO lanes keyed by an item field. */
+export const makeKeyedDrainableWorker = <A, K, E, R>(
+  keyOf: (item: A) => K,
+  process: (item: A) => Effect.Effect<void, E, R>,
+): Effect.Effect<DrainableWorker<A>, never, Scope.Scope | R> =>
+  Effect.gen(function* () {
+    const context = yield* Effect.context<R>();
+    const scope = yield* Scope.Scope;
+    type Entry = { readonly worker: DrainableWorker<A>; version: number };
+    const entries = new Map<K, Entry>();
+
+    const removeWhenIdle = (key: K, entry: Entry) =>
+      Effect.gen(function* () {
+        while (entries.get(key) === entry) {
+          const observedVersion = entry.version;
+          yield* entry.worker.drain;
+          if (entry.version === observedVersion && entries.get(key) === entry) {
+            entries.delete(key);
+            return;
+          }
+        }
+      });
+
+    const enqueue = (item: A): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        const key = keyOf(item);
+        const existing = entries.get(key);
+        if (existing !== undefined) {
+          existing.version += 1;
+          yield* existing.worker.enqueue(item);
+          return;
+        }
+        const worker = yield* makeDrainableWorker(process).pipe(
+          Effect.provide(context),
+          Scope.provide(scope),
+        );
+        const entry: Entry = { worker, version: 1 };
+        entries.set(key, entry);
+        yield* worker.enqueue(item);
+        yield* removeWhenIdle(key, entry).pipe(Effect.forkIn(scope));
+      });
+
+    return {
+      enqueue,
+      drain: Effect.suspend(() =>
+        Effect.forEach(entries.values(), (entry) => entry.worker.drain, {
+          concurrency: "unbounded",
+          discard: true,
+        }),
+      ),
+    } satisfies DrainableWorker<A>;
+  });
+
 /**
  * Create a drainable worker that processes items from an unbounded queue.
  *

--- a/packages/shared/src/DrainableWorker.ts
+++ b/packages/shared/src/DrainableWorker.ts
@@ -10,6 +10,7 @@
  */
 import * as Scope from "effect/Scope";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as TxQueue from "effect/TxQueue";
 import * as TxRef from "effect/TxRef";
 
@@ -36,8 +37,14 @@ export const makeKeyedDrainableWorker = <A, K, E, R>(
   Effect.gen(function* () {
     const context = yield* Effect.context<R>();
     const scope = yield* Scope.Scope;
-    type Entry = { readonly worker: DrainableWorker<A>; version: number };
+    type Entry = {
+      readonly worker: DrainableWorker<A>;
+      readonly scope: Scope.Closeable;
+      version: number;
+    };
     const entries = new Map<K, Entry>();
+    const processInParentScope = (item: A) =>
+      process(item).pipe(Effect.provide(context), Scope.provide(scope));
 
     const removeWhenIdle = (key: K, entry: Entry) =>
       Effect.gen(function* () {
@@ -46,6 +53,7 @@ export const makeKeyedDrainableWorker = <A, K, E, R>(
           yield* entry.worker.drain;
           if (entry.version === observedVersion && entries.get(key) === entry) {
             entries.delete(key);
+            yield* Scope.close(entry.scope, Exit.void);
             return;
           }
         }
@@ -60,11 +68,11 @@ export const makeKeyedDrainableWorker = <A, K, E, R>(
           yield* existing.worker.enqueue(item);
           return;
         }
-        const worker = yield* makeDrainableWorker(process).pipe(
-          Effect.provide(context),
-          Scope.provide(scope),
+        const laneScope = yield* Scope.fork(scope, "sequential");
+        const worker = yield* makeDrainableWorker(processInParentScope).pipe(
+          Scope.provide(laneScope),
         );
-        const entry: Entry = { worker, version: 1 };
+        const entry: Entry = { worker, scope: laneScope, version: 1 };
         entries.set(key, entry);
         yield* worker.enqueue(item);
         yield* removeWhenIdle(key, entry).pipe(Effect.forkIn(scope));


### PR DESCRIPTION
Fixes #6517.

ProviderCommandReactor used one global DrainableWorker for lifecycle, turn, response, and stop commands. A provider start/restart that never resolves therefore prevented unrelated threads from starting and left their statuses blank or stuck on Connecting.

This change extends the existing DrainableWorker owner with keyed FIFO lanes. Commands for different threads now process independently; commands for the same thread retain order. Idle lanes remove themselves after draining so the reactor does not retain a queue and fiber for every historical thread.

Focused regression coverage proves independent progress for different keys and FIFO ordering for the same key. The existing ProviderCommandReactor test file still passes (47 tests); the shared worker tests pass (2 tests). Server/shared typechecks, targeted lint, formatting, and `done-check --base upstream/main --no-tests` passed. Tests were run in the isolated worktree; no live T3 state was used.

Scope disposition: this PR fixes the cross-thread scheduling lockout only. It does not duplicate the still-open interrupt responsiveness work in #6531, nor fold in the separately scoped lifecycle timeout/stale-session/restart-recovery work tracked by #6560, #4944, and #4584. The Codex framing defect remains separate in #5389 and fork coordination issue https://github.com/clintebbesen/t3code/issues/1.

Verification environment: Codex harness, gpt-5.6-sol.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration concurrency for provider lifecycle/turn commands; same-thread ordering is preserved but cross-thread behavior is no longer globally serialized.
> 
> **Overview**
> Fixes cross-thread lockout where a **single global** provider command queue let one thread’s stuck start/restart block every other thread’s lifecycle and turn handling.
> 
> Adds **`makeKeyedDrainableWorker`** in shared `DrainableWorker`: one FIFO drainable worker per key, **concurrent across keys**, FIFO within a key, with **idle lanes torn down** after drain so historical threads don’t leak queues/fibers. **`ProviderCommandReactor`** now keys lanes on **`event.payload.threadId`** instead of `makeDrainableWorker`.
> 
> Regression test covers independent progress for different keys and FIFO for the same key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4822cc340af75f7970d7aed582507cd5a68049ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Isolate provider command processing into per-thread FIFO lanes
> - Adds `makeKeyedDrainableWorker` to [DrainableWorker.ts](https://github.com/pingdotgg/t3code/pull/7071/files#diff-2d561a184e3938cbea191a53a563811022519b39b830c22e7ac70825c79fe0d3), which maintains a per-key `makeDrainableWorker` lane, creating and cleaning up lanes dynamically as work arrives and drains.
> - Updates [ProviderCommandReactor.ts](https://github.com/pingdotgg/t3code/pull/7071/files#diff-0630e9ad70d5dcd1c8586d29297f9b7d5f5436cc8e10fc88dc22acc511f1450d) to key the worker by `event.payload.threadId`, so events on different threads are processed concurrently while preserving FIFO order within each thread.
> - Behavioral Change: previously all provider command events shared a single FIFO queue; now concurrency is possible across threads.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4822cc3. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->