### PR TITLE
fix(server): fall back to the remote default branch instead of assuming main

### DIFF
--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -2293,6 +2293,57 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
     }),
   );
 
+  it.effect("create_pr targets the remote default branch when it is not main", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      const remoteDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+      // A repository whose default branch is master, with no main anywhere.
+      yield* runGit(repoDir, ["push", "origin", "HEAD:master"]);
+      yield* runGit(repoDir, ["fetch", "origin"]);
+      yield* runGit(repoDir, ["remote", "set-head", "origin", "master"]);
+
+      yield* runGit(repoDir, ["checkout", "-b", "feature/master-default"]);
+      NodeFS.writeFileSync(NodePath.join(repoDir, "master-default.txt"), "master default\n");
+      yield* runGit(repoDir, ["add", "master-default.txt"]);
+      yield* runGit(repoDir, ["commit", "-m", "Master default"]);
+
+      const { manager, ghCalls } = yield* makeManager({
+        ghScenario: {
+          // Mirrors a provider that cannot report a default branch, as the Azure
+          // DevOps CLI does when it cannot detect the repository.
+          defaultBranch: "",
+          prListSequence: [
+            "[]",
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify([
+              {
+                number: 505,
+                title: "Master default",
+                url: "https://github.com/pingdotgg/codething-mvp/pull/505",
+                baseRefName: "master",
+                headRefName: "feature/master-default",
+              },
+            ]),
+          ],
+        },
+      });
+
+      const result = yield* runStackedAction(manager, {
+        cwd: repoDir,
+        action: "create_pr",
+      });
+
+      expect(result.pr.status).toBe("created");
+      expect(
+        ghCalls.some((call) =>
+          call.includes("pr create --base master --head feature/master-default"),
+        ),
+      ).toBe(true);
+    }),
+  );
+
   it.effect("returns existing PR metadata for commit/push/pr action", () =>
     Effect.gen(function* () {
       const repoDir = yield* makeTempDir("t3code-git-manager-");

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -1449,6 +1449,18 @@ export const make = Effect.gen(function* () {
       return defaultFromProvider;
     }
 
+    // The provider lookup can fail for reasons unrelated to the branch, so fall
+    // back to what the remote itself records before assuming a name. A repository
+    // whose default branch is master would otherwise get a base branch that does
+    // not exist.
+    const defaultFromRemote = yield* gitCore.resolvePrimaryRemoteName(cwd).pipe(
+      Effect.flatMap((remoteName) => gitCore.resolveDefaultBranchName(cwd, remoteName)),
+      Effect.orElseSucceed(() => null),
+    );
+    if (defaultFromRemote) {
+      return defaultFromRemote;
+    }
+
     return "main";
   });
 

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -288,6 +288,10 @@ export class GitVcsDriver extends Context.Service<
     ) => Effect.Effect<GitRefreshCheckedOutBranchResult, GitCommandError>;
     readonly ensureRemote: (input: GitEnsureRemoteInput) => Effect.Effect<string, GitCommandError>;
     readonly resolvePrimaryRemoteName: (cwd: string) => Effect.Effect<string, GitCommandError>;
+    readonly resolveDefaultBranchName: (
+      cwd: string,
+      remoteName: string,
+    ) => Effect.Effect<string | null, GitCommandError>;
     readonly fetchRemote: (input: GitFetchRemoteInput) => Effect.Effect<void, GitCommandError>;
     readonly remoteExists: (input: GitRemoteExistsInput) => Effect.Effect<boolean, GitCommandError>;
     readonly resolveRemoteTrackingCommit: (

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -3177,6 +3177,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       withListRefsInvalidation(input.cwd, refreshCheckedOutBranch(input)),
     ensureRemote: (input) => withListRefsInvalidation(input.cwd, ensureRemote(input)),
     resolvePrimaryRemoteName,
+    resolveDefaultBranchName,
     fetchRemote: (input) => withListRefsInvalidation(input.cwd, fetchRemote(input)),
     remoteExists,
     resolveRemoteTrackingCommit,


### PR DESCRIPTION
## What Changed

On a repository whose default branch is `master`, **Commit, push & PR** committed and pushed fine and then failed at the pull-request step. The branch showed up on the remote but no PR was ever created. Reported against Azure DevOps, where it happens every time.

T3 works out which branch to open the PR against in this order: a configured `branch.<name>.gh-merge-base`, then the branch's upstream, then the source-control provider, and if all of those come up empty it assumed `main`. For Azure DevOps the provider step cannot answer: `az repos show --detect true` requires `--repository`, and the shared provider interface has no repository to give it. So the chain fell through to `main`, which does not exist in a `master` repository, and the PR failed.

Before assuming a name, T3 now asks the remote what its default branch is.

## Why

The answer is already sitting in the clone. The reporter shows it themselves:

```
$ git symbolic-ref --short refs/remotes/origin/HEAD
origin/master
```

`resolveDefaultBranchName` already existed in the git driver, already runs exactly that command, and is already used in three other places. It simply was not reachable from `resolveBaseBranch`. This exposes it on the driver interface and adds one more step to the chain, so no new branch-detection logic was written.

The new step sits **after** the provider lookup, not before. Where the provider answers today it stays authoritative, since a default branch changed through a host's web UI can be newer than whatever `origin/HEAD` records locally. This only changes what happens when the old code was about to guess.

That also makes it provider-agnostic: any repository whose default branch is not `main` benefits, not just Azure DevOps.

## Scope

This does not make Azure DevOps' own `getDefaultBranch` work; that needs a repository identifier the shared interface does not carry, which is a larger change. This fixes the fallback so a `master` repository stops being handed a branch that does not exist.

## UI Changes

n/a - no visual change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (n/a)
- [x] I included a video for animation/interaction changes (n/a)

## Verification

```
vp test run apps/server/src/git/GitManager.test.ts -t "remote default branch"   # passes
vp run --filter t3 typecheck                                                    # exit 0, no errors
vp lint  apps/server/src/git/GitManager.ts apps/server/src/vcs/GitVcsDriver.ts apps/server/src/vcs/GitVcsDriverCore.ts
vp fmt --check <the changed files>
```

The added test builds a repository whose `origin/HEAD` points at `master`, drives `create_pr`, and asserts the PR is opened with `--base master`. Removing the new fallback makes it fail with `--base main`.

Note for anyone running the whole file: `emits ordered progress events for commit hooks` and `emits action_failed when a commit hook rejects` already fail on `main` here, unrelated to this change.

Fixes #5262

Implemented with Claude Opus 5 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to PR base-branch fallback ordering; provider answers remain authoritative when available, with limited blast radius beyond stacked git PR creation.
> 
> **Overview**
> **Commit, push & PR** no longer guesses `main` as the PR base when the source-control provider cannot return a default branch (notably Azure DevOps). `resolveBaseBranch` now asks the primary remote’s recorded default (`origin/HEAD` via existing `resolveDefaultBranchName`) **after** the provider step and **before** the hardcoded `main` fallback, so repos whose default is `master` get `--base master`.
> 
> The git VCS driver exposes `resolveDefaultBranchName` on its public interface (implementation was already in the core). A new `GitManager` test drives `create_pr` on a `master`-default remote with an empty provider default and asserts PR creation uses `--base master`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6415fe26339e127db3587be0214cf9bfe9241ea4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fall back to remote default branch instead of assuming `main` when creating PRs
> - In `GitManager`, after failing to get the default branch from the source control provider, the code now queries the git remote directly via `gitCore.resolveDefaultBranchName(cwd, remoteName)` before falling back to `'main'`.
> - Adds `resolveDefaultBranchName` to the `GitVcsDriver` service interface and wires it up in `GitVcsDriverCore`.
> - Behavioral Change: operations like PR creation will now use the remote's recorded default branch (e.g. `master`) rather than always defaulting to `main` when the provider cannot report one.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6415fe2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->