### PR TITLE
fix(mobile): enable agent activity publishing when linking from mobile

### DIFF
--- a/apps/mobile/src/features/agent-awareness/capabilities.ts
+++ b/apps/mobile/src/features/agent-awareness/capabilities.ts
@@ -1,5 +1,14 @@
 import Constants from "expo-constants";
+import { Platform } from "react-native";
 
 export function supportsAgentAwarenessPush() {
   return Constants.expoConfig?.extra?.iosPersonalTeamBuild !== true;
+}
+
+/** Whether this client can actually receive relay-delivered agent awareness
+    pushes. APNs registration is iOS-only (see `canRegisterRemoteLiveActivities`
+    in remoteRegistration), and personal-team builds ship without the push
+    entitlement, so neither can consume anything the environment publishes. */
+export function canReceiveAgentAwarenessPush() {
+  return Platform.OS === "ios" && supportsAgentAwarenessPush();
 }

--- a/apps/mobile/src/features/cloud/linkEnvironment.test.ts
+++ b/apps/mobile/src/features/cloud/linkEnvironment.test.ts
@@ -141,6 +141,17 @@ function validLinkResponse(environmentId = "env-1") {
   };
 }
 
+function validCloudLinkState() {
+  return {
+    linked: true,
+    cloudUserId: "user_123",
+    relayUrl: "https://relay.example.test",
+    relayIssuer: "https://relay.example.test",
+    managedTunnelActive: true,
+    publishAgentActivity: true,
+  };
+}
+
 function validLinkChallengeResponse() {
   return {
     challenge: "link-challenge",
@@ -755,6 +766,9 @@ describe("mobile cloud link environment client", () => {
         if (String(url).endsWith("/v1/client/environment-links")) {
           return Promise.resolve(Response.json(validLinkResponse()));
         }
+        if (String(url).endsWith("/api/connect/preferences")) {
+          return Promise.resolve(Response.json(validCloudLinkState()));
+        }
         return Promise.resolve(
           Response.json({ ok: true, endpointRuntimeStatus: { status: "configured" } }),
         );
@@ -789,6 +803,9 @@ describe("mobile cloud link environment client", () => {
         cloudUserId: "user_123",
         environmentCredential: "environment-credential",
       });
+      // Turning Live Activities off must still leave the environment
+      // publishing: the relay falls back to plain alert pushes in that mode.
+      expect(bodies[4]).toMatchObject({ publishAgentActivity: true });
     }),
   );
 
@@ -809,6 +826,9 @@ describe("mobile cloud link environment client", () => {
         }
         if (String(url).endsWith("/v1/client/environment-links")) {
           return Promise.resolve(Response.json(validLinkResponse()));
+        }
+        if (String(url).endsWith("/api/connect/preferences")) {
+          return Promise.resolve(Response.json(validCloudLinkState()));
         }
         return Promise.resolve(
           Response.json({ ok: true, endpointRuntimeStatus: { status: "configured" } }),

--- a/apps/mobile/src/features/cloud/linkEnvironment.ts
+++ b/apps/mobile/src/features/cloud/linkEnvironment.ts
@@ -30,6 +30,7 @@ import { makeEnvironmentHttpApiClient } from "@t3tools/client-runtime/rpc";
 
 import { authClientMetadata } from "../../lib/authClientMetadata";
 import type { SavedRemoteConnection } from "../../lib/connection";
+import { canReceiveAgentAwarenessPush } from "../agent-awareness/capabilities";
 import * as MobilePreferences from "../../persistence/mobile-preferences";
 import * as MobileStorage from "../../persistence/mobile-storage";
 import { resolveCloudPublicConfig } from "./publicConfig";
@@ -358,6 +359,27 @@ export function linkEnvironmentToCloudWithPreference(
       .pipe(
         Effect.mapError(cloudEnvironmentLinkError("Could not configure environment relay access.")),
       );
+
+    // Relay credentials alone do not make an environment emit anything:
+    // agent-activity publishing is a separate opt-in that defaults to off, so a
+    // mobile-linked environment stays silent and no Live Activity or push can
+    // ever arrive. Deliberately not gated on `liveActivitiesEnabled` — the
+    // relay falls back to plain alert pushes when Live Activities are off but
+    // notifications are on, and that path needs publishing just as much.
+    if (canReceiveAgentAwarenessPush()) {
+      yield* environmentClient.connect
+        .preferences({
+          headers: { authorization: `Bearer ${localBearerToken}` },
+          payload: { publishAgentActivity: true },
+        })
+        .pipe(
+          Effect.mapError(
+            cloudEnvironmentLinkError(
+              "Could not enable agent activity publishing on the environment.",
+            ),
+          ),
+        );
+    }
   });
 }
 


### PR DESCRIPTION
## What Changed

- After the mobile link flow configures relay access, it now enables `publishAgentActivity` on the environment through the existing authenticated `connect.preferences` endpoint.
- Adds `canReceiveAgentAwarenessPush()` to `agent-awareness/capabilities.ts`, so that call is limited to clients that can actually consume pushes.
- Adds regression coverage asserting publishing is still enabled when Live Activities are turned off.

3 files, +51 lines, no schema change, no client-visible payload change.

## Why

Linking an environment from mobile writes relay credentials but never sets the publish opt-in, so the environment stays silent and no Live Activity or push can ever arrive.

`linkEnvironmentToCloudWithPreference` ends at `connect.relayConfig` and never calls `connect.preferences`. The publish flag is a separate secret that defaults to off:

- `isAgentActivityPublishingEnabledValue(null)` → `null === "true"` → `false` (`apps/server/src/cloud/config.ts`)
- `AgentAwarenessRelay` reads that flag and returns before publishing when it is false

The result is a setting that looks enabled on the phone while the environment emits nothing. This is the "publishing disabled" precondition behind the stuck Live Activity in #4950 — the app arms a local placeholder and nothing ever arrives to repaint or end it.

Confirmed on a real install: an environment linked from mobile had `cloud-relay-*` credentials absent and no `cloud-publish-agent-activity` secret in `~/.t3/userdata/secrets/`, with zero agent-awareness entries in the server trace log. Verified still present on `main` at the time of writing.

## Decisions taken

- **Not gated on `liveActivitiesEnabled`.** When Live Activities are off but notifications are on, the relay builds `notificationOnlyAggregate` and sends plain alert pushes (`AgentActivityPublisher`). That path needs publishing just as much, so tying the two together would leave notification-only users silent. The added test covers this case.
- **Gated on push capability instead.** `canReceiveAgentAwarenessPush()` mirrors the existing iOS-only gate in `remoteRegistration.ts` (`canRegisterRemoteLiveActivities`) and the personal-team-build check, so publishing is not enabled for clients that provably cannot consume it.
- **Placed inside `linkEnvironmentToCloudWithPreference` rather than at the call site.** `setLiveActivityUpdatesEnabled` already routes through this function, so toggling Live Activities also repairs an environment that was linked before this fix.
- **Failure is surfaced, not swallowed.** A failed preferences call fails the link with a distinct message. Silent failure is the bug being fixed. `preferences` is defined in the same `connect` API group as `relayConfig`, so there is no version-skew risk between them.

## Relationship to #4998

#4998 targets the same root cause and is still open. This differs in two ways: it enables publishing independently of the Live Activities toggle (#4998 gates on it, which leaves notification-only users with no delivery path), and it hooks the shared preference function so the toggle path repairs already-linked environments. Happy to close this in favor of #4998 if that one is preferred — it predates this.

## Verification

Rebased onto `main` at `ad117235b`. Run on macOS, Node v23.11.0, pnpm 11.10.0:

- `vp test run src/features/cloud/linkEnvironment.test.ts` — 21 passed (1 new assertion)
- `vp test run` in `apps/mobile` — 716 passed, 110 files
- `tsc --noEmit` in `apps/mobile` — clean
- `vp lint --report-unused-disable-directives` on the 3 changed files — clean

Not run: the full monorepo suite (left to CI). No UI change, so no screenshots apply.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the mobile cloud link path to mutate environment publishing preferences; failures now block linking, but scope is limited to capable iOS clients and an existing authenticated connect API.
> 
> **Overview**
> Fixes mobile cloud linking leaving the desktop environment **silent** for agent-awareness delivery: relay credentials were written, but **`publishAgentActivity`** (separate opt-in, default off) was never turned on, so Live Activities and alert pushes could not arrive.
> 
> After **`connect.relayConfig`**, **`linkEnvironmentToCloudWithPreference`** now calls **`connect.preferences`** with **`publishAgentActivity: true`** when **`canReceiveAgentAwarenessPush()`** is true (iOS, non–personal-team build). That gate matches who can actually consume relay pushes; publishing is **not** tied to the Live Activities toggle so notification-only mode still gets plain alert pushes.
> 
> A failed preferences call **fails the link** with a clear error. Tests mock **`/api/connect/preferences`** and assert **`publishAgentActivity: true`** even when Live Activities are disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3528478b44319d520dc81227254bfa0e530dce26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable agent activity publishing when linking an environment from mobile on iOS
> - Adds `canReceiveAgentAwarenessPush` in [capabilities.ts](https://github.com/pingdotgg/t3code/pull/7106/files#diff-3c6247af989b8207ba9606467e5c9e7461ef0f09f423a9f54d62a46cf1170c79) that returns `true` only on iOS builds with the agent awareness push entitlement.
> - Updates `linkEnvironmentToCloudWithPreference` in [linkEnvironment.ts](https://github.com/pingdotgg/t3code/pull/7106/files#diff-14699cfea77b0136e19c830618d4732f12baf0fadf700dee05707865269277e1) to call `connect.preferences` with `{ publishAgentActivity: true }` after relay access is configured, when `canReceiveAgentAwarenessPush()` returns true.
> - Risk: if the preferences request fails, the entire link flow fails with a `CloudEnvironmentLinkError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3528478. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->