### PR TITLE
fix(desktop): keep the native preview User-Agent so Turnstile passes

### DIFF
--- a/apps/desktop/src/preview/BrowserSession.test.ts
+++ b/apps/desktop/src/preview/BrowserSession.test.ts
@@ -13,7 +13,7 @@ const { fromPartition, sessions } = vi.hoisted(() => ({
     {
       readonly clearCache: ReturnType<typeof vi.fn>;
       readonly clearStorageData: ReturnType<typeof vi.fn>;
-      readonly getUserAgent: ReturnType<typeof vi.fn>;
+      readonly getUserAgent: ReturnType<typeof vi.fn<() => string>>;
       readonly setPermissionRequestHandler: ReturnType<typeof vi.fn>;
       readonly setPermissionCheckHandler: ReturnType<typeof vi.fn>;
       readonly setUserAgent: ReturnType<typeof vi.fn>;
@@ -99,6 +99,44 @@ describe("BrowserSession", () => {
       assert.notStrictEqual(nondefaultProfile, legacyDefault);
       assert.isTrue(browserSessions.isPartition(legacyDefault));
       assert.isTrue(browserSessions.isPartition(nondefaultProfile));
+    }).pipe(Effect.provide(layer)),
+  );
+
+  // A rewritten session UA — any variant, even ones that keep the Electron
+  // token — makes Cloudflare Turnstile loop with error 600010 (#5002), so
+  // the guest must end up with Electron's native User-Agent. The mock applies
+  // setUserAgent calls, so this fails on any reintroduced rewrite while still
+  // permitting a harmless re-set of the unchanged native string.
+  it.effect("keeps the guest's effective User-Agent equal to Electron's native one", () =>
+    Effect.gen(function* () {
+      // Electron's real UA shape: app token, then Chrome, then Electron, then
+      // Safari — the token order and casing matter to any strip regex.
+      const nativeUserAgent =
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) T3Code(Alpha)/0.0.33 Chrome/146.0.7680.216 Electron/41.5.0 Safari/537.36";
+      fromPartition.mockReset();
+      fromPartition.mockImplementation((partition: string) => {
+        let userAgent = nativeUserAgent;
+        const browserSession = {
+          clearCache: vi.fn(() => Promise.resolve()),
+          clearStorageData: vi.fn(() => Promise.resolve()),
+          getUserAgent: vi.fn(() => userAgent),
+          setPermissionRequestHandler: vi.fn(),
+          setPermissionCheckHandler: vi.fn(),
+          setUserAgent: vi.fn((next: string) => {
+            userAgent = next;
+          }),
+        };
+        sessions.set(partition, browserSession);
+        return browserSession;
+      });
+
+      const browserSessions = yield* BrowserSession.BrowserSession;
+      const partition = yield* browserSessions.getPartition("scope-a");
+      yield* browserSessions.getSession("scope-a");
+
+      const browserSession = sessions.get(partition);
+      assert.isDefined(browserSession);
+      assert.strictEqual(browserSession.getUserAgent(), nativeUserAgent);
     }).pipe(Effect.provide(layer)),
   );
 

--- a/apps/desktop/src/preview/BrowserSession.ts
+++ b/apps/desktop/src/preview/BrowserSession.ts
@@ -197,11 +197,12 @@ export const make = Effect.gen(function* BrowserSessionMake() {
       return Effect.try({
         try: () => {
           const browserSession = session.fromPartition(partition);
-          const userAgent = browserSession
-            .getUserAgent()
-            .replace(/Electron\/[\d.]+ /, "")
-            .replace(/\s*t3code\/[\d.]+/, "");
-          browserSession.setUserAgent(userAgent);
+          // The guest keeps Electron's native User-Agent. Rewriting it in any
+          // form — even variants that keep the Electron token — makes Cloudflare
+          // Turnstile fail its integrity check with error 600010 and recreate
+          // the challenge every few seconds, so logins behind it never complete
+          // (#5002). Re-setting the unchanged native string is harmless, so it
+          // is the rewritten string itself that trips the check.
           browserSession.setPermissionRequestHandler((_webContents, permission, callback) => {
             callback(ALLOWED_PREVIEW_PERMISSIONS.has(permission));
           });


### PR DESCRIPTION
## What Changed

`apps/desktop/src/preview/BrowserSession.ts` no longer rewrites the preview guest's User-Agent (the `getUserAgent()` → strip `Electron/…` / `t3code/…` → `setUserAgent()` block is removed). A regression test asserts the guest's effective User-Agent stays equal to Electron's native one (the mock applies `setUserAgent` calls, so any reintroduced rewrite fails it — verified by mutation-testing it against the old code).

I checked for other UA-touching paths — `app.userAgentFallback`, a `useragent` attribute on the `<webview>`, `webRequest` header rewriting, other session setup — there are none, and the removal leaves no dead imports.

## Why

Fixes #5002. On https://dash.cloudflare.com/login the Turnstile widget fails with console error 600010 and is recreated every ~3.3s, so login can never complete.

**Why the rewrite existed:** it shipped with the original preview panel, and the design doc annotates it as *"strip electron/t3code from UA so dev preview doesn't trip bot detection"*. No other motivation (e.g. a specific OAuth breakage) is recorded in the history. Against Turnstile it empirically does the opposite: the rewrite is precisely what trips the bot check.

**What I measured:** I isolated the trigger with a minimal reproduction ([akriaueno/electron-turnstile-repro](https://github.com/akriaueno/electron-turnstile-repro)), each case in a fresh session, instrumented to dump the guest's `navigator.userAgent`, `navigator.userAgentData`, and the actually-sent request headers. Across every case `userAgentData` is identical and no `Sec-CH-UA*` headers are sent at all, so the UA string is the only variable — and it alone flips the outcome. Turnstile is closed, so I don't claim the exact discriminator; the reproducible observation is that the untouched native UA passes and every rewritten variant fails.

<details>
<summary>Measured matrix and everything else that was ruled out</summary>

Electron 41.5.0 / Chromium 146, Ubuntu 24.04, fresh `--user-data-dir` per case. The `User-Agent` header and `navigator.userAgent` always agree; in all four cases `navigator.userAgentData.brands` is `Not-A.Brand 24, Chromium 146` (no `Google Chrome`, no Electron entry) and no `Sec-CH-UA*` headers are sent.

| UA string presented to the page/site | Turnstile |
| --- | --- |
| native: `… <app>/0.0.0 Chrome/146.0.7680.216 Electron/41.5.0 Safari/537.36` | **passes** |
| `setUserAgent()` with the *unchanged* native string | **passes** |
| app token stripped, `Electron/…` kept | **fails (600010 loop)** |
| `Electron/…` stripped (what this app shipped) | **fails (600010 loop)** |

The no-op re-set passing rules out the `setUserAgent()` call itself; the app-token-stripped case failing shows no single token is the trigger.

Also ruled out as causes during the investigation: pre-granted permission handlers (the repro grants them like this app does — still passes), CDP debugger attachment (real Chrome passes with DevTools open; a diagnostic build that never attaches still looped), the preview preload / `contextIsolation` (a build without them still looped), WebGL/GPU state (real Chrome passes on the same machine with WebGL blocklisted), and `BrowserWindow` vs `<webview>`.

</details>

**Trade-off:** sites now see the stock Electron UA (Electron and app tokens included) instead of a Chrome-looking one — exactly what a default Electron `<webview>` sends, and the identity Turnstile accepts. The flip side is that services which block embedded browsers by UA sniffing (notably Google OAuth's `disallowed_useragent` policy) can now recognize the preview as Electron. If that ever needs solving, the honest route is overriding `userAgentMetadata` together with the UA via CDP (`Network.setUserAgentOverride`) so every layer stays consistent — a much larger, fingerprint-chasing change I deliberately left out.

Verified on Linux (Ubuntu 24.04): the login challenge completes and sign-in proceeds. `vp test run apps/desktop/src/preview/BrowserSession.test.ts` passes (7 tests); `tsgo --noEmit` in `apps/desktop` reports no new diagnostics.

## Screencast

https://github.com/user-attachments/assets/044f1a87-817d-4109-a84e-19b4df4360ce

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes — N/A, no UI changes
- [x] I included a video for animation/interaction changes — screencast of the Turnstile behavior above

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Preview identity visible to sites changes (full Electron UA vs Chrome-like), which can affect bot/OAuth UA policies, though scope is limited to preview partition sessions.
> 
> **Overview**
> Stops rewriting the desktop preview guest session **User-Agent** in `BrowserSession.getSession` — the previous `getUserAgent()` → strip `Electron/…` and `t3code/…` → `setUserAgent()` path is removed so the webview keeps Electron’s native string. That fixes **Cloudflare Turnstile** error 600010 / endless challenge loops on sites like the Cloudflare login (#5002).
> 
> Adds a regression test that models a session whose `setUserAgent` updates the effective UA and asserts it still matches the native value after `getSession`, so any future rewrite fails CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1043f766bcc4bcc5cc8c06b6586da93cd77a549e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep native Electron User-Agent in desktop preview session so Cloudflare Turnstile passes
> Removes the UA rewriting logic in `BrowserSession.getSession` that stripped Electron and `t3code` tokens from the session's User-Agent. Cloudflare Turnstile fails when the UA is modified, so the guest session now retains Electron's native UA unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1043f76.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved Electron’s native browser User-Agent for desktop sessions.
  - Fixed login failures with Cloudflare Turnstile caused by User-Agent rewriting.

- **Tests**
  - Added coverage confirming the User-Agent remains unchanged when a browser session is created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->