### PR TITLE
fix(web): surface draft sessions in the legacy sidebar

### DIFF
--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -22,6 +22,7 @@ import {
   ThreadWorktreeIndicator,
 } from "./ThreadStatusIndicators";
 import { ProjectFavicon } from "./ProjectFavicon";
+import { SidebarDraftBlock } from "./Sidebar";
 import { useAtomValue } from "@effect/atom-react";
 import { autoAnimate } from "@formkit/auto-animate";
 import React, { useCallback, useEffect, memo, useMemo, useRef, useState } from "react";
@@ -105,7 +106,7 @@ import {
 import { isModelPickerOpen } from "../modelPickerVisibility";
 import { useShortcutModifierState } from "../shortcutModifierState";
 import { ensureLocalApi, readLocalApi } from "../localApi";
-import { useComposerDraftStore } from "../composerDraftStore";
+import { type DraftId, useComposerDraftStore } from "../composerDraftStore";
 import { useNewThreadHandler } from "../hooks/useHandleNewThread";
 import { useDesktopUpdateState } from "../state/desktopUpdate";
 
@@ -2795,6 +2796,72 @@ interface SidebarProjectsContentProps {
   projectsLength: number;
 }
 
+// Drafts the user typed into but never sent, rendered above the projects
+// list so the legacy sidebar reaches parity with the v2 sidebar: without
+// these rows a draft started under this sidebar has no way back in and
+// silently piles up in the v2 list. Self-contained (own store and route
+// subscriptions) so per-keystroke composer updates re-render only this
+// block and SidebarProjectsContent's memo stays intact. SidebarDraftBlock
+// renders nothing at count 0, so the wrapping menu collapses to zero
+// height and costs the empty sidebar no space.
+function LegacySidebarDraftList() {
+  const projects = useProjects();
+  const navigate = useNavigate();
+  const { isMobile, setOpenMobile } = useSidebar();
+  const clearSelection = useThreadSelectionStore((s) => s.clearSelection);
+  const routeTarget = useParams({
+    strict: false,
+    select: (params) => resolveThreadRouteTarget(params),
+  });
+  const routeDraftId = routeTarget?.kind === "draft" ? routeTarget.draftId : null;
+  // The legacy list has no grouped display names on draft rows; the
+  // project's own title is what its header shows for local projects.
+  const projectTitleByKey = useMemo(
+    () =>
+      new Map(projects.map((project) => [`${project.environmentId}:${project.id}`, project.title])),
+    [projects],
+  );
+  const projectCwdByKey = useMemo(
+    () =>
+      new Map(
+        projects.map((project) => [
+          `${project.environmentId}:${project.id}`,
+          project.workspaceRoot,
+        ]),
+      ),
+    [projects],
+  );
+  const projectFaviconPathByKey = useMemo(
+    () =>
+      new Map(
+        projects.map((project) => [`${project.environmentId}:${project.id}`, project.faviconPath]),
+      ),
+    [projects],
+  );
+  const navigateToDraft = useCallback(
+    (draftId: DraftId) => {
+      clearSelection();
+      if (isMobile) {
+        setOpenMobile(false);
+      }
+      void navigate({ to: "/draft/$draftId", params: { draftId } });
+    },
+    [clearSelection, isMobile, navigate, setOpenMobile],
+  );
+  return (
+    <SidebarMenu>
+      <SidebarDraftBlock
+        projectDisplayNameByKey={projectTitleByKey}
+        projectCwdByKey={projectCwdByKey}
+        projectFaviconPathByKey={projectFaviconPathByKey}
+        scopedProjectKeys={null}
+        routeDraftId={routeDraftId}
+        onNavigateToDraft={navigateToDraft}
+      />
+    </SidebarMenu>
+  );
+}
+
 const SidebarProjectsContent = memo(function SidebarProjectsContent(
   props: SidebarProjectsContentProps,
 ) {
@@ -2911,6 +2978,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
       ) : null}
       <LocalSecondaryStatus />
       <SidebarGroup className="px-2 py-2">
+        <LegacySidebarDraftList />
         <div className="mb-1 flex items-center justify-between pl-2 pr-1.5">
           <span className="text-xs font-medium text-sidebar-muted-foreground/80">Projects</span>
           <div className="flex items-center gap-1">

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -565,7 +565,9 @@ interface SidebarDraftRowData {
 // interrupted "new thread" stays one click away. Self-contained (own store
 // subscription + closing divider) so per-keystroke composer updates
 // re-render only this block, never the whole sidebar. Vanishes at count 0.
-const SidebarDraftBlock = memo(function SidebarDraftBlock(props: {
+// Exported for the legacy sidebar, which renders the same block above its
+// projects list so drafts stay reachable there too.
+export const SidebarDraftBlock = memo(function SidebarDraftBlock(props: {
   projectDisplayNameByKey: ReadonlyMap<string, string>;
   projectCwdByKey: ReadonlyMap<string, string>;
   projectFaviconPathByKey: ReadonlyMap<string, string | null | undefined>;


### PR DESCRIPTION
## What Changed

The legacy sidebar now renders draft sessions (unsent new-thread composers with typed content), reusing the v2 sidebar's existing `SidebarDraftBlock` component.

- `SidebarDraftBlock` is exported from `Sidebar.tsx` (no behavior change there).
- `LegacySidebar.tsx` gains a small self-contained wrapper that supplies project title/cwd/favicon lookups, the active draft route, and `/draft/$draftId` navigation, mounted above the "Projects" header. It subscribes to the draft store itself, so per-keystroke composer updates re-render only this block and the projects content's memoization is untouched.
- With zero drafts the block renders nothing — the empty legacy sidebar is pixel-identical to before.

+72/−2 across the two sidebar files.

## Why

Fixes #6084.

Drafts created while using the legacy sidebar were kept by the store but had no UI there: navigate away and there was no row to click back into, while the drafts silently piled up in the v2 sidebar. Reusing the v2 block (rather than reimplementing rows) keeps the two sidebars showing identical draft state with one source of truth.

## UI Changes

## Sidebar v2 (Unchanged)

<img width="1104" height="781" alt="image" src="https://github.com/user-attachments/assets/ffe073d5-c9d9-4a66-ae8c-78f9adb84f93" />



## Legacy Sidebar Before

<img width="1101" height="779" alt="image" src="https://github.com/user-attachments/assets/fdf8c05c-63bc-49bd-a17a-ac96e177b82b" />

## Legacy Sidebar After

<img width="1107" height="777" alt="image" src="https://github.com/user-attachments/assets/0c097b2a-6fe3-4938-ba42-014da06a24be" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface draft sessions in the legacy sidebar above the projects list
> Adds a `LegacySidebarDraftList` component to [LegacySidebar.tsx](https://github.com/pingdotgg/t3code/pull/7120/files#diff-ef6c49faf62e0e2403f09772084537ac313e826ae0f90db230a898204f3bdd86) that renders a drafts section at the top of the legacy sidebar. Clicking a draft clears the current thread selection, navigates to `/draft/$draftId`, and closes the sidebar on mobile. `SidebarDraftBlock` in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/7120/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) is exported so the new component can reuse it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 799ba95.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only parity fix that reuses the existing v2 draft block and navigation; no auth, data, or API changes.
> 
> **Overview**
> **Unsent composer drafts now appear in the legacy sidebar** above the Projects list, matching the v2 sidebar so drafts started there stay one click away instead of only showing up in v2.
> 
> The change **exports** `SidebarDraftBlock` from `Sidebar.tsx` and adds **`LegacySidebarDraftList`** in `LegacySidebar.tsx`, which builds project title/cwd/favicon maps, reads the active draft from the route, and navigates to `/draft/$draftId` (clearing thread selection and closing the mobile sidebar). Draft store subscriptions live in that wrapper so typing in a draft does not bust memoization on the main projects list. With no drafts, the block still renders nothing and the layout stays unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 799ba957f51cd0b48ad8e5020090814318d0388f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->