### PR TITLE
feat(web): add cross-provider model handoff with structured context

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -251,6 +251,7 @@ import { environmentShell } from "../state/shell";
 import { ChatComposer, type ChatComposerHandle } from "./chat/ChatComposer";
 import { DraftHeroHeadline } from "./chat/DraftHeroHeadline";
 import { ExpandedImageDialog } from "./chat/ExpandedImageDialog";
+import { ThreadHandoffDialog } from "./chat/ThreadHandoffDialog";
 import { PullRequestThreadDialog } from "./PullRequestThreadDialog";
 import { MessagesTimeline } from "./chat/MessagesTimeline";
 import { resolveTimelineIsAtEnd } from "./chat/MessagesTimeline.logic";
@@ -321,6 +322,7 @@ import {
   revokeUserMessagePreviewUrls,
   shouldWriteThreadErrorToCurrentServerThread,
   startNewThreadForProject,
+  threadHasStarted,
   waitForStartedServerThread,
 } from "./ChatView.logic";
 import type { ThreadSyncPhase } from "../threadSync";
@@ -1382,6 +1384,9 @@ function ChatViewContent(props: ChatViewProps) {
   const [terminalFocusRequestId, setTerminalFocusRequestId] = useState(0);
   const [pullRequestDialogState, setPullRequestDialogState] =
     useState<PullRequestDialogState | null>(null);
+  const [isHandoffDialogOpen, setIsHandoffDialogOpen] = useState(false);
+  const [handoffTargetModelSelection, setHandoffTargetModelSelection] =
+    useState<ModelSelection | null>(null);
   const [terminalUiLaunchContext, setTerminalUiLaunchContext] =
     useState<TerminalLaunchContext | null>(null);
   const [attachmentPreviewHandoffByMessageId, setAttachmentPreviewHandoffByMessageId] = useState<
@@ -5875,9 +5880,139 @@ function ChatViewContent(props: ChatViewProps) {
     composerRef,
   ]);
 
+  const handleConfirmHandoff = useCallback(
+    async (handoffMarkdown: string, targetModelSelection: ModelSelection) => {
+      if (!activeProject || !activeThread) return;
+      const nextThreadId = newThreadId();
+      const nextThreadTitle = `${activeThread.title} (Handoff)`;
+      const createdAt = new Date().toISOString();
+
+      sendInFlightRef.current = true;
+      beginLocalDispatch({ preparingWorktree: false });
+      const finish = () => {
+        sendInFlightRef.current = false;
+        resetLocalDispatch();
+      };
+
+      const createResult = await createThread({
+        environmentId,
+        input: {
+          threadId: nextThreadId,
+          projectId: activeProject.id,
+          title: nextThreadTitle,
+          modelSelection: targetModelSelection,
+          runtimeMode,
+          interactionMode: "default",
+          branch: activeThreadBranch,
+          worktreePath: activeThread.worktreePath,
+          createdAt,
+        },
+      });
+      let failure: AtomCommandResult<unknown, unknown> | null =
+        createResult._tag === "Failure" ? createResult : null;
+
+      if (failure === null) {
+        const startResult = await startThreadTurn({
+          environmentId,
+          input: {
+            threadId: nextThreadId,
+            message: {
+              messageId: newMessageId(),
+              role: "user",
+              text: handoffMarkdown,
+              attachments: [],
+            },
+            modelSelection: targetModelSelection,
+            titleSeed: nextThreadTitle,
+            runtimeMode,
+            interactionMode: "default",
+            createdAt,
+          },
+        });
+        failure = startResult._tag === "Failure" ? startResult : null;
+      }
+
+      if (failure === null) {
+        const startedResult = await settlePromise(() =>
+          waitForStartedServerThread(scopeThreadRef(activeThread.environmentId, nextThreadId)),
+        );
+        failure = startedResult._tag === "Failure" ? startedResult : null;
+      }
+
+      if (failure === null) {
+        const navigateResult = await settlePromise(() =>
+          navigate({
+            to: "/$environmentId/$threadId",
+            params: {
+              environmentId: activeThread.environmentId,
+              threadId: nextThreadId,
+            },
+          }),
+        );
+        failure = navigateResult._tag === "Failure" ? navigateResult : null;
+      }
+
+      if (failure !== null) {
+        const cleanupResult = await deleteThread({
+          environmentId,
+          input: {
+            threadId: nextThreadId,
+          },
+        });
+        if (cleanupResult._tag === "Failure" && !isAtomCommandInterrupted(cleanupResult)) {
+          console.warn(
+            "Failed to clean up handoff thread after start failure.",
+            squashAtomCommandFailure(cleanupResult),
+          );
+        }
+        if (!isAtomCommandInterrupted(failure)) {
+          const error = squashAtomCommandFailure(failure);
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Could not start handoff thread",
+              description:
+                error instanceof Error
+                  ? error.message
+                  : typeof error === "string"
+                    ? error
+                    : "Failed to continue conversation in new thread.",
+            }),
+          );
+        }
+        finish();
+        return;
+      }
+
+      finish();
+      toastManager.add({
+        type: "success",
+        title: "Thread started with handoff",
+        description: `Continuing conversation with ${targetModelSelection.model}`,
+      });
+    },
+    [
+      activeProject,
+      activeThread,
+      activeThreadBranch,
+      beginLocalDispatch,
+      createThread,
+      deleteThread,
+      environmentId,
+      navigate,
+      resetLocalDispatch,
+      runtimeMode,
+      startThreadTurn,
+      waitForStartedServerThread,
+    ],
+  );
+
   const getModelDisabledReason = useCallback(
     (instanceId: ProviderInstanceId, model: string): string | null => {
       if (!activeThread) {
+        return null;
+      }
+      if (isServerThread && activeServerThread && threadHasStarted(activeServerThread)) {
         return null;
       }
       const reason = getStartedThreadModelChangeBlockReason({
@@ -5889,38 +6024,14 @@ function ChatViewContent(props: ChatViewProps) {
       });
       return reason ? `${reason.description} Start a new thread to use this model.` : null;
     },
-    [activeThread, providerStatuses],
+    [activeServerThread, activeThread, isServerThread, providerStatuses],
   );
 
   const onProviderModelSelect = useCallback(
     (instanceId: ProviderInstanceId, model: string) => {
       if (!activeThread) return;
-      // Look up the configured instance so model normalization and custom
-      // model lookup stay scoped to that exact instance. Unknown instance ids
-      // are rejected by returning early; the server remains authoritative too.
       const entry = providerStatuses.find((snapshot) => snapshot.instanceId === instanceId);
       const resolvedDriverKind = entry?.driver ?? null;
-      if (
-        lockedProvider !== null &&
-        resolvedDriverKind !== null &&
-        resolvedDriverKind !== lockedProvider
-      ) {
-        scheduleComposerFocus();
-        return;
-      }
-      if (lockedProvider !== null && activeThread.session?.providerInstanceId) {
-        const currentEntry = providerStatuses.find(
-          (snapshot) => snapshot.instanceId === activeThread.session?.providerInstanceId,
-        );
-        if (
-          currentEntry?.continuation?.groupKey &&
-          entry?.continuation?.groupKey &&
-          currentEntry.continuation.groupKey !== entry.continuation.groupKey
-        ) {
-          scheduleComposerFocus();
-          return;
-        }
-      }
       const resolvedModel = resolveAppModelSelectionForInstance(
         instanceId,
         settings,
@@ -5935,6 +6046,28 @@ function ChatViewContent(props: ChatViewProps) {
         instanceId,
         model: resolvedModel,
       };
+
+      const isCrossProvider =
+        isServerThread &&
+        activeServerThread !== null &&
+        threadHasStarted(activeServerThread) &&
+        ((lockedProvider !== null &&
+          resolvedDriverKind !== null &&
+          resolvedDriverKind !== lockedProvider) ||
+          (lockedProvider !== null &&
+            activeServerThread.session?.providerInstanceId &&
+            (() => {
+              const currentEntry = providerStatuses.find(
+                (snapshot) =>
+                  snapshot.instanceId === activeServerThread.session?.providerInstanceId,
+              );
+              return Boolean(
+                currentEntry?.continuation?.groupKey &&
+                entry?.continuation?.groupKey &&
+                currentEntry.continuation.groupKey !== entry.continuation.groupKey,
+              );
+            })()));
+
       const modelChangeBlockReason = getStartedThreadModelChangeBlockReason({
         providers: providerStatuses,
         hasStartedSession: activeThread.session !== null,
@@ -5942,6 +6075,19 @@ function ChatViewContent(props: ChatViewProps) {
         currentProviderInstanceId: activeThread.session?.providerInstanceId ?? null,
         nextModelSelection,
       });
+
+      if (
+        isCrossProvider ||
+        (modelChangeBlockReason &&
+          isServerThread &&
+          activeServerThread !== null &&
+          threadHasStarted(activeServerThread))
+      ) {
+        setHandoffTargetModelSelection(nextModelSelection);
+        setIsHandoffDialogOpen(true);
+        return;
+      }
+
       if (modelChangeBlockReason) {
         toastManager.add({
           type: "warning",
@@ -5959,12 +6105,14 @@ function ChatViewContent(props: ChatViewProps) {
       scheduleComposerFocus();
     },
     [
+      activeServerThread,
       activeThread,
+      isServerThread,
       lockedProvider,
+      providerStatuses,
       scheduleComposerFocus,
       setComposerDraftModelSelection,
       setStickyComposerModelSelection,
-      providerStatuses,
       settings,
     ],
   );
@@ -6592,6 +6740,17 @@ function ChatViewContent(props: ChatViewProps) {
                   }
                 }}
                 onPrepared={handlePreparedPullRequestThread}
+              />
+            ) : null}
+
+            {activeServerThread && handoffTargetModelSelection ? (
+              <ThreadHandoffDialog
+                open={isHandoffDialogOpen}
+                onOpenChange={setIsHandoffDialogOpen}
+                sourceThread={activeServerThread}
+                targetModelSelection={handoffTargetModelSelection}
+                providerInstanceEntries={providerInstanceEntries}
+                onConfirmHandoff={handleConfirmHandoff}
               />
             ) : null}
           </div>

--- a/apps/web/src/components/chat/ModelListRow.tsx
+++ b/apps/web/src/components/chat/ModelListRow.tsx
@@ -34,6 +34,7 @@ export const ModelListRow = memo(function ModelListRow(props: {
   preferShortName?: boolean;
   useTriggerLabel?: boolean;
   showNewBadge?: boolean;
+  isHandoff?: boolean;
   jumpLabel?: string | null;
   disabledReason?: string | null;
   onToggleFavorite: () => void;
@@ -73,6 +74,14 @@ export const ModelListRow = memo(function ModelListRow(props: {
               aria-label="New model"
             >
               New
+            </span>
+          ) : null}
+          {props.isHandoff ? (
+            <span
+              className="shrink-0 rounded border border-primary/30 bg-primary/10 px-1 py-0.5 text-[10px] font-medium leading-none text-primary"
+              aria-label="Handoff to new thread"
+            >
+              Handoff
             </span>
           ) : null}
         </div>

--- a/apps/web/src/components/chat/ModelPickerContent.tsx
+++ b/apps/web/src/components/chat/ModelPickerContent.tsx
@@ -90,6 +90,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
   modelOptionsByInstance: ReadonlyMap<ProviderInstanceId, ReadonlyArray<ModelEsque>>;
   terminalOpen: boolean;
   onRequestClose?: () => void;
+  allowHandoff?: boolean;
   getModelDisabledReason?: (instanceId: ProviderInstanceId, model: string) => string | null;
   onInstanceModelChange: (instanceId: ProviderInstanceId, model: string) => void;
 }) {
@@ -97,6 +98,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
     keybindings: providedKeybindings,
     modelOptionsByInstance,
     instanceEntries,
+    allowHandoff = true,
     getModelDisabledReason,
     onInstanceModelChange,
   } = props;
@@ -235,7 +237,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
     return out;
   }, [modelOptionsByInstance, entryByInstanceId, readyInstanceSet]);
 
-  const isLocked = props.lockedProvider !== null;
+  const isLocked = props.lockedProvider !== null && !allowHandoff;
   const isSearching = searchQuery.trim().length > 0;
   const lockedDisabledInstanceIds = useMemo(() => {
     if (!isLocked) {
@@ -314,7 +316,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
       // When searching, we only respect locked provider (by driver kind),
       // ignoring sidebar selection so account-scoped searches can find a
       // model before the user chooses a specific instance rail item.
-      if (props.lockedProvider !== null) {
+      if (!allowHandoff && props.lockedProvider !== null) {
         const lockedProviderMatches: Array<(typeof rankedMatches)[number]> = [];
         for (const rankedModel of rankedMatches) {
           if (matchesLockedProvider(rankedModel.model)) {
@@ -349,7 +351,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
         .map((rankedModel) => rankedModel.model);
     }
 
-    if (props.lockedProvider !== null) {
+    if (!allowHandoff && props.lockedProvider !== null) {
       result = result.filter((m) => matchesLockedProvider(m));
       if (selectedInstanceId === "favorites") {
         result = result.filter((m) => favoritesSet.has(providerModelKey(m.instanceId, m.slug)));
@@ -747,8 +749,11 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
                     if (!model) {
                       return null;
                     }
-                    const disabledReason =
-                      getModelDisabledReason?.(model.instanceId, model.slug) ?? null;
+                    const isCrossProvider =
+                      props.lockedProvider !== null && !matchesLockedProvider(model);
+                    const disabledReason = isCrossProvider
+                      ? null
+                      : (getModelDisabledReason?.(model.instanceId, model.slug) ?? null);
                     return (
                       <ModelListRow
                         key={modelKey}
@@ -768,6 +773,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
                         preferShortName={!isLocked}
                         useTriggerLabel={false}
                         showNewBadge={isModelPickerNewModel(model.driverKind, model.slug)}
+                        isHandoff={isCrossProvider}
                         jumpLabel={modelJumpLabelByKey.get(modelKey) ?? null}
                         disabledReason={disabledReason}
                         onToggleFavorite={() => toggleFavorite(model.instanceId, model.slug)}

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -41,6 +41,7 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
   triggerClassName?: string;
   triggerAriaLabel?: string;
   onOpenChange?: (open: boolean) => void;
+  allowHandoff?: boolean;
   getModelDisabledReason?: (instanceId: ProviderInstanceId, model: string) => string | null;
   onInstanceModelChange: (instanceId: ProviderInstanceId, model: string) => void;
 }) {
@@ -194,6 +195,7 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
           model={props.model}
           lockedProvider={props.lockedProvider}
           lockedContinuationGroupKey={props.lockedContinuationGroupKey ?? null}
+          allowHandoff={props.allowHandoff}
           instanceEntries={props.instanceEntries}
           {...(props.keybindings ? { keybindings: props.keybindings } : {})}
           modelOptionsByInstance={props.modelOptionsByInstance}

--- a/apps/web/src/components/chat/ThreadHandoffDialog.test.tsx
+++ b/apps/web/src/components/chat/ThreadHandoffDialog.test.tsx
@@ -1,0 +1,97 @@
+import {
+  IsoDateTime,
+  ProjectId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  ThreadId,
+} from "@t3tools/contracts";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+import { ThreadHandoffContent } from "./ThreadHandoffDialog";
+import type { ProviderInstanceEntry } from "../../providerInstances";
+
+describe("ThreadHandoffContent", () => {
+  const dummyInstanceEntries: ReadonlyArray<ProviderInstanceEntry> = [
+    {
+      instanceId: ProviderInstanceId.make("claudeAgent"),
+      displayName: "Claude Code",
+      driverKind: ProviderDriverKind.make("claudeAgent"),
+      enabled: true,
+      isAvailable: true,
+      configured: true,
+      hasCredentials: true,
+      isDefault: true,
+      models: [],
+      snapshot: null,
+      authStatus: "authorized",
+    },
+    {
+      instanceId: ProviderInstanceId.make("codex"),
+      displayName: "Codex",
+      driverKind: ProviderDriverKind.make("codex"),
+      enabled: true,
+      isAvailable: true,
+      configured: true,
+      hasCredentials: true,
+      isDefault: false,
+      models: [],
+      snapshot: null,
+      authStatus: "authorized",
+    },
+  ];
+
+  it("renders handoff content with source and target model indicators and markdown preview", () => {
+    const markup = renderToStaticMarkup(
+      <ThreadHandoffContent
+        sourceThread={{
+          id: ThreadId.make("thread-1"),
+          projectId: ProjectId.make("project-1"),
+          title: "Optimize database queries",
+          modelSelection: {
+            instanceId: ProviderInstanceId.make("claudeAgent"),
+            model: "claude-3-7-sonnet",
+          },
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          branch: "feat/optimize-db",
+          worktreePath: null,
+          latestTurn: null,
+          createdAt: IsoDateTime.make("2026-08-15T10:00:00.000Z"),
+          updatedAt: IsoDateTime.make("2026-08-15T10:00:00.000Z"),
+          archivedAt: null,
+          settledOverride: null,
+          settledAt: null,
+          deletedAt: null,
+          messages: [
+            {
+              id: "msg-1" as any,
+              role: "user",
+              text: "Add index to user_id column",
+              turnId: null,
+              streaming: false,
+              createdAt: IsoDateTime.make("2026-08-15T10:00:00.000Z"),
+              updatedAt: IsoDateTime.make("2026-08-15T10:00:00.000Z"),
+            },
+          ],
+          proposedPlans: [],
+          activities: [],
+          checkpoints: [],
+          session: null,
+        }}
+        targetModelSelection={{
+          instanceId: ProviderInstanceId.make("codex"),
+          model: "gpt-5.3-codex",
+        }}
+        providerInstanceEntries={dummyInstanceEntries}
+        onConfirmHandoff={() => {}}
+      />,
+    );
+
+    expect(markup).toContain("Continue in new thread");
+    expect(markup).toContain("claude-3-7-sonnet");
+    expect(markup).toContain("gpt-5.3-codex");
+    expect(markup).toContain("Handoff context (editable)");
+    expect(markup).toContain("Continue with gpt-5.3-codex");
+    expect(markup).toContain("Add index to user_id column");
+  });
+});

--- a/apps/web/src/components/chat/ThreadHandoffDialog.tsx
+++ b/apps/web/src/components/chat/ThreadHandoffDialog.tsx
@@ -1,0 +1,202 @@
+import { type ModelSelection, type OrchestrationThread } from "@t3tools/contracts";
+import { buildThreadHandoffMarkdown } from "@t3tools/client-runtime/handoff";
+import { ArrowRightIcon } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Button } from "../ui/button";
+import { Dialog, DialogFooter, DialogPanel, DialogPopup } from "../ui/dialog";
+import { Textarea } from "../ui/textarea";
+import { Spinner } from "../ui/spinner";
+import { ProviderInstanceIcon } from "./ProviderInstanceIcon";
+import type { ProviderInstanceEntry } from "../../providerInstances";
+
+export interface ThreadHandoffContentProps {
+  readonly sourceThread: OrchestrationThread;
+  readonly targetModelSelection: ModelSelection;
+  readonly providerInstanceEntries: ReadonlyArray<ProviderInstanceEntry>;
+  readonly isSubmitting?: boolean;
+  readonly onCancel?: () => void;
+  readonly onConfirmHandoff: (
+    handoffMarkdown: string,
+    targetModelSelection: ModelSelection,
+  ) => Promise<void> | void;
+}
+
+export function ThreadHandoffContent({
+  sourceThread,
+  targetModelSelection,
+  providerInstanceEntries,
+  isSubmitting = false,
+  onCancel,
+  onConfirmHandoff,
+}: ThreadHandoffContentProps) {
+  const [handoffText, setHandoffText] = useState(() =>
+    buildThreadHandoffMarkdown({
+      thread: sourceThread,
+      targetModelSelection,
+    }),
+  );
+
+  const sourceEntry = useMemo(() => {
+    const instanceId = sourceThread.modelSelection?.instanceId;
+    return providerInstanceEntries.find((entry) => entry.instanceId === instanceId) ?? null;
+  }, [providerInstanceEntries, sourceThread.modelSelection?.instanceId]);
+
+  const targetEntry = useMemo(() => {
+    return (
+      providerInstanceEntries.find(
+        (entry) => entry.instanceId === targetModelSelection.instanceId,
+      ) ?? null
+    );
+  }, [providerInstanceEntries, targetModelSelection]);
+
+  useEffect(() => {
+    const generated = buildThreadHandoffMarkdown({
+      thread: sourceThread,
+      targetModelSelection,
+    });
+    setHandoffText(generated);
+  }, [sourceThread, targetModelSelection]);
+
+  const handleConfirm = useCallback(() => {
+    return onConfirmHandoff(handoffText, targetModelSelection);
+  }, [handoffText, onConfirmHandoff, targetModelSelection]);
+
+  const sourceModelLabel = sourceThread.modelSelection?.model ?? "Current model";
+  const targetModelLabel = targetModelSelection.model;
+
+  return (
+    <>
+      <div className="flex flex-col space-y-1.5 p-6 pb-0">
+        <h2 className="text-lg font-semibold leading-none tracking-tight">
+          Continue in new thread
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Switch to a different model with a structured handoff of your current progress. The
+          original thread remains untouched.
+        </p>
+      </div>
+
+      <DialogPanel className="space-y-4 px-6 py-4">
+        <div className="flex items-center justify-between rounded-lg border bg-muted/40 p-3">
+          <div className="flex items-center gap-2.5">
+            {sourceEntry && (
+              <ProviderInstanceIcon
+                driverKind={sourceEntry.driverKind}
+                displayName={sourceEntry.displayName}
+                className="size-5 shrink-0"
+              />
+            )}
+            <div className="flex flex-col">
+              <span className="text-xs font-medium text-muted-foreground">From</span>
+              <span className="text-sm font-semibold">{sourceModelLabel}</span>
+            </div>
+          </div>
+
+          <ArrowRightIcon className="size-4 text-muted-foreground" />
+
+          <div className="flex items-center gap-2.5">
+            {targetEntry && (
+              <ProviderInstanceIcon
+                driverKind={targetEntry.driverKind}
+                displayName={targetEntry.displayName}
+                className="size-5 shrink-0"
+              />
+            )}
+            <div className="flex flex-col items-end">
+              <span className="text-xs font-medium text-muted-foreground">To</span>
+              <span className="text-sm font-semibold text-primary">{targetModelLabel}</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium text-muted-foreground">
+            Handoff context (editable)
+          </label>
+          <Textarea
+            value={handoffText}
+            onChange={(e) => setHandoffText(e.target.value)}
+            rows={12}
+            className="font-mono text-xs leading-relaxed resize-y"
+            placeholder="Structured context to be sent to the new model..."
+          />
+        </div>
+      </DialogPanel>
+
+      <DialogFooter className="px-6 pb-6">
+        <Button variant="outline" disabled={isSubmitting} onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button
+          variant="primary"
+          disabled={isSubmitting || handoffText.trim().length === 0}
+          onClick={handleConfirm}
+        >
+          {isSubmitting ? (
+            <>
+              <Spinner className="mr-2 size-4" />
+              Starting thread...
+            </>
+          ) : (
+            `Continue with ${targetModelLabel}`
+          )}
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+export interface ThreadHandoffDialogProps {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly sourceThread: OrchestrationThread;
+  readonly targetModelSelection: ModelSelection | null;
+  readonly providerInstanceEntries: ReadonlyArray<ProviderInstanceEntry>;
+  readonly onConfirmHandoff: (
+    handoffMarkdown: string,
+    targetModelSelection: ModelSelection,
+  ) => Promise<void> | void;
+}
+
+export function ThreadHandoffDialog({
+  open,
+  onOpenChange,
+  sourceThread,
+  targetModelSelection,
+  providerInstanceEntries,
+  onConfirmHandoff,
+}: ThreadHandoffDialogProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleConfirm = useCallback(
+    async (handoffMarkdown: string, selection: ModelSelection) => {
+      setIsSubmitting(true);
+      try {
+        await onConfirmHandoff(handoffMarkdown, selection);
+        onOpenChange(false);
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [onConfirmHandoff, onOpenChange],
+  );
+
+  if (!targetModelSelection) {
+    return null;
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogPopup className="max-w-2xl p-0">
+        <ThreadHandoffContent
+          sourceThread={sourceThread}
+          targetModelSelection={targetModelSelection}
+          providerInstanceEntries={providerInstanceEntries}
+          isSubmitting={isSubmitting}
+          onCancel={() => onOpenChange(false)}
+          onConfirmHandoff={handleConfirm}
+        />
+      </DialogPopup>
+    </Dialog>
+  );
+}

--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -39,6 +39,10 @@
       "types": "./src/relay/index.ts",
       "default": "./src/relay/index.ts"
     },
+    "./handoff": {
+      "types": "./src/handoff/index.ts",
+      "default": "./src/handoff/index.ts"
+    },
     "./state/auth": {
       "types": "./src/state/auth.ts",
       "default": "./src/state/auth.ts"

--- a/packages/client-runtime/src/handoff/index.ts
+++ b/packages/client-runtime/src/handoff/index.ts
@@ -1,0 +1,1 @@
+export * from "./threadHandoff.ts";

--- a/packages/client-runtime/src/handoff/threadHandoff.test.ts
+++ b/packages/client-runtime/src/handoff/threadHandoff.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { buildThreadHandoffMarkdown } from "./threadHandoff.ts";
+
+describe("buildThreadHandoffMarkdown", () => {
+  it("generates structured handoff from Claude to Codex with full context", () => {
+    const markdown = buildThreadHandoffMarkdown({
+      thread: {
+        id: "thread-123",
+        title: "Implement Antigravity driver",
+        branch: "feat/antigravity",
+        worktreePath: null,
+        modelSelection: {
+          instanceId: "claudeAgent",
+          model: "claude-3-7-sonnet",
+        },
+        messages: [
+          {
+            role: "user",
+            text: "Create the Antigravity driver and fix the process cleanup.",
+          },
+          {
+            role: "assistant",
+            text: "I implemented AntigravityAdapter and added unit tests in AntigravityAdapter.test.ts.",
+          },
+          {
+            role: "user",
+            text: "Now make sure turn interruption emits turn.completed with state interrupted.",
+          },
+        ],
+        activities: [
+          {
+            tone: "tool",
+            kind: "file",
+            summary: "Edited AntigravityAdapter.ts",
+            payload: { filePath: "apps/server/src/provider/Layers/AntigravityAdapter.ts" },
+          },
+          {
+            tone: "tool",
+            kind: "terminal",
+            summary: "pnpm test run AntigravityAdapter.test.ts",
+          },
+        ],
+        proposedPlans: [
+          {
+            planMarkdown: "- [x] Add AntigravityAdapter\n- [ ] Update interruptTurn logic",
+          },
+        ],
+        checkpoints: [
+          {
+            files: [
+              {
+                path: "apps/server/src/provider/Layers/AntigravityAdapter.ts",
+                additions: 50,
+                deletions: 10,
+              },
+            ],
+          },
+        ],
+      },
+      targetModelSelection: {
+        instanceId: "codex",
+        model: "gpt-5.3-codex",
+      },
+    });
+
+    expect(markdown).toContain("# Task Continuation Context");
+    expect(markdown).toContain(
+      "Continuing from **claudeAgent (claude-3-7-sonnet)** to **codex (gpt-5.3-codex)**.",
+    );
+    expect(markdown).toContain('Source thread: "Implement Antigravity driver" (ID: `thread-123`)');
+    expect(markdown).toContain("## 🎯 Original Goal & Instructions");
+    expect(markdown).toContain("Create the Antigravity driver and fix the process cleanup.");
+    expect(markdown).toContain("## 📝 Work Completed & Key Decisions");
+    expect(markdown).toContain("I implemented AntigravityAdapter and added unit tests");
+    expect(markdown).toContain("## 📂 Modified & Relevant Files");
+    expect(markdown).toContain("- `apps/server/src/provider/Layers/AntigravityAdapter.ts`");
+    expect(markdown).toContain("## ⚙️ Key Actions & Commands Executed");
+    expect(markdown).toContain("- pnpm test run AntigravityAdapter.test.ts");
+    expect(markdown).toContain("## 📋 Execution Plan");
+    expect(markdown).toContain("- [x] Add AntigravityAdapter");
+    expect(markdown).toContain("## ⏭️ Latest Request / Next Immediate Step");
+    expect(markdown).toContain(
+      "Now make sure turn interruption emits turn.completed with state interrupted.",
+    );
+  });
+
+  it("handles Codex to Claude transition cleanly", () => {
+    const markdown = buildThreadHandoffMarkdown({
+      thread: {
+        id: "thread-456",
+        title: "Fix Linux dock icon",
+        modelSelection: {
+          instanceId: "codex",
+          model: "gpt-5.3-codex",
+        },
+        messages: [
+          {
+            role: "user",
+            text: "Fix the Linux dock icon grouping in Electron.",
+          },
+        ],
+      },
+      targetModelSelection: {
+        instanceId: "claudeAgent",
+        model: "claude-3-7-sonnet",
+      },
+    });
+
+    expect(markdown).toContain(
+      "Continuing from **codex (gpt-5.3-codex)** to **claudeAgent (claude-3-7-sonnet)**.",
+    );
+    expect(markdown).toContain("Fix the Linux dock icon grouping in Electron.");
+  });
+
+  it("handles source thread with missing model or offline provider", () => {
+    const markdown = buildThreadHandoffMarkdown({
+      thread: {
+        id: "thread-789",
+        title: "Offline source thread",
+        modelSelection: null,
+        messages: [
+          {
+            role: "user",
+            text: "Initial prompt before provider crash.",
+          },
+        ],
+      },
+      targetModelSelection: {
+        instanceId: "antigravity",
+        model: "gemini-3.7-flash",
+      },
+    });
+
+    expect(markdown).toContain(
+      "Continuing from **previous model** to **antigravity (gemini-3.7-flash)**.",
+    );
+    expect(markdown).toContain("Initial prompt before provider crash.");
+  });
+});

--- a/packages/client-runtime/src/handoff/threadHandoff.ts
+++ b/packages/client-runtime/src/handoff/threadHandoff.ts
@@ -1,0 +1,164 @@
+export interface ThreadHandoffInput {
+  readonly thread: {
+    readonly id: string;
+    readonly title: string;
+    readonly branch?: string | null;
+    readonly worktreePath?: string | null;
+    readonly modelSelection?: {
+      readonly instanceId: string;
+      readonly model: string;
+    } | null;
+    readonly messages?: ReadonlyArray<{
+      readonly role: "user" | "assistant" | "system";
+      readonly text: string;
+    }>;
+    readonly activities?: ReadonlyArray<{
+      readonly tone: string;
+      readonly kind: string;
+      readonly summary: string;
+      readonly payload?: unknown;
+    }>;
+    readonly proposedPlans?: ReadonlyArray<{
+      readonly planMarkdown: string;
+    }>;
+    readonly checkpoints?: ReadonlyArray<{
+      readonly files: ReadonlyArray<{
+        readonly path: string;
+        readonly kind?: string;
+        readonly additions?: number;
+        readonly deletions?: number;
+      }>;
+    }>;
+  };
+  readonly targetModelSelection?: {
+    readonly instanceId: string;
+    readonly model: string;
+  } | null;
+}
+
+export function buildThreadHandoffMarkdown(input: ThreadHandoffInput): string {
+  const { thread, targetModelSelection } = input;
+  const sections: string[] = [];
+
+  const sourceModelLabel = thread.modelSelection
+    ? `${thread.modelSelection.instanceId} (${thread.modelSelection.model})`
+    : "previous model";
+  const targetModelLabel = targetModelSelection
+    ? `${targetModelSelection.instanceId} (${targetModelSelection.model})`
+    : "new model";
+
+  sections.push(
+    `# Task Continuation Context\n` +
+      `> Continuing from **${sourceModelLabel}** to **${targetModelLabel}**.\n` +
+      `> Source thread: "${thread.title}" (ID: \`${thread.id}\`)`,
+  );
+
+  const messages = (thread.messages ?? []).filter((m) => m.text.trim().length > 0);
+  const userMessages = messages.filter((m) => m.role === "user");
+  const assistantMessages = messages.filter((m) => m.role === "assistant");
+
+  if (userMessages.length > 0) {
+    const originalGoal = userMessages[0]?.text.trim();
+    if (originalGoal) {
+      sections.push(`## 🎯 Original Goal & Instructions\n${originalGoal}`);
+    }
+  }
+
+  if (assistantMessages.length > 0) {
+    const decisions: string[] = [];
+    for (const msg of assistantMessages) {
+      const text = msg.text.trim();
+      if (text.length > 0) {
+        decisions.push(text);
+      }
+    }
+    if (decisions.length > 0) {
+      const decisionSummary = decisions
+        .map((d, index) => {
+          if (decisions.length === 1) return d;
+          return `### Step ${index + 1} Summary\n${d}`;
+        })
+        .join("\n\n");
+      sections.push(`## 📝 Work Completed & Key Decisions\n${decisionSummary}`);
+    }
+  }
+
+  const modifiedFiles = new Set<string>();
+  if (thread.checkpoints) {
+    for (const checkpoint of thread.checkpoints) {
+      for (const file of checkpoint.files) {
+        if (file.path) {
+          modifiedFiles.add(file.path);
+        }
+      }
+    }
+  }
+  if (thread.activities) {
+    for (const activity of thread.activities) {
+      if (activity.payload && typeof activity.payload === "object") {
+        const payload = activity.payload as Record<string, unknown>;
+        if (typeof payload.filePath === "string") {
+          modifiedFiles.add(payload.filePath);
+        } else if (typeof payload.path === "string") {
+          modifiedFiles.add(payload.path);
+        } else if (Array.isArray(payload.files)) {
+          for (const f of payload.files) {
+            if (typeof f === "string") modifiedFiles.add(f);
+            else if (
+              f &&
+              typeof f === "object" &&
+              typeof (f as { path?: unknown }).path === "string"
+            ) {
+              modifiedFiles.add((f as { path: string }).path);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (modifiedFiles.size > 0) {
+    const fileList = Array.from(modifiedFiles)
+      .sort()
+      .map((f) => `- \`${f}\``)
+      .join("\n");
+    sections.push(`## 📂 Modified & Relevant Files\n${fileList}`);
+  }
+
+  if (thread.activities && thread.activities.length > 0) {
+    const relevantCommands: string[] = [];
+    for (const act of thread.activities) {
+      if (
+        act.kind === "terminal" ||
+        act.tone === "tool" ||
+        act.summary.toLowerCase().includes("run") ||
+        act.summary.toLowerCase().includes("test")
+      ) {
+        relevantCommands.push(`- ${act.summary}`);
+      }
+    }
+    if (relevantCommands.length > 0) {
+      const deduped = Array.from(new Set(relevantCommands)).slice(-10);
+      sections.push(`## ⚙️ Key Actions & Commands Executed\n${deduped.join("\n")}`);
+    }
+  }
+
+  if (thread.proposedPlans && thread.proposedPlans.length > 0) {
+    const latestPlan = thread.proposedPlans[thread.proposedPlans.length - 1];
+    if (latestPlan && latestPlan.planMarkdown.trim().length > 0) {
+      sections.push(`## 📋 Execution Plan\n${latestPlan.planMarkdown.trim()}`);
+    }
+  }
+
+  if (userMessages.length > 0) {
+    const latestUserMsg = userMessages[userMessages.length - 1]?.text.trim();
+    if (
+      latestUserMsg &&
+      (userMessages.length > 1 || !sections.some((s) => s.includes(latestUserMsg)))
+    ) {
+      sections.push(`## ⏭️ Latest Request / Next Immediate Step\n${latestUserMsg}`);
+    }
+  }
+
+  return sections.join("\n\n");
+}


### PR DESCRIPTION
### Summary
This PR implements cross-provider model switching via structured thread handoffs.

### Problem
Previously, once a thread started, switching to a different provider or incompatible driver (e.g. Claude Code ↔ Codex, Antigravity, etc.) was blocked because runtime session cursors and subprocess lifecycles are mutually incompatible across providers. Removing the lock directly was unsafe and could cause empty sessions or out-of-sync transcripts.

### Solution
- **Handoff Fork**: When selecting an incompatible provider or driver in an active conversation, the user is offered a structured handoff dialog (`ThreadHandoffDialog`) instead of being blocked.
- **Deterministic Context Synthesis**: Implemented `buildThreadHandoffMarkdown` in `@t3tools/client-runtime/handoff` to compile canonical goal, decisions, modified files, terminal commands, active plans, and latest requests without relying on external LLM summarization.
- **Transparency & Control**: The user can review, edit, or adjust the synthesized context before continuing into the new thread.
- **Thread Integrity**: The source thread remains untouched and accessible.

### Verification
- Added comprehensive unit tests in `@t3tools/client-runtime` for Claude ↔ Codex transitions and offline source threads.
- Added component tests for `ThreadHandoffDialog` in `@t3tools/web`.
- Validated with `vp fmt`, `vp lint`, and test suites.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches thread create/start/navigation and model-lock behavior on live conversations; failures are partially mitigated by cleanup and toasts, but a bad handoff could still start the wrong model or lose context if synthesis is incomplete.
> 
> **Overview**
> **Cross-provider model switching** on active server threads no longer hard-blocks incompatible picks in the composer. Choosing a different driver/continuation group—or a model change that would normally be blocked on a started thread—opens **`ThreadHandoffDialog`** so the user can review and edit context, then continue in a **new** thread; the original thread is left unchanged.
> 
> **`buildThreadHandoffMarkdown`** in `@t3tools/client-runtime/handoff` deterministically assembles handoff markdown from the source thread (messages, activities, checkpoints, plans, etc.). Confirming handoff **creates** a titled fork (`… (Handoff)`), **starts** the first turn with the markdown as the user message, **waits** for the thread to start, **navigates** to it, and **deletes** the new thread if anything fails.
> 
> The **model picker** gains an optional **`allowHandoff`** mode: cross-provider rows show a **Handoff** badge and stay selectable instead of being filtered/disabled when the provider is locked. Unit and component tests cover markdown generation and dialog rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e55a6cccdf2489624a4affe029ca1b8114fccbf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add cross-provider model handoff with structured context in chat threads
> - When a user selects a model from a different provider (or continuation group) in an active server thread, a handoff dialog opens instead of blocking the selection.
> - The dialog displays and allows editing of structured handoff markdown (built by `buildThreadHandoffMarkdown` in `packages/client-runtime/src/handoff/threadHandoff.ts`) that captures thread context such as the original goal, decisions, modified files, and latest request.
> - On confirmation, a new server thread is created with the handoff message as the seed, the UI navigates to it, and a success toast is shown; failures show an error toast and attempt to delete the created thread.
> - The model picker now shows cross-provider models as selectable with a 'Handoff' badge rather than filtering or disabling them when `allowHandoff` is true.
> - Behavioral Change: models that were previously disabled in the picker for started server threads are now enabled, and cross-provider selections trigger the handoff flow instead of a warning.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e55a6cc. 7 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->