### PR TITLE
fix(server): run the CLI on Node versions without import.meta.main

### DIFF
--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -12,6 +12,7 @@ import { connectCommand } from "./cli/connect.ts";
 import { pairCommand } from "./cli/pair.ts";
 import { hasCloudPublicConfig } from "./cloud/publicConfig.ts";
 import { sharedServerCommandFlags } from "./cli/config.ts";
+import { isEntrypoint } from "./entrypoint.ts";
 import { projectCommand } from "./cli/project.ts";
 import { runServerCommand, serveCommand, startCommand } from "./cli/server.ts";
 import { serviceCommand } from "./cli/service.ts";
@@ -61,7 +62,13 @@ export const makeCli = ({ cloudEnabled = hasCloudPublicConfig } = {}) =>
 
 export const cli = makeCli();
 
-if (import.meta.main) {
+if (
+  isEntrypoint({
+    moduleUrl: import.meta.url,
+    entryPath: process.argv[1],
+    runtimeMain: import.meta.main,
+  })
+) {
   Command.run(cli, { version: packageJson.version }).pipe(
     Effect.scoped,
     Effect.provide(CliRuntimeLayer),

--- a/apps/server/src/entrypoint.test.ts
+++ b/apps/server/src/entrypoint.test.ts
@@ -1,0 +1,89 @@
+// @effect-diagnostics nodeBuiltinImport:off - entrypoint detection is a Node filesystem boundary.
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import * as NodeURL from "node:url";
+
+import { describe, expect, it } from "vite-plus/test";
+
+import { isEntrypoint } from "./entrypoint.ts";
+
+const makeTempDir = () => NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-entrypoint-test-"));
+
+describe("isEntrypoint", () => {
+  it("uses the runtime answer when Node provides one", () => {
+    // Node 22.18+ and 24.2+ populate `import.meta.main`; nothing else is consulted.
+    expect(
+      isEntrypoint({
+        moduleUrl: "file:///somewhere/bin.mjs",
+        entryPath: "/elsewhere/other.mjs",
+        runtimeMain: true,
+      }),
+    ).toBe(true);
+    expect(
+      isEntrypoint({
+        moduleUrl: "file:///somewhere/bin.mjs",
+        entryPath: "/somewhere/bin.mjs",
+        runtimeMain: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("matches the entrypoint path when the runtime has no import.meta.main", () => {
+    // Node 22.16, 22.17 and 23.11 are inside `engines.node` but leave it undefined.
+    const dir = makeTempDir();
+    const entry = NodePath.join(dir, "bin.mjs");
+    NodeFS.writeFileSync(entry, "");
+
+    expect(
+      isEntrypoint({
+        moduleUrl: NodeURL.pathToFileURL(entry).href,
+        entryPath: entry,
+        runtimeMain: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it("matches through a symlinked entrypoint, as npm and npx install it", () => {
+    const dir = makeTempDir();
+    const real = NodePath.join(dir, "bin.mjs");
+    const link = NodePath.join(dir, "t3");
+    NodeFS.writeFileSync(real, "");
+    NodeFS.symlinkSync(real, link);
+
+    expect(
+      isEntrypoint({
+        moduleUrl: NodeURL.pathToFileURL(real).href,
+        entryPath: link,
+        runtimeMain: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it("stays false for an imported module that is not the entrypoint", () => {
+    // This is what keeps `bin.test.ts` from launching the CLI on import.
+    const dir = makeTempDir();
+    const entry = NodePath.join(dir, "bin.mjs");
+    const imported = NodePath.join(dir, "cli.mjs");
+    NodeFS.writeFileSync(entry, "");
+    NodeFS.writeFileSync(imported, "");
+
+    expect(
+      isEntrypoint({
+        moduleUrl: NodeURL.pathToFileURL(imported).href,
+        entryPath: entry,
+        runtimeMain: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("stays false when there is no entrypoint argument", () => {
+    expect(
+      isEntrypoint({
+        moduleUrl: "file:///somewhere/bin.mjs",
+        entryPath: undefined,
+        runtimeMain: undefined,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/server/src/entrypoint.ts
+++ b/apps/server/src/entrypoint.ts
@@ -1,0 +1,38 @@
+// @effect-diagnostics nodeBuiltinImport:off
+// Entrypoint detection runs before any Effect runtime is built, so it stays on
+// Node built-ins.
+import * as NodeFS from "node:fs";
+import * as NodeURL from "node:url";
+
+/**
+ * Whether the module identified by `moduleUrl` is the process entrypoint.
+ *
+ * `import.meta.main` answers this directly, but it only exists on Node 22.18+
+ * and 24.2+. This package's `engines.node` range also accepts 22.16, 22.17 and
+ * 23.11, where it is `undefined`: an `if (import.meta.main)` guard never runs,
+ * so the process loads every module and exits 0 without output. Fall back to
+ * comparing the entrypoint path on those versions.
+ */
+export const isEntrypoint = (input: {
+  readonly moduleUrl: string;
+  readonly entryPath: string | undefined;
+  readonly runtimeMain: boolean | undefined;
+}): boolean => {
+  if (input.runtimeMain !== undefined) {
+    return input.runtimeMain;
+  }
+  if (input.entryPath === undefined || input.entryPath === "") {
+    return false;
+  }
+  if (input.moduleUrl === NodeURL.pathToFileURL(input.entryPath).href) {
+    return true;
+  }
+  // npm and npx install the CLI as a symlink. Without `--preserve-symlinks` the
+  // module URL is the resolved real path while `process.argv[1]` keeps the link
+  // path, so the comparison above misses.
+  try {
+    return input.moduleUrl === NodeURL.pathToFileURL(NodeFS.realpathSync(input.entryPath)).href;
+  } catch {
+    return false;
+  }
+};

--- a/apps/server/src/serviceLauncher.ts
+++ b/apps/server/src/serviceLauncher.ts
@@ -27,6 +27,7 @@ import {
   SERVICE_STATE_FILE,
   SERVICE_STOP_MARKER_FILE,
 } from "./cloud/serviceProtocol.ts";
+import { isEntrypoint } from "./entrypoint.ts";
 
 const HANDOFF_DELAY_MS = 2_000;
 const PREPARED_TIMEOUT_MS = 120_000;
@@ -609,7 +610,13 @@ async function main(): Promise<void> {
   await new Launcher(baseDir, state).run();
 }
 
-if (import.meta.main) {
+if (
+  isEntrypoint({
+    moduleUrl: import.meta.url,
+    entryPath: process.argv[1],
+    runtimeMain: import.meta.main,
+  })
+) {
   main().catch((cause: unknown) => {
     const error = cause instanceof Error ? cause : new Error(String(cause));
     process.stderr.write(`[service-launcher] ${error.message}\n`);


### PR DESCRIPTION
Fixes #6465.

`bin.ts` and `serviceLauncher.ts` gate their entrypoints on `import.meta.main`. Node added that property in **22.18** and **24.2**, but `apps/server`'s engines range is `^22.16 || ^23.11 || >=24.10` — so a supported Node can load every module and exit 0 without running anything or printing a reason.

Measured here across real installs:

| Node | `import.meta.main` | today's guard |
|---|---|---|
| 22.17.0 | `undefined` | never runs, exit 0, no output |
| 23.11.0 | `undefined` | never runs, exit 0, no output |
| 22.18.0 | `true` | runs |
| 24.19.0 | `true` | runs |

**`^23.11` is affected too, not just the 22.16–22.17 window in the issue.** Node 23 reached end-of-life before the backport, so every `23.11.x` is in this state. That rules out narrowing the range as a fix — `^22.18 || ^23.11 || >=24.10` would still ship a broken branch — so this takes the other option in the issue and makes the guard version-agnostic.

The helper keeps `import.meta.main` whenever the runtime defines it, so on 22.18+/24.2+ nothing changes. It only falls back on versions where the property is missing, and those cannot start today, so the fallback has no working behavior to regress. The fallback also resolves through a symlink, which is how npm and npx install the CLI.

**Why `serviceLauncher.ts` is in here.** It has the identical guard and is the second shipped entrypoint. `bootService.ts` writes `ExecStart=<node> <launcher>` with `Restart=always`, and the unit test pins `/usr/bin/node` — the host runtime, not a pinned one. On an affected Node the launcher exits 0 silently and systemd restarts it forever. Same one-line guard, so it is here rather than in a follow-up, but happy to split it out if you would rather keep this to the reported path.

Verification, bundling the real source with esbuild and running it on each version: the current guard is silent on 22.17 and 23.11 for both entrypoints and the branch runs; output is identical on 22.18 and 24.19; the symlink shape behaves the same. `entrypoint.test.ts` covers the runtime-provided answer, the fallback, the symlink, the imported-not-entrypoint case that keeps `bin.test.ts` from launching the CLI, and a missing `argv[1]`. `bin.test.ts` 17/17 and `bootService`/`serviceLauncher` 15/15 still pass, `tsgo --noEmit` is clean.

One thing I did not touch: the issue also reports that on WSL a cold `bin.mjs --help` from `app.asar.unpacked` over 9p takes ~67s and blows the readiness window. That is a separate problem from this one and looks related to #5769.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the only shipped process entrypoints (CLI and systemd launcher); behavior is unchanged on Node 22.18+/24.2+ but the fallback path is new for affected engines.
> 
> **Overview**
> On supported Node versions where **`import.meta.main` is undefined** (e.g. 22.16–22.17, 23.11), the CLI and service launcher no longer exit silently with code 0 because their `if (import.meta.main)` guards never ran.
> 
> This PR adds **`isEntrypoint`**, which still defers to `import.meta.main` when Node defines it, and otherwise treats the current module as the entrypoint by comparing `import.meta.url` to **`process.argv[1]`**, including **`realpathSync`** so npm/npx symlink installs match. **`bin.ts`** and **`serviceLauncher.ts`** use that helper instead of a bare `import.meta.main` check; **`entrypoint.test.ts`** covers runtime main, path fallback, symlinks, non-entry imports, and missing `argv[1]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecd3c6dc4483a78e9efba7d842b99831acca162c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CLI and service launcher entry guards for Node versions without `import.meta.main`
> Replaces `import.meta.main` checks in [bin.ts](https://github.com/pingdotgg/t3code/pull/7141/files#diff-49e5d719869710e6cd7800547c130d0f20fcf22e14bb44b6ea8db436bb9a5a5f) and [serviceLauncher.ts](https://github.com/pingdotgg/t3code/pull/7141/files#diff-e78e0e76388457975864b3b8040aac6cbf3536b618de4b7e17fc66bfc0f75bf9) with a new `isEntrypoint` utility defined in [entrypoint.ts](https://github.com/pingdotgg/t3code/pull/7141/files#diff-c5630b9a87044abec2c4ff6c8ef4a7ea231fb6dbafa85c7ed9f3369789b1d481).
>
> - `isEntrypoint` returns `runtimeMain` directly when available, otherwise compares the entry path to the module URL, with a `realpath` fallback to handle symlinked executables.
> - Guards against missing or empty entry paths and catches filesystem errors from `realpath`.
> - Behavioral Change: on Node versions where `import.meta.main` is `undefined`, the CLI and service launcher previously may not have run; they now correctly detect the entrypoint.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ecd3c6d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->