### PR TITLE
fix(web): refresh pull request diff after updates

### DIFF
--- a/apps/server/src/pullRequest/BitbucketPullRequestProvider.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestProvider.ts
@@ -172,6 +172,9 @@ export const make = Effect.gen(function* () {
             deletions: diffStat.deletions,
             changedFiles: diffStat.changedFiles,
             body: pullRequest.body,
+            ...(pullRequest.diffRevision === undefined
+              ? {}
+              : { diffRevision: pullRequest.diffRevision }),
             mergedAt: pullRequest.state === "merged" ? pullRequest.updatedAt : null,
             closedAt: pullRequest.state === "closed" ? pullRequest.updatedAt : null,
             reviewers: pullRequest.reviewers,

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
@@ -2093,7 +2093,7 @@ layer("GitHubPullRequestCli.layer", (it) => {
       expect(detail.body).toBe("Core body");
       expect(activity.author?.login).toBe("octocat");
       expect(callAt(0).args.at(-1)).toBe(
-        "number,title,url,author,headRefName,baseRefName,state,isDraft,mergeable,reviewDecision,additions,deletions,createdAt,updatedAt,mergedAt,reviewRequests,labels,statusCheckRollup,body,changedFiles,closedAt,headRepositoryOwner,autoMergeRequest",
+        "number,title,url,author,headRefName,baseRefName,state,isDraft,mergeable,reviewDecision,additions,deletions,createdAt,updatedAt,mergedAt,reviewRequests,labels,statusCheckRollup,body,changedFiles,closedAt,headRepositoryOwner,baseRefOid,headRefOid,autoMergeRequest",
       );
       expect(callAt(1).args.at(-1)).toBe("author,comments,reviews,commits");
     }),

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
@@ -2067,6 +2067,9 @@ layer("GitHubPullRequestCli.layer", (it) => {
         ),
       );
       mockedExecute.mockReturnValueOnce(
+        Effect.succeed(output('{"baseRefOid":"base-oid","headRefOid":"head-oid"}')),
+      );
+      mockedExecute.mockReturnValueOnce(
         Effect.succeed(
           output(
             // @effect-diagnostics-next-line preferSchemaOverJson:off
@@ -2093,9 +2096,11 @@ layer("GitHubPullRequestCli.layer", (it) => {
       expect(detail.body).toBe("Core body");
       expect(activity.author?.login).toBe("octocat");
       expect(callAt(0).args.at(-1)).toBe(
-        "number,title,url,author,headRefName,baseRefName,state,isDraft,mergeable,reviewDecision,additions,deletions,createdAt,updatedAt,mergedAt,reviewRequests,labels,statusCheckRollup,body,changedFiles,closedAt,headRepositoryOwner,baseRefOid,headRefOid,autoMergeRequest",
+        "number,title,url,author,headRefName,baseRefName,state,isDraft,mergeable,reviewDecision,additions,deletions,createdAt,updatedAt,mergedAt,reviewRequests,labels,statusCheckRollup,body,changedFiles,closedAt,headRepositoryOwner,autoMergeRequest",
       );
-      expect(callAt(1).args.at(-1)).toBe("author,comments,reviews,commits");
+      expect(callAt(1).args.join(" ")).toContain("repos/acme/web/pulls/7");
+      expect(detail.diffRevision).toEqual({ baseOid: "base-oid", headOid: "head-oid" });
+      expect(callAt(2).args.at(-1)).toBe("author,comments,reviews,commits");
     }),
   );
 

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.ts
@@ -33,6 +33,7 @@ import {
   decodeActorAvatarsJson,
   decodePullRequestActivityJson,
   decodePullRequestDetailJson,
+  decodePullRequestDiffRevisionJson,
   decodePullRequestFilesJson,
   decodePullRequestListJson,
   decodePullRequestNodeIdJson,
@@ -1342,16 +1343,42 @@ export const make = Effect.gen(function* () {
         .pipe(
           Effect.flatMap((result) => {
             const decoded = decodePullRequestDetailJson(result.stdout.trim());
-            return Result.isSuccess(decoded)
-              ? Effect.succeed(decoded.success)
-              : Effect.fail(
-                  new GitHubPullRequestReadError({
-                    command: "gh",
-                    cwd: input.cwd,
-                    operation: "getPullRequestDetail",
-                    cause: decoded.failure,
-                  }),
-                );
+            if (!Result.isSuccess(decoded)) {
+              return Effect.fail(
+                new GitHubPullRequestReadError({
+                  command: "gh",
+                  cwd: input.cwd,
+                  operation: "getPullRequestDetail",
+                  cause: decoded.failure,
+                }),
+              );
+            }
+            const { owner, name } = parseRepositorySelector(input.repository);
+            return github
+              .execute({
+                cwd: input.cwd,
+                args: [
+                  "api",
+                  "--hostname",
+                  input.host,
+                  `repos/${owner}/${name}/pulls/${input.number}`,
+                  "--jq",
+                  "{baseRefOid: .base.sha, headRefOid: .head.sha}",
+                ],
+              })
+              .pipe(
+                Effect.flatMap((revisionResult) => {
+                  const revision = decodePullRequestDiffRevisionJson(revisionResult.stdout.trim());
+                  return Result.isSuccess(revision)
+                    ? Effect.succeed(
+                        revision.success === null
+                          ? decoded.success
+                          : { ...decoded.success, diffRevision: revision.success },
+                      )
+                    : Effect.succeed(decoded.success);
+                }),
+                Effect.orElseSucceed(() => decoded.success),
+              );
           }),
         ),
 

--- a/apps/server/src/pullRequest/PullRequestProvider.ts
+++ b/apps/server/src/pullRequest/PullRequestProvider.ts
@@ -160,6 +160,8 @@ export interface ProviderChangeRequestDetail extends ProviderChangeRequest {
   readonly checks: ReadonlyArray<PullRequestCheck>;
   readonly mergeCapabilities: PullRequestMergeCapabilities;
   readonly viewerPermissions: PullRequestViewerPermissions;
+  /** Immutable endpoints of the aggregate diff, when the host reports both. */
+  readonly diffRevision?: { readonly baseOid: string; readonly headOid: string };
   /** Absent from a host that cannot compare the branch with its base, which is most of them. */
   readonly baseComparison?: PullRequestBaseComparison;
   readonly behindBy?: number;

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -2792,6 +2792,167 @@ it.effect(
     }),
 );
 
+it.effect("scopes diff invalidation while full invalidation and mutations refresh every view", () =>
+  Effect.gen(function* () {
+    let detailCalls = 0;
+    let activityCalls = 0;
+    let aggregateDiffCalls = 0;
+    let commitDiffCalls = 0;
+    const reference = { projectId: "p1" as ProjectId, repository: "acme/web", number: 1 };
+    const service = yield* makeService({
+      projects: [project({ id: "p1", title: "web", workspaceRoot: "/a", repository: "acme/web" })],
+      providers: [
+        fakeProvider("github", {
+          getChangeRequest: () => {
+            detailCalls += 1;
+            return Effect.succeed({
+              ...changeRequest(1, "2026-07-02T00:00:00Z"),
+              body: "detail",
+              changedFiles: 1,
+              diffRevision: { baseOid: "base-oid", headOid: "head-oid" },
+              mergedAt: null,
+              closedAt: null,
+              reviewers: [],
+              checks: [],
+              mergeCapabilities: { merge: true, squash: true, rebase: true },
+              viewerPermissions: {
+                actions: ["merge"],
+                comment: true,
+                resolve: true,
+                verdicts: ["comment", "approve", "request-changes"],
+                requestReviewers: true,
+              },
+            });
+          },
+          getChangeRequestActivity: () => {
+            activityCalls += 1;
+            return Effect.succeed({
+              comments: [],
+              commentCount: 0,
+              commentsTruncated: false,
+              reviewThreads: [],
+              commits: [],
+            });
+          },
+          getDiff: (input) => {
+            const commitScoped = input.commit !== undefined;
+            if (commitScoped) commitDiffCalls += 1;
+            else aggregateDiffCalls += 1;
+            return Effect.succeed({
+              patch: commitScoped
+                ? `commit-diff-${commitDiffCalls}`
+                : `aggregate-diff-${aggregateDiffCalls}`,
+              truncated: false,
+              nextCursor: null,
+            });
+          },
+        }),
+      ],
+    });
+
+    yield* Effect.all([
+      service.detail(reference),
+      service.activity(reference),
+      service.diff(reference),
+      service.diff({ ...reference, commit: "commit-oid" }),
+    ]);
+    yield* service.invalidate({ reference, resource: "diff" });
+    const [detail, activity, diff, commitDiff] = yield* Effect.all([
+      service.detail(reference),
+      service.activity(reference),
+      service.diff(reference),
+      service.diff({ ...reference, commit: "commit-oid" }),
+    ]);
+
+    assert.strictEqual(detail.body, "detail");
+    assert.deepStrictEqual(detail.diffRevision, { baseOid: "base-oid", headOid: "head-oid" });
+    assert.deepStrictEqual(activity.comments, []);
+    assert.strictEqual(diff.patch, "aggregate-diff-2");
+    assert.strictEqual(commitDiff.patch, "commit-diff-1");
+    assert.deepStrictEqual(
+      { detailCalls, activityCalls, aggregateDiffCalls, commitDiffCalls },
+      { detailCalls: 1, activityCalls: 1, aggregateDiffCalls: 2, commitDiffCalls: 1 },
+    );
+
+    yield* service.invalidate({ reference });
+    yield* Effect.all([
+      service.detail(reference),
+      service.activity(reference),
+      service.diff(reference),
+      service.diff({ ...reference, commit: "commit-oid" }),
+    ]);
+    assert.deepStrictEqual(
+      { detailCalls, activityCalls, aggregateDiffCalls, commitDiffCalls },
+      { detailCalls: 2, activityCalls: 2, aggregateDiffCalls: 3, commitDiffCalls: 2 },
+    );
+
+    yield* service.comment({ ...reference, body: "freshen every cached view" });
+    yield* Effect.all([
+      service.detail(reference),
+      service.activity(reference),
+      service.diff(reference),
+      service.diff({ ...reference, commit: "commit-oid" }),
+    ]);
+    assert.deepStrictEqual(
+      { detailCalls, activityCalls, aggregateDiffCalls, commitDiffCalls },
+      { detailCalls: 3, activityCalls: 3, aggregateDiffCalls: 4, commitDiffCalls: 3 },
+    );
+  }),
+);
+
+it.effect("does not revive aggregate diff pages after their scoped epoch is evicted", () =>
+  Effect.gen(function* () {
+    const calls = new Map<string, number>();
+    const reference = { projectId: "p1" as ProjectId, repository: "acme/web", number: 1 };
+    const service = yield* makeService({
+      projects: [project({ id: "p1", title: "web", workspaceRoot: "/a", repository: "acme/web" })],
+      providers: [
+        fakeProvider("github", {
+          getDiff: (input) => {
+            const page = input.cursor ?? "first";
+            const call = (calls.get(page) ?? 0) + 1;
+            calls.set(page, call);
+            return Effect.succeed({
+              patch: `${page}-${call}`,
+              truncated: false,
+              nextCursor: null,
+            });
+          },
+        }),
+      ],
+    });
+    const readPages = () =>
+      Effect.all([service.diff(reference), service.diff({ ...reference, cursor: "next-page" })]);
+
+    const initial = yield* readPages();
+    assert.deepStrictEqual(
+      initial.map(({ patch }) => patch),
+      ["first-1", "next-page-1"],
+    );
+
+    yield* service.invalidate({ reference, resource: "diff" });
+    const refreshed = yield* readPages();
+    assert.deepStrictEqual(
+      refreshed.map(({ patch }) => patch),
+      ["first-2", "next-page-2"],
+    );
+
+    // Fill the bounded epoch map past its capacity, evicting `reference`. Its new fallback epoch
+    // must differ from both epochs whose first and continuation pages remain in the diff cache.
+    yield* Effect.forEach(
+      Array.from({ length: 2_048 }, (_, index) => ({ ...reference, number: index + 2 })),
+      (other) => service.invalidate({ reference: other, resource: "diff" }),
+      { discard: true },
+    );
+
+    const afterEviction = yield* readPages();
+    assert.deepStrictEqual(
+      afterEviction.map(({ patch }) => patch),
+      ["first-3", "next-page-3"],
+    );
+  }),
+);
+
 it.effect("carries an armed auto-merge through to the detail, and silence as silence", () =>
   Effect.gen(function* () {
     const detailWith = (autoMergeEnabled: boolean | undefined) =>

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -1183,6 +1183,9 @@ export const make = Effect.gen(function* () {
               checks: changeRequest.checks,
               mergeCapabilities: changeRequest.mergeCapabilities,
               viewerPermissions: changeRequest.viewerPermissions,
+              ...(changeRequest.diffRevision === undefined
+                ? {}
+                : { diffRevision: changeRequest.diffRevision }),
               ...(viewer === null || viewer.trim().length === 0 ? {} : { viewer }),
               ...(changeRequest.baseComparison === undefined
                 ? {}
@@ -1864,22 +1867,37 @@ export const make = Effect.gen(function* () {
 
   // Epochs are the invalidation mechanism: a key carries its scope's epoch, so bumping the
   // epoch strands every entry made under the old one — no enumerating a cache whose keys
-  // (cursors, commits) nothing holds a list of. The counter is shared and monotonic so a
-  // scope re-entering `refEpochs` after eviction can never mint a key an old entry still has.
+  // (cursors, commits) nothing holds a list of. Each bounded scope map advances its fallback
+  // when it evicts: an evicted scope can therefore never fall back to an old cache key.
   let epochCounter = 0;
   let listingsEpoch = 0;
-  const refEpochs = new Map<string, number>();
   const REF_EPOCH_CAPACITY = 2_048;
   const refScope = (ref: PullRequestRef) => `${ref.projectId} ${ref.repository} ${ref.number}`;
-  const refEpoch = (ref: PullRequestRef) => refEpochs.get(refScope(ref)) ?? 0;
-  const bumpRefEpoch = (ref: PullRequestRef) => {
-    const scope = refScope(ref);
-    if (!refEpochs.has(scope) && refEpochs.size >= REF_EPOCH_CAPACITY) {
-      const oldest = refEpochs.keys().next().value;
-      if (oldest !== undefined) refEpochs.delete(oldest);
-    }
-    refEpochs.set(scope, ++epochCounter);
+  const makeScopedEpochs = () => {
+    let fallback = 0;
+    const epochs = new Map<string, number>();
+    return {
+      get: (ref: PullRequestRef) => epochs.get(refScope(ref)) ?? fallback,
+      bump: (ref: PullRequestRef) => {
+        const scope = refScope(ref);
+        if (!epochs.has(scope) && epochs.size >= REF_EPOCH_CAPACITY) {
+          const oldest = epochs.keys().next().value;
+          if (oldest !== undefined) {
+            epochs.delete(oldest);
+            fallback = ++epochCounter;
+          }
+        }
+        epochs.set(scope, ++epochCounter);
+      },
+    };
   };
+  const refEpochs = makeScopedEpochs();
+  const aggregateDiffEpochs = makeScopedEpochs();
+  const refEpoch = (ref: PullRequestRef) => refEpochs.get(ref);
+  const aggregateDiffEpoch = (ref: PullRequestRef) => aggregateDiffEpochs.get(ref);
+  const bumpAggregateDiffEpoch = (ref: PullRequestRef) => aggregateDiffEpochs.bump(ref);
+  // Aggregate keys already carry this ref-wide epoch, so a full invalidation needs one bump.
+  const bumpRefEpoch = (ref: PullRequestRef) => refEpochs.bump(ref);
 
   /** The positional filter slot of a cache key, back as the record `listUncached` takes. */
   const filtersOfKey = (
@@ -2019,7 +2037,8 @@ export const make = Effect.gen(function* () {
 
   const diffCache = yield* Cache.makeWith(
     (key: string) => {
-      const [, projectId, repository, number, cursor, commit] = JSON.parse(key) as [
+      const [, , projectId, repository, number, cursor, commit] = JSON.parse(key) as [
+        number,
         number,
         string,
         string,
@@ -2039,7 +2058,7 @@ export const make = Effect.gen(function* () {
       capacity: DIFF_CACHE_CAPACITY,
       timeToLive: (exit, key) => {
         if (!Exit.isSuccess(exit)) return Duration.zero;
-        const commit = (JSON.parse(key) as ReadonlyArray<unknown>)[5];
+        const commit = (JSON.parse(key) as ReadonlyArray<unknown>)[6];
         return commit === null ? DIFF_CACHE_TTL : COMMIT_DIFF_CACHE_TTL;
       },
     },
@@ -2049,13 +2068,16 @@ export const make = Effect.gen(function* () {
     DIFF_CACHE_CAPACITY,
   );
   const diff: PullRequestService["Service"]["diff"] = (input) => {
+    const commit = input.commit ?? null;
     const key = JSON.stringify([
       refEpoch(input),
+      // A named commit is immutable. Only the aggregate diff follows the branch comparison epoch.
+      commit === null ? aggregateDiffEpoch(input) : 0,
       input.projectId,
       input.repository,
       input.number,
       input.cursor ?? null,
-      input.commit ?? null,
+      commit,
     ]);
     return staleDiff(key, Cache.get(diffCache, key));
   };
@@ -2100,6 +2122,10 @@ export const make = Effect.gen(function* () {
         // A whole-workspace refresh is the reader asking to be re-answered from the hosts,
         // and that includes who the hosts say they are.
         viewersByHost.clear();
+        return;
+      }
+      if (input.resource === "diff") {
+        bumpAggregateDiffEpoch(input.reference);
         return;
       }
       bumpRefEpoch(input.reference);

--- a/apps/server/src/pullRequest/bitbucketPullRequestJson.test.ts
+++ b/apps/server/src/pullRequest/bitbucketPullRequestJson.test.ts
@@ -24,8 +24,8 @@ function pullRequest(overrides: Record<string, unknown> = {}): Record<string, un
     created_on: "2026-06-16T05:04:32.258456+00:00",
     updated_on: "2026-06-16T05:04:33.750542+00:00",
     author: { display_name: "Bilal Hassan", nickname: "bilal", type: "user" },
-    source: { branch: { name: "feat/page" } },
-    destination: { branch: { name: "master" } },
+    source: { branch: { name: "feat/page" }, commit: { hash: "head-oid" } },
+    destination: { branch: { name: "master" }, commit: { hash: "base-oid" } },
     links: { html: { href: "https://bitbucket.org/acme/web/pull-requests/897" } },
     ...overrides,
   };
@@ -105,6 +105,28 @@ describe("decodePullRequestPageJson", () => {
 });
 
 describe("decodePullRequestJson", () => {
+  it("carries the immutable diff endpoints", () => {
+    expect(
+      expectSuccess(decodePullRequestJson(JSON.stringify(pullRequest()))).diffRevision,
+    ).toEqual({ baseOid: "base-oid", headOid: "head-oid" });
+  });
+
+  it("keeps a usable pull request when immutable diff endpoints are null or partial", () => {
+    const nullCommit = expectSuccess(
+      decodePullRequestJson(
+        JSON.stringify(pullRequest({ source: { branch: { name: "feat/page" }, commit: null } })),
+      ),
+    );
+    const partialCommit = expectSuccess(
+      decodePullRequestJson(
+        JSON.stringify(pullRequest({ source: { branch: { name: "feat/page" }, commit: {} } })),
+      ),
+    );
+
+    expect(nullCommit.diffRevision).toBeUndefined();
+    expect(partialCommit.diffRevision).toBeUndefined();
+  });
+
   it("reads reviewers as review requests", () => {
     const decoded = expectSuccess(
       decodePullRequestJson(

--- a/apps/server/src/pullRequest/bitbucketPullRequestJson.ts
+++ b/apps/server/src/pullRequest/bitbucketPullRequestJson.ts
@@ -52,6 +52,9 @@ const RawUserSchema = Schema.Struct({
  */
 const RawBranchSchema = Schema.Struct({
   branch: Schema.Struct({ name: TrimmedNonEmptyString }),
+  commit: Schema.optional(
+    Schema.NullOr(Schema.Struct({ hash: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)) })),
+  ),
 });
 
 const RawLinkSchema = Schema.Struct({ href: Schema.optional(Schema.String) });
@@ -178,6 +181,7 @@ export interface BitbucketPullRequest {
   readonly author: PullRequestActor | null;
   readonly headBranch: string;
   readonly baseBranch: string;
+  readonly diffRevision?: { readonly baseOid: string; readonly headOid: string };
   readonly state: PullRequestState;
   readonly isDraft: boolean;
   /**
@@ -285,6 +289,8 @@ function toPullRequest(raw: Schema.Schema.Type<typeof RawPullRequestSchema>): Bi
     const actor = toActor(reviewer);
     return actor === null ? [] : [actor];
   });
+  const baseOid = raw.destination.commit?.hash ?? null;
+  const headOid = raw.source.commit?.hash ?? null;
   return {
     number: raw.id,
     title: raw.title,
@@ -292,6 +298,7 @@ function toPullRequest(raw: Schema.Schema.Type<typeof RawPullRequestSchema>): Bi
     author: toActor(raw.author),
     headBranch: raw.source.branch.name,
     baseBranch: raw.destination.branch.name,
+    ...(baseOid === null || headOid === null ? {} : { diffRevision: { baseOid, headOid } }),
     state: toState(raw),
     isDraft: raw.draft ?? false,
     mergeability: "unknown",

--- a/apps/server/src/pullRequest/gitHubPullRequestJson.test.ts
+++ b/apps/server/src/pullRequest/gitHubPullRequestJson.test.ts
@@ -191,6 +191,8 @@ describe("pull request detail decoding", () => {
     createdAt: "2026-07-01T00:00:00Z",
     updatedAt: "2026-07-05T00:00:00Z",
     body: "Body",
+    baseRefOid: "base-oid",
+    headRefOid: "head-oid",
     statusCheckRollup: [
       { __typename: "CheckRun", name: "build", status: "IN_PROGRESS" },
       { __typename: "CheckRun", name: "test", status: "COMPLETED", conclusion: "FAILURE" },
@@ -221,6 +223,26 @@ describe("pull request detail decoding", () => {
       ["test", "failure"],
       ["ci/legacy", "success"],
     ]);
+  });
+
+  it("carries the immutable diff endpoints", () => {
+    expect(expectSuccess(decodePullRequestDetailJson(detailJson)).diffRevision).toEqual({
+      baseOid: "base-oid",
+      headOid: "head-oid",
+    });
+  });
+
+  it("keeps usable detail when immutable diff endpoints are null or partial", () => {
+    const raw = JSON.parse(detailJson) as Record<string, unknown>;
+    const withoutHead = { ...raw, headRefOid: undefined };
+
+    expect(
+      expectSuccess(decodePullRequestDetailJson(JSON.stringify({ ...raw, baseRefOid: null })))
+        .diffRevision,
+    ).toBeUndefined();
+    expect(
+      expectSuccess(decodePullRequestDetailJson(JSON.stringify(withoutHead))).diffRevision,
+    ).toBeUndefined();
   });
 
   it("reads an auto-merge request as armed, its null as off and its absence as neither", () => {

--- a/apps/server/src/pullRequest/gitHubPullRequestJson.ts
+++ b/apps/server/src/pullRequest/gitHubPullRequestJson.ts
@@ -359,6 +359,8 @@ const RawCommitSchema = Schema.Struct({
 
 const RawDetailSchema = Schema.Struct({
   ...RawListItemSchema.fields,
+  baseRefOid: Schema.optional(Schema.NullOr(Schema.String)),
+  headRefOid: Schema.optional(Schema.NullOr(Schema.String)),
   /** Names the fork a pull request came from, which is what qualifies its head ref. */
   headRepositoryOwner: Schema.optional(Schema.NullOr(Schema.Struct({ login: Schema.String }))),
   body: Schema.optional(Schema.String),
@@ -599,7 +601,7 @@ export function decodeActorAvatarsJson(
 export const PULL_REQUEST_LIST_JSON_FIELDS =
   "number,title,url,author,headRefName,baseRefName,state,isDraft,mergeable,reviewDecision,additions,deletions,createdAt,updatedAt,mergedAt,reviewRequests,labels,statusCheckRollup";
 
-export const PULL_REQUEST_DETAIL_JSON_FIELDS = `${PULL_REQUEST_LIST_JSON_FIELDS},body,changedFiles,closedAt,headRepositoryOwner,autoMergeRequest`;
+export const PULL_REQUEST_DETAIL_JSON_FIELDS = `${PULL_REQUEST_LIST_JSON_FIELDS},body,changedFiles,closedAt,headRepositoryOwner,baseRefOid,headRefOid,autoMergeRequest`;
 export const PULL_REQUEST_ACTIVITY_JSON_FIELDS = "author,comments,reviews,commits";
 
 /** GitHub's own ceiling on a connection page, which is what both thread reads ask for. */
@@ -1023,6 +1025,7 @@ export interface GitHubPullRequestDetail extends GitHubPullRequestListItem {
   readonly mergedAt: string | null;
   readonly closedAt: string | null;
   readonly checks: ReadonlyArray<PullRequestCheck>;
+  readonly diffRevision?: { readonly baseOid: string; readonly headOid: string };
   /** Absent where `gh` did not answer for auto-merge at all, which is not the same as off. */
   readonly autoMergeEnabled?: boolean;
 }
@@ -1361,6 +1364,8 @@ function toListItem(raw: Schema.Schema.Type<typeof RawListItemSchema>): GitHubPu
 }
 
 function toDetail(raw: Schema.Schema.Type<typeof RawDetailSchema>): GitHubPullRequestDetail {
+  const baseOid = trimmed(raw.baseRefOid);
+  const headOid = trimmed(raw.headRefOid);
   return {
     ...toListItem(raw),
     headRepositoryOwner: trimmed(raw.headRepositoryOwner?.login),
@@ -1369,6 +1374,7 @@ function toDetail(raw: Schema.Schema.Type<typeof RawDetailSchema>): GitHubPullRe
     mergedAt: trimmed(raw.mergedAt),
     closedAt: trimmed(raw.closedAt),
     checks: toChecks(raw.statusCheckRollup),
+    ...(baseOid === null || headOid === null ? {} : { diffRevision: { baseOid, headOid } }),
     // A JSON null is GitHub saying "nobody armed this"; a missing key is GitHub not saying, and
     // the difference survives here rather than being flattened into false.
     ...(raw.autoMergeRequest === undefined

--- a/apps/server/src/pullRequest/gitHubPullRequestJson.ts
+++ b/apps/server/src/pullRequest/gitHubPullRequestJson.ts
@@ -374,6 +374,11 @@ const RawDetailSchema = Schema.Struct({
   autoMergeRequest: Schema.optional(Schema.NullOr(Schema.Unknown)),
 });
 
+const RawPullRequestDiffRevisionSchema = Schema.Struct({
+  baseRefOid: Schema.optional(Schema.NullOr(Schema.String)),
+  headRefOid: Schema.optional(Schema.NullOr(Schema.String)),
+});
+
 const RawActivitySchema = Schema.Struct({
   author: Schema.optional(Schema.NullOr(RawActorSchema)),
   comments: Schema.optional(Schema.Array(RawCommentSchema)),
@@ -601,7 +606,7 @@ export function decodeActorAvatarsJson(
 export const PULL_REQUEST_LIST_JSON_FIELDS =
   "number,title,url,author,headRefName,baseRefName,state,isDraft,mergeable,reviewDecision,additions,deletions,createdAt,updatedAt,mergedAt,reviewRequests,labels,statusCheckRollup";
 
-export const PULL_REQUEST_DETAIL_JSON_FIELDS = `${PULL_REQUEST_LIST_JSON_FIELDS},body,changedFiles,closedAt,headRepositoryOwner,baseRefOid,headRefOid,autoMergeRequest`;
+export const PULL_REQUEST_DETAIL_JSON_FIELDS = `${PULL_REQUEST_LIST_JSON_FIELDS},body,changedFiles,closedAt,headRepositoryOwner,autoMergeRequest`;
 export const PULL_REQUEST_ACTIVITY_JSON_FIELDS = "author,comments,reviews,commits";
 
 /** GitHub's own ceiling on a connection page, which is what both thread reads ask for. */
@@ -1397,6 +1402,7 @@ const decodeSearch = decodeJsonResult(RawSearchSchema);
 const decodeSearchItem = Schema.decodeUnknownExit(RawSearchItemSchema);
 const decodeStats = decodeJsonResult(RawStatsSchema);
 const decodeDetail = decodeJsonResult(RawDetailSchema);
+const decodePullRequestDiffRevision = decodeJsonResult(RawPullRequestDiffRevisionSchema);
 const decodeActivity = decodeJsonResult(RawActivitySchema);
 const decodeFileEntry = Schema.decodeUnknownExit(RawPullRequestFileSchema);
 const decodeRepositoryAccess = decodeJsonResult(RawRepositoryAccessSchema);
@@ -1555,6 +1561,16 @@ export function decodePullRequestDetailJson(
   return Result.isSuccess(decoded)
     ? Result.succeed(toDetail(decoded.success))
     : Result.fail(decoded.failure);
+}
+
+export function decodePullRequestDiffRevisionJson(
+  raw: string,
+): Result.Result<{ readonly baseOid: string; readonly headOid: string } | null, DecodeFailure> {
+  const decoded = decodePullRequestDiffRevision(raw);
+  if (!Result.isSuccess(decoded)) return Result.fail(decoded.failure);
+  const baseOid = trimmed(decoded.success.baseRefOid);
+  const headOid = trimmed(decoded.success.headRefOid);
+  return Result.succeed(baseOid === null || headOid === null ? null : { baseOid, headOid });
 }
 
 export function decodePullRequestActivityJson(

--- a/apps/server/src/pullRequest/gitLabMergeRequestJson.test.ts
+++ b/apps/server/src/pullRequest/gitLabMergeRequestJson.test.ts
@@ -137,6 +137,30 @@ describe("decodeMergeRequestListJson", () => {
 });
 
 describe("decodeMergeRequestDetailJson", () => {
+  it("carries the immutable diff endpoints", () => {
+    const detail = expectSuccess(
+      decodeMergeRequestDetailJson(
+        detailJson({
+          diff_refs: { base_sha: "base-oid", head_sha: "head-oid", start_sha: "start-oid" },
+        }),
+      ),
+    );
+
+    expect(detail.diffRevision).toEqual({ baseOid: "start-oid", headOid: "head-oid" });
+  });
+
+  it("keeps usable detail when immutable diff endpoints are null or partial", () => {
+    expect(
+      expectSuccess(decodeMergeRequestDetailJson(detailJson({ diff_refs: { start_sha: null } })))
+        .diffRevision,
+    ).toBeUndefined();
+    expect(
+      expectSuccess(
+        decodeMergeRequestDetailJson(detailJson({ diff_refs: { start_sha: "start-oid" } })),
+      ).diffRevision,
+    ).toBeUndefined();
+  });
+
   it("reads the description, file count and pipeline", () => {
     const detail = expectSuccess(
       decodeMergeRequestDetailJson(

--- a/apps/server/src/pullRequest/gitLabMergeRequestJson.ts
+++ b/apps/server/src/pullRequest/gitLabMergeRequestJson.ts
@@ -41,6 +41,18 @@ const RawPipelineSchema = Schema.Struct({
   source: Schema.optional(Schema.NullOr(Schema.String)),
 });
 
+const RawDiffRevisionSchema = Schema.Struct({
+  base_sha: Schema.String,
+  head_sha: Schema.String,
+  start_sha: Schema.String,
+});
+
+const RawOptionalDiffRevisionSchema = Schema.Struct({
+  base_sha: Schema.optional(Schema.NullOr(Schema.String)),
+  head_sha: Schema.optional(Schema.NullOr(Schema.String)),
+  start_sha: Schema.optional(Schema.NullOr(Schema.String)),
+});
+
 const RawMergeRequestSchema = Schema.Struct({
   iid: Schema.Int,
   title: Schema.String,
@@ -87,6 +99,7 @@ const RawMergeRequestSchema = Schema.Struct({
    * single merge request — a list never carries it, however it is asked for.
    */
   diverged_commits_count: Schema.optional(Schema.NullOr(Schema.Int)),
+  diff_refs: Schema.optional(Schema.NullOr(RawOptionalDiffRevisionSchema)),
 });
 
 const RawNoteSchema = Schema.Struct({
@@ -139,15 +152,7 @@ const RawDiscussionSchema = Schema.Struct({
 });
 
 const RawDiffRefsSchema = Schema.Struct({
-  diff_refs: Schema.optional(
-    Schema.NullOr(
-      Schema.Struct({
-        base_sha: Schema.String,
-        head_sha: Schema.String,
-        start_sha: Schema.String,
-      }),
-    ),
-  ),
+  diff_refs: Schema.optional(Schema.NullOr(RawDiffRevisionSchema)),
 });
 
 const RawCommitSchema = Schema.Struct({
@@ -222,6 +227,7 @@ export interface GitLabMergeRequestDetail extends GitLabMergeRequestListItem {
   readonly closedAt: string | null;
   readonly reviewers: ReadonlyArray<PullRequestActor>;
   readonly checks: ReadonlyArray<PullRequestCheck>;
+  readonly diffRevision?: { readonly baseOid: string; readonly headOid: string };
   /** False only where GitLab said so; an answer without the field leaves merging permitted. */
   readonly viewerCanMerge: boolean;
   /** The reviewers as GitLab addresses them, which is what writing the set back takes. */
@@ -358,6 +364,8 @@ function toListItem(
 
 function toDetail(raw: Schema.Schema.Type<typeof RawMergeRequestSchema>): GitLabMergeRequestDetail {
   const listItem = toListItem(raw);
+  const baseOid = trimmed(raw.diff_refs?.start_sha);
+  const headOid = trimmed(raw.diff_refs?.head_sha);
   const autoMerge =
     raw.merge_when_pipeline_succeeds == null && raw.auto_merge_enabled == null
       ? undefined
@@ -374,6 +382,7 @@ function toDetail(raw: Schema.Schema.Type<typeof RawMergeRequestSchema>): GitLab
       return actor === null ? [] : [actor];
     }),
     checks: toChecks(raw),
+    ...(baseOid === null || headOid === null ? {} : { diffRevision: { baseOid, headOid } }),
     viewerCanMerge: raw.user?.can_merge !== false,
     reviewerIds: (raw.reviewers ?? []).flatMap((reviewer) =>
       reviewer.id === undefined ? [] : [reviewer.id],

--- a/apps/web/src/components/pullRequest/PullRequestCodeTab.test.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestCodeTab.test.tsx
@@ -1,0 +1,70 @@
+import { isValidElement, type ComponentProps, type ReactElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+vi.mock("../DiffWorkerPoolProvider", () => ({
+  DiffWorkerPoolProvider: ({ children }: { children: ReactNode }) => children,
+}));
+
+import { PullRequestCodeBootstrapBody, shouldRefreshAppliedCommitDiff } from "./PullRequestCodeTab";
+import { PullRequestsUnavailableState } from "./PullRequestsUnavailableState";
+
+describe("PullRequestCodeBootstrapBody", () => {
+  it("keeps initial aggregate loading in the diff body", () => {
+    const markup = renderToStaticMarkup(
+      <PullRequestCodeBootstrapBody error={null} onRetry={() => {}} />,
+    );
+
+    expect(markup).toContain("Loading pull request diff...");
+    expect(markup).not.toContain("Could not load pull request diff");
+  });
+
+  it("uses the diff-specific failure title and wires retry", () => {
+    const onRetry = vi.fn();
+    const body = PullRequestCodeBootstrapBody({ error: "GitHub did not answer.", onRetry });
+
+    expect(isValidElement(body)).toBe(true);
+    const unavailable = body as ReactElement<
+      ComponentProps<typeof PullRequestsUnavailableState>,
+      typeof PullRequestsUnavailableState
+    >;
+    expect(unavailable.type).toBe(PullRequestsUnavailableState);
+    expect(unavailable.props.title).toBe("Could not load pull request diff");
+    expect(unavailable.props.error).toBe("GitHub did not answer.");
+    expect(unavailable.props.onRetry).toBe(onRetry);
+
+    const markup = renderToStaticMarkup(body);
+    expect(markup).toContain("Could not load pull request diff");
+    expect(markup).toContain("GitHub did not answer.");
+    expect(markup).toContain("Retry");
+  });
+});
+
+describe("shouldRefreshAppliedCommitDiff", () => {
+  it("refreshes the same selected commit for a later applied snapshot", () => {
+    expect(
+      shouldRefreshAppliedCommitDiff(
+        { version: 1, commit: "commit-a" },
+        { version: 2, commit: "commit-a" },
+      ),
+    ).toBe(true);
+  });
+
+  it("leaves a changed commit to its newly mounted query", () => {
+    expect(
+      shouldRefreshAppliedCommitDiff(
+        { version: 1, commit: "commit-a" },
+        { version: 2, commit: "commit-b" },
+      ),
+    ).toBe(false);
+  });
+
+  it("leaves the first snapshot to its newly mounted query", () => {
+    expect(
+      shouldRefreshAppliedCommitDiff(
+        { version: null, commit: "commit-a" },
+        { version: 1, commit: "commit-a" },
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/components/pullRequest/PullRequestCodeTab.test.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestCodeTab.test.tsx
@@ -6,8 +6,13 @@ vi.mock("../DiffWorkerPoolProvider", () => ({
   DiffWorkerPoolProvider: ({ children }: { children: ReactNode }) => children,
 }));
 
-import { PullRequestCodeBootstrapBody, shouldRefreshAppliedCommitDiff } from "./PullRequestCodeTab";
+import {
+  PullRequestCodeBootstrapBody,
+  PullRequestCodeRefreshFailure,
+  shouldRefreshAppliedCommitDiff,
+} from "./PullRequestCodeTab";
 import { PullRequestsUnavailableState } from "./PullRequestsUnavailableState";
+import { Button } from "../ui/button";
 
 describe("PullRequestCodeBootstrapBody", () => {
   it("keeps initial aggregate loading in the diff body", () => {
@@ -36,6 +41,25 @@ describe("PullRequestCodeBootstrapBody", () => {
     const markup = renderToStaticMarkup(body);
     expect(markup).toContain("Could not load pull request diff");
     expect(markup).toContain("GitHub did not answer.");
+    expect(markup).toContain("Retry");
+  });
+});
+
+describe("PullRequestCodeRefreshFailure", () => {
+  it("marks a retained diff as stale and offers retry", () => {
+    const onRetry = vi.fn();
+    const failure = PullRequestCodeRefreshFailure({ error: "GitHub did not answer.", onRetry });
+    const children = failure.props.children as ReactNode[];
+    const retry = children[2] as ReactElement<ComponentProps<typeof Button>, typeof Button>;
+
+    expect(retry.type).toBe(Button);
+    expect(retry.props.onClick).toBe(onRetry);
+
+    const markup = renderToStaticMarkup(failure);
+
+    expect(markup).toContain('role="alert"');
+    expect(markup).toContain("Could not refresh pull request diff");
+    expect(markup).toContain("Showing the last loaded version. GitHub did not answer.");
     expect(markup).toContain("Retry");
   });
 });

--- a/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
@@ -19,6 +19,7 @@ import {
   Columns2Icon,
   MessageSquareIcon,
   MessageSquareOffIcon,
+  RefreshCwIcon,
   Rows3Icon,
   TextWrapIcon,
   TriangleAlertIcon,
@@ -231,6 +232,35 @@ export function PullRequestCodeBootstrapBody({
       error={error}
       onRetry={onRetry}
     />
+  );
+}
+
+/** Keeps an applied diff readable while making a failed attempt to replace it explicit. */
+export function PullRequestCodeRefreshFailure({
+  error,
+  onRetry,
+}: {
+  error: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div
+      role="alert"
+      className="flex shrink-0 items-start gap-2 border-b border-amber-500/25 bg-amber-500/8 px-3 py-2 text-xs"
+    >
+      <TriangleAlertIcon
+        aria-hidden
+        className="mt-0.5 size-3.5 shrink-0 text-amber-600 dark:text-amber-500"
+      />
+      <div className="min-w-0 flex-1">
+        <p className="font-medium text-foreground">Could not refresh pull request diff</p>
+        <p className="mt-0.5 text-muted-foreground">Showing the last loaded version. {error}</p>
+      </div>
+      <Button size="xs" variant="outline" className="shrink-0" onClick={onRetry}>
+        <RefreshCwIcon aria-hidden className="size-3" />
+        Retry
+      </Button>
+    </div>
   );
 }
 
@@ -1351,6 +1381,9 @@ export function PullRequestCodeTab({
   const withReviewBar = (body: ReactNode) => (
     <div className="flex h-full min-h-0 flex-col">
       {toolbar}
+      {hasSnapshot && bootstrapError !== null ? (
+        <PullRequestCodeRefreshFailure error={bootstrapError} onRetry={onBootstrapRetry} />
+      ) : null}
       {/* The overlay is anchored to this wrapper, not the scroller: absolute positioning
           inside an overflowing element tracks the content's bottom edge, which would carry
           the trigger away with the first scroll. */}

--- a/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
@@ -3,6 +3,7 @@ import type { CodeViewDiffItem } from "@pierre/diffs/react";
 import type {
   EnvironmentId,
   PullRequestDetailView,
+  PullRequestDiffResult,
   PullRequestDiffSide,
   PullRequestOmittedFileStat,
   PullRequestRef,
@@ -23,8 +24,16 @@ import {
   TriangleAlertIcon,
   XIcon,
 } from "lucide-react";
-import { useAtomRefresh } from "@effect/atom-react";
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { RegistryContext, useAtomRefresh } from "@effect/atom-react";
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 
 import { useClientSettings } from "~/hooks/useSettings";
 import { useTheme } from "~/hooks/useTheme";
@@ -50,8 +59,9 @@ import {
   type ReviewCommentContext,
 } from "~/reviewCommentContext";
 import { pullRequestEnvironment } from "~/state/pullRequests";
-import { useEnvironmentQuery } from "~/state/query";
+import { formatEnvironmentQueryError, useEnvironmentQuery } from "~/state/query";
 import { useAtomCommand } from "~/state/use-atom-command";
+import { useAtomQueryRunner } from "~/state/use-atom-query-runner";
 
 import { DiffPanelLoadingState } from "../DiffPanelShell";
 import { DiffWorkerPoolProvider } from "../DiffWorkerPoolProvider";
@@ -120,6 +130,16 @@ const REPLACE_FILE_COUNTS_CSS = `
 /** Nothing loaded yet, as one identity, so the memos below do not see a new array every render. */
 const NO_SLICES: ReadonlyArray<DiffSlice> = [];
 
+function diffSlice(cursor: string | null, page: PullRequestDiffResult): DiffSlice {
+  return {
+    cursor,
+    patch: page.patch,
+    truncated: page.truncated,
+    nextCursor: page.nextCursor,
+    omittedFileStats: page.omittedFileStats ?? [],
+  };
+}
+
 /** A group while it is still gathering what belongs on its line. */
 interface MutableAnnotationGroup {
   readonly side: PullRequestDiffSide;
@@ -183,6 +203,8 @@ export function PullRequestCodeTab({
   environmentId,
   reference,
   detail,
+  snapshotVersion,
+  firstPageDiff,
   selectedCommitOid,
   onSelectedCommitChange,
   pendingFinding,
@@ -190,11 +212,14 @@ export function PullRequestCodeTab({
   onFixFinding,
   onAddToAgentSelection,
   onRefresh,
-  refreshToken = 0,
 }: {
   environmentId: EnvironmentId;
   reference: PullRequestRef;
   detail: PullRequestDetailView;
+  /** Monotonic identity for successful refreshes, including same-revision replacements. */
+  snapshotVersion: number;
+  /** Aggregate first page applied by the panel with `detail`. */
+  firstPageDiff: PullRequestDiffResult;
   /** Commit whose diff is open. Null keeps the whole pull-request diff selected. */
   selectedCommitOid: string | null;
   onSelectedCommitChange: (oid: string | null) => void;
@@ -205,8 +230,6 @@ export function PullRequestCodeTab({
   /** Absent where there is no active agent composer to receive a local comment. */
   onAddToAgentSelection?: (input: PullRequestAgentSelectionInput) => void;
   onRefresh: () => void;
-  /** Bumped by the panel's refresh button: drop the accumulated pages and re-read the diff. */
-  refreshToken?: number;
 }) {
   const { resolvedTheme } = useTheme();
   const settings = useClientSettings();
@@ -238,10 +261,17 @@ export function PullRequestCodeTab({
   const parseCache = useRef(new Map<string, RenderablePatch>());
 
   const referenceKey = pullRequestReviewKey(reference);
+  const { projectId, repository, number } = reference;
   const commit = selectedCommitOid;
   // One commit's own changes and the whole change are two different diffs, paged separately, so
   // everything below is keyed by both.
-  const scopeKey = commit === null ? referenceKey : `${referenceKey}@${commit}`;
+  const scopeKey =
+    commit === null ? `${referenceKey}@aggregate:${snapshotVersion}` : `${referenceKey}@${commit}`;
+  const firstPageSlice = useMemo(() => diffSlice(null, firstPageDiff), [firstPageDiff]);
+  const initialSlices = useMemo(
+    () => (commit === null ? [firstPageSlice] : NO_SLICES),
+    [commit, firstPageSlice],
+  );
   // The panel keeps this mounted across pull requests, so an open composer would otherwise
   // survive the switch and attach its comment to whichever one is on screen when it is sent.
   useEffect(() => {
@@ -251,64 +281,133 @@ export function PullRequestCodeTab({
     setFoldOverride(null);
     setVisibleCommitCount(COMMIT_PAGE_SIZE);
     setOrphansOpen(false);
-    setSliceState({ key: scopeKey, cursor: null, slices: NO_SLICES });
+    setSliceState({
+      key: scopeKey,
+      cursor: null,
+      slices: initialSlices,
+    });
     parseCache.current.clear();
-  }, [scopeKey]);
+  }, [initialSlices, scopeKey]);
 
-  const loadedSlices = sliceState.key === scopeKey ? sliceState.slices : NO_SLICES;
+  // Project the new first page synchronously; the reset effect runs after this render.
+  const loadedSlices = sliceState.key === scopeKey ? sliceState.slices : initialSlices;
   const cursor = sliceState.key === scopeKey ? sliceState.cursor : null;
   const diffQuery = useEnvironmentQuery(
-    pullRequestEnvironment.diff({
-      environmentId,
-      input: {
-        ...reference,
-        ...(cursor === null ? {} : { cursor }),
-        ...(commit === null ? {} : { commit }),
-      },
-    }),
+    commit === null
+      ? null
+      : pullRequestEnvironment.diff({
+          environmentId,
+          input: {
+            ...reference,
+            ...(cursor === null ? {} : { cursor }),
+            ...(commit === null ? {} : { commit }),
+          },
+        }),
+  );
+  const runDiffQuery = useAtomQueryRunner(pullRequestEnvironment.diff, {
+    reportFailure: false,
+  });
+  const registry = useContext(RegistryContext);
+  const appendDiffPage = useCallback(
+    (pageCursor: string | null, data: PullRequestDiffResult) => {
+      setSliceState((previous) => {
+        const slices = previous.key === scopeKey ? previous.slices : NO_SLICES;
+        const next = diffSlice(pageCursor, data);
+        const index = slices.findIndex((slice) => slice.cursor === pageCursor);
+        if (index === -1) {
+          return { key: scopeKey, cursor: pageCursor, slices: [...slices, next] };
+        }
+        const existing = slices[index];
+        if (
+          existing !== undefined &&
+          existing.patch === next.patch &&
+          existing.truncated === next.truncated &&
+          existing.nextCursor === next.nextCursor &&
+          existing.omittedFileStats.length === next.omittedFileStats.length &&
+          existing.omittedFileStats.every((file, index) => {
+            const refreshed = next.omittedFileStats[index];
+            return (
+              refreshed !== undefined &&
+              refreshed.path === file.path &&
+              refreshed.additions === file.additions &&
+              refreshed.deletions === file.deletions
+            );
+          })
+        ) {
+          return previous;
+        }
+        return { key: scopeKey, cursor: pageCursor, slices: [...slices.slice(0, index), next] };
+      });
+    },
+    [scopeKey],
   );
   // Each answer is kept as its own slice. Concatenating the patches and re-parsing the growing
   // text would cost more with every slice, which is the wall the slicing exists to remove.
   useEffect(() => {
-    const data = diffQuery.data;
-    if (data === null) return;
-    setSliceState((previous) => {
-      const slices = previous.key === scopeKey ? previous.slices : NO_SLICES;
-      const next = {
-        cursor,
-        patch: data.patch,
-        truncated: data.truncated,
-        nextCursor: data.nextCursor,
-        omittedFileStats: data.omittedFileStats ?? [],
-      };
-      const index = slices.findIndex((slice) => slice.cursor === cursor);
-      if (index === -1) {
-        return { key: scopeKey, cursor, slices: [...slices, next] };
-      }
-      const existing = slices[index];
-      if (
-        existing !== undefined &&
-        existing.patch === next.patch &&
-        existing.truncated === next.truncated &&
-        existing.nextCursor === next.nextCursor &&
-        existing.omittedFileStats.length === next.omittedFileStats.length &&
-        existing.omittedFileStats.every((file, index) => {
-          const refreshed = next.omittedFileStats[index];
-          return (
-            refreshed !== undefined &&
-            refreshed.path === file.path &&
-            refreshed.additions === file.additions &&
-            refreshed.deletions === file.deletions
-          );
-        })
-      ) {
-        return previous;
-      }
-      // A page that came back different means the diff moved under the review. The slices
-      // after it go with the replacement: their cursors were positions in the old diff.
-      return { key: scopeKey, cursor, slices: [...slices.slice(0, index), next] };
-    });
-  }, [cursor, diffQuery.data, scopeKey]);
+    if (commit === null || diffQuery.data === null) return;
+    appendDiffPage(cursor, diffQuery.data);
+  }, [appendDiffPage, commit, cursor, diffQuery.data]);
+  const [aggregateCursorLoad, setAggregateCursorLoad] = useState<{
+    key: string;
+    error: string | null;
+    pending: boolean;
+  }>({ key: "", error: null, pending: false });
+  const aggregateCursorGeneration = useRef(0);
+  const aggregateCursorKey =
+    commit === null && cursor !== null
+      ? JSON.stringify([environmentId, referenceKey, snapshotVersion, cursor])
+      : null;
+  const refreshAggregateCursor = useCallback(async () => {
+    if (commit !== null || cursor === null || aggregateCursorKey === null) return;
+    const generation = ++aggregateCursorGeneration.current;
+    setAggregateCursorLoad({ key: aggregateCursorKey, error: null, pending: true });
+    const target = {
+      environmentId,
+      input: { projectId, repository, number, cursor },
+    };
+    registry.refresh(pullRequestEnvironment.diff(target));
+    const result = await runDiffQuery(target);
+    if (generation !== aggregateCursorGeneration.current) return;
+    if (result._tag === "Failure") {
+      setAggregateCursorLoad({
+        key: aggregateCursorKey,
+        error: formatEnvironmentQueryError(result.cause),
+        pending: false,
+      });
+      return;
+    }
+    appendDiffPage(cursor, result.value);
+    setAggregateCursorLoad({ key: aggregateCursorKey, error: null, pending: false });
+  }, [
+    aggregateCursorKey,
+    appendDiffPage,
+    commit,
+    cursor,
+    environmentId,
+    number,
+    projectId,
+    repository,
+    registry,
+    runDiffQuery,
+  ]);
+  useEffect(() => {
+    if (aggregateCursorKey === null) return;
+    void refreshAggregateCursor();
+    return () => {
+      aggregateCursorGeneration.current++;
+    };
+  }, [aggregateCursorKey, refreshAggregateCursor]);
+  const diffPage =
+    commit === null && cursor === null
+      ? { error: null, isPending: false }
+      : aggregateCursorKey !== null
+        ? {
+            error:
+              aggregateCursorLoad.key === aggregateCursorKey ? aggregateCursorLoad.error : null,
+            isPending:
+              aggregateCursorLoad.key !== aggregateCursorKey || aggregateCursorLoad.pending,
+          }
+        : diffQuery;
   // The refresh button rereads from the first page rather than the page the reader is on:
   // pages are positions in one snapshot of the diff, and a fresh snapshot starts over.
   const refreshFirstDiffPage = useAtomRefresh(
@@ -317,14 +416,16 @@ export function PullRequestCodeTab({
       input: { ...reference, ...(commit === null ? {} : { commit }) },
     }),
   );
-  const appliedRefreshToken = useRef(refreshToken);
+  const appliedSnapshotVersion = useRef(snapshotVersion);
   useEffect(() => {
-    if (appliedRefreshToken.current === refreshToken) return;
-    appliedRefreshToken.current = refreshToken;
-    setSliceState({ key: scopeKey, cursor: null, slices: NO_SLICES });
+    if (appliedSnapshotVersion.current === snapshotVersion) return;
+    appliedSnapshotVersion.current = snapshotVersion;
     // The panel already refreshes the mutable aggregate after invalidating the host cache.
-    if (commit !== null) refreshFirstDiffPage();
-  }, [commit, refreshToken, scopeKey, refreshFirstDiffPage]);
+    if (commit !== null) {
+      setSliceState({ key: scopeKey, cursor: null, slices: NO_SLICES });
+      refreshFirstDiffPage();
+    }
+  }, [commit, snapshotVersion, scopeKey, refreshFirstDiffPage]);
   const reviewKey = referenceKey;
   const pendingComments = usePendingReviewComments(reference);
   const addComment = usePullRequestReviewStore((store) => store.addComment);
@@ -348,9 +449,9 @@ export function PullRequestCodeTab({
         environmentId,
         reference,
         commit,
-        cacheKey: `pull-request:${referenceKey}:${detail.updatedAt}:${commit ?? "all"}`,
+        cacheKey: `pull-request:${environmentId}:${referenceKey}:${snapshotVersion}:${commit ?? "all"}`,
       }),
-    [commit, detail.updatedAt, environmentId, getDiffFileContents, reference, referenceKey],
+    [commit, environmentId, getDiffFileContents, reference, referenceKey, snapshotVersion],
   );
 
   // What is offered is the intersection of two different questions: what this host can do at
@@ -554,8 +655,8 @@ export function PullRequestCodeTab({
       sentinel === null ||
       nextCursor === null ||
       nextCursor === cursor ||
-      diffQuery.isPending ||
-      diffQuery.error !== null
+      diffPage.isPending ||
+      diffPage.error !== null
     ) {
       return;
     }
@@ -570,7 +671,7 @@ export function PullRequestCodeTab({
     );
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [cursor, diffQuery.error, diffQuery.isPending, nextCursor, sentinel]);
+  }, [cursor, diffPage.error, diffPage.isPending, nextCursor, sentinel]);
 
   // A stable identity: the viewer's SlotPortals memoizes each file's header/annotation portal on
   // these render props, so a fresh function here would recreate every visible file's portal on
@@ -671,19 +772,32 @@ export function PullRequestCodeTab({
           ref={setSentinel}
           className="flex items-center justify-center gap-2 py-2 text-xs text-muted-foreground"
         >
-          {diffQuery.error !== null ? (
+          {diffPage.error !== null ? (
             <>
               <span>The rest of this diff could not be loaded.</span>
-              <Button size="xs" variant="outline" onClick={() => diffQuery.refresh()}>
+              <Button
+                size="xs"
+                variant="outline"
+                onClick={() =>
+                  aggregateCursorKey === null ? diffQuery.refresh() : void refreshAggregateCursor()
+                }
+              >
                 Retry
               </Button>
             </>
-          ) : diffQuery.isPending ? (
+          ) : diffPage.isPending ? (
             "Loading more files..."
           ) : null}
         </div>
       ),
-    [nextCursor, diffQuery.error, diffQuery.isPending, diffQuery.refresh],
+    [
+      aggregateCursorKey,
+      nextCursor,
+      diffPage.error,
+      diffPage.isPending,
+      diffQuery.refresh,
+      refreshAggregateCursor,
+    ],
   );
 
   const renderHeaderPrefix = useCallback(
@@ -1176,15 +1290,15 @@ export function PullRequestCodeTab({
 
   // Under the toolbar rather than in place of it, so choosing a commit does not take the
   // dropdown that was just used off the screen while its diff loads.
-  if (diffQuery.isPending && loadedSlices.length === 0) {
+  if (diffPage.isPending && loadedSlices.length === 0) {
     return withReviewBar(<DiffPanelLoadingState label="Loading pull request diff..." />);
   }
 
   // A slice that fails once there are files on screen is reported at the end of them instead:
   // the diff already read is worth more than the error that stopped it growing.
-  if (diffQuery.error && loadedSlices.length === 0) {
+  if (diffPage.error && loadedSlices.length === 0) {
     return withReviewBar(
-      <p className="px-4 py-5 text-sm text-muted-foreground">{diffQuery.error}</p>,
+      <p className="px-4 py-5 text-sm text-muted-foreground">{diffPage.error}</p>,
     );
   }
 

--- a/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
@@ -322,8 +322,9 @@ export function PullRequestCodeTab({
     if (appliedRefreshToken.current === refreshToken) return;
     appliedRefreshToken.current = refreshToken;
     setSliceState({ key: scopeKey, cursor: null, slices: NO_SLICES });
-    refreshFirstDiffPage();
-  }, [refreshToken, scopeKey, refreshFirstDiffPage]);
+    // The panel already refreshes the mutable aggregate after invalidating the host cache.
+    if (commit !== null) refreshFirstDiffPage();
+  }, [commit, refreshToken, scopeKey, refreshFirstDiffPage]);
   const reviewKey = referenceKey;
   const pendingComments = usePendingReviewComments(reference);
   const addComment = usePullRequestReviewStore((store) => store.addComment);

--- a/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
@@ -297,7 +297,7 @@ export function PullRequestCodeTab({
   /** Cohesive detail and first-page diff; null until the aggregate bootstrap is complete. */
   snapshot: PullRequestCodeSnapshot | null;
   bootstrapError: string | null;
-  onBootstrapRetry: () => void;
+  onBootstrapRetry: () => void | Promise<void>;
   /** Commit whose diff is open. Null keeps the whole pull-request diff selected. */
   selectedCommitOid: string | null;
   onSelectedCommitChange: (oid: string | null) => void;
@@ -313,6 +313,15 @@ export function PullRequestCodeTab({
   // live detail supplies the same toolbar chrome without allowing any diff request to start here.
   const detail = snapshot?.detail ?? liveDetail;
   const hasSnapshot = snapshot !== null;
+  const [bootstrapRetryPending, setBootstrapRetryPending] = useState(false);
+  const retryBootstrap = useCallback(async () => {
+    setBootstrapRetryPending(true);
+    try {
+      await onBootstrapRetry();
+    } finally {
+      setBootstrapRetryPending(false);
+    }
+  }, [onBootstrapRetry]);
   const snapshotVersion = snapshot?.version ?? 0;
   const firstPageDiff = snapshot?.firstPageDiff ?? null;
   const { resolvedTheme } = useTheme();
@@ -1382,7 +1391,7 @@ export function PullRequestCodeTab({
     <div className="flex h-full min-h-0 flex-col">
       {toolbar}
       {hasSnapshot && bootstrapError !== null ? (
-        <PullRequestCodeRefreshFailure error={bootstrapError} onRetry={onBootstrapRetry} />
+        <PullRequestCodeRefreshFailure error={bootstrapError} onRetry={retryBootstrap} />
       ) : null}
       {/* The overlay is anchored to this wrapper, not the scroller: absolute positioning
           inside an overflowing element tracks the content's bottom edge, which would carry
@@ -1396,7 +1405,10 @@ export function PullRequestCodeTab({
 
   if (!hasSnapshot) {
     return withReviewBar(
-      <PullRequestCodeBootstrapBody error={bootstrapError} onRetry={onBootstrapRetry} />,
+      <PullRequestCodeBootstrapBody
+        error={bootstrapRetryPending ? null : bootstrapError}
+        onRetry={retryBootstrap}
+      />,
     );
   }
 
@@ -1474,6 +1486,9 @@ export function PullRequestCodeTab({
     <DiffWorkerPoolProvider>
       <div className="flex h-full min-h-0 flex-col">
         {toolbar}
+        {bootstrapError !== null ? (
+          <PullRequestCodeRefreshFailure error={bootstrapError} onRetry={retryBootstrap} />
+        ) : null}
         {/* Above the code, closed, and counted: these belong to the change rather than to any
             line of it, and in the stream they read as cards dropped into the patch. */}
         {orphanFiles.size > 0 ? (

--- a/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestCodeTab.tsx
@@ -24,7 +24,7 @@ import {
   TriangleAlertIcon,
   XIcon,
 } from "lucide-react";
-import { RegistryContext, useAtomRefresh } from "@effect/atom-react";
+import { RegistryContext } from "@effect/atom-react";
 import {
   useCallback,
   useContext,
@@ -80,6 +80,7 @@ import { Toggle, ToggleGroup } from "../ui/toggle-group";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { PendingReviewCommentCard, ReviewThreadCard } from "./PullRequestReviewAnnotation";
 import { PullRequestReviewBar } from "./PullRequestReviewBar";
+import { PullRequestsUnavailableState } from "./PullRequestsUnavailableState";
 import {
   isFileDiffCollapsed,
   isLineInFileDiff,
@@ -166,6 +167,32 @@ export interface PullRequestAgentSelectionInput {
   readonly request: string;
 }
 
+interface PullRequestCodeSnapshot {
+  readonly detail: PullRequestDetailView;
+  /** Monotonic identity for successful refreshes, including same-revision replacements. */
+  readonly version: number;
+  /** Aggregate first page applied atomically with `detail`. */
+  readonly firstPageDiff: PullRequestDiffResult;
+}
+
+interface AppliedCommitSnapshotIdentity {
+  readonly version: number | null;
+  readonly commit: string | null;
+}
+
+export function shouldRefreshAppliedCommitDiff(
+  previous: AppliedCommitSnapshotIdentity,
+  next: AppliedCommitSnapshotIdentity,
+): boolean {
+  return (
+    previous.version !== null &&
+    next.version !== null &&
+    previous.version !== next.version &&
+    next.commit !== null &&
+    previous.commit === next.commit
+  );
+}
+
 /** The contract's sides named the way the diff viewer names them, and back again. */
 function toViewerSide(side: PullRequestDiffSide) {
   return side === "left" ? ("deletions" as const) : ("additions" as const);
@@ -188,6 +215,25 @@ function getReviewPositionAnchor(position: PullRequestReviewPosition): {
   }
 }
 
+/** The bootstrap occupies the diff body so the toolbar around it never changes ownership. */
+export function PullRequestCodeBootstrapBody({
+  error,
+  onRetry,
+}: {
+  error: string | null;
+  onRetry: () => void;
+}) {
+  return error === null ? (
+    <DiffPanelLoadingState label="Loading pull request diff..." />
+  ) : (
+    <PullRequestsUnavailableState
+      title="Could not load pull request diff"
+      error={error}
+      onRetry={onRetry}
+    />
+  );
+}
+
 /**
  * Whether the viewer draws this line at all. A line counts the new file on the right and the old
  * one on the left, and each hunk covers one run of each; a line outside every run — a
@@ -202,9 +248,10 @@ function getReviewPositionAnchor(position: PullRequestReviewPosition): {
 export function PullRequestCodeTab({
   environmentId,
   reference,
-  detail,
-  snapshotVersion,
-  firstPageDiff,
+  detail: liveDetail,
+  snapshot,
+  bootstrapError,
+  onBootstrapRetry,
   selectedCommitOid,
   onSelectedCommitChange,
   pendingFinding,
@@ -215,11 +262,12 @@ export function PullRequestCodeTab({
 }: {
   environmentId: EnvironmentId;
   reference: PullRequestRef;
+  /** Live detail keeps the toolbar available while the first aggregate page is bootstrapped. */
   detail: PullRequestDetailView;
-  /** Monotonic identity for successful refreshes, including same-revision replacements. */
-  snapshotVersion: number;
-  /** Aggregate first page applied by the panel with `detail`. */
-  firstPageDiff: PullRequestDiffResult;
+  /** Cohesive detail and first-page diff; null until the aggregate bootstrap is complete. */
+  snapshot: PullRequestCodeSnapshot | null;
+  bootstrapError: string | null;
+  onBootstrapRetry: () => void;
   /** Commit whose diff is open. Null keeps the whole pull-request diff selected. */
   selectedCommitOid: string | null;
   onSelectedCommitChange: (oid: string | null) => void;
@@ -231,6 +279,12 @@ export function PullRequestCodeTab({
   onAddToAgentSelection?: (input: PullRequestAgentSelectionInput) => void;
   onRefresh: () => void;
 }) {
+  // Once a snapshot exists, every diff-dependent surface reads its applied detail. Before then,
+  // live detail supplies the same toolbar chrome without allowing any diff request to start here.
+  const detail = snapshot?.detail ?? liveDetail;
+  const hasSnapshot = snapshot !== null;
+  const snapshotVersion = snapshot?.version ?? 0;
+  const firstPageDiff = snapshot?.firstPageDiff ?? null;
   const { resolvedTheme } = useTheme();
   const settings = useClientSettings();
   const [toggledFiles, setToggledFiles] = useState<ReadonlySet<string>>(() => new Set());
@@ -267,10 +321,14 @@ export function PullRequestCodeTab({
   // everything below is keyed by both.
   const scopeKey =
     commit === null ? `${referenceKey}@aggregate:${snapshotVersion}` : `${referenceKey}@${commit}`;
-  const firstPageSlice = useMemo(() => diffSlice(null, firstPageDiff), [firstPageDiff]);
+  const firstPageSlice = useMemo(
+    () => (firstPageDiff === null ? null : diffSlice(null, firstPageDiff)),
+    [firstPageDiff],
+  );
   const initialSlices = useMemo(
-    () => (commit === null ? [firstPageSlice] : NO_SLICES),
-    [commit, firstPageSlice],
+    () =>
+      hasSnapshot && commit === null && firstPageSlice !== null ? [firstPageSlice] : NO_SLICES,
+    [commit, firstPageSlice, hasSnapshot],
   );
   // The panel keeps this mounted across pull requests, so an open composer would otherwise
   // survive the switch and attach its comment to whichever one is on screen when it is sent.
@@ -293,7 +351,7 @@ export function PullRequestCodeTab({
   const loadedSlices = sliceState.key === scopeKey ? sliceState.slices : initialSlices;
   const cursor = sliceState.key === scopeKey ? sliceState.cursor : null;
   const diffQuery = useEnvironmentQuery(
-    commit === null
+    !hasSnapshot || commit === null
       ? null
       : pullRequestEnvironment.diff({
           environmentId,
@@ -354,11 +412,11 @@ export function PullRequestCodeTab({
   }>({ key: "", error: null, pending: false });
   const aggregateCursorGeneration = useRef(0);
   const aggregateCursorKey =
-    commit === null && cursor !== null
+    hasSnapshot && commit === null && cursor !== null
       ? JSON.stringify([environmentId, referenceKey, snapshotVersion, cursor])
       : null;
   const refreshAggregateCursor = useCallback(async () => {
-    if (commit !== null || cursor === null || aggregateCursorKey === null) return;
+    if (!hasSnapshot || commit !== null || cursor === null || aggregateCursorKey === null) return;
     const generation = ++aggregateCursorGeneration.current;
     setAggregateCursorLoad({ key: aggregateCursorKey, error: null, pending: true });
     const target = {
@@ -389,6 +447,7 @@ export function PullRequestCodeTab({
     repository,
     registry,
     runDiffQuery,
+    hasSnapshot,
   ]);
   useEffect(() => {
     if (aggregateCursorKey === null) return;
@@ -408,24 +467,28 @@ export function PullRequestCodeTab({
               aggregateCursorLoad.key !== aggregateCursorKey || aggregateCursorLoad.pending,
           }
         : diffQuery;
-  // The refresh button rereads from the first page rather than the page the reader is on:
-  // pages are positions in one snapshot of the diff, and a fresh snapshot starts over.
-  const refreshFirstDiffPage = useAtomRefresh(
-    pullRequestEnvironment.diff({
-      environmentId,
-      input: { ...reference, ...(commit === null ? {} : { commit }) },
-    }),
-  );
-  const appliedSnapshotVersion = useRef(snapshotVersion);
+  // A later snapshot rereads a selected commit from its first page rather than the page the
+  // reader is on: cursors are positions in one snapshot, and a fresh snapshot starts over.
+  const appliedCommitSnapshot = useRef<AppliedCommitSnapshotIdentity>({
+    version: snapshot?.version ?? null,
+    commit,
+  });
   useEffect(() => {
-    if (appliedSnapshotVersion.current === snapshotVersion) return;
-    appliedSnapshotVersion.current = snapshotVersion;
+    const next = { version: snapshot?.version ?? null, commit };
+    const previous = appliedCommitSnapshot.current;
+    appliedCommitSnapshot.current = next;
+    // A newly selected commit mounts its atom and performs the sole first read. Only a later
+    // applied snapshot for that same commit needs to force the atom whose key did not change.
+    if (!shouldRefreshAppliedCommitDiff(previous, next) || next.commit === null) return;
     // The panel already refreshes the mutable aggregate after invalidating the host cache.
-    if (commit !== null) {
-      setSliceState({ key: scopeKey, cursor: null, slices: NO_SLICES });
-      refreshFirstDiffPage();
-    }
-  }, [commit, snapshotVersion, scopeKey, refreshFirstDiffPage]);
+    setSliceState({ key: scopeKey, cursor: null, slices: NO_SLICES });
+    registry.refresh(
+      pullRequestEnvironment.diff({
+        environmentId,
+        input: { ...reference, commit: next.commit },
+      }),
+    );
+  }, [commit, environmentId, reference, registry, scopeKey, snapshot?.version]);
   const reviewKey = referenceKey;
   const pendingComments = usePendingReviewComments(reference);
   const addComment = usePullRequestReviewStore((store) => store.addComment);
@@ -445,13 +508,23 @@ export function PullRequestCodeTab({
   const getDiffFileContents = useAtomCommand(pullRequestEnvironment.diffFileContents);
   const loadDiffFiles = useMemo(
     () =>
-      createPullRequestDiffFileContentsLoader(getDiffFileContents, {
-        environmentId,
-        reference,
-        commit,
-        cacheKey: `pull-request:${environmentId}:${referenceKey}:${snapshotVersion}:${commit ?? "all"}`,
-      }),
-    [commit, environmentId, getDiffFileContents, reference, referenceKey, snapshotVersion],
+      !hasSnapshot
+        ? undefined
+        : createPullRequestDiffFileContentsLoader(getDiffFileContents, {
+            environmentId,
+            reference,
+            commit,
+            cacheKey: `pull-request:${environmentId}:${referenceKey}:${snapshotVersion}:${commit ?? "all"}`,
+          }),
+    [
+      commit,
+      environmentId,
+      getDiffFileContents,
+      hasSnapshot,
+      reference,
+      referenceKey,
+      snapshotVersion,
+    ],
   );
 
   // What is offered is the intersection of two different questions: what this host can do at
@@ -860,7 +933,7 @@ export function PullRequestCodeTab({
       theme: resolveDiffThemeName(resolvedTheme),
       themeType: resolvedTheme,
       stickyHeaders: true,
-      loadDiffFiles,
+      ...(loadDiffFiles ? { loadDiffFiles } : {}),
       enableGutterUtility: canCommentOnLines && draft === null,
       enableLineSelection: canCommentOnLines && draft === null,
       // Two gestures reach the same place: dragging the line numbers selects a range, and the
@@ -1287,6 +1360,12 @@ export function PullRequestCodeTab({
       </div>
     </div>
   );
+
+  if (!hasSnapshot) {
+    return withReviewBar(
+      <PullRequestCodeBootstrapBody error={bootstrapError} onRetry={onBootstrapRetry} />,
+    );
+  }
 
   // Under the toolbar rather than in place of it, so choosing a commit does not take the
   // dropdown that was just used off the screen while its diff loads.

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -3,6 +3,8 @@ import { squashAtomCommandFailure } from "@t3tools/client-runtime/state/runtime"
 import type {
   EnvironmentId,
   PullRequestAction,
+  PullRequestDetailView,
+  PullRequestDiffResult,
   PullRequestMergeMethod,
   PullRequestUpdateMethod,
   PullRequestRef,
@@ -35,11 +37,13 @@ import {
   ServerIcon,
   TriangleAlertIcon,
 } from "lucide-react";
+import { RegistryContext } from "@effect/atom-react";
 import {
   lazy,
   Suspense,
   type MouseEvent as ReactMouseEvent,
   useCallback,
+  useContext,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -60,6 +64,7 @@ import { useEnvironmentQuery } from "~/state/query";
 import { useLiveRefresh } from "~/hooks/useLiveRefresh";
 import { pullRequestEnvironment } from "~/state/pullRequests";
 import { useAtomCommand } from "~/state/use-atom-command";
+import { useAtomQueryRunner } from "~/state/use-atom-query-runner";
 import { formatRelativeTimeLabel } from "~/timestampFormat";
 
 import {
@@ -101,16 +106,18 @@ import {
   buildFixFindingHandoff,
   buildFixFindingsHandoff,
   buildResolveConflictsPrompt,
+  createPullRequestDiffRefreshCoordinator,
   handoffPrompt,
   handoffReviewComments,
   pullRequestActionMenuHasGroup,
   pullRequestActionNeedsHostRefresh,
+  pullRequestCodeRevision,
+  pullRequestCodeTabDetail,
   pullRequestComposerTarget,
   pullRequestFindingKey,
   pullRequestHandoffLabels,
   readableFailure,
   resolveBaseFreshness,
-  refreshCurrentPullRequestDiff,
   type PullRequestFinding,
   shouldRefreshPullRequestActivity,
 } from "./pullRequestDetail.logic";
@@ -427,6 +434,7 @@ export function PullRequestDetailPanel({
       previous.has(tab) ? previous : new Set<DetailTab>(previous).add(tab),
     );
   }, [tab]);
+  const codeMounted = mountedTabs.has("code");
   const [chromeCondensed, setChromeCondensed] = useState(false);
   // Each tab remembers whether its chrome was condensed. Only the active tab can emit scroll
   // events, so the capture handler always writes the active tab's entry — and a tab switch
@@ -480,13 +488,6 @@ export function PullRequestDetailPanel({
   );
   const activityQuery = useEnvironmentQuery(
     pullRequestEnvironment.activity({ environmentId, input: reference }),
-  );
-  // Detail and diff are independent server reads, so the diff for the default view (no commit,
-  // no cursor) is started here too rather than waiting for the Code tab to mount. This is one
-  // extra cached read per opened pull request even for readers who never open the tab, but it
-  // turns the tab's first paint from a cold request into a cache hit.
-  const diffWarmUpQuery = useEnvironmentQuery(
-    pullRequestEnvironment.diff({ environmentId, input: { ...reference } }),
   );
   const coreDetail = detailQuery.data;
   const activity = activityQuery.data;
@@ -546,42 +547,185 @@ export function PullRequestDetailPanel({
   // invalidation goes first so the re-reads miss that cache; if it fails, the reads still run
   // and at worst answer from it.
   const invalidate = useAtomCommand(pullRequestEnvironment.invalidate, { reportFailure: false });
-  const [refreshToken, setRefreshToken] = useState(0);
-  const detailUpdatedAt = detail?.updatedAt ?? "";
-  const renderedDiffRevision = JSON.stringify([pullRequestKey, detailUpdatedAt]);
-  const activeDiffRevision = useRef(renderedDiffRevision);
-  activeDiffRevision.current = renderedDiffRevision;
-  const observedDiffRevision = useRef<{ pullRequestKey: string; updatedAt: string } | null>(null);
-  const refreshDiffFromHost = useCallback(
-    (revision: string) =>
-      refreshCurrentPullRequestDiff(
-        revision,
-        () => invalidate({ environmentId, input: { reference } }),
-        () => activeDiffRevision.current,
-        () => {
-          diffWarmUpQuery.refresh();
-          setRefreshToken((token) => token + 1);
-        },
-      ),
-    [diffWarmUpQuery.refresh, environmentId, invalidate, reference],
-  );
-  const refreshFromHost = useCallback(async () => {
-    if (await refreshDiffFromHost(activeDiffRevision.current)) refreshDetail();
-  }, [refreshDetail, refreshDiffFromHost]);
+  const runDetailQuery = useAtomQueryRunner(pullRequestEnvironment.detail, {
+    reportFailure: false,
+  });
+  const runActivityQuery = useAtomQueryRunner(pullRequestEnvironment.activity, {
+    reportFailure: false,
+  });
+  const runDiffQuery = useAtomQueryRunner(pullRequestEnvironment.diff, {
+    reportFailure: false,
+  });
+  const registry = useContext(RegistryContext);
+  const diffScope = JSON.stringify([environmentId, pullRequestKey]);
+  // Keep the last complete snapshot while the two halves refresh. Comment-only refreshes must not
+  // unmount the Code tab, and split responses must not look like two code revisions.
+  const [observedSnapshotState, setObservedSnapshotState] = useState<{
+    scope: string;
+    detail: PullRequestDetailView | null;
+  }>({ scope: diffScope, detail: null });
   useEffect(() => {
-    if (detailUpdatedAt === "") return;
-    const next = { pullRequestKey, updatedAt: detailUpdatedAt };
-    const previous = observedDiffRevision.current;
-    observedDiffRevision.current = next;
     if (
-      previous === null ||
-      previous.pullRequestKey !== next.pullRequestKey ||
-      previous.updatedAt === next.updatedAt
+      activity === null ||
+      detail === null ||
+      activityQuery.isPending ||
+      detailQuery.isPending ||
+      activityQuery.error !== null ||
+      detailQuery.error !== null
     )
       return;
-    void refreshDiffFromHost(renderedDiffRevision);
-  }, [detailUpdatedAt, pullRequestKey, refreshDiffFromHost, renderedDiffRevision]);
-  // A refresh asked for by the page: the detail, and through the token below, the diff with it.
+    setObservedSnapshotState({ scope: diffScope, detail });
+  }, [
+    activity,
+    activityQuery.error,
+    activityQuery.isPending,
+    detail,
+    detailQuery.error,
+    detailQuery.isPending,
+    diffScope,
+  ]);
+  const observedSnapshot =
+    observedSnapshotState.scope === diffScope ? observedSnapshotState.detail : null;
+  const [appliedSnapshot, setAppliedSnapshot] = useState<{
+    scope: string;
+    version: number;
+    revision: string;
+    detail: PullRequestDetailView;
+    firstPageDiff: PullRequestDiffResult;
+  } | null>(null);
+  const [diffBootstrapFailure, setDiffBootstrapFailure] = useState<{
+    scope: string;
+    error: string;
+  } | null>(null);
+  const currentAppliedSnapshot = appliedSnapshot?.scope === diffScope ? appliedSnapshot : null;
+  const codeTabDetail =
+    currentAppliedSnapshot === null
+      ? null
+      : pullRequestCodeTabDetail(
+          currentAppliedSnapshot.detail,
+          currentAppliedSnapshot.revision,
+          observedSnapshot,
+        );
+  const displayDetail = tab === "code" ? codeTabDetail : detail;
+  const coordinatorRef = useRef<ReturnType<
+    typeof createPullRequestDiffRefreshCoordinator<PullRequestDetailView, PullRequestDiffResult>
+  > | null>(null);
+  const coordinator =
+    coordinatorRef.current ??
+    createPullRequestDiffRefreshCoordinator<PullRequestDetailView, PullRequestDiffResult>(
+      pullRequestCodeRevision,
+    );
+  coordinatorRef.current = coordinator;
+  const refreshWork = useMemo(
+    () => ({
+      invalidate: () => invalidate({ environmentId, input: { reference } }),
+      readSnapshot: async () => {
+        detailQuery.refresh();
+        activityQuery.refresh();
+        const [nextDetail, nextActivity] = await Promise.all([
+          runDetailQuery({ environmentId, input: reference }),
+          runActivityQuery({ environmentId, input: reference }),
+        ]);
+        if (nextDetail._tag !== "Success" || nextActivity._tag !== "Success") {
+          const failure =
+            nextDetail._tag === "Failure"
+              ? squashAtomCommandFailure(nextDetail)
+              : nextActivity._tag === "Failure"
+                ? squashAtomCommandFailure(nextActivity)
+                : null;
+          return {
+            _tag: "Failure" as const,
+            error: readableFailure(failure, "The pull request could not be loaded."),
+          };
+        }
+        const core = nextDetail.value;
+        const activity = nextActivity.value;
+        return {
+          _tag: "Success" as const,
+          value: {
+            ...core,
+            author: activity.author ?? core.author,
+            reviewers: activity.reviewers ?? core.reviewers,
+            comments: activity.comments,
+            commentCount: activity.commentCount,
+            commentsTruncated: activity.commentsTruncated,
+            reviewThreads: activity.reviewThreads,
+            commits: activity.commits,
+            reactions: activity.reactions ?? [],
+          },
+        };
+      },
+      refreshAggregate: async () => {
+        registry.refresh(pullRequestEnvironment.diff({ environmentId, input: { ...reference } }));
+        const result = await runDiffQuery({ environmentId, input: { ...reference } });
+        if (result._tag === "Failure") {
+          return {
+            _tag: "Failure" as const,
+            error: readableFailure(
+              squashAtomCommandFailure(result),
+              "The pull request diff could not be loaded.",
+            ),
+          };
+        }
+        return { _tag: "Success" as const, value: result.value };
+      },
+      setFailure: (error: string | null) =>
+        setDiffBootstrapFailure(error === null ? null : { scope: diffScope, error }),
+      apply: (
+        scope: string,
+        revision: string,
+        appliedDetail: PullRequestDetailView,
+        firstPageDiff: PullRequestDiffResult,
+      ) => {
+        setAppliedSnapshot((previous) => ({
+          scope,
+          version: (previous?.version ?? 0) + 1,
+          revision,
+          detail: appliedDetail,
+          firstPageDiff,
+        }));
+      },
+    }),
+    [
+      activityQuery.refresh,
+      detailQuery.refresh,
+      diffScope,
+      environmentId,
+      invalidate,
+      reference,
+      registry,
+      runActivityQuery,
+      runDetailQuery,
+      runDiffQuery,
+    ],
+  );
+  const refreshFromHost = useCallback(async () => {
+    if (!codeMounted) {
+      await refreshWork.invalidate();
+      detailQuery.refresh();
+      activityQuery.refresh();
+      return;
+    }
+    await coordinator.refresh(diffScope, refreshWork);
+  }, [
+    activityQuery.refresh,
+    codeMounted,
+    coordinator,
+    detailQuery.refresh,
+    diffScope,
+    refreshWork,
+  ]);
+  useEffect(() => {
+    if (!codeMounted || observedSnapshot === null) return;
+    void coordinator.observe(diffScope, observedSnapshot, refreshWork);
+  }, [codeMounted, coordinator, diffScope, observedSnapshot, refreshWork]);
+  const codeBootstrapError =
+    currentAppliedSnapshot === null
+      ? (detailQuery.error ??
+        activityQuery.error ??
+        (diffBootstrapFailure?.scope === diffScope ? diffBootstrapFailure.error : null))
+      : null;
+  // A refresh asked for by the page joins the same causally ordered detail-and-diff lane.
   const appliedForcedToken = useRef(forcedRefreshToken);
   useEffect(() => {
     if (appliedForcedToken.current === forcedRefreshToken) return;
@@ -1040,13 +1184,14 @@ export function PullRequestDetailPanel({
   const selectedMergeMethod = allowedMergeMethods.includes(mergeMethod)
     ? mergeMethod
     : (allowedMergeMethods[0] ?? "merge");
-  const conflicting = detail?.state === "open" && detail.mergeability === "conflicting";
+  const actionDetail = displayDetail ?? detail;
+  const conflicting = actionDetail?.state === "open" && actionDetail.mergeability === "conflicting";
   // Only an outright yes arms it. A host that reports nothing has not said the merge is already
   // spoken for, and an off switch for something that may not be on says the wrong thing twice.
   const autoMergeArmed = detail?.state === "open" && detail.autoMergeEnabled === true;
   // Out of date with the base, and still cleanly mergeable — the one pairing an update button
   // exists for. Null everywhere else, including hosts that cannot compare at all.
-  const freshness = detail === null ? null : resolveBaseFreshness(detail);
+  const freshness = displayDetail === null ? null : resolveBaseFreshness(displayDetail);
   // A host that cannot produce a patch has no Code tab to open. The tabs themselves stay hidden
   // until the detail arrives, so the loading ghost is the panel's only unfinished UI.
   const visibleTabs = TABS.filter(
@@ -1538,41 +1683,48 @@ export function PullRequestDetailPanel({
                     </button>
                   ))}
                 </nav>
-                <span className="ml-auto inline-flex min-w-0 shrink items-center gap-1 font-mono text-[11px] text-muted-foreground">
-                  <Tooltip>
-                    <TooltipTrigger render={<span className="truncate" />}>
-                      {detail.baseBranch}
-                    </TooltipTrigger>
-                    <TooltipPopup side="top">{`${detail.baseBranch} ← ${detail.headBranch}`}</TooltipPopup>
-                  </Tooltip>
-                  {freshness ? (
-                    <PullRequestBaseFreshnessWarning
-                      baseBranch={detail.baseBranch}
-                      freshness={freshness}
-                      pending={actionPending}
-                      onUpdate={(method) => void perform("update-branch", undefined, method)}
-                      iconClassName="size-3"
-                    />
-                  ) : null}
-                  <ArrowLeftIcon aria-label="receives changes from" className="size-3 shrink-0" />
-                  <Tooltip>
-                    <TooltipTrigger render={<span className="truncate" />}>
-                      {detail.headBranch}
-                    </TooltipTrigger>
-                    <TooltipPopup side="top">{`${detail.baseBranch} ← ${detail.headBranch}`}</TooltipPopup>
-                  </Tooltip>
-                </span>
-                <span className="ml-2 inline-flex shrink-0 items-center gap-2 text-[11px] text-muted-foreground">
-                  <span className="inline-flex items-center gap-1 tabular-nums">
-                    <FileDiffIcon className="size-3" />
-                    {detail.changedFiles.toLocaleString()}
-                  </span>
-                  <PullRequestDiffStat
-                    additions={detail.additions}
-                    deletions={detail.deletions}
-                    className="shrink-0 font-mono text-[11px]"
-                  />
-                </span>
+                {displayDetail ? (
+                  <>
+                    <span className="ml-auto inline-flex min-w-0 shrink items-center gap-1 font-mono text-[11px] text-muted-foreground">
+                      <Tooltip>
+                        <TooltipTrigger render={<span className="truncate" />}>
+                          {displayDetail.baseBranch}
+                        </TooltipTrigger>
+                        <TooltipPopup side="top">{`${displayDetail.baseBranch} ← ${displayDetail.headBranch}`}</TooltipPopup>
+                      </Tooltip>
+                      {freshness ? (
+                        <PullRequestBaseFreshnessWarning
+                          baseBranch={displayDetail.baseBranch}
+                          freshness={freshness}
+                          pending={actionPending}
+                          onUpdate={(method) => void perform("update-branch", undefined, method)}
+                          iconClassName="size-3"
+                        />
+                      ) : null}
+                      <ArrowLeftIcon
+                        aria-label="receives changes from"
+                        className="size-3 shrink-0"
+                      />
+                      <Tooltip>
+                        <TooltipTrigger render={<span className="truncate" />}>
+                          {displayDetail.headBranch}
+                        </TooltipTrigger>
+                        <TooltipPopup side="top">{`${displayDetail.baseBranch} ← ${displayDetail.headBranch}`}</TooltipPopup>
+                      </Tooltip>
+                    </span>
+                    <span className="ml-2 inline-flex shrink-0 items-center gap-2 text-[11px] text-muted-foreground">
+                      <span className="inline-flex items-center gap-1 tabular-nums">
+                        <FileDiffIcon className="size-3" />
+                        {displayDetail.changedFiles.toLocaleString()}
+                      </span>
+                      <PullRequestDiffStat
+                        additions={displayDetail.additions}
+                        deletions={displayDetail.deletions}
+                        className="shrink-0 font-mono text-[11px]"
+                      />
+                    </span>
+                  </>
+                ) : null}
               </div>
             ) : null}
           </div>
@@ -1673,74 +1825,76 @@ export function PullRequestDetailPanel({
                   <span>updated {formatRelativeTimeLabel(detail.updatedAt)}</span>
                 </PullRequestMetaLine>
 
-                <div className="mt-4 flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
-                  <Tooltip>
-                    <TooltipTrigger
-                      render={
-                        <code className="min-w-0 max-w-48 shrink truncate rounded-md bg-muted px-2 py-1 font-mono text-xs text-foreground">
-                          {detail.baseBranch}
+                {displayDetail ? (
+                  <div className="mt-4 flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <code className="min-w-0 max-w-48 shrink truncate rounded-md bg-muted px-2 py-1 font-mono text-xs text-foreground">
+                            {displayDetail.baseBranch}
+                          </code>
+                        }
+                      />
+                      <TooltipPopup side="top">{displayDetail.baseBranch}</TooltipPopup>
+                    </Tooltip>
+                    {freshness ? (
+                      <PullRequestBaseFreshnessWarning
+                        baseBranch={displayDetail.baseBranch}
+                        freshness={freshness}
+                        pending={actionPending}
+                        onUpdate={(method) => void perform("update-branch", undefined, method)}
+                      />
+                    ) : null}
+                    <ArrowLeftIcon aria-label="receives changes from" className="size-4 shrink-0" />
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <button
+                            type="button"
+                            className="grid min-w-0 max-w-64 shrink cursor-pointer rounded-md bg-muted px-2 py-1 font-mono text-xs text-foreground outline-none transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                            aria-label={
+                              isBranchCopied ? "Branch name copied" : "Copy pull request branch"
+                            }
+                            onClick={() => copyBranchToClipboard(displayDetail.headBranch)}
+                          />
+                        }
+                      >
+                        <code
+                          className={cn(
+                            "col-start-1 row-start-1 min-w-0 truncate transition-opacity duration-150 motion-reduce:transition-none",
+                            isBranchCopied ? "opacity-0" : "opacity-100",
+                          )}
+                        >
+                          {displayDetail.headBranch}
                         </code>
-                      }
-                    />
-                    <TooltipPopup side="top">{detail.baseBranch}</TooltipPopup>
-                  </Tooltip>
-                  {freshness ? (
-                    <PullRequestBaseFreshnessWarning
-                      baseBranch={detail.baseBranch}
-                      freshness={freshness}
-                      pending={actionPending}
-                      onUpdate={(method) => void perform("update-branch", undefined, method)}
-                    />
-                  ) : null}
-                  <ArrowLeftIcon aria-label="receives changes from" className="size-4 shrink-0" />
-                  <Tooltip>
-                    <TooltipTrigger
-                      render={
-                        <button
-                          type="button"
-                          className="grid min-w-0 max-w-64 shrink cursor-pointer rounded-md bg-muted px-2 py-1 font-mono text-xs text-foreground outline-none transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
-                          aria-label={
-                            isBranchCopied ? "Branch name copied" : "Copy pull request branch"
-                          }
-                          onClick={() => copyBranchToClipboard(detail.headBranch)}
-                        />
-                      }
-                    >
-                      <code
-                        className={cn(
-                          "col-start-1 row-start-1 min-w-0 truncate transition-opacity duration-150 motion-reduce:transition-none",
-                          isBranchCopied ? "opacity-0" : "opacity-100",
-                        )}
-                      >
-                        {detail.headBranch}
-                      </code>
-                      <span
-                        aria-hidden="true"
-                        className={cn(
-                          "col-start-1 row-start-1 truncate text-center transition-opacity duration-150 motion-reduce:transition-none",
-                          isBranchCopied ? "opacity-100" : "opacity-0",
-                        )}
-                      >
-                        Copied
+                        <span
+                          aria-hidden="true"
+                          className={cn(
+                            "col-start-1 row-start-1 truncate text-center transition-opacity duration-150 motion-reduce:transition-none",
+                            isBranchCopied ? "opacity-100" : "opacity-0",
+                          )}
+                        >
+                          Copied
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipPopup side="top">
+                        {`${isBranchCopied ? "Copied" : "Copy pull request branch"}: ${displayDetail.headBranch}`}
+                      </TooltipPopup>
+                    </Tooltip>
+                    <span className="ml-auto inline-flex shrink-0 items-center justify-end gap-2">
+                      <span className="inline-flex items-center gap-1.5 tabular-nums">
+                        <FileDiffIcon className="size-3.5" />
+                        {displayDetail.changedFiles.toLocaleString()}{" "}
+                        {displayDetail.changedFiles === 1 ? "file" : "files"}
                       </span>
-                    </TooltipTrigger>
-                    <TooltipPopup side="top">
-                      {`${isBranchCopied ? "Copied" : "Copy pull request branch"}: ${detail.headBranch}`}
-                    </TooltipPopup>
-                  </Tooltip>
-                  <span className="ml-auto inline-flex shrink-0 items-center justify-end gap-2">
-                    <span className="inline-flex items-center gap-1.5 tabular-nums">
-                      <FileDiffIcon className="size-3.5" />
-                      {detail.changedFiles.toLocaleString()}{" "}
-                      {detail.changedFiles === 1 ? "file" : "files"}
+                      <PullRequestDiffStat
+                        additions={displayDetail.additions}
+                        deletions={displayDetail.deletions}
+                        className="shrink-0 font-mono text-xs"
+                      />
                     </span>
-                    <PullRequestDiffStat
-                      additions={detail.additions}
-                      deletions={detail.deletions}
-                      className="shrink-0 font-mono text-xs"
-                    />
-                  </span>
-                </div>
+                  </div>
+                ) : null}
               </div>
             ) : null}
 
@@ -1954,21 +2108,35 @@ export function PullRequestDetailPanel({
             ) : null}
             {mountedTabs.has("code") ? (
               <div className={cn("absolute inset-0", tab !== "code" && "invisible")}>
-                <Suspense fallback={<DiffPanelLoadingState label="Loading pull request diff..." />}>
-                  <PullRequestCodeTab
-                    {...(attachTarget ? { onAddToAgentSelection: addSelectionToAgent } : {})}
-                    environmentId={environmentId}
-                    reference={reference}
-                    detail={detail}
-                    selectedCommitOid={selectedCodeCommitOid}
-                    onSelectedCommitChange={selectCodeCommit}
-                    pendingFinding={handoff}
-                    fixFindingLabel={handoffLabels.fixFinding}
-                    onFixFinding={startFixFinding}
-                    onRefresh={refreshDetail}
-                    refreshToken={refreshToken}
-                  />
-                </Suspense>
+                {currentAppliedSnapshot === null || codeTabDetail === null ? (
+                  codeBootstrapError === null ? (
+                    <DiffPanelLoadingState label="Loading pull request diff..." />
+                  ) : (
+                    <PullRequestsUnavailableState
+                      error={codeBootstrapError}
+                      onRetry={() => void refreshFromHost()}
+                    />
+                  )
+                ) : (
+                  <Suspense
+                    fallback={<DiffPanelLoadingState label="Loading pull request diff..." />}
+                  >
+                    <PullRequestCodeTab
+                      {...(attachTarget ? { onAddToAgentSelection: addSelectionToAgent } : {})}
+                      environmentId={environmentId}
+                      reference={reference}
+                      detail={codeTabDetail}
+                      snapshotVersion={currentAppliedSnapshot.version}
+                      firstPageDiff={currentAppliedSnapshot.firstPageDiff}
+                      selectedCommitOid={selectedCodeCommitOid}
+                      onSelectedCommitChange={selectCodeCommit}
+                      pendingFinding={handoff}
+                      fixFindingLabel={handoffLabels.fixFinding}
+                      onFixFinding={startFixFinding}
+                      onRefresh={refreshDetail}
+                    />
+                  </Suspense>
+                )}
               </div>
             ) : null}
           </>

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -606,17 +606,14 @@ export function PullRequestDetailPanel({
           currentAppliedSnapshot.revision,
           observedSnapshot,
         );
-  const codeTabSnapshot = useMemo(
-    () =>
-      currentAppliedSnapshot === null || codeTabDetail === null
-        ? null
-        : {
-            detail: codeTabDetail,
-            version: currentAppliedSnapshot.version,
-            firstPageDiff: currentAppliedSnapshot.firstPageDiff,
-          },
-    [codeTabDetail, currentAppliedSnapshot],
-  );
+  const codeTabSnapshot =
+    currentAppliedSnapshot === null || codeTabDetail === null
+      ? null
+      : {
+          detail: codeTabDetail,
+          version: currentAppliedSnapshot.version,
+          firstPageDiff: currentAppliedSnapshot.firstPageDiff,
+        };
   const displayDetail = tab === "code" ? (codeTabDetail ?? detail) : detail;
   const coordinatorRef = useRef<ReturnType<
     typeof createPullRequestDiffRefreshCoordinator<PullRequestDetailView, PullRequestDiffResult>

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -707,6 +707,16 @@ export function PullRequestDetailPanel({
       runDiffQuery,
     ],
   );
+  // Observation reacts to already-read detail, but its aggregate diff cache can outlive that
+  // detail. Evict only that aggregate here; a reader-initiated refresh (including Update branch)
+  // still clears every cached resource for this pull request before rereading it.
+  const observeWork = useMemo(
+    () => ({
+      ...refreshWork,
+      invalidate: () => invalidate({ environmentId, input: { reference, resource: "diff" } }),
+    }),
+    [environmentId, invalidate, reference, refreshWork],
+  );
   const refreshFromHost = useCallback(async () => {
     if (!codeMounted) {
       await refreshWork.invalidate();
@@ -725,14 +735,12 @@ export function PullRequestDetailPanel({
   ]);
   useEffect(() => {
     if (!codeMounted || observedSnapshot === null) return;
-    void coordinator.observe(diffScope, observedSnapshot, refreshWork);
-  }, [codeMounted, coordinator, diffScope, observedSnapshot, refreshWork]);
+    void coordinator.observe(diffScope, observedSnapshot, observeWork);
+  }, [codeMounted, coordinator, diffScope, observedSnapshot, observeWork]);
   const codeBootstrapError =
-    currentAppliedSnapshot === null
-      ? (detailQuery.error ??
-        activityQuery.error ??
-        (diffBootstrapFailure?.scope === diffScope ? diffBootstrapFailure.error : null))
-      : null;
+    detailQuery.error ??
+    activityQuery.error ??
+    (diffBootstrapFailure?.scope === diffScope ? diffBootstrapFailure.error : null);
   // A refresh asked for by the page joins the same causally ordered detail-and-diff lane.
   const appliedForcedToken = useRef(forcedRefreshToken);
   useEffect(() => {

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -606,6 +606,17 @@ export function PullRequestDetailPanel({
           currentAppliedSnapshot.revision,
           observedSnapshot,
         );
+  const codeTabSnapshot = useMemo(
+    () =>
+      currentAppliedSnapshot === null || codeTabDetail === null
+        ? null
+        : {
+            detail: codeTabDetail,
+            version: currentAppliedSnapshot.version,
+            firstPageDiff: currentAppliedSnapshot.firstPageDiff,
+          },
+    [codeTabDetail, currentAppliedSnapshot],
+  );
   const displayDetail = tab === "code" ? (codeTabDetail ?? detail) : detail;
   const coordinatorRef = useRef<ReturnType<
     typeof createPullRequestDiffRefreshCoordinator<PullRequestDetailView, PullRequestDiffResult>
@@ -1184,8 +1195,7 @@ export function PullRequestDetailPanel({
   const selectedMergeMethod = allowedMergeMethods.includes(mergeMethod)
     ? mergeMethod
     : (allowedMergeMethods[0] ?? "merge");
-  const actionDetail = displayDetail ?? detail;
-  const conflicting = actionDetail?.state === "open" && actionDetail.mergeability === "conflicting";
+  const conflicting = detail?.state === "open" && detail.mergeability === "conflicting";
   // Only an outright yes arms it. A host that reports nothing has not said the merge is already
   // spoken for, and an off switch for something that may not be on says the wrong thing twice.
   const autoMergeArmed = detail?.state === "open" && detail.autoMergeEnabled === true;
@@ -2108,35 +2118,23 @@ export function PullRequestDetailPanel({
             ) : null}
             {mountedTabs.has("code") ? (
               <div className={cn("absolute inset-0", tab !== "code" && "invisible")}>
-                {currentAppliedSnapshot === null || codeTabDetail === null ? (
-                  codeBootstrapError === null ? (
-                    <DiffPanelLoadingState label="Loading pull request diff..." />
-                  ) : (
-                    <PullRequestsUnavailableState
-                      error={codeBootstrapError}
-                      onRetry={() => void refreshFromHost()}
-                    />
-                  )
-                ) : (
-                  <Suspense
-                    fallback={<DiffPanelLoadingState label="Loading pull request diff..." />}
-                  >
-                    <PullRequestCodeTab
-                      {...(attachTarget ? { onAddToAgentSelection: addSelectionToAgent } : {})}
-                      environmentId={environmentId}
-                      reference={reference}
-                      detail={codeTabDetail}
-                      snapshotVersion={currentAppliedSnapshot.version}
-                      firstPageDiff={currentAppliedSnapshot.firstPageDiff}
-                      selectedCommitOid={selectedCodeCommitOid}
-                      onSelectedCommitChange={selectCodeCommit}
-                      pendingFinding={handoff}
-                      fixFindingLabel={handoffLabels.fixFinding}
-                      onFixFinding={startFixFinding}
-                      onRefresh={refreshDetail}
-                    />
-                  </Suspense>
-                )}
+                <Suspense fallback={<DiffPanelLoadingState label="Loading pull request diff..." />}>
+                  <PullRequestCodeTab
+                    {...(attachTarget ? { onAddToAgentSelection: addSelectionToAgent } : {})}
+                    environmentId={environmentId}
+                    reference={reference}
+                    detail={detail}
+                    snapshot={codeTabSnapshot}
+                    bootstrapError={codeBootstrapError}
+                    onBootstrapRetry={refreshFromHost}
+                    selectedCommitOid={selectedCodeCommitOid}
+                    onSelectedCommitChange={selectCodeCommit}
+                    pendingFinding={handoff}
+                    fixFindingLabel={handoffLabels.fixFinding}
+                    onFixFinding={startFixFinding}
+                    onRefresh={refreshDetail}
+                  />
+                </Suspense>
               </div>
             ) : null}
           </>

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -110,6 +110,7 @@ import {
   pullRequestHandoffLabels,
   readableFailure,
   resolveBaseFreshness,
+  refreshCurrentPullRequestDiff,
   type PullRequestFinding,
   shouldRefreshPullRequestActivity,
 } from "./pullRequestDetail.logic";
@@ -484,7 +485,7 @@ export function PullRequestDetailPanel({
   // no cursor) is started here too rather than waiting for the Code tab to mount. This is one
   // extra cached read per opened pull request even for readers who never open the tab, but it
   // turns the tab's first paint from a cold request into a cache hit.
-  const _diffWarmUpQuery = useEnvironmentQuery(
+  const diffWarmUpQuery = useEnvironmentQuery(
     pullRequestEnvironment.diff({ environmentId, input: { ...reference } }),
   );
   const coreDetail = detailQuery.data;
@@ -546,11 +547,40 @@ export function PullRequestDetailPanel({
   // and at worst answer from it.
   const invalidate = useAtomCommand(pullRequestEnvironment.invalidate, { reportFailure: false });
   const [refreshToken, setRefreshToken] = useState(0);
+  const detailUpdatedAt = detail?.updatedAt ?? "";
+  const renderedDiffRevision = JSON.stringify([pullRequestKey, detailUpdatedAt]);
+  const activeDiffRevision = useRef(renderedDiffRevision);
+  activeDiffRevision.current = renderedDiffRevision;
+  const observedDiffRevision = useRef<{ pullRequestKey: string; updatedAt: string } | null>(null);
+  const refreshDiffFromHost = useCallback(
+    (revision: string) =>
+      refreshCurrentPullRequestDiff(
+        revision,
+        () => invalidate({ environmentId, input: { reference } }),
+        () => activeDiffRevision.current,
+        () => {
+          diffWarmUpQuery.refresh();
+          setRefreshToken((token) => token + 1);
+        },
+      ),
+    [diffWarmUpQuery.refresh, environmentId, invalidate, reference],
+  );
   const refreshFromHost = useCallback(async () => {
-    await invalidate({ environmentId, input: { reference } });
-    refreshDetail();
-    setRefreshToken((token) => token + 1);
-  }, [environmentId, invalidate, reference, refreshDetail]);
+    if (await refreshDiffFromHost(activeDiffRevision.current)) refreshDetail();
+  }, [refreshDetail, refreshDiffFromHost]);
+  useEffect(() => {
+    if (detailUpdatedAt === "") return;
+    const next = { pullRequestKey, updatedAt: detailUpdatedAt };
+    const previous = observedDiffRevision.current;
+    observedDiffRevision.current = next;
+    if (
+      previous === null ||
+      previous.pullRequestKey !== next.pullRequestKey ||
+      previous.updatedAt === next.updatedAt
+    )
+      return;
+    void refreshDiffFromHost(renderedDiffRevision);
+  }, [detailUpdatedAt, pullRequestKey, refreshDiffFromHost, renderedDiffRevision]);
   // A refresh asked for by the page: the detail, and through the token below, the diff with it.
   const appliedForcedToken = useRef(forcedRefreshToken);
   useEffect(() => {

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -606,7 +606,7 @@ export function PullRequestDetailPanel({
           currentAppliedSnapshot.revision,
           observedSnapshot,
         );
-  const displayDetail = tab === "code" ? codeTabDetail : detail;
+  const displayDetail = tab === "code" ? (codeTabDetail ?? detail) : detail;
   const coordinatorRef = useRef<ReturnType<
     typeof createPullRequestDiffRefreshCoordinator<PullRequestDetailView, PullRequestDiffResult>
   > | null>(null);

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
@@ -27,6 +27,7 @@ import {
   readableFailure,
   shouldRefreshPullRequestActivity,
   resolveBaseFreshness,
+  refreshCurrentPullRequestDiff,
   buildPullRequestTimeline,
   describePullRequestState,
   editPullRequestThreadComment,
@@ -114,6 +115,38 @@ describe("review thread comment pages", () => {
       { id: "c2", body: "saved body" },
       { id: "c3", body: "another loaded comment" },
     ]);
+  });
+});
+
+describe("pull request diff freshness", () => {
+  it("ignores a stale invalidation completion", async () => {
+    let finishInvalidation!: () => void;
+    const invalidation = new Promise<void>((resolve) => {
+      finishInvalidation = resolve;
+    });
+    let currentRevision = "pr-a@1";
+    let refreshes = 0;
+    const stale = refreshCurrentPullRequestDiff(
+      "pr-a@1",
+      () => invalidation,
+      () => currentRevision,
+      () => refreshes++,
+    );
+
+    currentRevision = "pr-a@2";
+    finishInvalidation();
+    expect(await stale).toBe(false);
+    expect(refreshes).toBe(0);
+
+    expect(
+      await refreshCurrentPullRequestDiff(
+        currentRevision,
+        async () => undefined,
+        () => currentRevision,
+        () => refreshes++,
+      ),
+    ).toBe(true);
+    expect(refreshes).toBe(1);
   });
 });
 

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
@@ -142,6 +142,7 @@ describe("pull request diff freshness", () => {
     additions: 12,
     deletions: 4,
     changedFiles: 3,
+    diffRevision: { baseOid: "base-oid", headOid: "head-oid" },
     commits: [{ oid: "base" }, { oid: "head" }],
   };
 
@@ -159,6 +160,25 @@ describe("pull request diff freshness", () => {
     expect(pullRequestCodeRevision({ ...codeSource, additions: 13 })).not.toBe(revision);
     expect(pullRequestCodeRevision({ ...codeSource, behindBy: 1 })).not.toBe(revision);
     expect(pullRequestCodeRevision({ ...codeSource, baseBranch: "release" })).not.toBe(revision);
+    expect(
+      pullRequestCodeRevision({
+        ...codeSource,
+        diffRevision: { ...codeSource.diffRevision, baseOid: "advanced-base" },
+      }),
+    ).not.toBe(revision);
+    expect(
+      pullRequestCodeRevision({
+        ...codeSource,
+        diffRevision: { ...codeSource.diffRevision, headOid: "pushed-head" },
+      }),
+    ).not.toBe(revision);
+  });
+
+  it("falls back to host-agnostic signals when immutable diff endpoints are unavailable", () => {
+    const withoutDiffRevision = { ...codeSource, diffRevision: undefined };
+    const revision = pullRequestCodeRevision(withoutDiffRevision);
+
+    expect(pullRequestCodeRevision({ ...withoutDiffRevision, additions: 13 })).not.toBe(revision);
   });
 
   it("overlays same-code conversation detail but retains applied detail across code changes", () => {

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
@@ -13,6 +13,7 @@ import {
   buildExplainPullRequestHandoff,
   buildFixFindingHandoff,
   buildFixFindingsHandoff,
+  createPullRequestDiffRefreshCoordinator,
   groupPullRequestTimelineConversations,
   handoffPrompt,
   handoffReviewComments,
@@ -21,13 +22,14 @@ import {
   orderPullRequestComments,
   pullRequestActionMenuHasGroup,
   pullRequestActionNeedsHostRefresh,
+  pullRequestCodeRevision,
+  pullRequestCodeTabDetail,
   pullRequestComposerTarget,
   pullRequestFindingKey,
   pullRequestHandoffLabels,
   readableFailure,
   shouldRefreshPullRequestActivity,
   resolveBaseFreshness,
-  refreshCurrentPullRequestDiff,
   buildPullRequestTimeline,
   describePullRequestState,
   editPullRequestThreadComment,
@@ -119,35 +121,276 @@ describe("review thread comment pages", () => {
 });
 
 describe("pull request diff freshness", () => {
-  it("ignores a stale invalidation completion", async () => {
-    let finishInvalidation!: () => void;
-    const invalidation = new Promise<void>((resolve) => {
-      finishInvalidation = resolve;
+  type RefreshResult<T> =
+    | { readonly _tag: "Success"; readonly value: T }
+    | { readonly _tag: "Failure"; readonly error: string };
+  const success = <T>(value: T): RefreshResult<T> => ({ _tag: "Success", value });
+  const failure = (error: string): RefreshResult<never> => ({ _tag: "Failure", error });
+
+  function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((done) => {
+      resolve = done;
     });
-    let currentRevision = "pr-a@1";
-    let refreshes = 0;
-    const stale = refreshCurrentPullRequestDiff(
-      "pr-a@1",
-      () => invalidation,
-      () => currentRevision,
-      () => refreshes++,
+    return { promise, resolve };
+  }
+
+  const codeSource = {
+    baseBranch: "main",
+    baseComparison: "up-to-date" as const,
+    behindBy: 0,
+    additions: 12,
+    deletions: 4,
+    changedFiles: 3,
+    commits: [{ oid: "base" }, { oid: "head" }],
+  };
+
+  it("keeps the code revision stable across comment-only updates and covers available base inputs", () => {
+    const revision = pullRequestCodeRevision(codeSource);
+    expect(pullRequestCodeRevision({ ...codeSource, commits: [...codeSource.commits] })).toBe(
+      revision,
     );
-
-    currentRevision = "pr-a@2";
-    finishInvalidation();
-    expect(await stale).toBe(false);
-    expect(refreshes).toBe(0);
-
     expect(
-      await refreshCurrentPullRequestDiff(
-        currentRevision,
-        async () => undefined,
-        () => currentRevision,
-        () => refreshes++,
-      ),
-    ).toBe(true);
-    expect(refreshes).toBe(1);
+      pullRequestCodeRevision({
+        ...codeSource,
+        commits: [...codeSource.commits, { oid: "pushed" }],
+      }),
+    ).not.toBe(revision);
+    expect(pullRequestCodeRevision({ ...codeSource, additions: 13 })).not.toBe(revision);
+    expect(pullRequestCodeRevision({ ...codeSource, behindBy: 1 })).not.toBe(revision);
+    expect(pullRequestCodeRevision({ ...codeSource, baseBranch: "release" })).not.toBe(revision);
   });
+
+  it("overlays same-code conversation detail but retains applied detail across code changes", () => {
+    const applied = { ...codeSource, metadata: "old" };
+    const revision = pullRequestCodeRevision(applied);
+    const conversationUpdate = { ...applied, metadata: "new" };
+    const codeUpdate = {
+      ...conversationUpdate,
+      commits: [...conversationUpdate.commits, { oid: "pushed" }],
+    };
+    expect(pullRequestCodeTabDetail(applied, revision, conversationUpdate)).toBe(
+      conversationUpdate,
+    );
+    expect(pullRequestCodeTabDetail(applied, revision, codeUpdate)).toBe(applied);
+  });
+
+  const concurrencyCases: ReadonlyArray<{
+    readonly name: string;
+    readonly run: () => Promise<void>;
+  }> = [
+    {
+      name: "bootstraps by invalidating, rereading, and forcing the aggregate in order",
+      run: async () => {
+        const coordinator = createPullRequestDiffRefreshCoordinator((revision: string) => revision);
+        const events: string[] = [];
+        await coordinator.observe("env-a/pr-a", "signal-a", {
+          invalidate: async () => {
+            events.push("invalidate");
+          },
+          readSnapshot: async () => {
+            events.push("read");
+            return success("snapshot-a");
+          },
+          refreshAggregate: async () => {
+            events.push("diff");
+            return success("first-page");
+          },
+          setFailure: () => undefined,
+          apply: (_scope, revision, snapshot, aggregate) =>
+            events.push(`apply:${revision}:${snapshot}:${aggregate}`),
+        });
+        expect(events).toEqual([
+          "invalidate",
+          "read",
+          "diff",
+          "apply:snapshot-a:snapshot-a:first-page",
+        ]);
+      },
+    },
+    {
+      name: "coalesces the reread revision while its aggregate is active",
+      run: async () => {
+        const coordinator = createPullRequestDiffRefreshCoordinator((revision: string) => revision);
+        const diff = deferred<RefreshResult<boolean>>();
+        let invalidations = 0;
+        const applied: string[] = [];
+        const work = {
+          invalidate: async () => {
+            invalidations++;
+          },
+          readSnapshot: async () => success("code-b"),
+          refreshAggregate: () => diff.promise,
+          setFailure: () => undefined,
+          apply: (_scope: string, revision: string) => applied.push(revision),
+        };
+        const first = coordinator.observe("env-a/pr-a", "code-a", work);
+        await Promise.resolve();
+        await Promise.resolve();
+        void coordinator.observe("env-a/pr-a", "code-b", work);
+        diff.resolve(success(true));
+        await first;
+        await coordinator.observe("env-a/pr-a", "code-b", work);
+        expect({ invalidations, applied }).toEqual({ invalidations: 1, applied: ["code-b"] });
+      },
+    },
+    {
+      name: "lets the original signal supersede when its reread produced a newer revision",
+      run: async () => {
+        const coordinator = createPullRequestDiffRefreshCoordinator((revision: string) => revision);
+        let nextSnapshot = "b";
+        const applied: string[] = [];
+        const baseline = {
+          invalidate: async () => undefined,
+          readSnapshot: async () => success(nextSnapshot),
+          refreshAggregate: async () => success(true),
+          setFailure: () => undefined,
+          apply: (_scope: string, revision: string) => applied.push(revision),
+        };
+        const bDiff = deferred<RefreshResult<boolean>>();
+        const active = coordinator.observe("env-a/pr-a", "a", {
+          ...baseline,
+          refreshAggregate: () => bDiff.promise,
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+        nextSnapshot = "a";
+        void coordinator.observe("env-a/pr-a", "a", baseline);
+        bDiff.resolve(success(true));
+        await active;
+        expect(applied).toEqual(["a"]);
+      },
+    },
+    {
+      name: "applies the coherent reread when invalidation advances the host again",
+      run: async () => {
+        const coordinator = createPullRequestDiffRefreshCoordinator((revision: string) => revision);
+        const applied: string[] = [];
+        await coordinator.observe("env-a/pr-a", "b", {
+          invalidate: async () => undefined,
+          readSnapshot: async () => success("c"),
+          refreshAggregate: async () => success(true),
+          setFailure: () => undefined,
+          apply: (_scope: string, revision: string) => applied.push(revision),
+        });
+        expect(applied).toEqual(["c"]);
+      },
+    },
+    {
+      name: "publishes only the latest detail and first page when a newer signal arrives",
+      run: async () => {
+        type Snapshot = { revision: string; detail: string };
+        const coordinator = createPullRequestDiffRefreshCoordinator<Snapshot, string>(
+          (snapshot) => snapshot.revision,
+        );
+        const oldDiff = deferred<RefreshResult<string>>();
+        const applied: Array<[string, string]> = [];
+        const failures: Array<string | null> = [];
+        const old = coordinator.observe(
+          "env-a/pr-a",
+          { revision: "a", detail: "signal-a" },
+          {
+            invalidate: async () => undefined,
+            readSnapshot: async () => success({ revision: "a", detail: "detail-a" }),
+            refreshAggregate: () => oldDiff.promise,
+            setFailure: (error) => failures.push(error),
+            apply: (_scope, _revision, snapshot, aggregate) =>
+              applied.push([snapshot.detail, aggregate]),
+          },
+        );
+        await Promise.resolve();
+        void coordinator.observe(
+          "env-a/pr-a",
+          { revision: "b", detail: "signal-b" },
+          {
+            invalidate: async () => {
+              // host invalidation/read establishes the exact cohort that may be committed
+            },
+            readSnapshot: async () => success({ revision: "b", detail: "detail-b" }),
+            refreshAggregate: async () => success("diff-b"),
+            setFailure: (error) => failures.push(error),
+            apply: (_scope, _revision, snapshot, aggregate) =>
+              applied.push([snapshot.detail, aggregate]),
+          },
+        );
+        oldDiff.resolve(failure("stale failure"));
+        await old;
+        expect(applied).toEqual([["detail-b", "diff-b"]]);
+        expect(failures).toEqual([null]);
+      },
+    },
+    {
+      name: "retries the same signal after a failed snapshot or aggregate",
+      run: async () => {
+        const coordinator = createPullRequestDiffRefreshCoordinator((revision: string) => revision);
+        let snapshot: RefreshResult<string> = failure("snapshot");
+        let aggregate: RefreshResult<true> = success(true);
+        const applied: string[] = [];
+        const failures: Array<string | null> = [];
+        const work = {
+          invalidate: async () => undefined,
+          readSnapshot: async () => snapshot,
+          refreshAggregate: async () => aggregate,
+          setFailure: (error: string | null) => failures.push(error),
+          apply: (_scope: string, revision: string) => applied.push(revision),
+        };
+        await coordinator.observe("env-a/pr-a", "a", work);
+        expect(applied).toEqual([]);
+        snapshot = success("a");
+        aggregate = failure("aggregate");
+        await coordinator.observe("env-a/pr-a", "a", work);
+        expect(applied).toEqual([]);
+        aggregate = success(true);
+        await coordinator.observe("env-a/pr-a", "a", work);
+        expect(applied).toEqual(["a"]);
+        expect(failures).toEqual(["snapshot", "aggregate", null]);
+      },
+    },
+    {
+      name: "reapplies an explicit same-revision refresh",
+      run: async () => {
+        const coordinator = createPullRequestDiffRefreshCoordinator((revision: string) => revision);
+        let applies = 0;
+        const work = {
+          invalidate: async () => undefined,
+          readSnapshot: async () => success("a"),
+          refreshAggregate: async () => success(true),
+          setFailure: () => undefined,
+          apply: () => applies++,
+        };
+        await coordinator.observe("env-a/pr-a", "a", work);
+        await coordinator.refresh("env-a/pr-a", work);
+        expect(applies).toBe(2);
+      },
+    },
+    {
+      name: "clears queued and applied state on an environment switch",
+      run: async () => {
+        const coordinator = createPullRequestDiffRefreshCoordinator((revision: string) => revision);
+        const oldDiff = deferred<RefreshResult<boolean>>();
+        const applied: string[] = [];
+        const old = coordinator.observe("env-a/pr-a", "same-code", {
+          invalidate: async () => undefined,
+          readSnapshot: async () => success("unused"),
+          refreshAggregate: () => oldDiff.promise,
+          setFailure: () => undefined,
+          apply: () => applied.push("env-a"),
+        });
+        void coordinator.observe("env-b/pr-a", "same-code", {
+          invalidate: async () => undefined,
+          readSnapshot: async () => success("unused"),
+          refreshAggregate: async () => success(true),
+          setFailure: () => undefined,
+          apply: () => applied.push("env-b"),
+        });
+        oldDiff.resolve(success(true));
+        await old;
+        expect(applied).toEqual(["env-b"]);
+      },
+    },
+  ];
+
+  it.each(concurrencyCases)("$name", async ({ run }) => run());
 });
 
 describe("pull request action menu", () => {

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
@@ -43,6 +43,19 @@ export function editPullRequestThreadComment<
   return comments.map((comment) => (comment.id === commentId ? { ...comment, body } : comment));
 }
 
+/** Invalidate first, then refresh only if the panel still shows the revision that asked. */
+export async function refreshCurrentPullRequestDiff(
+  revision: string,
+  invalidate: () => Promise<unknown>,
+  getCurrentRevision: () => string,
+  refresh: () => void,
+): Promise<boolean> {
+  await invalidate();
+  if (getCurrentRevision() !== revision) return false;
+  refresh();
+  return true;
+}
+
 /**
  * Whether the pull request on a right-panel surface is the thread's own one. Repository and
  * number are not enough: one environment can hold two checkouts of the same repository under

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
@@ -45,21 +45,26 @@ export function editPullRequestThreadComment<
 }
 
 /**
- * The code inputs exposed by the current contract: ordered head commits plus the base comparison's
- * branch, status, distance, and diff totals. The contract has no base SHA, so these are the
- * narrowest available signals for a base advance; conversation timestamps and review activity
- * deliberately stay out.
+ * Immutable diff endpoints where the host exposes them, plus the existing fallback signals for a
+ * host without them. Conversation timestamps and review activity deliberately stay out.
  */
 export function pullRequestCodeRevision(
   detail: Pick<
     PullRequestDetailView,
-    "additions" | "baseBranch" | "baseComparison" | "behindBy" | "changedFiles" | "deletions"
+    | "additions"
+    | "baseBranch"
+    | "baseComparison"
+    | "behindBy"
+    | "changedFiles"
+    | "deletions"
+    | "diffRevision"
   > & {
     readonly commits: ReadonlyArray<Pick<PullRequestCommit, "oid">>;
   },
 ): string {
   return JSON.stringify([
     detail.baseBranch,
+    detail.diffRevision ?? null,
     detail.baseComparison ?? null,
     detail.behindBy ?? null,
     detail.additions,

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
@@ -4,6 +4,7 @@ import type {
   PullRequestBaseComparison,
   PullRequestCheck,
   PullRequestComment,
+  PullRequestCommit,
   PullRequestDetailView,
   PullRequestMergeability,
   PullRequestReaction,
@@ -43,17 +44,152 @@ export function editPullRequestThreadComment<
   return comments.map((comment) => (comment.id === commentId ? { ...comment, body } : comment));
 }
 
-/** Invalidate first, then refresh only if the panel still shows the revision that asked. */
-export async function refreshCurrentPullRequestDiff(
-  revision: string,
-  invalidate: () => Promise<unknown>,
-  getCurrentRevision: () => string,
-  refresh: () => void,
-): Promise<boolean> {
-  await invalidate();
-  if (getCurrentRevision() !== revision) return false;
-  refresh();
-  return true;
+/**
+ * The code inputs exposed by the current contract: ordered head commits plus the base comparison's
+ * branch, status, distance, and diff totals. The contract has no base SHA, so these are the
+ * narrowest available signals for a base advance; conversation timestamps and review activity
+ * deliberately stay out.
+ */
+export function pullRequestCodeRevision(
+  detail: Pick<
+    PullRequestDetailView,
+    "additions" | "baseBranch" | "baseComparison" | "behindBy" | "changedFiles" | "deletions"
+  > & {
+    readonly commits: ReadonlyArray<Pick<PullRequestCommit, "oid">>;
+  },
+): string {
+  return JSON.stringify([
+    detail.baseBranch,
+    detail.baseComparison ?? null,
+    detail.behindBy ?? null,
+    detail.additions,
+    detail.deletions,
+    detail.changedFiles,
+    detail.commits.map((commit) => commit.oid),
+  ]);
+}
+
+/** Same-code conversation metadata may advance without replacing the applied code snapshot. */
+export function pullRequestCodeTabDetail<T extends Parameters<typeof pullRequestCodeRevision>[0]>(
+  applied: T,
+  appliedRevision: string,
+  observed: T | null,
+): T {
+  return observed !== null && pullRequestCodeRevision(observed) === appliedRevision
+    ? observed
+    : applied;
+}
+
+interface PullRequestDiffRefreshWork<Snapshot, Aggregate> {
+  readonly invalidate: () => Promise<unknown>;
+  readonly readSnapshot: () => Promise<PullRequestDiffRefreshResult<Snapshot>>;
+  readonly refreshAggregate: () => Promise<PullRequestDiffRefreshResult<Aggregate>>;
+  readonly setFailure: (error: string | null) => void;
+  readonly apply: (
+    scope: string,
+    codeRevision: string,
+    snapshot: Snapshot,
+    aggregate: Aggregate,
+  ) => void;
+}
+
+type PullRequestDiffRefreshResult<T> =
+  | { readonly _tag: "Success"; readonly value: T }
+  | { readonly _tag: "Failure"; readonly error: string };
+
+interface PullRequestDiffRefreshRequest<Snapshot, Aggregate> {
+  readonly generation: number;
+  readonly signal: string | null;
+  readonly work: PullRequestDiffRefreshWork<Snapshot, Aggregate>;
+}
+
+/** One latest-wins lane for every automatic and explicit refresh of the panel's current scope. */
+export function createPullRequestDiffRefreshCoordinator<Snapshot, Aggregate>(
+  revisionOf: (snapshot: Snapshot) => string,
+) {
+  let scope: string | null = null;
+  let generation = 0;
+  let appliedRevision: string | null = null;
+  let activeSignal: string | null = null;
+  let queued: PullRequestDiffRefreshRequest<Snapshot, Aggregate> | null = null;
+  let draining: Promise<void> | null = null;
+
+  const setScope = (nextScope: string) => {
+    if (scope === nextScope) return;
+    scope = nextScope;
+    generation++;
+    appliedRevision = null;
+    activeSignal = null;
+    queued = null;
+  };
+
+  const run = async () => {
+    try {
+      while (queued !== null) {
+        const request = queued;
+        queued = null;
+        const requestScope = scope;
+        if (requestScope === null) continue;
+        activeSignal = request.signal;
+        const isCurrent = () => scope === requestScope && generation === request.generation;
+        await request.work.invalidate();
+        if (!isCurrent()) continue;
+        const snapshotResult = await request.work.readSnapshot();
+        if (!isCurrent()) continue;
+        if (snapshotResult._tag === "Failure") {
+          request.work.setFailure(snapshotResult.error);
+          continue;
+        }
+        const snapshot = snapshotResult.value;
+        const codeRevision = revisionOf(snapshot);
+        activeSignal = codeRevision;
+        const aggregateResult = await request.work.refreshAggregate();
+        if (!isCurrent()) continue;
+        if (aggregateResult._tag === "Failure") {
+          request.work.setFailure(aggregateResult.error);
+          continue;
+        }
+        appliedRevision = codeRevision;
+        request.work.setFailure(null);
+        request.work.apply(requestScope, codeRevision, snapshot, aggregateResult.value);
+        activeSignal = null;
+      }
+    } finally {
+      // Clear before the promise settles, so an enqueue can never see a completed drain as live.
+      activeSignal = null;
+      draining = null;
+    }
+  };
+
+  const enqueue = (
+    nextScope: string,
+    signal: string | null,
+    explicit: boolean,
+    work: PullRequestDiffRefreshWork<Snapshot, Aggregate>,
+  ) => {
+    setScope(nextScope);
+    const latestSignal = queued?.signal ?? activeSignal;
+    if (
+      !explicit &&
+      (signal === latestSignal || (draining === null && signal === appliedRevision))
+    ) {
+      return draining ?? Promise.resolve();
+    }
+    generation++;
+    queued = { generation, signal, work };
+    if (draining === null) draining = run();
+    return draining;
+  };
+
+  return {
+    observe: (
+      nextScope: string,
+      snapshot: Snapshot,
+      work: PullRequestDiffRefreshWork<Snapshot, Aggregate>,
+    ) => enqueue(nextScope, revisionOf(snapshot), false, work),
+    refresh: (nextScope: string, work: PullRequestDiffRefreshWork<Snapshot, Aggregate>) =>
+      enqueue(nextScope, null, true, work),
+  };
 }
 
 /**

--- a/packages/contracts/src/pullRequest.ts
+++ b/packages/contracts/src/pullRequest.ts
@@ -636,6 +636,8 @@ export type PullRequestListStatsResult = typeof PullRequestListStatsResult.Type;
  */
 export const PullRequestInvalidateInput = Schema.Struct({
   reference: Schema.optional(PullRequestRef),
+  /** With a reference, forget only its aggregate diff; omitted keeps the full refresh behavior. */
+  resource: Schema.optional(Schema.Literal("diff")),
 });
 export type PullRequestInvalidateInput = typeof PullRequestInvalidateInput.Type;
 
@@ -661,6 +663,17 @@ export const PullRequestDetail = Schema.Struct({
   changedFiles: NonNegativeInt,
   headBranch: TrimmedNonEmptyString,
   baseBranch: TrimmedNonEmptyString,
+  /**
+   * The immutable endpoints of the aggregate diff. Optional for hosts that cannot expose a diff
+   * or do not report both endpoints; unlike branch names and totals, this changes whenever either
+   * side of the comparison moves.
+   */
+  diffRevision: Schema.optional(
+    Schema.Struct({
+      baseOid: TrimmedNonEmptyString,
+      headOid: TrimmedNonEmptyString,
+    }),
+  ),
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,
   mergedAt: Schema.NullOr(IsoDateTime),


### PR DESCRIPTION
## Problem

After a pull request receives new commits, the detail header can update while the Code tab's **All commits** diff remains on an older aggregate snapshot. Switching to a commit and back exposes the stale aggregate until the user explicitly refreshes it.

The detail panel keeps the aggregate diff query warm, but live refresh previously refreshed only detail and activity data. The aggregate diff query therefore remained mounted with stale data.

## Fix

- Observe same-PR `updatedAt` revisions and invalidate the host cache when the revision advances.
- Refresh the aggregate diff and reset Code-tab pagination after invalidation.
- Guard asynchronous invalidation so a completion from an older PR or revision cannot refresh the currently displayed PR.
- Continue refreshing immutable commit-scoped diffs directly without issuing a duplicate aggregate request.

## Validation

- Focused pull-request detail and diff tests: 72 passed.
- `@t3tools/web` typecheck passed.
- Targeted lint and format checks passed.
- `git diff --check` passed.
- Added a deferred-invalidation regression test proving stale async completions are ignored.

Built with GPT-5.6 in the Codex harness through T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refresh pull request diff after updates using snapshot coordination
> - Introduces a `createPullRequestDiffRefreshCoordinator` in [`pullRequestDetail.logic.ts`](https://github.com/pingdotgg/t3code/pull/7167/files#diff-2c5f917dba9decc3bd48ec3231f7b0db073e8b642379cf000265960a03718c18) that manages diff refresh with a latest-wins strategy, skipping redundant refreshes and surfacing failures via an alert banner.
> - `PullRequestDetailPanel` now drives diff refresh through the coordinator: builds a `PullRequestCodeSnapshot` (detail + first-page aggregate diff) and applies it coherently, replacing the previous eager warm-up and `refreshToken` approach.
> - `PullRequestCodeTab` boots from the snapshot, defers diff queries until the snapshot is available, handles aggregate pagination manually with per-cursor retry, and shows `PullRequestCodeRefreshFailure` on refresh errors without losing displayed content.
> - Server-side, GitHub, GitLab, and Bitbucket providers now return `diffRevision` (base/head OIDs) on PR detail; `PullRequestService` uses these to separate aggregate diff cache invalidation from commit-scoped diff and detail invalidation via `resource: "diff"`.
> - Behavioral Change: calling `invalidate` with `resource: "diff"` now only busts the aggregate diff cache, leaving detail and commit diff caches intact. Aggregate diff cache keys now include a second epoch slot, so existing cached keys are structurally incompatible.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 91a29c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches PR caching, multi-host detail decoding, and async refresh coordination; incorrect epoch or coordinator ordering could show stale diffs or skip updates, but behavior is heavily covered by new service and logic tests.
> 
> **Overview**
> Fixes **All commits** staying stale after new pushes while the detail header updates, by tying aggregate diff freshness to immutable base/head OIDs and a dedicated refresh path.
> 
> **Server & contracts:** Optional `diffRevision` (`baseOid` / `headOid`) is populated from GitHub (extra `gh api` after detail), GitLab (`diff_refs`), and Bitbucket (source/destination commit hashes). `invalidate` accepts `resource: "diff"` to bump only the **aggregate** diff epoch; commit-scoped diffs use a separate epoch and are not cleared on diff-only invalidation. Epoch maps advance a fallback on LRU eviction so evicted scopes cannot reuse stale cache keys.
> 
> **Web:** `PullRequestDetailPanel` drops eager diff warm-up and `refreshToken`; a `createPullRequestDiffRefreshCoordinator` invalidates diff cache, re-reads detail+activity, fetches the first aggregate page, and applies a versioned snapshot. `PullRequestCodeTab` bootstraps from that snapshot, shows loading/error and **stale diff + retry** banners on refresh failure, and pages aggregate vs commit diffs separately (`shouldRefreshAppliedCommitDiff` for same-commit snapshot bumps).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91a29c6379b2951aea4c7e4225de3013c4b47c5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Closes #7310