### PR TITLE
fix(usage): attribute account limits per provider instance

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -8,6 +8,7 @@ import {
   ProviderDriverKind,
   ProviderRuntimeEvent,
   ProviderSession,
+  ACCOUNT_LIMITS_CONTRACT_VERSION,
   ProviderInstanceId,
 } from "@t3tools/contracts";
 import {
@@ -222,7 +223,10 @@ describe("ProviderRuntimeIngestion", () => {
     }
   });
 
-  async function createHarness(options?: { serverSettings?: Partial<ServerSettings> }) {
+  async function createHarness(options?: {
+    serverSettings?: Partial<ServerSettings>;
+    accountLimitsLayer?: Layer.Layer<AccountLimitsService.AccountLimitsService>;
+  }) {
     const workspaceRoot = makeTempDir("t3-provider-project-");
     NodeFS.mkdirSync(NodePath.join(workspaceRoot, ".git"));
     const provider = createProviderServiceHarness();
@@ -247,7 +251,7 @@ describe("ProviderRuntimeIngestion", () => {
       Layer.provideMerge(ThreadPlanProgress.layer),
       Layer.provideMerge(SqlitePersistenceMemory),
       Layer.provideMerge(Layer.succeed(ProviderService, provider.service)),
-      Layer.provideMerge(AccountLimitsService.layerTest),
+      Layer.provideMerge(options?.accountLimitsLayer ?? AccountLimitsService.layerTest),
       Layer.provideMerge(makeTestServerSettingsLayer(options?.serverSettings)),
       Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
       Layer.provideMerge(NodeServices.layer),
@@ -323,6 +327,43 @@ describe("ProviderRuntimeIngestion", () => {
       drain,
     };
   }
+
+  it("forwards the event's providerInstanceId to the account-limits cache", async () => {
+    const ingested: AccountLimitsService.AccountLimitsIngestInput[] = [];
+    const recordingLayer = Layer.succeed(
+      AccountLimitsService.AccountLimitsService,
+      AccountLimitsService.AccountLimitsService.of({
+        readSummary: () =>
+          Effect.succeed({
+            contractVersion: ACCOUNT_LIMITS_CONTRACT_VERSION,
+            readAt: "1970-01-01T00:00:00.000Z",
+            snapshots: [],
+          }),
+        ingest: (input) =>
+          Effect.sync(() => {
+            ingested.push(input);
+          }),
+      }),
+    );
+    const harness = await createHarness({ accountLimitsLayer: recordingLayer });
+
+    harness.emit({
+      type: "account.rate-limits.updated",
+      eventId: asEventId("evt-rate-limits"),
+      provider: ProviderDriverKind.make("codex"),
+      providerInstanceId: ProviderInstanceId.make("codex_work"),
+      // The thread is deliberately unknown: account limits are not a thread
+      // projection and must survive the thread being gone.
+      threadId: asThreadId("thread-unknown"),
+      createdAt: "2026-01-01T00:00:00.000Z",
+      payload: { rateLimits: { limit_id: "codex" } },
+    });
+    await harness.drain();
+
+    expect(ingested).toHaveLength(1);
+    expect(ingested[0]?.provider).toBe("codex");
+    expect(ingested[0]?.providerInstanceId).toBe("codex_work");
+  });
 
   it("maps turn started/completed events into thread session updates", async () => {
     const harness = await createHarness();

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1484,6 +1484,9 @@ const make = Effect.gen(function* () {
           provider: event.provider,
           payload: event.payload.rateLimits,
           createdAt: event.createdAt,
+          ...(event.providerInstanceId !== undefined
+            ? { providerInstanceId: event.providerInstanceId }
+            : {}),
         });
       }
 

--- a/apps/server/src/usage/AccountLimitsService.test.ts
+++ b/apps/server/src/usage/AccountLimitsService.test.ts
@@ -1,0 +1,614 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { describe, expect, it } from "@effect/vitest";
+import { ProviderDriverKind, ProviderInstanceId, type ServerSettings } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+
+import * as ServerConfig from "../config.ts";
+import * as ServerSettingsModule from "../serverSettings.ts";
+import {
+  AccountLimitsService,
+  type CodexSeedTarget,
+  layer as accountLimitsLayer,
+  planCodexTranscriptSeeds,
+} from "./AccountLimitsService.ts";
+
+const asInstanceId = (value: string): ProviderInstanceId => ProviderInstanceId.make(value);
+const asDriver = (value: string): ProviderDriverKind => ProviderDriverKind.make(value);
+
+/** A codex app-server notification, shaped after a real transcript line. */
+const codexPayload = (usedPercent: number) => ({
+  limit_id: "codex",
+  limit_name: null,
+  primary: { used_percent: usedPercent, window_minutes: 10080, resets_at: 1_786_677_720 },
+  secondary: null,
+  plan_type: "pro",
+});
+
+/** A full Claude usage snapshot (the SDK usage control response). */
+const claudeUsagePayload = (fiveHour: number, weekly: number) => ({
+  subscription_type: "max",
+  rate_limits: {
+    five_hour: { utilization: fiveHour, resets_at: "2026-08-08T23:00:00.000Z" },
+    seven_day: { utilization: weekly, resets_at: "2026-08-11T17:00:00.000Z" },
+  },
+});
+
+/** The streamed single-window Claude event. */
+const claudeWindowPayload = (utilization: number) => ({
+  type: "rate_limit_event",
+  rate_limit_info: {
+    status: "allowed_warning",
+    rateLimitType: "five_hour",
+    utilization,
+    resetsAt: 1_786_600_800,
+  },
+});
+
+/**
+ * Every instance the tests ingest for must exist in settings: readSummary
+ * evicts rows for deleted instances. Codex homes point at paths that do not
+ * exist so the transcript seed can never touch this machine's real
+ * ~/.codex/sessions mid-test.
+ */
+const instanceRoster = (): Partial<ServerSettings> => ({
+  providerInstances: {
+    [asInstanceId("codex")]: {
+      driver: asDriver("codex"),
+      config: { homePath: "/nonexistent/t3-test-codex-default" },
+    },
+    [asInstanceId("codex_a")]: {
+      driver: asDriver("codex"),
+      config: { homePath: "/nonexistent/t3-test-codex-a" },
+    },
+    [asInstanceId("codex_b")]: {
+      driver: asDriver("codex"),
+      config: { homePath: "/nonexistent/t3-test-codex-b" },
+    },
+    [asInstanceId("claude_main")]: { driver: asDriver("claudeAgent") },
+    [asInstanceId("claude_partner")]: { driver: asDriver("claudeAgent") },
+  },
+});
+
+const makeLayer = (overrides: Partial<ServerSettings> = instanceRoster()) =>
+  accountLimitsLayer.pipe(
+    Layer.provideMerge(ServerSettingsModule.layerTest(overrides)),
+    Layer.provideMerge(
+      Layer.fresh(
+        ServerConfig.layerTest(process.cwd(), {
+          prefix: "t3code-account-limits-test-",
+        }),
+      ),
+    ),
+  );
+
+const makeLayerAt = (baseDir: string, overrides: Partial<ServerSettings> = instanceRoster()) =>
+  accountLimitsLayer.pipe(
+    Layer.provideMerge(ServerSettingsModule.layerTest(overrides)),
+    Layer.provideMerge(Layer.fresh(ServerConfig.layerTest(process.cwd(), baseDir))),
+  );
+
+it.layer(NodeServices.layer)("account limits service", (it) => {
+  it.effect("keeps one snapshot per instance - accounts no longer overwrite each other", () =>
+    Effect.gen(function* () {
+      const service = yield* AccountLimitsService;
+      yield* service.ingest({
+        provider: "codex",
+        payload: codexPayload(10),
+        createdAt: "2026-08-15T12:00:02.000Z",
+        providerInstanceId: asInstanceId("codex_a"),
+      });
+      // Older than codex_a's event: the per-slot ordering guard must not let
+      // one instance's traffic suppress another's - that is the bug.
+      yield* service.ingest({
+        provider: "codex",
+        payload: codexPayload(55),
+        createdAt: "2026-08-15T12:00:01.000Z",
+        providerInstanceId: asInstanceId("codex_b"),
+      });
+      const summary = yield* service.readSummary();
+      expect(
+        summary.snapshots.map((snapshot) => [
+          snapshot.instanceId,
+          snapshot.windows[0]?.usedPercent,
+        ]),
+      ).toEqual([
+        ["codex_a", 10],
+        ["codex_b", 55],
+      ]);
+    }).pipe(Effect.provide(makeLayer())),
+  );
+
+  it.effect("still guards ordering within one instance", () =>
+    Effect.gen(function* () {
+      const service = yield* AccountLimitsService;
+      yield* service.ingest({
+        provider: "codex",
+        payload: codexPayload(20),
+        createdAt: "2026-08-15T12:00:02.000Z",
+        providerInstanceId: asInstanceId("codex_a"),
+      });
+      yield* service.ingest({
+        provider: "codex",
+        payload: codexPayload(90),
+        createdAt: "2026-08-15T12:00:01.000Z",
+        providerInstanceId: asInstanceId("codex_a"),
+      });
+      const summary = yield* service.readSummary();
+      expect(summary.snapshots.map((snapshot) => snapshot.windows[0]?.usedPercent)).toEqual([20]);
+    }).pipe(Effect.provide(makeLayer())),
+  );
+
+  it.effect("events without an instance id flow to the driver's default instance", () =>
+    Effect.gen(function* () {
+      const service = yield* AccountLimitsService;
+      yield* service.ingest({
+        provider: "codex",
+        payload: codexPayload(33),
+        createdAt: "2026-08-15T12:00:00.000Z",
+      });
+      const summary = yield* service.readSummary();
+      expect(summary.snapshots.map((snapshot) => snapshot.instanceId)).toEqual(["codex"]);
+    }).pipe(Effect.provide(makeLayer())),
+  );
+
+  it.effect("claude window events patch their own instance's window set only", () =>
+    Effect.gen(function* () {
+      const service = yield* AccountLimitsService;
+      yield* service.ingest({
+        provider: "claudeAgent",
+        payload: claudeUsagePayload(24, 18),
+        createdAt: "2026-08-15T12:00:00.000Z",
+        providerInstanceId: asInstanceId("claude_main"),
+      });
+      yield* service.ingest({
+        provider: "claudeAgent",
+        payload: claudeWindowPayload(87.5),
+        createdAt: "2026-08-15T12:00:01.000Z",
+        providerInstanceId: asInstanceId("claude_partner"),
+      });
+      const summary = yield* service.readSummary();
+      const main = summary.snapshots.find((snapshot) => snapshot.instanceId === "claude_main");
+      const partner = summary.snapshots.find(
+        (snapshot) => snapshot.instanceId === "claude_partner",
+      );
+      // Main keeps its full two-window snapshot untouched; partner's streamed
+      // window must not have been patched into main's set.
+      expect(main?.windows.map((window) => [window.id, window.usedPercent])).toEqual([
+        ["five_hour", 24],
+        ["seven_day", 18],
+      ]);
+      expect(partner?.windows.map((window) => [window.id, window.usedPercent])).toEqual([
+        ["five_hour", 87.5],
+      ]);
+    }).pipe(Effect.provide(makeLayer())),
+  );
+
+  it.effect("v1 cache rows load under the default instance until live data settles them", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const config = yield* ServerConfig.ServerConfig;
+      // A row written before instance attribution: no instanceId field. It
+      // held "whichever account wrote last", so the default instance is only
+      // its least-wrong home, not its identity.
+      yield* fileSystem.writeFileString(
+        path.join(config.stateDir, "account-limits.json"),
+        `[
+          {
+            "provider": "claude",
+            "plan": "max",
+            "windows": [
+              {
+                "id": "five_hour",
+                "label": "5h",
+                "usedPercent": 62,
+                "resetsAt": "2026-08-08T23:00:00.000Z",
+                "windowMinutes": 300
+              }
+            ],
+            "asOf": "2026-08-08T22:00:00.000Z",
+            "source": "live"
+          }
+        ]`,
+      );
+      const service = yield* AccountLimitsService;
+      const summary = yield* service.readSummary();
+      expect(summary.snapshots.map((snapshot) => [snapshot.instanceId, snapshot.plan])).toEqual([
+        ["claudeAgent", "max"],
+      ]);
+      // Live data for a DIFFERENT instance of the same provider proves the
+      // migrated row may belong to somebody else: it is evicted, not kept
+      // as a ghost account beside the real one.
+      yield* service.ingest({
+        provider: "claudeAgent",
+        payload: claudeUsagePayload(10, 5),
+        createdAt: "2026-08-15T12:00:00.000Z",
+        providerInstanceId: asInstanceId("claude_partner"),
+      });
+      const after = yield* service.readSummary();
+      expect(after.snapshots.map((snapshot) => snapshot.instanceId)).toEqual(["claude_partner"]);
+    }).pipe(Effect.provide(makeLayer())),
+  );
+
+  it.effect("instance-keyed rows survive a restart", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const baseDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3code-account-limits-reload-",
+      });
+      yield* Effect.gen(function* () {
+        const service = yield* AccountLimitsService;
+        yield* service.ingest({
+          provider: "codex",
+          payload: codexPayload(10),
+          createdAt: "2026-08-15T12:00:00.000Z",
+          providerInstanceId: asInstanceId("codex_a"),
+        });
+        yield* service.ingest({
+          provider: "codex",
+          payload: codexPayload(55),
+          createdAt: "2026-08-15T12:00:01.000Z",
+          providerInstanceId: asInstanceId("codex_b"),
+        });
+      }).pipe(Effect.provide(makeLayerAt(baseDir)));
+      // A fresh service over the same state dir - the restart.
+      const summary = yield* Effect.gen(function* () {
+        const service = yield* AccountLimitsService;
+        return yield* service.readSummary();
+      }).pipe(Effect.provide(makeLayerAt(baseDir)));
+      expect(summary.snapshots.map((snapshot) => snapshot.instanceId)).toEqual([
+        "codex_a",
+        "codex_b",
+      ]);
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("rows for deleted instances are evicted; disabled instances are hidden", () =>
+    Effect.gen(function* () {
+      const service = yield* AccountLimitsService;
+      // codex_gone is not in settings at all; codex_b is disabled for this
+      // test's roster below.
+      yield* service.ingest({
+        provider: "codex",
+        payload: codexPayload(10),
+        createdAt: "2026-08-15T12:00:00.000Z",
+        providerInstanceId: asInstanceId("codex_gone"),
+      });
+      yield* service.ingest({
+        provider: "codex",
+        payload: codexPayload(20),
+        createdAt: "2026-08-15T12:00:01.000Z",
+        providerInstanceId: asInstanceId("codex_b"),
+      });
+      yield* service.ingest({
+        provider: "codex",
+        payload: codexPayload(30),
+        createdAt: "2026-08-15T12:00:02.000Z",
+        providerInstanceId: asInstanceId("codex_a"),
+      });
+      const summary = yield* service.readSummary();
+      expect(summary.snapshots.map((snapshot) => snapshot.instanceId)).toEqual(["codex_a"]);
+    }).pipe(
+      Effect.provide(
+        makeLayer({
+          providerInstances: {
+            [asInstanceId("codex_a")]: {
+              driver: asDriver("codex"),
+              config: { homePath: "/nonexistent/t3-test-codex-a" },
+            },
+            [asInstanceId("codex_b")]: {
+              driver: asDriver("codex"),
+              enabled: false,
+              config: { homePath: "/nonexistent/t3-test-codex-b" },
+            },
+          },
+        }),
+      ),
+    ),
+  );
+});
+
+// Plain `it`: the seed consults the real clock for its retry floor and
+// transcript-recency window, which the suite's virtual test clock (epoch
+// 0) would defeat.
+it("transcript seeding attributes a sole-owner dir and skips shared or disabled dirs", () =>
+  Effect.gen(function* () {
+    const soleDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-seed-sole-"));
+    const sharedDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-seed-shared-"));
+    const disabledDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-seed-disabled-"));
+    // @effect-diagnostics-next-line preferSchemaOverJson:off - fabricates one raw transcript line.
+    const line = JSON.stringify({
+      timestamp: "2026-08-15T10:00:00.000Z",
+      payload: { rate_limits: codexPayload(37) },
+    });
+    for (const dir of [soleDir, sharedDir, disabledDir]) {
+      NodeFS.mkdirSync(NodePath.join(dir, "sessions"), { recursive: true });
+      NodeFS.writeFileSync(NodePath.join(dir, "sessions", "rollout-1.jsonl"), `${line}\n`);
+    }
+    try {
+      const summary = yield* Effect.gen(function* () {
+        const service = yield* AccountLimitsService;
+        return yield* service.readSummary();
+      }).pipe(
+        Effect.provide(
+          makeLayer({
+            providerInstances: {
+              // Pin the auto-derived default instance away from the real
+              // ~/.codex - under the live clock this test's seed actually
+              // runs, and it must never read this machine's transcripts.
+              [asInstanceId("codex")]: {
+                driver: asDriver("codex"),
+                config: { homePath: "/nonexistent/t3-test-codex-default" },
+              },
+              [asInstanceId("codex_sole")]: {
+                driver: asDriver("codex"),
+                config: { homePath: soleDir },
+              },
+              // Two instances share one home: the dir has no honest owner.
+              [asInstanceId("codex_s1")]: {
+                driver: asDriver("codex"),
+                config: { homePath: sharedDir, shadowHomePath: `${sharedDir}-shadow-1` },
+              },
+              [asInstanceId("codex_s2")]: {
+                driver: asDriver("codex"),
+                config: { homePath: sharedDir, shadowHomePath: `${sharedDir}-shadow-2` },
+              },
+              // Sole owner, but disabled: counted for ownership, never read.
+              [asInstanceId("codex_off")]: {
+                driver: asDriver("codex"),
+                enabled: false,
+                config: { homePath: disabledDir },
+              },
+            },
+          }),
+        ),
+      );
+      expect(
+        summary.snapshots.map((snapshot) => [
+          snapshot.instanceId,
+          snapshot.source,
+          snapshot.windows[0]?.usedPercent,
+        ]),
+      ).toEqual([["codex_sole", "transcript", 37]]);
+    } finally {
+      for (const dir of [soleDir, sharedDir, disabledDir]) {
+        NodeFS.rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  }).pipe(Effect.provide(NodeServices.layer), Effect.runPromise));
+
+it("an unconfirmed migrated row keeps its v1 shape across restarts - the ghost eviction survives", () =>
+  Effect.gen(function* () {
+    const baseDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-limits-restart-"));
+    NodeFS.mkdirSync(NodePath.join(baseDir, "userdata"), { recursive: true });
+    const cachePath = NodePath.join(baseDir, "userdata", "account-limits.json");
+    // A v1 cache: one claude row, no instanceId.
+    NodeFS.writeFileSync(
+      cachePath,
+      // @effect-diagnostics-next-line preferSchemaOverJson:off - fabricates the raw cache file.
+      JSON.stringify([
+        {
+          provider: "claude",
+          plan: "max",
+          windows: [
+            {
+              id: "five_hour",
+              label: "5h",
+              usedPercent: 12,
+              resetsAt: "2026-08-08T23:00:00.000Z",
+              windowMinutes: 300,
+            },
+          ],
+          asOf: "2026-08-01T00:00:00.000Z",
+          source: "live",
+        },
+      ]),
+    );
+    const roster = {
+      providerInstances: {
+        [asInstanceId("claudeAgent")]: { driver: asDriver("claudeAgent") },
+        [asInstanceId("claude_partner")]: { driver: asDriver("claudeAgent") },
+        [asInstanceId("codex")]: {
+          driver: asDriver("codex"),
+          config: { homePath: "/nonexistent/t3-test-codex-default" },
+        },
+      },
+    };
+    try {
+      // First run: an UNRELATED codex ingest persists the cache. The migrated
+      // claude row must be written back in its v1 shape, still unconfirmed.
+      yield* Effect.gen(function* () {
+        const service = yield* AccountLimitsService;
+        yield* service.readSummary();
+        yield* service.ingest({
+          provider: asDriver("codex"),
+          payload: codexPayload(41),
+          createdAt: "2026-08-15T09:00:00.000Z",
+          providerInstanceId: asInstanceId("codex"),
+        });
+      }).pipe(Effect.provide(makeLayerAt(baseDir, roster)));
+      // @effect-diagnostics-next-line preferSchemaOverJson:off - reads the raw cache file back.
+      const persisted = JSON.parse(NodeFS.readFileSync(cachePath, "utf8")) as {
+        provider: string;
+        instanceId?: string;
+      }[];
+      expect(
+        persisted.map((row) => [row.provider, "instanceId" in row ? row.instanceId : "(none)"]),
+      ).toEqual([
+        ["claude", "(none)"],
+        ["codex", "codex"],
+      ]);
+      // Second run - a restart. Live claude data on ANOTHER instance must
+      // still evict the migrated default row instead of leaving a ghost.
+      const summary = yield* Effect.gen(function* () {
+        const service = yield* AccountLimitsService;
+        yield* service.ingest({
+          provider: asDriver("claudeAgent"),
+          payload: claudeUsagePayload(31, 9),
+          createdAt: "2026-08-15T10:00:00.000Z",
+          providerInstanceId: asInstanceId("claude_partner"),
+        });
+        return yield* service.readSummary();
+      }).pipe(Effect.provide(makeLayerAt(baseDir, roster)));
+      expect(summary.snapshots.map((snapshot) => [snapshot.provider, snapshot.instanceId])).toEqual(
+        [
+          ["claude", "claude_partner"],
+          ["codex", "codex"],
+        ],
+      );
+    } finally {
+      NodeFS.rmSync(baseDir, { recursive: true, force: true });
+    }
+  }).pipe(Effect.provide(NodeServices.layer), Effect.runPromise));
+
+it("evicts a row whose instance now runs a different driver", () =>
+  Effect.gen(function* () {
+    const baseDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-limits-flip-"));
+    NodeFS.mkdirSync(NodePath.join(baseDir, "userdata"), { recursive: true });
+    // A codex row cached while "personal" ran codex; the instance has since
+    // been reconfigured to another driver, so the row's account no longer
+    // exists here - and a stale row would be captioned with the new
+    // driver's display name.
+    NodeFS.writeFileSync(
+      NodePath.join(baseDir, "userdata", "account-limits.json"),
+      // @effect-diagnostics-next-line preferSchemaOverJson:off - fabricates the raw cache file.
+      JSON.stringify([
+        {
+          provider: "codex",
+          instanceId: "personal",
+          plan: "pro",
+          windows: [
+            {
+              id: "codex",
+              label: "Week",
+              usedPercent: 45,
+              resetsAt: "2099-01-01T00:00:00.000Z",
+              windowMinutes: 10080,
+            },
+          ],
+          asOf: "2026-08-15T10:00:00.000Z",
+          source: "live",
+        },
+      ]),
+    );
+    try {
+      const summary = yield* Effect.gen(function* () {
+        const service = yield* AccountLimitsService;
+        return yield* service.readSummary();
+      }).pipe(
+        Effect.provide(
+          makeLayerAt(baseDir, {
+            providerInstances: {
+              [asInstanceId("codex")]: {
+                driver: asDriver("codex"),
+                config: { homePath: "/nonexistent/t3-test-codex-default" },
+              },
+              [asInstanceId("personal")]: { driver: asDriver("grok") },
+            },
+          }),
+        ),
+      );
+      expect(summary.snapshots).toEqual([]);
+    } finally {
+      NodeFS.rmSync(baseDir, { recursive: true, force: true });
+    }
+  }).pipe(Effect.provide(NodeServices.layer), Effect.runPromise));
+
+it("seeds a codex instance homed by its environment's CODEX_HOME", () =>
+  Effect.gen(function* () {
+    // No homePath configured: the spawned CLI would resolve CODEX_HOME from
+    // its child env, so the seed must read the same place.
+    const envHome = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-seed-envhome-"));
+    NodeFS.mkdirSync(NodePath.join(envHome, "sessions"), { recursive: true });
+    NodeFS.writeFileSync(
+      NodePath.join(envHome, "sessions", "rollout-1.jsonl"),
+      // @effect-diagnostics-next-line preferSchemaOverJson:off - fabricates one raw transcript line.
+      `${JSON.stringify({
+        timestamp: "2026-08-15T10:00:00.000Z",
+        payload: { rate_limits: codexPayload(29) },
+      })}\n`,
+    );
+    try {
+      const summary = yield* Effect.gen(function* () {
+        const service = yield* AccountLimitsService;
+        return yield* service.readSummary();
+      }).pipe(
+        Effect.provide(
+          makeLayer({
+            providerInstances: {
+              [asInstanceId("codex")]: {
+                driver: asDriver("codex"),
+                config: { homePath: "/nonexistent/t3-test-codex-default" },
+              },
+              [asInstanceId("codex_env")]: {
+                driver: asDriver("codex"),
+                environment: [{ name: "CODEX_HOME", value: envHome, sensitive: false }],
+              },
+            },
+          }),
+        ),
+      );
+      expect(
+        summary.snapshots.map((snapshot) => [
+          snapshot.instanceId,
+          snapshot.source,
+          snapshot.windows[0]?.usedPercent,
+        ]),
+      ).toEqual([["codex_env", "transcript", 29]]);
+    } finally {
+      NodeFS.rmSync(envHome, { recursive: true, force: true });
+    }
+  }).pipe(Effect.provide(NodeServices.layer), Effect.runPromise));
+
+describe("planCodexTranscriptSeeds", () => {
+  const target = (instanceId: string, sessionsDir: string, enabled = true): CodexSeedTarget => ({
+    instanceId: asInstanceId(instanceId),
+    sessionsDir,
+    enabled,
+  });
+
+  it("keeps sole-owner sessions dirs and attributes them to their instance", () => {
+    expect(planCodexTranscriptSeeds([target("codex", "/home/user/.codex/sessions")])).toEqual([
+      target("codex", "/home/user/.codex/sessions"),
+    ]);
+  });
+
+  it("skips a dir that several instances write - no honest attribution exists", () => {
+    // The reported setup: three instances share one homePath (shadow homes
+    // symlink sessions/ back to it) - seeding any of them invents data.
+    expect(
+      planCodexTranscriptSeeds([
+        target("codex_a", "/home/user/.codex/sessions"),
+        target("codex_b", "/home/user/.codex/sessions"),
+        target("codex_c", "/home/user/.codex/sessions"),
+      ]),
+    ).toEqual([]);
+  });
+
+  it("counts disabled instances as owners - their transcripts share the dir", () => {
+    expect(
+      planCodexTranscriptSeeds([
+        target("codex_a", "/home/user/.codex/sessions"),
+        target("codex_off", "/home/user/.codex/sessions", false),
+      ]),
+    ).toEqual([]);
+  });
+
+  it("plans independent dirs independently", () => {
+    expect(
+      planCodexTranscriptSeeds([
+        target("codex_a", "/home/user/.codex/sessions"),
+        target("codex_b", "/home/user/.codex/sessions"),
+        target("codex_work", "/home/user/.codex-work/sessions"),
+      ]),
+    ).toEqual([target("codex_work", "/home/user/.codex-work/sessions")]);
+  });
+});

--- a/apps/server/src/usage/AccountLimitsService.test.ts
+++ b/apps/server/src/usage/AccountLimitsService.test.ts
@@ -13,12 +13,7 @@ import * as Path from "effect/Path";
 
 import * as ServerConfig from "../config.ts";
 import * as ServerSettingsModule from "../serverSettings.ts";
-import {
-  AccountLimitsService,
-  type CodexSeedTarget,
-  layer as accountLimitsLayer,
-  planCodexTranscriptSeeds,
-} from "./AccountLimitsService.ts";
+import * as AccountLimitsServiceModule from "./AccountLimitsService.ts";
 
 const asInstanceId = (value: string): ProviderInstanceId => ProviderInstanceId.make(value);
 const asDriver = (value: string): ProviderDriverKind => ProviderDriverKind.make(value);
@@ -78,7 +73,7 @@ const instanceRoster = (): Partial<ServerSettings> => ({
 });
 
 const makeLayer = (overrides: Partial<ServerSettings> = instanceRoster()) =>
-  accountLimitsLayer.pipe(
+  AccountLimitsServiceModule.layer.pipe(
     Layer.provideMerge(ServerSettingsModule.layerTest(overrides)),
     Layer.provideMerge(
       Layer.fresh(
@@ -90,7 +85,7 @@ const makeLayer = (overrides: Partial<ServerSettings> = instanceRoster()) =>
   );
 
 const makeLayerAt = (baseDir: string, overrides: Partial<ServerSettings> = instanceRoster()) =>
-  accountLimitsLayer.pipe(
+  AccountLimitsServiceModule.layer.pipe(
     Layer.provideMerge(ServerSettingsModule.layerTest(overrides)),
     Layer.provideMerge(Layer.fresh(ServerConfig.layerTest(process.cwd(), baseDir))),
   );
@@ -98,7 +93,7 @@ const makeLayerAt = (baseDir: string, overrides: Partial<ServerSettings> = insta
 it.layer(NodeServices.layer)("account limits service", (it) => {
   it.effect("keeps one snapshot per instance - accounts no longer overwrite each other", () =>
     Effect.gen(function* () {
-      const service = yield* AccountLimitsService;
+      const service = yield* AccountLimitsServiceModule.AccountLimitsService;
       yield* service.ingest({
         provider: "codex",
         payload: codexPayload(10),
@@ -128,7 +123,7 @@ it.layer(NodeServices.layer)("account limits service", (it) => {
 
   it.effect("still guards ordering within one instance", () =>
     Effect.gen(function* () {
-      const service = yield* AccountLimitsService;
+      const service = yield* AccountLimitsServiceModule.AccountLimitsService;
       yield* service.ingest({
         provider: "codex",
         payload: codexPayload(20),
@@ -148,7 +143,7 @@ it.layer(NodeServices.layer)("account limits service", (it) => {
 
   it.effect("events without an instance id flow to the driver's default instance", () =>
     Effect.gen(function* () {
-      const service = yield* AccountLimitsService;
+      const service = yield* AccountLimitsServiceModule.AccountLimitsService;
       yield* service.ingest({
         provider: "codex",
         payload: codexPayload(33),
@@ -161,7 +156,7 @@ it.layer(NodeServices.layer)("account limits service", (it) => {
 
   it.effect("claude window events patch their own instance's window set only", () =>
     Effect.gen(function* () {
-      const service = yield* AccountLimitsService;
+      const service = yield* AccountLimitsServiceModule.AccountLimitsService;
       yield* service.ingest({
         provider: "claudeAgent",
         payload: claudeUsagePayload(24, 18),
@@ -219,7 +214,7 @@ it.layer(NodeServices.layer)("account limits service", (it) => {
           }
         ]`,
       );
-      const service = yield* AccountLimitsService;
+      const service = yield* AccountLimitsServiceModule.AccountLimitsService;
       const summary = yield* service.readSummary();
       expect(summary.snapshots.map((snapshot) => [snapshot.instanceId, snapshot.plan])).toEqual([
         ["claudeAgent", "max"],
@@ -245,7 +240,7 @@ it.layer(NodeServices.layer)("account limits service", (it) => {
         prefix: "t3code-account-limits-reload-",
       });
       yield* Effect.gen(function* () {
-        const service = yield* AccountLimitsService;
+        const service = yield* AccountLimitsServiceModule.AccountLimitsService;
         yield* service.ingest({
           provider: "codex",
           payload: codexPayload(10),
@@ -261,7 +256,7 @@ it.layer(NodeServices.layer)("account limits service", (it) => {
       }).pipe(Effect.provide(makeLayerAt(baseDir)));
       // A fresh service over the same state dir - the restart.
       const summary = yield* Effect.gen(function* () {
-        const service = yield* AccountLimitsService;
+        const service = yield* AccountLimitsServiceModule.AccountLimitsService;
         return yield* service.readSummary();
       }).pipe(Effect.provide(makeLayerAt(baseDir)));
       expect(summary.snapshots.map((snapshot) => snapshot.instanceId)).toEqual([
@@ -273,7 +268,7 @@ it.layer(NodeServices.layer)("account limits service", (it) => {
 
   it.effect("rows for deleted instances are evicted; disabled instances are hidden", () =>
     Effect.gen(function* () {
-      const service = yield* AccountLimitsService;
+      const service = yield* AccountLimitsServiceModule.AccountLimitsService;
       // codex_gone is not in settings at all; codex_b is disabled for this
       // test's roster below.
       yield* service.ingest({
@@ -335,7 +330,7 @@ it("transcript seeding attributes a sole-owner dir and skips shared or disabled 
     }
     try {
       const summary = yield* Effect.gen(function* () {
-        const service = yield* AccountLimitsService;
+        const service = yield* AccountLimitsServiceModule.AccountLimitsService;
         return yield* service.readSummary();
       }).pipe(
         Effect.provide(
@@ -426,7 +421,7 @@ it("an unconfirmed migrated row keeps its v1 shape across restarts - the ghost e
       // First run: an UNRELATED codex ingest persists the cache. The migrated
       // claude row must be written back in its v1 shape, still unconfirmed.
       yield* Effect.gen(function* () {
-        const service = yield* AccountLimitsService;
+        const service = yield* AccountLimitsServiceModule.AccountLimitsService;
         yield* service.readSummary();
         yield* service.ingest({
           provider: asDriver("codex"),
@@ -449,7 +444,7 @@ it("an unconfirmed migrated row keeps its v1 shape across restarts - the ghost e
       // Second run - a restart. Live claude data on ANOTHER instance must
       // still evict the migrated default row instead of leaving a ghost.
       const summary = yield* Effect.gen(function* () {
-        const service = yield* AccountLimitsService;
+        const service = yield* AccountLimitsServiceModule.AccountLimitsService;
         yield* service.ingest({
           provider: asDriver("claudeAgent"),
           payload: claudeUsagePayload(31, 9),
@@ -501,7 +496,7 @@ it("evicts a row whose instance now runs a different driver", () =>
     );
     try {
       const summary = yield* Effect.gen(function* () {
-        const service = yield* AccountLimitsService;
+        const service = yield* AccountLimitsServiceModule.AccountLimitsService;
         return yield* service.readSummary();
       }).pipe(
         Effect.provide(
@@ -538,7 +533,7 @@ it("seeds a codex instance homed by its environment's CODEX_HOME", () =>
     );
     try {
       const summary = yield* Effect.gen(function* () {
-        const service = yield* AccountLimitsService;
+        const service = yield* AccountLimitsServiceModule.AccountLimitsService;
         return yield* service.readSummary();
       }).pipe(
         Effect.provide(
@@ -568,24 +563,86 @@ it("seeds a codex instance homed by its environment's CODEX_HOME", () =>
     }
   }).pipe(Effect.provide(NodeServices.layer), Effect.runPromise));
 
+it("a shadow-overlay instance seeds from its layout, not its CODEX_HOME env", () =>
+  Effect.gen(function* () {
+    const line = (percent: number) =>
+      `${JSON.stringify({
+        timestamp: "2026-08-15T10:00:00.000Z",
+        payload: { rate_limits: codexPayload(percent) },
+      })}\n`;
+    const plainEnvHome = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-seed-plainenv-"));
+    NodeFS.mkdirSync(NodePath.join(plainEnvHome, "sessions"), { recursive: true });
+    NodeFS.writeFileSync(NodePath.join(plainEnvHome, "sessions", "rollout-1.jsonl"), line(78));
+    const shadowEnvHome = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-seed-shadowenv-"));
+    NodeFS.mkdirSync(NodePath.join(shadowEnvHome, "sessions"), { recursive: true });
+    NodeFS.writeFileSync(NodePath.join(shadowEnvHome, "sessions", "rollout-1.jsonl"), line(77));
+    try {
+      const summary = yield* Effect.gen(function* () {
+        const service = yield* AccountLimitsServiceModule.AccountLimitsService;
+        return yield* service.readSummary();
+      }).pipe(
+        Effect.provide(
+          makeLayer({
+            providerInstances: {
+              [asInstanceId("codex")]: {
+                driver: asDriver("codex"),
+                config: { homePath: "/nonexistent/t3-test-codex-default" },
+              },
+              // No shadow: the env home is where the CLI writes - seeded.
+              [asInstanceId("codex_plain")]: {
+                driver: asDriver("codex"),
+                environment: [{ name: "CODEX_HOME", value: plainEnvHome, sensitive: false }],
+              },
+              // Shadow overlay: spawn pins CODEX_HOME to the overlay, so the
+              // instance env value never reaches the CLI - the seed must not
+              // read it either. (Its layout home may hold this machine's
+              // real transcripts; the assertions below stay independent of
+              // whatever that dir contains.)
+              [asInstanceId("codex_shadow")]: {
+                driver: asDriver("codex"),
+                config: { shadowHomePath: "/nonexistent/t3-test-codex-shadow" },
+                environment: [{ name: "CODEX_HOME", value: shadowEnvHome, sensitive: false }],
+              },
+            },
+          }),
+        ),
+      );
+      const plainRow = summary.snapshots.find((snapshot) => snapshot.instanceId === "codex_plain");
+      expect(plainRow?.windows[0]?.usedPercent).toBe(78);
+      // The trap percentage must appear on no row at all.
+      expect(
+        summary.snapshots.filter((snapshot) => snapshot.windows[0]?.usedPercent === 77),
+      ).toEqual([]);
+    } finally {
+      NodeFS.rmSync(plainEnvHome, { recursive: true, force: true });
+      NodeFS.rmSync(shadowEnvHome, { recursive: true, force: true });
+    }
+  }).pipe(Effect.provide(NodeServices.layer), Effect.runPromise));
+
 describe("planCodexTranscriptSeeds", () => {
-  const target = (instanceId: string, sessionsDir: string, enabled = true): CodexSeedTarget => ({
+  const target = (
+    instanceId: string,
+    sessionsDir: string,
+    enabled = true,
+  ): AccountLimitsServiceModule.CodexSeedTarget => ({
     instanceId: asInstanceId(instanceId),
     sessionsDir,
     enabled,
   });
 
   it("keeps sole-owner sessions dirs and attributes them to their instance", () => {
-    expect(planCodexTranscriptSeeds([target("codex", "/home/user/.codex/sessions")])).toEqual([
-      target("codex", "/home/user/.codex/sessions"),
-    ]);
+    expect(
+      AccountLimitsServiceModule.planCodexTranscriptSeeds([
+        target("codex", "/home/user/.codex/sessions"),
+      ]),
+    ).toEqual([target("codex", "/home/user/.codex/sessions")]);
   });
 
   it("skips a dir that several instances write - no honest attribution exists", () => {
     // The reported setup: three instances share one homePath (shadow homes
     // symlink sessions/ back to it) - seeding any of them invents data.
     expect(
-      planCodexTranscriptSeeds([
+      AccountLimitsServiceModule.planCodexTranscriptSeeds([
         target("codex_a", "/home/user/.codex/sessions"),
         target("codex_b", "/home/user/.codex/sessions"),
         target("codex_c", "/home/user/.codex/sessions"),
@@ -595,7 +652,7 @@ describe("planCodexTranscriptSeeds", () => {
 
   it("counts disabled instances as owners - their transcripts share the dir", () => {
     expect(
-      planCodexTranscriptSeeds([
+      AccountLimitsServiceModule.planCodexTranscriptSeeds([
         target("codex_a", "/home/user/.codex/sessions"),
         target("codex_off", "/home/user/.codex/sessions", false),
       ]),
@@ -604,7 +661,7 @@ describe("planCodexTranscriptSeeds", () => {
 
   it("plans independent dirs independently", () => {
     expect(
-      planCodexTranscriptSeeds([
+      AccountLimitsServiceModule.planCodexTranscriptSeeds([
         target("codex_a", "/home/user/.codex/sessions"),
         target("codex_b", "/home/user/.codex/sessions"),
         target("codex_work", "/home/user/.codex-work/sessions"),

--- a/apps/server/src/usage/AccountLimitsService.test.ts
+++ b/apps/server/src/usage/AccountLimitsService.test.ts
@@ -38,7 +38,7 @@ const claudeUsagePayload = (fiveHour: number, weekly: number) => ({
   },
 });
 
-/** The streamed single-window Claude event. */
+/** The streamed single-window Claude event. `utilization` is a 0-1 fraction. */
 const claudeWindowPayload = (utilization: number) => ({
   type: "rate_limit_event",
   rate_limit_info: {
@@ -167,7 +167,7 @@ it.layer(NodeServices.layer)("account limits service", (it) => {
       });
       yield* service.ingest({
         provider: "claudeAgent",
-        payload: claudeWindowPayload(87.5),
+        payload: claudeWindowPayload(0.875),
         createdAt: "2026-08-15T12:00:01.000Z",
         providerInstanceId: asInstanceId("claude_partner"),
       });

--- a/apps/server/src/usage/AccountLimitsService.test.ts
+++ b/apps/server/src/usage/AccountLimitsService.test.ts
@@ -6,6 +6,8 @@ import * as NodePath from "node:path";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { describe, expect, it } from "@effect/vitest";
 import { ProviderDriverKind, ProviderInstanceId, type ServerSettings } from "@t3tools/contracts";
+import * as Clock from "effect/Clock";
+import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
@@ -186,7 +188,7 @@ it.layer(NodeServices.layer)("account limits service", (it) => {
     }).pipe(Effect.provide(makeLayer())),
   );
 
-  it.effect("v1 cache rows load under the default instance until live data settles them", () =>
+  it.effect("v1 cache rows load under the default instance until a write settles them", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
@@ -379,6 +381,102 @@ it.live("transcript seeding attributes a sole-owner dir and skips shared or disa
       }
     }
   }).pipe(Effect.provide(NodeServices.layer)),
+);
+
+it.live(
+  "a transcript seed settles a migrated row like a live event - evicted by another instance, re-seeded by its own",
+  () =>
+    Effect.gen(function* () {
+      const workDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-seed-work-"));
+      const defaultDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-seed-default-"));
+      const baseDirs = [
+        NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-limits-seed-a-")),
+        NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-limits-seed-b-")),
+      ];
+      // Transcript lines must sit inside the seed's recency window, and the
+      // default instance's line must be newer than the v1 row it replaces.
+      const nowMs = yield* Clock.currentTimeMillis;
+      const isoAt = (offsetMs: number) => DateTime.formatIso(DateTime.makeUnsafe(nowMs - offsetMs));
+      const transcriptLine = (offsetMs: number, usedPercent: number) =>
+        JSON.stringify({
+          timestamp: isoAt(offsetMs),
+          payload: { rate_limits: codexPayload(usedPercent) },
+        });
+      NodeFS.mkdirSync(NodePath.join(workDir, "sessions"), { recursive: true });
+      NodeFS.writeFileSync(
+        NodePath.join(workDir, "sessions", "rollout-1.jsonl"),
+        `${transcriptLine(2 * 60 * 60 * 1000, 58)}\n`,
+      );
+      NodeFS.mkdirSync(NodePath.join(defaultDir, "sessions"), { recursive: true });
+      NodeFS.writeFileSync(
+        NodePath.join(defaultDir, "sessions", "rollout-1.jsonl"),
+        `${transcriptLine(60 * 60 * 1000, 23)}\n`,
+      );
+      // A v1 cache: one codex row, no instanceId - "whichever account wrote
+      // last", which may have been the work account as easily as the default.
+      const writeV1Cache = (baseDir: string) => {
+        NodeFS.mkdirSync(NodePath.join(baseDir, "userdata"), { recursive: true });
+        NodeFS.writeFileSync(
+          NodePath.join(baseDir, "userdata", "account-limits.json"),
+          JSON.stringify([
+            {
+              provider: "codex",
+              plan: "pro",
+              windows: [
+                {
+                  id: "weekly",
+                  label: "Weekly",
+                  usedPercent: 12,
+                  resetsAt: "2026-08-08T23:00:00.000Z",
+                  windowMinutes: 10080,
+                },
+              ],
+              asOf: isoAt(3 * 60 * 60 * 1000),
+              source: "live",
+            },
+          ]),
+        );
+      };
+      const roster = (defaultHome: string) => ({
+        providerInstances: {
+          [asInstanceId("codex")]: { driver: asDriver("codex"), config: { homePath: defaultHome } },
+          [asInstanceId("codex_work")]: {
+            driver: asDriver("codex"),
+            config: { homePath: workDir },
+          },
+        },
+      });
+      const readRows = (baseDir: string, defaultHome: string) =>
+        Effect.gen(function* () {
+          const service = yield* AccountLimitsServiceModule.AccountLimitsService;
+          const summary = yield* service.readSummary();
+          return summary.snapshots.map((snapshot) => [
+            snapshot.instanceId,
+            snapshot.source,
+            snapshot.windows[0]?.usedPercent,
+          ]);
+        }).pipe(Effect.provide(makeLayerAt(baseDir, roster(defaultHome))));
+      try {
+        // Only the work instance has transcripts: its seed is proof of a
+        // distinct account, so the unconfirmed migrated row goes the way it
+        // would under a live work event - evicted, not kept as a ghost.
+        writeV1Cache(baseDirs[0]!);
+        expect(yield* readRows(baseDirs[0]!, "/nonexistent/t3-test-codex-default")).toEqual([
+          ["codex_work", "transcript", 58],
+        ]);
+        // The default instance has transcripts of its own: the same pass
+        // seeds it back with real data, whichever order the seeds land in.
+        writeV1Cache(baseDirs[1]!);
+        expect(yield* readRows(baseDirs[1]!, defaultDir)).toEqual([
+          ["codex", "transcript", 23],
+          ["codex_work", "transcript", 58],
+        ]);
+      } finally {
+        for (const dir of [workDir, defaultDir, ...baseDirs]) {
+          NodeFS.rmSync(dir, { recursive: true, force: true });
+        }
+      }
+    }).pipe(Effect.provide(NodeServices.layer)),
 );
 
 it.live(

--- a/apps/server/src/usage/AccountLimitsService.test.ts
+++ b/apps/server/src/usage/AccountLimitsService.test.ts
@@ -314,7 +314,7 @@ it.layer(NodeServices.layer)("account limits service", (it) => {
 // Plain `it`: the seed consults the real clock for its retry floor and
 // transcript-recency window, which the suite's virtual test clock (epoch
 // 0) would defeat.
-it("transcript seeding attributes a sole-owner dir and skips shared or disabled dirs", () =>
+it.live("transcript seeding attributes a sole-owner dir and skips shared or disabled dirs", () =>
   Effect.gen(function* () {
     const soleDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-seed-sole-"));
     const sharedDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-seed-shared-"));
@@ -378,93 +378,97 @@ it("transcript seeding attributes a sole-owner dir and skips shared or disabled 
         NodeFS.rmSync(dir, { recursive: true, force: true });
       }
     }
-  }).pipe(Effect.provide(NodeServices.layer), Effect.runPromise));
+  }).pipe(Effect.provide(NodeServices.layer)),
+);
 
-it("an unconfirmed migrated row keeps its v1 shape across restarts - the ghost eviction survives", () =>
-  Effect.gen(function* () {
-    const baseDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-limits-restart-"));
-    NodeFS.mkdirSync(NodePath.join(baseDir, "userdata"), { recursive: true });
-    const cachePath = NodePath.join(baseDir, "userdata", "account-limits.json");
-    // A v1 cache: one claude row, no instanceId.
-    NodeFS.writeFileSync(
-      cachePath,
-      // @effect-diagnostics-next-line preferSchemaOverJson:off - fabricates the raw cache file.
-      JSON.stringify([
-        {
-          provider: "claude",
-          plan: "max",
-          windows: [
-            {
-              id: "five_hour",
-              label: "5h",
-              usedPercent: 12,
-              resetsAt: "2026-08-08T23:00:00.000Z",
-              windowMinutes: 300,
-            },
-          ],
-          asOf: "2026-08-01T00:00:00.000Z",
-          source: "live",
+it.live(
+  "an unconfirmed migrated row keeps its v1 shape across restarts - the ghost eviction survives",
+  () =>
+    Effect.gen(function* () {
+      const baseDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-limits-restart-"));
+      NodeFS.mkdirSync(NodePath.join(baseDir, "userdata"), { recursive: true });
+      const cachePath = NodePath.join(baseDir, "userdata", "account-limits.json");
+      // A v1 cache: one claude row, no instanceId.
+      NodeFS.writeFileSync(
+        cachePath,
+        // @effect-diagnostics-next-line preferSchemaOverJson:off - fabricates the raw cache file.
+        JSON.stringify([
+          {
+            provider: "claude",
+            plan: "max",
+            windows: [
+              {
+                id: "five_hour",
+                label: "5h",
+                usedPercent: 12,
+                resetsAt: "2026-08-08T23:00:00.000Z",
+                windowMinutes: 300,
+              },
+            ],
+            asOf: "2026-08-01T00:00:00.000Z",
+            source: "live",
+          },
+        ]),
+      );
+      const roster = {
+        providerInstances: {
+          [asInstanceId("claudeAgent")]: { driver: asDriver("claudeAgent") },
+          [asInstanceId("claude_partner")]: { driver: asDriver("claudeAgent") },
+          [asInstanceId("codex")]: {
+            driver: asDriver("codex"),
+            config: { homePath: "/nonexistent/t3-test-codex-default" },
+          },
         },
-      ]),
-    );
-    const roster = {
-      providerInstances: {
-        [asInstanceId("claudeAgent")]: { driver: asDriver("claudeAgent") },
-        [asInstanceId("claude_partner")]: { driver: asDriver("claudeAgent") },
-        [asInstanceId("codex")]: {
-          driver: asDriver("codex"),
-          config: { homePath: "/nonexistent/t3-test-codex-default" },
-        },
-      },
-    };
-    try {
-      // First run: an UNRELATED codex ingest persists the cache. The migrated
-      // claude row must be written back in its v1 shape, still unconfirmed.
-      yield* Effect.gen(function* () {
-        const service = yield* AccountLimitsServiceModule.AccountLimitsService;
-        yield* service.readSummary();
-        yield* service.ingest({
-          provider: asDriver("codex"),
-          payload: codexPayload(41),
-          createdAt: "2026-08-15T09:00:00.000Z",
-          providerInstanceId: asInstanceId("codex"),
-        });
-      }).pipe(Effect.provide(makeLayerAt(baseDir, roster)));
-      // @effect-diagnostics-next-line preferSchemaOverJson:off - reads the raw cache file back.
-      const persisted = JSON.parse(NodeFS.readFileSync(cachePath, "utf8")) as {
-        provider: string;
-        instanceId?: string;
-      }[];
-      expect(
-        persisted.map((row) => [row.provider, "instanceId" in row ? row.instanceId : "(none)"]),
-      ).toEqual([
-        ["claude", "(none)"],
-        ["codex", "codex"],
-      ]);
-      // Second run - a restart. Live claude data on ANOTHER instance must
-      // still evict the migrated default row instead of leaving a ghost.
-      const summary = yield* Effect.gen(function* () {
-        const service = yield* AccountLimitsServiceModule.AccountLimitsService;
-        yield* service.ingest({
-          provider: asDriver("claudeAgent"),
-          payload: claudeUsagePayload(31, 9),
-          createdAt: "2026-08-15T10:00:00.000Z",
-          providerInstanceId: asInstanceId("claude_partner"),
-        });
-        return yield* service.readSummary();
-      }).pipe(Effect.provide(makeLayerAt(baseDir, roster)));
-      expect(summary.snapshots.map((snapshot) => [snapshot.provider, snapshot.instanceId])).toEqual(
-        [
+      };
+      try {
+        // First run: an UNRELATED codex ingest persists the cache. The migrated
+        // claude row must be written back in its v1 shape, still unconfirmed.
+        yield* Effect.gen(function* () {
+          const service = yield* AccountLimitsServiceModule.AccountLimitsService;
+          yield* service.readSummary();
+          yield* service.ingest({
+            provider: asDriver("codex"),
+            payload: codexPayload(41),
+            createdAt: "2026-08-15T09:00:00.000Z",
+            providerInstanceId: asInstanceId("codex"),
+          });
+        }).pipe(Effect.provide(makeLayerAt(baseDir, roster)));
+        // @effect-diagnostics-next-line preferSchemaOverJson:off - reads the raw cache file back.
+        const persisted = JSON.parse(NodeFS.readFileSync(cachePath, "utf8")) as {
+          provider: string;
+          instanceId?: string;
+        }[];
+        expect(
+          persisted.map((row) => [row.provider, "instanceId" in row ? row.instanceId : "(none)"]),
+        ).toEqual([
+          ["claude", "(none)"],
+          ["codex", "codex"],
+        ]);
+        // Second run - a restart. Live claude data on ANOTHER instance must
+        // still evict the migrated default row instead of leaving a ghost.
+        const summary = yield* Effect.gen(function* () {
+          const service = yield* AccountLimitsServiceModule.AccountLimitsService;
+          yield* service.ingest({
+            provider: asDriver("claudeAgent"),
+            payload: claudeUsagePayload(31, 9),
+            createdAt: "2026-08-15T10:00:00.000Z",
+            providerInstanceId: asInstanceId("claude_partner"),
+          });
+          return yield* service.readSummary();
+        }).pipe(Effect.provide(makeLayerAt(baseDir, roster)));
+        expect(
+          summary.snapshots.map((snapshot) => [snapshot.provider, snapshot.instanceId]),
+        ).toEqual([
           ["claude", "claude_partner"],
           ["codex", "codex"],
-        ],
-      );
-    } finally {
-      NodeFS.rmSync(baseDir, { recursive: true, force: true });
-    }
-  }).pipe(Effect.provide(NodeServices.layer), Effect.runPromise));
+        ]);
+      } finally {
+        NodeFS.rmSync(baseDir, { recursive: true, force: true });
+      }
+    }).pipe(Effect.provide(NodeServices.layer)),
+);
 
-it("drops untouched windows at every entry - the persisted cache and the streamed patch", () =>
+it.live("drops untouched windows at every entry - the persisted cache and the streamed patch", () =>
   Effect.gen(function* () {
     const baseDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-limits-untouched-"));
     NodeFS.mkdirSync(NodePath.join(baseDir, "userdata"), { recursive: true });
@@ -533,22 +537,57 @@ it("drops untouched windows at every entry - the persisted cache and the streame
           createdAt: "2026-08-15T10:00:00.000Z",
           providerInstanceId: asInstanceId("claudeAgent"),
         });
+        // An untouched event naming the METERED window must not delete it -
+        // the patch is dropped entirely, not filtered after the merge.
+        yield* service.ingest({
+          provider: asDriver("claudeAgent"),
+          payload: {
+            type: "rate_limit_event",
+            rate_limit_info: { status: "allowed", rateLimitType: "five_hour" },
+          },
+          createdAt: "2026-08-15T10:00:01.000Z",
+          providerInstanceId: asInstanceId("claudeAgent"),
+        });
+        // Not-applicable (API key / Bedrock / Vertex) keeps what was known.
+        yield* service.ingest({
+          provider: asDriver("claudeAgent"),
+          payload: { rate_limits: null },
+          createdAt: "2026-08-15T10:00:02.000Z",
+          providerInstanceId: asInstanceId("claudeAgent"),
+        });
+        const kept = yield* service.readSummary();
+        expect(kept.snapshots.map((row) => row.windows.map((w) => [w.id, w.usedPercent]))).toEqual([
+          [["five_hour", 12]],
+        ]);
+        // An APPLICABLE snapshot whose windows are all untouched clears the
+        // row - the meters really are empty now, not still at their old
+        // readings.
+        yield* service.ingest({
+          provider: asDriver("claudeAgent"),
+          payload: {
+            subscription_type: "max",
+            rate_limits: { five_hour: { utilization: 0 }, seven_day: { utilization: 0 } },
+          },
+          createdAt: "2026-08-15T10:00:03.000Z",
+          providerInstanceId: asInstanceId("claudeAgent"),
+        });
         return yield* service.readSummary();
       }).pipe(Effect.provide(makeLayerAt(baseDir, roster)));
-      expect(summary.snapshots.map((row) => row.windows.map((w) => w.id))).toEqual([["five_hour"]]);
-      // The patch persisted the row back - the untouched window must not
-      // have ridden along to disk.
+      expect(summary.snapshots.map((row) => row.windows.map((w) => w.id))).toEqual([[]]);
+      // The cleared row persisted back without windows - and the untouched
+      // cache window never rode along to disk at any point.
       // @effect-diagnostics-next-line preferSchemaOverJson:off - reads the raw cache file back.
       const persisted = JSON.parse(NodeFS.readFileSync(cachePath, "utf8")) as {
         windows: { id: string }[];
       }[];
-      expect(persisted.map((row) => row.windows.map((w) => w.id))).toEqual([["five_hour"]]);
+      expect(persisted.map((row) => row.windows.map((w) => w.id))).toEqual([[]]);
     } finally {
       NodeFS.rmSync(baseDir, { recursive: true, force: true });
     }
-  }).pipe(Effect.provide(NodeServices.layer), Effect.runPromise));
+  }).pipe(Effect.provide(NodeServices.layer)),
+);
 
-it("evicts a row whose instance now runs a different driver", () =>
+it.live("evicts a row whose instance now runs a different driver", () =>
   Effect.gen(function* () {
     const baseDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-limits-flip-"));
     NodeFS.mkdirSync(NodePath.join(baseDir, "userdata"), { recursive: true });
@@ -599,9 +638,10 @@ it("evicts a row whose instance now runs a different driver", () =>
     } finally {
       NodeFS.rmSync(baseDir, { recursive: true, force: true });
     }
-  }).pipe(Effect.provide(NodeServices.layer), Effect.runPromise));
+  }).pipe(Effect.provide(NodeServices.layer)),
+);
 
-it("seeds a codex instance homed by its environment's CODEX_HOME", () =>
+it.live("seeds a codex instance homed by its environment's CODEX_HOME", () =>
   Effect.gen(function* () {
     // No homePath configured: the spawned CLI would resolve CODEX_HOME from
     // its child env, so the seed must read the same place.
@@ -645,9 +685,10 @@ it("seeds a codex instance homed by its environment's CODEX_HOME", () =>
     } finally {
       NodeFS.rmSync(envHome, { recursive: true, force: true });
     }
-  }).pipe(Effect.provide(NodeServices.layer), Effect.runPromise));
+  }).pipe(Effect.provide(NodeServices.layer)),
+);
 
-it("a shadow-overlay instance seeds from its layout, not its CODEX_HOME env", () =>
+it.live("a shadow-overlay instance seeds from its layout, not its CODEX_HOME env", () =>
   Effect.gen(function* () {
     const line = (percent: number) =>
       `${JSON.stringify({
@@ -701,7 +742,8 @@ it("a shadow-overlay instance seeds from its layout, not its CODEX_HOME env", ()
       NodeFS.rmSync(plainEnvHome, { recursive: true, force: true });
       NodeFS.rmSync(shadowEnvHome, { recursive: true, force: true });
     }
-  }).pipe(Effect.provide(NodeServices.layer), Effect.runPromise));
+  }).pipe(Effect.provide(NodeServices.layer)),
+);
 
 describe("planCodexTranscriptSeeds", () => {
   const target = (

--- a/apps/server/src/usage/AccountLimitsService.test.ts
+++ b/apps/server/src/usage/AccountLimitsService.test.ts
@@ -464,6 +464,90 @@ it("an unconfirmed migrated row keeps its v1 shape across restarts - the ghost e
     }
   }).pipe(Effect.provide(NodeServices.layer), Effect.runPromise));
 
+it("drops untouched windows at every entry - the persisted cache and the streamed patch", () =>
+  Effect.gen(function* () {
+    const baseDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-limits-untouched-"));
+    NodeFS.mkdirSync(NodePath.join(baseDir, "userdata"), { recursive: true });
+    const cachePath = NodePath.join(baseDir, "userdata", "account-limits.json");
+    // A pre-upgrade cache row carrying a bare 0%/no-reset window next to a
+    // metered one - written before untouched windows were filtered.
+    NodeFS.writeFileSync(
+      cachePath,
+      // @effect-diagnostics-next-line preferSchemaOverJson:off - fabricates the raw cache file.
+      JSON.stringify([
+        {
+          provider: "claude",
+          plan: "max",
+          windows: [
+            {
+              id: "five_hour",
+              label: "5h",
+              usedPercent: 12,
+              resetsAt: "2026-08-08T23:00:00.000Z",
+              windowMinutes: 300,
+            },
+            {
+              id: "seven_day",
+              label: "Week",
+              usedPercent: 0,
+              resetsAt: null,
+              windowMinutes: 10080,
+            },
+          ],
+          asOf: "2026-08-01T00:00:00.000Z",
+          source: "live",
+        },
+      ]),
+    );
+    const roster = {
+      providerInstances: {
+        [asInstanceId("claudeAgent")]: { driver: asDriver("claudeAgent") },
+        // A codex home that cannot exist, or the transcript seed reads this
+        // machine's real ~/.codex/sessions mid-test (see instanceRoster).
+        [asInstanceId("codex")]: {
+          driver: asDriver("codex"),
+          config: { homePath: "/nonexistent/t3-test-codex-untouched" },
+        },
+      },
+    };
+    try {
+      const summary = yield* Effect.gen(function* () {
+        const service = yield* AccountLimitsServiceModule.AccountLimitsService;
+        // The loaded row must come back without its untouched window.
+        const loaded = yield* service.readSummary();
+        expect(
+          loaded.snapshots.map((row) => [
+            row.provider,
+            row.instanceId,
+            row.windows.map((w) => w.id),
+          ]),
+        ).toEqual([["claude", "claudeAgent", ["five_hour"]]]);
+        // A streamed patch naming a window with no traffic must not add it:
+        // no utilization and no reset clock is the untouched shape.
+        yield* service.ingest({
+          provider: asDriver("claudeAgent"),
+          payload: {
+            type: "rate_limit_event",
+            rate_limit_info: { status: "allowed", rateLimitType: "seven_day" },
+          },
+          createdAt: "2026-08-15T10:00:00.000Z",
+          providerInstanceId: asInstanceId("claudeAgent"),
+        });
+        return yield* service.readSummary();
+      }).pipe(Effect.provide(makeLayerAt(baseDir, roster)));
+      expect(summary.snapshots.map((row) => row.windows.map((w) => w.id))).toEqual([["five_hour"]]);
+      // The patch persisted the row back - the untouched window must not
+      // have ridden along to disk.
+      // @effect-diagnostics-next-line preferSchemaOverJson:off - reads the raw cache file back.
+      const persisted = JSON.parse(NodeFS.readFileSync(cachePath, "utf8")) as {
+        windows: { id: string }[];
+      }[];
+      expect(persisted.map((row) => row.windows.map((w) => w.id))).toEqual([["five_hour"]]);
+    } finally {
+      NodeFS.rmSync(baseDir, { recursive: true, force: true });
+    }
+  }).pipe(Effect.provide(NodeServices.layer), Effect.runPromise));
+
 it("evicts a row whose instance now runs a different driver", () =>
   Effect.gen(function* () {
     const baseDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-limits-flip-"));

--- a/apps/server/src/usage/AccountLimitsService.ts
+++ b/apps/server/src/usage/AccountLimitsService.ts
@@ -9,7 +9,15 @@
  * fallback: its limits exist only on the live stream, which is why snapshots
  * are persisted across restarts.
  *
- * One snapshot per provider: T3 Code drives one account per provider today.
+ * One snapshot per (provider, instance). Limits belong to provider
+ * *accounts*, and the instance is the closest identity every event already
+ * carries: with several instances configured (work + personal accounts, the
+ * documented multi-account setup), a single per-provider slot makes the
+ * accounts overwrite and suppress each other. Two instances logged into the
+ * same account simply show the same numbers - honest, and free of credential
+ * reads on the event path. Cache rows that predate instance attribution load
+ * under the driver's default instance id, which is what the old single-slot
+ * world semantically was - see `migratedSlots` for how long that lasts.
  *
  * @module AccountLimitsService
  */
@@ -17,6 +25,11 @@ import {
   ACCOUNT_LIMITS_CONTRACT_VERSION,
   AccountLimitsSnapshot,
   type AccountLimitsSummary,
+  CodexSettings,
+  defaultInstanceIdForDriver,
+  ProviderDriverKind,
+  type ProviderInstanceConfigMap,
+  ProviderInstanceId,
   type UsageProviderKind,
 } from "@t3tools/contracts";
 import * as Clock from "effect/Clock";
@@ -31,8 +44,12 @@ import * as Semaphore from "effect/Semaphore";
 
 import { writeFileStringAtomically } from "../atomicWrite.ts";
 import { ServerConfig } from "../config.ts";
-import * as ServerSettings from "../serverSettings.ts";
 import { resolveCodexHomeLayout } from "../provider/Drivers/CodexHomeLayout.ts";
+import { deriveProviderInstanceConfigMap } from "../provider/Layers/ProviderInstanceRegistryHydration.ts";
+import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
+
+import { expandHomePath } from "../pathExpansion.ts";
+import * as ServerSettings from "../serverSettings.ts";
 import {
   claudeUsageSnapshotFromUnknown,
   claudeWindowFromRateLimitEvent,
@@ -53,6 +70,7 @@ const decodeLimitsCache = Schema.decodeUnknownEffect(
 const encodeLimitsCache = Schema.encodeEffect(
   Schema.fromJsonString(LimitsCacheFile as unknown as Schema.Codec<typeof LimitsCacheFile.Type>),
 );
+const decodeCodexSettings = Schema.decodeUnknownEffect(CodexSettings);
 
 export interface AccountLimitsIngestInput {
   /** Driver kind off the runtime event (`claudeAgent`, `codex`, ...). */
@@ -60,6 +78,12 @@ export interface AccountLimitsIngestInput {
   /** The event's `payload.rateLimits`, in whatever shape the adapter emitted. */
   readonly payload: unknown;
   readonly createdAt: string;
+  /**
+   * Instance routing key off the event envelope. Optional during the
+   * driver/instance migration; an absent value means the driver's default
+   * instance, exactly like the envelope field it mirrors.
+   */
+  readonly providerInstanceId?: ProviderInstanceId | undefined;
 }
 
 export class AccountLimitsService extends Context.Service<
@@ -90,13 +114,75 @@ function providerFromDriver(driver: string): UsageProviderKind | null {
   return null;
 }
 
+/**
+ * The instance that owns data carrying no instance id: legacy emitters and
+ * v1 cache rows. The legacy single-instance world used the driver kind
+ * itself as the instance id (see `defaultInstanceIdForDriver`), so this is
+ * not a guess - it is what that data always meant.
+ */
+function defaultInstanceIdForProvider(provider: UsageProviderKind): ProviderInstanceId {
+  return defaultInstanceIdForDriver(
+    ProviderDriverKind.make(provider === "claude" ? "claudeAgent" : "codex"),
+  );
+}
+
+/**
+ * Map key for one (provider, instance) slot. Structured, not interpolated:
+ * no spelling of an instance id can collide with another slot's key.
+ */
+function slotKey(provider: UsageProviderKind, instanceId: ProviderInstanceId): string {
+  return JSON.stringify([provider, instanceId]);
+}
+
+/** One codex instance's resolved transcript location. */
+export interface CodexSeedTarget {
+  readonly instanceId: ProviderInstanceId;
+  readonly sessionsDir: string;
+  /**
+   * Disabled instances still own their transcripts - their sessions share
+   * the dir whether or not the instance currently runs - so they count for
+   * ambiguity, and only enabled sole owners are actually seeded.
+   */
+  readonly enabled: boolean;
+}
+
+/**
+ * Sole-owner sessions dirs only. Shadow homes share `sessions/` with the
+ * home they overlay (see CodexHomeLayout), and a transcript names no
+ * account - so a directory that several instances write cannot be
+ * attributed honestly, and seeding it into any one of them invents data
+ * (seeding it into all of them invents more). Those dirs are skipped: live
+ * events still meter every instance; the transcripts just stop pretending
+ * to know whose usage they hold. Pure and exported for tests.
+ */
+export function planCodexTranscriptSeeds(
+  targets: readonly CodexSeedTarget[],
+): readonly CodexSeedTarget[] {
+  const byDir = new Map<string, readonly CodexSeedTarget[]>();
+  for (const target of targets) {
+    byDir.set(target.sessionsDir, [...(byDir.get(target.sessionsDir) ?? []), target]);
+  }
+  return [...byDir.values()].flatMap((owners) => (owners.length === 1 ? owners : []));
+}
+
 export const make = Effect.gen(function* () {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const config = yield* ServerConfig;
   const settingsService = yield* ServerSettings.ServerSettingsService;
 
-  const snapshots = new Map<UsageProviderKind, AccountLimitsSnapshot>();
+  const snapshots = new Map<string, AccountLimitsSnapshot>();
+  /**
+   * Slot keys holding rows migrated from the v1 single-slot cache. A v1 row
+   * was "whichever account wrote last", not "the default instance" - the
+   * default id is only the least-wrong home for it. The first live event
+   * proves the point either way: landing on the default slot confirms the
+   * row, landing on any other instance of the same provider proves the
+   * migrated row may belong to somebody else, so it is evicted rather than
+   * shown as a ghost account forever.
+   */
+  const hostEnvironment = yield* HostProcessEnvironment;
+  const migratedSlots = new Set<string>();
   const cachePath = path.join(config.stateDir, "account-limits.json");
   let lastCodexSeedAttemptAtMs = 0;
 
@@ -111,18 +197,26 @@ export const make = Effect.gen(function* () {
       );
       if (stored === null) return;
       for (const snapshot of stored) {
-        if (!snapshots.has(snapshot.provider)) snapshots.set(snapshot.provider, snapshot);
+        // Rows written before instance attribution migrate to the default
+        // instance rather than being discarded: Claude has no disk source,
+        // so a wiped cache is an empty Limits strip until a session runs.
+        const instanceId = snapshot.instanceId ?? defaultInstanceIdForProvider(snapshot.provider);
+        const key = slotKey(snapshot.provider, instanceId);
+        if (!snapshots.has(key)) {
+          snapshots.set(key, { ...snapshot, instanceId });
+          if (snapshot.instanceId === undefined) migratedSlots.add(key);
+        }
       }
     }),
   );
 
   /**
-   * All snapshot mutations - event ingest (worker fiber) and the transcript
-   * seed (RPC fiber) - run under this one permit, so each ordering guard,
-   * map write, and persist is atomic with respect to the others. Without it
-   * a concurrent pair can both pass their guard against the same prior
-   * snapshot and land in either order, rolling the state backwards. Reads
-   * stay lock-free.
+   * All snapshot mutations - event ingest (worker fiber), the transcript
+   * seed and instance eviction (RPC fiber) - run under this one permit, so
+   * each ordering guard, map write, and persist is atomic with respect to
+   * the others. Without it a concurrent pair can both pass their guard
+   * against the same prior snapshot and land in either order, rolling the
+   * state backwards. Reads stay lock-free.
    */
   const stateLock = yield* Semaphore.make(1);
 
@@ -130,7 +224,16 @@ export const make = Effect.gen(function* () {
   // called while holding `stateLock`, which is what serializes writes; the
   // temp-file + rename keeps a crashed write from tearing the file.
   const persist = Effect.fn("AccountLimitsService.persist")(function* () {
-    yield* encodeLimitsCache([...snapshots.values()]).pipe(
+    // A still-unconfirmed migrated row is written back in its v1 shape (no
+    // instanceId): the marker lives only in memory, and persisting the
+    // synthesized id would make the row look settled after any restart -
+    // permanently exempt from the other-instance eviction in `store`.
+    const rows = [...snapshots.entries()].map(([key, snapshot]) => {
+      if (!migratedSlots.has(key)) return snapshot;
+      const { instanceId: _instanceId, ...rest } = snapshot;
+      return rest;
+    });
+    yield* encodeLimitsCache(rows).pipe(
       Effect.flatMap((serialized) =>
         writeFileStringAtomically({ filePath: cachePath, contents: serialized }),
       ),
@@ -141,17 +244,28 @@ export const make = Effect.gen(function* () {
   });
 
   const store = Effect.fn("AccountLimitsService.store")(function* (
-    snapshot: AccountLimitsSnapshot,
+    snapshot: AccountLimitsSnapshot & { readonly instanceId: ProviderInstanceId },
   ) {
-    snapshots.set(snapshot.provider, snapshot);
+    const key = slotKey(snapshot.provider, snapshot.instanceId);
+    snapshots.set(key, snapshot);
+    // Live data on a slot settles what that slot is; live data on any OTHER
+    // instance of the provider evicts a still-unconfirmed migrated row (see
+    // `migratedSlots`).
+    migratedSlots.delete(key);
+    const defaultKey = slotKey(snapshot.provider, defaultInstanceIdForProvider(snapshot.provider));
+    if (key !== defaultKey && migratedSlots.has(defaultKey)) {
+      snapshots.delete(defaultKey);
+      migratedSlots.delete(defaultKey);
+    }
     yield* persist();
   });
 
   const ingestClaude = Effect.fn("AccountLimitsService.ingestClaude")(function* (
     payload: unknown,
     createdAt: string,
+    instanceId: ProviderInstanceId,
   ) {
-    const previous = snapshots.get("claude");
+    const previous = snapshots.get(slotKey("claude", instanceId));
     const full = claudeUsageSnapshotFromUnknown(payload);
     if (full !== null) {
       // Rate limits do not apply to this account (API key / Bedrock / Vertex):
@@ -159,6 +273,7 @@ export const make = Effect.gen(function* () {
       if (full.windows.length === 0) return;
       yield* store({
         provider: "claude",
+        instanceId,
         plan: full.plan ?? previous?.plan ?? null,
         windows: full.windows,
         asOf: createdAt,
@@ -167,7 +282,7 @@ export const make = Effect.gen(function* () {
       return;
     }
     // The streamed event names one window; patch it into whatever set the
-    // last full snapshot established.
+    // last full snapshot from the same instance established.
     const window = claudeWindowFromRateLimitEvent(payload);
     if (window === null) return;
     const windows = sortWindows([
@@ -176,6 +291,7 @@ export const make = Effect.gen(function* () {
     ]);
     yield* store({
       provider: "claude",
+      instanceId,
       plan: previous?.plan ?? null,
       windows,
       asOf: createdAt,
@@ -186,15 +302,17 @@ export const make = Effect.gen(function* () {
   const ingestCodex = Effect.fn("AccountLimitsService.ingestCodex")(function* (
     payload: unknown,
     createdAt: string,
+    instanceId: ProviderInstanceId,
   ) {
     const snapshot = codexSnapshotFromUnknown(payload);
     if (snapshot === null) return;
     // Per-model side meters (Spark) are not surfaced.
     if (!isPrimaryCodexLimit(snapshot.limitId)) return;
     if (snapshot.windows.length === 0) return;
-    const previous = snapshots.get("codex");
+    const previous = snapshots.get(slotKey("codex", instanceId));
     yield* store({
       provider: "codex",
+      instanceId,
       plan: snapshot.plan ?? previous?.plan ?? null,
       windows: snapshot.windows,
       asOf: createdAt,
@@ -207,71 +325,160 @@ export const make = Effect.gen(function* () {
   ) {
     const provider = providerFromDriver(input.provider);
     if (provider === null) return;
+    const instanceId = input.providerInstanceId ?? defaultInstanceIdForProvider(provider);
     yield* ensureLoaded;
     yield* stateLock.withPermits(1)(
       Effect.gen(function* () {
         // Guard against out-of-order delivery: an event older than what is
-        // already stored must not roll the snapshot backwards.
-        const existing = snapshots.get(provider);
+        // already stored must not roll the snapshot backwards. Per slot -
+        // one instance's traffic must not suppress another's.
+        const existing = snapshots.get(slotKey(provider, instanceId));
         if (existing !== undefined && input.createdAt < existing.asOf) return;
         if (provider === "claude") {
-          yield* ingestClaude(input.payload, input.createdAt);
+          yield* ingestClaude(input.payload, input.createdAt, instanceId);
         } else {
-          yield* ingestCodex(input.payload, input.createdAt);
+          yield* ingestCodex(input.payload, input.createdAt, instanceId);
         }
       }),
     );
   });
 
   /**
-   * Recovers the Codex snapshot from session transcripts when they are newer
+   * Recovers Codex snapshots from session transcripts when they are newer
    * than what the cache holds - which covers both a cold cache and Codex
-   * sessions driven outside T3 Code.
+   * sessions driven outside T3 Code. Instances are enumerated the same way
+   * the registry derives them, so the legacy single-instance mirror is
+   * included; only sessions dirs owned by exactly one instance are read
+   * (see `planCodexTranscriptSeeds`).
    */
   const maybeSeedCodexFromTranscripts = Effect.fn("AccountLimitsService.seedCodex")(function* (
     nowMs: number,
+    configMap: ProviderInstanceConfigMap | null,
   ) {
+    if (configMap === null) return;
     if (nowMs - lastCodexSeedAttemptAtMs < CODEX_SEED_MIN_INTERVAL_MS) return;
     lastCodexSeedAttemptAtMs = nowMs;
 
-    const settings = yield* settingsService.getSettings.pipe(
-      Effect.catchCause(() => Effect.succeed(null)),
-    );
-    if (settings === null) return;
-    const layout = yield* resolveCodexHomeLayout(settings.providers.codex).pipe(
-      Effect.provideService(Path.Path, path),
-    );
-    const sessionsDir = path.join(layout.sharedHomePath, "sessions");
-    const found = yield* Effect.promise(() => readLatestCodexRateLimits(sessionsDir, nowMs));
-    if (found === null) return;
+    const targets: CodexSeedTarget[] = [];
+    for (const [rawInstanceId, entry] of Object.entries(configMap)) {
+      if (entry.driver !== "codex") continue;
+      const codexSettings = yield* decodeCodexSettings(entry.config ?? {}).pipe(
+        Effect.catchCause(() => Effect.succeed(null)),
+      );
+      if (codexSettings === null) continue;
+      // Where the spawned CLI actually writes: an explicit homePath wins,
+      // else the CODEX_HOME its child env would carry (instance override,
+      // then ambient) - resolveCodexHomeLayout alone answers ~/.codex even
+      // when the CLI it describes is writing somewhere else.
+      let sessionsParent: string;
+      const envOverride = entry.environment
+        ?.find((variable) => variable.name === "CODEX_HOME")
+        ?.value.trim();
+      const envHome =
+        codexSettings.homePath.trim() === ""
+          ? envOverride || hostEnvironment["CODEX_HOME"]?.trim() || ""
+          : "";
+      if (envHome !== "") {
+        sessionsParent = expandHomePath(envHome);
+      } else {
+        const layout = yield* resolveCodexHomeLayout(codexSettings).pipe(
+          Effect.provideService(Path.Path, path),
+        );
+        sessionsParent = layout.sharedHomePath;
+      }
+      const sessionsDir = path.join(sessionsParent, "sessions");
+      // Compare filesystem identity, not spellings: a symlinked home and its
+      // target are one directory, and treating them as two would hand the
+      // same account-ambiguous transcripts to both.
+      const canonical = yield* fileSystem
+        .realPath(sessionsDir)
+        .pipe(Effect.catchCause(() => Effect.succeed(sessionsDir)));
+      targets.push({
+        instanceId: ProviderInstanceId.make(rawInstanceId),
+        sessionsDir: canonical,
+        enabled: entry.enabled !== false,
+      });
+    }
 
-    const asOf = DateTime.formatIso(DateTime.makeUnsafe(found.asOfMs));
-    // The slow transcript read happened outside the lock; only the
-    // guard-and-store is serialized against live ingests.
-    yield* stateLock.withPermits(1)(
-      Effect.gen(function* () {
-        const existing = snapshots.get("codex");
-        // ISO-8601 strings order lexicographically.
-        if (existing !== undefined && existing.asOf >= asOf) return;
-        yield* store({
-          provider: "codex",
-          plan: found.snapshot.plan ?? existing?.plan ?? null,
-          windows: found.snapshot.windows,
-          asOf,
-          source: "transcript",
-        });
-      }),
-    );
+    for (const target of planCodexTranscriptSeeds(targets)) {
+      if (!target.enabled) continue;
+      const found = yield* Effect.promise(() =>
+        readLatestCodexRateLimits(target.sessionsDir, nowMs),
+      );
+      if (found === null) continue;
+      const asOf = DateTime.formatIso(DateTime.makeUnsafe(found.asOfMs));
+      // The slow transcript reads happened outside the lock; only the
+      // guard-and-store is serialized against live ingests.
+      yield* stateLock.withPermits(1)(
+        Effect.gen(function* () {
+          const existing = snapshots.get(slotKey("codex", target.instanceId));
+          // ISO-8601 strings order lexicographically.
+          if (existing !== undefined && existing.asOf >= asOf) return;
+          yield* store({
+            provider: "codex",
+            instanceId: target.instanceId,
+            plan: found.snapshot.plan ?? existing?.plan ?? null,
+            windows: found.snapshot.windows,
+            asOf,
+            source: "transcript",
+          });
+        }),
+      );
+    }
   });
 
   const readSummary = Effect.fn("AccountLimitsService.readSummary")(function* () {
     yield* ensureLoaded;
     const nowMs = yield* Clock.currentTimeMillis;
-    yield* maybeSeedCodexFromTranscripts(nowMs).pipe(Effect.catchCause(() => Effect.void));
+    const settings = yield* settingsService.getSettings.pipe(
+      Effect.catchCause(() => Effect.succeed(null)),
+    );
+    const configMap = settings === null ? null : deriveProviderInstanceConfigMap(settings);
+    yield* maybeSeedCodexFromTranscripts(nowMs, configMap).pipe(
+      Effect.catchCause(() => Effect.void),
+    );
+    // A deleted instance takes its rows with it - anything else leaves a
+    // ghost account forcing the captioned multi-row UI forever. A merely
+    // disabled instance keeps its cache (re-enabling restores it) but stays
+    // out of the summary. Default instances always derive, so single-account
+    // setups are untouched by either rule.
+    if (configMap !== null) {
+      yield* stateLock.withPermits(1)(
+        Effect.gen(function* () {
+          let evicted = false;
+          for (const [key, snapshot] of snapshots) {
+            const instanceId =
+              snapshot.instanceId ?? defaultInstanceIdForProvider(snapshot.provider);
+            const entry = configMap[instanceId];
+            // Gone entirely, or reconfigured to a different driver: either
+            // way the row's data belongs to an account this id no longer
+            // names, and a stale row would be captioned with the NEW
+            // driver's display name.
+            if (entry === undefined || providerFromDriver(entry.driver) !== snapshot.provider) {
+              snapshots.delete(key);
+              migratedSlots.delete(key);
+              evicted = true;
+            }
+          }
+          if (evicted) yield* persist();
+        }),
+      );
+    }
+    const visible = [...snapshots.values()].filter((snapshot) => {
+      if (configMap === null) return true;
+      const instanceId = snapshot.instanceId ?? defaultInstanceIdForProvider(snapshot.provider);
+      return configMap[instanceId]?.enabled !== false;
+    });
     return {
       contractVersion: ACCOUNT_LIMITS_CONTRACT_VERSION,
       readAt: DateTime.formatIso(DateTime.makeUnsafe(nowMs)),
-      snapshots: [...snapshots.values()].sort((a, b) => a.provider.localeCompare(b.provider)),
+      // Codepoint order, not localeCompare: instance ids are user-authored
+      // slugs and the summary's order must not change with the host locale.
+      snapshots: visible.sort((a, b) => {
+        const left = `${a.provider} ${a.instanceId ?? ""}`;
+        const right = `${b.provider} ${b.instanceId ?? ""}`;
+        return left < right ? -1 : left > right ? 1 : 0;
+      }),
     } satisfies AccountLimitsSummary;
   });
 

--- a/apps/server/src/usage/AccountLimitsService.ts
+++ b/apps/server/src/usage/AccountLimitsService.ts
@@ -374,8 +374,10 @@ export const make = Effect.gen(function* () {
       const envOverride = entry.environment
         ?.find((variable) => variable.name === "CODEX_HOME")
         ?.value.trim();
+      // A shadow overlay pins the layout: spawn overrides CODEX_HOME with
+      // the overlay path, so an instance env value never reaches the CLI.
       const envHome =
-        codexSettings.homePath.trim() === ""
+        codexSettings.homePath.trim() === "" && codexSettings.shadowHomePath.trim() === ""
           ? envOverride || hostEnvironment["CODEX_HOME"]?.trim() || ""
           : "";
       if (envHome !== "") {

--- a/apps/server/src/usage/AccountLimitsService.ts
+++ b/apps/server/src/usage/AccountLimitsService.ts
@@ -56,6 +56,7 @@ import {
   codexSnapshotFromUnknown,
   isPrimaryCodexLimit,
   sortWindows,
+  windowHasTraffic,
 } from "./accountLimitsNormalize.ts";
 import { readLatestCodexRateLimits } from "./accountLimitsTranscripts.ts";
 
@@ -203,7 +204,13 @@ export const make = Effect.gen(function* () {
         const instanceId = snapshot.instanceId ?? defaultInstanceIdForProvider(snapshot.provider);
         const key = slotKey(snapshot.provider, instanceId);
         if (!snapshots.has(key)) {
-          snapshots.set(key, { ...snapshot, instanceId });
+          // Pre-upgrade caches were written before untouched windows were
+          // filtered, so a bare 0%/no-reset row can come back from disk.
+          snapshots.set(key, {
+            ...snapshot,
+            instanceId,
+            windows: snapshot.windows.filter(windowHasTraffic),
+          });
           if (snapshot.instanceId === undefined) migratedSlots.add(key);
         }
       }
@@ -247,7 +254,12 @@ export const make = Effect.gen(function* () {
     snapshot: AccountLimitsSnapshot & { readonly instanceId: ProviderInstanceId },
   ) {
     const key = slotKey(snapshot.provider, snapshot.instanceId);
-    snapshots.set(key, snapshot);
+    // Windows reach this map from more places than the provider parsers:
+    // the streamed Claude patch assembles its own array, and a patch can
+    // carry a window the account has never metered. Enforcing the filter at
+    // the single write path keeps the no-untouched-windows invariant true
+    // for every caller, present and future.
+    snapshots.set(key, { ...snapshot, windows: snapshot.windows.filter(windowHasTraffic) });
     // Live data on a slot settles what that slot is; live data on any OTHER
     // instance of the provider evicts a still-unconfirmed migrated row (see
     // `migratedSlots`).

--- a/apps/server/src/usage/AccountLimitsService.ts
+++ b/apps/server/src/usage/AccountLimitsService.ts
@@ -171,6 +171,7 @@ export const make = Effect.gen(function* () {
   const path = yield* Path.Path;
   const config = yield* ServerConfig;
   const settingsService = yield* ServerSettings.ServerSettingsService;
+  const hostEnvironment = yield* HostProcessEnvironment;
 
   const snapshots = new Map<string, AccountLimitsSnapshot>();
   /**
@@ -182,7 +183,6 @@ export const make = Effect.gen(function* () {
    * migrated row may belong to somebody else, so it is evicted rather than
    * shown as a ghost account forever.
    */
-  const hostEnvironment = yield* HostProcessEnvironment;
   const migratedSlots = new Set<string>();
   const cachePath = path.join(config.stateDir, "account-limits.json");
   let lastCodexSeedAttemptAtMs = 0;
@@ -282,7 +282,9 @@ export const make = Effect.gen(function* () {
     if (full !== null) {
       // Rate limits do not apply to this account (API key / Bedrock / Vertex):
       // nothing to show, and nothing worth clearing a previous snapshot over.
-      if (full.windows.length === 0) return;
+      // An APPLICABLE snapshot stores even with zero windows - all meters
+      // untouched means the previous readings are gone, not still current.
+      if (!full.rateLimitsApply) return;
       yield* store({
         provider: "claude",
         instanceId,
@@ -297,6 +299,10 @@ export const make = Effect.gen(function* () {
     // last full snapshot from the same instance established.
     const window = claudeWindowFromRateLimitEvent(payload);
     if (window === null) return;
+    // An untouched streamed window (no utilization, no reset clock) carries
+    // no reading - replacing the metered window it names would delete real
+    // data, so it must leave the previous set alone entirely.
+    if (!windowHasTraffic(window)) return;
     const windows = sortWindows([
       ...(previous?.windows ?? []).filter((existing) => existing.id !== window.id),
       window,

--- a/apps/server/src/usage/AccountLimitsService.ts
+++ b/apps/server/src/usage/AccountLimitsService.ts
@@ -177,11 +177,15 @@ export const make = Effect.gen(function* () {
   /**
    * Slot keys holding rows migrated from the v1 single-slot cache. A v1 row
    * was "whichever account wrote last", not "the default instance" - the
-   * default id is only the least-wrong home for it. The first live event
-   * proves the point either way: landing on the default slot confirms the
-   * row, landing on any other instance of the same provider proves the
-   * migrated row may belong to somebody else, so it is evicted rather than
-   * shown as a ghost account forever.
+   * default id is only the least-wrong home for it. The first write proves
+   * the point either way: landing on the default slot confirms the row,
+   * landing on any other instance of the same provider proves the migrated
+   * row may belong to somebody else, so it is evicted rather than shown as
+   * a ghost account forever. A transcript seed is a write like any other:
+   * a sole-owner sessions dir is the same evidence of a distinct account
+   * that a live event is, and the v1 row is no less ambiguous for having
+   * been contradicted from disk. A default instance with transcripts of its
+   * own re-seeds in the same pass, so nothing real is lost.
    */
   const migratedSlots = new Set<string>();
   const cachePath = path.join(config.stateDir, "account-limits.json");
@@ -260,9 +264,9 @@ export const make = Effect.gen(function* () {
     // the single write path keeps the no-untouched-windows invariant true
     // for every caller, present and future.
     snapshots.set(key, { ...snapshot, windows: snapshot.windows.filter(windowHasTraffic) });
-    // Live data on a slot settles what that slot is; live data on any OTHER
+    // A write to a slot settles what that slot is; a write to any OTHER
     // instance of the provider evicts a still-unconfirmed migrated row (see
-    // `migratedSlots`).
+    // `migratedSlots`). Live events and transcript seeds count alike.
     migratedSlots.delete(key);
     const defaultKey = slotKey(snapshot.provider, defaultInstanceIdForProvider(snapshot.provider));
     if (key !== defaultKey && migratedSlots.has(defaultKey)) {

--- a/apps/server/src/usage/accountLimitsNormalize.test.ts
+++ b/apps/server/src/usage/accountLimitsNormalize.test.ts
@@ -6,6 +6,7 @@ import {
   claudeWindowFromRateLimitEvent,
   codexSnapshotFromUnknown,
   isPrimaryCodexLimit,
+  windowHasTraffic,
 } from "./accountLimitsNormalize.ts";
 
 describe("claudeUsageSnapshotFromUnknown", () => {
@@ -62,14 +63,29 @@ describe("claudeUsageSnapshotFromUnknown", () => {
     ]);
   });
 
-  it("treats a null utilization as an untouched window", () => {
+  it("drops an untouched window - 0% used with no reset clock says nothing", () => {
+    // The provider materializes windows it has never metered (a null
+    // utilization, no reset). Passing them through gave every Claude card a
+    // permanent 0% row per novel provider-side slug; a window appears the
+    // moment it first carries usage.
     const snapshot = claudeUsageSnapshotFromUnknown({
       subscription_type: null,
-      rate_limits: { five_hour: { utilization: null, resets_at: null } },
+      rate_limits: {
+        five_hour: { utilization: null, resets_at: null },
+        seven_day: { utilization: 12, resets_at: null },
+      },
     });
-    expect(snapshot?.windows).toEqual([
-      { id: "five_hour", label: "5h", usedPercent: 0, resetsAt: null, windowMinutes: 300 },
-    ]);
+    expect(snapshot?.windows.map((window) => window.id)).toEqual(["seven_day"]);
+  });
+
+  it("keeps a drained window whose reset clock is still running", () => {
+    const snapshot = claudeUsageSnapshotFromUnknown({
+      subscription_type: null,
+      rate_limits: {
+        five_hour: { utilization: 0, resets_at: "2026-08-15T15:00:00.000Z" },
+      },
+    });
+    expect(snapshot?.windows.map((window) => window.id)).toEqual(["five_hour"]);
   });
 
   it("returns empty windows when rate limits do not apply", () => {
@@ -167,5 +183,27 @@ describe("codexSnapshotFromUnknown", () => {
     expect(isPrimaryCodexLimit(snapshot?.limitId ?? null)).toBe(false);
     expect(isPrimaryCodexLimit("codex")).toBe(true);
     expect(isPrimaryCodexLimit(null)).toBe(true);
+  });
+});
+
+describe("windowHasTraffic", () => {
+  const window = (usedPercent: number, resetsAt: string | null) => ({
+    id: "nimbus_quill",
+    label: "Nimbus quill",
+    usedPercent,
+    resetsAt,
+    windowMinutes: null,
+  });
+
+  it("hides an untouched window", () => {
+    expect(windowHasTraffic(window(0, null))).toBe(false);
+  });
+
+  it("shows a window the moment it carries usage", () => {
+    expect(windowHasTraffic(window(1, null))).toBe(true);
+  });
+
+  it("shows a drained window whose reset clock is still running", () => {
+    expect(windowHasTraffic(window(0, "2026-08-21T07:59:00.000Z"))).toBe(true);
   });
 });

--- a/apps/server/src/usage/accountLimitsNormalize.test.ts
+++ b/apps/server/src/usage/accountLimitsNormalize.test.ts
@@ -98,13 +98,15 @@ describe("claudeUsageSnapshotFromUnknown", () => {
 });
 
 describe("claudeWindowFromRateLimitEvent", () => {
-  it("maps the binding window with a unix-seconds reset", () => {
+  it("maps the binding window with a unix-seconds reset, scaling the 0-1 utilization", () => {
+    // The streamed field carries the response header's fraction, not the
+    // usage endpoint's percent: 0.875 here is the 87.5 the endpoint reports.
     const window = claudeWindowFromRateLimitEvent({
       type: "rate_limit_event",
       rate_limit_info: {
         status: "allowed_warning",
         rateLimitType: "five_hour",
-        utilization: 87.5,
+        utilization: 0.875,
         resetsAt: 1_786_600_800,
       },
     });
@@ -120,7 +122,7 @@ describe("claudeWindowFromRateLimitEvent", () => {
   it("drops hidden window types", () => {
     expect(
       claudeWindowFromRateLimitEvent({
-        rate_limit_info: { rateLimitType: "seven_day_opus", utilization: 90 },
+        rate_limit_info: { rateLimitType: "seven_day_opus", utilization: 0.9 },
       }),
     ).toBeNull();
   });

--- a/apps/server/src/usage/accountLimitsNormalize.ts
+++ b/apps/server/src/usage/accountLimitsNormalize.ts
@@ -120,6 +120,19 @@ function claudeWindowFromEntry(meta: ClaudeWindowMeta, entry: unknown): AccountL
   };
 }
 
+/**
+ * A window the provider has never metered says nothing: untouched windows
+ * report 0% used with no reset clock (the reset only exists once there is
+ * traffic). Dropping them here - the one place windows are assembled -
+ * keeps every client rendering the array as-is while sparing all of them a
+ * row like a bare provider-side slug at a permanent 0%. A window appears
+ * the moment it first carries usage, which is also when its reset clock
+ * starts meaning something.
+ */
+export function windowHasTraffic(window: AccountLimitsWindow): boolean {
+  return window.usedPercent > 0 || window.resetsAt !== null;
+}
+
 export interface ClaudeUsageSnapshot {
   readonly plan: string | null;
   readonly windows: AccountLimitsWindow[];
@@ -155,7 +168,10 @@ export function claudeUsageSnapshotFromUnknown(value: unknown): ClaudeUsageSnaps
     }
   }
 
-  return { plan: readString(value.subscription_type), windows: sortWindows([...windows.values()]) };
+  return {
+    plan: readString(value.subscription_type),
+    windows: sortWindows([...windows.values()].filter(windowHasTraffic)),
+  };
 }
 
 /** One entry of the newer `rate_limits.limits` array. */
@@ -263,7 +279,7 @@ export function codexSnapshotFromUnknown(value: unknown): CodexRateLimitsSnapsho
   }
   if (windows.length === 0 && limitId === null && plan === null) return null;
 
-  return { limitId, plan, windows: sortWindows(windows) };
+  return { limitId, plan, windows: sortWindows(windows.filter(windowHasTraffic)) };
 }
 
 /**

--- a/apps/server/src/usage/accountLimitsNormalize.ts
+++ b/apps/server/src/usage/accountLimitsNormalize.ts
@@ -123,11 +123,13 @@ function claudeWindowFromEntry(meta: ClaudeWindowMeta, entry: unknown): AccountL
 /**
  * A window the provider has never metered says nothing: untouched windows
  * report 0% used with no reset clock (the reset only exists once there is
- * traffic). Dropping them here - the one place windows are assembled -
- * keeps every client rendering the array as-is while sparing all of them a
- * row like a bare provider-side slug at a permanent 0%. A window appears
- * the moment it first carries usage, which is also when its reset clock
- * starts meaning something.
+ * traffic). Both provider parsers drop them, and AccountLimitsService
+ * re-applies the filter where windows are assembled outside these parsers
+ * (the streamed single-window patch, pre-upgrade cache rows loaded from
+ * disk) - so every client renders the array as-is without a row like a
+ * bare provider-side slug at a permanent 0%. A window appears the moment
+ * it first carries usage, which is also when its reset clock starts
+ * meaning something.
  */
 export function windowHasTraffic(window: AccountLimitsWindow): boolean {
   return window.usedPercent > 0 || window.resetsAt !== null;

--- a/apps/server/src/usage/accountLimitsNormalize.ts
+++ b/apps/server/src/usage/accountLimitsNormalize.ts
@@ -138,6 +138,14 @@ export function windowHasTraffic(window: AccountLimitsWindow): boolean {
 export interface ClaudeUsageSnapshot {
   readonly plan: string | null;
   readonly windows: AccountLimitsWindow[];
+  /**
+   * False when the account has no rate limits at all (API key / Bedrock /
+   * Vertex). An APPLICABLE snapshot can also come back with zero windows -
+   * every window untouched, e.g. right after a reset - and the two must not
+   * conflate: not-applicable keeps whatever was known, applicable-but-empty
+   * means the meters really are clear now.
+   */
+  readonly rateLimitsApply: boolean;
 }
 
 /**
@@ -148,7 +156,8 @@ export interface ClaudeUsageSnapshot {
 export function claudeUsageSnapshotFromUnknown(value: unknown): ClaudeUsageSnapshot | null {
   if (!isRecord(value)) return null;
   const rateLimits = value.rate_limits;
-  if (rateLimits === null) return { plan: readString(value.subscription_type), windows: [] };
+  if (rateLimits === null)
+    return { plan: readString(value.subscription_type), windows: [], rateLimitsApply: false };
   if (!isRecord(rateLimits)) return null;
 
   const windows = new Map<string, AccountLimitsWindow>();
@@ -173,6 +182,7 @@ export function claudeUsageSnapshotFromUnknown(value: unknown): ClaudeUsageSnaps
   return {
     plan: readString(value.subscription_type),
     windows: sortWindows([...windows.values()].filter(windowHasTraffic)),
+    rateLimitsApply: true,
   };
 }
 

--- a/apps/server/src/usage/accountLimitsNormalize.ts
+++ b/apps/server/src/usage/accountLimitsNormalize.ts
@@ -234,6 +234,12 @@ function claudeWindowFromLimitEntry(entry: unknown): AccountLimitsWindow | null 
  * Parses the streamed `rate_limit_event` SDK message into the one window it
  * names. Returns null for shapes that are not that message, and for windows
  * we hide.
+ *
+ * Units differ from the usage response: `rate_limit_info.utilization` mirrors
+ * the `anthropic-ratelimit-unified-*-utilization` response headers, which are
+ * a 0-1 fraction (`0.11` while the usage endpoint reports `12.0` for the same
+ * window at the same moment), so it is scaled here. Passing it through would
+ * show the binding window - the only one this message names - at 1/100th.
  */
 export function claudeWindowFromRateLimitEvent(value: unknown): AccountLimitsWindow | null {
   if (!isRecord(value)) return null;
@@ -248,7 +254,7 @@ export function claudeWindowFromRateLimitEvent(value: unknown): AccountLimitsWin
   return {
     id: meta.id,
     label: meta.label,
-    usedPercent: utilization === null ? 0 : clampPercent(utilization),
+    usedPercent: utilization === null ? 0 : clampPercent(utilization * 100),
     resetsAt: resetsAt === null ? null : isoFromUnixSeconds(resetsAt),
     windowMinutes: meta.minutes,
   };

--- a/apps/web/src/components/usage/AccountLimits.tsx
+++ b/apps/web/src/components/usage/AccountLimits.tsx
@@ -4,6 +4,13 @@
  * window a provider adds or brings back (Codex's paused 5-hour) appears
  * without a client change.
  *
+ * One block per provider; one row group per (environment, instance) under
+ * it. With a single row - the common case - nothing is captioned and the
+ * markup is identical to the single-account rendering. With several, each
+ * group is captioned with the instance's display name (and the environment
+ * label when more than one environment reports) so two accounts' numbers
+ * can never be mistaken for one another.
+ *
  * Every percentage is labelled `used` inline - a bare number cannot say
  * whether it is used or remaining. Snapshot age only renders once the data
  * is actually stale; fresh data needs no caption.
@@ -15,7 +22,7 @@ import { formatAgo, formatResetAt } from "@t3tools/shared/limitsFormat";
 import { useEffect, useState } from "react";
 
 import { cn } from "../../lib/utils";
-import { useAccountLimits } from "../../state/accountLimits";
+import { type AccountLimitsRow, useAccountLimits } from "../../state/accountLimits";
 import { PROVIDER_COLOR, PROVIDER_LABEL, PROVIDER_MARK, PROVIDER_ORDER } from "./usageProviders";
 
 /** Age past which a snapshot stops being "current" and earns a caption. */
@@ -63,23 +70,95 @@ function SnapshotAge({ snapshot, nowMs }: { snapshot: AccountLimitsSnapshot; now
   );
 }
 
+/** Stable key for one (environment, instance) row group. */
+function rowKey(row: AccountLimitsRow): string {
+  // The merge folds unkeyed snapshots onto the driver's default instance id,
+  // so the key must use the same spelling or an instance literally named
+  // "default" could collide with a legacy row.
+  const instanceId =
+    row.snapshot.instanceId ?? (row.snapshot.provider === "claude" ? "claudeAgent" : "codex");
+  return `${row.environmentId}:${instanceId}`;
+}
+
+/**
+ * "Work · laptop" - who a row group belongs to, shown only when a provider
+ * has more than one group and the numbers could otherwise be conflated.
+ */
+function RowCaption({
+  row,
+  nameEnvironment,
+  nowMs,
+  className,
+}: {
+  row: AccountLimitsRow;
+  nameEnvironment: boolean;
+  nowMs: number;
+  className: string;
+}) {
+  return (
+    <div className={cn("flex items-baseline gap-1.5", className)}>
+      <span className="truncate">
+        {row.instanceLabel}
+        {nameEnvironment && row.environmentLabel !== null ? ` · ${row.environmentLabel}` : ""}
+      </span>
+      <span className="ml-auto shrink-0">
+        <SnapshotAge snapshot={row.snapshot} nowMs={nowMs} />
+      </span>
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Sidebar hover card
 // ---------------------------------------------------------------------------
 
+function HoverWindowRow({
+  window,
+  color,
+  nowMs,
+}: {
+  window: AccountLimitsWindow;
+  color: string;
+  nowMs: number;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <span
+        className="w-9 shrink-0 truncate whitespace-nowrap text-[10px] text-muted-foreground"
+        title={window.label}
+      >
+        {window.label}
+      </span>
+      <LimitMeter window={window} color={color} />
+      <span
+        className={cn(
+          "shrink-0 whitespace-nowrap text-right text-[11px] tabular-nums text-foreground",
+          usageTone(window.usedPercent),
+        )}
+      >
+        {Math.round(window.usedPercent)}% used
+      </span>
+      <span className="shrink-0 whitespace-nowrap text-right text-[10px] tabular-nums text-muted-foreground">
+        {formatResetAt(window.resetsAt, nowMs) ?? ""}
+      </span>
+    </div>
+  );
+}
+
 /** Compact per-provider availability, shown on hovering the Usage button. */
 export function AccountLimitsHoverCard() {
-  const { snapshots, isPending, isSettling } = useAccountLimits();
+  const { byProvider, reportingEnvironments, isPending, isSettling } = useAccountLimits();
   const nowMs = useNowMs();
 
-  if (isPending && snapshots.size === 0) {
+  if (isPending && byProvider.size === 0) {
     return <p className="px-1 py-2 text-xs text-muted-foreground">Loading limits…</p>;
   }
 
   return (
     <div className="flex w-64 flex-col gap-2.5 p-1.5">
       {PROVIDER_ORDER.map((provider) => {
-        const snapshot = snapshots.get(provider);
+        const rows = byProvider.get(provider) ?? [];
+        const only = rows.length === 1 ? rows[0] : undefined;
         const Mark = PROVIDER_MARK[provider];
         return (
           <div key={provider} className="flex flex-col gap-1">
@@ -89,31 +168,40 @@ export function AccountLimitsHoverCard() {
                 {PROVIDER_LABEL[provider]}
               </span>
               <span className="ml-auto">
-                {snapshot !== undefined ? <SnapshotAge snapshot={snapshot} nowMs={nowMs} /> : null}
+                {only !== undefined ? <SnapshotAge snapshot={only.snapshot} nowMs={nowMs} /> : null}
               </span>
             </div>
-            {snapshot === undefined || snapshot.windows.length === 0 ? (
+            {rows.length === 0 || (only !== undefined && only.snapshot.windows.length === 0) ? (
               <p className="text-[11px] text-muted-foreground">
-                {snapshot === undefined && isSettling ? "Loading…" : "No limit data yet"}
+                {rows.length === 0 && isSettling ? "Loading…" : "No limit data yet"}
               </p>
+            ) : only !== undefined ? (
+              // Single group - the common case: same markup as one account.
+              only.snapshot.windows.map((window) => (
+                <HoverWindowRow
+                  key={window.id}
+                  window={window}
+                  color={PROVIDER_COLOR[provider]}
+                  nowMs={nowMs}
+                />
+              ))
             ) : (
-              snapshot.windows.map((window) => (
-                <div key={window.id} className="flex items-center gap-2">
-                  <span className="w-9 shrink-0 text-[10px] text-muted-foreground">
-                    {window.label}
-                  </span>
-                  <LimitMeter window={window} color={PROVIDER_COLOR[provider]} />
-                  <span
-                    className={cn(
-                      "shrink-0 whitespace-nowrap text-right text-[11px] tabular-nums text-foreground",
-                      usageTone(window.usedPercent),
-                    )}
-                  >
-                    {Math.round(window.usedPercent)}% used
-                  </span>
-                  <span className="shrink-0 whitespace-nowrap text-right text-[10px] tabular-nums text-muted-foreground">
-                    {formatResetAt(window.resetsAt, nowMs) ?? ""}
-                  </span>
+              rows.map((row) => (
+                <div key={rowKey(row)} className="flex flex-col gap-1">
+                  <RowCaption
+                    row={row}
+                    nameEnvironment={reportingEnvironments > 1}
+                    nowMs={nowMs}
+                    className="text-[10px] text-muted-foreground"
+                  />
+                  {row.snapshot.windows.map((window) => (
+                    <HoverWindowRow
+                      key={window.id}
+                      window={window}
+                      color={PROVIDER_COLOR[provider]}
+                      nowMs={nowMs}
+                    />
+                  ))}
                 </div>
               ))
             )}
@@ -128,9 +216,43 @@ export function AccountLimitsHoverCard() {
 // Usage page section
 // ---------------------------------------------------------------------------
 
+function SectionWindowRow({
+  window,
+  color,
+  nowMs,
+}: {
+  window: AccountLimitsWindow;
+  color: string;
+  nowMs: number;
+}) {
+  const resetAt = formatResetAt(window.resetsAt, nowMs);
+  return (
+    <div className="flex items-center gap-3">
+      <span
+        className="w-10 shrink-0 truncate whitespace-nowrap text-xs text-muted-foreground"
+        title={window.label}
+      >
+        {window.label}
+      </span>
+      <LimitMeter window={window} color={color} />
+      <span
+        className={cn(
+          "shrink-0 whitespace-nowrap text-right text-xs font-medium tabular-nums text-foreground",
+          usageTone(window.usedPercent),
+        )}
+      >
+        {Math.round(window.usedPercent)}% used
+      </span>
+      <span className="shrink-0 whitespace-nowrap text-right text-xs tabular-nums text-muted-foreground">
+        {resetAt === null ? "" : `resets ${resetAt}`}
+      </span>
+    </div>
+  );
+}
+
 /** The "Limits" strip above the analytics: one column per provider. */
 export function AccountLimitsSection() {
-  const { snapshots, isSettling } = useAccountLimits();
+  const { byProvider, reportingEnvironments, isSettling } = useAccountLimits();
   const nowMs = useNowMs();
 
   return (
@@ -138,7 +260,8 @@ export function AccountLimitsSection() {
       <h2 className="text-sm font-medium text-foreground">Limits</h2>
       <div className="grid gap-x-12 gap-y-4 sm:grid-cols-2">
         {PROVIDER_ORDER.map((provider) => {
-          const snapshot = snapshots.get(provider);
+          const rows = byProvider.get(provider) ?? [];
+          const only = rows.length === 1 ? rows[0] : undefined;
           const Mark = PROVIDER_MARK[provider];
           return (
             <div key={provider} className="flex flex-col gap-1.5">
@@ -148,38 +271,44 @@ export function AccountLimitsSection() {
                   {PROVIDER_LABEL[provider]}
                 </span>
                 <span className="ml-auto">
-                  {snapshot !== undefined ? (
-                    <SnapshotAge snapshot={snapshot} nowMs={nowMs} />
+                  {only !== undefined ? (
+                    <SnapshotAge snapshot={only.snapshot} nowMs={nowMs} />
                   ) : null}
                 </span>
               </div>
-              {snapshot === undefined || snapshot.windows.length === 0 ? (
+              {rows.length === 0 || (only !== undefined && only.snapshot.windows.length === 0) ? (
                 <p className="text-xs text-muted-foreground">
-                  {snapshot === undefined && isSettling ? "Loading…" : "No limit data yet"}
+                  {rows.length === 0 && isSettling ? "Loading…" : "No limit data yet"}
                 </p>
+              ) : only !== undefined ? (
+                // Single group - the common case: same markup as one account.
+                only.snapshot.windows.map((window) => (
+                  <SectionWindowRow
+                    key={window.id}
+                    window={window}
+                    color={PROVIDER_COLOR[provider]}
+                    nowMs={nowMs}
+                  />
+                ))
               ) : (
-                snapshot.windows.map((window) => {
-                  const resetAt = formatResetAt(window.resetsAt, nowMs);
-                  return (
-                    <div key={window.id} className="flex items-center gap-3">
-                      <span className="w-10 shrink-0 text-xs text-muted-foreground">
-                        {window.label}
-                      </span>
-                      <LimitMeter window={window} color={PROVIDER_COLOR[provider]} />
-                      <span
-                        className={cn(
-                          "shrink-0 whitespace-nowrap text-right text-xs font-medium tabular-nums text-foreground",
-                          usageTone(window.usedPercent),
-                        )}
-                      >
-                        {Math.round(window.usedPercent)}% used
-                      </span>
-                      <span className="shrink-0 whitespace-nowrap text-right text-xs tabular-nums text-muted-foreground">
-                        {resetAt === null ? "" : `resets ${resetAt}`}
-                      </span>
-                    </div>
-                  );
-                })
+                rows.map((row) => (
+                  <div key={rowKey(row)} className="flex flex-col gap-1.5">
+                    <RowCaption
+                      row={row}
+                      nameEnvironment={reportingEnvironments > 1}
+                      nowMs={nowMs}
+                      className="text-xs text-muted-foreground"
+                    />
+                    {row.snapshot.windows.map((window) => (
+                      <SectionWindowRow
+                        key={window.id}
+                        window={window}
+                        color={PROVIDER_COLOR[provider]}
+                        nowMs={nowMs}
+                      />
+                    ))}
+                  </div>
+                ))
               )}
             </div>
           );

--- a/apps/web/src/components/usage/AccountLimits.tsx
+++ b/apps/web/src/components/usage/AccountLimits.tsx
@@ -22,7 +22,11 @@ import { formatAgo, formatResetAt } from "@t3tools/shared/limitsFormat";
 import { useEffect, useState } from "react";
 
 import { cn } from "../../lib/utils";
-import { type AccountLimitsRow, useAccountLimits } from "../../state/accountLimits";
+import {
+  type AccountLimitsRow,
+  legacyInstanceIdFor,
+  useAccountLimits,
+} from "../../state/accountLimits";
 import { PROVIDER_COLOR, PROVIDER_LABEL, PROVIDER_MARK, PROVIDER_ORDER } from "./usageProviders";
 
 /** Age past which a snapshot stops being "current" and earns a caption. */
@@ -72,11 +76,9 @@ function SnapshotAge({ snapshot, nowMs }: { snapshot: AccountLimitsSnapshot; now
 
 /** Stable key for one (environment, instance) row group. */
 function rowKey(row: AccountLimitsRow): string {
-  // The merge folds unkeyed snapshots onto the driver's default instance id,
-  // so the key must use the same spelling or an instance literally named
-  // "default" could collide with a legacy row.
-  const instanceId =
-    row.snapshot.instanceId ?? (row.snapshot.provider === "claude" ? "claudeAgent" : "codex");
+  // The merge folds unkeyed snapshots onto the driver's default instance
+  // id, so the key must share the merge's own mapping.
+  const instanceId = row.snapshot.instanceId ?? legacyInstanceIdFor(row.snapshot.provider);
   return `${row.environmentId}:${instanceId}`;
 }
 
@@ -99,7 +101,7 @@ function RowCaption({
     <div className={cn("flex items-baseline gap-1.5", className)}>
       <span className="truncate">
         {row.instanceLabel}
-        {nameEnvironment && row.environmentLabel !== null ? ` · ${row.environmentLabel}` : ""}
+        {nameEnvironment ? ` · ${row.environmentLabel ?? row.environmentId}` : ""}
       </span>
       <span className="ml-auto shrink-0">
         <SnapshotAge snapshot={row.snapshot} nowMs={nowMs} />
@@ -194,14 +196,18 @@ export function AccountLimitsHoverCard() {
                     nowMs={nowMs}
                     className="text-[10px] text-muted-foreground"
                   />
-                  {row.snapshot.windows.map((window) => (
-                    <HoverWindowRow
-                      key={window.id}
-                      window={window}
-                      color={PROVIDER_COLOR[provider]}
-                      nowMs={nowMs}
-                    />
-                  ))}
+                  {row.snapshot.windows.length === 0 ? (
+                    <p className="text-[11px] text-muted-foreground">No limit data yet</p>
+                  ) : (
+                    row.snapshot.windows.map((window) => (
+                      <HoverWindowRow
+                        key={window.id}
+                        window={window}
+                        color={PROVIDER_COLOR[provider]}
+                        nowMs={nowMs}
+                      />
+                    ))
+                  )}
                 </div>
               ))
             )}
@@ -299,14 +305,18 @@ export function AccountLimitsSection() {
                       nowMs={nowMs}
                       className="text-xs text-muted-foreground"
                     />
-                    {row.snapshot.windows.map((window) => (
-                      <SectionWindowRow
-                        key={window.id}
-                        window={window}
-                        color={PROVIDER_COLOR[provider]}
-                        nowMs={nowMs}
-                      />
-                    ))}
+                    {row.snapshot.windows.length === 0 ? (
+                      <p className="text-xs text-muted-foreground">No limit data yet</p>
+                    ) : (
+                      row.snapshot.windows.map((window) => (
+                        <SectionWindowRow
+                          key={window.id}
+                          window={window}
+                          color={PROVIDER_COLOR[provider]}
+                          nowMs={nowMs}
+                        />
+                      ))
+                    )}
                   </div>
                 ))
               )}

--- a/apps/web/src/components/usage/AccountLimits.tsx
+++ b/apps/web/src/components/usage/AccountLimits.tsx
@@ -21,6 +21,7 @@ import type { AccountLimitsSnapshot, AccountLimitsWindow } from "@t3tools/contra
 import { formatAgo, formatResetAt } from "@t3tools/shared/limitsFormat";
 import { useEffect, useState } from "react";
 
+import { resolveEnvironmentOptionLabel } from "../BranchToolbar.logic";
 import { cn } from "../../lib/utils";
 import {
   type AccountLimitsRow,
@@ -101,7 +102,16 @@ function RowCaption({
     <div className={cn("flex items-baseline gap-1.5", className)}>
       <span className="truncate">
         {row.instanceLabel}
-        {nameEnvironment ? ` · ${row.environmentLabel ?? row.environmentId}` : ""}
+        {/* The shared option-label contract: blank labels normalize, and
+            the primary environment reads "This device" here exactly as it
+            does in the pickers. */}
+        {nameEnvironment
+          ? ` · ${resolveEnvironmentOptionLabel({
+              isPrimary: row.environmentIsPrimary,
+              environmentId: row.environmentId,
+              runtimeLabel: row.environmentLabel,
+            })}`
+          : ""}
       </span>
       <span className="ml-auto shrink-0">
         <SnapshotAge snapshot={row.snapshot} nowMs={nowMs} />

--- a/apps/web/src/state/accountLimits.test.ts
+++ b/apps/web/src/state/accountLimits.test.ts
@@ -34,6 +34,7 @@ const status = (
 ): EnvironmentLimitsStatus => ({
   environmentId: environmentId as EnvironmentId,
   environmentLabel: environmentId,
+  environmentIsPrimary: false,
   isPending: false,
   snapshots: [],
   providers: null,

--- a/apps/web/src/state/accountLimits.test.ts
+++ b/apps/web/src/state/accountLimits.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "@effect/vitest";
+import type {
+  AccountLimitsSnapshot,
+  EnvironmentId,
+  ServerProvider,
+  UsageProviderKind,
+} from "@t3tools/contracts";
+
+import { type EnvironmentLimitsStatus, mergeEnvironmentLimits } from "./accountLimits";
+
+const snapshot = (
+  provider: UsageProviderKind,
+  overrides: Partial<AccountLimitsSnapshot> = {},
+): AccountLimitsSnapshot => ({
+  provider,
+  plan: null,
+  windows: [],
+  asOf: "2026-08-15T12:00:00.000Z",
+  source: "live",
+  ...overrides,
+});
+
+const provider = (instanceId: string, overrides: Record<string, unknown> = {}) =>
+  ({ instanceId, auth: { status: "unknown" }, ...overrides }) as unknown as ServerProvider;
+
+const status = (
+  environmentId: string,
+  overrides: Partial<EnvironmentLimitsStatus> = {},
+): EnvironmentLimitsStatus => ({
+  environmentId: environmentId as EnvironmentId,
+  environmentLabel: environmentId,
+  isPending: false,
+  snapshots: [],
+  providers: null,
+  ...overrides,
+});
+
+describe("mergeEnvironmentLimits", () => {
+  it("rows differing only in content are not duplicates - the stamp alone must not collapse them", () => {
+    const window = (usedPercent: number) => ({
+      id: "seven_day",
+      label: "Week",
+      usedPercent,
+      resetsAt: null,
+      windowMinutes: 10080,
+    });
+    const merged = mergeEnvironmentLimits([
+      status("desktop", {
+        snapshots: [snapshot("codex", { windows: [window(10)] as never })],
+      }),
+      status("laptop", {
+        snapshots: [snapshot("codex", { windows: [window(90)] as never })],
+      }),
+    ]);
+    expect(merged.get("codex")?.map((row) => row.snapshot.windows[0]?.usedPercent)).toEqual([
+      10, 90,
+    ]);
+  });
+
+  it("a display name shared by two different instances falls back to instance ids", () => {
+    const merged = mergeEnvironmentLimits([
+      status("laptop", {
+        snapshots: [
+          snapshot("codex", { instanceId: "codex_a" as never }),
+          snapshot("codex", { instanceId: "codex_b" as never }),
+        ],
+        providers: [
+          provider("codex_a", { displayName: "Codex" }),
+          provider("codex_b", { displayName: "Codex" }),
+        ] as never,
+      }),
+    ]);
+    expect(merged.get("codex")?.map((row) => row.instanceLabel)).toEqual(["codex_a", "codex_b"]);
+  });
+
+  it("one instance seen from two environments keeps its shared display name", () => {
+    const rows = mergeEnvironmentLimits([
+      status("desktop", {
+        snapshots: [snapshot("codex", { instanceId: "codex_a" as never })],
+        providers: [provider("codex_a", { displayName: "Work" })] as never,
+      }),
+      status("laptop", {
+        snapshots: [
+          snapshot("codex", { instanceId: "codex_a" as never, asOf: "2026-08-15T13:00:00.000Z" }),
+        ],
+        providers: [provider("codex_a", { displayName: "Work" })] as never,
+      }),
+    ]).get("codex");
+    expect(rows?.map((row) => row.instanceLabel)).toEqual(["Work", "Work"]);
+  });
+
+  it("keeps one row per instance instead of collapsing a provider to one slot", () => {
+    const merged = mergeEnvironmentLimits([
+      status("laptop", {
+        snapshots: [
+          snapshot("codex", { instanceId: "codex_a" as never, asOf: "2026-08-15T12:00:01.000Z" }),
+          snapshot("codex", { instanceId: "codex_b" as never, asOf: "2026-08-15T12:00:02.000Z" }),
+        ],
+      }),
+    ]);
+    expect(merged.get("codex")?.map((row) => row.instanceLabel)).toEqual(["codex_a", "codex_b"]);
+  });
+
+  it("never dedupes across environments - clock skew must not delete a correct row", () => {
+    // Both environments run the default instance id. The desktop's clock is
+    // ahead; the laptop's row must survive anyway.
+    const merged = mergeEnvironmentLimits([
+      status("desktop", {
+        snapshots: [snapshot("codex", { asOf: "2026-08-15T12:00:09.000Z" })],
+      }),
+      status("laptop", {
+        snapshots: [snapshot("codex", { asOf: "2026-08-15T11:00:00.000Z" })],
+      }),
+    ]);
+    expect(merged.get("codex")?.map((row) => row.environmentId)).toEqual(["desktop", "laptop"]);
+  });
+
+  it("folds a legacy server's unkeyed snapshots onto the default instance, freshest wins", () => {
+    const merged = mergeEnvironmentLimits([
+      status("laptop", {
+        snapshots: [
+          snapshot("claude", { asOf: "2026-08-15T11:00:00.000Z" }),
+          snapshot("claude", {
+            instanceId: "claudeAgent" as never,
+            asOf: "2026-08-15T12:00:00.000Z",
+          }),
+        ],
+      }),
+    ]);
+    const rows = merged.get("claude") ?? [];
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.snapshot.asOf).toBe("2026-08-15T12:00:00.000Z");
+  });
+
+  it("collapses byte-identical rows reported by two environments on one machine", () => {
+    const twin = snapshot("codex", {
+      instanceId: "codex_a" as never,
+      asOf: "2026-08-15T12:00:05.000Z",
+    });
+    const merged = mergeEnvironmentLimits([
+      status("worktree-1", { snapshots: [twin] }),
+      status("worktree-2", { snapshots: [twin] }),
+    ]);
+    expect(merged.get("codex")).toHaveLength(1);
+  });
+
+  it("labels rows from the provider config already on the wire", () => {
+    const merged = mergeEnvironmentLimits([
+      status("laptop", {
+        providers: [
+          provider("claude_main", { displayName: "Claude Main" }),
+          // An authenticated email is deliberately NOT a label source: the
+          // provider UI blurs emails until clicked, and a caption must not
+          // leak what that redaction protects.
+          provider("claude_partner", {
+            auth: { status: "authenticated", email: "partner@example.com" },
+          }),
+        ],
+        snapshots: [
+          snapshot("claude", { instanceId: "claude_main" as never }),
+          snapshot("claude", { instanceId: "claude_partner" as never }),
+          snapshot("claude", { instanceId: "claude_unknown" as never }),
+        ],
+      }),
+    ]);
+    expect(merged.get("claude")?.map((row) => row.instanceLabel)).toEqual([
+      "Claude Main",
+      "claude_partner",
+      "claude_unknown",
+    ]);
+  });
+});

--- a/apps/web/src/state/accountLimits.test.ts
+++ b/apps/web/src/state/accountLimits.test.ts
@@ -21,7 +21,12 @@ const snapshot = (
 });
 
 const provider = (instanceId: string, overrides: Record<string, unknown> = {}) =>
-  ({ instanceId, auth: { status: "unknown" }, ...overrides }) as unknown as ServerProvider;
+  ({
+    instanceId,
+    driver: "codex",
+    auth: { status: "unknown" },
+    ...overrides,
+  }) as unknown as ServerProvider;
 
 const status = (
   environmentId: string,
@@ -57,6 +62,19 @@ describe("mergeEnvironmentLimits", () => {
     ]);
   });
 
+  it("unnamed instances caption with the app-wide humanized names", () => {
+    const merged = mergeEnvironmentLimits([
+      status("laptop", {
+        snapshots: [
+          snapshot("codex", { instanceId: "codex_a" as never }),
+          snapshot("codex", { instanceId: "codex_b" as never }),
+        ],
+        providers: [provider("codex_a"), provider("codex_b")] as never,
+      }),
+    ]);
+    expect(merged.get("codex")?.map((row) => row.instanceLabel)).toEqual(["Codex A", "Codex B"]);
+  });
+
   it("a display name shared by two different instances falls back to instance ids", () => {
     const merged = mergeEnvironmentLimits([
       status("laptop", {
@@ -65,8 +83,8 @@ describe("mergeEnvironmentLimits", () => {
           snapshot("codex", { instanceId: "codex_b" as never }),
         ],
         providers: [
-          provider("codex_a", { displayName: "Codex" }),
-          provider("codex_b", { displayName: "Codex" }),
+          provider("codex_a", { displayName: "Work" }),
+          provider("codex_b", { displayName: "Work" }),
         ] as never,
       }),
     ]);
@@ -148,11 +166,12 @@ describe("mergeEnvironmentLimits", () => {
     const merged = mergeEnvironmentLimits([
       status("laptop", {
         providers: [
-          provider("claude_main", { displayName: "Claude Main" }),
+          provider("claude_main", { driver: "claudeAgent", displayName: "Claude Main" }),
           // An authenticated email is deliberately NOT a label source: the
           // provider UI blurs emails until clicked, and a caption must not
           // leak what that redaction protects.
           provider("claude_partner", {
+            driver: "claudeAgent",
             auth: { status: "authenticated", email: "partner@example.com" },
           }),
         ],
@@ -165,7 +184,10 @@ describe("mergeEnvironmentLimits", () => {
     ]);
     expect(merged.get("claude")?.map((row) => row.instanceLabel)).toEqual([
       "Claude Main",
-      "claude_partner",
+      // Unnamed but configured: the app-wide resolver humanizes the id -
+      // and the authenticated email above is still not a label source.
+      "Claude Partner",
+      // Not in the provider config at all: nothing to resolve, raw id.
       "claude_unknown",
     ]);
   });

--- a/apps/web/src/state/accountLimits.ts
+++ b/apps/web/src/state/accountLimits.ts
@@ -38,6 +38,10 @@ export interface EnvironmentLimitsStatus {
   readonly environmentId: EnvironmentId;
   /** The environment's display label, for when several report. */
   readonly environmentLabel: string | null;
+  /** Whether this is the primary (local) environment - captions resolve
+   * environment names through the shared option-label contract, which
+   * needs it. */
+  readonly environmentIsPrimary: boolean;
   readonly isPending: boolean;
   readonly snapshots: readonly AccountLimitsSnapshot[] | null;
   /** Streamed provider config; the source of instance display names. */
@@ -53,6 +57,7 @@ const accountLimitsAtom = Atom.make((get): readonly EnvironmentLimitsStatus[] =>
     statuses.push({
       environmentId,
       environmentLabel: presentation.entry.target.label ?? null,
+      environmentIsPrimary: presentation.entry.target._tag === "PrimaryConnectionTarget",
       providers: presentation.serverConfig?.providers ?? null,
       isPending: result.waiting,
       snapshots:
@@ -68,6 +73,7 @@ const accountLimitsAtom = Atom.make((get): readonly EnvironmentLimitsStatus[] =>
 export interface AccountLimitsRow {
   readonly environmentId: EnvironmentId;
   readonly environmentLabel: string | null;
+  readonly environmentIsPrimary: boolean;
   /**
    * Instance display name off the provider config already streaming to the
    * client, else the raw instance id. Never the account email: the provider
@@ -137,6 +143,7 @@ export function mergeEnvironmentLimits(
       rows.push({
         environmentId: status.environmentId,
         environmentLabel: status.environmentLabel,
+        environmentIsPrimary: status.environmentIsPrimary,
         instanceLabel: entry?.displayName ?? instanceId,
         snapshot,
       });

--- a/apps/web/src/state/accountLimits.ts
+++ b/apps/web/src/state/accountLimits.ts
@@ -5,7 +5,11 @@
  * the client keeps ONE ROW PER (environment, provider, instance) and never
  * merges across environments: `asOf` comes from each environment's local
  * clock, and clock skew must not let one machine's reading replace another
- * machine's correct one. Within a single environment, a server predating
+ * machine's correct one. The one exception: byte-identical rows for the
+ * SAME instance id collapse, because identical content under one id is the
+ * same underlying reading seen twice (worktree servers sharing a home, two
+ * machines seeded from the same transcripts) and carries no extra
+ * information. Within a single environment, a server predating
  * instance attribution answers with unkeyed snapshots - those fold onto the
  * driver's default instance, freshest wins, which is exactly what that data
  * meant when it was written.
@@ -15,6 +19,7 @@
 import { useAtomValue } from "@effect/atom-react";
 import {
   ACCOUNT_LIMITS_ACCEPTED_VERSIONS,
+  ProviderInstanceId,
   type AccountLimitsSnapshot,
   type EnvironmentId,
   type ServerProvider,
@@ -24,6 +29,7 @@ import * as Option from "effect/Option";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
 import { useCallback, useMemo } from "react";
 
+import { getProviderInstanceEntry } from "../providerInstances";
 import { appAtomRegistry } from "../rpc/atomRegistry";
 import { environmentPresentations } from "./presentation";
 import { serverEnvironment } from "./server";
@@ -74,7 +80,7 @@ export interface AccountLimitsRow {
 }
 
 /** What an unkeyed (pre-instance-attribution) snapshot always meant. */
-const legacyInstanceIdFor = (provider: UsageProviderKind): string =>
+export const legacyInstanceIdFor = (provider: UsageProviderKind): string =>
   provider === "claude" ? "claudeAgent" : "codex";
 
 /**
@@ -119,12 +125,19 @@ export function mergeEnvironmentLimits(
       ]);
       if (seen.has(duplicateKey)) continue;
       seen.add(duplicateKey);
-      const provider = status.providers?.find((candidate) => candidate.instanceId === instanceId);
+      // Resolve the caption through the app-wide instance display-name
+      // contract (explicit name wins, non-default ids humanize, defaults
+      // keep the brand label), so Limits names accounts the same way the
+      // picker and provider settings do.
+      const entry = getProviderInstanceEntry(
+        status.providers ?? [],
+        ProviderInstanceId.make(instanceId),
+      );
       const rows = byProvider.get(snapshot.provider) ?? [];
       rows.push({
         environmentId: status.environmentId,
         environmentLabel: status.environmentLabel,
-        instanceLabel: provider?.displayName ?? instanceId,
+        instanceLabel: entry?.displayName ?? instanceId,
         snapshot,
       });
       byProvider.set(snapshot.provider, rows);

--- a/apps/web/src/state/accountLimits.ts
+++ b/apps/web/src/state/accountLimits.ts
@@ -1,17 +1,23 @@
 /**
  * Multi-environment account-limits state.
  *
- * Every connected environment reports its cached snapshot per provider; the
- * client keeps the freshest one per provider. Environments on the same
- * machine answer with identical data, so freshest-wins is also the dedupe.
+ * Every connected environment reports one snapshot per provider instance;
+ * the client keeps ONE ROW PER (environment, provider, instance) and never
+ * merges across environments: `asOf` comes from each environment's local
+ * clock, and clock skew must not let one machine's reading replace another
+ * machine's correct one. Within a single environment, a server predating
+ * instance attribution answers with unkeyed snapshots - those fold onto the
+ * driver's default instance, freshest wins, which is exactly what that data
+ * meant when it was written.
  *
  * @module state/accountLimits
  */
 import { useAtomValue } from "@effect/atom-react";
 import {
-  ACCOUNT_LIMITS_CONTRACT_VERSION,
+  ACCOUNT_LIMITS_ACCEPTED_VERSIONS,
   type AccountLimitsSnapshot,
   type EnvironmentId,
+  type ServerProvider,
   type UsageProviderKind,
 } from "@t3tools/contracts";
 import * as Option from "effect/Option";
@@ -22,23 +28,29 @@ import { appAtomRegistry } from "../rpc/atomRegistry";
 import { environmentPresentations } from "./presentation";
 import { serverEnvironment } from "./server";
 
-interface EnvironmentLimitsStatus {
+export interface EnvironmentLimitsStatus {
   readonly environmentId: EnvironmentId;
+  /** The environment's display label, for when several report. */
+  readonly environmentLabel: string | null;
   readonly isPending: boolean;
   readonly snapshots: readonly AccountLimitsSnapshot[] | null;
+  /** Streamed provider config; the source of instance display names. */
+  readonly providers: readonly ServerProvider[] | null;
 }
 
 const accountLimitsAtom = Atom.make((get): readonly EnvironmentLimitsStatus[] => {
   const presentations = get(environmentPresentations.presentationsAtom);
   const statuses: EnvironmentLimitsStatus[] = [];
-  for (const [environmentId] of presentations) {
+  for (const [environmentId, presentation] of presentations) {
     const result = get(serverEnvironment.accountLimits({ environmentId, input: {} }));
     const summary = Option.getOrNull(AsyncResult.value(result));
     statuses.push({
       environmentId,
+      environmentLabel: presentation.entry.target.label ?? null,
+      providers: presentation.serverConfig?.providers ?? null,
       isPending: result.waiting,
       snapshots:
-        summary === null || summary.contractVersion !== ACCOUNT_LIMITS_CONTRACT_VERSION
+        summary === null || !ACCOUNT_LIMITS_ACCEPTED_VERSIONS.includes(summary.contractVersion)
           ? null
           : summary.snapshots,
     });
@@ -46,9 +58,119 @@ const accountLimitsAtom = Atom.make((get): readonly EnvironmentLimitsStatus[] =>
   return statuses;
 }).pipe(Atom.withLabel("web-account-limits"));
 
+/** One rendered limits row: a provider instance seen from one environment. */
+export interface AccountLimitsRow {
+  readonly environmentId: EnvironmentId;
+  readonly environmentLabel: string | null;
+  /**
+   * Instance display name off the provider config already streaming to the
+   * client, else the raw instance id. Never the account email: the provider
+   * UI deliberately blurs emails until clicked, and a caption must not leak
+   * what that redaction protects. Rendering decides when a caption is worth
+   * showing.
+   */
+  readonly instanceLabel: string;
+  readonly snapshot: AccountLimitsSnapshot;
+}
+
+/** What an unkeyed (pre-instance-attribution) snapshot always meant. */
+const legacyInstanceIdFor = (provider: UsageProviderKind): string =>
+  provider === "claude" ? "claudeAgent" : "codex";
+
+/**
+ * Pure merge, exported for tests: dedupe freshest-wins per instance WITHIN
+ * an environment, never across environments (see module doc), grouped per
+ * provider for rendering.
+ */
+export function mergeEnvironmentLimits(
+  statuses: readonly EnvironmentLimitsStatus[],
+): ReadonlyMap<UsageProviderKind, readonly AccountLimitsRow[]> {
+  const byProvider = new Map<UsageProviderKind, AccountLimitsRow[]>();
+  // Two environments on one machine (worktree servers) can hold identical
+  // snapshots. Byte-identical rows carry no extra information, so exact
+  // duplicates collapse; rows that differ at all - clocks included - stay,
+  // because cross-environment freshness cannot be arbitrated (see module doc).
+  const seen = new Set<string>();
+  for (const status of statuses) {
+    const byInstance = new Map<string, AccountLimitsSnapshot>();
+    for (const snapshot of status.snapshots ?? []) {
+      const key = JSON.stringify([
+        snapshot.provider,
+        snapshot.instanceId ?? legacyInstanceIdFor(snapshot.provider),
+      ]);
+      const current = byInstance.get(key);
+      // ISO-8601 strings order lexicographically.
+      if (current === undefined || snapshot.asOf > current.asOf) {
+        byInstance.set(key, snapshot);
+      }
+    }
+    for (const snapshot of byInstance.values()) {
+      const instanceId = snapshot.instanceId ?? legacyInstanceIdFor(snapshot.provider);
+      // "Byte-identical" must mean the whole row: keying on the stamp alone
+      // would let two environments' same-instant-but-different readings
+      // collapse into one, silently deleting a real account's numbers.
+      const duplicateKey = JSON.stringify([
+        snapshot.provider,
+        instanceId,
+        snapshot.asOf,
+        snapshot.source,
+        snapshot.plan,
+        snapshot.windows,
+      ]);
+      if (seen.has(duplicateKey)) continue;
+      seen.add(duplicateKey);
+      const provider = status.providers?.find((candidate) => candidate.instanceId === instanceId);
+      const rows = byProvider.get(snapshot.provider) ?? [];
+      rows.push({
+        environmentId: status.environmentId,
+        environmentLabel: status.environmentLabel,
+        instanceLabel: provider?.displayName ?? instanceId,
+        snapshot,
+      });
+      byProvider.set(snapshot.provider, rows);
+    }
+  }
+  for (const rows of byProvider.values()) {
+    // A display name shared by two DIFFERENT instances identifies nothing -
+    // two unnamed Codex accounts must not both caption as "Codex". Those
+    // rows fall back to their raw instance id, which is unique per
+    // environment. Rows sharing one instance across environments keep the
+    // shared name; the environment label disambiguates them in rendering.
+    const instancesPerLabel = new Map<string, Set<string>>();
+    for (const row of rows) {
+      const instanceId = row.snapshot.instanceId ?? legacyInstanceIdFor(row.snapshot.provider);
+      const ids = instancesPerLabel.get(row.instanceLabel) ?? new Set<string>();
+      ids.add(instanceId);
+      instancesPerLabel.set(row.instanceLabel, ids);
+    }
+    for (let index = 0; index < rows.length; index++) {
+      const row = rows[index];
+      if (row === undefined) continue;
+      if ((instancesPerLabel.get(row.instanceLabel)?.size ?? 0) > 1) {
+        rows[index] = {
+          ...row,
+          instanceLabel: row.snapshot.instanceId ?? legacyInstanceIdFor(row.snapshot.provider),
+        };
+      }
+    }
+    rows.sort(
+      (a, b) =>
+        a.instanceLabel.localeCompare(b.instanceLabel) ||
+        a.environmentId.localeCompare(b.environmentId),
+    );
+  }
+  return byProvider;
+}
+
 export interface AccountLimitsView {
-  /** Freshest snapshot per provider, in no particular order. */
-  readonly snapshots: ReadonlyMap<UsageProviderKind, AccountLimitsSnapshot>;
+  /**
+   * Rows grouped per provider. Several rows under one provider mean several
+   * instances (or several environments), each labeled; most setups have
+   * exactly one.
+   */
+  readonly byProvider: ReadonlyMap<UsageProviderKind, readonly AccountLimitsRow[]>;
+  /** Environments that have answered - >1 means rows need their environment named. */
+  readonly reportingEnvironments: number;
   /** True until at least one environment has answered. */
   readonly isPending: boolean;
   /**
@@ -63,19 +185,7 @@ export interface AccountLimitsView {
 export function useAccountLimits(): AccountLimitsView {
   const environments = useAtomValue(accountLimitsAtom);
 
-  const snapshots = useMemo(() => {
-    const freshest = new Map<UsageProviderKind, AccountLimitsSnapshot>();
-    for (const environment of environments) {
-      for (const snapshot of environment.snapshots ?? []) {
-        const current = freshest.get(snapshot.provider);
-        // ISO-8601 strings order lexicographically.
-        if (current === undefined || snapshot.asOf > current.asOf) {
-          freshest.set(snapshot.provider, snapshot);
-        }
-      }
-    }
-    return freshest;
-  }, [environments]);
+  const byProvider = useMemo(() => mergeEnvironmentLimits(environments), [environments]);
 
   const refresh = useCallback(() => {
     for (const environment of environments) {
@@ -91,7 +201,8 @@ export function useAccountLimits(): AccountLimitsView {
   ).length;
 
   return {
-    snapshots,
+    byProvider,
+    reportingEnvironments: answered,
     isPending: answered === 0 && stillReporting > 0,
     isSettling: stillReporting > 0,
     refresh,

--- a/packages/contracts/src/accountLimits.ts
+++ b/packages/contracts/src/accountLimits.ts
@@ -4,8 +4,9 @@
  * Providers meter subscription usage in rolling windows (Claude: 5-hour and
  * weekly; Codex: weekly today, 5-hour whenever OpenAI turns it back on). Each
  * environment folds whatever the provider streams into one snapshot per
- * provider account and serves it here; the client merges environments and
- * keeps the freshest snapshot per provider.
+ * provider instance and serves it here; the client keeps one row per
+ * (environment, provider, instance) and never merges across environments -
+ * two machines' clocks cannot arbitrate freshness for each other.
  *
  * Windows are data, not schema: the set a provider reports changes without
  * notice (Codex paused its 5-hour window, Claude added model-scoped
@@ -17,14 +18,22 @@
 import * as Schema from "effect/Schema";
 
 import { TrimmedNonEmptyString } from "./baseSchemas.ts";
+import { ProviderInstanceId } from "./providerInstance.ts";
 import { UsageProviderKind } from "./usage.ts";
 
 /**
  * Bumped whenever the shape of {@link AccountLimitsSummary} changes
  * incompatibly. The client skips summaries reporting another version rather
  * than failing the merge.
+ *
+ * v1: at most one snapshot per provider, no `instanceId`.
+ * v2: at most one snapshot per provider instance. A v2-aware client also
+ * accepts v1 summaries (folding them onto the driver's default instance);
+ * a v1 client skips v2 summaries entirely - showing nothing beats showing
+ * one instance's numbers as the whole provider's.
  */
-export const ACCOUNT_LIMITS_CONTRACT_VERSION = 1 as const;
+export const ACCOUNT_LIMITS_CONTRACT_VERSION = 2 as const;
+export const ACCOUNT_LIMITS_ACCEPTED_VERSIONS: readonly number[] = [1, 2];
 
 export const AccountLimitsWindow = Schema.Struct({
   /**
@@ -51,6 +60,16 @@ export type AccountLimitsSource = typeof AccountLimitsSource.Type;
 
 export const AccountLimitsSnapshot = Schema.Struct({
   provider: UsageProviderKind,
+  /**
+   * Routing key of the provider instance these windows were observed on.
+   * Instances are the closest account identity every rate-limit event
+   * already carries: two instances logged into different accounts must not
+   * overwrite each other, and two logged into the same account simply show
+   * the same numbers. Optional on the wire so summaries from servers that
+   * predate instance attribution still decode; consumers treat an absent
+   * value as the driver's default instance.
+   */
+  instanceId: Schema.optional(ProviderInstanceId),
   /** Provider plan slug ("max", "pro"), when known. */
   plan: Schema.NullOr(TrimmedNonEmptyString),
   windows: Schema.Array(AccountLimitsWindow),
@@ -73,7 +92,10 @@ export type AccountLimitsSnapshot = typeof AccountLimitsSnapshot.Type;
 export const AccountLimitsSummary = Schema.Struct({
   contractVersion: Schema.Number,
   readAt: Schema.String,
-  /** At most one snapshot per provider. Empty until a session has reported. */
+  /**
+   * At most one snapshot per provider instance. Empty until a session has
+   * reported.
+   */
   snapshots: Schema.Array(AccountLimitsSnapshot),
 });
 export type AccountLimitsSummary = typeof AccountLimitsSummary.Type;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5156,10 +5156,12 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@yuuang/ffi-rs-android-arm64@1.3.2':
     resolution: {integrity: sha512-eDYLT0kVBkp7e2BwdRDmt6N1rkeDPUHDefk3ZX0/nok+GLsqfy1WBoSL3Yg7HVXN1EyW8OBVc2uK8Zq8HbmaSA==}


### PR DESCRIPTION
## What Changed

With more than one Claude or Codex instance configured, the account-limits cache keeps one snapshot per provider, so accounts overwrite each other - the multi-account report on #5739. Snapshots are now keyed by `(provider, instanceId)`, using the `providerInstanceId` already on every event envelope (ingestion was dropping it; no adapter changes).

Roughly 810 of these lines are source (after the review-fix commits); the rest is tests.

Server:
- Ordering guards and window patching are per instance, so one account's traffic can't suppress or roll back another's.
- v1 cache rows migrate to the driver's default instance. A migrated row is evicted once live data for a different instance shows it may belong to somebody else, and it's persisted back in its v1 shape until then, so that eviction still works after a restart.
- Transcript seeding enumerates instances the way the registry derives them (the previous read only saw the legacy `settings.providers.codex`), follows the `CODEX_HOME` the spawned CLI would actually use when no `homePath` is set, compares sessions dirs by filesystem identity, and seeds only dirs owned by exactly one enabled instance. A dir shared by several instances has no honest owner and is skipped - live events still meter those instances.
- Rows are dropped when their instance is deleted or reconfigured to a different driver; a disabled instance's row is hidden until it's re-enabled.
- `ACCOUNT_LIMITS_CONTRACT_VERSION` -> 2: a v1 client would merge per-instance snapshots freshest-wins per provider - the same bug on the mixed-version path - so it skips v2 summaries.

Client:
- One row per `(environment, provider, instance)`, never merged across environments (their clocks can't arbitrate each other's freshness). Duplicate collapse across same-machine environments keys on the full row content, not just the timestamp.
- Rows get an instance-name caption only when there's something to disambiguate; two unnamed instances of one provider fall back to their instance ids instead of both captioning as the provider name.
- With a single account the markup is identical to the current rendering.

Second commit, separable: windows the provider has never metered (0% used, no reset clock) no longer render. They were showing as a permanent bare 0% row on every Claude card. Happy to drop this commit if you'd rather take it separately.

## Why

Reproduced with real accounts on this branch - three Codex instances sharing one `homePath` with distinct `shadowHomePath`s, plus two Claude instances.

One transcript-seeded "Codex" row presented as all three instances' limits before any session ran:

![before: codex seeded from shared transcripts](https://raw.githubusercontent.com/derektrimm/t3code/receipts/limits-attribution/receipts/before-codex-seeded.png)

The single Claude block silently flipping accounts between turns - the 5h reset moves 15:10 -> 12:19 and the weekly reset 8/21 -> 8/20:

![before: after a turn on the first account](https://raw.githubusercontent.com/derektrimm/t3code/receipts/limits-attribution/receipts/before-after-main.png)
![before: after a turn on the second account](https://raw.githubusercontent.com/derektrimm/t3code/receipts/limits-attribution/receipts/before-after-partner.png)

## UI Changes

After - the same accounts, each metered under its own name; the shared transcript dir no longer seeded; single-account setups unchanged:

![after: per-instance attribution](https://raw.githubusercontent.com/derektrimm/t3code/receipts/limits-attribution/receipts/after-attribution.png)

**Video - multi-account limits, live:** the Usage page Limits section with two Codex and two Claude accounts reporting independently (stale snapshots carry their age captions), then the sidebar hover card showing the same per-account rows. Recorded on this branch against real account data.

https://github.com/user-attachments/assets/4ef0e3c6-b341-44c5-a9b0-6ab90d2ef864


## Checklist

- [x] `vp test run` on the touched files - 86 passing (attribution keying and ordering, v1 migration incl. the restart case, deleted/disabled/reconfigured-instance eviction, seed planning incl. shared and disabled dirs, live seed attribution against fabricated transcripts, ingestion forwarding via a recording layer, client merge)
- [x] Scoped `typecheck` clean for `t3`, `@t3tools/web`, `@t3tools/contracts`; `vp fmt` clean; scoped `vp lint` clean
- [x] Before/after screenshots captured live on this branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persisted account-limits cache migration, a contract version bump (v1 clients skip v2 summaries), and transcript-seed attribution. Wrong eviction or merge logic can hide or mislabel usage for real accounts.
> 
> **Overview**
> Stops multi-account setups from sharing one rate-limit slot per provider. Snapshots are now keyed by `(provider, instanceId)`, ingestion forwards `providerInstanceId`, and the contract is **v2** (v1 clients skip v2 rather than merge freshest-wins).
> 
> **Server:** ordering and Claude window patches are per instance. Legacy cache rows load on the default instance, stay unconfirmed on disk until a write settles them, and are evicted if another instance of the same provider reports first. Codex transcript seeding enumerates instances, follows the CLI’s real home (`CODEX_HOME` vs shadow overlay), and only seeds **sole-owner** sessions dirs. Deleted/driver-flipped rows are dropped; disabled instances are hidden.
> 
> **Client:** one row per `(environment, provider, instance)` with captions only when there is more than one group. Duplicate collapse is content-based, never across clocks. Single-account markup is unchanged.
> 
> Also drops **untouched** windows (0% and no reset) so Claude cards no longer show permanent empty 0% rows, and scales streamed Claude utilization from a 0–1 fraction to percent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b79b0f0385c649dea5293cb5c2d7622843fdae9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Attribute account limits per provider instance in `AccountLimitsService`
> - Refactors `AccountLimitsService` to cache and ingest snapshots per (provider, instance), migrating legacy v1 rows to a default instance and evicting ambiguous rows on new writes.
> - Extends `AccountLimitsSnapshot` contract with optional `instanceId` and bumps `ACCOUNT_LIMITS_CONTRACT_VERSION` to 2, accepting both v1 and v2.
> - Updates the web UI (`useAccountLimits` and `AccountLimits` components) to group and display limits by environment, provider, and instance.
> - Reworks Codex transcript seeding to target enabled instances with sole ownership of a sessions directory, skipping shared or disabled directories.
> - Risk: `claudeWindowFromRateLimitEvent` now scales `utilization` from a 0-1 fraction to 0-100 percent, and parsers drop untouched windows via the new `windowHasTraffic` filter.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b79b0f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


