### PR TITLE
fix(orchestration): do not revive idle tasks from status-free progress

### DIFF
--- a/apps/server/src/orchestration/ThreadBackgroundLiveness.test.ts
+++ b/apps/server/src/orchestration/ThreadBackgroundLiveness.test.ts
@@ -2,6 +2,32 @@ import { describe, expect, it } from "vite-plus/test";
 import * as ThreadBackgroundLiveness from "./ThreadBackgroundLiveness.ts";
 
 describe("ThreadBackgroundLiveness", () => {
+  it("does not let status-free progress restart an idle task", () => {
+    const liveness = ThreadBackgroundLiveness.make();
+    liveness.recordTaskLiveness({
+      threadId: "thread",
+      taskId: "task",
+      taskType: undefined,
+      status: undefined,
+      kind: "started",
+    });
+    liveness.recordTaskLiveness({
+      threadId: "thread",
+      taskId: "task",
+      taskType: undefined,
+      status: "idle",
+      kind: "updated",
+    });
+    liveness.recordTaskLiveness({
+      threadId: "thread",
+      taskId: "task",
+      taskType: undefined,
+      status: undefined,
+      kind: "progress",
+    });
+    expect(liveness.getThreadBackgroundLiveness("thread")).toBeNull();
+  });
+
   it("agents present as working; monitors as monitoring; agents win", () => {
     const liveness = ThreadBackgroundLiveness.make();
     const threadId = "t-live-1";

--- a/apps/server/src/orchestration/ThreadBackgroundLiveness.ts
+++ b/apps/server/src/orchestration/ThreadBackgroundLiveness.ts
@@ -130,6 +130,19 @@ export function make(): ThreadBackgroundLivenessService["Service"] {
         return;
       }
 
+      // Status-free progress is a description tick, not a restart. A delayed
+      // progress event after idle must not put the task back in the live set
+      // (#7128).
+      if (input.kind === "progress" && input.status === undefined) {
+        const existing = stateByThreadId.get(input.threadId);
+        const stillLive =
+          existing !== undefined &&
+          (existing.agents.has(input.taskId) || existing.monitors.has(input.taskId));
+        if (!stillLive) {
+          return;
+        }
+      }
+
       drop(input.threadId, input.taskId);
       const state = stateFor(input.threadId);
       const bucket =


### PR DESCRIPTION
## Summary

Fixes #7128.

A delayed `task.progress` with no `status` was treated as live work after the same task had already gone `idle`. The thread then stayed **Working** with zero live agents.

Status-free progress is now a description tick only: it cannot re-add a task that is not already in the live set.

## Test plan

- [x] `ThreadBackgroundLiveness` unit test matching the issue repro
- [ ] Confirm a finished Codex thread no longer stays Working after a late progress event

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to in-memory sidebar liveness with a matching unit test; no auth, persistence, or ingestion contract changes.
> 
> **Overview**
> Fixes threads that stayed **Working** in the sidebar after background work had already gone **idle** (#7128).
> 
> **`ThreadBackgroundLiveness.recordTaskLiveness`** now treats **`progress`** events with no **`status`** as description-only updates: they can refresh an already-live task but **cannot** re-add a task that was removed (e.g. by **`idle`**). A late **`task.progress`** no longer resurrects the task into the agents/monitors set.
> 
> Adds a unit test for **started → idle → status-free progress** asserting thread liveness is **`null`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10f223bada8b3da3c24eabc9258d3a3feb667f33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `recordTaskLiveness` to ignore status-free progress events for idle tasks
> A `progress` event without a status field was incorrectly re-adding tasks to the live set, reviving tasks that had already transitioned to idle or completed. `recordTaskLiveness` in [ThreadBackgroundLiveness.ts](https://github.com/pingdotgg/t3code/pull/7172/files#diff-b0c25dad649cb92e4b2e2045f18da810e4c2ecce6520501428293b115d9940cd) now returns early when a status-free `progress` event arrives for a task that is not currently in the live set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10f223b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->