### PR TITLE
fix(usage): do not scan ~/projects when Claude transcripts are missing

### DIFF
--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -38,6 +38,10 @@ import * as ServerSettings from "../serverSettings.ts";
 import { resolveClaudeHomePath } from "../provider/Drivers/ClaudeHome.ts";
 import { resolveCodexHomeLayout } from "../provider/Drivers/CodexHomeLayout.ts";
 import { UsageAggregator } from "./usageAggregation.ts";
+import {
+  isClaudeHomeExplicitOverride,
+  resolveClaudeTranscriptDirPath,
+} from "./usageClaudeTranscriptDir.ts";
 import { parseRateTable, type RateTable } from "./usagePricing.ts";
 import {
   listTranscriptFiles,
@@ -185,16 +189,22 @@ export const make = Effect.gen(function* () {
   });
 
   /**
-   * Claude's config dir is the home itself when overridden, but a default
-   * install nests transcripts under `~/.claude/projects`. Probe both.
+   * Default installs nest transcripts under `~/.claude/projects`. A custom
+   * CLAUDE_CONFIG_DIR uses `<home>/projects` only when that nested path is
+   * absent. Never fall back to `~/projects` for the OS home.
    */
-  const resolveClaudeTranscriptDir = (homePath: string) =>
+  const resolveClaudeTranscriptDir = (homePath: string, homeIsExplicitOverride: boolean) =>
     Effect.gen(function* () {
       const nested = path.join(homePath, ".claude", "projects");
       const nestedExists = yield* fileSystem
         .exists(nested)
         .pipe(Effect.catchCause(() => Effect.succeed(false)));
-      return nestedExists ? nested : path.join(homePath, "projects");
+      return resolveClaudeTranscriptDirPath({
+        homePath,
+        join: path.join,
+        nestedProjectsExists: nestedExists,
+        homeIsExplicitOverride,
+      });
     });
 
   /** Resolves the transcript directory for each provider. */
@@ -216,7 +226,10 @@ export const make = Effect.gen(function* () {
     );
 
     const claudeHome = yield* resolveClaudeHomePath(settings.providers.claudeAgent);
-    const claudeDir = yield* resolveClaudeTranscriptDir(claudeHome);
+    const claudeDir = yield* resolveClaudeTranscriptDir(
+      claudeHome,
+      isClaudeHomeExplicitOverride(settings.providers.claudeAgent.homePath),
+    );
     const codexLayout = yield* resolveCodexHomeLayout(settings.providers.codex);
 
     return [

--- a/apps/server/src/usage/usageClaudeTranscriptDir.test.ts
+++ b/apps/server/src/usage/usageClaudeTranscriptDir.test.ts
@@ -1,0 +1,90 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodePath from "node:path";
+
+import { describe, expect, it } from "@effect/vitest";
+
+import {
+  isClaudeHomeExplicitOverride,
+  resolveClaudeTranscriptDirPath,
+} from "./usageClaudeTranscriptDir.ts";
+
+function resolve(input: {
+  homePath: string;
+  nestedProjectsExists: boolean;
+  homeIsExplicitOverride: boolean;
+}): string {
+  return resolveClaudeTranscriptDirPath({
+    ...input,
+    join: NodePath.join,
+  });
+}
+
+describe("resolveClaudeTranscriptDirPath", () => {
+  it("keeps the default home on ~/.claude/projects when the nested dir is missing", () => {
+    const homePath = "/Users/alice";
+    const resolved = resolve({
+      homePath,
+      nestedProjectsExists: false,
+      homeIsExplicitOverride: false,
+    });
+
+    expect(resolved).toBe(NodePath.join(homePath, ".claude", "projects"));
+    expect(resolved).not.toBe(NodePath.join(homePath, "projects"));
+  });
+
+  it("uses ~/.claude/projects when it exists on the default home", () => {
+    const homePath = "/Users/alice";
+    expect(
+      resolve({
+        homePath,
+        nestedProjectsExists: true,
+        homeIsExplicitOverride: false,
+      }),
+    ).toBe(NodePath.join(homePath, ".claude", "projects"));
+  });
+
+  it("uses <override>/projects when a custom home has no nested projects dir", () => {
+    const homePath = "/opt/claude-config";
+    expect(
+      resolve({
+        homePath,
+        nestedProjectsExists: false,
+        homeIsExplicitOverride: true,
+      }),
+    ).toBe(NodePath.join(homePath, "projects"));
+  });
+
+  it("prefers <override>/.claude/projects when a custom home nests the same way", () => {
+    const homePath = "/opt/claude-config";
+    expect(
+      resolve({
+        homePath,
+        nestedProjectsExists: true,
+        homeIsExplicitOverride: true,
+      }),
+    ).toBe(NodePath.join(homePath, ".claude", "projects"));
+  });
+
+  it("treats empty or whitespace configured homePath as the default, not an override", () => {
+    const homePath = "/Users/alice";
+    for (const configured of ["", "   ", "\t", "\n", " \t\n "]) {
+      expect(isClaudeHomeExplicitOverride(configured)).toBe(false);
+      expect(
+        resolve({
+          homePath,
+          nestedProjectsExists: false,
+          homeIsExplicitOverride: isClaudeHomeExplicitOverride(configured),
+        }),
+      ).toBe(NodePath.join(homePath, ".claude", "projects"));
+    }
+  });
+});
+
+describe("isClaudeHomeExplicitOverride", () => {
+  it("is true only when the configured homePath is non-empty after trim", () => {
+    expect(isClaudeHomeExplicitOverride("~/.claude-work")).toBe(true);
+    expect(isClaudeHomeExplicitOverride("  /custom/claude  ")).toBe(true);
+    expect(isClaudeHomeExplicitOverride("")).toBe(false);
+    expect(isClaudeHomeExplicitOverride("   ")).toBe(false);
+  });
+});

--- a/apps/server/src/usage/usageClaudeTranscriptDir.ts
+++ b/apps/server/src/usage/usageClaudeTranscriptDir.ts
@@ -1,0 +1,29 @@
+/**
+ * Pure choice of Claude Code's on-disk transcript directory.
+ *
+ * Used by `UsageService` so a missing default `~/.claude/projects` is reported
+ * as missing instead of walking the user's `~/projects` tree.
+ *
+ * @module usageClaudeTranscriptDir
+ */
+
+export function isClaudeHomeExplicitOverride(configuredHomePath: string): boolean {
+  return configuredHomePath.trim().length > 0;
+}
+
+/**
+ * Default installs nest transcripts under `<home>/.claude/projects`. A custom
+ * CLAUDE_CONFIG_DIR uses `<home>/projects` only when that nested path is
+ * absent. The OS home never falls back to `<home>/projects`.
+ */
+export function resolveClaudeTranscriptDirPath(input: {
+  readonly homePath: string;
+  readonly join: (a: string, b: string, ...rest: string[]) => string;
+  readonly nestedProjectsExists: boolean;
+  readonly homeIsExplicitOverride: boolean;
+}): string {
+  const nested = input.join(input.homePath, ".claude", "projects");
+  if (input.nestedProjectsExists) return nested;
+  if (input.homeIsExplicitOverride) return input.join(input.homePath, "projects");
+  return nested;
+}


### PR DESCRIPTION
## Summary

Fixes #7088.

When Claude has never been used, a missing `~/.claude/projects` no longer falls back to walking the entire `~/projects` tree. The default missing dir is reported as a missing source. Custom `claudeAgent.homePath` / CLAUDE_CONFIG_DIR still uses `<home>/projects` when the nested path is absent.

## Test plan

- [ ] Usage page with no `~/.claude/projects` returns quickly and does not walk `~/projects`
- [ ] Custom Claude home still finds `<home>/projects` transcripts
- [ ] Codex usage unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized usage transcript path resolution with pure helpers and tests; no auth, data migration, or API contract changes beyond correct scan roots.
> 
> **Overview**
> Fixes incorrect Claude usage scanning when the default transcript folder is absent. **Previously**, a missing `~/.claude/projects` caused the scanner to fall back to `~/projects`, which could walk a huge tree and skew or slow usage reads.
> 
> **Now** path choice lives in `usageClaudeTranscriptDir.ts`: default installs always target `~/.claude/projects` (missing dir → **missing** source, no `~/projects` fallback). A non-empty configured `claudeAgent.homePath` still uses `<home>/projects` only when nested `.claude/projects` does not exist; whitespace-only config counts as default.
> 
> `UsageService` passes whether the home is an explicit override into that resolver after probing the nested directory on disk. Unit tests cover default, custom home, and override detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9695da9b4a90c3c8555585273a4b736c22c554db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Claude transcript resolution to avoid scanning `~/projects` when no explicit home override is set
> Previously, the Claude transcript directory resolver would fall back to `<home>/projects` when `<home>/.claude/projects` did not exist, even for default (non-overridden) home paths. This caused unintended directory scanning.
>
> - Adds [`isClaudeHomeExplicitOverride`](https://github.com/pingdotgg/t3code/pull/7177/files#diff-d27aa65f094ae64d3df993d9edc08aeade5f6d59eb2b893b29ca6882fcb209f3) to classify a configured `homePath` as explicit only when non-empty after trimming.
> - Adds [`resolveClaudeTranscriptDirPath`](https://github.com/pingdotgg/t3code/pull/7177/files#diff-d27aa65f094ae64d3df993d9edc08aeade5f6d59eb2b893b29ca6882fcb209f3) as a pure utility that skips the `<home>/projects` fallback unless the home path is an explicit override.
> - Updates [`UsageService`](https://github.com/pingdotgg/t3code/pull/7177/files#diff-1d90d173860922c384f65961de4b51bba0176aadd7982190e0dcf87e663f1a70) to pass the override flag when resolving transcript directories.
> - Behavioral Change: default Claude home paths no longer fall back to `~/projects`; only explicit home overrides may use the `<override>/projects` fallback.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9695da9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->