### PR TITLE
feat: open project GitHub remotes

### DIFF
--- a/apps/mobile/src/components/SourceControlIcon.tsx
+++ b/apps/mobile/src/components/SourceControlIcon.tsx
@@ -1,11 +1,12 @@
 import Svg, { Defs, LinearGradient, Path, Stop } from "react-native-svg";
+import type { ColorValue } from "react-native";
 
 export type SourceControlIconKind = "github" | "gitlab" | "bitbucket" | "azure-devops";
 
 export function SourceControlIcon(props: {
   readonly kind: SourceControlIconKind;
   readonly size?: number;
-  readonly color?: string;
+  readonly color?: ColorValue;
 }) {
   const size = props.size ?? 18;
 

--- a/apps/mobile/src/features/threads/thread-list-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-items.tsx
@@ -5,6 +5,7 @@ import type {
 } from "@t3tools/client-runtime/state/shell";
 import type { EnvironmentThreadSearchMatch } from "@t3tools/client-runtime/state/thread-search";
 import type { MenuAction } from "@react-native-menu/menu";
+import { getGitHubRepositoryUrlFromRemoteUrl } from "@t3tools/shared/git";
 import { SymbolView } from "../../components/AppSymbol";
 import { memo, useCallback, useMemo, type ComponentProps } from "react";
 import { Pressable, useColorScheme, useWindowDimensions, View } from "react-native";
@@ -14,8 +15,10 @@ import Svg, { Circle, Path } from "react-native-svg";
 import { AppText as Text } from "../../components/AppText";
 import { ControlPillMenu } from "../../components/ControlPill";
 import { ProjectFavicon } from "../../components/ProjectFavicon";
+import { SourceControlIcon } from "../../components/SourceControlIcon";
 import { cn } from "../../lib/cn";
 import { HOME_HORIZONTAL_INSET } from "../../lib/layoutMetrics";
+import { tryOpenExternalUrl } from "../../lib/openExternalUrl";
 import { relativeTime } from "../../lib/time";
 import { useThemeColor } from "../../lib/useThemeColor";
 import type { PendingNewTask } from "../../state/use-pending-new-tasks";
@@ -92,6 +95,9 @@ export const ThreadListGroupHeader = memo(function ThreadListGroupHeader(props: 
   const { groupKey, onGroupAction, onNewThread } = props;
   const newThreadTarget = props.newThreadTarget ?? null;
   const compact = props.variant === "compact";
+  const githubRepositoryUrl = getGitHubRepositoryUrlFromRemoteUrl(
+    props.project.repositoryIdentity?.locator.remoteUrl ?? null,
+  );
   const handleToggle = useCallback(
     () => onGroupAction(groupKey, "toggle-collapsed"),
     [groupKey, onGroupAction],
@@ -102,6 +108,11 @@ export const ThreadListGroupHeader = memo(function ThreadListGroupHeader(props: 
     }
   }, [newThreadTarget, onNewThread]);
   const showNewThreadButton = onNewThread !== undefined && newThreadTarget !== null;
+  const handleOpenGitHubRepository = useCallback(() => {
+    if (githubRepositoryUrl) {
+      void tryOpenExternalUrl(githubRepositoryUrl, "project-repository");
+    }
+  }, [githubRepositoryUrl]);
 
   // The new-thread button is a SIBLING of the collapse toggle, not a child:
   // nested touchables are unreachable to VoiceOver/TalkBack (the parent
@@ -161,6 +172,17 @@ export const ThreadListGroupHeader = memo(function ThreadListGroupHeader(props: 
           {props.threadCount}
         </Text>
       </Pressable>
+      {githubRepositoryUrl ? (
+        <Pressable
+          accessibilityLabel={`Open ${props.title} on GitHub`}
+          accessibilityRole="link"
+          hitSlop={{ ...verticalHitSlop, left: 10, right: 10 }}
+          onPress={handleOpenGitHubRepository}
+          style={({ pressed }) => ({ opacity: pressed ? 0.5 : 1, paddingLeft: 12 })}
+        >
+          <SourceControlIcon kind="github" size={compact ? 19 : 16} color={iconMutedColor} />
+        </Pressable>
+      ) : null}
       {showNewThreadButton ? (
         <Pressable
           accessibilityLabel={`Create new thread in ${props.title}`}

--- a/apps/mobile/src/lib/openExternalUrl.ts
+++ b/apps/mobile/src/lib/openExternalUrl.ts
@@ -1,7 +1,12 @@
 import * as Schema from "effect/Schema";
 import { Linking } from "react-native";
 
-const ExternalUrlTarget = Schema.Literals(["file-preview", "markdown-link", "pull-request"]);
+const ExternalUrlTarget = Schema.Literals([
+  "file-preview",
+  "markdown-link",
+  "project-repository",
+  "pull-request",
+]);
 
 export type ExternalUrlTarget = typeof ExternalUrlTarget.Type;
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6240,6 +6240,7 @@ function ChatViewContent(props: ChatViewProps) {
             activeProjectName={activeProject?.title}
             activeProjectCwd={activeProject?.workspaceRoot ?? null}
             activeProjectFaviconPath={activeProject?.faviconPath ?? null}
+            activeProjectRemoteUrl={activeProject?.repositoryIdentity?.locator.remoteUrl ?? null}
             openInCwd={gitCwd}
             activeProjectScripts={activeProject?.scripts}
             preferredScriptId={

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -57,6 +57,7 @@ import {
   scopeThreadRef,
 } from "@t3tools/client-runtime/environment";
 import { safeErrorLogAttributes } from "@t3tools/client-runtime/errors";
+import { getGitHubRepositoryUrlFromRemoteUrl } from "@t3tools/shared/git";
 import {
   isAtomCommandInterrupted,
   settlePromise,
@@ -1610,7 +1611,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
 
         const actionHandlers = new Map<string, () => Promise<void> | void>();
         const makeLeaf = (
-          action: "rename" | "grouping" | "copy-path" | "delete",
+          action: "open-github" | "rename" | "grouping" | "copy-path" | "delete",
           member: SidebarProjectGroupMember,
           options?: {
             destructive?: boolean;
@@ -1618,8 +1619,26 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
           },
         ): ContextMenuItem<string> => {
           const id = `${action}:${member.physicalProjectKey}`;
-          actionHandlers.set(id, () => {
+          actionHandlers.set(id, async () => {
             switch (action) {
+              case "open-github": {
+                const repositoryUrl = getGitHubRepositoryUrlFromRemoteUrl(
+                  member.repositoryIdentity?.locator.remoteUrl ?? null,
+                );
+                if (!repositoryUrl) return;
+                try {
+                  await api.shell.openExternal(repositoryUrl);
+                } catch (error) {
+                  toastManager.add(
+                    stackedThreadToast({
+                      type: "error",
+                      title: "Failed to open GitHub repository",
+                      description: error instanceof Error ? error.message : "An error occurred.",
+                    }),
+                  );
+                }
+                return;
+              }
               case "rename":
                 openProjectRenameDialog(member);
                 return;
@@ -1643,15 +1662,17 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         };
 
         const buildTargetedItem = (
-          action: "rename" | "grouping" | "copy-path" | "delete",
+          action: "open-github" | "rename" | "grouping" | "copy-path" | "delete",
           label: string,
           options?: {
             destructive?: boolean;
             isDisabled?: (member: SidebarProjectGroupMember) => boolean;
+            members?: readonly SidebarProjectGroupMember[];
           },
         ): ContextMenuItem<string> => {
-          if (project.memberProjects.length === 1) {
-            const singleMember = project.memberProjects[0]!;
+          const members = options?.members ?? project.memberProjects;
+          if (members.length === 1) {
+            const singleMember = members[0]!;
             return {
               ...makeLeaf(action, singleMember, {
                 ...(options?.destructive ? { destructive: true } : {}),
@@ -1666,7 +1687,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
             id: `${action}:submenu`,
             label,
             ...(action === "delete" ? { icon: "trash" } : {}),
-            children: project.memberProjects.map((member) =>
+            children: members.map((member) =>
               makeLeaf(action, member, {
                 ...(options?.destructive ? { destructive: true } : {}),
                 ...(options?.isDisabled?.(member) ? { disabled: true } : {}),
@@ -1675,8 +1696,23 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
           };
         };
 
+        const githubMembers = project.memberProjects.filter((member) =>
+          Boolean(
+            getGitHubRepositoryUrlFromRemoteUrl(
+              member.repositoryIdentity?.locator.remoteUrl ?? null,
+            ),
+          ),
+        );
+
         const clicked = await api.contextMenu.show(
           [
+            ...(githubMembers.length > 0
+              ? [
+                  buildTargetedItem("open-github", "Open on GitHub", {
+                    members: githubMembers,
+                  }),
+                ]
+              : []),
             buildTargetedItem("rename", "Rename"),
             buildTargetedItem("grouping", "Group into..."),
             buildTargetedItem("copy-path", "Copy Path"),

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -24,6 +24,7 @@ import {
 } from "react";
 import GitActionsControl from "../GitActionsControl";
 import { type DraftId } from "~/composerDraftStore";
+import { Button } from "../ui/button";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { toastManager } from "../ui/toast";
 import ProjectScriptsControl, {
@@ -279,11 +280,11 @@ export const ChatHeader = memo(function ChatHeader({
                 <Tooltip>
                   <TooltipTrigger
                     render={
-                      <button
-                        type="button"
+                      <Button
+                        size="icon-micro"
+                        variant="ghost-muted"
                         aria-label={`Open ${activeProjectName} on GitHub`}
                         onClick={openGitHubRepository}
-                        className="inline-flex shrink-0 cursor-pointer items-center rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
                       />
                     }
                   >

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -11,6 +11,7 @@ import {
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
 import type { ChangeRequestStateLike } from "@t3tools/client-runtime/state/thread-settled";
+import { getGitHubRepositoryUrlFromRemoteUrl } from "@t3tools/shared/git";
 import { ChevronDownIcon } from "lucide-react";
 import {
   memo,
@@ -37,12 +38,14 @@ import { useThreadActionMenu } from "~/hooks/useThreadActionMenu";
 import { threadEnvironment } from "../../state/threads";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { ProjectFavicon } from "../ProjectFavicon";
+import { GitHubIcon } from "../Icons";
 import {
   WorkspaceBreadcrumb,
   WorkspaceBreadcrumbItem,
   WorkspaceBreadcrumbSeparator,
 } from "../WorkspaceBreadcrumb";
 import { cn } from "~/lib/utils";
+import { readLocalApi } from "~/localApi";
 
 interface ChatHeaderProps {
   activeThreadEnvironmentId: EnvironmentId;
@@ -56,6 +59,7 @@ interface ChatHeaderProps {
   activeProjectName: string | undefined;
   activeProjectCwd: string | null;
   activeProjectFaviconPath: string | null;
+  activeProjectRemoteUrl: string | null;
   openInCwd: string | null;
   activeProjectScripts: ReadonlyArray<ProjectScript> | undefined;
   preferredScriptId: string | null;
@@ -117,6 +121,7 @@ export const ChatHeader = memo(function ChatHeader({
   activeProjectName,
   activeProjectCwd,
   activeProjectFaviconPath,
+  activeProjectRemoteUrl,
   openInCwd,
   activeProjectScripts,
   preferredScriptId,
@@ -143,6 +148,19 @@ export const ChatHeader = memo(function ChatHeader({
     primaryEnvironmentId,
     remoteOpenMode: remoteOpenState.mode,
   });
+  const githubRepositoryUrl = getGitHubRepositoryUrlFromRemoteUrl(activeProjectRemoteUrl);
+  const openGitHubRepository = useCallback(() => {
+    const api = readLocalApi();
+    if (!api || !githubRepositoryUrl) return;
+
+    void api.shell.openExternal(githubRepositoryUrl).catch((error: unknown) => {
+      toastManager.add({
+        type: "error",
+        title: "Failed to open GitHub repository",
+        description: error instanceof Error ? error.message : "An error occurred.",
+      });
+    });
+  }, [githubRepositoryUrl]);
   const activeThreadRef = useMemo(
     () => scopeThreadRef(activeThreadEnvironmentId, activeThreadId),
     [activeThreadEnvironmentId, activeThreadId],
@@ -235,7 +253,7 @@ export const ChatHeader = memo(function ChatHeader({
             doesn't answer it. */}
         {activeProjectName ? (
           <>
-            <WorkspaceBreadcrumbItem>
+            <WorkspaceBreadcrumbItem className="gap-2">
               <Tooltip>
                 <TooltipTrigger
                   render={
@@ -257,6 +275,23 @@ export const ChatHeader = memo(function ChatHeader({
                 </TooltipTrigger>
                 <TooltipPopup side="top">New thread in {activeProjectName}</TooltipPopup>
               </Tooltip>
+              {githubRepositoryUrl ? (
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <button
+                        type="button"
+                        aria-label={`Open ${activeProjectName} on GitHub`}
+                        onClick={openGitHubRepository}
+                        className="inline-flex shrink-0 cursor-pointer items-center rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+                      />
+                    }
+                  >
+                    <GitHubIcon className="size-3.5" />
+                  </TooltipTrigger>
+                  <TooltipPopup side="top">Open {activeProjectName} on GitHub</TooltipPopup>
+                </Tooltip>
+              ) : null}
             </WorkspaceBreadcrumbItem>
             <WorkspaceBreadcrumbSeparator />
           </>

--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -21,6 +21,7 @@ import type {
   ThreadEnvMode,
 } from "@t3tools/contracts";
 import { resolveEnvModeLabel } from "../BranchToolbar.logic";
+import { getGitHubRepositoryUrlFromRemoteUrl } from "@t3tools/shared/git";
 import { createModelSelection } from "@t3tools/shared/model";
 import { DEFAULT_RESOLVED_KEYBINDINGS } from "@t3tools/shared/keybindings";
 import { useCanGoBack, useNavigate } from "@tanstack/react-router";
@@ -72,6 +73,7 @@ import { primaryServerProvidersAtom, serverEnvironment } from "../../state/serve
 import { useAtomCommand } from "../../state/use-atom-command";
 import { ProviderModelPicker } from "../chat/ProviderModelPicker";
 import { TraitsPicker } from "../chat/TraitsPicker";
+import { GitHubIcon } from "../Icons";
 import { ProjectFavicon } from "../ProjectFavicon";
 import {
   EMPTY_PROJECT_SCRIPT_INPUT,
@@ -466,6 +468,23 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
   const selectedCheckout =
     group.memberProjects.find((member) => member.physicalProjectKey === selectedCheckoutKey) ??
     representative;
+  const githubRepositoryUrl = getGitHubRepositoryUrlFromRemoteUrl(
+    selectedCheckout.repositoryIdentity?.locator.remoteUrl ?? null,
+  );
+  const openGitHubRepository = useCallback(() => {
+    const api = readLocalApi();
+    if (!api || !githubRepositoryUrl) return;
+
+    void api.shell.openExternal(githubRepositoryUrl).catch((error: unknown) => {
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Failed to open GitHub repository",
+          description: error instanceof Error ? error.message : "An error occurred.",
+        }),
+      );
+    });
+  }, [githubRepositoryUrl]);
   const selectedServerConfig = useAtomValue(
     serverEnvironment.configValueAtom(selectedCheckout.environmentId),
   );
@@ -953,6 +972,20 @@ function ProjectDetail({ group }: { group: SidebarProjectSnapshot }) {
                 </code>
                 <CopyIcon className="size-4 shrink-0 opacity-60 group-hover:opacity-100" />
               </button>
+              {githubRepositoryUrl ? (
+                <Button
+                  size="xs"
+                  variant="ghost"
+                  type="button"
+                  className="shrink-0"
+                  aria-label={`Open ${selectedCheckout.title} on GitHub`}
+                  title={`Open ${selectedCheckout.title} on GitHub`}
+                  onClick={openGitHubRepository}
+                >
+                  <GitHubIcon className="size-3.5" />
+                  Open on GitHub
+                </Button>
+              ) : null}
               <div className="shrink-0 border-l border-border/60 px-2 tabular-nums">
                 {selectedCheckoutThreadCount === 1
                   ? "1 thread"

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -27,6 +27,11 @@ T3 Code works with the platforms your team already uses:
 - Use the **Publish Repository** action to create a new hosted repository (GitHub, GitLab, Bitbucket, or Azure DevOps), add it as your origin remote, and push, in one flow
 - If the local repository has no commits yet, publishing creates the remote and wires it up but does not push. Make a commit, then push normally.
 
+**Open a project's GitHub repository**
+
+- GitHub-backed projects show a GitHub button in the thread header and project controls
+- Select it to open the project's configured remote in your browser
+
 ### Manage Code Reviews Without Context Switching
 
 **Create pull requests while you work**

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   applyGitStatusStreamEvent,
   buildTemporaryWorktreeBranchName,
+  getGitHubRepositoryUrlFromRemoteUrl,
   isTemporaryWorktreeBranch,
   normalizeGitRemoteUrl,
   parseGitHubRepositoryNameWithOwnerFromRemoteUrl,
@@ -59,6 +60,33 @@ describe("parseGitHubRepositoryNameWithOwnerFromRemoteUrl", () => {
     expect(
       parseGitHubRepositoryNameWithOwnerFromRemoteUrl("https://github.com/T3Tools/T3Code.git"),
     ).toBe("T3Tools/T3Code");
+  });
+});
+
+describe("getGitHubRepositoryUrlFromRemoteUrl", () => {
+  it("converts common GitHub clone URLs to the repository page", () => {
+    expect(getGitHubRepositoryUrlFromRemoteUrl("git@github.com:T3Tools/T3Code.git")).toBe(
+      "https://github.com/T3Tools/T3Code",
+    );
+    expect(getGitHubRepositoryUrlFromRemoteUrl("https://github.com/T3Tools/T3Code.git")).toBe(
+      "https://github.com/T3Tools/T3Code",
+    );
+  });
+
+  it("supports self-hosted GitHub remotes without exposing clone credentials", () => {
+    expect(
+      getGitHubRepositoryUrlFromRemoteUrl(
+        "https://x-access-token:secret@github.company.test:8443/T3Tools/T3Code.git",
+      ),
+    ).toBe("https://github.company.test:8443/T3Tools/T3Code");
+    expect(getGitHubRepositoryUrlFromRemoteUrl("git@github.company.test:T3Tools/T3Code.git")).toBe(
+      "https://github.company.test/T3Tools/T3Code",
+    );
+  });
+
+  it("returns null for non-GitHub and missing remotes", () => {
+    expect(getGitHubRepositoryUrlFromRemoteUrl("git@gitlab.com:T3Tools/T3Code.git")).toBeNull();
+    expect(getGitHubRepositoryUrlFromRemoteUrl(null)).toBeNull();
   });
 });
 

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -160,6 +160,42 @@ export function parseGitHubRepositoryNameWithOwnerFromRemoteUrl(url: string | nu
   return repositoryNameWithOwner.length > 0 ? repositoryNameWithOwner : null;
 }
 
+/**
+ * Convert a GitHub clone URL into the HTTPS repository page users can open.
+ * Rebuild the URL from its host and path so clone credentials never reach the browser.
+ */
+export function getGitHubRepositoryUrlFromRemoteUrl(remoteUrl: string | null): string | null {
+  const trimmed = remoteUrl?.trim() ?? "";
+  const provider = trimmed ? detectSourceControlProviderFromRemoteUrl(trimmed) : null;
+  if (provider?.kind !== "github") return null;
+
+  let repositoryPath = "";
+  let baseUrl = provider.baseUrl;
+  if (/^(?:ssh|https?|git):\/\//iu.test(trimmed)) {
+    try {
+      const parsed = new URL(trimmed);
+      repositoryPath = parsed.pathname;
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        baseUrl = `https://${parsed.hostname}`;
+      }
+    } catch {
+      return null;
+    }
+  } else {
+    repositoryPath = /^git@[^:/\s]+:(.+)$/iu.exec(trimmed)?.[1] ?? "";
+  }
+
+  const segments = repositoryPath
+    .replace(/^\/+|\/+$/gu, "")
+    .replace(/\.git$/iu, "")
+    .split("/");
+  if (segments.length !== 2 || segments.some((segment) => !/^[a-z\d_.-]+$/iu.test(segment))) {
+    return null;
+  }
+
+  return `${baseUrl}/${segments.join("/")}`;
+}
+
 function deriveLocalBranchNameCandidatesFromRemoteRef(
   branchName: string,
   remoteName?: string,


### PR DESCRIPTION
Projects currently provide no direct path to their GitHub repository, forcing users to reconstruct URLs from remotes.

This parses GitHub repository URLs from common remote formats and adds repository actions in the thread header, project settings, legacy sidebar, and mobile project rows. Projects without a GitHub remote omit the action.

![Open GitHub remote action](https://raw.githubusercontent.com/gsimone/t3code/be5b344881a9bcb035cdc7bcedff53e34f3f1759/.github/pr-assets/7119/github-remote-navigation.png)

Tests:

- `vp test run packages/shared/src/git.test.ts apps/mobile/src/lib/openExternalUrl.test.ts apps/web/src/components/chat/ChatHeader.test.ts` (26 tests)
- Web, shared, and mobile typechecks
- Targeted lint

Built with GPT-5.6-Sol in T3 Code using the Codex harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add GitHub repository links to project UI across web and mobile
> - Adds a new `getGitHubRepositoryUrlFromRemoteUrl` utility in [git.ts](https://github.com/pingdotgg/t3code/pull/7119/files#diff-e52ee60f55e13d4ce4a00279168044882e11385edf15a01ad8073cd1442f5785) that parses SSH and HTTPS GitHub remote URLs (including self-hosted) and returns a safe, openable HTTPS repository URL or null.
> - Surfaces a GitHub icon button in the web chat header ([ChatHeader.tsx](https://github.com/pingdotgg/t3code/pull/7119/files#diff-124f699b87245f05f11a8bf7ef3d0b17dbe34657c443a51e23125ce90e0fcf0c)) and project settings panel ([ProjectSettingsPanel.tsx](https://github.com/pingdotgg/t3code/pull/7119/files#diff-0240d4863349583155edae77c3bfab65683d7e019508379850a5b96167960cdc)) for GitHub-backed projects; clicking opens the repo in the default browser.
> - Adds an 'Open on GitHub' context menu item to sidebar project items ([LegacySidebar.tsx](https://github.com/pingdotgg/t3code/pull/7119/files#diff-ef6c49faf62e0e2403f09772084537ac313e826ae0f90db230a898204f3bdd86)), with a submenu when multiple members have GitHub remotes.
> - Adds a GitHub icon button to project group headers in the mobile thread list ([thread-list-items.tsx](https://github.com/pingdotgg/t3code/pull/7119/files#diff-d7cca5a410b8a14057731c4f49de8786310bd38ded01b09dd02b4da1e3d01808)) that opens the repository via the system browser.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 46839b6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->