### PR TITLE
fix(server): enable the Cursor provider by default like every other provider

### DIFF
--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -134,6 +134,14 @@ describe("ServerSettings.providerInstances (slice-2 invariant)", () => {
     expect(decoded.providers.codex.enabled).toBe(true);
   });
 
+  it("enables every built-in provider by default", () => {
+    const decoded = decodeServerSettings({});
+    expect(decoded.providers.cursor.enabled).toBe(true);
+    expect(decoded.providers.claudeAgent.enabled).toBe(true);
+    expect(decoded.providers.grok.enabled).toBe(true);
+    expect(decoded.providers.opencode.enabled).toBe(true);
+  });
+
   it("decodes a multi-instance map mixing first-party and fork drivers", () => {
     const decoded = decodeServerSettings({
       providerInstances: {

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -369,7 +369,7 @@ export type ClaudeSettings = typeof ClaudeSettings.Type;
 export const CursorSettings = makeProviderSettingsSchema(
   {
     enabled: Schema.Boolean.pipe(
-      Schema.withDecodingDefault(Effect.succeed(false)),
+      Schema.withDecodingDefault(Effect.succeed(true)),
       Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
     ),
     binaryPath: makeBinaryPathSetting("cursor-agent").pipe(


### PR DESCRIPTION
## What Changed

Cursor never showed up in the provider list when starting a thread, even with `cursor-agent` installed and showing as available in Settings. There was no way to fix it from the app.

Every provider has an internal `enabled` flag. Cursor's decoding default was `false`; Codex, Claude, Grok and OpenCode all default to `true`. The provider picker skips anything that is not enabled:

```ts
if (!provider.enabled || !provider.installed || provider.auth.status === "unauthenticated") {
  continue;
}
```

`enabled` is separate from install detection, which is why Settings and the picker disagreed. Settings reported Cursor as available because the binary was found, and the picker dropped it because the flag was false.

The flag is annotated `providerSettingsForm: { hidden: true }` for all five providers, so it is not rendered as a toggle. That is fine when the default is right, but it meant a user could not turn Cursor on. Short of hand-editing the settings JSON, the provider was unreachable.

Cursor's default is now `true`, matching the other four.

## Why

I looked for a reason the default might be deliberate and did not find one:

- No feature flag, allowlist, experimental gate, or migration writes `enabled` for Cursor.
- No comment near the schema explains the difference.
- Nothing in the codebase treats Cursor as unreleased. It has a full provider and adapter, ACP support, its own text-generation module, and sizeable test suites.
- The `hidden: true` annotation is identical on all five providers, so Cursor is not being singled out there either.

A provider held back on purpose would expose the toggle, or leave a flag or a note. A hidden switch defaulted off with no way to reach it reads as an oversight, and the reported symptom is exactly what that produces.

Two things worth confirming, since this is a default that ships to everyone:

- **Users who already turned Cursor off are unaffected.** An explicit `enabled: false` in the on-disk settings still wins; a decoding default only applies when the key is absent.
- **Users without `cursor-agent` are unaffected.** `CursorProvider.ts:84` checks `enabled` before probing, and the missing-binary path is the same one Claude and Grok already take (`CursorProvider.ts:1031` mirrors `ClaudeProvider.ts:844` and `GrokProvider.ts:204`). Enabled without installed is not a selectable provider, it is just a probe that reports not-installed, which the other four already do.

If Cursor is off by default for a reason that does not live in the repo, this is the wrong change and I am happy to close it.

## UI Changes

n/a - no layout or styling change. Cursor now appears in the provider picker for users who have it installed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (n/a, see above)
- [x] I included a video for animation/interaction changes (n/a)

## Verification

```
vp test run packages/contracts/src/settings.test.ts                              # 33 passed
vp test run apps/server/src/provider/Layers/ProviderRegistry.test.ts             # 44 passed
vp test run apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts #  3 passed
vp test run apps/server/src/provider/Layers/CursorProvider.test.ts               # 23 passed
vp run --filter @t3tools/contracts typecheck                                     # exit 0
vp lint / vp fmt --check on both touched files                                   # clean
```

Putting the `false` back fails the new test:

```
FAIL  packages/contracts/src/settings.test.ts > enables every built-in provider by default
AssertionError: expected false to be true
```

I checked the tests that assert Cursor is disabled rather than assuming they were fine. `ProviderRegistry.test.ts` ("keeps cursor disabled and skips probing when the provider setting is disabled") sets `cursor: { enabled: false }` in its own fixture rather than leaning on the default, so it still passes and still covers the disabled path.

The new test covers all four other providers as well as Cursor. That is deliberate: the invariant being restored is that every built-in provider is enabled by default, and asserting it for one provider would not have caught this.

Fixes #5334

Implemented with Claude Opus 5 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single schema default change with a regression test; explicit disabled settings and missing-binary behavior are unchanged.
> 
> **Overview**
> **Fixes Cursor missing from the thread provider picker** when `cursor-agent` is installed. The hidden `providers.cursor.enabled` decoding default was `false` while Codex, Claude, Grok, and OpenCode default to `true`, so the picker filtered Cursor out even though Settings could show it as available.
> 
> `CursorSettings.enabled` now uses `Schema.withDecodingDefault(Effect.succeed(true))`, aligning with the other built-in providers. A contract test decodes empty `ServerSettings` and asserts every built-in provider’s `enabled` is `true`.
> 
> Explicit `enabled: false` on disk is unchanged. Users without the binary still won’t get a selectable provider—only the default when the key is absent changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07d694422fa22481d82b7a6d66602a59b2ba39ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable the Cursor provider by default in server settings
> Changes `CursorSettings.enabled` default from `false` to `true` in [settings.ts](https://github.com/pingdotgg/t3code/pull/7089/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c), matching the behavior of all other built-in providers. A test is added to assert that Cursor, claudeAgent, Grok, and opencode are all enabled when decoding an empty settings object. Risk: existing users who omitted `cursor.enabled` from their config will now have the Cursor provider active.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07d6944.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->