### PR TITLE
fix(web): indent auto-settle inactivity setting

### DIFF
--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1890,6 +1890,7 @@ export function GeneralSettingsPanel() {
         />
         {settings.sidebarAutoSettleAfterDays !== null ? (
           <SettingsRow
+            className="bg-muted/20 sm:pl-9"
             title="Days of inactivity before auto-settle"
             description="Any new activity un-settles a thread automatically."
             control={


### PR DESCRIPTION
## What changed

- Styled “Days of inactivity before auto-settle” as a child of “Auto-settle inactive threads”.
- Reused the same indentation and muted background treatment as “Start from origin”.

## Why

The inactivity-days control depends on the auto-settle toggle, but it used the default settings-row styling, making it appear as an unrelated top-level option.

## Impact

The General settings hierarchy is now visually clear and consistent with the existing New threads child setting.

## Validation

- `corepack pnpm --filter @t3tools/web typecheck`
- `git diff --check`

Prettier was not available as a repository command.

Generated with GPT-5.6 in Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Indent the "Days of inactivity before auto-settle" settings row
> Adds `bg-muted/20 sm:pl-9` CSS classes to the auto-settle inactivity `SettingsRow` in [SettingsPanels.tsx](https://github.com/pingdotgg/t3code/pull/7093/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18), visually indenting it under its parent setting on small screens.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 82605e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS class addition on a settings row; no logic, data, or API changes.
> 
> **Overview**
> The **Days of inactivity before auto-settle** row in General settings now uses the same child-row styling as **Start from origin** under New threads: `bg-muted/20` and `sm:pl-9` on its `SettingsRow`.
> 
> That row only appears when **Auto-settle inactive threads** is on; the change is visual only and does not alter behavior or settings values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82605e3aae316532d4eacb2524e08d8595285e6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Closes #7251