### PR TITLE
fix(opencode): settle pending approvals on session teardown

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -740,6 +740,77 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("cancels pending permission requests when the adapter scope closes", () =>
+    Effect.gen(function* () {
+      const scope = yield* Scope.make("sequential");
+      let scopeClosed = false;
+      try {
+        const adapterLayer = Layer.effect(
+          OpenCodeAdapter,
+          makeOpenCodeAdapter(openCodeAdapterTestSettings),
+        ).pipe(
+          Layer.provideMerge(Layer.succeed(OpenCodeRuntime, OpenCodeRuntimeTestDouble)),
+          Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
+          Layer.provideMerge(ServerSettingsService.layerTest()),
+          Layer.provideMerge(providerSessionDirectoryTestLayer),
+          Layer.provideMerge(NodeServices.layer),
+        );
+        const context = yield* Layer.buildWithScope(adapterLayer, scope);
+        const adapter = yield* Effect.service(OpenCodeAdapter).pipe(Effect.provide(context));
+        const threadId = asThreadId("thread-opencode-finalizer-pending-permission");
+        runtimeMock.state.subscribedEvents = [
+          {
+            type: "permission.asked",
+            properties: {
+              id: "perm-finalizer-1",
+              sessionID: "http://127.0.0.1:9999/session",
+              permission: "bash",
+              patterns: ["rm *"],
+              metadata: {},
+            },
+          },
+        ];
+        const opened = yield* Deferred.make<ProviderRuntimeEvent>();
+        const resolved = yield* Deferred.make<ProviderRuntimeEvent>();
+        const eventsFiber = yield* adapter.streamEvents.pipe(
+          Stream.runForEach((event) => {
+            if (event.threadId !== threadId) {
+              return Effect.void;
+            }
+            if (event.type === "request.opened") {
+              return Deferred.succeed(opened, event).pipe(Effect.asVoid, Effect.ignore);
+            }
+            if (event.type === "request.resolved") {
+              return Deferred.succeed(resolved, event).pipe(Effect.asVoid, Effect.ignore);
+            }
+            return Effect.void;
+          }),
+          Effect.forkChild,
+        );
+
+        yield* adapter.startSession({
+          provider: ProviderDriverKind.make("opencode"),
+          threadId,
+          runtimeMode: "full-access",
+        });
+        yield* Deferred.await(opened).pipe(Effect.timeout("1 second"));
+        yield* Scope.close(scope, Exit.void);
+        scopeClosed = true;
+        const resolvedEvent = yield* Deferred.await(resolved).pipe(Effect.timeout("1 second"));
+        NodeAssert.equal(resolvedEvent.type, "request.resolved");
+        if (resolvedEvent.type === "request.resolved") {
+          NodeAssert.equal(resolvedEvent.requestId, "perm-finalizer-1");
+          NodeAssert.equal(resolvedEvent.payload.decision, "cancel");
+        }
+        yield* Fiber.interrupt(eventsFiber);
+      } finally {
+        if (!scopeClosed) {
+          yield* Scope.close(scope, Exit.void).pipe(Effect.ignore);
+        }
+      }
+    }),
+  );
+
   it.effect("clears session state even when cleanup finalizers throw", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -2,6 +2,7 @@ import * as NodeAssert from "node:assert/strict";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it } from "@effect/vitest";
 import * as Context from "effect/Context";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
@@ -19,6 +20,7 @@ import {
   OpenCodeSettings,
   ProviderDriverKind,
   ProviderInstanceId,
+  type ProviderRuntimeEvent,
   ThreadId,
 } from "@t3tools/contracts";
 import { createModelSelection } from "@t3tools/shared/model";
@@ -625,6 +627,116 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         events.map((event) => event.type),
         ["session.started", "thread.started", "session.exited"],
       );
+    }),
+  );
+
+  it.effect("cancels pending permission requests when stopping a session", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-stop-pending-permission");
+      runtimeMock.state.subscribedEvents = [
+        {
+          type: "permission.asked",
+          properties: {
+            id: "perm-stop-1",
+            sessionID: "http://127.0.0.1:9999/session",
+            permission: "bash",
+            patterns: ["rm *"],
+            metadata: {},
+          },
+        },
+      ];
+      const opened = yield* Deferred.make<ProviderRuntimeEvent>();
+      const resolved = yield* Deferred.make<ProviderRuntimeEvent>();
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.runForEach((event) => {
+          if (event.threadId !== threadId) {
+            return Effect.void;
+          }
+          if (event.type === "request.opened") {
+            return Deferred.succeed(opened, event).pipe(Effect.asVoid, Effect.ignore);
+          }
+          if (event.type === "request.resolved") {
+            return Deferred.succeed(resolved, event).pipe(Effect.asVoid, Effect.ignore);
+          }
+          return Effect.void;
+        }),
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const openedEvent = yield* Deferred.await(opened).pipe(Effect.timeout("1 second"));
+      yield* adapter.stopSession(threadId);
+      const resolvedEvent = yield* Deferred.await(resolved).pipe(Effect.timeout("1 second"));
+
+      NodeAssert.equal(openedEvent.type, "request.opened");
+      if (openedEvent.type === "request.opened") {
+        NodeAssert.equal(openedEvent.requestId, "perm-stop-1");
+        NodeAssert.equal(openedEvent.payload.requestType, "command_execution_approval");
+      }
+      NodeAssert.equal(resolvedEvent.type, "request.resolved");
+      if (resolvedEvent.type === "request.resolved") {
+        NodeAssert.equal(resolvedEvent.requestId, "perm-stop-1");
+        NodeAssert.equal(resolvedEvent.payload.decision, "cancel");
+      }
+      yield* Fiber.interrupt(eventsFiber);
+    }),
+  );
+
+  it.effect("cancels pending permission requests on stopAll", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-stop-all-pending-permission");
+      runtimeMock.state.subscribedEvents = [
+        {
+          type: "permission.asked",
+          properties: {
+            id: "perm-stop-all-1",
+            sessionID: "http://127.0.0.1:9999/session",
+            permission: "edit",
+            patterns: [],
+            metadata: {},
+          },
+        },
+      ];
+      const opened = yield* Deferred.make<ProviderRuntimeEvent>();
+      const resolved = yield* Deferred.make<ProviderRuntimeEvent>();
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.runForEach((event) => {
+          if (event.threadId !== threadId) {
+            return Effect.void;
+          }
+          if (event.type === "request.opened") {
+            return Deferred.succeed(opened, event).pipe(Effect.asVoid, Effect.ignore);
+          }
+          if (event.type === "request.resolved") {
+            return Deferred.succeed(resolved, event).pipe(Effect.asVoid, Effect.ignore);
+          }
+          return Effect.void;
+        }),
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* Deferred.await(opened).pipe(Effect.timeout("1 second"));
+      yield* adapter.stopAll();
+      const resolvedEvent = yield* Deferred.await(resolved).pipe(Effect.timeout("1 second"));
+
+      NodeAssert.equal(resolvedEvent.type, "request.resolved");
+      if (resolvedEvent.type === "request.resolved") {
+        NodeAssert.equal(resolvedEvent.requestId, "perm-stop-all-1");
+        NodeAssert.equal(resolvedEvent.payload.requestType, "file_change_approval");
+        NodeAssert.equal(resolvedEvent.payload.decision, "cancel");
+      }
+      yield* Fiber.interrupt(eventsFiber);
     }),
   );
 

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -21,6 +21,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
+import * as Semaphore from "effect/Semaphore";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import type { OpencodeClient, Part, PermissionRequest, QuestionRequest } from "@opencode-ai/sdk/v2";
@@ -231,6 +232,12 @@ interface OpenCodeSessionContext {
   readonly pendingQuestions: Map<string, QuestionRequest>;
   /** False once teardown starts so the event pump cannot open new requests. */
   readonly acceptingRequests: Ref.Ref<boolean>;
+  /**
+   * Serializes `permission.asked` / `question.asked` against pending settlement
+   * so an in-flight asked handler cannot emit `request.opened` after teardown
+   * has already cancelled the same id.
+   */
+  readonly pendingGate: Semaphore.Semaphore;
   readonly messageRoleById: Map<string, "user" | "assistant">;
   readonly partById: Map<string, Part>;
   readonly emittedTextByPartId: Map<string, string>;
@@ -644,46 +651,48 @@ export function makeOpenCodeAdapter(
       Queue.offer(runtimeEvents, event).pipe(Effect.asVoid);
 
     const settleOpenCodePendingAsCancelled = (context: OpenCodeSessionContext) =>
-      Effect.gen(function* () {
-        yield* Ref.set(context.acceptingRequests, false);
-        const permissions = [...context.pendingPermissions.entries()];
-        yield* Effect.forEach(
-          permissions,
-          ([requestId, request]) =>
-            Effect.gen(function* () {
-              yield* emit({
-                ...(yield* buildEventBase({
-                  threadId: context.session.threadId,
-                  requestId,
-                })),
-                type: "request.resolved",
-                payload: {
-                  requestType: mapPermissionToRequestType(request.permission),
-                  decision: "cancel",
-                },
-              });
-              context.pendingPermissions.delete(requestId);
-            }),
-          { discard: true },
-        );
-        const questions = [...context.pendingQuestions.keys()];
-        yield* Effect.forEach(
-          questions,
-          (requestId) =>
-            Effect.gen(function* () {
-              yield* emit({
-                ...(yield* buildEventBase({
-                  threadId: context.session.threadId,
-                  requestId,
-                })),
-                type: "user-input.resolved",
-                payload: { answers: {} },
-              });
-              context.pendingQuestions.delete(requestId);
-            }),
-          { discard: true },
-        );
-      });
+      context.pendingGate.withPermits(1)(
+        Effect.gen(function* () {
+          yield* Ref.set(context.acceptingRequests, false);
+          const permissions = [...context.pendingPermissions.entries()];
+          yield* Effect.forEach(
+            permissions,
+            ([requestId, request]) =>
+              Effect.gen(function* () {
+                yield* emit({
+                  ...(yield* buildEventBase({
+                    threadId: context.session.threadId,
+                    requestId,
+                  })),
+                  type: "request.resolved",
+                  payload: {
+                    requestType: mapPermissionToRequestType(request.permission),
+                    decision: "cancel",
+                  },
+                });
+                context.pendingPermissions.delete(requestId);
+              }),
+            { discard: true },
+          );
+          const questions = [...context.pendingQuestions.keys()];
+          yield* Effect.forEach(
+            questions,
+            (requestId) =>
+              Effect.gen(function* () {
+                yield* emit({
+                  ...(yield* buildEventBase({
+                    threadId: context.session.threadId,
+                    requestId,
+                  })),
+                  type: "user-input.resolved",
+                  payload: { answers: {} },
+                });
+                context.pendingQuestions.delete(requestId);
+              }),
+            { discard: true },
+          );
+        }),
+      );
 
     // Layer-level finalizer: when the adapter layer shuts down, settle every
     // pending request then stop the session. Each session's `Scope.close`
@@ -1006,40 +1015,44 @@ export function makeOpenCodeAdapter(
         }
 
         case "permission.asked": {
-          if (!(yield* Ref.get(context.acceptingRequests))) {
-            yield* emit({
-              ...(yield* buildEventBase({
-                threadId: context.session.threadId,
-                turnId,
-                requestId: event.properties.id,
-                raw: event,
-              })),
-              type: "request.resolved",
-              payload: {
-                requestType: mapPermissionToRequestType(event.properties.permission),
-                decision: "cancel",
-              },
-            });
-            break;
-          }
-          context.pendingPermissions.set(event.properties.id, event.properties);
-          yield* emit({
-            ...(yield* buildEventBase({
-              threadId: context.session.threadId,
-              turnId,
-              requestId: event.properties.id,
-              raw: event,
-            })),
-            type: "request.opened",
-            payload: {
-              requestType: mapPermissionToRequestType(event.properties.permission),
-              detail:
-                event.properties.patterns.length > 0
-                  ? event.properties.patterns.join("\n")
-                  : event.properties.permission,
-              args: event.properties.metadata,
-            },
-          });
+          yield* context.pendingGate.withPermits(1)(
+            Effect.gen(function* () {
+              if (!(yield* Ref.get(context.acceptingRequests))) {
+                yield* emit({
+                  ...(yield* buildEventBase({
+                    threadId: context.session.threadId,
+                    turnId,
+                    requestId: event.properties.id,
+                    raw: event,
+                  })),
+                  type: "request.resolved",
+                  payload: {
+                    requestType: mapPermissionToRequestType(event.properties.permission),
+                    decision: "cancel",
+                  },
+                });
+                return;
+              }
+              context.pendingPermissions.set(event.properties.id, event.properties);
+              yield* emit({
+                ...(yield* buildEventBase({
+                  threadId: context.session.threadId,
+                  turnId,
+                  requestId: event.properties.id,
+                  raw: event,
+                })),
+                type: "request.opened",
+                payload: {
+                  requestType: mapPermissionToRequestType(event.properties.permission),
+                  detail:
+                    event.properties.patterns.length > 0
+                      ? event.properties.patterns.join("\n")
+                      : event.properties.permission,
+                  args: event.properties.metadata,
+                },
+              });
+            }),
+          );
           break;
         }
 
@@ -1062,32 +1075,36 @@ export function makeOpenCodeAdapter(
         }
 
         case "question.asked": {
-          if (!(yield* Ref.get(context.acceptingRequests))) {
-            yield* emit({
-              ...(yield* buildEventBase({
-                threadId: context.session.threadId,
-                turnId,
-                requestId: event.properties.id,
-                raw: event,
-              })),
-              type: "user-input.resolved",
-              payload: { answers: {} },
-            });
-            break;
-          }
-          context.pendingQuestions.set(event.properties.id, event.properties);
-          yield* emit({
-            ...(yield* buildEventBase({
-              threadId: context.session.threadId,
-              turnId,
-              requestId: event.properties.id,
-              raw: event,
-            })),
-            type: "user-input.requested",
-            payload: {
-              questions: normalizeQuestionRequest(event.properties),
-            },
-          });
+          yield* context.pendingGate.withPermits(1)(
+            Effect.gen(function* () {
+              if (!(yield* Ref.get(context.acceptingRequests))) {
+                yield* emit({
+                  ...(yield* buildEventBase({
+                    threadId: context.session.threadId,
+                    turnId,
+                    requestId: event.properties.id,
+                    raw: event,
+                  })),
+                  type: "user-input.resolved",
+                  payload: { answers: {} },
+                });
+                return;
+              }
+              context.pendingQuestions.set(event.properties.id, event.properties);
+              yield* emit({
+                ...(yield* buildEventBase({
+                  threadId: context.session.threadId,
+                  turnId,
+                  requestId: event.properties.id,
+                  raw: event,
+                })),
+                type: "user-input.requested",
+                payload: {
+                  questions: normalizeQuestionRequest(event.properties),
+                },
+              });
+            }),
+          );
           break;
         }
 
@@ -1475,6 +1492,7 @@ export function makeOpenCodeAdapter(
           pendingPermissions: new Map(),
           pendingQuestions: new Map(),
           acceptingRequests: yield* Ref.make(true),
+          pendingGate: yield* Semaphore.make(1),
           partById: new Map(),
           emittedTextByPartId: new Map(),
           messageRoleById: new Map(),

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -229,6 +229,8 @@ interface OpenCodeSessionContext {
   readonly openCodeSessionId: string;
   readonly pendingPermissions: Map<string, PermissionRequest>;
   readonly pendingQuestions: Map<string, QuestionRequest>;
+  /** False once teardown starts so the event pump cannot open new requests. */
+  readonly acceptingRequests: Ref.Ref<boolean>;
   readonly messageRoleById: Map<string, "user" | "assistant">;
   readonly partById: Map<string, Part>;
   readonly emittedTextByPartId: Map<string, string>;
@@ -671,38 +673,41 @@ export function makeOpenCodeAdapter(
 
     const settleOpenCodePendingAsCancelled = (context: OpenCodeSessionContext) =>
       Effect.gen(function* () {
+        yield* Ref.set(context.acceptingRequests, false);
         const permissions = [...context.pendingPermissions.entries()];
-        context.pendingPermissions.clear();
         yield* Effect.forEach(
           permissions,
           ([requestId, request]) =>
-            emit({
-              ...(yield *
-                buildEventBase({
+            Effect.gen(function* () {
+              yield* emit({
+                ...(yield* buildEventBase({
                   threadId: context.session.threadId,
                   requestId,
                 })),
-              type: "request.resolved",
-              payload: {
-                requestType: mapPermissionToRequestType(request.permission),
-                decision: "cancel",
-              },
+                type: "request.resolved",
+                payload: {
+                  requestType: mapPermissionToRequestType(request.permission),
+                  decision: "cancel",
+                },
+              });
+              context.pendingPermissions.delete(requestId);
             }),
           { discard: true },
         );
         const questions = [...context.pendingQuestions.keys()];
-        context.pendingQuestions.clear();
         yield* Effect.forEach(
           questions,
           (requestId) =>
-            emit({
-              ...(yield *
-                buildEventBase({
+            Effect.gen(function* () {
+              yield* emit({
+                ...(yield* buildEventBase({
                   threadId: context.session.threadId,
                   requestId,
                 })),
-              type: "user-input.resolved",
-              payload: { answers: {} },
+                type: "user-input.resolved",
+                payload: { answers: {} },
+              });
+              context.pendingQuestions.delete(requestId);
             }),
           { discard: true },
         );
@@ -996,6 +1001,22 @@ export function makeOpenCodeAdapter(
         }
 
         case "permission.asked": {
+          if (!(yield* Ref.get(context.acceptingRequests))) {
+            yield* emit({
+              ...(yield* buildEventBase({
+                threadId: context.session.threadId,
+                turnId,
+                requestId: event.properties.id,
+                raw: event,
+              })),
+              type: "request.resolved",
+              payload: {
+                requestType: mapPermissionToRequestType(event.properties.permission),
+                decision: "cancel",
+              },
+            });
+            break;
+          }
           context.pendingPermissions.set(event.properties.id, event.properties);
           yield* emit({
             ...(yield* buildEventBase({
@@ -1036,6 +1057,19 @@ export function makeOpenCodeAdapter(
         }
 
         case "question.asked": {
+          if (!(yield* Ref.get(context.acceptingRequests))) {
+            yield* emit({
+              ...(yield* buildEventBase({
+                threadId: context.session.threadId,
+                turnId,
+                requestId: event.properties.id,
+                raw: event,
+              })),
+              type: "user-input.resolved",
+              payload: { answers: {} },
+            });
+            break;
+          }
           context.pendingQuestions.set(event.properties.id, event.properties);
           yield* emit({
             ...(yield* buildEventBase({
@@ -1435,6 +1469,7 @@ export function makeOpenCodeAdapter(
           openCodeSessionId: started.openCodeSession.id,
           pendingPermissions: new Map(),
           pendingQuestions: new Map(),
+          acceptingRequests: yield* Ref.make(true),
           partById: new Map(),
           emittedTextByPartId: new Map(),
           messageRoleById: new Map(),

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -640,34 +640,6 @@ export function makeOpenCodeAdapter(
         })),
       );
 
-    // Layer-level finalizer: when the adapter layer shuts down, stop every
-    // session. Each session's `Scope.close` tears down its spawned OpenCode
-    // server (via the `ChildProcessSpawner` finalizer installed in
-    // `startOpenCodeServerProcess`) and interrupts the forked event/exit
-    // fibers. Consumers that can't reason about Effect scopes therefore
-    // cannot leak OpenCode child processes by forgetting to call `stopAll`.
-    yield* Effect.addFinalizer(() =>
-      Effect.gen(function* () {
-        const contexts = [...sessions.values()];
-        sessions.clear();
-        // `ignoreCause` swallows both typed failures (none here) and defects
-        // from throwing scope finalizers so a sibling's death can't interrupt
-        // the remaining cleanups.
-        yield* Effect.forEach(
-          contexts,
-          (context) => Effect.ignoreCause(stopOpenCodeContext(context)),
-          { concurrency: "unbounded", discard: true },
-        );
-        // Close the logger AFTER session teardown so any final lifecycle
-        // events emitted during shutdown still get written. `close` flushes
-        // the `Logger.batched` window and closes each per-thread
-        // `RotatingFileSink` handle owned by the logger's internal scope.
-        if (managedNativeEventLogger !== undefined) {
-          yield* managedNativeEventLogger.close();
-        }
-      }).pipe(Effect.ensuring(Queue.shutdown(runtimeEvents))),
-    );
-
     const emit = (event: ProviderRuntimeEvent) =>
       Queue.offer(runtimeEvents, event).pipe(Effect.asVoid);
 
@@ -712,6 +684,39 @@ export function makeOpenCodeAdapter(
           { discard: true },
         );
       });
+
+    // Layer-level finalizer: when the adapter layer shuts down, settle every
+    // pending request then stop the session. Each session's `Scope.close`
+    // tears down its spawned OpenCode server (via the `ChildProcessSpawner`
+    // finalizer installed in `startOpenCodeServerProcess`) and interrupts
+    // the forked event/exit fibers. Provider instance remove/replace closes
+    // this scope without calling `stopAll`, so settlement has to live here.
+    yield* Effect.addFinalizer(() =>
+      Effect.gen(function* () {
+        const contexts = [...sessions.values()];
+        sessions.clear();
+        // `ignoreCause` swallows both typed failures (none here) and defects
+        // from throwing scope finalizers so a sibling's death can't interrupt
+        // the remaining cleanups.
+        yield* Effect.forEach(
+          contexts,
+          (context) =>
+            Effect.ignoreCause(
+              settleOpenCodePendingAsCancelled(context).pipe(
+                Effect.andThen(stopOpenCodeContext(context)),
+              ),
+            ),
+          { concurrency: "unbounded", discard: true },
+        );
+        // Close the logger AFTER session teardown so any final lifecycle
+        // events emitted during shutdown still get written. `close` flushes
+        // the `Logger.batched` window and closes each per-thread
+        // `RotatingFileSink` handle owned by the logger's internal scope.
+        if (managedNativeEventLogger !== undefined) {
+          yield* managedNativeEventLogger.close();
+        }
+      }).pipe(Effect.ensuring(Queue.shutdown(runtimeEvents))),
+    );
     const writeNativeEvent = (
       threadId: ThreadId,
       event: {

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -668,6 +668,45 @@ export function makeOpenCodeAdapter(
 
     const emit = (event: ProviderRuntimeEvent) =>
       Queue.offer(runtimeEvents, event).pipe(Effect.asVoid);
+
+    const settleOpenCodePendingAsCancelled = (context: OpenCodeSessionContext) =>
+      Effect.gen(function* () {
+        const permissions = [...context.pendingPermissions.entries()];
+        context.pendingPermissions.clear();
+        yield* Effect.forEach(
+          permissions,
+          ([requestId, request]) =>
+            emit({
+              ...(yield *
+                buildEventBase({
+                  threadId: context.session.threadId,
+                  requestId,
+                })),
+              type: "request.resolved",
+              payload: {
+                requestType: mapPermissionToRequestType(request.permission),
+                decision: "cancel",
+              },
+            }),
+          { discard: true },
+        );
+        const questions = [...context.pendingQuestions.keys()];
+        context.pendingQuestions.clear();
+        yield* Effect.forEach(
+          questions,
+          (requestId) =>
+            emit({
+              ...(yield *
+                buildEventBase({
+                  threadId: context.session.threadId,
+                  requestId,
+                })),
+              type: "user-input.resolved",
+              payload: { answers: {} },
+            }),
+          { discard: true },
+        );
+      });
     const writeNativeEvent = (
       threadId: ThreadId,
       event: {
@@ -696,6 +735,7 @@ export function makeOpenCodeAdapter(
       }
       const turnId = context.activeTurnId;
       sessions.delete(context.session.threadId);
+      yield* settleOpenCodePendingAsCancelled(context).pipe(Effect.ignore);
       // Emit lifecycle events BEFORE tearing down the scope. Both call sites
       // run this inside a fiber forked via `Effect.forkIn(context.sessionScope)`;
       // closing that scope triggers the fiber-interrupt finalizer, so any
@@ -1210,6 +1250,7 @@ export function makeOpenCodeAdapter(
         const resumeSessionId = parseOpenCodeResume(input.resumeCursor)?.sessionId;
         const existing = sessions.get(input.threadId);
         if (existing) {
+          yield* settleOpenCodePendingAsCancelled(existing);
           yield* stopOpenCodeContext(existing);
           sessions.delete(input.threadId);
         }
@@ -1626,6 +1667,7 @@ export function makeOpenCodeAdapter(
             threadId,
           });
         }
+        yield* settleOpenCodePendingAsCancelled(context);
         const stopped = yield* stopOpenCodeContext(context);
         sessions.delete(threadId);
         if (!stopped) {
@@ -1710,7 +1752,12 @@ export function makeOpenCodeAdapter(
         // interrupt the sibling fibers. Same pattern as the layer finalizer.
         yield* Effect.forEach(
           contexts,
-          (context) => Effect.ignoreCause(stopOpenCodeContext(context)),
+          (context) =>
+            Effect.ignoreCause(
+              settleOpenCodePendingAsCancelled(context).pipe(
+                Effect.andThen(stopOpenCodeContext(context)),
+              ),
+            ),
           { concurrency: "unbounded", discard: true },
         );
       });


### PR DESCRIPTION
## Summary

Fixes #7113.

`OpenCodeAdapter` never resolved pending permission (or question) requests when a session tore down. Those rows stayed `pending` in `projection_pending_approvals`, `pending_approval_count` never returned to zero, and the thread could not be settled.

Stop, replace-session, `stopAll`, and unexpected-exit paths now emit `request.resolved` / `user-input.resolved` as cancelled before tearing down the session — the same contract Claude and Grok already follow.

## Test plan

- [ ] Start an OpenCode thread, trigger a permission prompt, stop the session
- [ ] Confirm the thread can be settled without editing `state.sqlite`
- [ ] Confirm a follow-up turn on a new session still works

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session lifecycle and runtime event projection for approvals, but behavior is localized to OpenCodeAdapter and aligned with other providers, with targeted tests.
> 
> **Overview**
> Fixes stuck **pending** approval/user-input state when an OpenCode session ends without a user response (threads could not settle because `projection_pending_approvals` never cleared).
> 
> **`OpenCodeAdapter`** now runs **`settleOpenCodePendingAsCancelled`** before teardown: emits **`request.resolved`** with decision **`cancel`** for open permissions and **`user-input.resolved`** with empty answers for open questions. This is wired into **`stopSession`**, **`stopAll`**, session replace in **`startSession`**, unexpected exit, and the **layer finalizer** (provider remove/replace without `stopAll`).
> 
> Each session gets **`acceptingRequests`** plus a **`pendingGate`** semaphore so teardown cannot race with in-flight **`permission.asked`** / **`question.asked`** handlers (late events auto-cancel instead of opening new requests). Tests cover stop, **`stopAll`**, and scope close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit debfa7617dbaab3000bb98800671c53883d82a44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Settle pending permission and question requests as cancelled on session teardown
> - Adds `settleOpenCodePendingAsCancelled` to [OpenCodeAdapter.ts](https://github.com/pingdotgg/t3code/pull/7173/files#diff-83b1b4a8f780ec9425450a3fca373dd3a591cd53f2fe4a83ca59a2c474db87cf), which emits `request.resolved` (decision `cancel`) and `user-input.resolved` (empty answers) for all pending requests before session teardown.
> - Wires settlement into `stopSession`, `stopAll`, `startSession` (when replacing an existing session), the adapter finalizer, and the unexpected-termination handler.
> - Adds `acceptingRequests` (`Ref<boolean>`) and `pendingGate` (`Semaphore`) to each session context to block new requests once teardown begins and serialize event handling against settlement.
> - Behavioral Change: incoming `permission.asked` and `question.asked` events received after teardown starts are now auto-cancelled/resolved instead of opening new requests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized debfa76.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->