### PR TITLE
fix(web): keep highlighted command menu items clear of the scroll fade

### DIFF
--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -144,7 +144,7 @@ export const ComposerCommandMenu = memo(function ComposerCommandMenu(props: {
         className="dropdown-glass relative w-full overflow-hidden rounded-[20px] shadow-[0_16px_40px_-18px_rgb(0_0_0/55%)] **:data-[slot=scroll-area-scrollbar]:data-[orientation=vertical]:my-4 dark:shadow-[0_18px_44px_-18px_rgb(0_0_0/80%)]"
       >
         {props.items.length > 0 ? (
-          <CommandList className="max-h-72">
+          <CommandList className="max-h-72 not-empty:py-3">
             {groups.map((group, groupIndex) => (
               <div key={group.id}>
                 {groupIndex > 0 ? <CommandSeparator className="my-0.5" /> : null}

--- a/apps/web/src/components/ui/scroll-area.tsx
+++ b/apps/web/src/components/ui/scroll-area.tsx
@@ -45,7 +45,7 @@ function ScrollArea({
           "h-full max-h-[inherit] overflow-auto overscroll-contain rounded-[inherit] outline-none transition-shadows focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background data-has-overflow-x:overscroll-x-contain",
           chainVerticalScroll && "overscroll-y-auto",
           scrollFade &&
-            "mask-t-from-[calc(100%-min(var(--fade-size),var(--scroll-area-overflow-y-start)))] mask-b-from-[calc(100%-min(var(--fade-size),var(--scroll-area-overflow-y-end)))] mask-l-from-[calc(100%-min(var(--fade-size),var(--scroll-area-overflow-x-start)))] mask-r-from-[calc(100%-min(var(--fade-size),var(--scroll-area-overflow-x-end)))] [--fade-size:1.5rem]",
+            "scroll-p-[var(--fade-size)] mask-t-from-[calc(100%-min(var(--fade-size),var(--scroll-area-overflow-y-start)))] mask-b-from-[calc(100%-min(var(--fade-size),var(--scroll-area-overflow-y-end)))] mask-l-from-[calc(100%-min(var(--fade-size),var(--scroll-area-overflow-x-start)))] mask-r-from-[calc(100%-min(var(--fade-size),var(--scroll-area-overflow-x-end)))] [--fade-size:1.5rem]",
           scrollbarGutter && "scrollbar-gutter-stable",
           hideScrollbars &&
             "[-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",


### PR DESCRIPTION
## Summary

Keyboard-navigating the composer command menu (slash commands, skills, @-paths) scrolls the active item flush against the viewport edge, where the 24px scroll fade dims it and the 20px container radius clips its corners. The `scroll-py-2` on the list never worked: the scroll container is the `ScrollArea` viewport, not the list element, so `scrollIntoView({ block: "nearest" })` had no scroll padding to respect.

The fix is two class changes:

- `ScrollArea` viewports with `scrollFade` now carry `scroll-p-[var(--fade-size)]`, so anything scrolled into view programmatically stays clear of the fade on all four edges. This benefits every faded scroll area, not just the composer menu.
- The composer command list gets `not-empty:py-3` so the first/last item (where the fade turns off but the scroll can't go further) clears the 20px rounded corner instead of getting clipped by it.

## Before / after

Active item scrolled mid-list (before: dimmed by the fade and flush against the edge; after: fully readable above the fade):

| Before | After |
| --- | --- |
| ![before mid](https://raw.githubusercontent.com/PollyGlot/t3code/assets/skills-list-clipping/before-mid.png) | ![after mid](https://raw.githubusercontent.com/PollyGlot/t3code/assets/skills-list-clipping/after-mid.png) |

Very last item highlighted (before: flush against the rounded corner; after: breathing room, corners intact):

| Before | After |
| --- | --- |
| ![before last](https://raw.githubusercontent.com/PollyGlot/t3code/assets/skills-list-clipping/before-last.png) | ![after last](https://raw.githubusercontent.com/PollyGlot/t3code/assets/skills-list-clipping/after2-lastitem.png) |

(Screenshots hosted on a throwaway `assets/skills-list-clipping` branch of my fork.)

## Test plan

- [x] Reproduced and verified in a real dev environment (Playwright against `vp run dev`, keyboard navigation through an overflowing list, both directions and both wrap extremes)
- [x] `vp test run` on `composerSlashCommandSearch.test.ts` and `composerMenuHighlight.test.ts`
- [x] Targeted lint and `tsgo --noEmit` on `apps/web`

Built with Claude Fable 5 on Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only scroll-padding and list spacing with no auth, data, or API changes.
> 
> **Overview**
> Keyboard navigation in the composer command menu (`scrollIntoView` on the active item) was scrolling highlights flush against the **ScrollArea** viewport edge, so the scroll fade dimmed them and the rounded dropdown clipped corners. List-level `scroll-py` did not apply because scrolling happens on the viewport, not the list.
> 
> **ScrollArea** viewports with `scrollFade` now include `scroll-p-[var(--fade-size)]`, so programmatic scroll-into-view keeps content inset from the fade on all sides (affects every faded scroll area, not only the composer menu).
> 
> The composer **CommandList** adds `not-empty:py-3` so first/last items get vertical breathing room when the scroll position cannot move further, avoiding clipping against the 20px rounded container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbb3401b4c348a5e9a742c532104044dbc6749a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep highlighted command menu items clear of the scroll fade overlay
> - Adds `not-empty:py-3` to the `CommandList` in [ComposerCommandMenu.tsx](https://github.com/pingdotgg/t3code/pull/7132/files#diff-ca7de5ada90d0c74157405378c7182002eab97a1ea23cd71e4376f8db6ba81a4), so vertical padding is applied only when the list has items.
> - Adds `scroll-p-[var(--fade-size)]` to the `ScrollArea` viewport in [scroll-area.tsx](https://github.com/pingdotgg/t3code/pull/7132/files#diff-065d9938063e2eb1a135871d2daf8a02f24528ad85dbc653955b23d805a9fb06) when `scrollFade` is enabled, so scroll snap targets align with the visible area rather than being obscured by the fade gradient.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fbb3401.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->