### PR TITLE
fix(server): check workspace dir before provider spawn

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -99,19 +99,19 @@ describe("ProviderCommandReactor", () => {
   let scope: Scope.Closeable | null = null;
   const createdStateDirs = new Set<string>();
   const createdBaseDirs = new Set<string>();
+  // Per-run workspace dirs so concurrent test runs don't race on the same path.
+  // The reactor's existence guard checks these before starting a provider session.
+  let workspaceRoot = "";
+  let workspaceWorktree = "";
 
-  // The workspace existence guard in ProviderCommandReactor checks that the
-  // project's workspaceRoot exists on disk before starting a provider session.
-  // Create the paths the suite uses once for the whole run.
-  const WORKSPACE_ROOT = "/tmp/provider-project";
-  const WORKSPACE_WORKTREE = "/tmp/provider-project-worktree";
   beforeAll(() => {
-    NodeFS.mkdirSync(WORKSPACE_ROOT, { recursive: true });
-    NodeFS.mkdirSync(WORKSPACE_WORKTREE, { recursive: true });
+    workspaceRoot = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3code-ws-"));
+    workspaceWorktree = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3code-wt-"));
   });
+
   afterAll(() => {
-    NodeFS.rmSync(WORKSPACE_ROOT, { recursive: true, force: true });
-    NodeFS.rmSync(WORKSPACE_WORKTREE, { recursive: true, force: true });
+    NodeFS.rmSync(workspaceRoot, { recursive: true, force: true });
+    NodeFS.rmSync(workspaceWorktree, { recursive: true, force: true });
   });
 
   afterEach(async () => {
@@ -444,7 +444,7 @@ describe("ProviderCommandReactor", () => {
         commandId: CommandId.make("cmd-project-create"),
         projectId: asProjectId("project-1"),
         title: "Provider Project",
-        workspaceRoot: input?.workspaceRoot ?? "/tmp/provider-project",
+        workspaceRoot: input?.workspaceRoot ?? workspaceRoot,
         defaultModelSelection: modelSelection,
         createdAt: now,
       }),
@@ -552,7 +552,7 @@ describe("ProviderCommandReactor", () => {
     await waitFor(() => harness.sendTurn.mock.calls.length === 1);
     expect(harness.startSession.mock.calls[0]?.[0]).toEqual(ThreadId.make("thread-1"));
     expect(harness.startSession.mock.calls[0]?.[1]).toMatchObject({
-      cwd: "/tmp/provider-project",
+      cwd: workspaceRoot,
       modelSelection: {
         instanceId: ProviderInstanceId.make("codex"),
         model: "gpt-5-codex",
@@ -680,7 +680,7 @@ describe("ProviderCommandReactor", () => {
   effectIt.effect("rejects a turn when the workspace directory no longer exists", () =>
     Effect.gen(function* () {
       const harness = yield* Effect.promise(() =>
-        createHarness({ workspaceRoot: "/tmp/provider-project-missing" }),
+        createHarness({ workspaceRoot: "/tmp/t3code-definitely-missing-" + process.pid }),
       );
       const now = "2026-01-01T00:00:00.000Z";
 
@@ -828,7 +828,7 @@ describe("ProviderCommandReactor", () => {
 
     expect(harness.generateThreadTitle).toHaveBeenCalledTimes(1);
     expect(harness.generateThreadTitle.mock.calls[0]?.[0]).toMatchObject({
-      cwd: "/tmp/provider-project",
+      cwd: workspaceRoot,
       previousTitle: "Investigate reconnect regressions",
       message: [
         "USER:",
@@ -1519,7 +1519,7 @@ describe("ProviderCommandReactor", () => {
         commandId: CommandId.make("cmd-thread-branch"),
         threadId: ThreadId.make("thread-1"),
         branch: "t3code/1234abcd",
-        worktreePath: "/tmp/provider-project-worktree",
+        worktreePath: workspaceWorktree,
       }),
     );
 
@@ -1560,7 +1560,7 @@ describe("ProviderCommandReactor", () => {
     expect(harness.generateBranchName.mock.calls[0]?.[0]).toMatchObject({
       message: "Add a safer reconnect backoff.",
     });
-    expect(harness.refreshStatus.mock.calls[0]?.[0]).toBe("/tmp/provider-project-worktree");
+    expect(harness.refreshStatus.mock.calls[0]?.[0]).toBe(workspaceWorktree);
   });
 
   it("forwards codex model options through session start and turn send", async () => {
@@ -2053,7 +2053,7 @@ describe("ProviderCommandReactor", () => {
     await waitFor(() => harness.startSession.mock.calls.length === 1);
     await waitFor(() => harness.sendTurn.mock.calls.length === 1);
     expect(harness.startSession.mock.calls[0]?.[1]).toMatchObject({
-      cwd: "/tmp/provider-project",
+      cwd: workspaceRoot,
     });
 
     await Effect.runPromise(
@@ -2061,7 +2061,7 @@ describe("ProviderCommandReactor", () => {
         type: "thread.meta.update",
         commandId: CommandId.make("cmd-thread-worktree-change"),
         threadId: ThreadId.make("thread-1"),
-        worktreePath: "/tmp/provider-project-worktree",
+        worktreePath: workspaceWorktree,
       }),
     );
 
@@ -2087,7 +2087,7 @@ describe("ProviderCommandReactor", () => {
     expect(harness.stopSession.mock.calls.length).toBe(0);
     expect(harness.startSession.mock.calls[1]?.[1]).toMatchObject({
       threadId: ThreadId.make("thread-1"),
-      cwd: "/tmp/provider-project-worktree",
+      cwd: workspaceWorktree,
       resumeCursor: { opaque: "resume-1" },
       modelSelection: {
         instanceId: ProviderInstanceId.make("claudeAgent"),
@@ -2620,7 +2620,7 @@ describe("ProviderCommandReactor", () => {
       status: "ready",
       runtimeMode: "approval-required",
       threadId: ThreadId.make("thread-1"),
-      cwd: "/tmp/provider-project",
+      cwd: workspaceRoot,
       resumeCursor: { opaque: "resume-without-instance" },
       createdAt: now,
       updatedAt: now,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -30,7 +30,7 @@ import * as PubSub from "effect/PubSub";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import { it as effectIt } from "@effect/vitest";
-import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 
 import { deriveServerPaths, ServerConfig } from "../../config.ts";
 import { TextGenerationError } from "@t3tools/contracts";
@@ -100,6 +100,20 @@ describe("ProviderCommandReactor", () => {
   const createdStateDirs = new Set<string>();
   const createdBaseDirs = new Set<string>();
 
+  // The workspace existence guard in ProviderCommandReactor checks that the
+  // project's workspaceRoot exists on disk before starting a provider session.
+  // Create the paths the suite uses once for the whole run.
+  const WORKSPACE_ROOT = "/tmp/provider-project";
+  const WORKSPACE_WORKTREE = "/tmp/provider-project-worktree";
+  beforeAll(() => {
+    NodeFS.mkdirSync(WORKSPACE_ROOT, { recursive: true });
+    NodeFS.mkdirSync(WORKSPACE_WORKTREE, { recursive: true });
+  });
+  afterAll(() => {
+    NodeFS.rmSync(WORKSPACE_ROOT, { recursive: true, force: true });
+    NodeFS.rmSync(WORKSPACE_WORKTREE, { recursive: true, force: true });
+  });
+
   afterEach(async () => {
     if (scope) {
       await Effect.runPromise(Scope.close(scope, Exit.void));
@@ -145,6 +159,7 @@ describe("ProviderCommandReactor", () => {
 
   async function createHarness(input?: {
     readonly baseDir?: string;
+    readonly workspaceRoot?: string;
     readonly threadModelSelection?: ModelSelection;
     readonly sessionModelSwitch?: "unsupported" | "in-session";
     readonly requiresNewThreadForModelChange?: boolean;
@@ -429,7 +444,7 @@ describe("ProviderCommandReactor", () => {
         commandId: CommandId.make("cmd-project-create"),
         projectId: asProjectId("project-1"),
         title: "Provider Project",
-        workspaceRoot: "/tmp/provider-project",
+        workspaceRoot: input?.workspaceRoot ?? "/tmp/provider-project",
         defaultModelSelection: modelSelection,
         createdAt: now,
       }),
@@ -659,6 +674,44 @@ describe("ProviderCommandReactor", () => {
       thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
       expect(thread?.session?.status).toBe("starting");
       expect(thread?.session?.lastError).toBeNull();
+    }),
+  );
+
+  effectIt.effect("rejects a turn when the workspace directory no longer exists", () =>
+    Effect.gen(function* () {
+      const harness = yield* Effect.promise(() =>
+        createHarness({ workspaceRoot: "/tmp/provider-project-missing" }),
+      );
+      const now = "2026-01-01T00:00:00.000Z";
+
+      yield* harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-missing-workspace"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-missing-workspace"),
+          role: "user",
+          text: "hello",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      });
+
+      yield* Effect.promise(() =>
+        waitFor(async () => {
+          const readModel = await harness.readModel();
+          return (
+            readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"))?.session
+              ?.status === "error"
+          );
+        }),
+      );
+      const readModel = yield* Effect.promise(() => harness.readModel());
+      const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+      expect(thread?.session?.lastError).toContain("no longer exists");
+      expect(harness.startSession).not.toHaveBeenCalled();
     }),
   );
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -19,6 +19,7 @@ import * as Crypto from "effect/Crypto";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Equal from "effect/Equal";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
@@ -604,6 +605,18 @@ const make = Effect.gen(function* () {
       thread,
       projects: project ? [project] : [],
     });
+
+    if (effectiveCwd) {
+      const fs = yield* FileSystem.FileSystem;
+      const exists = yield* fs.exists(effectiveCwd).pipe(Effect.orElseSucceed(() => false));
+      if (!exists) {
+        return yield* new ProviderAdapterRequestError({
+          provider: preferredProvider,
+          method: "thread.turn.start",
+          detail: `Workspace directory '${effectiveCwd}' no longer exists. Has it been moved or renamed? Update the project's workspace root in Settings to point at the new location.`,
+        });
+      }
+    }
 
     const startProviderSession = (input?: {
       readonly resumeCursor?: unknown;

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -608,12 +608,27 @@ const make = Effect.gen(function* () {
 
     if (effectiveCwd) {
       const fs = yield* FileSystem.FileSystem;
-      const exists = yield* fs.exists(effectiveCwd).pipe(Effect.orElseSucceed(() => false));
-      if (!exists) {
+      const stat = yield* fs.stat(effectiveCwd).pipe(
+        Effect.catchTags({
+          PlatformError: (cause) =>
+            cause.reason._tag === "NotFound"
+              ? Effect.succeed(null)
+              : new ProviderAdapterRequestError({
+                  provider: preferredProvider,
+                  method: "thread.turn.start",
+                  detail: `Could not access workspace directory '${effectiveCwd}': ${cause.reason._tag}`,
+                  cause,
+                }),
+        }),
+      );
+      if (stat === null || stat.type !== "Directory") {
+        const isWorktree = thread.worktreePath != null;
         return yield* new ProviderAdapterRequestError({
           provider: preferredProvider,
           method: "thread.turn.start",
-          detail: `Workspace directory '${effectiveCwd}' no longer exists. Has it been moved or renamed? Update the project's workspace root in Settings to point at the new location.`,
+          detail: isWorktree
+            ? `Worktree directory '${effectiveCwd}' no longer exists. It may have been cleaned up — start a new thread or recreate the worktree to continue.`
+            : `Workspace directory '${effectiveCwd}' no longer exists. Has it been moved or renamed? Update the project's workspace root in Settings to point at the new location.`,
         });
       }
     }


### PR DESCRIPTION
## What Changed

- Check if the effective cwd exists before starting a provider session in `ProviderCommandReactor`.

## Why

When a project's workspace root is renamed or moved outside T3 Code, starting a turn passed the stale path to the provider CLI, which failed with a confusing error (e.g. "Claude Code native binary not found") instead of telling the user the directory is gone. Now it returns a clear error with the path and remediation steps.

Closes #6622.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized guard on the turn-start path before provider spawn; behavior change is fail-fast with clearer errors rather than altered auth or data handling.
> 
> **Overview**
> **Turn starts now fail fast** when the resolved workspace or worktree path is missing or not a directory, instead of handing a stale `cwd` to the provider CLI and surfacing misleading errors.
> 
> In `ProviderCommandReactor`, `ensureSessionForThread` stats `effectiveCwd` before `startSession`. Missing paths yield a `ProviderAdapterRequestError` on `thread.turn.start` with worktree-specific vs project-root remediation text; other filesystem errors are wrapped similarly.
> 
> Tests use per-run temp workspace/worktree directories (so the existence guard is realistic under parallel runs) and add coverage that a missing workspace sets session **error** with a “no longer exists” message and never calls `startSession`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f49bdd15eaf28e9dd0aeee50244fe192084b958f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject `thread.turn.start` when workspace directory does not exist before provider spawn
> Before starting a provider session, `ProviderCommandReactor` now checks that the resolved workspace/worktree directory exists and is a directory. If the path is missing or not a directory, the turn is rejected with a `ProviderAdapterRequestError` and the provider session is never started. The error message distinguishes between worktree and workspace contexts.
> - Risk: existing flows where the workspace directory may have been silently missing will now surface an explicit error instead of proceeding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f49bdd1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->