### PR TITLE
fix(shared): preserve conventional prefixes in generated branch names

### DIFF
--- a/apps/server/src/textGeneration/CodexTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/CodexTextGeneration.test.ts
@@ -347,7 +347,7 @@ it.layer(CodexTextGenerationTestLayer)("CodexTextGeneration", (it) => {
           });
 
           expect(generated.subject).toBe("Add important change");
-          expect(generated.branch).toBe("feature/fix/important-system-change");
+          expect(generated.branch).toBe("fix/important-system-change");
         }),
     ),
   );

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -7,6 +7,7 @@ import {
   isTemporaryWorktreeBranch,
   normalizeGitRemoteUrl,
   parseGitHubRepositoryNameWithOwnerFromRemoteUrl,
+  sanitizeFeatureBranchName,
   WORKTREE_BRANCH_PREFIX,
 } from "./git.ts";
 
@@ -98,6 +99,30 @@ describe("isTemporaryWorktreeBranch", () => {
     expect(isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/feature/demo`)).toBe(false);
     expect(isTemporaryWorktreeBranch("main")).toBe(false);
     expect(isTemporaryWorktreeBranch(`${WORKTREE_BRANCH_PREFIX}/deadbeef-extra`)).toBe(false);
+  });
+});
+
+describe("sanitizeFeatureBranchName", () => {
+  it("preserves an existing feature/ prefix", () => {
+    expect(sanitizeFeatureBranchName("feature/refine-toolbar")).toBe("feature/refine-toolbar");
+  });
+
+  it("preserves a fix/ prefix instead of double-prefixing it", () => {
+    expect(sanitizeFeatureBranchName("fix/calendar-recruitment-filter")).toBe(
+      "fix/calendar-recruitment-filter",
+    );
+  });
+
+  it("preserves a feat/ prefix", () => {
+    expect(sanitizeFeatureBranchName("feat/user-auth")).toBe("feat/user-auth");
+  });
+
+  it("prepends feature/ to a plain fragment", () => {
+    expect(sanitizeFeatureBranchName("refine toolbar")).toBe("feature/refine-toolbar");
+  });
+
+  it("prepends feature/ to an unrecognized namespace", () => {
+    expect(sanitizeFeatureBranchName("add/user-auth")).toBe("feature/add/user-auth");
   });
 });
 

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -42,13 +42,35 @@ export function sanitizeBranchFragment(raw: string): string {
 }
 
 /**
+ * Namespace prefixes `sanitizeFeatureBranchName` keeps as-is instead of
+ * prepending `feature/`. Conventional Commit types, plus the `feature/` and
+ * `feat/` spellings of the feature-branch intent.
+ */
+const CONVENTIONAL_BRANCH_PREFIXES = new Set([
+  "build",
+  "chore",
+  "ci",
+  "docs",
+  "feat",
+  "feature",
+  "fix",
+  "perf",
+  "refactor",
+  "revert",
+  "style",
+  "test",
+]);
+
+/**
  * Sanitize a string into a `feature/…` refName name.
- * Preserves an existing `feature/` prefix or slash-separated namespace.
+ * Preserves an existing recognized namespace prefix (`feature/`, `feat/`,
+ * `fix/`, …) and otherwise prepends `feature/`.
  */
 export function sanitizeFeatureBranchName(raw: string): string {
   const sanitized = sanitizeBranchFragment(raw);
   if (sanitized.includes("/")) {
-    return sanitized.startsWith("feature/") ? sanitized : `feature/${sanitized}`;
+    const prefix = sanitized.slice(0, sanitized.indexOf("/"));
+    return CONVENTIONAL_BRANCH_PREFIXES.has(prefix) ? sanitized : `feature/${sanitized}`;
   }
   return `feature/${sanitized}`;
 }


### PR DESCRIPTION
> **AI disclosure:** every line of code in this PR was written by an AI agent. A human made the decisions, gave the guidance, and reviewed the diff, but wrote none of the code.

Closes https://github.com/pingdotgg/t3code/issues/7073

## What Changed

One function, one behavior, plus tests:

- `packages/shared/src/git.ts`: `sanitizeFeatureBranchName` now keeps a slash-separated prefix when it is a conventional type (`fix/`, `feat/`, `chore/`, `feature/`, and so on) instead of always prepending `feature/`.
- `packages/shared/src/git.test.ts`: added a `describe("sanitizeFeatureBranchName")` block covering the fixed case and the unchanged cases.
- `apps/server/src/textGeneration/CodexTextGeneration.test.ts`: one assertion updated. It previously expected the buggy `feature/fix/…` output.

## Why

When you create a PR from the default branch, the branch name comes from the model as a "short semantic git branch fragment". For a bug fix the model returns `fix/calendar-recruitment-filter`. The old code only treated `feature/` as already-complete and glued `feature/` onto every other slash-separated name, producing `feature/fix/calendar-recruitment-filter`. This removes that double prefix.

## What I did not change

- Plain fragments still become `feature/…`: `"refine toolbar"` -> `feature/refine-toolbar`.
- Unrecognized namespaces still become `feature/…`: `"add/user-auth"` -> `feature/add/user-auth`.
- `feature/…` still passes through unchanged.

## How to review

1. Read the one changed function in `packages/shared/src/git.ts` (about ten lines).
2. Check the new `describe("sanitizeFeatureBranchName")` block in `packages/shared/src/git.test.ts`. The first two cases cover the fix; the last three cover the unchanged behavior.
3. The `CodexTextGeneration.test.ts` change is a single-line assertion update.

## Verification

I could not run the test suite locally. This repo uses the `vp` toolchain, which is not installed in my environment and needs a full `vp i` install. I sanity-checked the sanitizer logic with a standalone Node script instead. Please run the `@t3tools/shared` and server `textGeneration` test suites before merging.

## UI Changes

No UI changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (N/A, no UI change)
- [x] I included a video for animation/interaction changes (N/A, no animation)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-tested change to branch string normalization with no auth or data-path impact; only affects how generated branch names are formatted.
> 
> **Overview**
> **`sanitizeFeatureBranchName`** no longer prepends `feature/` to every slash-separated name. It now keeps the branch as-is when the first segment is a recognized conventional prefix (`fix/`, `feat/`, `chore/`, `feature/`, and the rest of the Conventional Commit types); otherwise behavior is unchanged (plain fragments and unrecognized namespaces still get `feature/`).
> 
> That fixes double-prefixed names like `feature/fix/…` when AI-generated branch fragments already use `fix/` or similar. New unit tests cover the sanitizer; the Codex commit-message test expectation is updated from `feature/fix/important-system-change` to `fix/important-system-change`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c04d08a6cdf54c02f43f81a5935949317f91ab19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve conventional prefixes in `sanitizeFeatureBranchName` branch generation
> Previously, `sanitizeFeatureBranchName` only preserved `feature/` prefixes, causing inputs like `fix/foo` to become `feature/fix/foo`. Now, a set of conventional prefixes (`fix`, `feat`, `chore`, `ci`, etc.) is recognized and preserved as-is, while plain fragments and unrecognized prefixes still get `feature/` prepended. Behavioral Change: branch names with conventional prefixes (e.g. `fix/`, `feat/`) no longer gain a leading `feature/`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c04d08a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->