### PR TITLE
Draft: teleport backend — import/export engine

### DIFF
--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -123,6 +123,9 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.subscribeServerLifecycle]: AuthOrchestrationReadScope,
   [WS_METHODS.subscribeAuthAccess]: AuthAccessReadScope,
   [WS_METHODS.subscribeBackgroundPolicy]: AuthOrchestrationReadScope,
+  [WS_METHODS.teleportListSessions]: AuthOrchestrationReadScope,
+  [WS_METHODS.teleportImportSessions]: AuthOrchestrationOperateScope,
+  [WS_METHODS.teleportExportSession]: AuthOrchestrationOperateScope,
 } as const satisfies Readonly<Record<WsRpcMethod, AuthEnvironmentScope>>;
 
 export function requiredScopeForRpcMethod(method: string): AuthEnvironmentScope {

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -628,6 +628,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             pendingUserInputCount: 0,
             hasActionableProposedPlan: 0,
             deletedAt: null,
+            teleport: null,
           });
           return;
 
@@ -850,9 +851,25 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           return;
         }
 
+        case "thread.teleported": {
+          const existingRow = yield* projectionThreadRepository.getById({
+            threadId: event.payload.threadId,
+          });
+          if (Option.isNone(existingRow)) {
+            return;
+          }
+          yield* projectionThreadRepository.upsert({
+            ...existingRow.value,
+            teleport: event.payload.teleport,
+            updatedAt: event.payload.updatedAt,
+          });
+          return;
+        }
+
         case "thread.message-sent":
         case "thread.proposed-plan-upserted":
         case "thread.activity-appended":
+        case "thread.history-replaced":
         case "thread.approval-response-requested":
         case "thread.user-input-response-requested": {
           const existingRow = yield* projectionThreadRepository.getById({
@@ -1019,6 +1036,31 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           return;
         }
 
+        case "thread.history-replaced": {
+          yield* projectionThreadMessageRepository.deleteByThreadId({
+            threadId: event.payload.threadId,
+          });
+          yield* Effect.forEach(
+            event.payload.messages,
+            (message) =>
+              projectionThreadMessageRepository.upsert({
+                messageId: message.id,
+                threadId: event.payload.threadId,
+                turnId: message.turnId,
+                role: message.role,
+                text: message.text,
+                ...(message.attachments !== undefined
+                  ? { attachments: [...message.attachments] }
+                  : {}),
+                isStreaming: message.streaming,
+                createdAt: message.createdAt,
+                updatedAt: message.updatedAt,
+              }),
+            { concurrency: 1 },
+          ).pipe(Effect.asVoid);
+          return;
+        }
+
         default:
           return;
       }
@@ -1038,6 +1080,12 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             implementationThreadId: event.payload.proposedPlan.implementationThreadId,
             createdAt: event.payload.proposedPlan.createdAt,
             updatedAt: event.payload.proposedPlan.updatedAt,
+          });
+          return;
+
+        case "thread.history-replaced":
+          yield* projectionThreadProposedPlanRepository.deleteByThreadId({
+            threadId: event.payload.threadId,
           });
           return;
 
@@ -1092,6 +1140,12 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
               ? { sequence: event.payload.activity.sequence }
               : {}),
             createdAt: event.payload.activity.createdAt,
+          });
+          return;
+
+        case "thread.history-replaced":
+          yield* projectionThreadActivityRepository.deleteByThreadId({
+            threadId: event.payload.threadId,
           });
           return;
 
@@ -1447,6 +1501,12 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           });
           return;
         }
+
+        case "thread.history-replaced":
+          yield* projectionTurnRepository.deleteByThreadId({
+            threadId: event.payload.threadId,
+          });
+          return;
 
         case "thread.reverted": {
           const existingTurns = yield* projectionTurnRepository.listByThreadId({

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -2335,4 +2335,62 @@ projectionSnapshotLayer("ProjectionSnapshotQuery windowed thread detail", (it) =
       }
     }),
   );
+
+  it.effect("hydrates teleport presence onto thread detail and shell snapshots", () =>
+    Effect.gen(function* () {
+      const snapshotQuery = yield* ProjectionSnapshotQuery;
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* sql`DELETE FROM projection_projects`;
+      yield* sql`DELETE FROM projection_threads`;
+      yield* sql`DELETE FROM projection_state`;
+
+      yield* sql`
+        INSERT INTO projection_projects (
+          project_id, title, workspace_root, scripts_json, created_at, updated_at, deleted_at
+        )
+        VALUES (
+          'project-teleport', 'Teleport', '/tmp/project-teleport', '[]',
+          '2026-08-14T00:00:00.000Z', '2026-08-14T00:00:00.000Z', NULL
+        )
+      `;
+      yield* sql`
+        INSERT INTO projection_threads (
+          thread_id, project_id, title, model_selection_json, runtime_mode, interaction_mode,
+          pending_approval_count, pending_user_input_count, has_actionable_proposed_plan,
+          created_at, updated_at, deleted_at, teleport_json
+        )
+        VALUES (
+          'thread-teleport', 'project-teleport', 'Native thread',
+          '{"provider":"grok","model":"grok-4"}', 'full-access', 'default',
+          0, 0, 0, '2026-08-14T00:00:00.000Z', '2026-08-14T00:00:00.000Z', NULL,
+          '{"presence":"native","provider":"grok","externalSessionId":"session-1","nativePath":"/tmp/native","lastSyncedAt":"2026-08-14T00:00:01.000Z"}'
+        )
+      `;
+      for (const projector of Object.values(ORCHESTRATION_PROJECTOR_NAMES)) {
+        yield* sql`
+          INSERT INTO projection_state (projector, last_applied_sequence, updated_at)
+          VALUES (${projector}, 1, '2026-08-14T00:00:01.000Z')
+        `;
+      }
+
+      const expectedTeleport = {
+        presence: "native",
+        provider: "grok",
+        externalSessionId: "session-1",
+        nativePath: "/tmp/native",
+        lastSyncedAt: "2026-08-14T00:00:01.000Z",
+      };
+      const detail = yield* snapshotQuery.getThreadDetailById(ThreadId.make("thread-teleport"));
+      assert.equal(detail._tag, "Some");
+      if (detail._tag === "Some") {
+        assert.deepEqual(detail.value.teleport, expectedTeleport);
+      }
+      const shell = yield* snapshotQuery.getThreadShellById(ThreadId.make("thread-teleport"));
+      assert.equal(shell._tag, "Some");
+      if (shell._tag === "Some") {
+        assert.deepEqual(shell.value.teleport, expectedTeleport);
+      }
+    }),
+  );
 });

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -24,6 +24,7 @@ import {
   type OrchestrationThreadShell,
   ModelSelection,
   ProjectId,
+  TeleportThreadState,
   ThreadId,
 } from "@t3tools/contracts";
 import * as Arr from "effect/Array";
@@ -85,6 +86,9 @@ const ProjectionThreadProposedPlanDbRowSchema = ProjectionThreadProposedPlan;
 const ProjectionThreadDbRowSchema = ProjectionThread.mapFields(
   Struct.assign({
     modelSelection: Schema.fromJsonString(ModelSelection),
+    teleport: Schema.NullOr(Schema.fromJsonString(TeleportThreadState)).pipe(
+      Schema.withDecodingDefault(Effect.succeed(null)),
+    ),
   }),
 );
 const ProjectionThreadActivityDbRowSchema = ProjectionThreadActivity.mapFields(
@@ -434,7 +438,8 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           pending_approval_count AS "pendingApprovalCount",
           pending_user_input_count AS "pendingUserInputCount",
           has_actionable_proposed_plan AS "hasActionableProposedPlan",
-          deleted_at AS "deletedAt"
+          deleted_at AS "deletedAt",
+          teleport_json AS "teleport"
         FROM projection_threads
         ORDER BY created_at ASC, thread_id ASC
       `,
@@ -470,7 +475,8 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           pending_approval_count AS "pendingApprovalCount",
           pending_user_input_count AS "pendingUserInputCount",
           has_actionable_proposed_plan AS "hasActionableProposedPlan",
-          deleted_at AS "deletedAt"
+          deleted_at AS "deletedAt",
+          teleport_json AS "teleport"
         FROM projection_threads
         WHERE deleted_at IS NULL
           AND archived_at IS NULL
@@ -508,7 +514,8 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           pending_approval_count AS "pendingApprovalCount",
           pending_user_input_count AS "pendingUserInputCount",
           has_actionable_proposed_plan AS "hasActionableProposedPlan",
-          deleted_at AS "deletedAt"
+          deleted_at AS "deletedAt",
+          teleport_json AS "teleport"
         FROM projection_threads
         WHERE deleted_at IS NULL
           AND archived_at IS NOT NULL
@@ -950,7 +957,8 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           pending_approval_count AS "pendingApprovalCount",
           pending_user_input_count AS "pendingUserInputCount",
           has_actionable_proposed_plan AS "hasActionableProposedPlan",
-          deleted_at AS "deletedAt"
+          deleted_at AS "deletedAt",
+          teleport_json AS "teleport"
         FROM projection_threads
         WHERE thread_id = ${threadId}
           AND deleted_at IS NULL
@@ -1129,7 +1137,9 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
             'thread.activity-appended',
             'thread.turn-diff-completed',
             'thread.reverted',
-            'thread.session-set'
+            'thread.session-set',
+            'thread.history-replaced',
+            'thread.teleported'
           )
       `,
   });
@@ -1584,6 +1594,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                 activities: activitiesByThread.get(row.threadId) ?? [],
                 checkpoints: checkpointsByThread.get(row.threadId) ?? [],
                 session: sessionsByThread.get(row.threadId) ?? null,
+                ...(row.teleport == null ? {} : { teleport: row.teleport }),
               }));
 
               const snapshot = {
@@ -1791,6 +1802,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                   activities: [],
                   checkpoints: [],
                   session: sessionByThread.get(row.threadId) ?? null,
+                  ...(row.teleport == null ? {} : { teleport: row.teleport }),
                 });
               }
 
@@ -1930,6 +1942,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                         row.threadId,
                       ),
                       planProgress: threadPlanProgress.getThreadPlanProgress(row.threadId),
+                      ...(row.teleport == null ? {} : { teleport: row.teleport }),
                     } satisfies OrchestrationThreadShell)
                   : Result.failVoid,
               ),
@@ -2354,6 +2367,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           threadRow.value.threadId,
         ),
         planProgress: threadPlanProgress.getThreadPlanProgress(threadRow.value.threadId),
+        ...(threadRow.value.teleport == null ? {} : { teleport: threadRow.value.teleport }),
       } satisfies OrchestrationThreadShell);
     });
 
@@ -2508,6 +2522,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           completedAt: row.completedAt,
         })),
         session: Option.isSome(sessionRow) ? mapSessionRow(sessionRow.value) : null,
+        ...(threadRow.value.teleport == null ? {} : { teleport: threadRow.value.teleport }),
       };
 
       return Option.some(

--- a/apps/server/src/orchestration/Schemas.ts
+++ b/apps/server/src/orchestration/Schemas.ts
@@ -22,6 +22,8 @@ import {
   ThreadTurnDiffCompletedPayload as ContractsThreadTurnDiffCompletedPayloadSchema,
   ThreadRevertedPayload as ContractsThreadRevertedPayloadSchema,
   ThreadActivityAppendedPayload as ContractsThreadActivityAppendedPayloadSchema,
+  ThreadHistoryReplacedPayload as ContractsThreadHistoryReplacedPayloadSchema,
+  ThreadTeleportedPayload as ContractsThreadTeleportedPayloadSchema,
   ThreadTurnStartRequestedPayload as ContractsThreadTurnStartRequestedPayloadSchema,
   ThreadTurnInterruptRequestedPayload as ContractsThreadTurnInterruptRequestedPayloadSchema,
   ThreadApprovalResponseRequestedPayload as ContractsThreadApprovalResponseRequestedPayloadSchema,
@@ -55,6 +57,8 @@ export const ThreadSessionSetPayload = ContractsThreadSessionSetPayloadSchema;
 export const ThreadTurnDiffCompletedPayload = ContractsThreadTurnDiffCompletedPayloadSchema;
 export const ThreadRevertedPayload = ContractsThreadRevertedPayloadSchema;
 export const ThreadActivityAppendedPayload = ContractsThreadActivityAppendedPayloadSchema;
+export const ThreadHistoryReplacedPayload = ContractsThreadHistoryReplacedPayloadSchema;
+export const ThreadTeleportedPayload = ContractsThreadTeleportedPayloadSchema;
 
 export const ThreadTurnStartRequestedPayload = ContractsThreadTurnStartRequestedPayloadSchema;
 export const ThreadTurnInterruptRequestedPayload =

--- a/apps/server/src/orchestration/decider.teleport.test.ts
+++ b/apps/server/src/orchestration/decider.teleport.test.ts
@@ -1,0 +1,139 @@
+import {
+  CommandId,
+  MessageId,
+  ProjectId,
+  ProviderInstanceId,
+  ThreadId,
+  type OrchestrationReadModel,
+  type OrchestrationThread,
+  type TeleportThreadState,
+} from "@t3tools/contracts";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+import { decideOrchestrationCommand } from "./decider.ts";
+
+const NOW = "2026-01-01T00:00:00.000Z";
+
+const NATIVE_TELEPORT: TeleportThreadState = {
+  presence: "native",
+  provider: "codex",
+  externalSessionId: "01a00270-6f96-7ce3-9244-ab159194e668",
+  nativePath: "/home/ubuntu/.codex/sessions/session.jsonl",
+  lastSyncedAt: NOW,
+};
+
+function makeReadModel(input: {
+  readonly teleport?: OrchestrationThread["teleport"];
+}): OrchestrationReadModel {
+  return {
+    snapshotSequence: 0,
+    projects: [],
+    threads: [
+      {
+        id: ThreadId.make("thread-1"),
+        projectId: ProjectId.make("project-1"),
+        title: "Thread",
+        modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5.4" },
+        runtimeMode: "full-access",
+        interactionMode: "default",
+        branch: null,
+        worktreePath: null,
+        latestTurn: null,
+        createdAt: NOW,
+        updatedAt: NOW,
+        archivedAt: null,
+        settledOverride: null,
+        settledAt: null,
+        deletedAt: null,
+        messages: [],
+        proposedPlans: [],
+        activities: [],
+        checkpoints: [],
+        session: null,
+        ...(input.teleport !== undefined ? { teleport: input.teleport } : {}),
+      },
+    ],
+    updatedAt: NOW,
+  };
+}
+
+it.layer(NodeServices.layer)("teleport thread decider", (it) => {
+  it.effect("sets teleport presence on a thread", () =>
+    Effect.gen(function* () {
+      const event = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.teleport.set",
+          commandId: CommandId.make("cmd-teleport-set"),
+          threadId: ThreadId.make("thread-1"),
+          teleport: NATIVE_TELEPORT,
+          createdAt: NOW,
+        },
+        readModel: makeReadModel({}),
+      });
+      const events = Array.isArray(event) ? event : [event];
+      expect(events).toHaveLength(1);
+      expect(events[0]?.type).toBe("thread.teleported");
+      if (events[0]?.type === "thread.teleported") {
+        expect(events[0].payload.teleport).toEqual(NATIVE_TELEPORT);
+        expect(events[0].payload.updatedAt).toBe(NOW);
+      }
+    }),
+  );
+
+  it.effect("rejects turn start while the thread is in the native CLI", () =>
+    Effect.gen(function* () {
+      const error = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.turn.start",
+          commandId: CommandId.make("cmd-turn-start"),
+          threadId: ThreadId.make("thread-1"),
+          message: {
+            messageId: MessageId.make("message-1"),
+            role: "user",
+            text: "hello",
+            attachments: [],
+          },
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          createdAt: NOW,
+        },
+        readModel: makeReadModel({ teleport: NATIVE_TELEPORT }),
+      }).pipe(Effect.flip);
+      expect(error._tag).toBe("OrchestrationCommandInvariantError");
+      if (error._tag === "OrchestrationCommandInvariantError") {
+        expect(error.detail).toContain("native CLI");
+      }
+    }),
+  );
+
+  it.effect("allows turn start while the thread is owned by T3", () =>
+    Effect.gen(function* () {
+      const event = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.turn.start",
+          commandId: CommandId.make("cmd-turn-start"),
+          threadId: ThreadId.make("thread-1"),
+          message: {
+            messageId: MessageId.make("message-1"),
+            role: "user",
+            text: "hello",
+            attachments: [],
+          },
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          createdAt: NOW,
+        },
+        readModel: makeReadModel({
+          teleport: {
+            ...NATIVE_TELEPORT,
+            presence: "t3",
+          },
+        }),
+      });
+      const events = Array.isArray(event) ? event : [event];
+      expect(events.map((entry) => entry.type)).toContain("thread.turn-start-requested");
+    }),
+  );
+});

--- a/apps/server/src/orchestration/decider.teleport.test.ts
+++ b/apps/server/src/orchestration/decider.teleport.test.ts
@@ -20,7 +20,7 @@ const NATIVE_TELEPORT: TeleportThreadState = {
   presence: "native",
   provider: "codex",
   externalSessionId: "01a00270-6f96-7ce3-9244-ab159194e668",
-  nativePath: "/home/ubuntu/.codex/sessions/session.jsonl",
+  nativePath: "/home/user/.codex/sessions/session.jsonl",
   lastSyncedAt: NOW,
 };
 

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -941,6 +941,12 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           detail: `Proposed plan '${sourceProposedPlan?.planId}' belongs to thread '${sourceThread.id}' in a different project.`,
         });
       }
+      if (targetThread.teleport?.presence === "native") {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: "This thread is in the native CLI. Import it before sending messages from T3.",
+        });
+      }
       const userMessageEvent: Omit<OrchestrationEvent, "sequence"> = {
         ...(yield* withEventBase({
           aggregateKind: "thread",
@@ -1388,6 +1394,50 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         },
       };
       return [unsettledEvent, activityAppendedEvent];
+    }
+
+    case "thread.history.replace": {
+      yield* requireThread({
+        readModel,
+        command,
+        threadId: command.threadId,
+      });
+      return {
+        ...(yield* withEventBase({
+          aggregateKind: "thread",
+          aggregateId: command.threadId,
+          occurredAt: command.createdAt,
+          commandId: command.commandId,
+        })),
+        type: "thread.history-replaced",
+        payload: {
+          threadId: command.threadId,
+          messages: command.messages,
+          replacedAt: command.createdAt,
+        },
+      };
+    }
+
+    case "thread.teleport.set": {
+      yield* requireThread({
+        readModel,
+        command,
+        threadId: command.threadId,
+      });
+      return {
+        ...(yield* withEventBase({
+          aggregateKind: "thread",
+          aggregateId: command.threadId,
+          occurredAt: command.createdAt,
+          commandId: command.commandId,
+        })),
+        type: "thread.teleported",
+        payload: {
+          threadId: command.threadId,
+          teleport: command.teleport,
+          updatedAt: command.createdAt,
+        },
+      };
     }
 
     default: {

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -33,6 +33,8 @@ import {
   ThreadRevertedPayload,
   ThreadSessionSetPayload,
   ThreadTurnDiffCompletedPayload,
+  ThreadHistoryReplacedPayload,
+  ThreadTeleportedPayload,
 } from "./Schemas.ts";
 
 type ThreadPatch = Partial<Omit<OrchestrationThread, "id" | "projectId">>;
@@ -795,6 +797,51 @@ export function projectEvent(
             threads: updateThread(nextBase.threads, payload.threadId, {
               activities,
               updatedAt: event.occurredAt,
+            }),
+          };
+        }),
+      );
+
+    case "thread.history-replaced":
+      return decodeForEvent(
+        ThreadHistoryReplacedPayload,
+        event.payload,
+        event.type,
+        "payload",
+      ).pipe(
+        Effect.map((payload) => {
+          const thread = nextBase.threads.find((entry) => entry.id === payload.threadId);
+          if (!thread) {
+            return nextBase;
+          }
+
+          return {
+            ...nextBase,
+            threads: updateThread(nextBase.threads, payload.threadId, {
+              messages: payload.messages.slice(-MAX_THREAD_MESSAGES),
+              proposedPlans: [],
+              activities: [],
+              checkpoints: [],
+              latestTurn: null,
+              updatedAt: payload.replacedAt,
+            }),
+          };
+        }),
+      );
+
+    case "thread.teleported":
+      return decodeForEvent(ThreadTeleportedPayload, event.payload, event.type, "payload").pipe(
+        Effect.map((payload) => {
+          const thread = nextBase.threads.find((entry) => entry.id === payload.threadId);
+          if (!thread) {
+            return nextBase;
+          }
+
+          return {
+            ...nextBase,
+            threads: updateThread(nextBase.threads, payload.threadId, {
+              teleport: payload.teleport,
+              updatedAt: payload.updatedAt,
             }),
           };
         }),

--- a/apps/server/src/persistence/Layers/ProjectionThreads.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreads.ts
@@ -14,11 +14,14 @@ import {
   ProjectionThreadRepository,
   type ProjectionThreadRepositoryShape,
 } from "../Services/ProjectionThreads.ts";
-import { ModelSelection } from "@t3tools/contracts";
+import { ModelSelection, TeleportThreadState } from "@t3tools/contracts";
 
 const ProjectionThreadDbRow = ProjectionThread.mapFields(
   Struct.assign({
     modelSelection: Schema.fromJsonString(ModelSelection),
+    teleport: Schema.NullOr(Schema.fromJsonString(TeleportThreadState)).pipe(
+      Schema.withDecodingDefault(Effect.succeed(null)),
+    ),
   }),
 );
 type ProjectionThreadDbRow = typeof ProjectionThreadDbRow.Type;
@@ -55,7 +58,8 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
           pending_approval_count,
           pending_user_input_count,
           has_actionable_proposed_plan,
-          deleted_at
+          deleted_at,
+          teleport_json
         )
         VALUES (
           ${row.threadId},
@@ -82,7 +86,8 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
           ${row.pendingApprovalCount},
           ${row.pendingUserInputCount},
           ${row.hasActionableProposedPlan},
-          ${row.deletedAt}
+          ${row.deletedAt},
+          ${row.teleport == null ? null : JSON.stringify(row.teleport)}
         )
         ON CONFLICT (thread_id)
         DO UPDATE SET
@@ -109,7 +114,8 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
           pending_approval_count = excluded.pending_approval_count,
           pending_user_input_count = excluded.pending_user_input_count,
           has_actionable_proposed_plan = excluded.has_actionable_proposed_plan,
-          deleted_at = excluded.deleted_at
+          deleted_at = excluded.deleted_at,
+          teleport_json = excluded.teleport_json
       `,
   });
 
@@ -143,7 +149,8 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
           pending_approval_count AS "pendingApprovalCount",
           pending_user_input_count AS "pendingUserInputCount",
           has_actionable_proposed_plan AS "hasActionableProposedPlan",
-          deleted_at AS "deletedAt"
+          deleted_at AS "deletedAt",
+          teleport_json AS "teleport"
         FROM projection_threads
         WHERE thread_id = ${threadId}
       `,
@@ -179,7 +186,8 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
           pending_approval_count AS "pendingApprovalCount",
           pending_user_input_count AS "pendingUserInputCount",
           has_actionable_proposed_plan AS "hasActionableProposedPlan",
-          deleted_at AS "deletedAt"
+          deleted_at AS "deletedAt",
+          teleport_json AS "teleport"
         FROM projection_threads
         WHERE project_id = ${projectId}
         ORDER BY created_at ASC, thread_id ASC

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -53,6 +53,7 @@ import Migration0037 from "./Migrations/037_ProjectionTurnsKeysetIndex.ts";
 import Migration0038 from "./Migrations/038_ProjectionThreadsPinOrderKey.ts";
 import Migration0039 from "./Migrations/039_ProjectionProjectsDefaultThreadEnvMode.ts";
 import Migration0040 from "./Migrations/040_ProjectionProjectFaviconPath.ts";
+import Migration0041 from "./Migrations/041_ProjectionThreadsTeleport.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -105,6 +106,7 @@ export const migrationEntries = [
   [38, "ProjectionThreadsPinOrderKey", Migration0038],
   [39, "ProjectionProjectsDefaultThreadEnvMode", Migration0039],
   [40, "ProjectionProjectFaviconPath", Migration0040],
+  [41, "ProjectionThreadsTeleport", Migration0041],
 ] as const;
 
 export const migrationManifest = migrationEntries.map(([id, name]) => [id, name] as const);

--- a/apps/server/src/persistence/Migrations/041_ProjectionThreadsTeleport.ts
+++ b/apps/server/src/persistence/Migrations/041_ProjectionThreadsTeleport.ts
@@ -1,0 +1,63 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  const columns = yield* sql<{ readonly name: string }>`
+    PRAGMA table_info(projection_threads)
+  `;
+
+  if (!columns.some((column) => column.name === "teleport_json")) {
+    yield* sql`
+      ALTER TABLE projection_threads
+      ADD COLUMN teleport_json TEXT
+    `;
+  }
+
+  yield* sql`
+    UPDATE projection_threads
+    SET
+      teleport_json = (
+        SELECT
+          json_object(
+            'presence',
+            CASE
+              WHEN json_extract(runtime.runtime_payload_json, '$.teleport.presence') IS NOT NULL THEN json_extract(
+                runtime.runtime_payload_json,
+                '$.teleport.presence'
+              )
+              WHEN json_extract(runtime.runtime_payload_json, '$.teleport.lastSyncDirection') = 'export' THEN 'native'
+              ELSE 't3'
+            END,
+            'provider',
+            runtime.provider_name,
+            'externalSessionId',
+            json_extract(runtime.runtime_payload_json, '$.teleport.externalSessionId'),
+            'nativePath',
+            json_extract(runtime.runtime_payload_json, '$.teleport.nativePath'),
+            'lastSyncedAt',
+            json_extract(runtime.runtime_payload_json, '$.teleport.lastSyncedAt')
+          )
+        FROM provider_session_runtime AS runtime
+        WHERE
+          runtime.thread_id = projection_threads.thread_id
+          AND runtime.provider_name IN ('codex', 'claudeAgent', 'opencode', 'grok')
+          AND json_extract(runtime.runtime_payload_json, '$.teleport.externalSessionId') IS NOT NULL
+          AND json_extract(runtime.runtime_payload_json, '$.teleport.nativePath') IS NOT NULL
+          AND json_extract(runtime.runtime_payload_json, '$.teleport.lastSyncedAt') IS NOT NULL
+      )
+    WHERE
+      teleport_json IS NULL
+      AND EXISTS (
+        SELECT
+          1
+        FROM provider_session_runtime AS runtime
+        WHERE
+          runtime.thread_id = projection_threads.thread_id
+          AND runtime.provider_name IN ('codex', 'claudeAgent', 'opencode', 'grok')
+          AND json_extract(runtime.runtime_payload_json, '$.teleport.externalSessionId') IS NOT NULL
+          AND json_extract(runtime.runtime_payload_json, '$.teleport.nativePath') IS NOT NULL
+          AND json_extract(runtime.runtime_payload_json, '$.teleport.lastSyncedAt') IS NOT NULL
+      )
+  `;
+});

--- a/apps/server/src/persistence/Services/ProjectionThreads.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreads.ts
@@ -14,6 +14,7 @@ import {
   ProjectId,
   ProviderInteractionMode,
   RuntimeMode,
+  TeleportThreadState,
   ThreadId,
   TurnId,
 } from "@t3tools/contracts";
@@ -50,6 +51,7 @@ export const ProjectionThread = Schema.Struct({
   pendingUserInputCount: NonNegativeInt,
   hasActionableProposedPlan: NonNegativeInt,
   deletedAt: Schema.NullOr(IsoDateTime),
+  teleport: Schema.optional(Schema.NullOr(TeleportThreadState)),
 });
 export type ProjectionThread = typeof ProjectionThread.Type;
 

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -29,6 +29,7 @@ import {
   ProviderInstanceId,
   ResolvedKeybindingRule,
   ThreadId,
+  TELEPORT_SCHEMA_VERSION,
   WS_METHODS,
   WsRpcGroup,
   EditorId,
@@ -119,6 +120,7 @@ import * as ServerRuntimeStartup from "./serverRuntimeStartup.ts";
 import * as ServiceLauncherClient from "./cloud/serviceLauncherClient.ts";
 import * as ServerSettings from "./serverSettings.ts";
 import * as TerminalManager from "./terminal/Manager.ts";
+import { TeleportService } from "./teleport/Services/TeleportService.ts";
 import * as PreviewManager from "./preview/Manager.ts";
 import * as PortScanner from "./preview/PortScanner.ts";
 import * as BrowserTraceCollector from "./observability/BrowserTraceCollector.ts";
@@ -419,6 +421,7 @@ const buildAppUnderTest = (options?: {
     desktopTelemetryReceiver?: Partial<
       DesktopTelemetryReceiver.DesktopTelemetryReceiver["Service"]
     >;
+    teleportService?: Partial<TeleportService["Service"]>;
   };
 }) =>
   Effect.gen(function* () {
@@ -764,13 +767,30 @@ const buildAppUnderTest = (options?: {
         ),
       ),
       Layer.provide(
-        Layer.mock(OrchestrationEngine.OrchestrationEngineService)({
-          readEvents: () => Stream.empty,
-          dispatch: () => Effect.succeed({ sequence: 0 }),
-          streamDomainEvents: Stream.empty,
-          latestSequence: Effect.succeed(0),
-          ...options?.layers?.orchestrationEngine,
-        }),
+        Layer.mergeAll(
+          Layer.mock(OrchestrationEngine.OrchestrationEngineService)({
+            readEvents: () => Stream.empty,
+            dispatch: () => Effect.succeed({ sequence: 0 }),
+            streamDomainEvents: Stream.empty,
+            latestSequence: Effect.succeed(0),
+            ...options?.layers?.orchestrationEngine,
+          }),
+          Layer.mock(TeleportService)({
+            listSessions: () =>
+              Effect.succeed({
+                schemaVersion: TELEPORT_SCHEMA_VERSION,
+                sessions: [],
+              }),
+            importSessions: () =>
+              Effect.succeed({
+                schemaVersion: TELEPORT_SCHEMA_VERSION,
+                imported: [],
+              }),
+            exportSession: () =>
+              Effect.die("TeleportService.exportSession not stubbed in this test"),
+            ...options?.layers?.teleportService,
+          }),
+        ),
       ),
       Layer.provide(
         Layer.mock(ProjectionSnapshotQuery.ProjectionSnapshotQuery)({

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -42,6 +42,7 @@ import * as GitHubCli from "./sourceControl/GitHubCli.ts";
 import * as GitLabCli from "./sourceControl/GitLabCli.ts";
 import * as TextGeneration from "./textGeneration/TextGeneration.ts";
 import { ProviderInstanceRegistryHydrationLive } from "./provider/Layers/ProviderInstanceRegistryHydration.ts";
+import { TeleportServiceLive } from "./teleport/Layers/TeleportService.ts";
 import * as TerminalManager from "./terminal/Manager.ts";
 import * as McpHttpServer from "./mcp/McpHttpServer.ts";
 import * as McpSessionRegistry from "./mcp/McpSessionRegistry.ts";
@@ -412,7 +413,10 @@ const RuntimeCoreDependenciesLive = ReactorLayerLive.pipe(
   ),
 );
 
-const RuntimeDependenciesLive = RuntimeCoreDependenciesLive.pipe(
+const RuntimeDependenciesLive = Layer.mergeAll(
+  RuntimeCoreDependenciesLive,
+  TeleportServiceLive.pipe(Layer.provide(RuntimeCoreDependenciesLive)),
+).pipe(
   // Misc.
   Layer.provideMerge(BackgroundLayerLive),
   Layer.provideMerge(ResourceDiagnosticsLayerLive),

--- a/apps/server/src/teleport/Layers/TeleportService.ts
+++ b/apps/server/src/teleport/Layers/TeleportService.ts
@@ -1,0 +1,765 @@
+import {
+  CommandId,
+  DEFAULT_MODEL,
+  DEFAULT_MODEL_BY_PROVIDER,
+  DEFAULT_PROVIDER_INTERACTION_MODE,
+  DEFAULT_RUNTIME_MODE,
+  MessageId,
+  ProviderDriverKind,
+  TELEPORT_NATIVE_FORMAT_VERSION,
+  TELEPORT_SCHEMA_VERSION,
+  TeleportDiscoveryError,
+  TeleportInvalidInputError,
+  TeleportProjectResolutionError,
+  TeleportIdentityConflictError,
+  TeleportNativeWriteError,
+  TeleportUnsupportedProviderError,
+  ThreadId,
+  defaultInstanceIdForDriver,
+  isTeleportProvider,
+  resolveTeleportPresence,
+  type ModelSelection,
+  type OrchestrationMessage,
+  type TeleportExportSessionInput,
+  type TeleportImportedSession,
+  type TeleportImportSessionsInput,
+  type TeleportListSessionsInput,
+  type TeleportProvider,
+  type TeleportRuntimePayload,
+} from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as PlatformError from "effect/PlatformError";
+
+import * as OrchestrationEngine from "../../orchestration/Services/OrchestrationEngine.ts";
+import * as ProjectionSnapshotQuery from "../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import { ProviderInstanceRegistry } from "../../provider/Services/ProviderInstanceRegistry.ts";
+import { ProviderService } from "../../provider/Services/ProviderService.ts";
+import { ProviderSessionDirectory } from "../../provider/Services/ProviderSessionDirectory.ts";
+import * as ServerSettings from "../../serverSettings.ts";
+import { resolveTeleportCwdPath, teleportCwdsEquivalent } from "../cwd.ts";
+import { discoverTeleportSessions, loadTeleportSession } from "../discovery.ts";
+import { getTeleportFormat } from "../formats/registry.ts";
+import "../formats/register.ts";
+import { resolveTeleportHomes, type TeleportHomes } from "../homes.ts";
+import {
+  buildTeleportResumeCursor,
+  readTeleportExternalSessionId,
+  readTeleportRuntimePayload,
+  teleportThreadStateFromPayload,
+  toTeleportProvider,
+} from "../resumeCursors.ts";
+import { firstUserTitle, truncateTitle } from "../json.ts";
+import {
+  MAX_TELEPORT_MESSAGE_CHARS,
+  MAX_TELEPORT_MESSAGES,
+  nativeTextMessage,
+  type NativeTextMessage,
+  type ParsedNativeSession,
+} from "../types.ts";
+import { TeleportService } from "../Services/TeleportService.ts";
+
+function modelSelectionForProvider(provider: TeleportProvider): ModelSelection {
+  const driver = ProviderDriverKind.make(provider);
+  return {
+    instanceId: defaultInstanceIdForDriver(driver),
+    model: DEFAULT_MODEL_BY_PROVIDER[driver] ?? DEFAULT_MODEL,
+  };
+}
+
+function capMessages(messages: ReadonlyArray<NativeTextMessage>): NativeTextMessage[] {
+  return messages.slice(-MAX_TELEPORT_MESSAGES).map((message) =>
+    message.text.length > MAX_TELEPORT_MESSAGE_CHARS
+      ? {
+          ...message,
+          text: `${message.text.slice(0, MAX_TELEPORT_MESSAGE_CHARS)}\n\n[truncated]`,
+        }
+      : message,
+  );
+}
+
+function nativeMessagesToOrchestration(
+  messages: ReadonlyArray<NativeTextMessage>,
+  ids: ReadonlyArray<string>,
+  now: string,
+): OrchestrationMessage[] {
+  return messages.map((message, index) => ({
+    id: MessageId.make(message.id ?? ids[index] ?? `${index}`),
+    role: message.role,
+    text: message.text,
+    turnId: null,
+    streaming: false,
+    createdAt: message.createdAt ?? now,
+    updatedAt: message.createdAt ?? now,
+  }));
+}
+
+function orchestrationToNative(messages: ReadonlyArray<OrchestrationMessage>): NativeTextMessage[] {
+  return messages.flatMap((message) => {
+    if (message.role !== "user" && message.role !== "assistant") {
+      return [];
+    }
+    const text = message.text.trim();
+    if (text.length === 0) {
+      return [];
+    }
+    return [
+      nativeTextMessage({
+        role: message.role,
+        text: message.text,
+        createdAt: message.createdAt,
+        id: message.id,
+      }),
+    ];
+  });
+}
+
+function isBusySessionStatus(status: string | undefined): boolean {
+  return status === "starting" || status === "running";
+}
+
+function isIgnorableProviderStopError(error: { readonly _tag: string }): boolean {
+  switch (error._tag) {
+    case "ProviderValidationError":
+    case "ProviderSessionNotFoundError":
+    case "ProviderAdapterSessionNotFoundError":
+      return true;
+    default:
+      return false;
+  }
+}
+
+export const TeleportServiceLive = Layer.effect(
+  TeleportService,
+  Effect.gen(function* () {
+    const settingsService = yield* ServerSettings.ServerSettingsService;
+    const engine = yield* OrchestrationEngine.OrchestrationEngineService;
+    const snapshotQuery = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;
+    const directory = yield* ProviderSessionDirectory;
+    const instanceRegistry = yield* ProviderInstanceRegistry;
+    const providerService = yield* ProviderService;
+    const crypto = yield* Crypto.Crypto;
+    const nativeContext = yield* Effect.context<FileSystem.FileSystem | Path.Path>();
+    const provideNative = <A, E>(
+      effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>,
+    ): Effect.Effect<A, E> => effect.pipe(Effect.provideContext(nativeContext));
+
+    const nextId = () => crypto.randomUUIDv4;
+    const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+    const inFlight = new Set<string>();
+    const alreadyInFlightError = () =>
+      new TeleportInvalidInputError({
+        message: "Teleport already in progress for this session.",
+      });
+    const withInFlight = <A, E, R = never>(
+      keys: string[],
+      effect: Effect.Effect<A, E, R>,
+    ): Effect.Effect<A, E | TeleportInvalidInputError, R> =>
+      Effect.suspend((): Effect.Effect<A, E | TeleportInvalidInputError, R> => {
+        for (const key of keys) {
+          if (inFlight.has(key)) {
+            return alreadyInFlightError();
+          }
+        }
+        for (const key of keys) {
+          inFlight.add(key);
+        }
+        return effect.pipe(
+          Effect.ensuring(
+            Effect.sync(() => {
+              for (const key of keys) {
+                inFlight.delete(key);
+              }
+            }),
+          ),
+        );
+      });
+    const claimExtraInFlight = (keys: string[], extra: string) =>
+      Effect.suspend((): Effect.Effect<void, TeleportInvalidInputError> => {
+        if (keys.includes(extra)) {
+          return Effect.void;
+        }
+        if (inFlight.has(extra)) {
+          return alreadyInFlightError();
+        }
+        inFlight.add(extra);
+        keys.push(extra);
+        return Effect.void;
+      });
+
+    const mapDispatchError = (message: string) => (cause: unknown) =>
+      new TeleportInvalidInputError({
+        message,
+        cause,
+      });
+
+    const requireParsedSessionUnlocked = (parsed: ParsedNativeSession, homes: TeleportHomes) => {
+      const adapter = getTeleportFormat(parsed.provider);
+      if (!adapter) {
+        return new TeleportUnsupportedProviderError({
+          provider: ProviderDriverKind.make(parsed.provider),
+          message: `Teleport does not support provider '${parsed.provider}'.`,
+        });
+      }
+      return adapter.requireUnlocked({
+        homes,
+        nativePath: parsed.nativePath,
+      });
+    };
+
+    const listSessions = (input: TeleportListSessionsInput) =>
+      provideNative(
+        Effect.gen(function* () {
+          const cwd = yield* resolveTeleportCwdPath(input.cwd);
+          const settings = yield* settingsService.getSettings.pipe(
+            Effect.mapError(
+              (cause) =>
+                new TeleportDiscoveryError({
+                  message: "Server settings could not be read for teleport discovery.",
+                  cause,
+                }),
+            ),
+          );
+          const homes = yield* resolveTeleportHomes(settings);
+          return yield* discoverTeleportSessions({
+            homes,
+            cwd,
+            ...(input.providers ? { providers: input.providers } : {}),
+          });
+        }),
+      );
+
+    const importSessions = (input: TeleportImportSessionsInput) => {
+      const inFlightKeys = input.sessions.map(
+        (session) => `session:${session.provider}:${session.externalSessionId}`,
+      );
+      return withInFlight(
+        inFlightKeys,
+        provideNative(
+          Effect.gen(function* () {
+            const project = yield* snapshotQuery.getProjectShellById(input.projectId).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new TeleportProjectResolutionError({
+                    message: "Failed to load the target project.",
+                    cause,
+                  }),
+              ),
+            );
+            if (Option.isNone(project)) {
+              return yield* new TeleportProjectResolutionError({
+                message: `Project '${input.projectId}' was not found.`,
+              });
+            }
+            const cwd = yield* resolveTeleportCwdPath(input.cwd);
+            if (!(yield* teleportCwdsEquivalent(project.value.workspaceRoot, cwd))) {
+              return yield* new TeleportInvalidInputError({
+                message: "Import cwd must match the selected project's workspace root.",
+              });
+            }
+            const seenRefs = new Set<string>();
+            for (const ref of input.sessions) {
+              const key = `${ref.provider}:${ref.externalSessionId}`;
+              if (seenRefs.has(key)) {
+                return yield* new TeleportInvalidInputError({
+                  message: `Duplicate session '${ref.externalSessionId}' in the import batch.`,
+                });
+              }
+              seenRefs.add(key);
+            }
+
+            const settings = yield* settingsService.getSettings.pipe(
+              Effect.mapError(
+                (cause) =>
+                  new TeleportDiscoveryError({
+                    message: "Server settings could not be read for teleport import.",
+                    cause,
+                  }),
+              ),
+            );
+            const homes = yield* resolveTeleportHomes(settings);
+            const bindings = yield* directory.listBindings().pipe(
+              Effect.mapError(
+                (cause) =>
+                  new TeleportDiscoveryError({
+                    message: "Failed to read provider session bindings.",
+                    cause,
+                  }),
+              ),
+            );
+
+            const parsedSessions: ParsedNativeSession[] = [];
+            for (const ref of input.sessions) {
+              const parsed = yield* loadTeleportSession({
+                homes,
+                provider: ref.provider,
+                externalSessionId: ref.externalSessionId,
+                cwd,
+              });
+              yield* requireParsedSessionUnlocked(parsed, homes);
+              parsedSessions.push({
+                ...parsed,
+                messages: capMessages(parsed.messages),
+              });
+            }
+
+            const imported: TeleportImportedSession[] = [];
+            const now = yield* nowIso;
+
+            for (const parsed of parsedSessions) {
+              const driver = ProviderDriverKind.make(parsed.provider);
+              let existingThreadId: ThreadId | undefined;
+              let existingProjectId = input.projectId;
+              let existingStatus: (typeof bindings)[number]["status"];
+              for (const binding of bindings) {
+                if (binding.provider !== driver) {
+                  continue;
+                }
+                const externalSessionId = readTeleportExternalSessionId({
+                  provider: binding.provider,
+                  resumeCursor: binding.resumeCursor,
+                  runtimePayload: binding.runtimePayload,
+                });
+                if (externalSessionId !== parsed.externalSessionId) {
+                  continue;
+                }
+                const shell = yield* snapshotQuery.getThreadShellById(binding.threadId).pipe(
+                  Effect.mapError(
+                    (cause) =>
+                      new TeleportDiscoveryError({
+                        message: "Failed to load an existing teleport thread.",
+                        cause,
+                      }),
+                  ),
+                );
+                if (Option.isNone(shell) || shell.value.archivedAt !== null) {
+                  continue;
+                }
+                if (shell.value.projectId !== input.projectId) {
+                  return yield* new TeleportIdentityConflictError({
+                    provider: parsed.provider,
+                    externalSessionId: parsed.externalSessionId,
+                    existingThreadId: binding.threadId,
+                    existingProjectId: shell.value.projectId,
+                    message: `Session '${parsed.externalSessionId}' is already bound to another T3 project.`,
+                  });
+                }
+                existingThreadId = binding.threadId;
+                existingProjectId = shell.value.projectId;
+                existingStatus = binding.status;
+                if (isBusySessionStatus(shell.value.session?.status)) {
+                  return yield* new TeleportInvalidInputError({
+                    message: `Cannot import while T3 session '${parsed.externalSessionId}' is running.`,
+                  });
+                }
+                break;
+              }
+
+              const messageIds = yield* Effect.forEach(parsed.messages, () => nextId(), {
+                concurrency: 1,
+              });
+              const messages = nativeMessagesToOrchestration(parsed.messages, messageIds, now);
+              const title =
+                truncateTitle(
+                  parsed.title ?? firstUserTitle(parsed.messages) ?? "Imported session",
+                ) || "Imported session";
+              let threadId = existingThreadId;
+              let updatedInPlace = false;
+
+              if (threadId) {
+                yield* claimExtraInFlight(inFlightKeys, `thread:${threadId}`);
+                const latest = yield* snapshotQuery.getThreadDetailById(threadId).pipe(
+                  Effect.mapError(
+                    (cause) =>
+                      new TeleportDiscoveryError({
+                        message: "Failed to load the existing thread for in-place import.",
+                        cause,
+                      }),
+                  ),
+                );
+                if (Option.isNone(latest)) {
+                  return yield* new TeleportDiscoveryError({
+                    message: `Thread '${threadId}' was not found for in-place import.`,
+                  });
+                }
+                if (isBusySessionStatus(latest.value.session?.status)) {
+                  return yield* new TeleportInvalidInputError({
+                    message: `Cannot import while T3 session '${parsed.externalSessionId}' is running.`,
+                  });
+                }
+                if (
+                  parsed.messages.length === 0 &&
+                  orchestrationToNative(latest.value.messages).length > 0
+                ) {
+                  return yield* new TeleportInvalidInputError({
+                    message: "Native session has no messages; refusing to wipe this thread.",
+                  });
+                }
+                updatedInPlace = true;
+                const replaceCommandId = CommandId.make(yield* nextId());
+                yield* engine
+                  .dispatch({
+                    type: "thread.history.replace",
+                    commandId: replaceCommandId,
+                    threadId,
+                    messages,
+                    createdAt: now,
+                  })
+                  .pipe(Effect.mapError(mapDispatchError("Failed to replace thread history.")));
+                yield* engine
+                  .dispatch({
+                    type: "thread.meta.update",
+                    commandId: CommandId.make(yield* nextId()),
+                    threadId,
+                    title,
+                  })
+                  .pipe(
+                    Effect.mapError(mapDispatchError("Failed to update imported thread title.")),
+                  );
+              } else {
+                threadId = ThreadId.make(yield* nextId());
+                yield* engine
+                  .dispatch({
+                    type: "thread.create",
+                    commandId: CommandId.make(yield* nextId()),
+                    threadId,
+                    projectId: input.projectId,
+                    title,
+                    modelSelection: modelSelectionForProvider(parsed.provider),
+                    runtimeMode: DEFAULT_RUNTIME_MODE,
+                    interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+                    branch: null,
+                    worktreePath: null,
+                    createdAt: now,
+                  })
+                  .pipe(Effect.mapError(mapDispatchError("Failed to create an imported thread.")));
+                yield* engine
+                  .dispatch({
+                    type: "thread.history.replace",
+                    commandId: CommandId.make(yield* nextId()),
+                    threadId,
+                    messages,
+                    createdAt: now,
+                  })
+                  .pipe(
+                    Effect.mapError(mapDispatchError("Failed to write imported thread history.")),
+                  );
+              }
+
+              const teleportPayload: TeleportRuntimePayload = {
+                schemaVersion: TELEPORT_SCHEMA_VERSION,
+                externalSessionId: parsed.externalSessionId,
+                nativePath: parsed.nativePath,
+                lastSyncDirection: "import",
+                lastSyncedAt: now,
+                nativeFormatVersion: parsed.nativeFormatVersion,
+                presence: "t3",
+              };
+              yield* directory
+                .upsert({
+                  threadId,
+                  provider: driver,
+                  providerInstanceId: defaultInstanceIdForDriver(driver),
+                  status: existingStatus ?? "stopped",
+                  resumeCursor: buildTeleportResumeCursor({
+                    provider: parsed.provider,
+                    externalSessionId: parsed.externalSessionId,
+                  }),
+                  runtimePayload: { teleport: teleportPayload },
+                })
+                .pipe(
+                  Effect.mapError(
+                    (cause) =>
+                      new TeleportDiscoveryError({
+                        message: "Failed to bind the imported native session.",
+                        cause,
+                      }),
+                  ),
+                );
+              yield* engine
+                .dispatch({
+                  type: "thread.teleport.set",
+                  commandId: CommandId.make(yield* nextId()),
+                  threadId,
+                  teleport: teleportThreadStateFromPayload({
+                    provider: parsed.provider,
+                    payload: teleportPayload,
+                  }),
+                  createdAt: now,
+                })
+                .pipe(Effect.mapError(mapDispatchError("Failed to persist teleport presence.")));
+
+              imported.push({
+                threadId,
+                projectId: existingProjectId,
+                provider: parsed.provider,
+                providerInstanceId: defaultInstanceIdForDriver(driver),
+                externalSessionId: parsed.externalSessionId,
+                updatedInPlace,
+              });
+            }
+
+            return {
+              schemaVersion: TELEPORT_SCHEMA_VERSION,
+              imported,
+            };
+          }),
+        ).pipe(
+          Effect.catchTag(
+            "PlatformError",
+            (cause: PlatformError.PlatformError) =>
+              new TeleportDiscoveryError({
+                message: "Native filesystem error during teleport import.",
+                cause,
+              }),
+          ),
+        ),
+      );
+    };
+
+    const exportSession = (input: TeleportExportSessionInput) => {
+      const inFlightKeys = [`thread:${input.threadId}`];
+      return withInFlight(
+        inFlightKeys,
+        provideNative(
+          Effect.gen(function* () {
+            const thread = yield* snapshotQuery.getThreadDetailById(input.threadId).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new TeleportInvalidInputError({
+                    message: "Failed to load the thread for export.",
+                    cause,
+                  }),
+              ),
+            );
+            if (Option.isNone(thread)) {
+              return yield* new TeleportInvalidInputError({
+                message: `Thread '${input.threadId}' was not found.`,
+              });
+            }
+            if (isBusySessionStatus(thread.value.session?.status)) {
+              return yield* new TeleportInvalidInputError({
+                message: "Cannot export while this T3 session is running.",
+              });
+            }
+
+            const project = yield* snapshotQuery.getProjectShellById(thread.value.projectId).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new TeleportProjectResolutionError({
+                    message: "Failed to load the thread's project.",
+                    cause,
+                  }),
+              ),
+            );
+            if (Option.isNone(project)) {
+              return yield* new TeleportProjectResolutionError({
+                message: "The thread's project was not found.",
+              });
+            }
+
+            const binding = yield* directory.getBinding(input.threadId).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new TeleportInvalidInputError({
+                    message: "Failed to read the thread's provider binding.",
+                    cause,
+                  }),
+              ),
+            );
+            const instance = yield* instanceRegistry.getInstance(
+              thread.value.modelSelection.instanceId,
+            );
+            const driverKind =
+              Option.getOrUndefined(binding)?.provider ??
+              instance?.driverKind ??
+              (isTeleportProvider(thread.value.modelSelection.instanceId)
+                ? ProviderDriverKind.make(thread.value.modelSelection.instanceId)
+                : undefined);
+            if (!driverKind) {
+              return yield* new TeleportInvalidInputError({
+                message: "Teleport export could not resolve a supported provider for this thread.",
+              });
+            }
+            const provider = yield* toTeleportProvider(driverKind);
+            const existingPayload = Option.isSome(binding)
+              ? readTeleportRuntimePayload(binding.value.runtimePayload)
+              : undefined;
+            if (resolveTeleportPresence(existingPayload) === "native") {
+              return yield* new TeleportInvalidInputError({
+                message:
+                  "This thread is already in the native CLI. Import it before exporting again.",
+              });
+            }
+
+            yield* providerService.stopSession({ threadId: input.threadId }).pipe(
+              Effect.catchIf(isIgnorableProviderStopError, (error) =>
+                Effect.logDebug("teleport.export.stop-session-skipped", {
+                  threadId: input.threadId,
+                  reason: error._tag,
+                }),
+              ),
+              Effect.mapError(
+                (cause) =>
+                  new TeleportInvalidInputError({
+                    message: "Failed to stop the T3 provider session before export.",
+                    cause,
+                  }),
+              ),
+            );
+            const now = yield* nowIso;
+            yield* engine
+              .dispatch({
+                type: "thread.session.stop",
+                commandId: CommandId.make(yield* nextId()),
+                threadId: input.threadId,
+                createdAt: now,
+              })
+              .pipe(
+                Effect.catch(() =>
+                  Effect.logDebug("teleport.export.session-stop-dispatch-skipped", {
+                    threadId: input.threadId,
+                  }),
+                ),
+              );
+
+            const cwd = yield* resolveTeleportCwdPath(project.value.workspaceRoot);
+            const settings = yield* settingsService.getSettings.pipe(
+              Effect.mapError(
+                (cause) =>
+                  new TeleportNativeWriteError({
+                    nativePath: cwd,
+                    message: "Server settings could not be read for teleport export.",
+                    cause,
+                  }),
+              ),
+            );
+            const homes = yield* resolveTeleportHomes(settings);
+            const existingExternalId = Option.isSome(binding)
+              ? readTeleportExternalSessionId({
+                  provider: driverKind,
+                  resumeCursor: binding.value.resumeCursor,
+                  runtimePayload: binding.value.runtimePayload,
+                })
+              : undefined;
+            const externalSessionId = existingExternalId ?? (yield* nextId());
+            yield* claimExtraInFlight(inFlightKeys, `session:${provider}:${externalSessionId}`);
+            const latest = yield* snapshotQuery.getThreadDetailById(input.threadId).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new TeleportInvalidInputError({
+                    message: "Failed to re-check the thread before export.",
+                    cause,
+                  }),
+              ),
+            );
+            if (Option.isNone(latest)) {
+              return yield* new TeleportInvalidInputError({
+                message: `Thread '${input.threadId}' was not found.`,
+              });
+            }
+            const messages = capMessages(orchestrationToNative(latest.value.messages));
+            const nativeSession: ParsedNativeSession = {
+              provider,
+              externalSessionId,
+              cwd,
+              nativePath: "",
+              nativeFormatVersion: TELEPORT_NATIVE_FORMAT_VERSION,
+              title: thread.value.title,
+              createdAt: thread.value.createdAt,
+              updatedAt: now,
+              messages,
+            };
+
+            const existingNativePath = existingPayload?.nativePath;
+            const adapter = getTeleportFormat(provider);
+            if (!adapter) {
+              return yield* new TeleportUnsupportedProviderError({
+                provider: driverKind,
+                message: `Teleport does not support provider '${provider}'.`,
+              });
+            }
+            const nativePath = yield* adapter.write({
+              homes,
+              session: nativeSession,
+              ...(existingNativePath !== undefined ? { existingNativePath } : {}),
+            });
+
+            const teleportPayload: TeleportRuntimePayload = {
+              schemaVersion: TELEPORT_SCHEMA_VERSION,
+              externalSessionId,
+              nativePath,
+              lastSyncDirection: "export",
+              lastSyncedAt: now,
+              nativeFormatVersion: TELEPORT_NATIVE_FORMAT_VERSION,
+              presence: "native",
+            };
+            yield* directory
+              .upsert({
+                threadId: input.threadId,
+                provider: driverKind,
+                providerInstanceId:
+                  Option.getOrUndefined(binding)?.providerInstanceId ??
+                  defaultInstanceIdForDriver(driverKind),
+                status: "stopped",
+                resumeCursor: buildTeleportResumeCursor({ provider, externalSessionId }),
+                runtimePayload: { teleport: teleportPayload },
+              })
+              .pipe(
+                Effect.mapError(
+                  (cause) =>
+                    new TeleportNativeWriteError({
+                      nativePath,
+                      message: "Failed to bind the exported native session.",
+                      cause,
+                    }),
+                ),
+              );
+            yield* engine
+              .dispatch({
+                type: "thread.teleport.set",
+                commandId: CommandId.make(yield* nextId()),
+                threadId: input.threadId,
+                teleport: teleportThreadStateFromPayload({
+                  provider,
+                  payload: teleportPayload,
+                }),
+                createdAt: now,
+              })
+              .pipe(Effect.mapError(mapDispatchError("Failed to persist teleport presence.")));
+
+            return {
+              schemaVersion: TELEPORT_SCHEMA_VERSION,
+              provider,
+              providerInstanceId: defaultInstanceIdForDriver(driverKind),
+              externalSessionId,
+              nativePath,
+              cwd,
+            };
+          }),
+        ).pipe(
+          Effect.catchTag(
+            "PlatformError",
+            (cause: PlatformError.PlatformError) =>
+              new TeleportNativeWriteError({
+                nativePath: "native session",
+                message: "Native filesystem error during teleport export.",
+                cause,
+              }),
+          ),
+        ),
+      );
+    };
+
+    return TeleportService.of({
+      listSessions,
+      importSessions,
+      exportSession,
+    });
+  }),
+);

--- a/apps/server/src/teleport/Services/TeleportService.ts
+++ b/apps/server/src/teleport/Services/TeleportService.ts
@@ -1,0 +1,31 @@
+import type {
+  TeleportExportError,
+  TeleportExportSessionInput,
+  TeleportExportSessionResult,
+  TeleportImportError,
+  TeleportImportSessionsInput,
+  TeleportImportSessionsResult,
+  TeleportListSessionsError,
+  TeleportListSessionsInput,
+  TeleportListSessionsResult,
+} from "@t3tools/contracts";
+import * as Context from "effect/Context";
+import type * as Effect from "effect/Effect";
+
+export interface TeleportServiceShape {
+  readonly listSessions: (
+    input: TeleportListSessionsInput,
+  ) => Effect.Effect<TeleportListSessionsResult, TeleportListSessionsError>;
+
+  readonly importSessions: (
+    input: TeleportImportSessionsInput,
+  ) => Effect.Effect<TeleportImportSessionsResult, TeleportImportError>;
+
+  readonly exportSession: (
+    input: TeleportExportSessionInput,
+  ) => Effect.Effect<TeleportExportSessionResult, TeleportExportError>;
+}
+
+export class TeleportService extends Context.Service<TeleportService, TeleportServiceShape>()(
+  "t3/teleport/Services/TeleportService",
+) {}

--- a/apps/server/src/teleport/cwd.test.ts
+++ b/apps/server/src/teleport/cwd.test.ts
@@ -25,8 +25,8 @@ describe("teleport cwd matching", () => {
   it("treats a project folder as inside its OpenCode launch cwd", () => {
     assert.equal(
       isTeleportCwdWithin(
-        "/home/ubuntu/baanish-testing/native/opencode",
-        "/home/ubuntu/baanish-testing/native",
+        "/home/user/projects/native/opencode",
+        "/home/user/projects/native",
       ),
       true,
     );
@@ -37,16 +37,16 @@ describe("teleport cwd matching", () => {
   it("rejects home and temp roots as OpenCode launch directories", () => {
     assert.equal(isGenericTeleportCwd("/"), true);
     assert.equal(isGenericTeleportCwd("/tmp"), true);
-    assert.equal(isGenericTeleportCwd("/home/ubuntu"), true);
-    assert.equal(isGenericTeleportCwd("/home/ubuntu/baanish-testing/native"), false);
+    assert.equal(isGenericTeleportCwd("/home/user"), true);
+    assert.equal(isGenericTeleportCwd("/home/user/projects/native"), false);
     assert.equal(isGenericTeleportCwd("C:\\Users\\Foo"), true);
     assert.equal(isGenericTeleportCwd("C:\\Users\\Foo\\proj"), false);
   });
 
   it.effect("matches an OpenCode session whose cwd is a parent of the project", () =>
     opencodeSessionMatchesProjectCwd(
-      "/home/ubuntu/baanish-testing/native",
-      "/home/ubuntu/baanish-testing/native/opencode",
+      "/home/user/projects/native",
+      "/home/user/projects/native/opencode",
     ).pipe(
       Effect.provideService(HostProcessPlatform, "linux"),
       Effect.provide(NodeServices.layer),
@@ -67,21 +67,21 @@ describe("teleport cwd matching", () => {
   );
 
   it("does not treat sibling harness folders as OpenCode parent matches", () => {
-    assert.equal(isForeignOpenCodeProjectFolder("/home/ubuntu/baanish-testing/native/codex"), true);
+    assert.equal(isForeignOpenCodeProjectFolder("/home/user/projects/native/codex"), true);
     assert.equal(
-      isForeignOpenCodeProjectFolder("/home/ubuntu/baanish-testing/native/claude"),
+      isForeignOpenCodeProjectFolder("/home/user/projects/native/claude"),
       true,
     );
     assert.equal(
-      isForeignOpenCodeProjectFolder("/home/ubuntu/baanish-testing/native/opencode"),
+      isForeignOpenCodeProjectFolder("/home/user/projects/native/opencode"),
       false,
     );
   });
 
   it.effect("does not list a parent OpenCode session under a Codex project folder", () =>
     opencodeSessionMatchesProjectCwd(
-      "/home/ubuntu/baanish-testing/native",
-      "/home/ubuntu/baanish-testing/native/codex",
+      "/home/user/projects/native",
+      "/home/user/projects/native/codex",
     ).pipe(
       Effect.provideService(HostProcessPlatform, "linux"),
       Effect.provide(NodeServices.layer),

--- a/apps/server/src/teleport/cwd.test.ts
+++ b/apps/server/src/teleport/cwd.test.ts
@@ -1,0 +1,139 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+
+import {
+  isForeignOpenCodeProjectFolder,
+  isGenericTeleportCwd,
+  isTeleportCwdWithin,
+  opencodeSessionMatchesProjectCwd,
+  resolveTeleportCwdPath,
+  teleportCwdsEquivalent,
+  teleportCwdsMatch,
+} from "./cwd.ts";
+
+describe("teleport cwd matching", () => {
+  it("treats trailing slashes as the same project", () => {
+    assert.equal(teleportCwdsMatch("/workspace", "/workspace/"), true);
+    assert.equal(teleportCwdsMatch("/workspace", "/other"), false);
+  });
+
+  it("treats a project folder as inside its OpenCode launch cwd", () => {
+    assert.equal(
+      isTeleportCwdWithin(
+        "/home/ubuntu/baanish-testing/native/opencode",
+        "/home/ubuntu/baanish-testing/native",
+      ),
+      true,
+    );
+    assert.equal(isTeleportCwdWithin("/tmp/oc-wire-test", "/tmp"), true);
+    assert.equal(isTeleportCwdWithin("/foobar", "/foo"), false);
+  });
+
+  it("rejects home and temp roots as OpenCode launch directories", () => {
+    assert.equal(isGenericTeleportCwd("/"), true);
+    assert.equal(isGenericTeleportCwd("/tmp"), true);
+    assert.equal(isGenericTeleportCwd("/home/ubuntu"), true);
+    assert.equal(isGenericTeleportCwd("/home/ubuntu/baanish-testing/native"), false);
+    assert.equal(isGenericTeleportCwd("C:\\Users\\Foo"), true);
+    assert.equal(isGenericTeleportCwd("C:\\Users\\Foo\\proj"), false);
+  });
+
+  it.effect("matches an OpenCode session whose cwd is a parent of the project", () =>
+    opencodeSessionMatchesProjectCwd(
+      "/home/ubuntu/baanish-testing/native",
+      "/home/ubuntu/baanish-testing/native/opencode",
+    ).pipe(
+      Effect.provideService(HostProcessPlatform, "linux"),
+      Effect.provide(NodeServices.layer),
+      Effect.map((matched) => {
+        assert.equal(matched, true);
+      }),
+    ),
+  );
+
+  it.effect("does not match an OpenCode session launched from /tmp", () =>
+    opencodeSessionMatchesProjectCwd("/tmp", "/tmp/oc-wire-test").pipe(
+      Effect.provideService(HostProcessPlatform, "linux"),
+      Effect.provide(NodeServices.layer),
+      Effect.map((matched) => {
+        assert.equal(matched, false);
+      }),
+    ),
+  );
+
+  it("does not treat sibling harness folders as OpenCode parent matches", () => {
+    assert.equal(isForeignOpenCodeProjectFolder("/home/ubuntu/baanish-testing/native/codex"), true);
+    assert.equal(
+      isForeignOpenCodeProjectFolder("/home/ubuntu/baanish-testing/native/claude"),
+      true,
+    );
+    assert.equal(
+      isForeignOpenCodeProjectFolder("/home/ubuntu/baanish-testing/native/opencode"),
+      false,
+    );
+  });
+
+  it.effect("does not list a parent OpenCode session under a Codex project folder", () =>
+    opencodeSessionMatchesProjectCwd(
+      "/home/ubuntu/baanish-testing/native",
+      "/home/ubuntu/baanish-testing/native/codex",
+    ).pipe(
+      Effect.provideService(HostProcessPlatform, "linux"),
+      Effect.provide(NodeServices.layer),
+      Effect.map((matched) => {
+        assert.equal(matched, false);
+      }),
+    ),
+  );
+
+  it.effect("treats a symlink cwd as the same project", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({ prefix: "teleport-cwd-" });
+      const real = path.join(root, "real-project");
+      const link = path.join(root, "link-project");
+      yield* fs.makeDirectory(real, { recursive: true });
+      yield* fs.symlink(real, link);
+      assert.equal(yield* teleportCwdsEquivalent(real, link), true);
+      assert.equal(yield* teleportCwdsEquivalent(real, path.join(root, "other")), false);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("treats macOS cwd spellings as the same when they differ only by case", () =>
+    teleportCwdsEquivalent("/Users/Alex/proj", "/Users/alex/proj").pipe(
+      Effect.provideService(HostProcessPlatform, "darwin"),
+      Effect.provide(NodeServices.layer),
+      Effect.map((matched) => {
+        assert.equal(matched, true);
+      }),
+    ),
+  );
+
+  it.effect("does not case-fold missing Unix paths on Linux", () =>
+    teleportCwdsEquivalent("/Users/Alex/proj", "/Users/alex/proj").pipe(
+      Effect.provideService(HostProcessPlatform, "linux"),
+      Effect.provide(NodeServices.layer),
+      Effect.map((matched) => {
+        assert.equal(matched, false);
+      }),
+    ),
+  );
+
+  it.effect("resolves a persist cwd without lowercasing Unix paths", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({ prefix: "teleport-persist-cwd-" });
+      const project = path.join(root, "MixedCase");
+      yield* fs.makeDirectory(project, { recursive: true });
+      const resolved = yield* resolveTeleportCwdPath(`${project}/`);
+      assert.equal(resolved, yield* fs.realPath(project));
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+});

--- a/apps/server/src/teleport/cwd.ts
+++ b/apps/server/src/teleport/cwd.ts
@@ -49,7 +49,7 @@ export function isTeleportCwdWithin(inner: string, outer: string): boolean {
 /**
  * Home folders, temp roots, and drive roots. OpenCode often records the
  * process cwd, which can be a parent of the T3 project — but matching `/tmp`
- * or `/home/ubuntu` would pull in unrelated sessions.
+ * or `/home/user` would pull in unrelated sessions.
  */
 export function isGenericTeleportCwd(cwd: string): boolean {
   const posix = normalizeTeleportCwd(cwd).replaceAll("\\", "/").replace(/\/+$/u, "");

--- a/apps/server/src/teleport/cwd.ts
+++ b/apps/server/src/teleport/cwd.ts
@@ -1,0 +1,152 @@
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import {
+  normalizeProjectPathForComparison,
+  normalizeProjectPathForDispatch,
+} from "@t3tools/shared/path";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+export function normalizeTeleportCwd(value: string): string {
+  return normalizeProjectPathForComparison(value);
+}
+
+/**
+ * On-disk cwd spelling for native session files and folder names.
+ * Comparison-normalize lowercases Windows paths; the native CLIs look up
+ * the persisted case and separators instead.
+ */
+export const resolveTeleportCwdPath = Effect.fn("resolveTeleportCwdPath")(function* (
+  value: string,
+): Effect.fn.Return<string, never, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const resolved = path.resolve(normalizeProjectPathForDispatch(value));
+  return yield* fs.realPath(resolved).pipe(Effect.orElseSucceed(() => resolved));
+});
+
+export const canonicalizeTeleportCwd = Effect.fn("canonicalizeTeleportCwd")(function* (
+  value: string,
+): Effect.fn.Return<string, never, FileSystem.FileSystem | Path.Path> {
+  return normalizeTeleportCwd(yield* resolveTeleportCwdPath(value));
+});
+
+export function teleportCwdsMatch(left: string, right: string): boolean {
+  return normalizeTeleportCwd(left) === normalizeTeleportCwd(right);
+}
+
+export function isTeleportCwdWithin(inner: string, outer: string): boolean {
+  const innerCwd = normalizeTeleportCwd(inner);
+  const outerCwd = normalizeTeleportCwd(outer);
+  if (innerCwd === outerCwd) {
+    return true;
+  }
+  const separator = innerCwd.includes("\\") || outerCwd.includes("\\") ? "\\" : "/";
+  const prefix = outerCwd.endsWith(separator) ? outerCwd : `${outerCwd}${separator}`;
+  return innerCwd.startsWith(prefix);
+}
+
+/**
+ * Home folders, temp roots, and drive roots. OpenCode often records the
+ * process cwd, which can be a parent of the T3 project — but matching `/tmp`
+ * or `/home/ubuntu` would pull in unrelated sessions.
+ */
+export function isGenericTeleportCwd(cwd: string): boolean {
+  const posix = normalizeTeleportCwd(cwd).replaceAll("\\", "/").replace(/\/+$/u, "");
+  const lowered = posix.toLowerCase();
+  if (lowered === "" || lowered === "/") {
+    return true;
+  }
+  if (
+    lowered === "/tmp" ||
+    lowered === "/private/tmp" ||
+    lowered === "/var" ||
+    lowered === "/var/tmp" ||
+    lowered === "/home" ||
+    lowered === "/users" ||
+    lowered === "/root"
+  ) {
+    return true;
+  }
+  const parts = lowered.split("/").filter((part) => part.length > 0);
+  const first = parts[0];
+  if (first === undefined) {
+    return true;
+  }
+  if (first === "home" || first === "users" || first === "root") {
+    return parts.length <= 2;
+  }
+  if (/^[a-z]:$/u.test(first)) {
+    if (parts.length <= 1) {
+      return true;
+    }
+    if (parts[1] === "users") {
+      return parts.length <= 3;
+    }
+    if (parts[1] === "windows") {
+      return parts.length <= 2;
+    }
+  }
+  return false;
+}
+
+/**
+ * Same location, including macOS `/tmp` → `/private/tmp` and case-insensitive
+ * default volumes. Lexical equality short-circuits; otherwise both sides go
+ * through `realpath` so a native CLI cwd and a T3 project root still match.
+ */
+export const teleportCwdsEquivalent = Effect.fn("teleportCwdsEquivalent")(function* (
+  left: string,
+  right: string,
+) {
+  if (teleportCwdsMatch(left, right)) {
+    return true;
+  }
+  const leftCanon = yield* canonicalizeTeleportCwd(left);
+  const rightCanon = yield* canonicalizeTeleportCwd(right);
+  if (leftCanon === rightCanon) {
+    return true;
+  }
+  const platform = yield* HostProcessPlatform;
+  // Default macOS volumes are case-insensitive. realpath keeps on-disk case
+  // when the path exists; missing paths fall back to the input spelling.
+  if (platform === "darwin") {
+    return leftCanon.toLowerCase() === rightCanon.toLowerCase();
+  }
+  return false;
+});
+
+const FOREIGN_OPENCODE_PROJECT_FOLDERS = new Set([
+  "codex",
+  "claude",
+  "grok",
+  "claude-code",
+  "claudeagent",
+]);
+
+export function isForeignOpenCodeProjectFolder(projectCwd: string): boolean {
+  const posix = normalizeTeleportCwd(projectCwd).replaceAll("\\", "/");
+  const lastSlash = posix.lastIndexOf("/");
+  const base = (lastSlash === -1 ? posix : posix.slice(lastSlash + 1)).toLowerCase();
+  return base.length > 0 && FOREIGN_OPENCODE_PROJECT_FOLDERS.has(base);
+}
+
+/**
+ * OpenCode stores the process cwd, which is often a parent of the T3 project
+ * folder. Exact match still wins; otherwise the project may sit under the
+ * session directory unless that directory is a generic root or a sibling
+ * harness folder such as `codex` / `claude` / `grok`.
+ */
+export const opencodeSessionMatchesProjectCwd = Effect.fn("opencodeSessionMatchesProjectCwd")(
+  function* (sessionCwd: string, projectCwd: string) {
+    if (yield* teleportCwdsEquivalent(sessionCwd, projectCwd)) {
+      return true;
+    }
+    const sessionCanon = yield* canonicalizeTeleportCwd(sessionCwd);
+    const projectCanon = yield* canonicalizeTeleportCwd(projectCwd);
+    if (isGenericTeleportCwd(sessionCanon) || isForeignOpenCodeProjectFolder(projectCanon)) {
+      return false;
+    }
+    return isTeleportCwdWithin(projectCanon, sessionCanon);
+  },
+);

--- a/apps/server/src/teleport/discovery.test.ts
+++ b/apps/server/src/teleport/discovery.test.ts
@@ -1,0 +1,31 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+import { discoverTeleportSessions } from "./discovery.ts";
+import { resetTeleportFormats } from "./formats/registry.ts";
+import type { TeleportHomes } from "./homes.ts";
+
+describe("teleport discovery", () => {
+  it.effect("lists nothing when no native formats are registered", () =>
+    Effect.gen(function* () {
+      resetTeleportFormats();
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({ prefix: "teleport-empty-registry-" });
+      const homes: TeleportHomes = {
+        codexSessionsRoot: path.join(root, "codex", "sessions"),
+        claudeProjectsRoot: path.join(root, "claude", "projects"),
+        opencodeRoot: path.join(root, "opencode"),
+        grokSessionsRoot: path.join(root, "grok", "sessions"),
+      };
+      const listed = yield* discoverTeleportSessions({
+        homes,
+        cwd: "/workspace",
+      });
+      assert.deepStrictEqual(listed.sessions, []);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+});

--- a/apps/server/src/teleport/discovery.ts
+++ b/apps/server/src/teleport/discovery.ts
@@ -1,0 +1,84 @@
+import {
+  TELEPORT_SCHEMA_VERSION,
+  TeleportDiscoveryError,
+  TeleportSchemaVersionError,
+  type TeleportListSessionsResult,
+  type TeleportProvider,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+import { getTeleportFormat, listRegisteredTeleportProviders } from "./formats/registry.ts";
+import type { TeleportHomes } from "./homes.ts";
+import type { ParsedNativeSession } from "./types.ts";
+
+export const discoverTeleportSessions = Effect.fn("discoverTeleportSessions")(function* (input: {
+  readonly homes: TeleportHomes;
+  readonly cwd: string;
+  readonly providers?: ReadonlyArray<TeleportProvider>;
+}): Effect.fn.Return<
+  TeleportListSessionsResult,
+  TeleportSchemaVersionError | TeleportDiscoveryError,
+  FileSystem.FileSystem | Path.Path
+> {
+  const providers = input.providers ?? listRegisteredTeleportProviders();
+  const sessions = [];
+
+  for (const provider of providers) {
+    const adapter = getTeleportFormat(provider);
+    if (!adapter) {
+      continue;
+    }
+    sessions.push(...(yield* adapter.list({ homes: input.homes, cwd: input.cwd })));
+  }
+
+  return {
+    schemaVersion: TELEPORT_SCHEMA_VERSION,
+    sessions: sessions.toSorted((left, right) => {
+      const leftAt = left.updatedAt ?? left.createdAt ?? "";
+      const rightAt = right.updatedAt ?? right.createdAt ?? "";
+      return rightAt.localeCompare(leftAt);
+    }),
+  };
+});
+
+export const loadTeleportSession = Effect.fn("loadTeleportSession")(function* (input: {
+  readonly homes: TeleportHomes;
+  readonly provider: TeleportProvider;
+  readonly externalSessionId: string;
+  readonly cwd: string;
+}): Effect.fn.Return<
+  ParsedNativeSession,
+  TeleportSchemaVersionError | TeleportDiscoveryError,
+  FileSystem.FileSystem | Path.Path
+> {
+  const adapter = getTeleportFormat(input.provider);
+  if (!adapter) {
+    return yield* new TeleportDiscoveryError({
+      message: `Native ${input.provider} session support is not registered.`,
+    });
+  }
+
+  const listed = yield* discoverTeleportSessions({
+    homes: input.homes,
+    cwd: input.cwd,
+    providers: [input.provider],
+  });
+  const candidate = listed.sessions.find(
+    (session) =>
+      session.provider === input.provider && session.externalSessionId === input.externalSessionId,
+  );
+  if (!candidate) {
+    return yield* new TeleportDiscoveryError({
+      message: `Native ${input.provider} session '${input.externalSessionId}' was not found for this project.`,
+    });
+  }
+
+  return yield* adapter.load({
+    homes: input.homes,
+    cwd: input.cwd,
+    externalSessionId: input.externalSessionId,
+    nativePath: candidate.nativePath,
+  });
+});

--- a/apps/server/src/teleport/fileLock.ts
+++ b/apps/server/src/teleport/fileLock.ts
@@ -1,0 +1,68 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeChildProcess from "node:child_process";
+import * as NodeFSP from "node:fs/promises";
+import * as NodeUtil from "node:util";
+
+import { TeleportFileLockedError } from "@t3tools/contracts";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import * as Effect from "effect/Effect";
+
+const execFile = NodeUtil.promisify(NodeChildProcess.execFile);
+
+function nodeErrorCode(error: unknown): string | undefined {
+  if (typeof error === "object" && error !== null && "code" in error) {
+    const code = (error as { code?: unknown }).code;
+    return typeof code === "string" ? code : undefined;
+  }
+  return undefined;
+}
+
+const isWindowsPathInUse = Effect.fn("isWindowsPathInUse")(function* (nativePath: string) {
+  // Succeed with a boolean. `Effect.tryPromise` `catch` is the error channel
+  // and would leak `false` into export/import failures.
+  return yield* Effect.promise(async () => {
+    try {
+      const handle = await NodeFSP.open(nativePath, "r+");
+      await handle.close();
+      return false;
+    } catch (error) {
+      const code = nodeErrorCode(error);
+      if (code === "ENOENT" || code === "EISDIR") {
+        return false;
+      }
+      return code === "EBUSY" || code === "EPERM" || code === "EACCES";
+    }
+  });
+});
+
+export const isNativePathLocked = Effect.fn("isNativePathLocked")(function* (nativePath: string) {
+  const platform = yield* HostProcessPlatform;
+  if (platform === "win32") {
+    // `lsof` is not a Windows tool. Exclusive locks from a native CLI show up
+    // as EBUSY/EPERM/EACCES on a write-open instead.
+    return yield* isWindowsPathInUse(nativePath);
+  }
+  return yield* Effect.tryPromise({
+    try: () => execFile("lsof", ["-t", nativePath], { timeout: 2_000 }),
+    catch: () =>
+      new TeleportFileLockedError({
+        nativePath,
+        message: `Failed to check whether ${nativePath} is locked.`,
+      }),
+  }).pipe(
+    Effect.map((result) => result.stdout.trim().length > 0),
+    Effect.orElseSucceed(() => false),
+  );
+});
+
+export const requireNativePathUnlocked = Effect.fn("requireNativePathUnlocked")(function* (
+  nativePath: string,
+) {
+  const locked = yield* isNativePathLocked(nativePath);
+  if (locked) {
+    return yield* new TeleportFileLockedError({
+      nativePath,
+      message: `Native session file is locked: ${nativePath}`,
+    });
+  }
+});

--- a/apps/server/src/teleport/formats/adapter.ts
+++ b/apps/server/src/teleport/formats/adapter.ts
@@ -1,0 +1,51 @@
+import {
+  TeleportDiscoveryError,
+  TeleportFileLockedError,
+  TeleportNativeWriteError,
+  TeleportSchemaVersionError,
+  type TeleportProvider,
+  type TeleportSessionCandidate,
+} from "@t3tools/contracts";
+import type * as Effect from "effect/Effect";
+import type * as FileSystem from "effect/FileSystem";
+import type * as Path from "effect/Path";
+
+import type { TeleportHomes } from "../homes.ts";
+import type { ParsedNativeSession } from "../types.ts";
+
+export interface TeleportFormatAdapter {
+  readonly provider: TeleportProvider;
+  readonly list: (input: {
+    readonly homes: TeleportHomes;
+    readonly cwd: string;
+  }) => Effect.Effect<
+    ReadonlyArray<TeleportSessionCandidate>,
+    TeleportSchemaVersionError | TeleportDiscoveryError,
+    FileSystem.FileSystem | Path.Path
+  >;
+  readonly load: (input: {
+    readonly homes: TeleportHomes;
+    readonly cwd: string;
+    readonly externalSessionId: string;
+    readonly nativePath: string;
+  }) => Effect.Effect<
+    ParsedNativeSession,
+    TeleportSchemaVersionError | TeleportDiscoveryError,
+    FileSystem.FileSystem | Path.Path
+  >;
+  readonly write: (input: {
+    readonly homes: TeleportHomes;
+    readonly session: ParsedNativeSession;
+    readonly existingNativePath?: string;
+  }) => Effect.Effect<
+    string,
+    TeleportNativeWriteError | TeleportFileLockedError | TeleportSchemaVersionError,
+    FileSystem.FileSystem | Path.Path
+  >;
+  readonly requireUnlocked: (input: {
+    readonly homes: TeleportHomes;
+    readonly nativePath: string;
+  }) => Effect.Effect<void, TeleportFileLockedError, FileSystem.FileSystem | Path.Path>;
+  readonly resumeCursor: (externalSessionId: string) => unknown;
+  readonly readExternalSessionId: (resumeCursor: unknown) => string | undefined;
+}

--- a/apps/server/src/teleport/formats/register.ts
+++ b/apps/server/src/teleport/formats/register.ts
@@ -1,0 +1,2 @@
+// Native format adapters register themselves by importing their modules here.
+export function loadTeleportFormats(): void {}

--- a/apps/server/src/teleport/formats/registry.ts
+++ b/apps/server/src/teleport/formats/registry.ts
@@ -1,0 +1,21 @@
+import type { TeleportProvider } from "@t3tools/contracts";
+
+import type { TeleportFormatAdapter } from "./adapter.ts";
+
+const adapters = new Map<TeleportProvider, TeleportFormatAdapter>();
+
+export function registerTeleportFormat(adapter: TeleportFormatAdapter): void {
+  adapters.set(adapter.provider, adapter);
+}
+
+export function getTeleportFormat(provider: TeleportProvider): TeleportFormatAdapter | undefined {
+  return adapters.get(provider);
+}
+
+export function listRegisteredTeleportProviders(): ReadonlyArray<TeleportProvider> {
+  return [...adapters.keys()];
+}
+
+export function resetTeleportFormats(): void {
+  adapters.clear();
+}

--- a/apps/server/src/teleport/homes.ts
+++ b/apps/server/src/teleport/homes.ts
@@ -1,0 +1,43 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeOS from "node:os";
+
+import type { ServerSettings } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+import { expandHomePath } from "../pathExpansion.ts";
+import { resolveClaudeHomePath } from "../provider/Drivers/ClaudeHome.ts";
+import { resolveCodexHomeLayout } from "../provider/Drivers/CodexHomeLayout.ts";
+
+export interface TeleportHomes {
+  readonly codexSessionsRoot: string;
+  readonly claudeProjectsRoot: string;
+  readonly opencodeRoot: string;
+  readonly grokSessionsRoot: string;
+}
+
+export const resolveTeleportHomes = Effect.fn("resolveTeleportHomes")(function* (
+  settings: ServerSettings,
+): Effect.fn.Return<TeleportHomes, never, FileSystem.FileSystem | Path.Path> {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const codexLayout = yield* resolveCodexHomeLayout(settings.providers.codex);
+  const claudeHome = yield* resolveClaudeHomePath(settings.providers.claudeAgent);
+  const nestedClaude = path.join(claudeHome, ".claude", "projects");
+  const nestedExists = yield* fs.exists(nestedClaude).pipe(Effect.orElseSucceed(() => false));
+  const claudeProjectsRoot = nestedExists ? nestedClaude : path.join(claudeHome, "projects");
+  // OpenCode stores sessions at ~/.local/share/opencode on macOS/Linux and
+  // %USERPROFILE%\.local\share\opencode on Windows. XDG_DATA_HOME still wins.
+  const xdgData =
+    process.env.XDG_DATA_HOME && process.env.XDG_DATA_HOME.trim().length > 0
+      ? expandHomePath(process.env.XDG_DATA_HOME)
+      : path.join(NodeOS.homedir(), ".local", "share");
+
+  return {
+    codexSessionsRoot: path.join(codexLayout.sharedHomePath, "sessions"),
+    claudeProjectsRoot,
+    opencodeRoot: path.join(xdgData, "opencode"),
+    grokSessionsRoot: path.join(NodeOS.homedir(), ".grok", "sessions"),
+  };
+});

--- a/apps/server/src/teleport/json.ts
+++ b/apps/server/src/teleport/json.ts
@@ -1,0 +1,95 @@
+export function definedField<K extends string, V>(
+  key: K,
+  value: V | undefined,
+): Record<PropertyKey, never> | { readonly [P in K]: V } {
+  if (value === undefined) {
+    return {};
+  }
+  return { [key]: value } as { readonly [P in K]: V };
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function nonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function parseJsonObject(raw: string): Record<string, unknown> | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  return isRecord(parsed) ? parsed : undefined;
+}
+
+export function collectTextParts(content: unknown): string | undefined {
+  if (typeof content === "string") {
+    return nonEmptyString(content);
+  }
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  const parts: string[] = [];
+  for (const part of content) {
+    if (!isRecord(part)) {
+      continue;
+    }
+    const text = nonEmptyString(part.text);
+    if (text) {
+      parts.push(text);
+    }
+  }
+  return nonEmptyString(parts.join("\n"));
+}
+
+export function truncateTitle(input: string): string {
+  const normalized = input.replace(/\s+/gu, " ").trim();
+  if (normalized.length <= 80) {
+    return normalized;
+  }
+  return `${normalized.slice(0, 77).trimEnd()}...`;
+}
+
+export function isSyntheticNativeUserText(text: string): boolean {
+  const trimmed = text.trim();
+  return (
+    trimmed.startsWith("<environment_context>") ||
+    trimmed.startsWith("<skills_instructions>") ||
+    trimmed.startsWith("<permissions instructions>")
+  );
+}
+
+export function firstUserTitle(
+  messages: ReadonlyArray<{ role: string; text: string }>,
+): string | undefined {
+  for (const message of messages) {
+    if (message.role !== "user") {
+      continue;
+    }
+    if (isSyntheticNativeUserText(message.text)) {
+      continue;
+    }
+    const line = message.text
+      .split("\n")
+      .map((entry) => entry.trim())
+      .find((entry) => entry.length > 0);
+    if (line) {
+      return truncateTitle(line);
+    }
+  }
+  return undefined;
+}
+
+export const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/iu;
+
+export function uuidFromPath(filePath: string): string | undefined {
+  return filePath.match(UUID_RE)?.[0]?.toLowerCase();
+}

--- a/apps/server/src/teleport/nativeWrite.ts
+++ b/apps/server/src/teleport/nativeWrite.ts
@@ -1,0 +1,183 @@
+import { TeleportFileLockedError, TeleportNativeWriteError } from "@t3tools/contracts";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import type * as PlatformError from "effect/PlatformError";
+
+import { requireNativePathUnlocked } from "./fileLock.ts";
+
+function platformErrorTag(cause: unknown): string | undefined {
+  if (typeof cause !== "object" || cause === null) {
+    return undefined;
+  }
+  if ("reason" in cause) {
+    const reason = (cause as { reason?: { _tag?: unknown } }).reason;
+    if (reason && typeof reason._tag === "string") {
+      return reason._tag;
+    }
+  }
+  if ("_tag" in cause && typeof (cause as { _tag?: unknown })._tag === "string") {
+    return (cause as { _tag: string })._tag;
+  }
+  return undefined;
+}
+
+function nodeErrorCode(cause: unknown): string | undefined {
+  if (typeof cause !== "object" || cause === null) {
+    return undefined;
+  }
+  if ("code" in cause && typeof (cause as { code?: unknown }).code === "string") {
+    return (cause as { code: string }).code;
+  }
+  if ("reason" in cause) {
+    const nested = (cause as { reason?: { cause?: unknown } }).reason?.cause;
+    return nodeErrorCode(nested);
+  }
+  return undefined;
+}
+
+export function isNativeFileBusy(cause: unknown): boolean {
+  const tag = platformErrorTag(cause);
+  if (tag === "Busy") {
+    return true;
+  }
+  const code = nodeErrorCode(cause);
+  return code === "EBUSY";
+}
+
+function isReplaceConflict(cause: unknown): boolean {
+  const tag = platformErrorTag(cause);
+  if (tag === "AlreadyExists" || tag === "PermissionDenied") {
+    return true;
+  }
+  const code = nodeErrorCode(cause);
+  return code === "EEXIST" || code === "EPERM" || code === "EACCES";
+}
+
+/**
+ * Rename `from` onto `to`. Unix rename replaces an existing file; Windows
+ * throws if the destination exists, so we remove then rename. A locked
+ * destination becomes `TeleportFileLockedError`.
+ */
+export const replaceNativeFile = Effect.fn("replaceNativeFile")(function* (input: {
+  readonly from: string;
+  readonly to: string;
+}) {
+  const fs = yield* FileSystem.FileSystem;
+  const platform = yield* HostProcessPlatform;
+  const locked = (cause: unknown) =>
+    new TeleportFileLockedError({
+      nativePath: input.to,
+      message: `Native session file is locked: ${input.to}`,
+      cause,
+    });
+  const failed = (cause: unknown) =>
+    new TeleportNativeWriteError({
+      nativePath: input.to,
+      message: `Failed to replace ${input.to}.`,
+      cause,
+    });
+
+  const asReplaceError = (cause: unknown): TeleportFileLockedError | TeleportNativeWriteError =>
+    isNativeFileBusy(cause) ? locked(cause) : failed(cause);
+
+  const rename = fs.rename(input.from, input.to);
+  return yield* rename.pipe(
+    Effect.catch(
+      (
+        cause: PlatformError.PlatformError,
+      ): Effect.Effect<void, TeleportFileLockedError | TeleportNativeWriteError> => {
+        if (platform === "win32" && isReplaceConflict(cause) && !isNativeFileBusy(cause)) {
+          return fs.remove(input.to).pipe(
+            Effect.mapError((removeCause): TeleportFileLockedError | TeleportNativeWriteError =>
+              isNativeFileBusy(removeCause) || isReplaceConflict(removeCause)
+                ? locked(removeCause)
+                : failed(removeCause),
+            ),
+            Effect.andThen(rename.pipe(Effect.mapError(asReplaceError))),
+          );
+        }
+        return Effect.fail(asReplaceError(cause));
+      },
+    ),
+  );
+});
+
+export const writeNativeSessionAtomically = Effect.fn("writeNativeSessionAtomically")(
+  function* (input: {
+    readonly filePath: string;
+    readonly contents: string;
+    readonly verify: (contents: string) => Effect.Effect<unknown, TeleportNativeWriteError>;
+  }): Effect.fn.Return<
+    void,
+    TeleportNativeWriteError | TeleportFileLockedError,
+    FileSystem.FileSystem | Path.Path
+  > {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const targetDirectory = path.dirname(input.filePath);
+
+    yield* requireNativePathUnlocked(input.filePath);
+
+    const exists = yield* fs.exists(input.filePath).pipe(Effect.orElseSucceed(() => false));
+    if (exists) {
+      yield* requireNativePathUnlocked(input.filePath);
+    }
+
+    yield* fs.makeDirectory(targetDirectory, { recursive: true }).pipe(
+      Effect.mapError(
+        (cause) =>
+          new TeleportNativeWriteError({
+            nativePath: input.filePath,
+            message: `Failed to create directory for ${input.filePath}.`,
+            cause,
+          }),
+      ),
+    );
+
+    yield* Effect.scoped(
+      Effect.gen(function* () {
+        const tempDirectory = yield* fs
+          .makeTempDirectoryScoped({
+            directory: targetDirectory,
+            prefix: `${path.basename(input.filePath)}.`,
+          })
+          .pipe(
+            Effect.mapError(
+              (cause) =>
+                new TeleportNativeWriteError({
+                  nativePath: input.filePath,
+                  message: `Failed to create a temp file for ${input.filePath}.`,
+                  cause,
+                }),
+            ),
+          );
+        const tempPath = path.join(tempDirectory, "contents.tmp");
+        yield* fs.writeFileString(tempPath, input.contents).pipe(
+          Effect.mapError(
+            (cause) =>
+              new TeleportNativeWriteError({
+                nativePath: input.filePath,
+                message: `Failed to write temp session file for ${input.filePath}.`,
+                cause,
+              }),
+          ),
+        );
+        const written = yield* fs.readFileString(tempPath).pipe(
+          Effect.mapError(
+            (cause) =>
+              new TeleportNativeWriteError({
+                nativePath: input.filePath,
+                message: `Failed to re-read temp session file for ${input.filePath}.`,
+                cause,
+              }),
+          ),
+        );
+        yield* input.verify(written);
+        yield* requireNativePathUnlocked(input.filePath);
+        yield* replaceNativeFile({ from: tempPath, to: input.filePath });
+      }),
+    );
+  },
+);

--- a/apps/server/src/teleport/resumeCursors.test.ts
+++ b/apps/server/src/teleport/resumeCursors.test.ts
@@ -1,0 +1,41 @@
+import { assert, describe, it } from "@effect/vitest";
+import { ProviderDriverKind } from "@t3tools/contracts";
+
+import { resetTeleportFormats } from "./formats/registry.ts";
+import { buildTeleportResumeCursor, readTeleportExternalSessionId } from "./resumeCursors.ts";
+import { TELEPORT_TEST_SESSION_ID } from "./testFixtures.ts";
+
+describe("teleport resume cursors", () => {
+  it("prefers the teleport payload over a resume cursor", () => {
+    resetTeleportFormats();
+    assert.equal(
+      readTeleportExternalSessionId({
+        provider: ProviderDriverKind.make("grok"),
+        resumeCursor: { schemaVersion: 1, sessionId: "other" },
+        runtimePayload: {
+          teleport: { externalSessionId: TELEPORT_TEST_SESSION_ID },
+        },
+      }),
+      TELEPORT_TEST_SESSION_ID,
+    );
+  });
+
+  it("falls back to a generic session id when no format is registered", () => {
+    resetTeleportFormats();
+    assert.deepStrictEqual(
+      buildTeleportResumeCursor({
+        provider: "codex",
+        externalSessionId: TELEPORT_TEST_SESSION_ID,
+      }),
+      { sessionId: TELEPORT_TEST_SESSION_ID },
+    );
+    assert.equal(
+      readTeleportExternalSessionId({
+        provider: ProviderDriverKind.make("codex"),
+        resumeCursor: { threadId: TELEPORT_TEST_SESSION_ID },
+        runtimePayload: null,
+      }),
+      undefined,
+    );
+  });
+});

--- a/apps/server/src/teleport/resumeCursors.ts
+++ b/apps/server/src/teleport/resumeCursors.ts
@@ -1,0 +1,89 @@
+import {
+  isTeleportProvider,
+  ProviderDriverKind,
+  resolveTeleportPresence,
+  TeleportRuntimePayload,
+  TeleportUnsupportedProviderError,
+  type TeleportProvider,
+  type TeleportThreadState,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+
+import { getTeleportFormat } from "./formats/registry.ts";
+import { isRecord, nonEmptyString } from "./json.ts";
+
+const decodeTeleportRuntimePayload = Schema.decodeUnknownOption(TeleportRuntimePayload);
+
+export function toTeleportProvider(
+  provider: ProviderDriverKind,
+): Effect.Effect<TeleportProvider, TeleportUnsupportedProviderError> {
+  if (isTeleportProvider(provider)) {
+    return Effect.succeed(provider);
+  }
+  return Effect.fail(
+    new TeleportUnsupportedProviderError({
+      provider,
+      message: `Teleport does not support provider '${provider}'.`,
+    }),
+  );
+}
+
+export function buildTeleportResumeCursor(input: {
+  readonly provider: TeleportProvider;
+  readonly externalSessionId: string;
+}): unknown {
+  return (
+    getTeleportFormat(input.provider)?.resumeCursor(input.externalSessionId) ?? {
+      sessionId: input.externalSessionId,
+    }
+  );
+}
+
+export function readTeleportRuntimePayload(
+  runtimePayload: unknown,
+): TeleportRuntimePayload | undefined {
+  if (!isRecord(runtimePayload)) {
+    return undefined;
+  }
+  return Option.getOrUndefined(decodeTeleportRuntimePayload(runtimePayload.teleport));
+}
+
+export function teleportThreadStateFromPayload(input: {
+  readonly provider: TeleportProvider;
+  readonly payload: TeleportRuntimePayload;
+}): TeleportThreadState {
+  return {
+    presence: resolveTeleportPresence(input.payload),
+    provider: input.provider,
+    externalSessionId: input.payload.externalSessionId,
+    nativePath: input.payload.nativePath,
+    lastSyncedAt: input.payload.lastSyncedAt,
+  };
+}
+
+export function readTeleportExternalSessionId(input: {
+  readonly provider: ProviderDriverKind;
+  readonly resumeCursor: unknown;
+  readonly runtimePayload: unknown;
+}): string | undefined {
+  if (isRecord(input.runtimePayload)) {
+    const teleport = input.runtimePayload.teleport;
+    if (isRecord(teleport)) {
+      const externalSessionId = nonEmptyString(teleport.externalSessionId);
+      if (externalSessionId) {
+        return externalSessionId;
+      }
+    }
+  }
+
+  if (!isRecord(input.resumeCursor)) {
+    return undefined;
+  }
+
+  if (!isTeleportProvider(input.provider)) {
+    return undefined;
+  }
+  return getTeleportFormat(input.provider)?.readExternalSessionId(input.resumeCursor);
+}

--- a/apps/server/src/teleport/sessionFile.ts
+++ b/apps/server/src/teleport/sessionFile.ts
@@ -1,0 +1,32 @@
+import { TeleportSchemaVersionError } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Option from "effect/Option";
+
+import { MAX_TELEPORT_SESSION_BYTES, type ParsedNativeSession } from "./types.ts";
+
+export const readNativeSessionFile = Effect.fn("readNativeSessionFile")(function* (input: {
+  readonly nativePath: string;
+  readonly parse: (args: {
+    readonly contents: string;
+    readonly nativePath: string;
+  }) => Effect.Effect<Option.Option<ParsedNativeSession>, TeleportSchemaVersionError>;
+}): Effect.fn.Return<
+  Option.Option<ParsedNativeSession>,
+  TeleportSchemaVersionError,
+  FileSystem.FileSystem
+> {
+  const fs = yield* FileSystem.FileSystem;
+  const stat = yield* fs.stat(input.nativePath).pipe(Effect.orElseSucceed(() => null));
+  if (stat === null || stat.type !== "File") {
+    return Option.none();
+  }
+  if (typeof stat.size === "number" && stat.size > MAX_TELEPORT_SESSION_BYTES) {
+    return Option.none();
+  }
+  const contents = yield* fs.readFileString(input.nativePath).pipe(Effect.orElseSucceed(() => ""));
+  if (contents.length === 0) {
+    return Option.none();
+  }
+  return yield* input.parse({ contents, nativePath: input.nativePath });
+});

--- a/apps/server/src/teleport/testFixtures.ts
+++ b/apps/server/src/teleport/testFixtures.ts
@@ -1,0 +1,36 @@
+import { TELEPORT_NATIVE_FORMAT_VERSION } from "@t3tools/contracts";
+
+import type { ParsedNativeSession } from "./types.ts";
+
+export const TELEPORT_TEST_SESSION_ID = "11111111-1111-4111-8111-111111111111";
+export const TELEPORT_TEST_CREATED_AT = "2026-08-14T06:00:00.000Z";
+
+export function sampleTeleportSession(
+  provider: ParsedNativeSession["provider"],
+  cwd = "/workspace",
+): ParsedNativeSession {
+  return {
+    provider,
+    externalSessionId: TELEPORT_TEST_SESSION_ID,
+    cwd,
+    nativePath: `/tmp/${provider}.session`,
+    nativeFormatVersion: TELEPORT_NATIVE_FORMAT_VERSION,
+    title: "Fix the flaky matcher",
+    createdAt: TELEPORT_TEST_CREATED_AT,
+    updatedAt: "2026-08-14T06:01:00.000Z",
+    messages: [
+      {
+        role: "user",
+        text: "Fix the flaky matcher",
+        createdAt: TELEPORT_TEST_CREATED_AT,
+        id: "user-1",
+      },
+      {
+        role: "assistant",
+        text: "I'll tighten the path comparison and add a realpath fallback.",
+        createdAt: "2026-08-14T06:01:00.000Z",
+        id: "assistant-1",
+      },
+    ],
+  };
+}

--- a/apps/server/src/teleport/types.ts
+++ b/apps/server/src/teleport/types.ts
@@ -1,0 +1,74 @@
+import type { TeleportProvider, TeleportSessionCandidate } from "@t3tools/contracts";
+
+import { definedField } from "./json.ts";
+
+export interface NativeTextMessage {
+  readonly role: "user" | "assistant";
+  readonly text: string;
+  readonly createdAt?: string;
+  readonly id?: string;
+}
+
+export interface ParsedNativeSession {
+  readonly provider: TeleportProvider;
+  readonly externalSessionId: string;
+  readonly cwd: string;
+  readonly nativePath: string;
+  readonly nativeFormatVersion: number;
+  readonly title?: string;
+  readonly createdAt?: string;
+  readonly updatedAt?: string;
+  readonly messages: ReadonlyArray<NativeTextMessage>;
+}
+
+export function nativeTextMessage(input: {
+  readonly role: "user" | "assistant";
+  readonly text: string;
+  readonly createdAt: string | undefined;
+  readonly id: string | undefined;
+}): NativeTextMessage {
+  return {
+    role: input.role,
+    text: input.text,
+    ...definedField("createdAt", input.createdAt),
+    ...definedField("id", input.id),
+  };
+}
+
+export function parsedNativeSession(input: {
+  readonly provider: TeleportProvider;
+  readonly externalSessionId: string;
+  readonly cwd: string;
+  readonly nativePath: string;
+  readonly nativeFormatVersion: number;
+  readonly title: string | undefined;
+  readonly createdAt: string | undefined;
+  readonly updatedAt: string | undefined;
+  readonly messages: ReadonlyArray<NativeTextMessage>;
+}): ParsedNativeSession {
+  return {
+    provider: input.provider,
+    externalSessionId: input.externalSessionId,
+    cwd: input.cwd,
+    nativePath: input.nativePath,
+    nativeFormatVersion: input.nativeFormatVersion,
+    ...definedField("title", input.title),
+    ...definedField("createdAt", input.createdAt),
+    ...definedField("updatedAt", input.updatedAt),
+    messages: input.messages,
+  };
+}
+
+export function teleportCandidateFields(
+  session: ParsedNativeSession,
+): Pick<TeleportSessionCandidate, "title" | "createdAt" | "updatedAt"> {
+  return {
+    ...definedField("title", session.title),
+    ...definedField("createdAt", session.createdAt),
+    ...definedField("updatedAt", session.updatedAt),
+  };
+}
+
+export const MAX_TELEPORT_MESSAGES = 2_000;
+export const MAX_TELEPORT_MESSAGE_CHARS = 100_000;
+export const MAX_TELEPORT_SESSION_BYTES = 20 * 1024 * 1024;

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -123,6 +123,7 @@ import * as PairingGrantStore from "./auth/PairingGrantStore.ts";
 import * as SessionStore from "./auth/SessionStore.ts";
 import { failEnvironmentAuthInvalid, failEnvironmentInternal } from "./auth/http.ts";
 import * as RelayClient from "@t3tools/shared/relayClient";
+import { TeleportService } from "./teleport/Services/TeleportService.ts";
 const isOrchestrationDispatchCommandError = Schema.is(OrchestrationDispatchCommandError);
 
 const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
@@ -279,7 +280,9 @@ export function isThreadDetailEvent(event: OrchestrationEvent): event is Extract
       | "thread.activity-appended"
       | "thread.turn-diff-completed"
       | "thread.reverted"
-      | "thread.session-set";
+      | "thread.session-set"
+      | "thread.history-replaced"
+      | "thread.teleported";
   }
 > {
   return (
@@ -288,7 +291,9 @@ export function isThreadDetailEvent(event: OrchestrationEvent): event is Extract
     event.type === "thread.activity-appended" ||
     event.type === "thread.turn-diff-completed" ||
     event.type === "thread.reverted" ||
-    event.type === "thread.session-set"
+    event.type === "thread.session-set" ||
+    event.type === "thread.history-replaced" ||
+    event.type === "thread.teleported"
   );
 }
 
@@ -417,6 +422,7 @@ const makeWsRpcLayer = (
       const resourceTelemetry = yield* ResourceTelemetry.ResourceTelemetry;
       const usage = yield* UsageService.UsageService;
       const relayClient = yield* RelayClient.RelayClient;
+      const teleport = yield* TeleportService;
       const authorizationError = (requiredScope: AuthEnvironmentScope) =>
         new EnvironmentAuthorizationError({
           message: `The authenticated token is missing required scope: ${requiredScope}.`,
@@ -2271,6 +2277,18 @@ const makeWsRpcLayer = (
             ),
             { "rpc.aggregate": "server" },
           ),
+        [WS_METHODS.teleportListSessions]: (input) =>
+          observeRpcEffect(WS_METHODS.teleportListSessions, teleport.listSessions(input), {
+            "rpc.aggregate": "teleport",
+          }),
+        [WS_METHODS.teleportImportSessions]: (input) =>
+          observeRpcEffect(WS_METHODS.teleportImportSessions, teleport.importSessions(input), {
+            "rpc.aggregate": "teleport",
+          }),
+        [WS_METHODS.teleportExportSession]: (input) =>
+          observeRpcEffect(WS_METHODS.teleportExportSession, teleport.exportSession(input), {
+            "rpc.aggregate": "teleport",
+          }),
       });
     }),
   );

--- a/packages/client-runtime/src/state/entities.test.ts
+++ b/packages/client-runtime/src/state/entities.test.ts
@@ -229,6 +229,64 @@ describe("environment entity projections", () => {
     expect(merged?.messages).toBe(messages);
   });
 
+  it("fills missing detail teleport presence from the shell snapshot", () => {
+    const nativeTeleport = {
+      presence: "native" as const,
+      provider: "grok" as const,
+      externalSessionId: "session-1",
+      nativePath: "/tmp/native",
+      lastSyncedAt: "2026-08-14T23:00:00.000Z",
+    };
+    const detail = {
+      ...THREAD_SHELL,
+      environmentId: ENVIRONMENT_ID,
+      deletedAt: null,
+      messages: [],
+      proposedPlans: [],
+      activities: [],
+      checkpoints: [],
+    } satisfies OrchestrationThread & { readonly environmentId: EnvironmentId };
+    const shell = {
+      ...THREAD_SHELL,
+      environmentId: ENVIRONMENT_ID,
+      teleport: nativeTeleport,
+    };
+
+    expect(mergeEnvironmentThread(detail, shell)?.teleport).toEqual(nativeTeleport);
+  });
+
+  it("keeps live detail teleport presence over a stale shell snapshot", () => {
+    const nativeTeleport = {
+      presence: "native" as const,
+      provider: "codex" as const,
+      externalSessionId: "session-1",
+      nativePath: "/tmp/native",
+      lastSyncedAt: "2026-08-14T23:00:00.000Z",
+    };
+    const t3Teleport = {
+      ...nativeTeleport,
+      presence: "t3" as const,
+      lastSyncedAt: "2026-08-14T23:05:00.000Z",
+    };
+    const detail = {
+      ...THREAD_SHELL,
+      environmentId: ENVIRONMENT_ID,
+      deletedAt: null,
+      messages: [],
+      proposedPlans: [],
+      activities: [],
+      checkpoints: [],
+      teleport: t3Teleport,
+    } satisfies OrchestrationThread & { readonly environmentId: EnvironmentId };
+    const shell = {
+      ...THREAD_SHELL,
+      environmentId: ENVIRONMENT_ID,
+      teleport: nativeTeleport,
+    };
+
+    expect(mergeEnvironmentThread(detail, shell)?.teleport).toEqual(t3Teleport);
+  });
+
   it("preserves untouched project and thread identities across unrelated shell updates", () => {
     const harness = makeHarness();
     const projectRefsAtom = harness.projects.environmentProjectRefsAtom(ENVIRONMENT_ID);

--- a/packages/client-runtime/src/state/threadDetail.ts
+++ b/packages/client-runtime/src/state/threadDetail.ts
@@ -64,6 +64,10 @@ export function mergeEnvironmentThread(
     pinnedAt: shell.pinnedAt,
     pinOrderKey: shell.pinOrderKey,
     session: shell.session,
+    // Detail can resume from a cached snapshot and skip HTTP, so a backfilled
+    // `teleport_json` never arrives as `thread.teleported`. The shell snapshot
+    // is refetched per session; use it when detail has no presence yet.
+    teleport: detail.teleport ?? shell.teleport ?? null,
   };
 }
 

--- a/packages/client-runtime/src/state/threadReducer.test.ts
+++ b/packages/client-runtime/src/state/threadReducer.test.ts
@@ -882,6 +882,138 @@ describe("applyThreadDetailEvent", () => {
     });
   });
 
+  describe("thread.history-replaced", () => {
+    it("replaces messages and clears turn-derived state", () => {
+      const threadWithHistory: OrchestrationThread = {
+        ...baseThread,
+        messages: [
+          {
+            id: MessageId.make("old-1"),
+            role: "user",
+            text: "old",
+            turnId: TurnId.make("turn-1"),
+            streaming: false,
+            createdAt: "2026-04-01T01:00:00.000Z",
+            updatedAt: "2026-04-01T01:00:00.000Z",
+          },
+        ],
+        proposedPlans: [
+          {
+            id: "plan-1",
+            turnId: TurnId.make("turn-1"),
+            planMarkdown: "do things",
+            implementedAt: null,
+            implementationThreadId: null,
+            createdAt: "2026-04-01T01:00:00.000Z",
+            updatedAt: "2026-04-01T01:00:00.000Z",
+          },
+        ],
+        activities: [
+          {
+            id: EventId.make("act-1"),
+            turnId: TurnId.make("turn-1"),
+            tone: "tool",
+            kind: "file-edit",
+            summary: "old activity",
+            payload: {},
+            createdAt: "2026-04-01T01:00:00.000Z",
+          },
+        ],
+        checkpoints: [
+          {
+            turnId: TurnId.make("turn-1"),
+            checkpointTurnCount: 1,
+            checkpointRef: CheckpointRef.make("ref-1"),
+            status: "ready",
+            files: [],
+            assistantMessageId: MessageId.make("old-2"),
+            completedAt: "2026-04-01T01:00:00.000Z",
+          },
+        ],
+        latestTurn: {
+          turnId: TurnId.make("turn-1"),
+          state: "completed",
+          requestedAt: "2026-04-01T01:00:00.000Z",
+          startedAt: "2026-04-01T01:00:00.000Z",
+          completedAt: "2026-04-01T01:00:00.000Z",
+          assistantMessageId: MessageId.make("old-2"),
+        },
+      };
+
+      const messages = [
+        {
+          id: MessageId.make("new-1"),
+          role: "user" as const,
+          text: "imported",
+          turnId: null,
+          streaming: false,
+          createdAt: "2026-08-14T06:00:00.000Z",
+          updatedAt: "2026-08-14T06:00:00.000Z",
+        },
+      ];
+
+      const result = applyThreadDetailEvent(threadWithHistory, {
+        ...baseEventFields,
+        sequence: 20,
+        occurredAt: "2026-08-14T06:02:00.000Z",
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-1"),
+        type: "thread.history-replaced",
+        payload: {
+          threadId: ThreadId.make("thread-1"),
+          messages,
+          replacedAt: "2026-08-14T06:02:00.000Z",
+        },
+      });
+
+      expect(result.kind).toBe("updated");
+      if (result.kind === "updated") {
+        expect(result.thread.messages).toEqual(messages);
+        expect(result.thread.proposedPlans).toEqual([]);
+        expect(result.thread.activities).toEqual([]);
+        expect(result.thread.checkpoints).toEqual([]);
+        expect(result.thread.latestTurn).toBeNull();
+        expect(result.thread.updatedAt).toBe("2026-08-14T06:02:00.000Z");
+      }
+    });
+  });
+
+  describe("thread.teleported", () => {
+    it("stores teleport presence on the thread", () => {
+      const result = applyThreadDetailEvent(baseThread, {
+        ...baseEventFields,
+        sequence: 14,
+        occurredAt: "2026-08-14T22:00:00.000Z",
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-1"),
+        type: "thread.teleported",
+        payload: {
+          threadId: ThreadId.make("thread-1"),
+          teleport: {
+            presence: "native",
+            provider: "codex",
+            externalSessionId: "session-1",
+            nativePath: "/tmp/session.jsonl",
+            lastSyncedAt: "2026-08-14T22:00:00.000Z",
+          },
+          updatedAt: "2026-08-14T22:00:00.000Z",
+        },
+      });
+
+      expect(result.kind).toBe("updated");
+      if (result.kind === "updated") {
+        expect(result.thread.teleport).toEqual({
+          presence: "native",
+          provider: "codex",
+          externalSessionId: "session-1",
+          nativePath: "/tmp/session.jsonl",
+          lastSyncedAt: "2026-08-14T22:00:00.000Z",
+        });
+        expect(result.thread.updatedAt).toBe("2026-08-14T22:00:00.000Z");
+      }
+    });
+  });
+
   describe("no-op events", () => {
     it("returns unchanged for approval-response-requested", () => {
       const result = applyThreadDetailEvent(baseThread, {

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -559,6 +559,32 @@ export function applyThreadDetailEvent(
       };
     }
 
+    case "thread.history-replaced": {
+      return {
+        kind: "updated",
+        thread: {
+          ...thread,
+          messages: event.payload.messages,
+          proposedPlans: [],
+          activities: [],
+          checkpoints: [],
+          latestTurn: null,
+          updatedAt: event.payload.replacedAt,
+        },
+      };
+    }
+
+    case "thread.teleported": {
+      return {
+        kind: "updated",
+        thread: {
+          ...thread,
+          teleport: event.payload.teleport,
+          updatedAt: event.payload.updatedAt,
+        },
+      };
+    }
+
     // ── Activities ──────────────────────────────────────────────────
     case "thread.activity-appended": {
       const activity = event.payload.activity;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -30,4 +30,5 @@ export * from "./preview.ts";
 export * from "./previewAutomation.ts";
 export * from "./resourceTelemetry.ts";
 export * from "./usage.ts";
+export * from "./teleport.ts";
 export * from "./rpc.ts";

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -22,6 +22,7 @@ import {
   TurnId,
 } from "./baseSchemas.ts";
 import { ProviderInstanceId } from "./providerInstance.ts";
+import { TeleportThreadState } from "./teleport.ts";
 
 export const ORCHESTRATION_WS_METHODS = {
   dispatchCommand: "orchestration.dispatchCommand",
@@ -405,6 +406,8 @@ export const OrchestrationThread = Schema.Struct({
   activities: Schema.Array(OrchestrationThreadActivity),
   checkpoints: Schema.Array(OrchestrationCheckpointSummary),
   session: Schema.NullOr(OrchestrationSession),
+  // Optional so payloads from pre-teleport servers still decode.
+  teleport: Schema.optional(Schema.NullOr(TeleportThreadState)),
 });
 export type OrchestrationThread = typeof OrchestrationThread.Type;
 
@@ -480,6 +483,11 @@ export const OrchestrationThreadShell = Schema.Struct({
       }),
     ),
   ),
+  // Thread-level native/T3 presence. Optional so payloads from pre-teleport
+  // servers still decode. Lives on the shell because the environment snapshot
+  // is refreshed on every new session, unlike cached thread detail which can
+  // resume from events and miss a backfilled projection column.
+  teleport: Schema.optional(Schema.NullOr(TeleportThreadState)),
 });
 export type OrchestrationThreadShell = typeof OrchestrationThreadShell.Type;
 
@@ -1023,6 +1031,22 @@ const ThreadTitleRegenerationCompleteCommand = Schema.Struct({
   title: Schema.optional(TrimmedNonEmptyString),
 });
 
+const ThreadHistoryReplaceCommand = Schema.Struct({
+  type: Schema.Literal("thread.history.replace"),
+  commandId: CommandId,
+  threadId: ThreadId,
+  messages: Schema.Array(OrchestrationMessage),
+  createdAt: IsoDateTime,
+});
+
+const ThreadTeleportSetCommand = Schema.Struct({
+  type: Schema.Literal("thread.teleport.set"),
+  commandId: CommandId,
+  threadId: ThreadId,
+  teleport: TeleportThreadState,
+  createdAt: IsoDateTime,
+});
+
 const InternalOrchestrationCommand = Schema.Union([
   ThreadSessionSetCommand,
   ThreadMessageAssistantDeltaCommand,
@@ -1032,6 +1056,8 @@ const InternalOrchestrationCommand = Schema.Union([
   ThreadActivityAppendCommand,
   ThreadRevertCompleteCommand,
   ThreadTitleRegenerationCompleteCommand,
+  ThreadHistoryReplaceCommand,
+  ThreadTeleportSetCommand,
 ]);
 export type InternalOrchestrationCommand = typeof InternalOrchestrationCommand.Type;
 
@@ -1071,6 +1097,8 @@ export const OrchestrationEventType = Schema.Literals([
   "thread.proposed-plan-upserted",
   "thread.turn-diff-completed",
   "thread.activity-appended",
+  "thread.history-replaced",
+  "thread.teleported",
 ]);
 export type OrchestrationEventType = typeof OrchestrationEventType.Type;
 
@@ -1305,6 +1333,18 @@ export const ThreadActivityAppendedPayload = Schema.Struct({
   activity: OrchestrationThreadActivity,
 });
 
+export const ThreadHistoryReplacedPayload = Schema.Struct({
+  threadId: ThreadId,
+  messages: Schema.Array(OrchestrationMessage),
+  replacedAt: IsoDateTime,
+});
+
+export const ThreadTeleportedPayload = Schema.Struct({
+  threadId: ThreadId,
+  teleport: TeleportThreadState,
+  updatedAt: IsoDateTime,
+});
+
 export const OrchestrationEventMetadata = Schema.Struct({
   providerTurnId: Schema.optional(TrimmedNonEmptyString),
   providerItemId: Schema.optional(ProviderItemId),
@@ -1471,6 +1511,16 @@ export const OrchestrationEvent = Schema.Union([
     ...EventBaseFields,
     type: Schema.Literal("thread.activity-appended"),
     payload: ThreadActivityAppendedPayload,
+  }),
+  Schema.Struct({
+    ...EventBaseFields,
+    type: Schema.Literal("thread.history-replaced"),
+    payload: ThreadHistoryReplacedPayload,
+  }),
+  Schema.Struct({
+    ...EventBaseFields,
+    type: Schema.Literal("thread.teleported"),
+    payload: ThreadTeleportedPayload,
   }),
 ]);
 export type OrchestrationEvent = typeof OrchestrationEvent.Type;

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -189,6 +189,17 @@ import {
   SourceControlRepositoryLookupInput,
 } from "./sourceControl.ts";
 import { VcsError } from "./vcs.ts";
+import {
+  TeleportExportError,
+  TeleportExportSessionInput,
+  TeleportExportSessionResult,
+  TeleportImportError,
+  TeleportImportSessionsInput,
+  TeleportImportSessionsResult,
+  TeleportListSessionsError,
+  TeleportListSessionsInput,
+  TeleportListSessionsResult,
+} from "./teleport.ts";
 
 export const WS_METHODS = {
   // Project registry methods
@@ -297,6 +308,11 @@ export const WS_METHODS = {
   sourceControlLookupRepository: "sourceControl.lookupRepository",
   sourceControlCloneRepository: "sourceControl.cloneRepository",
   sourceControlPublishRepository: "sourceControl.publishRepository",
+
+  // Teleport session sync
+  teleportListSessions: "teleport.listSessions",
+  teleportImportSessions: "teleport.importSessions",
+  teleportExportSession: "teleport.exportSession",
 
   // Streaming subscriptions
   subscribeVcsStatus: "subscribeVcsStatus",
@@ -970,6 +986,24 @@ export const WsSubscribeResourceTelemetryRpc = Rpc.make(WS_METHODS.subscribeReso
   stream: true,
 });
 
+export const WsTeleportListSessionsRpc = Rpc.make(WS_METHODS.teleportListSessions, {
+  payload: TeleportListSessionsInput,
+  success: TeleportListSessionsResult,
+  error: Schema.Union([TeleportListSessionsError, EnvironmentAuthorizationError]),
+});
+
+export const WsTeleportImportSessionsRpc = Rpc.make(WS_METHODS.teleportImportSessions, {
+  payload: TeleportImportSessionsInput,
+  success: TeleportImportSessionsResult,
+  error: Schema.Union([TeleportImportError, EnvironmentAuthorizationError]),
+});
+
+export const WsTeleportExportSessionRpc = Rpc.make(WS_METHODS.teleportExportSession, {
+  payload: TeleportExportSessionInput,
+  success: TeleportExportSessionResult,
+  error: Schema.Union([TeleportExportError, EnvironmentAuthorizationError]),
+});
+
 export const WsRpcGroup = RpcGroup.make(
   WsServerProbeRpc,
   WsServerGetConfigRpc,
@@ -1061,6 +1095,9 @@ export const WsRpcGroup = RpcGroup.make(
   WsSubscribeAuthAccessRpc,
   WsSubscribeBackgroundPolicyRpc,
   WsSubscribeResourceTelemetryRpc,
+  WsTeleportListSessionsRpc,
+  WsTeleportImportSessionsRpc,
+  WsTeleportExportSessionRpc,
   WsOrchestrationDispatchCommandRpc,
   WsOrchestrationGetWorkflowScriptRpc,
   WsOrchestrationGetTurnDiffRpc,

--- a/packages/contracts/src/teleport.test.ts
+++ b/packages/contracts/src/teleport.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vite-plus/test";
+import * as Schema from "effect/Schema";
+
+import {
+  resolveTeleportPresence,
+  TeleportRuntimePayload,
+  TeleportThreadState,
+} from "./teleport.ts";
+
+const decodeTeleportThreadState = Schema.decodeUnknownSync(TeleportThreadState);
+const decodeTeleportRuntimePayload = Schema.decodeUnknownSync(TeleportRuntimePayload);
+
+describe("teleport presence", () => {
+  it("decodes a complete thread teleport state", () => {
+    const parsed = decodeTeleportThreadState({
+      presence: "native",
+      provider: "grok",
+      externalSessionId: "session-1",
+      nativePath: "/home/ubuntu/.grok/sessions/session-1",
+      lastSyncedAt: "2026-08-14T22:00:00.000Z",
+    });
+    expect(parsed.presence).toBe("native");
+    expect(parsed.provider).toBe("grok");
+  });
+
+  it("uses an explicit presence on the runtime payload", () => {
+    const parsed = decodeTeleportRuntimePayload({
+      schemaVersion: 1,
+      externalSessionId: "session-1",
+      nativePath: "/tmp/session.jsonl",
+      lastSyncDirection: "export",
+      lastSyncedAt: "2026-08-14T22:00:00.000Z",
+      nativeFormatVersion: 1,
+      presence: "t3",
+    });
+    expect(resolveTeleportPresence(parsed)).toBe("t3");
+  });
+
+  it("treats a legacy export as native presence", () => {
+    const parsed = decodeTeleportRuntimePayload({
+      schemaVersion: 1,
+      externalSessionId: "session-1",
+      nativePath: "/tmp/session.jsonl",
+      lastSyncDirection: "export",
+      lastSyncedAt: "2026-08-14T22:00:00.000Z",
+      nativeFormatVersion: 1,
+    });
+    expect(parsed.presence).toBeUndefined();
+    expect(resolveTeleportPresence(parsed)).toBe("native");
+  });
+
+  it("treats a legacy import as t3 presence", () => {
+    expect(
+      resolveTeleportPresence({
+        lastSyncDirection: "import",
+      }),
+    ).toBe("t3");
+  });
+});

--- a/packages/contracts/src/teleport.test.ts
+++ b/packages/contracts/src/teleport.test.ts
@@ -16,7 +16,7 @@ describe("teleport presence", () => {
       presence: "native",
       provider: "grok",
       externalSessionId: "session-1",
-      nativePath: "/home/ubuntu/.grok/sessions/session-1",
+      nativePath: "/home/user/.grok/sessions/session-1",
       lastSyncedAt: "2026-08-14T22:00:00.000Z",
     });
     expect(parsed.presence).toBe("native");

--- a/packages/contracts/src/teleport.ts
+++ b/packages/contracts/src/teleport.ts
@@ -1,0 +1,231 @@
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
+import { IsoDateTime, ProjectId, ThreadId, TrimmedNonEmptyString } from "./baseSchemas.ts";
+import { ProviderDriverKind, ProviderInstanceId } from "./providerInstance.ts";
+
+export const TELEPORT_SCHEMA_VERSION = 1 as const;
+export const TELEPORT_NATIVE_FORMAT_VERSION = 1 as const;
+
+export const TeleportProvider = Schema.Literals(["codex", "claudeAgent", "opencode", "grok"]);
+export type TeleportProvider = typeof TeleportProvider.Type;
+
+export const TeleportSyncDirection = Schema.Literals(["import", "export"]);
+export type TeleportSyncDirection = typeof TeleportSyncDirection.Type;
+
+export const TeleportPresence = Schema.Literals(["t3", "native"]);
+export type TeleportPresence = typeof TeleportPresence.Type;
+
+export const TeleportThreadState = Schema.Struct({
+  presence: TeleportPresence,
+  provider: TeleportProvider,
+  externalSessionId: TrimmedNonEmptyString,
+  nativePath: TrimmedNonEmptyString,
+  lastSyncedAt: IsoDateTime,
+});
+export type TeleportThreadState = typeof TeleportThreadState.Type;
+
+export const TeleportSessionRef = Schema.Struct({
+  provider: TeleportProvider,
+  externalSessionId: TrimmedNonEmptyString,
+});
+export type TeleportSessionRef = typeof TeleportSessionRef.Type;
+
+export const TeleportListSessionsInput = Schema.Struct({
+  cwd: TrimmedNonEmptyString,
+  providers: Schema.optional(Schema.Array(TeleportProvider)),
+});
+export type TeleportListSessionsInput = typeof TeleportListSessionsInput.Type;
+
+export const TeleportSessionCandidate = Schema.Struct({
+  provider: TeleportProvider,
+  providerInstanceId: ProviderInstanceId,
+  externalSessionId: TrimmedNonEmptyString,
+  cwd: TrimmedNonEmptyString,
+  nativePath: TrimmedNonEmptyString,
+  nativeFormatVersion: Schema.Int,
+  title: Schema.optional(TrimmedNonEmptyString),
+  createdAt: Schema.optional(IsoDateTime),
+  updatedAt: Schema.optional(IsoDateTime),
+});
+export type TeleportSessionCandidate = typeof TeleportSessionCandidate.Type;
+
+export const TeleportListSessionsResult = Schema.Struct({
+  schemaVersion: Schema.Literal(TELEPORT_SCHEMA_VERSION).pipe(
+    Schema.withDecodingDefault(Effect.succeed(TELEPORT_SCHEMA_VERSION)),
+  ),
+  sessions: Schema.Array(TeleportSessionCandidate),
+});
+export type TeleportListSessionsResult = typeof TeleportListSessionsResult.Type;
+
+export const TeleportImportSessionsInput = Schema.Struct({
+  projectId: ProjectId,
+  cwd: TrimmedNonEmptyString,
+  sessions: Schema.Array(TeleportSessionRef).check(Schema.isMinLength(1)),
+});
+export type TeleportImportSessionsInput = typeof TeleportImportSessionsInput.Type;
+
+export const TeleportImportedSession = Schema.Struct({
+  threadId: ThreadId,
+  projectId: ProjectId,
+  provider: TeleportProvider,
+  providerInstanceId: ProviderInstanceId,
+  externalSessionId: TrimmedNonEmptyString,
+  updatedInPlace: Schema.Boolean,
+});
+export type TeleportImportedSession = typeof TeleportImportedSession.Type;
+
+export const TeleportImportSessionsResult = Schema.Struct({
+  schemaVersion: Schema.Literal(TELEPORT_SCHEMA_VERSION).pipe(
+    Schema.withDecodingDefault(Effect.succeed(TELEPORT_SCHEMA_VERSION)),
+  ),
+  imported: Schema.Array(TeleportImportedSession),
+});
+export type TeleportImportSessionsResult = typeof TeleportImportSessionsResult.Type;
+
+export const TeleportExportSessionInput = Schema.Struct({
+  threadId: ThreadId,
+});
+export type TeleportExportSessionInput = typeof TeleportExportSessionInput.Type;
+
+export const TeleportExportSessionResult = Schema.Struct({
+  schemaVersion: Schema.Literal(TELEPORT_SCHEMA_VERSION).pipe(
+    Schema.withDecodingDefault(Effect.succeed(TELEPORT_SCHEMA_VERSION)),
+  ),
+  provider: TeleportProvider,
+  providerInstanceId: ProviderInstanceId,
+  externalSessionId: TrimmedNonEmptyString,
+  nativePath: TrimmedNonEmptyString,
+  cwd: TrimmedNonEmptyString,
+});
+export type TeleportExportSessionResult = typeof TeleportExportSessionResult.Type;
+
+export const TeleportRuntimePayload = Schema.Struct({
+  schemaVersion: Schema.Literal(TELEPORT_SCHEMA_VERSION),
+  externalSessionId: TrimmedNonEmptyString,
+  nativePath: TrimmedNonEmptyString,
+  lastSyncDirection: TeleportSyncDirection,
+  lastSyncedAt: IsoDateTime,
+  nativeFormatVersion: Schema.Int,
+  presence: Schema.optional(TeleportPresence),
+});
+export type TeleportRuntimePayload = typeof TeleportRuntimePayload.Type;
+
+export function isTeleportProvider(value: string): value is TeleportProvider {
+  return value === "codex" || value === "claudeAgent" || value === "opencode" || value === "grok";
+}
+
+export function resolveTeleportPresence(
+  payload: Pick<TeleportRuntimePayload, "presence" | "lastSyncDirection"> | null | undefined,
+): TeleportPresence {
+  if (payload?.presence) {
+    return payload.presence;
+  }
+  return payload?.lastSyncDirection === "export" ? "native" : "t3";
+}
+
+export function isTeleportedOut(teleport: TeleportThreadState | null | undefined): boolean {
+  return teleport?.presence === "native";
+}
+
+export class TeleportInvalidInputError extends Schema.TaggedErrorClass<TeleportInvalidInputError>()(
+  "TeleportInvalidInputError",
+  {
+    message: TrimmedNonEmptyString,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
+
+export class TeleportUnsupportedProviderError extends Schema.TaggedErrorClass<TeleportUnsupportedProviderError>()(
+  "TeleportUnsupportedProviderError",
+  {
+    provider: ProviderDriverKind,
+    message: TrimmedNonEmptyString,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
+
+export class TeleportSchemaVersionError extends Schema.TaggedErrorClass<TeleportSchemaVersionError>()(
+  "TeleportSchemaVersionError",
+  {
+    provider: Schema.optional(TeleportProvider),
+    nativePath: Schema.optional(TrimmedNonEmptyString),
+    foundVersion: Schema.optional(Schema.Int),
+    supportedVersion: Schema.Int,
+    message: TrimmedNonEmptyString,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
+
+export class TeleportFileLockedError extends Schema.TaggedErrorClass<TeleportFileLockedError>()(
+  "TeleportFileLockedError",
+  {
+    nativePath: TrimmedNonEmptyString,
+    message: TrimmedNonEmptyString,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
+
+export class TeleportIdentityConflictError extends Schema.TaggedErrorClass<TeleportIdentityConflictError>()(
+  "TeleportIdentityConflictError",
+  {
+    provider: TeleportProvider,
+    externalSessionId: TrimmedNonEmptyString,
+    existingThreadId: ThreadId,
+    existingProjectId: ProjectId,
+    message: TrimmedNonEmptyString,
+  },
+) {}
+
+export class TeleportProjectResolutionError extends Schema.TaggedErrorClass<TeleportProjectResolutionError>()(
+  "TeleportProjectResolutionError",
+  {
+    message: TrimmedNonEmptyString,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
+
+export class TeleportDiscoveryError extends Schema.TaggedErrorClass<TeleportDiscoveryError>()(
+  "TeleportDiscoveryError",
+  {
+    message: TrimmedNonEmptyString,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
+
+export class TeleportNativeWriteError extends Schema.TaggedErrorClass<TeleportNativeWriteError>()(
+  "TeleportNativeWriteError",
+  {
+    nativePath: TrimmedNonEmptyString,
+    message: TrimmedNonEmptyString,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
+
+export const TeleportListSessionsError = Schema.Union([
+  TeleportInvalidInputError,
+  TeleportDiscoveryError,
+  TeleportSchemaVersionError,
+]);
+export type TeleportListSessionsError = typeof TeleportListSessionsError.Type;
+
+export const TeleportImportError = Schema.Union([
+  TeleportInvalidInputError,
+  TeleportUnsupportedProviderError,
+  TeleportSchemaVersionError,
+  TeleportFileLockedError,
+  TeleportIdentityConflictError,
+  TeleportProjectResolutionError,
+  TeleportDiscoveryError,
+]);
+export type TeleportImportError = typeof TeleportImportError.Type;
+
+export const TeleportExportError = Schema.Union([
+  TeleportInvalidInputError,
+  TeleportUnsupportedProviderError,
+  TeleportSchemaVersionError,
+  TeleportFileLockedError,
+  TeleportProjectResolutionError,
+  TeleportNativeWriteError,
+]);
+export type TeleportExportError = typeof TeleportExportError.Type;


### PR DESCRIPTION
> **Draft. Do not merge.** First slice of two-way teleport. Review this stack, not a mega PR.
## What Changed
The teleport engine: contracts, `thread.history.replace`, presence, and the server service that lists, imports, and exports native CLI sessions.
Native files stay native. Import copies a CLI session onto a T3 thread. Export writes the thread back. Presence (`t3` vs `native`) is persisted so both sides are not writers at once.
No CLI format adapters are registered yet. `listSessions` returns an empty list. Import/export of an unregistered provider fails closed. Adapters land in the Codex / Claude / Grok / OpenCode PRs on top of this one.
## Why
Two-way teleport needs one shared engine before any provider-specific format. This is that engine.
## Stack
1. **This PR** — teleport backend
2. Teleport UI
3. Codex support
4. Claude support
5. Grok support
6. OpenCode support
## UI Changes
None. The picker and export button land in the next PR.
## Checklist
- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add teleport import/export engine with native session sync via WebSocket RPC
> - Introduces a `TeleportService` with three WebSocket RPC endpoints (`teleport.listSessions`, `teleport.importSessions`, `teleport.exportSession`) backed by a provider-driven adapter registry for syncing native AI tool sessions (Codex, Claude, Grok, etc.)
> - Adds `thread.history.replace` and `thread.teleport.set` commands that emit `thread.history-replaced` and `thread.teleported` events; these rewrite message history and persist teleport state through the projection pipeline, projector, and client-side reducer
> - Adds migration 041 to introduce a `teleport_json` column on `projection_threads` and backfill it from existing `provider_session_runtime` rows
> - Implements cross-platform atomic native file write (`writeNativeSessionAtomically`) with lock detection, temp-file staging, content verification, and OS-specific rename handling
> - Adds `opencodeSessionMatchesProjectCwd` with heuristics to match OpenCode sessions to projects while rejecting generic roots and known foreign harness folders
> - Risk: `thread.turn.start` now returns `OrchestrationCommandInvariantError` when a thread's teleport presence is `native`, blocking message sends until the session is imported
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3620294. 33 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->