### PR TITLE
fix(preview): make in-app browser automation work on real app pages

### DIFF
--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -75,6 +75,7 @@ export const PREVIEW_AUTOMATION_PRESS_CHANNEL = "desktop:preview-automation-pres
 export const PREVIEW_AUTOMATION_SCROLL_CHANNEL = "desktop:preview-automation-scroll";
 export const PREVIEW_AUTOMATION_EVALUATE_CHANNEL = "desktop:preview-automation-evaluate";
 export const PREVIEW_AUTOMATION_WAIT_FOR_CHANNEL = "desktop:preview-automation-wait-for";
+export const PREVIEW_AUTOMATION_SET_VIEWPORT_CHANNEL = "desktop:preview-automation-set-viewport";
 export const PREVIEW_RECORDING_START_CHANNEL = "desktop:preview-recording-start";
 export const PREVIEW_RECORDING_STOP_CHANNEL = "desktop:preview-recording-stop";
 export const PREVIEW_RECORDING_SAVE_CHANNEL = "desktop:preview-recording-save";

--- a/apps/desktop/src/ipc/methods/preview.ts
+++ b/apps/desktop/src/ipc/methods/preview.ts
@@ -290,18 +290,11 @@ export const automationSetViewport = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_AUTOMATION_SET_VIEWPORT_CHANNEL,
   payload: DesktopPreviewAutomationSetViewportInputSchema,
   result: Schema.Void,
-  handler: Effect.fn("desktop.ipc.preview.automationSetViewport")(function* ({
-    tabId,
-    width,
-    height,
-    clear,
-  }) {
+  handler: Effect.fn("desktop.ipc.preview.automationSetViewport")(function* (input) {
     const manager = yield* PreviewManager.PreviewManager;
     yield* manager.automationSetViewport(
-      tabId,
-      clear === true || width === undefined || height === undefined
-        ? { clear: true }
-        : { width, height },
+      input.tabId,
+      "clear" in input ? { clear: true } : { width: input.width, height: input.height },
     );
   }),
 });

--- a/apps/desktop/src/ipc/methods/preview.ts
+++ b/apps/desktop/src/ipc/methods/preview.ts
@@ -2,6 +2,8 @@ import {
   DesktopPreviewAnnotationThemeInputSchema,
   DesktopPreviewArtifactInputSchema,
   DesktopPreviewAutomationClickInputSchema,
+  DesktopPreviewAutomationSetViewportInputSchema,
+  DesktopPreviewAutomationSnapshotInputSchema,
   DesktopPreviewAutomationEvaluateInputSchema,
   DesktopPreviewAutomationPressInputSchema,
   DesktopPreviewAutomationScrollInputSchema,
@@ -276,11 +278,31 @@ export const automationStatus = DesktopIpc.makeIpcMethod({
 
 export const automationSnapshot = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_AUTOMATION_SNAPSHOT_CHANNEL,
-  payload: DesktopPreviewTabInputSchema,
+  payload: DesktopPreviewAutomationSnapshotInputSchema,
   result: PreviewAutomationSnapshot,
-  handler: Effect.fn("desktop.ipc.preview.automationSnapshot")(function* ({ tabId }) {
+  handler: Effect.fn("desktop.ipc.preview.automationSnapshot")(function* ({ tabId, include }) {
     const manager = yield* PreviewManager.PreviewManager;
-    return yield* manager.automationSnapshot(tabId);
+    return yield* manager.automationSnapshot(tabId, include ?? []);
+  }),
+});
+
+export const automationSetViewport = DesktopIpc.makeIpcMethod({
+  channel: IpcChannels.PREVIEW_AUTOMATION_SET_VIEWPORT_CHANNEL,
+  payload: DesktopPreviewAutomationSetViewportInputSchema,
+  result: Schema.Void,
+  handler: Effect.fn("desktop.ipc.preview.automationSetViewport")(function* ({
+    tabId,
+    width,
+    height,
+    clear,
+  }) {
+    const manager = yield* PreviewManager.PreviewManager;
+    yield* manager.automationSetViewport(
+      tabId,
+      clear === true || width === undefined || height === undefined
+        ? { clear: true }
+        : { width, height },
+    );
   }),
 });
 
@@ -381,6 +403,7 @@ export const methods = [
   closePictureInPicture,
   automationStatus,
   automationSnapshot,
+  automationSetViewport,
   automationClick,
   automationType,
   automationPress,

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -225,8 +225,16 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     automation: {
       status: (tabId) =>
         ipcRenderer.invoke(IpcChannels.PREVIEW_AUTOMATION_STATUS_CHANNEL, { tabId }),
-      snapshot: (tabId) =>
-        ipcRenderer.invoke(IpcChannels.PREVIEW_AUTOMATION_SNAPSHOT_CHANNEL, { tabId }),
+      snapshot: (tabId, include) =>
+        ipcRenderer.invoke(IpcChannels.PREVIEW_AUTOMATION_SNAPSHOT_CHANNEL, {
+          tabId,
+          ...(include === undefined ? {} : { include }),
+        }),
+      setViewport: (tabId, input) =>
+        ipcRenderer.invoke(IpcChannels.PREVIEW_AUTOMATION_SET_VIEWPORT_CHANNEL, {
+          tabId,
+          ...input,
+        }),
       click: (tabId, input) =>
         ipcRenderer.invoke(IpcChannels.PREVIEW_AUTOMATION_CLICK_CHANNEL, { tabId, input }),
       type: (tabId, input) =>

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -2842,26 +2842,23 @@ describe("Preview automation diagnostics", () => {
 
   it("names hidden, disabled, and ambiguous click failures without leaking the locator", () => {
     const selector = "role=button[name='target-secret']";
-    const hidden = new PreviewManager.PreviewAutomationTargetNotFoundError({
+    const hidden = new PreviewManager.PreviewAutomationTargetHiddenError({
       operation: "click",
       tabId: "tab_1",
       selectorKind: "locator",
       selectorLength: selector.length,
-      failureKind: "hidden",
     });
-    const disabled = new PreviewManager.PreviewAutomationTargetNotFoundError({
+    const disabled = new PreviewManager.PreviewAutomationTargetDisabledError({
       operation: "click",
       tabId: "tab_1",
       selectorKind: "locator",
       selectorLength: selector.length,
-      failureKind: "disabled",
     });
-    const ambiguous = new PreviewManager.PreviewAutomationTargetNotFoundError({
+    const ambiguous = new PreviewManager.PreviewAutomationTargetAmbiguousError({
       operation: "click",
       tabId: "tab_1",
       selectorKind: "locator",
       selectorLength: selector.length,
-      failureKind: "ambiguous",
       matchCount: 3,
     });
     expect(hidden.message).toContain("not visible");

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -2839,4 +2839,36 @@ describe("Preview automation diagnostics", () => {
     expect(JSON.stringify(error)).not.toContain(selector);
     expect("locator" in error).toBe(false);
   });
+
+  it("names hidden, disabled, and ambiguous click failures without leaking the locator", () => {
+    const selector = "role=button[name='target-secret']";
+    const hidden = new PreviewManager.PreviewAutomationTargetNotFoundError({
+      operation: "click",
+      tabId: "tab_1",
+      selectorKind: "locator",
+      selectorLength: selector.length,
+      failureKind: "hidden",
+    });
+    const disabled = new PreviewManager.PreviewAutomationTargetNotFoundError({
+      operation: "click",
+      tabId: "tab_1",
+      selectorKind: "locator",
+      selectorLength: selector.length,
+      failureKind: "disabled",
+    });
+    const ambiguous = new PreviewManager.PreviewAutomationTargetNotFoundError({
+      operation: "click",
+      tabId: "tab_1",
+      selectorKind: "locator",
+      selectorLength: selector.length,
+      failureKind: "ambiguous",
+      matchCount: 3,
+    });
+    expect(hidden.message).toContain("not visible");
+    expect(disabled.message).toContain("disabled");
+    expect(ambiguous.message).toContain("matched 3 elements");
+    expect(hidden.message).not.toContain("secret");
+    expect(disabled.message).not.toContain("secret");
+    expect(ambiguous.message).not.toContain("secret");
+  });
 });

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -3489,7 +3489,6 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
                   if (element.getAttribute("role") === "dialog") {
                     const slot = element.getAttribute("data-slot") || "";
                     if (slot.includes("trigger")) return false;
-                    return (element.innerText || "").trim().length > 0;
                   }
                   return true;
                 })()`

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -24,6 +24,7 @@ import type {
   PreviewAutomationNetworkEntry,
   PreviewAutomationScrollInput,
   PreviewAutomationSnapshot,
+  PreviewAutomationSnapshotInclude,
   PreviewAutomationStatus,
   PreviewAutomationTypeInput,
   PreviewAutomationWaitForInput,
@@ -2231,6 +2232,23 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     yield* applyColorScheme(tabId, wc, colorScheme);
   });
 
+  const automationSetViewport = Effect.fn("PreviewManager.automationSetViewport")(function* (
+    tabId: string,
+    input: { readonly width: number; readonly height: number } | { readonly clear: true },
+  ) {
+    const wc = yield* requireWebContents(tabId);
+    yield* withControlSession(tabId, wc, "resize", (send) =>
+      "clear" in input
+        ? send("Emulation.clearDeviceMetricsOverride")
+        : send("Emulation.setDeviceMetricsOverride", {
+            width: input.width,
+            height: input.height,
+            deviceScaleFactor: 1,
+            mobile: input.width < 768,
+          }),
+    );
+  });
+
   const captureScreenshot = Effect.fn("PreviewManager.captureScreenshot")(function* (
     tabId: string,
   ) {
@@ -2843,11 +2861,17 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   });
 
   const captureAutomationSnapshot = Effect.fn("PreviewManager.captureAutomationSnapshot")(
-    function* (tabId: string, wc: Electron.WebContents, send: SendCommand) {
-      yield* Effect.all([send("Runtime.enable"), send("Accessibility.enable")], {
-        concurrency: 2,
-        discard: true,
-      });
+    function* (
+      tabId: string,
+      wc: Electron.WebContents,
+      send: SendCommand,
+      include: ReadonlyArray<PreviewAutomationSnapshotInclude> = [],
+    ) {
+      const includeAx = include.includes("ax");
+      const includeConsole = include.includes("console");
+      const includeNetwork = include.includes("network");
+      yield* send("Runtime.enable");
+      if (includeAx) yield* send("Accessibility.enable");
       const page = yield* evaluateWithDebugger<{
         url: string;
         title: string;
@@ -2885,14 +2909,27 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
             const rect = element.getBoundingClientRect();
             return style.visibility !== "hidden" && style.display !== "none" && rect.width > 0 && rect.height > 0;
           };
+          const clickable = (element) => {
+            if (element.matches("a[href],button,input,textarea,select,[role],[tabindex]")) return true;
+            const role = element.getAttribute("role");
+            if (role === "row" || role === "gridcell" || role === "option") return true;
+            const style = getComputedStyle(element);
+            return style.cursor === "pointer" && (element.tagName === "TR" || element.tagName === "TD" || element.tagName === "DIV");
+          };
+          const seen = new Set();
           const elements = Array.from(document.querySelectorAll(
-            "a[href],button,input,textarea,select,[role],[tabindex]"
-          )).filter(visible).slice(0, ${MAX_INTERACTIVE_ELEMENTS}).map((element) => {
+            "a[href],button,input,textarea,select,[role],[tabindex],[role=row],tr,[role=gridcell]"
+          )).filter((element) => {
+            if (!visible(element) || !clickable(element) || seen.has(element)) return false;
+            seen.add(element);
+            return true;
+          }).slice(0, ${MAX_INTERACTIVE_ELEMENTS}).map((element, index) => {
             const rect = element.getBoundingClientRect();
             return {
+              id: "e" + (index + 1),
               tag: element.tagName.toLowerCase(),
               role: element.getAttribute("role"),
-              name: element.getAttribute("aria-label") || element.innerText || element.getAttribute("name") || "",
+              name: (element.getAttribute("aria-label") || element.innerText || element.getAttribute("name") || "").slice(0, 160),
               selector: selectorFor(element),
               x: rect.x,
               y: rect.y,
@@ -2900,29 +2937,45 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
               height: rect.height
             };
           });
+          const main = document.querySelector("main");
           return {
             url: location.href,
             title: document.title,
             loading: document.readyState !== "complete",
-            visibleText: (document.body?.innerText || "").slice(0, ${MAX_VISIBLE_TEXT_LENGTH}),
+            visibleText: ((main && main.innerText) || document.body?.innerText || "").slice(0, ${MAX_VISIBLE_TEXT_LENGTH}),
             interactiveElements: elements
           };
         })()`,
         true,
       );
-      const [accessibility, sourceImage, diagnostics, timelines] = yield* Effect.all([
-        send("Accessibility.getFullAXTree"),
-        attemptPromise(
-          {
-            operation: "automationSnapshot.capturePage",
-            tabId,
-            webContentsId: wc.id,
-          },
-          () => wc.capturePage(),
+      const accessibility = includeAx ? yield* send("Accessibility.getFullAXTree") : undefined;
+      const [diagnostics, timelines] = yield* Effect.all(
+        [Ref.get(diagnosticsRef), Ref.get(actionTimelineRef)],
+        { concurrency: 2 },
+      );
+      const sourceImage = yield* attemptPromise(
+        {
+          operation: "automationSnapshot.capturePage",
+          tabId,
+          webContentsId: wc.id,
+        },
+        () => wc.capturePage(),
+      ).pipe(
+        Effect.catch(() =>
+          send("Page.captureScreenshot", { format: "png" }).pipe(
+            Effect.map((result) => {
+              const data =
+                result !== null &&
+                typeof result === "object" &&
+                "data" in result &&
+                typeof result.data === "string"
+                  ? result.data
+                  : "";
+              return nativeImage.createFromBuffer(Buffer.from(data, "base64"));
+            }),
+          ),
         ),
-        Ref.get(diagnosticsRef),
-        Ref.get(actionTimelineRef),
-      ]);
+      );
       const sourceSize = sourceImage.getSize();
       const image =
         sourceSize.width > MAX_SCREENSHOT_WIDTH
@@ -2932,9 +2985,9 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       const browserDiagnostics = diagnostics.get(wc.id);
       return {
         ...page,
-        accessibilityTree: accessibility,
-        consoleEntries: [...(browserDiagnostics?.consoleEntries ?? [])],
-        networkEntries: [...(browserDiagnostics?.networkEntries ?? [])],
+        ...(includeAx ? { accessibilityTree: accessibility } : {}),
+        consoleEntries: includeConsole ? [...(browserDiagnostics?.consoleEntries ?? [])] : [],
+        networkEntries: includeNetwork ? [...(browserDiagnostics?.networkEntries ?? [])] : [],
         actionTimeline: [...(timelines.get(tabId) ?? [])],
         screenshot: {
           mimeType: "image/png" as const,
@@ -2948,10 +3001,11 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
 
   const automationSnapshot = Effect.fn("PreviewManager.automationSnapshot")(function* (
     tabId: string,
+    include: ReadonlyArray<PreviewAutomationSnapshotInclude> = [],
   ) {
     const wc = yield* requireWebContents(tabId);
     return yield* withControlSession(tabId, wc, "snapshot", (send) =>
-      captureAutomationSnapshot(tabId, wc, send),
+      captureAutomationSnapshot(tabId, wc, send, include),
     );
   });
 
@@ -2970,7 +3024,13 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       locator,
     );
     const point = yield* evaluateWithDebugger<
-      { x: number; y: number } | { invalidSelector: true; message: string } | { notFound: true }
+      | { x: number; y: number }
+      | { invalidSelector: true; message: string }
+      | {
+          notFound: true;
+          failureKind: "missing" | "hidden" | "disabled" | "ambiguous";
+          matchCount?: number;
+        }
     >(
       tabId,
       send,
@@ -2978,11 +3038,24 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           try {
             const injected = globalThis.__t3PlaywrightInjected;
             const parsed = injected.parseSelector(${locatorJson});
-            const element = injected.querySelector(parsed, document, true);
-            if (!element) return { notFound: true };
+            let element;
+            try {
+              element = injected.querySelector(parsed, document, true);
+            } catch (error) {
+              const message = String(error);
+              if (message.toLowerCase().includes("strict mode")) {
+                const matches = injected.querySelectorAll
+                  ? injected.querySelectorAll(parsed, document)
+                  : [];
+                return { notFound: true, failureKind: "ambiguous", matchCount: matches.length || 2 };
+              }
+              throw error;
+            }
+            if (!element) return { notFound: true, failureKind: "missing" };
             const visible = injected.elementState(element, "visible");
             const enabled = injected.elementState(element, "enabled");
-            if (!visible.matches || !enabled.matches) return { notFound: true };
+            if (!visible.matches) return { notFound: true, failureKind: "hidden" };
+            if (!enabled.matches) return { notFound: true, failureKind: "disabled" };
             element.scrollIntoView({ block: "center", inline: "center" });
             const rect = element.getBoundingClientRect();
             return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
@@ -3006,6 +3079,8 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         operation: "click",
         tabId,
         ...automationSelectorDiagnostics(input),
+        failureKind: point.failureKind,
+        ...(point.matchCount === undefined ? {} : { matchCount: point.matchCount }),
       });
     }
     return point;
@@ -3378,7 +3453,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     yield* send("Runtime.enable");
     const locator = automationLocator(input);
     if (locator) yield* ensurePlaywrightInjected(tabId, send);
-    const [locatorJson, textJson, urlIncludesJson] = yield* Effect.all([
+    const [locatorJson, textJson, urlIncludesJson, scopeJson] = yield* Effect.all([
       locator
         ? encodeJson({ operation: "automationWaitFor.encodeLocator", tabId }, locator)
         : Effect.succeed(null),
@@ -3388,6 +3463,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       input.urlIncludes
         ? encodeJson({ operation: "automationWaitFor.encodeUrl", tabId }, input.urlIncludes)
         : Effect.succeed(null),
+      encodeJson({ operation: "automationWaitFor.encodeScope", tabId }, input.scope ?? "main"),
     ]);
     const deadline = (yield* currentMillis) + timeoutMs;
     while ((yield* currentMillis) <= deadline) {
@@ -3398,9 +3474,30 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         send,
         `(() => {
               try {
-                const selectorMatched = ${locatorJson ? `(() => { const injected = globalThis.__t3PlaywrightInjected; return injected.querySelector(injected.parseSelector(${locatorJson}), document, false) !== null; })()` : "true"};
+                const root = ${scopeJson} === "document"
+                  ? document.documentElement
+                  : (document.querySelector("main") || document.documentElement);
+                const selectorMatched = ${
+                  locatorJson
+                    ? `(() => {
+                  const injected = globalThis.__t3PlaywrightInjected;
+                  const parsed = injected.parseSelector(${locatorJson});
+                  const element = injected.querySelector(parsed, root, false);
+                  if (!element) return false;
+                  const visible = injected.elementState(element, "visible");
+                  if (!visible.matches) return false;
+                  if (element.getAttribute("role") === "dialog") {
+                    const slot = element.getAttribute("data-slot") || "";
+                    if (slot.includes("trigger")) return false;
+                    return (element.innerText || "").trim().length > 0;
+                  }
+                  return true;
+                })()`
+                    : "true"
+                };
+                const textRoot = root instanceof Element ? root : (root.body || document.body);
                 const textMatched = ${
-                  textJson ? `(document.body?.innerText || "").includes(${textJson})` : "true"
+                  textJson ? `(textRoot?.innerText || "").includes(${textJson})` : "true"
                 };
                 const urlMatched = ${
                   urlIncludesJson ? `location.href.includes(${urlIncludesJson})` : "true"
@@ -3524,6 +3621,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     saveRecording,
     setAnnotationTheme,
     setColorScheme,
+    automationSetViewport,
     setMainWindow,
     startRecording,
     closePictureInPicture,
@@ -3655,10 +3753,24 @@ export class PreviewAutomationTargetNotFoundError extends Schema.TaggedErrorClas
     tabId: Schema.String,
     selectorKind: PreviewAutomationSelectorKind,
     selectorLength: Schema.optionalKey(Schema.Number),
+    failureKind: Schema.optionalKey(
+      Schema.Literals(["missing", "hidden", "disabled", "ambiguous"]),
+    ),
+    matchCount: Schema.optionalKey(Schema.Number),
   },
 ) {
   override get message(): string {
     const target = previewAutomationTargetLabel(this.selectorKind, this.selectorLength);
+    if (this.failureKind === "hidden") {
+      return `Preview automation ${this.operation} found ${target} in tab ${this.tabId}, but it is not visible`;
+    }
+    if (this.failureKind === "disabled") {
+      return `Preview automation ${this.operation} found ${target} in tab ${this.tabId}, but it is disabled`;
+    }
+    if (this.failureKind === "ambiguous") {
+      const count = this.matchCount ?? 0;
+      return `Preview automation ${this.operation} matched ${count} elements for ${target} in tab ${this.tabId}`;
+    }
     return `Preview automation ${this.operation} could not find ${target} in tab ${this.tabId}`;
   }
 }
@@ -3853,7 +3965,12 @@ export class PreviewManager extends Context.Service<
     ) => Effect.Effect<PreviewAutomationStatus, PreviewManagerError>;
     readonly automationSnapshot: (
       tabId: string,
+      include?: ReadonlyArray<PreviewAutomationSnapshotInclude>,
     ) => Effect.Effect<PreviewAutomationSnapshot, PreviewManagerError>;
+    readonly automationSetViewport: (
+      tabId: string,
+      input: { readonly width: number; readonly height: number } | { readonly clear: true },
+    ) => Effect.Effect<void, PreviewManagerError>;
     readonly automationClick: (
       tabId: string,
       input: PreviewAutomationClickInput,
@@ -3921,6 +4038,7 @@ export const make = Effect.gen(function* PreviewManagerMake() {
     reapplyZoom: operations.reapplyZoom,
     hardReload: operations.hardReload,
     setColorScheme: operations.setColorScheme,
+    automationSetViewport: operations.automationSetViewport,
     openDevTools: operations.openDevTools,
     clearCookies: Effect.fn("PreviewManager.clearCookies")(function* () {
       yield* browserSession

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -3075,7 +3075,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       });
     }
     if ("notFound" in point) {
-      return yield* new PreviewAutomationTargetNotFoundError({
+      return yield* raiseAutomationTargetLookupError({
         operation: "click",
         tabId,
         ...automationSelectorDiagnostics(input),
@@ -3745,34 +3745,84 @@ export class PreviewAutomationEvaluationError extends Schema.TaggedErrorClass<Pr
   }
 }
 
+const PreviewAutomationTargetLookupFields = {
+  operation: Schema.String,
+  tabId: Schema.String,
+  selectorKind: PreviewAutomationSelectorKind,
+  selectorLength: Schema.optionalKey(Schema.Number),
+};
+
 export class PreviewAutomationTargetNotFoundError extends Schema.TaggedErrorClass<PreviewAutomationTargetNotFoundError>()(
   "PreviewAutomationTargetNotFoundError",
+  PreviewAutomationTargetLookupFields,
+) {
+  override get message(): string {
+    const target = previewAutomationTargetLabel(this.selectorKind, this.selectorLength);
+    return `Preview automation ${this.operation} could not find ${target} in tab ${this.tabId}`;
+  }
+}
+
+export class PreviewAutomationTargetHiddenError extends Schema.TaggedErrorClass<PreviewAutomationTargetHiddenError>()(
+  "PreviewAutomationTargetHiddenError",
+  PreviewAutomationTargetLookupFields,
+) {
+  override get message(): string {
+    const target = previewAutomationTargetLabel(this.selectorKind, this.selectorLength);
+    return `Preview automation ${this.operation} found ${target} in tab ${this.tabId}, but it is not visible`;
+  }
+}
+
+export class PreviewAutomationTargetDisabledError extends Schema.TaggedErrorClass<PreviewAutomationTargetDisabledError>()(
+  "PreviewAutomationTargetDisabledError",
+  PreviewAutomationTargetLookupFields,
+) {
+  override get message(): string {
+    const target = previewAutomationTargetLabel(this.selectorKind, this.selectorLength);
+    return `Preview automation ${this.operation} found ${target} in tab ${this.tabId}, but it is disabled`;
+  }
+}
+
+export class PreviewAutomationTargetAmbiguousError extends Schema.TaggedErrorClass<PreviewAutomationTargetAmbiguousError>()(
+  "PreviewAutomationTargetAmbiguousError",
   {
-    operation: Schema.String,
-    tabId: Schema.String,
-    selectorKind: PreviewAutomationSelectorKind,
-    selectorLength: Schema.optionalKey(Schema.Number),
-    failureKind: Schema.optionalKey(
-      Schema.Literals(["missing", "hidden", "disabled", "ambiguous"]),
-    ),
-    matchCount: Schema.optionalKey(Schema.Number),
+    ...PreviewAutomationTargetLookupFields,
+    matchCount: Schema.Number,
   },
 ) {
   override get message(): string {
     const target = previewAutomationTargetLabel(this.selectorKind, this.selectorLength);
-    if (this.failureKind === "hidden") {
-      return `Preview automation ${this.operation} found ${target} in tab ${this.tabId}, but it is not visible`;
-    }
-    if (this.failureKind === "disabled") {
-      return `Preview automation ${this.operation} found ${target} in tab ${this.tabId}, but it is disabled`;
-    }
-    if (this.failureKind === "ambiguous") {
-      const count = this.matchCount ?? 0;
-      return `Preview automation ${this.operation} matched ${count} elements for ${target} in tab ${this.tabId}`;
-    }
-    return `Preview automation ${this.operation} could not find ${target} in tab ${this.tabId}`;
+    return `Preview automation ${this.operation} matched ${this.matchCount} elements for ${target} in tab ${this.tabId}`;
   }
 }
+
+const raiseAutomationTargetLookupError = (input: {
+  readonly operation: string;
+  readonly tabId: string;
+  readonly selectorKind: PreviewAutomationSelectorKind;
+  readonly selectorLength?: number;
+  readonly failureKind?: "missing" | "hidden" | "disabled" | "ambiguous";
+  readonly matchCount?: number;
+}) => {
+  const shared = {
+    operation: input.operation,
+    tabId: input.tabId,
+    selectorKind: input.selectorKind,
+    ...(input.selectorLength === undefined ? {} : { selectorLength: input.selectorLength }),
+  };
+  if (input.failureKind === "hidden") {
+    return new PreviewAutomationTargetHiddenError(shared);
+  }
+  if (input.failureKind === "disabled") {
+    return new PreviewAutomationTargetDisabledError(shared);
+  }
+  if (input.failureKind === "ambiguous") {
+    return new PreviewAutomationTargetAmbiguousError({
+      ...shared,
+      matchCount: input.matchCount ?? 0,
+    });
+  }
+  return new PreviewAutomationTargetNotFoundError(shared);
+};
 
 export class PreviewAutomationTargetNotEditableError extends Schema.TaggedErrorClass<PreviewAutomationTargetNotEditableError>()(
   "PreviewAutomationTargetNotEditableError",
@@ -3889,6 +3939,9 @@ export const PreviewManagerError = Schema.Union([
   PreviewAutomationDebuggerAttachedError,
   PreviewAutomationEvaluationError,
   PreviewAutomationTargetNotFoundError,
+  PreviewAutomationTargetHiddenError,
+  PreviewAutomationTargetDisabledError,
+  PreviewAutomationTargetAmbiguousError,
   PreviewAutomationTargetNotEditableError,
   PreviewAutomationCoordinatesOutsideViewportError,
   PreviewAutomationInvalidSelectorError,

--- a/apps/server/src/mcp/toolkits/preview/tools.ts
+++ b/apps/server/src/mcp/toolkits/preview/tools.ts
@@ -13,6 +13,7 @@ import {
   PreviewAutomationSetColorSchemeInput,
   PreviewAutomationSetColorSchemeResult,
   PreviewAutomationSnapshot,
+  PreviewAutomationSnapshotInput,
   PreviewAutomationStatus,
   PreviewAutomationTabTargetInput,
   PreviewAutomationTypeInput,
@@ -108,8 +109,8 @@ export const PreviewSetAppearanceTool = safeBrowserTool(
 export const PreviewSnapshotTool = readonlyBrowserTool(
   Tool.make("preview_snapshot", {
     description:
-      "Inspect a page before interacting. Pass tabId to inspect a specific tab; omit it to use this agent session's current tab. Returns page state, semantic elements, diagnostics, action history, and a PNG screenshot.",
-    parameters: PreviewAutomationTabTargetInput,
+      "Inspect a page before interacting. Default is a slim snapshot: URL, visible text, interactive elements, and a PNG. Pass include:['ax'], include:['console'], or include:['network'] only when you need those heavier slices. Hidden tabs still capture.",
+    parameters: PreviewAutomationSnapshotInput,
     success: PreviewAutomationSnapshot,
     failure: PreviewAutomationError,
     dependencies,
@@ -174,7 +175,7 @@ export const PreviewEvaluateTool = browserTool(
 export const PreviewWaitForTool = readonlyBrowserTool(
   Tool.make("preview_wait_for", {
     description:
-      "Wait in the tab selected by tabId, or this agent session's current tab when omitted, until all supplied locator, selector, text, and URL conditions match.",
+      "Wait in the tab selected by tabId, or this agent session's current tab when omitted, until all supplied locator, selector, text, and URL conditions match. Text defaults to the main landmark so sidebar labels do not satisfy the wait. Locators must match a visible element.",
     parameters: PreviewAutomationWaitForInput,
     success: PreviewActionResult,
     failure: PreviewAutomationError,

--- a/apps/web/src/browser/browserTargetResolver.test.ts
+++ b/apps/web/src/browser/browserTargetResolver.test.ts
@@ -173,7 +173,19 @@ describe("browser target resolver", () => {
         kind: "environment-port",
         port: 5173,
       }).resolvedUrl,
-    ).toBe("http://[::1]:5173/");
+    ).toBe("http://localhost:5173/");
+  });
+
+  it("maps local IPv4 environment ports onto localhost for dual-stack guests", async () => {
+    readPreparedConnection.mockReturnValue({ httpBaseUrl: "http://127.0.0.1:3773" });
+    const { resolveBrowserNavigationTarget } = await import("./browserTargetResolver");
+    expect(
+      resolveBrowserNavigationTarget(EnvironmentId.make("environment-1"), {
+        kind: "environment-port",
+        port: 5173,
+        path: "/app",
+      }).resolvedUrl,
+    ).toBe("http://localhost:5173/app");
   });
 
   it("leaves malformed input for the normal navigation error path", async () => {

--- a/apps/web/src/browser/browserTargetResolver.ts
+++ b/apps/web/src/browser/browserTargetResolver.ts
@@ -178,9 +178,13 @@ const resolveEnvironmentPortTarget = (
   const protocol = target.protocol ?? "http";
   const path = target.path?.startsWith("/") ? target.path : `/${target.path ?? ""}`;
   const normalizedEnvironmentHost = environmentUrl.hostname.replace(/^\[|\]$/g, "");
-  const resolvedHost = normalizedEnvironmentHost.includes(":")
-    ? `[${normalizedEnvironmentHost}]`
-    : normalizedEnvironmentHost;
+  // Local loopback environments should advertise `localhost` so Chromium
+  // dual-stack lookup can reach a Vite server bound only to ::1 or 127.0.0.1.
+  const resolvedHost = isLocalLoopbackHost(normalizedEnvironmentHost)
+    ? "localhost"
+    : normalizedEnvironmentHost.includes(":")
+      ? `[${normalizedEnvironmentHost}]`
+      : normalizedEnvironmentHost;
   const resolved = sourceUrl
     ? new URL(sourceUrl)
     : new URL(path, `${protocol}://${resolvedHost}:${target.port}`);

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -48,6 +48,7 @@ import { useAtomQueryRunner } from "~/state/use-atom-query-runner";
 import { useAtomCommand } from "~/state/use-atom-command";
 
 import { previewBridge } from "./previewBridge";
+import { applyPreviewGuestViewport } from "./previewGuestViewport";
 import {
   PreviewAutomationOperationError,
   PreviewAutomationOverlayTimeoutError,
@@ -499,16 +500,7 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
             const ready = await requireReadyTab();
             const input = request.input as PreviewAutomationResizeInput;
             const setting = resolvePreviewViewport(input);
-            if (ready.bridge.automation.setViewport) {
-              if (setting._tag === "fill") {
-                await ready.bridge.automation.setViewport(ready.runtimeTabId, { clear: true });
-              } else {
-                await ready.bridge.automation.setViewport(ready.runtimeTabId, {
-                  width: setting.width,
-                  height: setting.height,
-                });
-              }
-            }
+            const setViewport = ready.bridge.automation.setViewport;
             const persistViewport = async () => {
               const operationState = assertPreviewRuntimeCurrent(
                 threadRef,
@@ -530,18 +522,22 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
                 return raiseAtomCommandFailure(result);
               }
               updatePreviewServerSnapshot(threadRef, result.value);
+              try {
+                await applyPreviewGuestViewport(setViewport, ready.runtimeTabId, setting);
+              } catch (error) {
+                await applyPreviewGuestViewport(
+                  setViewport,
+                  ready.runtimeTabId,
+                  previousSetting,
+                ).catch(() => undefined);
+                throw error;
+              }
               return {
                 previousSetting,
                 serverEpoch: operationState.serverEpoch,
               };
             };
-            const applied = await runBrowserViewportMutation(
-              ready.runtimeTabId,
-              persistViewport,
-            ).catch((error) => {
-              if (!ready.bridge.automation.setViewport) throw error;
-              return persistViewport();
-            });
+            const applied = await runBrowserViewportMutation(ready.runtimeTabId, persistViewport);
             let viewport: PreviewRenderedViewportSize;
             try {
               viewport = await waitForRenderedViewport(
@@ -582,6 +578,11 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
                   if (rollback._tag !== "Failure") {
                     updatePreviewServerSnapshot(threadRef, rollback.value);
                   }
+                  await applyPreviewGuestViewport(
+                    setViewport,
+                    ready.runtimeTabId,
+                    applied.previousSetting,
+                  ).catch(() => undefined);
                 }
               });
               throw cause;

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -577,12 +577,12 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
                   });
                   if (rollback._tag !== "Failure") {
                     updatePreviewServerSnapshot(threadRef, rollback.value);
+                    await applyPreviewGuestViewport(
+                      setViewport,
+                      ready.runtimeTabId,
+                      applied.previousSetting,
+                    ).catch(() => undefined);
                   }
-                  await applyPreviewGuestViewport(
-                    setViewport,
-                    ready.runtimeTabId,
-                    applied.previousSetting,
-                  ).catch(() => undefined);
                 }
               });
               throw cause;

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -9,6 +9,7 @@ import {
   type PreviewAutomationNavigateInput,
   type PreviewAutomationOpenInput,
   type PreviewAutomationResizeInput,
+  type PreviewAutomationSnapshotInput,
   type PreviewAutomationResizeResult,
   type PreviewAutomationSetColorSchemeInput,
   type PreviewAutomationSetColorSchemeResult,
@@ -177,6 +178,14 @@ const waitForRenderedViewport = async (
       const appliedSettingKey = webview?.getAttribute("data-preview-viewport-key") ?? null;
       const declaredViewport = readDeclaredViewport(webview);
       const renderedViewport = webview ? await readWebviewViewport(webview) : null;
+      if (
+        setting._tag !== "fill" &&
+        renderedViewport &&
+        Math.abs(renderedViewport.width - setting.width) <= 1 &&
+        Math.abs(renderedViewport.height - setting.height) <= 1
+      ) {
+        return renderedViewport;
+      }
       if (
         renderedViewport &&
         isPreviewViewportReady({
@@ -490,7 +499,17 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
             const ready = await requireReadyTab();
             const input = request.input as PreviewAutomationResizeInput;
             const setting = resolvePreviewViewport(input);
-            const applied = await runBrowserViewportMutation(ready.runtimeTabId, async () => {
+            if (ready.bridge.automation.setViewport) {
+              if (setting._tag === "fill") {
+                await ready.bridge.automation.setViewport(ready.runtimeTabId, { clear: true });
+              } else {
+                await ready.bridge.automation.setViewport(ready.runtimeTabId, {
+                  width: setting.width,
+                  height: setting.height,
+                });
+              }
+            }
+            const persistViewport = async () => {
               const operationState = assertPreviewRuntimeCurrent(
                 threadRef,
                 ready.tabId,
@@ -515,6 +534,13 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
                 previousSetting,
                 serverEpoch: operationState.serverEpoch,
               };
+            };
+            const applied = await runBrowserViewportMutation(
+              ready.runtimeTabId,
+              persistViewport,
+            ).catch((error) => {
+              if (!ready.bridge.automation.setViewport) throw error;
+              return persistViewport();
             });
             let viewport: PreviewRenderedViewportSize;
             try {
@@ -577,7 +603,8 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
           }
           case "snapshot": {
             const ready = await requireReadyTab();
-            return await ready.bridge.automation.snapshot(ready.runtimeTabId);
+            const input = request.input as PreviewAutomationSnapshotInput;
+            return await ready.bridge.automation.snapshot(ready.runtimeTabId, input.include);
           }
           case "click": {
             const ready = await requireReadyTab();

--- a/apps/web/src/components/preview/PreviewView.tsx
+++ b/apps/web/src/components/preview/PreviewView.tsx
@@ -34,6 +34,7 @@ import { selectThreadPreviewMiniPlayer, usePreviewMiniPlayerStore } from "~/prev
 import { useRightPanelStore } from "~/rightPanelStore";
 
 import { previewBridge } from "./previewBridge";
+import { applyPreviewGuestViewport } from "./previewGuestViewport";
 import { subscribePreviewAction } from "./previewActionBus";
 import { openPreviewSession } from "./openPreviewSession";
 import { PreviewChromeRow } from "./PreviewChromeRow";
@@ -238,8 +239,15 @@ export function PreviewView({
         throw error;
       }
       updatePreviewServerSnapshot(threadRef, result.value);
+      if (runtimeTabId) {
+        await applyPreviewGuestViewport(
+          previewBridge?.automation.setViewport,
+          runtimeTabId,
+          nextViewport,
+        );
+      }
     },
-    [resize, tabId, threadRef],
+    [resize, runtimeTabId, tabId, threadRef],
   );
 
   const handleToggleDeviceToolbar = () => {

--- a/apps/web/src/components/preview/previewAutomationErrors.test.ts
+++ b/apps/web/src/components/preview/previewAutomationErrors.test.ts
@@ -1,0 +1,45 @@
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { PreviewAutomationOperationError } from "./previewAutomationErrors";
+
+describe("PreviewAutomationOperationError", () => {
+  const context = {
+    requestId: "request-1",
+    operation: "click" as const,
+    environmentId: EnvironmentId.make("environment-1"),
+    threadId: ThreadId.make("thread-1"),
+    tabId: "tab-1",
+  };
+
+  it("maps typed not-found failures to a visible/disabled/ambiguous reason", () => {
+    const hidden = PreviewAutomationOperationError.fromCause({
+      ...context,
+      cause: {
+        _tag: "PreviewAutomationTargetNotFoundError",
+        failureKind: "hidden",
+      },
+    });
+    const disabled = PreviewAutomationOperationError.fromCause({
+      ...context,
+      cause: {
+        _tag: "PreviewAutomationTargetNotFoundError",
+        failureKind: "disabled",
+      },
+    });
+    const ambiguous = PreviewAutomationOperationError.fromCause({
+      ...context,
+      cause: {
+        _tag: "PreviewAutomationTargetNotFoundError",
+        failureKind: "ambiguous",
+        matchCount: 3,
+      },
+    });
+    expect(hidden.message).toContain("not visible");
+    expect(disabled.message).toContain("disabled");
+    expect(ambiguous.message).toContain("matched 3 elements");
+    expect(hidden.message).not.toContain("secret");
+    expect(disabled.message).not.toContain("secret");
+    expect(ambiguous.message).not.toContain("secret");
+  });
+});

--- a/apps/web/src/components/preview/previewAutomationErrors.test.ts
+++ b/apps/web/src/components/preview/previewAutomationErrors.test.ts
@@ -15,29 +15,27 @@ describe("PreviewAutomationOperationError", () => {
   it("maps typed not-found failures to a visible/disabled/ambiguous reason", () => {
     const hidden = PreviewAutomationOperationError.fromCause({
       ...context,
+      cause: { _tag: "PreviewAutomationTargetHiddenError" },
+    });
+    const disabled = PreviewAutomationOperationError.fromCause({
+      ...context,
+      cause: { _tag: "PreviewAutomationTargetDisabledError" },
+    });
+    const ambiguous = PreviewAutomationOperationError.fromCause({
+      ...context,
+      cause: { _tag: "PreviewAutomationTargetAmbiguousError", matchCount: 3 },
+    });
+    const legacyHidden = PreviewAutomationOperationError.fromCause({
+      ...context,
       cause: {
         _tag: "PreviewAutomationTargetNotFoundError",
         failureKind: "hidden",
       },
     });
-    const disabled = PreviewAutomationOperationError.fromCause({
-      ...context,
-      cause: {
-        _tag: "PreviewAutomationTargetNotFoundError",
-        failureKind: "disabled",
-      },
-    });
-    const ambiguous = PreviewAutomationOperationError.fromCause({
-      ...context,
-      cause: {
-        _tag: "PreviewAutomationTargetNotFoundError",
-        failureKind: "ambiguous",
-        matchCount: 3,
-      },
-    });
     expect(hidden.message).toContain("not visible");
     expect(disabled.message).toContain("disabled");
     expect(ambiguous.message).toContain("matched 3 elements");
+    expect(legacyHidden.message).toContain("not visible");
     expect(hidden.message).not.toContain("secret");
     expect(disabled.message).not.toContain("secret");
     expect(ambiguous.message).not.toContain("secret");

--- a/apps/web/src/components/preview/previewAutomationErrors.ts
+++ b/apps/web/src/components/preview/previewAutomationErrors.ts
@@ -134,6 +134,72 @@ export class PreviewAutomationTargetNotEditableHostError extends Schema.TaggedEr
   }
 }
 
+const targetNotFoundDiagnostics = (
+  cause: unknown,
+): {
+  readonly failureKind?: "missing" | "hidden" | "disabled" | "ambiguous";
+  readonly matchCount?: number;
+} | null => {
+  if (
+    typeof cause !== "object" ||
+    cause === null ||
+    !("_tag" in cause) ||
+    cause._tag !== "PreviewAutomationTargetNotFoundError"
+  ) {
+    return null;
+  }
+  const failureKind =
+    "failureKind" in cause &&
+    (cause.failureKind === "missing" ||
+      cause.failureKind === "hidden" ||
+      cause.failureKind === "disabled" ||
+      cause.failureKind === "ambiguous")
+      ? cause.failureKind
+      : undefined;
+  const matchCount =
+    "matchCount" in cause &&
+    typeof cause.matchCount === "number" &&
+    Number.isInteger(cause.matchCount) &&
+    cause.matchCount >= 0
+      ? cause.matchCount
+      : undefined;
+  return {
+    ...(failureKind === undefined ? {} : { failureKind }),
+    ...(matchCount === undefined ? {} : { matchCount }),
+  };
+};
+
+export class PreviewAutomationTargetNotFoundHostError extends Schema.TaggedErrorClass<PreviewAutomationTargetNotFoundHostError>()(
+  "PreviewAutomationTargetNotFoundHostError",
+  {
+    requestId: TrimmedNonEmptyString,
+    operation: PreviewAutomationOperation,
+    environmentId: EnvironmentId,
+    threadId: ThreadId,
+    tabId: Schema.NullOr(PreviewTabId),
+    failureKind: Schema.optional(Schema.Literals(["missing", "hidden", "disabled", "ambiguous"])),
+    matchCount: Schema.optional(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))),
+  },
+) {
+  get responseTag() {
+    return "PreviewAutomationExecutionError" as const;
+  }
+
+  override get message(): string {
+    const tab = this.tabId ?? "unassigned";
+    if (this.failureKind === "hidden") {
+      return `Preview automation ${this.operation} request ${this.requestId} found a target in tab ${tab}, but it is not visible.`;
+    }
+    if (this.failureKind === "disabled") {
+      return `Preview automation ${this.operation} request ${this.requestId} found a target in tab ${tab}, but it is disabled.`;
+    }
+    if (this.failureKind === "ambiguous") {
+      return `Preview automation ${this.operation} request ${this.requestId} matched ${this.matchCount ?? 0} elements in tab ${tab}.`;
+    }
+    return `Preview automation ${this.operation} request ${this.requestId} could not find a target in tab ${tab}.`;
+  }
+}
+
 const targetNotEditableDiagnostics = (
   cause: unknown,
 ): {
@@ -183,6 +249,17 @@ export class PreviewAutomationOperationError extends Schema.TaggedErrorClass<Pre
     input: PreviewAutomationOperationContext & { readonly cause: unknown },
   ): PreviewAutomationHostError {
     if (isPreviewAutomationHostError(input.cause)) return input.cause;
+    const notFound = targetNotFoundDiagnostics(input.cause);
+    if (notFound) {
+      return new PreviewAutomationTargetNotFoundHostError({
+        requestId: input.requestId,
+        operation: input.operation,
+        environmentId: input.environmentId,
+        threadId: input.threadId,
+        tabId: input.tabId,
+        ...notFound,
+      });
+    }
     const diagnostics = targetNotEditableDiagnostics(input.cause);
     return diagnostics
       ? new PreviewAutomationTargetNotEditableHostError({
@@ -211,6 +288,7 @@ export const PreviewAutomationHostError = Schema.Union([
   PreviewAutomationViewportTimeoutError,
   PreviewAutomationTargetUnavailableError,
   PreviewAutomationRecordingNotActiveError,
+  PreviewAutomationTargetNotFoundHostError,
   PreviewAutomationTargetNotEditableHostError,
   PreviewAutomationOperationError,
 ]);

--- a/apps/web/src/components/preview/previewAutomationErrors.ts
+++ b/apps/web/src/components/preview/previewAutomationErrors.ts
@@ -134,51 +134,92 @@ export class PreviewAutomationTargetNotEditableHostError extends Schema.TaggedEr
   }
 }
 
-const targetNotFoundDiagnostics = (
+const PreviewAutomationTargetHostFields = {
+  requestId: TrimmedNonEmptyString,
+  operation: PreviewAutomationOperation,
+  environmentId: EnvironmentId,
+  threadId: ThreadId,
+  tabId: Schema.NullOr(PreviewTabId),
+  cause: Schema.Defect(),
+};
+
+const readTargetLookupKind = (
   cause: unknown,
-): {
-  readonly failureKind?: "missing" | "hidden" | "disabled" | "ambiguous";
-  readonly matchCount?: number;
-} | null => {
+): "missing" | "hidden" | "disabled" | "ambiguous" | null => {
+  if (typeof cause !== "object" || cause === null || !("_tag" in cause)) return null;
+  if (cause._tag === "PreviewAutomationTargetHiddenError") return "hidden";
+  if (cause._tag === "PreviewAutomationTargetDisabledError") return "disabled";
+  if (cause._tag === "PreviewAutomationTargetAmbiguousError") return "ambiguous";
+  if (cause._tag !== "PreviewAutomationTargetNotFoundError") return null;
   if (
-    typeof cause !== "object" ||
-    cause === null ||
-    !("_tag" in cause) ||
-    cause._tag !== "PreviewAutomationTargetNotFoundError"
-  ) {
-    return null;
-  }
-  const failureKind =
     "failureKind" in cause &&
-    (cause.failureKind === "missing" ||
-      cause.failureKind === "hidden" ||
+    (cause.failureKind === "hidden" ||
       cause.failureKind === "disabled" ||
       cause.failureKind === "ambiguous")
-      ? cause.failureKind
-      : undefined;
-  const matchCount =
+  ) {
+    return cause.failureKind;
+  }
+  return "missing";
+};
+
+const readAmbiguousMatchCount = (cause: unknown): number => {
+  if (
+    typeof cause === "object" &&
+    cause !== null &&
     "matchCount" in cause &&
     typeof cause.matchCount === "number" &&
     Number.isInteger(cause.matchCount) &&
     cause.matchCount >= 0
-      ? cause.matchCount
-      : undefined;
-  return {
-    ...(failureKind === undefined ? {} : { failureKind }),
-    ...(matchCount === undefined ? {} : { matchCount }),
-  };
+  ) {
+    return cause.matchCount;
+  }
+  return 0;
 };
 
 export class PreviewAutomationTargetNotFoundHostError extends Schema.TaggedErrorClass<PreviewAutomationTargetNotFoundHostError>()(
   "PreviewAutomationTargetNotFoundHostError",
+  PreviewAutomationTargetHostFields,
+) {
+  get responseTag() {
+    return "PreviewAutomationExecutionError" as const;
+  }
+
+  override get message(): string {
+    return `Preview automation ${this.operation} request ${this.requestId} could not find a target in tab ${this.tabId ?? "unassigned"}.`;
+  }
+}
+
+export class PreviewAutomationTargetHiddenHostError extends Schema.TaggedErrorClass<PreviewAutomationTargetHiddenHostError>()(
+  "PreviewAutomationTargetHiddenHostError",
+  PreviewAutomationTargetHostFields,
+) {
+  get responseTag() {
+    return "PreviewAutomationExecutionError" as const;
+  }
+
+  override get message(): string {
+    return `Preview automation ${this.operation} request ${this.requestId} found a target in tab ${this.tabId ?? "unassigned"}, but it is not visible.`;
+  }
+}
+
+export class PreviewAutomationTargetDisabledHostError extends Schema.TaggedErrorClass<PreviewAutomationTargetDisabledHostError>()(
+  "PreviewAutomationTargetDisabledHostError",
+  PreviewAutomationTargetHostFields,
+) {
+  get responseTag() {
+    return "PreviewAutomationExecutionError" as const;
+  }
+
+  override get message(): string {
+    return `Preview automation ${this.operation} request ${this.requestId} found a target in tab ${this.tabId ?? "unassigned"}, but it is disabled.`;
+  }
+}
+
+export class PreviewAutomationTargetAmbiguousHostError extends Schema.TaggedErrorClass<PreviewAutomationTargetAmbiguousHostError>()(
+  "PreviewAutomationTargetAmbiguousHostError",
   {
-    requestId: TrimmedNonEmptyString,
-    operation: PreviewAutomationOperation,
-    environmentId: EnvironmentId,
-    threadId: ThreadId,
-    tabId: Schema.NullOr(PreviewTabId),
-    failureKind: Schema.optional(Schema.Literals(["missing", "hidden", "disabled", "ambiguous"])),
-    matchCount: Schema.optional(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))),
+    ...PreviewAutomationTargetHostFields,
+    matchCount: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
   },
 ) {
   get responseTag() {
@@ -186,17 +227,7 @@ export class PreviewAutomationTargetNotFoundHostError extends Schema.TaggedError
   }
 
   override get message(): string {
-    const tab = this.tabId ?? "unassigned";
-    if (this.failureKind === "hidden") {
-      return `Preview automation ${this.operation} request ${this.requestId} found a target in tab ${tab}, but it is not visible.`;
-    }
-    if (this.failureKind === "disabled") {
-      return `Preview automation ${this.operation} request ${this.requestId} found a target in tab ${tab}, but it is disabled.`;
-    }
-    if (this.failureKind === "ambiguous") {
-      return `Preview automation ${this.operation} request ${this.requestId} matched ${this.matchCount ?? 0} elements in tab ${tab}.`;
-    }
-    return `Preview automation ${this.operation} request ${this.requestId} could not find a target in tab ${tab}.`;
+    return `Preview automation ${this.operation} request ${this.requestId} matched ${this.matchCount} elements in tab ${this.tabId ?? "unassigned"}.`;
   }
 }
 
@@ -249,16 +280,25 @@ export class PreviewAutomationOperationError extends Schema.TaggedErrorClass<Pre
     input: PreviewAutomationOperationContext & { readonly cause: unknown },
   ): PreviewAutomationHostError {
     if (isPreviewAutomationHostError(input.cause)) return input.cause;
-    const notFound = targetNotFoundDiagnostics(input.cause);
-    if (notFound) {
-      return new PreviewAutomationTargetNotFoundHostError({
+    const lookupKind = readTargetLookupKind(input.cause);
+    if (lookupKind) {
+      const shared = {
         requestId: input.requestId,
         operation: input.operation,
         environmentId: input.environmentId,
         threadId: input.threadId,
         tabId: input.tabId,
-        ...notFound,
-      });
+        cause: input.cause,
+      };
+      if (lookupKind === "hidden") return new PreviewAutomationTargetHiddenHostError(shared);
+      if (lookupKind === "disabled") return new PreviewAutomationTargetDisabledHostError(shared);
+      if (lookupKind === "ambiguous") {
+        return new PreviewAutomationTargetAmbiguousHostError({
+          ...shared,
+          matchCount: readAmbiguousMatchCount(input.cause),
+        });
+      }
+      return new PreviewAutomationTargetNotFoundHostError(shared);
     }
     const diagnostics = targetNotEditableDiagnostics(input.cause);
     return diagnostics
@@ -289,6 +329,9 @@ export const PreviewAutomationHostError = Schema.Union([
   PreviewAutomationTargetUnavailableError,
   PreviewAutomationRecordingNotActiveError,
   PreviewAutomationTargetNotFoundHostError,
+  PreviewAutomationTargetHiddenHostError,
+  PreviewAutomationTargetDisabledHostError,
+  PreviewAutomationTargetAmbiguousHostError,
   PreviewAutomationTargetNotEditableHostError,
   PreviewAutomationOperationError,
 ]);

--- a/apps/web/src/components/preview/previewAutomationRequestConsumer.test.ts
+++ b/apps/web/src/components/preview/previewAutomationRequestConsumer.test.ts
@@ -291,6 +291,55 @@ describe("previewAutomationRequestConsumer", () => {
     });
   });
 
+  it("maps hidden click targets to a named execution failure without leaking the locator", () => {
+    expect(
+      serializePreviewAutomationError(
+        {
+          _tag: "PreviewAutomationTargetNotFoundError",
+          failureKind: "hidden",
+          selector: "role=button[name='target-secret']",
+        },
+        {
+          requestId: "request-click",
+          operation: "click",
+          environmentId,
+          threadId,
+          tabId,
+        },
+      ),
+    ).toEqual({
+      _tag: "PreviewAutomationExecutionError",
+      message:
+        "Preview automation click request request-click found a target in tab tab-1, but it is not visible.",
+      detail: {
+        requestId: "request-click",
+        operation: "click",
+        environmentId: "environment-1",
+        threadId: "thread-1",
+        tabId: "tab-1",
+        failureKind: "hidden",
+      },
+    });
+    expect(
+      JSON.stringify(
+        serializePreviewAutomationError(
+          {
+            _tag: "PreviewAutomationTargetNotFoundError",
+            failureKind: "hidden",
+            selector: "role=button[name='target-secret']",
+          },
+          {
+            requestId: "request-click",
+            operation: "click",
+            environmentId,
+            threadId,
+            tabId,
+          },
+        ),
+      ),
+    ).not.toContain("secret");
+  });
+
   it("maps desktop non-editable targets to the public typed response", () => {
     expect(
       serializePreviewAutomationError(

--- a/apps/web/src/components/preview/previewAutomationRequestConsumer.test.ts
+++ b/apps/web/src/components/preview/previewAutomationRequestConsumer.test.ts
@@ -295,8 +295,7 @@ describe("previewAutomationRequestConsumer", () => {
     expect(
       serializePreviewAutomationError(
         {
-          _tag: "PreviewAutomationTargetNotFoundError",
-          failureKind: "hidden",
+          _tag: "PreviewAutomationTargetHiddenError",
           selector: "role=button[name='target-secret']",
         },
         {
@@ -317,7 +316,6 @@ describe("previewAutomationRequestConsumer", () => {
         environmentId: "environment-1",
         threadId: "thread-1",
         tabId: "tab-1",
-        failureKind: "hidden",
       },
     });
     expect(

--- a/apps/web/src/components/preview/previewGuestViewport.test.ts
+++ b/apps/web/src/components/preview/previewGuestViewport.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { applyPreviewGuestViewport, previewGuestViewportOverride } from "./previewGuestViewport";
+
+describe("previewGuestViewportOverride", () => {
+  it("clears fill mode and uses explicit dimensions for fixed viewports", () => {
+    expect(previewGuestViewportOverride({ _tag: "fill" })).toEqual({ clear: true });
+    expect(previewGuestViewportOverride({ _tag: "freeform", width: 1024, height: 768 })).toEqual({
+      width: 1024,
+      height: 768,
+    });
+    expect(
+      previewGuestViewportOverride({
+        _tag: "preset",
+        presetId: "iphone-12-pro",
+        width: 390,
+        height: 844,
+      }),
+    ).toEqual({ width: 390, height: 844 });
+  });
+});
+
+describe("applyPreviewGuestViewport", () => {
+  it("skips older desktops and applies the mapped override otherwise", async () => {
+    await applyPreviewGuestViewport(undefined, "tab-1", { _tag: "fill" });
+
+    const setViewport = vi.fn(async () => undefined);
+    await applyPreviewGuestViewport(setViewport, "tab-1", {
+      _tag: "freeform",
+      width: 800,
+      height: 600,
+    });
+    expect(setViewport).toHaveBeenCalledWith("tab-1", { width: 800, height: 600 });
+  });
+});

--- a/apps/web/src/components/preview/previewGuestViewport.ts
+++ b/apps/web/src/components/preview/previewGuestViewport.ts
@@ -1,0 +1,29 @@
+import type { PreviewViewportSetting } from "@t3tools/contracts";
+
+export type PreviewGuestViewportOverride =
+  | { readonly clear: true }
+  | { readonly width: number; readonly height: number };
+
+export type PreviewGuestViewportApplier = (
+  tabId: string,
+  input: PreviewGuestViewportOverride,
+) => Promise<void>;
+
+/** Maps a stored viewport setting onto the desktop CDP override. */
+export function previewGuestViewportOverride(
+  setting: PreviewViewportSetting,
+): PreviewGuestViewportOverride {
+  return setting._tag === "fill"
+    ? { clear: true }
+    : { width: setting.width, height: setting.height };
+}
+
+/** Applies or clears the guest CDP metrics override. No-op on older desktops. */
+export async function applyPreviewGuestViewport(
+  setViewport: PreviewGuestViewportApplier | undefined,
+  tabId: string,
+  setting: PreviewViewportSetting,
+): Promise<void> {
+  if (!setViewport) return;
+  await setViewport(tabId, previewGuestViewportOverride(setting));
+}

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -71,6 +71,7 @@ import {
   PreviewAutomationResponse,
   PreviewAutomationScrollInput,
   PreviewAutomationSnapshot,
+  PreviewAutomationSnapshotInclude,
   PreviewAutomationStatus,
   PreviewAutomationStreamEvent,
   PreviewAutomationTypeInput,
@@ -956,6 +957,18 @@ export const DesktopPreviewTabInputSchema = Schema.Struct({
   tabId: DesktopPreviewTabIdSchema,
 });
 
+export const DesktopPreviewAutomationSnapshotInputSchema = Schema.Struct({
+  tabId: DesktopPreviewTabIdSchema,
+  include: Schema.optional(Schema.Array(PreviewAutomationSnapshotInclude)),
+});
+
+export const DesktopPreviewAutomationSetViewportInputSchema = Schema.Struct({
+  tabId: DesktopPreviewTabIdSchema,
+  width: Schema.optional(Schema.Int.check(Schema.isGreaterThan(0))),
+  height: Schema.optional(Schema.Int.check(Schema.isGreaterThan(0))),
+  clear: Schema.optional(Schema.Boolean),
+});
+
 export const DesktopPreviewRegisterWebviewInputSchema = Schema.Struct({
   tabId: DesktopPreviewTabIdSchema,
   webContentsId: Schema.Int.check(Schema.isGreaterThan(0)),
@@ -1168,7 +1181,14 @@ export interface DesktopPreviewBridge {
   };
   automation: {
     status: (tabId: string) => Promise<PreviewAutomationStatus>;
-    snapshot: (tabId: string) => Promise<PreviewAutomationSnapshot>;
+    snapshot: (
+      tabId: string,
+      include?: ReadonlyArray<PreviewAutomationSnapshotInclude>,
+    ) => Promise<PreviewAutomationSnapshot>;
+    setViewport: (
+      tabId: string,
+      input: { readonly width: number; readonly height: number } | { readonly clear: true },
+    ) => Promise<void>;
     click: (tabId: string, input: PreviewAutomationClickInput) => Promise<void>;
     type: (tabId: string, input: PreviewAutomationTypeInput) => Promise<void>;
     press: (tabId: string, input: PreviewAutomationPressInput) => Promise<void>;

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -962,12 +962,17 @@ export const DesktopPreviewAutomationSnapshotInputSchema = Schema.Struct({
   include: Schema.optional(Schema.Array(PreviewAutomationSnapshotInclude)),
 });
 
-export const DesktopPreviewAutomationSetViewportInputSchema = Schema.Struct({
-  tabId: DesktopPreviewTabIdSchema,
-  width: Schema.optional(Schema.Int.check(Schema.isGreaterThan(0))),
-  height: Schema.optional(Schema.Int.check(Schema.isGreaterThan(0))),
-  clear: Schema.optional(Schema.Boolean),
-});
+export const DesktopPreviewAutomationSetViewportInputSchema = Schema.Union([
+  Schema.Struct({
+    tabId: DesktopPreviewTabIdSchema,
+    width: Schema.Int.check(Schema.isGreaterThan(0)),
+    height: Schema.Int.check(Schema.isGreaterThan(0)),
+  }),
+  Schema.Struct({
+    tabId: DesktopPreviewTabIdSchema,
+    clear: Schema.Literal(true),
+  }),
+]);
 
 export const DesktopPreviewRegisterWebviewInputSchema = Schema.Struct({
   tabId: DesktopPreviewTabIdSchema,

--- a/packages/contracts/src/preview.test.ts
+++ b/packages/contracts/src/preview.test.ts
@@ -17,7 +17,9 @@ import {
   PreviewAutomationOpenInput,
   PreviewAutomationResizeInput,
   PreviewAutomationResizeResult,
+  PreviewAutomationSnapshotInput,
   PreviewAutomationStatus,
+  PreviewAutomationWaitForInput,
 } from "./previewAutomation.ts";
 
 const decodePreviewEvent = Schema.decodeUnknownSync(PreviewEvent);
@@ -32,6 +34,8 @@ const decodeResizeResult = Schema.decodeUnknownSync(PreviewAutomationResizeResul
 const decodeAutomationHost = Schema.decodeUnknownSync(PreviewAutomationHost);
 const decodeAutomationError = Schema.decodeUnknownSync(PreviewAutomationError);
 const decodeAutomationStatus = Schema.decodeUnknownSync(PreviewAutomationStatus);
+const decodeSnapshotInput = Schema.decodeUnknownSync(PreviewAutomationSnapshotInput);
+const decodeWaitForInput = Schema.decodeUnknownSync(PreviewAutomationWaitForInput);
 
 describe("PreviewAutomationOpenInput", () => {
   it("accepts the inline preview visibility flag", () => {
@@ -220,6 +224,26 @@ describe("PreviewAutomationStatus", () => {
         viewport: { width: 412, height: 915 },
       }).viewport,
     ).toEqual({ width: 412, height: 915 });
+  });
+});
+
+describe("PreviewAutomationSnapshotInput", () => {
+  it("defaults to a slim snapshot and accepts extra diagnostic slices", () => {
+    expect(decodeSnapshotInput({})).toEqual({});
+    expect(decodeSnapshotInput({ include: ["ax", "console", "network"] }).include).toEqual([
+      "ax",
+      "console",
+      "network",
+    ]);
+    expect(() => decodeSnapshotInput({ include: ["screenshot"] })).toThrow();
+  });
+});
+
+describe("PreviewAutomationWaitForInput", () => {
+  it("defaults text and locators to the main landmark", () => {
+    expect(decodeWaitForInput({ text: "Dashboard" })).toEqual({ text: "Dashboard" });
+    expect(decodeWaitForInput({ text: "Dashboard", scope: "document" }).scope).toBe("document");
+    expect(() => decodeWaitForInput({ scope: "main" })).toThrow();
   });
 });
 

--- a/packages/contracts/src/preview.test.ts
+++ b/packages/contracts/src/preview.test.ts
@@ -11,6 +11,7 @@ import {
   PreviewSessionSnapshot,
   PreviewViewportSetting,
 } from "./preview.ts";
+import { DesktopPreviewAutomationSetViewportInputSchema } from "./ipc.ts";
 import {
   PreviewAutomationHost,
   PreviewAutomationError,
@@ -36,6 +37,9 @@ const decodeAutomationError = Schema.decodeUnknownSync(PreviewAutomationError);
 const decodeAutomationStatus = Schema.decodeUnknownSync(PreviewAutomationStatus);
 const decodeSnapshotInput = Schema.decodeUnknownSync(PreviewAutomationSnapshotInput);
 const decodeWaitForInput = Schema.decodeUnknownSync(PreviewAutomationWaitForInput);
+const decodeSetViewportInput = Schema.decodeUnknownSync(
+  DesktopPreviewAutomationSetViewportInputSchema,
+);
 
 describe("PreviewAutomationOpenInput", () => {
   it("accepts the inline preview visibility flag", () => {
@@ -244,6 +248,22 @@ describe("PreviewAutomationWaitForInput", () => {
     expect(decodeWaitForInput({ text: "Dashboard" })).toEqual({ text: "Dashboard" });
     expect(decodeWaitForInput({ text: "Dashboard", scope: "document" }).scope).toBe("document");
     expect(() => decodeWaitForInput({ scope: "main" })).toThrow();
+  });
+});
+
+describe("DesktopPreviewAutomationSetViewportInputSchema", () => {
+  it("accepts a complete size or an explicit clear, and rejects a partial size", () => {
+    expect(decodeSetViewportInput({ tabId: "tab-1", width: 800, height: 600 })).toEqual({
+      tabId: "tab-1",
+      width: 800,
+      height: 600,
+    });
+    expect(decodeSetViewportInput({ tabId: "tab-1", clear: true })).toEqual({
+      tabId: "tab-1",
+      clear: true,
+    });
+    expect(() => decodeSetViewportInput({ tabId: "tab-1", width: 800 })).toThrow();
+    expect(() => decodeSetViewportInput({ tabId: "tab-1" })).toThrow();
   });
 });
 

--- a/packages/contracts/src/previewAutomation.ts
+++ b/packages/contracts/src/previewAutomation.ts
@@ -63,6 +63,9 @@ const PreviewAutomationTabTargetFields = {
 export const PreviewAutomationTabTargetInput = Schema.Struct(PreviewAutomationTabTargetFields);
 export type PreviewAutomationTabTargetInput = typeof PreviewAutomationTabTargetInput.Type;
 
+export const PreviewAutomationSnapshotInclude = Schema.Literals(["ax", "console", "network"]);
+export type PreviewAutomationSnapshotInclude = typeof PreviewAutomationSnapshotInclude.Type;
+
 export const PreviewAutomationStatus = Schema.Struct({
   available: Schema.Boolean,
   visible: Schema.Boolean,
@@ -465,6 +468,15 @@ export const PreviewAutomationWaitForInput = Schema.Struct({
       description: "Substring that must appear in the current absolute URL.",
     }),
   ).annotate({ description: "Substring that must appear in the current absolute URL." }),
+  scope: Schema.optional(
+    Schema.Literals(["main", "document"]).annotate({
+      description:
+        "Where text and locators are searched. 'main' uses the main landmark when present (default). 'document' searches the whole page, including sidebars.",
+    }),
+  ).annotate({
+    description:
+      "Where text and locators are searched. Defaults to main so sidebar chrome does not satisfy the wait.",
+  }),
   timeoutMs: OptionalTimeoutMs,
 })
   .check(
@@ -488,6 +500,7 @@ export const PreviewAutomationWaitForInput = Schema.Struct({
 export type PreviewAutomationWaitForInput = typeof PreviewAutomationWaitForInput.Type;
 
 export const PreviewAutomationElement = Schema.Struct({
+  id: Schema.optional(Schema.String),
   tag: Schema.String,
   role: Schema.NullOr(Schema.String),
   name: Schema.String,
@@ -527,13 +540,25 @@ export const PreviewAutomationActionEvent = Schema.Struct({
 });
 export type PreviewAutomationActionEvent = typeof PreviewAutomationActionEvent.Type;
 
+export const PreviewAutomationSnapshotInput = Schema.Struct({
+  ...PreviewAutomationTabTargetFields,
+  include: Schema.optional(Schema.Array(PreviewAutomationSnapshotInclude)).annotate({
+    description:
+      "Optional extra snapshot slices. Default is screenshot, visible text, and interactive elements. Pass ax, console, and/or network when you need those heavier diagnostics.",
+  }),
+}).annotate({
+  description:
+    "Inspects the collaborative browser tab. Omit include for a slim snapshot; add ax, console, or network only when needed.",
+});
+export type PreviewAutomationSnapshotInput = typeof PreviewAutomationSnapshotInput.Type;
+
 export const PreviewAutomationSnapshot = Schema.Struct({
   url: Schema.String,
   title: Schema.String,
   loading: Schema.Boolean,
   visibleText: Schema.String,
   interactiveElements: Schema.Array(PreviewAutomationElement),
-  accessibilityTree: Schema.Unknown,
+  accessibilityTree: Schema.optional(Schema.Unknown),
   consoleEntries: Schema.Array(PreviewAutomationConsoleEntry),
   networkEntries: Schema.Array(PreviewAutomationNetworkEntry),
   actionTimeline: Schema.Array(PreviewAutomationActionEvent),


### PR DESCRIPTION
Agents inspecting a real app in the in-app browser were drowning in accessibility trees, matching sidebar chrome on wait, treating hidden buttons as missing, and timing out on resize when the preview panel was not visible.

Snapshots are slim by default (screenshot, main-landmark text, visible clickable elements). Wait defaults to `main`. Click reports hidden, disabled, or ambiguous targets without leaking locators. Local environment ports resolve to `localhost` so Vite on `::1` or `127.0.0.1` is reachable. Resize applies through CDP even when the panel is hidden. Console and network stay behind `preview_snapshot` `include`.

The preview tools assumed a simple, visible page. Real product UIs have sidebars, hidden dialog triggers, and dual-stack local servers, so agents spent turns fighting the harness instead of the app.

Implemented with Grok 4.6 through Grok CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desktop CDP automation, IPC contracts, and navigation URL resolution; behavior changes for agents using snapshot, wait, click, and resize, but scoped to preview automation with rollback and backward-compatible optional APIs.
>
> **Overview**
> **Preview automation** is tuned for real product UIs: slimmer defaults, clearer click failures, and guest viewport control when the panel is hidden.
>
> **Snapshots** default to URL, main-landmark visible text, filtered interactive elements (with stable `e1` ids), screenshot, and action timeline. Heavier **accessibility**, **console**, and **network** data load only when `include` requests them; AX tree fetch and optional slices are skipped otherwise, with screenshot fallback if `capturePage` fails.
>
> **Click** resolution distinguishes missing, hidden, disabled, and ambiguous (strict-mode) targets via new typed errors, mapped on the web host to execution messages **without leaking locators**. **Wait-for** gains optional `scope` (`main` vs `document`), searches text/locators in that root, requires visibility, and ignores dialog trigger slots.
>
> **Resize** persists server viewport state and applies **CDP device metrics** on the guest (`setViewport` / clear for fill), including rollback on failure and manual chrome resize—so automation size changes work when the preview is not visible.
>
> **Local dev URLs** map loopback environment hosts (`127.0.0.1`, `::1`) to **`localhost`** so dual-stack guests reach Vite bound on either stack.
>
> Contracts, IPC/preload, MCP tool descriptions, and tests cover the new inputs and error shapes.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7d8c918ea59e27ad11b79ee5efb4ac43c762ac6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix in-app browser automation to work on real app pages by adding viewport override and richer snapshot support
> - Adds a `setViewport` IPC channel and bridge method that applies or clears a CDP `Emulation.setDeviceMetricsOverride` per tab, so viewport changes take effect immediately in the guest webview.
> - Extends `automationSnapshot` to accept optional `include` flags (`ax`, `console`, `network`), making snapshots slimmer by default and returning diagnostics only on demand.
> - Improves click failure reporting with typed errors (`hidden`, `disabled`, `ambiguous`) instead of a generic not-found error, and maps these through the host-side error layer.
> - Normalizes loopback addresses (`::1`, `127.0.0.1`) to `localhost` in `resolveEnvironmentPortTarget` for dual-stack server compatibility.
> - `PreviewAutomationWaitFor` gains an optional `scope` field (`main` | `document`) to constrain text/selector matching to the main landmark.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f7d8c91.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->