### PR TITLE
fix(server): discover Claude commands and skills per workspace

### DIFF
--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -65,6 +65,7 @@ import {
 } from "@t3tools/shared/searchRanking";
 import { resolveProviderOptionDescriptors } from "../../lib/providerOptions";
 import { useComposerPathSearch } from "../../state/use-composer-path-search";
+import { useProviderWorkspaceCapabilities } from "../../state/queries";
 import { ComposerCommandPopover, type ComposerCommandItem } from "./ComposerCommandPopover";
 import {
   type ExistingThreadSettingsRouteSession,
@@ -378,6 +379,13 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     cwd: composerTrigger?.kind === "path" ? props.projectCwd : null,
     query: composerTrigger?.kind === "path" ? composerTrigger.query : null,
   });
+  const workspaceCapabilities = useProviderWorkspaceCapabilities({
+    environmentId: props.environmentId,
+    instanceId: props.selectedThread.modelSelection.instanceId,
+    projectId: props.selectedThread.projectId,
+    threadId: props.selectedThread.id,
+    enabled: composerTrigger?.kind === "slash-command" || composerTrigger?.kind === "skill",
+  });
 
   const composerMenuItems: ComposerCommandItem[] = useMemo(() => {
     if (!composerTrigger) return [];
@@ -410,7 +418,9 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
       const builtIn = allBuiltIn.filter((item) => item.command.includes(q));
 
       const providerCommands: ComposerCommandItem[] = [];
-      for (const cmd of selectedProviderStatus?.slashCommands ?? []) {
+      for (const cmd of workspaceCapabilities.slashCommands ??
+        selectedProviderStatus?.slashCommands ??
+        []) {
         if (!cmd.name.toLowerCase().includes(q)) continue;
         providerCommands.push({
           id: `pcmd:${cmd.name}`,
@@ -425,7 +435,11 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     }
 
     if (composerTrigger.kind === "skill") {
-      const enabledSkills = (selectedProviderStatus?.skills ?? []).filter((s) => s.enabled);
+      const enabledSkills = (
+        workspaceCapabilities.skills ??
+        selectedProviderStatus?.skills ??
+        []
+      ).filter((s) => s.enabled);
       const normalizedQuery = normalizeSearchQuery(composerTrigger.query, {
         trimLeadingPattern: /^\$+/,
       });
@@ -522,7 +536,13 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     }
 
     return [];
-  }, [composerTrigger, pathSearch.entries, selectedProviderStatus]);
+  }, [
+    composerTrigger,
+    pathSearch.entries,
+    selectedProviderStatus,
+    workspaceCapabilities.skills,
+    workspaceCapabilities.slashCommands,
+  ]);
 
   // ── Handle command selection ──────────────────────────────
   const { onChangeDraftMessage, onUpdateInteractionMode, draftMessage, onSendMessage } = props;

--- a/apps/mobile/src/state/queries.ts
+++ b/apps/mobile/src/state/queries.ts
@@ -2,6 +2,8 @@ import type { VcsRefTarget } from "@t3tools/client-runtime/state/vcs";
 import type {
   EnvironmentId,
   OrchestrationThread,
+  ProjectId,
+  ProviderInstanceId,
   ThreadId,
   VcsListRefsResult,
   VcsRef,
@@ -21,6 +23,7 @@ import { appAtomRegistry } from "./atom-registry";
 import { orchestrationEnvironment } from "./orchestration";
 import { projectEnvironment } from "./projects";
 import { useEnvironmentQuery } from "./query";
+import { serverEnvironment } from "./server";
 import { useEnvironmentThread } from "./threads";
 import { vcsEnvironment } from "./vcs";
 import {
@@ -134,6 +137,35 @@ export function useBranches(input: {
         })
       : null,
   );
+}
+
+export function useProviderWorkspaceCapabilities(target: {
+  readonly environmentId: EnvironmentId | null;
+  readonly instanceId: ProviderInstanceId | null;
+  readonly projectId: ProjectId | null;
+  readonly threadId: ThreadId | null;
+  readonly enabled: boolean;
+}) {
+  const result = useEnvironmentQuery(
+    target.enabled &&
+      target.environmentId !== null &&
+      target.instanceId !== null &&
+      target.projectId !== null
+      ? serverEnvironment.providerWorkspaceCapabilities({
+          environmentId: target.environmentId,
+          input: {
+            instanceId: target.instanceId,
+            projectId: target.projectId,
+            ...(target.threadId !== null ? { threadId: target.threadId } : {}),
+          },
+        })
+      : null,
+  );
+
+  return {
+    slashCommands: result.data?.slashCommands ?? null,
+    skills: result.data?.skills ?? null,
+  };
 }
 
 export function usePaginatedBranches(target: VcsRefTarget) {

--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -32,6 +32,7 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.serverProbe]: AuthOrchestrationReadScope,
   [WS_METHODS.serverGetConfig]: AuthOrchestrationReadScope,
   [WS_METHODS.serverRefreshProviders]: AuthOrchestrationOperateScope,
+  [WS_METHODS.serverListProviderWorkspaceCapabilities]: AuthOrchestrationReadScope,
   [WS_METHODS.serverUpdateProvider]: AuthOrchestrationOperateScope,
   [WS_METHODS.serverUpdateServer]: AuthOrchestrationOperateScope,
   [WS_METHODS.serverUpdateServerWithProgress]: AuthOrchestrationOperateScope,

--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -55,6 +55,7 @@ import {
   type ProviderSnapshotSettings,
 } from "../providerUpdateSettings.ts";
 import { makeClaudeCapabilitiesCacheKey, makeClaudeContinuationGroupKey } from "./ClaudeHome.ts";
+import { discoverClaudeSkills } from "./ClaudeSkills.ts";
 const decodeClaudeSettings = Schema.decodeSync(ClaudeSettings);
 
 const DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
@@ -163,6 +164,22 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
       });
       const capabilitiesCacheKey = yield* makeClaudeCapabilitiesCacheKey(effectiveConfig, cwd);
 
+      const workspaceCapabilitiesCache = yield* Cache.make({
+        capacity: 8,
+        timeToLive: CAPABILITIES_PROBE_TTL,
+        lookup: (workspaceCwd: string) =>
+          Effect.all(
+            {
+              probe: probeClaudeCapabilities(effectiveConfig, processEnv, workspaceCwd),
+              skills: discoverClaudeSkills(effectiveConfig, workspaceCwd, processEnv),
+            },
+            { concurrency: 2 },
+          ).pipe(
+            Effect.provideService(FileSystem.FileSystem, fileSystem),
+            Effect.provideService(Path.Path, path),
+          ),
+      });
+
       const checkProvider = checkClaudeProviderStatus(
         effectiveConfig,
         () => Cache.get(capabilitiesProbeCache, capabilitiesCacheKey),
@@ -203,6 +220,17 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         ),
       );
 
+      const listWorkspaceCapabilities = (workspaceCwd: string) =>
+        Effect.gen(function* () {
+          const { probe, skills } = yield* Cache.get(workspaceCapabilitiesCache, workspaceCwd);
+          if (!probe) {
+            yield* Cache.invalidate(workspaceCapabilitiesCache, workspaceCwd);
+            const currentSnapshot = yield* snapshot.getSnapshot;
+            return { slashCommands: currentSnapshot.slashCommands, skills };
+          }
+          return { slashCommands: probe.slashCommands, skills };
+        });
+
       return {
         instanceId,
         driverKind: DRIVER_KIND,
@@ -216,6 +244,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         snapshot,
         adapter,
         textGeneration,
+        listWorkspaceCapabilities,
       } satisfies ProviderInstance;
     }),
 };

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1020,6 +1020,16 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
               fallback.slashCommands.map((command) => command.name),
               ["codex-command"],
             );
+
+            const withoutWorkspace = yield* registry.listWorkspaceCapabilities({
+              instanceId: claudeInstanceId,
+              cwd: null,
+            });
+            assert.deepStrictEqual(
+              withoutWorkspace.slashCommands.map((command) => command.name),
+              ["server-cwd-command"],
+            );
+            assert.strictEqual(yield* Ref.get(probedCwd), "/workspaces/my-project");
           }).pipe(Effect.provide(runtimeServices));
         }),
       );

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -893,6 +893,137 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         }),
       );
 
+      it.effect("asks the instance for workspace capabilities, or falls back to its snapshot", () =>
+        Effect.gen(function* () {
+          const claudeDriver = ProviderDriverKind.make("claudeAgent");
+          const claudeInstanceId = ProviderInstanceId.make("claudeAgent");
+          const codexDriver = ProviderDriverKind.make("codex");
+          const codexInstanceId = ProviderInstanceId.make("codex");
+          const makeSnapshot = (
+            instanceId: ProviderInstanceId,
+            driver: ProviderDriverKind,
+            commandName: string,
+          ) =>
+            ({
+              instanceId,
+              driver,
+              status: "ready",
+              enabled: true,
+              installed: true,
+              auth: { status: "authenticated" },
+              checkedAt: "2026-06-10T00:00:00.000Z",
+              version: "1.0.0",
+              models: [],
+              slashCommands: [{ name: commandName }],
+              skills: [],
+            }) as const satisfies ServerProvider;
+          const claudeSnapshot = makeSnapshot(claudeInstanceId, claudeDriver, "server-cwd-command");
+          const codexSnapshot = makeSnapshot(codexInstanceId, codexDriver, "codex-command");
+          const probedCwd = yield* Ref.make<string | null>(null);
+          const makeInstance = (
+            instanceId: ProviderInstanceId,
+            driverKind: ProviderDriverKind,
+            snapshot: ServerProvider,
+            listWorkspaceCapabilities?: ProviderInstance["listWorkspaceCapabilities"],
+          ) =>
+            ({
+              instanceId,
+              driverKind,
+              continuationIdentity: { driverKind, continuationKey: `${driverKind}:${instanceId}` },
+              displayName: undefined,
+              enabled: true,
+              snapshot: {
+                maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
+                  provider: driverKind,
+                  packageName: null,
+                }),
+                getSnapshot: Effect.succeed(snapshot),
+                refresh: Effect.succeed(snapshot),
+                streamChanges: Stream.empty,
+              },
+              adapter: {} as ProviderInstance["adapter"],
+              textGeneration: {} as ProviderInstance["textGeneration"],
+              ...(listWorkspaceCapabilities ? { listWorkspaceCapabilities } : {}),
+            }) satisfies ProviderInstance;
+          const claudeInstance = makeInstance(
+            claudeInstanceId,
+            claudeDriver,
+            claudeSnapshot,
+            (cwd) =>
+              Ref.set(probedCwd, cwd).pipe(
+                Effect.as({
+                  slashCommands: [{ name: "project-command" }],
+                  skills: [
+                    {
+                      name: "project-skill",
+                      path: `${cwd}/.claude/skills/project-skill/SKILL.md`,
+                      enabled: true,
+                      scope: "project",
+                    },
+                  ],
+                }),
+              ),
+          );
+          const codexInstance = makeInstance(codexInstanceId, codexDriver, codexSnapshot);
+          const instanceRegistryLayer = Layer.succeed(
+            ProviderInstanceRegistry.ProviderInstanceRegistry,
+            {
+              getInstance: (instanceId) =>
+                Effect.succeed(
+                  instanceId === claudeInstanceId
+                    ? claudeInstance
+                    : instanceId === codexInstanceId
+                      ? codexInstance
+                      : undefined,
+                ),
+              listInstances: Effect.succeed([claudeInstance, codexInstance]),
+              listUnavailable: Effect.succeed([]),
+              streamChanges: Stream.empty,
+              subscribeChanges: Effect.flatMap(PubSub.unbounded<void>(), PubSub.subscribe),
+            },
+          );
+          const scope = yield* Scope.make();
+          yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
+          const runtimeServices = yield* Layer.build(
+            ProviderRegistryLive.pipe(
+              Layer.provideMerge(instanceRegistryLayer),
+              Layer.provideMerge(
+                ServerConfig.layerTest(process.cwd(), {
+                  prefix: "t3-provider-registry-workspace-capabilities-",
+                }),
+              ),
+              Layer.provideMerge(NodeServices.layer),
+            ),
+          ).pipe(Scope.provide(scope));
+          yield* Effect.gen(function* () {
+            const registry = yield* ProviderRegistry.ProviderRegistry;
+
+            const workspace = yield* registry.listWorkspaceCapabilities({
+              instanceId: claudeInstanceId,
+              cwd: "/workspaces/my-project",
+            });
+            assert.strictEqual(yield* Ref.get(probedCwd), "/workspaces/my-project");
+            assert.deepStrictEqual(
+              workspace.slashCommands.map((command) => command.name),
+              ["project-command"],
+            );
+            assert.deepStrictEqual(
+              workspace.skills.map((skill) => skill.name),
+              ["project-skill"],
+            );
+
+            const fallback = yield* registry.listWorkspaceCapabilities({
+              instanceId: codexInstanceId,
+              cwd: "/workspaces/my-project",
+            });
+            assert.deepStrictEqual(
+              fallback.slashCommands.map((command) => command.name),
+              ["codex-command"],
+            );
+          }).pipe(Effect.provide(runtimeServices));
+        }),
+      );
+
       it("persists merged provider snapshots for the providers that were refreshed", () => {
         const previousProviders = [
           {

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -510,12 +510,12 @@ export const ProviderRegistryLive = Layer.effect(
 
     const listWorkspaceCapabilities = Effect.fn("listWorkspaceCapabilities")(function* (input: {
       readonly instanceId: ProviderInstanceId;
-      readonly cwd: string;
+      readonly cwd: string | null;
     }) {
       const instance = Array.from((yield* Ref.get(liveSubsRef)).values()).find(
         (candidate) => candidate.instanceId === input.instanceId,
       );
-      if (instance?.listWorkspaceCapabilities) {
+      if (input.cwd !== null && instance?.listWorkspaceCapabilities) {
         return yield* instance.listWorkspaceCapabilities(input.cwd);
       }
       const snapshot = (yield* Ref.get(providersRef)).find(

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -508,6 +508,25 @@ export const ProviderRegistryLive = Layer.effect(
       );
     });
 
+    const listWorkspaceCapabilities = Effect.fn("listWorkspaceCapabilities")(function* (input: {
+      readonly instanceId: ProviderInstanceId;
+      readonly cwd: string;
+    }) {
+      const instance = Array.from((yield* Ref.get(liveSubsRef)).values()).find(
+        (candidate) => candidate.instanceId === input.instanceId,
+      );
+      if (instance?.listWorkspaceCapabilities) {
+        return yield* instance.listWorkspaceCapabilities(input.cwd);
+      }
+      const snapshot = (yield* Ref.get(providersRef)).find(
+        (candidate) => candidate.instanceId === input.instanceId,
+      );
+      return {
+        slashCommands: snapshot?.slashCommands ?? [],
+        skills: snapshot?.skills ?? [],
+      };
+    });
+
     /**
      * Diff the aggregator's live-source set against the current
      * `ProviderInstanceRegistry` and:
@@ -711,6 +730,7 @@ export const ProviderRegistryLive = Layer.effect(
       refreshInstance: (instanceId: ProviderInstanceId) =>
         refreshInstance(instanceId).pipe(Effect.catchCause(recoverRefreshFailure)),
       getProviderMaintenanceCapabilitiesForInstance,
+      listWorkspaceCapabilities,
       setProviderMaintenanceActionState,
       get streamChanges() {
         return Stream.fromPubSub(changesPubSub);

--- a/apps/server/src/provider/ProviderDriver.ts
+++ b/apps/server/src/provider/ProviderDriver.ts
@@ -25,6 +25,7 @@ import type {
   ProviderDriverKind,
   ProviderInstanceEnvironment,
   ProviderInstanceId,
+  ServerProviderWorkspaceCapabilities,
 } from "@t3tools/contracts";
 import type * as Effect from "effect/Effect";
 import type * as Schema from "effect/Schema";
@@ -71,6 +72,9 @@ export interface ProviderInstance {
   readonly snapshot: ServerProviderShape;
   readonly adapter: ProviderAdapterShape<ProviderAdapterError>;
   readonly textGeneration: TextGeneration.TextGeneration["Service"];
+  readonly listWorkspaceCapabilities?: (
+    cwd: string,
+  ) => Effect.Effect<ServerProviderWorkspaceCapabilities>;
 }
 
 export interface ProviderContinuationIdentity {

--- a/apps/server/src/provider/Services/ProviderRegistry.ts
+++ b/apps/server/src/provider/Services/ProviderRegistry.ts
@@ -11,6 +11,7 @@ import type {
   ProviderDriverKind,
   ServerProvider,
   ServerProviderUpdateState,
+  ServerProviderWorkspaceCapabilities,
 } from "@t3tools/contracts";
 import * as Context from "effect/Context";
 import type * as Effect from "effect/Effect";
@@ -56,6 +57,11 @@ export interface ProviderRegistryShape {
     instanceId: ProviderInstanceId,
     provider: ProviderDriverKind,
   ) => Effect.Effect<ProviderMaintenanceCapabilities>;
+
+  readonly listWorkspaceCapabilities: (input: {
+    readonly instanceId: ProviderInstanceId;
+    readonly cwd: string;
+  }) => Effect.Effect<ServerProviderWorkspaceCapabilities>;
 
   /**
    * Apply volatile maintenance-action state to one configured instance.

--- a/apps/server/src/provider/Services/ProviderRegistry.ts
+++ b/apps/server/src/provider/Services/ProviderRegistry.ts
@@ -60,7 +60,7 @@ export interface ProviderRegistryShape {
 
   readonly listWorkspaceCapabilities: (input: {
     readonly instanceId: ProviderInstanceId;
-    readonly cwd: string;
+    readonly cwd: string | null;
   }) => Effect.Effect<ServerProviderWorkspaceCapabilities>;
 
   /**

--- a/apps/server/src/provider/providerMaintenanceRunner.test.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.test.ts
@@ -191,6 +191,7 @@ function makeRegistry(
       refreshInstance: () => Ref.get(providersRef),
       getProviderMaintenanceCapabilitiesForInstance: (_instanceId, provider) =>
         Effect.succeed(lifecycleFor(provider)),
+      listWorkspaceCapabilities: () => Effect.succeed({ slashCommands: [], skills: [] }),
       setProviderMaintenanceActionState,
       streamChanges: Stream.empty,
     };

--- a/apps/server/src/provider/testUtils/providerRegistryMock.ts
+++ b/apps/server/src/provider/testUtils/providerRegistryMock.ts
@@ -13,6 +13,13 @@ export const makeProviderRegistryMock = (
   refreshInstance: () => Effect.succeed(providers),
   getProviderMaintenanceCapabilitiesForInstance: (_instanceId, provider) =>
     Effect.succeed(makeManualOnlyProviderMaintenanceCapabilities({ provider, packageName: null })),
+  listWorkspaceCapabilities: ({ instanceId }) => {
+    const snapshot = providers.find((candidate) => candidate.instanceId === instanceId);
+    return Effect.succeed({
+      slashCommands: snapshot?.slashCommands ?? [],
+      skills: snapshot?.skills ?? [],
+    });
+  },
   setProviderMaintenanceActionState: () => Effect.succeed(providers),
   streamChanges: Stream.empty,
 });

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -18,6 +18,7 @@ import {
   ExternalLauncherCommandNotFoundError,
   OrchestrationThreadDetailSnapshot,
   type OrchestrationThreadStreamItem,
+  type OrchestrationProjectShell,
   type OrchestrationThreadShell,
   TerminalNotRunningError,
   type OrchestrationCommand,
@@ -57,6 +58,7 @@ import * as Path from "effect/Path";
 import * as PubSub from "effect/PubSub";
 import * as Queue from "effect/Queue";
 import * as Schema from "effect/Schema";
+import * as Ref from "effect/Ref";
 import * as Stream from "effect/Stream";
 import * as TestClock from "effect/testing/TestClock";
 import { ChildProcessSpawner } from "effect/unstable/process";
@@ -3403,6 +3405,77 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       if (rpcError._tag === "EnvironmentAuthorizationError") {
         assert.equal(rpcError.requiredScope, "orchestration:read");
       }
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("resolves provider workspace capabilities from the thread worktree", () =>
+    Effect.gen(function* () {
+      const requestedCwds = yield* Ref.make<ReadonlyArray<string>>([]);
+      const projectShell = {
+        id: defaultProjectId,
+        title: "Default Project",
+        workspaceRoot: "/tmp/default-project",
+        defaultModelSelection,
+        scripts: [],
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      } satisfies OrchestrationProjectShell;
+      const threadShell = makeDefaultOrchestrationThreadShell({
+        worktreePath: "/tmp/worktrees/default-thread",
+      });
+
+      yield* buildAppUnderTest({
+        layers: {
+          projectionSnapshotQuery: {
+            getProjectShellById: (projectId) =>
+              Effect.succeed(
+                projectId === defaultProjectId ? Option.some(projectShell) : Option.none(),
+              ),
+            getThreadShellById: (threadId) =>
+              Effect.succeed(
+                threadId === defaultThreadId ? Option.some(threadShell) : Option.none(),
+              ),
+          },
+          providerRegistry: {
+            listWorkspaceCapabilities: ({ cwd }) =>
+              Ref.update(requestedCwds, (cwds) => [...cwds, cwd]).pipe(
+                Effect.as({ slashCommands: [{ name: "deploy" }], skills: [] }),
+              ),
+          },
+        },
+      });
+
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const responses = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          Effect.all({
+            withThread: client[WS_METHODS.serverListProviderWorkspaceCapabilities]({
+              instanceId: ProviderInstanceId.make("claudeAgent"),
+              projectId: defaultProjectId,
+              threadId: defaultThreadId,
+            }),
+            withoutThread: client[WS_METHODS.serverListProviderWorkspaceCapabilities]({
+              instanceId: ProviderInstanceId.make("claudeAgent"),
+              projectId: defaultProjectId,
+            }),
+            unknownThread: client[WS_METHODS.serverListProviderWorkspaceCapabilities]({
+              instanceId: ProviderInstanceId.make("claudeAgent"),
+              projectId: defaultProjectId,
+              threadId: ThreadId.make("thread-from-another-project"),
+            }),
+          }),
+        ),
+      );
+
+      assert.deepStrictEqual(yield* Ref.get(requestedCwds), [
+        "/tmp/worktrees/default-thread",
+        "/tmp/default-project",
+      ]);
+      assert.deepStrictEqual(
+        responses.withThread.slashCommands.map((command) => command.name),
+        ["deploy"],
+      );
+      assert.deepStrictEqual(responses.unknownThread.slashCommands, []);
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -3466,12 +3466,17 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
               projectId: defaultProjectId,
               threadId: ThreadId.make("thread-from-another-project"),
             }),
+            unknownProject: client[WS_METHODS.serverListProviderWorkspaceCapabilities]({
+              instanceId: ProviderInstanceId.make("claudeAgent"),
+              projectId: ProjectId.make("project-that-is-gone"),
+            }),
           }),
         ),
       );
 
       assert.deepStrictEqual(yield* Ref.get(requestedCwds), [
         "/tmp/worktrees/default-thread",
+        "/tmp/default-project",
         "/tmp/default-project",
         null,
       ]);
@@ -3481,6 +3486,10 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       );
       assert.deepStrictEqual(
         responses.unknownThread.slashCommands.map((command) => command.name),
+        ["deploy"],
+      );
+      assert.deepStrictEqual(
+        responses.unknownProject.slashCommands.map((command) => command.name),
         ["from-snapshot"],
       );
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -3410,7 +3410,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
 
   it.effect("resolves provider workspace capabilities from the thread worktree", () =>
     Effect.gen(function* () {
-      const requestedCwds = yield* Ref.make<ReadonlyArray<string>>([]);
+      const requestedCwds = yield* Ref.make<ReadonlyArray<string | null>>([]);
       const projectShell = {
         id: defaultProjectId,
         title: "Default Project",
@@ -3439,7 +3439,10 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
           providerRegistry: {
             listWorkspaceCapabilities: ({ cwd }) =>
               Ref.update(requestedCwds, (cwds) => [...cwds, cwd]).pipe(
-                Effect.as({ slashCommands: [{ name: "deploy" }], skills: [] }),
+                Effect.as({
+                  slashCommands: [{ name: cwd === null ? "from-snapshot" : "deploy" }],
+                  skills: [],
+                }),
               ),
           },
         },
@@ -3470,12 +3473,54 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       assert.deepStrictEqual(yield* Ref.get(requestedCwds), [
         "/tmp/worktrees/default-thread",
         "/tmp/default-project",
+        null,
       ]);
       assert.deepStrictEqual(
         responses.withThread.slashCommands.map((command) => command.name),
         ["deploy"],
       );
-      assert.deepStrictEqual(responses.unknownThread.slashCommands, []);
+      assert.deepStrictEqual(
+        responses.unknownThread.slashCommands.map((command) => command.name),
+        ["from-snapshot"],
+      );
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("fails provider workspace capabilities when the projection read fails", () =>
+    Effect.gen(function* () {
+      const projectionError = new PersistenceSqlError({
+        operation: "ProjectionSnapshotQuery.getProjectShellById:test",
+        detail: "failed to read the project shell",
+      });
+      const registryCalls = yield* Ref.make(0);
+
+      yield* buildAppUnderTest({
+        layers: {
+          projectionSnapshotQuery: {
+            getProjectShellById: () => Effect.fail(projectionError),
+          },
+          providerRegistry: {
+            listWorkspaceCapabilities: () =>
+              Ref.update(registryCalls, (count) => count + 1).pipe(
+                Effect.as({ slashCommands: [], skills: [] }),
+              ),
+          },
+        },
+      });
+
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const result = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[WS_METHODS.serverListProviderWorkspaceCapabilities]({
+            instanceId: ProviderInstanceId.make("claudeAgent"),
+            projectId: defaultProjectId,
+          }),
+        ).pipe(Effect.result),
+      );
+
+      assertTrue(result._tag === "Failure");
+      assertTrue(result.failure._tag === "OrchestrationGetSnapshotError");
+      assert.strictEqual(yield* Ref.get(registryCalls), 0);
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1487,7 +1487,7 @@ const makeWsRpcLayer = (
                 cwd =
                   Option.isSome(thread) && thread.value.projectId === input.projectId
                     ? (thread.value.worktreePath ?? projectRoot)
-                    : null;
+                    : projectRoot;
               }
 
               return yield* providerRegistry.listWorkspaceCapabilities({

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1460,20 +1460,34 @@ const makeWsRpcLayer = (
             Effect.gen(function* () {
               const project = yield* projectionSnapshotQuery
                 .getProjectShellById(input.projectId)
-                .pipe(Effect.orElseSucceed(() => Option.none()));
-              if (Option.isNone(project)) {
-                return { slashCommands: [], skills: [] };
-              }
+                .pipe(
+                  Effect.mapError(
+                    (cause) =>
+                      new OrchestrationGetSnapshotError({
+                        message: "Failed to read the project for provider workspace capabilities",
+                        cause,
+                      }),
+                  ),
+                );
+              const projectRoot = Option.isSome(project) ? project.value.workspaceRoot : null;
 
-              let cwd = project.value.workspaceRoot;
+              let cwd = projectRoot;
               if (input.threadId !== undefined) {
                 const thread = yield* projectionSnapshotQuery
                   .getThreadShellById(input.threadId)
-                  .pipe(Effect.orElseSucceed(() => Option.none()));
-                if (Option.isNone(thread) || thread.value.projectId !== input.projectId) {
-                  return { slashCommands: [], skills: [] };
-                }
-                cwd = thread.value.worktreePath ?? cwd;
+                  .pipe(
+                    Effect.mapError(
+                      (cause) =>
+                        new OrchestrationGetSnapshotError({
+                          message: "Failed to read the thread for provider workspace capabilities",
+                          cause,
+                        }),
+                    ),
+                  );
+                cwd =
+                  Option.isSome(thread) && thread.value.projectId === input.projectId
+                    ? (thread.value.worktreePath ?? projectRoot)
+                    : null;
               }
 
               return yield* providerRegistry.listWorkspaceCapabilities({

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1454,6 +1454,35 @@ const makeWsRpcLayer = (
             ).pipe(Effect.map((providers) => ({ providers }))),
             { "rpc.aggregate": "server" },
           ),
+        [WS_METHODS.serverListProviderWorkspaceCapabilities]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.serverListProviderWorkspaceCapabilities,
+            Effect.gen(function* () {
+              const project = yield* projectionSnapshotQuery
+                .getProjectShellById(input.projectId)
+                .pipe(Effect.orElseSucceed(() => Option.none()));
+              if (Option.isNone(project)) {
+                return { slashCommands: [], skills: [] };
+              }
+
+              let cwd = project.value.workspaceRoot;
+              if (input.threadId !== undefined) {
+                const thread = yield* projectionSnapshotQuery
+                  .getThreadShellById(input.threadId)
+                  .pipe(Effect.orElseSucceed(() => Option.none()));
+                if (Option.isNone(thread) || thread.value.projectId !== input.projectId) {
+                  return { slashCommands: [], skills: [] };
+                }
+                cwd = thread.value.worktreePath ?? cwd;
+              }
+
+              return yield* providerRegistry.listWorkspaceCapabilities({
+                instanceId: input.instanceId,
+                cwd,
+              });
+            }),
+            { "rpc.aggregate": "server" },
+          ),
         [WS_METHODS.serverUpdateProvider]: (input) =>
           observeRpcEffect(
             WS_METHODS.serverUpdateProvider,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6452,6 +6452,7 @@ function ChatViewContent(props: ChatViewProps) {
                             interactionMode={interactionMode}
                             lockedProvider={lockedProvider}
                             providerStatuses={providerStatuses as ServerProvider[]}
+                            activeProjectId={activeProject?.id ?? null}
                             activeProjectDefaultModelSelection={
                               activeProject?.defaultModelSelection
                             }

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -3,6 +3,7 @@ import type {
   EnvironmentId,
   ModelSelection,
   PreviewAnnotationPayload,
+  ProjectId,
   ProviderApprovalDecision,
   ProviderInteractionMode,
   ResolvedKeybindingsConfig,
@@ -76,6 +77,7 @@ import {
   removeInlineTerminalContextPlaceholder,
 } from "../../lib/terminalContext";
 import { useComposerPathSearch } from "../../lib/composerPathSearchState";
+import { useProviderWorkspaceCapabilities } from "../../state/queries";
 import { type ElementContextDraft } from "../../lib/elementContext";
 import { ComposerPendingElementContexts } from "./ComposerPendingElementContexts";
 import { ComposerPendingReviewComments } from "./ComposerPendingReviewComments";
@@ -555,6 +557,7 @@ export interface ChatComposerProps {
   // Provider / model
   lockedProvider: ProviderDriverKind | null;
   providerStatuses: ServerProvider[];
+  activeProjectId: ProjectId | null;
   activeProjectDefaultModelSelection: ModelSelection | null | undefined;
   activeThreadModelSelection: ModelSelection | null | undefined;
 
@@ -645,6 +648,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     interactionMode,
     lockedProvider,
     providerStatuses,
+    activeProjectId,
     activeProjectDefaultModelSelection,
     activeThreadModelSelection,
     activeThreadActivities,
@@ -1031,6 +1035,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     cwd: isPathTrigger ? gitCwd : null,
     query: isPathTrigger ? pathTriggerQuery : null,
   });
+  const workspaceCapabilities = useProviderWorkspaceCapabilities({
+    environmentId,
+    instanceId: selectedInstanceId,
+    projectId: activeProjectId,
+    threadId: activeThreadId,
+    enabled: composerTriggerKind === "slash-command" || composerTriggerKind === "skill",
+  });
 
   const composerMenuItems = useMemo<ComposerCommandItem[]>(() => {
     if (!composerTrigger) return [];
@@ -1072,16 +1083,18 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
             ] as const)
           : []),
       ] satisfies ReadonlyArray<Extract<ComposerCommandItem, { type: "slash-command" }>>;
-      const providerSlashCommandItems = (selectedProviderStatus?.slashCommands ?? []).map(
-        (command) => ({
-          id: `provider-slash-command:${selectedProvider}:${command.name}`,
-          type: "provider-slash-command" as const,
-          provider: selectedProvider,
-          command,
-          label: `/${command.name}`,
-          description: command.description ?? command.input?.hint ?? "Run provider command",
-        }),
-      );
+      const providerSlashCommandItems = (
+        workspaceCapabilities.slashCommands ??
+        selectedProviderStatus?.slashCommands ??
+        []
+      ).map((command) => ({
+        id: `provider-slash-command:${selectedProvider}:${command.name}`,
+        type: "provider-slash-command" as const,
+        provider: selectedProvider,
+        command,
+        label: `/${command.name}`,
+        description: command.description ?? command.input?.hint ?? "Run provider command",
+      }));
       const query = composerTrigger.query.trim().toLowerCase();
       const slashCommandItems = [...builtInSlashCommandItems, ...providerSlashCommandItems];
       if (!query) {
@@ -1090,19 +1103,20 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       return searchSlashCommandItems(slashCommandItems, query);
     }
     if (composerTrigger.kind === "skill") {
-      return searchProviderSkills(selectedProviderStatus?.skills ?? [], composerTrigger.query).map(
-        (skill) => ({
-          id: `skill:${selectedProvider}:${skill.name}`,
-          type: "skill" as const,
-          provider: selectedProvider,
-          skill,
-          label: formatProviderSkillDisplayName(skill),
-          description:
-            skill.shortDescription ??
-            skill.description ??
-            (skill.scope ? `${skill.scope} skill` : "Run provider skill"),
-        }),
-      );
+      return searchProviderSkills(
+        workspaceCapabilities.skills ?? selectedProviderStatus?.skills ?? [],
+        composerTrigger.query,
+      ).map((skill) => ({
+        id: `skill:${selectedProvider}:${skill.name}`,
+        type: "skill" as const,
+        provider: selectedProvider,
+        skill,
+        label: formatProviderSkillDisplayName(skill),
+        description:
+          skill.shortDescription ??
+          skill.description ??
+          (skill.scope ? `${skill.scope} skill` : "Run provider skill"),
+      }));
     }
     return [];
   }, [
@@ -1110,6 +1124,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     planModeUiEnabled,
     selectedProvider,
     selectedProviderStatus,
+    workspaceCapabilities.skills,
+    workspaceCapabilities.slashCommands,
     workspaceEntries.entries,
   ]);
 

--- a/apps/web/src/state/queries.ts
+++ b/apps/web/src/state/queries.ts
@@ -14,6 +14,8 @@ import type {
   OrchestrationThread,
   ProjectContentMatch,
   ProjectEntryKind,
+  ProjectId,
+  ProviderInstanceId,
   ThreadId,
   VcsListRefsResult,
   VcsRef,
@@ -28,6 +30,7 @@ import { orchestrationEnvironment } from "./orchestration";
 import { isPaginatedBranchesNextPagePending } from "./paginatedBranches";
 import { projectContentSearch, projectEnvironment } from "./projects";
 import { useEnvironmentQuery } from "./query";
+import { serverEnvironment } from "./server";
 import { useEnvironmentThread } from "./threads";
 import { vcsEnvironment } from "./vcs";
 
@@ -300,6 +303,35 @@ export function useProjectPathSearch(
 
 export function useComposerPathSearch(target: ComposerPathSearchTarget) {
   return useProjectPathSearch(target, COMPOSER_PATH_SEARCH_LIMIT);
+}
+
+export function useProviderWorkspaceCapabilities(target: {
+  readonly environmentId: EnvironmentId | null;
+  readonly instanceId: ProviderInstanceId | null;
+  readonly projectId: ProjectId | null;
+  readonly threadId: ThreadId | null;
+  readonly enabled: boolean;
+}) {
+  const result = useEnvironmentQuery(
+    target.enabled &&
+      target.environmentId !== null &&
+      target.instanceId !== null &&
+      target.projectId !== null
+      ? serverEnvironment.providerWorkspaceCapabilities({
+          environmentId: target.environmentId,
+          input: {
+            instanceId: target.instanceId,
+            projectId: target.projectId,
+            ...(target.threadId !== null ? { threadId: target.threadId } : {}),
+          },
+        })
+      : null,
+  );
+
+  return {
+    slashCommands: result.data?.slashCommands ?? null,
+    skills: result.data?.skills ?? null,
+  };
 }
 
 interface ProjectContentSearchTarget {

--- a/docs/user/providers-claude.md
+++ b/docs/user/providers-claude.md
@@ -41,6 +41,10 @@ T3 Code looks for Claude skills in the Claude config directory's `skills` folder
 
 If the same skill name exists in more than one folder, the later folder wins.
 
+The workspace is the folder the thread runs in: its worktree when it has one, and the
+project folder when it does not. The `/` and `$` menus list the commands and the skills
+of that workspace, so two projects show different entries.
+
 ## I Want Work And Personal Claude Accounts
 
 Use a different Claude config directory for each account.

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -717,7 +717,6 @@ export function createServerEnvironmentAtoms<R, E>(
     providerWorkspaceCapabilities: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:server:provider-workspace-capabilities",
       tag: WS_METHODS.serverListProviderWorkspaceCapabilities,
-      staleTimeMs: 300_000,
     }),
     configProjection,
     welcome: createEnvironmentRpcSubscriptionAtomFamily(runtime, {

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -714,6 +714,11 @@ export function createServerEnvironmentAtoms<R, E>(
       tag: WS_METHODS.serverGetUsageSummary,
       staleTimeMs: 60_000,
     }),
+    providerWorkspaceCapabilities: createEnvironmentRpcQueryAtomFamily(runtime, {
+      label: "environment-data:server:provider-workspace-capabilities",
+      tag: WS_METHODS.serverListProviderWorkspaceCapabilities,
+      staleTimeMs: 300_000,
+    }),
     configProjection,
     welcome: createEnvironmentRpcSubscriptionAtomFamily(runtime, {
       label: "environment-data:server:welcome",

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -358,7 +358,7 @@ export const WsServerListProviderWorkspaceCapabilitiesRpc = Rpc.make(
   {
     payload: ServerProviderWorkspaceCapabilitiesInput,
     success: ServerProviderWorkspaceCapabilities,
-    error: EnvironmentAuthorizationError,
+    error: Schema.Union([OrchestrationGetSnapshotError, EnvironmentAuthorizationError]),
   },
 );
 

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -154,6 +154,8 @@ import {
   ServerConfig,
   ServerProviderUpdateError,
   ServerProviderUpdateInput,
+  ServerProviderWorkspaceCapabilities,
+  ServerProviderWorkspaceCapabilitiesInput,
   ServerLifecycleStreamEvent,
   ServerRemoveKeybindingInput,
   ServerRemoveKeybindingResult,
@@ -253,6 +255,7 @@ export const WS_METHODS = {
   serverProbe: "server.probe",
   serverGetConfig: "server.getConfig",
   serverRefreshProviders: "server.refreshProviders",
+  serverListProviderWorkspaceCapabilities: "server.listProviderWorkspaceCapabilities",
   serverUpdateProvider: "server.updateProvider",
   serverUpdateServer: "server.updateServer",
   serverUpdateServerWithProgress: "server.updateServerWithProgress",
@@ -349,6 +352,15 @@ export const WsServerRefreshProvidersRpc = Rpc.make(WS_METHODS.serverRefreshProv
   success: ServerProviderUpdatedPayload,
   error: EnvironmentAuthorizationError,
 });
+
+export const WsServerListProviderWorkspaceCapabilitiesRpc = Rpc.make(
+  WS_METHODS.serverListProviderWorkspaceCapabilities,
+  {
+    payload: ServerProviderWorkspaceCapabilitiesInput,
+    success: ServerProviderWorkspaceCapabilities,
+    error: EnvironmentAuthorizationError,
+  },
+);
 
 export const WsServerUpdateProviderRpc = Rpc.make(WS_METHODS.serverUpdateProvider, {
   payload: ServerProviderUpdateInput,
@@ -977,6 +989,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsServerProbeRpc,
   WsServerGetConfigRpc,
   WsServerRefreshProvidersRpc,
+  WsServerListProviderWorkspaceCapabilitiesRpc,
   WsServerUpdateProviderRpc,
   WsServerUpdateServerRpc,
   WsServerUpdateServerWithProgressRpc,

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -96,6 +96,20 @@ export const ServerProviderSkill = Schema.Struct({
 });
 export type ServerProviderSkill = typeof ServerProviderSkill.Type;
 
+export const ServerProviderWorkspaceCapabilitiesInput = Schema.Struct({
+  instanceId: ProviderInstanceId,
+  projectId: ProjectId,
+  threadId: Schema.optional(ThreadId),
+});
+export type ServerProviderWorkspaceCapabilitiesInput =
+  typeof ServerProviderWorkspaceCapabilitiesInput.Type;
+
+export const ServerProviderWorkspaceCapabilities = Schema.Struct({
+  slashCommands: Schema.Array(ServerProviderSlashCommand),
+  skills: Schema.Array(ServerProviderSkill),
+});
+export type ServerProviderWorkspaceCapabilities = typeof ServerProviderWorkspaceCapabilities.Type;
+
 /**
  * Availability of a configured provider instance from the runtime's POV.
  *


### PR DESCRIPTION
## What Changed

- The composer now asks the server which commands and skills exist in the workspace it is about to send a turn to, instead of reading the single global list that ships with the provider snapshot.
- The client sends ids, never a path. The server picks the directory itself: the thread's worktree when it has one, otherwise the project folder.
- For Claude, the server runs the same capability probe and skill scan in that directory and keeps the answer for five minutes per workspace. A provider with nothing project-specific to report still answers from the global snapshot, so nothing else changes.

```
composer (web / mobile)
  └─ useProviderWorkspaceCapabilities()           apps/{web,mobile}/src/state/queries.ts
       └─ serverEnvironment.providerWorkspaceCapabilities   packages/client-runtime/src/state/server.ts
            └─ WS RPC "server.listProviderWorkspaceCapabilities"   packages/contracts/src/rpc.ts
                 └─ scope check                    apps/server/src/auth/RpcAuthorization.ts
                 └─ handler: resolve the cwd       apps/server/src/ws.ts
                      └─ ProviderRegistry.listWorkspaceCapabilities()
                           └─ instance.listWorkspaceCapabilities(cwd)   (optional)
                                └─ ClaudeDriver: probe + skill scan
```

## Why

Commands and skills that live inside a project never appear in the `/` and `$` menus, and every project shows the same list. Typing the command still works, because the thread itself runs in the project folder. Only the menus are wrong.

Discovery asks the directory the server process started in, not the project the user has open. In the desktop app those are never the same. The answer is then cached per provider, with nothing that records which project it came from, so opening another project cannot refresh it.

Left out on purpose: other providers keep their current behavior, and a probe that fails drops its cached entry instead of leaving a menu empty for the next five minutes.

Related: #4658. #4546 proposes the skills half of this, for the `$` picker only.

## Checklist

- [x] This PR is small and focused — one concern, the directory discovery reads
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes — no visual change; the menus look the same and list the open project's entries. I can add a matched pair.
- [ ] I included a video for animation/interaction changes — not applicable

Written by Claude Opus 5 in Claude Code, running inside T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New read RPC and cwd resolution from projections affect composer discovery; Claude runs per-workspace probes with caching, but behavior falls back to snapshots for non-Claude providers and failed probes.
> 
> **Overview**
> **Workspace-scoped provider menus** — Web and mobile composers no longer rely only on the global provider snapshot for `/` slash commands and `$` skills. While those menus are open, they call **`useProviderWorkspaceCapabilities`**, which hits **`server.listProviderWorkspaceCapabilities`** with project/thread ids (no client paths).
> 
> **Server resolution** — The WS handler resolves **cwd** from the thread worktree when it belongs to the project, otherwise the project workspace root, then **`ProviderRegistry.listWorkspaceCapabilities`**. Drivers may implement **`listWorkspaceCapabilities(cwd)`**; others keep snapshot lists.
> 
> **Claude** — **`ClaudeDriver`** probes capabilities and discovers skills in that **cwd**, caches per workspace (~5 minutes), and falls back to snapshot slash commands if the probe is empty.
> 
> Docs note that menus reflect the thread’s workspace folder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c05f4e6abb92d97a0be140aa96278e30855ebe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Discover Claude slash commands and skills per workspace in chat composers
> - Adds a new `server.listProviderWorkspaceCapabilities` RPC that resolves the workspace directory from the active thread's worktree path or project root, then queries the Claude provider for workspace-scoped slash commands and skills.
> - `ClaudeDriver` gains a `listWorkspaceCapabilities(cwd)` method backed by a capacity-8 cache, concurrently probing Claude capabilities and discovering skills, with fallback to the cached snapshot.
> - Web ([ChatComposer](https://github.com/pingdotgg/t3code/pull/7118/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a)) and mobile ([ThreadComposer](https://github.com/pingdotgg/t3code/pull/7118/files#diff-4c62d895b68dd46f4d2858321c8942fde0d3ddd37c5e4253cba04c18c21a6024)) composers call the new `useProviderWorkspaceCapabilities` hook when a slash-command or skill trigger is active, falling back to provider snapshot data if the query is unavailable.
> - Contract schemas, RPC group, client-runtime atoms, and RPC authorization scope are all updated to support the new endpoint.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c05f4e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->