### PR TITLE
fix(client): hide source providers that need setup

### DIFF
--- a/apps/mobile/src/features/projects/AddProjectScreen.tsx
+++ b/apps/mobile/src/features/projects/AddProjectScreen.tsx
@@ -2,7 +2,6 @@ import {
   addProjectRemoteSourceLabel,
   addProjectRemoteSourcePathHint,
   addProjectRemoteSourceProvider,
-  buildAddProjectRemoteSourceReadiness,
   buildProjectCreateCommand,
   canCreateProjectInEnvironment,
   findExistingAddProject,
@@ -10,8 +9,8 @@ import {
   getCloneDestinationBrowsePath,
   getCloneDestinationPath,
   getCloneDirectoryName,
+  listAddProjectRemoteSources,
   resolveAddProjectPath,
-  sortAddProjectProviderSources,
   type AddProjectRemoteSource,
 } from "@t3tools/client-runtime/operations/projects";
 import {
@@ -407,8 +406,6 @@ function EmptyEnvironmentState() {
 function SourceControlRow(props: {
   readonly source: AddProjectRemoteSource;
   readonly selectedEnvironmentId: EnvironmentId;
-  readonly ready: boolean;
-  readonly hint: string;
   readonly isFirst: boolean;
 }) {
   const navigation = useNavigation();
@@ -418,19 +415,13 @@ function SourceControlRow(props: {
   const subtitle =
     props.source === "url"
       ? "Clone from a remote URL"
-      : `Clone ${addProjectRemoteSourceLabel(props.source)} ${props.hint}`;
+      : `Clone ${addProjectRemoteSourceLabel(props.source)} ${addProjectRemoteSourcePathHint(props.source)}`;
   const icon =
     props.source === "url" ? (
       <SymbolView name="link" size={17} tintColor={iconColor} type="monochrome" />
     ) : (
       <SourceControlIcon kind={props.source} size={18} color={String(iconColor)} />
     );
-
-  if (!props.ready) {
-    return (
-      <ListRow title={title} subtitle={props.hint} icon={icon} disabled isFirst={props.isFirst} />
-    );
-  }
 
   return (
     <ListRow
@@ -464,8 +455,8 @@ export function AddProjectSourceScreen() {
           input: {},
         }),
   );
-  const readiness = useMemo(
-    () => buildAddProjectRemoteSourceReadiness(discoveryState.data),
+  const remoteSources = useMemo(
+    () => listAddProjectRemoteSources(discoveryState.data),
     [discoveryState.data],
   );
 
@@ -541,22 +532,14 @@ export function AddProjectSourceScreen() {
                 )
               }
             />
-            {(["url", ...sortAddProjectProviderSources(readiness)] as AddProjectRemoteSource[]).map(
-              (candidate) => (
-                <SourceControlRow
-                  key={candidate}
-                  source={candidate}
-                  selectedEnvironmentId={selectedEnvironment.environmentId}
-                  ready={readiness[candidate].ready}
-                  hint={
-                    readiness[candidate].ready
-                      ? addProjectRemoteSourcePathHint(candidate)
-                      : (readiness[candidate].hint ?? "")
-                  }
-                  isFirst={false}
-                />
-              ),
-            )}
+            {remoteSources.map((candidate) => (
+              <SourceControlRow
+                key={candidate}
+                source={candidate}
+                selectedEnvironmentId={selectedEnvironment.environmentId}
+                isFirst={false}
+              />
+            ))}
           </ListSection>
           {discoveryState.isPending ? <ActivityIndicator color={accentColor} /> : null}
         </>

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -2,10 +2,15 @@
 
 import { scopeProjectRef, scopeThreadRef } from "@t3tools/client-runtime/environment";
 import {
+  addProjectRemoteSourceLabel as remoteProjectSourceLabel,
+  addProjectRemoteSourcePathHint as remoteProjectSourcePathHint,
   canCreateProjectInEnvironment,
   getCloneDestinationBrowsePath,
   getCloneDestinationPath,
   getCloneDirectoryName,
+  listAddProjectRemoteSources,
+  type AddProjectRemoteProviderKind,
+  type AddProjectRemoteSource,
 } from "@t3tools/client-runtime/operations/projects";
 import { connectionStatusText } from "@t3tools/client-runtime/connection";
 import { threadSearchMatchKey } from "@t3tools/client-runtime/state/thread-search";
@@ -25,13 +30,10 @@ import {
   type EnvironmentId,
   type FilesystemBrowseResult,
   type ProjectId,
-  type SourceControlDiscoveryResult,
-  type SourceControlProviderKind,
   type SourceControlRepositoryInfo,
   PRIMARY_LOCAL_ENVIRONMENT_ID,
 } from "@t3tools/contracts";
 import { useNavigate, useParams } from "@tanstack/react-router";
-import * as Option from "effect/Option";
 import {
   ArrowLeftIcon,
   CornerLeftUpIcon,
@@ -204,12 +206,6 @@ interface AddProjectEnvironmentOption {
   readonly status: string;
 }
 
-type AddProjectRemoteProviderKind = Extract<
-  SourceControlProviderKind,
-  "github" | "gitlab" | "bitbucket" | "azure-devops"
->;
-type AddProjectRemoteSource = AddProjectRemoteProviderKind | "url";
-
 type AddProjectCloneFlow =
   | {
       readonly step: "repository";
@@ -224,50 +220,6 @@ type AddProjectCloneFlow =
       readonly repository: SourceControlRepositoryInfo | null;
       readonly remoteUrl: string;
     };
-
-const REMOTE_PROJECT_SOURCES: ReadonlyArray<AddProjectRemoteSource> = [
-  "url",
-  "github",
-  "gitlab",
-  "bitbucket",
-  "azure-devops",
-];
-const REMOTE_PROJECT_PROVIDER_SOURCES: ReadonlyArray<AddProjectRemoteProviderKind> = [
-  "github",
-  "gitlab",
-  "bitbucket",
-  "azure-devops",
-];
-
-function remoteProjectSourceLabel(source: AddProjectRemoteSource): string {
-  switch (source) {
-    case "github":
-      return "GitHub";
-    case "gitlab":
-      return "GitLab";
-    case "bitbucket":
-      return "Bitbucket";
-    case "azure-devops":
-      return "Azure DevOps";
-    case "url":
-      return "Git URL";
-  }
-}
-
-function remoteProjectSourcePathHint(source: AddProjectRemoteSource): string {
-  switch (source) {
-    case "github":
-      return "owner/repo";
-    case "gitlab":
-      return "group/project";
-    case "bitbucket":
-      return "workspace/repository";
-    case "azure-devops":
-      return "project/repository";
-    case "url":
-      return "URL";
-  }
-}
 
 function remoteProjectSourceProvider(
   source: AddProjectRemoteSource,
@@ -297,79 +249,6 @@ function remoteProjectInputPlaceholder(flow: AddProjectCloneFlow | null): string
     return "Enter Git clone URL";
   }
   return `Enter ${remoteProjectSourceLabel(flow.source)} repository (${remoteProjectSourcePathHint(flow.source)})`;
-}
-
-function sourceProviderKind(source: AddProjectRemoteSource): AddProjectRemoteProviderKind | null {
-  return source === "url" ? null : source;
-}
-
-function sortAddProjectProviderSources(
-  readinessBySource: AddProjectRemoteSourceReadiness,
-): ReadonlyArray<AddProjectRemoteProviderKind> {
-  return REMOTE_PROJECT_PROVIDER_SOURCES.toSorted((left, right) => {
-    const leftReady = readinessBySource[left].ready;
-    const rightReady = readinessBySource[right].ready;
-    if (leftReady !== rightReady) {
-      return leftReady ? -1 : 1;
-    }
-    return remoteProjectSourceLabel(left).localeCompare(remoteProjectSourceLabel(right));
-  });
-}
-
-type AddProjectRemoteSourceReadiness = Record<
-  AddProjectRemoteSource,
-  { readonly ready: boolean; readonly hint: string | null }
->;
-
-function buildAddProjectRemoteSourceReadiness(
-  discovery: SourceControlDiscoveryResult | null,
-): AddProjectRemoteSourceReadiness {
-  const unavailable = {
-    ready: false,
-    hint: "Provider status unavailable. Open Settings -> Source Control and rescan.",
-  } as const;
-  const defaultReadiness: AddProjectRemoteSourceReadiness = {
-    url: { ready: true, hint: null },
-    github: unavailable,
-    gitlab: unavailable,
-    bitbucket: unavailable,
-    "azure-devops": unavailable,
-  };
-
-  if (!discovery) {
-    return defaultReadiness;
-  }
-
-  const providerByKind = new Map(
-    discovery.sourceControlProviders.map((provider) => [provider.kind, provider]),
-  );
-  const readiness = { ...defaultReadiness };
-
-  for (const source of REMOTE_PROJECT_SOURCES) {
-    const kind = sourceProviderKind(source);
-    if (!kind) continue;
-    const provider = providerByKind.get(kind);
-    if (!provider) {
-      readiness[source] = unavailable;
-      continue;
-    }
-    if (provider.status !== "available") {
-      readiness[source] = { ready: false, hint: provider.installHint };
-      continue;
-    }
-    if (provider.auth.status === "unauthenticated") {
-      readiness[source] = {
-        ready: false,
-        hint:
-          Option.getOrNull(provider.auth.detail) ??
-          `${provider.label} is not authenticated. Open Settings -> Source Control for setup guidance.`,
-      };
-      continue;
-    }
-    readiness[source] = { ready: true, hint: null };
-  }
-
-  return readiness;
 }
 
 function errorMessage(error: unknown): string {
@@ -1243,15 +1122,10 @@ function OpenCommandPaletteDialog(props: {
     [pushPaletteView],
   );
 
-  const openSourceControlSettings = useCallback(() => {
-    setOpen(false);
-    void navigate({ to: "/settings/source-control" });
-  }, [navigate, setOpen]);
-
   const buildAddProjectSourceGroups = useCallback(
     (
       environmentId: EnvironmentId,
-      readinessBySource: AddProjectRemoteSourceReadiness,
+      remoteSources: ReadonlyArray<AddProjectRemoteSource>,
     ): CommandPaletteView["groups"] => {
       const sourceItems: Array<CommandPaletteActionItem | CommandPaletteSubmenuItem> = [
         {
@@ -1268,60 +1142,13 @@ function OpenCommandPaletteDialog(props: {
         },
       ];
 
-      const orderedSources: ReadonlyArray<AddProjectRemoteSource> = [
-        "url",
-        ...sortAddProjectProviderSources(readinessBySource),
-      ];
-
-      for (const source of orderedSources) {
+      for (const source of remoteSources) {
         const label = remoteProjectSourceLabel(source);
         const title = source === "url" ? "Git URL" : `${label} repository`;
         const description =
           source === "url"
             ? "Clone from a remote URL"
             : `Clone ${label} ${remoteProjectSourcePathHint(source)}`;
-        const readiness = readinessBySource[source];
-        const disabledHint = readiness.hint;
-
-        const titleTrailingContent = readiness.ready ? undefined : (
-          <span className="ml-auto">
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <Button
-                    variant="outline"
-                    size="xs"
-                    className="h-5 rounded-[.25rem] px-1.5 text-[10px] text-warning-foreground"
-                    onClick={() => {
-                      openSourceControlSettings();
-                    }}
-                  >
-                    Setup Required
-                  </Button>
-                }
-              />
-              <TooltipPopup align="end" side="left">
-                {disabledHint ?? "Open Settings -> Source Control to configure this provider."}
-              </TooltipPopup>
-            </Tooltip>
-          </span>
-        );
-
-        if (!readiness.ready) {
-          sourceItems.push({
-            kind: "action",
-            value: `action:add-project:${environmentId}:${source}:not-ready`,
-            searchTerms: ["clone", "remote", "repository", "repo", "git", label, "setup required"],
-            title,
-            description,
-            disabled: true,
-            icon: remoteProjectSourceIcon(source, ITEM_ICON_CLASS),
-            ...(titleTrailingContent ? { titleTrailingContent } : {}),
-            run: async () => {},
-          });
-          continue;
-        }
-
         sourceItems.push({
           kind: "action",
           value: `action:add-project:${environmentId}:${source}`,
@@ -1329,7 +1156,6 @@ function OpenCommandPaletteDialog(props: {
           title,
           description,
           icon: remoteProjectSourceIcon(source, ITEM_ICON_CLASS),
-          ...(titleTrailingContent ? { titleTrailingContent } : {}),
           keepOpen: true,
           run: async () => {
             startAddProjectClone(environmentId, source);
@@ -1339,7 +1165,7 @@ function OpenCommandPaletteDialog(props: {
 
       return [{ value: `sources:${environmentId}`, label: "Sources", items: sourceItems }];
     },
-    [openSourceControlSettings, startAddProjectBrowse, startAddProjectClone],
+    [startAddProjectBrowse, startAddProjectClone],
   );
 
   const startAddProjectSourceSelection = useCallback(
@@ -1363,7 +1189,7 @@ function OpenCommandPaletteDialog(props: {
         addonIcon: <FolderPlusIcon className={ADDON_ICON_CLASS} />,
         groups: buildAddProjectSourceGroups(
           environmentId,
-          buildAddProjectRemoteSourceReadiness(
+          listAddProjectRemoteSources(
             browseEnvironmentId === environmentId ? sourceControlDiscovery.data : null,
           ),
         ),
@@ -1661,7 +1487,7 @@ function OpenCommandPaletteDialog(props: {
     currentView.groups[0]?.value === sourceSelectionViewValue
       ? buildAddProjectSourceGroups(
           addProjectEnvironmentId,
-          buildAddProjectRemoteSourceReadiness(sourceControlDiscovery.data),
+          listAddProjectRemoteSources(sourceControlDiscovery.data),
         )
       : (currentView?.groups ?? rootGroups);
 

--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -16,6 +16,7 @@ import {
   getBackgroundActivityPresetSettings,
   resolveServerBackgroundActivitySettings,
 } from "@t3tools/shared/backgroundActivitySettings";
+import { isSourceControlProviderReady } from "@t3tools/shared/sourceControl";
 
 import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSettings";
 import { cn } from "../../lib/utils";
@@ -163,7 +164,7 @@ function RedactedAccount(props: { readonly account: string | null }) {
 function itemStatusDot(item: VcsDiscoveryItem | SourceControlProviderDiscoveryItem): string {
   if (isVcsNotReady(item)) return "bg-muted-foreground/35";
   if (item.status !== "available") return "bg-warning";
-  if (isProviderDiscoveryItem(item) && item.auth.status !== "authenticated") return "bg-warning";
+  if (isProviderDiscoveryItem(item) && !isSourceControlProviderReady(item)) return "bg-warning";
   return "bg-success";
 }
 
@@ -259,7 +260,7 @@ function DiscoveryItemRow({
 }) {
   const version = optionLabel(item.version);
   const enabled = isProviderDiscoveryItem(item)
-    ? item.status === "available" && item.auth.status === "authenticated"
+    ? isSourceControlProviderReady(item)
     : item.status === "available" && item.implemented;
   const auth = isProviderDiscoveryItem(item) ? item.auth : null;
   const authStatus = auth ? authPresentation(auth) : null;

--- a/packages/client-runtime/src/operations/projects.test.ts
+++ b/packages/client-runtime/src/operations/projects.test.ts
@@ -8,7 +8,6 @@ import {
 import * as Option from "effect/Option";
 
 import {
-  buildAddProjectRemoteSourceReadiness,
   buildProjectCreateCommand,
   canCreateProjectInEnvironment,
   findExistingAddProject,
@@ -16,8 +15,8 @@ import {
   getCloneDestinationBrowsePath,
   getCloneDestinationPath,
   getCloneDirectoryName,
+  listAddProjectRemoteSources,
   resolveAddProjectPath,
-  sortAddProjectProviderSources,
 } from "./projects.ts";
 import type { EnvironmentProject } from "../state/models.ts";
 
@@ -133,7 +132,7 @@ describe("add project shared logic", () => {
     ).toEqual({ ok: true, path: "/work/next" });
   });
 
-  it("marks authenticated source control providers as ready", () => {
+  it("shows only authenticated providers while hiding providers that need setup", () => {
     const discovery: SourceControlDiscoveryResult = {
       versionControlSystems: [],
       sourceControlProviders: [
@@ -152,27 +151,55 @@ describe("add project shared logic", () => {
           },
         },
         {
-          kind: "gitlab",
-          label: "GitLab",
+          kind: "bitbucket",
+          label: "Bitbucket",
           status: "available",
-          installHint: "Install glab",
-          version: Option.some("1.0.0"),
+          installHint: "Configure Bitbucket",
+          version: Option.none(),
           detail: Option.none(),
           auth: {
             status: "unauthenticated",
             account: Option.none(),
+            host: Option.some("bitbucket.org"),
+            detail: Option.some("Configure Bitbucket credentials"),
+          },
+        },
+        {
+          kind: "gitlab",
+          label: "GitLab",
+          status: "missing",
+          installHint: "Install glab",
+          version: Option.none(),
+          detail: Option.none(),
+          auth: {
+            status: "unknown",
+            account: Option.none(),
             host: Option.none(),
-            detail: Option.some("Run glab auth login"),
+            detail: Option.none(),
+          },
+        },
+        {
+          kind: "azure-devops",
+          label: "Azure DevOps",
+          status: "available",
+          installHint: "Install az",
+          version: Option.some("1.0.0"),
+          detail: Option.none(),
+          auth: {
+            status: "authenticated",
+            account: Option.none(),
+            host: Option.none(),
+            detail: Option.none(),
           },
         },
       ],
     };
 
-    const readiness = buildAddProjectRemoteSourceReadiness(discovery);
-    expect(readiness.url.ready).toBe(true);
-    expect(readiness.github.ready).toBe(true);
-    expect(readiness.gitlab).toEqual({ ready: false, hint: "Run glab auth login" });
-    expect(sortAddProjectProviderSources(readiness)[0]).toBe("github");
+    expect(listAddProjectRemoteSources(discovery)).toEqual(["url", "azure-devops", "github"]);
+  });
+
+  it("does not imply provider readiness before discovery", () => {
+    expect(listAddProjectRemoteSources(null)).toEqual(["url"]);
   });
 
   it("finds existing projects by normalized path in the target environment", () => {

--- a/packages/client-runtime/src/operations/projects.ts
+++ b/packages/client-runtime/src/operations/projects.ts
@@ -8,8 +8,8 @@ import type {
   SourceControlProviderKind,
   SourceControlRepositoryInfo,
 } from "@t3tools/contracts";
+import { isSourceControlProviderReady } from "@t3tools/shared/sourceControl";
 import * as Arr from "effect/Array";
-import * as Option from "effect/Option";
 import * as Order from "effect/Order";
 
 import {
@@ -35,11 +35,6 @@ export function canCreateProjectInEnvironment(
   return connectionPhase === "connected";
 }
 
-export type AddProjectRemoteSourceReadiness = Record<
-  AddProjectRemoteSource,
-  { readonly ready: boolean; readonly hint: string | null }
->;
-
 export type AddProjectCloneFlow =
   | {
       readonly step: "repository";
@@ -54,14 +49,6 @@ export type AddProjectCloneFlow =
       readonly repository: SourceControlRepositoryInfo | null;
       readonly remoteUrl: string;
     };
-
-const ADD_PROJECT_REMOTE_SOURCES: ReadonlyArray<AddProjectRemoteSource> = [
-  "url",
-  "github",
-  "gitlab",
-  "bitbucket",
-  "azure-devops",
-];
 
 const ADD_PROJECT_REMOTE_PROVIDER_SOURCES: ReadonlyArray<AddProjectRemoteProviderKind> = [
   "github",
@@ -106,70 +93,29 @@ export function addProjectRemoteSourceProvider(
   return source === "url" ? null : source;
 }
 
-export function sortAddProjectProviderSources(
-  readinessBySource: AddProjectRemoteSourceReadiness,
-): ReadonlyArray<AddProjectRemoteProviderKind> {
-  return Arr.sort(
-    ADD_PROJECT_REMOTE_PROVIDER_SOURCES,
-    Order.mapInput(
-      Order.Struct({
-        ready: Order.flip(Order.Boolean),
-        label: Order.String,
-      }),
-      (source: AddProjectRemoteProviderKind) => ({
-        ready: readinessBySource[source].ready,
-        label: addProjectRemoteSourceLabel(source),
-      }),
-    ),
-  );
-}
-
-export function buildAddProjectRemoteSourceReadiness(
-  discovery: SourceControlDiscoveryResult | null,
-): AddProjectRemoteSourceReadiness {
-  const unavailable = {
-    ready: false,
-    hint: "Provider status unavailable. Open Source Control settings and rescan.",
-  } as const;
-  const readiness: AddProjectRemoteSourceReadiness = {
-    url: { ready: true, hint: null },
-    github: unavailable,
-    gitlab: unavailable,
-    bitbucket: unavailable,
-    "azure-devops": unavailable,
-  };
-
+/** Lists Git URL plus discovered providers that are ready for project creation. */
+export function listAddProjectRemoteSources(discovery: SourceControlDiscoveryResult | null) {
   if (!discovery) {
-    return readiness;
+    return ["url" as const];
   }
 
   const providerByKind = new Map(
     discovery.sourceControlProviders.map((provider) => [provider.kind, provider]),
   );
-  for (const source of ADD_PROJECT_REMOTE_SOURCES) {
-    const kind = addProjectRemoteSourceProvider(source);
-    if (!kind) continue;
-    const provider = providerByKind.get(kind);
-    if (!provider) {
-      readiness[source] = unavailable;
-      continue;
-    }
-    if (provider.status !== "available") {
-      readiness[source] = { ready: false, hint: provider.installHint };
-      continue;
-    }
-    if (provider.auth.status === "unauthenticated") {
-      readiness[source] = {
-        ready: false,
-        hint:
-          Option.getOrNull(provider.auth.detail) ??
-          `${provider.label} is not authenticated. Open Source Control settings for setup guidance.`,
-      };
-      continue;
-    }
-    readiness[source] = { ready: true, hint: null };
-  }
-  return readiness;
+  const readyProviders = ADD_PROJECT_REMOTE_PROVIDER_SOURCES.filter((source) => {
+    const provider = providerByKind.get(source);
+    return provider !== undefined && isSourceControlProviderReady(provider);
+  });
+
+  return [
+    "url" as const,
+    ...Arr.sort(
+      readyProviders,
+      Order.mapInput(Order.String, (source: AddProjectRemoteProviderKind) =>
+        addProjectRemoteSourceLabel(source),
+      ),
+    ),
+  ];
 }
 
 export function getAddProjectInitialQuery(baseDirectory: string | null | undefined): string {

--- a/packages/shared/src/sourceControl.test.ts
+++ b/packages/shared/src/sourceControl.test.ts
@@ -1,11 +1,48 @@
 import { describe, expect, it } from "vite-plus/test";
+import type { SourceControlProviderDiscoveryItem } from "@t3tools/contracts";
+import * as Option from "effect/Option";
 
 import {
   detectSourceControlProviderFromRemoteUrl,
   getChangeRequestTerminologyForKind,
   isSshRemoteUrl,
+  isSourceControlProviderReady,
   resolveChangeRequestPresentation,
 } from "./sourceControl.ts";
+
+const readyProvider = {
+  kind: "github",
+  label: "GitHub",
+  status: "available",
+  installHint: "Install gh",
+  version: Option.some("1.0.0"),
+  detail: Option.none(),
+  auth: {
+    status: "authenticated",
+    account: Option.some("octo"),
+    host: Option.some("github.com"),
+    detail: Option.none(),
+  },
+} satisfies SourceControlProviderDiscoveryItem;
+
+describe("isSourceControlProviderReady", () => {
+  it("requires both availability and authentication", () => {
+    expect(isSourceControlProviderReady(readyProvider)).toBe(true);
+    expect(isSourceControlProviderReady({ ...readyProvider, status: "missing" })).toBe(false);
+    expect(
+      isSourceControlProviderReady({
+        ...readyProvider,
+        auth: { ...readyProvider.auth, status: "unauthenticated" },
+      }),
+    ).toBe(false);
+    expect(
+      isSourceControlProviderReady({
+        ...readyProvider,
+        auth: { ...readyProvider.auth, status: "unknown" },
+      }),
+    ).toBe(false);
+  });
+});
 
 describe("source control presentation", () => {
   it("uses merge request terminology for GitLab", () => {

--- a/packages/shared/src/sourceControl.ts
+++ b/packages/shared/src/sourceControl.ts
@@ -1,4 +1,8 @@
-import type { SourceControlProviderInfo, SourceControlProviderKind } from "@t3tools/contracts";
+import type {
+  SourceControlProviderDiscoveryItem,
+  SourceControlProviderInfo,
+  SourceControlProviderKind,
+} from "@t3tools/contracts";
 
 export interface ChangeRequestPresentation {
   readonly icon: "github" | "gitlab" | "azure-devops" | "bitbucket" | "change-request";
@@ -20,6 +24,11 @@ export const DEFAULT_CHANGE_REQUEST_TERMINOLOGY: ChangeRequestTerminology = {
   shortLabel: "PR",
   singular: "pull request",
 };
+
+/** Use this to decide whether a provider should appear in project-source pickers. */
+export function isSourceControlProviderReady(provider: SourceControlProviderDiscoveryItem) {
+  return provider.status === "available" && provider.auth.status === "authenticated";
+}
 
 const GITHUB_CHANGE_REQUEST_PRESENTATION: ChangeRequestPresentation = {
   icon: "github",


### PR DESCRIPTION
The Add Project picker currently includes source control providers that cannot be used until their CLI and authentication are configured. Those disabled rows crowd the picker and send setup work into a project-creation flow that cannot complete.

This keeps Git URL available and lists source control providers only when discovery reports them as both available and authenticated. Web and mobile use the same readiness rule, while setup and sign-in remain in Source Control settings.

Discussion: https://github.com/pingdotgg/t3code/discussions/6840

<img width="694" height="377" alt="image" src="https://github.com/user-attachments/assets/9a92d45f-9670-4f90-ad8f-d01a4a849ca1" />
<img width="1062" height="746" alt="image" src="https://github.com/user-attachments/assets/383716b8-50c9-4072-88bd-9f6b6ecf02a3" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only filtering of add-project sources; Git URL remains available and setup stays in Source Control settings.
> 
> **Overview**
> **Add Project** source lists on web and mobile no longer show greyed-out hosting providers with setup hints. They list **Git URL** always, plus provider clone options only when discovery reports the provider as **available and authenticated**.
> 
> Shared logic moves into **`isSourceControlProviderReady`** in `@t3tools/shared/sourceControl` and **`listAddProjectRemoteSources`** in client-runtime (replacing the readiness map and ready-first sorting). The web command palette drops duplicated label/hint helpers and the **Setup Required** affordance that jumped to Source Control settings. Source Control settings reuses the same readiness helper for status dots and the availability switch.
> 
> Until discovery finishes, pickers show **Git URL** only so unconfigured providers are not implied as usable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f89d8cdb477325def2f467a1c619bcc87a19f07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide unready source control providers from the Add Project source list
> - Replaces readiness-map logic (`buildAddProjectRemoteSourceReadiness`) with a new `listAddProjectRemoteSources` utility in [`packages/client-runtime/src/operations/projects.ts`](https://github.com/pingdotgg/t3code/pull/7146/files#diff-50bc4917fdd160661572e739c44cc80d565982b40d14cc5ce0a41cff3302c032) that returns only 'url' and providers that are both available and authenticated, sorted alphabetically.
> - Adds `isSourceControlProviderReady` to [`packages/shared/src/sourceControl.ts`](https://github.com/pingdotgg/t3code/pull/7146/files#diff-cb400671e313566c053c016f281d8ebad90db5adcec2fee1dea13d296d8b789d) as a single shared predicate used across the mobile app, web command palette, and settings UI.
> - Removes disabled-state rendering and setup hint UI from the mobile `SourceControlRow` component and the web `CommandPalette`; providers needing setup simply no longer appear.
> - Behavioral Change: Users will no longer see greyed-out provider rows with setup prompts — unready providers are fully hidden until configured.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1f89d8c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved project creation with selectable remote source-control providers.
  * Added clearer provider-specific labels, path hints, and navigation options across mobile and web.
  * URL-based project creation remains available before provider discovery completes.

* **Bug Fixes**
  * Provider options now accurately reflect availability and authentication status.
  * Removed misleading unavailable-provider states and setup prompts from project selection.
  * Remote source options are now consistently filtered and sorted for easier selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->