### PR TITLE
fix(server): preserve tool lifecycle identity

### DIFF
--- a/apps/server/src/orchestration/ActivityPayloadProjection.test.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.test.ts
@@ -20,7 +20,7 @@ function activity(payload: Record<string, unknown>): OrchestrationThreadActivity
  * If slimming ever moves to an allowlist over the whole payload, these
  * assertions are the tripwire.
  */
-describe("projectActivityPayload agent-field survival", () => {
+describe("projectActivityPayload", () => {
   it("preserves tool attribution (agentId/parentToolUseId) through data slimming", () => {
     const projected = projectActivityPayload(
       activity({
@@ -95,6 +95,45 @@ describe("projectActivityPayload agent-field survival", () => {
     expect(acpData.rawOutput).toEqual({ content: "hello from acp" });
     expect(JSON.stringify(claude.payload).length).toBeLessThan(500);
     expect(JSON.stringify(acp.payload).length).toBeLessThan(500);
+  });
+
+  it("normalizes Claude and OpenCode command inputs before slimming provider data", () => {
+    const claude = projectActivityPayload(
+      activity({
+        itemType: "command_execution",
+        toolCallId: "claude-call-1",
+        data: {
+          toolName: "Bash",
+          input: { command: "vp test run" },
+          result: { content: "x".repeat(5_000) },
+        },
+      }),
+    );
+    const openCode = projectActivityPayload(
+      activity({
+        itemType: "command_execution",
+        toolCallId: "opencode-call-1",
+        data: {
+          tool: "bash",
+          state: {
+            status: "running",
+            input: { command: "vp lint" },
+            output: "x".repeat(5_000),
+          },
+        },
+      }),
+    );
+
+    expect(claude.payload).toMatchObject({
+      toolCallId: "claude-call-1",
+      data: { command: "vp test run" },
+    });
+    expect(openCode.payload).toMatchObject({
+      toolCallId: "opencode-call-1",
+      data: { command: "vp lint" },
+    });
+    expect(JSON.stringify(claude.payload).length).toBeLessThan(200);
+    expect(JSON.stringify(openCode.payload).length).toBeLessThan(200);
   });
 
   it("slims Codex-shaped mcp_tool_call items to rendered fields plus a result summary", () => {

--- a/apps/server/src/orchestration/ActivityPayloadProjection.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.ts
@@ -125,6 +125,24 @@ function projectCommandData(data: Record<string, unknown>): Record<string, unkno
   return Object.keys(projectedItem).length > 0 ? projectedItem : undefined;
 }
 
+function projectCommandValue(data: Record<string, unknown>): unknown {
+  if (data.command !== undefined) {
+    return data.command;
+  }
+
+  const input = asRecord(data.input);
+  if (input?.command !== undefined) {
+    return input.command;
+  }
+
+  const stateInput = asRecord(asRecord(data.state)?.input);
+  if (stateInput?.command !== undefined) {
+    return stateInput.command;
+  }
+
+  return undefined;
+}
+
 function summarizeToolTextOutput(value: string): string | null {
   const lines: string[] = [];
   for (const rawLine of value.split(/\r?\n/u)) {
@@ -339,8 +357,9 @@ export function projectActivityPayload(
   if (item) {
     projectedData.item = item;
   }
-  if ("command" in data) {
-    projectedData.command = data.command;
+  const command = projectCommandValue(data);
+  if (command !== undefined) {
+    projectedData.command = command;
   }
 
   const changedFiles: string[] = [];
@@ -418,12 +437,10 @@ function dropStaleContextWindowActivities(
 }
 
 /**
- * Identity both clients use to fold a tool lifecycle row into the call it
- * belongs to (`deriveToolLifecycleCollapseKey` in web's `session-logic` and
- * mobile's `threadActivity`): an explicit `data.toolCallId` when the adapter
- * emits one, otherwise the itemType/title/detail triple. Returns null for rows
- * with no identity at all — those never collapse on the client either, so they
- * must not be dropped here.
+ * Identity used to retain only the newest lifecycle row for each call in a
+ * thread snapshot. Prefer the runtime item id, then the legacy nested id, and
+ * finally the itemType/title/detail triple. Rows without any identity remain
+ * untouched.
  */
 function toolLifecycleIdentity(activity: OrchestrationThreadActivity): string | null {
   const payload = asRecord(activity.payload);
@@ -431,7 +448,8 @@ function toolLifecycleIdentity(activity: OrchestrationThreadActivity): string | 
     return null;
   }
 
-  const toolCallId = asTrimmedString(asRecord(payload.data)?.toolCallId);
+  const toolCallId =
+    asTrimmedString(payload.toolCallId) ?? asTrimmedString(asRecord(payload.data)?.toolCallId);
   if (toolCallId) {
     return `id:${toolCallId}`;
   }

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -2815,11 +2815,16 @@ describe("ProviderRuntimeIngestion", () => {
       createdAt: now,
       threadId: asThreadId("thread-1"),
       turnId: asTurnId("turn-9"),
+      itemId: asItemId("tool-call-9"),
       payload: {
         itemType: "command_execution",
-        status: "in_progress",
-        title: "Read file",
-        detail: "/tmp/file.ts",
+        status: "inProgress",
+        title: "Command run",
+        detail: "Bash: vp test run",
+        data: {
+          toolName: "Bash",
+          input: { command: "vp test run" },
+        },
       },
     });
 
@@ -2834,11 +2839,20 @@ describe("ProviderRuntimeIngestion", () => {
     );
 
     expect(thread.session?.status).toBe("ready");
-    expect(
-      thread.activities.some(
-        (activity: ProviderRuntimeTestActivity) => activity.kind === "tool.started",
-      ),
-    ).toBe(true);
+    const activity = thread.activities.find(
+      (entry: ProviderRuntimeTestActivity) => entry.kind === "tool.started",
+    );
+    const payload = activity?.payload as Record<string, unknown> | undefined;
+    expect(payload).toMatchObject({
+      itemType: "command_execution",
+      toolCallId: "tool-call-9",
+      status: "inProgress",
+      detail: "Bash: vp test run",
+      data: {
+        toolName: "Bash",
+        input: { command: "vp test run" },
+      },
+    });
   });
 
   it("consumes P1 runtime events into thread metadata, diff checkpoints, and activities", async () => {
@@ -2956,6 +2970,7 @@ describe("ProviderRuntimeIngestion", () => {
     expect(toolUpdate?.kind).toBe("tool.updated");
     expect(toolUpdatePayload?.itemType).toBe("command_execution");
     expect(toolUpdatePayload?.status).toBe("in_progress");
+    expect(toolUpdatePayload?.toolCallId).toBe("item-p1-tool");
 
     const warning = thread.activities.find(
       (activity: ProviderRuntimeTestActivity) => activity.id === "evt-runtime-warning",

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -803,6 +803,7 @@ export function runtimeEventToActivities(
           summary: event.payload.title ?? "Tool updated",
           payload: {
             itemType: event.payload.itemType,
+            ...(event.itemId !== undefined ? { toolCallId: event.itemId } : {}),
             ...(event.payload.status ? { status: event.payload.status } : {}),
             ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
             ...(event.payload.data !== undefined ? { data: event.payload.data } : {}),
@@ -830,6 +831,8 @@ export function runtimeEventToActivities(
           summary: event.payload.title ?? "Tool",
           payload: {
             itemType: event.payload.itemType,
+            ...(event.itemId !== undefined ? { toolCallId: event.itemId } : {}),
+            ...(event.payload.status ? { status: event.payload.status } : {}),
             ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
             ...(event.payload.data !== undefined ? { data: event.payload.data } : {}),
             ...(event.payload.agentId ? { agentId: event.payload.agentId } : {}),
@@ -856,7 +859,10 @@ export function runtimeEventToActivities(
           summary: `${event.payload.title ?? "Tool"} started`,
           payload: {
             itemType: event.payload.itemType,
+            ...(event.itemId !== undefined ? { toolCallId: event.itemId } : {}),
+            ...(event.payload.status ? { status: event.payload.status } : {}),
             ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
+            ...(event.payload.data !== undefined ? { data: event.payload.data } : {}),
             ...(event.payload.agentId ? { agentId: event.payload.agentId } : {}),
             ...(event.payload.parentToolUseId
               ? { parentToolUseId: event.payload.parentToolUseId }


### PR DESCRIPTION
## What changed

- Carries provider item IDs into top-level `toolCallId` lifecycle identity for started, updated, and completed tool events.
- Preserves start status and provider command data so later completion events can be folded into the correct activity.
- Normalizes direct, Claude, and OpenCode command shapes during activity projection.

## Screenshots

Not applicable. This is a server-only lifecycle projection change; its visible web consumer is demonstrated in #7152.

## Why

This is the sensitive server layer that was hard to approve inside the original UI PR. It is intentionally above every independent UI layer. The stack can merge through #7150 without taking this change.

## Review notes

- Started-event provider data is newly retained in persisted activity payloads.
- No contracts change is required.
- Mobile still ignores `tool.started`; the new web behavior is implemented in #7152.

## Validation

- Activity payload projection tests
- Provider runtime ingestion tests
- Affected-package typechecks
- Changed-file lint and formatting checks

## Stack order

1. #7153 workspace and navigation
2. #7147 Usage
3. #7148 Pull Requests
4. #7149 terminal
5. #7150 composer
6. #7151 tool lifecycle projection, this PR
7. #7152 tool activity UI

Built with GPT-5.6-sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration activity identity and persisted tool.started payloads; deduplication keys shift for in-flight sessions at deploy time, though behavior is covered by projection and ingestion tests.
> 
> **Overview**
> **Propagates provider item IDs into persisted tool activities** so started, updated, and completed lifecycle rows share a stable top-level `toolCallId`. `toolLifecycleIdentity` now prefers that field when deduplicating to the newest row per call.
> 
> **Enriches `tool.started` payloads** to include provider `status` and `data` (aligned with update/complete), so clients can fold in-flight tool state into the same activity.
> 
> **Normalizes command strings during activity projection** via `projectCommandValue`, pulling commands from direct `data.command`, Claude-style `data.input.command`, or OpenCode-style `data.state.input.command` before slimming provider blobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 102ece2dee9ba6c17c412337f53da5ed7ec5f1a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `toolLifecycleIdentity` to prefer top-level `toolCallId`
> - `toolLifecycleIdentity` in [ActivityPayloadProjection.ts](https://github.com/pingdotgg/t3code/pull/7151/files#diff-debcaf6e868575f9d95bb6918b9983c3a8929d664039039b54e9e1c7ea3b4130) now checks `payload.toolCallId` before falling back to nested `data.toolCallId`; `projectActivityPayload` uses a new `projectCommandValue` helper to normalize command fields from Claude and OpenCode payload shapes. Tool activity payloads from `runtimeEventToActivities` in [ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/7151/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7) now include `toolCallId`, `status`, and `data` when present.
> - Composer UI is redesigned across many components in `apps/web/src/components/chat/` to use attached "drawer" styling with glass surfaces, shoulder tabs, and a new `Button` size `"micro"`. New `ComposerTasksBadge` and `ComposerTasksDrawer` show per-turn task progress; `ComposerStashBadge` and `ComposerStashMenu` gain inline placement and outside-click dismissal.
> - `addPlanStepDurations` in [session-logic.ts](https://github.com/pingdotgg/t3code/pull/7151/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) computes `durationMs` on completed plan steps by scanning `plan.update` transitions; `deriveActivePlanState` and `deriveTurnPlans` now return plans with per-step durations.
> - `resolveProviderSkillSourceKind` in [providerSkills.ts](https://github.com/pingdotgg/t3code/pull/7151/files#diff-476dddad7957a4fde40db8096524533f59b357b62c8d01c6d9f05f2c0b12c63c) replaces `formatProviderSkillInstallSource`, returning a normalized union (`'app'|'repo'|'project'|'personal'|'system'|'other'`); callers in web and mobile use it for skill icons.
> - Risk: `toolLifecycleIdentity` resolution change may alter which activity row is retained for a given tool call in snapshots — verify dedup logic in [ActivityPayloadProjection.ts](https://github.com/pingdotgg/t3code/pull/7151/files#diff-debcaf6e868575f9d95bb6918b9983c3a8929d664039039b54e9e1c7ea3b4130) handles top-level `toolCallId` collisions. Composer CSS in [index.css](https://github.com/pingdotgg/t3code/pull/7151/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) introduces new glass-surface rules and removes `background: transparent` from `code`, which may affect existing code element rendering.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9df356b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->