### PR TITLE
fix(threads): keep snoozed threads hidden when work finishes

### DIFF
--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1200,8 +1200,8 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
       // cleared here: snooze never pauses the agent, so its session starting
       // or erroring is not the user re-engaging. Blocked/failed work still
       // surfaces immediately — effectiveSnoozed refuses to classify a thread
-      // with a raised hand (approval / input / failure / fresh completion)
-      // as snoozed, without spending the return ticket.
+      // with a raised hand (approval / input / fresh failure) as snoozed,
+      // without spending the return ticket. Completion is not a raised hand.
       const isSessionActivity =
         command.session.status === "starting" || command.session.status === "running";
       // Real activity resets ANY override (settled wakes, active unpins).

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -804,10 +804,11 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   // A woken thread reappears at its original position (the sort is
   // deliberately static), so the pill has to carry the weight. Snoozing is
   // an explicit act, so the pill clears only when the user re-engages:
-  // reading a completion-triggered wake, clicking the pill, sending a
-  // message, settling, archiving, or a change request state that settles the
-  // thread. Timer wakes survive a mere visit. An unparseable visit timestamp
-  // counts as never-visited, so corrupt local data cannot eat the wake signal.
+  // visiting after a blocking early wake (approval / user-input / fresh
+  // error), clicking the pill, sending a message, settling, archiving, or a
+  // change request state that settles the thread. Timer wakes survive a mere
+  // visit. An unparseable visit timestamp counts as never-visited, so
+  // corrupt local data cannot eat the wake signal.
   const lastVisitedDate = lastVisitedAt === undefined ? null : parseTimestampDate(lastVisitedAt);
   const wokeAtDate = props.wokeAt === null ? null : parseTimestampDate(props.wokeAt);
   const isWoke =

--- a/packages/client-runtime/src/state/threadSettled.ts
+++ b/packages/client-runtime/src/state/threadSettled.ts
@@ -116,13 +116,13 @@ export type ThreadSnoozeShell = Pick<
 >;
 
 /**
- * A snoozed thread "raises its hand" when something happens that outranks
- * the user's snooze: the agent is blocked on them (approval / user input),
- * the session failed, or a run completed after the snooze was set — the
- * v1 taste of event-based snooze ("something happened" wakes early).
- * Raising a hand never clears the server-side snooze fields; it only stops
- * the thread from CLASSIFYING as snoozed, exactly like blocked work and
- * effectiveSettled.
+ * A snoozed thread "raises its hand" when something user-blocking outranks
+ * the chosen wake time: the agent is waiting on them (approval / user
+ * input), or the session failed after the snooze was set. Snooze is an
+ * attention overlay — work finishing updates execution state only and does
+ * not surface the thread. Raising a hand never clears the server-side
+ * snooze fields; it only stops the thread from CLASSIFYING as snoozed,
+ * exactly like blocked work and effectiveSettled.
  */
 export function threadRaisedHandWhileSnoozed(shell: ThreadSnoozeShell): boolean {
   if (shell.hasPendingApprovals || shell.hasPendingUserInput) return true;
@@ -133,14 +133,6 @@ export function threadRaisedHandWhileSnoozed(shell: ThreadSnoozeShell): boolean 
   if (
     shell.session?.status === "error" &&
     (shell.snoozedAt == null || Date.parse(shell.session.updatedAt) > Date.parse(shell.snoozedAt))
-  ) {
-    return true;
-  }
-  if (
-    shell.snoozedAt != null &&
-    shell.latestTurn?.state === "completed" &&
-    shell.latestTurn.completedAt != null &&
-    Date.parse(shell.latestTurn.completedAt) > Date.parse(shell.snoozedAt)
   ) {
     return true;
   }
@@ -209,14 +201,6 @@ export function threadWokeAt(
   // indicator the user already cleared by visiting (snoozedUntil is newer
   // than that visit's lastVisitedAt).
   if (threadRaisedHandWhileSnoozed(shell)) {
-    if (
-      shell.snoozedAt != null &&
-      shell.latestTurn?.state === "completed" &&
-      shell.latestTurn.completedAt != null &&
-      Date.parse(shell.latestTurn.completedAt) > Date.parse(shell.snoozedAt)
-    ) {
-      return shell.latestTurn.completedAt;
-    }
     return shell.session?.updatedAt ?? shell.snoozedAt ?? null;
   }
   // No raised hand: woke iff the timer elapsed (still-snoozed → null).

--- a/packages/client-runtime/src/state/threadSnoozed.test.ts
+++ b/packages/client-runtime/src/state/threadSnoozed.test.ts
@@ -122,13 +122,13 @@ describe("effectiveSnoozed", () => {
     ).toBe(true);
   });
 
-  it("wakes early when a run completes after the snooze was set", () => {
+  it("stays snoozed when a run completes after the snooze was set", () => {
     expect(
       effectiveSnoozed(
         makeShell({ snoozedUntil: FUTURE_WAKE, turnCompletedAt: "2026-04-10T10:30:00.000Z" }),
         { now: NOW },
       ),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("ignores runs that completed before the snooze — the user saw that result", () => {
@@ -138,6 +138,19 @@ describe("effectiveSnoozed", () => {
         { now: NOW },
       ),
     ).toBe(true);
+  });
+
+  it("still wakes on a pending approval after work has finished", () => {
+    expect(
+      effectiveSnoozed(
+        makeShell({
+          snoozedUntil: FUTURE_WAKE,
+          pending: "approval",
+          turnCompletedAt: "2026-04-10T10:30:00.000Z",
+        }),
+        { now: NOW },
+      ),
+    ).toBe(false);
   });
 });
 
@@ -158,6 +171,14 @@ describe("threadRaisedHandWhileSnoozed", () => {
         makeShell({ snoozedUntil: FUTURE_WAKE, sessionStatus: "error" }),
       ),
     ).toBe(true);
+  });
+
+  it("does not treat turn completion as a raised hand", () => {
+    expect(
+      threadRaisedHandWhileSnoozed(
+        makeShell({ snoozedUntil: FUTURE_WAKE, turnCompletedAt: "2026-04-10T10:30:00.000Z" }),
+      ),
+    ).toBe(false);
   });
 });
 
@@ -212,13 +233,22 @@ describe("threadWokeAt", () => {
     expect(threadWokeAt(makeShell({ snoozedUntil: PAST_WAKE }), { now: NOW })).toBe(PAST_WAKE);
   });
 
-  it("reports the completion time for an early run-completed wake", () => {
+  it("does not treat a later completion as an early wake", () => {
     expect(
       threadWokeAt(
         makeShell({ snoozedUntil: FUTURE_WAKE, turnCompletedAt: "2026-04-10T10:30:00.000Z" }),
         { now: NOW },
       ),
-    ).toBe("2026-04-10T10:30:00.000Z");
+    ).toBe(null);
+  });
+
+  it("reports the scheduled wake time even if a turn completed after the snooze", () => {
+    expect(
+      threadWokeAt(
+        makeShell({ snoozedUntil: PAST_WAKE, turnCompletedAt: "2026-04-10T10:30:00.000Z" }),
+        { now: NOW },
+      ),
+    ).toBe(PAST_WAKE);
   });
 
   it("falls back to session activity for blocked/failed early wakes", () => {
@@ -230,16 +260,15 @@ describe("threadWokeAt", () => {
   });
 
   it("keeps the early wake authoritative after the scheduled time passes", () => {
-    // Woke early at 10:30 via run-completed; the scheduled wake (PAST_WAKE
-    // 10:00 relative to a later now) has ALSO passed. Reporting the
-    // scheduled time would resurface a Woke pill the user already cleared
-    // by visiting between the early wake and now.
+    // Woke early at 11:00 via a fresh session error; the scheduled wake
+    // (PAST_WAKE 10:00 relative to a later now) has ALSO passed. Reporting
+    // the scheduled time would resurface a Woke pill the user already
+    // cleared by visiting between the early wake and now.
     expect(
-      threadWokeAt(
-        makeShell({ snoozedUntil: PAST_WAKE, turnCompletedAt: "2026-04-10T09:30:00.000Z" }),
-        { now: NOW },
-      ),
-    ).toBe("2026-04-10T09:30:00.000Z");
+      threadWokeAt(makeShell({ snoozedUntil: PAST_WAKE, sessionStatus: "error" }), {
+        now: NOW,
+      }),
+    ).toBe("2026-04-10T11:00:00.000Z");
   });
 });
 


### PR DESCRIPTION
Fixes #6368. Turn completion no longer raises a snoozed thread's hand. Approvals, user-input, fresh errors, and the scheduled wake time still surface it.

## What Changed

`threadRaisedHandWhileSnoozed` no longer treats a turn that completed after `snoozedAt` as a raised hand. `threadWokeAt` no longer reports that completion as an early wake.

## Why

Snooze is a time-based attention overlay. Work finishing updates execution state only. Completing a turn was unsnoozing the thread in the sidebar before the chosen wake time.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is localized to client-runtime snooze classification and sidebar wake UX, with tests updated; no auth, persistence, or API contract changes.
> 
> **Overview**
> **Snooze no longer treats turn completion as “raise your hand.”** Threads that finish a run while snoozed stay classified as snoozed until the scheduled wake time or a user-blocking signal (pending approval, user input, or a fresh session error).
> 
> In `threadSettled.ts`, `threadRaisedHandWhileSnoozed` drops the branch that compared `latestTurn.completedAt` to `snoozedAt`, and `threadWokeAt` no longer reports that completion as an early wake (including the special-case that used completion time after a hand-raise). `effectiveSnoozed` therefore keeps snoozed threads hidden when work merely completes.
> 
> Sidebar and server comments are aligned: the **Woke** pill clears on visit only for blocking early wakes, not for completion; the decider documents that completion is not a raised hand. Tests in `threadSnoozed.test.ts` flip expectations and add coverage that approvals still unsnooze after completion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90f8477fffe2c0998fa1d4db646caae517d0f1a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep snoozed threads hidden when work completes without requiring input
> - `threadRaisedHandWhileSnoozed` in [`threadSettled.ts`](https://github.com/pingdotgg/t3code/pull/7179/files#diff-89ad1700cfc6c0784f0813b572a6b6110e04b480f108c404b4c755705748083c) no longer treats a post-snooze turn completion as a raised hand; only pending approvals, pending user input, or a fresh session error qualify.
> - `threadWokeAt` no longer returns a turn's `completedAt` as an early wake timestamp; raised-hand wakes now report `session.updatedAt` or `snoozedAt`, and timer-elapsed wakes report `snoozedUntil`.
> - Behavioral Change: threads that finish work while snoozed stay hidden until the snooze timer elapses, rather than surfacing immediately in the sidebar.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 90f8477.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->