### PR TITLE
fix(server): stop late progress from reviving idle tasks

### DIFF
--- a/apps/server/src/orchestration/ThreadBackgroundLiveness.test.ts
+++ b/apps/server/src/orchestration/ThreadBackgroundLiveness.test.ts
@@ -147,6 +147,36 @@ describe("ThreadBackgroundLiveness", () => {
     expect(liveness.getThreadBackgroundLiveness(threadId)).toBeNull();
   });
 
+  it("late progress does not revive an idle task", () => {
+    const liveness = ThreadBackgroundLiveness.make();
+    const threadId = "t-live-late-progress";
+    liveness.recordTaskLiveness({
+      threadId,
+      taskId: "a1",
+      taskType: undefined,
+      status: undefined,
+      kind: "started",
+    });
+    liveness.recordTaskLiveness({
+      threadId,
+      taskId: "a1",
+      taskType: undefined,
+      status: "idle",
+      kind: "updated",
+    });
+    expect(liveness.getThreadBackgroundLiveness(threadId)).toBeNull();
+
+    // Providers can flush delayed progress after the terminal/idle update.
+    liveness.recordTaskLiveness({
+      threadId,
+      taskId: "a1",
+      taskType: undefined,
+      status: undefined,
+      kind: "progress",
+    });
+    expect(liveness.getThreadBackgroundLiveness(threadId)).toBeNull();
+  });
+
   it("plan tasks are inert; clear removes everything; instances are isolated", () => {
     const a = ThreadBackgroundLiveness.make();
     const b = ThreadBackgroundLiveness.make();

--- a/apps/server/src/orchestration/ThreadBackgroundLiveness.ts
+++ b/apps/server/src/orchestration/ThreadBackgroundLiveness.ts
@@ -104,6 +104,10 @@ export function make(): ThreadBackgroundLivenessService["Service"] {
   return {
     recordTaskLiveness: (input) => {
       const taskType = input.taskType;
+      const existingState = stateByThreadId.get(input.threadId);
+      const wasLive =
+        existingState?.agents.has(input.taskId) === true ||
+        existingState?.monitors.has(input.taskId) === true;
       if (taskType !== undefined && INERT_TASK_TYPES.has(taskType)) {
         drop(input.threadId, input.taskId);
         return;
@@ -127,6 +131,13 @@ export function make(): ThreadBackgroundLivenessService["Service"] {
         (input.status !== undefined && TERMINAL_STATUSES.has(input.status));
       if (terminal) {
         drop(input.threadId, input.taskId);
+        return;
+      }
+
+      // Ordinary progress is descriptive and carries no lifecycle status. It
+      // can arrive after an idle or terminal update, so it may keep existing
+      // work live but must not create a new live entry by itself.
+      if (input.kind === "progress" && input.status === undefined && !wasLive) {
         return;
       }
 


### PR DESCRIPTION
## What Changed

Status-free `task.progress` can now maintain an existing live task, but it cannot create a new live entry by itself.

This prevents delayed descriptive progress from reviving a task after an idle or terminal update removed it. Explicit lifecycle events can still start or resume tasks.

A focused regression test covers the observed `started → idle → delayed progress` sequence.

## Why

Providers can flush descriptive progress after a task becomes idle. `ThreadBackgroundLiveness` treated every non-terminal progress event as proof of live work.

The client then received `backgroundLiveness: "working"` while its agent fold reported zero live agents. This produced a persistent “Background work running” banner on finished threads.

Fixes #7128

## UI Changes

n/a — no layout or styling change. This corrects stale server state.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (n/a)
- [x] I included a video for animation/interaction changes (n/a)

## Verification

```sh
vp test run apps/server/src/orchestration
# 27 files, 272 tests passed

vp run --filter t3 typecheck
# exit 0

vp lint apps/server/src/orchestration/ThreadBackgroundLiveness.ts \
  apps/server/src/orchestration/ThreadBackgroundLiveness.test.ts

vp fmt --check apps/server/src/orchestration/ThreadBackgroundLiveness.ts \
  apps/server/src/orchestration/ThreadBackgroundLiveness.test.ts
```

Without the new guard, the regression test fails with:

`expected "working" to be null`

Implemented with GPT-5 via the Codex desktop app.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `recordTaskLiveness` to ignore late progress events that would revive idle tasks
> Progress events with undefined status no longer create a live entry in `ThreadBackgroundLivenessService` if the task was not already live. This prevents delayed progress updates from reviving thread liveness after a task has transitioned to idle or terminal state. The fix introduces a `wasLive` check computed from existing state sets before classifying the event as a drop or add.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ebe4eee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to in-memory liveness bookkeeping with a focused guard and test; no auth, persistence, or API surface changes.
> 
> **Overview**
> **`ThreadBackgroundLiveness`** no longer treats delayed, status-free **`progress`** events as proof of live work when the task is not already tracked.
> 
> After **`started → idle`**, providers can still flush descriptive **`task.progress`** payloads. Those events are ignored unless the task was already in the agent/monitor sets, so thread **`backgroundLiveness`** stays **`null`** instead of flipping back to **`working`**. Explicit lifecycle events (**`started`**, status-bearing updates) can still add or refresh entries.
> 
> A regression test covers the **`started → idle → delayed progress`** sequence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebe4eee1a7c28a2671bcc0e7895653c140b972c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->