### PR TITLE
feat(web): improve terminal workspace controls

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6189,7 +6189,6 @@ function ChatViewContent(props: ChatViewProps) {
             ? "thread"
             : "page"
         }
-        chromeVariant="collapse"
         composerDraftTarget={composerDraftTarget}
         onStateChange={handlePullRequestTabStatusChange}
       />

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -222,7 +222,11 @@ import {
 import { appendPreviewAnnotationPrompt } from "../lib/previewAnnotation";
 import { appendReviewCommentsToPrompt, type ReviewCommentContext } from "../reviewCommentContext";
 import { environmentCatalog } from "../connection/catalog";
-import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../terminalUiStateStore";
+import {
+  selectThreadTerminalCustomLabels,
+  selectThreadTerminalUiState,
+  useTerminalUiStateStore,
+} from "../terminalUiStateStore";
 import { useKnownTerminalSessions, useThreadRunningTerminalIds } from "../state/terminalSessions";
 import { projectEnvironment } from "../state/projects";
 import { useEnvironmentQuery } from "../state/query";
@@ -659,6 +663,7 @@ interface PersistentThreadTerminalDrawerProps {
   newShortcutLabel: string | undefined;
   closeShortcutLabel: string | undefined;
   keybindings: ResolvedKeybindingsConfig;
+  onHide: () => void;
   onAddTerminalContext: (selection: TerminalContextSelection) => void;
 }
 
@@ -673,6 +678,7 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
   newShortcutLabel,
   closeShortcutLabel,
   keybindings,
+  onHide,
   onAddTerminalContext,
 }: PersistentThreadTerminalDrawerProps) {
   const openTerminal = useAtomCommand(terminalEnvironment.open, "terminal open");
@@ -788,8 +794,14 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
     ) {
       return;
     }
-    reconcileTerminalIds(threadRef, serverOrderedTerminalIds);
-  }, [reconcileTerminalIds, serverOrderedTerminalIds, terminalUiState.terminalIds, threadRef]);
+    reconcileTerminalIds(threadRef, serverOrderedTerminalIds, [...panelTerminalIds]);
+  }, [
+    panelTerminalIds,
+    reconcileTerminalIds,
+    serverOrderedTerminalIds,
+    terminalUiState.terminalIds,
+    threadRef,
+  ]);
   const [localFocusRequestId, setLocalFocusRequestId] = useState(0);
   const worktreePath = serverThread?.worktreePath ?? draftThread?.worktreePath ?? null;
   const effectiveWorktreePath = useMemo(() => {
@@ -996,6 +1008,7 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
         onSplitTerminal={splitTerminal}
         onSplitTerminalVertical={splitTerminalVertical}
         onNewTerminal={createNewTerminal}
+        onHide={onHide}
         splitShortcutLabel={visible ? splitShortcutLabel : undefined}
         splitVerticalShortcutLabel={visible ? splitVerticalShortcutLabel : undefined}
         newShortcutLabel={visible ? newShortcutLabel : undefined}
@@ -1558,6 +1571,16 @@ function ChatViewContent(props: ChatViewProps) {
   const canCheckoutPullRequestIntoThread = isLocalDraftThread;
   const activeThreadId = activeThread?.id ?? null;
   const activeThreadEnvironmentId = activeThread?.environmentId ?? null;
+  const activeThreadRef = useMemo(
+    () =>
+      activeThreadEnvironmentId && activeThreadId
+        ? scopeThreadRef(activeThreadEnvironmentId, activeThreadId)
+        : null,
+    [activeThreadEnvironmentId, activeThreadId],
+  );
+  const activeTerminalCustomLabels = useTerminalUiStateStore((state) =>
+    selectThreadTerminalCustomLabels(state.terminalCustomLabelsByThreadKey, activeThreadRef),
+  );
   const runningTerminalIds = useThreadRunningTerminalIds({
     environmentId: activeThread?.environmentId ?? null,
     threadId: activeThreadId,
@@ -1587,18 +1610,15 @@ function ChatViewContent(props: ChatViewProps) {
     for (const session of activeThreadKnownSessions) {
       labels.set(
         session.target.terminalId,
-        resolveTerminalSessionLabel(session.target.terminalId, session.state.summary),
+        activeTerminalCustomLabels[session.target.terminalId] ??
+          resolveTerminalSessionLabel(session.target.terminalId, session.state.summary),
       );
     }
+    for (const [terminalId, label] of Object.entries(activeTerminalCustomLabels)) {
+      if (!labels.has(terminalId)) labels.set(terminalId, label);
+    }
     return labels;
-  }, [activeThreadKnownSessions]);
-  const activeThreadRef = useMemo(
-    () =>
-      activeThreadEnvironmentId && activeThreadId
-        ? scopeThreadRef(activeThreadEnvironmentId, activeThreadId)
-        : null,
-    [activeThreadEnvironmentId, activeThreadId],
-  );
+  }, [activeTerminalCustomLabels, activeThreadKnownSessions]);
   const activeThreadKey = activeThreadRef ? scopedThreadKey(activeThreadRef) : null;
   const changeRequestSnapshotByKey = useAtomValue(threadChangeRequestSnapshotsAtom);
   const [timelineAnchor, setTimelineAnchor] = useState<{
@@ -2835,6 +2855,7 @@ function ChatViewContent(props: ChatViewProps) {
     },
     [activeThreadRef, storeSetTerminalOpen],
   );
+  const hideTerminal = useCallback(() => setTerminalOpen(false), [setTerminalOpen]);
   const toggleTerminalVisibility = useCallback(() => {
     if (!activeThreadRef) return;
     const nextOpen = !terminalUiState.terminalOpen;
@@ -6632,6 +6653,7 @@ function ChatViewContent(props: ChatViewProps) {
             newShortcutLabel={newTerminalShortcutLabel ?? undefined}
             closeShortcutLabel={closeTerminalShortcutLabel ?? undefined}
             keybindings={keybindings}
+            onHide={hideTerminal}
             onAddTerminalContext={addTerminalContextToDraft}
           />
         ))}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -223,6 +223,7 @@ import { appendPreviewAnnotationPrompt } from "../lib/previewAnnotation";
 import { appendReviewCommentsToPrompt, type ReviewCommentContext } from "../reviewCommentContext";
 import { environmentCatalog } from "../connection/catalog";
 import {
+  getTerminalCustomLabel,
   selectThreadTerminalCustomLabels,
   selectThreadTerminalUiState,
   useTerminalUiStateStore,
@@ -1610,7 +1611,7 @@ function ChatViewContent(props: ChatViewProps) {
     for (const session of activeThreadKnownSessions) {
       labels.set(
         session.target.terminalId,
-        activeTerminalCustomLabels[session.target.terminalId] ??
+        getTerminalCustomLabel(activeTerminalCustomLabels, session.target.terminalId) ??
           resolveTerminalSessionLabel(session.target.terminalId, session.state.summary),
       );
     }

--- a/apps/web/src/components/ThreadTerminalDrawer.test.ts
+++ b/apps/web/src/components/ThreadTerminalDrawer.test.ts
@@ -1,12 +1,48 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  getTerminalSidebarMaxWidth,
+  resolveTerminalCustomLabelAfterRename,
   resolveTerminalSelectionActionPosition,
   shouldHandleTerminalExit,
   shouldHandleTerminalSelectionMouseUp,
+  shouldShowTerminalSidebar,
   terminalSelectionActionDelayForClickCount,
   terminalSelectionLineRange,
 } from "./ThreadTerminalDrawer";
+
+describe("resolveTerminalCustomLabelAfterRename", () => {
+  it("does not persist an untouched automatic label after it changes", () => {
+    expect(resolveTerminalCustomLabelAfterRename("bash", null, "bash", "vite")).toBeNull();
+  });
+
+  it("keeps an intentional custom label", () => {
+    expect(resolveTerminalCustomLabelAfterRename("server", null, "bash", "vite")).toBe("server");
+  });
+
+  it("keeps an untouched custom label when the automatic label changes to match it", () => {
+    expect(resolveTerminalCustomLabelAfterRename("server", "server", "bash", "server")).toBe(
+      "server",
+    );
+  });
+});
+
+describe("getTerminalSidebarMaxWidth", () => {
+  it("reserves usable terminal space in a narrow panel", () => {
+    expect(getTerminalSidebarMaxWidth()).toBe(320);
+    expect(getTerminalSidebarMaxWidth(360)).toBe(144);
+    expect(getTerminalSidebarMaxWidth(480)).toBe(264);
+    expect(getTerminalSidebarMaxWidth(800)).toBe(320);
+  });
+});
+
+describe("shouldShowTerminalSidebar", () => {
+  it("shows the sidebar only when there is more than one terminal", () => {
+    expect(shouldShowTerminalSidebar(0)).toBe(false);
+    expect(shouldShowTerminalSidebar(1)).toBe(false);
+    expect(shouldShowTerminalSidebar(2)).toBe(true);
+  });
+});
 
 describe("resolveTerminalSelectionActionPosition", () => {
   it("prefers the selection rect over the last pointer position", () => {

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -63,7 +63,11 @@ import {
 import { readLocalApi } from "~/localApi";
 import { useClientSettings } from "../hooks/useSettings";
 import { useLocalStorage } from "../hooks/useLocalStorage";
-import { selectThreadTerminalCustomLabels, useTerminalUiStateStore } from "../terminalUiStateStore";
+import {
+  getTerminalCustomLabel,
+  selectThreadTerminalCustomLabels,
+  useTerminalUiStateStore,
+} from "../terminalUiStateStore";
 import { useAttachedTerminalSession } from "../state/terminalSessions";
 import { serverEnvironment } from "../state/server";
 import { previewEnvironment } from "../state/preview";
@@ -1310,7 +1314,7 @@ export default function ThreadTerminalDrawer({
     for (const terminalId of normalizedTerminalIds) {
       next.set(
         terminalId,
-        terminalCustomLabels[terminalId]?.trim() ||
+        getTerminalCustomLabel(terminalCustomLabels, terminalId)?.trim() ||
           automaticTerminalLabelById.get(terminalId) ||
           getTerminalLabel(terminalId),
       );
@@ -1361,10 +1365,13 @@ export default function ThreadTerminalDrawer({
     (terminalId: string) => {
       cancelTerminalRenameRef.current = false;
       terminalRenameAutomaticLabelRef.current = automaticTerminalLabelById.get(terminalId) ?? "";
-      terminalRenameCustomLabelRef.current = terminalCustomLabels[terminalId] ?? null;
+      terminalRenameCustomLabelRef.current =
+        getTerminalCustomLabel(terminalCustomLabels, terminalId) ?? null;
       setRenamingTerminalId(terminalId);
       setTerminalRenameDraft(
-        terminalCustomLabels[terminalId] ?? terminalLabelById.get(terminalId) ?? "",
+        getTerminalCustomLabel(terminalCustomLabels, terminalId) ??
+          terminalLabelById.get(terminalId) ??
+          "",
       );
     },
     [automaticTerminalLabelById, terminalCustomLabels, terminalLabelById],
@@ -1741,7 +1748,8 @@ export default function ThreadTerminalDrawer({
                       const isActive = terminalId === resolvedActiveTerminalId;
                       const automaticLabel =
                         automaticTerminalLabelById.get(terminalId) ?? "Terminal";
-                      const customLabel = terminalCustomLabels[terminalId]?.trim() ?? "";
+                      const customLabel =
+                        getTerminalCustomLabel(terminalCustomLabels, terminalId)?.trim() ?? "";
                       const displayLabel = terminalLabelById.get(terminalId) ?? automaticLabel;
                       const isRenaming = renamingTerminalId === terminalId;
                       const terminalTabTooltipLabel = `${displayLabel}${customLabel && customLabel !== automaticLabel ? ` · ${automaticLabel}` : ""} — ${resolveTerminalLaunchLocation(terminalId).cwd}`;

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -81,6 +81,7 @@ import {
   TYPOGRAPHY_ADVANCED_STORAGE_KEY,
 } from "../appearanceFonts";
 import { RightPanelResizeHandle } from "./preview/RightPanelResizeHandle";
+import { Separator } from "./ui/separator";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
 
 const MIN_DRAWER_HEIGHT = 180;
@@ -1590,7 +1591,7 @@ export default function ThreadTerminalDrawer({
       </TerminalToolbarAction>
       {!isPanel && onHide ? (
         <>
-          <span aria-hidden className="mx-0.5 h-4 w-px bg-border/70" />
+          <Separator orientation="vertical" className="mx-0.5 h-4" />
           <TerminalToolbarAction label={hideTerminalActionLabel} onClick={onHide}>
             <PanelBottomCloseIcon className="size-3.5" />
           </TerminalToolbarAction>
@@ -1812,6 +1813,14 @@ export default function ThreadTerminalDrawer({
                                     onClick={() => onActiveTerminalChange(terminalId)}
                                     onDoubleClick={(event) => {
                                       event.preventDefault();
+                                      onActiveTerminalChange(terminalId);
+                                      startTerminalRename(terminalId);
+                                    }}
+                                    onKeyDown={(event) => {
+                                      if (event.nativeEvent.isComposing || event.key !== "F2")
+                                        return;
+                                      event.preventDefault();
+                                      event.stopPropagation();
                                       onActiveTerminalChange(terminalId);
                                       startTerminalRename(terminalId);
                                     }}

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -33,6 +33,7 @@ import {
   useState,
 } from "react";
 import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
 import { readTextFromClipboard, writeTextToClipboard } from "~/hooks/useCopyToClipboard";
 import { useResizableWidth } from "~/hooks/useResizableWidth";
 import { cn } from "~/lib/utils";
@@ -1354,8 +1355,8 @@ export default function ThreadTerminalDrawer({
     : "Close Terminal";
   const terminalToggleShortcutLabel = shortcutLabelForCommand(keybindings, "terminal.toggle");
   const hideTerminalActionLabel = terminalToggleShortcutLabel
-    ? `Toggle terminal drawer (${terminalToggleShortcutLabel})`
-    : "Toggle terminal drawer";
+    ? `Hide terminal drawer (${terminalToggleShortcutLabel})`
+    : "Hide terminal drawer";
   const onSplitTerminalAction = useCallback(() => {
     if (hasReachedSplitLimit) return;
     onSplitTerminal();
@@ -1777,11 +1778,12 @@ export default function ThreadTerminalDrawer({
                             <XIcon className="hidden size-3 group-hover/tab:block group-focus-visible/close:block pointer-coarse:block" />
                           </button>
                           {isRenaming ? (
-                            <input
+                            <Input
                               autoFocus
+                              size="compact"
                               value={terminalRenameDraft}
                               aria-label="Rename terminal"
-                              className="h-6 min-w-0 flex-1 rounded border border-input bg-background px-1.5 text-xs text-foreground outline-none focus:ring-2 focus:ring-ring"
+                              className="min-w-0 flex-1"
                               onFocus={(event) => event.currentTarget.select()}
                               onChange={(event) =>
                                 setTerminalRenameDraft(event.currentTarget.value)

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -1420,6 +1420,11 @@ export default function ThreadTerminalDrawer({
   }, [threadRef.environmentId, threadRef.threadId]);
 
   useEffect(() => {
+    if (!renamingTerminalId || normalizedTerminalIds.includes(renamingTerminalId)) return;
+    cancelTerminalRename();
+  }, [cancelTerminalRename, normalizedTerminalIds, renamingTerminalId]);
+
+  useEffect(() => {
     onHeightChangeRef.current = onHeightChange;
   }, [onHeightChange]);
 

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -5,11 +5,11 @@ import {
 } from "@t3tools/client-runtime/state/runtime";
 import { type TerminalSessionState } from "@t3tools/client-runtime/state/terminal";
 import {
+  PanelBottomCloseIcon,
   Plus,
   SquareSplitHorizontal,
   SquareSplitVertical,
   TerminalSquare,
-  Trash2,
   XIcon,
 } from "lucide-react";
 import {
@@ -21,19 +21,20 @@ import {
 import { getTerminalLabel } from "@t3tools/shared/terminalLabels";
 import * as Schema from "effect/Schema";
 import {
-  type PointerEvent as ReactPointerEvent,
   type ReactNode,
+  type PointerEvent as ReactPointerEvent,
   type SetStateAction,
   useCallback,
   useEffect,
   useEffectEvent,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
 } from "react";
-import { Popover, PopoverPopup, PopoverTrigger } from "~/components/ui/popover";
 import { Button } from "~/components/ui/button";
 import { readTextFromClipboard, writeTextToClipboard } from "~/hooks/useCopyToClipboard";
+import { useResizableWidth } from "~/hooks/useResizableWidth";
 import { cn } from "~/lib/utils";
 import { type TerminalContextSelection } from "~/lib/terminalContext";
 import {
@@ -50,6 +51,7 @@ import {
   isTerminalSplitShortcut,
   isTerminalSplitVerticalShortcut,
   isTerminalToggleShortcut,
+  shortcutLabelForCommand,
   terminalDeleteShortcutData,
   terminalNavigationShortcutData,
 } from "../keybindings";
@@ -61,6 +63,7 @@ import {
 import { readLocalApi } from "~/localApi";
 import { useClientSettings } from "../hooks/useSettings";
 import { useLocalStorage } from "../hooks/useLocalStorage";
+import { selectThreadTerminalCustomLabels, useTerminalUiStateStore } from "../terminalUiStateStore";
 import { useAttachedTerminalSession } from "../state/terminalSessions";
 import { serverEnvironment } from "../state/server";
 import { previewEnvironment } from "../state/preview";
@@ -73,10 +76,74 @@ import {
   resolveTerminalFontSizePreference,
   TYPOGRAPHY_ADVANCED_STORAGE_KEY,
 } from "../appearanceFonts";
+import { RightPanelResizeHandle } from "./preview/RightPanelResizeHandle";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
 
 const MIN_DRAWER_HEIGHT = 180;
 const MAX_DRAWER_HEIGHT_RATIO = 0.75;
 const MULTI_CLICK_SELECTION_ACTION_DELAY_MS = 260;
+const TERMINAL_SIDEBAR_DEFAULT_WIDTH = 144;
+const TERMINAL_SIDEBAR_MIN_WIDTH = 144;
+const TERMINAL_SIDEBAR_MAX_WIDTH = 320;
+const TERMINAL_VIEWPORT_MIN_WIDTH = 216;
+const TERMINAL_SIDEBAR_WIDTH_STORAGE_KEY = "t3code:terminal-sidebar-width";
+
+export function getTerminalSidebarMaxWidth(rowWidth?: number): number {
+  if (rowWidth === undefined) return TERMINAL_SIDEBAR_MAX_WIDTH;
+  return Math.max(
+    TERMINAL_SIDEBAR_MIN_WIDTH,
+    Math.min(TERMINAL_SIDEBAR_MAX_WIDTH, Math.floor(rowWidth) - TERMINAL_VIEWPORT_MIN_WIDTH),
+  );
+}
+
+export function resolveTerminalCustomLabelAfterRename(
+  draft: string,
+  startingCustomLabel: string | null,
+  startingAutomaticLabel: string,
+  currentAutomaticLabel: string,
+): string | null {
+  const nextLabel = draft.trim();
+  if (startingCustomLabel !== null && nextLabel === startingCustomLabel.trim()) {
+    return nextLabel;
+  }
+  return nextLabel.length === 0 ||
+    nextLabel === startingAutomaticLabel ||
+    nextLabel === currentAutomaticLabel
+    ? null
+    : nextLabel;
+}
+
+function TerminalToolbarAction({
+  label,
+  disabled = false,
+  onClick,
+  children,
+}: {
+  label: string;
+  disabled?: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            size="icon-micro"
+            variant="ghost"
+            aria-label={label}
+            aria-disabled={disabled || undefined}
+            className={cn(disabled && "cursor-not-allowed opacity-64")}
+            onClick={onClick}
+          />
+        }
+      >
+        {children}
+      </TooltipTrigger>
+      <TooltipPopup side="bottom">{label}</TooltipPopup>
+    </Tooltip>
+  );
+}
 
 function maxDrawerHeight(): number {
   if (typeof window === "undefined") return DEFAULT_THREAD_TERMINAL_HEIGHT;
@@ -243,6 +310,10 @@ export function shouldHandleTerminalSelectionMouseUp(
   button: number,
 ): boolean {
   return selectionGestureActive && button === 0;
+}
+
+export function shouldShowTerminalSidebar(terminalCount: number): boolean {
+  return terminalCount > 1;
 }
 
 export function terminalSelectionLineRange(position: {
@@ -999,6 +1070,7 @@ interface ThreadTerminalDrawerProps {
   onSplitTerminal: () => void;
   onSplitTerminalVertical: () => void;
   onNewTerminal: () => void;
+  onHide?: () => void;
   splitShortcutLabel?: string | undefined;
   splitVerticalShortcutLabel?: string | undefined;
   newShortcutLabel?: string | undefined;
@@ -1012,35 +1084,6 @@ interface ThreadTerminalDrawerProps {
   terminalLabelsById?: ReadonlyMap<string, string>;
   /** Prefer per-session launch locations when the server already knows a terminal. */
   terminalLaunchLocationsById?: ReadonlyMap<string, TerminalLaunchLocation>;
-}
-
-interface TerminalActionButtonProps {
-  label: string;
-  className: string;
-  onClick: () => void;
-  children: ReactNode;
-}
-
-function TerminalActionButton({ label, className, onClick, children }: TerminalActionButtonProps) {
-  return (
-    <Popover>
-      <PopoverTrigger
-        openOnHover
-        render={<button type="button" className={className} onClick={onClick} aria-label={label} />}
-      >
-        {children}
-      </PopoverTrigger>
-      <PopoverPopup
-        tooltipStyle
-        side="bottom"
-        sideOffset={6}
-        align="center"
-        className="pointer-events-none select-none"
-      >
-        {label}
-      </PopoverPopup>
-    </Popover>
-  );
 }
 
 export default function ThreadTerminalDrawer({
@@ -1060,6 +1103,7 @@ export default function ThreadTerminalDrawer({
   onSplitTerminal,
   onSplitTerminalVertical,
   onNewTerminal,
+  onHide,
   splitShortcutLabel,
   splitVerticalShortcutLabel,
   newShortcutLabel,
@@ -1073,6 +1117,15 @@ export default function ThreadTerminalDrawer({
   terminalLaunchLocationsById,
 }: ThreadTerminalDrawerProps) {
   const isPanel = mode === "panel";
+  const terminalCustomLabels = useTerminalUiStateStore((state) =>
+    selectThreadTerminalCustomLabels(state.terminalCustomLabelsByThreadKey, threadRef),
+  );
+  const setTerminalCustomLabel = useTerminalUiStateStore((state) => state.setTerminalCustomLabel);
+  const [renamingTerminalId, setRenamingTerminalId] = useState<string | null>(null);
+  const [terminalRenameDraft, setTerminalRenameDraft] = useState("");
+  const cancelTerminalRenameRef = useRef(false);
+  const terminalRenameAutomaticLabelRef = useRef("");
+  const terminalRenameCustomLabelRef = useRef<string | null>(null);
   const [advancedTypography] = useLocalStorage(
     TYPOGRAPHY_ADVANCED_STORAGE_KEY,
     false,
@@ -1123,6 +1176,27 @@ export default function ThreadTerminalDrawer({
     }
     return normalizedIds;
   }, [terminalIds]);
+  const terminalLayoutRef = useRef<HTMLDivElement | null>(null);
+  const [terminalLayoutWidth, setTerminalLayoutWidth] = useState<number>();
+  useLayoutEffect(() => {
+    if (!visible) return;
+    const row = terminalLayoutRef.current;
+    if (!row) return;
+    const measure = () => setTerminalLayoutWidth(row.clientWidth);
+    measure();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(row);
+    return () => observer.disconnect();
+  }, [normalizedTerminalIds.length, visible]);
+  const { width: terminalSidebarWidth, handlers: terminalSidebarResizeHandlers } =
+    useResizableWidth({
+      storageKey: TERMINAL_SIDEBAR_WIDTH_STORAGE_KEY,
+      defaultWidth: TERMINAL_SIDEBAR_DEFAULT_WIDTH,
+      minWidth: TERMINAL_SIDEBAR_MIN_WIDTH,
+      maxWidth: getTerminalSidebarMaxWidth(terminalLayoutWidth),
+      edge: "left",
+    });
 
   const resolvedActiveTerminalId =
     normalizedTerminalIds.length === 0
@@ -1221,19 +1295,28 @@ export default function ThreadTerminalDrawer({
     (normalizedTerminalIds.length > 0 ? [resolvedActiveTerminalId] : []);
   const splitDirection =
     resolvedTerminalGroups[resolvedActiveGroupIndex]?.splitDirection ?? "horizontal";
-  const hasTerminalSidebar = normalizedTerminalIds.length > 1;
+  const hasTerminalSidebar = shouldShowTerminalSidebar(normalizedTerminalIds.length);
   const isSplitView = visibleTerminalIds.length > 1;
-  const showGroupHeaders =
-    resolvedTerminalGroups.length > 1 ||
-    resolvedTerminalGroups.some((terminalGroup) => terminalGroup.terminalIds.length > 1);
   const hasReachedSplitLimit = visibleTerminalIds.length >= MAX_TERMINALS_PER_GROUP;
-  const terminalLabelById = useMemo(() => {
+  const automaticTerminalLabelById = useMemo(() => {
     const next = new Map<string, string>();
     for (const terminalId of normalizedTerminalIds) {
       next.set(terminalId, terminalLabelsById?.get(terminalId) ?? getTerminalLabel(terminalId));
     }
     return next;
   }, [normalizedTerminalIds, terminalLabelsById]);
+  const terminalLabelById = useMemo(() => {
+    const next = new Map<string, string>();
+    for (const terminalId of normalizedTerminalIds) {
+      next.set(
+        terminalId,
+        terminalCustomLabels[terminalId]?.trim() ||
+          automaticTerminalLabelById.get(terminalId) ||
+          getTerminalLabel(terminalId),
+      );
+    }
+    return next;
+  }, [automaticTerminalLabelById, normalizedTerminalIds, terminalCustomLabels]);
   const resolveTerminalLaunchLocation = useCallback(
     (terminalId: string): TerminalLaunchLocation => {
       return (
@@ -1246,6 +1329,9 @@ export default function ThreadTerminalDrawer({
     },
     [cwd, runtimeEnv, terminalLaunchLocationsById, worktreePath],
   );
+  const newTerminalActionLabel = newShortcutLabel
+    ? `New Terminal (${newShortcutLabel})`
+    : "New Terminal";
   const splitTerminalActionLabel = hasReachedSplitLimit
     ? `Split Terminal Horizontally (max ${MAX_TERMINALS_PER_GROUP} per group)`
     : splitShortcutLabel
@@ -1256,12 +1342,13 @@ export default function ThreadTerminalDrawer({
     : splitVerticalShortcutLabel
       ? `Split Terminal Vertically (${splitVerticalShortcutLabel})`
       : "Split Terminal Vertically";
-  const newTerminalActionLabel = newShortcutLabel
-    ? `New Terminal (${newShortcutLabel})`
-    : "New Terminal";
   const closeTerminalActionLabel = closeShortcutLabel
     ? `Close Terminal (${closeShortcutLabel})`
     : "Close Terminal";
+  const terminalToggleShortcutLabel = shortcutLabelForCommand(keybindings, "terminal.toggle");
+  const hideTerminalActionLabel = terminalToggleShortcutLabel
+    ? `Toggle terminal drawer (${terminalToggleShortcutLabel})`
+    : "Toggle terminal drawer";
   const onSplitTerminalAction = useCallback(() => {
     if (hasReachedSplitLimit) return;
     onSplitTerminal();
@@ -1270,9 +1357,67 @@ export default function ThreadTerminalDrawer({
     if (hasReachedSplitLimit) return;
     onSplitTerminalVertical();
   }, [hasReachedSplitLimit, onSplitTerminalVertical]);
-  const onNewTerminalAction = useCallback(() => {
-    onNewTerminal();
-  }, [onNewTerminal]);
+  const startTerminalRename = useCallback(
+    (terminalId: string) => {
+      cancelTerminalRenameRef.current = false;
+      terminalRenameAutomaticLabelRef.current = automaticTerminalLabelById.get(terminalId) ?? "";
+      terminalRenameCustomLabelRef.current = terminalCustomLabels[terminalId] ?? null;
+      setRenamingTerminalId(terminalId);
+      setTerminalRenameDraft(
+        terminalCustomLabels[terminalId] ?? terminalLabelById.get(terminalId) ?? "",
+      );
+    },
+    [automaticTerminalLabelById, terminalCustomLabels, terminalLabelById],
+  );
+  const finishTerminalRename = useCallback(() => {
+    if (!renamingTerminalId) return;
+    const automaticLabel = automaticTerminalLabelById.get(renamingTerminalId) ?? "";
+    setTerminalCustomLabel(
+      threadRef,
+      renamingTerminalId,
+      resolveTerminalCustomLabelAfterRename(
+        terminalRenameDraft,
+        terminalRenameCustomLabelRef.current,
+        terminalRenameAutomaticLabelRef.current,
+        automaticLabel,
+      ),
+    );
+    terminalRenameAutomaticLabelRef.current = "";
+    terminalRenameCustomLabelRef.current = null;
+    setRenamingTerminalId(null);
+  }, [
+    automaticTerminalLabelById,
+    renamingTerminalId,
+    setTerminalCustomLabel,
+    terminalRenameDraft,
+    threadRef,
+  ]);
+  const cancelTerminalRename = useCallback(() => {
+    cancelTerminalRenameRef.current = true;
+    terminalRenameAutomaticLabelRef.current = "";
+    terminalRenameCustomLabelRef.current = null;
+    setRenamingTerminalId(null);
+  }, []);
+  const closeTerminalSafely = useCallback(
+    (terminalId: string) => {
+      if (renamingTerminalId === terminalId) {
+        cancelTerminalRenameRef.current = true;
+        terminalRenameAutomaticLabelRef.current = "";
+        terminalRenameCustomLabelRef.current = null;
+        setRenamingTerminalId(null);
+      }
+      onCloseTerminal(terminalId);
+    },
+    [onCloseTerminal, renamingTerminalId],
+  );
+
+  useEffect(() => {
+    cancelTerminalRenameRef.current = false;
+    terminalRenameAutomaticLabelRef.current = "";
+    terminalRenameCustomLabelRef.current = null;
+    setRenamingTerminalId(null);
+    setTerminalRenameDraft("");
+  }, [threadRef.environmentId, threadRef.threadId]);
 
   useEffect(() => {
     onHeightChangeRef.current = onHeightChange;
@@ -1397,7 +1542,7 @@ export default function ThreadTerminalDrawer({
         ) : null}
         <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 px-4 py-6 text-center text-sm text-muted-foreground">
           <p>No terminal sessions for this thread yet.</p>
-          <Button size="xs" variant="outline" onClick={onNewTerminalAction}>
+          <Button size="xs" variant="outline" onClick={onNewTerminal}>
             {newTerminalActionLabel}
           </Button>
         </div>
@@ -1406,7 +1551,41 @@ export default function ThreadTerminalDrawer({
   }
 
   const activeTerminalLaunchLocation = resolveTerminalLaunchLocation(resolvedActiveTerminalId);
-
+  const compactTerminalToolbar = (
+    <>
+      <TerminalToolbarAction
+        label={splitTerminalActionLabel}
+        disabled={hasReachedSplitLimit}
+        onClick={onSplitTerminalAction}
+      >
+        <SquareSplitHorizontal className="size-3.5" />
+      </TerminalToolbarAction>
+      <TerminalToolbarAction
+        label={splitTerminalVerticalActionLabel}
+        disabled={hasReachedSplitLimit}
+        onClick={onSplitTerminalVerticalAction}
+      >
+        <SquareSplitVertical className="size-3.5" />
+      </TerminalToolbarAction>
+      <TerminalToolbarAction label={newTerminalActionLabel} onClick={onNewTerminal}>
+        <Plus className="size-3.5" />
+      </TerminalToolbarAction>
+      <TerminalToolbarAction
+        label={closeTerminalActionLabel}
+        onClick={() => closeTerminalSafely(resolvedActiveTerminalId)}
+      >
+        <XIcon className="size-3.5" />
+      </TerminalToolbarAction>
+      {!isPanel && onHide ? (
+        <>
+          <span aria-hidden className="mx-0.5 h-4 w-px bg-border/70" />
+          <TerminalToolbarAction label={hideTerminalActionLabel} onClick={onHide}>
+            <PanelBottomCloseIcon className="size-3.5" />
+          </TerminalToolbarAction>
+        </>
+      ) : null}
+    </>
+  );
   return (
     <aside
       data-terminal-owner={isPanel ? "right-panel" : "drawer"}
@@ -1426,277 +1605,227 @@ export default function ThreadTerminalDrawer({
         />
       ) : null}
 
-      {!hasTerminalSidebar && (
-        <div className="pointer-events-none absolute right-2 top-2 z-20">
-          <div className="pointer-events-auto inline-flex items-center overflow-hidden rounded-md border border-border/80 bg-background shadow-xs">
-            <TerminalActionButton
-              className={`p-1 text-foreground/90 transition-colors ${
-                hasReachedSplitLimit
-                  ? "cursor-not-allowed opacity-45 hover:bg-transparent"
-                  : "hover:bg-accent"
-              }`}
-              onClick={onSplitTerminalAction}
-              label={splitTerminalActionLabel}
-            >
-              <SquareSplitHorizontal className="size-3.25" />
-            </TerminalActionButton>
-            <div className="h-4 w-px bg-border/80" />
-            <TerminalActionButton
-              className={`p-1 text-foreground/90 transition-colors ${
-                hasReachedSplitLimit
-                  ? "cursor-not-allowed opacity-45 hover:bg-transparent"
-                  : "hover:bg-accent"
-              }`}
-              onClick={onSplitTerminalVerticalAction}
-              label={splitTerminalVerticalActionLabel}
-            >
-              <SquareSplitVertical className="size-3.25" />
-            </TerminalActionButton>
-            <div className="h-4 w-px bg-border/80" />
-            <TerminalActionButton
-              className="p-1 text-foreground/90 transition-colors hover:bg-accent"
-              onClick={onNewTerminalAction}
-              label={newTerminalActionLabel}
-            >
-              <Plus className="size-3.25" />
-            </TerminalActionButton>
-            <div className="h-4 w-px bg-border/80" />
-            <TerminalActionButton
-              className="p-1 text-foreground/90 transition-colors hover:bg-accent"
-              onClick={() => onCloseTerminal(resolvedActiveTerminalId)}
-              label={closeTerminalActionLabel}
-            >
-              <Trash2 className="size-3.25" />
-            </TerminalActionButton>
+      {!hasTerminalSidebar ? (
+        <div className="pointer-events-none absolute top-2 right-2 z-20">
+          <div className="pointer-events-auto flex h-8 items-center rounded-lg border border-border/70 bg-background p-0.5 shadow-xs">
+            {compactTerminalToolbar}
           </div>
         </div>
-      )}
+      ) : null}
 
-      <div className="min-h-0 w-full flex-1">
-        <div className={`flex h-full min-h-0 ${hasTerminalSidebar ? "gap-1.5" : ""}`}>
-          <div className="min-w-0 flex-1">
-            {isSplitView ? (
-              <div
-                className="grid h-full w-full min-w-0 gap-0 overflow-hidden"
-                style={
-                  splitDirection === "vertical"
-                    ? {
-                        gridTemplateRows: `repeat(${visibleTerminalIds.length}, minmax(0, 1fr))`,
-                      }
-                    : {
-                        gridTemplateColumns: `repeat(${visibleTerminalIds.length}, minmax(0, 1fr))`,
-                      }
-                }
-              >
-                {visibleTerminalIds.map((terminalId) => {
-                  const terminalLaunchLocation = resolveTerminalLaunchLocation(terminalId);
-                  return (
-                    <div
-                      key={terminalId}
-                      className={`min-h-0 min-w-0 ${
-                        splitDirection === "vertical"
-                          ? "border-t first:border-t-0"
-                          : "border-l first:border-l-0"
-                      } ${
-                        terminalId === resolvedActiveTerminalId
-                          ? "border-border"
-                          : "border-border/70"
-                      }`}
-                      onMouseDown={() => {
-                        if (terminalId !== resolvedActiveTerminalId) {
-                          onActiveTerminalChange(terminalId);
-                        }
-                      }}
-                    >
-                      <div className="h-full p-1">
-                        <TerminalViewport
-                          advancedTypography={advancedTypography}
-                          threadRef={threadRef}
-                          threadId={threadId}
-                          terminalId={terminalId}
-                          terminalLabel={terminalLabelById.get(terminalId) ?? "Terminal"}
-                          cwd={terminalLaunchLocation.cwd}
-                          {...(terminalLaunchLocation.worktreePath !== undefined
-                            ? { worktreePath: terminalLaunchLocation.worktreePath }
-                            : {})}
-                          {...(terminalLaunchLocation.runtimeEnv
-                            ? { runtimeEnv: terminalLaunchLocation.runtimeEnv }
-                            : {})}
-                          onSessionExited={() => onCloseTerminal(terminalId)}
-                          onAddTerminalContext={onAddTerminalContext}
-                          focusRequestId={focusRequestId}
-                          autoFocus={terminalId === resolvedActiveTerminalId}
-                          resizeEpoch={resizeEpoch}
-                          drawerHeight={drawerHeight}
-                          keybindings={keybindings}
-                        />
-                      </div>
+      <div ref={terminalLayoutRef} className="flex min-h-0 w-full flex-1">
+        <div className="min-w-0 flex-1">
+          {isSplitView ? (
+            <div
+              className="grid h-full w-full min-w-0 gap-0 overflow-hidden"
+              style={
+                splitDirection === "vertical"
+                  ? {
+                      gridTemplateRows: `repeat(${visibleTerminalIds.length}, minmax(0, 1fr))`,
+                    }
+                  : {
+                      gridTemplateColumns: `repeat(${visibleTerminalIds.length}, minmax(0, 1fr))`,
+                    }
+              }
+            >
+              {visibleTerminalIds.map((terminalId) => {
+                const terminalLaunchLocation = resolveTerminalLaunchLocation(terminalId);
+                const isActive = terminalId === resolvedActiveTerminalId;
+                return (
+                  <div
+                    key={terminalId}
+                    className={cn(
+                      "min-h-0 min-w-0",
+                      splitDirection === "vertical"
+                        ? "border-t first:border-t-0"
+                        : "border-l first:border-l-0",
+                      isActive ? "border-border" : "border-border/70",
+                    )}
+                    onMouseDown={() => {
+                      if (!isActive) onActiveTerminalChange(terminalId);
+                    }}
+                  >
+                    <div className="h-full p-1">
+                      <TerminalViewport
+                        advancedTypography={advancedTypography}
+                        threadRef={threadRef}
+                        threadId={threadId}
+                        terminalId={terminalId}
+                        terminalLabel={terminalLabelById.get(terminalId) ?? "Terminal"}
+                        cwd={terminalLaunchLocation.cwd}
+                        {...(terminalLaunchLocation.worktreePath !== undefined
+                          ? { worktreePath: terminalLaunchLocation.worktreePath }
+                          : {})}
+                        {...(terminalLaunchLocation.runtimeEnv
+                          ? { runtimeEnv: terminalLaunchLocation.runtimeEnv }
+                          : {})}
+                        onSessionExited={() => closeTerminalSafely(terminalId)}
+                        onAddTerminalContext={onAddTerminalContext}
+                        focusRequestId={focusRequestId}
+                        autoFocus={isActive && renamingTerminalId === null}
+                        resizeEpoch={resizeEpoch}
+                        drawerHeight={drawerHeight}
+                        keybindings={keybindings}
+                      />
                     </div>
-                  );
-                })}
-              </div>
-            ) : (
-              <div className="h-full p-1">
-                <TerminalViewport
-                  advancedTypography={advancedTypography}
-                  key={resolvedActiveTerminalId}
-                  threadRef={threadRef}
-                  threadId={threadId}
-                  terminalId={resolvedActiveTerminalId}
-                  terminalLabel={terminalLabelById.get(resolvedActiveTerminalId) ?? "Terminal"}
-                  cwd={activeTerminalLaunchLocation.cwd}
-                  {...(activeTerminalLaunchLocation.worktreePath !== undefined
-                    ? { worktreePath: activeTerminalLaunchLocation.worktreePath }
-                    : {})}
-                  {...(activeTerminalLaunchLocation.runtimeEnv
-                    ? { runtimeEnv: activeTerminalLaunchLocation.runtimeEnv }
-                    : {})}
-                  onSessionExited={() => onCloseTerminal(resolvedActiveTerminalId)}
-                  onAddTerminalContext={onAddTerminalContext}
-                  focusRequestId={focusRequestId}
-                  autoFocus
-                  resizeEpoch={resizeEpoch}
-                  drawerHeight={drawerHeight}
-                  keybindings={keybindings}
-                />
-              </div>
-            )}
-          </div>
-
-          {hasTerminalSidebar && (
-            <aside className="flex w-36 min-w-36 flex-col border border-border/70 bg-muted/10">
-              <div className="flex h-[22px] items-stretch justify-end border-b border-border/70">
-                <div className="inline-flex h-full items-stretch">
-                  <TerminalActionButton
-                    className={`inline-flex h-full items-center px-1 text-foreground/90 transition-colors ${
-                      hasReachedSplitLimit
-                        ? "cursor-not-allowed opacity-45 hover:bg-transparent"
-                        : "hover:bg-accent/70"
-                    }`}
-                    onClick={onSplitTerminalAction}
-                    label={splitTerminalActionLabel}
-                  >
-                    <SquareSplitHorizontal className="size-3.25" />
-                  </TerminalActionButton>
-                  <TerminalActionButton
-                    className={`inline-flex h-full items-center border-l border-border/70 px-1 text-foreground/90 transition-colors ${
-                      hasReachedSplitLimit
-                        ? "cursor-not-allowed opacity-45 hover:bg-transparent"
-                        : "hover:bg-accent/70"
-                    }`}
-                    onClick={onSplitTerminalVerticalAction}
-                    label={splitTerminalVerticalActionLabel}
-                  >
-                    <SquareSplitVertical className="size-3.25" />
-                  </TerminalActionButton>
-                  <TerminalActionButton
-                    className="inline-flex h-full items-center border-l border-border/70 px-1 text-foreground/90 transition-colors hover:bg-accent/70"
-                    onClick={onNewTerminalAction}
-                    label={newTerminalActionLabel}
-                  >
-                    <Plus className="size-3.25" />
-                  </TerminalActionButton>
-                  <TerminalActionButton
-                    className="inline-flex h-full items-center border-l border-border/70 px-1 text-foreground/90 transition-colors hover:bg-accent/70"
-                    onClick={() => onCloseTerminal(resolvedActiveTerminalId)}
-                    label={closeTerminalActionLabel}
-                  >
-                    <Trash2 className="size-3.25" />
-                  </TerminalActionButton>
-                </div>
-              </div>
-
-              <div className="min-h-0 flex-1 overflow-y-auto px-1 py-1">
-                {resolvedTerminalGroups.map((terminalGroup, groupIndex) => {
-                  const isGroupActive =
-                    terminalGroup.terminalIds.includes(resolvedActiveTerminalId);
-                  const groupActiveTerminalId = isGroupActive
-                    ? resolvedActiveTerminalId
-                    : (terminalGroup.terminalIds[0] ?? resolvedActiveTerminalId);
-
-                  return (
-                    <div key={terminalGroup.id} className="pb-0.5">
-                      {showGroupHeaders && (
-                        <button
-                          type="button"
-                          className={`flex w-full items-center rounded px-1 py-0.5 text-[10px] uppercase tracking-[0.08em] ${
-                            isGroupActive
-                              ? "bg-accent/70 text-foreground"
-                              : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
-                          }`}
-                          onClick={() => onActiveTerminalChange(groupActiveTerminalId)}
-                        >
-                          Group {groupIndex + 1}
-                        </button>
-                      )}
-
-                      <div
-                        className={showGroupHeaders ? "ml-1 border-l border-border/60 pl-1.5" : ""}
-                      >
-                        {terminalGroup.terminalIds.map((terminalId) => {
-                          const isActive = terminalId === resolvedActiveTerminalId;
-                          const closeTerminalLabel = `Close ${
-                            terminalLabelById.get(terminalId) ?? "terminal"
-                          }${isActive && closeShortcutLabel ? ` (${closeShortcutLabel})` : ""}`;
-                          return (
-                            <div
-                              key={terminalId}
-                              className={`group flex items-center gap-1 rounded px-1 py-0.5 text-[11px] ${
-                                isActive
-                                  ? "bg-accent text-foreground"
-                                  : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
-                              }`}
-                            >
-                              {showGroupHeaders && (
-                                <span className="text-[10px] text-muted-foreground/80">└</span>
-                              )}
-                              <button
-                                type="button"
-                                className="flex min-w-0 flex-1 items-center gap-1 text-left"
-                                onClick={() => onActiveTerminalChange(terminalId)}
-                              >
-                                <TerminalSquare className="size-3 shrink-0" />
-                                <span className="truncate">
-                                  {terminalLabelById.get(terminalId) ?? "Terminal"}
-                                </span>
-                              </button>
-                              {normalizedTerminalIds.length > 1 && (
-                                <Popover>
-                                  <PopoverTrigger
-                                    openOnHover
-                                    render={
-                                      <button
-                                        type="button"
-                                        className="inline-flex size-3.5 items-center justify-center rounded text-xs font-medium leading-none text-muted-foreground opacity-0 transition hover:bg-accent hover:text-foreground group-hover:opacity-100"
-                                        onClick={() => onCloseTerminal(terminalId)}
-                                        aria-label={closeTerminalLabel}
-                                      />
-                                    }
-                                  >
-                                    <XIcon className="size-2.5" />
-                                  </PopoverTrigger>
-                                  <PopoverPopup
-                                    tooltipStyle
-                                    side="bottom"
-                                    sideOffset={6}
-                                    align="center"
-                                    className="pointer-events-none select-none"
-                                  >
-                                    {closeTerminalLabel}
-                                  </PopoverPopup>
-                                </Popover>
-                              )}
-                            </div>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            </aside>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="h-full p-1">
+              <TerminalViewport
+                advancedTypography={advancedTypography}
+                key={resolvedActiveTerminalId}
+                threadRef={threadRef}
+                threadId={threadId}
+                terminalId={resolvedActiveTerminalId}
+                terminalLabel={terminalLabelById.get(resolvedActiveTerminalId) ?? "Terminal"}
+                cwd={activeTerminalLaunchLocation.cwd}
+                {...(activeTerminalLaunchLocation.worktreePath !== undefined
+                  ? { worktreePath: activeTerminalLaunchLocation.worktreePath }
+                  : {})}
+                {...(activeTerminalLaunchLocation.runtimeEnv
+                  ? { runtimeEnv: activeTerminalLaunchLocation.runtimeEnv }
+                  : {})}
+                onSessionExited={() => closeTerminalSafely(resolvedActiveTerminalId)}
+                onAddTerminalContext={onAddTerminalContext}
+                focusRequestId={focusRequestId}
+                autoFocus={renamingTerminalId === null}
+                resizeEpoch={resizeEpoch}
+                drawerHeight={drawerHeight}
+                keybindings={keybindings}
+              />
+            </div>
           )}
         </div>
+
+        <aside
+          className={cn(
+            "relative flex shrink-0 flex-col border-l border-border/70 bg-muted/10",
+            !hasTerminalSidebar && "hidden",
+          )}
+          style={{ width: `${terminalSidebarWidth}px` }}
+        >
+          <RightPanelResizeHandle handlers={terminalSidebarResizeHandlers} />
+          <div className="flex h-9 shrink-0 items-center justify-center border-b border-border/70 px-2">
+            {hasTerminalSidebar ? compactTerminalToolbar : null}
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto p-1">
+            {resolvedTerminalGroups.map((terminalGroup, groupIndex) => {
+              const isSplitGroup = terminalGroup.terminalIds.length > 1;
+              const splitVertically = terminalGroup.splitDirection === "vertical";
+              const SplitIcon = splitVertically ? SquareSplitVertical : SquareSplitHorizontal;
+              return (
+                <div
+                  key={terminalGroup.id}
+                  className={cn(
+                    groupIndex > 0 && "mt-1",
+                    isSplitGroup && "rounded-lg border border-border/80 bg-muted/20 p-1",
+                  )}
+                >
+                  {isSplitGroup ? (
+                    <div className="flex h-5 items-center gap-1 px-1 text-[10px] font-medium text-muted-foreground">
+                      <SplitIcon className="size-3" />
+                      <span>{splitVertically ? "Split down" : "Split right"}</span>
+                    </div>
+                  ) : null}
+                  <div className={cn(isSplitGroup && "space-y-0.5")}>
+                    {terminalGroup.terminalIds.map((terminalId) => {
+                      const isActive = terminalId === resolvedActiveTerminalId;
+                      const automaticLabel =
+                        automaticTerminalLabelById.get(terminalId) ?? "Terminal";
+                      const customLabel = terminalCustomLabels[terminalId]?.trim() ?? "";
+                      const displayLabel = terminalLabelById.get(terminalId) ?? automaticLabel;
+                      const isRenaming = renamingTerminalId === terminalId;
+                      const terminalTabTooltipLabel = `${displayLabel}${customLabel && customLabel !== automaticLabel ? ` · ${automaticLabel}` : ""} — ${resolveTerminalLaunchLocation(terminalId).cwd}`;
+                      return (
+                        <div
+                          key={terminalId}
+                          className={cn(
+                            "group/tab flex h-6 items-center gap-0.5 rounded-md pr-2 text-xs",
+                            isSplitGroup ? "pl-0.5" : "pl-1.5",
+                            isActive
+                              ? "bg-accent text-foreground"
+                              : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                          )}
+                        >
+                          <button
+                            type="button"
+                            className="group/close relative flex size-4 shrink-0 cursor-pointer items-center justify-center rounded-sm hover:bg-muted"
+                            aria-label={`Close ${displayLabel}`}
+                            onClick={() => closeTerminalSafely(terminalId)}
+                          >
+                            <TerminalSquare className="size-3 shrink-0 group-hover/tab:hidden group-focus-visible/close:hidden pointer-coarse:hidden" />
+                            <XIcon className="hidden size-3 group-hover/tab:block group-focus-visible/close:block pointer-coarse:block" />
+                          </button>
+                          {isRenaming ? (
+                            <input
+                              autoFocus
+                              value={terminalRenameDraft}
+                              aria-label="Rename terminal"
+                              className="h-6 min-w-0 flex-1 rounded border border-input bg-background px-1.5 text-xs text-foreground outline-none focus:ring-2 focus:ring-ring"
+                              onFocus={(event) => event.currentTarget.select()}
+                              onChange={(event) =>
+                                setTerminalRenameDraft(event.currentTarget.value)
+                              }
+                              onBlur={() => {
+                                if (cancelTerminalRenameRef.current) {
+                                  cancelTerminalRenameRef.current = false;
+                                  return;
+                                }
+                                finishTerminalRename();
+                              }}
+                              onKeyDown={(event) => {
+                                event.stopPropagation();
+                                if (event.nativeEvent.isComposing) return;
+                                if (event.key === "Enter") {
+                                  event.preventDefault();
+                                  finishTerminalRename();
+                                } else if (event.key === "Escape") {
+                                  event.preventDefault();
+                                  cancelTerminalRename();
+                                }
+                              }}
+                            />
+                          ) : (
+                            <Tooltip>
+                              <TooltipTrigger
+                                render={
+                                  <button
+                                    type="button"
+                                    className="flex min-w-0 flex-1 cursor-pointer items-center text-left outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                    onClick={() => onActiveTerminalChange(terminalId)}
+                                    onDoubleClick={(event) => {
+                                      event.preventDefault();
+                                      onActiveTerminalChange(terminalId);
+                                      startTerminalRename(terminalId);
+                                    }}
+                                  />
+                                }
+                              >
+                                <span className="min-w-0 flex-1 truncate">
+                                  {displayLabel}
+                                  {customLabel && customLabel !== automaticLabel ? (
+                                    <span className="font-normal text-muted-foreground/80">
+                                      {` · ${automaticLabel}`}
+                                    </span>
+                                  ) : null}
+                                </span>
+                              </TooltipTrigger>
+                              <TooltipPopup side="left">{terminalTabTooltipLabel}</TooltipPopup>
+                            </Tooltip>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </aside>
       </div>
     </aside>
   );

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -1761,7 +1761,8 @@ export default function ThreadTerminalDrawer({
                         <div
                           key={terminalId}
                           className={cn(
-                            "group/tab flex h-6 items-center gap-0.5 rounded-md pr-2 text-xs",
+                            "group/tab flex items-center gap-0.5 rounded-md pr-2 text-xs",
+                            isRenaming ? "min-h-6" : "h-6",
                             isSplitGroup ? "pl-0.5" : "pl-1.5",
                             isActive
                               ? "bg-accent text-foreground"

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -138,7 +138,9 @@ function TerminalToolbarAction({
             variant="ghost"
             aria-label={label}
             aria-disabled={disabled || undefined}
-            className={cn(disabled && "cursor-not-allowed opacity-64")}
+            className={cn(
+              disabled && "cursor-not-allowed opacity-64 [:hover,[data-pressed]]:bg-transparent",
+            )}
             onClick={onClick}
           />
         }

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -93,6 +93,7 @@ const TERMINAL_SIDEBAR_MIN_WIDTH = 144;
 const TERMINAL_SIDEBAR_MAX_WIDTH = 320;
 const TERMINAL_VIEWPORT_MIN_WIDTH = 216;
 const TERMINAL_SIDEBAR_WIDTH_STORAGE_KEY = "t3code:terminal-sidebar-width";
+const TERMINAL_PANEL_SIDEBAR_WIDTH_STORAGE_KEY = "t3code:terminal-panel-sidebar-width";
 
 export function getTerminalSidebarMaxWidth(rowWidth?: number): number {
   if (rowWidth === undefined) return TERMINAL_SIDEBAR_MAX_WIDTH;
@@ -1199,7 +1200,9 @@ export default function ThreadTerminalDrawer({
   }, [normalizedTerminalIds.length, visible]);
   const { width: terminalSidebarWidth, handlers: terminalSidebarResizeHandlers } =
     useResizableWidth({
-      storageKey: TERMINAL_SIDEBAR_WIDTH_STORAGE_KEY,
+      storageKey: isPanel
+        ? TERMINAL_PANEL_SIDEBAR_WIDTH_STORAGE_KEY
+        : TERMINAL_SIDEBAR_WIDTH_STORAGE_KEY,
       defaultWidth: TERMINAL_SIDEBAR_DEFAULT_WIDTH,
       minWidth: TERMINAL_SIDEBAR_MIN_WIDTH,
       maxWidth: getTerminalSidebarMaxWidth(terminalLayoutWidth),

--- a/apps/web/src/components/chat/PanelLayoutControls.test.tsx
+++ b/apps/web/src/components/chat/PanelLayoutControls.test.tsx
@@ -1,0 +1,28 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import { PanelLayoutControls } from "./PanelLayoutControls";
+
+describe("PanelLayoutControls", () => {
+  it("keeps unavailable panel tooltip triggers interactive", () => {
+    const markup = renderToStaticMarkup(
+      <PanelLayoutControls
+        showTerminalControl
+        terminalAvailable={false}
+        terminalOpen={false}
+        terminalShortcutLabel={null}
+        rightPanelAvailable={false}
+        rightPanelOpen={false}
+        rightPanelShortcutLabel={null}
+        liveAgentCount={0}
+        onToggleTerminal={() => {}}
+        onToggleRightPanel={() => {}}
+      />,
+    );
+
+    expect(markup.match(/data-slot="tooltip-trigger"/g)).toHaveLength(2);
+    expect(markup.match(/data-slot="tooltip-trigger"[^>]*><button[^>]*disabled=""/g)).toHaveLength(
+      2,
+    );
+  });
+});

--- a/apps/web/src/components/chat/PanelLayoutControls.tsx
+++ b/apps/web/src/components/chat/PanelLayoutControls.tsx
@@ -12,6 +12,7 @@ interface PanelLayoutControlsProps {
   rightPanelAvailable: boolean;
   rightPanelOpen: boolean;
   rightPanelShortcutLabel: string | null;
+  rightPanelUnavailableLabel?: string;
   /** Running + waiting subagents in this thread; badges the right panel toggle. */
   liveAgentCount: number;
   onToggleTerminal: () => void;
@@ -26,6 +27,7 @@ export const PanelLayoutControls = memo(function PanelLayoutControls({
   rightPanelAvailable,
   rightPanelOpen,
   rightPanelShortcutLabel,
+  rightPanelUnavailableLabel = "Right panel is unavailable",
   liveAgentCount,
   onToggleTerminal,
   onToggleRightPanel,
@@ -37,21 +39,19 @@ export const PanelLayoutControls = memo(function PanelLayoutControls({
     >
       {showTerminalControl ? (
         <Tooltip>
-          <TooltipTrigger
-            render={
-              <Toggle
-                className="shrink-0 [-webkit-app-region:no-drag]"
-                pressed={terminalOpen}
-                onPressedChange={onToggleTerminal}
-                aria-label="Toggle terminal drawer"
-                variant="ghost"
-                size="sm"
-                disabled={!terminalAvailable}
-              >
-                <PanelBottomIcon className="size-4" />
-              </Toggle>
-            }
-          />
+          <TooltipTrigger render={<span className="flex shrink-0" />}>
+            <Toggle
+              className="shrink-0 [-webkit-app-region:no-drag]"
+              pressed={terminalOpen}
+              onPressedChange={onToggleTerminal}
+              aria-label="Toggle terminal drawer"
+              variant="ghost"
+              size="sm"
+              disabled={!terminalAvailable}
+            >
+              <PanelBottomIcon className="size-4" />
+            </Toggle>
+          </TooltipTrigger>
           <TooltipPopup side="bottom">
             {terminalAvailable
               ? `Toggle terminal drawer${terminalShortcutLabel ? ` (${terminalShortcutLabel})` : ""}`
@@ -60,33 +60,31 @@ export const PanelLayoutControls = memo(function PanelLayoutControls({
         </Tooltip>
       ) : null}
       <Tooltip>
-        <TooltipTrigger
-          render={
-            <Toggle
-              className="shrink-0 [-webkit-app-region:no-drag]"
-              pressed={rightPanelOpen}
-              onPressedChange={onToggleRightPanel}
-              aria-label={
-                liveAgentCount > 0
-                  ? `Toggle right panel, ${liveAgentCount} ${liveAgentCount === 1 ? "agent" : "agents"} working`
-                  : "Toggle right panel"
-              }
-              variant="ghost"
-              size="sm"
-              disabled={!rightPanelAvailable}
-            >
-              <PanelRightIcon className="size-4" />
-              {liveAgentCount > 0 ? (
-                <span
-                  aria-hidden
-                  className="absolute -top-1 -right-1 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-info px-1 text-[9px] font-semibold tabular-nums text-white"
-                >
-                  {liveAgentCount}
-                </span>
-              ) : null}
-            </Toggle>
-          }
-        />
+        <TooltipTrigger render={<span className="flex shrink-0" />}>
+          <Toggle
+            className="shrink-0 [-webkit-app-region:no-drag]"
+            pressed={rightPanelOpen}
+            onPressedChange={onToggleRightPanel}
+            aria-label={
+              liveAgentCount > 0
+                ? `Toggle right panel, ${liveAgentCount} ${liveAgentCount === 1 ? "agent" : "agents"} working`
+                : "Toggle right panel"
+            }
+            variant="ghost"
+            size="sm"
+            disabled={!rightPanelAvailable}
+          >
+            <PanelRightIcon className="size-4" />
+            {liveAgentCount > 0 ? (
+              <span
+                aria-hidden
+                className="absolute -top-1 -right-1 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-info px-1 text-[9px] font-semibold tabular-nums text-white"
+              >
+                {liveAgentCount}
+              </span>
+            ) : null}
+          </Toggle>
+        </TooltipTrigger>
         <TooltipPopup side="bottom">
           {rightPanelAvailable
             ? `Toggle right panel${rightPanelShortcutLabel ? ` (${rightPanelShortcutLabel})` : ""}${
@@ -94,7 +92,7 @@ export const PanelLayoutControls = memo(function PanelLayoutControls({
                   ? ` · ${liveAgentCount} ${liveAgentCount === 1 ? "agent" : "agents"} working`
                   : ""
               }`
-            : "Right panel is unavailable"}
+            : rightPanelUnavailableLabel}
         </TooltipPopup>
       </Tooltip>
     </div>

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -1117,7 +1117,7 @@ export function PullRequestDetailPanel({
             aria-hidden={condensed}
             inert={condensed}
             className={cn(
-              "col-start-1 row-start-1 flex min-w-0 items-center gap-1 text-sm text-muted-foreground transition-[opacity,transform] ease-out motion-reduce:transform-none motion-reduce:transition-none",
+              "col-start-1 row-start-1 flex min-w-0 items-center gap-1 text-sm text-muted-foreground transition-[opacity,transform] ease-out motion-reduce:transform-none motion-reduce:transition-none sm:text-xs",
               condensed
                 ? "pointer-events-none -translate-y-1 opacity-0 duration-100"
                 : "translate-y-0 opacity-100 delay-50 duration-150",
@@ -1173,7 +1173,7 @@ export function PullRequestDetailPanel({
             aria-hidden={!condensed}
             inert={!condensed}
             className={cn(
-              "col-start-1 row-start-1 flex min-w-0 items-center gap-1 text-sm text-muted-foreground transition-[opacity,transform] ease-out motion-reduce:transform-none motion-reduce:transition-none",
+              "col-start-1 row-start-1 flex min-w-0 items-center gap-1 text-sm text-muted-foreground transition-[opacity,transform] ease-out motion-reduce:transform-none motion-reduce:transition-none sm:text-xs",
               condensed
                 ? "translate-y-0 opacity-100 delay-50 duration-150"
                 : "pointer-events-none translate-y-1 opacity-0 duration-100",

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -25,6 +25,7 @@ import {
   GitPullRequestDraftIcon,
   GitPullRequestIcon,
   HammerIcon,
+  LayersIcon,
   MessageCircleQuestionIcon,
   MessageSquareIcon,
   LinkIcon,
@@ -50,6 +51,7 @@ import {
 import { type DraftId, useComposerDraftStore } from "~/composerDraftStore";
 import { useNewThreadHandler } from "~/hooks/useHandleNewThread";
 import { useCopyToClipboard, writeTextToClipboard } from "~/hooks/useCopyToClipboard";
+import { changeRequestRepositoryUrl } from "~/lib/openPullRequestLink";
 import { usePreparePullRequestThreadAction } from "~/lib/sourceControlActions";
 import { cn } from "~/lib/utils";
 import { readLocalApi } from "~/localApi";
@@ -60,6 +62,7 @@ import { useEnvironmentQuery } from "~/state/query";
 import { useLiveRefresh } from "~/hooks/useLiveRefresh";
 import { pullRequestEnvironment } from "~/state/pullRequests";
 import { useAtomCommand } from "~/state/use-atom-command";
+import { vcsEnvironment } from "~/state/vcs";
 import { formatRelativeTimeLabel } from "~/timestampFormat";
 
 import {
@@ -74,6 +77,7 @@ import {
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
+import { Toggle, ToggleGroup } from "../ui/toggle-group";
 import {
   Menu,
   MenuItem,
@@ -104,6 +108,7 @@ import {
   handoffPrompt,
   handoffReviewComments,
   latestPullRequestReviewOutcomes,
+  isStackedPullRequestBase,
   pullRequestActionMenuHasGroup,
   pullRequestActionNeedsHostRefresh,
   pullRequestComposerTarget,
@@ -121,6 +126,7 @@ import {
 } from "./pullRequestProjectAssignment.logic";
 import { PullRequestChecksPopover } from "./PullRequestChecksPopover";
 import {
+  PullRequestActorAvatar,
   PullRequestActorLabel,
   PullRequestDiffStat,
   PullRequestMetaLine,
@@ -362,7 +368,6 @@ export function PullRequestDetailPanel({
   onClose,
   onStateChange,
   context = "page",
-  chromeVariant = "full",
   composerDraftTarget,
 }: {
   environmentId: EnvironmentId;
@@ -394,12 +399,6 @@ export function PullRequestDetailPanel({
    * again is at best a no-op and at worst git refusing a branch two checkouts.
    */
   context?: "page" | "thread";
-  /**
-   * How the metadata above the content behaves: `full` keeps every row pinned; `collapse`
-   * folds the whole of it into the top row once the active tab scrolls, and unfolds at the
-   * top — the chrome spends its height on what is being read.
-   */
-  chromeVariant?: "full" | "collapse";
   /**
    * The open thread's composer. Beside the thread whose own pull request this is, hand-offs
    * land here instead of opening a new thread — the branch is already under the reader's feet.
@@ -436,26 +435,13 @@ export function PullRequestDetailPanel({
     );
   }, [tab]);
   const [chromeCondensed, setChromeCondensed] = useState(false);
-  // Each tab remembers whether its chrome was condensed. Only the active tab can emit scroll
-  // events, so the capture handler always writes the active tab's entry — and a tab switch
-  // reads the destination's memory instead of inheriting the tab being left. A tab too short
-  // to scroll remembers "expanded", which is what keeps it from being stranded under a chrome
-  // it has no scrollbar to reopen.
   const chromeStateByTab = useRef<Partial<Record<DetailTab, boolean>>>({});
   useEffect(() => {
     setChromeCondensed(chromeStateByTab.current[tab] ?? false);
   }, [tab]);
-  const condensed = chromeVariant === "collapse" && chromeCondensed;
-  // Collapsing removes the fold's height from the chrome, which would otherwise hand that
-  // height to the scrollport and leap the content up by it mid-scroll. The cure is exact
-  // compensation: collapse only once the reader has scrolled at least the fold's height,
-  // then give that height back to `scrollTop` before the next paint — the content under
-  // their eyes does not move, and the collapse itself is the only thing that changes.
+  const condensed = chromeCondensed;
   const scrollerRef = useRef<HTMLElement | null>(null);
   const foldRef = useRef<HTMLDivElement | null>(null);
-  // The condensed chrome's second row opens as the fold closes, so the height the scrollport
-  // gains is the fold's minus this row's. Measured the same way the fold is: `scrollHeight`
-  // through a zero track reads its natural height in either state.
   const condensedRowRef = useRef<HTMLDivElement | null>(null);
   const compensationRef = useRef<number | null>(null);
   useLayoutEffect(() => {
@@ -478,7 +464,6 @@ export function PullRequestDetailPanel({
     target: "branch name",
     timeout: 1600,
   });
-
   // The chunk is fetched as soon as the panel exists rather than waiting for the Code tab to be
   // clicked, so a reader who does click it lands on a chunk already in the module cache.
   useEffect(() => {
@@ -517,6 +502,23 @@ export function PullRequestDetailPanel({
           },
     [activity, coreDetail],
   );
+  const repositoryUrl = detail === null ? null : changeRequestRepositoryUrl(detail.url);
+  const branchRefsQuery = useEnvironmentQuery(
+    detail === null
+      ? null
+      : vcsEnvironment.listRefs({
+          environmentId,
+          input: {
+            cwd: detail.workspaceRoot,
+            includeMatchingRemoteRefs: true,
+            // listRefs keeps the current ref first and a known default second.
+            limit: 2,
+          },
+        }),
+  );
+  const isStackedPullRequest =
+    detail !== null &&
+    isStackedPullRequestBase(detail.baseBranch, branchRefsQuery.data?.refs ?? []);
   const activityPending = activityQuery.isPending && activity === null;
   const activityError = activity === null ? activityQuery.error : null;
   const refreshDetail = useCallback(() => {
@@ -1046,17 +1048,17 @@ export function PullRequestDetailPanel({
   const can = (action: PullRequestAction) =>
     detail?.capabilities.actions.includes(action) === true &&
     detail.viewerPermissions.actions.includes(action);
-  // One live action holds the slot. A conflicting change cannot be merged now, so the slot goes
-  // to the thing that would help instead of a Merge button that only ever says no.
+  // One live action holds the slot. Conflicts take priority because every other completion action
+  // depends on resolving them first, even for a reader who cannot merge on the host themselves.
   const primaryAction =
     detail === null || detail.state !== "open"
       ? null
-      : detail.isDraft && can("ready")
-        ? "ready"
-        : !can("merge")
-          ? null
-          : conflicting
-            ? "resolve"
+      : conflicting
+        ? "resolve"
+        : detail.isDraft && can("ready")
+          ? "ready"
+          : !can("merge")
+            ? null
             : allowedMergeMethods.length > 0
               ? "merge"
               : null;
@@ -1081,7 +1083,7 @@ export function PullRequestDetailPanel({
     !conflicting &&
     allowedMergeMethods.length > 1;
   // The pull request number carries this state in the overview and the right-panel tab mirrors
-  // it. Conflicts keep their own row below: an open pull request remains green there.
+  // it. The conflict action is separate from this state: an open pull request remains green.
   const statePresentation = detail
     ? resolvePullRequestState({ state: detail.state, isDraft: detail.isDraft })
     : null;
@@ -1101,34 +1103,47 @@ export function PullRequestDetailPanel({
         ).length
       : 0;
 
+  if (detailQuery.isPending && !detail) {
+    return <PullRequestDetailGhost />;
+  }
+
   return (
     <div className="flex h-full min-h-0 w-full flex-col bg-background">
-      {/* The top row's geometry never changes: both of its states occupy the same stacked
-          cell and crossfade, so the actions on the right have one home whatever the chrome
-          is doing below. The fold and this fade share one 200ms clock. */}
       <div className="grid shrink-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-x-2 border-b border-border/60">
-        {/* The fixed height lives on the two top-row cells — not the grid, whose later rows
-            are the fold — so the actions have one immovable home in both states. */}
-        <div className="ml-4 grid h-11 min-w-0 items-center">
+        <div className="ml-4 grid h-7 min-w-0 items-center">
           <div
             aria-hidden={condensed}
             inert={condensed}
             className={cn(
-              "col-start-1 row-start-1 flex min-w-0 items-center gap-1 text-sm text-muted-foreground transition-opacity sm:text-xs motion-reduce:transition-none",
-              // Sequenced, not simultaneous: the leaving layer clears quickly before the
-              // arriving one lands, so no frame shows both texts superimposed at half opacity.
+              "col-start-1 row-start-1 flex min-w-0 items-center gap-1 text-sm text-muted-foreground transition-[opacity,transform] ease-out motion-reduce:transform-none motion-reduce:transition-none",
               condensed
-                ? "pointer-events-none opacity-0 duration-100"
-                : "opacity-100 delay-75 duration-150",
+                ? "pointer-events-none -translate-y-1 opacity-0 duration-100"
+                : "translate-y-0 opacity-100 delay-50 duration-150",
             )}
           >
             {detail && statePresentation ? (
               <>
                 <Tooltip>
                   <TooltipTrigger
-                    render={<span className="min-w-0 truncate">{detail.repository}</span>}
+                    render={
+                      repositoryUrl ? (
+                        <button
+                          type="button"
+                          onClick={() => void readLocalApi()?.shell.openExternal(repositoryUrl)}
+                          className="min-w-0 cursor-pointer truncate text-left font-medium text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+                        >
+                          {detail.repository}
+                        </button>
+                      ) : (
+                        <span className="min-w-0 truncate font-medium text-muted-foreground">
+                          {detail.repository}
+                        </span>
+                      )
+                    }
                   />
-                  <TooltipPopup side="top">{detail.repository}</TooltipPopup>
+                  <TooltipPopup side="top">
+                    {repositoryUrl ? `Open ${detail.repository} repository` : detail.repository}
+                  </TooltipPopup>
                 </Tooltip>
                 <Tooltip>
                   <TooltipTrigger
@@ -1156,10 +1171,10 @@ export function PullRequestDetailPanel({
             aria-hidden={!condensed}
             inert={!condensed}
             className={cn(
-              "col-start-1 row-start-1 flex min-w-0 items-center gap-1.5 text-sm transition-opacity sm:text-xs motion-reduce:transition-none",
+              "col-start-1 row-start-1 flex min-w-0 items-center gap-1 text-sm text-muted-foreground transition-[opacity,transform] ease-out motion-reduce:transform-none motion-reduce:transition-none",
               condensed
-                ? "opacity-100 delay-75 duration-150"
-                : "pointer-events-none opacity-0 duration-100",
+                ? "translate-y-0 opacity-100 delay-50 duration-150"
+                : "pointer-events-none translate-y-1 opacity-0 duration-100",
             )}
           >
             {detail && statePresentation ? (
@@ -1194,29 +1209,103 @@ export function PullRequestDetailPanel({
                   />
                   <TooltipPopup side="top">{detail.title}</TooltipPopup>
                 </Tooltip>
-                {conflicting ? (
-                  <Badge
-                    variant="error"
-                    className="h-5 shrink-0 gap-1 rounded px-1.5 text-[10px] text-destructive"
-                  >
-                    <TriangleAlertIcon className="size-3" />
-                    Conflicts
-                  </Badge>
-                ) : checksSummary ? (
-                  <span className="flex shrink-0 items-center gap-1 text-[10px] text-muted-foreground">
-                    {detail && checksState !== null ? (
-                      <PullRequestChecksPopover checks={detail.checks} checksState={checksState} />
-                    ) : null}
-                    {checksSummary}
-                  </span>
-                ) : null}
               </>
             ) : null}
           </div>
         </div>
-        <div className="mr-4 flex h-11 min-w-0 flex-nowrap items-center justify-end gap-1">
+        <div className="mr-4 flex h-7 min-w-0 flex-nowrap items-center justify-end gap-1">
           {detail ? (
             <>
+              {/* Checking a pull request out is the reason to open one here at all, so it is a
+                  button of its own rather than a side effect of asking an agent for something.
+                  It asks where, because the two answers are not interchangeable: one leaves your
+                  work where it is, the other moves the repository you are standing in. Only on
+                  the page: beside a thread the branch is already checked out right there. */}
+              {context === "page" ? (
+                <Menu>
+                  <MenuTrigger
+                    disabled={handoff !== null}
+                    render={
+                      <Button size="xs" variant="outline">
+                        <GitBranchIcon aria-hidden className="size-3.5" />
+                        {handoff?.startsWith("checkout") ? "Checking out..." : "Check out"}
+                        <ChevronDownIcon aria-hidden className="size-3.5 text-muted-foreground" />
+                      </Button>
+                    }
+                  />
+                  <MenuPopup align="end" side="bottom" className="min-w-72">
+                    <MenuItem onClick={() => startCheckout("worktree")}>
+                      <GitBranchIcon className="mt-0.5 size-3.5 shrink-0 self-start" />
+                      <span className="flex min-w-0 flex-col">
+                        <span>In a separate worktree</span>
+                        <span className="text-xs text-muted-foreground">
+                          Its own folder and thread. Nothing you have open moves.
+                        </span>
+                      </span>
+                    </MenuItem>
+                    <MenuItem onClick={() => startCheckout("local")}>
+                      <FolderGit2Icon className="mt-0.5 size-3.5 shrink-0 self-start" />
+                      <span className="flex min-w-0 flex-col">
+                        <span>In this repository</span>
+                        <span className="text-xs text-muted-foreground">
+                          Switches the branch you are working in, like `gh pr checkout`.
+                        </span>
+                      </span>
+                    </MenuItem>
+                    {pickableEnvironments.length > 0 ? (
+                      <ActOnEnvironmentPicker
+                        environments={pickableEnvironments}
+                        value={actingEnvironmentId}
+                        onChange={(next) => setActingScope({ pullRequestKey, environmentId: next })}
+                        disabled={handoff !== null}
+                      />
+                    ) : null}
+                  </MenuPopup>
+                </Menu>
+              ) : null}
+              {/* Said where the Merge button is, because it is the answer to why nobody has
+                  pressed it: the merge is already asked for, and the host is holding it. */}
+              {autoMergeArmed ? (
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <Badge
+                        variant="info"
+                        className="h-5 shrink-0 gap-1 rounded px-1.5 text-[10px]"
+                      >
+                        <GitMergeIcon aria-hidden className="size-3" />
+                        Auto-merge
+                      </Badge>
+                    }
+                  />
+                  <TooltipPopup side="top">
+                    The host will merge this on its own once its requirements are met
+                  </TooltipPopup>
+                </Tooltip>
+              ) : null}
+              {primaryAction === "resolve" ? (
+                <Button
+                  size="xs"
+                  variant="destructive-outline"
+                  disabled={handoff !== null}
+                  onClick={startResolveConflicts}
+                >
+                  <TriangleAlertIcon className="size-3.5" />
+                  {handoff === "conflicts" ? "Preparing..." : "Resolve conflicts"}
+                </Button>
+              ) : primaryAction === "ready" ? (
+                <Button size="xs" disabled={actionPending} onClick={() => void perform("ready")}>
+                  Ready for review
+                </Button>
+              ) : primaryAction === "merge" ? (
+                <Button
+                  size="xs"
+                  disabled={actionPending}
+                  onClick={() => setConfirmation({ open: true, action: "merge" })}
+                >
+                  {pendingAction === "merge" ? "Merging..." : selectedMergeMethodLabel}
+                </Button>
+              ) : null}
               <Menu>
                 <MenuTrigger
                   render={
@@ -1361,13 +1450,6 @@ export function PullRequestDetailPanel({
                     <LinkIcon className="size-3.5" />
                     Copy link
                   </MenuItem>
-                  {/* Only where the button row could not take it, so it is never offered twice. */}
-                  {conflicting && primaryAction !== "resolve" ? (
-                    <MenuItem disabled={handoff !== null} onClick={startResolveConflicts}>
-                      <GitMergeIcon className="size-3.5" />
-                      {handoff === "conflicts" ? "Preparing..." : handoffLabels.resolveConflicts}
-                    </MenuItem>
-                  ) : null}
                   {detail.state === "open" && can("close") ? (
                     <>
                       <MenuSeparator />
@@ -1391,92 +1473,6 @@ export function PullRequestDetailPanel({
                   ) : null}
                 </MenuPopup>
               </Menu>
-              {/* Checking a pull request out is the reason to open one here at all, so it is a
-                  button of its own rather than a side effect of asking an agent for something.
-                  It asks where, because the two answers are not interchangeable: one leaves your
-                  work where it is, the other moves the repository you are standing in. Only on
-                  the page: beside a thread the branch is already checked out right there. */}
-              {context === "page" ? (
-                <Menu>
-                  <MenuTrigger
-                    disabled={handoff !== null}
-                    render={
-                      <Button size="xs" variant="outline">
-                        {handoff?.startsWith("checkout") ? (
-                          "Checking out..."
-                        ) : (
-                          <>
-                            <GitBranchIcon className="size-3" />
-                            Check out
-                            <ChevronDownIcon className="size-3 text-muted-foreground" />
-                          </>
-                        )}
-                      </Button>
-                    }
-                  />
-                  <MenuPopup align="end" side="bottom" className="min-w-72">
-                    <MenuItem onClick={() => startCheckout("worktree")}>
-                      <GitBranchIcon className="mt-0.5 size-3.5 shrink-0 self-start" />
-                      <span className="flex min-w-0 flex-col">
-                        <span>In a separate worktree</span>
-                        <span className="text-xs text-muted-foreground">
-                          Its own folder and thread. Nothing you have open moves.
-                        </span>
-                      </span>
-                    </MenuItem>
-                    <MenuItem onClick={() => startCheckout("local")}>
-                      <FolderGit2Icon className="mt-0.5 size-3.5 shrink-0 self-start" />
-                      <span className="flex min-w-0 flex-col">
-                        <span>In this repository</span>
-                        <span className="text-xs text-muted-foreground">
-                          Switches the branch you are working in, like `gh pr checkout`.
-                        </span>
-                      </span>
-                    </MenuItem>
-                    {pickableEnvironments.length > 0 ? (
-                      <ActOnEnvironmentPicker
-                        environments={pickableEnvironments}
-                        value={actingEnvironmentId}
-                        onChange={(next) => setActingScope({ pullRequestKey, environmentId: next })}
-                        disabled={handoff !== null}
-                      />
-                    ) : null}
-                  </MenuPopup>
-                </Menu>
-              ) : null}
-              {/* Said where the Merge button is, because it is the answer to why nobody has
-                  pressed it: the merge is already asked for, and the host is holding it. */}
-              {autoMergeArmed ? (
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <Badge
-                        variant="info"
-                        className="h-5 shrink-0 gap-1 rounded px-1.5 text-[10px]"
-                      >
-                        <GitMergeIcon aria-hidden className="size-3" />
-                        Auto-merge
-                      </Badge>
-                    }
-                  />
-                  <TooltipPopup side="top">
-                    The host will merge this on its own once its requirements are met
-                  </TooltipPopup>
-                </Tooltip>
-              ) : null}
-              {primaryAction === "ready" ? (
-                <Button size="xs" disabled={actionPending} onClick={() => void perform("ready")}>
-                  Ready for review
-                </Button>
-              ) : primaryAction === "merge" ? (
-                <Button
-                  size="xs"
-                  disabled={actionPending}
-                  onClick={() => setConfirmation({ open: true, action: "merge" })}
-                >
-                  {pendingAction === "merge" ? "Merging..." : selectedMergeMethodLabel}
-                </Button>
-              ) : null}
             </>
           ) : null}
           {onClose ? (
@@ -1491,14 +1487,9 @@ export function PullRequestDetailPanel({
           ) : null}
         </div>
 
-        {/* The condensed chrome's second row: the tabs that the closing fold takes with it,
-            and compact copies of the branch pair and diff stat so they stay in sight while
-            the full rows are folded away. Same zero-track mechanism as the fold, inverted. */}
         <div
           className={cn(
             "col-span-2 grid",
-            // Inverse of the fold's track: closing eases while the fold above eases open,
-            // so the chrome trades rows in one motion instead of two jumps.
             condensed
               ? "grid-rows-[1fr]"
               : "grid-rows-[0fr] transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none",
@@ -1507,84 +1498,86 @@ export function PullRequestDetailPanel({
           <div
             ref={condensedRowRef}
             className={cn(
-              "min-h-0 overflow-hidden",
+              "min-h-0 overflow-hidden transition-[opacity,transform] duration-150 ease-out motion-reduce:transform-none motion-reduce:transition-none",
               condensed
-                ? "opacity-100 transition-opacity duration-200 ease-out motion-reduce:transition-none"
-                : "opacity-0",
+                ? "translate-y-0 opacity-100 delay-50"
+                : "translate-y-1 opacity-0 duration-100",
             )}
             inert={!condensed}
           >
             {detail ? (
-              <div className="flex min-w-0 items-center gap-1 px-4 pb-2">
-                <nav aria-label="Pull request tabs" className="flex shrink-0 items-center gap-0.5">
-                  {visibleTabs.map((item) => (
-                    <button
-                      key={item.value}
-                      type="button"
-                      tabIndex={condensed ? 0 : -1}
-                      aria-pressed={tab === item.value}
-                      onClick={() => setTab(item.value)}
-                      className={cn(
-                        "rounded-md px-2 py-1 text-[11px] transition-colors",
-                        tab === item.value
-                          ? "bg-accent text-foreground"
-                          : "text-muted-foreground hover:text-foreground",
-                      )}
-                    >
-                      {item.label}
-                    </button>
-                  ))}
-                </nav>
-                <span className="ml-auto inline-flex min-w-0 shrink items-center gap-1 font-mono text-[11px] text-muted-foreground">
-                  <Tooltip>
-                    <TooltipTrigger render={<span className="truncate" />}>
-                      {detail.baseBranch}
-                    </TooltipTrigger>
-                    <TooltipPopup side="top">{`${detail.baseBranch} ← ${detail.headBranch}`}</TooltipPopup>
-                  </Tooltip>
-                  {freshness ? (
-                    <PullRequestBaseFreshnessWarning
-                      baseBranch={detail.baseBranch}
-                      freshness={freshness}
-                      pending={actionPending}
-                      onUpdate={(method) => void perform("update-branch", undefined, method)}
-                      iconClassName="size-3"
-                    />
-                  ) : null}
-                  <ArrowLeftIcon aria-label="receives changes from" className="size-3 shrink-0" />
-                  <Tooltip>
-                    <TooltipTrigger render={<span className="truncate" />}>
-                      {detail.headBranch}
-                    </TooltipTrigger>
-                    <TooltipPopup side="top">{`${detail.baseBranch} ← ${detail.headBranch}`}</TooltipPopup>
-                  </Tooltip>
-                </span>
-                <span className="ml-2 inline-flex shrink-0 items-center gap-2 text-[11px] text-muted-foreground">
-                  <span className="inline-flex items-center gap-1 tabular-nums">
-                    <FileDiffIcon className="size-3" />
-                    {detail.changedFiles.toLocaleString()}
+              <div className="col-span-2 min-w-0 px-4 pb-2 pt-1">
+                <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+                  <span className="flex min-w-0 shrink items-center gap-1.5 overflow-hidden text-xs text-muted-foreground">
+                    <PullRequestActorAvatar actor={detail.author} className="shrink-0" />
+                    <span className="sr-only">{detail.author?.login ?? "ghost"}</span>
+                    <span className="shrink-0">{formatRelativeTimeLabel(detail.updatedAt)}</span>
                   </span>
-                  <PullRequestDiffStat
-                    additions={detail.additions}
-                    deletions={detail.deletions}
-                    className="shrink-0 font-mono text-[11px]"
-                  />
-                </span>
+                  <span aria-hidden className="h-3 w-px shrink-0 bg-border/70" />
+                  <span className="flex min-w-0 flex-1 items-center gap-1.5 font-mono text-[11px] text-muted-foreground/65">
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <span className="inline-flex min-w-0 max-w-[40%] shrink-0 items-center gap-1">
+                            {isStackedPullRequest ? (
+                              <LayersIcon
+                                aria-label="Stacked pull request"
+                                className="size-3 shrink-0"
+                              />
+                            ) : null}
+                            <code className="min-w-0 truncate">{detail.baseBranch}</code>
+                          </span>
+                        }
+                      />
+                      <TooltipPopup side="top">{detail.baseBranch}</TooltipPopup>
+                    </Tooltip>
+                    {freshness ? (
+                      <PullRequestBaseFreshnessWarning
+                        baseBranch={detail.baseBranch}
+                        freshness={freshness}
+                        pending={actionPending}
+                        onUpdate={(method) => void perform("update-branch", undefined, method)}
+                        iconClassName="size-3"
+                      />
+                    ) : null}
+                    <ArrowLeftIcon
+                      aria-label="receives changes from"
+                      className="size-3 shrink-0 opacity-60"
+                    />
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <code className="min-w-0 flex-1 truncate">{detail.headBranch}</code>
+                        }
+                      />
+                      <TooltipPopup side="top">{detail.headBranch}</TooltipPopup>
+                    </Tooltip>
+                  </span>
+                  <span className="ml-auto inline-flex shrink-0 items-center justify-end gap-2 text-[11px]">
+                    <span
+                      className="inline-flex items-center gap-1 tabular-nums"
+                      aria-label={`${detail.changedFiles.toLocaleString()} changed ${
+                        detail.changedFiles === 1 ? "file" : "files"
+                      }`}
+                    >
+                      <FileDiffIcon aria-hidden className="size-3" />
+                      {detail.changedFiles.toLocaleString()}
+                    </span>
+                    <PullRequestDiffStat
+                      additions={detail.additions}
+                      deletions={detail.deletions}
+                      className="shrink-0 font-mono text-[11px]"
+                    />
+                  </span>
+                </div>
               </div>
             ) : null}
           </div>
         </div>
 
-        {/* Folding is a grid track going to zero: the rows below stay mounted, the track
-            animates closed over them, and `inert` takes the hidden controls out of the tab
-            order for as long as the chrome is condensed. */}
         <div
           className={cn(
             "col-span-2 grid",
-            // Collapse is instant: it happens mid-scroll, and the compensation that keeps the
-            // content pinned would fight an animated track frame by frame. Reopening happens
-            // at the top with no compensation, so the fold can ease back in instead of
-            // snapping the content down.
             condensed
               ? "grid-rows-[0fr]"
               : "grid-rows-[1fr] transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none",
@@ -1592,19 +1585,16 @@ export function PullRequestDetailPanel({
         >
           <div
             ref={foldRef}
-            // One-way on purpose: appearing content eases in over ground the instant track
-            // already reserved; departing content cuts, because its ground is gone in the
-            // same frame and the scroll compensation reads it as scrolled past.
             className={cn(
-              "min-h-0 overflow-hidden",
+              "min-h-0 overflow-hidden transition-[opacity,transform] duration-150 ease-out motion-reduce:transform-none motion-reduce:transition-none",
               condensed
-                ? "opacity-0"
-                : "opacity-100 transition-opacity duration-200 ease-out motion-reduce:transition-none",
+                ? "-translate-y-1 opacity-0 duration-100"
+                : "translate-y-0 opacity-100 delay-50",
             )}
             inert={condensed}
           >
             {detail ? (
-              <div className="col-span-2 mt-3 min-w-0 px-4 pb-4">
+              <div className="col-span-2 mt-1 min-w-0 px-4 pb-4">
                 {titleDraft === null ? (
                   <div className="group flex min-w-0 items-start gap-1">
                     <h1 className="min-w-0 flex-1 text-base font-semibold leading-snug">
@@ -1671,60 +1661,71 @@ export function PullRequestDetailPanel({
                 </PullRequestMetaLine>
 
                 <div className="mt-4 flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
-                  <Tooltip>
-                    <TooltipTrigger
-                      render={
-                        <code className="min-w-0 max-w-48 shrink truncate rounded-md bg-muted px-2 py-1 font-mono text-xs text-foreground">
-                          {detail.baseBranch}
+                  <span className="flex min-w-0 flex-1 items-center gap-1.5 font-mono text-xs text-muted-foreground/70">
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <span className="inline-flex min-w-0 max-w-[40%] shrink-0 items-center gap-1">
+                            {isStackedPullRequest ? (
+                              <LayersIcon
+                                aria-label="Stacked pull request"
+                                className="size-3 shrink-0"
+                              />
+                            ) : null}
+                            <code className="min-w-0 truncate">{detail.baseBranch}</code>
+                          </span>
+                        }
+                      />
+                      <TooltipPopup side="top">{detail.baseBranch}</TooltipPopup>
+                    </Tooltip>
+                    {freshness ? (
+                      <PullRequestBaseFreshnessWarning
+                        baseBranch={detail.baseBranch}
+                        freshness={freshness}
+                        pending={actionPending}
+                        onUpdate={(method) => void perform("update-branch", undefined, method)}
+                      />
+                    ) : null}
+                    <ArrowLeftIcon
+                      aria-label="receives changes from"
+                      className="size-3.5 shrink-0 opacity-60"
+                    />
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <button
+                            type="button"
+                            className="grid w-fit min-w-0 max-w-full shrink cursor-pointer rounded px-1 py-0.5 text-left outline-none transition-colors hover:bg-accent/45 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                            aria-label={
+                              isBranchCopied ? "Branch name copied" : "Copy pull request branch"
+                            }
+                            onClick={() => copyBranchToClipboard(detail.headBranch)}
+                          />
+                        }
+                      >
+                        <code
+                          className={cn(
+                            "col-start-1 row-start-1 min-w-0 truncate transition-opacity duration-150 motion-reduce:transition-none",
+                            isBranchCopied ? "opacity-0" : "opacity-100",
+                          )}
+                        >
+                          {detail.headBranch}
                         </code>
-                      }
-                    />
-                    <TooltipPopup side="top">{detail.baseBranch}</TooltipPopup>
-                  </Tooltip>
-                  {freshness ? (
-                    <PullRequestBaseFreshnessWarning
-                      baseBranch={detail.baseBranch}
-                      freshness={freshness}
-                      pending={actionPending}
-                      onUpdate={(method) => void perform("update-branch", undefined, method)}
-                    />
-                  ) : null}
-                  <ArrowLeftIcon aria-label="receives changes from" className="size-4 shrink-0" />
-                  <Tooltip>
-                    <TooltipTrigger
-                      render={
-                        <button
-                          type="button"
-                          className="grid min-w-0 max-w-64 shrink cursor-pointer rounded-md bg-muted px-2 py-1 font-mono text-xs text-foreground outline-none transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
-                          aria-label={
-                            isBranchCopied ? "Branch name copied" : "Copy pull request branch"
-                          }
-                          onClick={() => copyBranchToClipboard(detail.headBranch)}
-                        />
-                      }
-                    >
-                      <code
-                        className={cn(
-                          "col-start-1 row-start-1 min-w-0 truncate transition-opacity duration-150 motion-reduce:transition-none",
-                          isBranchCopied ? "opacity-0" : "opacity-100",
-                        )}
-                      >
-                        {detail.headBranch}
-                      </code>
-                      <span
-                        aria-hidden="true"
-                        className={cn(
-                          "col-start-1 row-start-1 truncate text-center transition-opacity duration-150 motion-reduce:transition-none",
-                          isBranchCopied ? "opacity-100" : "opacity-0",
-                        )}
-                      >
-                        Copied
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipPopup side="top">
-                      {`${isBranchCopied ? "Copied" : "Copy pull request branch"}: ${detail.headBranch}`}
-                    </TooltipPopup>
-                  </Tooltip>
+                        <span
+                          aria-hidden="true"
+                          className={cn(
+                            "col-start-1 row-start-1 truncate text-center transition-opacity duration-150 motion-reduce:transition-none",
+                            isBranchCopied ? "opacity-100" : "opacity-0",
+                          )}
+                        >
+                          Copied
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipPopup side="top">
+                        {`${isBranchCopied ? "Copied" : "Copy pull request branch"}: ${detail.headBranch}`}
+                      </TooltipPopup>
+                    </Tooltip>
+                  </span>
                   <span className="ml-auto inline-flex shrink-0 items-center justify-end gap-2">
                     <span className="inline-flex items-center gap-1.5 tabular-nums">
                       <FileDiffIcon className="size-3.5" />
@@ -1740,165 +1741,129 @@ export function PullRequestDetailPanel({
                 </div>
               </div>
             ) : null}
+          </div>
+        </div>
 
-            {detail && conflicting ? (
-              <div className="col-span-2 flex items-center gap-1 px-4 pb-3">
-                <Badge
-                  variant="error"
-                  className="h-auto gap-1.5 rounded-md px-3 py-1.5 text-xs text-destructive"
+        {detail ? (
+          <nav
+            className="col-span-2 flex min-w-0 items-center gap-1 overflow-x-auto border-t border-border/60 px-4 py-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            aria-label="Pull request tabs"
+          >
+            <ToggleGroup
+              size="segmented"
+              variant="segmented"
+              value={[tab]}
+              onValueChange={(next) => {
+                const nextTab = visibleTabs.find((item) => item.value === next[0])?.value;
+                if (nextTab) setTab(nextTab);
+              }}
+            >
+              {visibleTabs.map((item) => (
+                <Toggle key={item.value} value={item.value}>
+                  {item.label}
+                </Toggle>
+              ))}
+            </ToggleGroup>
+            {tab === "summary" ? (
+              <span
+                className="ml-auto inline-flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground"
+                aria-label={checksSummary ? `Checks: ${checksSummary}` : "Checks"}
+              >
+                {checksState !== null ? (
+                  <PullRequestChecksPopover checks={detail.checks} checksState={checksState} />
+                ) : (
+                  <CircleDotIcon aria-hidden className="size-3.5" />
+                )}
+                {checksSummary}
+              </span>
+            ) : tab === "timeline" ? (
+              <div className="ml-auto flex shrink-0 items-center gap-2 text-xs text-muted-foreground">
+                <PullRequestMetaLine
+                  className={cn(
+                    "whitespace-nowrap text-[11px] transition-opacity",
+                    (activityPending || activityError) && "opacity-35",
+                  )}
                 >
-                  <TriangleAlertIcon className="size-3.5" />
-                  Merge conflicts
-                </Badge>
+                  <span
+                    className="inline-flex items-center gap-1"
+                    aria-label={
+                      activityError
+                        ? "Comments unavailable"
+                        : `${detail.commentCount.toLocaleString()} ${
+                            detail.commentCount === 1 ? "comment" : "comments"
+                          }`
+                    }
+                  >
+                    <MessageSquareIcon aria-hidden className="size-3" />
+                    {activityError
+                      ? "—"
+                      : activityPending
+                        ? "…"
+                        : detail.commentCount.toLocaleString()}
+                  </span>
+                  <span
+                    className="inline-flex items-center gap-1"
+                    aria-label={
+                      activityError
+                        ? "Commits unavailable"
+                        : `${detail.commits.length.toLocaleString()} ${
+                            detail.commits.length === 1 ? "commit" : "commits"
+                          }`
+                    }
+                  >
+                    <GitCommitHorizontalIcon aria-hidden className="size-3" />
+                    {activityError
+                      ? "—"
+                      : activityPending
+                        ? "…"
+                        : detail.commits.length.toLocaleString()}
+                  </span>
+                  {approvalCount > 0 ? (
+                    <span
+                      className={cn(
+                        "inline-flex items-center gap-1",
+                        pullRequestReviewOutcomeToneClassName("approved"),
+                      )}
+                    >
+                      <PullRequestReviewOutcomeIcon outcome="approved" className="size-3" />
+                      {approvalCount.toLocaleString()}
+                      <span className="sr-only">
+                        {approvalCount === 1 ? "approval" : "approvals"}
+                      </span>
+                    </span>
+                  ) : null}
+                </PullRequestMetaLine>
                 <Button
                   size="xs"
                   variant="ghost"
-                  className="ml-auto text-destructive hover:bg-destructive/8 hover:text-destructive"
-                  disabled={handoff !== null}
-                  onClick={startResolveConflicts}
+                  className="h-7 px-2 text-[10px] text-muted-foreground"
+                  aria-label={
+                    timelineOrder === "newest"
+                      ? "Show oldest activity first"
+                      : "Show newest activity first"
+                  }
+                  onClick={() =>
+                    setTimelineOrder((value) => (value === "newest" ? "oldest" : "newest"))
+                  }
                 >
-                  {handoff === "conflicts" ? "Preparing..." : handoffLabels.resolve}
-                  <ArrowUpRightIcon className="size-3.5 text-destructive" />
+                  <ArrowDownUpIcon aria-hidden className="size-3" />
+                  {timelineOrder === "newest" ? "Newest first" : "Oldest first"}
                 </Button>
               </div>
             ) : null}
-
-            {detail ? (
-              <nav
-                className="col-span-2 flex min-w-0 items-center gap-1 overflow-x-auto border-t border-border/60 px-4 py-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-                aria-label="Pull request tabs"
-              >
-                {visibleTabs.map((item) => (
-                  <button
-                    key={item.value}
-                    type="button"
-                    aria-pressed={tab === item.value}
-                    onClick={() => setTab(item.value)}
-                    className={cn(
-                      "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs transition-colors",
-                      tab === item.value
-                        ? "bg-accent text-foreground"
-                        : "text-muted-foreground hover:text-foreground",
-                    )}
-                  >
-                    {item.label}
-                  </button>
-                ))}
-                {tab === "summary" ? (
-                  <span
-                    className="ml-auto inline-flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground"
-                    aria-label={checksSummary ? `Checks: ${checksSummary}` : "Checks"}
-                  >
-                    {/* The rollup icon opens the checks behind the summary; with none reported
-                        there is nothing to open, so the plain glyph stays. */}
-                    {detail && checksState !== null ? (
-                      <PullRequestChecksPopover checks={detail.checks} checksState={checksState} />
-                    ) : (
-                      <CircleDotIcon aria-hidden className="size-3.5" />
-                    )}
-                    {checksSummary}
-                  </span>
-                ) : tab === "timeline" ? (
-                  <div className="ml-auto flex shrink-0 items-center gap-2 text-xs text-muted-foreground">
-                    <PullRequestMetaLine
-                      className={cn(
-                        "whitespace-nowrap text-[11px] transition-opacity",
-                        (activityPending || activityError) && "opacity-35",
-                      )}
-                    >
-                      <span
-                        className="inline-flex items-center gap-1"
-                        aria-label={
-                          activityError
-                            ? "Comments unavailable"
-                            : `${detail.commentCount.toLocaleString()} ${
-                                detail.commentCount === 1 ? "comment" : "comments"
-                              }`
-                        }
-                      >
-                        <MessageSquareIcon aria-hidden className="size-3" />
-                        {activityError
-                          ? "—"
-                          : activityPending
-                            ? "…"
-                            : detail.commentCount.toLocaleString()}
-                      </span>
-                      <span
-                        className="inline-flex items-center gap-1"
-                        aria-label={
-                          activityError
-                            ? "Commits unavailable"
-                            : `${detail.commits.length.toLocaleString()} ${
-                                detail.commits.length === 1 ? "commit" : "commits"
-                              }`
-                        }
-                      >
-                        <GitCommitHorizontalIcon aria-hidden className="size-3" />
-                        {activityError
-                          ? "—"
-                          : activityPending
-                            ? "…"
-                            : detail.commits.length.toLocaleString()}
-                      </span>
-                      {/* Only once somebody has approved: a nought beside a tick would read as a
-                          verdict of its own on a change nobody has looked at yet. */}
-                      {approvalCount > 0 ? (
-                        <span
-                          className={cn(
-                            "inline-flex items-center gap-1",
-                            pullRequestReviewOutcomeToneClassName("approved"),
-                          )}
-                        >
-                          <PullRequestReviewOutcomeIcon outcome="approved" className="size-3" />
-                          {approvalCount.toLocaleString()}
-                          {/* The icon is decorative and a name written onto a generic span is
-                              not announced, so the bare number says what it counts in words. */}
-                          <span className="sr-only">
-                            {approvalCount === 1 ? "approval" : "approvals"}
-                          </span>
-                        </span>
-                      ) : null}
-                    </PullRequestMetaLine>
-                    <Button
-                      size="xs"
-                      variant="ghost"
-                      className="h-7 px-2 text-[10px] text-muted-foreground"
-                      aria-label={
-                        timelineOrder === "newest"
-                          ? "Show oldest activity first"
-                          : "Show newest activity first"
-                      }
-                      onClick={() =>
-                        setTimelineOrder((value) => (value === "newest" ? "oldest" : "newest"))
-                      }
-                    >
-                      <ArrowDownUpIcon aria-hidden className="size-3" />
-                      {timelineOrder === "newest" ? "Newest first" : "Oldest first"}
-                    </Button>
-                  </div>
-                ) : null}
-              </nav>
-            ) : null}
-          </div>
-        </div>
+          </nav>
+        ) : null}
       </div>
 
       <div
         className="relative min-h-0 flex-1 overflow-hidden"
-        // Scroll does not bubble, but it captures: one listener hears every tab's own scroll
-        // container. Collapse past two line-heights, expand only back at the very top, so the
-        // boundary row cannot flap the chrome open and shut.
         onScrollCapture={(event) => {
-          if (chromeVariant !== "collapse") return;
           const scroller = event.target as HTMLElement;
           scrollerRef.current = scroller;
           const top = scroller.scrollTop;
           setChromeCondensed((previous) => {
             let next = previous;
-            // `scrollHeight` reads the fold's natural height whichever state the track is in.
             const foldHeight = foldRef.current?.scrollHeight ?? 0;
-            // The chrome trades the fold for the condensed second row, so the height the
-            // scrollport actually gains is the difference between the two.
             const chromeDelta = foldHeight - (condensedRowRef.current?.scrollHeight ?? 0);
             if (previous) {
               // The hard top reopens the chrome with no refund: the reader asked for the top,
@@ -1916,17 +1881,7 @@ export function PullRequestDetailPanel({
           });
         }}
       >
-        {detailQuery.isPending && !detail ? (
-          // The ghost wears the shape of the tab being waited on, so switching tabs mid-load
-          // does not flash a summary outline under a timeline heading.
-          tab === "timeline" ? (
-            <PullRequestTimelineGhost />
-          ) : tab === "code" ? (
-            <DiffPanelLoadingState label="Loading pull request diff..." />
-          ) : (
-            <PullRequestDetailGhost />
-          )
-        ) : detailQuery.error && !detail ? (
+        {detailQuery.error && !detail ? (
           <PullRequestsUnavailableState error={detailQuery.error} onRetry={refreshDetail} />
         ) : detail ? (
           <>

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -1578,6 +1578,8 @@ export function PullRequestDetailPanel({
         <div
           className={cn(
             "col-span-2 grid",
+            // Collapse before the scroll refund paints; only reopening eases back in. Animating
+            // both directions makes the shrinking track fight the scrollTop correction.
             condensed
               ? "grid-rows-[0fr]"
               : "grid-rows-[1fr] transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none",
@@ -1864,6 +1866,7 @@ export function PullRequestDetailPanel({
           setChromeCondensed((previous) => {
             let next = previous;
             const foldHeight = foldRef.current?.scrollHeight ?? 0;
+            // The condensed row remains mounted, so refund only the height that actually leaves.
             const chromeDelta = foldHeight - (condensedRowRef.current?.scrollHeight ?? 0);
             if (previous) {
               // The hard top reopens the chrome with no refund: the reader asked for the top,

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -1531,7 +1531,11 @@ export function PullRequestDetailPanel({
                           </span>
                         }
                       />
-                      <TooltipPopup side="top">{detail.baseBranch}</TooltipPopup>
+                      <TooltipPopup side="top">
+                        {isStackedPullRequest
+                          ? `Stacked on ${detail.baseBranch}`
+                          : detail.baseBranch}
+                      </TooltipPopup>
                     </Tooltip>
                     {freshness ? (
                       <PullRequestBaseFreshnessWarning
@@ -1680,7 +1684,11 @@ export function PullRequestDetailPanel({
                           </span>
                         }
                       />
-                      <TooltipPopup side="top">{detail.baseBranch}</TooltipPopup>
+                      <TooltipPopup side="top">
+                        {isStackedPullRequest
+                          ? `Stacked on ${detail.baseBranch}`
+                          : detail.baseBranch}
+                      </TooltipPopup>
                     </Tooltip>
                     {freshness ? (
                       <PullRequestBaseFreshnessWarning

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -1511,8 +1511,19 @@ export function PullRequestDetailPanel({
               <div className="col-span-2 min-w-0 px-4 pb-2 pt-1">
                 <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
                   <span className="flex min-w-0 shrink items-center gap-1.5 overflow-hidden text-xs text-muted-foreground">
-                    <PullRequestActorAvatar actor={detail.author} className="shrink-0" />
-                    <span className="sr-only">{detail.author?.login ?? "ghost"}</span>
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <span
+                            className="shrink-0 rounded-full"
+                            aria-label={detail.author?.login ?? "ghost"}
+                          />
+                        }
+                      >
+                        <PullRequestActorAvatar actor={detail.author} />
+                      </TooltipTrigger>
+                      <TooltipPopup side="top">{detail.author?.login ?? "ghost"}</TooltipPopup>
+                    </Tooltip>
                     <span className="shrink-0">{formatRelativeTimeLabel(detail.updatedAt)}</span>
                   </span>
                   <span aria-hidden className="h-3 w-px shrink-0 bg-border/70" />

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -435,6 +435,7 @@ export function PullRequestDetailPanel({
     );
   }, [tab]);
   const [chromeCondensed, setChromeCondensed] = useState(false);
+  // Each mounted tab remembers its own scroll chrome; short tabs cannot scroll to reopen it.
   const chromeStateByTab = useRef<Partial<Record<DetailTab, boolean>>>({});
   useEffect(() => {
     setChromeCondensed(chromeStateByTab.current[tab] ?? false);
@@ -443,6 +444,7 @@ export function PullRequestDetailPanel({
   const scrollerRef = useRef<HTMLElement | null>(null);
   const foldRef = useRef<HTMLDivElement | null>(null);
   const condensedRowRef = useRef<HTMLDivElement | null>(null);
+  // Refund after the fold commits so the content under the reader does not jump with its height.
   const compensationRef = useRef<number | null>(null);
   useLayoutEffect(() => {
     if (compensationRef.current === null) return;

--- a/apps/web/src/components/pullRequest/PullRequestGhosts.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestGhosts.tsx
@@ -45,13 +45,11 @@ export function PullRequestListGhost({
           <GhostBar className="size-4 rounded-full" />
           <div className="min-w-0 space-y-1.5">
             <GhostBar className={cn("h-3.5", TITLE_WIDTHS[index % TITLE_WIDTHS.length])} />
-            <GhostBar
-              className={cn("bg-muted-foreground/10", META_WIDTHS[index % META_WIDTHS.length])}
-            />
+            <GhostBar className={META_WIDTHS[index % META_WIDTHS.length]} />
           </div>
           <div className="flex flex-col items-end gap-1.5">
             <GhostBar className="w-12" />
-            <GhostBar className="w-16 bg-muted-foreground/10" />
+            <GhostBar className="w-16" />
           </div>
         </div>
       ))}
@@ -59,32 +57,101 @@ export function PullRequestListGhost({
   );
 }
 
-/** The summary's own shape: a title, a byline, the facts rows, the description. */
+/**
+ * The detail panel's current expanded shape. Keeping the chrome, summary facts, and description
+ * boundaries in the ghost prevents the loaded pull request from replacing one layout with
+ * another a moment later.
+ */
 export function PullRequestDetailGhost() {
   return (
     <div
       role="status"
       aria-label="Loading pull request"
-      className="animate-ghost-pulse space-y-6 px-4 py-5"
+      className="animate-ghost-pulse flex h-full min-h-0 flex-col overflow-hidden bg-background"
     >
-      <div className="space-y-2">
-        <GhostBar className="h-5 w-4/5" />
-        <GhostBar className="w-2/5 bg-muted-foreground/10" />
-      </div>
-      <div className="space-y-3">
-        {Array.from({ length: 4 }, (_, index) => (
-          <div key={index} className="flex items-center gap-3">
-            <GhostBar className="size-3.5 rounded-full" />
-            <GhostBar className="w-20 bg-muted-foreground/10" />
-            <GhostBar className={TITLE_WIDTHS[(index + 1) % TITLE_WIDTHS.length]} />
+      <div className="shrink-0 border-b border-border/60">
+        <div className="flex h-7 items-center justify-between gap-3 px-4">
+          <div className="flex min-w-0 flex-1 items-center gap-1.5">
+            <GhostBar className="w-24" />
+            <GhostBar className="w-9" />
           </div>
-        ))}
+          <div className="flex shrink-0 items-center gap-1">
+            <GhostBar className="h-5 w-16 rounded-md" />
+            <GhostBar className="size-5 rounded-md" />
+          </div>
+        </div>
+
+        <div className="px-4 pb-4 pt-1">
+          <GhostBar className="h-5 w-4/5 max-w-md" />
+          <div className="mt-2 flex items-center gap-1.5">
+            <GhostBar className="size-4 rounded-full" />
+            <GhostBar className="w-24" />
+          </div>
+          <div className="mt-4 flex min-w-0 items-center gap-2">
+            <GhostBar className="h-6 w-24 rounded-md" />
+            <GhostBar className="size-3 rounded-full" />
+            <GhostBar className="h-6 w-32 rounded-md" />
+            <div className="ml-auto flex shrink-0 items-center gap-2">
+              <GhostBar className="w-10" />
+              <GhostBar className="w-20" />
+            </div>
+          </div>
+        </div>
+
+        <div className="flex min-h-10 items-center justify-between gap-3 border-t border-border/60 px-4 py-2">
+          <div className="flex items-center gap-1 p-0.5">
+            <GhostBar className="h-6 w-16 rounded-md" />
+            <GhostBar className="h-6 w-16 rounded-md" />
+            <GhostBar className="h-6 w-12 rounded-md" />
+          </div>
+          <GhostBar className="w-20" />
+        </div>
       </div>
-      <div className="space-y-2 pt-1">
-        <GhostBar className="w-full bg-muted-foreground/10" />
-        <GhostBar className="w-11/12 bg-muted-foreground/10" />
-        <GhostBar className="w-4/5 bg-muted-foreground/10" />
-        <GhostBar className="w-2/3 bg-muted-foreground/10" />
+
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <section className="px-4 py-3">
+          <div className="grid min-h-8 grid-cols-[6rem_minmax(0,1fr)] items-center gap-2">
+            <div className="flex items-center gap-1.5">
+              <GhostBar className="size-3.5 rounded-full" />
+              <GhostBar className="w-14" />
+            </div>
+            <div className="flex items-center gap-1">
+              <GhostBar className="size-4 rounded-full" />
+              <GhostBar className="size-4 rounded-full" />
+              <GhostBar className="ml-1 size-5 rounded-md" />
+            </div>
+          </div>
+          <div className="grid min-h-8 grid-cols-[6rem_minmax(0,1fr)] items-center gap-2">
+            <div className="flex items-center gap-1.5">
+              <GhostBar className="size-3.5 rounded-full" />
+              <GhostBar className="w-10" />
+            </div>
+            <div className="flex items-center gap-1">
+              <GhostBar className="h-5 w-24 rounded-full" />
+              <GhostBar className="h-5 w-20 rounded-full" />
+            </div>
+          </div>
+          <div className="grid min-h-8 grid-cols-[6rem_minmax(0,1fr)] items-center gap-2">
+            <div className="flex items-center gap-1.5">
+              <GhostBar className="size-3.5 rounded-full" />
+              <GhostBar className="w-14" />
+            </div>
+            <GhostBar className="w-20" />
+          </div>
+        </section>
+
+        <section className="border-t border-border/60">
+          <div className="flex min-h-11 items-center gap-1.5 px-4 py-3">
+            <GhostBar className="h-4 w-24" />
+            <GhostBar className="size-3.5 rounded-full" />
+          </div>
+          <div className="space-y-2 px-4 pb-4">
+            <GhostBar className="w-full" />
+            <GhostBar className="w-11/12" />
+            <GhostBar className="w-4/5" />
+            <GhostBar className="w-2/3" />
+          </div>
+        </section>
       </div>
     </div>
   );
@@ -113,7 +180,7 @@ export function PullRequestTimelineGhost({ rows = 6 }: { rows?: number }) {
           <div key={index} className="relative pb-5">
             <GhostBar className="absolute -left-[1.55rem] top-1 size-2 rounded-full" />
             <GhostBar className={cn("h-3.5", TITLE_WIDTHS[index % TITLE_WIDTHS.length])} />
-            <GhostBar className="mt-1.5 w-16 bg-muted-foreground/10" />
+            <GhostBar className="mt-1.5 w-16" />
           </div>
         ))}
       </div>
@@ -134,8 +201,8 @@ export function PullRequestConversationGhost({ rows = 3 }: { rows?: number }) {
           <GhostBar className="size-5 shrink-0 rounded-full" />
           <div className="flex-1 space-y-1.5">
             <GhostBar className={META_WIDTHS[index % META_WIDTHS.length]} />
-            <GhostBar className="w-full bg-muted-foreground/10" />
-            <GhostBar className="w-3/4 bg-muted-foreground/10" />
+            <GhostBar className="w-full" />
+            <GhostBar className="w-3/4" />
           </div>
         </div>
       ))}

--- a/apps/web/src/components/pullRequest/PullRequestListFilters.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestListFilters.tsx
@@ -25,6 +25,7 @@ import { cn } from "~/lib/utils";
 import { getSourceControlPresentationForKind } from "~/sourceControlPresentation";
 import { ProjectFavicon } from "../ProjectFavicon";
 import { InputGroup, InputGroupAddon, InputGroupInput } from "../ui/input-group";
+import { Button } from "../ui/button";
 
 import {
   Menu,
@@ -273,12 +274,14 @@ export function PullRequestFiltersMenu({
   return (
     <Menu>
       <MenuTrigger
-        className={cn(
-          // The icon-button size that pairs with a full-height input, so the two read as one strip.
-          "relative inline-flex size-9 shrink-0 items-center justify-center rounded-lg border border-input text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground sm:size-8",
-          filtered && "text-foreground",
-        )}
-        aria-label="Filter pull requests"
+        render={
+          <Button
+            className={cn("relative", filtered && "[--control-icon-color:currentColor]")}
+            size="icon"
+            variant="outline"
+            aria-label="Filter pull requests"
+          />
+        }
       >
         <ListFilterIcon className="size-4" />
         {filtered ? (

--- a/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
@@ -220,12 +220,12 @@ function MetaRow({
   children: ReactNode;
 }) {
   return (
-    <div className="flex items-center gap-2 py-1.5 text-xs">
-      <span className="flex w-24 shrink-0 items-center gap-1.5 text-muted-foreground">
+    <div className="grid min-h-8 grid-cols-[6rem_minmax(0,1fr)] items-center gap-2 py-1.5 text-xs">
+      <span className="flex min-w-0 items-center gap-1.5 text-muted-foreground">
         {icon}
         {label}
       </span>
-      <span className="min-w-0 flex-1 text-foreground">{children}</span>
+      <span className="min-w-0 text-foreground">{children}</span>
     </div>
   );
 }

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
@@ -17,6 +17,7 @@ import {
   handoffPrompt,
   handoffReviewComments,
   isPullRequestVerdictStale,
+  isStackedPullRequestBase,
   isThreadOwnPullRequest,
   latestPullRequestReviewOutcomes,
   newestPullRequestCommitAt,
@@ -164,6 +165,47 @@ describe("pull request composer target", () => {
 
     expect(pullRequestComposerTarget("page", target)).toBeNull();
     expect(pullRequestComposerTarget("thread", target)).toBe(target);
+  });
+});
+
+describe("stacked pull request classification", () => {
+  it("requires a known default branch", () => {
+    expect(isStackedPullRequestBase("main", [{ name: "main", isDefault: false }])).toBe(false);
+  });
+
+  it("recognizes local and remote forms of the default branch", () => {
+    expect(
+      isStackedPullRequestBase("main", [{ name: "main", isDefault: true, isRemote: false }]),
+    ).toBe(false);
+    expect(
+      isStackedPullRequestBase("main", [
+        { name: "origin/main", isDefault: true, isRemote: true, remoteName: "origin" },
+      ]),
+    ).toBe(false);
+  });
+
+  it("classifies a non-default base as stacked once the default is known", () => {
+    expect(
+      isStackedPullRequestBase("feature-base", [
+        { name: "origin/main", isDefault: true, isRemote: true, remoteName: "origin" },
+      ]),
+    ).toBe(true);
+  });
+
+  it("does not mistake a nested branch suffix for the default branch", () => {
+    expect(
+      isStackedPullRequestBase("main", [
+        {
+          name: "origin/feature/main",
+          isDefault: true,
+          isRemote: true,
+          remoteName: "origin",
+        },
+      ]),
+    ).toBe(true);
+    expect(
+      isStackedPullRequestBase("1.0", [{ name: "release/1.0", isDefault: true, isRemote: false }]),
+    ).toBe(true);
   });
 });
 

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
@@ -143,8 +143,6 @@ describe("pull request handoff labels", () => {
       fixFinding: "Fix in this thread",
       fixCheck: "Fix in this thread",
       fixFindings: "Fix findings in this thread",
-      resolve: "Resolve in this thread",
-      resolveConflicts: "Resolve conflicts in this thread",
     });
   });
 
@@ -153,8 +151,6 @@ describe("pull request handoff labels", () => {
       fixFinding: "Fix in a thread",
       fixCheck: "Fix",
       fixFindings: "Fix findings in a thread",
-      resolve: "Resolve in a new thread",
-      resolveConflicts: "Resolve conflicts in a thread",
     });
   });
 });

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
@@ -11,6 +11,7 @@ import type {
   PullRequestReviewThread,
   PullRequestState,
   PullRequestUpdateMethod,
+  VcsRef,
 } from "@t3tools/contracts";
 
 import { inferReviewCommentFenceLanguage, type ReviewCommentContext } from "~/reviewCommentContext";
@@ -101,6 +102,20 @@ export function pullRequestActionMenuHasGroup(
   showsMergeMethods: boolean,
 ): boolean {
   return showsDraftToggle || showsAutoMerge || showsMergeMethods;
+}
+
+export function isStackedPullRequestBase(
+  baseBranch: string,
+  refs: ReadonlyArray<Pick<VcsRef, "name" | "isDefault" | "isRemote" | "remoteName">>,
+): boolean {
+  const defaultRef = refs.find((refName) => refName.isDefault);
+  if (!defaultRef) return false;
+  if (defaultRef.isRemote !== true) return defaultRef.name !== baseBranch;
+  const remotePrefix = `${defaultRef.remoteName ?? defaultRef.name.split("/")[0]}/`;
+  const defaultBranch = defaultRef.name.startsWith(remotePrefix)
+    ? defaultRef.name.slice(remotePrefix.length)
+    : defaultRef.name;
+  return defaultBranch !== baseBranch;
 }
 
 /** Plain-language state, shown beside the author. Conflicts are a merge signal, not a state. */

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
@@ -76,15 +76,11 @@ export function pullRequestHandoffLabels(inThisThread: boolean) {
         fixFinding: "Fix in this thread",
         fixCheck: "Fix in this thread",
         fixFindings: "Fix findings in this thread",
-        resolve: "Resolve in this thread",
-        resolveConflicts: "Resolve conflicts in this thread",
       }
     : {
         fixFinding: "Fix in a thread",
         fixCheck: "Fix",
         fixFindings: "Fix findings in a thread",
-        resolve: "Resolve in a new thread",
-        resolveConflicts: "Resolve conflicts in a thread",
       };
 }
 

--- a/apps/web/src/hooks/useResizableWidth.ts
+++ b/apps/web/src/hooks/useResizableWidth.ts
@@ -67,14 +67,10 @@ export function useResizableWidth(options: UseResizableWidthOptions): {
   } | null>(null);
 
   useEffect(() => {
-    if (
-      dragStateRef.current === null &&
-      dragWidth !== null &&
-      clamp(storedWidth) === clamp(dragWidth)
-    ) {
+    if (dragStateRef.current === null && dragWidth !== null) {
       setDragWidth(null);
     }
-  }, [clamp, dragWidth, storedWidth]);
+  }, [dragWidth, storedWidth]);
 
   const releasePointer = useCallback((pointerId: number) => {
     const state = dragStateRef.current;

--- a/apps/web/src/hooks/useResizableWidth.ts
+++ b/apps/web/src/hooks/useResizableWidth.ts
@@ -1,7 +1,13 @@
 import * as Schema from "effect/Schema";
-import { type PointerEvent as ReactPointerEvent, useCallback, useRef, useState } from "react";
+import {
+  type PointerEvent as ReactPointerEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
-import { getLocalStorageItem, setLocalStorageItem } from "./useLocalStorage";
+import { useLocalStorage } from "./useLocalStorage";
 
 const WidthSchema = Schema.Finite;
 
@@ -28,12 +34,10 @@ export interface ResizableWidthHandlers {
 
 /**
  * Width state for a side-anchored panel resized via a drag handle on the
- * specified edge. Width is read from localStorage on mount and persisted on
- * drag-end (not on every rAF tick — would otherwise be ~60 writes/sec).
+ * specified edge. Mounted consumers sharing a storage key stay synchronized.
  *
- * The hook updates an internal `width` state during drag (so the panel
- * follows the cursor live) and only commits to localStorage when the user
- * lifts the pointer.
+ * The hook keeps drag width local so the panel follows the cursor without
+ * writing at rAF frequency, then commits once when the pointer lifts.
  */
 export function useResizableWidth(options: UseResizableWidthOptions): {
   readonly width: number;
@@ -49,19 +53,9 @@ export function useResizableWidth(options: UseResizableWidthOptions): {
     [defaultWidth, maxWidth, minWidth],
   );
 
-  // No cross-tab subscription: panel width is per-window state.
-  const [width, setWidth] = useState<number>(() => {
-    if (typeof window === "undefined") return defaultWidth;
-    try {
-      const stored = getLocalStorageItem(storageKey, WidthSchema);
-      return clamp(stored ?? defaultWidth);
-    } catch (error) {
-      console.error("Could not read persisted panel width.", error);
-      return defaultWidth;
-    }
-  });
-
-  const clampedWidth = clamp(width);
+  const [storedWidth, setStoredWidth] = useLocalStorage(storageKey, defaultWidth, WidthSchema);
+  const [dragWidth, setDragWidth] = useState<number | null>(null);
+  const clampedWidth = clamp(dragWidth ?? storedWidth);
 
   const dragStateRef = useRef<{
     pointerId: number;
@@ -71,6 +65,16 @@ export function useResizableWidth(options: UseResizableWidthOptions): {
     rafId: number | null;
     target: HTMLElement;
   } | null>(null);
+
+  useEffect(() => {
+    if (
+      dragStateRef.current === null &&
+      dragWidth !== null &&
+      clamp(storedWidth) === clamp(dragWidth)
+    ) {
+      setDragWidth(null);
+    }
+  }, [clamp, dragWidth, storedWidth]);
 
   const releasePointer = useCallback((pointerId: number) => {
     const state = dragStateRef.current;
@@ -127,7 +131,7 @@ export function useResizableWidth(options: UseResizableWidthOptions): {
         const active = dragStateRef.current;
         if (!active) return;
         active.rafId = null;
-        setWidth(active.pending);
+        setDragWidth(active.pending);
       });
     },
     [clamp, edge],
@@ -139,24 +143,19 @@ export function useResizableWidth(options: UseResizableWidthOptions): {
       if (!state || state.pointerId !== event.pointerId) return;
       const finalWidth = clamp(state.pending);
       releasePointer(event.pointerId);
-      // Commit once at drag-end to avoid 60Hz localStorage writes.
-      try {
-        setLocalStorageItem(storageKey, finalWidth, WidthSchema);
-      } catch (error) {
-        console.error("Could not persist panel width.", error);
-      }
-      setWidth(finalWidth);
+      setDragWidth(finalWidth);
+      setStoredWidth(finalWidth);
     },
-    [clamp, releasePointer, storageKey],
+    [clamp, releasePointer, setStoredWidth],
   );
 
   const onPointerCancel = useCallback(
     (event: ReactPointerEvent<HTMLElement>) => {
       const state = dragStateRef.current;
       if (!state || state.pointerId !== event.pointerId) return;
-      // Don't persist a cancelled drag; revert to the start width.
+      // Don't persist a cancelled drag; use the latest shared stored width.
       releasePointer(event.pointerId);
-      setWidth(state.startWidth);
+      setDragWidth(null);
     },
     [releasePointer],
   );

--- a/apps/web/src/lib/openPullRequestLink.test.ts
+++ b/apps/web/src/lib/openPullRequestLink.test.ts
@@ -1,12 +1,31 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
+  changeRequestRepositoryUrl,
   findProjectForChangeRequest,
   openPullRequestLink,
   parseChangeRequestUrl,
   PullRequestLinkOpenError,
   shouldOpenPullRequestExternally,
 } from "./openPullRequestLink";
+
+describe("changeRequestRepositoryUrl", () => {
+  it("preserves repository path casing", () => {
+    expect(
+      changeRequestRepositoryUrl(
+        "https://gitlab.example.test/Team/Platform/Repo/-/merge_requests/42/diffs#note_1",
+      ),
+    ).toBe("https://gitlab.example.test/Team/Platform/Repo");
+  });
+
+  it("keeps pull-like segments inside nested GitLab repository paths", () => {
+    expect(
+      changeRequestRepositoryUrl(
+        "https://gitlab.example.test/group/pull/123/repo/-/merge_requests/42",
+      ),
+    ).toBe("https://gitlab.example.test/group/pull/123/repo");
+  });
+});
 
 describe("openPullRequestLink", () => {
   it("opens the requested pull request URL", async () => {

--- a/apps/web/src/lib/openPullRequestLink.ts
+++ b/apps/web/src/lib/openPullRequestLink.ts
@@ -118,6 +118,23 @@ export function parseChangeRequestUrl(targetUrl: string): ChangeRequestLink | nu
   return null;
 }
 
+/** The repository root behind a recognised change-request URL, without PR-specific state. */
+export function changeRequestRepositoryUrl(targetUrl: string): string | null {
+  const changeRequest = parseChangeRequestUrl(targetUrl);
+  if (changeRequest === null) return null;
+  const url = new URL(targetUrl);
+  const repositoryPath =
+    /^(.*?)\/-\/merge_requests\/\d+(?:\/|$)/iu.exec(url.pathname)?.[1] ??
+    /^(.*?)(?:\/pull\/\d+|\/-\/merge_requests\/\d+|\/pull-requests\/\d+|\/pullrequest\/\d+)(?:\/|$)/iu.exec(
+      url.pathname,
+    )?.[1];
+  if (!repositoryPath) return null;
+  url.pathname = repositoryPath;
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+}
+
 function claim(host: string, match: RegExpExecArray | null): ChangeRequestLink | null {
   const repository = match?.[1];
   const number = Number(match?.[2]);

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -74,6 +74,8 @@ import {
   WorkspaceBreadcrumbItem,
   WorkspaceBreadcrumbSeparator,
 } from "../components/WorkspaceBreadcrumb";
+import { WorkspacePageContainer, WorkspacePageHeader } from "../components/WorkspacePageContainer";
+import { isElectron } from "../env";
 import { PanelLayoutControls } from "../components/chat/PanelLayoutControls";
 import { Button } from "../components/ui/button";
 import { Menu, MenuPopup, MenuRadioGroup, MenuRadioItem, MenuTrigger } from "../components/ui/menu";
@@ -100,7 +102,6 @@ import {
 import { useAtomCommand } from "../state/use-atom-command";
 import { cn } from "~/lib/utils";
 import { getSourceControlPresentationForKind } from "~/sourceControlPresentation";
-import { COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS } from "~/workspaceTitlebar";
 
 export interface PullRequestsSearch {
   readonly involvement: PullRequestInvolvement;
@@ -1181,6 +1182,7 @@ function PullRequestsRouteView() {
         : null,
     [search.number, search.repository, selectedProject],
   );
+  const rightPanelAvailable = selectedPullRequestSurface !== null;
   useEffect(() => {
     if (!pullRequestsSupported || rightPanelRef === null || linkedSelection === null) return;
     useRightPanelStore.getState().openPullRequest(rightPanelRef, linkedSelection);
@@ -1294,9 +1296,10 @@ function PullRequestsRouteView() {
       terminalAvailable={false}
       terminalOpen={false}
       terminalShortcutLabel={null}
-      rightPanelAvailable={rightPanelState.surfaces.length > 0}
+      rightPanelAvailable={rightPanelAvailable}
       rightPanelOpen={rightPanelState.isOpen}
       rightPanelShortcutLabel={null}
+      rightPanelUnavailableLabel="Select a pull request first"
       liveAgentCount={0}
       onToggleTerminal={() => undefined}
       onToggleRightPanel={toggleRightPanel}
@@ -1603,7 +1606,6 @@ function PullRequestsRouteView() {
                 reviewingQuery.refresh();
               }}
               onStateChange={handlePullRequestTabStatusChange}
-              chromeVariant="collapse"
             />
           </RightPanelTabs>
         ) : null}
@@ -1612,10 +1614,7 @@ function PullRequestsRouteView() {
   );
 }
 
-/**
- * A compact stand-in for one pill group: the trigger wears the current choice, the choices
- * live in a menu. Same options, same handler — only the footprint changes.
- */
+/** A compact stand-in for one pill group when the header is narrow. */
 function CompactFilterMenu<Value extends string>({
   label,
   value,
@@ -1627,7 +1626,8 @@ function CompactFilterMenu<Value extends string>({
   options: ReadonlyArray<PullRequestFilterOption<Value>>;
   onChange: (value: Value) => void;
 }) {
-  const current = options.find((option) => option.value === value) ?? options[0]!;
+  const current = options.find((option) => option.value === value) ?? options[0];
+  if (!current) return null;
   return (
     <Menu>
       <MenuTrigger
@@ -1640,15 +1640,12 @@ function CompactFilterMenu<Value extends string>({
       <MenuPopup align="start" side="bottom" className="min-w-40">
         <MenuRadioGroup value={value} onValueChange={(next) => onChange(next as Value)}>
           {options.map((option) => {
-            // A host the server has already said it cannot read is not a choice here either.
-            // The pills disable it; a menu that offers it would answer the press by replacing
-            // a working list with the same failure the pill row exists to explain.
             const item = (
               <MenuRadioItem
                 key={option.value}
                 value={option.value}
-                className={option.unavailable ? "data-disabled:pointer-events-auto" : undefined}
                 disabled={option.unavailable !== undefined}
+                className="data-disabled:pointer-events-auto"
               >
                 <span className="flex min-w-0 items-center gap-2">
                   <option.Icon aria-hidden className="size-3.5" />
@@ -1656,11 +1653,12 @@ function CompactFilterMenu<Value extends string>({
                 </span>
               </MenuRadioItem>
             );
-            if (!option.unavailable) return item;
-            return (
+            return option.unavailable === undefined ? (
+              item
+            ) : (
               <Tooltip key={option.value}>
                 <TooltipTrigger render={item} />
-                <TooltipPopup side="top" className="max-w-80">
+                <TooltipPopup side="right" className="max-w-64 break-words">
                   {option.unavailable}
                 </TooltipPopup>
               </Tooltip>
@@ -1838,18 +1836,10 @@ function PullRequestsColumn({
     // Painted flat like the chat column: the inset underneath carries the chrome grain, and a
     // content surface that lets it show reads as a different background than every thread.
     <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background">
-      <header
-        className={cn(
-          "drag-region flex h-[var(--workspace-topbar-height)] min-h-[var(--workspace-topbar-height)] shrink-0 items-center gap-1.5 px-3 sm:px-5",
-          // A closed right panel leaves this column full-width, so its header runs
-          // underneath the native window controls on Windows; reserve the inset the
-          // way Settings and the chat view do. While the panel is open the column
-          // ends at the panel's left edge and the absolute controls strip (already
-          // WCO-aware) owns the top-right corner.
-          !rightPanelOpen && "wco:pr-[var(--workspace-native-controls-inset)]",
-          COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS,
-        )}
-      >
+      {/* A closed right panel leaves this column full-width, so the shared header
+          reserves native window controls. While the panel is open, the column ends
+          at the panel and the absolute controls strip owns the top-right corner. */}
+      <WorkspacePageHeader electron={isElectron} reserveNativeControls={!rightPanelOpen}>
         {condensed ? (
           <WorkspaceBreadcrumb ariaLabel="Pull request scope">
             {/* The page name remains the foreground anchor in both states; the live filters are
@@ -1891,27 +1881,22 @@ function PullRequestsColumn({
         )}
         <div className="min-w-0 flex-1" />
         {condensed ? (
-          <ExpandableSearch
-            searchInput={searchInput}
-            searchValue={searchValue}
-            open={searchOpen}
-            onOpenChange={setSearchOpen}
-            focusToken={searchFocusToken}
-            onFocusWithin={(focused) => {
-              topbarSearchFocusedRef.current = focused;
-            }}
-          />
+          <div className="flex shrink-0 items-center gap-1.5">
+            <ExpandableSearch
+              searchInput={searchInput}
+              searchValue={searchValue}
+              open={searchOpen}
+              onOpenChange={setSearchOpen}
+              focusToken={searchFocusToken}
+              onFocusWithin={(focused) => {
+                topbarSearchFocusedRef.current = focused;
+              }}
+            />
+            <PullRequestRefreshControl compact refreshing={refreshing} onRefresh={onRefresh} />
+          </div>
         ) : null}
-        <Button
-          size="icon-sm"
-          variant="ghost"
-          aria-label="Refresh pull requests"
-          onClick={onRefresh}
-        >
-          <RefreshCwIcon className={cn("size-4", refreshing && "animate-spin")} />
-        </Button>
         {rightPanelControl}
-      </header>
+      </WorkspacePageHeader>
 
       <div
         ref={scrollRef}
@@ -1920,19 +1905,44 @@ function PullRequestsColumn({
         {/* The top padding is the fade band's own height (1.5rem here), the same pairing the
             settings page makes: at rest the controls sit fully below the mask, and only
             content actually passing under the chrome fades. */}
-        <div className="mx-auto flex w-full max-w-4xl flex-col gap-4 px-5 pt-6 pb-12">
+        <WorkspacePageContainer className="gap-4">
           <div className="flex flex-col gap-3">
             <div ref={inFlowSearchRef} className="flex items-center gap-2">
               {searchInput}
               {filtersMenu}
+              {!condensed ? (
+                <PullRequestRefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+              ) : null}
             </div>
             {/* Scrolled past this marker, the controls are gone and the title takes over. */}
             <div ref={markerRef} aria-hidden className="-mt-3 h-px w-full" />
           </div>
 
           {listBody}
-        </div>
+        </WorkspacePageContainer>
       </div>
     </div>
+  );
+}
+
+function PullRequestRefreshControl({
+  compact = false,
+  refreshing,
+  onRefresh,
+}: {
+  compact?: boolean;
+  refreshing: boolean;
+  onRefresh: () => void;
+}) {
+  return (
+    <Button
+      size={compact ? "icon-sm" : "icon"}
+      variant={compact ? "ghost" : "outline"}
+      aria-label="Refresh pull requests"
+      onClick={onRefresh}
+      disabled={refreshing}
+    >
+      <RefreshCwIcon className={cn("size-4", refreshing && "animate-spin")} />
+    </Button>
   );
 }

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -74,7 +74,8 @@ import {
   WorkspaceBreadcrumbItem,
   WorkspaceBreadcrumbSeparator,
 } from "../components/WorkspaceBreadcrumb";
-import { WorkspacePageContainer, WorkspacePageHeader } from "../components/WorkspacePageContainer";
+import { WorkspacePageContainer } from "../components/WorkspacePageContainer";
+import { WorkspacePageHeader } from "../components/WorkspacePageHeader";
 import { isElectron } from "../env";
 import { PanelLayoutControls } from "../components/chat/PanelLayoutControls";
 import { Button } from "../components/ui/button";

--- a/apps/web/src/terminalUiStateStore.test.ts
+++ b/apps/web/src/terminalUiStateStore.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it } from "vite-plus/test";
 
 import {
   migratePersistedTerminalUiStateStoreState,
+  selectThreadTerminalCustomLabels,
   selectThreadTerminalUiState,
   useTerminalUiStateStore,
 } from "./terminalUiStateStore";
@@ -18,6 +19,7 @@ describe("terminalUiStateStore actions", () => {
     useTerminalUiStateStore.persist.clearStorage();
     useTerminalUiStateStore.setState({
       terminalUiStateByThreadKey: {},
+      terminalCustomLabelsByThreadKey: {},
       suppressedTerminalIdsByThreadKey: {},
     });
   });
@@ -212,9 +214,53 @@ describe("terminalUiStateStore actions", () => {
     });
   });
 
+  it("normalizes persisted terminal labels", () => {
+    const migrated = migratePersistedTerminalUiStateStoreState(
+      {
+        terminalCustomLabelsByThreadKey: {
+          [scopedThreadKey(THREAD_REF)]: {
+            " term-1 ": " API server ",
+            empty: "   ",
+            invalid: 42,
+          },
+          "legacy-thread-id": { "term-2": "Ignored" },
+        },
+      },
+      4,
+    );
+
+    expect(migrated).toEqual({
+      terminalUiStateByThreadKey: {},
+      terminalCustomLabelsByThreadKey: {
+        [scopedThreadKey(THREAD_REF)]: { "term-1": "API server" },
+      },
+    });
+  });
+
+  it("sets and clears a terminal label", () => {
+    const store = useTerminalUiStateStore.getState();
+    store.setTerminalCustomLabel(THREAD_REF, "term-1", " API server ");
+
+    expect(
+      selectThreadTerminalCustomLabels(
+        useTerminalUiStateStore.getState().terminalCustomLabelsByThreadKey,
+        THREAD_REF,
+      ),
+    ).toEqual({ "term-1": "API server" });
+
+    store.setTerminalCustomLabel(THREAD_REF, "term-1", null);
+    expect(
+      selectThreadTerminalCustomLabels(
+        useTerminalUiStateStore.getState().terminalCustomLabelsByThreadKey,
+        THREAD_REF,
+      ),
+    ).toEqual({});
+  });
+
   it("resets to default and clears persisted entry when closing the last terminal", () => {
     const store = useTerminalUiStateStore.getState();
     store.newTerminal(THREAD_REF, "terminal-only");
+    store.setTerminalCustomLabel(THREAD_REF, "terminal-only", "Build");
     store.closeTerminal(THREAD_REF, "terminal-only");
 
     expect(
@@ -226,6 +272,12 @@ describe("terminalUiStateStore actions", () => {
         THREAD_REF,
       ).terminalIds,
     ).toEqual([]);
+    expect(
+      selectThreadTerminalCustomLabels(
+        useTerminalUiStateStore.getState().terminalCustomLabelsByThreadKey,
+        THREAD_REF,
+      ),
+    ).toEqual({});
   });
 
   it("keeps a valid active terminal after closing an active split terminal", () => {
@@ -248,6 +300,8 @@ describe("terminalUiStateStore actions", () => {
   it("reconciles terminal ids from an external ordered list", () => {
     const store = useTerminalUiStateStore.getState();
     store.setTerminalOpen(THREAD_REF, true);
+    store.setTerminalCustomLabel(THREAD_REF, "term-a", "API server");
+    store.setTerminalCustomLabel(THREAD_REF, "stale-term", "Old task");
     store.reconcileTerminalIds(THREAD_REF, ["term-a", "term-b"]);
 
     const terminalUiState = selectThreadTerminalUiState(
@@ -260,6 +314,34 @@ describe("terminalUiStateStore actions", () => {
       { id: "group-term-a", terminalIds: ["term-a"] },
       { id: "group-term-b", terminalIds: ["term-b"] },
     ]);
+    expect(
+      useTerminalUiStateStore.getState().terminalCustomLabelsByThreadKey[
+        scopedThreadKey(THREAD_REF)
+      ],
+    ).toEqual({ "term-a": "API server" });
+  });
+
+  it("preserves labels for panel terminals during drawer reconciliation", () => {
+    const store = useTerminalUiStateStore.getState();
+    store.setTerminalCustomLabel(THREAD_REF, "drawer-term", "Shell");
+    store.setTerminalCustomLabel(THREAD_REF, "panel-term", "Server");
+    store.setTerminalCustomLabel(THREAD_REF, "stale-term", "Old task");
+
+    store.reconcileTerminalIds(THREAD_REF, ["drawer-term"], ["panel-term"]);
+    expect(
+      selectThreadTerminalCustomLabels(
+        useTerminalUiStateStore.getState().terminalCustomLabelsByThreadKey,
+        THREAD_REF,
+      ),
+    ).toEqual({ "drawer-term": "Shell", "panel-term": "Server" });
+
+    store.reconcileTerminalIds(THREAD_REF, ["drawer-term"]);
+    expect(
+      selectThreadTerminalCustomLabels(
+        useTerminalUiStateStore.getState().terminalCustomLabelsByThreadKey,
+        THREAD_REF,
+      ),
+    ).toEqual({ "drawer-term": "Shell" });
   });
 
   it("does not import a closed panel terminal from stale metadata", () => {

--- a/apps/web/src/terminalUiStateStore.test.ts
+++ b/apps/web/src/terminalUiStateStore.test.ts
@@ -280,6 +280,26 @@ describe("terminalUiStateStore actions", () => {
     ).toEqual({});
   });
 
+  it("normalizes terminal ids when closing", () => {
+    const store = useTerminalUiStateStore.getState();
+    store.newTerminal(THREAD_REF, "terminal-only");
+    store.setTerminalCustomLabel(THREAD_REF, "terminal-only", "Build");
+    store.closeTerminal(THREAD_REF, " terminal-only ");
+
+    expect(
+      selectThreadTerminalUiState(
+        useTerminalUiStateStore.getState().terminalUiStateByThreadKey,
+        THREAD_REF,
+      ).terminalIds,
+    ).toEqual([]);
+    expect(
+      selectThreadTerminalCustomLabels(
+        useTerminalUiStateStore.getState().terminalCustomLabelsByThreadKey,
+        THREAD_REF,
+      ),
+    ).toEqual({});
+  });
+
   it("keeps a valid active terminal after closing an active split terminal", () => {
     const store = useTerminalUiStateStore.getState();
     store.splitTerminal(THREAD_REF, "terminal-2");

--- a/apps/web/src/terminalUiStateStore.test.ts
+++ b/apps/web/src/terminalUiStateStore.test.ts
@@ -3,6 +3,7 @@ import { ThreadId } from "@t3tools/contracts";
 import { beforeEach, describe, expect, it } from "vite-plus/test";
 
 import {
+  getTerminalCustomLabel,
   migratePersistedTerminalUiStateStoreState,
   selectThreadTerminalCustomLabels,
   selectThreadTerminalUiState,
@@ -255,6 +256,40 @@ describe("terminalUiStateStore actions", () => {
         THREAD_REF,
       ),
     ).toEqual({});
+  });
+
+  it("treats prototype keys as terminal ids only when explicitly labeled", () => {
+    const store = useTerminalUiStateStore.getState();
+    store.setTerminalCustomLabel(THREAD_REF, "term-1", "API server");
+
+    let labels = selectThreadTerminalCustomLabels(
+      useTerminalUiStateStore.getState().terminalCustomLabelsByThreadKey,
+      THREAD_REF,
+    );
+    expect(getTerminalCustomLabel(labels, "toString")).toBeUndefined();
+
+    store.setTerminalCustomLabel(THREAD_REF, "toString", null);
+    expect(
+      selectThreadTerminalCustomLabels(
+        useTerminalUiStateStore.getState().terminalCustomLabelsByThreadKey,
+        THREAD_REF,
+      ),
+    ).toEqual({ "term-1": "API server" });
+
+    store.setTerminalCustomLabel(THREAD_REF, "toString", "Shell");
+    labels = selectThreadTerminalCustomLabels(
+      useTerminalUiStateStore.getState().terminalCustomLabelsByThreadKey,
+      THREAD_REF,
+    );
+    expect(getTerminalCustomLabel(labels, "toString")).toBe("Shell");
+
+    store.setTerminalCustomLabel(THREAD_REF, "toString", null);
+    expect(
+      selectThreadTerminalCustomLabels(
+        useTerminalUiStateStore.getState().terminalCustomLabelsByThreadKey,
+        THREAD_REF,
+      ),
+    ).toEqual({ "term-1": "API server" });
   });
 
   it("resets to default and clears persisted entry when closing the last terminal", () => {

--- a/apps/web/src/terminalUiStateStore.ts
+++ b/apps/web/src/terminalUiStateStore.ts
@@ -528,6 +528,15 @@ export function selectThreadTerminalCustomLabels(
   );
 }
 
+export function getTerminalCustomLabel(
+  terminalCustomLabels: Readonly<Record<string, string>>,
+  terminalId: string,
+): string | undefined {
+  return Object.prototype.hasOwnProperty.call(terminalCustomLabels, terminalId)
+    ? terminalCustomLabels[terminalId]
+    : undefined;
+}
+
 function updateTerminalUiStateByThreadKey(
   terminalUiStateByThreadKey: Record<string, ThreadTerminalUiState>,
   threadRef: ScopedThreadRef,
@@ -668,7 +677,8 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
             : "";
           const currentLabels = state.terminalCustomLabelsByThreadKey[threadKey] ?? {};
           let nextTerminalCustomLabelsByThreadKey =
-            terminalIdToClear.length > 0 && currentLabels[terminalIdToClear] !== undefined
+            terminalIdToClear.length > 0 &&
+            getTerminalCustomLabel(currentLabels, terminalIdToClear) !== undefined
               ? Object.keys(currentLabels).length === 1
                 ? removeRecordEntry(state.terminalCustomLabelsByThreadKey, threadKey)
                 : {
@@ -781,7 +791,9 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
             const currentLabels = state.terminalCustomLabelsByThreadKey[threadKey] ?? {};
             const normalizedLabel = label?.trim().slice(0, 80) ?? "";
             if (normalizedLabel.length > 0) {
-              if (currentLabels[normalizedTerminalId] === normalizedLabel) return state;
+              if (getTerminalCustomLabel(currentLabels, normalizedTerminalId) === normalizedLabel) {
+                return state;
+              }
               return {
                 terminalCustomLabelsByThreadKey: {
                   ...state.terminalCustomLabelsByThreadKey,
@@ -789,7 +801,9 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
                 },
               };
             }
-            if (currentLabels[normalizedTerminalId] === undefined) return state;
+            if (getTerminalCustomLabel(currentLabels, normalizedTerminalId) === undefined) {
+              return state;
+            }
             const { [normalizedTerminalId]: _removed, ...remainingLabels } = currentLabels;
             return {
               terminalCustomLabelsByThreadKey:

--- a/apps/web/src/terminalUiStateStore.ts
+++ b/apps/web/src/terminalUiStateStore.ts
@@ -32,7 +32,10 @@ const TERMINAL_UI_STATE_STORAGE_KEY = "t3code:terminal-state:v1";
 interface PersistedTerminalUiStateStoreState {
   terminalUiStateByThreadKey?: Record<string, ThreadTerminalUiState>;
   terminalStateByThreadKey?: Record<string, ThreadTerminalUiState>;
+  terminalCustomLabelsByThreadKey?: Record<string, Record<string, string>>;
 }
+
+const EMPTY_TERMINAL_CUSTOM_LABELS: Readonly<Record<string, string>> = Object.freeze({});
 
 export function migratePersistedTerminalUiStateStoreState(
   persistedState: unknown,
@@ -50,8 +53,32 @@ export function migratePersistedTerminalUiStateStoreState(
       parseScopedThreadKey(threadKey),
     ),
   );
+  const terminalCustomLabelsByThreadKey = Object.fromEntries(
+    Object.entries(candidate.terminalCustomLabelsByThreadKey ?? {}).flatMap(
+      ([threadKey, labels]) => {
+        if (!parseScopedThreadKey(threadKey) || !labels || typeof labels !== "object") return [];
+        const normalizedLabels = Object.fromEntries(
+          Object.entries(labels).flatMap(([terminalId, label]) => {
+            const normalizedTerminalId = terminalId.trim();
+            const normalizedLabel = typeof label === "string" ? label.trim().slice(0, 80) : "";
+            return normalizedTerminalId && normalizedLabel
+              ? [[normalizedTerminalId, normalizedLabel] as const]
+              : [];
+          }),
+        );
+        return Object.keys(normalizedLabels).length > 0
+          ? [[threadKey, normalizedLabels] as const]
+          : [];
+      },
+    ),
+  );
 
-  return { terminalUiStateByThreadKey };
+  return {
+    terminalUiStateByThreadKey,
+    ...(Object.keys(terminalCustomLabelsByThreadKey).length > 0
+      ? { terminalCustomLabelsByThreadKey }
+      : {}),
+  };
 }
 
 function createTerminalUiStateStorage() {
@@ -489,6 +516,18 @@ export function selectThreadTerminalUiState(
   );
 }
 
+export function selectThreadTerminalCustomLabels(
+  terminalCustomLabelsByThreadKey: Record<string, Record<string, string>>,
+  threadRef: ScopedThreadRef | null | undefined,
+): Readonly<Record<string, string>> {
+  if (!threadRef || threadRef.threadId.length === 0) {
+    return EMPTY_TERMINAL_CUSTOM_LABELS;
+  }
+  return (
+    terminalCustomLabelsByThreadKey[terminalThreadKey(threadRef)] ?? EMPTY_TERMINAL_CUSTOM_LABELS
+  );
+}
+
 function updateTerminalUiStateByThreadKey(
   terminalUiStateByThreadKey: Record<string, ThreadTerminalUiState>,
   threadRef: ScopedThreadRef,
@@ -562,6 +601,7 @@ function removeRecordEntry<T>(record: Record<string, T>, key: string): Record<st
 
 interface TerminalUiStateStoreState {
   terminalUiStateByThreadKey: Record<string, ThreadTerminalUiState>;
+  terminalCustomLabelsByThreadKey: Record<string, Record<string, string>>;
   /** Closed ids hidden from stale server metadata until that id is explicitly opened again. */
   suppressedTerminalIdsByThreadKey: Record<string, string[]>;
   setTerminalOpen: (threadRef: ScopedThreadRef, open: boolean) => void;
@@ -575,8 +615,17 @@ interface TerminalUiStateStoreState {
     options?: { open?: boolean; active?: boolean },
   ) => void;
   setActiveTerminal: (threadRef: ScopedThreadRef, terminalId: string) => void;
+  setTerminalCustomLabel: (
+    threadRef: ScopedThreadRef,
+    terminalId: string,
+    label: string | null,
+  ) => void;
   closeTerminal: (threadRef: ScopedThreadRef, terminalId: string) => void;
-  reconcileTerminalIds: (threadRef: ScopedThreadRef, nextIds: string[]) => void;
+  reconcileTerminalIds: (
+    threadRef: ScopedThreadRef,
+    nextIds: string[],
+    preserveCustomLabelIds?: readonly string[],
+  ) => void;
   clearTerminalUiState: (threadRef: ScopedThreadRef) => void;
   removeTerminalUiState: (threadRef: ScopedThreadRef) => void;
   removeOrphanedTerminalUiStates: (activeThreadKeys: Set<string>) => void;
@@ -591,7 +640,12 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
           state: ThreadTerminalUiState,
           suppressedTerminalIds: readonly string[],
         ) => ThreadTerminalUiState,
-        suppression?: { terminalId: string; suppressed: boolean },
+        suppression?: {
+          terminalId: string;
+          suppressed: boolean;
+          clearCustomLabel?: boolean;
+        },
+        preserveCustomLabelIds: readonly string[] | null = null,
       ) => {
         set((state) => {
           const threadKey = terminalThreadKey(threadRef);
@@ -609,21 +663,58 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
                 suppression.suppressed,
               )
             : state.suppressedTerminalIdsByThreadKey;
+          const terminalIdToClear = suppression?.clearCustomLabel
+            ? suppression.terminalId.trim()
+            : "";
+          const currentLabels = state.terminalCustomLabelsByThreadKey[threadKey] ?? {};
+          let nextTerminalCustomLabelsByThreadKey =
+            terminalIdToClear.length > 0 && currentLabels[terminalIdToClear] !== undefined
+              ? Object.keys(currentLabels).length === 1
+                ? removeRecordEntry(state.terminalCustomLabelsByThreadKey, threadKey)
+                : {
+                    ...state.terminalCustomLabelsByThreadKey,
+                    [threadKey]: removeRecordEntry(currentLabels, terminalIdToClear),
+                  }
+              : state.terminalCustomLabelsByThreadKey;
+          if (preserveCustomLabelIds) {
+            const survivingIds = new Set([
+              ...selectThreadTerminalUiState(nextTerminalUiStateByThreadKey, threadRef).terminalIds,
+              ...preserveCustomLabelIds,
+            ]);
+            const labelsForThread = nextTerminalCustomLabelsByThreadKey[threadKey] ?? {};
+            const survivingLabels = Object.fromEntries(
+              Object.entries(labelsForThread).filter(([terminalId]) =>
+                survivingIds.has(terminalId),
+              ),
+            );
+            if (Object.keys(survivingLabels).length !== Object.keys(labelsForThread).length) {
+              nextTerminalCustomLabelsByThreadKey =
+                Object.keys(survivingLabels).length > 0
+                  ? {
+                      ...nextTerminalCustomLabelsByThreadKey,
+                      [threadKey]: survivingLabels,
+                    }
+                  : removeRecordEntry(nextTerminalCustomLabelsByThreadKey, threadKey);
+            }
+          }
           if (
             nextTerminalUiStateByThreadKey === state.terminalUiStateByThreadKey &&
-            nextSuppressedTerminalIdsByThreadKey === state.suppressedTerminalIdsByThreadKey
+            nextSuppressedTerminalIdsByThreadKey === state.suppressedTerminalIdsByThreadKey &&
+            nextTerminalCustomLabelsByThreadKey === state.terminalCustomLabelsByThreadKey
           ) {
             return state;
           }
           return {
             terminalUiStateByThreadKey: nextTerminalUiStateByThreadKey,
             suppressedTerminalIdsByThreadKey: nextSuppressedTerminalIdsByThreadKey,
+            terminalCustomLabelsByThreadKey: nextTerminalCustomLabelsByThreadKey,
           };
         });
       };
 
       return {
         terminalUiStateByThreadKey: {},
+        terminalCustomLabelsByThreadKey: {},
         suppressedTerminalIdsByThreadKey: {},
         setTerminalOpen: (threadRef, open) => {
           const terminalState = selectThreadTerminalUiState(
@@ -682,22 +773,56 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
           ),
         setActiveTerminal: (threadRef, terminalId) =>
           updateTerminal(threadRef, (state) => setThreadActiveTerminal(state, terminalId)),
+        setTerminalCustomLabel: (threadRef, terminalId, label) =>
+          set((state) => {
+            const normalizedTerminalId = terminalId.trim();
+            if (normalizedTerminalId.length === 0) return state;
+            const threadKey = terminalThreadKey(threadRef);
+            const currentLabels = state.terminalCustomLabelsByThreadKey[threadKey] ?? {};
+            const normalizedLabel = label?.trim().slice(0, 80) ?? "";
+            if (normalizedLabel.length > 0) {
+              if (currentLabels[normalizedTerminalId] === normalizedLabel) return state;
+              return {
+                terminalCustomLabelsByThreadKey: {
+                  ...state.terminalCustomLabelsByThreadKey,
+                  [threadKey]: { ...currentLabels, [normalizedTerminalId]: normalizedLabel },
+                },
+              };
+            }
+            if (currentLabels[normalizedTerminalId] === undefined) return state;
+            const { [normalizedTerminalId]: _removed, ...remainingLabels } = currentLabels;
+            return {
+              terminalCustomLabelsByThreadKey:
+                Object.keys(remainingLabels).length > 0
+                  ? {
+                      ...state.terminalCustomLabelsByThreadKey,
+                      [threadKey]: remainingLabels,
+                    }
+                  : removeRecordEntry(state.terminalCustomLabelsByThreadKey, threadKey),
+            };
+          }),
         closeTerminal: (threadRef, terminalId) =>
           updateTerminal(threadRef, (state) => closeThreadTerminal(state, terminalId), {
             terminalId,
             suppressed: true,
+            clearCustomLabel: true,
           }),
-        reconcileTerminalIds: (threadRef, nextIds) =>
-          updateTerminal(threadRef, (state, suppressedTerminalIds) => {
-            if (suppressedTerminalIds.length === 0) {
-              return reconcileThreadTerminalSessionIds(state, nextIds);
-            }
-            const suppressedIds = new Set(suppressedTerminalIds);
-            return reconcileThreadTerminalSessionIds(
-              state,
-              nextIds.filter((terminalId) => !suppressedIds.has(terminalId)),
-            );
-          }),
+        reconcileTerminalIds: (threadRef, nextIds, preserveCustomLabelIds = []) =>
+          updateTerminal(
+            threadRef,
+            (state, suppressedTerminalIds) => {
+              if (suppressedTerminalIds.length === 0) {
+                return reconcileThreadTerminalSessionIds(state, nextIds);
+              }
+              const suppressedIds = new Set(suppressedTerminalIds);
+              return reconcileThreadTerminalSessionIds(
+                state,
+                nextIds.filter((terminalId) => !suppressedIds.has(terminalId)),
+              );
+            },
+            undefined,
+            preserveCustomLabelIds,
+          ),
         clearTerminalUiState: (threadRef) =>
           set((state) => {
             const threadKey = terminalThreadKey(threadRef);
@@ -708,14 +833,20 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
             );
             const hadSuppressedTerminalIds =
               state.suppressedTerminalIdsByThreadKey[threadKey] !== undefined;
+            const hadCustomLabels = state.terminalCustomLabelsByThreadKey[threadKey] !== undefined;
             if (
               nextTerminalUiStateByThreadKey === state.terminalUiStateByThreadKey &&
-              !hadSuppressedTerminalIds
+              !hadSuppressedTerminalIds &&
+              !hadCustomLabels
             ) {
               return state;
             }
             return {
               terminalUiStateByThreadKey: nextTerminalUiStateByThreadKey,
+              terminalCustomLabelsByThreadKey: removeRecordEntry(
+                state.terminalCustomLabelsByThreadKey,
+                threadKey,
+              ),
               suppressedTerminalIdsByThreadKey: removeRecordEntry(
                 state.suppressedTerminalIdsByThreadKey,
                 threadKey,
@@ -728,12 +859,17 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
             const hadTerminalUiState = state.terminalUiStateByThreadKey[threadKey] !== undefined;
             const hadSuppressedTerminalIds =
               state.suppressedTerminalIdsByThreadKey[threadKey] !== undefined;
-            if (!hadTerminalUiState && !hadSuppressedTerminalIds) {
+            const hadCustomLabels = state.terminalCustomLabelsByThreadKey[threadKey] !== undefined;
+            if (!hadTerminalUiState && !hadSuppressedTerminalIds && !hadCustomLabels) {
               return state;
             }
             return {
               terminalUiStateByThreadKey: removeRecordEntry(
                 state.terminalUiStateByThreadKey,
+                threadKey,
+              ),
+              terminalCustomLabelsByThreadKey: removeRecordEntry(
+                state.terminalCustomLabelsByThreadKey,
                 threadKey,
               ),
               suppressedTerminalIdsByThreadKey: removeRecordEntry(
@@ -747,6 +883,7 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
             const orphanedIds = new Set(
               [
                 ...Object.keys(state.terminalUiStateByThreadKey),
+                ...Object.keys(state.terminalCustomLabelsByThreadKey),
                 ...Object.keys(state.suppressedTerminalIdsByThreadKey),
               ].filter((key) => !activeThreadKeys.has(key)),
             );
@@ -757,12 +894,17 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
             const nextSuppressedTerminalIdsByThreadKey = {
               ...state.suppressedTerminalIdsByThreadKey,
             };
+            const nextTerminalCustomLabelsByThreadKey = {
+              ...state.terminalCustomLabelsByThreadKey,
+            };
             for (const id of orphanedIds) {
               delete nextTerminalUiStateByThreadKey[id];
+              delete nextTerminalCustomLabelsByThreadKey[id];
               delete nextSuppressedTerminalIdsByThreadKey[id];
             }
             return {
               terminalUiStateByThreadKey: nextTerminalUiStateByThreadKey,
+              terminalCustomLabelsByThreadKey: nextTerminalCustomLabelsByThreadKey,
               suppressedTerminalIdsByThreadKey: nextSuppressedTerminalIdsByThreadKey,
             };
           }),
@@ -770,11 +912,12 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
     },
     {
       name: TERMINAL_UI_STATE_STORAGE_KEY,
-      version: 4,
+      version: 5,
       storage: createJSONStorage(createTerminalUiStateStorage),
       migrate: migratePersistedTerminalUiStateStoreState,
       partialize: (state) => ({
         terminalUiStateByThreadKey: state.terminalUiStateByThreadKey,
+        terminalCustomLabelsByThreadKey: state.terminalCustomLabelsByThreadKey,
       }),
     },
   ),

--- a/apps/web/src/terminalUiStateStore.ts
+++ b/apps/web/src/terminalUiStateStore.ts
@@ -802,7 +802,7 @@ export const useTerminalUiStateStore = create<TerminalUiStateStoreState>()(
             };
           }),
         closeTerminal: (threadRef, terminalId) =>
-          updateTerminal(threadRef, (state) => closeThreadTerminal(state, terminalId), {
+          updateTerminal(threadRef, (state) => closeThreadTerminal(state, terminalId.trim()), {
             terminalId,
             suppressed: true,
             clearCustomLabel: true,


### PR DESCRIPTION
## What changed

- Reworks the terminal drawer controls and multi-session sidebar while retaining split groups and resize behavior.
- Persists custom terminal names by scoped thread, prunes stale labels, and clears labels when terminals or threads disappear.
- Adds an explicit drawer hide path and keeps single-terminal sessions free of unnecessary sidebar chrome.


## Screenshots

_Direct parent on the left; this PR on the right. Same viewport and copied application state._

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/50b1c810-ad64-46d6-9887-66e0da5434dd" alt="Terminal drawer before" width="500"></td>
<td><img src="https://github.com/user-attachments/assets/a0f611e0-c7dc-42c7-9b2c-57510bb02b8c" alt="Terminal drawer after" width="500"></td>
</tr>
</table>
## Why

Terminal state and interaction changes need a focused review. This layer depends only on the shared chat header from #7153.

## Validation

- Terminal drawer tests
- Terminal UI store migration, naming, cleanup, reconciliation, and sidebar tests
- Affected-package typechecks
- Changed-file lint and formatting checks

## Stack order

1. #7153 workspace and navigation
2. #7147 Usage
3. #7148 Pull Requests
4. #7149 terminal, this PR
5. #7150 composer
6. #7151 tool lifecycle projection
7. #7152 tool activity UI

Built with GPT-5.6-sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persisted terminal UI state (migration v5) and server/client terminal ID reconciliation; behavior is covered by tests but wrong label pruning could affect multi-surface terminal UX.
> 
> **Overview**
> **Reworks the thread terminal drawer** with a resizable session sidebar, persisted per-terminal names, and a toolbar action to hide the drawer without closing sessions.
> 
> The multi-terminal sidebar moves to the right of the viewport with a drag handle (`useResizableWidth` + separate localStorage keys for drawer vs panel). Width is capped so the terminal area keeps a minimum usable width. Toolbar actions switch from popover hover buttons to compact icon tooltips; drawer mode adds **Hide** (wired from `ChatView` via `onHide`).
> 
> **Custom terminal labels** are stored in `terminalUiStateStore` (persist v5): rename via double-click or F2, with logic so unchanged automatic titles are not saved as custom names. Labels apply in the drawer list and in `ChatView` composer terminal chips. Closing a terminal or pruning during `reconcileTerminalIds` drops stale labels; reconciliation can pass **panel** terminal ids so right-panel sessions keep names when drawer state syncs from the server.
> 
> Single-terminal layout keeps a floating compact toolbar only (no sidebar chrome).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69bbbf1c65590d38f735e6c848cf2da954d54904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve terminal workspace controls with inline renaming, custom labels, and resizable sidebar
> - Adds inline terminal renaming (double-click or F2) in `ThreadTerminalDrawer`, persisting custom labels up to 80 chars in `terminalUiStateStore` (version bumped 4→5 with migration).
> - Introduces a resizable terminal sidebar with dynamic max-width clamping and per-context persisted widths; sidebar hides when only one terminal is open.
> - Adds `onHide` callback to `ThreadTerminalDrawer` and wires it through `ChatViewContent` so the drawer can request to be hidden.
> - Reworks `PullRequestDetailPanel` to prioritize conflict resolution in the primary action slot and adds a stacked-PR detection via `isStackedPullRequestBase` and a new `listRefs` query.
> - Adds `rightPanelUnavailableLabel` prop to `PanelLayoutControls` and ensures tooltip triggers remain interactive when toggles are disabled.
> - Removes `chromeVariant` prop from `PullRequestDetailPanel` and its callers; condensed state is now derived solely from scroll position.
> - Risk: `terminalUiStateStore` persistence version increment triggers migration for all existing users; label data not matching the new schema is silently dropped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 69bbbf1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->