### PR TITLE
fix(vcs): fetch GitLab merge-request refs for worktree checkout

### DIFF
--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -275,7 +275,7 @@ export class GitVcsDriver extends Context.Service<
     readonly fetchPullRequestBranch: (
       input: GitFetchPullRequestBranchInput,
     ) => Effect.Effect<void, GitCommandError>;
-    /** Fetches `refs/pull/<n>/head` without writing a branch, for heads that exist nowhere else. */
+    /** Fetches GitHub `refs/pull/<n>/head` or GitLab `refs/merge-requests/<n>/head` without writing a branch. */
     readonly fetchPullRequestHeadCommit: (
       input: GitFetchPullRequestHeadCommitInput,
     ) => Effect.Effect<GitResolveCommitResult, GitCommandError>;

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -635,6 +635,109 @@ it.effect("backs off failed upstream refreshes across linked worktrees", () =>
   ).pipe(Effect.provide(ServerConfigLayer.pipe(Layer.provideMerge(NodeServices.layer)))),
 );
 
+it.effect("retries GitLab merge-request refs after a GitHub pull-ref fetch fails", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const delegate = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const fetchSpecs = yield* Ref.make<string[]>([]);
+      const spawner = ChildProcessSpawner.make((command) =>
+        Effect.gen(function* () {
+          if (!ChildProcess.isStandardCommand(command)) {
+            return yield* Effect.die("expected a standard Git command");
+          }
+          if (command.args.includes("fetch") && command.args.includes("--quiet")) {
+            const spec = command.args.at(-1) ?? "";
+            yield* Ref.update(fetchSpecs, (specs) => [...specs, spec]);
+            if (spec.includes("refs/pull/")) {
+              return makeNonRepositoryHandle();
+            }
+            return makeSuccessfulHandle("");
+          }
+          return yield* delegate.spawn(command);
+        }),
+      );
+      const driver = yield* makeGitVcsDriverCore().pipe(
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      );
+      const cwd = yield* makeTmpDir();
+      const remote = yield* makeTmpDir("git-vcs-driver-remote-");
+      const runGit = (workingDirectory: string, args: ReadonlyArray<string>) =>
+        driver.execute({
+          operation: "GitVcsDriver.test.fetchPullRequestBranchFallback",
+          cwd: workingDirectory,
+          args,
+          timeoutMs: 10_000,
+        });
+
+      yield* driver.initRepo({ cwd });
+      yield* runGit(cwd, ["config", "user.email", "test@test.com"]);
+      yield* runGit(cwd, ["config", "user.name", "Test"]);
+      yield* writeTextFile(cwd, "README.md", "# test\n");
+      yield* runGit(cwd, ["add", "."]);
+      yield* runGit(cwd, ["commit", "-m", "initial commit"]);
+      yield* runGit(remote, ["init", "--bare"]);
+      yield* runGit(cwd, ["remote", "add", "origin", remote]);
+
+      yield* driver.fetchPullRequestBranch({ cwd, prNumber: 42, branch: "pr-42" });
+      const specs = yield* Ref.get(fetchSpecs);
+      assert.isTrue(specs.some((spec) => spec.includes("refs/pull/42/head")));
+      assert.isTrue(specs.some((spec) => spec.includes("refs/merge-requests/42/head")));
+    }),
+  ).pipe(Effect.provide(ServerConfigLayer.pipe(Layer.provideMerge(NodeServices.layer)))),
+);
+
+it.effect("aggregates both pull and merge-request fetch failures", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const delegate = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const fetchSpecs = yield* Ref.make<string[]>([]);
+      const spawner = ChildProcessSpawner.make((command) =>
+        Effect.gen(function* () {
+          if (!ChildProcess.isStandardCommand(command)) {
+            return yield* Effect.die("expected a standard Git command");
+          }
+          if (command.args.includes("fetch") && command.args.includes("--quiet")) {
+            const spec = command.args.at(-1) ?? "";
+            yield* Ref.update(fetchSpecs, (specs) => [...specs, spec]);
+            return makeNonRepositoryHandle();
+          }
+          return yield* delegate.spawn(command);
+        }),
+      );
+      const driver = yield* makeGitVcsDriverCore().pipe(
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      );
+      const cwd = yield* makeTmpDir();
+      const remote = yield* makeTmpDir("git-vcs-driver-remote-");
+      const runGit = (workingDirectory: string, args: ReadonlyArray<string>) =>
+        driver.execute({
+          operation: "GitVcsDriver.test.fetchPullRequestBranchBothFail",
+          cwd: workingDirectory,
+          args,
+          timeoutMs: 10_000,
+        });
+
+      yield* driver.initRepo({ cwd });
+      yield* runGit(cwd, ["config", "user.email", "test@test.com"]);
+      yield* runGit(cwd, ["config", "user.name", "Test"]);
+      yield* writeTextFile(cwd, "README.md", "# test\n");
+      yield* runGit(cwd, ["add", "."]);
+      yield* runGit(cwd, ["commit", "-m", "initial commit"]);
+      yield* runGit(remote, ["init", "--bare"]);
+      yield* runGit(cwd, ["remote", "add", "origin", remote]);
+
+      const error = yield* driver
+        .fetchPullRequestBranch({ cwd, prNumber: 7, branch: "pr-7" })
+        .pipe(Effect.flip);
+      assert.instanceOf(error, GitCommandError);
+      assert.instanceOf(error.cause, AggregateError);
+      const specs = yield* Ref.get(fetchSpecs);
+      assert.isTrue(specs.some((spec) => spec.includes("refs/pull/7/head")));
+      assert.isTrue(specs.some((spec) => spec.includes("refs/merge-requests/7/head")));
+    }),
+  ).pipe(Effect.provide(ServerConfigLayer.pipe(Layer.provideMerge(NodeServices.layer)))),
+);
+
 it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
   describe("process environment", () => {
     it.effect("preserves the caller locale for general Git subprocesses", () =>

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -2794,19 +2794,28 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
   const fetchPullRequestBranch: GitVcsDriver.GitVcsDriver["Service"]["fetchPullRequestBranch"] =
     Effect.fn("fetchPullRequestBranch")(function* (input) {
       const remoteName = yield* resolvePrimaryRemoteName(input.cwd);
+      const fetchSpecs = [
+        `+refs/pull/${input.prNumber}/head:refs/heads/${input.branch}`,
+        `+refs/merge-requests/${input.prNumber}/head:refs/heads/${input.branch}`,
+      ];
       yield* executeGit(
         "GitVcsDriver.fetchPullRequestBranch",
         input.cwd,
-        [
-          "fetch",
-          "--quiet",
-          "--no-tags",
-          remoteName,
-          `+refs/pull/${input.prNumber}/head:refs/heads/${input.branch}`,
-        ],
+        ["fetch", "--quiet", "--no-tags", remoteName, fetchSpecs[0]!],
         {
           fallbackErrorDetail: "git fetch pull request branch failed",
         },
+      ).pipe(
+        Effect.orElse(() =>
+          executeGit(
+            "GitVcsDriver.fetchPullRequestBranch",
+            input.cwd,
+            ["fetch", "--quiet", "--no-tags", remoteName, fetchSpecs[1]!],
+            {
+              fallbackErrorDetail: "git fetch merge request branch failed",
+            },
+          ),
+        ),
       );
     });
 
@@ -2834,6 +2843,23 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
         {
           fallbackErrorDetail: "git fetch pull request head failed",
         },
+      ).pipe(
+        Effect.orElse(() =>
+          executeGit(
+            "GitVcsDriver.fetchPullRequestHeadCommit",
+            input.cwd,
+            [
+              "fetch",
+              "--quiet",
+              "--no-tags",
+              remoteName,
+              `refs/merge-requests/${input.prNumber}/head`,
+            ],
+            {
+              fallbackErrorDetail: "git fetch merge request head failed",
+            },
+          ),
+        ),
       );
 
       return yield* resolveCommit({ cwd: input.cwd, revision: "FETCH_HEAD" });

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -2791,31 +2791,55 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     };
   });
 
+  const fetchPullThenMergeRequestRef = (
+    operation: string,
+    cwd: string,
+    remoteName: string,
+    pullSpec: string,
+    mergeRequestSpec: string,
+    pullFailureDetail: string,
+    mergeRequestFailureDetail: string,
+  ) =>
+    executeGit(operation, cwd, ["fetch", "--quiet", "--no-tags", remoteName, pullSpec], {
+      fallbackErrorDetail: pullFailureDetail,
+    }).pipe(
+      Effect.catch((pullRefFailure) =>
+        executeGit(
+          operation,
+          cwd,
+          ["fetch", "--quiet", "--no-tags", remoteName, mergeRequestSpec],
+          { fallbackErrorDetail: mergeRequestFailureDetail },
+        ).pipe(
+          Effect.mapError(
+            (mergeRequestFailure) =>
+              new GitCommandError({
+                ...gitCommandContext({
+                  operation,
+                  cwd,
+                  args: ["fetch", "--quiet", "--no-tags", remoteName, mergeRequestSpec],
+                }),
+                detail: "git fetch of pull and merge request refs both failed",
+                cause: new AggregateError(
+                  [pullRefFailure, mergeRequestFailure],
+                  "git fetch of pull and merge request refs both failed",
+                ),
+              }),
+          ),
+        ),
+      ),
+    );
+
   const fetchPullRequestBranch: GitVcsDriver.GitVcsDriver["Service"]["fetchPullRequestBranch"] =
     Effect.fn("fetchPullRequestBranch")(function* (input) {
       const remoteName = yield* resolvePrimaryRemoteName(input.cwd);
-      const fetchSpecs = [
-        `+refs/pull/${input.prNumber}/head:refs/heads/${input.branch}`,
-        `+refs/merge-requests/${input.prNumber}/head:refs/heads/${input.branch}`,
-      ];
-      yield* executeGit(
+      yield* fetchPullThenMergeRequestRef(
         "GitVcsDriver.fetchPullRequestBranch",
         input.cwd,
-        ["fetch", "--quiet", "--no-tags", remoteName, fetchSpecs[0]!],
-        {
-          fallbackErrorDetail: "git fetch pull request branch failed",
-        },
-      ).pipe(
-        Effect.orElse(() =>
-          executeGit(
-            "GitVcsDriver.fetchPullRequestBranch",
-            input.cwd,
-            ["fetch", "--quiet", "--no-tags", remoteName, fetchSpecs[1]!],
-            {
-              fallbackErrorDetail: "git fetch merge request branch failed",
-            },
-          ),
-        ),
+        remoteName,
+        `+refs/pull/${input.prNumber}/head:refs/heads/${input.branch}`,
+        `+refs/merge-requests/${input.prNumber}/head:refs/heads/${input.branch}`,
+        "git fetch pull request branch failed",
+        "git fetch merge request branch failed",
       );
     });
 
@@ -2836,30 +2860,14 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       const remoteName = yield* resolvePrimaryRemoteName(input.cwd);
       // No refspec destination: the pull head lands in FETCH_HEAD (per worktree) instead of a
       // branch, which is the only way to read it while that branch is checked out somewhere.
-      yield* executeGit(
+      yield* fetchPullThenMergeRequestRef(
         "GitVcsDriver.fetchPullRequestHeadCommit",
         input.cwd,
-        ["fetch", "--quiet", "--no-tags", remoteName, `refs/pull/${input.prNumber}/head`],
-        {
-          fallbackErrorDetail: "git fetch pull request head failed",
-        },
-      ).pipe(
-        Effect.orElse(() =>
-          executeGit(
-            "GitVcsDriver.fetchPullRequestHeadCommit",
-            input.cwd,
-            [
-              "fetch",
-              "--quiet",
-              "--no-tags",
-              remoteName,
-              `refs/merge-requests/${input.prNumber}/head`,
-            ],
-            {
-              fallbackErrorDetail: "git fetch merge request head failed",
-            },
-          ),
-        ),
+        remoteName,
+        `refs/pull/${input.prNumber}/head`,
+        `refs/merge-requests/${input.prNumber}/head`,
+        "git fetch pull request head failed",
+        "git fetch merge request head failed",
       );
 
       return yield* resolveCommit({ cwd: input.cwd, revision: "FETCH_HEAD" });


### PR DESCRIPTION
## Summary

Fixes #6448.

`fetchPullRequestBranch` / `fetchPullRequestHeadCommit` hardcoded GitHub's `refs/pull/<n>/head`. GitLab publishes `refs/merge-requests/<n>/head`, so every **Checkout merge request → Worktree** on a GitLab remote failed with `couldn't find remote ref`.

The fetch now tries the GitHub layout first and falls back to the GitLab layout.

## Test plan

- [ ] GitHub: Checkout PR → Worktree still works
- [ ] GitLab: Checkout MR → Worktree fetches `refs/merge-requests/<n>/head` and opens the draft thread
- [ ] Local mode for the same MR still works

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared Git fetch paths used for checkout/worktree; behavior change is additive fallback, but mis-numbered or missing refs on both hosts still fail and now surface an aggregate error.
> 
> **Overview**
> Fixes GitLab **Checkout merge request → Worktree** failures caused by only fetching GitHub-style `refs/pull/<n>/head`.
> 
> `GitVcsDriverCore` adds **`fetchPullThenMergeRequestRef`**, which tries the GitHub pull ref first and on failure retries with GitLab’s `refs/merge-requests/<n>/head`. **`fetchPullRequestBranch`** and **`fetchPullRequestHeadCommit`** both use this helper (branch refspec vs. `FETCH_HEAD` unchanged). When both fetches fail, callers get a **`GitCommandError`** whose **`cause`** is an **`AggregateError`** holding both underlying errors.
> 
> Tests cover successful GitLab fallback after a failed GitHub fetch and the dual-failure aggregation path. The public API comment on **`fetchPullRequestHeadCommit`** now documents both ref layouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eeb0c39757ff9e806789be7c75c12855325b87e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `fetchPullRequestBranch` and `fetchPullRequestHeadCommit` to fall back to GitLab merge-request refs
> - Both methods in [`GitVcsDriverCore.ts`](https://github.com/pingdotgg/t3code/pull/7174/files#diff-1c3e2b9763c6526006485633fb677c83dc54cc1ea5563a1e51aab707c35854d8) previously only attempted GitHub `refs/pull/<n>/head`, failing silently on GitLab repositories.
> - A new `fetchPullThenMergeRequestRef` helper tries the GitHub refspec first, then falls back to the GitLab `refs/merge-requests/<n>/head` refspec on failure.
> - If both fetches fail, a `GitCommandError` is thrown with an `AggregateError` cause containing both failures.
> - Behavioral Change: callers that previously received a single `GitCommandError` on failure will now receive one whose `cause` is an `AggregateError` when both refspecs are attempted and fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6eeb0c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->