### PR TITLE
fix(opencode): settle pending questions before teardown

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -64,9 +64,18 @@ const runtimeMock = {
     authHeaders: [] as Array<string | null>,
     abortCalls: [] as string[],
     questionRejectCalls: [] as string[],
+    questionReplyCalls: [] as string[],
     lifecycleCalls: [] as string[],
     questionRejectError: null as Error | null,
     questionRejectHangs: false,
+    questionReplyHangs: false,
+    lateSubscribedEvent: null as unknown,
+    releaseLateSubscribedEvent: null as (() => void) | null,
+    onLateSubscribedEventWait: null as (() => void) | null,
+    onLateSubscribedEventConsumed: null as (() => void) | null,
+    onQuestionReject: null as (() => void) | null,
+    onQuestionReply: null as (() => void) | null,
+    releaseLateEventOnQuestionReject: true,
     closeCalls: [] as string[],
     revertCalls: [] as Array<{ sessionID: string; messageID?: string }>,
     promptCalls: [] as Array<unknown>,
@@ -88,9 +97,18 @@ const runtimeMock = {
     this.state.authHeaders.length = 0;
     this.state.abortCalls.length = 0;
     this.state.questionRejectCalls.length = 0;
+    this.state.questionReplyCalls.length = 0;
     this.state.lifecycleCalls.length = 0;
     this.state.questionRejectError = null;
     this.state.questionRejectHangs = false;
+    this.state.questionReplyHangs = false;
+    this.state.lateSubscribedEvent = null;
+    this.state.releaseLateSubscribedEvent = null;
+    this.state.onLateSubscribedEventWait = null;
+    this.state.onLateSubscribedEventConsumed = null;
+    this.state.onQuestionReject = null;
+    this.state.onQuestionReply = null;
+    this.state.releaseLateEventOnQuestionReject = true;
     this.state.closeCalls.length = 0;
     this.state.revertCalls.length = 0;
     this.state.promptCalls.length = 0;
@@ -215,11 +233,22 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
         },
       },
       question: {
+        reply: async ({ requestID }: { requestID: string }) => {
+          runtimeMock.state.questionReplyCalls.push(requestID);
+          runtimeMock.state.onQuestionReply?.();
+          if (runtimeMock.state.questionReplyHangs) {
+            await new Promise<never>(() => {});
+          }
+        },
         reject: async ({ requestID }: { requestID: string }) => {
           runtimeMock.state.questionRejectCalls.push(requestID);
           runtimeMock.state.lifecycleCalls.push(`reject:${requestID}`);
+          runtimeMock.state.onQuestionReject?.();
           if (runtimeMock.state.questionRejectError) {
             throw runtimeMock.state.questionRejectError;
+          }
+          if (runtimeMock.state.releaseLateEventOnQuestionReject) {
+            runtimeMock.state.releaseLateSubscribedEvent?.();
           }
           if (runtimeMock.state.questionRejectHangs) {
             await new Promise<never>(() => {});
@@ -231,6 +260,14 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
           stream: (async function* () {
             for (const event of runtimeMock.state.subscribedEvents) {
               yield event;
+            }
+            if (runtimeMock.state.lateSubscribedEvent !== null) {
+              runtimeMock.state.onLateSubscribedEventWait?.();
+              await new Promise<void>((resolve) => {
+                runtimeMock.state.releaseLateSubscribedEvent = resolve;
+              });
+              yield runtimeMock.state.lateSubscribedEvent;
+              runtimeMock.state.onLateSubscribedEventConsumed?.();
             }
           })(),
         }),
@@ -752,6 +789,88 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("does not reject a question while its reply is in flight", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-reply-interrupt-race");
+      const requestId = ApprovalRequestId.make("question-reply-interrupt-race-1");
+      runtimeMock.state.subscribedEvents = [pendingQuestionEvent(requestId)];
+      const questionReplyStarted = new Promise<void>((resolve) => {
+        runtimeMock.state.onQuestionReply = resolve;
+      });
+      const events: Array<{ type: string }> = [];
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.runForEach((event) => Effect.sync(() => events.push(event))),
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* advanceTestClock(10);
+      runtimeMock.state.questionReplyHangs = true;
+      const replyFiber = yield* adapter
+        .respondToUserInput(threadId, requestId, {})
+        .pipe(Effect.forkChild);
+      yield* Effect.promise(() => questionReplyStarted);
+
+      yield* adapter.interruptTurn(threadId, TurnId.make("turn-opencode-reply-interrupt-race"));
+      yield* Effect.yieldNow;
+
+      NodeAssert.deepEqual(runtimeMock.state.questionReplyCalls, [requestId]);
+      NodeAssert.deepEqual(runtimeMock.state.questionRejectCalls, []);
+      NodeAssert.equal(
+        events.some((event) => event.type === "user-input.resolved"),
+        true,
+      );
+      yield* Fiber.interrupt(replyFiber);
+      yield* Fiber.interrupt(eventsFiber);
+      runtimeMock.state.questionReplyHangs = false;
+      runtimeMock.state.onQuestionReply = null;
+      yield* adapter.stopSession(threadId);
+      NodeAssert.deepEqual(runtimeMock.state.questionRejectCalls, []);
+    }),
+  );
+
+  it.effect("does not start a reply while question settlement is active", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-interrupt-reply-race");
+      const requestId = ApprovalRequestId.make("question-interrupt-reply-race-1");
+      runtimeMock.state.subscribedEvents = [pendingQuestionEvent(requestId)];
+      const questionRejectStarted = new Promise<void>((resolve) => {
+        runtimeMock.state.onQuestionReject = resolve;
+      });
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* advanceTestClock(10);
+      runtimeMock.state.questionRejectHangs = true;
+      const interruptFiber = yield* adapter
+        .interruptTurn(threadId, TurnId.make("turn-opencode-interrupt-reply-race"))
+        .pipe(Effect.forkChild);
+      yield* Effect.promise(() => questionRejectStarted);
+
+      const response = yield* adapter
+        .respondToUserInput(threadId, requestId, {})
+        .pipe(Effect.result);
+
+      NodeAssert.equal(response._tag, "Failure");
+      NodeAssert.deepEqual(runtimeMock.state.questionReplyCalls, []);
+      yield* advanceTestClock(5_000);
+      yield* Fiber.join(interruptFiber);
+      runtimeMock.state.questionRejectHangs = false;
+      runtimeMock.state.onQuestionReject = null;
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("still interrupts when pending-question rejection fails", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;
@@ -834,6 +953,207 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         events.map((event) => event.type),
         ["session.started", "thread.started", "user-input.requested", "user-input.resolved"],
       );
+    }),
+  );
+
+  it.effect("closes the session scope when stop is interrupted during question settlement", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-interrupted-stop-question");
+      const requestId = ApprovalRequestId.make("question-interrupted-stop-1");
+      runtimeMock.state.subscribedEvents = [pendingQuestionEvent(requestId)];
+      const questionRejectStarted = new Promise<void>((resolve) => {
+        runtimeMock.state.onQuestionReject = resolve;
+      });
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* advanceTestClock(10);
+      runtimeMock.state.questionRejectHangs = true;
+      const stopFiber = yield* adapter.stopSession(threadId).pipe(Effect.forkChild);
+      yield* Effect.promise(() => questionRejectStarted);
+      yield* Fiber.interrupt(stopFiber);
+
+      NodeAssert.deepEqual(runtimeMock.state.closeCalls, ["http://127.0.0.1:9999"]);
+      NodeAssert.equal(yield* adapter.hasSession(threadId), false);
+      NodeAssert.deepEqual(yield* adapter.listSessions(), []);
+    }),
+  );
+
+  it.effect("keeps a replacement session when prior cleanup finishes later", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-delayed-replacement-cleanup");
+      const requestId = ApprovalRequestId.make("question-delayed-replacement-cleanup-1");
+      runtimeMock.state.subscribedEvents = [pendingQuestionEvent(requestId)];
+      const questionRejectStarted = new Promise<void>((resolve) => {
+        runtimeMock.state.onQuestionReject = resolve;
+      });
+      const events: Array<{ type: string }> = [];
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.runForEach((event) => Effect.sync(() => events.push(event))),
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* advanceTestClock(10);
+      runtimeMock.state.subscribedEvents = [];
+      runtimeMock.state.questionRejectHangs = true;
+      const stopFiber = yield* adapter.stopSession(threadId).pipe(Effect.forkChild);
+      yield* Effect.promise(() => questionRejectStarted);
+
+      const replacement = yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* advanceTestClock(5_000);
+      yield* Fiber.join(stopFiber);
+
+      NodeAssert.equal(yield* adapter.hasSession(threadId), true);
+      NodeAssert.deepEqual(yield* adapter.listSessions(), [replacement]);
+      NodeAssert.equal(
+        events.some((event) => event.type === "session.exited"),
+        false,
+      );
+      yield* Fiber.interrupt(eventsFiber);
+      runtimeMock.state.questionRejectHangs = false;
+      runtimeMock.state.onQuestionReject = null;
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("ignores questions delivered while interruption settles pending input", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-late-question");
+      const requestId = ApprovalRequestId.make("question-before-interrupt-1");
+      const lateRequestId = ApprovalRequestId.make("question-during-interrupt-2");
+      runtimeMock.state.subscribedEvents = [pendingQuestionEvent(requestId)];
+      runtimeMock.state.lateSubscribedEvent = pendingQuestionEvent(lateRequestId);
+      const lateEventWaitStarted = new Promise<void>((resolve) => {
+        runtimeMock.state.onLateSubscribedEventWait = resolve;
+      });
+      const questionRejectStarted = new Promise<void>((resolve) => {
+        runtimeMock.state.onQuestionReject = resolve;
+      });
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(5),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* Effect.promise(() => lateEventWaitStarted);
+      yield* advanceTestClock(10);
+      runtimeMock.state.questionRejectHangs = true;
+      const interruptFiber = yield* adapter
+        .interruptTurn(threadId, TurnId.make("turn-opencode-late-question"))
+        .pipe(Effect.forkChild);
+      yield* Effect.promise(() => questionRejectStarted);
+      yield* Effect.yieldNow;
+      yield* advanceTestClock(5_000);
+      yield* Fiber.join(interruptFiber);
+
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      NodeAssert.deepEqual(
+        events.map((event) => event.type),
+        [
+          "session.started",
+          "thread.started",
+          "user-input.requested",
+          "user-input.resolved",
+          "turn.aborted",
+        ],
+      );
+      NodeAssert.equal(
+        events.some(
+          (event) =>
+            event.type === "user-input.requested" &&
+            String(event.requestId) === String(lateRequestId),
+        ),
+        false,
+      );
+      runtimeMock.state.questionRejectHangs = false;
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("keeps the question gate closed across concurrent interruptions", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-concurrent-question-settlement");
+      const requestId = ApprovalRequestId.make("question-before-concurrent-interrupt-1");
+      const lateRequestId = ApprovalRequestId.make("question-during-concurrent-interrupt-2");
+      runtimeMock.state.subscribedEvents = [pendingQuestionEvent(requestId)];
+      runtimeMock.state.lateSubscribedEvent = pendingQuestionEvent(lateRequestId);
+      runtimeMock.state.releaseLateEventOnQuestionReject = false;
+      const lateEventWaitStarted = new Promise<void>((resolve) => {
+        runtimeMock.state.onLateSubscribedEventWait = resolve;
+      });
+      const lateEventConsumed = new Promise<void>((resolve) => {
+        runtimeMock.state.onLateSubscribedEventConsumed = resolve;
+      });
+      let rejectionCount = 0;
+      const rejectionStarted = new Promise<void>((resolve) => {
+        runtimeMock.state.onQuestionReject = () => {
+          rejectionCount += 1;
+          resolve();
+        };
+      });
+      const events: Array<{ type: string; requestId?: unknown }> = [];
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.runForEach((event) => Effect.sync(() => events.push(event))),
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* Effect.promise(() => lateEventWaitStarted);
+      yield* advanceTestClock(10);
+      runtimeMock.state.questionRejectHangs = true;
+      const firstInterrupt = yield* adapter
+        .interruptTurn(threadId, TurnId.make("turn-opencode-concurrent-question-1"))
+        .pipe(Effect.forkChild);
+      const secondInterrupt = yield* adapter
+        .interruptTurn(threadId, TurnId.make("turn-opencode-concurrent-question-2"))
+        .pipe(Effect.forkChild);
+      yield* Effect.promise(() => rejectionStarted);
+      runtimeMock.state.releaseLateSubscribedEvent?.();
+      yield* Effect.promise(() => lateEventConsumed);
+      yield* advanceTestClock(5_000);
+      yield* Fiber.join(firstInterrupt);
+      yield* Fiber.join(secondInterrupt);
+      yield* Fiber.interrupt(eventsFiber);
+
+      NodeAssert.equal(
+        events.some(
+          (event) =>
+            event.type === "user-input.requested" &&
+            String(event.requestId) === String(lateRequestId),
+        ),
+        false,
+      );
+      NodeAssert.equal(rejectionCount, 1);
+      runtimeMock.state.questionRejectHangs = false;
+      runtimeMock.state.onQuestionReject = null;
+      yield* adapter.stopSession(threadId);
     }),
   );
 

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -16,10 +16,12 @@ import * as TestClock from "effect/testing/TestClock";
 import { beforeEach } from "vite-plus/test";
 
 import {
+  ApprovalRequestId,
   OpenCodeSettings,
   ProviderDriverKind,
   ProviderInstanceId,
   ThreadId,
+  TurnId,
 } from "@t3tools/contracts";
 import { createModelSelection } from "@t3tools/shared/model";
 import { ServerConfig } from "../../config.ts";
@@ -61,6 +63,10 @@ const runtimeMock = {
     sessionCreateInputs: [] as Array<Record<string, unknown>>,
     authHeaders: [] as Array<string | null>,
     abortCalls: [] as string[],
+    questionRejectCalls: [] as string[],
+    lifecycleCalls: [] as string[],
+    questionRejectError: null as Error | null,
+    questionRejectHangs: false,
     closeCalls: [] as string[],
     revertCalls: [] as Array<{ sessionID: string; messageID?: string }>,
     promptCalls: [] as Array<unknown>,
@@ -81,6 +87,10 @@ const runtimeMock = {
     this.state.sessionCreateInputs.length = 0;
     this.state.authHeaders.length = 0;
     this.state.abortCalls.length = 0;
+    this.state.questionRejectCalls.length = 0;
+    this.state.lifecycleCalls.length = 0;
+    this.state.questionRejectError = null;
+    this.state.questionRejectHangs = false;
     this.state.closeCalls.length = 0;
     this.state.revertCalls.length = 0;
     this.state.promptCalls.length = 0;
@@ -176,6 +186,7 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
         },
         abort: async ({ sessionID }: { sessionID: string }) => {
           runtimeMock.state.abortCalls.push(sessionID);
+          runtimeMock.state.lifecycleCalls.push(`abort:${sessionID}`);
         },
         promptAsync: async (input: unknown) => {
           runtimeMock.state.promptCalls.push(input);
@@ -201,6 +212,18 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
             targetIndex >= 0
               ? runtimeMock.state.messages.slice(0, targetIndex + 1)
               : runtimeMock.state.messages;
+        },
+      },
+      question: {
+        reject: async ({ requestID }: { requestID: string }) => {
+          runtimeMock.state.questionRejectCalls.push(requestID);
+          runtimeMock.state.lifecycleCalls.push(`reject:${requestID}`);
+          if (runtimeMock.state.questionRejectError) {
+            throw runtimeMock.state.questionRejectError;
+          }
+          if (runtimeMock.state.questionRejectHangs) {
+            await new Promise<never>(() => {});
+          }
         },
       },
       event: {
@@ -279,6 +302,22 @@ beforeEach(() => {
 
 const advanceTestClock = (ms: number) =>
   TestClock.adjust(`${ms} millis`).pipe(Effect.andThen(Effect.yieldNow));
+
+const pendingQuestionEvent = (requestId: string) => ({
+  type: "question.asked",
+  properties: {
+    id: requestId,
+    sessionID: "http://127.0.0.1:9999/session",
+    questions: [
+      {
+        header: "Scope",
+        question: "Which scope should be used?",
+        options: [{ label: "Focused", description: "Change only the affected adapter" }],
+        multiple: false,
+      },
+    ],
+  },
+});
 
 it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
   it.effect("reuses a configured OpenCode server URL instead of spawning a local server", () =>
@@ -624,6 +663,176 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       NodeAssert.deepEqual(
         events.map((event) => event.type),
         ["session.started", "thread.started", "session.exited"],
+      );
+    }),
+  );
+
+  it.effect("rejects pending questions before interrupting a turn", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-interrupt-question");
+      const requestId = ApprovalRequestId.make("question-interrupt-1");
+      runtimeMock.state.subscribedEvents = [pendingQuestionEvent(requestId)];
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(5),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* advanceTestClock(10);
+      yield* adapter.interruptTurn(threadId, TurnId.make("turn-opencode-interrupt-question"));
+
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      NodeAssert.deepEqual(runtimeMock.state.lifecycleCalls, [
+        `reject:${requestId}`,
+        "abort:http://127.0.0.1:9999/session",
+      ]);
+      NodeAssert.deepEqual(
+        events.map((event) => event.type),
+        [
+          "session.started",
+          "thread.started",
+          "user-input.requested",
+          "user-input.resolved",
+          "turn.aborted",
+        ],
+      );
+
+      const response = yield* adapter
+        .respondToUserInput(threadId, requestId, {})
+        .pipe(Effect.result);
+      NodeAssert.equal(response._tag, "Failure");
+      NodeAssert.equal(response.failure._tag, "ProviderAdapterRequestError");
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("rejects pending questions before stopping a session", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-stop-question");
+      const requestId = ApprovalRequestId.make("question-stop-1");
+      runtimeMock.state.subscribedEvents = [pendingQuestionEvent(requestId)];
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(5),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* advanceTestClock(10);
+      yield* adapter.stopSession(threadId);
+
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      NodeAssert.deepEqual(runtimeMock.state.lifecycleCalls, [
+        `reject:${requestId}`,
+        "abort:http://127.0.0.1:9999/session",
+      ]);
+      NodeAssert.deepEqual(
+        events.map((event) => event.type),
+        [
+          "session.started",
+          "thread.started",
+          "user-input.requested",
+          "user-input.resolved",
+          "session.exited",
+        ],
+      );
+    }),
+  );
+
+  it.effect("still interrupts when pending-question rejection fails", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-reject-question-failure");
+      const requestId = ApprovalRequestId.make("question-reject-failure-1");
+      runtimeMock.state.subscribedEvents = [pendingQuestionEvent(requestId)];
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* advanceTestClock(10);
+      runtimeMock.state.questionRejectError = new Error("question rejection failed");
+
+      yield* adapter.interruptTurn(threadId, TurnId.make("turn-opencode-reject-question-failure"));
+
+      NodeAssert.deepEqual(runtimeMock.state.questionRejectCalls, [requestId]);
+      NodeAssert.deepEqual(runtimeMock.state.abortCalls, ["http://127.0.0.1:9999/session"]);
+      runtimeMock.state.questionRejectError = null;
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("still interrupts after pending-question rejection times out", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-reject-question-timeout");
+      const requestId = ApprovalRequestId.make("question-reject-timeout-1");
+      runtimeMock.state.subscribedEvents = [pendingQuestionEvent(requestId)];
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* advanceTestClock(10);
+      runtimeMock.state.questionRejectHangs = true;
+      const interruptFiber = yield* adapter
+        .interruptTurn(threadId, TurnId.make("turn-opencode-reject-question-timeout"))
+        .pipe(Effect.forkChild);
+      yield* Effect.yieldNow;
+      yield* advanceTestClock(5_000);
+      yield* Fiber.join(interruptFiber);
+
+      NodeAssert.deepEqual(runtimeMock.state.questionRejectCalls, [requestId]);
+      NodeAssert.deepEqual(runtimeMock.state.abortCalls, ["http://127.0.0.1:9999/session"]);
+      runtimeMock.state.questionRejectHangs = false;
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("rejects pending questions during bulk shutdown", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-stop-all-question");
+      const requestId = ApprovalRequestId.make("question-stop-all-1");
+      runtimeMock.state.subscribedEvents = [pendingQuestionEvent(requestId)];
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(4),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* advanceTestClock(10);
+      yield* adapter.stopAll();
+
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      NodeAssert.deepEqual(runtimeMock.state.lifecycleCalls, [
+        `reject:${requestId}`,
+        "abort:http://127.0.0.1:9999/session",
+      ]);
+      NodeAssert.deepEqual(
+        events.map((event) => event.type),
+        ["session.started", "thread.started", "user-input.requested", "user-input.resolved"],
       );
     }),
   );

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -557,11 +557,14 @@ function updateProviderSession(
 
 const stopOpenCodeContext = Effect.fn("stopOpenCodeContext")(function* (
   context: OpenCodeSessionContext,
+  beforeAbort: Effect.Effect<void, never> = Effect.void,
 ) {
   // Race-safe one-shot: first caller flips the flag, everyone else no-ops.
   if (yield* Ref.getAndSet(context.stopped, true)) {
     return false;
   }
+
+  yield* beforeAbort;
 
   // Best-effort remote abort. The scope close below tears down the local
   // handles (event-pump fiber, server-exit fiber, event-subscribe fetch),
@@ -653,7 +656,8 @@ export function makeOpenCodeAdapter(
         // the remaining cleanups.
         yield* Effect.forEach(
           contexts,
-          (context) => Effect.ignoreCause(stopOpenCodeContext(context)),
+          (context) =>
+            Effect.ignoreCause(stopOpenCodeContext(context, settlePendingQuestions(context))),
           { concurrency: "unbounded", discard: true },
         );
         // Close the logger AFTER session teardown so any final lifecycle
@@ -668,6 +672,61 @@ export function makeOpenCodeAdapter(
 
     const emit = (event: ProviderRuntimeEvent) =>
       Queue.offer(runtimeEvents, event).pipe(Effect.asVoid);
+    const settlePendingQuestions = Effect.fn("settlePendingQuestions")(function* (
+      context: OpenCodeSessionContext,
+    ) {
+      const requestIds = [...context.pendingQuestions.keys()];
+      if (requestIds.length === 0) {
+        return;
+      }
+
+      const rejectionExit = yield* Effect.forEach(
+        requestIds,
+        (requestId) =>
+          runOpenCodeSdk("question.reject", () =>
+            context.client.question.reject({ requestID: requestId }),
+          ),
+        { discard: true },
+      ).pipe(Effect.timeoutOption("5 seconds"), Effect.exit);
+      if (Exit.isFailure(rejectionExit)) {
+        yield* Effect.logWarning("opencode.pending-questions.reject-failed", {
+          threadId: context.session.threadId,
+          cause: Cause.squash(rejectionExit.cause),
+        });
+      } else if (Option.isNone(rejectionExit.value)) {
+        yield* Effect.logWarning("opencode.pending-questions.reject-timed-out", {
+          threadId: context.session.threadId,
+          timeout: "5 seconds",
+        });
+      }
+
+      for (const requestId of requestIds) {
+        if (!context.pendingQuestions.has(requestId)) {
+          continue;
+        }
+        yield* buildEventBase({
+          threadId: context.session.threadId,
+          turnId: context.activeTurnId,
+          requestId,
+        }).pipe(
+          Effect.flatMap((eventBase) =>
+            emit({
+              ...eventBase,
+              type: "user-input.resolved",
+              payload: { answers: {} },
+            }),
+          ),
+          Effect.catchCause((cause) =>
+            Effect.logWarning("opencode.pending-questions.resolve-emit-failed", {
+              threadId: context.session.threadId,
+              requestId,
+              cause: Cause.squash(cause),
+            }),
+          ),
+        );
+        context.pendingQuestions.delete(requestId);
+      }
+    });
     const writeNativeEvent = (
       threadId: ThreadId,
       event: {
@@ -1210,7 +1269,7 @@ export function makeOpenCodeAdapter(
         const resumeSessionId = parseOpenCodeResume(input.resumeCursor)?.sessionId;
         const existing = sessions.get(input.threadId);
         if (existing) {
-          yield* stopOpenCodeContext(existing);
+          yield* stopOpenCodeContext(existing, settlePendingQuestions(existing));
           sessions.delete(input.threadId);
         }
 
@@ -1558,6 +1617,7 @@ export function makeOpenCodeAdapter(
     const interruptTurn: OpenCodeAdapterShape["interruptTurn"] = Effect.fn("interruptTurn")(
       function* (threadId, turnId) {
         const context = yield* ensureSessionContext(sessions, threadId);
+        yield* settlePendingQuestions(context);
         yield* runOpenCodeSdk("session.abort", () =>
           context.client.session.abort({ sessionID: context.openCodeSessionId }),
         ).pipe(Effect.mapError(toRequestError));
@@ -1626,7 +1686,7 @@ export function makeOpenCodeAdapter(
             threadId,
           });
         }
-        const stopped = yield* stopOpenCodeContext(context);
+        const stopped = yield* stopOpenCodeContext(context, settlePendingQuestions(context));
         sessions.delete(threadId);
         if (!stopped) {
           return;
@@ -1710,7 +1770,8 @@ export function makeOpenCodeAdapter(
         // interrupt the sibling fibers. Same pattern as the layer finalizer.
         yield* Effect.forEach(
           contexts,
-          (context) => Effect.ignoreCause(stopOpenCodeContext(context)),
+          (context) =>
+            Effect.ignoreCause(stopOpenCodeContext(context, settlePendingQuestions(context))),
           { concurrency: "unbounded", discard: true },
         );
       });

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -221,6 +221,13 @@ function isOpenCodeDefaultTitle(title: string): boolean {
   return OPENCODE_DEFAULT_TITLE_PATTERN.test(title);
 }
 
+interface OpenCodeQuestionState {
+  readonly pendingQuestions: Map<string, QuestionRequest>;
+  readonly replyingQuestions: Map<string, QuestionRequest>;
+  readonly settlementCount: number;
+  readonly settlementVersion: number;
+}
+
 interface OpenCodeSessionContext {
   session: ProviderSession;
   readonly client: OpencodeClient;
@@ -228,7 +235,7 @@ interface OpenCodeSessionContext {
   readonly directory: string;
   readonly openCodeSessionId: string;
   readonly pendingPermissions: Map<string, PermissionRequest>;
-  readonly pendingQuestions: Map<string, QuestionRequest>;
+  readonly questionState: Ref.Ref<OpenCodeQuestionState>;
   readonly messageRoleById: Map<string, "user" | "assistant">;
   readonly partById: Map<string, Part>;
   readonly emittedTextByPartId: Map<string, string>;
@@ -558,26 +565,41 @@ function updateProviderSession(
 const stopOpenCodeContext = Effect.fn("stopOpenCodeContext")(function* (
   context: OpenCodeSessionContext,
   beforeAbort: Effect.Effect<void, never> = Effect.void,
+  afterClose: Effect.Effect<void, never> = Effect.void,
 ) {
-  // Race-safe one-shot: first caller flips the flag, everyone else no-ops.
-  if (yield* Ref.getAndSet(context.stopped, true)) {
-    return false;
-  }
+  return yield* Effect.uninterruptibleMask((restore) =>
+    Effect.gen(function* () {
+      // Race-safe one-shot: first caller flips the flag, everyone else no-ops.
+      if (yield* Ref.getAndSet(context.stopped, true)) {
+        return false;
+      }
+      yield* Ref.update(context.questionState, (state) => ({
+        ...state,
+        settlementCount: state.settlementCount + 1,
+        settlementVersion: state.settlementVersion + 1,
+      }));
 
-  yield* beforeAbort;
+      const cleanupExit = yield* restore(
+        Effect.gen(function* () {
+          yield* beforeAbort;
 
-  // Best-effort remote abort. The scope close below tears down the local
-  // handles (event-pump fiber, server-exit fiber, event-subscribe fetch),
-  // but we still want to tell OpenCode that this session is done.
-  yield* runOpenCodeSdk("session.abort", () =>
-    context.client.session.abort({ sessionID: context.openCodeSessionId }),
-  ).pipe(Effect.ignore({ log: true }));
+          // Best-effort remote abort. The scope close below tears down the local
+          // handles, but we still want to tell OpenCode that this session is done.
+          yield* runOpenCodeSdk("session.abort", () =>
+            context.client.session.abort({ sessionID: context.openCodeSessionId }),
+          ).pipe(Effect.ignore({ log: true }));
+        }),
+      ).pipe(Effect.exit);
 
-  // Closing the session scope interrupts every fiber forked into it and
-  // runs each finalizer we registered — the `AbortController.abort()` call,
-  // the child-process termination, etc.
-  yield* Scope.close(context.sessionScope, Exit.void);
-  return true;
+      // The mask guarantees scope ownership is released after the one-shot
+      // guard flips, even when the caller interrupts the work above.
+      yield* Scope.close(context.sessionScope, Exit.void).pipe(Effect.ensuring(afterClose));
+      if (Exit.isFailure(cleanupExit)) {
+        return yield* Effect.failCause(cleanupExit.cause);
+      }
+      return true;
+    }),
+  );
 });
 
 export function makeOpenCodeAdapter(
@@ -675,35 +697,40 @@ export function makeOpenCodeAdapter(
     const settlePendingQuestions = Effect.fn("settlePendingQuestions")(function* (
       context: OpenCodeSessionContext,
     ) {
-      const requestIds = [...context.pendingQuestions.keys()];
-      if (requestIds.length === 0) {
+      const { rejectIds, resolveIds } = yield* Ref.modify(context.questionState, (state) => [
+        {
+          rejectIds: [...state.pendingQuestions.keys()],
+          resolveIds: [...state.pendingQuestions.keys(), ...state.replyingQuestions.keys()],
+        },
+        { ...state, pendingQuestions: new Map(), replyingQuestions: new Map() },
+      ]);
+      if (resolveIds.length === 0) {
         return;
       }
 
-      const rejectionExit = yield* Effect.forEach(
-        requestIds,
-        (requestId) =>
-          runOpenCodeSdk("question.reject", () =>
-            context.client.question.reject({ requestID: requestId }),
-          ),
-        { discard: true },
-      ).pipe(Effect.timeoutOption("5 seconds"), Effect.exit);
-      if (Exit.isFailure(rejectionExit)) {
-        yield* Effect.logWarning("opencode.pending-questions.reject-failed", {
-          threadId: context.session.threadId,
-          cause: Cause.squash(rejectionExit.cause),
-        });
-      } else if (Option.isNone(rejectionExit.value)) {
-        yield* Effect.logWarning("opencode.pending-questions.reject-timed-out", {
-          threadId: context.session.threadId,
-          timeout: "5 seconds",
-        });
+      if (rejectIds.length > 0) {
+        const rejectionExit = yield* Effect.forEach(
+          rejectIds,
+          (requestId) =>
+            runOpenCodeSdk("question.reject", () =>
+              context.client.question.reject({ requestID: requestId }),
+            ),
+          { discard: true },
+        ).pipe(Effect.timeoutOption("5 seconds"), Effect.exit);
+        if (Exit.isFailure(rejectionExit)) {
+          yield* Effect.logWarning("opencode.pending-questions.reject-failed", {
+            threadId: context.session.threadId,
+            cause: Cause.squash(rejectionExit.cause),
+          });
+        } else if (Option.isNone(rejectionExit.value)) {
+          yield* Effect.logWarning("opencode.pending-questions.reject-timed-out", {
+            threadId: context.session.threadId,
+            timeout: "5 seconds",
+          });
+        }
       }
 
-      for (const requestId of requestIds) {
-        if (!context.pendingQuestions.has(requestId)) {
-          continue;
-        }
+      for (const requestId of resolveIds) {
         yield* buildEventBase({
           threadId: context.session.threadId,
           turnId: context.activeTurnId,
@@ -724,7 +751,6 @@ export function makeOpenCodeAdapter(
             }),
           ),
         );
-        context.pendingQuestions.delete(requestId);
       }
     });
     const writeNativeEvent = (
@@ -1055,7 +1081,20 @@ export function makeOpenCodeAdapter(
         }
 
         case "question.asked": {
-          context.pendingQuestions.set(event.properties.id, event.properties);
+          if (yield* Ref.get(context.stopped)) {
+            break;
+          }
+          const accepted = yield* Ref.modify(context.questionState, (state) => {
+            if (state.settlementCount > 0) {
+              return [false, state];
+            }
+            const pendingQuestions = new Map(state.pendingQuestions);
+            pendingQuestions.set(event.properties.id, event.properties);
+            return [true, { ...state, pendingQuestions }];
+          });
+          if (!accepted) {
+            break;
+          }
           yield* emit({
             ...(yield* buildEventBase({
               threadId: context.session.threadId,
@@ -1072,10 +1111,24 @@ export function makeOpenCodeAdapter(
         }
 
         case "question.replied": {
-          const request = context.pendingQuestions.get(event.properties.requestID);
-          context.pendingQuestions.delete(event.properties.requestID);
+          const request = yield* Ref.modify(context.questionState, (state) => {
+            const request =
+              state.pendingQuestions.get(event.properties.requestID) ??
+              state.replyingQuestions.get(event.properties.requestID);
+            if (!request) {
+              return [undefined, state];
+            }
+            const pendingQuestions = new Map(state.pendingQuestions);
+            const replyingQuestions = new Map(state.replyingQuestions);
+            pendingQuestions.delete(event.properties.requestID);
+            replyingQuestions.delete(event.properties.requestID);
+            return [request, { ...state, pendingQuestions, replyingQuestions }];
+          });
+          if (!request) {
+            break;
+          }
           const answers = Object.fromEntries(
-            (request?.questions ?? []).map((question, index) => [
+            request.questions.map((question, index) => [
               openCodeQuestionId(index, question),
               event.properties.answers[index]?.join(", ") ?? "",
             ]),
@@ -1094,7 +1147,22 @@ export function makeOpenCodeAdapter(
         }
 
         case "question.rejected": {
-          context.pendingQuestions.delete(event.properties.requestID);
+          const wasPending = yield* Ref.modify(context.questionState, (state) => {
+            if (
+              !state.pendingQuestions.has(event.properties.requestID) &&
+              !state.replyingQuestions.has(event.properties.requestID)
+            ) {
+              return [false, state];
+            }
+            const pendingQuestions = new Map(state.pendingQuestions);
+            const replyingQuestions = new Map(state.replyingQuestions);
+            pendingQuestions.delete(event.properties.requestID);
+            replyingQuestions.delete(event.properties.requestID);
+            return [true, { ...state, pendingQuestions, replyingQuestions }];
+          });
+          if (!wasPending) {
+            break;
+          }
           yield* emit({
             ...(yield* buildEventBase({
               threadId: context.session.threadId,
@@ -1269,8 +1337,15 @@ export function makeOpenCodeAdapter(
         const resumeSessionId = parseOpenCodeResume(input.resumeCursor)?.sessionId;
         const existing = sessions.get(input.threadId);
         if (existing) {
-          yield* stopOpenCodeContext(existing, settlePendingQuestions(existing));
-          sessions.delete(input.threadId);
+          yield* stopOpenCodeContext(
+            existing,
+            settlePendingQuestions(existing),
+            Effect.sync(() => {
+              if (sessions.get(input.threadId) === existing) {
+                sessions.delete(input.threadId);
+              }
+            }),
+          );
         }
 
         const started = yield* Effect.gen(function* () {
@@ -1410,7 +1485,7 @@ export function makeOpenCodeAdapter(
         // Guard against a concurrent startSession call that may have raced
         // and already inserted a session while we were awaiting async work.
         const raceWinner = sessions.get(input.threadId);
-        if (raceWinner) {
+        if (raceWinner && !(yield* Ref.get(raceWinner.stopped))) {
           // Another call won the race — clean up. Only abort the remote
           // session if we created it here; a resumed one is shared upstream
           // state the winner is now using.
@@ -1423,6 +1498,9 @@ export function makeOpenCodeAdapter(
           }
           yield* Scope.close(started.sessionScope, Exit.void).pipe(Effect.ignore);
           return raceWinner.session;
+        }
+        if (raceWinner && sessions.get(input.threadId) === raceWinner) {
+          sessions.delete(input.threadId);
         }
 
         const createdAt = yield* nowIso;
@@ -1452,7 +1530,12 @@ export function makeOpenCodeAdapter(
           directory,
           openCodeSessionId: started.openCodeSession.id,
           pendingPermissions: new Map(),
-          pendingQuestions: new Map(),
+          questionState: yield* Ref.make({
+            pendingQuestions: new Map(),
+            replyingQuestions: new Map(),
+            settlementCount: 0,
+            settlementVersion: 0,
+          }),
           partById: new Map(),
           emittedTextByPartId: new Map(),
           messageRoleById: new Map(),
@@ -1617,10 +1700,24 @@ export function makeOpenCodeAdapter(
     const interruptTurn: OpenCodeAdapterShape["interruptTurn"] = Effect.fn("interruptTurn")(
       function* (threadId, turnId) {
         const context = yield* ensureSessionContext(sessions, threadId);
-        yield* settlePendingQuestions(context);
-        yield* runOpenCodeSdk("session.abort", () =>
-          context.client.session.abort({ sessionID: context.openCodeSessionId }),
-        ).pipe(Effect.mapError(toRequestError));
+        yield* Effect.gen(function* () {
+          yield* Ref.update(context.questionState, (state) => ({
+            ...state,
+            settlementCount: state.settlementCount + 1,
+            settlementVersion: state.settlementVersion + 1,
+          }));
+          yield* settlePendingQuestions(context);
+          yield* runOpenCodeSdk("session.abort", () =>
+            context.client.session.abort({ sessionID: context.openCodeSessionId }),
+          ).pipe(Effect.mapError(toRequestError));
+        }).pipe(
+          Effect.ensuring(
+            Ref.update(context.questionState, (state) => ({
+              ...state,
+              settlementCount: Math.max(0, state.settlementCount - 1),
+            })),
+          ),
+        );
         if (turnId ?? context.activeTurnId) {
           yield* emit({
             ...(yield* buildEventBase({
@@ -1660,21 +1757,60 @@ export function makeOpenCodeAdapter(
       "respondToUserInput",
     )(function* (threadId, requestId, answers) {
       const context = yield* ensureSessionContext(sessions, threadId);
-      const request = context.pendingQuestions.get(requestId);
-      if (!request) {
-        return yield* new ProviderAdapterRequestError({
-          provider: PROVIDER,
-          method: "question.reply",
-          detail: `Unknown pending user-input request: ${requestId}`,
-        });
-      }
+      return yield* Effect.uninterruptibleMask((restore) =>
+        Effect.gen(function* () {
+          const claim = yield* Ref.modify(context.questionState, (state) => {
+            if (state.settlementCount > 0) {
+              return [undefined, state];
+            }
+            const request = state.pendingQuestions.get(requestId);
+            if (!request) {
+              return [undefined, state];
+            }
+            const pendingQuestions = new Map(state.pendingQuestions);
+            const replyingQuestions = new Map(state.replyingQuestions);
+            pendingQuestions.delete(requestId);
+            replyingQuestions.set(requestId, request);
+            return [
+              { request, settlementVersion: state.settlementVersion },
+              { ...state, pendingQuestions, replyingQuestions },
+            ];
+          });
+          if (!claim) {
+            return yield* new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "question.reply",
+              detail: `Unknown pending user-input request: ${requestId}`,
+            });
+          }
 
-      yield* runOpenCodeSdk("question.reply", () =>
-        context.client.question.reply({
-          requestID: requestId,
-          answers: toOpenCodeQuestionAnswers(request, answers),
+          const replyExit = yield* restore(
+            runOpenCodeSdk("question.reply", () =>
+              context.client.question.reply({
+                requestID: requestId,
+                answers: toOpenCodeQuestionAnswers(claim.request, answers),
+              }),
+            ).pipe(Effect.mapError(toRequestError)),
+          ).pipe(Effect.exit);
+          if (Exit.isFailure(replyExit)) {
+            yield* Ref.update(context.questionState, (state) => {
+              if (
+                state.settlementCount > 0 ||
+                state.settlementVersion !== claim.settlementVersion ||
+                state.replyingQuestions.get(requestId) !== claim.request
+              ) {
+                return state;
+              }
+              const pendingQuestions = new Map(state.pendingQuestions);
+              const replyingQuestions = new Map(state.replyingQuestions);
+              replyingQuestions.delete(requestId);
+              pendingQuestions.set(requestId, claim.request);
+              return { ...state, pendingQuestions, replyingQuestions };
+            });
+            return yield* Effect.failCause(replyExit.cause);
+          }
         }),
-      ).pipe(Effect.mapError(toRequestError));
+      );
     });
 
     const stopSession: OpenCodeAdapterShape["stopSession"] = Effect.fn("stopSession")(
@@ -1686,9 +1822,18 @@ export function makeOpenCodeAdapter(
             threadId,
           });
         }
-        const stopped = yield* stopOpenCodeContext(context, settlePendingQuestions(context));
-        sessions.delete(threadId);
-        if (!stopped) {
+        let removed = false;
+        const stopped = yield* stopOpenCodeContext(
+          context,
+          settlePendingQuestions(context),
+          Effect.sync(() => {
+            if (sessions.get(threadId) === context) {
+              sessions.delete(threadId);
+              removed = true;
+            }
+          }),
+        );
+        if (!stopped || !removed) {
           return;
         }
         yield* emit({


### PR DESCRIPTION
Written by inayayousfi, typed by openai/gpt-5.6-sol running in OpenCode.
Every call here is inayayousfi's, and no agent acted on its own.

## Problem

OpenCode keeps unanswered question requests in memory when a turn or session stops. The client continues rendering that request after the provider can no longer answer it, which leaves the composer stuck in question mode.

## Fix

Reject pending OpenCode questions before interrupting or stopping a session, then emit the existing resolved event and clear the local request. The same cleanup now runs during session replacement, bulk shutdown, and adapter shutdown.

Provider rejection gets a five-second budget. A failure or timeout is logged, but teardown continues so the Stop action cannot hang.

## Related work

Related to #5454, which covers pending user input after a provider session dies.

This addresses the pending-question counterpart noted in #7113. Pending OpenCode permission cleanup remains outside this pull request.

This also complements #5453. That pull request recovers requests after a dead-provider response fails, while this change prevents OpenCode from leaving the question open during teardown.

The Claude counterpart was reported in #5119.

## Testing

- `vp test run apps/server/src/provider/Layers/OpenCodeAdapter.test.ts` (37 tests passed)
- `vp run --filter t3 typecheck`
- `vp fmt --check apps/server/src/provider/Layers/OpenCodeAdapter.ts apps/server/src/provider/Layers/OpenCodeAdapter.test.ts`
- `git diff --check`

OpenCode may still publish its native rejection event after local resolution. That can produce a duplicate resolved activity, but pending state remains closed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Settle pending questions before session teardown in OpenCodeAdapter
> - Adds `OpenCodeQuestionState` to track pending and in-flight questions per session, replacing the old flat `pendingQuestions` map.
> - `interruptTurn`, `stopSession`, `stopAll`, and the layer finalizer now call a new `settlePendingQuestions` step that rejects pending questions (with a 5-second timeout) and emits `user-input.resolved` before aborting.
> - `respondToUserInput` atomically claims a question and moves it to `replyingQuestions`; it fails if settlement is active or the question is unknown, and restores the question on reply failure.
> - New questions are silently dropped when settlement is in progress (`settlementCount > 0`).
> - Behavioral Change: sessions being replaced or stopped now emit `user-input.resolved` for all outstanding questions before the remote abort, and `session.exited` is only emitted when the session entry is actually removed from the map.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 073397c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider lifecycle, user-input events, and concurrent interrupt/stop/reply paths; behavior is heavily tested but wrong settlement ordering could still leave stale UI or duplicate resolved events.
> 
> **Overview**
> Fixes the composer staying in question mode when a turn or session ends while OpenCode still has an unanswered question.
> 
> **Pending question settlement** runs before `session.abort` on interrupt, stop, bulk shutdown, session replacement, and adapter shutdown. It calls `question.reject` (5s timeout, failures logged) and emits `user-input.resolved` so local state closes even if the provider is gone.
> 
> **Concurrency** moves question tracking into a `Ref` with pending vs in-flight replies and a `settlementCount` gate: new questions are ignored during teardown, replies are blocked while settlement runs, and in-flight replies are not double-rejected on interrupt.
> 
> **Teardown** wraps `stopOpenCodeContext` in an uninterruptible mask with injectable pre-abort work, and tightens session-map removal so a slow stop cannot drop a replacement session.
> 
> Tests cover interrupt/stop ordering, reject failure/timeout, reply vs interrupt races, late events during settlement, and concurrent interrupts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 073397ccb4cb8b8ff2f879630dbcc6410788c1c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->