### PR TITLE
fix(threads): do not auto-settle closed unmerged pull requests

### DIFF
--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1840,7 +1840,7 @@ export function GeneralSettingsPanel() {
 
         <SettingsRow
           {...searchableSetting("auto-settle-merged-threads")}
-          description="Settle a thread when its pull request merges. Closed pull requests still settle automatically."
+          description="Settle a thread when its pull request merges."
           resetAction={
             settings.sidebarAutoSettleOnMerge !==
             DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleOnMerge ? (

--- a/packages/client-runtime/src/state/threadSettled.test.ts
+++ b/packages/client-runtime/src/state/threadSettled.test.ts
@@ -25,7 +25,8 @@ describe("changeRequestAutoSettles", () => {
     ["open", true, false],
     ["merged", true, true],
     ["merged", false, false],
-    ["closed", false, true],
+    ["closed", true, false],
+    ["closed", false, false],
     [null, false, false],
   ] as const)("state=%s autoSettleOnMerge=%s returns %s", (state, autoSettleOnMerge, expected) => {
     expect(changeRequestAutoSettles(state, autoSettleOnMerge)).toBe(expected);
@@ -106,7 +107,7 @@ describe("threadLastActivityAt", () => {
 
 describe("effectiveSettled", () => {
   const overrideCases = [null, "settled", "active"] as const;
-  const changeRequestStates = [undefined, "open", "merged"] as const;
+  const changeRequestStates = [undefined, "open", "merged", "closed"] as const;
   const inactivityCases = [
     ["fresh", FRESH],
     ["stale", STALE],
@@ -167,7 +168,7 @@ describe("effectiveSettled", () => {
     },
   );
 
-  it("treats closed change requests like merged ones", () => {
+  it("does not auto-settle a closed unmerged change request when inactivity is off", () => {
     const shell = makeShell({ activityAt: null });
     expect(
       effectiveSettled(shell, {
@@ -175,20 +176,53 @@ describe("effectiveSettled", () => {
         autoSettleAfterDays: null,
         changeRequestState: "closed",
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  it("settles immediately when a change request merges or closes", () => {
+  it("does not short-circuit settle a recently active closed change request", () => {
     const recentlyActive = makeShell({ activityAt: "2026-04-09T23:59:59.999Z" });
-    for (const changeRequestState of ["merged", "closed"] as const) {
-      expect(
-        effectiveSettled(recentlyActive, {
-          now: NOW,
-          autoSettleAfterDays: null,
-          changeRequestState,
-        }),
-      ).toBe(true);
-    }
+    expect(
+      effectiveSettled(recentlyActive, {
+        now: NOW,
+        autoSettleAfterDays: 3,
+        changeRequestState: "closed",
+      }),
+    ).toBe(false);
+  });
+
+  it("settles a stale closed change request via inactivity, same as no PR", () => {
+    const stale = makeShell({ activityAt: STALE });
+    expect(
+      effectiveSettled(stale, {
+        now: NOW,
+        autoSettleAfterDays: 3,
+        changeRequestState: "closed",
+      }),
+    ).toBe(true);
+    expect(effectiveSettled(stale, { now: NOW, autoSettleAfterDays: 3 })).toBe(true);
+  });
+
+  it("does not short-circuit a closed change request when auto-settle on merge is off", () => {
+    const recentlyActive = makeShell({ activityAt: "2026-04-09T23:59:59.999Z" });
+    expect(
+      effectiveSettled(recentlyActive, {
+        now: NOW,
+        autoSettleAfterDays: null,
+        autoSettleOnMerge: false,
+        changeRequestState: "closed",
+      }),
+    ).toBe(false);
+  });
+
+  it("settles immediately when a change request merges", () => {
+    const recentlyActive = makeShell({ activityAt: "2026-04-09T23:59:59.999Z" });
+    expect(
+      effectiveSettled(recentlyActive, {
+        now: NOW,
+        autoSettleAfterDays: null,
+        changeRequestState: "merged",
+      }),
+    ).toBe(true);
   });
 
   it("can keep a merged change request active", () => {
@@ -201,15 +235,37 @@ describe("effectiveSettled", () => {
         changeRequestState: "merged",
       }),
     ).toBe(false);
+  });
 
+  it("lets an explicit settled override win over a closed change request", () => {
+    const settled = makeShell({ settledOverride: "settled", activityAt: FRESH });
     expect(
-      effectiveSettled(recentlyActive, {
+      effectiveSettled(settled, {
         now: NOW,
         autoSettleAfterDays: null,
-        autoSettleOnMerge: false,
         changeRequestState: "closed",
       }),
     ).toBe(true);
+  });
+
+  it("keeps a running or pending closed-PR thread active", () => {
+    const running = makeShell({ activityAt: STALE, sessionStatus: "running" });
+    expect(
+      effectiveSettled(running, {
+        now: NOW,
+        autoSettleAfterDays: 3,
+        changeRequestState: "closed",
+      }),
+    ).toBe(false);
+
+    const pending = makeShell({ activityAt: STALE, pending: "approval" });
+    expect(
+      effectiveSettled(pending, {
+        now: NOW,
+        autoSettleAfterDays: 3,
+        changeRequestState: "closed",
+      }),
+    ).toBe(false);
   });
 
   it("never auto-settles a stale thread with an open change request", () => {

--- a/packages/client-runtime/src/state/threadSettled.ts
+++ b/packages/client-runtime/src/state/threadSettled.ts
@@ -3,12 +3,14 @@ import type { OrchestrationThreadShell } from "@t3tools/contracts";
 
 export type ChangeRequestStateLike = "open" | "closed" | "merged";
 
-/** Returns whether the change request state settles the thread immediately. */
+/** Returns whether the change request state settles the thread immediately.
+ * Only a merge does, and only when auto-settle-on-merge is on. Closed-without-
+ * merge never short-circuits: continuing work after a close is real activity. */
 export function changeRequestAutoSettles(
   state: ChangeRequestStateLike | null | undefined,
   autoSettleOnMerge = true,
 ): boolean {
-  return state === "closed" || (state === "merged" && autoSettleOnMerge);
+  return state === "merged" && autoSettleOnMerge;
 }
 
 const DAY_MS = 24 * 60 * 60 * 1_000;
@@ -94,7 +96,7 @@ export function canSettle(
   if (shell.hasPendingApprovals || shell.hasPendingUserInput) return false;
   if (shell.session?.status === "starting" || shell.session?.status === "running") return false;
   // Queued work is as blocked-on-progress as a live session: settling it
-  // (or auto-settling it on a closed PR) would hide a just-requested turn.
+  // (or auto-settling it on a merged PR) would hide a just-requested turn.
   if (hasQueuedTurnStart(shell, options)) return false;
   return true;
 }
@@ -230,10 +232,12 @@ export function threadWokeAt(
  * override. Past the blockers, the explicit user override (thread.settle /
  * thread.unsettle commands, projected into settledOverride + settledAt)
  * wins in both directions; without one, a thread can auto-settle on a
- * merged PR, always settles on a closed PR, or settles on inactivity past
- * the window. An open PR blocks the inactivity path entirely. The server
- * un-settles on real activity (user message, session start, approval/
- * user-input request), so an override never goes stale silently.
+ * merged PR or settle on inactivity past the window. An open PR blocks the
+ * inactivity path entirely. A closed-without-merge PR does not force settle
+ * — continuing work after a close is real activity — but inactivity can
+ * still apply if configured. The server un-settles on real activity (user
+ * message, session start, approval/user-input request), so an override
+ * never goes stale silently.
  */
 export function effectiveSettled(
   shell: OrchestrationThreadShell,
@@ -272,8 +276,9 @@ export function effectiveSettled(
   }
   // An open PR is unfinished business regardless of how long the thread has
   // been quiet: review can take days, and hiding the thread would bury the
-  // work waiting on it. A configured merge, a close, or an explicit user
-  // settle resolves it.
+  // work waiting on it. A configured merge or an explicit user settle
+  // resolves it. Closed-without-merge does not short-circuit — it can still
+  // settle later via the inactivity window if one is configured.
   if (options.changeRequestState === "open") return false;
   if (options.autoSettleAfterDays === null) return false;
 


### PR DESCRIPTION
Fixes #6417.

Merged pull requests still auto-settle immediately when that setting is on. Closed-without-merge no longer short-circuits: after Un-settle, a follow-up turn stays in the active list instead of bouncing back into Settled when the agent finishes.

Closed threads can still settle later through the inactivity window if one is configured. Explicit settle/unsettle, running/pending blockers, and open-PR review blocking are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes client-side thread settled classification used by the sidebar and chat UI; behavior is well covered by updated tests but affects which threads appear active vs settled.
> 
> **Overview**
> **Closed PRs no longer force threads into Settled.** Only **merged** PRs still short-circuit to settled when auto-settle-on-merge is enabled; a closed-without-merge PR is treated like normal work so follow-up turns (e.g. after Un-settle) stay in the active list.
> 
> **Inactivity auto-settle still applies** to closed-PR threads when that setting is on—same as threads with no PR. Open PRs still block the inactivity path; running sessions, pending approval/input, and explicit settle/unsettle behave as before.
> 
> The General settings copy for auto-settle on merge was trimmed to describe merge-only behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0e48cd1bbfff8b2a5949ef80ad3573f3693c3a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `changeRequestAutoSettles` to not auto-settle closed unmerged pull requests
> - Previously, closing a PR (without merging) would immediately settle its associated thread, regardless of the auto-settle-on-merge setting.
> - `changeRequestAutoSettles` in [threadSettled.ts](https://github.com/pingdotgg/t3code/pull/7178/files#diff-89ad1700cfc6c0784f0813b572a6b6110e04b480f108c404b4c755705748083c) now only returns `true` for `merged` PRs when `autoSettleOnMerge` is enabled; `closed` PRs no longer short-circuit to settled.
> - Threads with a closed (unmerged) PR now follow the same inactivity-based settling path as threads with no PR.
> - The settings UI copy in [SettingsPanels.tsx](https://github.com/pingdotgg/t3code/pull/7178/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18) is updated to remove the now-incorrect mention of closed PRs auto-settling.
> - Behavioral Change: closed PRs no longer immediately settle threads; they now require inactivity thresholds or an explicit override to settle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f0e48cd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->