### PR TITLE
fix(server): key assistant text blocks by message id instead of stream position

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -3918,6 +3918,72 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect(
+    "synthesizes a snapshot-only message instead of claiming a completed id-less block",
+    () => {
+      const harness = makeHarness();
+      const snapshotOnlyText = "Second, snapshot-only message.";
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+
+        // One short of turn.completed on purpose: a regression (the snapshot claiming the
+        // completed block and being skipped) produces fewer events and fails fast below.
+        const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 9).pipe(
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+
+        const session = yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          runtimeMode: "full-access",
+        });
+
+        yield* adapter.sendTurn({
+          threadId: session.threadId,
+          input: "go",
+          attachments: [],
+        });
+
+        // A message streams and completes WITHOUT message_start — its block carries no
+        // message id, which is what forces the backfill onto the id-less fallback path.
+        harness.query.emit(textBlockStart("idless-start-1", 0));
+        harness.query.emit(textDelta("idless-delta-1", 0, "First answer."));
+        harness.query.emit(blockStop("idless-stop-1", 0));
+
+        // The next message never streams at all: it arrives only as a snapshot, reusing
+        // content index 0. The completed id-less block must not swallow it.
+        harness.query.emit(
+          assistantSnapshot("idless-snapshot", "msg-snapshot-only", [snapshotOnlyText]),
+        );
+        harness.query.emit(successResult("idless-result"));
+
+        const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+        const deltas = assistantTextDeltas(runtimeEvents);
+        assert.equal(deltas.length, 2);
+        assert.equal(deltaText(deltas[0]), "First answer.");
+        assert.equal(deltaText(deltas[1]), snapshotOnlyText);
+        assert.notEqual(String(deltas[0]?.itemId), String(deltas[1]?.itemId));
+
+        const completions = runtimeEvents.filter(
+          (event) =>
+            event.type === "item.completed" && event.payload.itemType === "assistant_message",
+        );
+        // The streamed block carries no detail (nothing was backfilled into it); the
+        // synthesized one completes from its snapshot text.
+        assert.deepEqual(
+          completions.map((event) =>
+            event.type === "item.completed" ? event.payload.detail : undefined,
+          ),
+          [undefined, snapshotOnlyText],
+        );
+      }).pipe(
+        Effect.provideService(Random.Random, makeDeterministicRandomService()),
+        Effect.provide(harness.layer),
+      );
+    },
+  );
+
   it.effect("segments Claude assistant text blocks around tool calls", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -3618,6 +3618,306 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  const streamEvent = (uuid: string, event: unknown, parentToolUseId: string | null = null) =>
+    ({
+      type: "stream_event",
+      session_id: "sdk-session-message-scoped",
+      uuid,
+      parent_tool_use_id: parentToolUseId,
+      event,
+    }) as unknown as SDKMessage;
+
+  const messageStart = (uuid: string, messageId: string, parentToolUseId: string | null = null) =>
+    streamEvent(uuid, { type: "message_start", message: { id: messageId } }, parentToolUseId);
+
+  const textBlockStart = (uuid: string, index: number) =>
+    streamEvent(uuid, {
+      type: "content_block_start",
+      index,
+      content_block: { type: "text", text: "" },
+    });
+
+  const textDelta = (uuid: string, index: number, text: string) =>
+    streamEvent(uuid, {
+      type: "content_block_delta",
+      index,
+      delta: { type: "text_delta", text },
+    });
+
+  const blockStop = (uuid: string, index: number, parentToolUseId: string | null = null) =>
+    streamEvent(uuid, { type: "content_block_stop", index }, parentToolUseId);
+
+  const successResult = (uuid: string) =>
+    ({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      errors: [],
+      session_id: "sdk-session-message-scoped",
+      uuid,
+    }) as unknown as SDKMessage;
+
+  const assistantSnapshot = (uuid: string, messageId: string, texts: ReadonlyArray<string>) =>
+    ({
+      type: "assistant",
+      session_id: "sdk-session-message-scoped",
+      uuid,
+      parent_tool_use_id: null,
+      message: {
+        id: messageId,
+        content: texts.map((text) => ({ type: "text", text })),
+      },
+    }) as unknown as SDKMessage;
+
+  const assistantTextDeltas = (events: ReadonlyArray<ProviderRuntimeEvent>) =>
+    events.filter(
+      (event) => event.type === "content.delta" && event.payload.streamKind === "assistant_text",
+    );
+
+  const deltaText = (event: ProviderRuntimeEvent | undefined) =>
+    event?.type === "content.delta" ? event.payload.delta : undefined;
+
+  it.effect("repairs a stalled text stream from the snapshot of the message it belongs to", () => {
+    const harness = makeHarness();
+    const fullText = "PR is open: https://example.test/pull/1";
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      // One short of the full sequence on purpose: without the repair the stream still reaches
+      // 10 events (ending in turn.completed), so a regression fails on the assertion below
+      // instead of hanging until the test timeout.
+      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 10).pipe(
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "go",
+        attachments: [],
+      });
+
+      // First message of the turn streams and closes normally.
+      harness.query.emit(messageStart("stalled-msg-start-1", "msg-first"));
+      harness.query.emit(textBlockStart("stalled-start-1", 0));
+      harness.query.emit(textDelta("stalled-delta-1", 0, "Pushing now."));
+      harness.query.emit(blockStop("stalled-stop-1", 0));
+
+      // Second message: the stream dies after one delta. No content_block_stop ever arrives,
+      // and the finished message is handed over as a single snapshot instead.
+      harness.query.emit(messageStart("stalled-msg-start-2", "msg-second"));
+      harness.query.emit(textBlockStart("stalled-start-2", 0));
+      harness.query.emit(textDelta("stalled-delta-2", 0, "P"));
+      harness.query.emit(assistantSnapshot("stalled-snapshot", "msg-second", [fullText]));
+      harness.query.emit(successResult("stalled-result"));
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      assert.deepEqual(
+        runtimeEvents.map((event) => event.type),
+        [
+          "session.started",
+          "session.configured",
+          "session.state.changed",
+          "turn.started",
+          "thread.started",
+          "content.delta",
+          "item.completed",
+          "content.delta",
+          "content.delta",
+          "item.completed",
+        ],
+      );
+
+      const deltas = assistantTextDeltas(runtimeEvents);
+      assert.equal(deltas.length, 3);
+
+      // The repair ships only the suffix the client never saw, so appending the deltas of the
+      // second message reconstructs the full text exactly once.
+      const secondMessageDeltas = deltas.slice(1);
+      assert.equal(secondMessageDeltas.map(deltaText).join(""), fullText);
+
+      // Both deltas of the second message belong to one item: the whole bug was the repair
+      // landing on the item of an earlier message.
+      assert.equal(new Set(secondMessageDeltas.map((event) => String(event.itemId))).size, 1);
+      assert.notEqual(String(deltas[0]?.itemId), String(deltas[1]?.itemId));
+
+      const completions = runtimeEvents.filter(
+        (event) =>
+          event.type === "item.completed" && event.payload.itemType === "assistant_message",
+      );
+      assert.equal(completions.length, 2);
+      assert.equal(String(completions[1]?.itemId), String(deltas[1]?.itemId));
+      const repaired = completions[1];
+      if (repaired?.type === "item.completed") {
+        assert.equal(repaired.payload.detail, fullText);
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("repairs only the unfinished block of a multi-block assistant message", () => {
+    const harness = makeHarness();
+    const firstText = "Looked at the logs. ";
+    const secondText = "Second block, finished only in the snapshot.";
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 10).pipe(
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "go",
+        attachments: [],
+      });
+
+      // A single message with two text blocks: the first closes, the second stalls.
+      harness.query.emit(messageStart("multi-msg-start", "msg-multi"));
+      harness.query.emit(textBlockStart("multi-start-0", 0));
+      harness.query.emit(textDelta("multi-delta-0", 0, firstText));
+      harness.query.emit(blockStop("multi-stop-0", 0));
+      harness.query.emit(textBlockStart("multi-start-1", 1));
+      harness.query.emit(textDelta("multi-delta-1", 1, "Second block,"));
+      harness.query.emit(assistantSnapshot("multi-snapshot", "msg-multi", [firstText, secondText]));
+      harness.query.emit(successResult("multi-result"));
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      const deltas = assistantTextDeltas(runtimeEvents);
+      assert.equal(deltas.length, 3);
+
+      // The closed block must not be replayed: its text is already on screen.
+      assert.equal(deltaText(deltas[0]), firstText);
+      assert.equal(deltas.slice(1).map(deltaText).join(""), secondText);
+      assert.equal(new Set(deltas.slice(1).map((event) => String(event.itemId))).size, 1);
+      assert.notEqual(String(deltas[0]?.itemId), String(deltas[1]?.itemId));
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("keeps two messages apart when the second reuses an unclosed block index", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 9).pipe(
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "go",
+        attachments: [],
+      });
+
+      // First message never closes its block; the next message starts over at index 0.
+      harness.query.emit(messageStart("reuse-msg-start-1", "msg-alpha"));
+      harness.query.emit(textBlockStart("reuse-start-1", 0));
+      harness.query.emit(textDelta("reuse-delta-1", 0, "Alpha"));
+      harness.query.emit(messageStart("reuse-msg-start-2", "msg-beta"));
+      harness.query.emit(textBlockStart("reuse-start-2", 0));
+      harness.query.emit(textDelta("reuse-delta-2", 0, "Beta"));
+      harness.query.emit(successResult("reuse-result"));
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      const deltas = assistantTextDeltas(runtimeEvents);
+      assert.equal(deltas.length, 2);
+      assert.equal(deltaText(deltas[0]), "Alpha");
+      assert.equal(deltaText(deltas[1]), "Beta");
+      // Two API messages must stay two chat messages, not one spliced "AlphaBeta".
+      assert.notEqual(String(deltas[0]?.itemId), String(deltas[1]?.itemId));
+
+      const completions = runtimeEvents.filter(
+        (event) =>
+          event.type === "item.completed" && event.payload.itemType === "assistant_message",
+      );
+      assert.equal(completions.length, 2);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("ignores a subagent content_block_stop for the parent's text block", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 8).pipe(
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "go",
+        attachments: [],
+      });
+
+      harness.query.emit(messageStart("sub-msg-start", "msg-parent"));
+      harness.query.emit(textBlockStart("sub-start", 0));
+      harness.query.emit(textDelta("sub-delta-1", 0, "Parent "));
+      // A subagent closes its own block 0 while the parent is still writing into block 0.
+      harness.query.emit(blockStop("sub-stop-subagent", 0, "toolu_subagent"));
+      harness.query.emit(textDelta("sub-delta-2", 0, "text."));
+      harness.query.emit(blockStop("sub-stop-parent", 0));
+      harness.query.emit(successResult("sub-result"));
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      assert.deepEqual(
+        runtimeEvents.map((event) => event.type),
+        [
+          "session.started",
+          "session.configured",
+          "session.state.changed",
+          "turn.started",
+          "thread.started",
+          "content.delta",
+          "content.delta",
+          "item.completed",
+        ],
+      );
+
+      const deltas = assistantTextDeltas(runtimeEvents);
+      assert.equal(deltas.length, 2);
+      // The parent's message must stay whole and stay one item.
+      assert.equal(new Set(deltas.map((event) => String(event.itemId))).size, 1);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("segments Claude assistant text blocks around tool calls", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -3984,6 +3984,74 @@ describe("ClaudeAdapterLive", () => {
     },
   );
 
+  it.effect(
+    "synthesizes a snapshot-only message instead of dropping it as a divergent snapshot of a stalled id-less block",
+    () => {
+      const harness = makeHarness();
+      const firstText = "First answer.";
+      const snapshotOnlyText = "Second, snapshot-only message.";
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+
+        const runtimeEventsFiber = yield* Stream.takeUntil(
+          adapter.streamEvents,
+          (event) => event.type === "turn.completed",
+        ).pipe(Stream.runCollect, Effect.forkChild);
+
+        const session = yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          runtimeMode: "full-access",
+        });
+
+        yield* adapter.sendTurn({
+          threadId: session.threadId,
+          input: "go",
+          attachments: [],
+        });
+
+        // A message streams WITHOUT message_start and stalls: no content_block_stop ever
+        // arrives, so its id-less block stays open. Its own snapshot repairs the missing
+        // suffix but must not close the block (late deltas could still follow).
+        harness.query.emit(textBlockStart("stalled-start-1", 0));
+        harness.query.emit(textDelta("stalled-delta-1", 0, "First ans"));
+        harness.query.emit(assistantSnapshot("stalled-snapshot-1", "msg-first", [firstText]));
+
+        // The next message never streams at all and reuses content index 0. The still-open
+        // block already has its snapshot, so this one is a different message: it must be
+        // materialized, not logged away as a divergent snapshot of the first.
+        harness.query.emit(
+          assistantSnapshot("snapshot-only-2", "msg-snapshot-only", [snapshotOnlyText]),
+        );
+        harness.query.emit(successResult("stalled-result"));
+
+        const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+        const deltas = assistantTextDeltas(runtimeEvents);
+        // The stalled block's missing suffix ("wer.") is shipped when the block completes,
+        // which only the turn result does here — so it lands after the snapshot-only message.
+        assert.deepEqual(deltas.map(deltaText), ["First ans", snapshotOnlyText, "wer."]);
+        assert.equal(String(deltas[0]?.itemId), String(deltas[2]?.itemId));
+        assert.notEqual(String(deltas[0]?.itemId), String(deltas[1]?.itemId));
+
+        const completions = runtimeEvents.filter(
+          (event) =>
+            event.type === "item.completed" && event.payload.itemType === "assistant_message",
+        );
+        // The snapshot-only message completes from its snapshot right away; the stalled
+        // block is only closed by the turn result, with its repaired text as detail.
+        assert.deepEqual(
+          completions.map((event) =>
+            event.type === "item.completed" ? event.payload.detail : undefined,
+          ),
+          [snapshotOnlyText, firstText],
+        );
+      }).pipe(
+        Effect.provideService(Random.Random, makeDeterministicRandomService()),
+        Effect.provide(harness.layer),
+      );
+    },
+  );
+
   it.effect("segments Claude assistant text blocks around tool calls", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -174,6 +174,8 @@ interface AssistantTextBlockState {
    */
   streamedText: string;
   fallbackText: string;
+  /** True once this block's own `claude/assistant` snapshot has been applied to it. */
+  snapshotApplied: boolean;
   streamClosed: boolean;
   completionEmitted: boolean;
 }
@@ -1891,6 +1893,8 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       readonly fallbackText?: string;
       readonly streamClosed?: boolean;
       readonly messageId?: string | undefined;
+      /** The caller is materializing a `claude/assistant` snapshot rather than a stream event. */
+      readonly fromSnapshot?: boolean;
     },
   ) {
     const turnState = context.turnState;
@@ -1905,10 +1909,13 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     // message, so when a previous message left an unclosed block behind, reusing it by index
     // alone spliced two separate answers into one chat message. Only reuse when the message
     // matches — or when neither side knows its message (no `message_start`), which keeps the
-    // pre-existing behaviour for non-streaming paths.
+    // pre-existing behaviour for non-streaming paths. Even without ids, an open block that
+    // already received its own snapshot is not the home of a second, different snapshot (a
+    // message delivers exactly one); late stream deltas may still continue it, so only
+    // snapshots are turned away.
     const belongsToSameMessage =
       existing?.messageId === undefined || messageId === undefined
-        ? true
+        ? !(options?.fromSnapshot === true && existing?.snapshotApplied === true)
         : existing.messageId === messageId;
     if (existing && !existing.completionEmitted && belongsToSameMessage) {
       if (existing.fallbackText.length === 0 && options?.fallbackText) {
@@ -1926,6 +1933,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       messageId,
       streamedText: "",
       fallbackText: options?.fallbackText ?? "",
+      snapshotApplied: false,
       streamClosed: options?.streamClosed ?? false,
       completionEmitted: false,
     };
@@ -1954,6 +1962,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         fallbackText,
         streamClosed: true,
         messageId: location.messageId,
+        fromSnapshot: true,
       });
     },
   );
@@ -2075,18 +2084,23 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         candidates.findLast(
           (block) => block.messageId !== undefined && block.messageId === snapshotMessageId,
         ) ??
-        // Without ids the block is only "this snapshot's" when it is still open or its
-        // delivered text matches. A completed block with DIFFERENT text belongs to an earlier
-        // message — claiming it would swallow a snapshot-only message entirely; excluding
-        // every completed block would re-synthesize the ordinary stream→stop→snapshot flow as
-        // a duplicate.
-        candidates.findLast(
-          (block) =>
-            (block.messageId === undefined || snapshotMessageId === undefined) &&
-            (!block.completionEmitted ||
-              block.streamedText === text ||
-              block.fallbackText === text),
-        );
+        // Without ids the block is only "this snapshot's" when its delivered text matches or
+        // it is still open and has not received a snapshot yet. A completed block with
+        // DIFFERENT text belongs to an earlier message — claiming it would swallow a
+        // snapshot-only message entirely; excluding every completed block would re-synthesize
+        // the ordinary stream→stop→snapshot flow as a duplicate. A message delivers exactly one
+        // snapshot, so an open block that already has its own belongs to an earlier message
+        // too: a second, different snapshot at that index is a snapshot-only message, not a
+        // divergent repeat.
+        candidates.findLast((block) => {
+          if (block.messageId !== undefined && snapshotMessageId !== undefined) {
+            return false;
+          }
+          if (block.completionEmitted) {
+            return block.streamedText === text || block.fallbackText === text;
+          }
+          return !block.snapshotApplied || block.fallbackText === text;
+        });
 
       const block =
         existing ??
@@ -2115,6 +2129,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       }
 
       block.fallbackText = text;
+      block.snapshotApplied = true;
 
       // A snapshot alone is not grounds for completing the block: late deltas may still
       // follow. `content_block_stop` or the turn result closes it.

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -2075,8 +2075,17 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         candidates.findLast(
           (block) => block.messageId !== undefined && block.messageId === snapshotMessageId,
         ) ??
+        // Without ids the block is only "this snapshot's" when it is still open or its
+        // delivered text matches. A completed block with DIFFERENT text belongs to an earlier
+        // message — claiming it would swallow a snapshot-only message entirely; excluding
+        // every completed block would re-synthesize the ordinary stream→stop→snapshot flow as
+        // a duplicate.
         candidates.findLast(
-          (block) => block.messageId === undefined || snapshotMessageId === undefined,
+          (block) =>
+            (block.messageId === undefined || snapshotMessageId === undefined) &&
+            (!block.completionEmitted ||
+              block.streamedText === text ||
+              block.fallbackText === text),
         );
 
       const block =

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -152,13 +152,27 @@ interface ClaudeTurnState {
   readonly capturedProposedPlanKeys: Set<string>;
   latestAssistantUsage: unknown | undefined;
   compactedSinceLatestAssistantUsage: boolean;
-  nextSyntheticAssistantBlockIndex: number;
+  /**
+   * `Message.id` of the API message currently streaming, captured from `message_start`.
+   * A turn holds several API messages, and their content-block indexes restart at 0 in
+   * each one — this is what tells two blocks with the same index apart. Undefined until
+   * the first `message_start` (older SDKs and non-streaming paths never send one).
+   */
+  currentAssistantMessageId: string | undefined;
 }
 
 interface AssistantTextBlockState {
   readonly itemId: string;
+  /** Index of this block inside its own API message — matches `content_block_*.index`. */
   readonly blockIndex: number;
-  emittedTextDelta: boolean;
+  /** API message this block belongs to; undefined when no `message_start` was seen. */
+  readonly messageId: string | undefined;
+  /**
+   * Text already shipped to the client as `content.delta`. Every consumer appends deltas
+   * rather than replacing text, so this is what the user currently sees for this block —
+   * it lets a stalled stream be repaired by sending only the missing suffix.
+   */
+  streamedText: string;
   fallbackText: string;
   streamClosed: boolean;
   completionEmitted: boolean;
@@ -1413,7 +1427,22 @@ function nativeProviderRefs(
   return {};
 }
 
-function extractAssistantTextBlocks(message: SDKMessage): Array<string> {
+interface SnapshotTextBlock {
+  /** Position inside `message.content`, which is the same index the stream events carry. */
+  readonly contentIndex: number;
+  readonly text: string;
+}
+
+/** `Message.id` of an assistant snapshot — the key that ties it to its `message_start`. */
+function assistantSnapshotMessageId(message: SDKMessage): string | undefined {
+  if (message.type !== "assistant") {
+    return undefined;
+  }
+  const id = (message.message as { id?: unknown } | undefined)?.id;
+  return typeof id === "string" && id.length > 0 ? id : undefined;
+}
+
+function extractAssistantTextBlocks(message: SDKMessage): Array<SnapshotTextBlock> {
   if (message.type !== "assistant") {
     return [];
   }
@@ -1423,8 +1452,8 @@ function extractAssistantTextBlocks(message: SDKMessage): Array<string> {
     return [];
   }
 
-  const fragments: string[] = [];
-  for (const block of content) {
+  const fragments: Array<SnapshotTextBlock> = [];
+  for (const [contentIndex, block] of content.entries()) {
     if (!block || typeof block !== "object") {
       continue;
     }
@@ -1434,7 +1463,7 @@ function extractAssistantTextBlocks(message: SDKMessage): Array<string> {
       typeof candidate.text === "string" &&
       candidate.text.length > 0
     ) {
-      fragments.push(candidate.text);
+      fragments.push({ contentIndex, text: candidate.text });
     }
   }
 
@@ -1861,6 +1890,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     options?: {
       readonly fallbackText?: string;
       readonly streamClosed?: boolean;
+      readonly messageId?: string | undefined;
     },
   ) {
     const turnState = context.turnState;
@@ -1868,8 +1898,19 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       return undefined;
     }
 
+    const messageId =
+      options && "messageId" in options ? options.messageId : turnState.currentAssistantMessageId;
     const existing = turnState.assistantTextBlocks.get(blockIndex);
-    if (existing && !existing.completionEmitted) {
+    // A block belongs to exactly one API message. Content-block indexes restart at 0 in every
+    // message, so when a previous message left an unclosed block behind, reusing it by index
+    // alone spliced two separate answers into one chat message. Only reuse when the message
+    // matches — or when neither side knows its message (no `message_start`), which keeps the
+    // pre-existing behaviour for non-streaming paths.
+    const belongsToSameMessage =
+      existing?.messageId === undefined || messageId === undefined
+        ? true
+        : existing.messageId === messageId;
+    if (existing && !existing.completionEmitted && belongsToSameMessage) {
       if (existing.fallbackText.length === 0 && options?.fallbackText) {
         existing.fallbackText = options.fallbackText;
       }
@@ -1882,7 +1923,8 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     const block: AssistantTextBlockState = {
       itemId: yield* randomUUIDv4,
       blockIndex,
-      emittedTextDelta: false,
+      messageId,
+      streamedText: "",
       fallbackText: options?.fallbackText ?? "",
       streamClosed: options?.streamClosed ?? false,
       completionEmitted: false,
@@ -1892,18 +1934,26 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     return { blockIndex, block };
   });
 
+  /**
+   * Materializes a text block that the stream never announced — the message was delivered
+   * only as a snapshot. Keyed by the snapshot's own content index and message id so a repeat
+   * of the same snapshot finds the block again instead of emitting the text twice.
+   */
   const createSyntheticAssistantTextBlock = Effect.fn("createSyntheticAssistantTextBlock")(
-    function* (context: ClaudeSessionContext, fallbackText: string) {
+    function* (
+      context: ClaudeSessionContext,
+      fallbackText: string,
+      location: { readonly contentIndex: number; readonly messageId: string | undefined },
+    ) {
       const turnState = context.turnState;
       if (!turnState) {
         return undefined;
       }
 
-      const blockIndex = turnState.nextSyntheticAssistantBlockIndex;
-      turnState.nextSyntheticAssistantBlockIndex -= 1;
-      return yield* ensureAssistantTextBlock(context, blockIndex, {
+      return yield* ensureAssistantTextBlock(context, location.contentIndex, {
         fallbackText,
         streamClosed: true,
+        messageId: location.messageId,
       });
     },
   );
@@ -1926,7 +1976,18 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       return;
     }
 
-    if (!block.emittedTextDelta && block.fallbackText.length > 0) {
+    // The snapshot text can be ahead of what the delta stream actually delivered: when a
+    // stream stalls mid-message the CLI ships the finished message as one `claude/assistant`
+    // snapshot and never sends the remaining deltas (nor `content_block_stop`). Every consumer
+    // appends deltas, so emit only the part the client has not seen — sending the whole
+    // snapshot would render as the prefix twice. With nothing streamed this degrades to
+    // shipping the entire fallback, exactly as before.
+    const pendingText = block.fallbackText.startsWith(block.streamedText)
+      ? block.fallbackText.slice(block.streamedText.length)
+      : "";
+
+    if (pendingText.length > 0) {
+      block.streamedText = block.fallbackText;
       const deltaStamp = yield* makeEventStamp();
       yield* offerRuntimeEvent({
         type: "content.delta",
@@ -1938,7 +1999,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         itemId: asRuntimeItemId(block.itemId),
         payload: {
           streamKind: "assistant_text",
-          delta: block.fallbackText,
+          delta: pendingText,
         },
         providerRefs: nativeProviderRefs(context),
         ...(options?.rawMethod || options?.rawPayload
@@ -1999,34 +2060,57 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       return;
     }
 
-    const orderedBlocks = turnState.assistantTextBlockOrder.map((block) => ({
-      blockIndex: block.blockIndex,
-      block,
-    }));
+    const snapshotMessageId = assistantSnapshotMessageId(message);
 
-    for (const [position, text] of snapshotTextBlocks.entries()) {
-      const existingEntry = orderedBlocks[position];
-      const entry =
-        existingEntry ??
-        (yield* createSyntheticAssistantTextBlock(context, text).pipe(
-          Effect.map((created) => {
-            if (!created) {
-              return undefined;
-            }
-            orderedBlocks.push(created);
-            return created;
-          }),
-        ));
-      if (!entry) {
+    for (const { contentIndex, text } of snapshotTextBlocks) {
+      // Match on the identity the data actually carries: the API message plus the position of
+      // the block inside it. Matching by position in the turn-wide block list used to pour a
+      // snapshot's text into blocks of *earlier* messages of the same turn, so the message
+      // whose stream broke was never repaired. When either side has no message id (no
+      // `message_start` was seen) fall back to the most recent block at that index.
+      const candidates = turnState.assistantTextBlockOrder.filter(
+        (block) => block.blockIndex === contentIndex,
+      );
+      const existing =
+        candidates.findLast(
+          (block) => block.messageId !== undefined && block.messageId === snapshotMessageId,
+        ) ??
+        candidates.findLast(
+          (block) => block.messageId === undefined || snapshotMessageId === undefined,
+        );
+
+      const block =
+        existing ??
+        (yield* createSyntheticAssistantTextBlock(context, text, {
+          contentIndex,
+          messageId: snapshotMessageId,
+        }))?.block;
+
+      // Already delivered — the ordinary stream → `content_block_stop` → snapshot order. Its
+      // text came from the deltas and re-emitting anything here would duplicate it.
+      if (!block || block.completionEmitted) {
         continue;
       }
 
-      if (entry.block.fallbackText.length === 0) {
-        entry.block.fallbackText = text;
+      if (!text.startsWith(block.streamedText)) {
+        // The client has already seen text this snapshot does not continue. Appending would
+        // corrupt the message, and there is no way to retract a delta, so leave it alone.
+        yield* Effect.logWarning("claude.assistant.snapshot-diverged", {
+          threadId: context.session.threadId,
+          messageId: snapshotMessageId,
+          contentIndex,
+          streamedLength: block.streamedText.length,
+          snapshotLength: text.length,
+        });
+        continue;
       }
 
-      if (entry.block.streamClosed && !entry.block.completionEmitted) {
-        yield* completeAssistantTextBlock(context, entry.block, {
+      block.fallbackText = text;
+
+      // A snapshot alone is not grounds for completing the block: late deltas may still
+      // follow. `content_block_stop` or the turn result closes it.
+      if (block.streamClosed) {
+        yield* completeAssistantTextBlock(context, block, {
           rawMethod: "claude/assistant",
           rawPayload: message,
         });
@@ -2474,6 +2558,23 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       }
     }
 
+    // Remember which API message the following content blocks belong to. Their indexes
+    // restart at 0 in every message, so without this two messages of one turn are
+    // indistinguishable. Subagent traffic must not overwrite the parent's message.
+    if (event.type === "message_start") {
+      if (streamParentToolUseId !== null && streamParentToolUseId !== undefined) {
+        return;
+      }
+      if (context.turnState) {
+        const startedMessageId = (event.message as { id?: unknown } | undefined)?.id;
+        context.turnState.currentAssistantMessageId =
+          typeof startedMessageId === "string" && startedMessageId.length > 0
+            ? startedMessageId
+            : undefined;
+      }
+      return;
+    }
+
     if (event.type === "message_delta") {
       if (message.parent_tool_use_id !== null && message.parent_tool_use_id !== undefined) {
         return;
@@ -2518,7 +2619,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
                 }
               : undefined;
         if (assistantBlockEntry?.block && event.delta.type === "text_delta") {
-          assistantBlockEntry.block.emittedTextDelta = true;
+          assistantBlockEntry.block.streamedText += deltaText;
         }
         const stamp = yield* makeEventStamp();
         yield* offerRuntimeEvent({
@@ -2734,7 +2835,13 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
     if (event.type === "content_block_stop") {
       const { index } = event;
-      const assistantBlock = context.turnState?.assistantTextBlocks.get(index);
+      // A subagent's stop frame reaches us (only its text/thinking start and deltas are
+      // dropped above) and carries the subagent's own block index. Closing the parent's block
+      // on it truncated the parent's message at whatever had streamed so far.
+      const assistantBlock =
+        streamParentToolUseId === null || streamParentToolUseId === undefined
+          ? context.turnState?.assistantTextBlocks.get(index)
+          : undefined;
       if (assistantBlock) {
         assistantBlock.streamClosed = true;
         yield* completeAssistantTextBlock(context, assistantBlock, {
@@ -2966,7 +3073,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         capturedProposedPlanKeys: new Set(),
         latestAssistantUsage: undefined,
         compactedSinceLatestAssistantUsage: false,
-        nextSyntheticAssistantBlockIndex: -1,
+        currentAssistantMessageId: undefined,
       };
       context.session = {
         ...context.session,
@@ -4627,7 +4734,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         capturedProposedPlanKeys: new Set(),
         latestAssistantUsage: undefined,
         compactedSinceLatestAssistantUsage: false,
-        nextSyntheticAssistantBlockIndex: -1,
+        currentAssistantMessageId: undefined,
       };
 
       const updatedAt = yield* nowIso;


### PR DESCRIPTION
Fixes #7137. Fixes #11353. This was the deeper of two alternative fixes; the smaller positional-repair one (#7142) was closed on 2026-08-28 during the backlog cleanup, with this PR kept open as the review path for incomplete Claude assistant text. Rebased onto current main on 2026-09-03; the diff is the adapter and its tests only.

## What changed

`ClaudeAdapter` tracked assistant text blocks in one turn-long list and matched snapshot text to blocks by list position. A `claude/assistant` snapshot describes one message, not the whole turn, so any turn with more than one assistant message could mismatch.

The adapter now reads `message_start` — previously ignored entirely — and keys every text block by its message id plus the block index within that message. Snapshot backfill resolves blocks of its own message only. A block whose stream was cut mid-message is completed from the snapshot when the snapshot text extends the streamed prefix; a snapshot that contradicts already-shown text is never written over it (warning logged instead).

## Why this fixes four defects with one root cause

- **A stalled stream truncates the message to its first delta** — the incident in #7137: one `text_delta` (`P`), 3m16s of silence, no `content_block_stop`, full 2.4 KB snapshot at the end. Positional matching wrote the snapshot onto an earlier completed block and the real block was force-completed empty.
- **Multi-text-block messages** (text → tool call → text) could backfill the wrong block, since position-in-turn and position-in-message disagree.
- **Two consecutive messages merged into one** when the second message restarted block indexes at zero while the first was still open.
- **A subagent's `content_block_stop` closed the parent's open block**, truncating the parent message mid-stream.

Worth noting for review: #6429 (thinking blocks in timelines, now closed) copied the positional scheme into a new `backfillReasoningBlocksFromSnapshot`. Any future reasoning-block backfill should build on the message-scoped base from this PR instead of inheriting the same truncation bug.

## Tests

- Four new regression tests, one per defect above, each replaying the SDK event sequence; all four fail without the fix and pass with it.
- Full server suite: 230 files passed, 2510 tests passed, 7 skipped, on top of current main.

Diff is +147/−40 source; the rest is tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live streaming and snapshot reconciliation for Claude assistant output—user-visible message text—with nuanced id-less and subagent paths, though behavior is heavily covered by new regression tests.
> 
> **Overview**
> **Fixes incomplete or merged Claude assistant text** by scoping text blocks to each API message (`message_start` → `currentAssistantMessageId`) plus content-block index, instead of matching snapshots to turn-wide block order.
> 
> Snapshot backfill now finds the right block for that message (with fallbacks when ids are missing), materializes snapshot-only messages without stealing completed blocks, and on completion emits only the **unseen suffix** of snapshot text relative to deltas already sent (`streamedText`). Subagent stream events no longer overwrite the parent message id or close the parent’s text block on `content_block_stop`.
> 
> Adds integration tests for stalled-stream repair, multi-block messages, reused block indexes across messages, subagent isolation, and id-less / snapshot-only edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27530a12fc4140702f77e3e7b3f4356b0f985c2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ClaudeAdapter` to key assistant text blocks by message id instead of stream position
> - Replaces the turn-wide synthetic negative block-index counter with the assistant API message identifier captured from `message-start` events, so blocks from different messages with the same content index stay separate
> - Snapshot completion now compares snapshot fallback text against accumulated streamed text and emits only the missing suffix instead of replaying the already-delivered prefix
> - Subagent `content_block_stop` frames carrying a parent tool-use identifier can no longer close a parent assistant text block; only the parent's own stop frame completes it
> - Id-less streamed blocks fall back to compatible-block reuse, but reject a second snapshot for an already-snapshotted block and synthesize new runtime items for unmatched snapshot fragments
> - Risk: `ensureAssistantTextBlock` and `completeAssistantTextBlock` in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/7143/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc) change block lookup and completion semantics; existing consumers relying on synthetic negative indexes or full-prefix replay will break
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 27530a1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->