### PR TITLE
fix(web): keep Windows drive paths as chat file links

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -81,6 +81,7 @@ import {
   rewriteMarkdownFileUriHref,
   type MarkdownFileLinkMeta,
 } from "../markdown-links";
+import { findTaskListMarkerOffset } from "../markdown-task-list";
 import { readLocalApi } from "../localApi";
 import { cn } from "../lib/utils";
 import { useRightPanelStore } from "../rightPanelStore";
@@ -145,17 +146,6 @@ const highlightedCodeCache = new LRUCache<string>(
   MAX_HIGHLIGHT_CACHE_ENTRIES,
   MAX_HIGHLIGHT_CACHE_MEMORY_BYTES,
 );
-
-function findTaskListMarkerOffset(markdown: string, listItemStart: number): number | null {
-  const firstLineEnd = markdown.indexOf("\n", listItemStart);
-  const firstLine = markdown.slice(
-    listItemStart,
-    firstLineEnd === -1 ? markdown.length : firstLineEnd,
-  );
-  const match = firstLine.match(/^(?:\s*(?:[-+*]|\d+[.)])\s+)(\[[ xX]\])/);
-  if (!match?.[1]) return null;
-  return listItemStart + firstLine.indexOf(match[1]);
-}
 
 /**
  * The default `1.25rem` marker gutter (`.chat-markdown ol`) fits two-digit
@@ -1592,7 +1582,7 @@ function ChatMarkdown({
         const listItemStart = node?.position?.start.offset;
         const markerOffset =
           typeof listItemStart === "number"
-            ? findTaskListMarkerOffset(markdownSource, listItemStart)
+            ? findTaskListMarkerOffset(text, listItemStart, markdownSource)
             : null;
         return (
           <li {...props} data-task-marker-offset={markerOffset ?? undefined}>
@@ -1777,6 +1767,7 @@ function ChatMarkdown({
     markdownFileLinkMetaByHref,
     markdownSource,
     onTaskListChange,
+    text,
     openFileInPanel,
     openInPreferredEditor,
     openExternalLinkInPreview,

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -75,6 +75,7 @@ import {
 import { remarkNormalizeListItemIndentation } from "../markdown-list-indentation";
 import {
   normalizeMarkdownLinkDestination,
+  normalizeWindowsMarkdownFileLinks,
   resolveInlineCodeFileLinkMeta,
   resolveMarkdownFileLinkMeta,
   rewriteMarkdownFileUriHref,
@@ -1382,12 +1383,13 @@ function ChatMarkdown({
     serverConfig?.availableEditors ?? [],
   );
   const diffThemeName = resolveDiffThemeName(resolvedTheme);
+  const markdownSource = useMemo(() => normalizeWindowsMarkdownFileLinks(text), [text]);
   const markdownFileLinkMetaByHref = useMemo(() => {
     const metaByHref = new Map<
       string,
       NonNullable<ReturnType<typeof resolveMarkdownFileLinkMeta>>
     >();
-    for (const href of extractMarkdownLinkHrefs(text)) {
+    for (const href of extractMarkdownLinkHrefs(markdownSource)) {
       const normalizedHref = normalizeMarkdownLinkHrefKey(href);
       if (metaByHref.has(normalizedHref)) continue;
       const meta = resolveMarkdownFileLinkMeta(normalizedHref, cwd);
@@ -1396,10 +1398,10 @@ function ChatMarkdown({
       }
     }
     return metaByHref;
-  }, [cwd, text]);
+  }, [cwd, markdownSource]);
   const inlineCodeFileLinkMetaByText = useMemo(() => {
     const metaByText = new Map<string, MarkdownFileLinkMeta>();
-    for (const span of extractInlineCodeSpans(text)) {
+    for (const span of extractInlineCodeSpans(markdownSource)) {
       if (metaByText.has(span)) continue;
       const meta = resolveInlineCodeFileLinkMeta(span, cwd);
       if (meta) {
@@ -1407,7 +1409,7 @@ function ChatMarkdown({
       }
     }
     return metaByText;
-  }, [cwd, text]);
+  }, [cwd, markdownSource]);
   const fileLinkParentSuffixByPath = useMemo(() => {
     const filePaths = [
       ...[...markdownFileLinkMetaByHref.values()].map((meta) => meta.filePath),
@@ -1589,7 +1591,9 @@ function ChatMarkdown({
       li({ node, children, ...props }) {
         const listItemStart = node?.position?.start.offset;
         const markerOffset =
-          typeof listItemStart === "number" ? findTaskListMarkerOffset(text, listItemStart) : null;
+          typeof listItemStart === "number"
+            ? findTaskListMarkerOffset(markdownSource, listItemStart)
+            : null;
         return (
           <li {...props} data-task-marker-offset={markerOffset ?? undefined}>
             {renderSkillInlineMarkdownChildren(children, skills)}
@@ -1771,6 +1775,7 @@ function ChatMarkdown({
     inlineCodeFileLinkMetaByText,
     isStreaming,
     markdownFileLinkMetaByHref,
+    markdownSource,
     onTaskListChange,
     openFileInPanel,
     openInPreferredEditor,
@@ -1778,7 +1783,6 @@ function ChatMarkdown({
     openMarkdownFileInPreview,
     resolvedTheme,
     skills,
-    text,
     threadRef,
   ]);
   /* eslint-enable react/no-unstable-nested-components */
@@ -1803,7 +1807,7 @@ function ChatMarkdown({
         components={markdownComponents}
         urlTransform={markdownUrlTransform}
       >
-        {text}
+        {markdownSource}
       </ReactMarkdown>
     </div>
   );

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -264,6 +264,13 @@ describe("normalizeWindowsMarkdownFileLinks", () => {
       "```\ncode\n```\n[D:\\tmp\\file.md](file:///D:/tmp/file.md)",
     );
   });
+
+  it("does not rewrite Windows paths inside blockquote or list fences", () => {
+    const quoted = "> ```\n> D:\\tmp\\file.md\n> ```";
+    const listed = "1. ```\n   D:\\tmp\\file.md\n   ```";
+    expect(normalizeWindowsMarkdownFileLinks(quoted)).toBe(quoted);
+    expect(normalizeWindowsMarkdownFileLinks(listed)).toBe(listed);
+  });
 });
 
 describe("resolveInlineCodeFileLinkMeta", () => {

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -243,6 +243,27 @@ describe("normalizeWindowsMarkdownFileLinks", () => {
       "See [M:\\batches\\issue-40-v1\\docs\\prompt.md](file:///M:/batches/issue-40-v1/docs/prompt.md).",
     );
   });
+
+  it("does not consume emphasis markers around a bare windows path", () => {
+    expect(normalizeWindowsMarkdownFileLinks("**D:\\foo.md**")).toBe(
+      "**[D:\\foo.md](file:///D:/foo.md)**",
+    );
+  });
+
+  it("does not rewrite indented code or fenced code with a mid-line fence sequence", () => {
+    const indented = "    D:\\tmp\\file.md";
+    const tabIndented = "\tD:\\tmp\\file.md";
+    const fencedMidline = '```\nconst s = "```";\nD:\\tmp\\file.md\n```';
+    expect(normalizeWindowsMarkdownFileLinks(indented)).toBe(indented);
+    expect(normalizeWindowsMarkdownFileLinks(tabIndented)).toBe(tabIndented);
+    expect(normalizeWindowsMarkdownFileLinks(fencedMidline)).toBe(fencedMidline);
+  });
+
+  it("still autolinks a path after a closed fence", () => {
+    expect(normalizeWindowsMarkdownFileLinks("```\ncode\n```\nD:\\tmp\\file.md")).toBe(
+      "```\ncode\n```\n[D:\\tmp\\file.md](file:///D:/tmp/file.md)",
+    );
+  });
 });
 
 describe("resolveInlineCodeFileLinkMeta", () => {

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -1,11 +1,19 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  normalizeWindowsMarkdownFileLinks,
   resolveInlineCodeFileLinkMeta,
   resolveMarkdownFileLinkMeta,
   resolveMarkdownFileLinkTarget,
   rewriteMarkdownFileUriHref,
 } from "./markdown-links";
+
+function firstMarkdownLinkDestination(markdown: string): string {
+  const match = markdown.match(/\[[^\]]*]\(([^)]+)\)/);
+  const dest = match?.[1];
+  if (!dest) throw new Error(`expected a markdown link in: ${markdown}`);
+  return dest;
+}
 
 describe("rewriteMarkdownFileUriHref", () => {
   it("rewrites file uri hrefs into direct path hrefs", () => {
@@ -32,6 +40,29 @@ describe("rewriteMarkdownFileUriHref", () => {
     expect(
       rewriteMarkdownFileUriHref(" <file:///D:/Programme/t3code/apps/web/src/markdown-links.ts> "),
     ).toBe("D:/Programme/t3code/apps/web/src/markdown-links.ts");
+  });
+
+  it("rewrites unc file urls into windows unc paths", () => {
+    expect(rewriteMarkdownFileUriHref("file://server/share/file.txt")).toBe(
+      "\\\\server\\share\\file.txt",
+    );
+  });
+
+  it("keeps leftover windows drive and unc hrefs", () => {
+    expect(rewriteMarkdownFileUriHref("D:/tmp/t3-link-repro/example.md")).toBe(
+      "D:/tmp/t3-link-repro/example.md",
+    );
+    expect(rewriteMarkdownFileUriHref("M:\\batches\\issue-40-v1\\docs\\prompt.md")).toBe(
+      "M:\\batches\\issue-40-v1\\docs\\prompt.md",
+    );
+    expect(rewriteMarkdownFileUriHref("\\\\server\\share\\file.txt")).toBe(
+      "\\\\server\\share\\file.txt",
+    );
+  });
+
+  it("does not treat other schemes as filesystem hrefs", () => {
+    expect(rewriteMarkdownFileUriHref("https://example.com/docs")).toBeNull();
+    expect(rewriteMarkdownFileUriHref("javascript:alert(1)")).toBeNull();
   });
 });
 
@@ -126,6 +157,91 @@ describe("resolveMarkdownFileLinkTarget", () => {
 
   it("does not treat app routes as file links", () => {
     expect(resolveMarkdownFileLinkTarget("/chat/settings")).toBeNull();
+  });
+
+  it("resolves windows drive destinations", () => {
+    expect(resolveMarkdownFileLinkTarget("D:/tmp/t3-link-repro/example.md")).toBe(
+      "D:/tmp/t3-link-repro/example.md",
+    );
+  });
+
+  it("resolves unc file urls back to windows unc paths", () => {
+    expect(resolveMarkdownFileLinkTarget("file://server/share/file.txt")).toBe(
+      "\\\\server\\share\\file.txt",
+    );
+  });
+});
+
+describe("normalizeWindowsMarkdownFileLinks", () => {
+  it("rewrites windows drive destinations to file urls that resolve", () => {
+    const rewritten = normalizeWindowsMarkdownFileLinks("[Open](D:/tmp/t3-link-repro/example.md)");
+    const dest = firstMarkdownLinkDestination(rewritten);
+    expect(dest).toBe("file:///D:/tmp/t3-link-repro/example.md");
+    expect(rewriteMarkdownFileUriHref(dest)).toBe("D:/tmp/t3-link-repro/example.md");
+    expect(resolveMarkdownFileLinkTarget(dest)).toBe("D:/tmp/t3-link-repro/example.md");
+  });
+
+  it("rewrites backslash drive destinations and angle-bracket destinations", () => {
+    expect(normalizeWindowsMarkdownFileLinks("[Open](D:\\tmp\\t3-link-repro\\example.md)")).toBe(
+      "[Open](file:///D:/tmp/t3-link-repro/example.md)",
+    );
+    expect(normalizeWindowsMarkdownFileLinks("[Open](<D:/tmp/t3-link-repro/example.md>)")).toBe(
+      "[Open](<file:///D:/tmp/t3-link-repro/example.md>)",
+    );
+    expect(normalizeWindowsMarkdownFileLinks("<D:/tmp/t3-link-repro/example.md>")).toBe(
+      "<file:///D:/tmp/t3-link-repro/example.md>",
+    );
+  });
+
+  it("autolinks bare windows drive paths", () => {
+    const rewritten = normalizeWindowsMarkdownFileLinks(
+      "See M:\\batches\\issue-40-v1\\docs\\prompt.md please",
+    );
+    expect(rewritten).toBe(
+      "See [M:\\batches\\issue-40-v1\\docs\\prompt.md](file:///M:/batches/issue-40-v1/docs/prompt.md) please",
+    );
+    expect(resolveMarkdownFileLinkTarget(firstMarkdownLinkDestination(rewritten))).toBe(
+      "M:/batches/issue-40-v1/docs/prompt.md",
+    );
+  });
+
+  it("autolinks unc paths", () => {
+    const rewritten = normalizeWindowsMarkdownFileLinks("See \\\\server\\share\\file.txt");
+    expect(rewritten).toBe("See [\\\\server\\share\\file.txt](file://server/share/file.txt)");
+    expect(resolveMarkdownFileLinkTarget(firstMarkdownLinkDestination(rewritten))).toBe(
+      "\\\\server\\share\\file.txt",
+    );
+  });
+
+  it("does not rewrite inside fenced code or inline code", () => {
+    const fenced = "```\nD:/tmp/t3-link-repro/example.md\n```";
+    const inline = "Use `D:/tmp/t3-link-repro/example.md` here";
+    const tilde = "~~~\nM:\\batches\\issue-40-v1\\docs\\prompt.md\n~~~";
+    expect(normalizeWindowsMarkdownFileLinks(fenced)).toBe(fenced);
+    expect(normalizeWindowsMarkdownFileLinks(inline)).toBe(inline);
+    expect(normalizeWindowsMarkdownFileLinks(tilde)).toBe(tilde);
+  });
+
+  it("does not touch https links", () => {
+    const httpsLink = "[docs](https://example.com/D:/not-a-path)";
+    expect(normalizeWindowsMarkdownFileLinks(httpsLink)).toBe(httpsLink);
+    expect(
+      normalizeWindowsMarkdownFileLinks("See https://example.com/docs and D:/tmp/example.md"),
+    ).toBe("See https://example.com/docs and [D:/tmp/example.md](file:///D:/tmp/example.md)");
+  });
+
+  it("leaves existing file urls and drive roots alone", () => {
+    const fileUrl = "[Open](file:///D:/tmp/t3-link-repro/example.md)";
+    expect(normalizeWindowsMarkdownFileLinks(fileUrl)).toBe(fileUrl);
+    expect(normalizeWindowsMarkdownFileLinks("See D:\\ and C:/")).toBe("See D:\\ and C:/");
+  });
+
+  it("strips trailing sentence punctuation from autolinked paths", () => {
+    expect(
+      normalizeWindowsMarkdownFileLinks("See M:\\batches\\issue-40-v1\\docs\\prompt.md."),
+    ).toBe(
+      "See [M:\\batches\\issue-40-v1\\docs\\prompt.md](file:///M:/batches/issue-40-v1/docs/prompt.md).",
+    );
   });
 });
 

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -259,8 +259,10 @@ function rewriteWindowsMarkdownInText(text: string): string {
 }
 
 const INLINE_CODE_SEGMENT_PATTERN = /(`[^`\n]+`)/;
-const OPEN_FENCE_PATTERN = /^( {0,3})(`{3,}|~{3,})(.*)$/;
-const CLOSE_FENCE_PATTERN = /^( {0,3})(`{3,}|~{3,})[ \t]*$/;
+// Optional CommonMark container prefixes so `> ```js` and `1. ```js` still
+// open a fence. Mid-line backticks are not fences.
+const OPEN_FENCE_PATTERN = /^(?: {0,3}(?:>[ \t]?|[*+-][ \t]|\d{1,9}[.)][ \t])*)(`{3,}|~{3,})(.*)$/;
+const CLOSE_FENCE_PATTERN = /^(?: {0,3}(?:>[ \t]?|[*+-][ \t]|\d{1,9}[.)][ \t])*)(`{3,}|~{3,})[ \t]*$/;
 
 function mapOutsideInlineCode(text: string, transform: (chunk: string) => string): string {
   return text
@@ -275,17 +277,17 @@ function lineWithoutCarriageReturn(line: string): string {
 
 function openingFenceMarker(line: string): string | null {
   const match = OPEN_FENCE_PATTERN.exec(line);
-  if (!match?.[2]) return null;
-  const marker = match[2];
-  const info = match[3] ?? "";
+  const marker = match?.[1];
+  if (!marker) return null;
+  const info = match[2] ?? "";
   if (marker.startsWith("`") && info.includes("`")) return null;
   return marker;
 }
 
 function isClosingFenceLine(line: string, openMarker: string): boolean {
   const match = CLOSE_FENCE_PATTERN.exec(line);
-  if (!match?.[2]) return false;
-  const marker = match[2];
+  const marker = match?.[1];
+  if (!marker) return false;
   return marker[0] === openMarker[0] && marker.length >= openMarker.length;
 }
 

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -140,13 +140,13 @@ const MARKDOWN_LINK_DEFINITION_PATTERN =
 const ANGLE_AUTOLINK_PATTERN = /<([^<>\n]+)>/g;
 const PROTECTED_MARKDOWN_SPAN_PATTERN = /!?\[[^\]]*]\([^)]*\)|!?\[[^\]]*]\[[^\]]*]|<[^>\n]+>/g;
 const BARE_WINDOWS_PATH_PATTERN =
-  /(?<![A-Za-z0-9_/])(?:[A-Za-z]:[\\/][^\s<>[\]()`]+|\\\\[^\s<>[\]()`\\/]+(?:[\\/][^\s<>[\]()`]+)+)/g;
+  /(?<![A-Za-z0-9_/])(?:[A-Za-z]:[\\/][^\s<>[\]()`*]+|\\\\[^\s<>[\]()`*\\/]+(?:[\\/][^\s<>[\]()`*]+)+)/g;
 const AUTOLINK_TRAILING_PUNCTUATION_PATTERN = /[.,;:!?')\]}"]+$/;
 
 /**
  * Rewrites Windows drive/UNC markdown destinations and bare paths to `file://`
  * URLs so rehype-sanitize does not treat `D:` as an unknown protocol.
- * Leaves fenced code, inline code, and non-file links alone.
+ * Leaves fenced code, indented code, inline code, and non-file links alone.
  */
 export function normalizeWindowsMarkdownFileLinks(markdown: string): string {
   if (markdown.length === 0 || !HAS_WINDOWS_FILESYSTEM_PATH_PATTERN.test(markdown)) {
@@ -258,8 +258,9 @@ function rewriteWindowsMarkdownInText(text: string): string {
   return autolinkBareWindowsPaths(rewriteWindowsAngleAutolinks(withDestinations));
 }
 
-const FENCED_CODE_SEGMENT_PATTERN = /(```[\s\S]*?(?:```|$)|~~~[\s\S]*?(?:~~~|$))/;
 const INLINE_CODE_SEGMENT_PATTERN = /(`[^`\n]+`)/;
+const OPEN_FENCE_PATTERN = /^( {0,3})(`{3,}|~{3,})(.*)$/;
+const CLOSE_FENCE_PATTERN = /^( {0,3})(`{3,}|~{3,})[ \t]*$/;
 
 function mapOutsideInlineCode(text: string, transform: (chunk: string) => string): string {
   return text
@@ -268,11 +269,70 @@ function mapOutsideInlineCode(text: string, transform: (chunk: string) => string
     .join("");
 }
 
+function lineWithoutCarriageReturn(line: string): string {
+  return line.endsWith("\r") ? line.slice(0, -1) : line;
+}
+
+function openingFenceMarker(line: string): string | null {
+  const match = OPEN_FENCE_PATTERN.exec(line);
+  if (!match?.[2]) return null;
+  const marker = match[2];
+  const info = match[3] ?? "";
+  if (marker.startsWith("`") && info.includes("`")) return null;
+  return marker;
+}
+
+function isClosingFenceLine(line: string, openMarker: string): boolean {
+  const match = CLOSE_FENCE_PATTERN.exec(line);
+  if (!match?.[2]) return false;
+  const marker = match[2];
+  return marker[0] === openMarker[0] && marker.length >= openMarker.length;
+}
+
+function isIndentedCodeLine(line: string): boolean {
+  return line.startsWith("    ") || line.startsWith("\t");
+}
+
 function mapMarkdownOutsideCode(markdown: string, transform: (text: string) => string): string {
-  return markdown
-    .split(FENCED_CODE_SEGMENT_PATTERN)
-    .map((segment, index) => (index % 2 === 1 ? segment : mapOutsideInlineCode(segment, transform)))
-    .join("");
+  let output = "";
+  let index = 0;
+  let openFence: string | null = null;
+
+  while (index < markdown.length) {
+    const lineEnd = markdown.indexOf("\n", index);
+    const lineLimit = lineEnd === -1 ? markdown.length : lineEnd;
+    const line = markdown.slice(index, lineLimit);
+    const newline = lineEnd === -1 ? "" : "\n";
+    const matchLine = lineWithoutCarriageReturn(line);
+
+    if (openFence !== null) {
+      output += line + newline;
+      if (isClosingFenceLine(matchLine, openFence)) {
+        openFence = null;
+      }
+      index = lineLimit + newline.length;
+      continue;
+    }
+
+    const fence = openingFenceMarker(matchLine);
+    if (fence !== null) {
+      openFence = fence;
+      output += line + newline;
+      index = lineLimit + newline.length;
+      continue;
+    }
+
+    if (isIndentedCodeLine(matchLine)) {
+      output += line + newline;
+      index = lineLimit + newline.length;
+      continue;
+    }
+
+    output += mapOutsideInlineCode(line, transform) + newline;
+    index = lineLimit + newline.length;
+  }
+
+  return output;
 }
 
 function looksLikePosixFilesystemPath(path: string): boolean {

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -77,6 +77,10 @@ function normalizeWindowsDrivePath(path: string): string {
   return /^\/[A-Za-z]:[\\/]/.test(path) ? path.slice(1) : path;
 }
 
+function decodeFileUrlPath(path: string, decodePath: boolean | undefined): string {
+  return decodePath === false ? path : safeDecode(path);
+}
+
 function parseFileUrlHref(
   href: string,
   options?: { readonly decodePath?: boolean },
@@ -88,11 +92,23 @@ function parseFileUrlHref(
     const rawPath = parsed.pathname;
     if (rawPath.length === 0) return null;
 
+    const hostname = parsed.hostname;
+    if (hostname && hostname.toLowerCase() !== "localhost") {
+      const uncTail = decodeFileUrlPath(rawPath, options?.decodePath).replaceAll("/", "\\");
+      return { path: `\\\\${hostname}${uncTail}`, hash: parsed.hash };
+    }
+
+    const decodedPath = decodeFileUrlPath(rawPath, options?.decodePath);
+    // file://///server/share/file.txt → pathname "//server/share/file.txt"
+    if (decodedPath.startsWith("//")) {
+      return { path: decodedPath.replaceAll("/", "\\"), hash: parsed.hash };
+    }
+
     // Browser URL parser encodes "C:/foo" as "/C:/foo" for file URLs.
-    const normalizedPath = normalizeWindowsDrivePath(rawPath);
+    const normalizedPath = normalizeWindowsDrivePath(decodedPath);
 
     return {
-      path: options?.decodePath === false ? normalizedPath : safeDecode(normalizedPath),
+      path: normalizedPath,
       hash: parsed.hash,
     };
   } catch {
@@ -104,8 +120,159 @@ export function rewriteMarkdownFileUriHref(href: string | undefined): string | n
   if (!href) return null;
   const normalizedHref = normalizeMarkdownLinkDestination(href);
   const target = parseFileUrlHref(normalizedHref, { decodePath: false });
-  if (!target) return null;
-  return `${target.path}${target.hash}`;
+  if (target) return `${target.path}${target.hash}`;
+  // Leftover `D:/...` / UNC hrefs never became file: URLs. Keep them so
+  // react-markdown's urlTransform does not treat the drive letter as a protocol.
+  if (
+    WINDOWS_DRIVE_PATH_PATTERN.test(normalizedHref) ||
+    WINDOWS_UNC_PATH_PATTERN.test(normalizedHref)
+  ) {
+    return normalizedHref;
+  }
+  return null;
+}
+
+const HAS_WINDOWS_FILESYSTEM_PATH_PATTERN = /[A-Za-z]:[\\/]|\\\\/;
+const INLINE_MARKDOWN_LINK_PATTERN =
+  /(!?\[[^\]]*])\(([ \t]*)(?:<([^>\n]*)>|([^ \t\n)]+))((?:[ \t]+(?:"[^"]*"|'[^']*'|\([^)]*\)))?)([ \t]*)\)/g;
+const MARKDOWN_LINK_DEFINITION_PATTERN =
+  /^([ \t]{0,3}\[[^\]]+\]:[ \t]+)(?:<([^>\n]*)>|(\S+))((?:[ \t]+(?:"[^"]*"|'[^']*'|\([^)]*\)))?)([ \t]*)$/gm;
+const ANGLE_AUTOLINK_PATTERN = /<([^<>\n]+)>/g;
+const PROTECTED_MARKDOWN_SPAN_PATTERN = /!?\[[^\]]*]\([^)]*\)|!?\[[^\]]*]\[[^\]]*]|<[^>\n]+>/g;
+const BARE_WINDOWS_PATH_PATTERN =
+  /(?<![A-Za-z0-9_/])(?:[A-Za-z]:[\\/][^\s<>[\]()`]+|\\\\[^\s<>[\]()`\\/]+(?:[\\/][^\s<>[\]()`]+)+)/g;
+const AUTOLINK_TRAILING_PUNCTUATION_PATTERN = /[.,;:!?')\]}"]+$/;
+
+/**
+ * Rewrites Windows drive/UNC markdown destinations and bare paths to `file://`
+ * URLs so rehype-sanitize does not treat `D:` as an unknown protocol.
+ * Leaves fenced code, inline code, and non-file links alone.
+ */
+export function normalizeWindowsMarkdownFileLinks(markdown: string): string {
+  if (markdown.length === 0 || !HAS_WINDOWS_FILESYSTEM_PATH_PATTERN.test(markdown)) {
+    return markdown;
+  }
+  return mapMarkdownOutsideCode(markdown, rewriteWindowsMarkdownInText);
+}
+
+function windowsFilesystemPathToFileUrl(path: string): string | null {
+  const value = unwrapMarkdownLinkDestination(path.trim());
+  if (value.length === 0) return null;
+
+  const { path: pathOnly, hash } = stripSearchAndHash(value);
+
+  if (WINDOWS_DRIVE_PATH_PATTERN.test(pathOnly)) {
+    if (!/[^\s\\/]/.test(pathOnly.slice(3))) return null;
+    return `file:///${pathOnly.replaceAll("\\", "/")}${hash}`;
+  }
+
+  if (WINDOWS_UNC_PATH_PATTERN.test(pathOnly)) {
+    const parts = pathOnly
+      .slice(2)
+      .split(/[\\/]/)
+      .filter((part) => part.length > 0);
+    if (parts.length < 2) return null;
+    return `file://${parts.join("/")}${hash}`;
+  }
+
+  return null;
+}
+
+function rewriteInlineWindowsLinkDestinations(text: string): string {
+  return text.replace(
+    INLINE_MARKDOWN_LINK_PATTERN,
+    (
+      match,
+      label: string,
+      ws: string,
+      angleDest: string | undefined,
+      bareDest: string | undefined,
+      title: string,
+      trailWs: string,
+    ) => {
+      const fileUrl = windowsFilesystemPathToFileUrl(angleDest ?? bareDest ?? "");
+      if (!fileUrl) return match;
+      const dest = angleDest !== undefined ? `<${fileUrl}>` : fileUrl;
+      return `${label}(${ws}${dest}${title}${trailWs})`;
+    },
+  );
+}
+
+function rewriteWindowsLinkDefinitions(text: string): string {
+  return text.replace(
+    MARKDOWN_LINK_DEFINITION_PATTERN,
+    (
+      match,
+      prefix: string,
+      angleDest: string | undefined,
+      bareDest: string | undefined,
+      title: string,
+      trailWs: string,
+    ) => {
+      const fileUrl = windowsFilesystemPathToFileUrl(angleDest ?? bareDest ?? "");
+      if (!fileUrl) return match;
+      const dest = angleDest !== undefined ? `<${fileUrl}>` : fileUrl;
+      return `${prefix}${dest}${title}${trailWs}`;
+    },
+  );
+}
+
+function rewriteWindowsAngleAutolinks(text: string): string {
+  return text.replace(ANGLE_AUTOLINK_PATTERN, (match, dest: string) => {
+    const fileUrl = windowsFilesystemPathToFileUrl(dest);
+    return fileUrl ? `<${fileUrl}>` : match;
+  });
+}
+
+function splitAutolinkWindowsPath(raw: string): { path: string; trailing: string } {
+  if (POSITION_SUFFIX_PATTERN.test(raw)) return { path: raw, trailing: "" };
+  const trimmed = raw.replace(AUTOLINK_TRAILING_PUNCTUATION_PATTERN, "");
+  if (trimmed.length === 0 || trimmed === raw) return { path: raw, trailing: "" };
+  if (!windowsFilesystemPathToFileUrl(trimmed)) return { path: raw, trailing: "" };
+  return { path: trimmed, trailing: raw.slice(trimmed.length) };
+}
+
+function autolinkBareWindowsPaths(text: string): string {
+  const slots: string[] = [];
+  const withSlots = text.replace(PROTECTED_MARKDOWN_SPAN_PATTERN, (match) => {
+    const token = `\0${slots.length}\0`;
+    slots.push(match);
+    return token;
+  });
+
+  const linked = withSlots.replace(BARE_WINDOWS_PATH_PATTERN, (raw) => {
+    const { path, trailing } = splitAutolinkWindowsPath(raw);
+    const fileUrl = windowsFilesystemPathToFileUrl(path);
+    if (!fileUrl) return raw;
+    return `[${path}](${fileUrl})${trailing}`;
+  });
+
+  if (slots.length === 0) return linked;
+  return linked.replace(/\0(\d+)\0/g, (_, index: string) => slots[Number(index)] ?? "");
+}
+
+function rewriteWindowsMarkdownInText(text: string): string {
+  const withDestinations = rewriteWindowsLinkDefinitions(
+    rewriteInlineWindowsLinkDestinations(text),
+  );
+  return autolinkBareWindowsPaths(rewriteWindowsAngleAutolinks(withDestinations));
+}
+
+const FENCED_CODE_SEGMENT_PATTERN = /(```[\s\S]*?(?:```|$)|~~~[\s\S]*?(?:~~~|$))/;
+const INLINE_CODE_SEGMENT_PATTERN = /(`[^`\n]+`)/;
+
+function mapOutsideInlineCode(text: string, transform: (chunk: string) => string): string {
+  return text
+    .split(INLINE_CODE_SEGMENT_PATTERN)
+    .map((segment, index) => (index % 2 === 1 ? segment : transform(segment)))
+    .join("");
+}
+
+function mapMarkdownOutsideCode(markdown: string, transform: (text: string) => string): string {
+  return markdown
+    .split(FENCED_CODE_SEGMENT_PATTERN)
+    .map((segment, index) => (index % 2 === 1 ? segment : mapOutsideInlineCode(segment, transform)))
+    .join("");
 }
 
 function looksLikePosixFilesystemPath(path: string): boolean {

--- a/apps/web/src/markdown-task-list.test.ts
+++ b/apps/web/src/markdown-task-list.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { setMarkdownTaskChecked } from "./components/files/filePreviewMode";
+import { normalizeWindowsMarkdownFileLinks } from "./markdown-links";
+import { findTaskListMarkerOffset } from "./markdown-task-list";
+
+describe("findTaskListMarkerOffset", () => {
+  it("uses the original text when a windows rewrite shifts later offsets", () => {
+    const original = "See D:\\tmp\\file.md\n- [ ] later";
+    const parsed = normalizeWindowsMarkdownFileLinks(original);
+    const parsedListItemStart = parsed.indexOf("- [ ]");
+    expect(parsedListItemStart).toBeGreaterThan(original.indexOf("- [ ]"));
+
+    const markerOffset = findTaskListMarkerOffset(original, parsedListItemStart, parsed);
+    expect(markerOffset).toBe(original.indexOf("["));
+    expect(setMarkdownTaskChecked(original, markerOffset!, true)).toBe(
+      "See D:\\tmp\\file.md\n- [x] later",
+    );
+  });
+
+  it("keeps the checkbox offset when the rewrite is after the marker", () => {
+    const original = "- [ ] Open D:\\tmp\\file.md";
+    const parsed = normalizeWindowsMarkdownFileLinks(original);
+    const markerOffset = findTaskListMarkerOffset(original, 0, parsed);
+    expect(markerOffset).toBe(2);
+    expect(setMarkdownTaskChecked(original, markerOffset!, true)).toBe(
+      "- [x] Open D:\\tmp\\file.md",
+    );
+  });
+});

--- a/apps/web/src/markdown-task-list.ts
+++ b/apps/web/src/markdown-task-list.ts
@@ -1,0 +1,55 @@
+function lineIndexAtOffset(source: string, offset: number): number {
+  let line = 0;
+  const limit = Math.min(Math.max(offset, 0), source.length);
+  for (let i = 0; i < limit; i++) {
+    if (source.charCodeAt(i) === 10) line++;
+  }
+  return line;
+}
+
+function lineStartOffset(source: string, lineIndex: number): number {
+  if (lineIndex <= 0) return 0;
+  let line = 0;
+  for (let i = 0; i < source.length; i++) {
+    if (source.charCodeAt(i) === 10) {
+      line++;
+      if (line === lineIndex) return i + 1;
+    }
+  }
+  return source.length;
+}
+
+function taskListMarkerStart(markdown: string, listItemStart: number): number | null {
+  const firstLineEnd = markdown.indexOf("\n", listItemStart);
+  const firstLine = markdown.slice(
+    listItemStart,
+    firstLineEnd === -1 ? markdown.length : firstLineEnd,
+  );
+  const match = firstLine.match(/^(?:\s*(?:[-+*]|\d+[.)])\s+)(\[[ xX]\])/);
+  if (!match?.[1]) return null;
+  return listItemStart + firstLine.indexOf(match[1]);
+}
+
+/**
+ * Task clicks mutate `markdown` (the raw message/file). `listItemStart` comes
+ * from the parsed tree, which may be a rewritten source whose earlier offsets
+ * no longer match.
+ */
+export function findTaskListMarkerOffset(
+  markdown: string,
+  listItemStart: number,
+  parsedMarkdown: string = markdown,
+): number | null {
+  if (
+    parsedMarkdown === markdown ||
+    (listItemStart <= markdown.length &&
+      markdown.startsWith(parsedMarkdown.slice(0, listItemStart)))
+  ) {
+    return taskListMarkerStart(markdown, listItemStart);
+  }
+
+  return taskListMarkerStart(
+    markdown,
+    lineStartOffset(markdown, lineIndexAtOffset(parsedMarkdown, listItemStart)),
+  );
+}


### PR DESCRIPTION
## What Changed

Fixes #6418. Markdown destinations like `D:/...` are rewritten to `file:///` before sanitize, and bare Windows paths are autolinked. Workspace vs external-editor behavior is unchanged.

## Why

On Windows, `[Open](D:/tmp/file.md)` survives Markdown parse as a link, but `rehype-sanitize` treats `D:` as an unknown protocol and strips the href before `urlTransform` / `rewriteMarkdownFileUriHref` can keep it. Bare paths such as `M:\batches\...\prompt.md` never become links because GFM does not autolink filesystem paths.

This preprocesses those destinations (and conservative bare drive/UNC paths) into `file:///` URLs so sanitize keeps them. Existing `rewriteMarkdownFileUriHref` / `resolveMarkdownFileLinkMeta` still decide chips, tooltips, and workspace vs external-editor behavior. Drive-letter schemes are not added to the sanitize allowlist.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a large regex-based markdown preprocessor on the chat render path; behavior is heavily tested but edge cases in mixed Windows paths, emphasis, and code fences could still mis-link or mis-map task checkboxes.
> 
> **Overview**
> Fixes Windows chat markdown where `D:/...` link destinations were stripped by **rehype-sanitize** (drive letter treated as a protocol) and bare paths never became links.
> 
> **`normalizeWindowsMarkdownFileLinks`** preprocesses the message before parse/render: rewrites inline/link-definition/angle-bracket Windows destinations to `file:///` URLs, conservatively autolinks bare drive and UNC paths, and skips fenced code, indented code, and inline code. **`ChatMarkdown`** renders and resolves file-link metadata from this rewritten `markdownSource` while task-checkbox edits still target the original `text`.
> 
> **`rewriteMarkdownFileUriHref`** and **`parseFileUrlHref`** now handle UNC `file://` URLs and pass leftover bare `D:/` / UNC hrefs through so `urlTransform` does not drop them. **`findTaskListMarkerOffset`** moves to `markdown-task-list.ts` and maps AST offsets from the rewritten source back to the raw string by line when earlier autolinking shifts byte positions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18b22ae976c5083c3b7c40446457384b9ddfcb90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Windows drive and UNC paths to render as clickable file links in chat markdown
> - Adds `normalizeWindowsMarkdownFileLinks` in [markdown-links.ts](https://github.com/pingdotgg/t3code/pull/7182/files#diff-010f94b966be6604cb228ce225d1f3ce41b15470b641a970ec5ed07cd2ed2040) to preprocess chat markdown before rendering, converting bare Windows drive paths (e.g. `C:\...`) and UNC paths (e.g. `\\server\share`) into `file://` links while skipping code blocks and existing links.
> - Updates `parseFileUrlHref` and `rewriteMarkdownFileUriHref` to correctly round-trip Windows drive and UNC `file://` URLs back to their path forms instead of dropping them.
> - Updates [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/7182/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05) to run this normalization before parsing, and introduces `findTaskListMarkerOffset` in [markdown-task-list.ts](https://github.com/pingdotgg/t3code/pull/7182/files#diff-955a4934f1cd03d4acfa5c6f9b2dfdacd0427681f3b81dd61ae20323d071bcc6) to correctly map checkbox marker positions back to the original (pre-normalized) source when toggling task list items.
> - Behavioral Change: task list checkbox offsets are now computed against original text; rewrites earlier in the document shift parsed offsets but are now correctly remapped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 18b22ae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->