### PR TITLE
fix(mobile): prevent excessive updates while dragging font-size sliders

### DIFF
--- a/apps/mobile/src/features/settings/appearance/components/FontSizeSliderRow.tsx
+++ b/apps/mobile/src/features/settings/appearance/components/FontSizeSliderRow.tsx
@@ -35,6 +35,7 @@ export function FontSizeSliderRow(props: {
   readonly step: number;
   readonly value: number;
   readonly onChange: (value: number) => void;
+  readonly onPreviewChange?: (value: number | null) => void;
 }) {
   const icon = useThemeColor("--color-icon");
   const iconMuted = String(useThemeColor("--color-icon-muted"));
@@ -48,21 +49,30 @@ export function FontSizeSliderRow(props: {
   const fraction = (value - min) / (max - min);
 
   const progress = useSharedValue(clampFraction(fraction));
+  const previewValue = useSharedValue(value);
   const trackWidth = useSharedValue(0);
   const dragging = useSharedValue(false);
 
   useEffect(() => {
     if (!dragging.value) {
       progress.value = withTiming(clampFraction(fraction), SNAP_ANIMATION);
+      previewValue.value = value;
     }
-  }, [dragging, fraction, progress]);
+  }, [dragging, fraction, previewValue, progress, value]);
+
+  const preview = useCallback((next: number | null) => {
+    latest.current.onPreviewChange?.(next);
+  }, []);
 
   const commit = useCallback((next: number) => {
-    if (next === latest.current.value) {
+    const current = latest.current;
+    if (next === current.value) {
+      current.onPreviewChange?.(null);
       return;
     }
     Haptics.selectionAsync().catch(() => undefined);
-    latest.current.onChange(next);
+    current.onChange(next);
+    current.onPreviewChange?.(null);
   }, []);
 
   const gesture = useMemo(() => {
@@ -96,29 +106,52 @@ export function FontSizeSliderRow(props: {
         dragging.value = true;
         const f = fractionAt(event.x);
         progress.value = f;
-        runOnJS(commit)(valueAtFraction(f));
+        const next = valueAtFraction(f);
+        if (next !== previewValue.value) {
+          previewValue.value = next;
+          runOnJS(preview)(next);
+        }
       })
-      .onFinalize(() => {
+      .onFinalize((_event, success) => {
         if (!dragging.value) {
           return;
         }
         dragging.value = false;
-        progress.value = withTiming(
-          fractionOfValue(valueAtFraction(progress.value)),
-          SNAP_ANIMATION,
-        );
+        if (!success) {
+          previewValue.value = value;
+          progress.value = withTiming(fractionOfValue(value), SNAP_ANIMATION);
+          runOnJS(preview)(null);
+          return;
+        }
+        const next = valueAtFraction(progress.value);
+        previewValue.value = next;
+        progress.value = withTiming(fractionOfValue(next), SNAP_ANIMATION);
+        runOnJS(commit)(next);
       });
 
     const tap = Gesture.Tap()
       .enabled(!disabled)
       .onEnd((event) => {
         const next = valueAtFraction(fractionAt(event.x));
+        previewValue.value = next;
         progress.value = withTiming(fractionOfValue(next), SNAP_ANIMATION);
         runOnJS(commit)(next);
       });
 
     return Gesture.Race(pan, tap);
-  }, [commit, disabled, dragging, max, min, progress, step, trackWidth]);
+  }, [
+    commit,
+    disabled,
+    dragging,
+    max,
+    min,
+    preview,
+    previewValue,
+    progress,
+    step,
+    trackWidth,
+    value,
+  ]);
 
   const fillStyle = useAnimatedStyle(() => ({
     width: THUMB_SIZE / 2 + progress.value * Math.max(0, trackWidth.value - THUMB_SIZE),

--- a/apps/mobile/src/features/settings/appearance/sections/CodeAppearanceSection.tsx
+++ b/apps/mobile/src/features/settings/appearance/sections/CodeAppearanceSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 
 import {
   CODE_FONT_SIZE_STEP,
@@ -17,6 +17,8 @@ import { FontSizeSliderRow } from "../components/FontSizeSliderRow";
 export function CodeAppearanceSection() {
   const { isReady, appearance, setCodeFontSize, setCodeWordBreak } = useAppearancePreferences();
   const custom = appearance.isCodeFontSizeCustom;
+  const [previewFontSize, setPreviewFontSize] = useState<number | null>(null);
+  const fontSize = previewFontSize ?? appearance.codeFontSize;
 
   const handleToggleCustom = useCallback(
     (enabled: boolean) => {
@@ -27,10 +29,7 @@ export function CodeAppearanceSection() {
 
   return (
     <SettingsSection card title="Code & Diffs">
-      <CodeAppearancePreview
-        fontSize={appearance.codeFontSize}
-        wordBreak={appearance.codeWordBreak}
-      />
+      <CodeAppearancePreview fontSize={fontSize} wordBreak={appearance.codeWordBreak} />
       <AppearancePreviewSeparator />
       <SettingsSwitchRow
         disabled={!isReady}
@@ -47,9 +46,10 @@ export function CodeAppearanceSection() {
           max={MAX_CODE_FONT_SIZE}
           min={MIN_CODE_FONT_SIZE}
           onChange={setCodeFontSize}
+          onPreviewChange={setPreviewFontSize}
           step={CODE_FONT_SIZE_STEP}
           value={appearance.codeFontSize}
-          valueLabel={`${appearance.codeFontSize} pt`}
+          valueLabel={`${fontSize} pt`}
         />
       ) : null}
       <SettingsSwitchRow

--- a/apps/mobile/src/features/settings/appearance/sections/TerminalAppearanceSection.tsx
+++ b/apps/mobile/src/features/settings/appearance/sections/TerminalAppearanceSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 
 import {
   MAX_TERMINAL_FONT_SIZE,
@@ -17,6 +17,8 @@ import { FontSizeSliderRow } from "../components/FontSizeSliderRow";
 export function TerminalAppearanceSection() {
   const { isReady, appearance, setTerminalFontSize } = useAppearancePreferences();
   const custom = appearance.isTerminalFontSizeCustom;
+  const [previewFontSize, setPreviewFontSize] = useState<number | null>(null);
+  const fontSize = previewFontSize ?? appearance.terminalFontSize;
 
   const handleToggleCustom = useCallback(
     (enabled: boolean) => {
@@ -27,7 +29,7 @@ export function TerminalAppearanceSection() {
 
   return (
     <SettingsSection card title="Terminal">
-      <TerminalAppearancePreview fontSize={appearance.terminalFontSize} />
+      <TerminalAppearancePreview fontSize={fontSize} />
       <AppearancePreviewSeparator />
       <SettingsSwitchRow
         disabled={!isReady}
@@ -44,9 +46,10 @@ export function TerminalAppearanceSection() {
           max={MAX_TERMINAL_FONT_SIZE}
           min={MIN_TERMINAL_FONT_SIZE}
           onChange={setTerminalFontSize}
+          onPreviewChange={setPreviewFontSize}
           step={TERMINAL_FONT_SIZE_STEP}
           value={appearance.terminalFontSize}
-          valueLabel={`${appearance.terminalFontSize.toFixed(1)} pt`}
+          valueLabel={`${fontSize.toFixed(1)} pt`}
         />
       ) : null}
     </SettingsSection>

--- a/apps/mobile/src/features/settings/appearance/sections/TextAppearanceSection.tsx
+++ b/apps/mobile/src/features/settings/appearance/sections/TextAppearanceSection.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 import {
   BASE_FONT_SIZE_STEP,
   MAX_BASE_FONT_SIZE,
@@ -13,10 +15,12 @@ import { FontSizeSliderRow } from "../components/FontSizeSliderRow";
 
 export function TextAppearanceSection() {
   const { isReady, appearance, setBaseFontSize } = useAppearancePreferences();
+  const [previewFontSize, setPreviewFontSize] = useState<number | null>(null);
+  const fontSize = previewFontSize ?? appearance.baseFontSize;
 
   return (
     <SettingsSection card title="Text">
-      <TextAppearancePreview fontSize={appearance.baseFontSize} />
+      <TextAppearancePreview fontSize={fontSize} />
       <AppearancePreviewSeparator />
       <FontSizeSliderRow
         disabled={!isReady}
@@ -25,9 +29,10 @@ export function TextAppearanceSection() {
         max={MAX_BASE_FONT_SIZE}
         min={MIN_BASE_FONT_SIZE}
         onChange={setBaseFontSize}
+        onPreviewChange={setPreviewFontSize}
         step={BASE_FONT_SIZE_STEP}
         value={appearance.baseFontSize}
-        valueLabel={`${appearance.baseFontSize} pt`}
+        valueLabel={`${fontSize} pt`}
       />
     </SettingsSection>
   );


### PR DESCRIPTION
## What Changed

- Preview snapped font-size values locally inside the Appearance screen while a slider is dragged.
- Persist the selected value and apply global typography only once when the gesture completes.
- Restore the committed preview when a gesture is cancelled.
- Keep taps, accessibility actions, and previews for text, terminal, and code font sizes consistent.

## Why

The slider previously wrote every intermediate drag value to mobile preferences. For the base text size, each write also reapplied the app-wide Uniwind typography variables. Rapid back-and-forth scrubbing could queue enough global updates that the thumb kept replaying old values after release and React eventually reported `Maximum update depth exceeded`.

Keeping the in-progress value local preserves real-time feedback in the Appearance preview and value label without repeatedly persisting preferences or relaying out the rest of the app. The final snapped value is committed once on release.

## UI Changes

There is no visual redesign. The interaction changes from app-wide live resizing during a drag to a responsive local preview followed by one global update on release.

### Before

Heavy scrubbing could lag, continue after release, and trigger the maximum update depth error.

https://github.com/user-attachments/assets/0bd7d72f-6fe4-41f4-892c-8cebaf4b98ce

### After

Only the local Appearance preview and value label update during the drag; the global value updates once on release.

https://github.com/user-attachments/assets/7c5ef962-cb16-4e21-b0bb-fdbddb9e6ad5

## Validation

- `vp fmt --check` on the four changed files
- `vp lint --report-unused-disable-directives` on the four changed files
- Mobile `tsc --noEmit`
- `git diff --check`
- Reproduced the original maximum update depth failure on an iPhone development build before the fix
- Captured before/after physical-device recordings of rapid slider scrubbing

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Built with GPT-5 using the Codex desktop harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep font size preview labels and previews responsive during slider interaction
> - Adds an `onPreviewChange` prop to `FontSizeSliderRow` that emits live (uncommitted) font size values while dragging or tapping, and emits `null` on commit or gesture cancellation.
> - Each appearance section (`CodeAppearanceSection`, `TerminalAppearanceSection`, `TextAppearanceSection`) now holds a transient `previewFontSize` state, falling back to the persisted value when the preview is cleared.
> - The preview panel and value label update in real time during slider interaction and revert to the committed value on release or cancel.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0aeda45.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to mobile Appearance settings slider gesture handling and local preview state; no auth, data, or API changes.
> 
> **Overview**
> **Font size sliders** no longer persist preferences on every pan frame. `FontSizeSliderRow` adds optional `onPreviewChange` so drags only update a local preview; `onChange` runs once when the gesture completes (or on tap), with preview cleared on cancel or unchanged commit.
> 
> **Text, Terminal, and Code appearance** sections hold `previewFontSize` state and drive previews and value labels from `preview ?? saved` while scrubbing, so feedback stays on the Appearance screen without repeated global typography updates until release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0aeda451e1492b58a3816789df9bcb8432d1cfbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->