### PR TITLE
fix(server): include archived Codex sessions in usage totals

### DIFF
--- a/apps/server/src/provider/Drivers/CodexHomeLayout.ts
+++ b/apps/server/src/provider/Drivers/CodexHomeLayout.ts
@@ -29,6 +29,17 @@ const KNOWN_SHARED_DIRECTORIES = [
   "mcp-oauth-locks",
 ] as const;
 
+/**
+ * Shared directories holding rollout transcripts. Codex moves a rollout from
+ * `sessions` to `archived_sessions` when it archives it, so anything reading
+ * usage has to walk both or the rollout drops out of the totals on archive.
+ *
+ * Order decides reporting, not totals. A rollout under both roots is claimed by
+ * whichever is walked first, so the live root owns it in the per-source file and
+ * session counts; the summed totals are the same either way.
+ */
+export const CODEX_TRANSCRIPT_DIRECTORIES = ["sessions", "archived_sessions"] as const;
+
 const PRIVATE_ENTRY_NAMES = new Set(["auth.json", "models_cache.json"]);
 const SHADOW_LOCAL_ENTRY_NAMES = new Set(["log", "memories", "tmp"]);
 const REPLACEABLE_SHARED_RUNTIME_DIRECTORIES = new Set(["mcp-oauth-locks"]);

--- a/apps/server/src/usage/UsageService.test.ts
+++ b/apps/server/src/usage/UsageService.test.ts
@@ -7,7 +7,7 @@ import * as NodePath from "node:path";
 import { assert, describe, it } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
-import { UsageDay, type UsageSummaryInput } from "@t3tools/contracts";
+import { UsageDay, type UsageSummaryInput, type UsageTokenTotals } from "@t3tools/contracts";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
@@ -20,6 +20,7 @@ import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 import * as ServerConfig from "../config.ts";
 import * as ServerSettings from "../serverSettings.ts";
 import * as UsageService from "./UsageService.ts";
+import * as usageTranscripts from "./usageTranscripts.ts";
 
 function claudeLine(id: number, outputTokens: number): string {
   return `${JSON.stringify({
@@ -34,6 +35,49 @@ function claudeLine(id: number, outputTokens: number): string {
     },
   })}\n`;
 }
+
+/** Shaped after a real Codex rollout: session_meta, turn_context, then a token delta. */
+function codexLines(input: {
+  sessionId: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+}): string {
+  const sessionMeta = JSON.stringify({
+    type: "session_meta",
+    timestamp: "2026-08-01T10:00:00Z",
+    payload: { type: "session_meta", id: input.sessionId },
+  });
+  const turnContext = JSON.stringify({
+    type: "turn_context",
+    timestamp: "2026-08-01T10:00:01Z",
+    payload: { type: "turn_context", model: input.model },
+  });
+  const tokenCount = JSON.stringify({
+    type: "event_msg",
+    timestamp: "2026-08-01T10:00:02Z",
+    payload: {
+      type: "token_count",
+      info: {
+        last_token_usage: {
+          input_tokens: input.inputTokens,
+          cached_input_tokens: 0,
+          cache_write_input_tokens: 0,
+          output_tokens: input.outputTokens,
+          reasoning_output_tokens: 0,
+        },
+      },
+    },
+  });
+  return `${sessionMeta}\n${turnContext}\n${tokenCount}\n`;
+}
+
+const CODEX_MODEL = "gpt-5.6-sol";
+
+/** Rates for `CODEX_MODEL`, so archived tokens can be asserted as priced. */
+const CODEX_RATES = {
+  [CODEX_MODEL]: { input_cost_per_token: 1e-6, output_cost_per_token: 1e-5 },
+};
 
 const WINDOW: UsageSummaryInput = {
   timeZone: "UTC",
@@ -93,6 +137,13 @@ const serviceLayers = (input: {
 
 function totalOutputTokens(summary: { buckets: readonly { totals: { outputTokens: number } }[] }) {
   return summary.buckets.reduce((sum, bucket) => sum + bucket.totals.outputTokens, 0);
+}
+
+function totalTokens(summary: { buckets: readonly { totals: UsageTokenTotals }[] }) {
+  return summary.buckets.reduce(
+    (sum, bucket) => sum + usageTranscripts.totalTokens(bucket.totals),
+    0,
+  );
 }
 
 describe("UsageService", () => {
@@ -186,6 +237,158 @@ describe("UsageService", () => {
       assert.strictEqual(refreshed.status, "fresh");
       assert.strictEqual(refreshed.knownModels, 1);
     }).pipe(Effect.scoped, Effect.provide(TestClock.layer())),
+  );
+
+  it.live("counts usage rotated into Codex's archived_sessions directory", () =>
+    Effect.gen(function* () {
+      const { settings, home } = yield* setup;
+      const codexHome = NodePath.join(home, "codex");
+      const liveDir = NodePath.join(codexHome, "sessions", "2026", "08", "01");
+      // Codex nests live rollouts under `YYYY/MM/DD` but writes the archive flat.
+      const archivedDir = NodePath.join(codexHome, "archived_sessions");
+      yield* Effect.promise(() => NodeFSP.mkdir(liveDir, { recursive: true }));
+      yield* Effect.promise(() => NodeFSP.mkdir(archivedDir, { recursive: true }));
+
+      const rollout = (n: number) => `rollout-00000000-0000-0000-0000-00000000000${n}.jsonl`;
+      const write = (dir: string, name: string, contents: string) =>
+        Effect.promise(() => NodeFSP.writeFile(NodePath.join(dir, name), contents));
+
+      // A rollout Codex has not archived yet.
+      yield* write(
+        liveDir,
+        rollout(1),
+        codexLines({
+          sessionId: "live-session-1",
+          model: CODEX_MODEL,
+          inputTokens: 1000,
+          outputTokens: 100,
+        }),
+      );
+      // A rollout that has aged into the archive. Invisible before this fix.
+      yield* write(
+        archivedDir,
+        rollout(2),
+        codexLines({
+          sessionId: "archived-session-1",
+          model: CODEX_MODEL,
+          inputTokens: 2000,
+          outputTokens: 200,
+        }),
+      );
+      // The same rollout under both roots: counted once, not twice.
+      const shared = codexLines({
+        sessionId: "shared-session-1",
+        model: CODEX_MODEL,
+        inputTokens: 4000,
+        outputTokens: 400,
+      });
+      yield* write(liveDir, rollout(3), shared);
+      yield* write(archivedDir, rollout(3), shared);
+      // A rollout that reads empty under `sessions` - how one moved out
+      // mid-scan looks - whose records are in the archive. The empty read must
+      // not claim the basename and drop the copy that has the usage.
+      yield* write(liveDir, rollout(4), "");
+      yield* write(
+        archivedDir,
+        rollout(4),
+        codexLines({
+          sessionId: "moved-session-1",
+          model: CODEX_MODEL,
+          inputTokens: 8000,
+          outputTokens: 800,
+        }),
+      );
+
+      const service = yield* UsageService.make.pipe(
+        Effect.provide(
+          serviceLayers({
+            prefix: "usage-service-archived-test",
+            home,
+            settings,
+            ratesDocument: CODEX_RATES,
+          }),
+        ),
+      );
+
+      const summary = yield* service.readSummary(WINDOW);
+
+      // 100 + 200 + 400 (shared, once) + 800 (moved) = 1500. Double counting
+      // the shared rollout gives 1900; dropping the moved one gives 700.
+      assert.strictEqual(totalOutputTokens(summary), 1500);
+      assert.strictEqual(totalTokens(summary), 16500);
+
+      // Archived tokens are priced, not carried as unpriced volume.
+      const codexBuckets = summary.buckets.filter((bucket) => bucket.provider === "codex");
+      assert.isAbove(codexBuckets.length, 0);
+      for (const bucket of codexBuckets) {
+        assert.strictEqual(bucket.costSource, "modelPriced");
+        assert.strictEqual(bucket.unpricedRecords, 0);
+      }
+      assert.isAbove(
+        codexBuckets.reduce((sum, bucket) => sum + bucket.costUsd, 0),
+        0,
+      );
+
+      const codexSources = summary.sources.filter(
+        (source) => source.fingerprint.provider === "codex",
+      );
+      assert.deepStrictEqual(
+        codexSources.map((source) => source.fingerprint.resolvedHomePath).sort(),
+        [archivedDir, NodePath.join(codexHome, "sessions")].sort(),
+      );
+
+      const archivedSource = codexSources.find(
+        (source) => source.fingerprint.resolvedHomePath === archivedDir,
+      );
+      assert.isDefined(archivedSource);
+      assert.strictEqual(archivedSource?.status, "ok");
+      // The archived-only rollout and the moved one; the shared duplicate is not a session here.
+      assert.strictEqual(archivedSource?.distinctSessions, 2);
+
+      // Six files on disk, four counted: the duplicate basename in the archive
+      // and the empty live copy of the moved rollout are skipped.
+      assert.strictEqual(
+        codexSources.reduce((sum, source) => sum + source.scannedFiles, 0),
+        4,
+      );
+      assert.strictEqual(
+        codexSources.reduce((sum, source) => sum + source.skippedFiles, 0),
+        2,
+      );
+    }).pipe(Effect.scoped),
+  );
+
+  it.live("keeps Claude transcripts that share a basename across projects", () =>
+    Effect.gen(function* () {
+      // The Codex rollout dedupe keys on basename alone, which is a Codex fact:
+      // rollout names embed a UUID. Claude nests transcripts per project, so the
+      // same basename under two projects is two different files and both have to
+      // be read. Widening the dedupe past Codex silently drops the second one.
+      const { transcript, settings, home } = yield* setup;
+      yield* Effect.promise(() => NodeFSP.writeFile(transcript, claudeLine(1, 5)));
+      const otherProject = NodePath.join(home, "claude", "projects", "proj-b");
+      yield* Effect.promise(() => NodeFSP.mkdir(otherProject, { recursive: true }));
+      yield* Effect.promise(() =>
+        // Same basename as `transcript`, different project directory.
+        NodeFSP.writeFile(NodePath.join(otherProject, "session.jsonl"), claudeLine(2, 7)),
+      );
+
+      const service = yield* UsageService.make.pipe(
+        Effect.provide(
+          serviceLayers({ prefix: "usage-service-claude-basename-test", home, settings }),
+        ),
+      );
+
+      const summary = yield* service.readSummary(WINDOW);
+      // Both files counted. Deduping Claude by basename would report only 5.
+      assert.strictEqual(totalOutputTokens(summary), 12);
+
+      const claudeSource = summary.sources.find(
+        (source) => source.fingerprint.provider === "claude",
+      );
+      assert.strictEqual(claudeSource?.scannedFiles, 2);
+      assert.strictEqual(claudeSource?.skippedFiles, 0);
+    }).pipe(Effect.scoped),
   );
 
   it.live("does not orphan an in-flight scan when its first caller is interrupted", () =>

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -42,7 +42,10 @@ import { ServerConfig } from "../config.ts";
 import { expandHomePath } from "../pathExpansion.ts";
 import * as ServerSettings from "../serverSettings.ts";
 import { resolveClaudeHomePath } from "../provider/Drivers/ClaudeHome.ts";
-import { resolveCodexHomeLayout } from "../provider/Drivers/CodexHomeLayout.ts";
+import {
+  CODEX_TRANSCRIPT_DIRECTORIES,
+  resolveCodexHomeLayout,
+} from "../provider/Drivers/CodexHomeLayout.ts";
 import { UsageAggregator } from "./usageAggregation.ts";
 import { parseRateTable, type RateTable } from "./usagePricing.ts";
 import {
@@ -263,7 +266,13 @@ export const make = Effect.gen(function* () {
 
     return [
       { provider: "claude" as const, dir: claudeDir },
-      { provider: "codex" as const, dir: path.join(codexLayout.sharedHomePath, "sessions") },
+      ...CODEX_TRANSCRIPT_DIRECTORIES.map((directory) => ({
+        provider: "codex" as const,
+        dir: path.join(codexLayout.sharedHomePath, directory),
+        // Spread from a `map` rather than written inline, so the key has to be
+        // present for `fileName` to stay destructurable across the union.
+        fileName: undefined,
+      })),
       {
         provider: "grok" as const,
         dir: path.join(grokHome, "sessions"),
@@ -384,6 +393,15 @@ export const make = Effect.gen(function* () {
     // instance we already hold so the scan stays context-free.
     const dirs = yield* resolveTranscriptDirs().pipe(Effect.provideService(Path.Path, path));
     const scanned: ScannedDir[] = [];
+    // Codex archives a rollout by moving it, so one that moves between the walk
+    // of `sessions` and the walk of `archived_sessions` would otherwise be read
+    // from both and counted twice. A rollout's file name embeds a UUID, so the
+    // name identifies it wherever it sits. That is a Codex fact and not a
+    // general one: Claude nests transcripts per project and the same basename
+    // in two project directories is two different files, so Claude is not
+    // deduped here. Records carry `dedupeKey: null` for Codex, so the
+    // aggregator's cross-file pass cannot catch this on its own.
+    const scannedCodexRollouts = new Set<string>();
     for (const { provider, dir, fileName } of dirs) {
       const volumeId = yield* Effect.promise(() => readDirectoryVolumeId(dir));
       const exists = yield* fileSystem
@@ -398,7 +416,20 @@ export const make = Effect.gen(function* () {
       );
       const parsedFiles: { path: string; records: readonly UsageRecord[] }[] = [];
       for (const file of files) {
+        const rolloutName = provider === "codex" ? path.basename(file.path) : null;
+        if (rolloutName !== null && scannedCodexRollouts.has(rolloutName)) {
+          // Recorded with no records so the caller's counters treat it as
+          // skipped, and so the path still counts as live for cache pruning.
+          parsedFiles.push({ path: file.path, records: [] });
+          continue;
+        }
         const records = yield* readFileRecords(file.path, file.size, file.mtimeMs, provider);
+        // Claimed only once the read produced records. A file that reads empty
+        // - a rollout moved out of this root between the listing and the read,
+        // say - must not block its copy in the other root.
+        if (rolloutName !== null && records.length > 0) {
+          scannedCodexRollouts.add(rolloutName);
+        }
         parsedFiles.push({ path: file.path, records });
       }
       scanned.push({ provider, dir, volumeId, files: parsedFiles });


### PR DESCRIPTION
## What Changed

Codex usage dropped off the Usage page as soon as a session was archived. The work still happened and the tokens were still spent, but the rollout stopped being counted, so totals for past days quietly shrank over time.

Codex keeps rollouts in `sessions/` and moves older ones into `archived_sessions/`. The usage scan only ever looked at `sessions/`, so an archived rollout was invisible to it. The scan now walks both, and dedupes a rollout that appears in both.

## Why

`CodexHomeLayout` already treats both as first-class parts of the Codex home — `KNOWN_SHARED_DIRECTORIES` lists `sessions` and `archived_sessions` side by side. Only `resolveTranscriptDirs` in `UsageService` was missing the second one:

```ts
{ provider: "codex" as const, dir: path.join(codexLayout.sharedHomePath, "sessions") },
```

Rather than add a second hardcoded string next to that one, the pair now lives in `CodexHomeLayout` as `CODEX_TRANSCRIPT_DIRECTORIES`, next to the layout knowledge it belongs to, and `resolveTranscriptDirs` maps over it.

A directory that does not exist is recorded as a `missing` source and skipped, which is what happens for anyone who has never archived a session.

Worth noting for review: `sessions/` nests rollouts under `YYYY/MM/DD/` while `archived_sessions/` is flat. `listTranscriptFiles` walks recursively, so both shapes are handled without changes.

## On double counting, and the dedupe that review added

My original reasoning here was that double counting was impossible, because Codex *moves* a rollout rather than copying it, and I checked a real Codex home to confirm the two directories were disjoint: 323 rollouts in `sessions/`, 1 in `archived_sessions/`, no shared filenames.

**That reasoning was incomplete and review was right to push on it.** Disjointness holds for a snapshot; it says nothing about a rollout that moves between the scan of one root and the scan of the other. Codex records carry `dedupeKey: null`, so `UsageAggregator`'s cross-file `#seen` set cannot catch the duplicate. The scan now tracks rollout basenames it has already read in this pass and skips a repeat:

- **Codex only.** Keying on provider + basename would not have closed it — two colliding Claude files are both `provider: "claude"` and would still collide with each other. Claude scanning is untouched.
- **Claimed only after a non-empty read.** An earlier revision recorded the basename *before* `readFileRecords`, so a rollout that moved out of `sessions/` between the listing and the read reserved its name, returned nothing, and left its `archived_sessions/` copy to be skipped — the same disappearing-usage bug this PR set out to fix, through a narrower window.

Rollout filenames embed a UUID, so a basename is a stable identity for the same rollout across both roots.

## Rebased onto current `main`

This branch was cut before the appended-byte scanner landed, and the conflict was more than textual. `main` split the scan in two: `collectDirs` walks each root and parses records into `ScannedDir.files`, and `scanSummary` only aggregates from what is already parsed. The dedupe used to sit in the aggregation loop next to `readFileRecords`; that loop no longer reads anything, so the basename set now lives in `collectDirs`, spanning every root in one pass.

A skipped duplicate is recorded as `{ path, records: [] }` rather than dropped outright, which keeps two behaviours intact:

- `scanSummary`'s existing `records.length === 0` branch counts it in `skippedFiles`, so the counters read the same as before the split.
- the path still enters `livePaths`, so `pruneScanCache` does not evict a cache entry for a file that is still on disk and may stop being a duplicate on a later scan.

`resolveTranscriptDirs` also gained a Grok root with a `fileName` filter since this branch was cut. Spreading a `map` produces a union member with no `fileName` key, which breaks the `const { provider, dir, fileName } of dirs` destructuring, so the mapped Codex entries carry `fileName: undefined` explicitly.

## Carryover from #9226

Picked up per the closure-pass note. The `UsageService.test.ts` case `counts usage rotated into Codex's archived_sessions directory` is preserved by name, along with its assertions that archived usage reaches the totals and is priced, and it now carries this PR's duplicate-basename and empty-first-read fixtures in the same case, written against the current scanner and against `main`'s existing `setup` / `serviceLayers` helpers.

The `CODEX_TRANSCRIPT_DIRECTORIES` test in `CodexHomeLayout.test.ts` is gone. It only restated the constant's literal value, which is what the conventions review asked to replace with coverage of the scan itself, and AGENTS.md rules out tests that mirror the implementation. The scan test now fails outright when `archived_sessions` is dropped from the constant, so nothing is lost.

**Still open, deliberately not in this PR:** the mixed-version, same-host environment merge. `usageMerge.claimSources` claims per source fingerprint, but `ownedContribution` then grants an environment *every* bucket for a provider it owns *any* source for. So an older server reporting only `codex/sessions` and a newer one reporting both roots each contribute their full codex buckets, and the `sessions` usage they share is counted twice. That is a granularity bug in the merge rather than in the scan, and adding a second Codex root is what makes it reachable. The Unpriced web metric from #9226 is likewise separate scope.

## UI Changes

n/a — no layout or styling change. Codex totals on the Usage page get larger for anyone with archived sessions, because they now include work that was already theirs.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (n/a)
- [x] I included a video for animation/interaction changes (n/a)

## Verification

```
vp test run src/usage/ src/provider/Drivers/CodexHomeLayout.test.ts   # 8 files, 81 passed
tsgo --noEmit                                                          # 0 errors under apps/server/src
vp lint / vp fmt --check on the touched files                          # clean
```

The scan test drives the real service against a temporary Codex home. It seeds four rollouts:

- one only in `sessions/YYYY/MM/DD/`
- a different one only in `archived_sessions/` (flat, which is how Codex writes it)
- the same rollout basename in **both** roots — counted once, not twice
- a basename whose `sessions/` copy reads empty and whose `archived_sessions/` copy has the records — the moved-mid-scan case

It asserts 1500 output tokens and 16500 total tokens across the buckets, that every Codex bucket is `modelPriced` with no unpriced records, and that the `archived_sessions` source reports `ok` with 2 distinct sessions and the two roots together scanned 4 files and skipped 2.

A second case, `keeps Claude transcripts that share a basename across projects`, pins the dedupe to Codex. It writes `session.jsonl` under two different project directories and asserts both are counted. That was the regression review caught in an earlier revision, and until now the fix for it was implemented but unpinned: making the dedupe provider-agnostic again left the whole usage suite green.

I checked the assertions actually bite, by mutating the fix four ways:

| Mutation | Result |
| --- | --- |
| drop `archived_sessions` from `CODEX_TRANSCRIPT_DIRECTORIES` | `AssertionError: expected 500 to equal 1500` |
| remove the duplicate-basename skip | `AssertionError: expected 1900 to equal 1500` |
| claim the basename before the read instead of after | `AssertionError: expected 700 to equal 1500` |
| drop the `provider === "codex"` guard on the dedupe | `AssertionError: expected 5 to equal 12` |

**What I could not verify:** any of this against a real Codex home mid-archive. The move race is reproduced through the empty-read path, which is what the code actually observes, rather than by racing a live `mv`.

Fixes #7090

Implemented with Claude Opus 5 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes usage accounting for Codex (totals will rise for users with archives) and adds scan-time dedupe logic where a wrong guard could under-count Codex or Claude usage.
> 
> **Overview**
> **Codex usage no longer disappears when rollouts move to `archived_sessions`.** The usage scan now walks both live `sessions` and `archived_sessions`, using a shared `CODEX_TRANSCRIPT_DIRECTORIES` tuple in `CodexHomeLayout` instead of hardcoding only `sessions`.
> 
> During `collectDirs`, **Codex-only dedupe by rollout basename** prevents double-counting when the same UUID-named file appears under both roots (e.g. mid-archive). The first root that yields records claims the rollout; later copies are recorded as empty so they count as skipped and stay in cache pruning. **Claim happens only after a non-empty read**, so an empty live file from a move does not block the archived copy. Claude scanning is unchanged—same basename in different project dirs still counts twice.
> 
> Integration tests cover archived-only usage, shared duplicates, empty-live/archive pairs, pricing for archived tokens, and a regression that Claude basename collisions are not deduped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d33cbd7ad67f31e173517f4e036a83434fa4679. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Include archived Codex `sessions` in usage totals
> - Adds `CODEX_TRANSCRIPT_DIRECTORIES` ordered tuple covering both live `sessions` and `archived_sessions` transcript roots in [CodexHomeLayout.ts](https://github.com/pingdotgg/t3code/pull/7096/files#diff-17973143128131a5e3f30fc3e32012a3a86aee719917b08d60615a47558fb8d5)
> - `UsageService.make` resolves one directory entry per tuple entry, so archived rollouts are scanned and priced alongside live ones
> - Introduces per-basename deduplication during scanning: the first root to yield records for a Codex rollout claims it, and later duplicates are recorded as empty and skipped; an empty read from one root does not block the other root's copy
> - Adds integration tests covering archived-only usage, duplicate rollouts, empty-live/archive copy, and Claude transcripts sharing a basename across project directories
> - Risk: deduplication keys on basename only within Codex roots; if two distinct archived rollouts ever share a basename, the second would be silently skipped. Claude and Grok scanning are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7d33cbd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->