### PR TITLE
feat(web): open View PR externally with modifier click

### DIFF
--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -17,7 +17,15 @@ import type {
 } from "@t3tools/contracts";
 import { useNavigate } from "@tanstack/react-router";
 import * as Option from "effect/Option";
-import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
+import {
+  type MouseEvent,
+  useCallback,
+  useEffect,
+  useEffectEvent,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { flushSync } from "react-dom";
 import {
   CheckIcon,
@@ -90,7 +98,7 @@ import { resolvePathLinkTarget } from "~/terminal-links";
 import { type DraftId, useComposerDraftStore } from "~/composerDraftStore";
 import { readLocalApi } from "~/localApi";
 import { getSourceControlPresentation } from "~/sourceControlPresentation";
-import { openPullRequestLink } from "~/lib/openPullRequestLink";
+import { openPullRequestLink, shouldOpenPullRequestExternally } from "~/lib/openPullRequestLink";
 
 interface GitActionsControlProps {
   gitCwd: string | null;
@@ -1220,44 +1228,47 @@ export default function GitActionsControl({
     };
   }, [activeEnvironmentId, gitCwd, refreshVcsStatus]);
 
-  const openExistingPr = useCallback(async () => {
-    const openPr = gitStatusForActions?.pr?.state === "open" ? gitStatusForActions.pr : null;
-    // Beside the thread where it was made, the way the browser opens beside it. Checked before
-    // the shell, which opening in the app does not need.
-    if (openPr && onOpenPullRequest) {
-      onOpenPullRequest(openPr.number);
-      return;
-    }
-    const api = readLocalApi();
-    if (!api) {
-      toastManager.add({
-        type: "error",
-        title: "Link opening is unavailable.",
-        data: threadToastData,
-      });
-      return;
-    }
-    const prUrl = openPr?.url ?? null;
-    if (!prUrl) {
-      toastManager.add({
-        type: "error",
-        title: "No open pull request found.",
-        data: threadToastData,
-      });
-      return;
-    }
-    void openPullRequestLink(api.shell, prUrl).catch((err: unknown) => {
-      console.error(err);
-      toastManager.add(
-        stackedThreadToast({
+  const openExistingPr = useCallback(
+    async (openExternally = false) => {
+      const openPr = gitStatusForActions?.pr?.state === "open" ? gitStatusForActions.pr : null;
+      // Beside the thread where it was made, the way the browser opens beside it. Checked before
+      // the shell, which opening in the app does not need.
+      if (openPr && onOpenPullRequest && !openExternally) {
+        onOpenPullRequest(openPr.number);
+        return;
+      }
+      const api = readLocalApi();
+      if (!api) {
+        toastManager.add({
           type: "error",
-          title: "Unable to open pull request link",
-          description: err instanceof Error ? err.message : "An error occurred.",
-          ...(threadToastData !== undefined ? { data: threadToastData } : {}),
-        }),
-      );
-    });
-  }, [gitStatusForActions, onOpenPullRequest, threadToastData]);
+          title: "Link opening is unavailable.",
+          data: threadToastData,
+        });
+        return;
+      }
+      const prUrl = openPr?.url ?? null;
+      if (!prUrl) {
+        toastManager.add({
+          type: "error",
+          title: "No open pull request found.",
+          data: threadToastData,
+        });
+        return;
+      }
+      void openPullRequestLink(api.shell, prUrl).catch((err: unknown) => {
+        console.error(err);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Unable to open pull request link",
+            description: err instanceof Error ? err.message : "An error occurred.",
+            ...(threadToastData !== undefined ? { data: threadToastData } : {}),
+          }),
+        );
+      });
+    },
+    [gitStatusForActions, onOpenPullRequest, threadToastData],
+  );
 
   runGitActionWithToast = useEffectEvent(
     async ({
@@ -1539,9 +1550,9 @@ export default function GitActionsControl({
     });
   };
 
-  const runQuickAction = () => {
+  const runQuickAction = (event: MouseEvent<HTMLElement>) => {
     if (quickAction.kind === "open_pr") {
-      void openExistingPr();
+      void openExistingPr(shouldOpenPullRequestExternally(event));
       return;
     }
     if (quickAction.kind === "open_publish") {
@@ -1602,10 +1613,10 @@ export default function GitActionsControl({
     }
   };
 
-  const openDialogForMenuItem = (item: GitActionMenuItem) => {
+  const openDialogForMenuItem = (item: GitActionMenuItem, event: MouseEvent<HTMLElement>) => {
     if (item.disabled) return;
     if (item.kind === "open_pr") {
-      void openExistingPr();
+      void openExistingPr(shouldOpenPullRequestExternally(event));
       return;
     }
     if (item.dialogAction === "push") {
@@ -1789,8 +1800,8 @@ export default function GitActionsControl({
                   <MenuItem
                     key={`${item.id}-${item.label}`}
                     disabled={item.disabled}
-                    onClick={() => {
-                      openDialogForMenuItem(item);
+                    onClick={(event) => {
+                      openDialogForMenuItem(item, event);
                     }}
                   >
                     <GitActionItemIcon icon={item.icon} SourceControlIcon={SourceControlIcon} />


### PR DESCRIPTION
## What changed

- Preserve the existing plain-click behavior that opens a thread's pull request in the right panel.
- Open the pull request in the external browser when the **View PR** quick action is Command-clicked or Control-clicked.
- Apply the same modifier behavior to the **View PR** dropdown action.

## Why

PR links elsewhere in T3 Code already preserve native modifier-click semantics. The View PR shortcut is rendered as a button, so it needs to explicitly route modifier clicks through the external opener.

## Impact

Users can keep the current thread visible while opening its pull request externally with the familiar Command/Control-click gesture. There is no visual change, so before/after images are not applicable.

## Validation

- `vp test run apps/web/src/lib/openPullRequestLink.test.ts apps/web/src/components/GitActionsControl.logic.test.ts` (77 tests passed)
- `vp run typecheck` from `apps/web`

Model: GPT-5
Harness: Codex desktop

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Open pull request externally in 'GitActionsControl' when using a modifier click
> Adds modifier-click support to the "View PR" action so users can open a pull request in the browser instead of in-app. The `openExistingPr` callback now accepts an `openExternally` boolean; when true, it skips `onOpenPullRequest` and opens the PR URL via shell using `openPullRequestLink`. Both the quick action handler (`runQuickAction`) and menu item handler (`openDialogForMenuItem`) now receive the click `MouseEvent` and pass the result of `shouldOpenPullRequestExternally(event)` to `openExistingPr`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b9662af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX routing change in GitActionsControl with no auth or data handling impact; default click behavior is unchanged.
> 
> **Overview**
> **View PR** in git actions now matches PR link behavior elsewhere: plain click still opens in the thread side panel when `onOpenPullRequest` is available; **Cmd/Ctrl+click** forces the PR URL through `openPullRequestLink` instead of the in-app handler.
> 
> The quick-action button and dropdown **View PR** menu item pass the click `MouseEvent` into `openExistingPr` via `shouldOpenPullRequestExternally(event)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9662af7986481aed90735da0be0e86eafbee833. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Closes #7250