### PR TITLE
fix(web): remember the right panel width per thread

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -141,6 +141,7 @@ import { closePreviewSession } from "./preview/closePreviewSession";
 import { ThreadPreviewMiniPlayer } from "./preview/ThreadPreviewMiniPlayer";
 import { subscribePreviewAction } from "./preview/previewActionBus";
 import { getConfiguredPreviewUrls } from "./preview/previewEmptyStateLogic";
+import { rightPanelWidthStorageKey } from "./preview/rightPanelWidthStorageKey";
 import { makeWorkspaceFileDropHandlers } from "./chat/workspaceFileDrop";
 import {
   selectThreadPreviewMiniPlayer,
@@ -6623,6 +6624,9 @@ function ChatViewContent(props: ChatViewProps) {
         <RightPanelTabs
           mode="inline"
           maximized={rightPanelMaximized}
+          {...(activeThreadKey
+            ? { widthStorageKey: rightPanelWidthStorageKey(activeThreadKey) }
+            : {})}
           surfaces={rightPanelState.surfaces}
           activeSurfaceId={activeRightPanelSurface?.id ?? null}
           pendingSurfaceIds={pendingFileSurfaceIds}

--- a/apps/web/src/components/preview/rightPanelWidthStorageKey.test.ts
+++ b/apps/web/src/components/preview/rightPanelWidthStorageKey.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { rightPanelWidthStorageKey } from "./rightPanelWidthStorageKey";
+
+describe("rightPanelWidthStorageKey", () => {
+  it("gives two threads separate keys so one resize does not move the other", () => {
+    const threadA = rightPanelWidthStorageKey("local/thread-a");
+    const threadB = rightPanelWidthStorageKey("local/thread-b");
+
+    expect(threadA).not.toBe(threadB);
+  });
+
+  it("returns the same key for the same thread so the width survives a reload", () => {
+    expect(rightPanelWidthStorageKey("local/thread-a")).toBe(
+      rightPanelWidthStorageKey("local/thread-a"),
+    );
+  });
+
+  it("stays under the shared preview-panel prefix", () => {
+    expect(rightPanelWidthStorageKey("local/thread-a")).toBe(
+      "t3code:preview-panel-width:local/thread-a",
+    );
+  });
+});

--- a/apps/web/src/components/preview/rightPanelWidthStorageKey.ts
+++ b/apps/web/src/components/preview/rightPanelWidthStorageKey.ts
@@ -1,0 +1,8 @@
+/**
+ * Scopes the remembered right-panel width to one thread. Without a thread in the
+ * key every thread reads and writes the same width, so resizing the panel in one
+ * thread resizes it in all of them.
+ */
+export function rightPanelWidthStorageKey(threadKey: string): string {
+  return `t3code:preview-panel-width:${threadKey}`;
+}


### PR DESCRIPTION
## What Changed

Resizing the right panel in one thread resized it in every other thread. Make it narrow in thread A, switch to thread B and pull it wide, come back to A, and A is now wide too. Threads that want different layouts (a wide diff in one, a narrow terminal in another) fight over one width.

The panel width is persisted in browser storage, and the key had no thread in it, so every thread read and wrote the same entry.

The key is now scoped to the thread. Each thread remembers its own width, it survives a reload, and a thread that has never been resized still gets the default.

## Why

`PreviewPanelShell` already supports this. It takes an optional `widthStorageKey` and falls back to the shared one:

```ts
storageKey: props.widthStorageKey ?? PREVIEW_PANEL_WIDTH_STORAGE_KEY,
```

Its own comment explains the intent: "Callers embedding this shell for a different surface (e.g. the pull requests page) should pass their own key so resizing one panel doesn't clobber the other's remembered width." The pull requests page does exactly that with `widthStorageKey="t3code:pull-request-panel-width"`.

The chat view never passed one, so it kept the shared default. This passes a per-thread key, using `activeThreadKey`, the same scoped key the right panel already uses for its surface state (`byThreadKey`). That keeps width consistent with everything else remembered per thread.

The key builder is a small module of its own rather than an inline template string, so it can be unit tested. The panel itself needs a rendered chat view to exercise, and this directory already keeps its small logic in tested modules next to the components (`previewAutomationClientId.ts`, `fileExplorerLabel.ts`, `addBrowserSurface.ts`).

Only the inline panel is touched. The sheet presentation does not use a resizable width - `PreviewPanelShell` applies `width` only when `isInline && !maximized` - so there is nothing to scope there.

## UI Changes

n/a - no layout or styling change. The panel is the same panel at the same default width; it just stops overwriting other threads' widths.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (n/a, see above)
- [x] I included a video for animation/interaction changes (n/a)

## Verification

```
vp test run apps/web/src/components/preview/rightPanelWidthStorageKey.test.ts   # 3 passed
vp fmt --check <the three touched files>                                        # clean
```

The three tests cover what the report asks for: two threads get different keys, the same thread gets a stable key across calls (so the width survives a reload), and the key stays under the existing `t3code:preview-panel-width` prefix.

One thing I could not run, so I am flagging it rather than claiming it: a full `@t3tools/web` typecheck. My checkout is behind `main` on several unrelated files, so `tsgo` reports errors for symbols that exist upstream but not locally, none of them on the lines this PR changes. What I did verify against current `main`: `activeThreadKey` is in scope at the call site, `RightPanelTabs.tsx` is byte-identical to `main` so its `widthStorageKey?: string` prop is current, and `PreviewPanelShell.tsx` still reads `props.widthStorageKey ?? PREVIEW_PANEL_WIDTH_STORAGE_KEY`. The diff against `main` is 4 added lines in `ChatView.tsx` and one new module, with no deletions. CI will be the real check on the full typecheck.

Fixes #5548

Implemented with Claude Opus 5 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI persistence change with no auth, data, or API impact; only affects which localStorage key stores panel width.
> 
> **Overview**
> **Fixes shared right-panel width across chat threads** by persisting resize width per thread instead of one global `localStorage` entry.
> 
> `ChatView` now passes `widthStorageKey: rightPanelWidthStorageKey(activeThreadKey)` into inline `RightPanelTabs`, which forwards it to `PreviewPanelShell` (same pattern as the pull-requests page). A small `rightPanelWidthStorageKey` helper builds keys like `t3code:preview-panel-width:<threadKey>`; unit tests cover per-thread isolation, stability on reload, and the storage prefix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31f36345eb8951a8f205cca10ab131a5669eb332. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remember right panel width per thread in ChatView
> The right panel width is now stored and restored per thread rather than globally. A new `rightPanelWidthStorageKey` utility generates a namespaced localStorage key (`t3code:preview-panel-width:<threadKey>`) for each thread, passed to `RightPanelTabs` via `widthStorageKey` when `activeThreadKey` is defined.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 31f3634. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->