### PR TITLE
fix(server): backfill assistant text from the snapshot when a stalled stream never closes its block

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -3116,6 +3116,161 @@ describe("ClaudeAdapterLive", () => {
     },
   );
 
+  it.effect(
+    "aligns a multi-block snapshot by streamed prefix when the stall predates later blocks",
+    () => {
+      const harness = makeHarness();
+      const firstParagraph = "Fixing the adapter now.";
+      const secondParagraph = "Second paragraph the stream never reached.";
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+
+        const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 12).pipe(
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+
+        const session = yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          runtimeMode: "full-access",
+        });
+
+        yield* adapter.sendTurn({
+          threadId: session.threadId,
+          input: "go",
+          attachments: [],
+        });
+
+        // An earlier message of the same turn completes normally, leaving a completed block
+        // at the head of the turn-wide block list.
+        harness.query.emit({
+          type: "stream_event",
+          session_id: "sdk-session-misaligned-snapshot",
+          uuid: "misaligned-start-1",
+          parent_tool_use_id: null,
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "text", text: "" },
+          },
+        } as unknown as SDKMessage);
+
+        harness.query.emit({
+          type: "stream_event",
+          session_id: "sdk-session-misaligned-snapshot",
+          uuid: "misaligned-delta-1",
+          parent_tool_use_id: null,
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "text_delta", text: "Earlier answer." },
+          },
+        } as unknown as SDKMessage);
+
+        harness.query.emit({
+          type: "stream_event",
+          session_id: "sdk-session-misaligned-snapshot",
+          uuid: "misaligned-stop-1",
+          parent_tool_use_id: null,
+          event: { type: "content_block_stop", index: 0 },
+        } as unknown as SDKMessage);
+
+        // The next message stalls after one delta of its FIRST text block; its second text
+        // block never starts streaming. Naive tail alignment would slide the snapshot's last
+        // block onto the stalled one and attach the wrong paragraph.
+        harness.query.emit({
+          type: "stream_event",
+          session_id: "sdk-session-misaligned-snapshot",
+          uuid: "misaligned-start-2",
+          parent_tool_use_id: null,
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "text", text: "" },
+          },
+        } as unknown as SDKMessage);
+
+        harness.query.emit({
+          type: "stream_event",
+          session_id: "sdk-session-misaligned-snapshot",
+          uuid: "misaligned-delta-2",
+          parent_tool_use_id: null,
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "text_delta", text: "Fixing" },
+          },
+        } as unknown as SDKMessage);
+
+        harness.query.emit({
+          type: "assistant",
+          session_id: "sdk-session-misaligned-snapshot",
+          uuid: "misaligned-assistant-snapshot",
+          parent_tool_use_id: null,
+          message: {
+            id: "assistant-message-misaligned",
+            content: [
+              { type: "text", text: firstParagraph },
+              { type: "text", text: secondParagraph },
+            ],
+          },
+        } as unknown as SDKMessage);
+
+        harness.query.emit({
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          errors: [],
+          session_id: "sdk-session-misaligned-snapshot",
+          uuid: "result-misaligned",
+        } as unknown as SDKMessage);
+
+        const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+
+        const assistantDeltas = runtimeEvents.filter(
+          (event) =>
+            event.type === "content.delta" && event.payload.streamKind === "assistant_text",
+        );
+        const deltaText = (event: (typeof assistantDeltas)[number]) =>
+          event.type === "content.delta" ? String(event.payload.delta) : "";
+
+        // Stalled block: streamed prefix plus the repaired suffix, exactly once.
+        const stalledItemId = String(assistantDeltas[1]?.itemId);
+        const stalledText = assistantDeltas
+          .filter((event) => String(event.itemId) === stalledItemId)
+          .map(deltaText)
+          .join("");
+        assert.equal(stalledText, firstParagraph);
+
+        // The paragraph that never streamed is synthesized as its own block, not glued onto
+        // the stalled one and not dropped.
+        const synthesizedDelta = assistantDeltas.find(
+          (event) => deltaText(event) === secondParagraph,
+        );
+        assert.ok(synthesizedDelta);
+        assert.notEqual(String(synthesizedDelta?.itemId), stalledItemId);
+
+        const assistantCompletions = runtimeEvents.filter(
+          (event) =>
+            event.type === "item.completed" && event.payload.itemType === "assistant_message",
+        );
+        // Completion order: the streamed first message (no detail — nothing was backfilled),
+        // then the synthesized paragraph (closed right at the snapshot), and the stalled block
+        // last — it stays open for late deltas until the turn result force-completes it.
+        assert.deepEqual(
+          assistantCompletions.map((event) =>
+            event.type === "item.completed" ? event.payload.detail : undefined,
+          ),
+          [undefined, secondParagraph, firstParagraph],
+        );
+      }).pipe(
+        Effect.provideService(Random.Random, makeDeterministicRandomService()),
+        Effect.provide(harness.layer),
+      );
+    },
+  );
+
   it.effect("segments Claude assistant text blocks around tool calls", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -2951,6 +2951,171 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect(
+    "repairs a stalled text stream from the snapshot of a later message in the turn",
+    () => {
+      const harness = makeHarness();
+      const fullText = "PR is open: https://example.test/pull/1";
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+
+        // Deliberately one short of the full sequence: without the repair delta the stream still
+        // reaches 10 events (it ends with turn.completed instead), so a regression fails on the
+        // assertion below rather than hanging until the test timeout.
+        const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 10).pipe(
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+
+        const session = yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          runtimeMode: "full-access",
+        });
+
+        yield* adapter.sendTurn({
+          threadId: session.threadId,
+          input: "go",
+          attachments: [],
+        });
+
+        // First assistant message of the turn streams and closes normally.
+        harness.query.emit({
+          type: "stream_event",
+          session_id: "sdk-session-stalled-stream",
+          uuid: "stalled-start-1",
+          parent_tool_use_id: null,
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "text", text: "" },
+          },
+        } as unknown as SDKMessage);
+
+        harness.query.emit({
+          type: "stream_event",
+          session_id: "sdk-session-stalled-stream",
+          uuid: "stalled-delta-1",
+          parent_tool_use_id: null,
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "text_delta", text: "Pushing now." },
+          },
+        } as unknown as SDKMessage);
+
+        harness.query.emit({
+          type: "stream_event",
+          session_id: "sdk-session-stalled-stream",
+          uuid: "stalled-stop-1",
+          parent_tool_use_id: null,
+          event: { type: "content_block_stop", index: 0 },
+        } as unknown as SDKMessage);
+
+        // Second message: the stream dies after one delta. No content_block_stop ever arrives.
+        harness.query.emit({
+          type: "stream_event",
+          session_id: "sdk-session-stalled-stream",
+          uuid: "stalled-start-2",
+          parent_tool_use_id: null,
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "text", text: "" },
+          },
+        } as unknown as SDKMessage);
+
+        harness.query.emit({
+          type: "stream_event",
+          session_id: "sdk-session-stalled-stream",
+          uuid: "stalled-delta-2",
+          parent_tool_use_id: null,
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "text_delta", text: "P" },
+          },
+        } as unknown as SDKMessage);
+
+        // The CLI then hands over the finished message as a single snapshot.
+        harness.query.emit({
+          type: "assistant",
+          session_id: "sdk-session-stalled-stream",
+          uuid: "stalled-assistant-snapshot",
+          parent_tool_use_id: null,
+          message: {
+            id: "assistant-message-stalled",
+            content: [{ type: "text", text: fullText }],
+          },
+        } as unknown as SDKMessage);
+
+        harness.query.emit({
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          errors: [],
+          session_id: "sdk-session-stalled-stream",
+          uuid: "result-stalled",
+        } as unknown as SDKMessage);
+
+        const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+        assert.deepEqual(
+          runtimeEvents.map((event) => event.type),
+          [
+            "session.started",
+            "session.configured",
+            "session.state.changed",
+            "turn.started",
+            "thread.started",
+            "content.delta",
+            "item.completed",
+            "content.delta",
+            "content.delta",
+            "item.completed",
+          ],
+        );
+
+        const assistantDeltas = runtimeEvents.filter(
+          (event) =>
+            event.type === "content.delta" && event.payload.streamKind === "assistant_text",
+        );
+        assert.equal(assistantDeltas.length, 3);
+
+        // The repair ships only the suffix the client never saw, so appending the deltas of the
+        // second message reconstructs the full text exactly once.
+        const secondMessageDeltas = assistantDeltas.slice(1);
+        assert.equal(
+          secondMessageDeltas
+            .map((event) => (event.type === "content.delta" ? event.payload.delta : ""))
+            .join(""),
+          fullText,
+        );
+
+        // Both deltas of the second message must belong to the same item — the whole bug was the
+        // repair landing on the item of an earlier message.
+        const secondMessageItemIds = new Set(
+          secondMessageDeltas.map((event) => String(event.itemId)),
+        );
+        assert.equal(secondMessageItemIds.size, 1);
+        assert.notEqual(String(assistantDeltas[0]?.itemId), String(assistantDeltas[1]?.itemId));
+
+        const assistantCompletions = runtimeEvents.filter(
+          (event) =>
+            event.type === "item.completed" && event.payload.itemType === "assistant_message",
+        );
+        assert.equal(assistantCompletions.length, 2);
+        assert.equal(String(assistantCompletions[1]?.itemId), String(assistantDeltas[1]?.itemId));
+        const secondCompletion = assistantCompletions[1];
+        if (secondCompletion?.type === "item.completed") {
+          assert.equal(secondCompletion.payload.detail, fullText);
+        }
+      }).pipe(
+        Effect.provideService(Random.Random, makeDeterministicRandomService()),
+        Effect.provide(harness.layer),
+      );
+    },
+  );
+
   it.effect("segments Claude assistant text blocks around tool calls", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -147,7 +147,12 @@ interface ClaudeTurnState {
 interface AssistantTextBlockState {
   readonly itemId: string;
   readonly blockIndex: number;
-  emittedTextDelta: boolean;
+  /**
+   * Text already shipped to the client as `content.delta`. The projection appends
+   * deltas, so this is what the user currently sees for this block — it lets a
+   * stalled stream be repaired by sending only the missing suffix.
+   */
+  streamedText: string;
   fallbackText: string;
   streamClosed: boolean;
   completionEmitted: boolean;
@@ -1813,7 +1818,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     const block: AssistantTextBlockState = {
       itemId: yield* randomUUIDv4,
       blockIndex,
-      emittedTextDelta: false,
+      streamedText: "",
       fallbackText: options?.fallbackText ?? "",
       streamClosed: options?.streamClosed ?? false,
       completionEmitted: false,
@@ -1857,7 +1862,17 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       return;
     }
 
-    if (!block.emittedTextDelta && block.fallbackText.length > 0) {
+    // The snapshot text can be ahead of what the delta stream actually delivered: when a
+    // stream stalls mid-message the CLI ships the finished message as one `claude/assistant`
+    // snapshot and never sends the remaining deltas (nor `content_block_stop`). Emit only the
+    // part the client has not seen yet, so a repair never duplicates text. When nothing
+    // streamed at all this degrades to shipping the whole fallback, as before.
+    const pendingText = block.fallbackText.startsWith(block.streamedText)
+      ? block.fallbackText.slice(block.streamedText.length)
+      : "";
+
+    if (pendingText.length > 0) {
+      block.streamedText = block.fallbackText;
       const deltaStamp = yield* makeEventStamp();
       yield* offerRuntimeEvent({
         type: "content.delta",
@@ -1869,7 +1884,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         itemId: asRuntimeItemId(block.itemId),
         payload: {
           streamKind: "assistant_text",
-          delta: block.fallbackText,
+          delta: pendingText,
         },
         providerRefs: nativeProviderRefs(context),
         ...(options?.rawMethod || options?.rawPayload
@@ -1935,8 +1950,18 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       block,
     }));
 
+    // A snapshot describes ONE assistant message, but `assistantTextBlockOrder` accumulates
+    // every text block of the whole turn and is never reset between messages. Matching from
+    // the head therefore poured the snapshot's text into blocks of *earlier* messages once a
+    // turn contained more than one of them, leaving the message whose stream actually broke
+    // unrepaired. The snapshot's blocks are the most recent ones, so skip the leftovers of
+    // earlier messages. Never shift past the head: when the snapshot has MORE text blocks than
+    // the turn recorded, some block never started streaming at all, and the trailing entries
+    // are the ones missing — those still have to be synthesized head-first, as before.
+    const tailOffset = Math.max(0, orderedBlocks.length - snapshotTextBlocks.length);
+
     for (const [position, text] of snapshotTextBlocks.entries()) {
-      const existingEntry = orderedBlocks[position];
+      const existingEntry = orderedBlocks[tailOffset + position];
       const entry =
         existingEntry ??
         (yield* createSyntheticAssistantTextBlock(context, text).pipe(
@@ -1948,15 +1973,15 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
             return created;
           }),
         ));
-      if (!entry) {
+      if (!entry || entry.block.completionEmitted) {
         continue;
       }
 
-      if (entry.block.fallbackText.length === 0) {
-        entry.block.fallbackText = text;
-      }
+      // For a block that has not been delivered yet the snapshot is authoritative: a stalled
+      // stream leaves a partial prefix behind, and only the snapshot knows the rest.
+      entry.block.fallbackText = text;
 
-      if (entry.block.streamClosed && !entry.block.completionEmitted) {
+      if (entry.block.streamClosed) {
         yield* completeAssistantTextBlock(context, entry.block, {
           rawMethod: "claude/assistant",
           rawPayload: message,
@@ -2468,7 +2493,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
                 }
               : undefined;
         if (assistantBlockEntry?.block && event.delta.type === "text_delta") {
-          assistantBlockEntry.block.emittedTextDelta = true;
+          assistantBlockEntry.block.streamedText += deltaText;
         }
         const stamp = yield* makeEventStamp();
         yield* offerRuntimeEvent({

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -1951,14 +1951,38 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     }));
 
     // A snapshot describes ONE assistant message, but `assistantTextBlockOrder` accumulates
-    // every text block of the whole turn and is never reset between messages. Matching from
-    // the head therefore poured the snapshot's text into blocks of *earlier* messages once a
-    // turn contained more than one of them, leaving the message whose stream actually broke
-    // unrepaired. The snapshot's blocks are the most recent ones, so skip the leftovers of
-    // earlier messages. Never shift past the head: when the snapshot has MORE text blocks than
-    // the turn recorded, some block never started streaming at all, and the trailing entries
-    // are the ones missing — those still have to be synthesized head-first, as before.
-    const tailOffset = Math.max(0, orderedBlocks.length - snapshotTextBlocks.length);
+    // every text block of the whole turn and is never reset between messages, so position
+    // alone cannot say which trailing blocks are the snapshot's. Pure tail alignment breaks
+    // the moment the stream died before every snapshot block was opened: the window then
+    // swallows completed blocks of earlier messages and each paragraph lands one block off.
+    // The streamed prefixes disambiguate — the snapshot must extend whatever its open blocks
+    // already streamed. Pick the shift that binds the most open blocks compatibly. Ties keep
+    // the FIRST such shift: preferring a later one would slide past a fully-completed message
+    // whose snapshot arrives after the fact and re-synthesize its text as a duplicate block.
+    let tailOffset = Math.max(0, orderedBlocks.length - snapshotTextBlocks.length);
+    let bestBoundOpenBlocks = -1;
+    for (let shift = 0; shift <= orderedBlocks.length; shift++) {
+      let boundOpenBlocks = 0;
+      let compatible = true;
+      for (const [position, text] of snapshotTextBlocks.entries()) {
+        const candidate = orderedBlocks[shift + position];
+        if (!candidate) {
+          break;
+        }
+        if (candidate.block.completionEmitted) {
+          continue;
+        }
+        if (!text.startsWith(candidate.block.streamedText)) {
+          compatible = false;
+          break;
+        }
+        boundOpenBlocks += 1;
+      }
+      if (compatible && boundOpenBlocks > bestBoundOpenBlocks) {
+        bestBoundOpenBlocks = boundOpenBlocks;
+        tailOffset = shift;
+      }
+    }
 
     for (const [position, text] of snapshotTextBlocks.entries()) {
       const existingEntry = orderedBlocks[tailOffset + position];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5184,10 +5184,12 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@yuuang/ffi-rs-android-arm64@1.3.2':
     resolution: {integrity: sha512-eDYLT0kVBkp7e2BwdRDmt6N1rkeDPUHDefk3ZX0/nok+GLsqfy1WBoSL3Yg7HVXN1EyW8OBVc2uK8Zq8HbmaSA==}


### PR DESCRIPTION
One of two alternative fixes for #7137 — this is the small one. The deeper alternative is #7143: it keys blocks by message id instead of repairing the positional matching, and fixes three adjacent defects along the way. Pick one, they are not meant to be merged together.

## What changed

`ClaudeAdapter` assembles assistant text from stream deltas and uses the `claude/assistant` snapshot as a safety net when deltas go missing. Two defects made that net miss:

1. `backfillAssistantTextBlocksFromSnapshot` aligned snapshot text blocks against the turn-long block list **by position from the start**. A snapshot describes one message, but the list accumulates across the whole turn — so in any turn with an earlier text message, the snapshot text landed on the wrong, already-completed block.
2. The backfill only filled a block whose accumulated text was empty, and only completed one whose stream was already closed. A stream that dies mid-message satisfies neither.

This PR aligns snapshot blocks to the **tail** of the block list (last N open blocks, N = text blocks in the snapshot), and lets the backfill extend an open block when the snapshot text extends the streamed prefix. If the snapshot does not extend what was already shown to the user, nothing is overwritten and a warning is logged.

## Why

Hit organically (full event log in #7137): a stream emitted one `text_delta` — the letter `P` — then went silent for 3m16s and never sent `content_block_stop`. The finished 2.4 KB message arrived as a single snapshot. The snapshot text was written onto the wrong block, the dangling block was force-completed empty, and the message was persisted as `P`. Unrecoverable by restart: the event store never contained the text.

## Tests

- New regression test replays the exact incident event sequence; it fails without the fix (message persisted as `P`) and passes with it.
- Full server suite: 230 files passed, 2507 tests passed, 7 skipped, on top of current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stalled assistant stream repair to backfill only the unstreamed suffix from the snapshot
> - `AssistantTextBlockState` replaces the `emittedTextDelta` boolean with a `streamedText` string that accumulates all text already sent to the client, enabling suffix-only repairs.
> - `completeAssistantTextBlock` now emits only the missing suffix (snapshot text minus already-streamed prefix) instead of re-sending the full fallback text, preventing duplicate deltas.
> - The assistant snapshot handler aligns snapshot text blocks to open turn blocks by streamed prefix match rather than tail position, avoiding mis-assignment when stalls occur before later blocks arrive.
> - Never-streamed paragraphs in a snapshot are synthesized as new blocks with distinct item IDs.
> - Behavioral Change: blocks that stalled mid-stream now receive a partial delta repair rather than a full-text retransmission.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c0d7a59.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes assistant text projection and persistence in the Claude adapter—a user-visible runtime path—but the behavior is narrowly scoped to stalled-stream repair with dedicated regression tests.
> 
> **Overview**
> Fixes **lost or truncated assistant messages** when the Claude stream stalls mid-text and the finished content arrives only as a `claude/assistant` snapshot.
> 
> **`ClaudeAdapter`** now tracks **`streamedText`** per text block (replacing a boolean “had a delta” flag) and, on completion/backfill, emits **`content.delta` only for the suffix** the client has not already seen—so repairs do not duplicate partial stream output.
> 
> Snapshot blocks are **aligned to the correct assistant message** in a multi-message turn by choosing a shift into the turn-wide block list that best matches **open blocks whose streamed prefixes extend the snapshot text**, instead of matching from the head of the list. Undelivered snapshot paragraphs can be **synthesized as new blocks**; `fallbackText` is treated as authoritative for open blocks.
> 
> **Tests** add regressions for a stalled second message in a turn and for multi-block snapshots when streaming dies before later paragraphs start.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0d7a59634d7c19b522daf3e7e18a15db1258e51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->