### PR TITLE
fix(web): keep timestamp date and time in the same locale

### DIFF
--- a/apps/web/src/timestampFormat.test.ts
+++ b/apps/web/src/timestampFormat.test.ts
@@ -176,6 +176,20 @@ describe("formatDayAwareTimestamp", () => {
     );
   });
 
+  it("uses the host locale for both the numeric date and wall-clock time", async () => {
+    vi.stubGlobal("window", {
+      desktopBridge: { getSystemLocale: () => "en-GB" },
+    });
+    vi.resetModules();
+
+    const { formatDayAwareTimestamp: formatWithHostLocale } = await import("./timestampFormat");
+    const messageAt = iso(2026, 7, 12, 15, 44);
+
+    expect(formatWithHostLocale(messageAt, "locale", now)).toBe("12/08 15:44");
+
+    vi.unstubAllGlobals();
+  });
+
   it("returns an empty string for invalid input", () => {
     expect(formatDayAwareTimestamp("not-a-date", "12-hour", now)).toBe("");
   });

--- a/apps/web/src/timestampFormat.ts
+++ b/apps/web/src/timestampFormat.ts
@@ -127,11 +127,11 @@ export function formatShortTimestamp(isoDate: string, timestampFormat: Timestamp
   return getTimestampFormatter(timestampFormat, false).format(date);
 }
 
-const numericDateFormatter = new Intl.DateTimeFormat(undefined, {
+const numericDateFormatter = new Intl.DateTimeFormat(timestampLocale, {
   month: "numeric",
   day: "numeric",
 });
-const numericDateWithYearFormatter = new Intl.DateTimeFormat(undefined, {
+const numericDateWithYearFormatter = new Intl.DateTimeFormat(timestampLocale, {
   month: "numeric",
   day: "numeric",
   year: "numeric",


### PR DESCRIPTION
Follow-up to #6190.

Older chat timestamps could mix locale conventions on desktop: the wall-clock time used the host locale while the numeric date prefix used the JavaScript runtime default. For an en-GB host this could render as `8/12 15:44` instead of `12/08 15:44`.

This constructs both numeric date formatters with the same resolved host locale already used by the time formatter, and adds a regression test for an en-GB desktop bridge.

Impact: date and time portions of older chat timestamps now use one consistent locale.

Checks:
- `vp test run src/timestampFormat.test.ts --project unit` (31 passed)
- targeted `vp lint --report-unused-disable-directives`
- targeted `vp fmt --check`
- web, desktop, and contracts typechecks

Implemented with GPT-5.6 Sol in the T3 Code Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix date and time formatting to use the same locale in timestamps
> In [timestampFormat.ts](https://github.com/pingdotgg/t3code/pull/7081/files#diff-3c87b91789abf1f3644a1a66f0da1d791ac92e439c18f8a651d177cd2ed1601b), `numericDateFormatter` and `numericDateWithYearFormatter` were passing `undefined` as the locale to `Intl.DateTimeFormat`, causing the date portion to use the runtime default locale while the time portion used `timestampLocale`. Both formatters now pass `timestampLocale` explicitly, so date and time are formatted consistently. A new test covers the `en-GB` locale to prevent regression.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d26f46e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small display-formatting change in timestamp helpers with no auth, data, or API impact.
> 
> **Overview**
> Fixes **mixed locale conventions** in older chat timestamps on desktop, where the numeric date prefix could follow the JS runtime default (e.g. `8/12`) while wall-clock time used the host locale (e.g. `15:44`).
> 
> `numericDateFormatter` and `numericDateWithYearFormatter` in `timestampFormat.ts` now pass **`timestampLocale`** (same resolved host locale as the time formatter) instead of `undefined` to `Intl.DateTimeFormat`. A regression test stubs the desktop bridge with **en-GB** and asserts `formatDayAwareTimestamp` renders **`12/08 15:44`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d26f46edbddabd9ffbbe11766aaf256e92440a53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->