### PR TITLE
fix(mobile): accept a pairing code however it was typed

### DIFF
--- a/apps/mobile/src/features/connection/ConnectionsNewRouteScreen.tsx
+++ b/apps/mobile/src/features/connection/ConnectionsNewRouteScreen.tsx
@@ -1,6 +1,7 @@
 import { CameraView, useCameraPermissions } from "expo-camera";
 import { NativeHeaderToolbar, NativeStackScreenOptions } from "../../native/StackHeader";
 import { StackActions, useNavigation, type StaticScreenProps } from "@react-navigation/native";
+import { normalizePairingCode } from "@t3tools/shared/remote";
 import { AsyncResult } from "effect/unstable/reactivity";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Alert, Linking, Platform, ScrollView, View } from "react-native";
@@ -78,7 +79,10 @@ export function ConnectionsNewRouteScreen({
   }, []);
 
   const handleCodeChange = useCallback((value: string) => {
-    setCodeInput(value);
+    // Only what the user types is repaired. A scanned or deep-linked code is
+    // written straight to state and never reaches this handler, which matters
+    // because those can carry a hosted token from a different alphabet.
+    setCodeInput(normalizePairingCode(value));
   }, []);
 
   const openScanner = useCallback(async () => {

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -86,7 +86,11 @@ import { Button } from "../ui/button";
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "../ui/empty";
 import { AnimatedHeight } from "../AnimatedHeight";
 import { Textarea } from "../ui/textarea";
-import { getPairingTokenFromUrl, setPairingTokenOnUrl } from "../../pairingUrl";
+import {
+  getPairingTokenFromUrl,
+  normalizePairingCode,
+  setPairingTokenOnUrl,
+} from "../../pairingUrl";
 import { readHostedPairingRequest } from "../../hostedPairing";
 import {
   createServerPairingCredential,
@@ -2423,7 +2427,9 @@ export function ConnectionsSettings() {
           <span className="mb-1.5 block text-xs font-medium text-foreground">Pairing code</span>
           <Input
             value={savedBackendPairingCode}
-            onChange={(event) => setSavedBackendPairingCode(event.target.value)}
+            onChange={(event) =>
+              setSavedBackendPairingCode(normalizePairingCode(event.target.value))
+            }
             placeholder="PAIRCODE"
             disabled={isAddingSavedBackend}
             spellCheck={false}

--- a/apps/web/src/pairingUrl.ts
+++ b/apps/web/src/pairingUrl.ts
@@ -1,5 +1,6 @@
 export {
   getPairingTokenFromUrl,
+  normalizePairingCode,
   setPairingTokenOnUrl,
   stripPairingTokenFromUrl,
 } from "@t3tools/shared/remote";

--- a/packages/shared/src/remote.test.ts
+++ b/packages/shared/src/remote.test.ts
@@ -5,6 +5,7 @@ import {
   RemoteBackendUrlMissingError,
   RemotePairingTokenMissingError,
   RemotePairingUrlInvalidError,
+  normalizePairingCode,
   resolveRemotePairingTarget,
 } from "./remote.ts";
 
@@ -198,6 +199,29 @@ describe("remote", () => {
         host: "remote.example.com",
       }),
     );
+  });
+
+  it("repairs a hand-typed pairing code whatever spacing or case it arrived in", () => {
+    for (const typed of ["abcd2345efgh", "ABCD-2345-EFGH", "abcd 2345 efgh", " AbCd-2345 EfGh "]) {
+      expect(normalizePairingCode(typed.trim())).toBe("ABCD2345EFGH");
+    }
+  });
+
+  it("does not normalize a token that came out of a pairing URL", () => {
+    // Hosted tokens are issued elsewhere, are not drawn from the uppercase
+    // pairing alphabet, and reach resolveRemotePairingTarget through the same
+    // pairingCode field - so the normalizer must stay out of this path.
+    expect(
+      resolveRemotePairingTarget({
+        pairingUrl: "https://remote.example.com/pair#token=MiXeD-case_token",
+      }).credential,
+    ).toBe("MiXeD-case_token");
+    expect(
+      resolveRemotePairingTarget({
+        host: "https://remote.example.com",
+        pairingCode: "MiXeD-case_token",
+      }).credential,
+    ).toBe("MiXeD-case_token");
   });
 
   it("preserves URL parsing causes with their input source", () => {

--- a/packages/shared/src/remote.ts
+++ b/packages/shared/src/remote.ts
@@ -185,6 +185,16 @@ export const readHostedPairingRequest = (url: URL): HostedPairingRequest | null 
   };
 };
 
+/**
+ * Repairs a pairing code a person typed. Issued codes only use
+ * `PAIRING_TOKEN_ALPHABET` (uppercase, no separators), so this cannot alter a
+ * real one. Call it where someone types and nowhere else: a pasted URL reaches
+ * `resolveRemotePairingTarget` through the same `pairingCode` field, and a
+ * hosted token has its own alphabet that normalizing would corrupt.
+ */
+export const normalizePairingCode = (code: string): string =>
+  code.replace(/[\s-]+/g, "").toUpperCase();
+
 export const resolveRemotePairingTarget = (input: {
   readonly pairingUrl?: string;
   readonly host?: string;


### PR DESCRIPTION
## What Changed

Pairing codes are issued from `PAIRING_TOKEN_ALPHABET = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ"` at 12 characters (`PairingGrantStore.ts:260-261`) — uppercase, no separators, no `0`/`1`/`O`/`I`. The code fields send whatever was typed straight through and the server compares it exactly, so `abc-123-xyz` comes back `401 auth_invalid`. The mobile field's own placeholder is `abc-123-xyz`, which invites precisely the format that fails.

A shared `normalizePairingCode` (strip whitespace and dashes, upper-case) is now applied at the two fields that take a pairing code and nothing else:

- `ConnectionsNewRouteScreen.tsx` — `handleCodeChange`, the mobile Add Environment field
- `ConnectionsSettings.tsx` — the Pairing code input in web/desktop Settings

Since the issued alphabet has no lowercase, dashes or spaces, normalizing cannot turn one valid code into another or accept anything the server would reject. It only repairs input that could never have been valid.

## Why these two call sites and not the shared parser

The tidy-looking place is `resolveRemotePairingTarget` — one function, every surface at once. That is wrong here, because **machine-issued tokens reach the same `pairingCode` field**, and those are not drawn from the pairing alphabet:

- `ConnectionsSettings.tsx` `handleSavedBackendHostChange` splits a pairing URL pasted into the *host* box and writes its token into the pairing-code state. On submit the host no longer parses as a URL, so it falls through the same branch.
- `parsePairingUrlFields` returns `pairingCode: hostedPairingRequest.token` for a hosted link, and hosted tokens are issued outside this repo.
- On mobile, `handleQrScan` writes the scanned token into `codeInput`, which submit then re-reads.

Both patched call sites are *typing* handlers, so a scan, a paste-split or a deep link never passes through them. `remote.test.ts` carries a guard for this: it asserts a mixed-case token survives `resolveRemotePairingTarget` untouched through both the `pairingUrl` and the `pairingCode` field, so a later refactor that "simplifies" this into the parser fails the suite instead of silently breaking hosted pairing.

## A third call site I added and reverted

Worth stating plainly, since the review history shows it and two resolved-by-deletion comments still point at the file. An earlier commit also normalized the credential field on the local `/pair` page. That was wrong and CI caught it: that field is not pairing-code-only — `describeSupportedMethods` advertises it for a one-time token **or** a desktop bootstrap credential, and the bootstrap credential is lowercase hex (`/^[0-9a-f]{48}$/i`, see `DesktopBackendConfiguration.test.ts:152`). Since `PairingGrantStore.consume` matches exactly, upper-casing would have made every pasted bootstrap credential fail authentication. The field is also explicitly `autoCapitalize="none"`.

It is gone as of `2ddc8f0`; `PairingRouteSurface.tsx` is untouched by this PR. Calling it out because "this input holds a credential" is not the same as "this input holds a pairing code", and that distinction is the whole reason the fix sits where it does.

## UI Changes

n/a — no layout or component change. The visible difference is that the two code fields now show the canonical form as you type: entering `abcd-2345-efgh` leaves `ABCD2345EFGH` in the box. Worth knowing when reviewing, since it is a live transform rather than a submit-time one — deliberate, so what the user sees is what gets sent.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (n/a)
- [x] I included a video for animation/interaction changes (n/a)

## Verification

```
vp test run packages/shared/src/remote.test.ts                                  # 17 passed (15 before)
vp test run apps/mobile/src/features/connection/pairing.test.ts                 #  7 passed, unchanged
vp test run apps/web/src/components/settings/ConnectionsSettings.logic.test.ts  #  8 passed, unchanged
vp run --filter @t3tools/shared typecheck                                       # clean
vp run --filter @t3tools/mobile typecheck                                       # clean
vp run --filter @t3tools/web typecheck                                          # no errors in the touched files
vp lint / vp fmt --check on all five touched files                              # clean
```

Two new cases in `remote.test.ts`: one pins the repair across the forms a person actually types (`abcd2345efgh`, `ABCD-2345-EFGH`, `abcd 2345 efgh`, ` AbCd-2345 EfGh ` all give `ABCD2345EFGH`), the other is the anti-regression guard described above.

**What I could not verify.** The two call sites are one-line changes inside UI event handlers and there is no seam to unit test them through — `apps/mobile` has no React Native component test infrastructure, and `ConnectionsSettings.tsx` is a large component whose colocated test covers extracted logic rather than rendered input. So the normalizer is covered by tests and its wiring is not; the wiring is two one-liners and is best judged by reading them. I also have no Android device here, so the end-to-end pairing round trip is reasoned from the alphabet and the call sites rather than observed.

**Not addressed:** the issue's second claim, the false timeout. I could not tie the reported `10000ms` to any constant in the mobile connection path and did not want to guess. It may be the auth failure above surfacing late rather than an independent bug, but I have not established that, so this PR does not touch it and the issue should stay open for it.

Fixes #4889

Implemented with Claude Opus 5 via Claude Code.
