### PR TITLE
fix(orchestrator): Stop finished Codex turns from sitting on Waiting

### DIFF
--- a/apps/server/src/orchestration-v2/Adapters/CodexAdapterV2.test.ts
+++ b/apps/server/src/orchestration-v2/Adapters/CodexAdapterV2.test.ts
@@ -3813,6 +3813,235 @@ describe("CodexAdapterV2 post-settle continuation", () => {
     ),
   );
 
+  const ORPHAN_WAIT_SCENARIO = "codex-orphaned-dynamic-tool";
+  const ORPHAN_WAIT_NATIVE_THREAD = "native-codex-orphan-wait-thread";
+  const ORPHAN_WAIT_NATIVE_TURN = "native-codex-orphan-wait-turn";
+  const ORPHAN_WAIT_ITEM = "exec-4669f3bb-78c9-4af1-b44e-daa340d2c538";
+  const PERSISTENT_MONITOR_ITEM = "exec-persistent-monitor";
+  const COMPLETED_WAIT_ITEM = "exec-completed-wait";
+  const ORPHAN_WAIT_PROMPT = "Wait on two nested tasks, then finish.";
+
+  const orphanedDynamicToolTranscript = makeCodexReplayTranscript({
+    scenario: ORPHAN_WAIT_SCENARIO,
+    entries: [
+      ...codexReplayPreamble({
+        nativeThreadId: ORPHAN_WAIT_NATIVE_THREAD,
+        nativeTurnId: ORPHAN_WAIT_NATIVE_TURN,
+        prompt: ORPHAN_WAIT_PROMPT,
+      }),
+      {
+        type: "emit_inbound",
+        label: "item/started/completed-wait",
+        frame: {
+          method: "item/started",
+          params: {
+            item: {
+              type: "mcpToolCall",
+              id: COMPLETED_WAIT_ITEM,
+              server: "t3-code",
+              tool: "t3_thread_wait",
+              status: "inProgress",
+              arguments: { threadId: "thread:completed-wait", timeoutMs: 30000 },
+            },
+            threadId: ORPHAN_WAIT_NATIVE_THREAD,
+            turnId: ORPHAN_WAIT_NATIVE_TURN,
+            startedAtMs: 1782622440500,
+          },
+        },
+      },
+      {
+        type: "emit_inbound",
+        label: "item/completed/completed-wait",
+        frame: {
+          method: "item/completed",
+          params: {
+            item: {
+              type: "mcpToolCall",
+              id: COMPLETED_WAIT_ITEM,
+              server: "t3-code",
+              tool: "t3_thread_wait",
+              status: "completed",
+              arguments: { threadId: "thread:completed-wait", timeoutMs: 30000 },
+              result: { content: [{ type: "text", text: "idle" }] },
+            },
+            threadId: ORPHAN_WAIT_NATIVE_THREAD,
+            turnId: ORPHAN_WAIT_NATIVE_TURN,
+            completedAtMs: 1782622441500,
+          },
+        },
+      },
+      {
+        type: "emit_inbound",
+        label: "item/started/orphan-wait",
+        frame: {
+          method: "item/started",
+          params: {
+            item: {
+              type: "mcpToolCall",
+              id: ORPHAN_WAIT_ITEM,
+              server: "t3-code",
+              tool: "t3_thread_wait",
+              status: "inProgress",
+              arguments: {
+                threadId:
+                  "thread:delegated-task:command%3Amcp%3Aaafffab1-e811-458a-ae83-558e542c61ff%3Adelegate-task%3Areview-mobile-reconnect-opus-20260815",
+                timeoutMs: 30000,
+              },
+            },
+            threadId: ORPHAN_WAIT_NATIVE_THREAD,
+            turnId: ORPHAN_WAIT_NATIVE_TURN,
+            startedAtMs: 1782622442500,
+          },
+        },
+      },
+      {
+        type: "emit_inbound",
+        label: "item/started/persistent-monitor",
+        frame: {
+          method: "item/started",
+          params: {
+            item: {
+              type: "dynamicToolCall",
+              id: PERSISTENT_MONITOR_ITEM,
+              namespace: "grok",
+              tool: "monitor",
+              status: "inProgress",
+              arguments: { persistent: true, command: "tail -f" },
+            },
+            threadId: ORPHAN_WAIT_NATIVE_THREAD,
+            turnId: ORPHAN_WAIT_NATIVE_TURN,
+            startedAtMs: 1782622443500,
+          },
+        },
+      },
+      {
+        type: "emit_inbound",
+        label: "turn/completed",
+        frame: {
+          method: "turn/completed",
+          params: {
+            threadId: ORPHAN_WAIT_NATIVE_THREAD,
+            turn: makeCodexReplayTurn({
+              id: ORPHAN_WAIT_NATIVE_TURN,
+              status: "completed",
+            }),
+          },
+        },
+      },
+      {
+        type: "emit_inbound",
+        label: "item/completed/persistent-monitor",
+        afterMs: 30_000,
+        frame: {
+          method: "item/completed",
+          params: {
+            item: {
+              type: "dynamicToolCall",
+              id: PERSISTENT_MONITOR_ITEM,
+              namespace: "grok",
+              tool: "monitor",
+              status: "completed",
+              arguments: { persistent: true, command: "tail -f" },
+              result: { content: [{ type: "text", text: "stopped" }] },
+            },
+            threadId: ORPHAN_WAIT_NATIVE_THREAD,
+            turnId: ORPHAN_WAIT_NATIVE_TURN,
+            completedAtMs: 1782622473500,
+          },
+        },
+      },
+    ],
+  });
+
+  it.effect(
+    "terminalizes leftover nonpersistent dynamic tools when a completed turn never closes them",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const harness = yield* makeCodexReplayHarness(orphanedDynamicToolTranscript);
+          const now = yield* DateTime.now;
+
+          yield* harness.runtime.startTurn(
+            makeCodexTestTurnInput({
+              threadId: harness.threadId,
+              providerThread: harness.providerThread,
+              now,
+              attemptId: RunAttemptId.make("attempt-codex-orphan-wait"),
+              text: ORPHAN_WAIT_PROMPT,
+            }),
+          );
+          yield* awaitUntil(() => harness.terminalEvents().length === 1, "completed terminal");
+          assert.equal(harness.terminalEvents()[0]?.status, "completed");
+
+          const terminalIndex = harness.events.findIndex((event) => event.type === "turn.terminal");
+          const cancelledWait = harness.events.find(
+            (event, index) =>
+              index < terminalIndex &&
+              event.type === "turn_item.updated" &&
+              event.turnItem.type === "dynamic_tool" &&
+              event.turnItem.nativeItemRef?.nativeId === ORPHAN_WAIT_ITEM &&
+              event.turnItem.status === "cancelled",
+          );
+          assert.isDefined(cancelledWait);
+          assert.isAbove(
+            terminalIndex,
+            harness.events.indexOf(cancelledWait!),
+            "orphaned wait terminalization must precede turn.terminal",
+          );
+
+          const completedWaitStatuses = harness.events.flatMap((event) =>
+            event.type === "turn_item.updated" &&
+            event.turnItem.type === "dynamic_tool" &&
+            event.turnItem.nativeItemRef?.nativeId === COMPLETED_WAIT_ITEM
+              ? [event.turnItem.status]
+              : [],
+          );
+          assert.isTrue(
+            completedWaitStatuses.includes("completed"),
+            "the wait that received item/completed must stay completed",
+          );
+          assert.isFalse(
+            completedWaitStatuses.includes("cancelled"),
+            "a completed wait must not be rewritten as cancelled",
+          );
+
+          const persistentMonitorStatuses = harness.events.flatMap((event) =>
+            event.type === "turn_item.updated" &&
+            event.turnItem.type === "dynamic_tool" &&
+            event.turnItem.nativeItemRef?.nativeId === PERSISTENT_MONITOR_ITEM
+              ? [event.turnItem.status]
+              : [],
+          );
+          assert.isTrue(persistentMonitorStatuses.includes("running"));
+          assert.isFalse(
+            persistentMonitorStatuses.includes("cancelled"),
+            "persistent monitors must remain running after the root turn completes",
+          );
+          assert.isTrue(
+            yield* harness.hasPendingBackgroundWork,
+            "persistent dynamic tools must keep the session residency pin until they complete",
+          );
+
+          yield* TestClock.adjust("30 seconds");
+          const lateMonitorUpdateIndex = () =>
+            harness.events.findIndex(
+              (event, index) =>
+                index > terminalIndex &&
+                event.type === "turn_item.updated" &&
+                event.turnItem.type === "dynamic_tool" &&
+                event.turnItem.nativeItemRef?.nativeId === PERSISTENT_MONITOR_ITEM &&
+                event.turnItem.status === "completed",
+            );
+          yield* awaitUntil(
+            () => lateMonitorUpdateIndex() > terminalIndex,
+            "post-settle persistent tool completion",
+          );
+          assert.lengthOf(harness.terminalEvents(), 1);
+          assert.isFalse(yield* harness.hasPendingBackgroundWork);
+        }).pipe(Effect.provide(Layer.merge(idAllocatorLayer, NodeServices.layer))),
+      ),
+  );
+
   const RESUME_SCENARIO = "codex-resume-subagent";
   const RESUME_NATIVE_THREAD = "native-codex-resume-thread";
   const RESUME_NATIVE_TURN = "native-codex-resume-root-turn";

--- a/apps/server/src/orchestration-v2/Adapters/CodexAdapterV2.test.ts
+++ b/apps/server/src/orchestration-v2/Adapters/CodexAdapterV2.test.ts
@@ -1212,7 +1212,10 @@ describe("CodexAdapterV2 post-settle continuation", () => {
       return yield* Effect.die(`Timed out waiting for ${label}.`);
     });
 
-  const makeCodexReplayHarness = (transcript: CodexReplay.CodexAppServerReplayTranscript) =>
+  const makeCodexReplayHarness = (
+    transcript: CodexReplay.CodexAppServerReplayTranscript,
+    onEvent: (event: ProviderAdapterV2Event) => Effect.Effect<unknown> = () => Effect.void,
+  ) =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
       const idAllocator = yield* IdAllocatorV2;
@@ -1273,6 +1276,7 @@ describe("CodexAdapterV2 post-settle continuation", () => {
                 ? Deferred.succeed(firstTerminal, undefined)
                 : Effect.void,
             ),
+            Effect.andThen(onEvent(event)),
           ),
         ),
         Effect.forkScoped,
@@ -3958,7 +3962,15 @@ describe("CodexAdapterV2 post-settle continuation", () => {
     () =>
       Effect.scoped(
         Effect.gen(function* () {
-          const harness = yield* makeCodexReplayHarness(orphanedDynamicToolTranscript);
+          const monitorCompleted = yield* Deferred.make<void>();
+          const harness = yield* makeCodexReplayHarness(orphanedDynamicToolTranscript, (event) =>
+            event.type === "turn_item.updated" &&
+            event.turnItem.type === "dynamic_tool" &&
+            event.turnItem.nativeItemRef?.nativeId === PERSISTENT_MONITOR_ITEM &&
+            event.turnItem.status === "completed"
+              ? Deferred.succeed(monitorCompleted, undefined)
+              : Effect.void,
+          );
           const now = yield* DateTime.now;
 
           yield* harness.runtime.startTurn(
@@ -3970,7 +3982,7 @@ describe("CodexAdapterV2 post-settle continuation", () => {
               text: ORPHAN_WAIT_PROMPT,
             }),
           );
-          yield* awaitUntil(() => harness.terminalEvents().length === 1, "completed terminal");
+          yield* harness.firstTerminal;
           assert.equal(harness.terminalEvents()[0]?.status, "completed");
 
           const terminalIndex = harness.events.findIndex((event) => event.type === "turn.terminal");
@@ -3989,32 +4001,36 @@ describe("CodexAdapterV2 post-settle continuation", () => {
             "orphaned wait terminalization must precede turn.terminal",
           );
 
-          const completedWaitStatuses = harness.events.flatMap((event) =>
-            event.type === "turn_item.updated" &&
-            event.turnItem.type === "dynamic_tool" &&
-            event.turnItem.nativeItemRef?.nativeId === COMPLETED_WAIT_ITEM
-              ? [event.turnItem.status]
-              : [],
+          const completedWaitStatuses = new Set(
+            harness.events.flatMap((event) =>
+              event.type === "turn_item.updated" &&
+              event.turnItem.type === "dynamic_tool" &&
+              event.turnItem.nativeItemRef?.nativeId === COMPLETED_WAIT_ITEM
+                ? [event.turnItem.status]
+                : [],
+            ),
           );
           assert.isTrue(
-            completedWaitStatuses.includes("completed"),
+            completedWaitStatuses.has("completed"),
             "the wait that received item/completed must stay completed",
           );
           assert.isFalse(
-            completedWaitStatuses.includes("cancelled"),
+            completedWaitStatuses.has("cancelled"),
             "a completed wait must not be rewritten as cancelled",
           );
 
-          const persistentMonitorStatuses = harness.events.flatMap((event) =>
-            event.type === "turn_item.updated" &&
-            event.turnItem.type === "dynamic_tool" &&
-            event.turnItem.nativeItemRef?.nativeId === PERSISTENT_MONITOR_ITEM
-              ? [event.turnItem.status]
-              : [],
+          const persistentMonitorStatuses = new Set(
+            harness.events.flatMap((event) =>
+              event.type === "turn_item.updated" &&
+              event.turnItem.type === "dynamic_tool" &&
+              event.turnItem.nativeItemRef?.nativeId === PERSISTENT_MONITOR_ITEM
+                ? [event.turnItem.status]
+                : [],
+            ),
           );
-          assert.isTrue(persistentMonitorStatuses.includes("running"));
+          assert.isTrue(persistentMonitorStatuses.has("running"));
           assert.isFalse(
-            persistentMonitorStatuses.includes("cancelled"),
+            persistentMonitorStatuses.has("cancelled"),
             "persistent monitors must remain running after the root turn completes",
           );
           assert.isTrue(
@@ -4023,18 +4039,19 @@ describe("CodexAdapterV2 post-settle continuation", () => {
           );
 
           yield* TestClock.adjust("30 seconds");
-          const lateMonitorUpdateIndex = () =>
-            harness.events.findIndex(
-              (event, index) =>
-                index > terminalIndex &&
-                event.type === "turn_item.updated" &&
-                event.turnItem.type === "dynamic_tool" &&
-                event.turnItem.nativeItemRef?.nativeId === PERSISTENT_MONITOR_ITEM &&
-                event.turnItem.status === "completed",
-            );
-          yield* awaitUntil(
-            () => lateMonitorUpdateIndex() > terminalIndex,
-            "post-settle persistent tool completion",
+          yield* Deferred.await(monitorCompleted);
+          const lateMonitorUpdateIndex = harness.events.findIndex(
+            (event, index) =>
+              index > terminalIndex &&
+              event.type === "turn_item.updated" &&
+              event.turnItem.type === "dynamic_tool" &&
+              event.turnItem.nativeItemRef?.nativeId === PERSISTENT_MONITOR_ITEM &&
+              event.turnItem.status === "completed",
+          );
+          assert.isAbove(
+            lateMonitorUpdateIndex,
+            terminalIndex,
+            "persistent tool completion must follow turn.terminal",
           );
           assert.lengthOf(harness.terminalEvents(), 1);
           assert.isFalse(yield* harness.hasPendingBackgroundWork);

--- a/apps/server/src/orchestration-v2/Adapters/CodexAdapterV2.ts
+++ b/apps/server/src/orchestration-v2/Adapters/CodexAdapterV2.ts
@@ -891,6 +891,14 @@ interface TrackedRunningCommandItem {
   readonly processId?: string;
 }
 
+function isPersistentCodexDynamicTool(item: CodexDynamicToolItem): boolean {
+  const input = item.arguments;
+  if (input === null || typeof input !== "object" || Array.isArray(input)) {
+    return false;
+  }
+  return Reflect.get(input, "persistent") === true;
+}
+
 type CodexRootTerminalEvent = Extract<ProviderAdapterV2Event, { readonly type: "turn.terminal" }>;
 
 interface DeferredCodexRootTerminal {
@@ -1571,6 +1579,9 @@ export function makeCodexAdapterV2(adapterOptions: CodexAdapterV2Options): Provi
         const runningCommandItemsByTurn = yield* Ref.make(
           new Map<string, Map<string, TrackedRunningCommandItem>>(),
         );
+        const runningDynamicToolsByTurn = yield* Ref.make(
+          new Map<string, Map<string, CodexDynamicToolItem>>(),
+        );
         const interruptingNativeTurns = yield* Ref.make(new Set<string>());
         const terminalizedNonCompletedNativeTurns = yield* Ref.make(new Set<string>());
         // Keep the run event stream open until descendant provider state is
@@ -1748,6 +1759,89 @@ export function makeCodexAdapterV2(adapterOptions: CodexAdapterV2Options): Provi
             return [remaining.size === 0, updated] as const;
           });
 
+        const trackRunningDynamicTool = (nativeTurnId: string, item: CodexDynamicToolItem) =>
+          Ref.update(runningDynamicToolsByTurn, (current) => {
+            const updated = new Map(current);
+            const items = new Map(updated.get(nativeTurnId) ?? []);
+            items.set(item.id, item);
+            updated.set(nativeTurnId, items);
+            return updated;
+          });
+
+        const clearRunningDynamicTool = (nativeTurnId: string, nativeItemId: string) =>
+          Ref.update(runningDynamicToolsByTurn, (current) => {
+            const items = current.get(nativeTurnId);
+            if (items === undefined || !items.has(nativeItemId)) {
+              return current;
+            }
+            const remaining = new Map(items);
+            remaining.delete(nativeItemId);
+            const updated = new Map(current);
+            if (remaining.size === 0) {
+              updated.delete(nativeTurnId);
+            } else {
+              updated.set(nativeTurnId, remaining);
+            }
+            return updated;
+          });
+
+        const turnHasRetainedBackgroundWork = (nativeTurnId: string) =>
+          Effect.gen(function* () {
+            const commands = (yield* Ref.get(runningCommandItemsByTurn)).get(nativeTurnId);
+            if (commands !== undefined && commands.size > 0) {
+              return true;
+            }
+            const tools = (yield* Ref.get(runningDynamicToolsByTurn)).get(nativeTurnId);
+            if (tools === undefined) {
+              return false;
+            }
+            for (const item of tools.values()) {
+              if (isPersistentCodexDynamicTool(item)) {
+                return true;
+              }
+            }
+            return false;
+          });
+
+        const releaseSettledTurnIfIdle = (nativeTurnId: string) =>
+          Effect.gen(function* () {
+            if (yield* turnHasRetainedBackgroundWork(nativeTurnId)) {
+              return;
+            }
+            yield* Ref.update(settledTurns, (current) => {
+              if (!current.has(nativeTurnId)) {
+                return current;
+              }
+              const updated = new Map(current);
+              updated.delete(nativeTurnId);
+              return updated;
+            });
+            yield* Ref.update(offeredContinuationItemsByTurn, (current) => {
+              if (!current.has(nativeTurnId)) {
+                return current;
+              }
+              const updated = new Map(current);
+              updated.delete(nativeTurnId);
+              return updated;
+            });
+            yield* Ref.update(completedFinalAnswerTextsByTurn, (current) => {
+              if (!current.has(nativeTurnId)) {
+                return current;
+              }
+              const updated = new Map(current);
+              updated.delete(nativeTurnId);
+              return updated;
+            });
+            yield* Ref.update(finalAnswerItemIdsByTurn, (current) => {
+              if (!current.has(nativeTurnId)) {
+                return current;
+              }
+              const updated = new Map(current);
+              updated.delete(nativeTurnId);
+              return updated;
+            });
+          });
+
         /**
          * When a turn is interrupted or failed, Codex often leaves commandExecution
          * items mid-flight (no item/completed). Emit terminal turn items before
@@ -1824,6 +1918,69 @@ export function makeCodexAdapterV2(adapterOptions: CodexAdapterV2Options): Provi
                 turnItem,
               });
             }
+          });
+
+        /**
+         * Yielded exec cells can start MCP / dynamic tools that never receive
+         * item/completed when functions.wait terminates the cell. Terminalize
+         * leftover nonpersistent tools before turn.terminal. Persistent tools
+         * can outlive the root turn and must stay running.
+         */
+        const terminalizeRunningDynamicTools = (
+          context: ActiveCodexTurnContext,
+          nativeTurnId: string,
+          status: "cancelled" | "interrupted" | "failed",
+          completedAt: DateTime.Utc,
+          includePersistent: boolean,
+        ) =>
+          Effect.gen(function* () {
+            const items = (yield* Ref.get(runningDynamicToolsByTurn)).get(nativeTurnId);
+            if (items === undefined || items.size === 0) {
+              return;
+            }
+            for (const tracked of items.values()) {
+              if (!includePersistent && isPersistentCodexDynamicTool(tracked)) {
+                continue;
+              }
+              const artifacts = yield* buildDynamicToolArtifacts(context, tracked);
+              yield* emitProviderEvent({
+                type: "node.updated",
+                driver: CODEX_PROVIDER,
+                node: {
+                  ...artifacts.node,
+                  status,
+                  completedAt,
+                },
+              });
+              yield* emitProviderEvent({
+                type: "turn_item.updated",
+                driver: CODEX_PROVIDER,
+                turnItem: {
+                  ...artifacts.turnItem,
+                  status,
+                  completedAt,
+                  updatedAt: completedAt,
+                },
+              });
+            }
+            yield* Ref.update(runningDynamicToolsByTurn, (current) => {
+              if (!current.has(nativeTurnId)) {
+                return current;
+              }
+              const remaining = new Map(current.get(nativeTurnId) ?? []);
+              for (const tracked of remaining.values()) {
+                if (includePersistent || !isPersistentCodexDynamicTool(tracked)) {
+                  remaining.delete(tracked.id);
+                }
+              }
+              const updated = new Map(current);
+              if (remaining.size === 0) {
+                updated.delete(nativeTurnId);
+              } else {
+                updated.set(nativeTurnId, remaining);
+              }
+              return updated;
+            });
           });
 
         const resolveItemOrdinal = (context: ActiveCodexTurnContext, nativeItemId: string) =>
@@ -3555,6 +3712,9 @@ export function makeCodexAdapterV2(adapterOptions: CodexAdapterV2Options): Provi
             }
 
             if (payload.item.type === "mcpToolCall" || payload.item.type === "dynamicToolCall") {
+              if (!codexItemStatus(payload.item.status).completed) {
+                yield* trackRunningDynamicTool(payload.turnId, payload.item);
+              }
               const artifacts = yield* buildDynamicToolArtifacts(context, payload.item);
               yield* emitProviderEvent({
                 type: "node.updated",
@@ -3649,41 +3809,14 @@ export function makeCodexAdapterV2(adapterOptions: CodexAdapterV2Options): Provi
                   }
                 }
                 if (turnDrained) {
-                  yield* Ref.update(settledTurns, (current) => {
-                    const updated = new Map(current);
-                    updated.delete(payload.turnId);
-                    return updated;
-                  });
-                  yield* Ref.update(offeredContinuationItemsByTurn, (current) => {
-                    if (!current.has(payload.turnId)) {
-                      return current;
-                    }
-                    const updated = new Map(current);
-                    updated.delete(payload.turnId);
-                    return updated;
-                  });
-                  yield* Ref.update(completedFinalAnswerTextsByTurn, (current) => {
-                    if (!current.has(payload.turnId)) {
-                      return current;
-                    }
-                    const updated = new Map(current);
-                    updated.delete(payload.turnId);
-                    return updated;
-                  });
-                  yield* Ref.update(finalAnswerItemIdsByTurn, (current) => {
-                    if (!current.has(payload.turnId)) {
-                      return current;
-                    }
-                    const updated = new Map(current);
-                    updated.delete(payload.turnId);
-                    return updated;
-                  });
+                  yield* releaseSettledTurnIfIdle(payload.turnId);
                 }
               }
               return;
             }
 
             if (payload.item.type === "mcpToolCall" || payload.item.type === "dynamicToolCall") {
+              yield* clearRunningDynamicTool(payload.turnId, payload.item.id);
               const artifacts = yield* buildDynamicToolArtifacts(context, payload.item);
               yield* emitProviderEvent({
                 type: "node.updated",
@@ -3695,6 +3828,9 @@ export function makeCodexAdapterV2(adapterOptions: CodexAdapterV2Options): Provi
                 driver: CODEX_PROVIDER,
                 turnItem: artifacts.turnItem,
               });
+              if (settled) {
+                yield* releaseSettledTurnIfIdle(payload.turnId);
+              }
               return;
             }
 
@@ -4575,6 +4711,17 @@ export function makeCodexAdapterV2(adapterOptions: CodexAdapterV2Options): Provi
                   input.completedAt,
                 );
               }
+              const dynamicToolStatus: "cancelled" | "interrupted" | "failed" =
+                input.status === "interrupted" || input.status === "failed"
+                  ? input.status
+                  : "cancelled";
+              yield* terminalizeRunningDynamicTools(
+                input.context,
+                input.nativeTurnId,
+                dynamicToolStatus,
+                input.completedAt,
+                input.status === "interrupted" || input.status === "failed",
+              );
               if (input.context.subagent === null) {
                 yield* emitOrDeferRootTerminal({
                   ...input,
@@ -4585,16 +4732,15 @@ export function makeCodexAdapterV2(adapterOptions: CodexAdapterV2Options): Provi
               if (waiter !== undefined) {
                 yield* Deferred.succeed(waiter, undefined);
               }
-              const runningItems = (yield* Ref.get(runningCommandItemsByTurn)).get(
-                input.nativeTurnId,
-              );
               const interruptInProgress = (yield* Ref.get(interruptingNativeTurns)).has(
                 input.nativeTurnId,
               );
-              // Completed turns can retain late background command context.
-              // Interrupted and failed turns never wake from late item events.
+              // Completed turns can retain late background command context and
+              // leftover persistent dynamic tools. Interrupted and failed turns
+              // never wake from late item events.
               const retainSettledContext =
-                input.status === "completed" && runningItems !== undefined && runningItems.size > 0;
+                input.status === "completed" &&
+                (yield* turnHasRetainedBackgroundWork(input.nativeTurnId));
               if (retainSettledContext) {
                 yield* Ref.update(settledTurns, (current) => {
                   const updated = new Map(current);
@@ -4610,6 +4756,14 @@ export function makeCodexAdapterV2(adapterOptions: CodexAdapterV2Options): Provi
               yield* flushReadyRootTerminals();
               if (!retainSettledContext && !interruptInProgress) {
                 yield* Ref.update(runningCommandItemsByTurn, (current) => {
+                  if (!current.has(input.nativeTurnId)) {
+                    return current;
+                  }
+                  const updated = new Map(current);
+                  updated.delete(input.nativeTurnId);
+                  return updated;
+                });
+                yield* Ref.update(runningDynamicToolsByTurn, (current) => {
                   if (!current.has(input.nativeTurnId)) {
                     return current;
                   }
@@ -4676,6 +4830,11 @@ export function makeCodexAdapterV2(adapterOptions: CodexAdapterV2Options): Provi
           // signal to pin on.
           hasPendingBackgroundWork: Effect.gen(function* () {
             for (const items of (yield* Ref.get(runningCommandItemsByTurn)).values()) {
+              if (items.size > 0) {
+                return true;
+              }
+            }
+            for (const items of (yield* Ref.get(runningDynamicToolsByTurn)).values()) {
               if (items.size > 0) {
                 return true;
               }

--- a/apps/server/src/orchestration-v2/ProviderRuntimeRecoveryService.test.ts
+++ b/apps/server/src/orchestration-v2/ProviderRuntimeRecoveryService.test.ts
@@ -868,13 +868,7 @@ it.effect(
       Layer.provide(
         Layer.mergeAll(
           Layer.mock(ProjectionStore.ProjectionStoreV2)({
-            getShellSnapshot: () =>
-              Effect.succeed({
-                schemaVersion: 2,
-                snapshotSequence: 0,
-                threads: [{ id: threadId }],
-                archivedThreads: [],
-              } as never),
+            getRecoveryThreadIds: () => Effect.succeed([threadId]),
             getThreadProjection: () => Effect.succeed(projection),
           }),
           Layer.mock(EventSink.EventSinkV2)({

--- a/apps/server/src/orchestration-v2/ProviderRuntimeRecoveryService.test.ts
+++ b/apps/server/src/orchestration-v2/ProviderRuntimeRecoveryService.test.ts
@@ -794,6 +794,134 @@ it.effect(
 );
 
 it.effect(
+  "terminalizes a leftover nonpersistent dynamic_tool on a settled run after process loss",
+  () => {
+    const threadId = ThreadId.make("thread_recovery_orphan_wait");
+    const settledRunId = RunId.make("run_recovery_orphan_wait_settled");
+    const providerThreadId = ProviderThreadId.make("provider_thread_recovery_orphan_wait");
+    const orphanWaitItemId = TurnItemId.make(
+      "turn-item:provider:codex:native-item:exec-4669f3bb-78c9-4af1-b44e-daa340d2c538",
+    );
+    const persistentMonitorItemId = TurnItemId.make(
+      "turn-item:provider:codex:native-item:exec-persistent-monitor",
+    );
+    const orphanWaitNodeId = NodeId.make("node_recovery_orphan_wait");
+    const persistentMonitorNodeId = NodeId.make("node_recovery_persistent_monitor");
+    const codexInstanceId = ProviderInstanceId.make("codex");
+    let committedInput: Parameters<EventSink.EventSinkV2["Service"]["commitCommand"]>[0] | null =
+      null;
+    const projection = {
+      thread: { id: threadId, providerInstanceId: codexInstanceId },
+      runtimeRequests: [],
+      providerSessions: [],
+      providerThreads: [
+        {
+          id: providerThreadId,
+          driver: ProviderDriverKind.make("codex"),
+          providerInstanceId: codexInstanceId,
+          status: "idle",
+          pendingBackgroundTasks: [],
+        },
+      ],
+      providerTurns: [],
+      runs: [{ id: settledRunId, status: "completed", providerInstanceId: codexInstanceId }],
+      attempts: [],
+      nodes: [
+        { id: orphanWaitNodeId, runId: settledRunId, status: "running", kind: "tool_call" },
+        {
+          id: persistentMonitorNodeId,
+          runId: settledRunId,
+          status: "running",
+          kind: "tool_call",
+        },
+      ],
+      subagents: [],
+      messages: [],
+      turnItems: [
+        {
+          id: orphanWaitItemId,
+          runId: settledRunId,
+          nodeId: orphanWaitNodeId,
+          providerThreadId,
+          type: "dynamic_tool",
+          status: "running",
+          toolName: "t3-code.t3_thread_wait",
+          input: {
+            threadId:
+              "thread:delegated-task:command%3Amcp%3Aaafffab1-e811-458a-ae83-558e542c61ff%3Adelegate-task%3Areview-mobile-reconnect-opus-20260815",
+            timeoutMs: 30000,
+          },
+        },
+        {
+          id: persistentMonitorItemId,
+          runId: settledRunId,
+          nodeId: persistentMonitorNodeId,
+          providerThreadId,
+          type: "dynamic_tool",
+          status: "running",
+          toolName: "grok.monitor",
+          input: { persistent: true, command: "tail -f" },
+        },
+      ],
+    } as unknown as OrchestrationV2ThreadProjection;
+    const layer = ProviderRuntimeRecovery.layer.pipe(
+      Layer.provide(
+        Layer.mergeAll(
+          Layer.mock(ProjectionStore.ProjectionStoreV2)({
+            getShellSnapshot: () =>
+              Effect.succeed({
+                schemaVersion: 2,
+                snapshotSequence: 0,
+                threads: [{ id: threadId }],
+                archivedThreads: [],
+              } as never),
+            getThreadProjection: () => Effect.succeed(projection),
+          }),
+          Layer.mock(EventSink.EventSinkV2)({
+            commitCommand: (input) => {
+              committedInput = input;
+              return Effect.succeed({ committed: true, cancelledEffectCount: 0 } as never);
+            },
+          }),
+          IdAllocator.layer,
+          Layer.mock(EffectWorker.OrchestrationEffectWorkerV2)({ runOnce: Effect.succeed(false) }),
+          Layer.mock(EffectOutbox.EffectOutboxV2)({
+            listByCommandId: () => Effect.succeed([]),
+            reconcileAfterProcessLoss: Effect.succeed({ requeued: 0, cancelled: 0 }),
+          }),
+        ),
+      ),
+    );
+
+    return Effect.gen(function* () {
+      const summary =
+        yield* (yield* ProviderRuntimeRecovery.ProviderRuntimeRecoveryService).reconcile("startup");
+      assert.equal(summary.terminalizedRuns, 0);
+      const turnItemCancels = (committedInput?.events ?? []).filter(
+        (event) => event.type === "turn-item.updated" && event.payload.status === "cancelled",
+      );
+      // Process loss means the provider is gone, so even a persistent monitor
+      // cannot still be alive. The leftover wait and the monitor both close.
+      assert.equal(turnItemCancels.length, 2);
+      assert.deepEqual(
+        turnItemCancels
+          .map((event) => event.type === "turn-item.updated" && event.payload.id)
+          .sort(),
+        [orphanWaitItemId, persistentMonitorItemId].sort(),
+      );
+      const nodeCancels = (committedInput?.events ?? []).filter(
+        (event) => event.type === "node.updated" && event.payload.status === "cancelled",
+      );
+      assert.equal(nodeCancels.length, 2);
+      assert.deepEqual(
+        nodeCancels.map((event) => event.type === "node.updated" && event.payload.id).sort(),
+        [orphanWaitNodeId, persistentMonitorNodeId].sort(),
+      );
+    }).pipe(Effect.provide(layer));
+  },
+);
+
+it.effect(
   "terminalizes the linked subagent and node for a stale subagent item on a settled run",
   () => {
     const threadId = ThreadId.make("thread_recovery_subagent");

--- a/apps/server/src/orchestration-v2/ProviderRuntimeRecoveryService.ts
+++ b/apps/server/src/orchestration-v2/ProviderRuntimeRecoveryService.ts
@@ -322,6 +322,7 @@ export const make = Effect.gen(function* () {
       // cancelled above for recovered nonterminal runs to avoid duplicate
       // cancellation events.
       const recoveredNonterminalRunIds = new Set(runs.map((run) => run.id));
+      const cancelledStaleNodeIds = new Set<string>();
       for (const item of projection.turnItems ?? []) {
         if (item.runId !== null && recoveredNonterminalRunIds.has(item.runId)) {
           continue;
@@ -343,13 +344,32 @@ export const make = Effect.gen(function* () {
           occurredAt: now,
           payload: { ...item, status: "cancelled", completedAt: now, updatedAt: now },
         });
+        if (item.nodeId !== null && item.nodeId !== undefined) {
+          const staleItemNode = projection.nodes.find(
+            (candidate) =>
+              candidate.id === item.nodeId && isNonterminalNodeStatus(candidate.status),
+          );
+          if (staleItemNode !== undefined && !cancelledStaleNodeIds.has(staleItemNode.id)) {
+            cancelledStaleNodeIds.add(staleItemNode.id);
+            events.push({
+              id: yield* allocateEventId(),
+              type: "node.updated",
+              threadId: projection.thread.id,
+              ...(item.runId === null ? {} : { runId: item.runId }),
+              nodeId: staleItemNode.id,
+              providerInstanceId,
+              occurredAt: now,
+              payload: { ...staleItemNode, status: "cancelled", completedAt: now },
+            });
+          }
+        }
         if (item.type !== "subagent") {
           continue;
         }
         // Cancelling only the turn item would leave the linked subagent entity
-        // and its execution node non-terminal forever, since the dead provider
-        // process can no longer emit their terminal events. Match the exact
-        // linked ids so a subagent that already finished is never overwritten.
+        // non-terminal forever, since the dead provider process can no longer
+        // emit its terminal event. Match the exact linked id so a subagent
+        // that already finished is never overwritten.
         const staleSubagent = projection.subagents.find(
           (candidate) =>
             candidate.id === item.subagentId && isNonterminalSubagentStatus(candidate.status),
@@ -371,7 +391,8 @@ export const make = Effect.gen(function* () {
           (candidate) =>
             candidate.id === item.subagentId && isNonterminalNodeStatus(candidate.status),
         );
-        if (staleSubagentNode !== undefined) {
+        if (staleSubagentNode !== undefined && !cancelledStaleNodeIds.has(staleSubagentNode.id)) {
+          cancelledStaleNodeIds.add(staleSubagentNode.id);
           events.push({
             id: yield* allocateEventId(),
             type: "node.updated",


### PR DESCRIPTION
Codex can finish a turn without sending completion events for dynamic tools left behind by a terminated exec cell. Those tools and their execution nodes could leave an otherwise completed thread displaying Waiting, including after server restart.

Track in-flight dynamic tools and cancel nonpersistent leftovers before publishing the turn's terminal event. Persistent monitors retain their context until they finish; interrupted and failed turns terminate their remaining tools. Restart recovery now cancels the matching orphan execution nodes as well as their turn items, without cancelling a node twice.

Rebased onto v2 at `07e8f8d40d`, with test fixtures adapted to the current recovery API. Against that exact base, the new orphan-wait and recovery regressions fail. With this change, both focused adapter/recovery test files pass (65 tests), covering cancellation order, normally completed tools, persistent monitors, late completion, and restart cleanup. Server typecheck, targeted lint, and formatting pass. This is a provider lifecycle fix; the before/after proof is protocol replay and recovery assertions rather than screenshots.

Current-head CI remains blocked by failures already present on v2: formatting, the migration-count expectation, lockfile-free dependency patch resolution, and stale provider replay fixtures. The focused checks above pass; these results do not establish green CI.

Original implementation by Mike Olson. Preparation: GPT-6 via Codex.
