### PR TITLE
fix(server): keep claude slash commands when a capability probe fails

### DIFF
--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -12,13 +12,19 @@
  *
  * @module provider/Drivers/ClaudeDriver
  */
-import { ClaudeSettings, ProviderDriverKind, type ServerProvider } from "@t3tools/contracts";
+import {
+  ClaudeSettings,
+  ProviderDriverKind,
+  type ServerProvider,
+  type ServerProviderSlashCommand,
+} from "@t3tools/contracts";
 import * as Cache from "effect/Cache";
 import * as Duration from "effect/Duration";
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
+import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import { HttpClient } from "effect/unstable/http";
 import { ChildProcessSpawner } from "effect/unstable/process";
@@ -163,11 +169,21 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
       });
       const capabilitiesCacheKey = yield* makeClaudeCapabilitiesCacheKey(effectiveConfig, cwd);
 
+      const lastKnownSlashCommands = yield* Ref.make<ReadonlyArray<ServerProviderSlashCommand>>([]);
+
       const checkProvider = checkClaudeProviderStatus(
         effectiveConfig,
-        () => Cache.get(capabilitiesProbeCache, capabilitiesCacheKey),
+        () =>
+          Cache.get(capabilitiesProbeCache, capabilitiesCacheKey).pipe(
+            Effect.tap((capabilities) =>
+              capabilities
+                ? Ref.set(lastKnownSlashCommands, capabilities.slashCommands)
+                : Effect.void,
+            ),
+          ),
         processEnv,
         cwd,
+        Ref.get(lastKnownSlashCommands),
       ).pipe(
         Effect.map(stampIdentity),
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -811,6 +811,7 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
   ) => Effect.Effect<ClaudeCapabilitiesProbe | undefined>,
   environment?: NodeJS.ProcessEnv,
   cwd?: string,
+  lastKnownSlashCommands?: Effect.Effect<ReadonlyArray<ServerProviderSlashCommand>>,
 ): Effect.fn.Return<
   ServerProviderDraft,
   never,
@@ -927,7 +928,8 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
     ? yield* resolveCapabilities(claudeSettings).pipe(Effect.orElseSucceed(() => undefined))
     : undefined;
   const skills = yield* discoverClaudeSkills(claudeSettings, cwd, resolvedEnvironment);
-  const slashCommands = capabilities?.slashCommands ?? [];
+  const slashCommands =
+    capabilities?.slashCommands ?? (lastKnownSlashCommands ? yield* lastKnownSlashCommands : []);
   const dedupedSlashCommands = dedupeSlashCommands(slashCommands);
 
   if (!capabilities) {

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -2282,6 +2282,63 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         ),
       );
 
+      it.effect("keeps the last known slash commands when the capability probe fails", () =>
+        Effect.gen(function* () {
+          const status = yield* checkClaudeProviderStatus(
+            defaultClaudeSettings,
+            noClaudeCapabilities,
+            undefined,
+            undefined,
+            Effect.succeed([{ name: "review", description: "Review a pull request" }]),
+          );
+
+          assert.deepStrictEqual(status.slashCommands, [
+            { name: "review", description: "Review a pull request" },
+          ]);
+          assert.strictEqual(status.status, "warning");
+          assert.strictEqual(status.auth.status, "unknown");
+        }).pipe(
+          Effect.provide(
+            mockSpawnerLayer((args) => {
+              const joined = args.join(" ");
+              if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
+              if (joined === "auth status")
+                return {
+                  stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
+                  stderr: "",
+                  code: 0,
+                };
+              throw new Error(`Unexpected args: ${joined}`);
+            }),
+          ),
+        ),
+      );
+
+      it.effect("reports no slash commands when a failed probe has nothing to fall back on", () =>
+        Effect.gen(function* () {
+          const status = yield* checkClaudeProviderStatus(
+            defaultClaudeSettings,
+            noClaudeCapabilities,
+          );
+
+          assert.deepStrictEqual(status.slashCommands, []);
+        }).pipe(
+          Effect.provide(
+            mockSpawnerLayer((args) => {
+              const joined = args.join(" ");
+              if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
+              if (joined === "auth status")
+                return {
+                  stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
+                  stderr: "",
+                  code: 0,
+                };
+              throw new Error(`Unexpected args: ${joined}`);
+            }),
+          ),
+        ),
+      );
+
       it.effect("returns an api key label for claude api key auth", () =>
         Effect.gen(function* () {
           const status = yield* checkClaudeProviderStatus(


### PR DESCRIPTION
## What Changed

- `ClaudeDriver` now holds the slash commands from the last capability probe that succeeded in a `Ref`, updated whenever a probe returns capabilities.
- `checkClaudeProviderStatus` takes an optional `lastKnownSlashCommands` effect, read on every run, and falls back to it when the probe reports no capabilities.
- Two tests in `ProviderRegistry.test.ts` cover the fallback and the unchanged empty default.

## Why

A capability probe that fails or exceeds its 25-second timeout reports `undefined`. `checkClaudeProviderStatus` read that as "the CLI has no commands" and published an empty `slashCommands`, so every provider command vanished from the composer `/` menu, leaving only the built-ins.

Two things made it stick. `ClaudeDriver` caches the failed probe for the full 5-minute `CAPABILITIES_PROBE_TTL`, and `ProviderRegistry.persistProvider` writes every published snapshot to the on-disk status cache, so the empty list was reloaded after a restart.

Keeping the last good list makes an unreadable probe a no-op for the menu. A failed probe still reports `warning` / `unknown` auth, so a real auth problem is not masked — only the command list is reused.

Related: #7111

## Checklist

- [x] This PR is small and focused — 21 non-test lines across two files
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes — no UI change; the diff is server-only
- [ ] I included a video for animation/interaction changes — not applicable

Written by Claude Opus 5 in Claude Code, running inside T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, server-only change to Claude status snapshot assembly with unit tests; no auth or generation path changes beyond preserving slash command metadata on probe failure.
> 
> **Overview**
> When the Claude **capability probe** times out or fails, published provider snapshots no longer clear **`slashCommands`**, so the composer `/` menu keeps provider commands instead of dropping them until the next successful probe.
> 
> **`ClaudeDriver`** remembers slash commands from the last successful probe in a per-instance **`Ref`** and refreshes that list whenever a cached probe returns capabilities. **`checkClaudeProviderStatus`** accepts an optional **`lastKnownSlashCommands`** source and uses it when the probe yields no capabilities; auth still surfaces as **`warning`** / **`unknown`**. Tests cover fallback behavior and the empty default when nothing was ever probed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bbd9b007b83208d13096357de50d7f5209bf790. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Claude slash commands being lost when capability probe fails
> - Introduces a `lastKnownSlashCommands` ref in [`ClaudeDriver`](https://github.com/pingdotgg/t3code/pull/7112/files#diff-ba53e6d81a740dcc6a51b95425b062ab10a4a38017e700c9b10f4cc6ca7d7ebd) that persists slash commands from the last successful capability probe.
> - Updates [`checkClaudeProviderStatus`](https://github.com/pingdotgg/t3code/pull/7112/files#diff-e02234c11270ac47a7034404a1d2c663a776f6f2847a6361aae778bc850a34d3) to accept an optional fallback effect; when the probe yields no result, it uses the last known slash commands instead of defaulting to an empty array.
> - Adds test coverage for both the fallback and no-fallback cases in [`ProviderRegistry.test.ts`](https://github.com/pingdotgg/t3code/pull/7112/files#diff-28b6372c54d8310c6909678b338ea3a67f48ea13b57386544bfe5ffdfa742b6f).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4bbd9b0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->