### PR TITLE
fix(desktop): keep tailscale spawn defects from breaking advertised endpoints

### DIFF
--- a/packages/tailscale/src/tailscale.test.ts
+++ b/packages/tailscale/src/tailscale.test.ts
@@ -212,6 +212,45 @@ describe("tailscale", () => {
     });
   });
 
+  it.effect("turns spawn defects into typed spawn failures", () => {
+    // A non-directory entry on PATH makes node's spawn throw ENOTDIR
+    // synchronously. The platform spawner calls `NodeChildProcess.spawn` from
+    // inside an `Effect.callback` registration, so that throw arrives as a
+    // defect rather than a typed error - the shape reproduced here.
+    const defect = Object.assign(new Error("spawn tailscale ENOTDIR"), { code: "ENOTDIR" });
+    const layer = Layer.succeed(
+      ChildProcessSpawner.ChildProcessSpawner,
+      ChildProcessSpawner.make(() =>
+        Effect.callback<never, never>(() => {
+          throw defect;
+        }),
+      ),
+    );
+
+    return Effect.gen(function* () {
+      const statusError = yield* readTailscaleStatus.pipe(Effect.flip, Effect.provide(layer));
+      assert.instanceOf(statusError, TailscaleCommandSpawnError);
+      assert.equal(statusError.subcommand, "status");
+      assert.strictEqual(statusError.cause, defect);
+
+      const serveError = yield* ensureTailscaleServe({ localPort: 13773, servePort: 8443 }).pipe(
+        Effect.flip,
+        Effect.provide(layer),
+      );
+      assert.instanceOf(serveError, TailscaleCommandSpawnError);
+      assert.equal(serveError.subcommand, "serve");
+      assert.strictEqual(serveError.cause, defect);
+
+      // What callers actually rely on: the desktop endpoint providers recover
+      // with `Effect.orElseSucceed`, which only sees the typed error channel.
+      const degraded = yield* readTailscaleStatus.pipe(
+        Effect.orElseSucceed(() => null),
+        Effect.provide(layer),
+      );
+      assert.equal(degraded, null);
+    });
+  });
+
   it.effect("keeps nonzero exit diagnostics structured", () => {
     const layer = mockSpawnerLayer(() => ({
       code: 7,

--- a/packages/tailscale/src/tailscale.ts
+++ b/packages/tailscale/src/tailscale.ts
@@ -228,11 +228,15 @@ export const readTailscaleStatus = Effect.gen(function* () {
     argumentCount: args.length,
   };
   return yield* Effect.gen(function* () {
-    const child = yield* spawner
-      .spawn(ChildProcess.make(executable, args))
-      .pipe(
-        Effect.mapError((cause) => new TailscaleCommandSpawnError({ ...commandContext, cause })),
-      );
+    const child = yield* spawner.spawn(ChildProcess.make(executable, args)).pipe(
+      Effect.mapError((cause) => new TailscaleCommandSpawnError({ ...commandContext, cause })),
+      // Spawning can also fail as a defect rather than a typed error - a
+      // non-directory entry on PATH makes node throw ENOTDIR synchronously.
+      // `mapError` never sees that, so it would escape as an uncaught error.
+      Effect.catchDefect((cause) =>
+        Effect.fail(new TailscaleCommandSpawnError({ ...commandContext, cause })),
+      ),
+    );
     const [stdout, stderr, exitCode] = yield* Effect.all(
       [
         collectStdout(child.stdout),
@@ -299,11 +303,12 @@ const runTailscaleCommand = (
     };
     const timeout = Duration.fromInputUnsafe(timeoutInput);
     return yield* Effect.gen(function* () {
-      const child = yield* spawner
-        .spawn(ChildProcess.make(executable, args))
-        .pipe(
-          Effect.mapError((cause) => new TailscaleCommandSpawnError({ ...commandContext, cause })),
-        );
+      const child = yield* spawner.spawn(ChildProcess.make(executable, args)).pipe(
+        Effect.mapError((cause) => new TailscaleCommandSpawnError({ ...commandContext, cause })),
+        Effect.catchDefect((cause) =>
+          Effect.fail(new TailscaleCommandSpawnError({ ...commandContext, cause })),
+        ),
+      );
       const [stderr, exitCode] = yield* Effect.all(
         [collectStderr(child.stderr), child.exitCode.pipe(Effect.map(Number))],
         { concurrency: "unbounded" },


### PR DESCRIPTION
## What Changed

With a file rather than a directory on `PATH`, opening Settings → Connections killed the whole endpoint list:

```
Error occurred in handler for 'desktop:get-advertised-endpoints': Error: spawn ENOTDIR
```

Both Tailscale spawn sites wrapped the spawn in `Effect.mapError(... -> TailscaleCommandSpawnError)`. That maps the typed error channel only. Node's spawn throws `ENOTDIR` **synchronously**, which reaches Effect as a defect, so `mapError` never sees it and the raw error escapes the handler.

`readTailscaleStatus` and `runTailscaleCommand` now also `Effect.catchDefect` the spawn into the same `TailscaleCommandSpawnError` they already produce for typed spawn failures.

## Why

The desktop endpoint providers are already written to degrade when Tailscale is unavailable. Both `tailscaleEndpointProvider.ts:122` and `DesktopServerExposure.ts:419` recover with `Effect.orElseSucceed(() => null)`. That recovery reads the typed error channel too, so a defect blew straight past it and rejected the entire advertised-endpoints request, taking loopback and LAN down with a Tailscale-only failure.

Typing the defect at the source is what lets the existing recovery do its job, which is the behaviour the issue asks for: Tailscale endpoints unavailable, everything else still listed. The alternative — teaching each caller to also catch defects — would spread the same guard across every consumer and still leave the next one exposed.

## What this does not change

The guard is scoped to the spawn call and nothing else. Defects from later stages of the same pipeline (stdout/stderr collection, JSON parse, timeout) still surface as defects. They are not the reported failure, and converting them would turn genuine programmer bugs into a "Tailscale is unavailable" message.

Error shape is unchanged: `TailscaleCommandSpawnError` already carries `cause: Schema.Defect()` and its `message` never quotes the cause, so nothing new reaches a log.

## UI Changes

n/a - no interface change. The visible difference is that the Connections panel keeps its loopback and LAN rows instead of failing to load.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (n/a)
- [x] I included a video for animation/interaction changes (n/a)

## Verification

```
vp test run packages/tailscale/src/tailscale.test.ts    # 14 passed (13 before)
vp run --filter @t3tools/tailscale typecheck            # clean
vp lint / vp fmt --check on both touched files          # clean
```

The new test, `turns spawn defects into typed spawn failures`, reproduces the defect the way the platform spawner actually produces it rather than with a bare `Effect.die`: `NodeChildProcessSpawner` calls `NodeChildProcess.spawn` from inside an `Effect.callback` registration, so the test's spawner throws from that same position. (Checked separately that node really does throw here rather than emit an `error` event — `spawn("x", [], { env: { PATH: "/a/regular/file" } })` throws `ENOTDIR` synchronously on this machine.) It then asserts both entry points (`readTailscaleStatus` and `ensureTailscaleServe`, which routes through `runTailscaleCommand`) surface a `TailscaleCommandSpawnError` carrying the original cause. Its last assertion is the one that matters for the issue: `readTailscaleStatus.pipe(Effect.orElseSucceed(() => null))` now yields `null`, i.e. the caller-side recovery finally works.

Reverting only the source change fails it with the issue's own symptom, the defect escaping untyped:

```
FAIL  packages/tailscale/src/tailscale.test.ts > turns spawn defects into typed spawn failures
Error: spawn tailscale ENOTDIR
```

**Not verified:** I have no macOS desktop build with a malformed `PATH` here, so the panel behaviour end to end is reasoned from the two call sites rather than observed. The defect escape itself is reproduced in the unit test above.

Fixes #5111

Implemented with Claude Opus 5 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, spawn-scoped error-channel change in the tailscale package with targeted tests; no auth or data-model changes.
> 
> **Overview**
> **Tailscale CLI spawn failures** that surface as Effect **defects** (e.g. Node’s synchronous `ENOTDIR` when `PATH` contains a file) are now converted to **`TailscaleCommandSpawnError`** on both **`readTailscaleStatus`** and **`runTailscaleServe`** / **`runTailscaleCommand`**, alongside the existing `mapError` handling for typed spawn errors.
> 
> That lets desktop code that already degrades with **`Effect.orElseSucceed(() => null)`** treat broken Tailscale as unavailable instead of rejecting the whole advertised-endpoints flow (e.g. Settings → Connections).
> 
> A new unit test reproduces a spawner that throws from inside **`Effect.callback`** and asserts typed errors plus successful degradation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f8f3bf676e5753484030c73f16e416874bb870b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Convert Tailscale spawn defects to typed `TailscaleCommandSpawnError` failures
> Synchronous spawn errors (e.g. `ENOTDIR`) thrown during `readTailscaleStatus` or `runTailscaleCommand` previously propagated as unhandled defects, bypassing the error channel. Both functions now catch these defects and re-raise them as `TailscaleCommandSpawnError`, making them recoverable via standard Effect error handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f8f3bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->