### PR TITLE
fix(web): fix thread jumping after reorder

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { defaultAnimateLayoutChanges, type AnimateLayoutChanges } from "@dnd-kit/sortable";
 import {
+  animatePinnedLayoutChanges,
   archiveSelectedThreadEntries,
   buildBulkTitleRegenerationContextMenuItem,
   buildMultiSelectThreadContextMenuItems,
@@ -52,6 +54,32 @@ import {
 } from "../types";
 
 const localEnvironmentId = EnvironmentId.make("environment-local");
+
+describe("animatePinnedLayoutChanges", () => {
+  const baseArgs: Parameters<AnimateLayoutChanges>[0] = {
+    active: null,
+    containerId: "pinned-threads",
+    isDragging: false,
+    isSorting: false,
+    id: "thread-a",
+    index: 1,
+    items: ["thread-b", "thread-a"],
+    newIndex: 0,
+    previousItems: ["thread-a", "thread-b"],
+    previousContainerId: "pinned-threads",
+    transition: { duration: 200, easing: "ease" },
+    wasDragging: true,
+  };
+
+  it("does not replay layout movement after the pointer is released", () => {
+    expect(defaultAnimateLayoutChanges(baseArgs)).toBe(true);
+    expect(animatePinnedLayoutChanges(baseArgs)).toBe(false);
+  });
+
+  it("keeps layout movement while the user is sorting", () => {
+    expect(animatePinnedLayoutChanges({ ...baseArgs, isSorting: true })).toBe(true);
+  });
+});
 
 describe("shouldNavigateAfterProjectRemoval", () => {
   const projectThreads = [{ environmentId: "environment-local", id: "thread-1" }];

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { defaultAnimateLayoutChanges, type AnimateLayoutChanges } from "@dnd-kit/sortable";
 import type { ContextMenuItem } from "@t3tools/contracts";
 import type { SidebarProjectSortOrder, SidebarThreadSortOrder } from "@t3tools/contracts/settings";
 import {
@@ -22,6 +23,12 @@ export const THREAD_JUMP_HINT_SHOW_DELAY_MS = 100;
 // so this limit is a direct renderer-heap and server-load multiplier — keep
 // it small; cold opens still render instantly from the cached snapshot.
 export const SIDEBAR_THREAD_PREWARM_LIMIT = 3;
+
+// The list already reaches its destination through sortable transforms while
+// the pointer is down. dnd-kit's default also animates the committed DOM order
+// after release, replaying the same movement across every affected row.
+export const animatePinnedLayoutChanges: AnimateLayoutChanges = (args) =>
+  args.isSorting ? defaultAnimateLayoutChanges(args) : false;
 
 type SidebarProject = {
   id: string;

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -121,6 +121,7 @@ import type { SidebarThreadSummary } from "../types";
 import { cn } from "~/lib/utils";
 import { buildThreadActionMenuItems } from "./threadActionMenu.logic";
 import {
+  animatePinnedLayoutChanges,
   buildBulkTitleRegenerationContextMenuItem,
   formatWorkingDurationLabel,
   firstValidTimestampMs,
@@ -448,6 +449,7 @@ function SortablePinnedThreadRow(props: {
 }) {
   const { listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: props.id,
+    animateLayoutChanges: animatePinnedLayoutChanges,
   });
   return props.children({ listeners, setNodeRef, transform, transition, isDragging });
 }


### PR DESCRIPTION
## Problem

Pinned sidebar rows already reach their destination while dragging, but dnd-kit's default layout-change behavior animates the committed DOM order again after release. That produces a redundant whole-list shift after a single manual reorder.

## Fix

Use a pinned-thread-specific layout animation predicate that preserves dnd-kit's guarded behavior during pointer and keyboard sorting, while disabling only the post-drop layout replay. Add focused coverage that pins the intentional difference from dnd-kit's default.

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td>



https://github.com/user-attachments/assets/2c03d984-d0f2-4ee6-8cd4-dae8e4b33e47



 <td>


https://github.com/user-attachments/assets/3f5c2358-750e-44a9-b726-986bfd83463e



</table>

Built with GPT-5.6 Codex in T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop pinned threads animating after a drag-and-drop is released
> After dropping a pinned thread, dnd-kit replays layout animations to reconcile the committed DOM order, causing threads to visually jump. A new `animatePinnedLayoutChanges` function is introduced in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/7103/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) and passed as `animateLayoutChanges` to the `useSortable` hook in `SortablePinnedThreadRow`. It returns `false` when not actively sorting, suppressing the post-release animation, and delegates to `defaultAnimateLayoutChanges` while sorting is in progress.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bc3e4ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only dnd-kit animation tweak for pinned rows with tests; no data, auth, or reorder persistence changes.
> 
> **Overview**
> Fixes a **visual jump** after reordering pinned sidebar threads: rows already move via dnd-kit transforms while dragging, but the library’s default **post-release layout animation** replayed the same shift on the committed DOM order.
> 
> Adds **`animatePinnedLayoutChanges`** in `Sidebar.logic.ts`—it keeps **`defaultAnimateLayoutChanges`** while `isSorting` is true and returns **`false`** afterward so only the redundant replay is skipped. **`SortablePinnedThreadRow`** passes it as **`animateLayoutChanges`** on `useSortable`. Unit tests assert the difference from dnd-kit’s default on drop vs during sort.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc3e4abfa947ddeade83b2d7552e538cd01a05c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->