### PR TITLE
feat(models): support capabilities for custom models

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -287,7 +287,7 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
-  it("hides custom controls the Claude adapter cannot send", () => {
+  it("keeps arbitrary custom controls in the Claude catalog", () => {
     const resolved = getClaudeModelCapabilities("vendor/preview", {
       "vendor/preview": {
         optionDescriptors: [
@@ -309,7 +309,7 @@ describe("ClaudeAdapterLive", () => {
 
     assert.deepEqual(
       resolved.optionDescriptors?.map((descriptor) => descriptor.id),
-      ["effort"],
+      ["effort", "serviceTier"],
     );
   });
 

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -38,6 +38,7 @@ import { ServerSettingsService } from "../../serverSettings.ts";
 import { ProviderAdapterProcessError, ProviderAdapterValidationError } from "../Errors.ts";
 import type { ClaudeAdapterShape } from "../Services/ClaudeAdapter.ts";
 import { makeClaudeAdapter, type ClaudeAdapterLiveOptions } from "./ClaudeAdapter.ts";
+import { getClaudeModelCapabilities } from "./ClaudeProvider.ts";
 const decodeClaudeSettings = Schema.decodeSync(ClaudeSettings);
 
 // Test-local service tag so the rest of the file can keep using `yield* ClaudeAdapter`.
@@ -273,6 +274,19 @@ const THREAD_ID = ThreadId.make("thread-claude-1");
 const RESUME_THREAD_ID = ThreadId.make("thread-claude-resume");
 
 describe("ClaudeAdapterLive", () => {
+  it("keeps built-in capabilities ahead of custom metadata", () => {
+    const builtIn = getClaudeModelCapabilities("claude-opus-5");
+    const resolved = getClaudeModelCapabilities("claude-opus-5", {
+      "claude-opus-5": { optionDescriptors: [] },
+    });
+
+    assert.deepEqual(resolved, builtIn);
+    assert.equal(
+      resolved.optionDescriptors?.some((descriptor) => descriptor.id === "effort"),
+      true,
+    );
+  });
+
   it.effect("returns validation error for non-claude provider on startSession", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {
@@ -694,6 +708,71 @@ describe("ClaudeAdapterLive", () => {
 
       const createInput = harness.getLastCreateQueryInput();
       assert.equal(createInput?.options.settings, undefined);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("forwards declared custom-model controls to Claude SDK launch options", () => {
+    const customModelCapabilities = {
+      "gateway/model": {
+        optionDescriptors: [
+          {
+            id: "effort",
+            label: "Reasoning",
+            type: "select" as const,
+            options: [
+              { id: "low", label: "Low" },
+              { id: "xhigh", label: "Extra High" },
+              { id: "max", label: "Max", isDefault: true },
+            ],
+          },
+          {
+            id: "fastMode",
+            label: "Fast Mode",
+            type: "boolean" as const,
+          },
+          {
+            id: "contextWindow",
+            label: "Context Window",
+            type: "select" as const,
+            options: [
+              { id: "200k", label: "200k" },
+              { id: "1m", label: "1M", isDefault: true },
+            ],
+          },
+        ],
+      },
+    };
+    const harness = makeHarness({
+      claudeConfig: {
+        customModels: ["gateway/model"],
+        customModelCapabilities,
+      } as Partial<ClaudeSettings>,
+    });
+
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("claudeAgent"),
+          "gateway/model",
+          [
+            { id: "effort", value: "xhigh" },
+            { id: "fastMode", value: false },
+            { id: "contextWindow", value: "1m" },
+          ],
+        ),
+        runtimeMode: "full-access",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.model, "gateway/model[1m]");
+      assert.equal(createInput?.options.effort, "xhigh");
+      assert.deepEqual(createInput?.options.settings, { fastMode: false });
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -779,6 +779,40 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("forwards default custom-model controls to Claude SDK launch options", () => {
+    const harness = makeHarness({
+      claudeConfig: {
+        customModels: ["gpt-5.6-sol"],
+      } as Partial<ClaudeSettings>,
+    });
+
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("claudeAgent"),
+          "gpt-5.6-sol",
+          [
+            { id: "effort", value: "xhigh" },
+            { id: "fastMode", value: true },
+            { id: "contextWindow", value: "1m" },
+          ],
+        ),
+        runtimeMode: "full-access",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.model, "gpt-5.6-sol[1m]");
+      assert.equal(createInput?.options.effort, "xhigh");
+      assert.deepEqual(createInput?.options.settings, { fastMode: true });
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("treats ultrathink as a prompt keyword instead of a session effort", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {
@@ -2476,6 +2510,7 @@ describe("ClaudeAdapterLive", () => {
           usage: {
             usedTokens: 321,
             lastUsedTokens: 321,
+            maxTokens: 200_000,
             toolUses: 2,
             durationMs: 654,
           },

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -779,64 +779,6 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
-  it.effect("forwards default custom-model controls to Claude SDK launch options", () => {
-    const harness = makeHarness({
-      claudeConfig: {
-        customModels: ["  gpt-5.6-sol  "],
-      } as Partial<ClaudeSettings>,
-    });
-
-    return Effect.gen(function* () {
-      const adapter = yield* ClaudeAdapter;
-      yield* adapter.startSession({
-        threadId: THREAD_ID,
-        provider: ProviderDriverKind.make("claudeAgent"),
-        modelSelection: createModelSelection(
-          ProviderInstanceId.make("claudeAgent"),
-          "gpt-5.6-sol",
-          [
-            { id: "effort", value: "xhigh" },
-            { id: "fastMode", value: true },
-            { id: "contextWindow", value: "1m" },
-          ],
-        ),
-        runtimeMode: "full-access",
-      });
-
-      const createInput = harness.getLastCreateQueryInput();
-      assert.equal(createInput?.options.model, "gpt-5.6-sol[1m]");
-      assert.equal(createInput?.options.effort, "xhigh");
-      assert.deepEqual(createInput?.options.settings, { fastMode: true });
-    }).pipe(
-      Effect.provideService(Random.Random, makeDeterministicRandomService()),
-      Effect.provide(harness.layer),
-    );
-  });
-
-  it.effect("does not send fallback effort until a custom-model control is selected", () => {
-    const harness = makeHarness({
-      claudeConfig: {
-        customModels: ["gpt-5.6-sol"],
-      } as Partial<ClaudeSettings>,
-    });
-
-    return Effect.gen(function* () {
-      const adapter = yield* ClaudeAdapter;
-      yield* adapter.startSession({
-        threadId: THREAD_ID,
-        provider: ProviderDriverKind.make("claudeAgent"),
-        modelSelection: createModelSelection(ProviderInstanceId.make("claudeAgent"), "gpt-5.6-sol"),
-        runtimeMode: "full-access",
-      });
-
-      const createInput = harness.getLastCreateQueryInput();
-      assert.equal(createInput?.options.effort, undefined);
-    }).pipe(
-      Effect.provideService(Random.Random, makeDeterministicRandomService()),
-      Effect.provide(harness.layer),
-    );
-  });
-
   it.effect("treats ultrathink as a prompt keyword instead of a session effort", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {
@@ -2534,7 +2476,6 @@ describe("ClaudeAdapterLive", () => {
           usage: {
             usedTokens: 321,
             lastUsedTokens: 321,
-            maxTokens: 200_000,
             toolUses: 2,
             durationMs: 654,
           },

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -782,7 +782,7 @@ describe("ClaudeAdapterLive", () => {
   it.effect("forwards default custom-model controls to Claude SDK launch options", () => {
     const harness = makeHarness({
       claudeConfig: {
-        customModels: ["gpt-5.6-sol"],
+        customModels: ["  gpt-5.6-sol  "],
       } as Partial<ClaudeSettings>,
     });
 
@@ -807,6 +807,30 @@ describe("ClaudeAdapterLive", () => {
       assert.equal(createInput?.options.model, "gpt-5.6-sol[1m]");
       assert.equal(createInput?.options.effort, "xhigh");
       assert.deepEqual(createInput?.options.settings, { fastMode: true });
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("does not send fallback effort until a custom-model control is selected", () => {
+    const harness = makeHarness({
+      claudeConfig: {
+        customModels: ["gpt-5.6-sol"],
+      } as Partial<ClaudeSettings>,
+    });
+
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        modelSelection: createModelSelection(ProviderInstanceId.make("claudeAgent"), "gpt-5.6-sol"),
+        runtimeMode: "full-access",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.effort, undefined);
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -287,6 +287,38 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it("hides custom controls the Claude adapter cannot send", () => {
+    const resolved = getClaudeModelCapabilities("vendor/preview", {
+      "vendor/preview": {
+        optionDescriptors: [
+          {
+            id: "effort",
+            label: "Reasoning",
+            type: "select",
+            options: [{ id: "high", label: "High" }],
+          },
+          {
+            id: "serviceTier",
+            label: "Service Tier",
+            type: "select",
+            options: [{ id: "priority", label: "Priority" }],
+          },
+        ],
+      },
+    });
+
+    assert.deepEqual(
+      resolved.optionDescriptors?.map((descriptor) => descriptor.id),
+      ["effort"],
+    );
+  });
+
+  it("does not read inherited object keys as Claude custom capabilities", () => {
+    const resolved = getClaudeModelCapabilities("constructor", {});
+
+    assert.deepEqual(resolved, { optionDescriptors: [] });
+  });
+
   it.effect("returns validation error for non-claude provider on startSession", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {
@@ -734,6 +766,11 @@ describe("ClaudeAdapterLive", () => {
             type: "boolean" as const,
           },
           {
+            id: "thinking",
+            label: "Thinking",
+            type: "boolean" as const,
+          },
+          {
             id: "contextWindow",
             label: "Context Window",
             type: "select" as const,
@@ -763,6 +800,7 @@ describe("ClaudeAdapterLive", () => {
           [
             { id: "effort", value: "xhigh" },
             { id: "fastMode", value: false },
+            { id: "thinking", value: false },
             { id: "contextWindow", value: "1m" },
           ],
         ),
@@ -772,7 +810,10 @@ describe("ClaudeAdapterLive", () => {
       const createInput = harness.getLastCreateQueryInput();
       assert.equal(createInput?.options.model, "gateway/model[1m]");
       assert.equal(createInput?.options.effort, "xhigh");
-      assert.deepEqual(createInput?.options.settings, { fastMode: false });
+      assert.deepEqual(createInput?.options.settings, {
+        alwaysThinkingEnabled: false,
+        fastMode: false,
+      });
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -80,6 +80,7 @@ import { resolveClaudeSdkExecutablePath } from "../Drivers/ClaudeExecutable.ts";
 import { makeClaudeEnvironment } from "../Drivers/ClaudeHome.ts";
 import {
   getClaudeModelCapabilities,
+  isCustomClaudeModel,
   isClaudeUltracodeEffort,
   normalizeClaudeCliEffort,
   resolveClaudeApiModelId,
@@ -1666,7 +1667,6 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 ) {
   const boundInstanceId = options?.instanceId ?? ProviderInstanceId.make("claudeAgent");
   const customModelCapabilities = claudeSettings.customModelCapabilities ?? {};
-  const customModelSlugs = new Set(claudeSettings.customModels);
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const serverConfig = yield* ServerConfig;
@@ -4132,7 +4132,15 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         customModelCapabilities,
       );
       const rawEffort = getModelSelectionStringOptionValue(modelSelection, "effort");
-      const effort = resolveClaudeEffort(caps, rawEffort) ?? null;
+      const customModel = isCustomClaudeModel(modelSelection?.model, claudeSettings.customModels);
+      const usesFallbackCapabilities =
+        customModel &&
+        modelSelection?.model !== undefined &&
+        customModelCapabilities[modelSelection.model] === undefined;
+      const effort =
+        usesFallbackCapabilities && rawEffort === undefined
+          ? null
+          : (resolveClaudeEffort(caps, rawEffort) ?? null);
       const fastModeSupported = descriptors.some(
         (descriptor) => descriptor.type === "boolean" && descriptor.id === "fastMode",
       );
@@ -4149,7 +4157,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       const effectiveEffort = getEffectiveClaudeAgentEffort(
         effort,
         modelSelection?.model,
-        modelSelection ? customModelSlugs.has(modelSelection.model) : false,
+        customModel,
       );
       const runtimeModeToPermission: Record<string, PermissionMode> = {
         "auto-accept-edits": "acceptEdits",
@@ -4405,16 +4413,17 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         model: modelSelection.model,
       };
       const turnCaps = getClaudeModelCapabilities(modelSelection.model, customModelCapabilities);
-      const turnEffort = resolveClaudeEffort(
-        turnCaps,
-        getModelSelectionStringOptionValue(modelSelection, "effort"),
-      );
+      const rawTurnEffort = getModelSelectionStringOptionValue(modelSelection, "effort");
+      const customModel = isCustomClaudeModel(modelSelection.model, claudeSettings.customModels);
+      const usesFallbackCapabilities =
+        customModel && customModelCapabilities[modelSelection.model] === undefined;
+      const turnEffort =
+        usesFallbackCapabilities && rawTurnEffort === undefined
+          ? undefined
+          : resolveClaudeEffort(turnCaps, rawTurnEffort);
       context.currentEffort =
-        getEffectiveClaudeAgentEffort(
-          turnEffort ?? null,
-          modelSelection.model,
-          customModelSlugs.has(modelSelection.model),
-        ) ?? undefined;
+        getEffectiveClaudeAgentEffort(turnEffort ?? null, modelSelection.model, customModel) ??
+        undefined;
     }
 
     // Apply interaction mode by switching the SDK's permission mode.

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -80,7 +80,6 @@ import { resolveClaudeSdkExecutablePath } from "../Drivers/ClaudeExecutable.ts";
 import { makeClaudeEnvironment } from "../Drivers/ClaudeHome.ts";
 import {
   getClaudeModelCapabilities,
-  isCustomClaudeModel,
   isClaudeUltracodeEffort,
   normalizeClaudeCliEffort,
   resolveClaudeApiModelId,
@@ -4132,15 +4131,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         customModelCapabilities,
       );
       const rawEffort = getModelSelectionStringOptionValue(modelSelection, "effort");
-      const customModel = isCustomClaudeModel(modelSelection?.model, claudeSettings.customModels);
-      const usesFallbackCapabilities =
-        customModel &&
-        modelSelection?.model !== undefined &&
-        customModelCapabilities[modelSelection.model] === undefined;
-      const effort =
-        usesFallbackCapabilities && rawEffort === undefined
-          ? null
-          : (resolveClaudeEffort(caps, rawEffort) ?? null);
+      const effort = resolveClaudeEffort(caps, rawEffort) ?? null;
       const fastModeSupported = descriptors.some(
         (descriptor) => descriptor.type === "boolean" && descriptor.id === "fastMode",
       );
@@ -4157,7 +4148,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       const effectiveEffort = getEffectiveClaudeAgentEffort(
         effort,
         modelSelection?.model,
-        customModel,
+        modelSelection ? customModelCapabilities[modelSelection.model] === caps : false,
       );
       const runtimeModeToPermission: Record<string, PermissionMode> = {
         "auto-accept-edits": "acceptEdits",
@@ -4413,17 +4404,16 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         model: modelSelection.model,
       };
       const turnCaps = getClaudeModelCapabilities(modelSelection.model, customModelCapabilities);
-      const rawTurnEffort = getModelSelectionStringOptionValue(modelSelection, "effort");
-      const customModel = isCustomClaudeModel(modelSelection.model, claudeSettings.customModels);
-      const usesFallbackCapabilities =
-        customModel && customModelCapabilities[modelSelection.model] === undefined;
-      const turnEffort =
-        usesFallbackCapabilities && rawTurnEffort === undefined
-          ? undefined
-          : resolveClaudeEffort(turnCaps, rawTurnEffort);
+      const turnEffort = resolveClaudeEffort(
+        turnCaps,
+        getModelSelectionStringOptionValue(modelSelection, "effort"),
+      );
       context.currentEffort =
-        getEffectiveClaudeAgentEffort(turnEffort ?? null, modelSelection.model, customModel) ??
-        undefined;
+        getEffectiveClaudeAgentEffort(
+          turnEffort ?? null,
+          modelSelection.model,
+          customModelCapabilities[modelSelection.model] === turnCaps,
+        ) ?? undefined;
     }
 
     // Apply interaction mode by switching the SDK's permission mode.

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -31,6 +31,7 @@ import {
   ProviderDriverKind,
   ProviderInstanceId,
   type ModelSelection,
+  type ModelCapabilities,
   ProviderItemId,
   type ProviderRuntimeEvent,
   type ProviderRuntimeTurnStatus,
@@ -351,8 +352,9 @@ function normalizeClaudeStreamMessages(
 function getEffectiveClaudeAgentEffort(
   effort: string | null | undefined,
   model: string | null | undefined,
+  isCustomModel = false,
 ): ClaudeSdkEffort | null {
-  const normalized = normalizeClaudeCliEffort(effort, model);
+  const normalized = normalizeClaudeCliEffort(effort, model, isCustomModel);
   return normalized ? (normalized as ClaudeSdkEffort) : null;
 }
 
@@ -439,6 +441,7 @@ function maxClaudeContextWindowFromModelUsage(
 
 function selectedClaudeContextWindow(
   modelSelection: ModelSelection | undefined,
+  customModelCapabilities: Readonly<Record<string, ModelCapabilities>> = {},
 ): number | undefined {
   switch (modelSelection?.model) {
     case "claude-opus-4-8":
@@ -447,7 +450,7 @@ function selectedClaudeContextWindow(
       return 1_000_000;
   }
 
-  switch (resolveClaudeContextWindow(modelSelection)) {
+  switch (resolveClaudeContextWindow(modelSelection, customModelCapabilities)) {
     case "1m":
       return 1_000_000;
     case "200k":
@@ -1210,6 +1213,7 @@ const CLAUDE_SETTING_SOURCES = [
 function buildPromptText(
   input: ProviderSendTurnInput,
   boundInstanceId: ProviderInstanceId,
+  customModelCapabilities: Readonly<Record<string, ModelCapabilities>> = {},
 ): string {
   const rawEffort =
     input.modelSelection?.instanceId === boundInstanceId
@@ -1217,7 +1221,7 @@ function buildPromptText(
       : null;
   const claudeModel =
     input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection.model : undefined;
-  const caps = getClaudeModelCapabilities(claudeModel);
+  const caps = getClaudeModelCapabilities(claudeModel, customModelCapabilities);
 
   const promptEffort = resolvePromptInjectedEffort(caps, rawEffort);
   return applyClaudePromptEffortPrefix(input.input?.trim() ?? "", promptEffort);
@@ -1257,9 +1261,14 @@ const buildUserMessageEffect = Effect.fn("buildUserMessageEffect")(function* (
     readonly fileSystem: FileSystem.FileSystem;
     readonly attachmentsDir: string;
     readonly boundInstanceId: ProviderInstanceId;
+    readonly customModelCapabilities: Readonly<Record<string, ModelCapabilities>>;
   },
 ) {
-  const text = buildPromptText(input, dependencies.boundInstanceId);
+  const text = buildPromptText(
+    input,
+    dependencies.boundInstanceId,
+    dependencies.customModelCapabilities,
+  );
   const sdkContent: Array<Record<string, unknown>> = [];
 
   if (text.length > 0) {
@@ -1656,6 +1665,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
   options?: ClaudeAdapterLiveOptions,
 ) {
   const boundInstanceId = options?.instanceId ?? ProviderInstanceId.make("claudeAgent");
+  const customModelCapabilities = claudeSettings.customModelCapabilities ?? {};
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const serverConfig = yield* ServerConfig;
@@ -4111,10 +4121,15 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       const extraArgs = parseCliArgs(claudeSettings.launchArgs).flags;
       const modelSelection =
         input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
-      const caps = getClaudeModelCapabilities(modelSelection?.model);
+      const caps = getClaudeModelCapabilities(modelSelection?.model, customModelCapabilities);
       const descriptors = getProviderOptionDescriptors({ caps });
-      const apiModelId = modelSelection ? resolveClaudeApiModelId(modelSelection) : undefined;
-      const initialContextWindow = selectedClaudeContextWindow(modelSelection);
+      const apiModelId = modelSelection
+        ? resolveClaudeApiModelId(modelSelection, customModelCapabilities)
+        : undefined;
+      const initialContextWindow = selectedClaudeContextWindow(
+        modelSelection,
+        customModelCapabilities,
+      );
       const rawEffort = getModelSelectionStringOptionValue(modelSelection, "effort");
       const effort = resolveClaudeEffort(caps, rawEffort) ?? null;
       const fastModeSupported = descriptors.some(
@@ -4123,14 +4138,18 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       const thinkingSupported = descriptors.some(
         (descriptor) => descriptor.type === "boolean" && descriptor.id === "thinking",
       );
-      const fastMode =
-        getModelSelectionBooleanOptionValue(modelSelection, "fastMode") === true &&
-        fastModeSupported;
+      const fastMode = fastModeSupported
+        ? getModelSelectionBooleanOptionValue(modelSelection, "fastMode")
+        : undefined;
       const thinking = thinkingSupported
         ? getModelSelectionBooleanOptionValue(modelSelection, "thinking")
         : undefined;
       const ultracode = isClaudeUltracodeEffort(effort);
-      const effectiveEffort = getEffectiveClaudeAgentEffort(effort, modelSelection?.model);
+      const effectiveEffort = getEffectiveClaudeAgentEffort(
+        effort,
+        modelSelection?.model,
+        modelSelection ? customModelCapabilities[modelSelection.model] === caps : false,
+      );
       const runtimeModeToPermission: Record<string, PermissionMode> = {
         "auto-accept-edits": "acceptEdits",
         auto: "auto",
@@ -4139,7 +4158,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       const permissionMode = runtimeModeToPermission[input.runtimeMode];
       const settings = {
         ...(typeof thinking === "boolean" ? { alwaysThinkingEnabled: thinking } : {}),
-        ...(fastMode ? { fastMode: true } : {}),
+        ...(typeof fastMode === "boolean" ? { fastMode } : {}),
         ...(ultracode ? { ultracode: true } : {}),
       };
       const mcpSession = McpProviderSession.readMcpProviderSession(input.threadId);
@@ -4303,7 +4322,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
             ...(input.cwd ? { cwd: input.cwd } : {}),
             ...(effectiveEffort ? { effort: effectiveEffort } : {}),
             ...(permissionMode ? { permissionMode } : {}),
-            ...(fastMode ? { fastMode: true } : {}),
+            ...(typeof fastMode === "boolean" ? { fastMode } : {}),
           },
         },
         providerRefs: {},
@@ -4372,7 +4391,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     }
 
     if (modelSelection?.model) {
-      const apiModelId = resolveClaudeApiModelId(modelSelection);
+      const apiModelId = resolveClaudeApiModelId(modelSelection, customModelCapabilities);
       if (context.currentApiModelId !== apiModelId) {
         yield* Effect.tryPromise({
           try: () => context.query.setModel(apiModelId),
@@ -4384,13 +4403,17 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         ...context.session,
         model: modelSelection.model,
       };
-      const turnCaps = getClaudeModelCapabilities(modelSelection.model);
+      const turnCaps = getClaudeModelCapabilities(modelSelection.model, customModelCapabilities);
       const turnEffort = resolveClaudeEffort(
         turnCaps,
         getModelSelectionStringOptionValue(modelSelection, "effort"),
       );
       context.currentEffort =
-        getEffectiveClaudeAgentEffort(turnEffort ?? null, modelSelection.model) ?? undefined;
+        getEffectiveClaudeAgentEffort(
+          turnEffort ?? null,
+          modelSelection.model,
+          customModelCapabilities[modelSelection.model] === turnCaps,
+        ) ?? undefined;
     }
 
     // Apply interaction mode by switching the SDK's permission mode.
@@ -4447,6 +4470,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       fileSystem,
       attachmentsDir: serverConfig.attachmentsDir,
       boundInstanceId,
+      customModelCapabilities,
     });
 
     yield* Queue.offer(context.promptQueue, {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -1666,6 +1666,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 ) {
   const boundInstanceId = options?.instanceId ?? ProviderInstanceId.make("claudeAgent");
   const customModelCapabilities = claudeSettings.customModelCapabilities ?? {};
+  const customModelSlugs = new Set(claudeSettings.customModels);
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const serverConfig = yield* ServerConfig;
@@ -4148,7 +4149,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       const effectiveEffort = getEffectiveClaudeAgentEffort(
         effort,
         modelSelection?.model,
-        modelSelection ? customModelCapabilities[modelSelection.model] === caps : false,
+        modelSelection ? customModelSlugs.has(modelSelection.model) : false,
       );
       const runtimeModeToPermission: Record<string, PermissionMode> = {
         "auto-accept-edits": "acceptEdits",
@@ -4412,7 +4413,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         getEffectiveClaudeAgentEffort(
           turnEffort ?? null,
           modelSelection.model,
-          customModelCapabilities[modelSelection.model] === turnCaps,
+          customModelSlugs.has(modelSelection.model),
         ) ?? undefined;
     }
 

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -80,6 +80,7 @@ import { resolveClaudeSdkExecutablePath } from "../Drivers/ClaudeExecutable.ts";
 import { makeClaudeEnvironment } from "../Drivers/ClaudeHome.ts";
 import {
   getClaudeModelCapabilities,
+  isConfiguredCustomClaudeModel,
   isClaudeUltracodeEffort,
   normalizeClaudeCliEffort,
   resolveClaudeApiModelId,
@@ -4148,7 +4149,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       const effectiveEffort = getEffectiveClaudeAgentEffort(
         effort,
         modelSelection?.model,
-        modelSelection ? customModelCapabilities[modelSelection.model] === caps : false,
+        isConfiguredCustomClaudeModel(modelSelection?.model, customModelCapabilities),
       );
       const runtimeModeToPermission: Record<string, PermissionMode> = {
         "auto-accept-edits": "acceptEdits",
@@ -4412,7 +4413,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         getEffectiveClaudeAgentEffort(
           turnEffort ?? null,
           modelSelection.model,
-          customModelCapabilities[modelSelection.model] === turnCaps,
+          isConfiguredCustomClaudeModel(modelSelection.model, customModelCapabilities),
         ) ?? undefined;
     }
 

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -2,7 +2,6 @@ import {
   type ClaudeSettings,
   type ModelCapabilities,
   type ModelSelection,
-  ProviderDriverKind,
   type ServerProviderModel,
   type ServerProviderSlashCommand,
 } from "@t3tools/contracts";
@@ -15,7 +14,6 @@ import * as Result from "effect/Result";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import {
   createModelCapabilities,
-  filterCustomModelCapabilities,
   getDeclaredCustomModelCapabilities,
   getModelSelectionStringOptionValue,
   getProviderOptionCurrentValue,
@@ -49,8 +47,6 @@ import { discoverClaudeSkills } from "../Drivers/ClaudeSkills.ts";
 const DEFAULT_CLAUDE_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabilities({
   optionDescriptors: [],
 });
-const CLAUDE_DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
-
 const CLAUDE_PRESENTATION = {
   displayName: "Claude",
   showInteractionModeToggle: true,
@@ -400,9 +396,7 @@ export function getClaudeModelCapabilities(
   const customCapabilities = getDeclaredCustomModelCapabilities(customModelCapabilities, slug);
   return (
     BUILT_IN_MODELS.find((candidate) => candidate.slug === slug)?.capabilities ??
-    (customCapabilities
-      ? filterCustomModelCapabilities(CLAUDE_DRIVER_KIND, customCapabilities)
-      : undefined) ??
+    customCapabilities ??
     DEFAULT_CLAUDE_MODEL_CAPABILITIES
   );
 }
@@ -857,7 +851,6 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
     claudeSettings.customModels,
     DEFAULT_CLAUDE_MODEL_CAPABILITIES,
     {
-      provider: CLAUDE_DRIVER_KIND,
       customModelCapabilities: claudeSettings.customModelCapabilities,
     },
   );
@@ -951,7 +944,6 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
     claudeSettings.customModels.filter((model) => !BUILT_IN_MODEL_SLUGS.has(model.trim())),
     DEFAULT_CLAUDE_MODEL_CAPABILITIES,
     {
-      provider: CLAUDE_DRIVER_KIND,
       customModelCapabilities: claudeSettings.customModelCapabilities,
     },
   );
@@ -1028,7 +1020,6 @@ export const makePendingClaudeProvider = (
       claudeSettings.customModels,
       DEFAULT_CLAUDE_MODEL_CAPABILITIES,
       {
-        provider: CLAUDE_DRIVER_KIND,
         customModelCapabilities: claudeSettings.customModelCapabilities,
       },
     );

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -44,7 +44,38 @@ import { makeClaudeEnvironment } from "../Drivers/ClaudeHome.ts";
 import { discoverClaudeSkills } from "../Drivers/ClaudeSkills.ts";
 
 const DEFAULT_CLAUDE_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabilities({
-  optionDescriptors: [],
+  optionDescriptors: [
+    buildSelectOptionDescriptor({
+      id: "effort",
+      label: "Reasoning",
+      options: [
+        { value: "low", label: "Low" },
+        { value: "medium", label: "Medium" },
+        { value: "high", label: "High", isDefault: true },
+        { value: "xhigh", label: "Extra High" },
+        { value: "max", label: "Max" },
+        {
+          value: "ultracode",
+          label: "Ultracode",
+          description: "xhigh effort plus multi-agent workflow orchestration",
+        },
+        { value: "ultrathink", label: "Ultrathink" },
+      ],
+      promptInjectedValues: ["ultrathink"],
+    }),
+    buildBooleanOptionDescriptor({
+      id: "fastMode",
+      label: "Fast Mode",
+    }),
+    buildSelectOptionDescriptor({
+      id: "contextWindow",
+      label: "Context Window",
+      options: [
+        { value: "200k", label: "200k", isDefault: true },
+        { value: "1m", label: "1M" },
+      ],
+    }),
+  ],
 });
 
 const CLAUDE_PRESENTATION = {

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -330,6 +330,7 @@ const CLAUDE_MODEL_CATALOG: ReadonlyArray<ServerProviderModel> = [
 const BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = CLAUDE_MODEL_CATALOG.map((model) =>
   isLegacyClaudeModel(model.slug) ? { ...model, isLegacy: true } : model,
 );
+const BUILT_IN_MODEL_SLUGS = new Set(BUILT_IN_MODELS.map((model) => model.slug));
 
 function supportsClaudeOpus5(version: string | null | undefined): boolean {
   return version ? compareSemverVersions(version, MINIMUM_CLAUDE_OPUS_5_VERSION) >= 0 : false;
@@ -387,10 +388,14 @@ function formatClaudeOpus47UpgradeMessage(version: string | null): string {
   return `Claude Code ${versionLabel} is too old for Claude Opus 4.7. Upgrade to v${MINIMUM_CLAUDE_OPUS_4_7_VERSION} or newer to access it.`;
 }
 
-export function getClaudeModelCapabilities(model: string | null | undefined): ModelCapabilities {
+export function getClaudeModelCapabilities(
+  model: string | null | undefined,
+  customModelCapabilities: Readonly<Record<string, ModelCapabilities>> = {},
+): ModelCapabilities {
   const slug = model?.trim();
   return (
     BUILT_IN_MODELS.find((candidate) => candidate.slug === slug)?.capabilities ??
+    (slug ? customModelCapabilities[slug] : undefined) ??
     DEFAULT_CLAUDE_MODEL_CAPABILITIES
   );
 }
@@ -421,12 +426,16 @@ export function resolveClaudeEffort(
 export function normalizeClaudeCliEffort(
   effort: string | null | undefined,
   model: string | null | undefined,
+  isCustomModel = false,
 ): string | undefined {
   if (!effort || effort === "ultrathink") {
     return undefined;
   }
   if (effort === "ultracode") {
     return "xhigh";
+  }
+  if (isCustomModel) {
+    return effort;
   }
   if (
     effort === "xhigh" &&
@@ -449,8 +458,9 @@ export function isClaudeUltracodeEffort(effort: string | null | undefined): bool
 
 export function resolveClaudeContextWindow(
   modelSelection: ModelSelection | undefined,
+  customModelCapabilities: Readonly<Record<string, ModelCapabilities>> = {},
 ): string | undefined {
-  const caps = getClaudeModelCapabilities(modelSelection?.model);
+  const caps = getClaudeModelCapabilities(modelSelection?.model, customModelCapabilities);
   const raw = getModelSelectionStringOptionValue(modelSelection, "contextWindow");
   const descriptors = getProviderOptionDescriptors({
     caps,
@@ -461,10 +471,15 @@ export function resolveClaudeContextWindow(
   return typeof value === "string" ? value : undefined;
 }
 
-export function resolveClaudeApiModelId(modelSelection: ModelSelection): string {
-  switch (resolveClaudeContextWindow(modelSelection)) {
+export function resolveClaudeApiModelId(
+  modelSelection: ModelSelection,
+  customModelCapabilities: Readonly<Record<string, ModelCapabilities>> = {},
+): string {
+  switch (resolveClaudeContextWindow(modelSelection, customModelCapabilities)) {
     case "1m":
-      return `${modelSelection.model}[1m]`;
+      return modelSelection.model.endsWith("[1m]")
+        ? modelSelection.model
+        : `${modelSelection.model}[1m]`;
     default:
       return modelSelection.model;
   }
@@ -822,6 +837,7 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
     BUILT_IN_MODELS,
     claudeSettings.customModels,
     DEFAULT_CLAUDE_MODEL_CAPABILITIES,
+    claudeSettings.customModelCapabilities,
   );
 
   if (!claudeSettings.enabled) {
@@ -910,8 +926,9 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
 
   const models = providerModelsFromSettings(
     getBuiltInClaudeModelsForVersion(parsedVersion),
-    claudeSettings.customModels,
+    claudeSettings.customModels.filter((model) => !BUILT_IN_MODEL_SLUGS.has(model.trim())),
     DEFAULT_CLAUDE_MODEL_CAPABILITIES,
+    claudeSettings.customModelCapabilities,
   );
   const versionUpgradeMessage = supportsClaudeOpus5(parsedVersion)
     ? undefined
@@ -985,6 +1002,7 @@ export const makePendingClaudeProvider = (
       BUILT_IN_MODELS,
       claudeSettings.customModels,
       DEFAULT_CLAUDE_MODEL_CAPABILITIES,
+      claudeSettings.customModelCapabilities,
     );
 
     if (!claudeSettings.enabled) {

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -431,6 +431,18 @@ export function getClaudeModelCapabilities(
   );
 }
 
+export function isCustomClaudeModel(
+  model: string | null | undefined,
+  customModels: ReadonlyArray<string>,
+): boolean {
+  const slug = model?.trim();
+  return Boolean(
+    slug &&
+    !BUILT_IN_MODELS.some((candidate) => candidate.slug === slug) &&
+    customModels.some((candidate) => candidate.trim() === slug),
+  );
+}
+
 export function resolveClaudeEffort(
   caps: ModelCapabilities,
   raw: string | null | undefined,

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -44,38 +44,7 @@ import { makeClaudeEnvironment } from "../Drivers/ClaudeHome.ts";
 import { discoverClaudeSkills } from "../Drivers/ClaudeSkills.ts";
 
 const DEFAULT_CLAUDE_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabilities({
-  optionDescriptors: [
-    buildSelectOptionDescriptor({
-      id: "effort",
-      label: "Reasoning",
-      options: [
-        { value: "low", label: "Low" },
-        { value: "medium", label: "Medium" },
-        { value: "high", label: "High", isDefault: true },
-        { value: "xhigh", label: "Extra High" },
-        { value: "max", label: "Max" },
-        {
-          value: "ultracode",
-          label: "Ultracode",
-          description: "xhigh effort plus multi-agent workflow orchestration",
-        },
-        { value: "ultrathink", label: "Ultrathink" },
-      ],
-      promptInjectedValues: ["ultrathink"],
-    }),
-    buildBooleanOptionDescriptor({
-      id: "fastMode",
-      label: "Fast Mode",
-    }),
-    buildSelectOptionDescriptor({
-      id: "contextWindow",
-      label: "Context Window",
-      options: [
-        { value: "200k", label: "200k", isDefault: true },
-        { value: "1m", label: "1M" },
-      ],
-    }),
-  ],
+  optionDescriptors: [],
 });
 
 const CLAUDE_PRESENTATION = {
@@ -428,18 +397,6 @@ export function getClaudeModelCapabilities(
     BUILT_IN_MODELS.find((candidate) => candidate.slug === slug)?.capabilities ??
     (slug ? customModelCapabilities[slug] : undefined) ??
     DEFAULT_CLAUDE_MODEL_CAPABILITIES
-  );
-}
-
-export function isCustomClaudeModel(
-  model: string | null | undefined,
-  customModels: ReadonlyArray<string>,
-): boolean {
-  const slug = model?.trim();
-  return Boolean(
-    slug &&
-    !BUILT_IN_MODELS.some((candidate) => candidate.slug === slug) &&
-    customModels.some((candidate) => candidate.trim() === slug),
   );
 }
 

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -2,6 +2,7 @@ import {
   type ClaudeSettings,
   type ModelCapabilities,
   type ModelSelection,
+  ProviderDriverKind,
   type ServerProviderModel,
   type ServerProviderSlashCommand,
 } from "@t3tools/contracts";
@@ -14,6 +15,8 @@ import * as Result from "effect/Result";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import {
   createModelCapabilities,
+  filterCustomModelCapabilities,
+  getDeclaredCustomModelCapabilities,
   getModelSelectionStringOptionValue,
   getProviderOptionCurrentValue,
   getProviderOptionDescriptors,
@@ -46,6 +49,7 @@ import { discoverClaudeSkills } from "../Drivers/ClaudeSkills.ts";
 const DEFAULT_CLAUDE_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabilities({
   optionDescriptors: [],
 });
+const CLAUDE_DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
 
 const CLAUDE_PRESENTATION = {
   displayName: "Claude",
@@ -393,10 +397,25 @@ export function getClaudeModelCapabilities(
   customModelCapabilities: Readonly<Record<string, ModelCapabilities>> = {},
 ): ModelCapabilities {
   const slug = model?.trim();
+  const customCapabilities = getDeclaredCustomModelCapabilities(customModelCapabilities, slug);
   return (
     BUILT_IN_MODELS.find((candidate) => candidate.slug === slug)?.capabilities ??
-    (slug ? customModelCapabilities[slug] : undefined) ??
+    (customCapabilities
+      ? filterCustomModelCapabilities(CLAUDE_DRIVER_KIND, customCapabilities)
+      : undefined) ??
     DEFAULT_CLAUDE_MODEL_CAPABILITIES
+  );
+}
+
+export function isConfiguredCustomClaudeModel(
+  model: string | null | undefined,
+  customModelCapabilities: Readonly<Record<string, ModelCapabilities>>,
+): boolean {
+  const slug = model?.trim();
+  return Boolean(
+    slug &&
+    !BUILT_IN_MODEL_SLUGS.has(slug) &&
+    getDeclaredCustomModelCapabilities(customModelCapabilities, slug),
   );
 }
 
@@ -837,7 +856,10 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
     BUILT_IN_MODELS,
     claudeSettings.customModels,
     DEFAULT_CLAUDE_MODEL_CAPABILITIES,
-    claudeSettings.customModelCapabilities,
+    {
+      provider: CLAUDE_DRIVER_KIND,
+      customModelCapabilities: claudeSettings.customModelCapabilities,
+    },
   );
 
   if (!claudeSettings.enabled) {
@@ -928,7 +950,10 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
     getBuiltInClaudeModelsForVersion(parsedVersion),
     claudeSettings.customModels.filter((model) => !BUILT_IN_MODEL_SLUGS.has(model.trim())),
     DEFAULT_CLAUDE_MODEL_CAPABILITIES,
-    claudeSettings.customModelCapabilities,
+    {
+      provider: CLAUDE_DRIVER_KIND,
+      customModelCapabilities: claudeSettings.customModelCapabilities,
+    },
   );
   const versionUpgradeMessage = supportsClaudeOpus5(parsedVersion)
     ? undefined
@@ -1002,7 +1027,10 @@ export const makePendingClaudeProvider = (
       BUILT_IN_MODELS,
       claudeSettings.customModels,
       DEFAULT_CLAUDE_MODEL_CAPABILITIES,
-      claudeSettings.customModelCapabilities,
+      {
+        provider: CLAUDE_DRIVER_KIND,
+        customModelCapabilities: claudeSettings.customModelCapabilities,
+      },
     );
 
     if (!claudeSettings.enabled) {

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -361,6 +361,52 @@ sessionErrorLayer("CodexAdapterLive session errors", (it) => {
     }),
   );
 
+  it.effect("passes configured custom model IDs to session and turn runtime requests", () => {
+    const runtimeFactory = makeRuntimeFactory();
+    const layer = Layer.effect(
+      CodexAdapter,
+      Effect.gen(function* () {
+        const codexConfig = decodeCodexSettings({ customModels: ["gpt-5-codex"] });
+        return yield* makeCodexAdapter(codexConfig, {
+          makeRuntime: runtimeFactory.factory,
+        });
+      }),
+    ).pipe(
+      Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
+      Layer.provideMerge(ServerSettingsService.layerTest()),
+      Layer.provideMerge(providerSessionDirectoryTestLayer),
+      Layer.provideMerge(NodeServices.layer),
+    );
+
+    return Effect.gen(function* () {
+      const adapter = yield* CodexAdapter;
+      const selection = createModelSelection(ProviderInstanceId.make("codex"), "gpt-5-codex");
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("codex"),
+        threadId: asThreadId("sess-custom-model-id"),
+        runtimeMode: "full-access",
+        modelSelection: selection,
+      });
+
+      const runtime = runtimeFactory.lastRuntime;
+      NodeAssert.ok(runtime);
+      NodeAssert.equal(runtime.options.model, "gpt-5-codex");
+      NodeAssert.deepStrictEqual(runtime.options.customModels, ["gpt-5-codex"]);
+
+      yield* adapter.sendTurn({
+        threadId: asThreadId("sess-custom-model-id"),
+        input: "hello",
+        modelSelection: selection,
+        attachments: [],
+      });
+
+      NodeAssert.deepStrictEqual(runtime.sendTurnImpl.mock.calls[0]?.[0], {
+        input: "hello",
+        model: "gpt-5-codex",
+      });
+    }).pipe(Effect.provide(layer));
+  });
+
   it.effect("passes configured launch args into the session runtime", () => {
     const runtimeFactory = makeRuntimeFactory();
     const layer = Layer.effect(

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1658,10 +1658,11 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           yield* Effect.suspend(() => stopSessionInternal(existing));
         }
 
-        const serviceTier =
-          input.modelSelection?.instanceId === boundInstanceId
-            ? getCodexServiceTierOptionValue(input.modelSelection)
-            : undefined;
+        const modelSelection =
+          input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
+        const serviceTier = modelSelection
+          ? getCodexServiceTierOptionValue(modelSelection)
+          : undefined;
         const mcpSession = McpProviderSession.readMcpProviderSession(input.threadId);
         const runtimeInput: CodexSessionRuntimeOptions = {
           threadId: input.threadId,
@@ -1675,8 +1676,13 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
             ? { resumeCursor: input.resumeCursor }
             : {}),
           runtimeMode: input.runtimeMode,
-          ...(input.modelSelection?.instanceId === boundInstanceId
-            ? { model: input.modelSelection.model }
+          ...(modelSelection
+            ? {
+                model: modelSelection.model,
+              }
+            : {}),
+          ...(codexConfig.customModels.length > 0
+            ? { customModels: codexConfig.customModels }
             : {}),
           ...(serviceTier ? { serviceTier } : {}),
           ...(mcpSession
@@ -1808,19 +1814,19 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     );
 
     const session = yield* requireSession(input.threadId);
-    const reasoningEffort =
-      input.modelSelection?.instanceId === boundInstanceId
-        ? getModelSelectionStringOptionValue(input.modelSelection, "reasoningEffort")
-        : undefined;
-    const serviceTier =
-      input.modelSelection?.instanceId === boundInstanceId
-        ? getCodexServiceTierOptionValue(input.modelSelection)
-        : undefined;
+    const modelSelection =
+      input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
+    const reasoningEffort = modelSelection
+      ? getModelSelectionStringOptionValue(modelSelection, "reasoningEffort")
+      : undefined;
+    const serviceTier = modelSelection ? getCodexServiceTierOptionValue(modelSelection) : undefined;
     return yield* session.runtime
       .sendTurn({
         ...(input.input !== undefined ? { input: input.input } : {}),
-        ...(input.modelSelection?.instanceId === boundInstanceId
-          ? { model: input.modelSelection.model }
+        ...(modelSelection
+          ? {
+              model: modelSelection.model,
+            }
           : {}),
         ...(reasoningEffort
           ? {

--- a/apps/server/src/provider/Layers/CodexProvider.test.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.test.ts
@@ -1,10 +1,16 @@
 import { assert, it } from "@effect/vitest";
+import { CodexSettings } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
 
 import {
   applyPreferredCodexDefaultModel,
   isLegacyCodexModel,
+  makePendingCodexProvider,
   mapCodexModelCapabilities,
 } from "./CodexProvider.ts";
+
+const decodeCodexSettings = Schema.decodeSync(CodexSettings);
 
 it("keeps only the GPT-5.6 Codex family out of legacy models", () => {
   assert.deepStrictEqual(
@@ -82,6 +88,39 @@ it("maps current Codex model capability fields", () => {
     },
   ]);
 });
+
+it.effect("keeps arbitrary custom controls in the Codex catalog", () =>
+  Effect.gen(function* () {
+    const provider = yield* makePendingCodexProvider(
+      decodeCodexSettings({
+        customModels: ["vendor/preview"],
+        customModelCapabilities: {
+          "vendor/preview": {
+            optionDescriptors: [
+              {
+                id: "temperature",
+                label: "Temperature",
+                type: "select",
+                options: [{ id: "warm", label: "Warm" }],
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    assert.deepStrictEqual(provider.models[0]?.capabilities, {
+      optionDescriptors: [
+        {
+          id: "temperature",
+          label: "Temperature",
+          type: "select",
+          options: [{ id: "warm", label: "Warm" }],
+        },
+      ],
+    });
+  }),
+);
 
 it("uses standard routing when the catalog has no default service tier", () => {
   const capabilities = mapCodexModelCapabilities({

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -228,6 +228,7 @@ export function applyPreferredCodexDefaultModel(
 function appendCustomCodexModels(
   models: ReadonlyArray<ServerProviderModel>,
   customModels: ReadonlyArray<string>,
+  customModelCapabilities: Readonly<Record<string, ModelCapabilities>> = {},
 ): ReadonlyArray<ServerProviderModel> {
   if (customModels.length === 0) {
     return models;
@@ -246,7 +247,7 @@ function appendCustomCodexModels(
       slug,
       name: slug,
       isCustom: true,
-      capabilities: fallbackCapabilities,
+      capabilities: customModelCapabilities[slug] ?? fallbackCapabilities,
     });
   }
   return customEntries.length === 0 ? models : [...models, ...customEntries];
@@ -325,6 +326,7 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
   readonly launchArgs?: string;
   readonly cwd: string;
   readonly customModels?: ReadonlyArray<string>;
+  readonly customModelCapabilities?: Readonly<Record<string, ModelCapabilities>>;
   readonly environment?: NodeJS.ProcessEnv;
 }) {
   // `~` is not shell-expanded when env vars are set via `child_process.spawn`,
@@ -390,7 +392,7 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
     return {
       account: accountResponse,
       version,
-      models: appendCustomCodexModels([], input.customModels ?? []),
+      models: appendCustomCodexModels([], input.customModels ?? [], input.customModelCapabilities),
       skills: [],
     } satisfies CodexAppServerProviderSnapshot;
   }
@@ -409,7 +411,7 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
     account: accountResponse,
     version,
     models: applyPreferredCodexDefaultModel(
-      appendCustomCodexModels(models, input.customModels ?? []),
+      appendCustomCodexModels(models, input.customModels ?? [], input.customModelCapabilities),
     ),
     skills: parseCodexSkillsListResponse(skillsResponse, input.cwd),
   } satisfies CodexAppServerProviderSnapshot;
@@ -427,7 +429,7 @@ const emptyCodexModelsFromSettings = (codexSettings: CodexSettings): ServerProvi
     slug: model,
     name: model,
     isCustom: true,
-    capabilities: null,
+    capabilities: codexSettings.customModelCapabilities?.[model] ?? null,
   }));
 };
 
@@ -508,6 +510,7 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
     readonly launchArgs?: string;
     readonly cwd: string;
     readonly customModels: ReadonlyArray<string>;
+    readonly customModelCapabilities?: Readonly<Record<string, ModelCapabilities>>;
     readonly environment?: NodeJS.ProcessEnv;
   }) => Effect.Effect<
     CodexAppServerProviderSnapshot,
@@ -547,6 +550,9 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
     launchArgs: resolveCodexLaunchArgs(codexSettings.launchArgs, resolvedEnvironment),
     cwd: process.cwd(),
     customModels: codexSettings.customModels,
+    ...(codexSettings.customModelCapabilities
+      ? { customModelCapabilities: codexSettings.customModelCapabilities }
+      : {}),
     environment: resolvedEnvironment,
   }).pipe(
     Effect.scoped,

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -22,9 +22,17 @@ import type {
   ServerProviderModel,
   ServerProviderSkill,
 } from "@t3tools/contracts";
-import { PREFERRED_DEFAULT_CODEX_MODELS, ServerSettingsError } from "@t3tools/contracts";
+import {
+  PREFERRED_DEFAULT_CODEX_MODELS,
+  ProviderDriverKind,
+  ServerSettingsError,
+} from "@t3tools/contracts";
 
-import { createModelCapabilities } from "@t3tools/shared/model";
+import {
+  createModelCapabilities,
+  filterCustomModelCapabilities,
+  getDeclaredCustomModelCapabilities,
+} from "@t3tools/shared/model";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import { codexAppServerArgs, resolveCodexLaunchArgs } from "./codexLaunchArgs.ts";
 import {
@@ -37,6 +45,7 @@ import packageJson from "../../../package.json" with { type: "json" };
 const isCodexAppServerSpawnError = Schema.is(CodexErrors.CodexAppServerSpawnError);
 
 const CODEX_APP_SERVER_PROBE_FORCE_KILL_AFTER = "2 seconds" as const;
+const CODEX_DRIVER_KIND = ProviderDriverKind.make("codex");
 
 const CODEX_PRESENTATION = {
   displayName: "Codex",
@@ -243,11 +252,14 @@ function appendCustomCodexModels(
       continue;
     }
     seen.add(slug);
+    const declaredCapabilities = getDeclaredCustomModelCapabilities(customModelCapabilities, slug);
     customEntries.push({
       slug,
       name: slug,
       isCustom: true,
-      capabilities: customModelCapabilities[slug] ?? fallbackCapabilities,
+      capabilities: declaredCapabilities
+        ? filterCustomModelCapabilities(CODEX_DRIVER_KIND, declaredCapabilities)
+        : fallbackCapabilities,
     });
   }
   return customEntries.length === 0 ? models : [...models, ...customEntries];
@@ -425,12 +437,20 @@ const emptyCodexModelsFromSettings = (codexSettings: CodexSettings): ServerProvi
       models.add(trimmed);
     }
   }
-  return Array.from(models, (model) => ({
-    slug: model,
-    name: model,
-    isCustom: true,
-    capabilities: codexSettings.customModelCapabilities?.[model] ?? null,
-  }));
+  return Array.from(models, (model) => {
+    const capabilities = getDeclaredCustomModelCapabilities(
+      codexSettings.customModelCapabilities,
+      model,
+    );
+    return {
+      slug: model,
+      name: model,
+      isCustom: true,
+      capabilities: capabilities
+        ? filterCustomModelCapabilities(CODEX_DRIVER_KIND, capabilities)
+        : null,
+    };
+  });
 };
 
 const makePendingCodexProvider = (

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -22,17 +22,9 @@ import type {
   ServerProviderModel,
   ServerProviderSkill,
 } from "@t3tools/contracts";
-import {
-  PREFERRED_DEFAULT_CODEX_MODELS,
-  ProviderDriverKind,
-  ServerSettingsError,
-} from "@t3tools/contracts";
+import { PREFERRED_DEFAULT_CODEX_MODELS, ServerSettingsError } from "@t3tools/contracts";
 
-import {
-  createModelCapabilities,
-  filterCustomModelCapabilities,
-  getDeclaredCustomModelCapabilities,
-} from "@t3tools/shared/model";
+import { createModelCapabilities, getDeclaredCustomModelCapabilities } from "@t3tools/shared/model";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import { codexAppServerArgs, resolveCodexLaunchArgs } from "./codexLaunchArgs.ts";
 import {
@@ -45,8 +37,6 @@ import packageJson from "../../../package.json" with { type: "json" };
 const isCodexAppServerSpawnError = Schema.is(CodexErrors.CodexAppServerSpawnError);
 
 const CODEX_APP_SERVER_PROBE_FORCE_KILL_AFTER = "2 seconds" as const;
-const CODEX_DRIVER_KIND = ProviderDriverKind.make("codex");
-
 const CODEX_PRESENTATION = {
   displayName: "Codex",
   showInteractionModeToggle: true,
@@ -257,9 +247,7 @@ function appendCustomCodexModels(
       slug,
       name: slug,
       isCustom: true,
-      capabilities: declaredCapabilities
-        ? filterCustomModelCapabilities(CODEX_DRIVER_KIND, declaredCapabilities)
-        : fallbackCapabilities,
+      capabilities: declaredCapabilities ?? fallbackCapabilities,
     });
   }
   return customEntries.length === 0 ? models : [...models, ...customEntries];
@@ -446,9 +434,7 @@ const emptyCodexModelsFromSettings = (codexSettings: CodexSettings): ServerProvi
       slug: model,
       name: model,
       isCustom: true,
-      capabilities: capabilities
-        ? filterCustomModelCapabilities(CODEX_DRIVER_KIND, capabilities)
-        : null,
+      capabilities: capabilities ?? null,
     };
   });
 };

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -181,6 +181,47 @@ describe("buildTurnStartParams", () => {
     });
   });
 
+  it.effect("keeps exact custom IDs and built-in aliases distinct across model switches", () =>
+    Effect.gen(function* () {
+      const customModels = ["gpt-5-codex"];
+      const custom = yield* buildTurnStartParams({
+        threadId: "provider-thread-1",
+        runtimeMode: "full-access",
+        prompt: "Implement it",
+        model: "gpt-5-codex",
+        customModels,
+        interactionMode: "default",
+      });
+      const builtIn = yield* buildTurnStartParams({
+        threadId: "provider-thread-1",
+        runtimeMode: "full-access",
+        prompt: "Implement it",
+        model: "5.4",
+        customModels,
+        interactionMode: "default",
+      });
+      const afterCustom = yield* buildTurnStartParams({
+        threadId: "provider-thread-1",
+        runtimeMode: "full-access",
+        ...(custom.model ? { model: custom.model } : {}),
+        customModels,
+      });
+      const afterBuiltIn = yield* buildTurnStartParams({
+        threadId: "provider-thread-1",
+        runtimeMode: "full-access",
+        ...(builtIn.model ? { model: builtIn.model } : {}),
+        customModels,
+      });
+
+      NodeAssert.equal(custom.model, "gpt-5-codex");
+      NodeAssert.equal(custom.collaborationMode?.settings.model, "gpt-5-codex");
+      NodeAssert.equal(afterCustom.model, "gpt-5-codex");
+      NodeAssert.equal(builtIn.model, "gpt-5.4");
+      NodeAssert.equal(builtIn.collaborationMode?.settings.model, "gpt-5.4");
+      NodeAssert.equal(afterBuiltIn.model, "gpt-5.4");
+    }),
+  );
+
   it("reports the same fallback model and effort in settings and instructions", () => {
     const params = Effect.runSync(
       buildTurnStartParams({
@@ -545,6 +586,46 @@ describe("isRecoverableThreadResumeError", () => {
 });
 
 describe("openCodexThread", () => {
+  it.effect("distinguishes exact custom model IDs from built-in aliases in thread requests", () =>
+    Effect.gen(function* () {
+      const models: Array<string | undefined> = [];
+      const client = {
+        request: <M extends "thread/start" | "thread/resume">(
+          _method: M,
+          payload: CodexRpc.ClientRequestParamsByMethod[M],
+        ) => {
+          models.push("model" in payload ? (payload.model ?? undefined) : undefined);
+          return Effect.succeed(
+            makeThreadOpenResponse("fresh-thread") as CodexRpc.ClientRequestResponsesByMethod[M],
+          );
+        },
+      };
+
+      yield* openCodexThread({
+        client,
+        threadId: ThreadId.make("custom-thread"),
+        runtimeMode: "full-access",
+        cwd: "/tmp/project",
+        requestedModel: "gpt-5-codex",
+        customModels: ["gpt-5-codex"],
+        serviceTier: undefined,
+        resumeThreadId: undefined,
+      });
+      yield* openCodexThread({
+        client,
+        threadId: ThreadId.make("built-in-thread"),
+        runtimeMode: "full-access",
+        cwd: "/tmp/project",
+        requestedModel: "5.4",
+        customModels: ["gpt-5-codex"],
+        serviceTier: undefined,
+        resumeThreadId: undefined,
+      });
+
+      NodeAssert.deepStrictEqual(models, ["gpt-5-codex", "gpt-5.4"]);
+    }),
+  );
+
   it.effect("falls back to thread/start when resume fails recoverably", () =>
     Effect.gen(function* () {
       const calls: Array<{ method: "thread/start" | "thread/resume"; payload: unknown }> = [];

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -17,7 +17,7 @@ import {
   TurnId,
 } from "@t3tools/contracts";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
-import { normalizeModelSlug } from "@t3tools/shared/model";
+import { normalizeCustomModelSlug, normalizeModelSlug } from "@t3tools/shared/model";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Deferred from "effect/Deferred";
@@ -104,6 +104,7 @@ export interface CodexSessionRuntimeOptions {
   readonly cwd: string;
   readonly runtimeMode: RuntimeMode;
   readonly model?: string;
+  readonly customModels?: ReadonlyArray<string> | undefined;
   readonly serviceTier?: CodexServiceTier | undefined;
   readonly resumeCursor?: CodexResumeCursor;
   readonly appServerArgs?: ReadonlyArray<string>;
@@ -244,16 +245,13 @@ function makeCodexServerNotification<M extends CodexRpc.ServerNotificationMethod
 
 function normalizeCodexModelSlug(
   model: string | undefined | null,
-  preferredId?: string,
+  customModels: ReadonlyArray<string> = [],
 ): string | undefined {
-  const normalized = normalizeModelSlug(model);
-  if (!normalized) {
-    return undefined;
-  }
-  if (preferredId?.endsWith("-codex") && preferredId !== normalized) {
-    return preferredId;
-  }
-  return normalized;
+  const customSlug = normalizeCustomModelSlug(model);
+  if (!customSlug) return undefined;
+  return customModels.some((candidate) => normalizeCustomModelSlug(candidate) === customSlug)
+    ? customSlug
+    : (normalizeModelSlug(customSlug) ?? undefined);
 }
 
 function readResumeCursorThreadId(
@@ -302,15 +300,17 @@ function buildThreadStartParams(input: {
   readonly cwd: string;
   readonly runtimeMode: RuntimeMode;
   readonly model: string | undefined;
+  readonly customModels?: ReadonlyArray<string> | undefined;
   readonly serviceTier: CodexServiceTier | undefined;
 }): EffectCodexSchema.V2ThreadStartParams {
   const config = runtimeModeToThreadConfig(input.runtimeMode);
+  const model = normalizeCodexModelSlug(input.model, input.customModels);
   return {
     cwd: input.cwd,
     approvalPolicy: config.approvalPolicy,
     sandbox: config.sandbox,
     approvalsReviewer: config.approvalsReviewer,
-    ...(input.model ? { model: input.model } : {}),
+    ...(model ? { model } : {}),
     ...(input.serviceTier ? { serviceTier: input.serviceTier } : {}),
   };
 }
@@ -344,7 +344,7 @@ function buildCodexCollaborationMode(input: {
   if (input.interactionMode === undefined) {
     return undefined;
   }
-  const model = normalizeCodexModelSlug(input.model) ?? DEFAULT_MODEL;
+  const model = input.model ?? DEFAULT_MODEL;
   const reasoningEffort = input.effort ?? "medium";
   return {
     mode: input.interactionMode,
@@ -368,6 +368,7 @@ export function buildTurnStartParams(input: {
     readonly url: string;
   }>;
   readonly model?: string;
+  readonly customModels?: ReadonlyArray<string> | undefined;
   readonly serviceTier?: CodexServiceTier;
   readonly effort?: EffectCodexSchema.V2TurnStartParams__ReasoningEffort;
   readonly interactionMode?: ProviderInteractionMode;
@@ -387,9 +388,10 @@ export function buildTurnStartParams(input: {
   }
 
   const config = runtimeModeToThreadConfig(input.runtimeMode);
+  const model = normalizeCodexModelSlug(input.model, input.customModels);
   const collaborationMode = buildCodexCollaborationMode({
     ...(input.interactionMode ? { interactionMode: input.interactionMode } : {}),
-    ...(input.model ? { model: input.model } : {}),
+    ...(model ? { model } : {}),
     ...(input.effort ? { effort: input.effort } : {}),
   });
 
@@ -399,7 +401,7 @@ export function buildTurnStartParams(input: {
     approvalPolicy: config.approvalPolicy,
     approvalsReviewer: config.approvalsReviewer,
     sandboxPolicy: runtimeModeToTurnSandboxPolicy(input.runtimeMode),
-    ...(input.model ? { model: input.model } : {}),
+    ...(model ? { model } : {}),
     ...(input.serviceTier ? { serviceTier: input.serviceTier } : {}),
     ...(input.effort ? { effort: input.effort } : {}),
     ...(collaborationMode ? { collaborationMode } : {}),
@@ -461,6 +463,7 @@ export const openCodexThread = (input: {
   readonly runtimeMode: RuntimeMode;
   readonly cwd: string;
   readonly requestedModel: string | undefined;
+  readonly customModels?: ReadonlyArray<string> | undefined;
   readonly serviceTier: CodexServiceTier | undefined;
   readonly resumeThreadId: string | undefined;
 }): Effect.Effect<CodexThreadOpenResponse, CodexErrors.CodexAppServerError> => {
@@ -469,6 +472,7 @@ export const openCodexThread = (input: {
     cwd: input.cwd,
     runtimeMode: input.runtimeMode,
     model: input.requestedModel,
+    customModels: input.customModels,
     serviceTier: input.serviceTier,
   });
 
@@ -1738,14 +1742,13 @@ export const makeCodexSessionRuntime = (
       yield* client.request("initialize", buildCodexInitializeParams());
       yield* client.notify("initialized", undefined);
 
-      const requestedModel = normalizeCodexModelSlug(options.model);
-
       const opened = yield* openCodexThread({
         client,
         threadId: options.threadId,
         runtimeMode: options.runtimeMode,
         cwd: options.cwd,
-        requestedModel,
+        requestedModel: options.model,
+        customModels: options.customModels,
         serviceTier: options.serviceTier,
         resumeThreadId: readResumeCursorThreadId(options.resumeCursor),
       });
@@ -1810,19 +1813,19 @@ export const makeCodexSessionRuntime = (
               ),
             );
           }
-          const normalizedModel = normalizeCodexModelSlug(
-            input.model ?? (yield* Ref.get(sessionRef)).model,
-          );
+          const selectedModel = input.model ?? (yield* Ref.get(sessionRef)).model;
           const params = yield* buildTurnStartParams({
             threadId: providerThreadId,
             runtimeMode: options.runtimeMode,
             ...(input.input ? { prompt: input.input } : {}),
             ...(input.attachments ? { attachments: input.attachments } : {}),
-            ...(normalizedModel ? { model: normalizedModel } : {}),
+            ...(selectedModel ? { model: selectedModel } : {}),
+            customModels: options.customModels,
             ...(input.serviceTier ? { serviceTier: input.serviceTier } : {}),
             ...(input.effort ? { effort: input.effort } : {}),
             ...(input.interactionMode ? { interactionMode: input.interactionMode } : {}),
           });
+          const normalizedModel = params.model;
           const rawResponse = yield* client.raw.request("turn/start", params);
           const response = yield* decodeV2TurnStartResponse(rawResponse).pipe(
             Effect.mapError((error) =>

--- a/apps/server/src/provider/Layers/CursorProvider.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.ts
@@ -8,7 +8,6 @@ import type {
   ServerProviderModel,
   ServerProviderState,
 } from "@t3tools/contracts";
-import { ProviderDriverKind } from "@t3tools/contracts";
 import type * as EffectAcpSchema from "effect-acp/schema";
 import { causeErrorTag } from "@t3tools/shared/observability";
 import * as Crypto from "effect/Crypto";
@@ -59,8 +58,6 @@ const CURSOR_PRESENTATION = {
 const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
   optionDescriptors: [],
 });
-const CURSOR_DRIVER_KIND = ProviderDriverKind.make("cursor");
-
 const CURSOR_ACP_MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
 const CURSOR_PARAMETERIZED_MODEL_PICKER_MIN_VERSION_DATE = 2026_04_08;
 const CURSOR_CLI_INSTALLATION_DOCS_URL = "https://cursor.com/docs/cli/installation";
@@ -577,7 +574,6 @@ export function getCursorFallbackModels(
   cursorSettings: Pick<CursorSettings, "customModels" | "customModelCapabilities">,
 ): ReadonlyArray<ServerProviderModel> {
   return providerModelsFromSettings([], cursorSettings.customModels, EMPTY_CAPABILITIES, {
-    provider: CURSOR_DRIVER_KIND,
     customModelCapabilities: cursorSettings.customModelCapabilities,
   });
 }
@@ -644,7 +640,6 @@ export function buildCursorProviderSnapshot(input: {
       input.cursorSettings.customModels,
       EMPTY_CAPABILITIES,
       {
-        provider: CURSOR_DRIVER_KIND,
         customModelCapabilities: input.cursorSettings.customModelCapabilities,
       },
     ),

--- a/apps/server/src/provider/Layers/CursorProvider.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.ts
@@ -572,9 +572,14 @@ export const discoverCursorModelsViaAcp = (
 ) => discoverCursorModelsViaListAvailableModels(cursorSettings, environment);
 
 export function getCursorFallbackModels(
-  cursorSettings: Pick<CursorSettings, "customModels">,
+  cursorSettings: Pick<CursorSettings, "customModels" | "customModelCapabilities">,
 ): ReadonlyArray<ServerProviderModel> {
-  return providerModelsFromSettings([], cursorSettings.customModels, EMPTY_CAPABILITIES);
+  return providerModelsFromSettings(
+    [],
+    cursorSettings.customModels,
+    EMPTY_CAPABILITIES,
+    cursorSettings.customModelCapabilities,
+  );
 }
 
 /** Timeout for `agent about` — it's slower than a simple `--version` probe. */
@@ -638,6 +643,7 @@ export function buildCursorProviderSnapshot(input: {
       input.discoveredModels ?? [],
       input.cursorSettings.customModels,
       EMPTY_CAPABILITIES,
+      input.cursorSettings.customModelCapabilities,
     ),
     probe: {
       installed: true,

--- a/apps/server/src/provider/Layers/CursorProvider.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.ts
@@ -8,6 +8,7 @@ import type {
   ServerProviderModel,
   ServerProviderState,
 } from "@t3tools/contracts";
+import { ProviderDriverKind } from "@t3tools/contracts";
 import type * as EffectAcpSchema from "effect-acp/schema";
 import { causeErrorTag } from "@t3tools/shared/observability";
 import * as Crypto from "effect/Crypto";
@@ -58,6 +59,7 @@ const CURSOR_PRESENTATION = {
 const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
   optionDescriptors: [],
 });
+const CURSOR_DRIVER_KIND = ProviderDriverKind.make("cursor");
 
 const CURSOR_ACP_MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
 const CURSOR_PARAMETERIZED_MODEL_PICKER_MIN_VERSION_DATE = 2026_04_08;
@@ -574,12 +576,10 @@ export const discoverCursorModelsViaAcp = (
 export function getCursorFallbackModels(
   cursorSettings: Pick<CursorSettings, "customModels" | "customModelCapabilities">,
 ): ReadonlyArray<ServerProviderModel> {
-  return providerModelsFromSettings(
-    [],
-    cursorSettings.customModels,
-    EMPTY_CAPABILITIES,
-    cursorSettings.customModelCapabilities,
-  );
+  return providerModelsFromSettings([], cursorSettings.customModels, EMPTY_CAPABILITIES, {
+    provider: CURSOR_DRIVER_KIND,
+    customModelCapabilities: cursorSettings.customModelCapabilities,
+  });
 }
 
 /** Timeout for `agent about` — it's slower than a simple `--version` probe. */
@@ -643,7 +643,10 @@ export function buildCursorProviderSnapshot(input: {
       input.discoveredModels ?? [],
       input.cursorSettings.customModels,
       EMPTY_CAPABILITIES,
-      input.cursorSettings.customModelCapabilities,
+      {
+        provider: CURSOR_DRIVER_KIND,
+        customModelCapabilities: input.cursorSettings.customModelCapabilities,
+      },
     ),
     probe: {
       installed: true,

--- a/apps/server/src/provider/Layers/GrokProvider.test.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.test.ts
@@ -35,7 +35,7 @@ describe("buildInitialGrokProviderSnapshot", () => {
     }),
   );
 
-  it.effect("keeps unsupported custom controls out of the Grok catalog", () =>
+  it.effect("keeps arbitrary custom controls in the Grok catalog", () =>
     Effect.gen(function* () {
       const snapshot = yield* buildInitialGrokProviderSnapshot(
         decodeGrokSettings({
@@ -56,7 +56,16 @@ describe("buildInitialGrokProviderSnapshot", () => {
       );
       const custom = snapshot.models.find((model) => model.slug === "vendor/preview");
 
-      expect(custom?.capabilities).toEqual({ optionDescriptors: [] });
+      expect(custom?.capabilities).toEqual({
+        optionDescriptors: [
+          {
+            id: "effort",
+            label: "Reasoning",
+            type: "select",
+            options: [{ id: "high", label: "High" }],
+          },
+        ],
+      });
     }),
   );
 });

--- a/apps/server/src/provider/Layers/GrokProvider.test.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.test.ts
@@ -34,6 +34,31 @@ describe("buildInitialGrokProviderSnapshot", () => {
       expect(snapshot.requiresNewThreadForModelChange).toBe(true);
     }),
   );
+
+  it.effect("keeps unsupported custom controls out of the Grok catalog", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* buildInitialGrokProviderSnapshot(
+        decodeGrokSettings({
+          customModels: ["vendor/preview"],
+          customModelCapabilities: {
+            "vendor/preview": {
+              optionDescriptors: [
+                {
+                  id: "effort",
+                  label: "Reasoning",
+                  type: "select",
+                  options: [{ id: "high", label: "High" }],
+                },
+              ],
+            },
+          },
+        }),
+      );
+      const custom = snapshot.models.find((model) => model.slug === "vendor/preview");
+
+      expect(custom?.capabilities).toEqual({ optionDescriptors: [] });
+    }),
+  );
 });
 
 it.layer(NodeServices.layer)("checkGrokProviderStatus", (it) => {

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -58,7 +58,7 @@ export function buildInitialGrokProviderSnapshot(
 ): Effect.Effect<ServerProviderDraft> {
   return Effect.gen(function* () {
     const checkedAt = yield* Effect.map(DateTime.now, DateTime.formatIso);
-    const models = grokModelsFromSettings(grokSettings.customModels);
+    const models = grokModelsFromSettings(grokSettings);
 
     if (!grokSettings.enabled) {
       return buildServerProvider({
@@ -93,10 +93,15 @@ export function buildInitialGrokProviderSnapshot(
 }
 
 function grokModelsFromSettings(
-  customModels: ReadonlyArray<string> | undefined,
+  grokSettings: Pick<GrokSettings, "customModels" | "customModelCapabilities">,
   builtInModels: ReadonlyArray<ServerProviderModel> = GROK_BUILT_IN_MODELS,
 ): ReadonlyArray<ServerProviderModel> {
-  return providerModelsFromSettings(builtInModels, customModels ?? [], EMPTY_CAPABILITIES);
+  return providerModelsFromSettings(
+    builtInModels,
+    grokSettings.customModels,
+    EMPTY_CAPABILITIES,
+    grokSettings.customModelCapabilities,
+  );
 }
 
 function buildGrokDiscoveredModelsFromSessionModelState(
@@ -167,7 +172,7 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
   ChildProcessSpawner.ChildProcessSpawner | Crypto.Crypto
 > {
   const checkedAt = DateTime.formatIso(yield* DateTime.now);
-  const fallbackModels = grokModelsFromSettings(grokSettings.customModels);
+  const fallbackModels = grokModelsFromSettings(grokSettings);
 
   if (!grokSettings.enabled) {
     return buildServerProvider({
@@ -294,7 +299,7 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
   const discoveredModels = discoveryExit.value.value;
   const models =
     discoveredModels.length > 0
-      ? grokModelsFromSettings(grokSettings.customModels, discoveredModels)
+      ? grokModelsFromSettings(grokSettings, discoveredModels)
       : fallbackModels;
 
   return buildServerProvider({

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -1,5 +1,4 @@
 import {
-  ProviderDriverKind,
   type GrokSettings,
   type ModelCapabilities,
   type ServerProvider,
@@ -41,8 +40,6 @@ const GROK_PRESENTATION = {
 const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
   optionDescriptors: [],
 });
-const GROK_DRIVER_KIND = ProviderDriverKind.make("grok");
-
 const VERSION_PROBE_TIMEOUT_MS = 4_000;
 const GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
 
@@ -99,7 +96,6 @@ function grokModelsFromSettings(
   builtInModels: ReadonlyArray<ServerProviderModel> = GROK_BUILT_IN_MODELS,
 ): ReadonlyArray<ServerProviderModel> {
   return providerModelsFromSettings(builtInModels, grokSettings.customModels, EMPTY_CAPABILITIES, {
-    provider: GROK_DRIVER_KIND,
     customModelCapabilities: grokSettings.customModelCapabilities,
   });
 }

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -1,4 +1,5 @@
 import {
+  ProviderDriverKind,
   type GrokSettings,
   type ModelCapabilities,
   type ServerProvider,
@@ -40,6 +41,7 @@ const GROK_PRESENTATION = {
 const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
   optionDescriptors: [],
 });
+const GROK_DRIVER_KIND = ProviderDriverKind.make("grok");
 
 const VERSION_PROBE_TIMEOUT_MS = 4_000;
 const GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
@@ -96,12 +98,10 @@ function grokModelsFromSettings(
   grokSettings: Pick<GrokSettings, "customModels" | "customModelCapabilities">,
   builtInModels: ReadonlyArray<ServerProviderModel> = GROK_BUILT_IN_MODELS,
 ): ReadonlyArray<ServerProviderModel> {
-  return providerModelsFromSettings(
-    builtInModels,
-    grokSettings.customModels,
-    EMPTY_CAPABILITIES,
-    grokSettings.customModelCapabilities,
-  );
+  return providerModelsFromSettings(builtInModels, grokSettings.customModels, EMPTY_CAPABILITIES, {
+    provider: GROK_DRIVER_KIND,
+    customModelCapabilities: grokSettings.customModelCapabilities,
+  });
 }
 
 function buildGrokDiscoveredModelsFromSessionModelState(

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -259,6 +259,7 @@ export const makePendingOpenCodeProvider = (
       [],
       openCodeSettings.customModels,
       DEFAULT_OPENCODE_MODEL_CAPABILITIES,
+      openCodeSettings.customModelCapabilities,
     );
 
     if (!openCodeSettings.enabled) {
@@ -304,6 +305,7 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
   const resolvedEnvironment = environment ?? process.env;
   const checkedAt = DateTime.formatIso(yield* DateTime.now);
   const customModels = openCodeSettings.customModels;
+  const customModelCapabilities = openCodeSettings.customModelCapabilities;
   const isExternalServer = openCodeSettings.serverUrl.trim().length > 0;
 
   const fallback = (cause: unknown, version: string | null = null) => {
@@ -316,7 +318,12 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
       presentation: OPENCODE_PRESENTATION,
       enabled: openCodeSettings.enabled,
       checkedAt,
-      models: providerModelsFromSettings([], customModels, DEFAULT_OPENCODE_MODEL_CAPABILITIES),
+      models: providerModelsFromSettings(
+        [],
+        customModels,
+        DEFAULT_OPENCODE_MODEL_CAPABILITIES,
+        customModelCapabilities,
+      ),
       probe: {
         installed: failure.installed,
         version,
@@ -332,7 +339,12 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
       presentation: OPENCODE_PRESENTATION,
       enabled: false,
       checkedAt,
-      models: providerModelsFromSettings([], customModels, DEFAULT_OPENCODE_MODEL_CAPABILITIES),
+      models: providerModelsFromSettings(
+        [],
+        customModels,
+        DEFAULT_OPENCODE_MODEL_CAPABILITIES,
+        customModelCapabilities,
+      ),
       probe: {
         installed: false,
         version: null,
@@ -378,7 +390,12 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
         presentation: OPENCODE_PRESENTATION,
         enabled: openCodeSettings.enabled,
         checkedAt,
-        models: providerModelsFromSettings([], customModels, DEFAULT_OPENCODE_MODEL_CAPABILITIES),
+        models: providerModelsFromSettings(
+          [],
+          customModels,
+          DEFAULT_OPENCODE_MODEL_CAPABILITIES,
+          customModelCapabilities,
+        ),
         probe: {
           installed: true,
           version,
@@ -428,6 +445,7 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
     flattenOpenCodeModels(inventoryExit.value),
     customModels,
     DEFAULT_OPENCODE_MODEL_CAPABILITIES,
+    customModelCapabilities,
   );
   const connectedCount = inventoryExit.value.providerList.connected.length;
   return buildServerProvider({

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -1,4 +1,5 @@
 import {
+  ProviderDriverKind,
   type ModelCapabilities,
   type OpenCodeSettings,
   type ServerProviderModel,
@@ -28,6 +29,7 @@ const OPENCODE_PRESENTATION = {
   displayName: "OpenCode",
   showInteractionModeToggle: false,
 } as const;
+const OPENCODE_DRIVER_KIND = ProviderDriverKind.make("opencode");
 const MINIMUM_OPENCODE_VERSION = "1.14.19";
 
 class OpenCodeProbeError extends Data.TaggedError("OpenCodeProbeError")<{
@@ -259,7 +261,10 @@ export const makePendingOpenCodeProvider = (
       [],
       openCodeSettings.customModels,
       DEFAULT_OPENCODE_MODEL_CAPABILITIES,
-      openCodeSettings.customModelCapabilities,
+      {
+        provider: OPENCODE_DRIVER_KIND,
+        customModelCapabilities: openCodeSettings.customModelCapabilities,
+      },
     );
 
     if (!openCodeSettings.enabled) {
@@ -318,12 +323,10 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
       presentation: OPENCODE_PRESENTATION,
       enabled: openCodeSettings.enabled,
       checkedAt,
-      models: providerModelsFromSettings(
-        [],
-        customModels,
-        DEFAULT_OPENCODE_MODEL_CAPABILITIES,
+      models: providerModelsFromSettings([], customModels, DEFAULT_OPENCODE_MODEL_CAPABILITIES, {
+        provider: OPENCODE_DRIVER_KIND,
         customModelCapabilities,
-      ),
+      }),
       probe: {
         installed: failure.installed,
         version,
@@ -339,12 +342,10 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
       presentation: OPENCODE_PRESENTATION,
       enabled: false,
       checkedAt,
-      models: providerModelsFromSettings(
-        [],
-        customModels,
-        DEFAULT_OPENCODE_MODEL_CAPABILITIES,
+      models: providerModelsFromSettings([], customModels, DEFAULT_OPENCODE_MODEL_CAPABILITIES, {
+        provider: OPENCODE_DRIVER_KIND,
         customModelCapabilities,
-      ),
+      }),
       probe: {
         installed: false,
         version: null,
@@ -390,12 +391,10 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
         presentation: OPENCODE_PRESENTATION,
         enabled: openCodeSettings.enabled,
         checkedAt,
-        models: providerModelsFromSettings(
-          [],
-          customModels,
-          DEFAULT_OPENCODE_MODEL_CAPABILITIES,
+        models: providerModelsFromSettings([], customModels, DEFAULT_OPENCODE_MODEL_CAPABILITIES, {
+          provider: OPENCODE_DRIVER_KIND,
           customModelCapabilities,
-        ),
+        }),
         probe: {
           installed: true,
           version,
@@ -445,7 +444,7 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
     flattenOpenCodeModels(inventoryExit.value),
     customModels,
     DEFAULT_OPENCODE_MODEL_CAPABILITIES,
-    customModelCapabilities,
+    { provider: OPENCODE_DRIVER_KIND, customModelCapabilities },
   );
   const connectedCount = inventoryExit.value.providerList.connected.length;
   return buildServerProvider({

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -1,5 +1,4 @@
 import {
-  ProviderDriverKind,
   type ModelCapabilities,
   type OpenCodeSettings,
   type ServerProviderModel,
@@ -29,7 +28,6 @@ const OPENCODE_PRESENTATION = {
   displayName: "OpenCode",
   showInteractionModeToggle: false,
 } as const;
-const OPENCODE_DRIVER_KIND = ProviderDriverKind.make("opencode");
 const MINIMUM_OPENCODE_VERSION = "1.14.19";
 
 class OpenCodeProbeError extends Data.TaggedError("OpenCodeProbeError")<{
@@ -262,7 +260,6 @@ export const makePendingOpenCodeProvider = (
       openCodeSettings.customModels,
       DEFAULT_OPENCODE_MODEL_CAPABILITIES,
       {
-        provider: OPENCODE_DRIVER_KIND,
         customModelCapabilities: openCodeSettings.customModelCapabilities,
       },
     );
@@ -324,7 +321,6 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
       enabled: openCodeSettings.enabled,
       checkedAt,
       models: providerModelsFromSettings([], customModels, DEFAULT_OPENCODE_MODEL_CAPABILITIES, {
-        provider: OPENCODE_DRIVER_KIND,
         customModelCapabilities,
       }),
       probe: {
@@ -343,7 +339,6 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
       enabled: false,
       checkedAt,
       models: providerModelsFromSettings([], customModels, DEFAULT_OPENCODE_MODEL_CAPABILITIES, {
-        provider: OPENCODE_DRIVER_KIND,
         customModelCapabilities,
       }),
       probe: {
@@ -392,7 +387,6 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
         enabled: openCodeSettings.enabled,
         checkedAt,
         models: providerModelsFromSettings([], customModels, DEFAULT_OPENCODE_MODEL_CAPABILITIES, {
-          provider: OPENCODE_DRIVER_KIND,
           customModelCapabilities,
         }),
         probe: {
@@ -444,7 +438,7 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
     flattenOpenCodeModels(inventoryExit.value),
     customModels,
     DEFAULT_OPENCODE_MODEL_CAPABILITIES,
-    { provider: OPENCODE_DRIVER_KIND, customModelCapabilities },
+    { customModelCapabilities },
   );
   const connectedCount = inventoryExit.value.providerList.connected.length;
   return buildServerProvider({

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1914,7 +1914,13 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
       it.effect("hides Claude Opus 5 on older Claude Code versions", () =>
         Effect.gen(function* () {
           const status = yield* checkClaudeProviderStatus(
-            defaultClaudeSettings,
+            {
+              ...defaultClaudeSettings,
+              customModels: ["claude-opus-5"],
+              customModelCapabilities: {
+                "claude-opus-5": { optionDescriptors: [] },
+              },
+            },
             claudeCapabilities(),
           );
           assert.strictEqual(

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -56,6 +56,9 @@ const encodeServerSettings = Schema.encodeSync(ServerSettings);
 const encodedDefaultServerSettings = encodeServerSettings(DEFAULT_SERVER_SETTINGS);
 
 const defaultClaudeSettings: ClaudeSettings = Schema.decodeSync(ClaudeSettings)({});
+const customClaudeSettings: ClaudeSettings = Schema.decodeSync(ClaudeSettings)({
+  customModels: ["gpt-5.6-sol"],
+});
 const defaultCodexSettings: CodexSettings = Schema.decodeSync(CodexSettings)({});
 const decodeCodexSettings = Schema.decodeSync(CodexSettings);
 const disabledCodexSettings: CodexSettings = Schema.decodeSync(CodexSettings)({
@@ -1850,6 +1853,51 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             mockSpawnerLayer((args) => {
               const joined = args.join(" ");
               if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
+              if (joined === "auth status")
+                return {
+                  stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
+                  stderr: "",
+                  code: 0,
+                };
+              throw new Error(`Unexpected args: ${joined}`);
+            }),
+          ),
+        ),
+      );
+
+      it.effect("exposes all Claude controls for custom models by default", () =>
+        Effect.gen(function* () {
+          const status = yield* checkClaudeProviderStatus(
+            customClaudeSettings,
+            claudeCapabilities(),
+          );
+          const customModel = status.models.find((model) => model.slug === "gpt-5.6-sol");
+
+          assert(customModel?.capabilities != null);
+          const descriptors = customModel.capabilities.optionDescriptors ?? [];
+          assert.deepEqual(
+            descriptors.map((descriptor) =>
+              descriptor.type === "select"
+                ? {
+                    id: descriptor.id,
+                    options: descriptor.options.map((option) => option.id),
+                  }
+                : { id: descriptor.id },
+            ),
+            [
+              {
+                id: "effort",
+                options: ["low", "medium", "high", "xhigh", "max", "ultracode", "ultrathink"],
+              },
+              { id: "fastMode" },
+              { id: "contextWindow", options: ["200k", "1m"] },
+            ],
+          );
+        }).pipe(
+          Effect.provide(
+            mockSpawnerLayer((args) => {
+              const joined = args.join(" ");
+              if (joined === "--version") return { stdout: "2.1.219\n", stderr: "", code: 0 };
               if (joined === "auth status")
                 return {
                   stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -56,9 +56,6 @@ const encodeServerSettings = Schema.encodeSync(ServerSettings);
 const encodedDefaultServerSettings = encodeServerSettings(DEFAULT_SERVER_SETTINGS);
 
 const defaultClaudeSettings: ClaudeSettings = Schema.decodeSync(ClaudeSettings)({});
-const customClaudeSettings: ClaudeSettings = Schema.decodeSync(ClaudeSettings)({
-  customModels: ["gpt-5.6-sol"],
-});
 const defaultCodexSettings: CodexSettings = Schema.decodeSync(CodexSettings)({});
 const decodeCodexSettings = Schema.decodeSync(CodexSettings);
 const disabledCodexSettings: CodexSettings = Schema.decodeSync(CodexSettings)({
@@ -1853,51 +1850,6 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             mockSpawnerLayer((args) => {
               const joined = args.join(" ");
               if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
-              if (joined === "auth status")
-                return {
-                  stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
-                  stderr: "",
-                  code: 0,
-                };
-              throw new Error(`Unexpected args: ${joined}`);
-            }),
-          ),
-        ),
-      );
-
-      it.effect("exposes all Claude controls for custom models by default", () =>
-        Effect.gen(function* () {
-          const status = yield* checkClaudeProviderStatus(
-            customClaudeSettings,
-            claudeCapabilities(),
-          );
-          const customModel = status.models.find((model) => model.slug === "gpt-5.6-sol");
-
-          assert(customModel?.capabilities != null);
-          const descriptors = customModel.capabilities.optionDescriptors ?? [];
-          assert.deepEqual(
-            descriptors.map((descriptor) =>
-              descriptor.type === "select"
-                ? {
-                    id: descriptor.id,
-                    options: descriptor.options.map((option) => option.id),
-                  }
-                : { id: descriptor.id },
-            ),
-            [
-              {
-                id: "effort",
-                options: ["low", "medium", "high", "xhigh", "max", "ultracode", "ultrathink"],
-              },
-              { id: "fastMode" },
-              { id: "contextWindow", options: ["200k", "1m"] },
-            ],
-          );
-        }).pipe(
-          Effect.provide(
-            mockSpawnerLayer((args) => {
-              const joined = args.join(" ");
-              if (joined === "--version") return { stdout: "2.1.219\n", stderr: "", code: 0 };
               if (joined === "auth status")
                 return {
                   stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',

--- a/apps/server/src/provider/providerSnapshot.test.ts
+++ b/apps/server/src/provider/providerSnapshot.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
 import type { ModelCapabilities } from "@t3tools/contracts";
-import { ProviderDriverKind } from "@t3tools/contracts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { createModelCapabilities } from "@t3tools/shared/model";
 import * as Effect from "effect/Effect";
@@ -41,7 +40,6 @@ describe("providerModelsFromSettings", () => {
       [],
       ["openai/gpt-5"],
       OPENCODE_CUSTOM_MODEL_CAPABILITIES,
-      { provider: ProviderDriverKind.make("opencode") },
     );
 
     expect(models).toEqual([
@@ -67,7 +65,6 @@ describe("providerModelsFromSettings", () => {
       ],
       [" opus "],
       capabilities,
-      { provider: ProviderDriverKind.make("claudeAgent") },
     );
 
     expect(models.map((model) => model.slug)).toEqual(["claude-opus-4-8", "opus"]);
@@ -77,7 +74,6 @@ describe("providerModelsFromSettings", () => {
   it("does not read inherited object keys as custom capabilities", () => {
     const fallbackCapabilities = createModelCapabilities({ optionDescriptors: [] });
     const models = providerModelsFromSettings([], ["constructor"], fallbackCapabilities, {
-      provider: ProviderDriverKind.make("codex"),
       customModelCapabilities: {},
     });
 
@@ -101,8 +97,27 @@ describe("providerModelsFromSettings", () => {
     });
 
     const models = providerModelsFromSettings([], ["gateway/model"], fallbackCapabilities, {
-      provider: ProviderDriverKind.make("claudeAgent"),
       customModelCapabilities: { "gateway/model": declaredCapabilities },
+    });
+
+    expect(models[0]?.capabilities).toEqual(declaredCapabilities);
+  });
+
+  it("keeps arbitrary descriptors without a provider allowlist", () => {
+    const fallbackCapabilities = createModelCapabilities({ optionDescriptors: [] });
+    const declaredCapabilities = createModelCapabilities({
+      optionDescriptors: [
+        {
+          id: "temperature",
+          label: "Temperature",
+          type: "select",
+          options: [{ id: "warm", label: "Warm" }],
+        },
+      ],
+    });
+
+    const models = providerModelsFromSettings([], ["vendor/preview"], fallbackCapabilities, {
+      customModelCapabilities: { "vendor/preview": declaredCapabilities },
     });
 
     expect(models[0]?.capabilities).toEqual(declaredCapabilities);

--- a/apps/server/src/provider/providerSnapshot.test.ts
+++ b/apps/server/src/provider/providerSnapshot.test.ts
@@ -70,6 +70,29 @@ describe("providerModelsFromSettings", () => {
     expect(models.map((model) => model.slug)).toEqual(["claude-opus-4-8", "opus"]);
     expect(models[1]?.isCustom).toBe(true);
   });
+
+  it("uses per-model capabilities when a custom model declares them", () => {
+    const fallbackCapabilities = createModelCapabilities({ optionDescriptors: [] });
+    const declaredCapabilities = createModelCapabilities({
+      optionDescriptors: [
+        {
+          id: "effort",
+          label: "Reasoning",
+          type: "select",
+          options: [
+            { id: "low", label: "Low" },
+            { id: "max", label: "Max", isDefault: true },
+          ],
+        },
+      ],
+    });
+
+    const models = providerModelsFromSettings([], ["gateway/model"], fallbackCapabilities, {
+      "gateway/model": declaredCapabilities,
+    });
+
+    expect(models[0]?.capabilities).toEqual(declaredCapabilities);
+  });
 });
 
 describe("ProviderCommandNotFoundError", () => {

--- a/apps/server/src/provider/providerSnapshot.test.ts
+++ b/apps/server/src/provider/providerSnapshot.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import type { ModelCapabilities } from "@t3tools/contracts";
+import { ProviderDriverKind } from "@t3tools/contracts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { createModelCapabilities } from "@t3tools/shared/model";
 import * as Effect from "effect/Effect";
@@ -40,6 +41,7 @@ describe("providerModelsFromSettings", () => {
       [],
       ["openai/gpt-5"],
       OPENCODE_CUSTOM_MODEL_CAPABILITIES,
+      { provider: ProviderDriverKind.make("opencode") },
     );
 
     expect(models).toEqual([
@@ -65,10 +67,21 @@ describe("providerModelsFromSettings", () => {
       ],
       [" opus "],
       capabilities,
+      { provider: ProviderDriverKind.make("claudeAgent") },
     );
 
     expect(models.map((model) => model.slug)).toEqual(["claude-opus-4-8", "opus"]);
     expect(models[1]?.isCustom).toBe(true);
+  });
+
+  it("does not read inherited object keys as custom capabilities", () => {
+    const fallbackCapabilities = createModelCapabilities({ optionDescriptors: [] });
+    const models = providerModelsFromSettings([], ["constructor"], fallbackCapabilities, {
+      provider: ProviderDriverKind.make("codex"),
+      customModelCapabilities: {},
+    });
+
+    expect(models[0]?.capabilities).toBe(fallbackCapabilities);
   });
 
   it("uses per-model capabilities when a custom model declares them", () => {
@@ -88,7 +101,8 @@ describe("providerModelsFromSettings", () => {
     });
 
     const models = providerModelsFromSettings([], ["gateway/model"], fallbackCapabilities, {
-      "gateway/model": declaredCapabilities,
+      provider: ProviderDriverKind.make("claudeAgent"),
+      customModelCapabilities: { "gateway/model": declaredCapabilities },
     });
 
     expect(models[0]?.capabilities).toEqual(declaredCapabilities);

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -13,7 +13,11 @@ import * as PlatformError from "effect/PlatformError";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
-import { normalizeCustomModelSlug } from "@t3tools/shared/model";
+import {
+  filterCustomModelCapabilities,
+  getDeclaredCustomModelCapabilities,
+  normalizeCustomModelSlug,
+} from "@t3tools/shared/model";
 import { isWindowsCommandNotFound } from "../processRunner.ts";
 import { createProviderVersionAdvisory } from "./providerMaintenance.ts";
 import { collectUint8StreamText } from "../stream/collectUint8StreamText.ts";
@@ -142,7 +146,10 @@ export function providerModelsFromSettings(
   builtInModels: ReadonlyArray<ServerProviderModel>,
   customModels: ReadonlyArray<string>,
   fallbackCapabilities: ModelCapabilities,
-  customModelCapabilities: Readonly<Record<string, ModelCapabilities>> = {},
+  options: {
+    readonly provider: ProviderDriverKind;
+    readonly customModelCapabilities?: Readonly<Record<string, ModelCapabilities>> | undefined;
+  },
 ): ReadonlyArray<ServerProviderModel> {
   const resolvedBuiltInModels = [...builtInModels];
   const seen = new Set(resolvedBuiltInModels.map((model) => model.slug));
@@ -154,11 +161,17 @@ export function providerModelsFromSettings(
       continue;
     }
     seen.add(normalized);
+    const declaredCapabilities = getDeclaredCustomModelCapabilities(
+      options.customModelCapabilities,
+      normalized,
+    );
     customEntries.push({
       slug: normalized,
       name: normalized,
       isCustom: true,
-      capabilities: customModelCapabilities[normalized] ?? fallbackCapabilities,
+      capabilities: declaredCapabilities
+        ? filterCustomModelCapabilities(options.provider, declaredCapabilities)
+        : fallbackCapabilities,
     });
   }
 

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -14,7 +14,6 @@ import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import {
-  filterCustomModelCapabilities,
   getDeclaredCustomModelCapabilities,
   normalizeCustomModelSlug,
 } from "@t3tools/shared/model";
@@ -147,9 +146,8 @@ export function providerModelsFromSettings(
   customModels: ReadonlyArray<string>,
   fallbackCapabilities: ModelCapabilities,
   options: {
-    readonly provider: ProviderDriverKind;
     readonly customModelCapabilities?: Readonly<Record<string, ModelCapabilities>> | undefined;
-  },
+  } = {},
 ): ReadonlyArray<ServerProviderModel> {
   const resolvedBuiltInModels = [...builtInModels];
   const seen = new Set(resolvedBuiltInModels.map((model) => model.slug));
@@ -169,9 +167,7 @@ export function providerModelsFromSettings(
       slug: normalized,
       name: normalized,
       isCustom: true,
-      capabilities: declaredCapabilities
-        ? filterCustomModelCapabilities(options.provider, declaredCapabilities)
-        : fallbackCapabilities,
+      capabilities: declaredCapabilities ?? fallbackCapabilities,
     });
   }
 

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -141,7 +141,8 @@ export function parseGenericCliVersion(output: string): string | null {
 export function providerModelsFromSettings(
   builtInModels: ReadonlyArray<ServerProviderModel>,
   customModels: ReadonlyArray<string>,
-  customModelCapabilities: ModelCapabilities,
+  fallbackCapabilities: ModelCapabilities,
+  customModelCapabilities: Readonly<Record<string, ModelCapabilities>> = {},
 ): ReadonlyArray<ServerProviderModel> {
   const resolvedBuiltInModels = [...builtInModels];
   const seen = new Set(resolvedBuiltInModels.map((model) => model.slug));
@@ -157,7 +158,7 @@ export function providerModelsFromSettings(
       slug: normalized,
       name: normalized,
       isCustom: true,
-      capabilities: customModelCapabilities,
+      capabilities: customModelCapabilities[normalized] ?? fallbackCapabilities,
     });
   }
 

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -156,7 +156,7 @@ it.layer(NodeServices.layer)("server settings", (it) => {
     }),
   );
 
-  it.effect("decodes custom-model capability metadata in settings and patches", () =>
+  it.effect("decodes custom-model capability metadata for every provider and patches", () =>
     Effect.gen(function* () {
       const customModelCapabilities = {
         "gateway/model": {
@@ -176,24 +176,33 @@ it.layer(NodeServices.layer)("server settings", (it) => {
 
       const decoded = yield* decodeServerSettings({
         providers: {
-          claudeAgent: {
-            customModels: ["gateway/model"],
-            customModelCapabilities,
-          },
+          codex: { customModels: ["gateway/model"], customModelCapabilities },
+          claudeAgent: { customModels: ["gateway/model"], customModelCapabilities },
+          cursor: { customModels: ["gateway/model"], customModelCapabilities },
+          grok: { customModels: ["gateway/model"], customModelCapabilities },
+          opencode: { customModels: ["gateway/model"], customModelCapabilities },
         },
       });
       const patch = yield* decodeSettingsPatch({
-        providers: { claudeAgent: { customModelCapabilities } },
+        providers: {
+          codex: { customModelCapabilities },
+          claudeAgent: { customModelCapabilities },
+          cursor: { customModelCapabilities },
+          grok: { customModelCapabilities },
+          opencode: { customModelCapabilities },
+        },
       });
 
-      assert.deepEqual(
-        decoded.providers.claudeAgent.customModelCapabilities,
-        customModelCapabilities,
-      );
-      assert.deepEqual(
-        patch.providers?.claudeAgent?.customModelCapabilities,
-        customModelCapabilities,
-      );
+      for (const provider of ["codex", "claudeAgent", "cursor", "grok", "opencode"] as const) {
+        assert.deepEqual(
+          decoded.providers[provider].customModelCapabilities,
+          customModelCapabilities,
+        );
+        assert.deepEqual(
+          patch.providers?.[provider]?.customModelCapabilities,
+          customModelCapabilities,
+        );
+      }
     }),
   );
 

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -136,9 +136,85 @@ it.layer(NodeServices.layer)("server settings", (it) => {
       }),
   );
 
+  it.effect("keeps old custom-model settings valid with empty capability metadata", () =>
+    Effect.gen(function* () {
+      const decoded = yield* decodeServerSettings({
+        providers: {
+          claudeAgent: {
+            customModels: ["gateway/model"],
+          },
+        },
+      });
+
+      assert.deepEqual(decoded.providers.claudeAgent, {
+        enabled: true,
+        binaryPath: "claude",
+        homePath: "",
+        customModels: ["gateway/model"],
+        launchArgs: "",
+      });
+    }),
+  );
+
+  it.effect("decodes custom-model capability metadata in settings and patches", () =>
+    Effect.gen(function* () {
+      const customModelCapabilities = {
+        "gateway/model": {
+          optionDescriptors: [
+            {
+              id: "contextWindow",
+              label: "Context Window",
+              type: "select" as const,
+              options: [
+                { id: "200k", label: "200k" },
+                { id: "1m", label: "1M", isDefault: true },
+              ],
+            },
+          ],
+        },
+      };
+
+      const decoded = yield* decodeServerSettings({
+        providers: {
+          claudeAgent: {
+            customModels: ["gateway/model"],
+            customModelCapabilities,
+          },
+        },
+      });
+      const patch = yield* decodeSettingsPatch({
+        providers: { claudeAgent: { customModelCapabilities } },
+      });
+
+      assert.deepEqual(
+        decoded.providers.claudeAgent.customModelCapabilities,
+        customModelCapabilities,
+      );
+      assert.deepEqual(
+        patch.providers?.claudeAgent?.customModelCapabilities,
+        customModelCapabilities,
+      );
+    }),
+  );
+
   it.effect("deep merges nested settings updates without dropping siblings", () =>
     Effect.gen(function* () {
       const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+      const customModelCapabilities = {
+        "claude-custom": {
+          optionDescriptors: [
+            {
+              id: "contextWindow",
+              label: "Context Window",
+              type: "select" as const,
+              options: [
+                { id: "200k", label: "200k" },
+                { id: "1m", label: "1M", isDefault: true },
+              ],
+            },
+          ],
+        },
+      };
 
       yield* serverSettings.updateSettings({
         providers: {
@@ -149,6 +225,7 @@ it.layer(NodeServices.layer)("server settings", (it) => {
           claudeAgent: {
             binaryPath: "/usr/local/bin/claude",
             customModels: ["claude-custom"],
+            customModelCapabilities,
           },
         },
         textGenerationModelSelection: {
@@ -189,6 +266,7 @@ it.layer(NodeServices.layer)("server settings", (it) => {
         binaryPath: "/usr/local/bin/claude",
         homePath: "",
         customModels: ["claude-custom"],
+        customModelCapabilities,
         launchArgs: "",
       });
       assert.deepEqual(

--- a/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
@@ -290,6 +290,74 @@ it.layer(ClaudeTextGenerationTestLayer)("ClaudeTextGeneration", (it) => {
     ),
   );
 
+  it.effect("forwards custom model controls to Claude CLI", () =>
+    withFakeClaudeEnv(
+      {
+        output: JSON.stringify({
+          structured_output: {
+            title: "Use gateway model",
+            body: "Body",
+          },
+        }),
+        argsMustContain: '--model gateway/model[1m] --effort xhigh --settings {"fastMode":false}',
+        claudeConfig: {
+          customModels: ["gateway/model"],
+          customModelCapabilities: {
+            "gateway/model": {
+              optionDescriptors: [
+                {
+                  id: "effort",
+                  label: "Reasoning",
+                  type: "select",
+                  options: [
+                    { id: "low", label: "Low" },
+                    { id: "xhigh", label: "Extra High", isDefault: true },
+                  ],
+                },
+                {
+                  id: "fastMode",
+                  label: "Fast Mode",
+                  type: "boolean",
+                },
+                {
+                  id: "contextWindow",
+                  label: "Context Window",
+                  type: "select",
+                  options: [
+                    { id: "200k", label: "200k" },
+                    { id: "1m", label: "1M", isDefault: true },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      },
+      (textGeneration) =>
+        Effect.gen(function* () {
+          const generated = yield* textGeneration.generatePrContent({
+            cwd: process.cwd(),
+            baseBranch: "main",
+            headBranch: "feature/custom-model",
+            commitSummary: "Use gateway model",
+            diffSummary: "1 file changed",
+            diffPatch: "diff --git a/README.md b/README.md",
+            modelSelection: createModelSelection(
+              ProviderInstanceId.make("claudeAgent"),
+              "gateway/model",
+              [
+                { id: "effort", value: "xhigh" },
+                { id: "fastMode", value: false },
+                { id: "contextWindow", value: "1m" },
+              ],
+            ),
+          });
+
+          expect(generated.title).toBe("Use gateway model");
+        }),
+    ),
+  );
+
   it.effect("generates thread titles through the Claude provider", () =>
     withFakeClaudeEnv(
       {

--- a/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
@@ -257,7 +257,7 @@ it.layer(ClaudeTextGenerationTestLayer)("ClaudeTextGeneration", (it) => {
     ),
   );
 
-  it.effect("keeps built-in effort compatibility when a custom slug collides", () =>
+  it.effect("forwards Claude fast mode and supported effort", () =>
     withFakeClaudeEnv(
       {
         output: JSON.stringify({
@@ -266,8 +266,7 @@ it.layer(ClaudeTextGenerationTestLayer)("ClaudeTextGeneration", (it) => {
             body: "Body",
           },
         }),
-        argsMustContain: "--effort high",
-        claudeConfig: { customModels: ["claude-sonnet-4-6"] },
+        argsMustContain: '--effort max --settings {"fastMode":true}',
       },
       (textGeneration) =>
         Effect.gen(function* () {
@@ -279,8 +278,9 @@ it.layer(ClaudeTextGenerationTestLayer)("ClaudeTextGeneration", (it) => {
             diffSummary: "1 file changed",
             diffPatch: "diff --git a/README.md b/README.md",
             modelSelection: {
-              ...createModelSelection(ProviderInstanceId.make("claudeAgent"), "claude-sonnet-4-6", [
+              ...createModelSelection(ProviderInstanceId.make("claudeAgent"), "claude-opus-4-6", [
                 { id: "effort", value: "max" },
+                { id: "fastMode", value: true },
               ]),
             },
           });

--- a/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
@@ -257,7 +257,7 @@ it.layer(ClaudeTextGenerationTestLayer)("ClaudeTextGeneration", (it) => {
     ),
   );
 
-  it.effect("forwards Claude fast mode and supported effort", () =>
+  it.effect("keeps built-in effort compatibility when a custom slug collides", () =>
     withFakeClaudeEnv(
       {
         output: JSON.stringify({
@@ -266,7 +266,8 @@ it.layer(ClaudeTextGenerationTestLayer)("ClaudeTextGeneration", (it) => {
             body: "Body",
           },
         }),
-        argsMustContain: '--effort max --settings {"fastMode":true}',
+        argsMustContain: "--effort high",
+        claudeConfig: { customModels: ["claude-sonnet-4-6"] },
       },
       (textGeneration) =>
         Effect.gen(function* () {
@@ -278,9 +279,8 @@ it.layer(ClaudeTextGenerationTestLayer)("ClaudeTextGeneration", (it) => {
             diffSummary: "1 file changed",
             diffPatch: "diff --git a/README.md b/README.md",
             modelSelection: {
-              ...createModelSelection(ProviderInstanceId.make("claudeAgent"), "claude-opus-4-6", [
+              ...createModelSelection(ProviderInstanceId.make("claudeAgent"), "claude-sonnet-4-6", [
                 { id: "effort", value: "max" },
-                { id: "fastMode", value: true },
               ]),
             },
           });

--- a/apps/server/src/textGeneration/ClaudeTextGeneration.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.ts
@@ -126,7 +126,8 @@ export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(fu
       toJsonSchemaObject(outputSchemaJson),
       "Failed to encode structured output schema.",
     );
-    const caps = getClaudeModelCapabilities(modelSelection.model);
+    const customModelCapabilities = claudeSettings.customModelCapabilities ?? {};
+    const caps = getClaudeModelCapabilities(modelSelection.model, customModelCapabilities);
     const descriptors = getProviderOptionDescriptors({
       caps,
       selections: modelSelection.options,
@@ -134,7 +135,11 @@ export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(fu
     const findDescriptor = (id: string) => descriptors.find((descriptor) => descriptor.id === id);
     const rawEffortSelection = getModelSelectionStringOptionValue(modelSelection, "effort");
     const resolvedEffort = resolveClaudeEffort(caps, rawEffortSelection);
-    const cliEffort = normalizeClaudeCliEffort(resolvedEffort, modelSelection.model);
+    const cliEffort = normalizeClaudeCliEffort(
+      resolvedEffort,
+      modelSelection.model,
+      customModelCapabilities[modelSelection.model] === caps,
+    );
     const ultracode = isClaudeUltracodeEffort(resolvedEffort);
     const thinkingDescriptor = findDescriptor("thinking");
     const fastModeDescriptor = findDescriptor("fastMode");
@@ -144,7 +149,7 @@ export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(fu
       fastModeDescriptor?.type === "boolean" ? fastModeDescriptor.currentValue : undefined;
     const settings = {
       ...(typeof thinking === "boolean" ? { alwaysThinkingEnabled: thinking } : {}),
-      ...(fastMode ? { fastMode: true } : {}),
+      ...(typeof fastMode === "boolean" ? { fastMode } : {}),
       ...(ultracode ? { ultracode: true } : {}),
     };
     const settingsJson =
@@ -166,7 +171,7 @@ export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(fu
           "--json-schema",
           jsonSchemaStr,
           "--model",
-          resolveClaudeApiModelId(modelSelection),
+          resolveClaudeApiModelId(modelSelection, customModelCapabilities),
           ...(cliEffort ? ["--effort", cliEffort] : []),
           ...(settingsJson ? ["--settings", settingsJson] : []),
           "--dangerously-skip-permissions",

--- a/apps/server/src/textGeneration/ClaudeTextGeneration.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.ts
@@ -38,6 +38,7 @@ import {
 } from "@t3tools/shared/model";
 import {
   getClaudeModelCapabilities,
+  isCustomClaudeModel,
   isClaudeUltracodeEffort,
   normalizeClaudeCliEffort,
   resolveClaudeApiModelId,
@@ -134,12 +135,14 @@ export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(fu
     });
     const findDescriptor = (id: string) => descriptors.find((descriptor) => descriptor.id === id);
     const rawEffortSelection = getModelSelectionStringOptionValue(modelSelection, "effort");
-    const resolvedEffort = resolveClaudeEffort(caps, rawEffortSelection);
-    const cliEffort = normalizeClaudeCliEffort(
-      resolvedEffort,
-      modelSelection.model,
-      claudeSettings.customModels.includes(modelSelection.model),
-    );
+    const customModel = isCustomClaudeModel(modelSelection.model, claudeSettings.customModels);
+    const usesFallbackCapabilities =
+      customModel && customModelCapabilities[modelSelection.model] === undefined;
+    const resolvedEffort =
+      usesFallbackCapabilities && rawEffortSelection === undefined
+        ? undefined
+        : resolveClaudeEffort(caps, rawEffortSelection);
+    const cliEffort = normalizeClaudeCliEffort(resolvedEffort, modelSelection.model, customModel);
     const ultracode = isClaudeUltracodeEffort(resolvedEffort);
     const thinkingDescriptor = findDescriptor("thinking");
     const fastModeDescriptor = findDescriptor("fastMode");

--- a/apps/server/src/textGeneration/ClaudeTextGeneration.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.ts
@@ -38,7 +38,6 @@ import {
 } from "@t3tools/shared/model";
 import {
   getClaudeModelCapabilities,
-  isCustomClaudeModel,
   isClaudeUltracodeEffort,
   normalizeClaudeCliEffort,
   resolveClaudeApiModelId,
@@ -135,14 +134,12 @@ export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(fu
     });
     const findDescriptor = (id: string) => descriptors.find((descriptor) => descriptor.id === id);
     const rawEffortSelection = getModelSelectionStringOptionValue(modelSelection, "effort");
-    const customModel = isCustomClaudeModel(modelSelection.model, claudeSettings.customModels);
-    const usesFallbackCapabilities =
-      customModel && customModelCapabilities[modelSelection.model] === undefined;
-    const resolvedEffort =
-      usesFallbackCapabilities && rawEffortSelection === undefined
-        ? undefined
-        : resolveClaudeEffort(caps, rawEffortSelection);
-    const cliEffort = normalizeClaudeCliEffort(resolvedEffort, modelSelection.model, customModel);
+    const resolvedEffort = resolveClaudeEffort(caps, rawEffortSelection);
+    const cliEffort = normalizeClaudeCliEffort(
+      resolvedEffort,
+      modelSelection.model,
+      customModelCapabilities[modelSelection.model] === caps,
+    );
     const ultracode = isClaudeUltracodeEffort(resolvedEffort);
     const thinkingDescriptor = findDescriptor("thinking");
     const fastModeDescriptor = findDescriptor("fastMode");

--- a/apps/server/src/textGeneration/ClaudeTextGeneration.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.ts
@@ -38,6 +38,7 @@ import {
 } from "@t3tools/shared/model";
 import {
   getClaudeModelCapabilities,
+  isConfiguredCustomClaudeModel,
   isClaudeUltracodeEffort,
   normalizeClaudeCliEffort,
   resolveClaudeApiModelId,
@@ -138,7 +139,7 @@ export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(fu
     const cliEffort = normalizeClaudeCliEffort(
       resolvedEffort,
       modelSelection.model,
-      customModelCapabilities[modelSelection.model] === caps,
+      isConfiguredCustomClaudeModel(modelSelection.model, customModelCapabilities),
     );
     const ultracode = isClaudeUltracodeEffort(resolvedEffort);
     const thinkingDescriptor = findDescriptor("thinking");

--- a/apps/server/src/textGeneration/ClaudeTextGeneration.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.ts
@@ -138,7 +138,7 @@ export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(fu
     const cliEffort = normalizeClaudeCliEffort(
       resolvedEffort,
       modelSelection.model,
-      customModelCapabilities[modelSelection.model] === caps,
+      claudeSettings.customModels.includes(modelSelection.model),
     );
     const ultracode = isClaudeUltracodeEffort(resolvedEffort);
     const thinkingDescriptor = findDescriptor("thinking");

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -190,7 +190,7 @@ function getTraitsSectionVisibility(input: {
     showFastMode,
     showContextWindow,
     showAgent,
-    hasAnyControls: showEffort || showThinking || showFastMode || showContextWindow || showAgent,
+    hasAnyControls: selected.selectDescriptors.length > 0 || selected.booleanDescriptors.length > 0,
   };
 }
 

--- a/apps/web/src/components/chat/composerProviderState.test.tsx
+++ b/apps/web/src/components/chat/composerProviderState.test.tsx
@@ -141,6 +141,70 @@ describe("getComposerProviderState", () => {
     });
   });
 
+  it("shows only controls declared by a custom model", () => {
+    const models: ReadonlyArray<ServerProviderModel> = [
+      {
+        slug: MODEL,
+        name: MODEL,
+        isCustom: true,
+        capabilities: {
+          optionDescriptors: [
+            selectDescriptor("contextWindow", [
+              { id: "200k", label: "200k" },
+              { id: "1m", label: "1M", isDefault: true },
+            ]),
+          ],
+        },
+      },
+    ];
+
+    const state = getComposerProviderState({
+      provider: PROVIDER,
+      model: MODEL,
+      models,
+      modelOptions: selections(["effort", "max"], ["fastMode", true], ["contextWindow", "200k"]),
+    });
+
+    expect(state.modelOptionsForDispatch).toEqual(selections(["contextWindow", "200k"]));
+  });
+  it("prefers an exact custom model ID over a built-in alias", () => {
+    const claude = ProviderDriverKind.make("claudeAgent");
+    const models: ReadonlyArray<ServerProviderModel> = [
+      {
+        slug: "claude-sonnet-5",
+        name: "Claude Sonnet 5",
+        isCustom: false,
+        capabilities: {
+          optionDescriptors: [
+            selectDescriptor("effort", [{ id: "high", label: "High", isDefault: true }]),
+          ],
+        },
+      },
+      {
+        slug: "sonnet",
+        name: "sonnet",
+        isCustom: true,
+        capabilities: {
+          optionDescriptors: [
+            selectDescriptor("contextWindow", [
+              { id: "200k", label: "200K" },
+              { id: "1m", label: "1M", isDefault: true },
+            ]),
+          ],
+        },
+      },
+    ];
+
+    const state = getComposerProviderState({
+      provider: claude,
+      model: "sonnet",
+      models,
+      modelOptions: selections(["effort", "high"], ["contextWindow", "1m"]),
+    });
+
+    expect(state.modelOptionsForDispatch).toEqual(selections(["contextWindow", "1m"]));
+  });
+
   it("derives promptEffort from the first select descriptor and preserves all others for dispatch", () => {
     const state = getComposerProviderState({
       provider: PROVIDER,

--- a/apps/web/src/components/chat/composerProviderState.test.tsx
+++ b/apps/web/src/components/chat/composerProviderState.test.tsx
@@ -11,6 +11,7 @@ import {
   renderProviderTraitsMenuContent,
   renderProviderTraitsPicker,
 } from "./composerProviderState";
+import { DraftId } from "../../composerDraftStore";
 
 // Everything in composerProviderState is now data-driven by the model's
 // optionDescriptors, so these tests use a single synthetic provider/model and
@@ -293,6 +294,21 @@ describe("getComposerProviderState", () => {
 });
 
 describe("provider traits render guards", () => {
+  it("renders an arbitrary on/off descriptor for a custom model", () => {
+    const args = {
+      provider: PROVIDER,
+      model: MODEL,
+      models: modelWith([booleanDescriptor("option")]),
+      modelOptions: undefined,
+      prompt: "",
+      onPromptChange: () => {},
+      draftId: DraftId.make("draft-custom-boolean"),
+    };
+
+    expect(renderProviderTraitsPicker(args)).not.toBeNull();
+    expect(renderProviderTraitsMenuContent(args)).not.toBeNull();
+  });
+
   it("returns null when no thread target is provided", () => {
     const models = modelWith([
       selectDescriptor("effort", [{ id: "high", label: "High", isDefault: true }]),

--- a/apps/web/src/components/settings/ProviderInstanceCard.test.ts
+++ b/apps/web/src/components/settings/ProviderInstanceCard.test.ts
@@ -82,4 +82,27 @@ describe("deriveProviderModelsForDisplay", () => {
       new: { optionDescriptors: [] },
     });
   });
+
+  it("stores reserved model IDs as own capability keys", () => {
+    const capabilities = reconcileCustomModelCapabilities({
+      capabilities: {},
+      currentModels: [],
+      nextModels: ["__proto__", "constructor"],
+    });
+
+    expect(Object.hasOwn(capabilities, "__proto__")).toBe(true);
+    expect(capabilities["__proto__"]).toEqual({ optionDescriptors: [] });
+    expect(Object.hasOwn(capabilities, "constructor")).toBe(true);
+    expect(capabilities.constructor).toEqual({ optionDescriptors: [] });
+  });
+
+  it("does not read inherited properties as configured capabilities", () => {
+    const [model] = deriveProviderModelsForDisplay({
+      liveModels: [],
+      customModels: ["constructor"],
+      customModelCapabilities: {},
+    });
+
+    expect(model?.capabilities).toBeNull();
+  });
 });

--- a/apps/web/src/components/settings/ProviderInstanceCard.test.ts
+++ b/apps/web/src/components/settings/ProviderInstanceCard.test.ts
@@ -4,6 +4,7 @@ import type { ModelCapabilities, ServerProviderModel } from "@t3tools/contracts"
 import {
   deriveProviderModelsForDisplay,
   reconcileCustomModelCapabilities,
+  updateCustomModelCapabilitiesRecord,
 } from "./ProviderInstanceCard";
 
 describe("deriveProviderModelsForDisplay", () => {
@@ -81,5 +82,18 @@ describe("deriveProviderModelsForDisplay", () => {
       configured,
       new: { optionDescriptors: [] },
     });
+  });
+
+  it("stores prototype-shaped model IDs as own capability keys", () => {
+    const capabilities: ModelCapabilities = {
+      optionDescriptors: [{ id: "fastMode", label: "Fast Mode", type: "boolean" }],
+    };
+
+    const updated = updateCustomModelCapabilitiesRecord({}, "__proto__", capabilities);
+    expect(Object.hasOwn(updated, "__proto__")).toBe(true);
+    expect(updated["__proto__"]).toEqual(capabilities);
+
+    const removed = updateCustomModelCapabilitiesRecord(updated, "__proto__", undefined);
+    expect(Object.hasOwn(removed, "__proto__")).toBe(false);
   });
 });

--- a/apps/web/src/components/settings/ProviderInstanceCard.test.ts
+++ b/apps/web/src/components/settings/ProviderInstanceCard.test.ts
@@ -95,5 +95,13 @@ describe("deriveProviderModelsForDisplay", () => {
 
     const removed = updateCustomModelCapabilitiesRecord(updated, "__proto__", undefined);
     expect(Object.hasOwn(removed, "__proto__")).toBe(false);
+
+    const reconciled = reconcileCustomModelCapabilities({
+      capabilities: {},
+      currentModels: [],
+      nextModels: ["constructor"],
+    });
+    expect(Object.hasOwn(reconciled, "constructor")).toBe(true);
+    expect(reconciled["constructor"]).toEqual({ optionDescriptors: [] });
   });
 });

--- a/apps/web/src/components/settings/ProviderInstanceCard.test.ts
+++ b/apps/web/src/components/settings/ProviderInstanceCard.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vite-plus/test";
-import type { ServerProviderModel } from "@t3tools/contracts";
+import type { ModelCapabilities, ServerProviderModel } from "@t3tools/contracts";
 
-import { deriveProviderModelsForDisplay } from "./ProviderInstanceCard";
+import {
+  deriveProviderModelsForDisplay,
+  reconcileCustomModelCapabilities,
+} from "./ProviderInstanceCard";
 
 describe("deriveProviderModelsForDisplay", () => {
   it("uses current config custom models instead of stale live custom rows", () => {
@@ -29,8 +32,54 @@ describe("deriveProviderModelsForDisplay", () => {
     expect(
       deriveProviderModelsForDisplay({
         liveModels,
-        customModels: ["kept-custom"],
+        customModels: ["server-model", "kept-custom"],
       }).map((model) => model.slug),
     ).toEqual(["server-model", "kept-custom"]);
+  });
+
+  it("uses current config capabilities while the live custom row is stale", () => {
+    const capabilities: ModelCapabilities = {
+      optionDescriptors: [
+        {
+          id: "effort",
+          label: "Reasoning",
+          type: "select",
+          options: [{ id: "high", label: "High", isDefault: true }],
+        },
+      ],
+    };
+    const input = {
+      liveModels: [
+        {
+          slug: "gateway/model",
+          name: "gateway/model",
+          isCustom: true,
+          capabilities: null,
+        },
+      ],
+      customModels: ["gateway/model"],
+      customModelCapabilities: { "gateway/model": capabilities },
+    } satisfies Parameters<typeof deriveProviderModelsForDisplay>[0] & {
+      readonly customModelCapabilities: Readonly<Record<string, ModelCapabilities>>;
+    };
+
+    expect(deriveProviderModelsForDisplay(input)[0]?.capabilities).toEqual(capabilities);
+  });
+
+  it("keeps legacy metadata absent and seeds newly added models with no controls", () => {
+    const configured: ModelCapabilities = {
+      optionDescriptors: [{ id: "fastMode", label: "Fast Mode", type: "boolean" }],
+    };
+
+    expect(
+      reconcileCustomModelCapabilities({
+        capabilities: { configured, removed: { optionDescriptors: [] } },
+        currentModels: ["legacy", "configured", "removed"],
+        nextModels: ["legacy", "configured", "new"],
+      }),
+    ).toEqual({
+      configured,
+      new: { optionDescriptors: [] },
+    });
   });
 });

--- a/apps/web/src/components/settings/ProviderInstanceCard.test.ts
+++ b/apps/web/src/components/settings/ProviderInstanceCard.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vite-plus/test";
-import type { ModelCapabilities, ServerProviderModel } from "@t3tools/contracts";
+import {
+  ProviderDriverKind,
+  type ModelCapabilities,
+  type ServerProviderModel,
+} from "@t3tools/contracts";
 
 import {
   deriveProviderModelsForDisplay,
@@ -33,6 +37,7 @@ describe("deriveProviderModelsForDisplay", () => {
       deriveProviderModelsForDisplay({
         liveModels,
         customModels: ["server-model", "kept-custom"],
+        driverKind: ProviderDriverKind.make("codex"),
       }).map((model) => model.slug),
     ).toEqual(["server-model", "kept-custom"]);
   });
@@ -59,11 +64,34 @@ describe("deriveProviderModelsForDisplay", () => {
       ],
       customModels: ["gateway/model"],
       customModelCapabilities: { "gateway/model": capabilities },
+      driverKind: ProviderDriverKind.make("claudeAgent"),
     } satisfies Parameters<typeof deriveProviderModelsForDisplay>[0] & {
       readonly customModelCapabilities: Readonly<Record<string, ModelCapabilities>>;
     };
 
     expect(deriveProviderModelsForDisplay(input)[0]?.capabilities).toEqual(capabilities);
+  });
+
+  it("filters unsupported capabilities from optimistic custom rows", () => {
+    const [model] = deriveProviderModelsForDisplay({
+      liveModels: [],
+      customModels: ["vendor/preview"],
+      customModelCapabilities: {
+        "vendor/preview": {
+          optionDescriptors: [
+            {
+              id: "effort",
+              label: "Reasoning",
+              type: "select",
+              options: [{ id: "high", label: "High" }],
+            },
+          ],
+        },
+      },
+      driverKind: ProviderDriverKind.make("grok"),
+    });
+
+    expect(model?.capabilities).toEqual({ optionDescriptors: [] });
   });
 
   it("keeps legacy metadata absent and seeds newly added models with no controls", () => {
@@ -101,6 +129,7 @@ describe("deriveProviderModelsForDisplay", () => {
       liveModels: [],
       customModels: ["constructor"],
       customModelCapabilities: {},
+      driverKind: ProviderDriverKind.make("codex"),
     });
 
     expect(model?.capabilities).toBeNull();

--- a/apps/web/src/components/settings/ProviderInstanceCard.test.ts
+++ b/apps/web/src/components/settings/ProviderInstanceCard.test.ts
@@ -4,7 +4,6 @@ import type { ModelCapabilities, ServerProviderModel } from "@t3tools/contracts"
 import {
   deriveProviderModelsForDisplay,
   reconcileCustomModelCapabilities,
-  updateCustomModelCapabilitiesRecord,
 } from "./ProviderInstanceCard";
 
 describe("deriveProviderModelsForDisplay", () => {
@@ -82,26 +81,5 @@ describe("deriveProviderModelsForDisplay", () => {
       configured,
       new: { optionDescriptors: [] },
     });
-  });
-
-  it("stores prototype-shaped model IDs as own capability keys", () => {
-    const capabilities: ModelCapabilities = {
-      optionDescriptors: [{ id: "fastMode", label: "Fast Mode", type: "boolean" }],
-    };
-
-    const updated = updateCustomModelCapabilitiesRecord({}, "__proto__", capabilities);
-    expect(Object.hasOwn(updated, "__proto__")).toBe(true);
-    expect(updated["__proto__"]).toEqual(capabilities);
-
-    const removed = updateCustomModelCapabilitiesRecord(updated, "__proto__", undefined);
-    expect(Object.hasOwn(removed, "__proto__")).toBe(false);
-
-    const reconciled = reconcileCustomModelCapabilities({
-      capabilities: {},
-      currentModels: [],
-      nextModels: ["constructor"],
-    });
-    expect(Object.hasOwn(reconciled, "constructor")).toBe(true);
-    expect(reconciled["constructor"]).toEqual({ optionDescriptors: [] });
   });
 });

--- a/apps/web/src/components/settings/ProviderInstanceCard.test.ts
+++ b/apps/web/src/components/settings/ProviderInstanceCard.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
-import {
-  ProviderDriverKind,
-  type ModelCapabilities,
-  type ServerProviderModel,
-} from "@t3tools/contracts";
+import type { ModelCapabilities, ServerProviderModel } from "@t3tools/contracts";
 
 import {
   deriveProviderModelsForDisplay,
@@ -37,7 +33,6 @@ describe("deriveProviderModelsForDisplay", () => {
       deriveProviderModelsForDisplay({
         liveModels,
         customModels: ["server-model", "kept-custom"],
-        driverKind: ProviderDriverKind.make("codex"),
       }).map((model) => model.slug),
     ).toEqual(["server-model", "kept-custom"]);
   });
@@ -64,7 +59,6 @@ describe("deriveProviderModelsForDisplay", () => {
       ],
       customModels: ["gateway/model"],
       customModelCapabilities: { "gateway/model": capabilities },
-      driverKind: ProviderDriverKind.make("claudeAgent"),
     } satisfies Parameters<typeof deriveProviderModelsForDisplay>[0] & {
       readonly customModelCapabilities: Readonly<Record<string, ModelCapabilities>>;
     };
@@ -72,26 +66,24 @@ describe("deriveProviderModelsForDisplay", () => {
     expect(deriveProviderModelsForDisplay(input)[0]?.capabilities).toEqual(capabilities);
   });
 
-  it("filters unsupported capabilities from optimistic custom rows", () => {
+  it("preserves arbitrary capabilities in optimistic custom rows", () => {
+    const capabilities: ModelCapabilities = {
+      optionDescriptors: [
+        {
+          id: "temperature",
+          label: "Temperature",
+          type: "select",
+          options: [{ id: "warm", label: "Warm" }],
+        },
+      ],
+    };
     const [model] = deriveProviderModelsForDisplay({
       liveModels: [],
       customModels: ["vendor/preview"],
-      customModelCapabilities: {
-        "vendor/preview": {
-          optionDescriptors: [
-            {
-              id: "effort",
-              label: "Reasoning",
-              type: "select",
-              options: [{ id: "high", label: "High" }],
-            },
-          ],
-        },
-      },
-      driverKind: ProviderDriverKind.make("grok"),
+      customModelCapabilities: { "vendor/preview": capabilities },
     });
 
-    expect(model?.capabilities).toEqual({ optionDescriptors: [] });
+    expect(model?.capabilities).toEqual(capabilities);
   });
 
   it("keeps legacy metadata absent and seeds newly added models with no controls", () => {
@@ -129,7 +121,6 @@ describe("deriveProviderModelsForDisplay", () => {
       liveModels: [],
       customModels: ["constructor"],
       customModelCapabilities: {},
-      driverKind: ProviderDriverKind.make("codex"),
     });
 
     expect(model?.capabilities).toBeNull();

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -25,10 +25,7 @@ import {
   type ServerProvider,
   type ServerProviderModel,
 } from "@t3tools/contracts";
-import {
-  filterCustomModelCapabilities,
-  getDeclaredCustomModelCapabilities,
-} from "@t3tools/shared/model";
+import { getDeclaredCustomModelCapabilities } from "@t3tools/shared/model";
 
 import { cn } from "../../lib/utils";
 import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
@@ -148,7 +145,6 @@ export function deriveProviderModelsForDisplay(input: {
   readonly liveModels: ReadonlyArray<ServerProviderModel> | undefined;
   readonly customModels: ReadonlyArray<string>;
   readonly customModelCapabilities?: Readonly<Record<string, ModelCapabilities>>;
-  readonly driverKind: ProviderDriverKind | null;
 }): ReadonlyArray<ServerProviderModel> {
   const liveCustomModelsBySlug = new Map(
     Arr.filterMap(input.liveModels ?? [], (model) =>
@@ -165,10 +161,7 @@ export function deriveProviderModelsForDisplay(input: {
         input.customModelCapabilities,
         slug,
       );
-      const capabilities =
-        configuredCapabilities && input.driverKind
-          ? filterCustomModelCapabilities(input.driverKind, configuredCapabilities)
-          : configuredCapabilities;
+      const capabilities = configuredCapabilities;
       if (liveModel) {
         return capabilities ? { ...liveModel, capabilities } : liveModel;
       }
@@ -503,7 +496,6 @@ export function ProviderInstanceCard({
     liveModels: liveProvider?.models,
     customModels,
     customModelCapabilities,
-    driverKind,
   });
 
   const updateDisplayName = (value: string) => {

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -367,6 +367,7 @@ interface ProviderInstanceCardProps {
   readonly instance: ProviderInstanceConfig;
   readonly driverOption: DriverOption | undefined;
   readonly liveProvider: ServerProvider | undefined;
+  readonly sourceProviders: ReadonlyArray<ServerProvider>;
   readonly isExpanded: boolean;
   readonly onExpandedChange: (open: boolean) => void;
   readonly onUpdate: (nextInstance: ProviderInstanceConfig) => void;
@@ -424,6 +425,7 @@ export function ProviderInstanceCard({
   instance,
   driverOption,
   liveProvider,
+  sourceProviders,
   isExpanded,
   onExpandedChange,
   onUpdate,
@@ -852,6 +854,7 @@ export function ProviderInstanceCard({
                 instanceId={instanceId}
                 driverKind={driverKind}
                 models={modelsForDisplay}
+                sourceProviders={sourceProviders}
                 customModels={customModels}
                 customModelCapabilities={customModelCapabilities}
                 onCustomModelCapabilitiesChange={updateCustomModelCapabilities}

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -126,37 +126,16 @@ export function reconcileCustomModelCapabilities(input: {
   readonly nextModels: ReadonlyArray<string>;
 }): Readonly<Record<string, ModelCapabilities>> {
   const currentModels = new Set(input.currentModels);
-  const entries: Array<readonly [string, ModelCapabilities]> = [];
+  const nextCapabilities: Record<string, ModelCapabilities> = {};
   for (const slug of input.nextModels) {
-    const capabilities = Object.hasOwn(input.capabilities, slug)
-      ? input.capabilities[slug]
-      : undefined;
+    const capabilities = input.capabilities[slug];
     if (capabilities) {
-      entries.push([slug, capabilities]);
+      nextCapabilities[slug] = capabilities;
     } else if (!currentModels.has(slug)) {
-      entries.push([slug, { optionDescriptors: [] }]);
+      nextCapabilities[slug] = { optionDescriptors: [] };
     }
   }
-  return Object.fromEntries(entries);
-}
-
-export function updateCustomModelCapabilitiesRecord(
-  current: Readonly<Record<string, ModelCapabilities>>,
-  slug: string,
-  capabilities: ModelCapabilities | undefined,
-): Readonly<Record<string, ModelCapabilities>> {
-  const next = Object.fromEntries(Object.entries(current));
-  if (capabilities) {
-    Object.defineProperty(next, slug, {
-      value: capabilities,
-      enumerable: true,
-      configurable: true,
-      writable: true,
-    });
-  } else {
-    delete next[slug];
-  }
-  return next;
+  return nextCapabilities;
 }
 
 export function deriveProviderModelsForDisplay(input: {
@@ -565,11 +544,12 @@ export function ProviderInstanceCard({
     slug: string,
     capabilities: ModelCapabilities | undefined,
   ) => {
-    const nextCapabilities = updateCustomModelCapabilitiesRecord(
-      customModelCapabilities,
-      slug,
-      capabilities,
-    );
+    const nextCapabilities = { ...customModelCapabilities };
+    if (capabilities) {
+      nextCapabilities[slug] = capabilities;
+    } else {
+      delete nextCapabilities[slug];
+    }
     const nextConfig = nextConfigBlobWithValue(instance.config, "customModels", [...customModels]);
     if (Object.keys(nextCapabilities).length > 0) {
       nextConfig.customModelCapabilities = nextCapabilities;

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -12,9 +12,12 @@ import {
 } from "lucide-react";
 import * as Arr from "effect/Array";
 import * as Result from "effect/Result";
+import * as Schema from "effect/Schema";
 import { useState, type ReactNode } from "react";
 import {
+  CustomModelCapabilities,
   isProviderDriverKind,
+  type ModelCapabilities,
   type ProviderInstanceConfig,
   type ProviderInstanceEnvironmentVariable,
   type ProviderInstanceId,
@@ -53,6 +56,8 @@ import {
 
 const ENVIRONMENT_VARIABLE_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
+const isCustomModelCapabilities = Schema.is(CustomModelCapabilities);
+
 let environmentVariableDraftId = 0;
 const nextEnvironmentVariableDraftId = () => `provider-env-${environmentVariableDraftId++}`;
 
@@ -90,6 +95,12 @@ function readConfigStringArray(config: unknown, key: string): ReadonlyArray<stri
   return value.filter((entry): entry is string => typeof entry === "string");
 }
 
+function readCustomModelCapabilities(config: unknown): Readonly<Record<string, ModelCapabilities>> {
+  if (config === null || typeof config !== "object") return {};
+  const value = (config as Record<string, unknown>).customModelCapabilities;
+  return isCustomModelCapabilities(value) ? value : {};
+}
+
 /**
  * Set `key` to an arbitrary value on the opaque config blob. Unlike
  * provider settings field updates, does not drop empty-looking values — the
@@ -109,9 +120,28 @@ function nextConfigBlobWithValue(
   return base;
 }
 
+export function reconcileCustomModelCapabilities(input: {
+  readonly capabilities: Readonly<Record<string, ModelCapabilities>>;
+  readonly currentModels: ReadonlyArray<string>;
+  readonly nextModels: ReadonlyArray<string>;
+}): Readonly<Record<string, ModelCapabilities>> {
+  const currentModels = new Set(input.currentModels);
+  const nextCapabilities: Record<string, ModelCapabilities> = {};
+  for (const slug of input.nextModels) {
+    const capabilities = input.capabilities[slug];
+    if (capabilities) {
+      nextCapabilities[slug] = capabilities;
+    } else if (!currentModels.has(slug)) {
+      nextCapabilities[slug] = { optionDescriptors: [] };
+    }
+  }
+  return nextCapabilities;
+}
+
 export function deriveProviderModelsForDisplay(input: {
   readonly liveModels: ReadonlyArray<ServerProviderModel> | undefined;
   readonly customModels: ReadonlyArray<string>;
+  readonly customModelCapabilities?: Readonly<Record<string, ModelCapabilities>>;
 }): ReadonlyArray<ServerProviderModel> {
   const liveCustomModelsBySlug = new Map(
     Arr.filterMap(input.liveModels ?? [], (model) =>
@@ -119,15 +149,22 @@ export function deriveProviderModelsForDisplay(input: {
     ),
   );
   const serverModels = input.liveModels?.filter((model) => !model.isCustom) ?? [];
-  const customModels = input.customModels.map(
-    (slug) =>
-      liveCustomModelsBySlug.get(slug) ?? {
+  const serverModelSlugs = new Set(serverModels.map((model) => model.slug));
+  const customModels = input.customModels
+    .filter((slug) => !serverModelSlugs.has(slug))
+    .map((slug) => {
+      const liveModel = liveCustomModelsBySlug.get(slug);
+      const capabilities = input.customModelCapabilities?.[slug];
+      if (liveModel) {
+        return capabilities ? { ...liveModel, capabilities } : liveModel;
+      }
+      return {
         slug,
         name: slug,
         isCustom: true,
-        capabilities: null,
-      },
-  );
+        capabilities: capabilities ?? null,
+      };
+    });
   return [...serverModels, ...customModels];
 }
 
@@ -444,12 +481,14 @@ export function ProviderInstanceCard({
     : null;
 
   const customModels = readConfigStringArray(instance.config, "customModels");
+  const customModelCapabilities = readCustomModelCapabilities(instance.config);
   // Server-returned models may lag behind settings writes. Treat probe
   // models as the source for built-ins only; custom rows come directly
   // from the current instance config so add/remove reflects immediately.
   const modelsForDisplay = deriveProviderModelsForDisplay({
     liveModels: liveProvider?.models,
     customModels,
+    customModelCapabilities,
   });
 
   const updateDisplayName = (value: string) => {
@@ -487,6 +526,36 @@ export function ProviderInstanceCard({
 
   const updateCustomModels = (next: ReadonlyArray<string>) => {
     const nextConfig = nextConfigBlobWithValue(instance.config, "customModels", [...next]);
+    const remainingCapabilities = reconcileCustomModelCapabilities({
+      capabilities: customModelCapabilities,
+      currentModels: customModels,
+      nextModels: next,
+    });
+    if (Object.keys(remainingCapabilities).length > 0) {
+      nextConfig.customModelCapabilities = remainingCapabilities;
+    } else {
+      delete nextConfig.customModelCapabilities;
+    }
+    const { config: _omit, ...rest } = instance;
+    onUpdate({ ...rest, config: nextConfig } as ProviderInstanceConfig);
+  };
+
+  const updateCustomModelCapabilities = (
+    slug: string,
+    capabilities: ModelCapabilities | undefined,
+  ) => {
+    const nextCapabilities = { ...customModelCapabilities };
+    if (capabilities) {
+      nextCapabilities[slug] = capabilities;
+    } else {
+      delete nextCapabilities[slug];
+    }
+    const nextConfig = nextConfigBlobWithValue(instance.config, "customModels", [...customModels]);
+    if (Object.keys(nextCapabilities).length > 0) {
+      nextConfig.customModelCapabilities = nextCapabilities;
+    } else {
+      delete nextConfig.customModelCapabilities;
+    }
     const { config: _omit, ...rest } = instance;
     onUpdate({ ...rest, config: nextConfig } as ProviderInstanceConfig);
   };
@@ -779,6 +848,8 @@ export function ProviderInstanceCard({
                 driverKind={driverKind}
                 models={modelsForDisplay}
                 customModels={customModels}
+                customModelCapabilities={customModelCapabilities}
+                onCustomModelCapabilitiesChange={updateCustomModelCapabilities}
                 hiddenModels={hiddenModels}
                 favoriteModels={favoriteModels}
                 modelOrder={modelOrder}

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -128,7 +128,9 @@ export function reconcileCustomModelCapabilities(input: {
   const currentModels = new Set(input.currentModels);
   const entries: Array<readonly [string, ModelCapabilities]> = [];
   for (const slug of input.nextModels) {
-    const capabilities = input.capabilities[slug];
+    const capabilities = Object.hasOwn(input.capabilities, slug)
+      ? input.capabilities[slug]
+      : undefined;
     if (capabilities) {
       entries.push([slug, capabilities]);
     } else if (!currentModels.has(slug)) {

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -25,6 +25,10 @@ import {
   type ServerProvider,
   type ServerProviderModel,
 } from "@t3tools/contracts";
+import {
+  filterCustomModelCapabilities,
+  getDeclaredCustomModelCapabilities,
+} from "@t3tools/shared/model";
 
 import { cn } from "../../lib/utils";
 import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
@@ -144,6 +148,7 @@ export function deriveProviderModelsForDisplay(input: {
   readonly liveModels: ReadonlyArray<ServerProviderModel> | undefined;
   readonly customModels: ReadonlyArray<string>;
   readonly customModelCapabilities?: Readonly<Record<string, ModelCapabilities>>;
+  readonly driverKind: ProviderDriverKind | null;
 }): ReadonlyArray<ServerProviderModel> {
   const liveCustomModelsBySlug = new Map(
     Arr.filterMap(input.liveModels ?? [], (model) =>
@@ -156,10 +161,14 @@ export function deriveProviderModelsForDisplay(input: {
     .filter((slug) => !serverModelSlugs.has(slug))
     .map((slug) => {
       const liveModel = liveCustomModelsBySlug.get(slug);
+      const configuredCapabilities = getDeclaredCustomModelCapabilities(
+        input.customModelCapabilities,
+        slug,
+      );
       const capabilities =
-        input.customModelCapabilities && Object.hasOwn(input.customModelCapabilities, slug)
-          ? input.customModelCapabilities[slug]
-          : undefined;
+        configuredCapabilities && input.driverKind
+          ? filterCustomModelCapabilities(input.driverKind, configuredCapabilities)
+          : configuredCapabilities;
       if (liveModel) {
         return capabilities ? { ...liveModel, capabilities } : liveModel;
       }
@@ -494,6 +503,7 @@ export function ProviderInstanceCard({
     liveModels: liveProvider?.models,
     customModels,
     customModelCapabilities,
+    driverKind,
   });
 
   const updateDisplayName = (value: string) => {

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -126,16 +126,35 @@ export function reconcileCustomModelCapabilities(input: {
   readonly nextModels: ReadonlyArray<string>;
 }): Readonly<Record<string, ModelCapabilities>> {
   const currentModels = new Set(input.currentModels);
-  const nextCapabilities: Record<string, ModelCapabilities> = {};
+  const entries: Array<readonly [string, ModelCapabilities]> = [];
   for (const slug of input.nextModels) {
     const capabilities = input.capabilities[slug];
     if (capabilities) {
-      nextCapabilities[slug] = capabilities;
+      entries.push([slug, capabilities]);
     } else if (!currentModels.has(slug)) {
-      nextCapabilities[slug] = { optionDescriptors: [] };
+      entries.push([slug, { optionDescriptors: [] }]);
     }
   }
-  return nextCapabilities;
+  return Object.fromEntries(entries);
+}
+
+export function updateCustomModelCapabilitiesRecord(
+  current: Readonly<Record<string, ModelCapabilities>>,
+  slug: string,
+  capabilities: ModelCapabilities | undefined,
+): Readonly<Record<string, ModelCapabilities>> {
+  const next = Object.fromEntries(Object.entries(current));
+  if (capabilities) {
+    Object.defineProperty(next, slug, {
+      value: capabilities,
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+  } else {
+    delete next[slug];
+  }
+  return next;
 }
 
 export function deriveProviderModelsForDisplay(input: {
@@ -544,12 +563,11 @@ export function ProviderInstanceCard({
     slug: string,
     capabilities: ModelCapabilities | undefined,
   ) => {
-    const nextCapabilities = { ...customModelCapabilities };
-    if (capabilities) {
-      nextCapabilities[slug] = capabilities;
-    } else {
-      delete nextCapabilities[slug];
-    }
+    const nextCapabilities = updateCustomModelCapabilitiesRecord(
+      customModelCapabilities,
+      slug,
+      capabilities,
+    );
     const nextConfig = nextConfigBlobWithValue(instance.config, "customModels", [...customModels]);
     if (Object.keys(nextCapabilities).length > 0) {
       nextConfig.customModelCapabilities = nextCapabilities;

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -126,16 +126,18 @@ export function reconcileCustomModelCapabilities(input: {
   readonly nextModels: ReadonlyArray<string>;
 }): Readonly<Record<string, ModelCapabilities>> {
   const currentModels = new Set(input.currentModels);
-  const nextCapabilities: Record<string, ModelCapabilities> = {};
+  const entries: Array<readonly [string, ModelCapabilities]> = [];
   for (const slug of input.nextModels) {
-    const capabilities = input.capabilities[slug];
+    const capabilities = Object.hasOwn(input.capabilities, slug)
+      ? input.capabilities[slug]
+      : undefined;
     if (capabilities) {
-      nextCapabilities[slug] = capabilities;
+      entries.push([slug, capabilities]);
     } else if (!currentModels.has(slug)) {
-      nextCapabilities[slug] = { optionDescriptors: [] };
+      entries.push([slug, { optionDescriptors: [] }]);
     }
   }
-  return nextCapabilities;
+  return Object.fromEntries(entries);
 }
 
 export function deriveProviderModelsForDisplay(input: {
@@ -154,7 +156,10 @@ export function deriveProviderModelsForDisplay(input: {
     .filter((slug) => !serverModelSlugs.has(slug))
     .map((slug) => {
       const liveModel = liveCustomModelsBySlug.get(slug);
-      const capabilities = input.customModelCapabilities?.[slug];
+      const capabilities =
+        input.customModelCapabilities && Object.hasOwn(input.customModelCapabilities, slug)
+          ? input.customModelCapabilities[slug]
+          : undefined;
       if (liveModel) {
         return capabilities ? { ...liveModel, capabilities } : liveModel;
       }
@@ -544,12 +549,10 @@ export function ProviderInstanceCard({
     slug: string,
     capabilities: ModelCapabilities | undefined,
   ) => {
-    const nextCapabilities = { ...customModelCapabilities };
-    if (capabilities) {
-      nextCapabilities[slug] = capabilities;
-    } else {
-      delete nextCapabilities[slug];
-    }
+    const nextCapabilities = Object.fromEntries([
+      ...Object.entries(customModelCapabilities).filter(([key]) => key !== slug),
+      ...(capabilities ? ([[slug, capabilities]] as const) : []),
+    ]);
     const nextConfig = nextConfigBlobWithValue(instance.config, "customModels", [...customModels]);
     if (Object.keys(nextCapabilities).length > 0) {
       nextConfig.customModelCapabilities = nextCapabilities;

--- a/apps/web/src/components/settings/ProviderModelsSection.test.ts
+++ b/apps/web/src/components/settings/ProviderModelsSection.test.ts
@@ -224,6 +224,26 @@ describe("custom model capability configuration", () => {
     ).toEqual({ optionDescriptors: [] });
   });
 
+  it("replaces a control without changing its position", () => {
+    const effort = {
+      id: "effort",
+      label: "Effort",
+      type: "select" as const,
+      options: [{ id: "high", label: "High", isDefault: true }],
+    };
+    const fastMode = { id: "fastMode", label: "Fast Mode", type: "boolean" as const };
+
+    expect(
+      replaceCustomModelCapabilityDescriptor(
+        [effort, fastMode],
+        { ...effort, label: "Reasoning effort" },
+        effort.id,
+      ),
+    ).toEqual({
+      optionDescriptors: [{ ...effort, label: "Reasoning effort" }, fastMode],
+    });
+  });
+
   it("uses legacy fallback controls only when explicit metadata is absent", () => {
     const inherited: ModelCapabilities = {
       optionDescriptors: [{ id: "fastMode", label: "Fast Mode", type: "boolean" }],

--- a/apps/web/src/components/settings/ProviderModelsSection.test.ts
+++ b/apps/web/src/components/settings/ProviderModelsSection.test.ts
@@ -89,6 +89,7 @@ describe("custom model capability configuration", () => {
     expect(markup).toContain('aria-pressed="true"');
     expect(markup).toContain("quality,high");
     expect(markup).toContain('placeholder="Add value…"');
+    expect(markup).toContain("focus-within:ring-[3px]");
   });
 
   it("adds one trimmed select value without changing existing labels", () => {

--- a/apps/web/src/components/settings/ProviderModelsSection.test.ts
+++ b/apps/web/src/components/settings/ProviderModelsSection.test.ts
@@ -117,6 +117,32 @@ describe("custom model capability configuration", () => {
       currentValue: "ultra",
     });
   });
+
+  it("uses the declared default when currentValue is absent", () => {
+    const template = {
+      id: "effort",
+      label: "Reasoning",
+      type: "select" as const,
+      options: [
+        { id: "low", label: "Low" },
+        { id: "high", label: "High", isDefault: true },
+      ],
+    };
+
+    expect(makeSelectCustomModelCapabilityDescriptor(template, ["low", "high"], undefined)).toEqual(
+      {
+        id: "effort",
+        label: "Reasoning",
+        type: "select",
+        options: [
+          { id: "low", label: "Low" },
+          { id: "high", label: "High", isDefault: true },
+        ],
+        currentValue: "high",
+      },
+    );
+  });
+
   it("accepts arbitrary values for every select descriptor", () => {
     const template = {
       id: "contextWindow",

--- a/apps/web/src/components/settings/ProviderModelsSection.test.ts
+++ b/apps/web/src/components/settings/ProviderModelsSection.test.ts
@@ -8,95 +8,51 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import {
+  CustomModelCapabilitiesEditor,
   ProviderModelsSection,
-  getCustomModelCapabilityTemplates,
+  createCustomModelCapabilityDescriptor,
   getConfiguredCustomModelOptionDescriptors,
   makeSelectCustomModelCapabilityDescriptor,
   replaceCustomModelCapabilityDescriptor,
 } from "./ProviderModelsSection";
 describe("custom model capability configuration", () => {
-  it("merges every reported descriptor and configured custom value", () => {
-    const configured: ModelCapabilities = {
-      optionDescriptors: [
-        {
-          id: "effort",
-          label: "Reasoning",
-          type: "select",
-          options: [{ id: "ultra", label: "Ultra", isDefault: true }],
-          promptInjectedValues: ["ultra"],
-        },
-      ],
-    };
-    const models: ReadonlyArray<ServerProviderModel> = [
-      {
-        slug: "built-in",
-        name: "Built In",
-        isCustom: false,
-        capabilities: {
-          optionDescriptors: [
-            {
-              id: "effort",
-              label: "Reasoning",
-              type: "select",
-              options: [
-                { id: "low", label: "Low" },
-                { id: "high", label: "High", isDefault: true },
-              ],
-            },
-            {
-              id: "fastMode",
-              label: "Fast Mode",
-              type: "boolean",
-            },
-            {
-              id: "toolMode",
-              label: "Tool Mode",
-              type: "boolean",
-            },
-          ],
-        },
-      },
-    ];
+  it("creates free-form select and boolean descriptors without provider templates", () => {
+    const select = createCustomModelCapabilityDescriptor([], "select");
+    const boolean = createCustomModelCapabilityDescriptor([select], "boolean");
 
-    expect(getCustomModelCapabilityTemplates(models, configured)).toEqual([
-      {
-        id: "effort",
-        label: "Reasoning",
-        type: "select",
-        options: [
-          { id: "low", label: "Low" },
-          { id: "high", label: "High", isDefault: true },
-          { id: "ultra", label: "Ultra", isDefault: true },
-        ],
-        promptInjectedValues: ["ultra"],
-      },
-      {
-        id: "fastMode",
-        label: "Fast Mode",
-        type: "boolean",
-      },
-      {
-        id: "toolMode",
-        label: "Tool Mode",
-        type: "boolean",
-      },
-    ]);
+    expect(select).toEqual({
+      id: "option",
+      label: "Option",
+      type: "select",
+      options: [{ id: "default", label: "Default", isDefault: true }],
+      currentValue: "default",
+    });
+    expect(boolean).toEqual({
+      id: "option2",
+      label: "Option 2",
+      type: "boolean",
+      currentValue: false,
+    });
   });
 
-  it("supports arbitrary select and boolean descriptor IDs", () => {
-    const configured: ModelCapabilities = {
-      optionDescriptors: [
-        { id: "streaming", label: "Streaming", type: "boolean" },
-        {
-          id: "temperature",
-          label: "Temperature",
-          type: "select",
-          options: [{ id: "balanced", label: "Balanced" }],
-        },
-      ],
+  it("offers free-form descriptor types when provider reports no templates", () => {
+    const model: ServerProviderModel = {
+      slug: "vendor/model",
+      name: "vendor/model",
+      isCustom: true,
+      capabilities: { optionDescriptors: [] },
     };
+    const markup = renderToStaticMarkup(
+      createElement(CustomModelCapabilitiesEditor, {
+        model,
+        value: { optionDescriptors: [] },
+        onChange: () => undefined,
+      }),
+    );
 
-    expect(getCustomModelCapabilityTemplates([], configured)).toEqual(configured.optionDescriptors);
+    expect(markup).toContain('aria-label="Add select control for vendor/model"');
+    expect(markup).toContain('aria-label="Add boolean control for vendor/model"');
+    expect(markup).not.toContain("Provider has not reported configurable model controls");
   });
 
   it("shows model details for arbitrary descriptors", () => {
@@ -161,7 +117,7 @@ describe("custom model capability configuration", () => {
       currentValue: "ultra",
     });
   });
-  it("keeps context values within the provider-supported options", () => {
+  it("accepts arbitrary values for every select descriptor", () => {
     const template = {
       id: "contextWindow",
       label: "Context Window",
@@ -183,14 +139,22 @@ describe("custom model capability configuration", () => {
       label: "Context Window",
       type: "select",
       options: [
-        { id: "200k", label: "200K", isDefault: true },
+        { id: "200k", label: "200K" },
+        { id: "unsupported", label: "Unsupported", isDefault: true },
         { id: "1m", label: "1M" },
       ],
-      currentValue: "200k",
+      currentValue: "unsupported",
     });
-    expect(makeSelectCustomModelCapabilityDescriptor(template, ["unsupported"], undefined)).toBe(
-      undefined,
+    expect(makeSelectCustomModelCapabilityDescriptor(template, ["unsupported"], undefined)).toEqual(
+      {
+        id: "contextWindow",
+        label: "Context Window",
+        type: "select",
+        options: [{ id: "unsupported", label: "Unsupported", isDefault: true }],
+        currentValue: "unsupported",
+      },
     );
+    expect(makeSelectCustomModelCapabilityDescriptor(template, [], undefined)).toBeUndefined();
   });
 
   it("preserves an explicit empty capability set when the last control is disabled", () => {

--- a/apps/web/src/components/settings/ProviderModelsSection.test.ts
+++ b/apps/web/src/components/settings/ProviderModelsSection.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vite-plus/test";
-import type { ModelCapabilities, ServerProviderModel } from "@t3tools/contracts";
+import {
+  ProviderDriverKind,
+  type ModelCapabilities,
+  type ServerProviderModel,
+} from "@t3tools/contracts";
 
 import {
   getCustomModelCapabilityTemplates,
@@ -51,7 +55,9 @@ describe("custom model capability configuration", () => {
       },
     ];
 
-    expect(getCustomModelCapabilityTemplates(models, configured)).toEqual([
+    expect(
+      getCustomModelCapabilityTemplates(models, configured, ProviderDriverKind.make("claudeAgent")),
+    ).toEqual([
       {
         id: "effort",
         label: "Reasoning",
@@ -69,6 +75,27 @@ describe("custom model capability configuration", () => {
         type: "boolean",
       },
     ]);
+  });
+
+  it("shows Cursor thinking but hides controls unsupported by the selected harness", () => {
+    const configured: ModelCapabilities = {
+      optionDescriptors: [
+        { id: "thinking", label: "Thinking", type: "boolean" },
+        {
+          id: "effort",
+          label: "Reasoning",
+          type: "select",
+          options: [{ id: "high", label: "High" }],
+        },
+      ],
+    };
+
+    expect(
+      getCustomModelCapabilityTemplates([], configured, ProviderDriverKind.make("cursor")),
+    ).toEqual([{ id: "thinking", label: "Thinking", type: "boolean" }]);
+    expect(
+      getCustomModelCapabilityTemplates([], configured, ProviderDriverKind.make("grok")),
+    ).toEqual([]);
   });
 
   it("builds declared supported values with one explicit default", () => {

--- a/apps/web/src/components/settings/ProviderModelsSection.test.ts
+++ b/apps/web/src/components/settings/ProviderModelsSection.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
   ProviderInstanceId,
+  ProviderDriverKind,
   type ModelCapabilities,
   type SelectProviderOptionDescriptor,
   type ServerProviderModel,
@@ -10,11 +11,16 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import {
   CustomModelCapabilitiesEditor,
+  CustomModelCapabilityCopyPicker,
   ProviderModelsSection,
   addSelectCustomModelCapabilityValue,
   applySelectCustomModelCapabilityUpdate,
+  collectCustomModelCapabilityCopySources,
+  copyCustomModelCapabilityDescriptors,
   createCustomModelCapabilityDescriptor,
+  filterCustomModelCapabilityCopySources,
   getConfiguredCustomModelOptionDescriptors,
+  getSelectedCustomModelCapabilityCopyDescriptors,
   isSelectCustomModelCapabilityValueCommitKey,
   makeSelectCustomModelCapabilityDescriptor,
   replaceCustomModelCapabilityDescriptor,
@@ -52,6 +58,7 @@ describe("custom model capability configuration", () => {
         model,
         value: { optionDescriptors: [] },
         onChange: () => undefined,
+        copySources: [],
         onSave: () => undefined,
       }),
     );
@@ -83,6 +90,7 @@ describe("custom model capability configuration", () => {
           ],
         },
         onChange: () => undefined,
+        copySources: [],
         onSave: () => undefined,
       }),
     );
@@ -197,12 +205,268 @@ describe("custom model capability configuration", () => {
           ],
         },
         onChange: () => undefined,
+        copySources: [],
         onSave: () => undefined,
       }),
     );
 
     expect(markup).toContain("ON / OFF");
     expect(markup).toContain(">Save</button>");
+    expect(markup).toContain(">Copy controls</button>");
+  });
+
+  it("collects declared controls from multiple harnesses", () => {
+    expect(
+      collectCustomModelCapabilityCopySources([
+        {
+          instanceId: ProviderInstanceId.make("codex_default"),
+          driver: ProviderDriverKind.make("codex"),
+          displayName: "Work Codex",
+          models: [
+            {
+              slug: "gpt-5",
+              name: "GPT 5",
+              isCustom: false,
+              capabilities: {
+                optionDescriptors: [
+                  {
+                    id: "fastMode",
+                    label: "Fast Mode",
+                    type: "boolean",
+                    currentValue: false,
+                  },
+                ],
+              },
+            },
+            {
+              slug: "plain-model",
+              name: "Plain model",
+              isCustom: false,
+              capabilities: null,
+            },
+          ],
+        },
+        {
+          instanceId: ProviderInstanceId.make("claude_default"),
+          driver: ProviderDriverKind.make("claudeAgent"),
+          models: [
+            {
+              slug: "opus",
+              name: "Opus",
+              isCustom: false,
+              capabilities: {
+                optionDescriptors: [
+                  {
+                    id: "fastMode",
+                    label: "Fast Mode",
+                    type: "boolean",
+                    currentValue: false,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ]),
+    ).toEqual([
+      {
+        providerInstanceId: ProviderInstanceId.make("codex_default"),
+        providerLabel: "Work Codex",
+        modelSlug: "gpt-5",
+        modelName: "GPT 5",
+        optionDescriptors: [
+          {
+            id: "fastMode",
+            label: "Fast Mode",
+            type: "boolean",
+            currentValue: false,
+          },
+        ],
+      },
+      {
+        providerInstanceId: ProviderInstanceId.make("claude_default"),
+        providerLabel: "claudeAgent",
+        modelSlug: "opus",
+        modelName: "Opus",
+        optionDescriptors: [
+          {
+            id: "fastMode",
+            label: "Fast Mode",
+            type: "boolean",
+            currentValue: false,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("disambiguates harness instances that share a display name", () => {
+    const providers = ["codex_one", "codex_two"].map((instanceId) => ({
+      instanceId: ProviderInstanceId.make(instanceId),
+      driver: ProviderDriverKind.make("codex"),
+      displayName: "Codex",
+      models: [
+        {
+          slug: `${instanceId}/model`,
+          name: `${instanceId} model`,
+          isCustom: false,
+          capabilities: {
+            optionDescriptors: [{ id: "effort", label: "Reasoning", type: "boolean" as const }],
+          },
+        },
+      ],
+    }));
+
+    expect(
+      collectCustomModelCapabilityCopySources(providers).map((source) => source.providerLabel),
+    ).toEqual(["Codex (codex_one)", "Codex (codex_two)"]);
+  });
+
+  it("clears checked controls when a refreshed catalog changes the source model", () => {
+    const source = {
+      providerInstanceId: ProviderInstanceId.make("codex_default"),
+      providerLabel: "Codex",
+      modelSlug: "new-model",
+      modelName: "New model",
+      optionDescriptors: [{ id: "effort", label: "New effort", type: "boolean" as const }],
+    };
+
+    expect(
+      getSelectedCustomModelCapabilityCopyDescriptors(source, {
+        providerInstanceId: ProviderInstanceId.make("codex_default"),
+        modelSlug: "removed-model",
+        descriptorIds: new Set(["effort"]),
+      }),
+    ).toEqual([]);
+  });
+
+  it("excludes only the custom model currently being edited from copy sources", () => {
+    const sources = [
+      {
+        providerInstanceId: ProviderInstanceId.make("codex_default"),
+        providerLabel: "Codex",
+        modelSlug: "target",
+        modelName: "Target",
+        optionDescriptors: [{ id: "effort", label: "Reasoning", type: "boolean" as const }],
+      },
+      {
+        providerInstanceId: ProviderInstanceId.make("codex_default"),
+        providerLabel: "Codex",
+        modelSlug: "other",
+        modelName: "Other",
+        optionDescriptors: [{ id: "effort", label: "Reasoning", type: "boolean" as const }],
+      },
+      {
+        providerInstanceId: ProviderInstanceId.make("claude_default"),
+        providerLabel: "Claude",
+        modelSlug: "target",
+        modelName: "Target",
+        optionDescriptors: [{ id: "effort", label: "Reasoning", type: "boolean" as const }],
+      },
+    ];
+
+    expect(
+      filterCustomModelCapabilityCopySources(
+        sources,
+        ProviderInstanceId.make("codex_default"),
+        "target",
+      ).map((source) => `${source.providerInstanceId}:${source.modelSlug}`),
+    ).toEqual(["codex_default:other", "claude_default:target"]);
+  });
+
+  it("shows harness, model, and multiple controls in the copy picker", () => {
+    const markup = renderToStaticMarkup(
+      createElement(CustomModelCapabilityCopyPicker, {
+        sources: [
+          {
+            providerInstanceId: ProviderInstanceId.make("codex_default"),
+            providerLabel: "Work Codex",
+            modelSlug: "gpt-5",
+            modelName: "GPT 5",
+            optionDescriptors: [
+              {
+                id: "reasoningEffort",
+                label: "Reasoning",
+                type: "select",
+                options: [{ id: "high", label: "High", isDefault: true }],
+                currentValue: "high",
+              },
+              {
+                id: "serviceTier",
+                label: "Fast service",
+                type: "boolean",
+                currentValue: false,
+              },
+            ],
+          },
+        ],
+        onCopy: () => undefined,
+        onCancel: () => undefined,
+      }),
+    );
+
+    expect(markup).toContain('aria-label="Harness to copy controls from"');
+    expect(markup).toContain("Work Codex");
+    expect(markup).toContain('aria-label="Model to copy controls from"');
+    expect(markup).toContain("GPT 5");
+    expect(markup).toContain('aria-label="Copy Reasoning (reasoningEffort)"');
+    expect(markup).toContain('aria-label="Copy Fast service (serviceTier)"');
+    expect(markup).toContain("Copies exact IDs and values");
+    expect(markup).toContain(">Copy selected</button>");
+  });
+
+  it("replaces copied controls in place and appends new controls", () => {
+    expect(
+      copyCustomModelCapabilityDescriptors(
+        [
+          {
+            id: "effort",
+            label: "Old effort",
+            type: "select",
+            options: [{ id: "medium", label: "Medium" }],
+          },
+          { id: "thinking", label: "Thinking", type: "boolean", currentValue: false },
+        ],
+        [
+          {
+            id: "effort",
+            label: "Reasoning",
+            type: "select",
+            options: [
+              { id: "low", label: "Low" },
+              { id: "high", label: "High", isDefault: true },
+            ],
+            currentValue: "high",
+          },
+          {
+            id: "contextWindow",
+            label: "Context Window",
+            type: "select",
+            options: [{ id: "1m", label: "1M", isDefault: true }],
+            currentValue: "1m",
+          },
+        ],
+      ),
+    ).toEqual([
+      {
+        id: "effort",
+        label: "Reasoning",
+        type: "select",
+        options: [
+          { id: "low", label: "Low" },
+          { id: "high", label: "High", isDefault: true },
+        ],
+        currentValue: "high",
+      },
+      { id: "thinking", label: "Thinking", type: "boolean", currentValue: false },
+      {
+        id: "contextWindow",
+        label: "Context Window",
+        type: "select",
+        options: [{ id: "1m", label: "1M", isDefault: true }],
+        currentValue: "1m",
+      },
+    ]);
   });
 
   it("shows model details for arbitrary descriptors", () => {
@@ -227,6 +491,7 @@ describe("custom model capability configuration", () => {
         driverKind: null,
         models: [model],
         customModels: [model.slug],
+        sourceProviders: [],
         customModelCapabilities: {},
         onCustomModelCapabilitiesChange: () => undefined,
         hiddenModels: [],

--- a/apps/web/src/components/settings/ProviderModelsSection.test.ts
+++ b/apps/web/src/components/settings/ProviderModelsSection.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { ModelCapabilities, ServerProviderModel } from "@t3tools/contracts";
+
+import {
+  getCustomModelCapabilityTemplates,
+  getConfiguredCustomModelOptionDescriptors,
+  makeSelectCustomModelCapabilityDescriptor,
+  replaceCustomModelCapabilityDescriptor,
+} from "./ProviderModelsSection";
+describe("custom model capability configuration", () => {
+  it("merges provider-supported controls and configured custom values", () => {
+    const configured: ModelCapabilities = {
+      optionDescriptors: [
+        {
+          id: "effort",
+          label: "Reasoning",
+          type: "select",
+          options: [{ id: "ultra", label: "Ultra", isDefault: true }],
+        },
+      ],
+    };
+    const models: ReadonlyArray<ServerProviderModel> = [
+      {
+        slug: "built-in",
+        name: "Built In",
+        isCustom: false,
+        capabilities: {
+          optionDescriptors: [
+            {
+              id: "effort",
+              label: "Reasoning",
+              type: "select",
+              options: [
+                { id: "low", label: "Low" },
+                { id: "high", label: "High", isDefault: true },
+              ],
+            },
+            {
+              id: "fastMode",
+              label: "Fast Mode",
+              type: "boolean",
+            },
+            {
+              id: "toolMode",
+              label: "Tool Mode",
+              type: "boolean",
+            },
+          ],
+        },
+      },
+    ];
+
+    expect(getCustomModelCapabilityTemplates(models, configured)).toEqual([
+      {
+        id: "effort",
+        label: "Reasoning",
+        type: "select",
+        options: [
+          { id: "low", label: "Low" },
+          { id: "high", label: "High", isDefault: true },
+          { id: "ultra", label: "Ultra", isDefault: true },
+        ],
+      },
+      {
+        id: "fastMode",
+        label: "Fast Mode",
+        type: "boolean",
+      },
+    ]);
+  });
+
+  it("builds declared supported values with one explicit default", () => {
+    const template = {
+      id: "effort",
+      label: "Reasoning",
+      description: "Controls reasoning effort.",
+      type: "select" as const,
+      options: [
+        { id: "low", label: "Low" },
+        { id: "high", label: "High", isDefault: true },
+        { id: "ultra", label: "Ultra" },
+      ],
+    };
+
+    expect(makeSelectCustomModelCapabilityDescriptor(template, ["low", "ultra"], "ultra")).toEqual({
+      id: "effort",
+      label: "Reasoning",
+      description: "Controls reasoning effort.",
+      type: "select",
+      options: [
+        { id: "low", label: "Low" },
+        { id: "ultra", label: "Ultra", isDefault: true },
+      ],
+      currentValue: "ultra",
+    });
+  });
+  it("keeps context values within the provider-supported options", () => {
+    const template = {
+      id: "contextWindow",
+      label: "Context Window",
+      type: "select" as const,
+      options: [
+        { id: "200k", label: "200K", isDefault: true },
+        { id: "1m", label: "1M" },
+      ],
+    };
+
+    expect(
+      makeSelectCustomModelCapabilityDescriptor(
+        template,
+        ["200k", "unsupported", "1m"],
+        "unsupported",
+      ),
+    ).toEqual({
+      id: "contextWindow",
+      label: "Context Window",
+      type: "select",
+      options: [
+        { id: "200k", label: "200K", isDefault: true },
+        { id: "1m", label: "1M" },
+      ],
+      currentValue: "200k",
+    });
+    expect(makeSelectCustomModelCapabilityDescriptor(template, ["unsupported"], undefined)).toBe(
+      undefined,
+    );
+  });
+
+  it("preserves an explicit empty capability set when the last control is disabled", () => {
+    expect(
+      replaceCustomModelCapabilityDescriptor(
+        [{ id: "fastMode", label: "Fast Mode", type: "boolean" }],
+        undefined,
+        "fastMode",
+      ),
+    ).toEqual({ optionDescriptors: [] });
+  });
+
+  it("uses legacy fallback controls only when explicit metadata is absent", () => {
+    const inherited: ModelCapabilities = {
+      optionDescriptors: [{ id: "fastMode", label: "Fast Mode", type: "boolean" }],
+    };
+
+    expect(getConfiguredCustomModelOptionDescriptors(undefined, inherited)).toEqual(
+      inherited.optionDescriptors,
+    );
+    expect(getConfiguredCustomModelOptionDescriptors({}, inherited)).toEqual([]);
+    expect(getConfiguredCustomModelOptionDescriptors({ optionDescriptors: [] }, inherited)).toEqual(
+      [],
+    );
+  });
+});

--- a/apps/web/src/components/settings/ProviderModelsSection.test.ts
+++ b/apps/web/src/components/settings/ProviderModelsSection.test.ts
@@ -16,7 +16,6 @@ describe("custom model capability configuration", () => {
           label: "Reasoning",
           type: "select",
           options: [{ id: "ultra", label: "Ultra", isDefault: true }],
-          promptInjectedValues: ["ultra"],
         },
       ],
     };
@@ -61,7 +60,6 @@ describe("custom model capability configuration", () => {
           { id: "high", label: "High", isDefault: true },
           { id: "ultra", label: "Ultra", isDefault: true },
         ],
-        promptInjectedValues: ["ultra"],
       },
       {
         id: "fastMode",

--- a/apps/web/src/components/settings/ProviderModelsSection.test.ts
+++ b/apps/web/src/components/settings/ProviderModelsSection.test.ts
@@ -1,18 +1,21 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
-  ProviderDriverKind,
+  ProviderInstanceId,
   type ModelCapabilities,
   type ServerProviderModel,
 } from "@t3tools/contracts";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 
 import {
+  ProviderModelsSection,
   getCustomModelCapabilityTemplates,
   getConfiguredCustomModelOptionDescriptors,
   makeSelectCustomModelCapabilityDescriptor,
   replaceCustomModelCapabilityDescriptor,
 } from "./ProviderModelsSection";
 describe("custom model capability configuration", () => {
-  it("merges provider-supported controls and configured custom values", () => {
+  it("merges every reported descriptor and configured custom value", () => {
     const configured: ModelCapabilities = {
       optionDescriptors: [
         {
@@ -55,9 +58,7 @@ describe("custom model capability configuration", () => {
       },
     ];
 
-    expect(
-      getCustomModelCapabilityTemplates(models, configured, ProviderDriverKind.make("claudeAgent")),
-    ).toEqual([
+    expect(getCustomModelCapabilityTemplates(models, configured)).toEqual([
       {
         id: "effort",
         label: "Reasoning",
@@ -74,28 +75,65 @@ describe("custom model capability configuration", () => {
         label: "Fast Mode",
         type: "boolean",
       },
+      {
+        id: "toolMode",
+        label: "Tool Mode",
+        type: "boolean",
+      },
     ]);
   });
 
-  it("shows Cursor thinking but hides controls unsupported by the selected harness", () => {
+  it("supports arbitrary select and boolean descriptor IDs", () => {
     const configured: ModelCapabilities = {
       optionDescriptors: [
-        { id: "thinking", label: "Thinking", type: "boolean" },
+        { id: "streaming", label: "Streaming", type: "boolean" },
         {
-          id: "effort",
-          label: "Reasoning",
+          id: "temperature",
+          label: "Temperature",
           type: "select",
-          options: [{ id: "high", label: "High" }],
+          options: [{ id: "balanced", label: "Balanced" }],
         },
       ],
     };
 
-    expect(
-      getCustomModelCapabilityTemplates([], configured, ProviderDriverKind.make("cursor")),
-    ).toEqual([{ id: "thinking", label: "Thinking", type: "boolean" }]);
-    expect(
-      getCustomModelCapabilityTemplates([], configured, ProviderDriverKind.make("grok")),
-    ).toEqual([]);
+    expect(getCustomModelCapabilityTemplates([], configured)).toEqual(configured.optionDescriptors);
+  });
+
+  it("shows model details for arbitrary descriptors", () => {
+    const model: ServerProviderModel = {
+      slug: "vendor/model",
+      name: "vendor/model",
+      isCustom: true,
+      capabilities: {
+        optionDescriptors: [
+          {
+            id: "temperature",
+            label: "Temperature",
+            type: "select",
+            options: [{ id: "balanced", label: "Balanced" }],
+          },
+        ],
+      },
+    };
+    const markup = renderToStaticMarkup(
+      createElement(ProviderModelsSection, {
+        instanceId: ProviderInstanceId.make("test-provider"),
+        driverKind: null,
+        models: [model],
+        customModels: [model.slug],
+        customModelCapabilities: {},
+        onCustomModelCapabilitiesChange: () => undefined,
+        hiddenModels: [],
+        favoriteModels: [],
+        modelOrder: [],
+        onChange: () => undefined,
+        onHiddenModelsChange: () => undefined,
+        onFavoriteModelsChange: () => undefined,
+        onModelOrderChange: () => undefined,
+      }),
+    );
+
+    expect(markup).toContain('aria-label="Details for vendor/model"');
   });
 
   it("builds declared supported values with one explicit default", () => {

--- a/apps/web/src/components/settings/ProviderModelsSection.test.ts
+++ b/apps/web/src/components/settings/ProviderModelsSection.test.ts
@@ -16,6 +16,7 @@ describe("custom model capability configuration", () => {
           label: "Reasoning",
           type: "select",
           options: [{ id: "ultra", label: "Ultra", isDefault: true }],
+          promptInjectedValues: ["ultra"],
         },
       ],
     };
@@ -60,6 +61,7 @@ describe("custom model capability configuration", () => {
           { id: "high", label: "High", isDefault: true },
           { id: "ultra", label: "Ultra", isDefault: true },
         ],
+        promptInjectedValues: ["ultra"],
       },
       {
         id: "fastMode",

--- a/apps/web/src/components/settings/ProviderModelsSection.test.ts
+++ b/apps/web/src/components/settings/ProviderModelsSection.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   ProviderInstanceId,
   type ModelCapabilities,
+  type SelectProviderOptionDescriptor,
   type ServerProviderModel,
 } from "@t3tools/contracts";
 import { createElement } from "react";
@@ -11,6 +12,7 @@ import {
   CustomModelCapabilitiesEditor,
   ProviderModelsSection,
   addSelectCustomModelCapabilityValue,
+  applySelectCustomModelCapabilityUpdate,
   createCustomModelCapabilityDescriptor,
   getConfiguredCustomModelOptionDescriptors,
   isSelectCustomModelCapabilityValueCommitKey,
@@ -131,6 +133,43 @@ describe("custom model capability configuration", () => {
       ],
       currentValue: "high",
     });
+  });
+
+  it("keeps a blurred value when the next tag action sets the default", () => {
+    const descriptorRef: { current: SelectProviderOptionDescriptor } = {
+      current: {
+        id: "effort",
+        label: "Reasoning",
+        type: "select" as const,
+        options: [
+          { id: "low", label: "Low", isDefault: true },
+          { id: "high", label: "High" },
+        ],
+        currentValue: "low",
+      },
+    };
+    let savedDescriptor: SelectProviderOptionDescriptor = descriptorRef.current;
+    const saveDescriptor = (descriptor: SelectProviderOptionDescriptor) => {
+      savedDescriptor = descriptor;
+    };
+
+    applySelectCustomModelCapabilityUpdate(
+      descriptorRef,
+      (descriptor) => addSelectCustomModelCapabilityValue(descriptor, "max"),
+      saveDescriptor,
+    );
+    applySelectCustomModelCapabilityUpdate(
+      descriptorRef,
+      (descriptor) => setSelectCustomModelCapabilityDefault(descriptor, "high"),
+      saveDescriptor,
+    );
+
+    expect(savedDescriptor.options).toEqual([
+      { id: "low", label: "Low" },
+      { id: "high", label: "High", isDefault: true },
+      { id: "max", label: "Max" },
+    ]);
+    expect(savedDescriptor.currentValue).toBe("high");
   });
 
   it("commits select values with space, comma, or Enter", () => {

--- a/apps/web/src/components/settings/ProviderModelsSection.test.ts
+++ b/apps/web/src/components/settings/ProviderModelsSection.test.ts
@@ -10,10 +10,13 @@ import { renderToStaticMarkup } from "react-dom/server";
 import {
   CustomModelCapabilitiesEditor,
   ProviderModelsSection,
+  addSelectCustomModelCapabilityValue,
   createCustomModelCapabilityDescriptor,
   getConfiguredCustomModelOptionDescriptors,
+  isSelectCustomModelCapabilityValueCommitKey,
   makeSelectCustomModelCapabilityDescriptor,
   replaceCustomModelCapabilityDescriptor,
+  setSelectCustomModelCapabilityDefault,
 } from "./ProviderModelsSection";
 describe("custom model capability configuration", () => {
   it("creates free-form select and boolean descriptors without provider templates", () => {
@@ -47,6 +50,7 @@ describe("custom model capability configuration", () => {
         model,
         value: { optionDescriptors: [] },
         onChange: () => undefined,
+        onSave: () => undefined,
       }),
     );
 
@@ -55,7 +59,7 @@ describe("custom model capability configuration", () => {
     expect(markup).not.toContain("Provider has not reported configurable model controls");
   });
 
-  it("renders each select value independently so commas stay inside IDs", () => {
+  it("renders exact select values as tags so commas stay inside IDs", () => {
     const model: ServerProviderModel = {
       slug: "vendor/model",
       name: "vendor/model",
@@ -77,13 +81,88 @@ describe("custom model capability configuration", () => {
           ],
         },
         onChange: () => undefined,
+        onSave: () => undefined,
       }),
     );
 
-    expect(markup).toContain('aria-label="Value 1 for Quality"');
-    expect(markup).toContain('aria-label="Value label 1 for Quality"');
-    expect(markup).toContain('value="quality,high"');
-    expect(markup).toContain('value="Quality high"');
+    expect(markup).toContain('aria-label="Set quality,high as default for Quality"');
+    expect(markup).toContain('aria-pressed="true"');
+    expect(markup).toContain("quality,high");
+    expect(markup).toContain('placeholder="Add value…"');
+  });
+
+  it("adds one trimmed select value without changing existing labels", () => {
+    const descriptor = {
+      id: "quality",
+      label: "Quality",
+      type: "select" as const,
+      options: [{ id: "low", label: "Low quality", isDefault: true }],
+      currentValue: "low",
+    };
+
+    expect(addSelectCustomModelCapabilityValue(descriptor, " quality,high ")).toEqual({
+      ...descriptor,
+      options: [
+        { id: "low", label: "Low quality", isDefault: true },
+        { id: "quality,high", label: "Quality,high" },
+      ],
+    });
+    expect(addSelectCustomModelCapabilityValue(descriptor, " low ")).toBe(descriptor);
+  });
+
+  it("makes a clicked select value the only default", () => {
+    const descriptor = {
+      id: "effort",
+      label: "Reasoning",
+      type: "select" as const,
+      options: [
+        { id: "low", label: "Low", isDefault: true },
+        { id: "high", label: "High" },
+      ],
+      currentValue: "low",
+    };
+
+    expect(setSelectCustomModelCapabilityDefault(descriptor, "high")).toEqual({
+      ...descriptor,
+      options: [
+        { id: "low", label: "Low" },
+        { id: "high", label: "High", isDefault: true },
+      ],
+      currentValue: "high",
+    });
+  });
+
+  it("commits select values with space, comma, or Enter", () => {
+    expect([" ", ",", "Enter"].map(isSelectCustomModelCapabilityValueCommitKey)).toEqual([
+      true,
+      true,
+      true,
+    ]);
+    expect(isSelectCustomModelCapabilityValueCommitKey("Tab")).toBe(false);
+  });
+
+  it("shows a Save action and capitalized boolean heading", () => {
+    const model: ServerProviderModel = {
+      slug: "vendor/model",
+      name: "vendor/model",
+      isCustom: true,
+      capabilities: { optionDescriptors: [] },
+    };
+    const markup = renderToStaticMarkup(
+      createElement(CustomModelCapabilitiesEditor, {
+        model,
+        value: {
+          optionDescriptors: [
+            { id: "fastMode", label: "Fast Mode", type: "boolean", currentValue: false },
+          ],
+        },
+        onChange: () => undefined,
+        onSave: () => undefined,
+      }),
+    );
+
+    expect(markup).toContain("ON / OFF");
+    expect(markup).toContain(">Save</button>");
   });
 
   it("shows model details for arbitrary descriptors", () => {

--- a/apps/web/src/components/settings/ProviderModelsSection.test.ts
+++ b/apps/web/src/components/settings/ProviderModelsSection.test.ts
@@ -55,6 +55,37 @@ describe("custom model capability configuration", () => {
     expect(markup).not.toContain("Provider has not reported configurable model controls");
   });
 
+  it("renders each select value independently so commas stay inside IDs", () => {
+    const model: ServerProviderModel = {
+      slug: "vendor/model",
+      name: "vendor/model",
+      isCustom: true,
+      capabilities: { optionDescriptors: [] },
+    };
+    const markup = renderToStaticMarkup(
+      createElement(CustomModelCapabilitiesEditor, {
+        model,
+        value: {
+          optionDescriptors: [
+            {
+              id: "quality",
+              label: "Quality",
+              type: "select",
+              options: [{ id: "quality,high", label: "Quality high", isDefault: true }],
+              currentValue: "quality,high",
+            },
+          ],
+        },
+        onChange: () => undefined,
+      }),
+    );
+
+    expect(markup).toContain('aria-label="Value 1 for Quality"');
+    expect(markup).toContain('aria-label="Value label 1 for Quality"');
+    expect(markup).toContain('value="quality,high"');
+    expect(markup).toContain('value="Quality high"');
+  });
+
   it("shows model details for arbitrary descriptors", () => {
     const model: ServerProviderModel = {
       slug: "vendor/model",

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -134,8 +134,15 @@ export function replaceCustomModelCapabilityDescriptor(
   descriptor: ProviderOptionDescriptor | undefined,
   id: string,
 ): ModelCapabilities {
-  const next = configured.filter((candidate) => candidate.id !== id);
-  if (descriptor) next.push(descriptor);
+  const next = [...configured];
+  const index = next.findIndex((candidate) => candidate.id === id);
+  if (index < 0) {
+    if (descriptor) next.push(descriptor);
+  } else if (descriptor) {
+    next[index] = descriptor;
+  } else {
+    next.splice(index, 1);
+  }
   return { optionDescriptors: next };
 }
 

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -163,11 +163,23 @@ export function isSelectCustomModelCapabilityValueCommitKey(key: string): boolea
   return key === " " || key === "," || key === "Enter";
 }
 
+export function applySelectCustomModelCapabilityUpdate(
+  descriptorRef: { current: SelectProviderOptionDescriptor },
+  update: (descriptor: SelectProviderOptionDescriptor) => SelectProviderOptionDescriptor,
+  onChange: (descriptor: SelectProviderOptionDescriptor) => void,
+): void {
+  const descriptor = update(descriptorRef.current);
+  if (descriptor === descriptorRef.current) return;
+  descriptorRef.current = descriptor;
+  onChange(descriptor);
+}
+
 function SelectCustomModelCapabilityValueTag(props: {
   readonly descriptor: SelectProviderOptionDescriptor;
   readonly option: SelectProviderOptionDescriptor["options"][number];
   readonly defaultValue: string | undefined;
-  readonly onChange: (descriptor: SelectProviderOptionDescriptor) => void;
+  readonly onSelect: () => void;
+  readonly onRemove: () => void;
 }) {
   const isDefault = props.option.id === props.defaultValue;
   return (
@@ -181,9 +193,7 @@ function SelectCustomModelCapabilityValueTag(props: {
         className="h-full min-w-0 cursor-pointer truncate rounded-l-sm py-0.5 ps-1.5 pe-1 text-[11px] outline-none focus-visible:ring-2 focus-visible:ring-ring"
         aria-label={`Set ${props.option.id} as default for ${props.descriptor.label}`}
         aria-pressed={isDefault}
-        onClick={() =>
-          props.onChange(setSelectCustomModelCapabilityDefault(props.descriptor, props.option.id))
-        }
+        onClick={props.onSelect}
       >
         {props.option.id}
       </button>
@@ -192,16 +202,7 @@ function SelectCustomModelCapabilityValueTag(props: {
         className="flex h-full w-5 cursor-pointer items-center justify-center rounded-r-sm outline-none opacity-70 hover:opacity-100 focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-35"
         disabled={props.descriptor.options.length === 1}
         aria-label={`Remove ${props.option.id} from ${props.descriptor.label}`}
-        onClick={() => {
-          const descriptor = makeSelectCustomModelCapabilityDescriptor(
-            props.descriptor,
-            props.descriptor.options
-              .filter((candidate) => candidate.id !== props.option.id)
-              .map((candidate) => candidate.id),
-            props.descriptor.currentValue,
-          );
-          if (descriptor) props.onChange(descriptor);
-        }}
+        onClick={props.onRemove}
       >
         <XIcon className="size-3" />
       </button>
@@ -214,14 +215,18 @@ function SelectCustomModelCapabilityValues(props: {
   readonly onChange: (descriptor: SelectProviderOptionDescriptor) => void;
 }) {
   const [draftValue, setDraftValue] = useState("");
+  const descriptorRef = useRef(props.descriptor);
+  descriptorRef.current = props.descriptor;
   const defaultValue = resolveSelectCustomModelCapabilityDefault(
     props.descriptor,
     props.descriptor.options.map((option) => option.id),
     props.descriptor.currentValue,
   );
+  const updateDescriptor = (
+    update: (descriptor: SelectProviderOptionDescriptor) => SelectProviderOptionDescriptor,
+  ) => applySelectCustomModelCapabilityUpdate(descriptorRef, update, props.onChange);
   const commitInput = () => {
-    const next = addSelectCustomModelCapabilityValue(props.descriptor, draftValue);
-    if (next !== props.descriptor) props.onChange(next);
+    updateDescriptor((descriptor) => addSelectCustomModelCapabilityValue(descriptor, draftValue));
     setDraftValue("");
   };
 
@@ -235,7 +240,23 @@ function SelectCustomModelCapabilityValues(props: {
             descriptor={props.descriptor}
             option={option}
             defaultValue={defaultValue}
-            onChange={props.onChange}
+            onSelect={() =>
+              updateDescriptor((descriptor) =>
+                setSelectCustomModelCapabilityDefault(descriptor, option.id),
+              )
+            }
+            onRemove={() =>
+              updateDescriptor(
+                (descriptor) =>
+                  makeSelectCustomModelCapabilityDescriptor(
+                    descriptor,
+                    descriptor.options
+                      .filter((candidate) => candidate.id !== option.id)
+                      .map((candidate) => candidate.id),
+                    descriptor.currentValue,
+                  ) ?? descriptor,
+              )
+            }
           />
         ))}
         <Input
@@ -447,12 +468,17 @@ function CustomModelCapabilitiesPopover(props: {
 }) {
   const [open, setOpen] = useState(false);
   const [draft, setDraft] = useState(props.value);
+  const draftRef = useRef(props.value);
+  const updateDraft = (capabilities: ModelCapabilities | undefined) => {
+    draftRef.current = capabilities;
+    setDraft(capabilities);
+  };
 
   return (
     <Popover
       open={open}
       onOpenChange={(nextOpen) => {
-        if (nextOpen) setDraft(props.value);
+        if (nextOpen) updateDraft(props.value);
         setOpen(nextOpen);
       }}
     >
@@ -482,9 +508,9 @@ function CustomModelCapabilitiesPopover(props: {
         <CustomModelCapabilitiesEditor
           model={props.model}
           value={draft}
-          onChange={setDraft}
+          onChange={updateDraft}
           onSave={() => {
-            props.onSave(draft);
+            props.onSave(draftRef.current);
             setOpen(false);
           }}
         />

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -22,7 +22,6 @@ import {
 } from "@t3tools/contracts";
 import {
   getDeclaredCustomModelCapabilities,
-  isCustomModelOptionDescriptorSupported,
   normalizeCustomModelSlug,
 } from "@t3tools/shared/model";
 
@@ -54,7 +53,6 @@ const CLAUDE_DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
 export function getCustomModelCapabilityTemplates(
   models: ReadonlyArray<ServerProviderModel>,
   configured: ModelCapabilities | undefined,
-  driverKind: ProviderDriverKind | null,
 ): ReadonlyArray<ProviderOptionDescriptor> {
   const templates = new Map<string, ProviderOptionDescriptor>();
   const descriptors = [
@@ -63,7 +61,6 @@ export function getCustomModelCapabilityTemplates(
   ];
 
   for (const descriptor of descriptors) {
-    if (!driverKind || !isCustomModelOptionDescriptorSupported(driverKind, descriptor)) continue;
     const current = templates.get(descriptor.id);
     if (!current) {
       templates.set(descriptor.id, descriptor);
@@ -170,7 +167,7 @@ function CustomModelCapabilitiesEditor(props: {
     props.value,
     props.model.capabilities,
   );
-  const templates = getCustomModelCapabilityTemplates(props.models, props.value, props.driverKind);
+  const templates = getCustomModelCapabilityTemplates(props.models, props.value);
 
   const replaceDescriptor = (descriptor: ProviderOptionDescriptor | undefined, id: string) => {
     props.onChange(replaceCustomModelCapabilityDescriptor(configuredDescriptors, descriptor, id));
@@ -483,7 +480,6 @@ export function ProviderModelsSection({
       <div ref={listRef} className="mt-2 max-h-40 overflow-y-auto pb-1">
         {orderedModels.map((model, index) => {
           const caps = model.capabilities;
-          const capLabels: string[] = [];
           const isHidden = !model.isCustom && hiddenModelSet.has(model.slug);
           const isFavorite = favoriteModelSet.has(model.slug);
           const previousModel = orderedModels[index - 1];
@@ -493,24 +489,7 @@ export function ProviderModelsSection({
           const canMoveDown =
             nextModel !== undefined && favoriteModelSet.has(nextModel.slug) === isFavorite;
           const descriptors = caps?.optionDescriptors ?? [];
-          if (descriptors.some((descriptor) => descriptor.id === "fastMode")) {
-            capLabels.push("Fast mode");
-          }
-          if (descriptors.some((descriptor) => descriptor.id === "thinking")) {
-            capLabels.push("Thinking");
-          }
-          if (
-            descriptors.some(
-              (descriptor) =>
-                descriptor.type === "select" &&
-                (descriptor.id === "reasoningEffort" ||
-                  descriptor.id === "effort" ||
-                  descriptor.id === "reasoning" ||
-                  descriptor.id === "variant"),
-            )
-          ) {
-            capLabels.push("Reasoning");
-          }
+          const capLabels = [...new Set(descriptors.map((descriptor) => descriptor.label))];
           const hasDetails = capLabels.length > 0 || model.name !== model.slug;
 
           return (

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -28,11 +28,11 @@ import {
 import { cn } from "../../lib/utils";
 import { sortModelsForProviderInstance } from "../../modelOrdering";
 import { MAX_CUSTOM_MODEL_LENGTH } from "../../modelSelection";
+import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { DraftInput } from "../ui/draft-input";
 import { Input } from "../ui/input";
 import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
-import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
 import { Switch } from "../ui/switch";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 
@@ -129,6 +129,145 @@ export function makeSelectCustomModelCapabilityDescriptor(
     ...(promptInjectedValues && promptInjectedValues.length > 0 ? { promptInjectedValues } : {}),
   };
 }
+
+export function addSelectCustomModelCapabilityValue(
+  descriptor: SelectProviderOptionDescriptor,
+  rawValue: string,
+): SelectProviderOptionDescriptor {
+  const id = rawValue.trim();
+  if (!id || descriptor.options.some((option) => option.id === id)) return descriptor;
+  return (
+    makeSelectCustomModelCapabilityDescriptor(
+      descriptor,
+      [...descriptor.options.map((option) => option.id), id],
+      descriptor.currentValue,
+    ) ?? descriptor
+  );
+}
+
+export function setSelectCustomModelCapabilityDefault(
+  descriptor: SelectProviderOptionDescriptor,
+  defaultValueId: string,
+): SelectProviderOptionDescriptor {
+  if (!descriptor.options.some((option) => option.id === defaultValueId)) return descriptor;
+  return (
+    makeSelectCustomModelCapabilityDescriptor(
+      descriptor,
+      descriptor.options.map((option) => option.id),
+      defaultValueId,
+    ) ?? descriptor
+  );
+}
+
+export function isSelectCustomModelCapabilityValueCommitKey(key: string): boolean {
+  return key === " " || key === "," || key === "Enter";
+}
+
+function SelectCustomModelCapabilityValueTag(props: {
+  readonly descriptor: SelectProviderOptionDescriptor;
+  readonly option: SelectProviderOptionDescriptor["options"][number];
+  readonly defaultValue: string | undefined;
+  readonly onChange: (descriptor: SelectProviderOptionDescriptor) => void;
+}) {
+  const isDefault = props.option.id === props.defaultValue;
+  return (
+    <Badge
+      variant={isDefault ? "default" : "outline"}
+      className="h-5.5 gap-0 px-0 sm:h-5"
+      title={props.option.label === props.option.id ? undefined : props.option.label}
+    >
+      <button
+        type="button"
+        className="h-full min-w-0 cursor-pointer truncate rounded-l-sm py-0.5 ps-1.5 pe-1 text-[11px] outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        aria-label={`Set ${props.option.id} as default for ${props.descriptor.label}`}
+        aria-pressed={isDefault}
+        onClick={() =>
+          props.onChange(setSelectCustomModelCapabilityDefault(props.descriptor, props.option.id))
+        }
+      >
+        {props.option.id}
+      </button>
+      <button
+        type="button"
+        className="flex h-full w-5 cursor-pointer items-center justify-center rounded-r-sm outline-none opacity-70 hover:opacity-100 focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-35"
+        disabled={props.descriptor.options.length === 1}
+        aria-label={`Remove ${props.option.id} from ${props.descriptor.label}`}
+        onClick={() => {
+          const descriptor = makeSelectCustomModelCapabilityDescriptor(
+            props.descriptor,
+            props.descriptor.options
+              .filter((candidate) => candidate.id !== props.option.id)
+              .map((candidate) => candidate.id),
+            props.descriptor.currentValue,
+          );
+          if (descriptor) props.onChange(descriptor);
+        }}
+      >
+        <XIcon className="size-3" />
+      </button>
+    </Badge>
+  );
+}
+
+function SelectCustomModelCapabilityValues(props: {
+  readonly descriptor: SelectProviderOptionDescriptor;
+  readonly onChange: (descriptor: SelectProviderOptionDescriptor) => void;
+}) {
+  const [draftValue, setDraftValue] = useState("");
+  const defaultValue = resolveSelectCustomModelCapabilityDefault(
+    props.descriptor,
+    props.descriptor.options.map((option) => option.id),
+    props.descriptor.currentValue,
+  );
+  const commitInput = () => {
+    const next = addSelectCustomModelCapabilityValue(props.descriptor, draftValue);
+    if (next !== props.descriptor) props.onChange(next);
+    setDraftValue("");
+  };
+
+  return (
+    <div className="grid gap-1">
+      <span className="text-[11px] text-muted-foreground">Values</span>
+      <div className="flex min-h-8 flex-wrap items-center gap-1 rounded-md border border-input bg-background p-1 shadow-xs/5 dark:bg-input/32">
+        {props.descriptor.options.map((option) => (
+          <SelectCustomModelCapabilityValueTag
+            key={option.id}
+            descriptor={props.descriptor}
+            option={option}
+            defaultValue={defaultValue}
+            onChange={props.onChange}
+          />
+        ))}
+        <Input
+          nativeInput
+          unstyled
+          size="compact"
+          className="min-w-20 flex-1"
+          value={draftValue}
+          onChange={(event) => setDraftValue(event.target.value)}
+          onKeyDown={(event) => {
+            if (
+              event.nativeEvent.isComposing ||
+              !isSelectCustomModelCapabilityValueCommitKey(event.key)
+            ) {
+              return;
+            }
+            event.preventDefault();
+            commitInput();
+          }}
+          onBlur={commitInput}
+          placeholder="Add value…"
+          aria-label={`Add value to ${props.descriptor.label}`}
+          spellCheck={false}
+        />
+      </div>
+      <span className="text-[10px] leading-snug text-muted-foreground">
+        Press Space, comma, or Enter to add. Click a value to make it the default.
+      </span>
+    </div>
+  );
+}
+
 export function replaceCustomModelCapabilityDescriptor(
   configured: ReadonlyArray<ProviderOptionDescriptor>,
   descriptor: ProviderOptionDescriptor | undefined,
@@ -159,6 +298,7 @@ export function CustomModelCapabilitiesEditor(props: {
   readonly model: ServerProviderModel;
   readonly value: ModelCapabilities | undefined;
   readonly onChange: (value: ModelCapabilities | undefined) => void;
+  readonly onSave: () => void;
 }) {
   const configuredDescriptors = getConfiguredCustomModelOptionDescriptors(
     props.value,
@@ -211,7 +351,7 @@ export function CustomModelCapabilitiesEditor(props: {
           <div key={descriptor.id} className="rounded-md border border-border/70 p-2.5">
             <div className="flex items-center justify-between gap-2">
               <span className="text-[11px] font-medium text-muted-foreground">
-                {descriptor.type === "select" ? "Select" : "On / off"}
+                {descriptor.type === "select" ? "Select" : "ON / OFF"}
               </span>
               <Button
                 size="icon-micro"
@@ -246,164 +386,11 @@ export function CustomModelCapabilitiesEditor(props: {
             </div>
 
             {descriptor.type === "select" ? (
-              <div className="mt-2 grid gap-2">
-                <div className="grid gap-1 text-[11px] text-muted-foreground">
-                  <span>Values</span>
-                  <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_1.25rem] gap-1.5 px-0.5 text-[10px]">
-                    <span>ID</span>
-                    <span>Label</span>
-                  </div>
-                  {descriptor.options.map((option, index) => (
-                    <div
-                      key={option.id}
-                      className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_1.25rem] items-center gap-1.5"
-                    >
-                      <DraftInput
-                        size="compact"
-                        value={option.id}
-                        onCommit={(value) => {
-                          const id = value.trim();
-                          if (
-                            !id ||
-                            descriptor.options.some(
-                              (candidate, candidateIndex) =>
-                                candidateIndex !== index && candidate.id === id,
-                            )
-                          ) {
-                            return;
-                          }
-                          replaceDescriptor(
-                            {
-                              ...descriptor,
-                              options: descriptor.options.map((candidate, candidateIndex) =>
-                                candidateIndex === index ? { ...candidate, id } : candidate,
-                              ),
-                              ...(descriptor.currentValue === option.id
-                                ? { currentValue: id }
-                                : {}),
-                              ...(descriptor.promptInjectedValues
-                                ? {
-                                    promptInjectedValues: descriptor.promptInjectedValues.map(
-                                      (value) => (value === option.id ? id : value),
-                                    ),
-                                  }
-                                : {}),
-                            },
-                            descriptor.id,
-                          );
-                        }}
-                        aria-label={`Value ${index + 1} for ${descriptor.label}`}
-                        spellCheck={false}
-                      />
-                      <DraftInput
-                        size="compact"
-                        value={option.label}
-                        onCommit={(value) => {
-                          const label = value.trim();
-                          if (!label) return;
-                          replaceDescriptor(
-                            {
-                              ...descriptor,
-                              options: descriptor.options.map((candidate, candidateIndex) =>
-                                candidateIndex === index ? { ...candidate, label } : candidate,
-                              ),
-                            },
-                            descriptor.id,
-                          );
-                        }}
-                        aria-label={`Value label ${index + 1} for ${descriptor.label}`}
-                      />
-                      <Button
-                        size="icon-micro"
-                        variant="ghost-muted"
-                        disabled={descriptor.options.length === 1}
-                        onClick={() =>
-                          replaceDescriptor(
-                            makeSelectCustomModelCapabilityDescriptor(
-                              descriptor,
-                              descriptor.options
-                                .filter((_, candidateIndex) => candidateIndex !== index)
-                                .map((candidate) => candidate.id),
-                              descriptor.currentValue,
-                            ),
-                            descriptor.id,
-                          )
-                        }
-                        aria-label={`Remove ${option.id} from ${descriptor.label}`}
-                      >
-                        <XIcon />
-                      </Button>
-                    </div>
-                  ))}
-                  <Button
-                    size="xs"
-                    variant="ghost-muted"
-                    className="w-fit"
-                    onClick={() => {
-                      const ids = new Set(descriptor.options.map((option) => option.id));
-                      let suffix = 1;
-                      while (ids.has(suffix === 1 ? "value" : `value${suffix}`)) suffix += 1;
-                      const id = suffix === 1 ? "value" : `value${suffix}`;
-                      const isFirst = descriptor.options.length === 0;
-                      replaceDescriptor(
-                        {
-                          ...descriptor,
-                          options: [
-                            ...descriptor.options,
-                            {
-                              id,
-                              label: capabilityOptionLabel(id),
-                              ...(isFirst ? { isDefault: true } : {}),
-                            },
-                          ],
-                          ...(isFirst ? { currentValue: id } : {}),
-                        },
-                        descriptor.id,
-                      );
-                    }}
-                    aria-label={`Add value to ${descriptor.label}`}
-                  >
-                    <PlusIcon />
-                    Add value
-                  </Button>
-                </div>
-                <label className="grid gap-1 text-[11px] text-muted-foreground">
-                  Default
-                  <Select
-                    value={
-                      resolveSelectCustomModelCapabilityDefault(
-                        descriptor,
-                        descriptor.options.map((option) => option.id),
-                        descriptor.currentValue,
-                      ) ?? ""
-                    }
-                    onValueChange={(value) =>
-                      replaceDescriptor(
-                        makeSelectCustomModelCapabilityDescriptor(
-                          descriptor,
-                          descriptor.options.map((option) => option.id),
-                          value ?? undefined,
-                        ),
-                        descriptor.id,
-                      )
-                    }
-                  >
-                    <SelectTrigger
-                      size="compact"
-                      className="w-full min-w-0"
-                      aria-label={`Default ${descriptor.label}`}
-                    >
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectPopup alignItemWithTrigger={false}>
-                      {descriptor.options.map((option) => (
-                        <SelectItem key={option.id} value={option.id}>
-                          {option.label}
-                        </SelectItem>
-                      ))}
-                    </SelectPopup>
-                  </Select>
-                </label>
+              <div className="mt-2">
+                <SelectCustomModelCapabilityValues
+                  descriptor={descriptor}
+                  onChange={(next) => replaceDescriptor(next, descriptor.id)}
+                />
               </div>
             ) : (
               <div className="mt-2 flex items-center justify-between gap-3 text-[11px] text-muted-foreground">
@@ -424,27 +411,85 @@ export function CustomModelCapabilitiesEditor(props: {
         );
       })}
 
-      <div className="flex flex-wrap gap-1.5">
-        <Button
-          size="xs"
-          variant="outline"
-          onClick={() => addDescriptor("select")}
-          aria-label={`Add select control for ${props.model.name}`}
-        >
-          <PlusIcon />
-          Add select
-        </Button>
-        <Button
-          size="xs"
-          variant="outline"
-          onClick={() => addDescriptor("boolean")}
-          aria-label={`Add boolean control for ${props.model.name}`}
-        >
-          <PlusIcon />
-          Add on / off
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex flex-wrap gap-1.5">
+          <Button
+            size="xs"
+            variant="outline"
+            onClick={() => addDescriptor("select")}
+            aria-label={`Add select control for ${props.model.name}`}
+          >
+            <PlusIcon />
+            Add select
+          </Button>
+          <Button
+            size="xs"
+            variant="outline"
+            onClick={() => addDescriptor("boolean")}
+            aria-label={`Add boolean control for ${props.model.name}`}
+          >
+            <PlusIcon />
+            Add on / off
+          </Button>
+        </div>
+        <Button size="xs" onClick={props.onSave}>
+          Save
         </Button>
       </div>
     </div>
+  );
+}
+
+function CustomModelCapabilitiesPopover(props: {
+  readonly model: ServerProviderModel;
+  readonly value: ModelCapabilities | undefined;
+  readonly onSave: (capabilities: ModelCapabilities | undefined) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState(props.value);
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (nextOpen) setDraft(props.value);
+        setOpen(nextOpen);
+      }}
+    >
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <PopoverTrigger
+              render={
+                <Button
+                  size="icon-micro"
+                  variant="ghost-muted"
+                  aria-label={`Configure capabilities for ${props.model.slug}`}
+                />
+              }
+            />
+          }
+        >
+          <Settings2Icon className="size-3" />
+        </TooltipTrigger>
+        <TooltipPopup side="top">Configure model controls</TooltipPopup>
+      </Tooltip>
+      <PopoverPopup
+        side="left"
+        align="start"
+        className="w-[min(24rem,calc(100vw-1.5rem))] [--popup-width:min(24rem,calc(100vw-1.5rem))]"
+      >
+        <CustomModelCapabilitiesEditor
+          model={props.model}
+          value={draft}
+          onChange={setDraft}
+          onSave={() => {
+            props.onSave(draft);
+            setOpen(false);
+          }}
+        />
+      </PopoverPopup>
+    </Popover>
   );
 }
 
@@ -754,40 +799,13 @@ export function ProviderModelsSection({
                   </Tooltip>
                 ) : null}
                 {model.isCustom ? (
-                  <Popover>
-                    <Tooltip>
-                      <TooltipTrigger
-                        render={
-                          <PopoverTrigger
-                            render={
-                              <Button
-                                size="icon-micro"
-                                variant="ghost-muted"
-                                aria-label={`Configure capabilities for ${model.slug}`}
-                              />
-                            }
-                          />
-                        }
-                      >
-                        <Settings2Icon className="size-3" />
-                      </TooltipTrigger>
-                      <TooltipPopup side="top">Configure model controls</TooltipPopup>
-                    </Tooltip>
-                    <PopoverPopup
-                      side="left"
-                      align="start"
-                      className="w-[min(24rem,calc(100vw-1.5rem))] [--popup-width:min(24rem,calc(100vw-1.5rem))]"
-                    >
-                      <CustomModelCapabilitiesEditor
-                        model={model}
-                        value={getDeclaredCustomModelCapabilities(
-                          customModelCapabilities,
-                          model.slug,
-                        )}
-                        onChange={(value) => onCustomModelCapabilitiesChange(model.slug, value)}
-                      />
-                    </PopoverPopup>
-                  </Popover>
+                  <CustomModelCapabilitiesPopover
+                    model={model}
+                    value={getDeclaredCustomModelCapabilities(customModelCapabilities, model.slug)}
+                    onSave={(capabilities) =>
+                      onCustomModelCapabilitiesChange(model.slug, capabilities)
+                    }
+                  />
                 ) : null}
                 {model.isCustom ? (
                   <Tooltip>

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -272,7 +272,11 @@ function CustomModelCapabilitiesEditor(props: {
                         )
                       }
                     >
-                      <SelectTrigger size="compact" aria-label={`Default ${template.label}`}>
+                      <SelectTrigger
+                        size="compact"
+                        className="w-full min-w-0"
+                        aria-label={`Default ${template.label}`}
+                      >
                         <SelectValue />
                       </SelectTrigger>
                       <SelectPopup alignItemWithTrigger={false}>

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -77,19 +77,12 @@ export function getCustomModelCapabilityTemplates(
     if (current.type !== "select" || descriptor.type !== "select") continue;
 
     const optionIds = new Set(current.options.map((option) => option.id));
-    const promptInjectedValues = [
-      ...new Set([
-        ...(current.promptInjectedValues ?? []),
-        ...(descriptor.promptInjectedValues ?? []),
-      ]),
-    ];
     templates.set(descriptor.id, {
       ...current,
       options: [
         ...current.options,
         ...descriptor.options.filter((option) => !optionIds.has(option.id)),
       ],
-      ...(promptInjectedValues.length > 0 ? { promptInjectedValues } : {}),
     });
   }
 
@@ -240,7 +233,6 @@ function CustomModelCapabilitiesEditor(props: {
                   <label className="grid gap-1 text-[11px] text-muted-foreground">
                     Supported values
                     <DraftInput
-                      size="compact"
                       value={configured.options.map((option) => option.id).join(", ")}
                       onCommit={(value) => {
                         const supportedValues = value.split(",").map((entry) => entry.trim());
@@ -272,11 +264,7 @@ function CustomModelCapabilitiesEditor(props: {
                         )
                       }
                     >
-                      <SelectTrigger
-                        size="compact"
-                        className="w-full min-w-0"
-                        aria-label={`Default ${template.label}`}
-                      >
+                      <SelectTrigger size="compact" aria-label={`Default ${template.label}`}>
                         <SelectValue />
                       </SelectTrigger>
                       <SelectPopup alignItemWithTrigger={false}>
@@ -650,24 +638,17 @@ export function ProviderModelsSection({
                 ) : null}
                 {model.isCustom ? (
                   <Popover>
-                    <Tooltip>
-                      <TooltipTrigger
-                        render={
-                          <PopoverTrigger
-                            render={
-                              <Button
-                                size="icon-micro"
-                                variant="ghost-muted"
-                                aria-label={`Configure capabilities for ${model.slug}`}
-                              />
-                            }
-                          />
-                        }
-                      >
-                        <Settings2Icon className="size-3" />
-                      </TooltipTrigger>
-                      <TooltipPopup side="top">Configure model controls</TooltipPopup>
-                    </Tooltip>
+                    <PopoverTrigger
+                      render={
+                        <Button
+                          size="icon-micro"
+                          variant="ghost-muted"
+                          aria-label={`Configure capabilities for ${model.slug}`}
+                        >
+                          <Settings2Icon className="size-3" />
+                        </Button>
+                      }
+                    />
                     <PopoverPopup
                       side="left"
                       align="start"

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -20,7 +20,11 @@ import {
   type SelectProviderOptionDescriptor,
   type ServerProviderModel,
 } from "@t3tools/contracts";
-import { normalizeCustomModelSlug } from "@t3tools/shared/model";
+import {
+  getDeclaredCustomModelCapabilities,
+  isCustomModelOptionDescriptorSupported,
+  normalizeCustomModelSlug,
+} from "@t3tools/shared/model";
 
 import { cn } from "../../lib/utils";
 import { sortModelsForProviderInstance } from "../../modelOrdering";
@@ -47,19 +51,10 @@ const CUSTOM_MODEL_PLACEHOLDER_BY_KIND: Partial<Record<ProviderDriverKind, strin
 };
 
 const CLAUDE_DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
-const CONFIGURABLE_CUSTOM_MODEL_OPTION_IDS = new Set([
-  "effort",
-  "reasoningEffort",
-  "reasoning",
-  "variant",
-  "fastMode",
-  "serviceTier",
-  "contextWindow",
-]);
-
 export function getCustomModelCapabilityTemplates(
   models: ReadonlyArray<ServerProviderModel>,
   configured: ModelCapabilities | undefined,
+  driverKind: ProviderDriverKind | null,
 ): ReadonlyArray<ProviderOptionDescriptor> {
   const templates = new Map<string, ProviderOptionDescriptor>();
   const descriptors = [
@@ -68,7 +63,7 @@ export function getCustomModelCapabilityTemplates(
   ];
 
   for (const descriptor of descriptors) {
-    if (!CONFIGURABLE_CUSTOM_MODEL_OPTION_IDS.has(descriptor.id)) continue;
+    if (!driverKind || !isCustomModelOptionDescriptorSupported(driverKind, descriptor)) continue;
     const current = templates.get(descriptor.id);
     if (!current) {
       templates.set(descriptor.id, descriptor);
@@ -175,7 +170,7 @@ function CustomModelCapabilitiesEditor(props: {
     props.value,
     props.model.capabilities,
   );
-  const templates = getCustomModelCapabilityTemplates(props.models, props.value);
+  const templates = getCustomModelCapabilityTemplates(props.models, props.value, props.driverKind);
 
   const replaceDescriptor = (descriptor: ProviderOptionDescriptor | undefined, id: string) => {
     props.onChange(replaceCustomModelCapabilityDescriptor(configuredDescriptors, descriptor, id));
@@ -677,7 +672,10 @@ export function ProviderModelsSection({
                         driverKind={driverKind}
                         models={models}
                         model={model}
-                        value={customModelCapabilities[model.slug]}
+                        value={getDeclaredCustomModelCapabilities(
+                          customModelCapabilities,
+                          model.slug,
+                        )}
                         onChange={(value) => onCustomModelCapabilitiesChange(model.slug, value)}
                       />
                     </PopoverPopup>

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -77,12 +77,19 @@ export function getCustomModelCapabilityTemplates(
     if (current.type !== "select" || descriptor.type !== "select") continue;
 
     const optionIds = new Set(current.options.map((option) => option.id));
+    const promptInjectedValues = [
+      ...new Set([
+        ...(current.promptInjectedValues ?? []),
+        ...(descriptor.promptInjectedValues ?? []),
+      ]),
+    ];
     templates.set(descriptor.id, {
       ...current,
       options: [
         ...current.options,
         ...descriptor.options.filter((option) => !optionIds.has(option.id)),
       ],
+      ...(promptInjectedValues.length > 0 ? { promptInjectedValues } : {}),
     });
   }
 
@@ -233,6 +240,7 @@ function CustomModelCapabilitiesEditor(props: {
                   <label className="grid gap-1 text-[11px] text-muted-foreground">
                     Supported values
                     <DraftInput
+                      size="compact"
                       value={configured.options.map((option) => option.id).join(", ")}
                       onCommit={(value) => {
                         const supportedValues = value.split(",").map((entry) => entry.trim());
@@ -264,7 +272,11 @@ function CustomModelCapabilitiesEditor(props: {
                         )
                       }
                     >
-                      <SelectTrigger size="compact" aria-label={`Default ${template.label}`}>
+                      <SelectTrigger
+                        size="compact"
+                        className="w-full min-w-0"
+                        aria-label={`Default ${template.label}`}
+                      >
                         <SelectValue />
                       </SelectTrigger>
                       <SelectPopup alignItemWithTrigger={false}>
@@ -638,17 +650,24 @@ export function ProviderModelsSection({
                 ) : null}
                 {model.isCustom ? (
                   <Popover>
-                    <PopoverTrigger
-                      render={
-                        <Button
-                          size="icon-micro"
-                          variant="ghost-muted"
-                          aria-label={`Configure capabilities for ${model.slug}`}
-                        >
-                          <Settings2Icon className="size-3" />
-                        </Button>
-                      }
-                    />
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <PopoverTrigger
+                            render={
+                              <Button
+                                size="icon-micro"
+                                variant="ghost-muted"
+                                aria-label={`Configure capabilities for ${model.slug}`}
+                              />
+                            }
+                          />
+                        }
+                      >
+                        <Settings2Icon className="size-3" />
+                      </TooltipTrigger>
+                      <TooltipPopup side="top">Configure model controls</TooltipPopup>
+                    </Tooltip>
                     <PopoverPopup
                       side="left"
                       align="start"

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -3,6 +3,7 @@
 import {
   ArrowDownIcon,
   ArrowUpIcon,
+  CopyIcon,
   EyeIcon,
   EyeOffIcon,
   InfoIcon,
@@ -18,6 +19,7 @@ import {
   type ProviderInstanceId,
   type ProviderOptionDescriptor,
   type SelectProviderOptionDescriptor,
+  type ServerProvider,
   type ServerProviderModel,
 } from "@t3tools/contracts";
 import {
@@ -28,9 +30,11 @@ import {
 import { cn } from "../../lib/utils";
 import { sortModelsForProviderInstance } from "../../modelOrdering";
 import { MAX_CUSTOM_MODEL_LENGTH } from "../../modelSelection";
+import { Checkbox } from "../ui/checkbox";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { DraftInput } from "../ui/draft-input";
+import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
 import { Input } from "../ui/input";
 import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
 import { Switch } from "../ui/switch";
@@ -315,12 +319,239 @@ export function getConfiguredCustomModelOptionDescriptors(
     : (configured.optionDescriptors ?? []);
 }
 
+type CustomModelCapabilitySourceProvider = Pick<
+  ServerProvider,
+  "instanceId" | "driver" | "displayName" | "models"
+>;
+
+interface CustomModelCapabilityCopySource {
+  readonly providerInstanceId: ProviderInstanceId;
+  readonly providerLabel: string;
+  readonly modelSlug: string;
+  readonly modelName: string;
+  readonly optionDescriptors: ReadonlyArray<ProviderOptionDescriptor>;
+}
+
+interface CustomModelCapabilityCopySelection {
+  readonly providerInstanceId: ProviderInstanceId;
+  readonly modelSlug: string;
+  readonly descriptorIds: ReadonlySet<string>;
+}
+
+export function collectCustomModelCapabilityCopySources(
+  providers: ReadonlyArray<CustomModelCapabilitySourceProvider>,
+): ReadonlyArray<CustomModelCapabilityCopySource> {
+  const sources: Array<CustomModelCapabilityCopySource> = [];
+  for (const provider of providers) {
+    const baseLabel = provider.displayName ?? String(provider.driver);
+    const hasDuplicateLabel = providers.some(
+      (candidate) =>
+        candidate.instanceId !== provider.instanceId &&
+        (candidate.displayName ?? String(candidate.driver)) === baseLabel,
+    );
+    for (const model of provider.models) {
+      const optionDescriptors = model.capabilities?.optionDescriptors ?? [];
+      if (optionDescriptors.length === 0) continue;
+      sources.push({
+        providerInstanceId: provider.instanceId,
+        providerLabel: hasDuplicateLabel ? `${baseLabel} (${provider.instanceId})` : baseLabel,
+        modelSlug: model.slug,
+        modelName: model.name,
+        optionDescriptors,
+      });
+    }
+  }
+  return sources;
+}
+
+export function filterCustomModelCapabilityCopySources(
+  sources: ReadonlyArray<CustomModelCapabilityCopySource>,
+  instanceId: ProviderInstanceId,
+  modelSlug: string,
+): ReadonlyArray<CustomModelCapabilityCopySource> {
+  return sources.filter(
+    (source) => source.providerInstanceId !== instanceId || source.modelSlug !== modelSlug,
+  );
+}
+
+export function getSelectedCustomModelCapabilityCopyDescriptors(
+  source: CustomModelCapabilityCopySource,
+  selection: CustomModelCapabilityCopySelection | undefined,
+): ReadonlyArray<ProviderOptionDescriptor> {
+  if (
+    selection?.providerInstanceId !== source.providerInstanceId ||
+    selection.modelSlug !== source.modelSlug
+  ) {
+    return [];
+  }
+  return source.optionDescriptors.filter((descriptor) =>
+    selection.descriptorIds.has(descriptor.id),
+  );
+}
+
+export function copyCustomModelCapabilityDescriptors(
+  configured: ReadonlyArray<ProviderOptionDescriptor>,
+  copied: ReadonlyArray<ProviderOptionDescriptor>,
+): ReadonlyArray<ProviderOptionDescriptor> {
+  const copiedById = new Map(copied.map((descriptor) => [descriptor.id, descriptor]));
+  const configuredIds = new Set(configured.map((descriptor) => descriptor.id));
+  return [
+    ...configured.map((descriptor) => copiedById.get(descriptor.id) ?? descriptor),
+    ...copied.filter((descriptor) => !configuredIds.has(descriptor.id)),
+  ];
+}
+
+export function CustomModelCapabilityCopyPicker(props: {
+  readonly sources: ReadonlyArray<CustomModelCapabilityCopySource>;
+  readonly onCopy: (descriptors: ReadonlyArray<ProviderOptionDescriptor>) => void;
+  readonly onCancel: () => void;
+}) {
+  const providers = [
+    ...new Map(
+      props.sources.map((source) => [
+        source.providerInstanceId,
+        {
+          instanceId: source.providerInstanceId,
+          label: source.providerLabel,
+        },
+      ]),
+    ).values(),
+  ];
+  const [providerInstanceId, setProviderInstanceId] = useState(
+    props.sources[0]?.providerInstanceId,
+  );
+  const provider =
+    providers.find((candidate) => candidate.instanceId === providerInstanceId) ?? providers[0];
+  const models = props.sources.filter(
+    (candidate) => candidate.providerInstanceId === provider?.instanceId,
+  );
+  const [modelSlug, setModelSlug] = useState(props.sources[0]?.modelSlug);
+  const [selection, setSelection] = useState<CustomModelCapabilityCopySelection>();
+  const source = models.find((candidate) => candidate.modelSlug === modelSlug) ?? models[0];
+
+  if (!provider || !source) return null;
+  const selectedDescriptors = getSelectedCustomModelCapabilityCopyDescriptors(source, selection);
+  const selectedIds = new Set(selectedDescriptors.map((descriptor) => descriptor.id));
+
+  const selectProvider = (value: ProviderInstanceId | null) => {
+    if (value === null) return;
+    const nextProvider = providers.find((candidate) => candidate.instanceId === value);
+    if (!nextProvider) return;
+    const nextSource = props.sources.find(
+      (candidate) => candidate.providerInstanceId === nextProvider.instanceId,
+    );
+    setProviderInstanceId(nextProvider.instanceId);
+    setModelSlug(nextSource?.modelSlug);
+    setSelection(undefined);
+  };
+
+  const selectModel = (value: string | null) => {
+    if (value === null) return;
+    if (!models.some((candidate) => candidate.modelSlug === value)) return;
+    setModelSlug(value);
+    setSelection(undefined);
+  };
+
+  const toggleDescriptor = (id: string, checked: boolean) => {
+    const descriptorIds = new Set(selectedIds);
+    if (checked) descriptorIds.add(id);
+    else descriptorIds.delete(id);
+    setSelection({
+      providerInstanceId: source.providerInstanceId,
+      modelSlug: source.modelSlug,
+      descriptorIds,
+    });
+  };
+
+  return (
+    <div className="grid gap-2.5 rounded-md border border-border/70 p-2.5">
+      <div className="grid grid-cols-2 gap-2">
+        <label className="grid min-w-0 gap-1 text-[11px] text-muted-foreground">
+          Harness
+          <Select value={provider.instanceId} onValueChange={selectProvider}>
+            <SelectTrigger
+              size="compact"
+              className="w-full min-w-0"
+              aria-label="Harness to copy controls from"
+            >
+              <SelectValue>{provider.label}</SelectValue>
+            </SelectTrigger>
+            <SelectPopup alignItemWithTrigger={false}>
+              {providers.map((candidate) => (
+                <SelectItem key={candidate.instanceId} hideIndicator value={candidate.instanceId}>
+                  {candidate.label}
+                </SelectItem>
+              ))}
+            </SelectPopup>
+          </Select>
+        </label>
+        <label className="grid min-w-0 gap-1 text-[11px] text-muted-foreground">
+          Model
+          <Select value={source.modelSlug} onValueChange={selectModel}>
+            <SelectTrigger
+              size="compact"
+              className="w-full min-w-0"
+              aria-label="Model to copy controls from"
+            >
+              <SelectValue>{source.modelName}</SelectValue>
+            </SelectTrigger>
+            <SelectPopup alignItemWithTrigger={false}>
+              {models.map((candidate) => (
+                <SelectItem key={candidate.modelSlug} hideIndicator value={candidate.modelSlug}>
+                  {candidate.modelName}
+                </SelectItem>
+              ))}
+            </SelectPopup>
+          </Select>
+        </label>
+      </div>
+
+      <div className="grid gap-1">
+        {source.optionDescriptors.map((descriptor) => (
+          <label
+            key={descriptor.id}
+            className="flex min-h-7 items-center gap-2 rounded-sm px-1.5 text-xs text-foreground hover:bg-muted/50"
+          >
+            <Checkbox
+              checked={selectedIds.has(descriptor.id)}
+              onCheckedChange={(checked) => toggleDescriptor(descriptor.id, Boolean(checked))}
+              aria-label={`Copy ${descriptor.label} (${descriptor.id})`}
+            />
+            <span className="min-w-0 truncate">{descriptor.label}</span>
+            <code className="ml-auto shrink-0 text-[10px] text-muted-foreground">
+              {descriptor.id}
+            </code>
+          </label>
+        ))}
+      </div>
+
+      <p className="text-[10px] leading-snug text-muted-foreground">
+        Copies exact IDs and values. Target harness decides whether it can send them.
+      </p>
+      <div className="flex justify-end gap-1.5">
+        <Button size="xs" variant="ghost-muted" onClick={props.onCancel}>
+          Cancel
+        </Button>
+        <Button
+          size="xs"
+          disabled={selectedDescriptors.length === 0}
+          onClick={() => props.onCopy(selectedDescriptors)}
+        >
+          Copy selected
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 export function CustomModelCapabilitiesEditor(props: {
   readonly model: ServerProviderModel;
   readonly value: ModelCapabilities | undefined;
+  readonly copySources: ReadonlyArray<CustomModelCapabilityCopySource>;
   readonly onChange: (value: ModelCapabilities | undefined) => void;
   readonly onSave: () => void;
 }) {
+  const [copyOpen, setCopyOpen] = useState(false);
   const configuredDescriptors = getConfiguredCustomModelOptionDescriptors(
     props.value,
     props.model.capabilities,
@@ -431,9 +662,44 @@ export function CustomModelCapabilitiesEditor(props: {
           </div>
         );
       })}
+      {copyOpen ? (
+        props.copySources.length > 0 ? (
+          <CustomModelCapabilityCopyPicker
+            sources={props.copySources}
+            onCopy={(descriptors) => {
+              props.onChange({
+                optionDescriptors: copyCustomModelCapabilityDescriptors(
+                  configuredDescriptors,
+                  descriptors,
+                ),
+              });
+              setCopyOpen(false);
+            }}
+            onCancel={() => setCopyOpen(false)}
+          />
+        ) : (
+          <div className="flex items-center justify-between gap-2 rounded-md border border-border/70 p-2.5">
+            <span className="text-xs text-muted-foreground">
+              No model controls available to copy.
+            </span>
+            <Button size="xs" variant="ghost-muted" onClick={() => setCopyOpen(false)}>
+              Close
+            </Button>
+          </div>
+        )
+      ) : null}
 
       <div className="flex items-center justify-between gap-2">
         <div className="flex flex-wrap gap-1.5">
+          <Button
+            size="xs"
+            variant="outline"
+            aria-expanded={copyOpen}
+            onClick={() => setCopyOpen((open) => !open)}
+          >
+            <CopyIcon />
+            Copy controls
+          </Button>
           <Button
             size="xs"
             variant="outline"
@@ -464,6 +730,7 @@ export function CustomModelCapabilitiesEditor(props: {
 function CustomModelCapabilitiesPopover(props: {
   readonly model: ServerProviderModel;
   readonly value: ModelCapabilities | undefined;
+  readonly copySources: ReadonlyArray<CustomModelCapabilityCopySource>;
   readonly onSave: (capabilities: ModelCapabilities | undefined) => void;
 }) {
   const [open, setOpen] = useState(false);
@@ -508,6 +775,7 @@ function CustomModelCapabilitiesPopover(props: {
         <CustomModelCapabilitiesEditor
           model={props.model}
           value={draft}
+          copySources={props.copySources}
           onChange={updateDraft}
           onSave={() => {
             props.onSave(draftRef.current);
@@ -532,6 +800,7 @@ interface ProviderModelsSectionProps {
    * and custom entries, distinguished by `isCustom`.
    */
   readonly models: ReadonlyArray<ServerProviderModel>;
+  readonly sourceProviders: ReadonlyArray<CustomModelCapabilitySourceProvider>;
   /**
    * The persisted custom-model slug list for this instance. Drives dedup,
    * and is the array we hand back verbatim (with the new slug appended /
@@ -575,6 +844,7 @@ export function ProviderModelsSection({
   instanceId,
   driverKind,
   models,
+  sourceProviders,
   customModels,
   customModelCapabilities,
   onCustomModelCapabilitiesChange,
@@ -591,6 +861,10 @@ export function ProviderModelsSection({
   const listRef = useRef<HTMLDivElement | null>(null);
   const hiddenModelSet = useMemo(() => new Set(hiddenModels), [hiddenModels]);
   const favoriteModelSet = useMemo(() => new Set(favoriteModels), [favoriteModels]);
+  const copySources = useMemo(
+    () => collectCustomModelCapabilityCopySources(sourceProviders),
+    [sourceProviders],
+  );
   const orderedModels = useMemo(() => {
     return sortModelsForProviderInstance(models, {
       favoriteModels: favoriteModelSet,
@@ -828,6 +1102,11 @@ export function ProviderModelsSection({
                   <CustomModelCapabilitiesPopover
                     model={model}
                     value={getDeclaredCustomModelCapabilities(customModelCapabilities, model.slug)}
+                    copySources={filterCustomModelCapabilityCopySources(
+                      copySources,
+                      instanceId,
+                      model.slug,
+                    )}
                     onSave={(capabilities) =>
                       onCustomModelCapabilitiesChange(model.slug, capabilities)
                     }

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -29,7 +29,6 @@ import { cn } from "../../lib/utils";
 import { sortModelsForProviderInstance } from "../../modelOrdering";
 import { MAX_CUSTOM_MODEL_LENGTH } from "../../modelSelection";
 import { Button } from "../ui/button";
-import { Checkbox } from "../ui/checkbox";
 import { DraftInput } from "../ui/draft-input";
 import { Input } from "../ui/input";
 import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
@@ -49,48 +48,30 @@ const CUSTOM_MODEL_PLACEHOLDER_BY_KIND: Partial<Record<ProviderDriverKind, strin
   [ProviderDriverKind.make("opencode")]: "openai/gpt-5",
 };
 
-const CLAUDE_DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
-export function getCustomModelCapabilityTemplates(
-  models: ReadonlyArray<ServerProviderModel>,
-  configured: ModelCapabilities | undefined,
-): ReadonlyArray<ProviderOptionDescriptor> {
-  const templates = new Map<string, ProviderOptionDescriptor>();
-  const descriptors = [
-    ...models.flatMap((model) => model.capabilities?.optionDescriptors ?? []),
-    ...(configured?.optionDescriptors ?? []),
-  ];
-
-  for (const descriptor of descriptors) {
-    const current = templates.get(descriptor.id);
-    if (!current) {
-      templates.set(descriptor.id, descriptor);
-      continue;
-    }
-    if (current.type !== "select" || descriptor.type !== "select") continue;
-
-    const optionIds = new Set(current.options.map((option) => option.id));
-    const promptInjectedValues = [
-      ...new Set([
-        ...(current.promptInjectedValues ?? []),
-        ...(descriptor.promptInjectedValues ?? []),
-      ]),
-    ];
-    templates.set(descriptor.id, {
-      ...current,
-      options: [
-        ...current.options,
-        ...descriptor.options.filter((option) => !optionIds.has(option.id)),
-      ],
-      ...(promptInjectedValues.length > 0 ? { promptInjectedValues } : {}),
-    });
-  }
-
-  return [...templates.values()];
-}
-
 function capabilityOptionLabel(id: string): string {
   const words = id.replaceAll(/[-_]+/g, " ").trim();
   return words.length > 0 ? words[0]!.toUpperCase() + words.slice(1) : id;
+}
+
+export function createCustomModelCapabilityDescriptor(
+  configured: ReadonlyArray<ProviderOptionDescriptor>,
+  type: ProviderOptionDescriptor["type"],
+): ProviderOptionDescriptor {
+  const ids = new Set(configured.map((descriptor) => descriptor.id));
+  let suffix = 1;
+  while (ids.has(suffix === 1 ? "option" : `option${suffix}`)) suffix += 1;
+  const id = suffix === 1 ? "option" : `option${suffix}`;
+  const label = suffix === 1 ? "Option" : `Option ${suffix}`;
+
+  return type === "select"
+    ? {
+        id,
+        label,
+        type,
+        options: [{ id: "default", label: "Default", isDefault: true }],
+        currentValue: "default",
+      }
+    : { id, label, type, currentValue: false };
 }
 
 export function makeSelectCustomModelCapabilityDescriptor(
@@ -98,19 +79,12 @@ export function makeSelectCustomModelCapabilityDescriptor(
   supportedValues: ReadonlyArray<string>,
   requestedDefault: string | undefined,
 ): SelectProviderOptionDescriptor | undefined {
-  const templateIds = new Set(template.options.map((option) => option.id));
   const values = [
-    ...new Set(
-      supportedValues
-        .map((value) => value.trim())
-        .filter((value) => value && (template.id !== "contextWindow" || templateIds.has(value))),
-    ),
+    ...new Set(supportedValues.map((value) => value.trim()).filter((value) => value.length > 0)),
   ];
-  if (values.length === 0) {
-    return undefined;
-  }
+  if (values.length === 0) return undefined;
   const defaultValue =
-    requestedDefault && values.includes(requestedDefault) ? requestedDefault : values[0]!;
+    requestedDefault && values.includes(requestedDefault) ? requestedDefault : values[0];
   const templateOptions = new Map(template.options.map((option) => [option.id, option]));
   const options = values.map((id) => {
     const templateOption = templateOptions.get(id);
@@ -133,7 +107,7 @@ export function makeSelectCustomModelCapabilityDescriptor(
     type: "select",
     options,
     ...(template.description ? { description: template.description } : {}),
-    currentValue: defaultValue,
+    ...(defaultValue ? { currentValue: defaultValue } : {}),
     ...(promptInjectedValues && promptInjectedValues.length > 0 ? { promptInjectedValues } : {}),
   };
 }
@@ -156,9 +130,7 @@ export function getConfiguredCustomModelOptionDescriptors(
     : (configured.optionDescriptors ?? []);
 }
 
-function CustomModelCapabilitiesEditor(props: {
-  readonly driverKind: ProviderDriverKind | null;
-  readonly models: ReadonlyArray<ServerProviderModel>;
+export function CustomModelCapabilitiesEditor(props: {
   readonly model: ServerProviderModel;
   readonly value: ModelCapabilities | undefined;
   readonly onChange: (value: ModelCapabilities | undefined) => void;
@@ -167,10 +139,17 @@ function CustomModelCapabilitiesEditor(props: {
     props.value,
     props.model.capabilities,
   );
-  const templates = getCustomModelCapabilityTemplates(props.models, props.value);
 
   const replaceDescriptor = (descriptor: ProviderOptionDescriptor | undefined, id: string) => {
     props.onChange(replaceCustomModelCapabilityDescriptor(configuredDescriptors, descriptor, id));
+  };
+  const addDescriptor = (type: ProviderOptionDescriptor["type"]) => {
+    props.onChange({
+      optionDescriptors: [
+        ...configuredDescriptors,
+        createCustomModelCapabilityDescriptor(configuredDescriptors, type),
+      ],
+    });
   };
 
   return (
@@ -178,141 +157,162 @@ function CustomModelCapabilitiesEditor(props: {
       <div>
         <p className="text-xs font-medium text-foreground">Custom model controls</p>
         <p className="mt-0.5 text-[11px] leading-snug text-muted-foreground">
-          Enable only controls supported by {props.model.name}. Separate values with commas.
+          Add controls by exact option ID. Provider adapter decides how each value is sent.
         </p>
       </div>
 
-      {templates.length === 0 ? (
-        <p className="text-xs text-muted-foreground">
-          Provider has not reported configurable model controls.
-        </p>
-      ) : (
-        templates.map((template) => {
-          const configured = configuredDescriptors.find(
-            (candidate) => candidate.id === template.id && candidate.type === template.type,
-          );
-          const enabled = configured !== undefined;
+      {configuredDescriptors.length === 0 ? (
+        <p className="text-xs text-muted-foreground">No controls added.</p>
+      ) : null}
+      {configuredDescriptors.map((descriptor) => {
+        const commitId = (value: string) => {
+          const id = value.trim();
+          if (
+            !id ||
+            configuredDescriptors.some(
+              (candidate) => candidate.id === id && candidate.id !== descriptor.id,
+            )
+          ) {
+            return;
+          }
+          replaceDescriptor({ ...descriptor, id }, descriptor.id);
+        };
+        const commitLabel = (value: string) => {
+          const label = value.trim();
+          if (label) replaceDescriptor({ ...descriptor, label }, descriptor.id);
+        };
 
-          const toggle = (checked: boolean) => {
-            if (!checked) {
-              replaceDescriptor(undefined, template.id);
-              return;
-            }
-            if (template.type === "select") {
-              const supportedValues = template.options.map((option) => option.id);
-              const defaultValue =
-                template.currentValue ??
-                template.options.find((option) => option.isDefault)?.id ??
-                supportedValues[0];
-              replaceDescriptor(
-                makeSelectCustomModelCapabilityDescriptor(template, supportedValues, defaultValue),
-                template.id,
-              );
-              return;
-            }
-            replaceDescriptor(
-              { ...template, currentValue: template.currentValue ?? false },
-              template.id,
-            );
-          };
+        return (
+          <div key={descriptor.id} className="rounded-md border border-border/70 p-2.5">
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-[11px] font-medium text-muted-foreground">
+                {descriptor.type === "select" ? "Select" : "On / off"}
+              </span>
+              <Button
+                size="icon-micro"
+                variant="ghost-muted"
+                onClick={() => replaceDescriptor(undefined, descriptor.id)}
+                aria-label={`Remove ${descriptor.label} from ${props.model.name}`}
+              >
+                <XIcon />
+              </Button>
+            </div>
 
-          return (
-            <div key={template.id} className="rounded-md border border-border/70 p-2.5">
-              <label className="flex cursor-pointer items-center gap-2 text-xs font-medium text-foreground">
-                <Checkbox
-                  checked={enabled}
-                  onCheckedChange={(checked) => toggle(Boolean(checked))}
-                  aria-label={`Enable ${template.label} for ${props.model.name}`}
+            <div className="mt-2 grid grid-cols-2 gap-2">
+              <label className="grid gap-1 text-[11px] text-muted-foreground">
+                ID
+                <DraftInput
+                  size="compact"
+                  value={descriptor.id}
+                  onCommit={commitId}
+                  aria-label={`Control ID for ${descriptor.label}`}
+                  spellCheck={false}
                 />
-                {template.label}
               </label>
+              <label className="grid gap-1 text-[11px] text-muted-foreground">
+                Label
+                <DraftInput
+                  size="compact"
+                  value={descriptor.label}
+                  onCommit={commitLabel}
+                  aria-label={`Control label for ${descriptor.id}`}
+                />
+              </label>
+            </div>
 
-              {enabled && configured?.type === "select" && template.type === "select" ? (
-                <div className="mt-2 grid gap-2 sm:grid-cols-[minmax(0,1fr)_8rem]">
-                  <label className="grid gap-1 text-[11px] text-muted-foreground">
-                    Supported values
-                    <DraftInput
-                      size="compact"
-                      value={configured.options.map((option) => option.id).join(", ")}
-                      onCommit={(value) => {
-                        const supportedValues = value.split(",").map((entry) => entry.trim());
-                        replaceDescriptor(
-                          makeSelectCustomModelCapabilityDescriptor(
-                            template,
-                            supportedValues,
-                            configured.currentValue,
-                          ),
-                          template.id,
-                        );
-                      }}
-                      aria-label={`Supported ${template.label} values for ${props.model.name}`}
-                      spellCheck={false}
-                    />
-                  </label>
-                  <label className="grid gap-1 text-[11px] text-muted-foreground">
-                    Default
-                    <Select
-                      value={configured.currentValue ?? configured.options[0]?.id ?? ""}
-                      onValueChange={(value) =>
-                        replaceDescriptor(
-                          makeSelectCustomModelCapabilityDescriptor(
-                            template,
-                            configured.options.map((option) => option.id),
-                            value ?? undefined,
-                          ),
-                          template.id,
-                        )
-                      }
-                    >
-                      <SelectTrigger
-                        size="compact"
-                        className="w-full min-w-0"
-                        aria-label={`Default ${template.label}`}
-                      >
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectPopup alignItemWithTrigger={false}>
-                        {configured.options.map((option) => (
-                          <SelectItem key={option.id} value={option.id}>
-                            {option.label}
-                          </SelectItem>
-                        ))}
-                      </SelectPopup>
-                    </Select>
-                  </label>
-                </div>
-              ) : null}
-
-              {enabled && configured?.type === "boolean" ? (
-                <div className="mt-2 flex items-center justify-between gap-3 text-[11px] text-muted-foreground">
-                  <span>Default {configured.currentValue ? "On" : "Off"}</span>
-                  <Switch
-                    checked={configured.currentValue ?? false}
-                    onCheckedChange={(checked) =>
+            {descriptor.type === "select" ? (
+              <div className="mt-2 grid gap-2 sm:grid-cols-[minmax(0,1fr)_8rem]">
+                <label className="grid gap-1 text-[11px] text-muted-foreground">
+                  Values
+                  <DraftInput
+                    size="compact"
+                    value={descriptor.options.map((option) => option.id).join(", ")}
+                    onCommit={(value) => {
+                      const supportedValues = value.split(",").map((entry) => entry.trim());
                       replaceDescriptor(
-                        { ...configured, currentValue: Boolean(checked) },
-                        template.id,
+                        makeSelectCustomModelCapabilityDescriptor(
+                          descriptor,
+                          supportedValues,
+                          descriptor.currentValue,
+                        ),
+                        descriptor.id,
+                      );
+                    }}
+                    aria-label={`Values for ${descriptor.label}`}
+                    spellCheck={false}
+                  />
+                </label>
+                <label className="grid gap-1 text-[11px] text-muted-foreground">
+                  Default
+                  <Select
+                    value={descriptor.currentValue ?? descriptor.options[0]?.id ?? ""}
+                    onValueChange={(value) =>
+                      replaceDescriptor(
+                        makeSelectCustomModelCapabilityDescriptor(
+                          descriptor,
+                          descriptor.options.map((option) => option.id),
+                          value ?? undefined,
+                        ),
+                        descriptor.id,
                       )
                     }
-                    aria-label={`Default ${template.label} for ${props.model.name}`}
-                  />
-                </div>
-              ) : null}
+                  >
+                    <SelectTrigger
+                      size="compact"
+                      className="w-full min-w-0"
+                      aria-label={`Default ${descriptor.label}`}
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectPopup alignItemWithTrigger={false}>
+                      {descriptor.options.map((option) => (
+                        <SelectItem key={option.id} value={option.id}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectPopup>
+                  </Select>
+                </label>
+              </div>
+            ) : (
+              <div className="mt-2 flex items-center justify-between gap-3 text-[11px] text-muted-foreground">
+                <span>Default {descriptor.currentValue ? "On" : "Off"}</span>
+                <Switch
+                  checked={descriptor.currentValue ?? false}
+                  onCheckedChange={(checked) =>
+                    replaceDescriptor(
+                      { ...descriptor, currentValue: Boolean(checked) },
+                      descriptor.id,
+                    )
+                  }
+                  aria-label={`Default ${descriptor.label} for ${props.model.name}`}
+                />
+              </div>
+            )}
+          </div>
+        );
+      })}
 
-              {template.id === "fastMode" && props.driverKind === CLAUDE_DRIVER_KIND ? (
-                <p className="mt-2 text-[10px] leading-snug text-muted-foreground">
-                  Claude fast mode is a Claude SDK setting. It is not OpenAI priority service.
-                </p>
-              ) : null}
-              {template.id === "contextWindow" && props.driverKind === CLAUDE_DRIVER_KIND ? (
-                <p className="mt-2 text-[10px] leading-snug text-muted-foreground">
-                  1M adds Claude model selector at launch. Saved model ID stays unchanged.
-                </p>
-              ) : null}
-            </div>
-          );
-        })
-      )}
+      <div className="flex flex-wrap gap-1.5">
+        <Button
+          size="xs"
+          variant="outline"
+          onClick={() => addDescriptor("select")}
+          aria-label={`Add select control for ${props.model.name}`}
+        >
+          <PlusIcon />
+          Add select
+        </Button>
+        <Button
+          size="xs"
+          variant="outline"
+          onClick={() => addDescriptor("boolean")}
+          aria-label={`Add boolean control for ${props.model.name}`}
+        >
+          <PlusIcon />
+          Add on / off
+        </Button>
+      </div>
     </div>
   );
 }
@@ -648,8 +648,6 @@ export function ProviderModelsSection({
                       className="w-[min(24rem,calc(100vw-1.5rem))] [--popup-width:min(24rem,calc(100vw-1.5rem))]"
                     >
                       <CustomModelCapabilitiesEditor
-                        driverKind={driverKind}
-                        models={models}
                         model={model}
                         value={getDeclaredCustomModelCapabilities(
                           customModelCapabilities,

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -77,12 +77,19 @@ export function getCustomModelCapabilityTemplates(
     if (current.type !== "select" || descriptor.type !== "select") continue;
 
     const optionIds = new Set(current.options.map((option) => option.id));
+    const promptInjectedValues = [
+      ...new Set([
+        ...(current.promptInjectedValues ?? []),
+        ...(descriptor.promptInjectedValues ?? []),
+      ]),
+    ];
     templates.set(descriptor.id, {
       ...current,
       options: [
         ...current.options,
         ...descriptor.options.filter((option) => !optionIds.has(option.id)),
       ],
+      ...(promptInjectedValues.length > 0 ? { promptInjectedValues } : {}),
     });
   }
 
@@ -233,6 +240,7 @@ function CustomModelCapabilitiesEditor(props: {
                   <label className="grid gap-1 text-[11px] text-muted-foreground">
                     Supported values
                     <DraftInput
+                      size="compact"
                       value={configured.options.map((option) => option.id).join(", ")}
                       onCommit={(value) => {
                         const supportedValues = value.split(",").map((entry) => entry.trim());
@@ -638,17 +646,24 @@ export function ProviderModelsSection({
                 ) : null}
                 {model.isCustom ? (
                   <Popover>
-                    <PopoverTrigger
-                      render={
-                        <Button
-                          size="icon-micro"
-                          variant="ghost-muted"
-                          aria-label={`Configure capabilities for ${model.slug}`}
-                        >
-                          <Settings2Icon className="size-3" />
-                        </Button>
-                      }
-                    />
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <PopoverTrigger
+                            render={
+                              <Button
+                                size="icon-micro"
+                                variant="ghost-muted"
+                                aria-label={`Configure capabilities for ${model.slug}`}
+                              />
+                            }
+                          />
+                        }
+                      >
+                        <Settings2Icon className="size-3" />
+                      </TooltipTrigger>
+                      <TooltipPopup side="top">Configure model controls</TooltipPopup>
+                    </Tooltip>
                     <PopoverPopup
                       side="left"
                       align="start"

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -228,7 +228,7 @@ function SelectCustomModelCapabilityValues(props: {
   return (
     <div className="grid gap-1">
       <span className="text-[11px] text-muted-foreground">Values</span>
-      <div className="flex min-h-8 flex-wrap items-center gap-1 rounded-md border border-input bg-background p-1 shadow-xs/5 dark:bg-input/32">
+      <div className="flex min-h-8 flex-wrap items-center gap-1 rounded-md border border-input bg-background p-1 shadow-xs/5 ring-ring/24 transition-shadow focus-within:border-ring focus-within:ring-[3px] dark:bg-input/32">
         {props.descriptor.options.map((option) => (
           <SelectCustomModelCapabilityValueTag
             key={option.id}

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -7,13 +7,17 @@ import {
   EyeOffIcon,
   InfoIcon,
   PlusIcon,
+  Settings2Icon,
   StarIcon,
   XIcon,
 } from "lucide-react";
 import { useMemo, useRef, useState } from "react";
 import {
   ProviderDriverKind,
+  type ModelCapabilities,
   type ProviderInstanceId,
+  type ProviderOptionDescriptor,
+  type SelectProviderOptionDescriptor,
   type ServerProviderModel,
 } from "@t3tools/contracts";
 import { normalizeCustomModelSlug } from "@t3tools/shared/model";
@@ -22,7 +26,12 @@ import { cn } from "../../lib/utils";
 import { sortModelsForProviderInstance } from "../../modelOrdering";
 import { MAX_CUSTOM_MODEL_LENGTH } from "../../modelSelection";
 import { Button } from "../ui/button";
+import { Checkbox } from "../ui/checkbox";
+import { DraftInput } from "../ui/draft-input";
 import { Input } from "../ui/input";
+import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
+import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
+import { Switch } from "../ui/switch";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 
 /**
@@ -36,6 +45,273 @@ const CUSTOM_MODEL_PLACEHOLDER_BY_KIND: Partial<Record<ProviderDriverKind, strin
   [ProviderDriverKind.make("cursor")]: "claude-sonnet-4-6",
   [ProviderDriverKind.make("opencode")]: "openai/gpt-5",
 };
+
+const CLAUDE_DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
+const CONFIGURABLE_CUSTOM_MODEL_OPTION_IDS = new Set([
+  "effort",
+  "reasoningEffort",
+  "reasoning",
+  "variant",
+  "fastMode",
+  "serviceTier",
+  "contextWindow",
+]);
+
+export function getCustomModelCapabilityTemplates(
+  models: ReadonlyArray<ServerProviderModel>,
+  configured: ModelCapabilities | undefined,
+): ReadonlyArray<ProviderOptionDescriptor> {
+  const templates = new Map<string, ProviderOptionDescriptor>();
+  const descriptors = [
+    ...models.flatMap((model) => model.capabilities?.optionDescriptors ?? []),
+    ...(configured?.optionDescriptors ?? []),
+  ];
+
+  for (const descriptor of descriptors) {
+    if (!CONFIGURABLE_CUSTOM_MODEL_OPTION_IDS.has(descriptor.id)) continue;
+    const current = templates.get(descriptor.id);
+    if (!current) {
+      templates.set(descriptor.id, descriptor);
+      continue;
+    }
+    if (current.type !== "select" || descriptor.type !== "select") continue;
+
+    const optionIds = new Set(current.options.map((option) => option.id));
+    templates.set(descriptor.id, {
+      ...current,
+      options: [
+        ...current.options,
+        ...descriptor.options.filter((option) => !optionIds.has(option.id)),
+      ],
+    });
+  }
+
+  return [...templates.values()];
+}
+
+function capabilityOptionLabel(id: string): string {
+  const words = id.replaceAll(/[-_]+/g, " ").trim();
+  return words.length > 0 ? words[0]!.toUpperCase() + words.slice(1) : id;
+}
+
+export function makeSelectCustomModelCapabilityDescriptor(
+  template: SelectProviderOptionDescriptor,
+  supportedValues: ReadonlyArray<string>,
+  requestedDefault: string | undefined,
+): SelectProviderOptionDescriptor | undefined {
+  const templateIds = new Set(template.options.map((option) => option.id));
+  const values = [
+    ...new Set(
+      supportedValues
+        .map((value) => value.trim())
+        .filter((value) => value && (template.id !== "contextWindow" || templateIds.has(value))),
+    ),
+  ];
+  if (values.length === 0) {
+    return undefined;
+  }
+  const defaultValue =
+    requestedDefault && values.includes(requestedDefault) ? requestedDefault : values[0]!;
+  const templateOptions = new Map(template.options.map((option) => [option.id, option]));
+  const options = values.map((id) => {
+    const templateOption = templateOptions.get(id);
+    const { isDefault: _isDefault, ...rest } = templateOption ?? {
+      id,
+      label: capabilityOptionLabel(id),
+    };
+    return {
+      ...rest,
+      ...(id === defaultValue ? { isDefault: true } : {}),
+    };
+  });
+  const promptInjectedValues = template.promptInjectedValues?.filter((value) =>
+    values.includes(value),
+  );
+
+  return {
+    id: template.id,
+    label: template.label,
+    type: "select",
+    options,
+    ...(template.description ? { description: template.description } : {}),
+    currentValue: defaultValue,
+    ...(promptInjectedValues && promptInjectedValues.length > 0 ? { promptInjectedValues } : {}),
+  };
+}
+export function replaceCustomModelCapabilityDescriptor(
+  configured: ReadonlyArray<ProviderOptionDescriptor>,
+  descriptor: ProviderOptionDescriptor | undefined,
+  id: string,
+): ModelCapabilities {
+  const next = configured.filter((candidate) => candidate.id !== id);
+  if (descriptor) next.push(descriptor);
+  return { optionDescriptors: next };
+}
+
+export function getConfiguredCustomModelOptionDescriptors(
+  configured: ModelCapabilities | undefined,
+  fallback: ModelCapabilities | null,
+): ReadonlyArray<ProviderOptionDescriptor> {
+  return configured === undefined
+    ? (fallback?.optionDescriptors ?? [])
+    : (configured.optionDescriptors ?? []);
+}
+
+function CustomModelCapabilitiesEditor(props: {
+  readonly driverKind: ProviderDriverKind | null;
+  readonly models: ReadonlyArray<ServerProviderModel>;
+  readonly model: ServerProviderModel;
+  readonly value: ModelCapabilities | undefined;
+  readonly onChange: (value: ModelCapabilities | undefined) => void;
+}) {
+  const configuredDescriptors = getConfiguredCustomModelOptionDescriptors(
+    props.value,
+    props.model.capabilities,
+  );
+  const templates = getCustomModelCapabilityTemplates(props.models, props.value);
+
+  const replaceDescriptor = (descriptor: ProviderOptionDescriptor | undefined, id: string) => {
+    props.onChange(replaceCustomModelCapabilityDescriptor(configuredDescriptors, descriptor, id));
+  };
+
+  return (
+    <div className="grid gap-3">
+      <div>
+        <p className="text-xs font-medium text-foreground">Custom model controls</p>
+        <p className="mt-0.5 text-[11px] leading-snug text-muted-foreground">
+          Enable only controls supported by {props.model.name}. Separate values with commas.
+        </p>
+      </div>
+
+      {templates.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          Provider has not reported configurable model controls.
+        </p>
+      ) : (
+        templates.map((template) => {
+          const configured = configuredDescriptors.find(
+            (candidate) => candidate.id === template.id && candidate.type === template.type,
+          );
+          const enabled = configured !== undefined;
+
+          const toggle = (checked: boolean) => {
+            if (!checked) {
+              replaceDescriptor(undefined, template.id);
+              return;
+            }
+            if (template.type === "select") {
+              const supportedValues = template.options.map((option) => option.id);
+              const defaultValue =
+                template.currentValue ??
+                template.options.find((option) => option.isDefault)?.id ??
+                supportedValues[0];
+              replaceDescriptor(
+                makeSelectCustomModelCapabilityDescriptor(template, supportedValues, defaultValue),
+                template.id,
+              );
+              return;
+            }
+            replaceDescriptor(
+              { ...template, currentValue: template.currentValue ?? false },
+              template.id,
+            );
+          };
+
+          return (
+            <div key={template.id} className="rounded-md border border-border/70 p-2.5">
+              <label className="flex cursor-pointer items-center gap-2 text-xs font-medium text-foreground">
+                <Checkbox
+                  checked={enabled}
+                  onCheckedChange={(checked) => toggle(Boolean(checked))}
+                  aria-label={`Enable ${template.label} for ${props.model.name}`}
+                />
+                {template.label}
+              </label>
+
+              {enabled && configured?.type === "select" && template.type === "select" ? (
+                <div className="mt-2 grid gap-2 sm:grid-cols-[minmax(0,1fr)_8rem]">
+                  <label className="grid gap-1 text-[11px] text-muted-foreground">
+                    Supported values
+                    <DraftInput
+                      value={configured.options.map((option) => option.id).join(", ")}
+                      onCommit={(value) => {
+                        const supportedValues = value.split(",").map((entry) => entry.trim());
+                        replaceDescriptor(
+                          makeSelectCustomModelCapabilityDescriptor(
+                            template,
+                            supportedValues,
+                            configured.currentValue,
+                          ),
+                          template.id,
+                        );
+                      }}
+                      aria-label={`Supported ${template.label} values for ${props.model.name}`}
+                      spellCheck={false}
+                    />
+                  </label>
+                  <label className="grid gap-1 text-[11px] text-muted-foreground">
+                    Default
+                    <Select
+                      value={configured.currentValue ?? configured.options[0]?.id ?? ""}
+                      onValueChange={(value) =>
+                        replaceDescriptor(
+                          makeSelectCustomModelCapabilityDescriptor(
+                            template,
+                            configured.options.map((option) => option.id),
+                            value ?? undefined,
+                          ),
+                          template.id,
+                        )
+                      }
+                    >
+                      <SelectTrigger size="compact" aria-label={`Default ${template.label}`}>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectPopup alignItemWithTrigger={false}>
+                        {configured.options.map((option) => (
+                          <SelectItem key={option.id} value={option.id}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectPopup>
+                    </Select>
+                  </label>
+                </div>
+              ) : null}
+
+              {enabled && configured?.type === "boolean" ? (
+                <div className="mt-2 flex items-center justify-between gap-3 text-[11px] text-muted-foreground">
+                  <span>Default {configured.currentValue ? "On" : "Off"}</span>
+                  <Switch
+                    checked={configured.currentValue ?? false}
+                    onCheckedChange={(checked) =>
+                      replaceDescriptor(
+                        { ...configured, currentValue: Boolean(checked) },
+                        template.id,
+                      )
+                    }
+                    aria-label={`Default ${template.label} for ${props.model.name}`}
+                  />
+                </div>
+              ) : null}
+
+              {template.id === "fastMode" && props.driverKind === CLAUDE_DRIVER_KIND ? (
+                <p className="mt-2 text-[10px] leading-snug text-muted-foreground">
+                  Claude fast mode is a Claude SDK setting. It is not OpenAI priority service.
+                </p>
+              ) : null}
+              {template.id === "contextWindow" && props.driverKind === CLAUDE_DRIVER_KIND ? (
+                <p className="mt-2 text-[10px] leading-snug text-muted-foreground">
+                  1M adds Claude model selector at launch. Saved model ID stays unchanged.
+                </p>
+              ) : null}
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+}
 
 interface ProviderModelsSectionProps {
   /** Identifier used to namespace input ids within the DOM. */
@@ -56,6 +332,11 @@ interface ProviderModelsSectionProps {
    * removed) via `onChange`.
    */
   readonly customModels: ReadonlyArray<string>;
+  readonly customModelCapabilities: Readonly<Record<string, ModelCapabilities>>;
+  readonly onCustomModelCapabilitiesChange: (
+    slug: string,
+    capabilities: ModelCapabilities | undefined,
+  ) => void;
   /** Server-returned model slugs hidden from the model picker. */
   readonly hiddenModels: ReadonlyArray<string>;
   /** Model slugs favorited for this provider instance. */
@@ -89,6 +370,8 @@ export function ProviderModelsSection({
   driverKind,
   models,
   customModels,
+  customModelCapabilities,
+  onCustomModelCapabilitiesChange,
   hiddenModels,
   favoriteModels,
   modelOrder,
@@ -352,6 +635,34 @@ export function ProviderModelsSection({
                       {isHidden ? "Show in picker" : "Hide from picker"}
                     </TooltipPopup>
                   </Tooltip>
+                ) : null}
+                {model.isCustom ? (
+                  <Popover>
+                    <PopoverTrigger
+                      render={
+                        <Button
+                          size="icon-micro"
+                          variant="ghost-muted"
+                          aria-label={`Configure capabilities for ${model.slug}`}
+                        >
+                          <Settings2Icon className="size-3" />
+                        </Button>
+                      }
+                    />
+                    <PopoverPopup
+                      side="left"
+                      align="start"
+                      className="w-[min(24rem,calc(100vw-1.5rem))] [--popup-width:min(24rem,calc(100vw-1.5rem))]"
+                    >
+                      <CustomModelCapabilitiesEditor
+                        driverKind={driverKind}
+                        models={models}
+                        model={model}
+                        value={customModelCapabilities[model.slug]}
+                        onChange={(value) => onCustomModelCapabilitiesChange(model.slug, value)}
+                      />
+                    </PopoverPopup>
+                  </Popover>
                 ) : null}
                 {model.isCustom ? (
                   <Tooltip>

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -239,27 +239,127 @@ export function CustomModelCapabilitiesEditor(props: {
             </div>
 
             {descriptor.type === "select" ? (
-              <div className="mt-2 grid gap-2 sm:grid-cols-[minmax(0,1fr)_8rem]">
-                <label className="grid gap-1 text-[11px] text-muted-foreground">
-                  Values
-                  <DraftInput
-                    size="compact"
-                    value={descriptor.options.map((option) => option.id).join(", ")}
-                    onCommit={(value) => {
-                      const supportedValues = value.split(",").map((entry) => entry.trim());
+              <div className="mt-2 grid gap-2">
+                <div className="grid gap-1 text-[11px] text-muted-foreground">
+                  <span>Values</span>
+                  <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_1.25rem] gap-1.5 px-0.5 text-[10px]">
+                    <span>ID</span>
+                    <span>Label</span>
+                  </div>
+                  {descriptor.options.map((option, index) => (
+                    <div
+                      key={option.id}
+                      className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_1.25rem] items-center gap-1.5"
+                    >
+                      <DraftInput
+                        size="compact"
+                        value={option.id}
+                        onCommit={(value) => {
+                          const id = value.trim();
+                          if (
+                            !id ||
+                            descriptor.options.some(
+                              (candidate, candidateIndex) =>
+                                candidateIndex !== index && candidate.id === id,
+                            )
+                          ) {
+                            return;
+                          }
+                          replaceDescriptor(
+                            {
+                              ...descriptor,
+                              options: descriptor.options.map((candidate, candidateIndex) =>
+                                candidateIndex === index ? { ...candidate, id } : candidate,
+                              ),
+                              ...(descriptor.currentValue === option.id
+                                ? { currentValue: id }
+                                : {}),
+                              ...(descriptor.promptInjectedValues
+                                ? {
+                                    promptInjectedValues: descriptor.promptInjectedValues.map(
+                                      (value) => (value === option.id ? id : value),
+                                    ),
+                                  }
+                                : {}),
+                            },
+                            descriptor.id,
+                          );
+                        }}
+                        aria-label={`Value ${index + 1} for ${descriptor.label}`}
+                        spellCheck={false}
+                      />
+                      <DraftInput
+                        size="compact"
+                        value={option.label}
+                        onCommit={(value) => {
+                          const label = value.trim();
+                          if (!label) return;
+                          replaceDescriptor(
+                            {
+                              ...descriptor,
+                              options: descriptor.options.map((candidate, candidateIndex) =>
+                                candidateIndex === index ? { ...candidate, label } : candidate,
+                              ),
+                            },
+                            descriptor.id,
+                          );
+                        }}
+                        aria-label={`Value label ${index + 1} for ${descriptor.label}`}
+                      />
+                      <Button
+                        size="icon-micro"
+                        variant="ghost-muted"
+                        disabled={descriptor.options.length === 1}
+                        onClick={() =>
+                          replaceDescriptor(
+                            makeSelectCustomModelCapabilityDescriptor(
+                              descriptor,
+                              descriptor.options
+                                .filter((_, candidateIndex) => candidateIndex !== index)
+                                .map((candidate) => candidate.id),
+                              descriptor.currentValue,
+                            ),
+                            descriptor.id,
+                          )
+                        }
+                        aria-label={`Remove ${option.id} from ${descriptor.label}`}
+                      >
+                        <XIcon />
+                      </Button>
+                    </div>
+                  ))}
+                  <Button
+                    size="xs"
+                    variant="ghost-muted"
+                    className="w-fit"
+                    onClick={() => {
+                      const ids = new Set(descriptor.options.map((option) => option.id));
+                      let suffix = 1;
+                      while (ids.has(suffix === 1 ? "value" : `value${suffix}`)) suffix += 1;
+                      const id = suffix === 1 ? "value" : `value${suffix}`;
+                      const isFirst = descriptor.options.length === 0;
                       replaceDescriptor(
-                        makeSelectCustomModelCapabilityDescriptor(
-                          descriptor,
-                          supportedValues,
-                          descriptor.currentValue,
-                        ),
+                        {
+                          ...descriptor,
+                          options: [
+                            ...descriptor.options,
+                            {
+                              id,
+                              label: capabilityOptionLabel(id),
+                              ...(isFirst ? { isDefault: true } : {}),
+                            },
+                          ],
+                          ...(isFirst ? { currentValue: id } : {}),
+                        },
                         descriptor.id,
                       );
                     }}
-                    aria-label={`Values for ${descriptor.label}`}
-                    spellCheck={false}
-                  />
-                </label>
+                    aria-label={`Add value to ${descriptor.label}`}
+                  >
+                    <PlusIcon />
+                    Add value
+                  </Button>
+                </div>
                 <label className="grid gap-1 text-[11px] text-muted-foreground">
                   Default
                   <Select

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -53,6 +53,21 @@ function capabilityOptionLabel(id: string): string {
   return words.length > 0 ? words[0]!.toUpperCase() + words.slice(1) : id;
 }
 
+function resolveSelectCustomModelCapabilityDefault(
+  descriptor: SelectProviderOptionDescriptor,
+  supportedValues: ReadonlyArray<string>,
+  requestedDefault: string | undefined,
+): string | undefined {
+  return (
+    (requestedDefault && supportedValues.includes(requestedDefault)
+      ? requestedDefault
+      : undefined) ??
+    descriptor.options.find((option) => option.isDefault && supportedValues.includes(option.id))
+      ?.id ??
+    supportedValues[0]
+  );
+}
+
 export function createCustomModelCapabilityDescriptor(
   configured: ReadonlyArray<ProviderOptionDescriptor>,
   type: ProviderOptionDescriptor["type"],
@@ -83,8 +98,11 @@ export function makeSelectCustomModelCapabilityDescriptor(
     ...new Set(supportedValues.map((value) => value.trim()).filter((value) => value.length > 0)),
   ];
   if (values.length === 0) return undefined;
-  const defaultValue =
-    requestedDefault && values.includes(requestedDefault) ? requestedDefault : values[0];
+  const defaultValue = resolveSelectCustomModelCapabilityDefault(
+    template,
+    values,
+    requestedDefault,
+  );
   const templateOptions = new Map(template.options.map((option) => [option.id, option]));
   const options = values.map((id) => {
     const templateOption = templateOptions.get(id);
@@ -245,7 +263,13 @@ export function CustomModelCapabilitiesEditor(props: {
                 <label className="grid gap-1 text-[11px] text-muted-foreground">
                   Default
                   <Select
-                    value={descriptor.currentValue ?? descriptor.options[0]?.id ?? ""}
+                    value={
+                      resolveSelectCustomModelCapabilityDefault(
+                        descriptor,
+                        descriptor.options.map((option) => option.id),
+                        descriptor.currentValue,
+                      ) ?? ""
+                    }
                     onValueChange={(value) =>
                       replaceDescriptor(
                         makeSelectCustomModelCapabilityDescriptor(

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -830,6 +830,7 @@ export function EnvironmentProviderSettings({
                 instance={row.instance}
                 driverOption={driverOption}
                 liveProvider={liveProvider}
+                sourceProviders={serverProviders}
                 isExpanded={openInstanceDetails[row.instanceId] ?? false}
                 onExpandedChange={(open) =>
                   setOpenInstanceDetails((existing) => ({

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -1415,6 +1415,21 @@ describe("composerDraftStore modelSelection", () => {
     );
   });
 
+  it("preserves an exact custom model ID when its first control changes", () => {
+    const store = useComposerDraftStore.getState();
+
+    store.setProviderModelOptions(
+      threadRef,
+      CLAUDE_AGENT_DRIVER,
+      toSelections({ effort: "high" }),
+      { model: "opus" },
+    );
+
+    expect(
+      draftFor(threadId, TEST_ENVIRONMENT_ID)?.modelSelectionByProvider[CLAUDE_AGENT_INSTANCE],
+    ).toEqual(modelSelection(CLAUDE_AGENT_DRIVER, "opus", { effort: "high" }));
+  });
+
   it("updates only the draft when sticky persistence is omitted", () => {
     const store = useComposerDraftStore.getState();
 
@@ -1598,6 +1613,21 @@ describe("composerDraftStore setModelSelection", () => {
     expect(
       draftFor(threadId, TEST_ENVIRONMENT_ID)?.modelSelectionByProvider[CODEX_INSTANCE],
     ).toEqual(modelSelection(CODEX_DRIVER, "gpt-5.3-codex"));
+  });
+
+  it("preserves provider-owned IDs in canonical selections", () => {
+    const store = useComposerDraftStore.getState();
+
+    store.setModelSelection(threadRef, modelSelection(CODEX_DRIVER, "gpt-5-codex"));
+    store.setModelSelection(threadRef, modelSelection(CLAUDE_AGENT_DRIVER, "opus"));
+
+    const draft = draftFor(threadId, TEST_ENVIRONMENT_ID);
+    expect(draft?.modelSelectionByProvider[CODEX_INSTANCE]).toEqual(
+      modelSelection(CODEX_DRIVER, "gpt-5-codex"),
+    );
+    expect(draft?.modelSelectionByProvider[CLAUDE_AGENT_INSTANCE]).toEqual(
+      modelSelection(CLAUDE_AGENT_DRIVER, "opus"),
+    );
   });
 });
 

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -29,7 +29,11 @@ import * as Schema from "effect/Schema";
 import * as Equal from "effect/Equal";
 import * as Effect from "effect/Effect";
 import { DeepMutable } from "effect/Types";
-import { createModelSelection, normalizeModelSlug } from "@t3tools/shared/model";
+import {
+  createModelSelection,
+  normalizeCustomModelSlug,
+  normalizeModelSlug,
+} from "@t3tools/shared/model";
 import { useMemo } from "react";
 import { getLocalStorageItem } from "./hooks/useLocalStorage";
 import { resolveAppModelSelection, resolveAppModelSelectionForInstance } from "./modelSelection";
@@ -875,13 +879,16 @@ function normalizeModelSelection(
   if (typeof rawModel !== "string") {
     return null;
   }
-  // Slug normalization can use provider-kind-specific rules when a legacy
-  // driver key is present. Instance-only selections are not reverse-inferred
-  // into a driver kind here; they get generic default normalization.
-  const driverKindHint =
-    normalizeProviderDriverKind(candidate?.provider ?? legacy?.provider) ??
-    ProviderDriverKind.make("codex");
-  const model = normalizeModelSlug(rawModel, driverKindHint);
+  // Canonical selections preserve provider-owned IDs. Only legacy provider-shaped
+  // selections expand aliases with driver-specific rules.
+  const model =
+    candidate?.instanceId !== undefined
+      ? normalizeCustomModelSlug(rawModel)
+      : normalizeModelSlug(
+          rawModel,
+          normalizeProviderDriverKind(candidate?.provider ?? legacy?.provider) ??
+            ProviderDriverKind.make("codex"),
+        );
   if (!model) {
     return null;
   }
@@ -2817,7 +2824,7 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
           }
           const instanceKey = options?.instanceId ?? defaultInstanceIdForDriver(normalizedProvider);
           const fallbackModel =
-            normalizeModelSlug(options?.model, normalizedProvider) ??
+            normalizeCustomModelSlug(options?.model) ??
             DEFAULT_MODEL_BY_PROVIDER[normalizedProvider] ??
             DEFAULT_MODEL;
           const providerOpts =

--- a/apps/web/src/providerModels.ts
+++ b/apps/web/src/providerModels.ts
@@ -82,6 +82,10 @@ export function getProviderModelCapabilities(
   model: string | null | undefined,
   provider: ProviderDriverKind,
 ): ModelCapabilities {
+  const exactModel = model ? models.find((candidate) => candidate.slug === model) : undefined;
+  if (exactModel) {
+    return exactModel.capabilities ?? EMPTY_CAPABILITIES;
+  }
   const slug = normalizeModelSlug(model, provider);
   return models.find((candidate) => candidate.slug === slug)?.capabilities ?? EMPTY_CAPABILITIES;
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,8 @@
 - [Keeping app and server in sync](./user/updating.md)
 - [Source control integrations](./user/source-control.md)
 - [Background service (Linux)](./user/background-service.md)
-- Providers: [Codex](./user/providers-codex.md) · [Claude](./user/providers-claude.md)
+- Providers: [Custom models](./user/providers-custom-models.md) ·
+  [Codex](./user/providers-codex.md) · [Claude](./user/providers-claude.md)
 
 Mobile app: [apps/mobile/README.md](../apps/mobile/README.md)
 

--- a/docs/user/providers-claude.md
+++ b/docs/user/providers-claude.md
@@ -10,6 +10,31 @@ Common reasons:
 - run Claude through a router such as Claude Code Router
 - use external providers exposed through a Claude-compatible workflow
 
+## Custom Model Controls
+
+Add a custom model in **Settings → Providers → Claude → Models**. Use the settings button beside
+the model to declare the controls that model supports. You can enable reasoning effort, Claude fast
+mode, and context-window controls, then set supported values and defaults. The message composer only
+shows controls you enable.
+
+The saved model ID stays exact. For example, a custom model saved as `gateway/model` stays visible as
+`gateway/model`. If you declare a `1m` context option and select it, T3 Code gives Claude Code the
+`gateway/model[1m]` launch selector. T3 Code stores the configured gateway model ID without that
+selector. T3 Code does not assume 1M support for other custom models.
+
+Reasoning selections use the Claude Agent SDK effort option. Custom model names do not force a
+built-in Claude effort mapping. Existing `ultracode` and `ultrathink` behavior still applies. Only
+list values supported by your Claude Code version and gateway.
+
+Claude fast mode has an important limit: it is Claude Code's native `fastMode` setting. It is not
+OpenAI priority service, and the Claude Agent SDK does not provide an OpenAI `serviceTier` option.
+Enable fast mode only when your Claude runtime and gateway support Claude's native fast-mode
+setting. A gateway that only supports OpenAI priority service cannot receive that choice through
+the Claude provider.
+
+Existing custom models keep working without changes. A custom model with no declared controls keeps
+the same empty capability metadata and shows no extra composer controls.
+
 ## I Only Use One Claude Account
 
 Use the default provider.

--- a/docs/user/providers-claude.md
+++ b/docs/user/providers-claude.md
@@ -13,10 +13,9 @@ Common reasons:
 ## Custom Model Controls
 
 Add a custom model in **Settings → Providers → Claude → Models**. Use the settings button beside
-the model to declare the controls that model supports. You can enable reasoning effort, Claude fast
-mode, context-window, and thinking controls, then set supported values and defaults. The message
-composer only shows controls you enable. See [Custom models](./providers-custom-models.md) for the
-controls supported by every provider.
+the model to add controls by exact option ID, then set their labels, values, and defaults. Claude's
+adapter recognizes `effort`, `fastMode`, `contextWindow`, and `thinking`. The message composer shows
+every control you add. See [Custom models](./providers-custom-models.md) for adapter behavior.
 
 The saved model ID stays exact. For example, a custom model saved as `gateway/model` stays visible as
 `gateway/model`. If you declare a `1m` context option and select it, T3 Code gives Claude Code the

--- a/docs/user/providers-claude.md
+++ b/docs/user/providers-claude.md
@@ -14,8 +14,9 @@ Common reasons:
 
 Add a custom model in **Settings → Providers → Claude → Models**. Use the settings button beside
 the model to declare the controls that model supports. You can enable reasoning effort, Claude fast
-mode, and context-window controls, then set supported values and defaults. The message composer only
-shows controls you enable.
+mode, context-window, and thinking controls, then set supported values and defaults. The message
+composer only shows controls you enable. See [Custom models](./providers-custom-models.md) for the
+controls supported by every provider.
 
 The saved model ID stays exact. For example, a custom model saved as `gateway/model` stays visible as
 `gateway/model`. If you declare a `1m` context option and select it, T3 Code gives Claude Code the

--- a/docs/user/providers-codex.md
+++ b/docs/user/providers-codex.md
@@ -14,7 +14,8 @@ Common reasons:
 
 Add a custom model in **Settings → Providers → Codex → Models**. Use the settings button beside the
 model to declare supported controls, values, and defaults. The message composer only shows controls
-you enable.
+you enable. See [Custom models](./providers-custom-models.md) for the controls supported by every
+provider.
 
 Codex reasoning choices are sent as `reasoningEffort`. Service-tier choices are sent as
 `serviceTier`; this is where Standard, Fast, priority, or other tiers reported by the Codex app

--- a/docs/user/providers-codex.md
+++ b/docs/user/providers-codex.md
@@ -10,6 +10,22 @@ Common reasons:
 - switch to another account when one account hits limits
 - keep one shared Codex history instead of maintaining two separate Codex setups
 
+## Custom Model Controls
+
+Add a custom model in **Settings → Providers → Codex → Models**. Use the settings button beside the
+model to declare supported controls, values, and defaults. The message composer only shows controls
+you enable.
+
+Codex reasoning choices are sent as `reasoningEffort`. Service-tier choices are sent as
+`serviceTier`; this is where Standard, Fast, priority, or other tiers reported by the Codex app
+server belong. A tier only works when the selected Codex endpoint supports it.
+
+T3 Code does not treat Claude fast mode as a Codex or OpenAI service tier. Each provider adapter uses
+its own native request option. The Codex adapter has no context-window request option today, so T3
+Code does not offer a Codex context-window template.
+
+Existing custom models with no declared controls continue to work as before.
+
 ## I Only Use One Codex Account
 
 Use the default provider.

--- a/docs/user/providers-codex.md
+++ b/docs/user/providers-codex.md
@@ -13,17 +13,16 @@ Common reasons:
 ## Custom Model Controls
 
 Add a custom model in **Settings → Providers → Codex → Models**. Use the settings button beside the
-model to declare supported controls, values, and defaults. The message composer only shows controls
-you enable. See [Custom models](./providers-custom-models.md) for the controls supported by every
-provider.
+model to add controls by exact option ID, then set their labels, values, and defaults. Codex's
+adapter recognizes `reasoningEffort` and `serviceTier`. The message composer shows every control you
+add. See [Custom models](./providers-custom-models.md) for adapter behavior.
 
 Codex reasoning choices are sent as `reasoningEffort`. Service-tier choices are sent as
 `serviceTier`; this is where Standard, Fast, priority, or other tiers reported by the Codex app
 server belong. A tier only works when the selected Codex endpoint supports it.
 
 T3 Code does not treat Claude fast mode as a Codex or OpenAI service tier. Each provider adapter uses
-its own native request option. The Codex adapter has no context-window request option today, so T3
-Code does not offer a Codex context-window template.
+its own native request option. The Codex adapter has no `contextWindow` request translation today.
 
 Existing custom models with no declared controls continue to work as before.
 

--- a/docs/user/providers-custom-models.md
+++ b/docs/user/providers-custom-models.md
@@ -1,34 +1,32 @@
 # Custom models
 
-Add a model in **Settings → Providers → Models**. Use the settings button beside the custom model
-to declare only the controls that model supports. Set its supported values and default value. The
-message composer then shows only those controls.
+Add a model in **Settings → Providers → your provider → Models**. Use the settings button beside the
+custom model to add any select or on/off control by its exact option ID. Set its label, values, and
+default. The message composer then shows the declared controls.
 
 T3 Code keeps the saved model ID exact. A provider adapter can change request syntax only when its
 native API requires it. Existing custom models with no capability metadata keep their old behavior.
 
-## Supported controls
+## Adapter behavior
 
-| Provider | Custom controls T3 Code can send                             |
-| -------- | ------------------------------------------------------------ |
-| Claude   | Reasoning effort, Claude fast mode, context window, thinking |
-| Codex    | Reasoning effort, service tier                               |
-| Cursor   | Reasoning, context window, fast mode, thinking               |
-| OpenCode | Variant and agent                                            |
-| Grok     | None; T3 Code's Grok adapter sends only model selection      |
+| Provider | Control IDs with runtime translation                    |
+| -------- | ------------------------------------------------------- |
+| Claude   | `effort`, `fastMode`, `contextWindow`, `thinking`       |
+| Codex    | `reasoningEffort`, `serviceTier`                        |
+| Cursor   | `reasoning`, `contextWindow`, `fastMode`, `thinking`    |
+| OpenCode | `variant`, `agent`                                      |
+| Grok     | None; T3 Code's Grok adapter sends only model selection |
 
-T3 Code hides metadata with an unsupported control name or value type. This prevents a control from
-appearing when its provider adapter cannot send it.
-
-The capability editor renders every select or on/off descriptor offered by the provider. New control
-IDs do not need model-specific UI code.
+The capability editor and composer render every declared select or on/off descriptor without a
+provider control list. This does not add a new provider API option. An adapter sends IDs it
+understands and ignores other selections.
 
 Cursor sends choices through ACP session configuration. A choice is applied only when the active
 Cursor CLI reports a matching configuration option for the selected model.
 
 OpenCode sends `variant` and `agent` through its SDK request. Its adapter has no model speed-tier or
-context-window request option. The Grok session data T3 Code consumes reports models but no supported
-model options, so Grok custom models do not show capability controls.
+context-window request option. The Grok adapter sends only model selection, so custom controls can be
+displayed but do not change its request.
 
 Claude `fastMode` is a Claude Code setting. It is not OpenAI priority service. Codex sends speed as
 its native `serviceTier` value. Do not use one as a substitute for the other.

--- a/docs/user/providers-custom-models.md
+++ b/docs/user/providers-custom-models.md
@@ -1,0 +1,35 @@
+# Custom models
+
+Add a model in **Settings → Providers → Models**. Use the settings button beside the custom model
+to declare only the controls that model supports. Set its supported values and default value. The
+message composer then shows only those controls.
+
+T3 Code keeps the saved model ID exact. A provider adapter can change request syntax only when its
+native API requires it. Existing custom models with no capability metadata keep their old behavior.
+
+## Supported controls
+
+| Provider | Custom controls T3 Code can send                             |
+| -------- | ------------------------------------------------------------ |
+| Claude   | Reasoning effort, Claude fast mode, context window, thinking |
+| Codex    | Reasoning effort, service tier                               |
+| Cursor   | Reasoning, context window, fast mode, thinking               |
+| OpenCode | Variant, used as the model effort choice                     |
+| Grok     | None; T3 Code's Grok adapter sends only model selection      |
+
+T3 Code hides metadata with an unsupported control name or value type. This prevents a control from
+appearing when its provider adapter cannot send it.
+
+Cursor sends choices through ACP session configuration. A choice is applied only when the active
+Cursor CLI reports a matching configuration option for the selected model.
+
+OpenCode sends `variant` through its SDK request. Its adapter has no model speed-tier or context-window
+request option. The Grok session data T3 Code consumes reports models but no supported model options,
+so Grok custom models do not show capability controls.
+
+Claude `fastMode` is a Claude Code setting. It is not OpenAI priority service. Codex sends speed as
+its native `serviceTier` value. Do not use one as a substitute for the other.
+
+For Claude only, selecting a declared `1m` context value adds Claude Code's `[1m]` model selector at
+launch. The saved and displayed custom model ID stays unchanged. T3 Code does not assume 1M support
+for any model that did not declare it.

--- a/docs/user/providers-custom-models.md
+++ b/docs/user/providers-custom-models.md
@@ -14,18 +14,21 @@ native API requires it. Existing custom models with no capability metadata keep 
 | Claude   | Reasoning effort, Claude fast mode, context window, thinking |
 | Codex    | Reasoning effort, service tier                               |
 | Cursor   | Reasoning, context window, fast mode, thinking               |
-| OpenCode | Variant, used as the model effort choice                     |
+| OpenCode | Variant and agent                                            |
 | Grok     | None; T3 Code's Grok adapter sends only model selection      |
 
 T3 Code hides metadata with an unsupported control name or value type. This prevents a control from
 appearing when its provider adapter cannot send it.
 
+The capability editor renders every select or on/off descriptor offered by the provider. New control
+IDs do not need model-specific UI code.
+
 Cursor sends choices through ACP session configuration. A choice is applied only when the active
 Cursor CLI reports a matching configuration option for the selected model.
 
-OpenCode sends `variant` through its SDK request. Its adapter has no model speed-tier or context-window
-request option. The Grok session data T3 Code consumes reports models but no supported model options,
-so Grok custom models do not show capability controls.
+OpenCode sends `variant` and `agent` through its SDK request. Its adapter has no model speed-tier or
+context-window request option. The Grok session data T3 Code consumes reports models but no supported
+model options, so Grok custom models do not show capability controls.
 
 Claude `fastMode` is a Claude Code setting. It is not OpenAI priority service. Codex sends speed as
 its native `serviceTier` value. Do not use one as a substitute for the other.

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -127,6 +127,9 @@ export const ModelCapabilities = Schema.Struct({
 });
 export type ModelCapabilities = typeof ModelCapabilities.Type;
 
+export const CustomModelCapabilities = Schema.Record(TrimmedNonEmptyString, ModelCapabilities);
+export type CustomModelCapabilities = typeof CustomModelCapabilities.Type;
+
 const CODEX_DRIVER_KIND = ProviderDriverKind.make("codex");
 const CLAUDE_DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
 const CURSOR_DRIVER_KIND = ProviderDriverKind.make("cursor");

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -5,6 +5,7 @@ import * as SchemaTransformation from "effect/SchemaTransformation";
 import { TrimmedNonEmptyString, TrimmedString } from "./baseSchemas.ts";
 import { ThreadEnvMode } from "./environment.ts";
 import {
+  CustomModelCapabilities,
   DEFAULT_TEXT_GENERATION_MODEL,
   DEFAULT_TEXT_GENERATION_REASONING_EFFORT,
   ProviderOptionSelections,
@@ -315,6 +316,9 @@ export const CodexSettings = makeProviderSettingsSchema(
       Schema.withDecodingDefault(Effect.succeed([])),
       Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
     ),
+    customModelCapabilities: Schema.optionalKey(CustomModelCapabilities).pipe(
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
   },
   {
     order: ["binaryPath", "homePath", "shadowHomePath", "launchArgs"],
@@ -346,6 +350,9 @@ export const ClaudeSettings = makeProviderSettingsSchema(
     ),
     customModels: Schema.Array(Schema.String).pipe(
       Schema.withDecodingDefault(Effect.succeed([])),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+    customModelCapabilities: Schema.optionalKey(CustomModelCapabilities).pipe(
       Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
     ),
     launchArgs: Schema.String.pipe(
@@ -394,6 +401,9 @@ export const CursorSettings = makeProviderSettingsSchema(
       Schema.withDecodingDefault(Effect.succeed([])),
       Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
     ),
+    customModelCapabilities: Schema.optionalKey(CustomModelCapabilities).pipe(
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
   },
   {
     order: ["binaryPath", "apiEndpoint"],
@@ -416,6 +426,9 @@ export const GrokSettings = makeProviderSettingsSchema(
     ),
     customModels: Schema.Array(Schema.String).pipe(
       Schema.withDecodingDefault(Effect.succeed([])),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+    customModelCapabilities: Schema.optionalKey(CustomModelCapabilities).pipe(
       Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
     ),
   },
@@ -466,6 +479,9 @@ export const OpenCodeSettings = makeProviderSettingsSchema(
     ),
     customModels: Schema.Array(Schema.String).pipe(
       Schema.withDecodingDefault(Effect.succeed([])),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+    customModelCapabilities: Schema.optionalKey(CustomModelCapabilities).pipe(
       Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
     ),
   },
@@ -677,6 +693,7 @@ const CodexSettingsPatch = Schema.Struct({
   shadowHomePath: Schema.optionalKey(TrimmedString),
   launchArgs: Schema.optionalKey(TrimmedString),
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+  customModelCapabilities: Schema.optionalKey(CustomModelCapabilities),
 });
 
 const ClaudeSettingsPatch = Schema.Struct({
@@ -684,6 +701,7 @@ const ClaudeSettingsPatch = Schema.Struct({
   binaryPath: Schema.optionalKey(TrimmedString),
   homePath: Schema.optionalKey(TrimmedString),
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+  customModelCapabilities: Schema.optionalKey(CustomModelCapabilities),
   launchArgs: Schema.optionalKey(TrimmedString),
 });
 
@@ -692,12 +710,14 @@ const CursorSettingsPatch = Schema.Struct({
   binaryPath: Schema.optionalKey(TrimmedString),
   apiEndpoint: Schema.optionalKey(TrimmedString),
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+  customModelCapabilities: Schema.optionalKey(CustomModelCapabilities),
 });
 
 const GrokSettingsPatch = Schema.Struct({
   enabled: Schema.optionalKey(Schema.Boolean),
   binaryPath: Schema.optionalKey(TrimmedString),
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+  customModelCapabilities: Schema.optionalKey(CustomModelCapabilities),
 });
 
 const OpenCodeSettingsPatch = Schema.Struct({
@@ -706,6 +726,7 @@ const OpenCodeSettingsPatch = Schema.Struct({
   serverUrl: Schema.optionalKey(TrimmedString),
   serverPassword: Schema.optionalKey(TrimmedString),
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+  customModelCapabilities: Schema.optionalKey(CustomModelCapabilities),
 });
 
 export const ServerSettingsPatch = Schema.Struct({

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -10,7 +10,6 @@ import {
   getProviderOptionDescriptors,
   getProviderOptionBooleanSelectionValue,
   getProviderOptionStringSelectionValue,
-  isCustomModelOptionDescriptorSupported,
   normalizeCustomModelSlug,
   normalizeModelSlug,
 } from "./model.ts";
@@ -154,57 +153,5 @@ describe("model slug normalization", () => {
 
     expect(normalizeModelSlug("opus", claude)).toBe("claude-opus-5");
     expect(normalizeCustomModelSlug(" opus ")).toBe("opus");
-  });
-});
-
-describe("custom model option support", () => {
-  it("matches only option shapes each provider adapter can send", () => {
-    const select = (id: string) => ({
-      id,
-      label: id,
-      type: "select" as const,
-      options: [{ id: "value", label: "Value" }],
-    });
-    const boolean = (id: string) => ({ id, label: id, type: "boolean" as const });
-
-    expect(
-      isCustomModelOptionDescriptorSupported(
-        ProviderDriverKind.make("claudeAgent"),
-        select("effort"),
-      ),
-    ).toBe(true);
-    expect(
-      isCustomModelOptionDescriptorSupported(
-        ProviderDriverKind.make("claudeAgent"),
-        boolean("thinking"),
-      ),
-    ).toBe(true);
-    expect(
-      isCustomModelOptionDescriptorSupported(
-        ProviderDriverKind.make("codex"),
-        select("serviceTier"),
-      ),
-    ).toBe(true);
-    expect(
-      isCustomModelOptionDescriptorSupported(
-        ProviderDriverKind.make("cursor"),
-        boolean("thinking"),
-      ),
-    ).toBe(true);
-    expect(
-      isCustomModelOptionDescriptorSupported(
-        ProviderDriverKind.make("opencode"),
-        select("variant"),
-      ),
-    ).toBe(true);
-    expect(
-      isCustomModelOptionDescriptorSupported(ProviderDriverKind.make("opencode"), select("agent")),
-    ).toBe(true);
-    expect(
-      isCustomModelOptionDescriptorSupported(ProviderDriverKind.make("grok"), select("effort")),
-    ).toBe(false);
-    expect(
-      isCustomModelOptionDescriptorSupported(ProviderDriverKind.make("cursor"), select("fastMode")),
-    ).toBe(false);
   });
 });

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -10,6 +10,7 @@ import {
   getProviderOptionDescriptors,
   getProviderOptionBooleanSelectionValue,
   getProviderOptionStringSelectionValue,
+  isCustomModelOptionDescriptorSupported,
   normalizeCustomModelSlug,
   normalizeModelSlug,
 } from "./model.ts";
@@ -153,5 +154,54 @@ describe("model slug normalization", () => {
 
     expect(normalizeModelSlug("opus", claude)).toBe("claude-opus-5");
     expect(normalizeCustomModelSlug(" opus ")).toBe("opus");
+  });
+});
+
+describe("custom model option support", () => {
+  it("matches only option shapes each provider adapter can send", () => {
+    const select = (id: string) => ({
+      id,
+      label: id,
+      type: "select" as const,
+      options: [{ id: "value", label: "Value" }],
+    });
+    const boolean = (id: string) => ({ id, label: id, type: "boolean" as const });
+
+    expect(
+      isCustomModelOptionDescriptorSupported(
+        ProviderDriverKind.make("claudeAgent"),
+        select("effort"),
+      ),
+    ).toBe(true);
+    expect(
+      isCustomModelOptionDescriptorSupported(
+        ProviderDriverKind.make("claudeAgent"),
+        boolean("thinking"),
+      ),
+    ).toBe(true);
+    expect(
+      isCustomModelOptionDescriptorSupported(
+        ProviderDriverKind.make("codex"),
+        select("serviceTier"),
+      ),
+    ).toBe(true);
+    expect(
+      isCustomModelOptionDescriptorSupported(
+        ProviderDriverKind.make("cursor"),
+        boolean("thinking"),
+      ),
+    ).toBe(true);
+    expect(
+      isCustomModelOptionDescriptorSupported(
+        ProviderDriverKind.make("opencode"),
+        select("variant"),
+      ),
+    ).toBe(true);
+    expect(
+      isCustomModelOptionDescriptorSupported(ProviderDriverKind.make("grok"), select("effort")),
+    ).toBe(false);
+    expect(
+      isCustomModelOptionDescriptorSupported(ProviderDriverKind.make("cursor"), select("fastMode")),
+    ).toBe(false);
   });
 });

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -198,6 +198,9 @@ describe("custom model option support", () => {
       ),
     ).toBe(true);
     expect(
+      isCustomModelOptionDescriptorSupported(ProviderDriverKind.make("opencode"), select("agent")),
+    ).toBe(true);
+    expect(
       isCustomModelOptionDescriptorSupported(ProviderDriverKind.make("grok"), select("effort")),
     ).toBe(false);
     expect(

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -12,26 +12,6 @@ import {
 
 const DEFAULT_PROVIDER_DRIVER_KIND = ProviderDriverKind.make("codex");
 
-const CUSTOM_MODEL_OPTION_TYPES_BY_PROVIDER: Readonly<
-  Record<string, Readonly<Record<string, ProviderOptionDescriptor["type"]>>>
-> = {
-  codex: { reasoningEffort: "select", serviceTier: "select" },
-  claudeAgent: {
-    effort: "select",
-    fastMode: "boolean",
-    contextWindow: "select",
-    thinking: "boolean",
-  },
-  cursor: {
-    reasoning: "select",
-    fastMode: "boolean",
-    contextWindow: "select",
-    thinking: "boolean",
-  },
-  opencode: { variant: "select", agent: "select" },
-  grok: {},
-};
-
 export interface SelectableModelOption {
   slug: string;
   name: string;
@@ -43,27 +23,6 @@ export function createModelCapabilities(input: {
   return {
     optionDescriptors: input.optionDescriptors.map(cloneDescriptor),
   };
-}
-
-export function isCustomModelOptionDescriptorSupported(
-  provider: ProviderDriverKind,
-  descriptor: ProviderOptionDescriptor,
-): boolean {
-  return CUSTOM_MODEL_OPTION_TYPES_BY_PROVIDER[provider]?.[descriptor.id] === descriptor.type;
-}
-
-export function filterCustomModelCapabilities(
-  provider: ProviderDriverKind,
-  capabilities: ModelCapabilities,
-): ModelCapabilities {
-  return capabilities.optionDescriptors === undefined
-    ? capabilities
-    : {
-        ...capabilities,
-        optionDescriptors: capabilities.optionDescriptors.filter((descriptor) =>
-          isCustomModelOptionDescriptorSupported(provider, descriptor),
-        ),
-      };
 }
 
 export function getDeclaredCustomModelCapabilities(

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -28,7 +28,7 @@ const CUSTOM_MODEL_OPTION_TYPES_BY_PROVIDER: Readonly<
     contextWindow: "select",
     thinking: "boolean",
   },
-  opencode: { variant: "select" },
+  opencode: { variant: "select", agent: "select" },
   grok: {},
 };
 

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -12,6 +12,26 @@ import {
 
 const DEFAULT_PROVIDER_DRIVER_KIND = ProviderDriverKind.make("codex");
 
+const CUSTOM_MODEL_OPTION_TYPES_BY_PROVIDER: Readonly<
+  Record<string, Readonly<Record<string, ProviderOptionDescriptor["type"]>>>
+> = {
+  codex: { reasoningEffort: "select", serviceTier: "select" },
+  claudeAgent: {
+    effort: "select",
+    fastMode: "boolean",
+    contextWindow: "select",
+    thinking: "boolean",
+  },
+  cursor: {
+    reasoning: "select",
+    fastMode: "boolean",
+    contextWindow: "select",
+    thinking: "boolean",
+  },
+  opencode: { variant: "select" },
+  grok: {},
+};
+
 export interface SelectableModelOption {
   slug: string;
   name: string;
@@ -23,6 +43,36 @@ export function createModelCapabilities(input: {
   return {
     optionDescriptors: input.optionDescriptors.map(cloneDescriptor),
   };
+}
+
+export function isCustomModelOptionDescriptorSupported(
+  provider: ProviderDriverKind,
+  descriptor: ProviderOptionDescriptor,
+): boolean {
+  return CUSTOM_MODEL_OPTION_TYPES_BY_PROVIDER[provider]?.[descriptor.id] === descriptor.type;
+}
+
+export function filterCustomModelCapabilities(
+  provider: ProviderDriverKind,
+  capabilities: ModelCapabilities,
+): ModelCapabilities {
+  return capabilities.optionDescriptors === undefined
+    ? capabilities
+    : {
+        ...capabilities,
+        optionDescriptors: capabilities.optionDescriptors.filter((descriptor) =>
+          isCustomModelOptionDescriptorSupported(provider, descriptor),
+        ),
+      };
+}
+
+export function getDeclaredCustomModelCapabilities(
+  declarations: Readonly<Record<string, ModelCapabilities>> | null | undefined,
+  model: string | null | undefined,
+): ModelCapabilities | undefined {
+  return declarations && model && Object.hasOwn(declarations, model)
+    ? declarations[model]
+    : undefined;
 }
 
 function getRawSelectionValueById(

--- a/packages/shared/src/serverSettings.test.ts
+++ b/packages/shared/src/serverSettings.test.ts
@@ -298,6 +298,53 @@ describe("serverSettings helpers", () => {
     });
   });
 
+  it("replaces legacy custom model capability maps", () => {
+    const capabilities = {
+      optionDescriptors: [{ id: "fastMode", label: "Fast Mode", type: "boolean" as const }],
+    };
+    const current = {
+      ...DEFAULT_SERVER_SETTINGS,
+      providers: {
+        codex: {
+          ...DEFAULT_SERVER_SETTINGS.providers.codex,
+          customModelCapabilities: { old: capabilities },
+        },
+        claudeAgent: {
+          ...DEFAULT_SERVER_SETTINGS.providers.claudeAgent,
+          customModelCapabilities: { old: capabilities },
+        },
+        cursor: {
+          ...DEFAULT_SERVER_SETTINGS.providers.cursor,
+          customModelCapabilities: { old: capabilities },
+        },
+        grok: {
+          ...DEFAULT_SERVER_SETTINGS.providers.grok,
+          customModelCapabilities: { old: capabilities },
+        },
+        opencode: {
+          ...DEFAULT_SERVER_SETTINGS.providers.opencode,
+          customModelCapabilities: { old: capabilities },
+        },
+      },
+    };
+
+    const next = applyServerSettingsPatch(current, {
+      providers: {
+        codex: { customModelCapabilities: {} },
+        claudeAgent: { customModelCapabilities: { next: capabilities } },
+        cursor: { customModelCapabilities: {} },
+        grok: { customModelCapabilities: {} },
+        opencode: { customModelCapabilities: {} },
+      },
+    });
+
+    expect(next.providers.codex.customModelCapabilities).toEqual({});
+    expect(next.providers.claudeAgent.customModelCapabilities).toEqual({ next: capabilities });
+    expect(next.providers.cursor.customModelCapabilities).toEqual({});
+    expect(next.providers.grok.customModelCapabilities).toEqual({});
+    expect(next.providers.opencode.customModelCapabilities).toEqual({});
+  });
+
   it("stores background activity profiles as a versioned object and syncs legacy aliases", () => {
     const next = applyServerSettingsPatch(DEFAULT_SERVER_SETTINGS, {
       backgroundActivity: {

--- a/packages/shared/src/serverSettings.test.ts
+++ b/packages/shared/src/serverSettings.test.ts
@@ -298,6 +298,41 @@ describe("serverSettings helpers", () => {
     });
   });
 
+  it("replaces legacy custom model capability maps", () => {
+    const capabilities = {
+      optionDescriptors: [{ id: "fastMode", label: "Fast Mode", type: "boolean" as const }],
+    };
+    const current = {
+      ...DEFAULT_SERVER_SETTINGS,
+      providers: {
+        ...DEFAULT_SERVER_SETTINGS.providers,
+        claudeAgent: {
+          ...DEFAULT_SERVER_SETTINGS.providers.claudeAgent,
+          customModelCapabilities: {
+            "gateway/one": capabilities,
+            "gateway/two": capabilities,
+          },
+        },
+      },
+    };
+
+    const replaced = applyServerSettingsPatch(current, {
+      providers: {
+        claudeAgent: {
+          customModelCapabilities: { "gateway/one": capabilities },
+        },
+      },
+    });
+    expect(replaced.providers.claudeAgent.customModelCapabilities).toEqual({
+      "gateway/one": capabilities,
+    });
+
+    const cleared = applyServerSettingsPatch(current, {
+      providers: { claudeAgent: { customModelCapabilities: {} } },
+    });
+    expect(cleared.providers.claudeAgent.customModelCapabilities).toEqual({});
+  });
+
   it("stores background activity profiles as a versioned object and syncs legacy aliases", () => {
     const next = applyServerSettingsPatch(DEFAULT_SERVER_SETTINGS, {
       backgroundActivity: {

--- a/packages/shared/src/serverSettings.test.ts
+++ b/packages/shared/src/serverSettings.test.ts
@@ -298,41 +298,6 @@ describe("serverSettings helpers", () => {
     });
   });
 
-  it("replaces legacy custom model capability maps", () => {
-    const capabilities = {
-      optionDescriptors: [{ id: "fastMode", label: "Fast Mode", type: "boolean" as const }],
-    };
-    const current = {
-      ...DEFAULT_SERVER_SETTINGS,
-      providers: {
-        ...DEFAULT_SERVER_SETTINGS.providers,
-        claudeAgent: {
-          ...DEFAULT_SERVER_SETTINGS.providers.claudeAgent,
-          customModelCapabilities: {
-            "gateway/one": capabilities,
-            "gateway/two": capabilities,
-          },
-        },
-      },
-    };
-
-    const replaced = applyServerSettingsPatch(current, {
-      providers: {
-        claudeAgent: {
-          customModelCapabilities: { "gateway/one": capabilities },
-        },
-      },
-    });
-    expect(replaced.providers.claudeAgent.customModelCapabilities).toEqual({
-      "gateway/one": capabilities,
-    });
-
-    const cleared = applyServerSettingsPatch(current, {
-      providers: { claudeAgent: { customModelCapabilities: {} } },
-    });
-    expect(cleared.providers.claudeAgent.customModelCapabilities).toEqual({});
-  });
-
   it("stores background activity profiles as a versioned object and syncs legacy aliases", () => {
     const next = applyServerSettingsPatch(DEFAULT_SERVER_SETTINGS, {
       backgroundActivity: {

--- a/packages/shared/src/serverSettings.ts
+++ b/packages/shared/src/serverSettings.ts
@@ -121,6 +121,15 @@ function mergeModelSelectionOptionsById(input: {
   return [...merged.entries()].map(([id, value]) => ({ id, value }));
 }
 
+function replaceCustomModelCapabilities<
+  Current extends { readonly customModelCapabilities?: unknown },
+  Patch extends { readonly customModelCapabilities?: Current["customModelCapabilities"] },
+>(current: Current, patch: Patch | undefined): Current {
+  return patch?.customModelCapabilities === undefined
+    ? current
+    : ({ ...current, customModelCapabilities: patch.customModelCapabilities } as Current);
+}
+
 export function applyServerSettingsPatch(
   current: ServerSettings,
   patch: ServerSettingsPatch,
@@ -171,6 +180,17 @@ export function applyServerSettingsPatch(
   const next = deepMerge(current, patchForMerge);
   const nextWithReplacementsBase = {
     ...next,
+    providers: {
+      ...next.providers,
+      claudeAgent: replaceCustomModelCapabilities(
+        next.providers.claudeAgent,
+        patch.providers?.claudeAgent,
+      ),
+      codex: replaceCustomModelCapabilities(next.providers.codex, patch.providers?.codex),
+      cursor: replaceCustomModelCapabilities(next.providers.cursor, patch.providers?.cursor),
+      grok: replaceCustomModelCapabilities(next.providers.grok, patch.providers?.grok),
+      opencode: replaceCustomModelCapabilities(next.providers.opencode, patch.providers?.opencode),
+    },
     ...(backgroundActivity !== undefined
       ? {
           backgroundActivity: {

--- a/packages/shared/src/serverSettings.ts
+++ b/packages/shared/src/serverSettings.ts
@@ -121,15 +121,6 @@ function mergeModelSelectionOptionsById(input: {
   return [...merged.entries()].map(([id, value]) => ({ id, value }));
 }
 
-function replaceCustomModelCapabilities<
-  Current extends { readonly customModelCapabilities?: unknown },
-  Patch extends { readonly customModelCapabilities?: Current["customModelCapabilities"] },
->(current: Current, patch: Patch | undefined): Current {
-  return patch?.customModelCapabilities === undefined
-    ? current
-    : ({ ...current, customModelCapabilities: patch.customModelCapabilities } as Current);
-}
-
 export function applyServerSettingsPatch(
   current: ServerSettings,
   patch: ServerSettingsPatch,
@@ -180,17 +171,6 @@ export function applyServerSettingsPatch(
   const next = deepMerge(current, patchForMerge);
   const nextWithReplacementsBase = {
     ...next,
-    providers: {
-      ...next.providers,
-      claudeAgent: replaceCustomModelCapabilities(
-        next.providers.claudeAgent,
-        patch.providers?.claudeAgent,
-      ),
-      codex: replaceCustomModelCapabilities(next.providers.codex, patch.providers?.codex),
-      cursor: replaceCustomModelCapabilities(next.providers.cursor, patch.providers?.cursor),
-      grok: replaceCustomModelCapabilities(next.providers.grok, patch.providers?.grok),
-      opencode: replaceCustomModelCapabilities(next.providers.opencode, patch.providers?.opencode),
-    },
     ...(backgroundActivity !== undefined
       ? {
           backgroundActivity: {


### PR DESCRIPTION
## Problem

Custom model inference worked, but custom catalog entries had empty `ModelCapabilities`. The
composer therefore hid reasoning, speed, context-window, and other model controls. Claude 1M
context also required putting `[1m]` in the visible custom model ID.

## Root cause

Provider settings stored custom model IDs only. Per-model descriptors never reached the provider
catalog, composer, `ModelSelection`, or adapter request path.

## Design

Custom models can now store optional `ModelCapabilities` keyed by their exact model ID.

- Reuses the existing `ProviderOptionDescriptor` and `ModelSelection` contracts.
- Lets users add any current descriptor type: select or on/off.
- Lets users set each descriptor's exact ID and label, add exact select values, choose defaults,
  and set boolean defaults.
- Lets users copy one or more exact descriptors from any model catalog exposed by another supported
  harness instance.
- Replaces an existing control with the same ID in place; newly copied IDs append.
- Uses no model-name, provider, control-ID, or template allowlist in the editor or catalog.
- Renders only the descriptors declared for that custom model.
- Keeps arbitrary descriptors intact across settings, snapshots, and clients.
- Keeps provider-specific request translation inside each adapter.
- Preserves exact custom model IDs, including IDs that resemble built-in aliases.
- Keeps built-in capability resolution unchanged and ahead of custom metadata.

An unknown descriptor can still be saved and shown. It has no request effect until that provider
adapter supports its ID. This keeps the UI generic without sending guessed provider options.

## Provider behavior

| Provider | Descriptor IDs translated at runtime | Translation |
| --- | --- | --- |
| Claude | `effort`, `fastMode`, `contextWindow`, `thinking` | Claude SDK options and settings |
| Codex | `reasoningEffort`, `serviceTier` | Codex app-server options |
| Cursor | `reasoning`, `contextWindow`, `fastMode`, `thinking` | Matching ACP session configuration reported by the active Cursor CLI |
| OpenCode | `variant`, `agent` | OpenCode SDK request options |
| Grok | None today | Current Grok adapter sends model selection only |

Claude `fastMode` is Claude Code's native setting. It is not OpenAI priority service. Codex speed
uses native `serviceTier`; T3 Code does not translate one into the other.

Cursor applies a selection only when the active CLI reports a matching ACP configuration option.
OpenCode has no speed-tier or context-window request option today. Grok has no model-option request
path today.

Copying preserves exact descriptor IDs and values. It does not translate meanings between
providers. The target adapter still decides whether a copied descriptor can affect its request.

## Context-window handling

For Claude only, selecting a declared `contextWindow=1m` adds Claude Code's `[1m]` selector to the
request model ID. The stored and visible custom model ID stays exact. No model gets a global 1M
assumption.

## Backward compatibility

- Existing settings without capability metadata decode unchanged.
- Existing custom models keep their prior behavior.
- Existing select option labels stay intact; new values derive labels from their exact IDs.
- New custom models start with an explicit empty capability set.
- Explicit empty metadata stays distinct from absent legacy metadata.
- Removing a custom model removes its saved capability metadata.
- Existing built-in models and their capabilities stay unchanged.

## UI

Custom-model rows now have a generic control editor. Select values render as tags. Space, comma,
Enter, or blur commits a value; clicking a tag selects its default; and its remove action deletes
it. Stored exact values, including values containing commas, remain intact.

`Copy controls` opens a harness picker, a model picker, and a checkbox list. Users can copy one or
more controls. Duplicate harness names include their instance ID. The model being edited is the
only excluded source. Catalog refreshes clear stale checked controls before a copy can occur.

Manual edits and copied controls stay local until Save is selected. Closing the editor without Save
cancels them. The boolean control heading is `ON / OFF`.

Web and desktop share this UI. Composer option rendering and selection storage continue to use the
existing shared descriptor system used by web, desktop, and mobile.

The author will attach an updated UI video separately.

## Tests

Coverage includes:

- old settings decoding and capability-map persistence
- built-in precedence and exact custom capability resolution
- reserved and inherited object-key safety
- generic select/on-off descriptor creation, exact select-choice IDs, and composer visibility
- tag entry delimiters, comma-bearing values, tag default selection, Save action, and `ON / OFF`
- cross-harness source collection, exact multi-control copy, replacement order, self-source
  exclusion, duplicate harness labels, and catalog-refresh selection safety
- explicit empty versus absent legacy metadata
- exact alias-shaped custom IDs through start, model switches, and follow-up turns
- Claude effort, fast-mode true/false, context, and thinking options
- Codex reasoning and service-tier options
- Cursor ACP and OpenCode SDK option paths
- Grok's model-only limitation

Latest copy-controls verification:

- `vp test run apps/web/src/components/settings/ProviderModelsSection.test.ts apps/web/src/components/settings/ProviderInstanceCard.test.ts apps/web/src/components/settings/ProviderSettingsPanel.environment.test.tsx` — 32 passed
- `vpr -F @t3tools/web typecheck` — passed
- focused `vp lint ... --deny-warnings` — passed
- focused `vp fmt ... --check` — passed
- `git diff --check` — passed

Earlier branch-wide verification before the UI-only follow-ups:

- Focused capability suite — 355 passed across 15 files
- `vp check` — 0 errors; 12 existing repository warnings
- `vpr typecheck` — passed across 15 packages
- `vp run test` — 8,215 passed; 7 skipped
- `vp run lint:mobile` — passed; optional native linters are unavailable on this Linux host
- `vp run release:smoke` — passed

Built with GPT-5.6-sol through the Codex harness.

<!-- t3bot-requester: discord_user_id=1144295423314493490 github=Bil0000 message_id=1538269419975868596 -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-custom-model capability configuration across all providers
> - Introduces a `CustomModelCapabilities` schema (a map of model slug → `ModelCapabilities`) added to settings for all providers (Claude, Codex, Cursor, Grok, OpenCode).
> - Provider snapshot builders (`providerModelsFromSettings`) now assign declared per-model capabilities from this map instead of always using a shared fallback.
> - Claude adapter and text generation forward custom capabilities into model ID resolution (including `[1m]` suffix), effort normalization, context window selection, and `fastMode`/`thinking` boolean settings.
> - Codex session runtime preserves exact custom model IDs through normalization and propagates `customModels` to thread/turn start requests.
> - Settings UI gains a per-custom-model capabilities popover in `ProviderModelsSection`, with controls to add/edit select and boolean descriptors, copy from other providers, and reconcile capabilities when the custom model list changes.
> - `applyServerSettingsPatch` now replaces `customModelCapabilities` maps instead of deep-merging them, preventing stale keys from persisting across updates.
> - `TraitsPicker` visibility now responds to any declared descriptor, not just the hardcoded built-in controls.
> - Risk: `customModelCapabilities` patch semantics changed to replace-not-merge; existing tooling that relies on partial-patch behavior to update individual model capabilities will overwrite the entire map.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fd65aee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
