### PR TITLE
feat(web): add workspace thread tabs system

### DIFF
--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -42,6 +42,8 @@ import {
   WorkspaceBreadcrumbItem,
   WorkspaceBreadcrumbSeparator,
 } from "../WorkspaceBreadcrumb";
+import { useTabsEnabled } from "~/hooks/useSettings";
+import { WorkspaceTabs } from "./WorkspaceTabs";
 import { cn } from "~/lib/utils";
 
 interface ChatHeaderProps {
@@ -131,6 +133,7 @@ export const ChatHeader = memo(function ChatHeader({
   onUpdateProjectScript,
   onDeleteProjectScript,
 }: ChatHeaderProps) {
+  const tabsEnabled = useTabsEnabled();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
   const fileScripts = useT3ProjectFileScripts(
     activeThreadEnvironmentId,
@@ -229,88 +232,98 @@ export const ChatHeader = memo(function ChatHeader({
       className="@container/header-actions flex min-w-0 flex-1 items-center gap-2 sm:gap-3"
       onContextMenu={handleHeaderContextMenu}
     >
-      <WorkspaceBreadcrumb ariaLabel="Thread breadcrumb" className="flex-1">
-        {/* The project always leads the header: knowing which project a
-            thread lives in is priority zero, and the thread title alone
-            doesn't answer it. */}
-        {activeProjectName ? (
-          <>
-            <WorkspaceBreadcrumbItem>
+      {tabsEnabled ? (
+        <WorkspaceTabs
+          activeThreadEnvironmentId={activeThreadEnvironmentId}
+          activeThreadId={isServerThread ? activeThreadId : undefined}
+          draftId={!isServerThread ? draftId : undefined}
+          activeThreadTitle={activeThreadTitle}
+          activeProjectName={activeProjectName}
+          activeProjectCwd={activeProjectCwd}
+          activeProjectFaviconPath={activeProjectFaviconPath}
+          onNewTab={onNewThreadInProject}
+        />
+      ) : (
+        <WorkspaceBreadcrumb ariaLabel="Thread breadcrumb" className="flex-1">
+          {activeProjectName ? (
+            <>
+              <WorkspaceBreadcrumbItem>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <button
+                        type="button"
+                        aria-label={`New thread in ${activeProjectName}`}
+                        onClick={onNewThreadInProject}
+                        className="inline-flex min-w-0 cursor-pointer items-center gap-1.5 rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+                      />
+                    }
+                  >
+                    <ProjectFavicon
+                      environmentId={activeThreadEnvironmentId}
+                      cwd={activeProjectCwd ?? ""}
+                      faviconPath={activeProjectFaviconPath}
+                      className="size-3.5"
+                    />
+                    <span className="max-w-40 truncate">{activeProjectName}</span>
+                  </TooltipTrigger>
+                  <TooltipPopup side="top">New thread in {activeProjectName}</TooltipPopup>
+                </Tooltip>
+              </WorkspaceBreadcrumbItem>
+              <WorkspaceBreadcrumbSeparator />
+            </>
+          ) : null}
+          <WorkspaceBreadcrumbItem current className="flex-1">
+            {renamingTitle !== null ? (
+              <input
+                autoFocus
+                aria-label="Thread title"
+                className="min-w-0 flex-1 rounded-sm bg-transparent text-sm font-medium text-foreground outline-none ring-1 ring-ring/50 focus:ring-ring"
+                defaultValue={renamingTitle}
+                onBlur={(event) => {
+                  if (renameCommittedRef.current) return;
+                  commitRename(event.currentTarget.value);
+                }}
+                onFocus={(event) => event.currentTarget.select()}
+                onKeyDown={handleRenameKeyDown}
+              />
+            ) : isServerThread ? (
               <Tooltip>
                 <TooltipTrigger
                   render={
                     <button
+                      ref={titleButtonRef}
                       type="button"
-                      aria-label={`New thread in ${activeProjectName}`}
-                      onClick={onNewThreadInProject}
-                      className="inline-flex min-w-0 cursor-pointer items-center gap-1.5 rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+                      aria-label={`Thread actions for ${activeThreadTitle}`}
+                      aria-haspopup="menu"
+                      onClick={openMenuFromTitle}
+                      className="group/thread-title inline-flex min-w-0 max-w-full cursor-pointer items-center gap-1 rounded-sm text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
                     />
                   }
                 >
-                  <ProjectFavicon
-                    environmentId={activeThreadEnvironmentId}
-                    cwd={activeProjectCwd ?? ""}
-                    faviconPath={activeProjectFaviconPath}
-                    className="size-3.5"
+                  <h2 className="min-w-0 truncate">{activeThreadTitle}</h2>
+                  <ChevronDownIcon
+                    aria-hidden
+                    className="size-3.5 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover/thread-title:opacity-100 group-focus-visible/thread-title:opacity-100"
                   />
-                  <span className="max-w-40 truncate">{activeProjectName}</span>
                 </TooltipTrigger>
-                <TooltipPopup side="top">New thread in {activeProjectName}</TooltipPopup>
+                <TooltipPopup side="top">{activeThreadTitle}</TooltipPopup>
               </Tooltip>
-            </WorkspaceBreadcrumbItem>
-            <WorkspaceBreadcrumbSeparator />
-          </>
-        ) : null}
-        <WorkspaceBreadcrumbItem current className="flex-1">
-          {renamingTitle !== null ? (
-            <input
-              autoFocus
-              aria-label="Thread title"
-              className="min-w-0 flex-1 rounded-sm bg-transparent text-sm font-medium text-foreground outline-none ring-1 ring-ring/50 focus:ring-ring"
-              defaultValue={renamingTitle}
-              onBlur={(event) => {
-                if (renameCommittedRef.current) return;
-                commitRename(event.currentTarget.value);
-              }}
-              onFocus={(event) => event.currentTarget.select()}
-              onKeyDown={handleRenameKeyDown}
-            />
-          ) : isServerThread ? (
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <button
-                    ref={titleButtonRef}
-                    type="button"
-                    aria-label={`Thread actions for ${activeThreadTitle}`}
-                    aria-haspopup="menu"
-                    onClick={openMenuFromTitle}
-                    className="group/thread-title inline-flex min-w-0 max-w-full cursor-pointer items-center gap-1 rounded-sm text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
-                  />
-                }
-              >
-                <h2 className="min-w-0 truncate">{activeThreadTitle}</h2>
-                <ChevronDownIcon
-                  aria-hidden
-                  className="size-3.5 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover/thread-title:opacity-100 group-focus-visible/thread-title:opacity-100"
+            ) : (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <h2 aria-label={activeThreadTitle} className="min-w-0 flex-1 truncate">
+                      {activeThreadTitle}
+                    </h2>
+                  }
                 />
-              </TooltipTrigger>
-              <TooltipPopup side="top">{activeThreadTitle}</TooltipPopup>
-            </Tooltip>
-          ) : (
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <h2 aria-label={activeThreadTitle} className="min-w-0 flex-1 truncate">
-                    {activeThreadTitle}
-                  </h2>
-                }
-              />
-              <TooltipPopup side="top">{activeThreadTitle}</TooltipPopup>
-            </Tooltip>
-          )}
-        </WorkspaceBreadcrumbItem>
-      </WorkspaceBreadcrumb>
+                <TooltipPopup side="top">{activeThreadTitle}</TooltipPopup>
+              </Tooltip>
+            )}
+          </WorkspaceBreadcrumbItem>
+        </WorkspaceBreadcrumb>
+      )}
       <div
         data-chat-header-actions
         className={cn(

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -249,6 +249,13 @@ export const ChatHeader = memo(function ChatHeader({
             setRenaming(null);
           }}
           onRenameKeyDown={handleRenameKeyDown}
+          onOpenThreadMenu={(rect) => {
+            if (rect) {
+              openMenu({ x: rect.left, y: rect.bottom + 4 });
+            } else {
+              openMenuFromTitle();
+            }
+          }}
         />
       ) : (
         <WorkspaceBreadcrumb ariaLabel="Thread breadcrumb" className="flex-1">

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -242,6 +242,13 @@ export const ChatHeader = memo(function ChatHeader({
           activeProjectCwd={activeProjectCwd}
           activeProjectFaviconPath={activeProjectFaviconPath}
           onNewTab={onNewThreadInProject}
+          renamingTitle={renamingTitle}
+          onCommitRename={commitRename}
+          onCancelRename={() => {
+            renameCommittedRef.current = true;
+            setRenaming(null);
+          }}
+          onRenameKeyDown={handleRenameKeyDown}
         />
       ) : (
         <WorkspaceBreadcrumb ariaLabel="Thread breadcrumb" className="flex-1">

--- a/apps/web/src/components/chat/WorkspaceTabs.test.tsx
+++ b/apps/web/src/components/chat/WorkspaceTabs.test.tsx
@@ -1,0 +1,61 @@
+import { EnvironmentId, ProjectId, ThreadId } from "@t3tools/contracts";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { WorkspaceTabs } from "./WorkspaceTabs";
+import { serverTabKey, useWorkspaceTabsStore } from "~/workspaceTabsStore";
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+describe("WorkspaceTabs", () => {
+  const envId = EnvironmentId.make("env-local");
+  const threadId = ThreadId.make("thread-1");
+
+  beforeEach(() => {
+    useWorkspaceTabsStore.setState({
+      tabs: [
+        {
+          key: serverTabKey(envId, threadId),
+          kind: "server",
+          environmentId: envId,
+          threadId,
+          title: "My Active Thread",
+          projectId: ProjectId.make("project-1"),
+          projectName: "Project Alpha",
+        },
+      ],
+      activeTabKey: serverTabKey(envId, threadId),
+    });
+  });
+
+  it("renders tabs container and active tab title", () => {
+    const html = renderToStaticMarkup(
+      <WorkspaceTabs
+        activeThreadEnvironmentId={envId}
+        activeThreadId={threadId}
+        activeThreadTitle="My Active Thread"
+        activeProjectName="Project Alpha"
+        onNewTab={() => {}}
+      />,
+    );
+
+    expect(html).toContain("data-workspace-tabs");
+    expect(html).toContain("My Active Thread");
+    expect(html).toContain('data-tab-key="new-thread"');
+  });
+
+  it("renders new thread tab", () => {
+    const html = renderToStaticMarkup(
+      <WorkspaceTabs
+        activeThreadEnvironmentId={envId}
+        activeThreadId={threadId}
+        activeThreadTitle="My Active Thread"
+        activeProjectName="Project Alpha"
+        onNewTab={() => {}}
+      />,
+    );
+
+    expect(html).toContain("New thread");
+  });
+});

--- a/apps/web/src/components/chat/WorkspaceTabs.test.tsx
+++ b/apps/web/src/components/chat/WorkspaceTabs.test.tsx
@@ -58,4 +58,44 @@ describe("WorkspaceTabs", () => {
 
     expect(html).toContain("New thread");
   });
+
+  it("renders dedicated thread actions dropdown trigger only for active tab", () => {
+    const inactiveThreadId = ThreadId.make("thread-2");
+    useWorkspaceTabsStore.setState({
+      tabs: [
+        {
+          key: serverTabKey(envId, threadId),
+          kind: "server",
+          environmentId: envId,
+          threadId,
+          title: "Active Thread",
+          projectId: ProjectId.make("project-1"),
+          projectName: "Project Alpha",
+        },
+        {
+          key: serverTabKey(envId, inactiveThreadId),
+          kind: "server",
+          environmentId: envId,
+          threadId: inactiveThreadId,
+          title: "Inactive Thread",
+          projectId: ProjectId.make("project-1"),
+          projectName: "Project Alpha",
+        },
+      ],
+      activeTabKey: serverTabKey(envId, threadId),
+    });
+
+    const html = renderToStaticMarkup(
+      <WorkspaceTabs
+        activeThreadEnvironmentId={envId}
+        activeThreadId={threadId}
+        activeThreadTitle="Active Thread"
+        activeProjectName="Project Alpha"
+        onNewTab={() => {}}
+      />,
+    );
+
+    expect(html).toContain('aria-label="Thread actions for Active Thread"');
+    expect(html).not.toContain('aria-label="Thread actions for Inactive Thread"');
+  });
 });

--- a/apps/web/src/components/chat/WorkspaceTabs.tsx
+++ b/apps/web/src/components/chat/WorkspaceTabs.tsx
@@ -1,0 +1,432 @@
+import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { scopeThreadRef } from "@t3tools/client-runtime/environment";
+import { useNavigate } from "@tanstack/react-router";
+import { Pin, Plus, X } from "lucide-react";
+import {
+  type DragEvent as ReactDragEvent,
+  type MouseEvent as ReactMouseEvent,
+  type WheelEvent as ReactWheelEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { DraftId } from "~/composerDraftStore";
+import { cn } from "~/lib/utils";
+import { readLocalApi } from "~/localApi";
+import { ScrollArea } from "../ui/scroll-area";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+import { ProjectFavicon } from "../ProjectFavicon";
+import { useThreadShell } from "../../state/entities";
+import { serverTabKey, useWorkspaceTabsStore, type WorkspaceTab } from "../../workspaceTabsStore";
+
+interface WorkspaceTabsProps {
+  readonly activeThreadEnvironmentId: EnvironmentId;
+  readonly activeThreadId?: ThreadId | undefined;
+  readonly draftId?: DraftId | undefined;
+  readonly activeThreadTitle: string;
+  readonly activeProjectName?: string | undefined;
+  readonly activeProjectCwd?: string | null | undefined;
+  readonly activeProjectFaviconPath?: string | null | undefined;
+  readonly isWorking?: boolean | undefined;
+  readonly onNewTab: () => void;
+}
+
+function ServerThreadTabItem({
+  tab,
+  isActive,
+  isDragged,
+  isDragOver,
+  onActivate,
+  onClose,
+  onAuxClick,
+  onContextMenu,
+  onDragStart,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+  onDragEnd,
+}: {
+  readonly tab: WorkspaceTab;
+  readonly isActive: boolean;
+  readonly isDragged: boolean;
+  readonly isDragOver: boolean;
+  readonly onActivate: () => void;
+  readonly onClose: (e: ReactMouseEvent) => void;
+  readonly onAuxClick: (e: ReactMouseEvent) => void;
+  readonly onContextMenu: (e: ReactMouseEvent) => void;
+  readonly onDragStart: (e: ReactDragEvent) => void;
+  readonly onDragOver: (e: ReactDragEvent) => void;
+  readonly onDragLeave: () => void;
+  readonly onDrop: (e: ReactDragEvent) => void;
+  readonly onDragEnd: () => void;
+}) {
+  const itemRef = useRef<HTMLDivElement | null>(null);
+  const threadRef = useMemo(
+    () => scopeThreadRef(tab.environmentId, tab.threadId),
+    [tab.environmentId, tab.threadId],
+  );
+  const shell = useThreadShell(threadRef);
+  const title = shell?.title || tab.title || "Thread";
+  const fullLabel = tab.projectName ? `${tab.projectName} · ${title}` : title;
+
+  useEffect(() => {
+    if (isActive && itemRef.current) {
+      itemRef.current.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "nearest" });
+    }
+  }, [isActive]);
+
+  return (
+    <div
+      ref={itemRef}
+      draggable
+      data-active-tab={isActive ? "true" : "false"}
+      data-tab-key={tab.key}
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
+      onDragEnd={onDragEnd}
+      onAuxClick={onAuxClick}
+      onContextMenu={onContextMenu}
+      className={cn(
+        "group/tab relative flex h-7 max-w-48 min-w-24 shrink-0 cursor-pointer select-none items-center gap-1.5 rounded-md px-2 text-xs transition-all duration-150",
+        isActive
+          ? "border border-border/80 bg-accent text-foreground shadow-2xs font-medium"
+          : "border border-transparent text-muted-foreground hover:bg-accent/60 hover:text-foreground",
+        isDragged && "opacity-40 scale-95",
+        isDragOver && !isDragged && "ring-2 ring-primary/80 bg-accent/90",
+      )}
+    >
+      <div className="flex min-w-0 flex-1 items-center gap-1.5" onClick={onActivate}>
+        <ProjectFavicon
+          environmentId={tab.environmentId}
+          cwd={tab.projectCwd ?? ""}
+          faviconPath={tab.faviconPath}
+          className="size-3.5 shrink-0"
+        />
+        <Tooltip>
+          <TooltipTrigger render={<span className="truncate">{title}</span>} />
+          <TooltipPopup side="bottom">{fullLabel}</TooltipPopup>
+        </Tooltip>
+        {tab.pinned ? <Pin className="size-2.5 shrink-0 rotate-45 opacity-60" /> : null}
+      </div>
+
+      <button
+        type="button"
+        aria-label={`Close ${title}`}
+        onClick={onClose}
+        className={cn(
+          "flex size-4 shrink-0 cursor-pointer items-center justify-center rounded-sm text-muted-foreground hover:bg-muted hover:text-foreground",
+          isActive
+            ? "opacity-60 hover:opacity-100"
+            : "opacity-0 group-hover/tab:opacity-100 focus-visible:opacity-100",
+        )}
+      >
+        <X className="size-3" />
+      </button>
+    </div>
+  );
+}
+
+export function WorkspaceTabs({
+  activeThreadEnvironmentId,
+  activeThreadId,
+  draftId,
+  activeThreadTitle,
+  activeProjectName,
+  activeProjectCwd,
+  activeProjectFaviconPath,
+  onNewTab,
+}: WorkspaceTabsProps) {
+  const navigate = useNavigate();
+  const tabs = useWorkspaceTabsStore((state) => state.tabs);
+  const openTab = useWorkspaceTabsStore((state) => state.openTab);
+  const closeTab = useWorkspaceTabsStore((state) => state.closeTab);
+  const closeOtherTabs = useWorkspaceTabsStore((state) => state.closeOtherTabs);
+  const closeTabsToRight = useWorkspaceTabsStore((state) => state.closeTabsToRight);
+  const closeAllTabs = useWorkspaceTabsStore((state) => state.closeAllTabs);
+  const reorderTabs = useWorkspaceTabsStore((state) => state.reorderTabs);
+  const togglePinTab = useWorkspaceTabsStore((state) => state.togglePinTab);
+
+  const [draggedKey, setDraggedKey] = useState<string | null>(null);
+  const [dragOverKey, setDragOverKey] = useState<string | null>(null);
+
+  const currentTabKey = activeThreadId
+    ? serverTabKey(activeThreadEnvironmentId, activeThreadId)
+    : null;
+
+  const isDraftActive = !activeThreadId || Boolean(draftId);
+
+  useEffect(() => {
+    if (!activeThreadId) return;
+    openTab({
+      key: serverTabKey(activeThreadEnvironmentId, activeThreadId),
+      kind: "server",
+      environmentId: activeThreadEnvironmentId,
+      threadId: activeThreadId,
+      title: activeThreadTitle || "Thread",
+      projectName: activeProjectName,
+      projectCwd: activeProjectCwd,
+      faviconPath: activeProjectFaviconPath,
+    });
+  }, [
+    activeProjectCwd,
+    activeProjectFaviconPath,
+    activeProjectName,
+    activeThreadEnvironmentId,
+    activeThreadId,
+    activeThreadTitle,
+    openTab,
+  ]);
+
+  const effectiveTabs = useMemo(() => {
+    if (
+      !activeThreadId ||
+      tabs.some(
+        (t) => t.threadId === activeThreadId && t.environmentId === activeThreadEnvironmentId,
+      )
+    ) {
+      return tabs;
+    }
+    const currentTab: WorkspaceTab = {
+      key: serverTabKey(activeThreadEnvironmentId, activeThreadId),
+      kind: "server",
+      environmentId: activeThreadEnvironmentId,
+      threadId: activeThreadId,
+      title: activeThreadTitle || "Thread",
+      projectName: activeProjectName,
+      projectCwd: activeProjectCwd,
+      faviconPath: activeProjectFaviconPath,
+    };
+    return [currentTab, ...tabs];
+  }, [
+    activeProjectCwd,
+    activeProjectFaviconPath,
+    activeProjectName,
+    activeThreadEnvironmentId,
+    activeThreadId,
+    activeThreadTitle,
+    tabs,
+  ]);
+
+  const handleNavigateToTab = useCallback(
+    (tab: WorkspaceTab) => {
+      void navigate({
+        to: "/$environmentId/$threadId",
+        params: { environmentId: tab.environmentId, threadId: tab.threadId },
+      });
+    },
+    [navigate],
+  );
+
+  const handleCloseTab = useCallback(
+    (tab: WorkspaceTab, event?: ReactMouseEvent) => {
+      event?.stopPropagation();
+      event?.preventDefault();
+
+      const nextActive = closeTab(tab.key);
+      if (tab.key === currentTabKey) {
+        if (nextActive) {
+          handleNavigateToTab(nextActive);
+        } else {
+          onNewTab();
+        }
+      }
+    },
+    [closeTab, currentTabKey, handleNavigateToTab, onNewTab],
+  );
+
+  const handleTabAuxClick = useCallback(
+    (event: ReactMouseEvent, tab: WorkspaceTab) => {
+      if (event.button === 1) {
+        event.preventDefault();
+        event.stopPropagation();
+        handleCloseTab(tab);
+      }
+    },
+    [handleCloseTab],
+  );
+
+  const handleTabContextMenu = useCallback(
+    async (event: ReactMouseEvent, tab: WorkspaceTab) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const api = readLocalApi();
+      if (!api) return;
+
+      const tabIndex = effectiveTabs.findIndex((t) => t.key === tab.key);
+      if (tabIndex < 0) return;
+
+      const items = [
+        { id: "close", label: "Close" },
+        {
+          id: "close-others",
+          label: "Close others",
+          disabled: effectiveTabs.length <= 1,
+        },
+        {
+          id: "close-to-right",
+          label: "Close to the right",
+          disabled: tabIndex >= effectiveTabs.length - 1,
+        },
+        {
+          id: "close-all",
+          label: "Close all",
+          disabled: effectiveTabs.length === 0,
+        },
+        {
+          id: "toggle-pin",
+          label: tab.pinned ? "Unpin tab" : "Pin tab",
+        },
+      ];
+
+      const action = await api.contextMenu.show(items, { x: event.clientX, y: event.clientY });
+      switch (action) {
+        case "close":
+          handleCloseTab(tab);
+          break;
+        case "close-others":
+          closeOtherTabs(tab.key);
+          if (currentTabKey !== tab.key) {
+            handleNavigateToTab(tab);
+          }
+          break;
+        case "close-to-right":
+          closeTabsToRight(tab.key);
+          if (effectiveTabs.findIndex((t) => t.key === currentTabKey) > tabIndex) {
+            handleNavigateToTab(tab);
+          }
+          break;
+        case "close-all":
+          closeAllTabs();
+          onNewTab();
+          break;
+        case "toggle-pin":
+          togglePinTab(tab.key);
+          break;
+        case null:
+          break;
+      }
+    },
+    [
+      closeAllTabs,
+      closeOtherTabs,
+      closeTabsToRight,
+      currentTabKey,
+      effectiveTabs,
+      handleCloseTab,
+      handleNavigateToTab,
+      onNewTab,
+      togglePinTab,
+    ],
+  );
+
+  const handleDragStart = useCallback((e: ReactDragEvent, tabKey: string) => {
+    e.dataTransfer.setData("text/plain", tabKey);
+    e.dataTransfer.effectAllowed = "move";
+    setDraggedKey(tabKey);
+  }, []);
+
+  const handleDragOver = useCallback((e: ReactDragEvent, tabKey: string) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+    setDragOverKey(tabKey);
+  }, []);
+
+  const handleDragLeave = useCallback((tabKey: string) => {
+    setDragOverKey((prev) => (prev === tabKey ? null : prev));
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: ReactDragEvent, targetKey: string) => {
+      e.preventDefault();
+      if (draggedKey && draggedKey !== targetKey) {
+        const sourceIndex = effectiveTabs.findIndex((t) => t.key === draggedKey);
+        const targetIndex = effectiveTabs.findIndex((t) => t.key === targetKey);
+        if (sourceIndex >= 0 && targetIndex >= 0) {
+          reorderTabs(sourceIndex, targetIndex);
+        }
+      }
+      setDraggedKey(null);
+      setDragOverKey(null);
+    },
+    [draggedKey, effectiveTabs, reorderTabs],
+  );
+
+  const handleDragEnd = useCallback(() => {
+    setDraggedKey(null);
+    setDragOverKey(null);
+  }, []);
+
+  const handleWheel = useCallback((e: ReactWheelEvent<HTMLDivElement>) => {
+    if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
+      e.currentTarget.scrollLeft += e.deltaY;
+    }
+  }, []);
+
+  return (
+    <div className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden" data-workspace-tabs="">
+      <ScrollArea
+        hideScrollbars
+        scrollFade
+        className="min-w-0 flex-1 rounded-none"
+        data-workspace-tab-list=""
+      >
+        <div
+          onWheel={handleWheel}
+          className="flex h-full w-max min-w-full items-center gap-1 py-0.5"
+        >
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <div
+                  data-active-tab={isDraftActive ? "true" : "false"}
+                  data-tab-key="new-thread"
+                  onClick={onNewTab}
+                  className={cn(
+                    "group/tab relative flex h-7 max-w-40 min-w-24 shrink-0 cursor-pointer select-none items-center gap-1.5 rounded-md px-2.5 text-xs transition-colors duration-150",
+                    isDraftActive
+                      ? "border border-border/80 bg-accent text-foreground shadow-2xs font-medium"
+                      : "border border-transparent text-muted-foreground hover:bg-accent/60 hover:text-foreground",
+                  )}
+                >
+                  <Plus className="size-3.5 shrink-0 text-muted-foreground group-hover/tab:text-foreground" />
+                  <span className="truncate">New thread</span>
+                </div>
+              }
+            />
+            <TooltipPopup side="bottom">New thread</TooltipPopup>
+          </Tooltip>
+
+          {effectiveTabs.map((tab) => {
+            const isActive = tab.key === currentTabKey;
+            const isDragged = tab.key === draggedKey;
+            const isDragOver = tab.key === dragOverKey;
+
+            return (
+              <ServerThreadTabItem
+                key={tab.key}
+                tab={tab}
+                isActive={isActive}
+                isDragged={isDragged}
+                isDragOver={isDragOver}
+                onActivate={() => handleNavigateToTab(tab)}
+                onClose={(e) => handleCloseTab(tab, e)}
+                onAuxClick={(e) => handleTabAuxClick(e, tab)}
+                onContextMenu={(e) => void handleTabContextMenu(e, tab)}
+                onDragStart={(e) => handleDragStart(e, tab.key)}
+                onDragOver={(e) => handleDragOver(e, tab.key)}
+                onDragLeave={() => handleDragLeave(tab.key)}
+                onDrop={(e) => handleDrop(e, tab.key)}
+                onDragEnd={handleDragEnd}
+              />
+            );
+          })}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/WorkspaceTabs.tsx
+++ b/apps/web/src/components/chat/WorkspaceTabs.tsx
@@ -372,11 +372,14 @@ export function WorkspaceTabs({
         case "close-all": {
           closeAllTabs();
           const { tabs: remainingTabs, activeTabKey } = useWorkspaceTabsStore.getState();
-          const nextActiveTab = remainingTabs.find((t) => t.key === activeTabKey);
-          if (nextActiveTab) {
-            handleNavigateToTab(nextActiveTab);
-          } else {
-            onNewTab();
+          const isCurrentStillOpen = remainingTabs.some((t) => t.key === currentTabKey);
+          if (!isCurrentStillOpen) {
+            const nextActiveTab = remainingTabs.find((t) => t.key === activeTabKey);
+            if (nextActiveTab) {
+              handleNavigateToTab(nextActiveTab);
+            } else {
+              onNewTab();
+            }
           }
           break;
         }

--- a/apps/web/src/components/chat/WorkspaceTabs.tsx
+++ b/apps/web/src/components/chat/WorkspaceTabs.tsx
@@ -1,7 +1,7 @@
 import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import { scopeThreadRef } from "@t3tools/client-runtime/environment";
 import { useNavigate } from "@tanstack/react-router";
-import { Pin, Plus, X } from "lucide-react";
+import { ChevronDown, Pin, Plus, X } from "lucide-react";
 import {
   type DragEvent as ReactDragEvent,
   type KeyboardEvent as ReactKeyboardEvent,
@@ -37,6 +37,7 @@ interface WorkspaceTabsProps {
   readonly onCommitRename?: ((title: string) => void) | undefined;
   readonly onCancelRename?: (() => void) | undefined;
   readonly onRenameKeyDown?: ((event: ReactKeyboardEvent<HTMLInputElement>) => void) | undefined;
+  readonly onOpenThreadMenu?: ((targetRect?: DOMRect) => void) | undefined;
 }
 
 function ServerThreadTabItem({
@@ -47,6 +48,7 @@ function ServerThreadTabItem({
   renamingTitle,
   onCommitRename,
   onRenameKeyDown,
+  onOpenThreadMenu,
   onActivate,
   onClose,
   onAuxClick,
@@ -64,6 +66,7 @@ function ServerThreadTabItem({
   readonly renamingTitle?: string | null | undefined;
   readonly onCommitRename?: ((title: string) => void) | undefined;
   readonly onRenameKeyDown?: ((event: ReactKeyboardEvent<HTMLInputElement>) => void) | undefined;
+  readonly onOpenThreadMenu?: ((targetRect?: DOMRect) => void) | undefined;
   readonly onActivate: () => void;
   readonly onClose: (e: ReactMouseEvent) => void;
   readonly onAuxClick: (e: ReactMouseEvent) => void;
@@ -75,6 +78,7 @@ function ServerThreadTabItem({
   readonly onDragEnd: () => void;
 }) {
   const itemRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
   const threadRef = useMemo(
     () => scopeThreadRef(tab.environmentId, tab.threadId),
     [tab.environmentId, tab.threadId],
@@ -91,12 +95,25 @@ function ServerThreadTabItem({
 
   const isRenaming = isActive && renamingTitle !== null && renamingTitle !== undefined;
 
+  const handleActivationClick = useCallback(() => {
+    if (isActive) {
+      if (triggerRef.current && onOpenThreadMenu) {
+        onOpenThreadMenu(triggerRef.current.getBoundingClientRect());
+      }
+    } else {
+      onActivate();
+    }
+  }, [isActive, onActivate, onOpenThreadMenu]);
+
   return (
     <div
       ref={itemRef}
       draggable={!isRenaming}
       data-active-tab={isActive ? "true" : "false"}
       data-tab-key={tab.key}
+      onMouseDown={(event) => {
+        if (event.button === 1) event.preventDefault();
+      }}
       onDragStart={onDragStart}
       onDragOver={onDragOver}
       onDragLeave={onDragLeave}
@@ -127,9 +144,11 @@ function ServerThreadTabItem({
         />
       ) : (
         <button
+          ref={triggerRef}
           type="button"
           aria-label={fullLabel}
-          onClick={onActivate}
+          aria-haspopup={isActive ? "menu" : undefined}
+          onClick={handleActivationClick}
           className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 rounded-sm text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
         >
           <ProjectFavicon
@@ -142,6 +161,12 @@ function ServerThreadTabItem({
             <TooltipTrigger render={<span className="truncate">{title}</span>} />
             <TooltipPopup side="bottom">{fullLabel}</TooltipPopup>
           </Tooltip>
+          {isActive ? (
+            <ChevronDown
+              aria-hidden
+              className="size-3 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover/tab:opacity-100 group-focus-visible/tab:opacity-100"
+            />
+          ) : null}
           {tab.pinned ? <Pin className="size-2.5 shrink-0 rotate-45 opacity-60" /> : null}
         </button>
       )}
@@ -176,6 +201,7 @@ export function WorkspaceTabs({
   renamingTitle,
   onCommitRename,
   onRenameKeyDown,
+  onOpenThreadMenu,
 }: WorkspaceTabsProps) {
   const navigate = useNavigate();
   const tabs = useWorkspaceTabsStore((state) => state.tabs);
@@ -288,11 +314,11 @@ export function WorkspaceTabs({
 
   const handleTabContextMenu = useCallback(
     async (event: ReactMouseEvent, tab: WorkspaceTab) => {
-      event.preventDefault();
-      event.stopPropagation();
-
       const api = readLocalApi();
       if (!api) return;
+
+      event.preventDefault();
+      event.stopPropagation();
 
       const tabIndex = effectiveTabs.findIndex((t) => t.key === tab.key);
       if (tabIndex < 0) return;
@@ -458,6 +484,11 @@ export function WorkspaceTabs({
                 renamingTitle={renamingTitle}
                 onCommitRename={onCommitRename}
                 onRenameKeyDown={onRenameKeyDown}
+                onOpenThreadMenu={(rect) => {
+                  if (rect && onOpenThreadMenu) {
+                    onOpenThreadMenu(rect);
+                  }
+                }}
                 onActivate={() => handleNavigateToTab(tab)}
                 onClose={(e) => handleCloseTab(tab, e)}
                 onAuxClick={(e) => handleTabAuxClick(e, tab)}

--- a/apps/web/src/components/chat/WorkspaceTabs.tsx
+++ b/apps/web/src/components/chat/WorkspaceTabs.tsx
@@ -96,16 +96,6 @@ function ServerThreadTabItem({
 
   const isRenaming = isActive && renamingTitle !== null && renamingTitle !== undefined;
 
-  const handleActivationClick = useCallback(() => {
-    if (isActive) {
-      if (triggerRef.current && onOpenThreadMenu) {
-        onOpenThreadMenu(triggerRef.current.getBoundingClientRect());
-      }
-    } else {
-      onActivate();
-    }
-  }, [isActive, onActivate, onOpenThreadMenu]);
-
   return (
     <div
       ref={itemRef}
@@ -149,12 +139,10 @@ function ServerThreadTabItem({
             <TooltipTrigger
               render={
                 <Button
-                  ref={triggerRef}
                   size="xs"
                   variant="outline"
                   aria-label={fullLabel}
-                  aria-haspopup={isActive ? "menu" : undefined}
-                  onClick={handleActivationClick}
+                  onClick={onActivate}
                   className={cn(
                     "max-w-44 ps-[8.5px] text-xs font-normal",
                     isActive
@@ -169,9 +157,6 @@ function ServerThreadTabItem({
                     className="size-3.5 shrink-0"
                   />
                   <span className="truncate">{title}</span>
-                  {isActive ? (
-                    <ChevronDown className="size-3 shrink-0 text-muted-foreground" />
-                  ) : null}
                   {tab.pinned ? <Pin className="size-2.5 shrink-0 rotate-45 opacity-60" /> : null}
                 </Button>
               }
@@ -179,6 +164,27 @@ function ServerThreadTabItem({
             <TooltipPopup side="bottom">{fullLabel}</TooltipPopup>
           </Tooltip>
         )}
+        {isActive ? (
+          <>
+            <GroupSeparator />
+            <Button
+              ref={triggerRef}
+              size="icon-xs"
+              variant="outline"
+              aria-label={`Thread actions for ${title}`}
+              aria-haspopup="menu"
+              onClick={(event) => {
+                event.stopPropagation();
+                if (triggerRef.current && onOpenThreadMenu) {
+                  onOpenThreadMenu(triggerRef.current.getBoundingClientRect());
+                }
+              }}
+              className="bg-accent text-foreground ring-1 ring-ring/40 shadow-xs"
+            >
+              <ChevronDown className="size-3 text-muted-foreground hover:text-foreground" />
+            </Button>
+          </>
+        ) : null}
         <GroupSeparator />
         <Button
           size="icon-xs"

--- a/apps/web/src/components/chat/WorkspaceTabs.tsx
+++ b/apps/web/src/components/chat/WorkspaceTabs.tsx
@@ -149,7 +149,7 @@ function ServerThreadTabItem({
           aria-label={fullLabel}
           aria-haspopup={isActive ? "menu" : undefined}
           onClick={handleActivationClick}
-          className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 rounded-sm text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+          className="group/tab-trigger flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 rounded-sm text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
         >
           <ProjectFavicon
             environmentId={tab.environmentId}
@@ -164,7 +164,7 @@ function ServerThreadTabItem({
           {isActive ? (
             <ChevronDown
               aria-hidden
-              className="size-3 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover/tab:opacity-100 group-focus-visible/tab:opacity-100"
+              className="size-3 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover/tab:opacity-100 group-focus-visible/tab-trigger:opacity-100"
             />
           ) : null}
           {tab.pinned ? <Pin className="size-2.5 shrink-0 rotate-45 opacity-60" /> : null}
@@ -369,10 +369,17 @@ export function WorkspaceTabs({
           }
           break;
         }
-        case "close-all":
+        case "close-all": {
           closeAllTabs();
-          onNewTab();
+          const { tabs: remainingTabs, activeTabKey } = useWorkspaceTabsStore.getState();
+          const nextActiveTab = remainingTabs.find((t) => t.key === activeTabKey);
+          if (nextActiveTab) {
+            handleNavigateToTab(nextActiveTab);
+          } else {
+            onNewTab();
+          }
           break;
+        }
         case "toggle-pin":
           togglePinTab(tab.key);
           break;

--- a/apps/web/src/components/chat/WorkspaceTabs.tsx
+++ b/apps/web/src/components/chat/WorkspaceTabs.tsx
@@ -17,6 +17,7 @@ import type { DraftId } from "~/composerDraftStore";
 import { cn } from "~/lib/utils";
 import { readLocalApi } from "~/localApi";
 import { Button } from "../ui/button";
+import { Group, GroupSeparator } from "../ui/group";
 import { ScrollArea } from "../ui/scroll-area";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { ProjectFavicon } from "../ProjectFavicon";
@@ -122,69 +123,76 @@ function ServerThreadTabItem({
       onAuxClick={onAuxClick}
       onContextMenu={onContextMenu}
       className={cn(
-        "group/tab relative flex h-7 max-w-48 min-w-24 shrink-0 cursor-pointer select-none items-center gap-1.5 rounded-md px-2 text-xs transition-all duration-150 [-webkit-app-region:no-drag]",
-        isActive
-          ? "border border-border/80 bg-accent text-foreground shadow-2xs font-medium"
-          : "border border-transparent text-muted-foreground hover:bg-accent/60 hover:text-foreground",
+        "group/tab shrink-0 transition-opacity duration-150 [-webkit-app-region:no-drag]",
+        isActive ? "opacity-100" : "opacity-60 hover:opacity-100",
         isDragged && "opacity-40 scale-95",
-        isDragOver && !isDragged && "ring-2 ring-primary/80 bg-accent/90",
+        isDragOver && !isDragged && "ring-2 ring-primary/80 opacity-100",
       )}
     >
-      {isRenaming ? (
-        <input
-          autoFocus
-          aria-label="Thread title"
-          className="min-w-0 flex-1 rounded-sm bg-transparent text-xs font-medium text-foreground outline-none ring-1 ring-ring/50 focus:ring-ring"
-          defaultValue={renamingTitle}
-          onBlur={(event) => {
-            onCommitRename?.(event.currentTarget.value);
-          }}
-          onFocus={(event) => event.currentTarget.select()}
-          onKeyDown={onRenameKeyDown}
-        />
-      ) : (
-        <button
-          ref={triggerRef}
-          type="button"
-          aria-label={fullLabel}
-          aria-haspopup={isActive ? "menu" : undefined}
-          onClick={handleActivationClick}
-          className="group/tab-trigger flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 rounded-sm text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
-        >
-          <ProjectFavicon
-            environmentId={tab.environmentId}
-            cwd={tab.projectCwd ?? ""}
-            faviconPath={tab.faviconPath}
-            className="size-3.5 shrink-0"
-          />
+      <Group aria-label={fullLabel} className="shrink-0">
+        {isRenaming ? (
+          <div className="flex h-7 items-center rounded-s-[var(--control-radius)] border border-e-0 border-input bg-popover px-2 text-xs dark:bg-input/32">
+            <input
+              autoFocus
+              aria-label="Thread title"
+              className="w-28 bg-transparent text-xs font-medium text-foreground outline-none ring-1 ring-ring/50 focus:ring-ring"
+              defaultValue={renamingTitle}
+              onBlur={(event) => {
+                onCommitRename?.(event.currentTarget.value);
+              }}
+              onFocus={(event) => event.currentTarget.select()}
+              onKeyDown={onRenameKeyDown}
+            />
+          </div>
+        ) : (
           <Tooltip>
-            <TooltipTrigger render={<span className="truncate">{title}</span>} />
+            <TooltipTrigger
+              render={
+                <Button
+                  ref={triggerRef}
+                  size="xs"
+                  variant="outline"
+                  aria-label={fullLabel}
+                  aria-haspopup={isActive ? "menu" : undefined}
+                  onClick={handleActivationClick}
+                  className={cn(
+                    "max-w-44 ps-[8.5px] text-xs font-normal",
+                    isActive
+                      ? "bg-accent font-medium text-foreground ring-1 ring-ring/40 shadow-xs"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  <ProjectFavicon
+                    environmentId={tab.environmentId}
+                    cwd={tab.projectCwd ?? ""}
+                    faviconPath={tab.faviconPath}
+                    className="size-3.5 shrink-0"
+                  />
+                  <span className="truncate">{title}</span>
+                  {isActive ? (
+                    <ChevronDown className="size-3 shrink-0 text-muted-foreground" />
+                  ) : null}
+                  {tab.pinned ? <Pin className="size-2.5 shrink-0 rotate-45 opacity-60" /> : null}
+                </Button>
+              }
+            />
             <TooltipPopup side="bottom">{fullLabel}</TooltipPopup>
           </Tooltip>
-          {isActive ? (
-            <ChevronDown
-              aria-hidden
-              className="size-3 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover/tab:opacity-100 group-focus-visible/tab-trigger:opacity-100"
-            />
-          ) : null}
-          {tab.pinned ? <Pin className="size-2.5 shrink-0 rotate-45 opacity-60" /> : null}
-        </button>
-      )}
-
-      <Button
-        size="icon-micro"
-        variant="ghost-muted"
-        aria-label={`Close ${title}`}
-        onClick={onClose}
-        className={cn(
-          "shrink-0",
-          isActive
-            ? "opacity-60 hover:opacity-100"
-            : "opacity-0 group-hover/tab:opacity-100 focus-visible:opacity-100",
         )}
-      >
-        <X className="size-3" />
-      </Button>
+        <GroupSeparator />
+        <Button
+          size="icon-xs"
+          variant="outline"
+          aria-label={`Close ${title}`}
+          onClick={onClose}
+          className={cn(
+            "text-muted-foreground hover:text-foreground",
+            isActive && "bg-accent ring-1 ring-ring/40 shadow-xs text-foreground",
+          )}
+        >
+          <X className="size-3.5" />
+        </Button>
+      </Group>
     </div>
   );
 }
@@ -444,36 +452,39 @@ export function WorkspaceTabs({
   }, []);
 
   return (
-    <div className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden" data-workspace-tabs="">
+    <div
+      className="flex h-full min-w-0 flex-1 items-center gap-1.5 overflow-hidden"
+      data-workspace-tabs=""
+    >
       <ScrollArea
         hideScrollbars
-        scrollFade
-        className="min-w-0 flex-1 rounded-none"
+        className="h-full min-w-0 flex-1 rounded-none"
         data-workspace-tab-list=""
       >
         <div
           onWheel={handleWheel}
-          className="flex h-full w-max min-w-full items-center gap-1 py-0.5"
+          className="flex h-full w-max min-w-full items-center gap-1.5 px-0.5"
         >
           <Tooltip>
             <TooltipTrigger
               render={
-                <button
-                  type="button"
+                <Button
+                  size="xs"
+                  variant="outline"
                   aria-label="New thread"
                   data-active-tab={isDraftActive ? "true" : "false"}
                   data-tab-key="new-thread"
                   onClick={onNewTab}
                   className={cn(
-                    "group/tab relative flex h-7 max-w-40 min-w-24 shrink-0 cursor-pointer select-none items-center gap-1.5 rounded-md px-2.5 text-xs transition-colors duration-150 [-webkit-app-region:no-drag] focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
+                    "shrink-0 ps-[8.5px] text-xs font-normal [-webkit-app-region:no-drag]",
                     isDraftActive
-                      ? "border border-border/80 bg-accent text-foreground shadow-2xs font-medium"
-                      : "border border-transparent text-muted-foreground hover:bg-accent/60 hover:text-foreground",
+                      ? "bg-accent font-medium text-foreground ring-1 ring-ring/40 shadow-xs"
+                      : "text-foreground",
                   )}
                 >
-                  <Plus className="size-3.5 shrink-0 text-muted-foreground group-hover/tab:text-foreground" />
+                  <Plus className="size-3.5 shrink-0" />
                   <span className="truncate">New thread</span>
-                </button>
+                </Button>
               }
             />
             <TooltipPopup side="bottom">New thread</TooltipPopup>

--- a/apps/web/src/components/chat/WorkspaceTabs.tsx
+++ b/apps/web/src/components/chat/WorkspaceTabs.tsx
@@ -1,5 +1,5 @@
 import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
-import { scopeThreadRef } from "@t3tools/client-runtime/environment";
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
 import { useNavigate } from "@tanstack/react-router";
 import { ChevronDown, Pin, Plus, X } from "lucide-react";
 import {
@@ -16,6 +16,8 @@ import {
 import type { DraftId } from "~/composerDraftStore";
 import { cn } from "~/lib/utils";
 import { readLocalApi } from "~/localApi";
+import { hasUnseenCompletion } from "../Sidebar.logic";
+import { useUiStateStore } from "~/uiStateStore";
 import { Button } from "../ui/button";
 import { Group, GroupSeparator } from "../ui/group";
 import { ScrollArea } from "../ui/scroll-area";
@@ -84,7 +86,13 @@ function ServerThreadTabItem({
     () => scopeThreadRef(tab.environmentId, tab.threadId),
     [tab.environmentId, tab.threadId],
   );
+  const threadKey = useMemo(() => scopedThreadKey(threadRef), [threadRef]);
   const shell = useThreadShell(threadRef);
+  const lastVisitedAt = useUiStateStore((state) => state.threadLastVisitedAtById[threadKey]);
+  const isUnread = useMemo(() => {
+    if (isActive || !shell) return false;
+    return hasUnseenCompletion({ ...shell, lastVisitedAt });
+  }, [isActive, shell, lastVisitedAt]);
   const title = shell?.title || tab.title || "Thread";
   const fullLabel = tab.projectName ? `${tab.projectName} · ${title}` : title;
 
@@ -158,6 +166,12 @@ function ServerThreadTabItem({
                   />
                   <span className="truncate">{title}</span>
                   {tab.pinned ? <Pin className="size-2.5 shrink-0 rotate-45 opacity-60" /> : null}
+                  {isUnread ? (
+                    <span
+                      aria-hidden
+                      className="pointer-events-none absolute -top-0.5 -right-0.5 size-2 rounded-full bg-destructive shadow-xs ring-1 ring-background"
+                    />
+                  ) : null}
                 </Button>
               }
             />

--- a/apps/web/src/components/chat/WorkspaceTabs.tsx
+++ b/apps/web/src/components/chat/WorkspaceTabs.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { Pin, Plus, X } from "lucide-react";
 import {
   type DragEvent as ReactDragEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
   type WheelEvent as ReactWheelEvent,
   useCallback,
@@ -15,6 +16,7 @@ import {
 import type { DraftId } from "~/composerDraftStore";
 import { cn } from "~/lib/utils";
 import { readLocalApi } from "~/localApi";
+import { Button } from "../ui/button";
 import { ScrollArea } from "../ui/scroll-area";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { ProjectFavicon } from "../ProjectFavicon";
@@ -31,6 +33,10 @@ interface WorkspaceTabsProps {
   readonly activeProjectFaviconPath?: string | null | undefined;
   readonly isWorking?: boolean | undefined;
   readonly onNewTab: () => void;
+  readonly renamingTitle?: string | null | undefined;
+  readonly onCommitRename?: ((title: string) => void) | undefined;
+  readonly onCancelRename?: (() => void) | undefined;
+  readonly onRenameKeyDown?: ((event: ReactKeyboardEvent<HTMLInputElement>) => void) | undefined;
 }
 
 function ServerThreadTabItem({
@@ -38,6 +44,9 @@ function ServerThreadTabItem({
   isActive,
   isDragged,
   isDragOver,
+  renamingTitle,
+  onCommitRename,
+  onRenameKeyDown,
   onActivate,
   onClose,
   onAuxClick,
@@ -52,6 +61,9 @@ function ServerThreadTabItem({
   readonly isActive: boolean;
   readonly isDragged: boolean;
   readonly isDragOver: boolean;
+  readonly renamingTitle?: string | null | undefined;
+  readonly onCommitRename?: ((title: string) => void) | undefined;
+  readonly onRenameKeyDown?: ((event: ReactKeyboardEvent<HTMLInputElement>) => void) | undefined;
   readonly onActivate: () => void;
   readonly onClose: (e: ReactMouseEvent) => void;
   readonly onAuxClick: (e: ReactMouseEvent) => void;
@@ -77,10 +89,12 @@ function ServerThreadTabItem({
     }
   }, [isActive]);
 
+  const isRenaming = isActive && renamingTitle !== null && renamingTitle !== undefined;
+
   return (
     <div
       ref={itemRef}
-      draggable
+      draggable={!isRenaming}
       data-active-tab={isActive ? "true" : "false"}
       data-tab-key={tab.key}
       onDragStart={onDragStart}
@@ -91,7 +105,7 @@ function ServerThreadTabItem({
       onAuxClick={onAuxClick}
       onContextMenu={onContextMenu}
       className={cn(
-        "group/tab relative flex h-7 max-w-48 min-w-24 shrink-0 cursor-pointer select-none items-center gap-1.5 rounded-md px-2 text-xs transition-all duration-150",
+        "group/tab relative flex h-7 max-w-48 min-w-24 shrink-0 cursor-pointer select-none items-center gap-1.5 rounded-md px-2 text-xs transition-all duration-150 [-webkit-app-region:no-drag]",
         isActive
           ? "border border-border/80 bg-accent text-foreground shadow-2xs font-medium"
           : "border border-transparent text-muted-foreground hover:bg-accent/60 hover:text-foreground",
@@ -99,33 +113,53 @@ function ServerThreadTabItem({
         isDragOver && !isDragged && "ring-2 ring-primary/80 bg-accent/90",
       )}
     >
-      <div className="flex min-w-0 flex-1 items-center gap-1.5" onClick={onActivate}>
-        <ProjectFavicon
-          environmentId={tab.environmentId}
-          cwd={tab.projectCwd ?? ""}
-          faviconPath={tab.faviconPath}
-          className="size-3.5 shrink-0"
+      {isRenaming ? (
+        <input
+          autoFocus
+          aria-label="Thread title"
+          className="min-w-0 flex-1 rounded-sm bg-transparent text-xs font-medium text-foreground outline-none ring-1 ring-ring/50 focus:ring-ring"
+          defaultValue={renamingTitle}
+          onBlur={(event) => {
+            onCommitRename?.(event.currentTarget.value);
+          }}
+          onFocus={(event) => event.currentTarget.select()}
+          onKeyDown={onRenameKeyDown}
         />
-        <Tooltip>
-          <TooltipTrigger render={<span className="truncate">{title}</span>} />
-          <TooltipPopup side="bottom">{fullLabel}</TooltipPopup>
-        </Tooltip>
-        {tab.pinned ? <Pin className="size-2.5 shrink-0 rotate-45 opacity-60" /> : null}
-      </div>
+      ) : (
+        <button
+          type="button"
+          aria-label={fullLabel}
+          onClick={onActivate}
+          className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 rounded-sm text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <ProjectFavicon
+            environmentId={tab.environmentId}
+            cwd={tab.projectCwd ?? ""}
+            faviconPath={tab.faviconPath}
+            className="size-3.5 shrink-0"
+          />
+          <Tooltip>
+            <TooltipTrigger render={<span className="truncate">{title}</span>} />
+            <TooltipPopup side="bottom">{fullLabel}</TooltipPopup>
+          </Tooltip>
+          {tab.pinned ? <Pin className="size-2.5 shrink-0 rotate-45 opacity-60" /> : null}
+        </button>
+      )}
 
-      <button
-        type="button"
+      <Button
+        size="icon-micro"
+        variant="ghost-muted"
         aria-label={`Close ${title}`}
         onClick={onClose}
         className={cn(
-          "flex size-4 shrink-0 cursor-pointer items-center justify-center rounded-sm text-muted-foreground hover:bg-muted hover:text-foreground",
+          "shrink-0",
           isActive
             ? "opacity-60 hover:opacity-100"
             : "opacity-0 group-hover/tab:opacity-100 focus-visible:opacity-100",
         )}
       >
         <X className="size-3" />
-      </button>
+      </Button>
     </div>
   );
 }
@@ -139,6 +173,9 @@ export function WorkspaceTabs({
   activeProjectCwd,
   activeProjectFaviconPath,
   onNewTab,
+  renamingTitle,
+  onCommitRename,
+  onRenameKeyDown,
 }: WorkspaceTabsProps) {
   const navigate = useNavigate();
   const tabs = useWorkspaceTabsStore((state) => state.tabs);
@@ -288,18 +325,24 @@ export function WorkspaceTabs({
         case "close":
           handleCloseTab(tab);
           break;
-        case "close-others":
+        case "close-others": {
           closeOtherTabs(tab.key);
-          if (currentTabKey !== tab.key) {
+          const remainingTabs = useWorkspaceTabsStore.getState().tabs;
+          const isCurrentStillOpen = remainingTabs.some((t) => t.key === currentTabKey);
+          if (!isCurrentStillOpen) {
             handleNavigateToTab(tab);
           }
           break;
-        case "close-to-right":
+        }
+        case "close-to-right": {
           closeTabsToRight(tab.key);
-          if (effectiveTabs.findIndex((t) => t.key === currentTabKey) > tabIndex) {
+          const remainingTabs = useWorkspaceTabsStore.getState().tabs;
+          const isCurrentStillOpen = remainingTabs.some((t) => t.key === currentTabKey);
+          if (!isCurrentStillOpen) {
             handleNavigateToTab(tab);
           }
           break;
+        }
         case "close-all":
           closeAllTabs();
           onNewTab();
@@ -344,16 +387,12 @@ export function WorkspaceTabs({
     (e: ReactDragEvent, targetKey: string) => {
       e.preventDefault();
       if (draggedKey && draggedKey !== targetKey) {
-        const sourceIndex = effectiveTabs.findIndex((t) => t.key === draggedKey);
-        const targetIndex = effectiveTabs.findIndex((t) => t.key === targetKey);
-        if (sourceIndex >= 0 && targetIndex >= 0) {
-          reorderTabs(sourceIndex, targetIndex);
-        }
+        reorderTabs(draggedKey, targetKey);
       }
       setDraggedKey(null);
       setDragOverKey(null);
     },
-    [draggedKey, effectiveTabs, reorderTabs],
+    [draggedKey, reorderTabs],
   );
 
   const handleDragEnd = useCallback(() => {
@@ -362,9 +401,10 @@ export function WorkspaceTabs({
   }, []);
 
   const handleWheel = useCallback((e: ReactWheelEvent<HTMLDivElement>) => {
-    if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
-      e.currentTarget.scrollLeft += e.deltaY;
-    }
+    if (Math.abs(e.deltaY) <= Math.abs(e.deltaX)) return;
+    const viewport = e.currentTarget.closest<HTMLElement>('[data-slot="scroll-area-viewport"]');
+    if (!viewport) return;
+    viewport.scrollLeft += e.deltaY;
   }, []);
 
   return (
@@ -382,12 +422,14 @@ export function WorkspaceTabs({
           <Tooltip>
             <TooltipTrigger
               render={
-                <div
+                <button
+                  type="button"
+                  aria-label="New thread"
                   data-active-tab={isDraftActive ? "true" : "false"}
                   data-tab-key="new-thread"
                   onClick={onNewTab}
                   className={cn(
-                    "group/tab relative flex h-7 max-w-40 min-w-24 shrink-0 cursor-pointer select-none items-center gap-1.5 rounded-md px-2.5 text-xs transition-colors duration-150",
+                    "group/tab relative flex h-7 max-w-40 min-w-24 shrink-0 cursor-pointer select-none items-center gap-1.5 rounded-md px-2.5 text-xs transition-colors duration-150 [-webkit-app-region:no-drag] focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
                     isDraftActive
                       ? "border border-border/80 bg-accent text-foreground shadow-2xs font-medium"
                       : "border border-transparent text-muted-foreground hover:bg-accent/60 hover:text-foreground",
@@ -395,7 +437,7 @@ export function WorkspaceTabs({
                 >
                   <Plus className="size-3.5 shrink-0 text-muted-foreground group-hover/tab:text-foreground" />
                   <span className="truncate">New thread</span>
-                </div>
+                </button>
               }
             />
             <TooltipPopup side="bottom">New thread</TooltipPopup>
@@ -413,6 +455,9 @@ export function WorkspaceTabs({
                 isActive={isActive}
                 isDragged={isDragged}
                 isDragOver={isDragOver}
+                renamingTitle={renamingTitle}
+                onCommitRename={onCommitRename}
+                onRenameKeyDown={onRenameKeyDown}
                 onActivate={() => handleNavigateToTab(tab)}
                 onClose={(e) => handleCloseTab(tab, e)}
                 onAuxClick={(e) => handleTabAuxClick(e, tab)}

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -578,13 +578,24 @@ export function useSettingsRestore(onRestored?: () => void) {
     );
     if (!confirmed) return;
 
+    // Only touch the theme keys that are actually dirty, so a theme-storage
+    // failure cannot block restoring unrelated settings. Preferences are
+    // re-read after the confirmation dialog: they may have changed (another
+    // tab, an OS flip) while it was open, and rollback must restore the live
+    // values rather than the ones captured at render time.
     let previousTheme = theme;
     try {
       previousTheme = readThemePreference();
-    } catch {}
+    } catch {
+      // Storage is unreadable; the render-time value is the best rollback.
+    }
+    // The mix may have changed while the confirmation dialog was open; both
+    // the dirty check and the rollback must see the live value.
     const liveHalves = readThemeHalves();
     const needsThemeReset = previousTheme !== "system";
     const needsMixReset = liveHalves !== null;
+    // Same for the appearance mode: trusting the render-time value would skip
+    // the reset and report success while a non-system mode stayed in storage.
     const needsFollowSystemReset = readAppearanceModePreference(previousTheme) !== "system";
     const notifyThemeRestoreFailure = () => {
       toastManager.add(
@@ -595,6 +606,9 @@ export function useSettingsRestore(onRestored?: () => void) {
         }),
       );
     };
+    // Rollback restores the base preference first (which clears any mix) and
+    // then re-applies the captured mix on top, so no failure path can leave
+    // the pair of keys half-restored.
     const previousHalves = liveHalves;
     const rollbackThemeState = () => {
       if (needsThemeReset) setTheme(previousTheme);

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1839,6 +1839,28 @@ export function GeneralSettingsPanel() {
         />
 
         <SettingsRow
+          {...searchableSetting("workspace-tabs")}
+          description="Show open conversations as tabs in the workspace topbar."
+          resetAction={
+            settings.tabsEnabled !== DEFAULT_UNIFIED_SETTINGS.tabsEnabled ? (
+              <SettingResetButton
+                label="workspace tabs"
+                onClick={() =>
+                  updateSettings({ tabsEnabled: DEFAULT_UNIFIED_SETTINGS.tabsEnabled })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.tabsEnabled}
+              onCheckedChange={(checked) => updateSettings({ tabsEnabled: Boolean(checked) })}
+              aria-label="Workspace tabs"
+            />
+          }
+        />
+
+        <SettingsRow
           {...searchableSetting("auto-settle-merged-threads")}
           description="Settle a thread when its pull request merges. Closed pull requests still settle automatically."
           resetAction={

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -496,6 +496,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.sidebarAutoSettleOnMerge !== DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleOnMerge
         ? ["Auto-settle merged threads"]
         : []),
+      ...(settings.tabsEnabled !== DEFAULT_UNIFIED_SETTINGS.tabsEnabled ? ["Workspace tabs"] : []),
       ...(settings.wordWrap !== DEFAULT_UNIFIED_SETTINGS.wordWrap ? ["Word wrap"] : []),
       ...getChangedTypographySettingLabels(settings),
       ...(settings.diffIgnoreWhitespace !== DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace
@@ -557,6 +558,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.sidebarAutoSettleOnMerge,
       settings.sidebarProjectGroupingMode,
       settings.sidebarThreadPreviewCount,
+      settings.tabsEnabled,
       settings.timestampFormat,
       settings.wordWrap,
       followSystem,
@@ -576,24 +578,13 @@ export function useSettingsRestore(onRestored?: () => void) {
     );
     if (!confirmed) return;
 
-    // Only touch the theme keys that are actually dirty, so a theme-storage
-    // failure cannot block restoring unrelated settings. Preferences are
-    // re-read after the confirmation dialog: they may have changed (another
-    // tab, an OS flip) while it was open, and rollback must restore the live
-    // values rather than the ones captured at render time.
     let previousTheme = theme;
     try {
       previousTheme = readThemePreference();
-    } catch {
-      // Storage is unreadable; the render-time value is the best rollback.
-    }
-    // The mix may have changed while the confirmation dialog was open; both
-    // the dirty check and the rollback must see the live value.
+    } catch {}
     const liveHalves = readThemeHalves();
     const needsThemeReset = previousTheme !== "system";
     const needsMixReset = liveHalves !== null;
-    // Same for the appearance mode: trusting the render-time value would skip
-    // the reset and report success while a non-system mode stayed in storage.
     const needsFollowSystemReset = readAppearanceModePreference(previousTheme) !== "system";
     const notifyThemeRestoreFailure = () => {
       toastManager.add(
@@ -604,9 +595,6 @@ export function useSettingsRestore(onRestored?: () => void) {
         }),
       );
     };
-    // Rollback restores the base preference first (which clears any mix) and
-    // then re-applies the captured mix on top, so no failure path can leave
-    // the pair of keys half-restored.
     const previousHalves = liveHalves;
     const rollbackThemeState = () => {
       if (needsThemeReset) setTheme(previousTheme);
@@ -637,6 +625,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       sidebarProjectGroupingMode: DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
       sidebarAutoSettleAfterDays: DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays,
       sidebarAutoSettleOnMerge: DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleOnMerge,
+      tabsEnabled: DEFAULT_UNIFIED_SETTINGS.tabsEnabled,
       enableLegacyTokenStreaming: DEFAULT_UNIFIED_SETTINGS.enableLegacyTokenStreaming,
       enableProviderUpdateChecks: DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks,
       backgroundActivity: DEFAULT_UNIFIED_SETTINGS.backgroundActivity,

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -186,6 +186,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/general",
   },
   {
+    id: "workspace-tabs",
+    title: "Workspace tabs",
+    to: "/settings/general",
+  },
+  {
     id: "keybindings",
     title: "Keybindings",
     to: "/settings/keybindings",

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -278,6 +278,12 @@ export function useLegacySidebarEnabled(): boolean {
   return settingsHydrated && legacySidebarEnabled;
 }
 
+export function useTabsEnabled(): boolean {
+  const settingsHydrated = useClientSettingsHydrated();
+  const tabsEnabled = useClientSettingsValue().tabsEnabled;
+  return !settingsHydrated || tabsEnabled;
+}
+
 /** Read current settings for one environment, merged with client-local preferences. */
 export function useEnvironmentSettings<T = UnifiedSettings>(
   environmentId: EnvironmentId,

--- a/apps/web/src/routes/_chat.draft.$draftId.tsx
+++ b/apps/web/src/routes/_chat.draft.$draftId.tsx
@@ -11,6 +11,7 @@ import { SidebarInset } from "../components/ui/sidebar";
 import { waitForDraftHeroTransition } from "../components/chat/draftHeroTransition";
 import { buildThreadRouteParams } from "../threadRoutes";
 import { useThread, useThreadRefs } from "../state/entities";
+import { serverTabKey, useWorkspaceTabsStore } from "../workspaceTabsStore";
 
 function DraftChatThreadRouteView() {
   const navigate = useNavigate();
@@ -42,6 +43,14 @@ function DraftChatThreadRouteView() {
       return;
     }
 
+    useWorkspaceTabsStore.getState().openTab({
+      key: serverTabKey(canonicalThreadRef.environmentId, canonicalThreadRef.threadId),
+      kind: "server",
+      environmentId: canonicalThreadRef.environmentId,
+      threadId: canonicalThreadRef.threadId,
+      title: serverThread?.title || "Thread",
+    });
+
     let cancelled = false;
     void waitForDraftHeroTransition().then(() => {
       if (cancelled) {
@@ -57,7 +66,7 @@ function DraftChatThreadRouteView() {
     return () => {
       cancelled = true;
     };
-  }, [canonicalThreadRef, navigate]);
+  }, [canonicalThreadRef, draftId, navigate, serverThread?.title]);
 
   useEffect(() => {
     if (draftSession || canonicalThreadRef) {

--- a/apps/web/src/workspaceTabsStore.test.ts
+++ b/apps/web/src/workspaceTabsStore.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+import { EnvironmentId, ProjectId, ThreadId } from "@t3tools/contracts";
+import { serverTabKey, useWorkspaceTabsStore, type WorkspaceTab } from "./workspaceTabsStore";
+
+const envId = EnvironmentId.make("env-local");
+const projId = ProjectId.make("project-1");
+const thread1Id = ThreadId.make("thread-1");
+const thread2Id = ThreadId.make("thread-2");
+const thread3Id = ThreadId.make("thread-3");
+
+function createServerTab(id: ThreadId, title = `Thread ${id}`): WorkspaceTab {
+  return {
+    key: serverTabKey(envId, id),
+    kind: "server",
+    environmentId: envId,
+    threadId: id,
+    title,
+    projectId: projId,
+    projectName: "My Project",
+  };
+}
+
+describe("workspaceTabsStore", () => {
+  beforeEach(() => {
+    useWorkspaceTabsStore.setState({ tabs: [], activeTabKey: null });
+  });
+
+  it("opens a new tab and sets it active", () => {
+    const tab1 = createServerTab(thread1Id);
+    useWorkspaceTabsStore.getState().openTab(tab1);
+
+    const state = useWorkspaceTabsStore.getState();
+    expect(state.tabs).toHaveLength(1);
+    expect(state.tabs[0]?.key).toBe(tab1.key);
+    expect(state.activeTabKey).toBe(tab1.key);
+  });
+
+  it("updates existing tab title without creating duplicate", () => {
+    const tab1 = createServerTab(thread1Id, "Initial Title");
+    useWorkspaceTabsStore.getState().openTab(tab1);
+
+    const tab1Updated = createServerTab(thread1Id, "Updated Title");
+    useWorkspaceTabsStore.getState().openTab(tab1Updated);
+
+    const state = useWorkspaceTabsStore.getState();
+    expect(state.tabs).toHaveLength(1);
+    expect(state.tabs[0]?.title).toBe("Updated Title");
+    expect(state.activeTabKey).toBe(tab1.key);
+  });
+
+  it("prepends new tabs at the beginning", () => {
+    const tab1 = createServerTab(thread1Id);
+    const tab2 = createServerTab(thread2Id);
+    const tab3 = createServerTab(thread3Id);
+
+    useWorkspaceTabsStore.getState().openTab(tab1);
+    useWorkspaceTabsStore.getState().openTab(tab2);
+    useWorkspaceTabsStore.getState().openTab(tab3);
+
+    const state = useWorkspaceTabsStore.getState();
+    expect(state.tabs.map((t) => t.key)).toEqual([tab3.key, tab2.key, tab1.key]);
+  });
+
+  it("closes inactive tab without changing active tab", () => {
+    const tab1 = createServerTab(thread1Id);
+    const tab2 = createServerTab(thread2Id);
+
+    useWorkspaceTabsStore.getState().openTab(tab1);
+    useWorkspaceTabsStore.getState().openTab(tab2);
+
+    const nextActive = useWorkspaceTabsStore.getState().closeTab(tab1.key);
+    expect(nextActive).toBeNull();
+
+    const state = useWorkspaceTabsStore.getState();
+    expect(state.tabs).toHaveLength(1);
+    expect(state.activeTabKey).toBe(tab2.key);
+  });
+
+  it("closes active tab and selects adjacent tab", () => {
+    const tab1 = createServerTab(thread1Id);
+    const tab2 = createServerTab(thread2Id);
+    const tab3 = createServerTab(thread3Id);
+
+    useWorkspaceTabsStore.getState().openTab(tab1);
+    useWorkspaceTabsStore.getState().openTab(tab2);
+    useWorkspaceTabsStore.getState().openTab(tab3);
+    useWorkspaceTabsStore.getState().openTab(tab2);
+
+    const nextActive = useWorkspaceTabsStore.getState().closeTab(tab2.key);
+    expect(nextActive?.key).toBe(tab1.key);
+
+    const state = useWorkspaceTabsStore.getState();
+    expect(state.tabs.map((t) => t.key)).toEqual([tab3.key, tab1.key]);
+    expect(state.activeTabKey).toBe(tab1.key);
+  });
+
+  it("closes active tab when closing last tab in list", () => {
+    const tab1 = createServerTab(thread1Id);
+    const tab2 = createServerTab(thread2Id);
+
+    useWorkspaceTabsStore.getState().openTab(tab2);
+    useWorkspaceTabsStore.getState().openTab(tab1);
+
+    const nextActive = useWorkspaceTabsStore.getState().closeTab(tab1.key);
+    expect(nextActive?.key).toBe(tab2.key);
+
+    const state = useWorkspaceTabsStore.getState();
+    expect(state.tabs.map((t) => t.key)).toEqual([tab2.key]);
+    expect(state.activeTabKey).toBe(tab2.key);
+  });
+
+  it("closes other tabs preserving keepTabKey", () => {
+    const tab1 = createServerTab(thread1Id);
+    const tab2 = createServerTab(thread2Id);
+    const tab3 = createServerTab(thread3Id);
+
+    useWorkspaceTabsStore.getState().openTab(tab1);
+    useWorkspaceTabsStore.getState().openTab(tab2);
+    useWorkspaceTabsStore.getState().openTab(tab3);
+
+    useWorkspaceTabsStore.getState().closeOtherTabs(tab2.key);
+
+    const state = useWorkspaceTabsStore.getState();
+    expect(state.tabs).toHaveLength(1);
+    expect(state.tabs[0]?.key).toBe(tab2.key);
+    expect(state.activeTabKey).toBe(tab2.key);
+  });
+
+  it("closes tabs to the right", () => {
+    const tab1 = createServerTab(thread1Id);
+    const tab2 = createServerTab(thread2Id);
+    const tab3 = createServerTab(thread3Id);
+
+    useWorkspaceTabsStore.getState().openTab(tab1);
+    useWorkspaceTabsStore.getState().openTab(tab2);
+    useWorkspaceTabsStore.getState().openTab(tab3);
+
+    useWorkspaceTabsStore.getState().closeTabsToRight(tab2.key);
+
+    const state = useWorkspaceTabsStore.getState();
+    expect(state.tabs.map((t) => t.key)).toEqual([tab3.key, tab2.key]);
+  });
+
+  it("reorders tabs correctly", () => {
+    const tab1 = createServerTab(thread1Id);
+    const tab2 = createServerTab(thread2Id);
+    const tab3 = createServerTab(thread3Id);
+
+    useWorkspaceTabsStore.getState().openTab(tab1);
+    useWorkspaceTabsStore.getState().openTab(tab2);
+    useWorkspaceTabsStore.getState().openTab(tab3);
+
+    useWorkspaceTabsStore.getState().reorderTabs(0, 2);
+
+    const state = useWorkspaceTabsStore.getState();
+    expect(state.tabs.map((t) => t.key)).toEqual([tab2.key, tab1.key, tab3.key]);
+  });
+
+  it("toggles pin status on tab", () => {
+    const tab1 = createServerTab(thread1Id);
+    useWorkspaceTabsStore.getState().openTab(tab1);
+
+    useWorkspaceTabsStore.getState().togglePinTab(tab1.key);
+    expect(useWorkspaceTabsStore.getState().tabs[0]?.pinned).toBe(true);
+
+    useWorkspaceTabsStore.getState().togglePinTab(tab1.key);
+    expect(useWorkspaceTabsStore.getState().tabs[0]?.pinned).toBe(false);
+  });
+});

--- a/apps/web/src/workspaceTabsStore.test.ts
+++ b/apps/web/src/workspaceTabsStore.test.ts
@@ -150,7 +150,7 @@ describe("workspaceTabsStore", () => {
     useWorkspaceTabsStore.getState().openTab(tab2);
     useWorkspaceTabsStore.getState().openTab(tab3);
 
-    useWorkspaceTabsStore.getState().reorderTabs(0, 2);
+    useWorkspaceTabsStore.getState().reorderTabs(tab3.key, tab1.key);
 
     const state = useWorkspaceTabsStore.getState();
     expect(state.tabs.map((t) => t.key)).toEqual([tab2.key, tab1.key, tab3.key]);

--- a/apps/web/src/workspaceTabsStore.ts
+++ b/apps/web/src/workspaceTabsStore.ts
@@ -26,7 +26,7 @@ export interface WorkspaceTabsState {
   readonly closeOtherTabs: (keepTabKey: string) => void;
   readonly closeTabsToRight: (fromTabKey: string) => void;
   readonly closeAllTabs: () => void;
-  readonly reorderTabs: (sourceIndex: number, targetIndex: number) => void;
+  readonly reorderTabs: (sourceKey: string, targetKey: string) => void;
   readonly togglePinTab: (tabKey: string) => void;
 }
 
@@ -150,6 +150,8 @@ export const useWorkspaceTabsStore = create<WorkspaceTabsState>((set, get) => ({
 
   closeOtherTabs: (keepTabKey: string) => {
     set((state) => {
+      const exists = state.tabs.some((t) => t.key === keepTabKey);
+      if (!exists) return state;
       const nextTabs = state.tabs.filter((t) => t.key === keepTabKey || t.pinned);
       const nextActiveKey = nextTabs.some((t) => t.key === state.activeTabKey)
         ? state.activeTabKey
@@ -181,15 +183,11 @@ export const useWorkspaceTabsStore = create<WorkspaceTabsState>((set, get) => ({
     });
   },
 
-  reorderTabs: (sourceIndex: number, targetIndex: number) => {
+  reorderTabs: (sourceKey: string, targetKey: string) => {
     set((state) => {
-      if (
-        sourceIndex < 0 ||
-        sourceIndex >= state.tabs.length ||
-        targetIndex < 0 ||
-        targetIndex >= state.tabs.length ||
-        sourceIndex === targetIndex
-      ) {
+      const sourceIndex = state.tabs.findIndex((t) => t.key === sourceKey);
+      const targetIndex = state.tabs.findIndex((t) => t.key === targetKey);
+      if (sourceIndex === -1 || targetIndex === -1 || sourceIndex === targetIndex) {
         return state;
       }
       const tab = state.tabs[sourceIndex];

--- a/apps/web/src/workspaceTabsStore.ts
+++ b/apps/web/src/workspaceTabsStore.ts
@@ -1,0 +1,212 @@
+import { create } from "zustand";
+import type { EnvironmentId, ProjectId, ThreadId } from "@t3tools/contracts";
+
+export interface WorkspaceTab {
+  readonly key: string;
+  readonly kind: "server";
+  readonly environmentId: EnvironmentId;
+  readonly threadId: ThreadId;
+  readonly title: string;
+  readonly projectId?: ProjectId | null | undefined;
+  readonly projectCwd?: string | null | undefined;
+  readonly projectName?: string | null | undefined;
+  readonly faviconPath?: string | null | undefined;
+  readonly pinned?: boolean | undefined;
+}
+
+export function serverTabKey(environmentId: EnvironmentId, threadId: ThreadId): string {
+  return `server:${environmentId}:${threadId}`;
+}
+
+export interface WorkspaceTabsState {
+  readonly tabs: readonly WorkspaceTab[];
+  readonly activeTabKey: string | null;
+  readonly openTab: (tab: WorkspaceTab) => void;
+  readonly closeTab: (tabKey: string) => WorkspaceTab | null;
+  readonly closeOtherTabs: (keepTabKey: string) => void;
+  readonly closeTabsToRight: (fromTabKey: string) => void;
+  readonly closeAllTabs: () => void;
+  readonly reorderTabs: (sourceIndex: number, targetIndex: number) => void;
+  readonly togglePinTab: (tabKey: string) => void;
+}
+
+export const WORKSPACE_TABS_STORAGE_KEY = "t3code:workspace-tabs:v1";
+
+interface PersistedTabsPayload {
+  tabs: WorkspaceTab[];
+  activeTabKey: string | null;
+}
+
+function loadPersistedTabs(): { tabs: WorkspaceTab[]; activeTabKey: string | null } {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return { tabs: [], activeTabKey: null };
+  }
+  try {
+    const raw = window.localStorage.getItem(WORKSPACE_TABS_STORAGE_KEY);
+    if (!raw) return { tabs: [], activeTabKey: null };
+    const parsed = JSON.parse(raw) as PersistedTabsPayload;
+    if (!parsed || !Array.isArray(parsed.tabs)) {
+      return { tabs: [], activeTabKey: null };
+    }
+    const seen = new Set<string>();
+    const sanitizedTabs: WorkspaceTab[] = [];
+    for (const tab of parsed.tabs) {
+      if (
+        tab &&
+        tab.kind === "server" &&
+        typeof tab.environmentId === "string" &&
+        typeof tab.threadId === "string"
+      ) {
+        const key = serverTabKey(tab.environmentId as EnvironmentId, tab.threadId as ThreadId);
+        if (!seen.has(key)) {
+          seen.add(key);
+          sanitizedTabs.push({
+            ...tab,
+            key,
+            kind: "server",
+            environmentId: tab.environmentId as EnvironmentId,
+            threadId: tab.threadId as ThreadId,
+          });
+        }
+      }
+    }
+    const activeTabKey =
+      typeof parsed.activeTabKey === "string" &&
+      sanitizedTabs.some((tab) => tab.key === parsed.activeTabKey)
+        ? parsed.activeTabKey
+        : (sanitizedTabs[0]?.key ?? null);
+    return { tabs: sanitizedTabs, activeTabKey };
+  } catch {
+    return { tabs: [], activeTabKey: null };
+  }
+}
+
+function savePersistedTabs(tabs: readonly WorkspaceTab[], activeTabKey: string | null): void {
+  if (typeof window === "undefined" || !window.localStorage) return;
+  try {
+    const payload: PersistedTabsPayload = {
+      tabs: [...tabs],
+      activeTabKey,
+    };
+    window.localStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(payload));
+  } catch {}
+}
+
+const initial = loadPersistedTabs();
+
+export const useWorkspaceTabsStore = create<WorkspaceTabsState>((set, get) => ({
+  tabs: initial.tabs,
+  activeTabKey: initial.activeTabKey,
+
+  openTab: (tab: WorkspaceTab) => {
+    set((state) => {
+      const existingIndex = state.tabs.findIndex((t) => t.key === tab.key);
+      let nextTabs: WorkspaceTab[];
+      if (existingIndex >= 0) {
+        nextTabs = state.tabs.map((t, idx) =>
+          idx === existingIndex
+            ? {
+                ...t,
+                ...tab,
+                title: tab.title || t.title,
+                projectName: tab.projectName ?? t.projectName,
+                projectCwd: tab.projectCwd ?? t.projectCwd,
+                faviconPath: tab.faviconPath ?? t.faviconPath,
+              }
+            : t,
+        );
+      } else {
+        nextTabs = [tab, ...state.tabs];
+      }
+      savePersistedTabs(nextTabs, tab.key);
+      return { tabs: nextTabs, activeTabKey: tab.key };
+    });
+  },
+
+  closeTab: (tabKey: string) => {
+    const state = get();
+    const index = state.tabs.findIndex((t) => t.key === tabKey);
+    if (index === -1) return null;
+
+    const isClosingActive = state.activeTabKey === tabKey;
+    const nextTabs = state.tabs.filter((t) => t.key !== tabKey);
+    let nextActiveTab: WorkspaceTab | null = null;
+
+    if (isClosingActive) {
+      if (nextTabs.length > 0) {
+        const nextIndex = Math.min(index, nextTabs.length - 1);
+        nextActiveTab = nextTabs[nextIndex] ?? null;
+      }
+    } else {
+      nextActiveTab = state.tabs.find((t) => t.key === state.activeTabKey) ?? null;
+    }
+
+    const nextActiveKey = nextActiveTab ? nextActiveTab.key : null;
+    savePersistedTabs(nextTabs, nextActiveKey);
+    set({ tabs: nextTabs, activeTabKey: nextActiveKey });
+
+    return isClosingActive ? nextActiveTab : null;
+  },
+
+  closeOtherTabs: (keepTabKey: string) => {
+    set((state) => {
+      const nextTabs = state.tabs.filter((t) => t.key === keepTabKey || t.pinned);
+      const nextActiveKey = nextTabs.some((t) => t.key === state.activeTabKey)
+        ? state.activeTabKey
+        : keepTabKey;
+      savePersistedTabs(nextTabs, nextActiveKey);
+      return { tabs: nextTabs, activeTabKey: nextActiveKey };
+    });
+  },
+
+  closeTabsToRight: (fromTabKey: string) => {
+    set((state) => {
+      const index = state.tabs.findIndex((t) => t.key === fromTabKey);
+      if (index === -1) return state;
+      const nextTabs = state.tabs.filter((t, i) => i <= index || t.pinned);
+      const nextActiveKey = nextTabs.some((t) => t.key === state.activeTabKey)
+        ? state.activeTabKey
+        : fromTabKey;
+      savePersistedTabs(nextTabs, nextActiveKey);
+      return { tabs: nextTabs, activeTabKey: nextActiveKey };
+    });
+  },
+
+  closeAllTabs: () => {
+    set((state) => {
+      const nextTabs = state.tabs.filter((t) => t.pinned);
+      const nextActiveKey = nextTabs[0]?.key ?? null;
+      savePersistedTabs(nextTabs, nextActiveKey);
+      return { tabs: nextTabs, activeTabKey: nextActiveKey };
+    });
+  },
+
+  reorderTabs: (sourceIndex: number, targetIndex: number) => {
+    set((state) => {
+      if (
+        sourceIndex < 0 ||
+        sourceIndex >= state.tabs.length ||
+        targetIndex < 0 ||
+        targetIndex >= state.tabs.length ||
+        sourceIndex === targetIndex
+      ) {
+        return state;
+      }
+      const tab = state.tabs[sourceIndex];
+      if (!tab) return state;
+      const nextTabs = [...state.tabs];
+      nextTabs.splice(sourceIndex, 1);
+      nextTabs.splice(targetIndex, 0, tab);
+      savePersistedTabs(nextTabs, state.activeTabKey);
+      return { tabs: nextTabs };
+    });
+  },
+
+  togglePinTab: (tabKey: string) => {
+    set((state) => {
+      const nextTabs = state.tabs.map((t) => (t.key === tabKey ? { ...t, pinned: !t.pinned } : t));
+      savePersistedTabs(nextTabs, state.activeTabKey);
+      return { tabs: nextTabs };
+    });
+  },
+}));

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -71,8 +71,14 @@ describe("ClientSettings sidebar", () => {
   it("defaults to the current sidebar with automatic merge and inactivity settling", () => {
     const settings = decodeClientSettings({});
     expect(settings.legacySidebarEnabled).toBe(false);
+    expect(settings.tabsEnabled).toBe(true);
     expect(settings.sidebarAutoSettleAfterDays).toBe(3);
     expect(settings.sidebarAutoSettleOnMerge).toBe(true);
+  });
+
+  it("preserves an explicit tabsEnabled setting", () => {
+    expect(decodeClientSettings({ tabsEnabled: false }).tabsEnabled).toBe(false);
+    expect(decodeClientSettingsPatch({ tabsEnabled: false }).tabsEnabled).toBe(false);
   });
 
   it("drops the retired sidebar v2 beta keys, resetting everyone to the default", () => {

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -180,6 +180,7 @@ export const ClientSettingsSchema = Schema.Struct({
   // old keys, so everyone, including prior beta opt-outs, resets to the new
   // default sidebar.
   legacySidebarEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  tabsEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   sidebarAutoSettleAfterDays: Schema.NullOr(SidebarAutoSettleAfterDays).pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_AUTO_SETTLE_AFTER_DAYS)),
   ),
@@ -797,6 +798,7 @@ export const ClientSettingsPatch = Schema.Struct({
   ),
   planModeEnabled: Schema.optionalKey(Schema.Boolean),
   legacySidebarEnabled: Schema.optionalKey(Schema.Boolean),
+  tabsEnabled: Schema.optionalKey(Schema.Boolean),
   sidebarAutoSettleAfterDays: Schema.optionalKey(Schema.NullOr(SidebarAutoSettleAfterDays)),
   sidebarAutoSettleOnMerge: Schema.optionalKey(Schema.Boolean),
   sidebarProjectGroupingMode: Schema.optionalKey(SidebarProjectGroupingMode),


### PR DESCRIPTION
### Summary
This PR introduces a configurable workspace thread tabs system enabled by default, allowing users to effortlessly switch, organize, and manage open conversations in the workspace topbar.

### Features
- **Permanent 'New thread' tab**: Always positioned at the start of the tab strip for quick conversation launching.
- **Dynamic Thread Tabs**: New threads are automatically added to the left (next to New thread) with project favicons, live synchronized titles, and active state indicators.
- **Interactive Controls**: Close tabs via close button or mouse middle-click with intelligent adjacent fallback navigation; right-click context menu with options to close other tabs, close tabs to the right, close all, or toggle pin.
- **Drag & Drop Reordering**: Reorganize tabs smoothly via native HTML5 drag-and-drop, persisted across sessions in localStorage.
- **Smooth Scrolling**: Horizontal mouse wheel scrolling and automatic scroll-into-view for active tabs.
- **Settings Toggle**: Enable/disable thread tabs in Settings -> General, fully integrated with the settings search catalog.

Google Antigravity

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default-on header/navigation UX affects all users; routing and tab-close fallbacks must stay correct, but changes are client-only UI state.
> 
> **Overview**
> Adds an optional **workspace thread tab strip** in the chat header (on by default via new client setting `tabsEnabled`), replacing the project/thread breadcrumb when enabled.
> 
> A **localStorage-backed Zustand store** tracks open server threads; tabs support close (including middle-click), bulk close from a context menu, pin, drag reorder, horizontal scroll, live titles/favicons, unread dots, and wiring for rename and the existing thread actions menu. Closing the active tab navigates to an adjacent tab or starts a new thread. Draft promotion registers the server thread in the store before route replace.
> 
> **Settings → General** gains a “Workspace tabs” toggle (searchable, restore-defaults); contracts add `tabsEnabled` (default `true`). Unit tests cover the store and tab UI markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52f78fbf60f1a67bcfde99cf57c0642000d770ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add workspace thread tabs system to chat header
> - Introduces a persistent, horizontally scrollable tab strip ([WorkspaceTabs.tsx](https://github.com/pingdotgg/t3code/pull/7080/files#diff-f862d552d95e7810f4f7c7e26bf03fe1b3a88bf846faa29266d3cc70f81e7e83)) in the chat header, replacing the breadcrumb UI when tabs are enabled.
> - Adds a Zustand store ([workspaceTabsStore.ts](https://github.com/pingdotgg/t3code/pull/7080/files#diff-8cc988d3b4c2ea002eb4028f66f9ab7f06e63356e241ca018747d516fdfa246a)) that persists tab state to localStorage, supporting open/close, pin, bulk-close, and drag-to-reorder operations.
> - Tabs support middle-click to close, unread badges on inactive tabs, inline title renaming, and a per-tab actions dropdown.
> - A new `tabsEnabled` setting (defaulting to `true`) is added to `ClientSettingsSchema` and exposed in General Settings, allowing users to toggle the tab UI.
> - Behavioral Change: before settings hydrate, the app defaults to tabs enabled to avoid UI flicker; draft threads promoted to server threads now also register a workspace tab.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 52f78fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->