### PR TITLE
fix(web): improve disconnected composer placeholder

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -3075,7 +3075,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                           : noProviderAvailable
                             ? "Enable a provider in Settings to send a message"
                             : phase === "disconnected"
-                              ? "Ask for follow-up changes or attach images"
+                              ? "Ask for changes, send follow-ups, or attach images"
                               : "Ask anything, @tag files/folders, $use skills, or / for commands"
                 }
                 disabled={isConnecting || isComposerApprovalState || projectSelectionRequired}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -42,6 +42,7 @@ import {
   replaceTextRange,
   shouldSubmitComposerOnEnter,
 } from "../../composer-logic";
+import { DISCONNECTED_COMPOSER_PLACEHOLDER } from "../../composerPlaceholder";
 import { deriveComposerSendState, readFileAsDataUrl } from "../ChatView.logic";
 import {
   dataTransferHasComposerMention,
@@ -3075,7 +3076,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                           : noProviderAvailable
                             ? "Enable a provider in Settings to send a message"
                             : phase === "disconnected"
-                              ? "Ask for changes, send follow-ups, or attach images"
+                              ? DISCONNECTED_COMPOSER_PLACEHOLDER
                               : "Ask anything, @tag files/folders, $use skills, or / for commands"
                 }
                 disabled={isConnecting || isComposerApprovalState || projectSelectionRequired}

--- a/apps/web/src/components/settings/SettingsFontPreviews.tsx
+++ b/apps/web/src/components/settings/SettingsFontPreviews.tsx
@@ -43,7 +43,7 @@ export function PromptFontPreview() {
         terminalContexts={EMPTY_TERMINAL_CONTEXTS}
         skills={EMPTY_SKILLS}
         disabled={false}
-        placeholder="Ask for follow-up changes or attach images"
+        placeholder="Ask for changes, send follow-ups, or attach images"
         className="max-h-40 min-h-12"
         onRemoveTerminalContext={noop}
         onChange={onChange}

--- a/apps/web/src/components/settings/SettingsFontPreviews.tsx
+++ b/apps/web/src/components/settings/SettingsFontPreviews.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { ComposerPromptEditor, type ComposerPromptEditorHandle } from "../ComposerPromptEditor";
 import { terminalThemeFromApp } from "../ThreadTerminalDrawer";
 import { useTheme } from "../../hooks/useTheme";
+import { DISCONNECTED_COMPOSER_PLACEHOLDER } from "../../composerPlaceholder";
 import { resolveDiffThemeName, type DiffThemeName } from "../../lib/diffRendering";
 import { GhosttyTerminalSurface } from "~/terminal/ghostty/surface";
 
@@ -43,7 +44,7 @@ export function PromptFontPreview() {
         terminalContexts={EMPTY_TERMINAL_CONTEXTS}
         skills={EMPTY_SKILLS}
         disabled={false}
-        placeholder="Ask for changes, send follow-ups, or attach images"
+        placeholder={DISCONNECTED_COMPOSER_PLACEHOLDER}
         className="max-h-40 min-h-12"
         onRemoveTerminalContext={noop}
         onChange={onChange}

--- a/apps/web/src/composerPlaceholder.ts
+++ b/apps/web/src/composerPlaceholder.ts
@@ -1,0 +1,2 @@
+export const DISCONNECTED_COMPOSER_PLACEHOLDER =
+  "Ask for changes, send follow-ups, or attach images";


### PR DESCRIPTION
Written by @inayayousfi, typed by GPT-5.6 Sol running in OpenCode.
Every call here is @inayayousfi's, and no agent acted on its own.

The disconnected composer currently says “Ask for follow-up changes or attach images,” which makes “follow-up” sound like it modifies “changes.”

This updates the text to “Ask for changes, send follow-ups, or attach images” and keeps the typography preview in sync.

## Before

![The previous disconnected composer placeholder](https://raw.githubusercontent.com/inayayousfi/t3code/pr-assets/composer-placeholder-copy/before-composer-placeholder.png)

## After

![The revised disconnected composer placeholder](https://raw.githubusercontent.com/inayayousfi/t3code/pr-assets/composer-placeholder-copy/after-composer-placeholder.png)

## Testing

- `pnpm --filter @t3tools/web typecheck`
- `vp fmt --check`

## request provenance

- requested by: @maria-rcks

<!-- t3bot-requester: discord_user_id=1456050980322808049 github=maria-rcks message_id=1539414368712917044 -->


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update disconnected composer placeholder text to use a shared constant
> Extracts the disconnected-state placeholder string into a new shared constant `DISCONNECTED_COMPOSER_PLACEHOLDER` in [`composerPlaceholder.ts`](https://github.com/pingdotgg/t3code/pull/7122/files#diff-2a4009624c6a3c6dcff5a928460dbd49c92b51ec15f476b1c1b669dbf9ca7a83). Both [`ChatComposer`](https://github.com/pingdotgg/t3code/pull/7122/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a) and the font preview in [`SettingsFontPreviews`](https://github.com/pingdotgg/t3code/pull/7122/files#diff-41c2627f285aa954989f64cc12c833d239ab22024e21d3690434eb1d2fb8dacc) now reference this constant instead of their own hard-coded strings. The visible placeholder text changes to "Ask for changes, send follow-ups, or attach images".
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0cbfbe7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->