### PR TITLE
fix(mobile): stop a directly-saved backend from hiding its T3 Connect environment

### DIFF
--- a/apps/mobile/src/features/connection/environmentSections.test.ts
+++ b/apps/mobile/src/features/connection/environmentSections.test.ts
@@ -2,7 +2,7 @@ import { EnvironmentId } from "@t3tools/contracts";
 import type { RelayClientEnvironmentRecord } from "@t3tools/contracts/relay";
 import { describe, expect, it } from "vite-plus/test";
 import type { ConnectedEnvironmentSummary } from "../../state/remote-runtime-types";
-import { splitEnvironmentSections } from "./environmentSections";
+import { relayManagedEnvironmentIds, splitEnvironmentSections } from "./environmentSections";
 
 function connectedEnvironment(
   input: Omit<Partial<ConnectedEnvironmentSummary>, "environmentId"> & {
@@ -33,6 +33,17 @@ function cloudEnvironment(environmentId: string): RelayClientEnvironmentRecord {
     linkedAt: "2026-01-01T00:00:00.000Z",
   };
 }
+
+describe("relayManagedEnvironmentIds", () => {
+  it("leaves out a backend that was saved directly", () => {
+    const ids = relayManagedEnvironmentIds([
+      connectedEnvironment({ environmentId: "environment-local", isRelayManaged: false }),
+      connectedEnvironment({ environmentId: "environment-cloud", isRelayManaged: true }),
+    ]);
+
+    expect([...ids]).toEqual([EnvironmentId.make("environment-cloud")]);
+  });
+});
 
 describe("mobile environment settings sections", () => {
   it("keeps saved relay-managed connections under T3 Connect", () => {
@@ -109,6 +120,24 @@ describe("mobile environment settings sections", () => {
 
     expect(sections.connectedCloudEnvironments).toEqual([cloud]);
     expect(sections.availableCloudEnvironments).toEqual([]);
+  });
+
+  it("still offers a cloud environment saved directly as a local backend", () => {
+    const local = connectedEnvironment({
+      environmentId: "environment-cloud",
+      isRelayManaged: false,
+    });
+
+    const sections = splitEnvironmentSections({
+      connectedEnvironments: [local],
+      cloudEnvironments: [cloudEnvironment("environment-cloud")],
+    });
+
+    expect(sections.localEnvironments).toEqual([local]);
+    expect(sections.connectedCloudEnvironments).toEqual([]);
+    expect(
+      sections.availableCloudEnvironments.map((environment) => environment.environmentId),
+    ).toEqual([EnvironmentId.make("environment-cloud")]);
   });
 
   it("keeps failed relay environments in the local connection row", () => {

--- a/apps/mobile/src/features/connection/environmentSections.ts
+++ b/apps/mobile/src/features/connection/environmentSections.ts
@@ -1,3 +1,4 @@
+import type { EnvironmentId } from "@t3tools/contracts";
 import type { RelayClientEnvironmentRecord } from "@t3tools/contracts/relay";
 import type { ConnectedEnvironmentSummary } from "../../state/remote-runtime-types";
 
@@ -12,10 +13,25 @@ export interface EnvironmentSections {
   readonly availableCloudEnvironments: ReadonlyArray<RelayClientEnvironmentRecord>;
 }
 
-export function splitEnvironmentSections(input: EnvironmentSectionsInput): EnvironmentSections {
-  const savedEnvironmentIds = new Set(
-    input.connectedEnvironments.map((environment) => environment.environmentId),
+/**
+ * Ids of the environments that already occupy a T3 Connect slot. A backend saved directly is
+ * not one of them, so it must not suppress the cloud environment that happens to share its id.
+ */
+export function relayManagedEnvironmentIds(
+  environments: ReadonlyArray<{
+    readonly environmentId: EnvironmentId;
+    readonly isRelayManaged: boolean;
+  }>,
+): ReadonlySet<EnvironmentId> {
+  return new Set(
+    environments
+      .filter((environment) => environment.isRelayManaged)
+      .map((environment) => environment.environmentId),
   );
+}
+
+export function splitEnvironmentSections(input: EnvironmentSectionsInput): EnvironmentSections {
+  const savedEnvironmentIds = relayManagedEnvironmentIds(input.connectedEnvironments);
 
   return {
     localEnvironments: input.connectedEnvironments.filter(

--- a/apps/mobile/src/features/connection/useConnectionController.ts
+++ b/apps/mobile/src/features/connection/useConnectionController.ts
@@ -20,6 +20,7 @@ import { useEnvironments } from "../../state/environments";
 import { relayEnvironmentDiscovery } from "../../state/relay";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { projectWorkspaceEnvironment, type WorkspaceEnvironment } from "../../state/workspaceModel";
+import { relayManagedEnvironmentIds } from "./environmentSections";
 
 export interface RelayEnvironmentView {
   readonly environment: RelayClientEnvironmentRecord;
@@ -49,7 +50,7 @@ export function useConnectionController() {
     [environments],
   );
   const registeredIds = useMemo(
-    () => new Set(connectedEnvironments.map((environment) => environment.environmentId)),
+    () => relayManagedEnvironmentIds(connectedEnvironments),
     [connectedEnvironments],
   );
   const relayEnvironments = useMemo<ReadonlyArray<RelayEnvironmentView>>(


### PR DESCRIPTION
## What Changed

On mobile, saving a backend directly made the matching T3 Connect environment disappear from the connection screen. If you added a backend by pairing URL and that backend already existed as a cloud environment, the cloud row for it showed up nowhere: not under T3 Connect as a connected environment, and not in the list of environments still available to add. The only way to get it back was to remove the direct connection.

The cloud list hides anything you have already added, so the same environment is not offered twice. That "already added" set was built from every connected environment, including ones saved directly. A directly-saved backend does not occupy a T3 Connect slot though, so it should not be in that set. It landed there anyway, the cloud row got filtered out as a duplicate, and the bucket that would have shown it (`connectedCloudEnvironments`) only accepts relay-managed entries, so it was dropped there too.

The set is now built from relay-managed environments only. A backend you saved directly still appears as a local connection, and its cloud counterpart stays offered under T3 Connect.

## Why

The same "which ids are already taken" logic existed twice, and both copies were wrong the same way:

- `useConnectionController.registeredIds` — this is the one users see. `CloudEnvironmentRows` reads `availableRelayEnvironments`, which is filtered by this set.
- `splitEnvironmentSections.savedEnvironmentIds` — same defect in the helper that splits the settings screen into sections.

Rather than patch the same condition in two places and let them drift again, this pulls it into one exported `relayManagedEnvironmentIds` helper that both call. That also puts the logic somewhere it can actually be tested: the hook needs atom mocking to exercise directly, the helper is a pure function sitting next to an existing test file.

## UI Changes

n/a - no layout or styling change. The difference is which rows the T3 Connect section lists.

I could not capture a device before/after for this one. Reproducing it on a simulator needs a real T3 Connect account holding an environment whose id also matches a directly-paired backend, which I do not have. The behaviour is covered by unit tests on the shared helper instead, described below.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (see note above)
- [x] I included a video for animation/interaction changes (n/a)

## Verification

```
vp test run apps/mobile/src/features/connection/environmentSections.test.ts   # 7 passed
vp run --filter @t3tools/mobile typecheck                                     # exit 0
vp lint <the three touched files>                                             # clean
vp fmt --check <the three touched files>                                      # clean
```

Reverting the filter inside `relayManagedEnvironmentIds` fails both new tests:

```
FAIL  relayManagedEnvironmentIds > leaves out a backend that was saved directly
      expected [ 'environment-local', …(1) ] to deeply equal [ 'environment-cloud' ]
FAIL  mobile environment settings sections > still offers a cloud environment saved directly as a local backend
      expected [] to deeply equal [ 'environment-cloud' ]
```

The five pre-existing tests in that file pass either way. The one worth calling out is "does not duplicate a saved relay environment in the available cloud listing" — its environment is relay-managed, so it is still in the set and still filtered out. The de-duplication that test protects is unaffected.

Fixes #5242

Implemented with Claude Opus 5 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized mobile connection-list filtering with a shared pure helper and new unit tests; no auth, persistence, or API changes.
> 
> **Overview**
> Fixes a case where pairing a backend directly could make the **same-id T3 Connect environment vanish** from the connection UI: it was neither listed as connected cloud nor as available to add.
> 
> **“Already taken” environment ids** for hiding duplicate cloud rows now come only from **relay-managed** connections, via a shared `relayManagedEnvironmentIds` helper used by `splitEnvironmentSections` and `useConnectionController.registeredIds`. Direct/local backends no longer suppress the matching cloud listing.
> 
> Unit tests cover the helper and the settings-section split when a cloud id is saved only as a local backend.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6213c7e5cc5729e08d2202e8450a1a41b7dcee48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix directly-saved backends hiding their T3 Connect cloud environment in mobile
> Previously, `splitEnvironmentSections` suppressed a cloud environment if any saved backend shared its ID, including locally saved (non-relay-managed) backends. This meant a directly saved backend would hide its corresponding T3 Connect cloud environment.
>
> - Adds `relayManagedEnvironmentIds` in [environmentSections.ts](https://github.com/pingdotgg/t3code/pull/7086/files#diff-dac838c1cb8857a82c19a2bc88f7847567270e0831786997e7b6e2d9f49c802d) to compute only the IDs of relay-managed connections, excluding locally saved backends.
> - Updates `splitEnvironmentSections` to use `relayManagedEnvironmentIds` when filtering available cloud environments, so locally saved backends no longer suppress their cloud counterpart.
> - Updates `useConnectionController` to use `relayManagedEnvironmentIds` for `registeredIds` consistently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6213c7e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->