### PR TITLE
fix(web): do not reuse archived thread ids as new drafts

### DIFF
--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -824,24 +824,61 @@ describe("composerDraftStore project draft thread mapping", () => {
     });
   });
 
-  it("retires a project draft mapping that still points at an archived thread", () => {
+  it("retires a project draft mapping without wiping aliased composer content", () => {
     const store = useComposerDraftStore.getState();
     const threadRef = scopeThreadRef(TEST_ENVIRONMENT_ID, threadId);
-    // Write the server-thread composer first so it lands on the scoped key
-    // instead of being aliased onto the later draft session.
-    store.setPrompt(threadRef, "keep the archived thread composer");
+    const originalRevokeObjectUrl = URL.revokeObjectURL;
+    const revokeSpy = vi.fn<(url: string) => void>();
+    URL.revokeObjectURL = revokeSpy;
+
+    try {
+      // Composer lives under the draft id and is only reachable from the
+      // server thread via alias. Archive must not delete that entry.
+      store.setProjectDraftThreadId(projectRef, draftId, { threadId });
+      store.setPrompt(draftId, "keep the archived thread composer");
+      store.addImage(
+        draftId,
+        makeImage({ id: "img-archive-keep", previewUrl: "blob:archive-keep" }),
+      );
+      store.setProjectDraftThreadId(otherProjectRef, otherDraftId, { threadId: otherThreadId });
+
+      retireProjectDraftMappingForThread(threadRef);
+
+      const next = useComposerDraftStore.getState();
+      expect(next.getDraftSessionByLogicalProjectKey(scopedProjectKey(projectRef))).toBeNull();
+      expect(next.getComposerDraft(threadRef)?.prompt).toBe("keep the archived thread composer");
+      expect(next.getComposerDraft(draftId)?.prompt).toBe("keep the archived thread composer");
+      expect(next.getComposerDraft(threadRef)?.images).toHaveLength(1);
+      expect(next.getDraftThread(draftId)?.threadId).toBe(threadId);
+      expect(next.getDraftThreadByProjectRef(otherProjectRef)?.threadId).toBe(otherThreadId);
+      expect(revokeSpy).not.toHaveBeenCalled();
+    } finally {
+      URL.revokeObjectURL = originalRevokeObjectUrl;
+    }
+  });
+
+  it("does not reuse a deleted or promoted thread id as the project's next draft", () => {
+    const store = useComposerDraftStore.getState();
+    const threadRef = scopeThreadRef(TEST_ENVIRONMENT_ID, threadId);
     store.setProjectDraftThreadId(projectRef, draftId, { threadId });
-    store.setPrompt(draftId, "draft session prompt");
-    store.setProjectDraftThreadId(otherProjectRef, otherDraftId, { threadId: otherThreadId });
+    store.setPrompt(draftId, "already sent");
+
+    markPromotedDraftThreadByRef(threadRef);
+    expect(
+      useComposerDraftStore
+        .getState()
+        .getDraftSessionByLogicalProjectKey(scopedProjectKey(projectRef)),
+    ).toBeNull();
 
     retireProjectDraftMappingForThread(threadRef);
 
     const next = useComposerDraftStore.getState();
     expect(next.getDraftSessionByLogicalProjectKey(scopedProjectKey(projectRef))).toBeNull();
-    expect(next.getDraftThread(draftId)).toBeNull();
-    expect(draftByKey(draftId)).toBeUndefined();
-    expect(next.getComposerDraft(threadRef)?.prompt).toBe("keep the archived thread composer");
-    expect(next.getDraftThreadByProjectRef(otherProjectRef)?.threadId).toBe(otherThreadId);
+    expect(
+      next.logicalProjectDraftThreadKeyByLogicalProjectKey[scopedProjectKey(projectRef)],
+    ).toBeUndefined();
+    expect(next.getDraftThread(draftId)?.promotedTo).toEqual(threadRef);
+    expect(next.getComposerDraft(threadRef)?.prompt).toBe("already sent");
   });
 
   it("leaves a mapping alone when it points at a different thread", () => {

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -65,6 +65,7 @@ import {
   markPromotedDraftThreadByRef,
   markPromotedDraftThreads,
   markPromotedDraftThreadsByRef,
+  retireProjectDraftMappingForThread,
   type ComposerImageAttachment,
   useComposerDraftStore,
   DraftId,
@@ -821,6 +822,37 @@ describe("composerDraftStore project draft thread mapping", () => {
       interactionMode: "default",
       createdAt: "2026-01-01T00:00:00.000Z",
     });
+  });
+
+  it("retires a project draft mapping that still points at an archived thread", () => {
+    const store = useComposerDraftStore.getState();
+    const threadRef = scopeThreadRef(TEST_ENVIRONMENT_ID, threadId);
+    // Write the server-thread composer first so it lands on the scoped key
+    // instead of being aliased onto the later draft session.
+    store.setPrompt(threadRef, "keep the archived thread composer");
+    store.setProjectDraftThreadId(projectRef, draftId, { threadId });
+    store.setPrompt(draftId, "draft session prompt");
+    store.setProjectDraftThreadId(otherProjectRef, otherDraftId, { threadId: otherThreadId });
+
+    retireProjectDraftMappingForThread(threadRef);
+
+    const next = useComposerDraftStore.getState();
+    expect(next.getDraftSessionByLogicalProjectKey(scopedProjectKey(projectRef))).toBeNull();
+    expect(next.getDraftThread(draftId)).toBeNull();
+    expect(draftByKey(draftId)).toBeUndefined();
+    expect(next.getComposerDraft(threadRef)?.prompt).toBe("keep the archived thread composer");
+    expect(next.getDraftThreadByProjectRef(otherProjectRef)?.threadId).toBe(otherThreadId);
+  });
+
+  it("leaves a mapping alone when it points at a different thread", () => {
+    const store = useComposerDraftStore.getState();
+    store.setProjectDraftThreadId(projectRef, draftId, { threadId });
+
+    retireProjectDraftMappingForThread(scopeThreadRef(TEST_ENVIRONMENT_ID, otherThreadId));
+
+    expect(useComposerDraftStore.getState().getDraftThreadByProjectRef(projectRef)?.threadId).toBe(
+      threadId,
+    );
   });
 
   it("clears only matching project draft mapping entries", () => {

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -846,10 +846,11 @@ describe("composerDraftStore project draft thread mapping", () => {
 
       const next = useComposerDraftStore.getState();
       expect(next.getDraftSessionByLogicalProjectKey(scopedProjectKey(projectRef))).toBeNull();
-      expect(next.getComposerDraft(threadRef)?.prompt).toBe("keep the archived thread composer");
       expect(next.getComposerDraft(draftId)?.prompt).toBe("keep the archived thread composer");
-      expect(next.getComposerDraft(threadRef)?.images).toHaveLength(1);
-      expect(next.getDraftThread(draftId)?.threadId).toBe(threadId);
+      expect(next.getComposerDraft(draftId)?.images).toHaveLength(1);
+      expect(next.getDraftThread(draftId)?.threadId).not.toBe(threadId);
+      expect(next.getDraftThread(draftId)?.threadId).toEqual(expect.any(String));
+      expect(next.getDraftThread(threadRef)).toBeNull();
       expect(next.getDraftThreadByProjectRef(otherProjectRef)?.threadId).toBe(otherThreadId);
       expect(revokeSpy).not.toHaveBeenCalled();
     } finally {

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -421,7 +421,7 @@ interface ComposerDraftStoreState {
     projectRef: ScopedProjectRef,
     threadRef: ComposerThreadTarget,
   ) => void;
-  /** Drops any project new-thread mapping whose draft still uses this server thread id. */
+  /** Drops the project new-thread mapping for this server thread; composer state stays. */
   retireProjectDraftMappingForThread: (threadRef: ScopedThreadRef) => void;
   /** Marks a draft session as being promoted to a real server thread. */
   markDraftThreadPromoting: (threadRef: ComposerThreadTarget, promotedTo?: ScopedThreadRef) => void;
@@ -2545,21 +2545,35 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
         },
         retireProjectDraftMappingForThread: (threadRef) => {
           set((state) => {
-            const matchingDraftIds = Object.entries(state.draftThreadsByThreadKey)
-              .filter(
-                ([, draftThread]) =>
-                  draftThread.environmentId === threadRef.environmentId &&
-                  draftThread.threadId === threadRef.threadId,
-              )
-              .map(([draftId]) => draftId);
-            if (matchingDraftIds.length === 0) {
+            // Archive/delete only need the project to stop treating this
+            // server thread as the next `+` target. Composer content and
+            // draft-session metadata stay so an unsent prompt is not wiped.
+            const matchingDraftIds = new Set(
+              Object.entries(state.draftThreadsByThreadKey)
+                .filter(
+                  ([, draftThread]) =>
+                    draftThread.environmentId === threadRef.environmentId &&
+                    draftThread.threadId === threadRef.threadId,
+                )
+                .map(([draftId]) => draftId),
+            );
+            if (matchingDraftIds.size === 0) {
               return state;
             }
-            let nextState = state;
-            for (const draftId of matchingDraftIds) {
-              nextState = removeDraftThreadReferences(nextState, draftId);
+            const nextLogicalMappings = Object.fromEntries(
+              Object.entries(state.logicalProjectDraftThreadKeyByLogicalProjectKey).filter(
+                ([, draftId]) => !matchingDraftIds.has(draftId),
+              ),
+            ) as Record<string, string>;
+            if (
+              Object.keys(nextLogicalMappings).length ===
+              Object.keys(state.logicalProjectDraftThreadKeyByLogicalProjectKey).length
+            ) {
+              return state;
             }
-            return nextState;
+            return {
+              logicalProjectDraftThreadKeyByLogicalProjectKey: nextLogicalMappings,
+            };
           });
         },
         markDraftThreadPromoting: (threadRef, promotedTo) => {
@@ -3716,20 +3730,20 @@ export function useEffectiveComposerModelState(input: {
 }
 
 /**
+ * Drop the project new-thread mapping for this server thread without touching
+ * composer content. Used after archive or delete so the next `+` mints a new id.
+ */
+export function retireProjectDraftMappingForThread(threadRef: ScopedThreadRef): void {
+  useComposerDraftStore.getState().retireProjectDraftMappingForThread(threadRef);
+}
+
+/**
  * Mark a draft thread as promoting once the server has materialized the same thread id.
  *
  * Use the single-thread helper for live `thread.created` events and the
  * iterable helper for bootstrap/recovery paths that discover multiple server
  * threads at once.
  */
-/**
- * Retire a project's stored new-thread draft when it still points at this
- * server thread. Used after archive so the next `+` cannot reuse that id.
- */
-export function retireProjectDraftMappingForThread(threadRef: ScopedThreadRef): void {
-  useComposerDraftStore.getState().retireProjectDraftMappingForThread(threadRef);
-}
-
 export function markPromotedDraftThread(threadId: ThreadId): void {
   const store = useComposerDraftStore.getState();
   const draftThreadTargets: ComposerThreadTarget[] = [];

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -2565,14 +2565,33 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
                 ([, draftId]) => !matchingDraftIds.has(draftId),
               ),
             ) as Record<string, string>;
-            if (
+            // Unpromoted leftovers keep their composer, but the archived
+            // thread id is burned — remint so sidebar send cannot recreate it.
+            let nextDraftThreads: Record<string, DraftThreadState> | undefined;
+            for (const draftId of matchingDraftIds) {
+              const existing = state.draftThreadsByThreadKey[draftId];
+              if (!existing || isDraftThreadPromoting(existing)) {
+                continue;
+              }
+              nextDraftThreads ??= { ...state.draftThreadsByThreadKey };
+              nextDraftThreads[draftId] = {
+                ...existing,
+                threadId: ThreadId.make(globalThis.crypto.randomUUID()),
+              };
+            }
+            const mappingUnchanged =
               Object.keys(nextLogicalMappings).length ===
-              Object.keys(state.logicalProjectDraftThreadKeyByLogicalProjectKey).length
-            ) {
+              Object.keys(state.logicalProjectDraftThreadKeyByLogicalProjectKey).length;
+            if (mappingUnchanged && nextDraftThreads === undefined) {
               return state;
             }
             return {
-              logicalProjectDraftThreadKeyByLogicalProjectKey: nextLogicalMappings,
+              ...(mappingUnchanged
+                ? {}
+                : { logicalProjectDraftThreadKeyByLogicalProjectKey: nextLogicalMappings }),
+              ...(nextDraftThreads === undefined
+                ? {}
+                : { draftThreadsByThreadKey: nextDraftThreads }),
             };
           });
         },

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -421,6 +421,8 @@ interface ComposerDraftStoreState {
     projectRef: ScopedProjectRef,
     threadRef: ComposerThreadTarget,
   ) => void;
+  /** Drops any project new-thread mapping whose draft still uses this server thread id. */
+  retireProjectDraftMappingForThread: (threadRef: ScopedThreadRef) => void;
   /** Marks a draft session as being promoted to a real server thread. */
   markDraftThreadPromoting: (threadRef: ComposerThreadTarget, promotedTo?: ScopedThreadRef) => void;
   /** Removes draft-session metadata after promotion is complete. */
@@ -2541,6 +2543,25 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             return removeDraftThreadReferences(state, threadKey);
           });
         },
+        retireProjectDraftMappingForThread: (threadRef) => {
+          set((state) => {
+            const matchingDraftIds = Object.entries(state.draftThreadsByThreadKey)
+              .filter(
+                ([, draftThread]) =>
+                  draftThread.environmentId === threadRef.environmentId &&
+                  draftThread.threadId === threadRef.threadId,
+              )
+              .map(([draftId]) => draftId);
+            if (matchingDraftIds.length === 0) {
+              return state;
+            }
+            let nextState = state;
+            for (const draftId of matchingDraftIds) {
+              nextState = removeDraftThreadReferences(nextState, draftId);
+            }
+            return nextState;
+          });
+        },
         markDraftThreadPromoting: (threadRef, promotedTo) => {
           const threadKey = resolveComposerDraftKey(get(), threadRef);
           if (!threadKey) {
@@ -3701,6 +3722,14 @@ export function useEffectiveComposerModelState(input: {
  * iterable helper for bootstrap/recovery paths that discover multiple server
  * threads at once.
  */
+/**
+ * Retire a project's stored new-thread draft when it still points at this
+ * server thread. Used after archive so the next `+` cannot reuse that id.
+ */
+export function retireProjectDraftMappingForThread(threadRef: ScopedThreadRef): void {
+  useComposerDraftStore.getState().retireProjectDraftMappingForThread(threadRef);
+}
+
 export function markPromotedDraftThread(threadId: ThreadId): void {
   const store = useComposerDraftStore.getState();
   const draftThreadTargets: ComposerThreadTarget[] = [];

--- a/apps/web/src/hooks/useHandleNewThread.logic.ts
+++ b/apps/web/src/hooks/useHandleNewThread.logic.ts
@@ -1,0 +1,35 @@
+import type { ScopedThreadRef } from "@t3tools/contracts";
+
+export type StoredDraftReuseDecision = "reuse" | "mint";
+
+/**
+ * Decide whether a project's stored new-thread draft can keep its thread id.
+ *
+ * An id that already exists in any lifecycle (live, archived, deleted) is
+ * burned. Promoted/sent drafts are never reused, even when both snapshots miss
+ * them. An unloaded archive snapshot is unknown, not absent.
+ */
+export function decideStoredDraftReuse(input: {
+  readonly storedDraftThreadRef: ScopedThreadRef | null;
+  readonly liveShellExists: boolean;
+  readonly archivedShellExists: boolean | null;
+  readonly deletedShellExists?: boolean | null;
+  readonly promoted: boolean;
+}): StoredDraftReuseDecision {
+  if (input.storedDraftThreadRef === null) {
+    return "mint";
+  }
+  if (input.liveShellExists) {
+    return "mint";
+  }
+  if (input.archivedShellExists === true) {
+    return "mint";
+  }
+  if (input.deletedShellExists === true) {
+    return "mint";
+  }
+  if (input.promoted) {
+    return "mint";
+  }
+  return "reuse";
+}

--- a/apps/web/src/hooks/useHandleNewThread.test.ts
+++ b/apps/web/src/hooks/useHandleNewThread.test.ts
@@ -56,6 +56,18 @@ describe("decideStoredDraftReuse", () => {
     ).toBe("mint");
   });
 
+  it("mints a new draft when a previously promoted id later disappears after delete", () => {
+    expect(
+      decideStoredDraftReuse({
+        storedDraftThreadRef,
+        liveShellExists: false,
+        archivedShellExists: false,
+        deletedShellExists: false,
+        promoted: true,
+      }),
+    ).toBe("mint");
+  });
+
   it("mints a new draft when the stored id is visible as deleted", () => {
     expect(
       decideStoredDraftReuse({

--- a/apps/web/src/hooks/useHandleNewThread.test.ts
+++ b/apps/web/src/hooks/useHandleNewThread.test.ts
@@ -1,0 +1,92 @@
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { scopeThreadRef } from "@t3tools/client-runtime/environment";
+import { describe, expect, it } from "vite-plus/test";
+
+import { decideStoredDraftReuse } from "./useHandleNewThread.logic";
+
+const storedDraftThreadRef = scopeThreadRef(
+  EnvironmentId.make("environment-1"),
+  ThreadId.make("thread-1"),
+);
+
+describe("decideStoredDraftReuse", () => {
+  it("mints a new draft when the stored id is still a live shell", () => {
+    expect(
+      decideStoredDraftReuse({
+        storedDraftThreadRef,
+        liveShellExists: true,
+        archivedShellExists: false,
+        promoted: false,
+      }),
+    ).toBe("mint");
+  });
+
+  it("mints a new draft when the stored id is only in archived shells", () => {
+    expect(
+      decideStoredDraftReuse({
+        storedDraftThreadRef,
+        liveShellExists: false,
+        archivedShellExists: true,
+        promoted: false,
+      }),
+    ).toBe("mint");
+  });
+
+  it("reuses an empty draft when the stored id is unknown and not promoted", () => {
+    expect(
+      decideStoredDraftReuse({
+        storedDraftThreadRef,
+        liveShellExists: false,
+        archivedShellExists: false,
+        deletedShellExists: false,
+        promoted: false,
+      }),
+    ).toBe("reuse");
+  });
+
+  it("mints a new draft when a promoted id is missing from both snapshots", () => {
+    expect(
+      decideStoredDraftReuse({
+        storedDraftThreadRef,
+        liveShellExists: false,
+        archivedShellExists: null,
+        deletedShellExists: null,
+        promoted: true,
+      }),
+    ).toBe("mint");
+  });
+
+  it("mints a new draft when the stored id is visible as deleted", () => {
+    expect(
+      decideStoredDraftReuse({
+        storedDraftThreadRef,
+        liveShellExists: false,
+        archivedShellExists: false,
+        deletedShellExists: true,
+        promoted: false,
+      }),
+    ).toBe("mint");
+  });
+
+  it("reuses an unpromoted draft when the archived snapshot is not loaded", () => {
+    expect(
+      decideStoredDraftReuse({
+        storedDraftThreadRef,
+        liveShellExists: false,
+        archivedShellExists: null,
+        promoted: false,
+      }),
+    ).toBe("reuse");
+  });
+
+  it("mints a new draft when there is no stored draft to reuse", () => {
+    expect(
+      decideStoredDraftReuse({
+        storedDraftThreadRef: null,
+        liveShellExists: false,
+        archivedShellExists: null,
+        promoted: false,
+      }),
+    ).toBe("mint");
+  });
+});

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -4,7 +4,12 @@ import {
   scopeProjectRef,
   scopeThreadRef,
 } from "@t3tools/client-runtime/environment";
-import { DEFAULT_RUNTIME_MODE, type ScopedProjectRef, type ThreadId } from "@t3tools/contracts";
+import {
+  DEFAULT_RUNTIME_MODE,
+  type ScopedProjectRef,
+  type ScopedThreadRef,
+  type ThreadId,
+} from "@t3tools/contracts";
 import { useParams, useRouter } from "@tanstack/react-router";
 import { useCallback, useMemo } from "react";
 import {
@@ -15,6 +20,7 @@ import {
   type DraftThreadState,
   useComposerDraftStore,
 } from "../composerDraftStore";
+import { readArchivedThreadExists } from "../lib/archivedThreadsState";
 import { newDraftId, newThreadId } from "../lib/utils";
 import { orderItemsByPreferredIds } from "../components/Sidebar.logic";
 import {
@@ -29,6 +35,7 @@ import { readT3ProjectFileDefaultThreadEnvMode } from "../lib/t3ProjectFileDefau
 import { primaryServerSettingsAtom } from "../state/server";
 import { resolveThreadRouteTarget } from "../threadRoutes";
 import { legacyProjectCwdPreferenceKey, useUiStateStore } from "../uiStateStore";
+import { decideStoredDraftReuse, type StoredDraftReuseDecision } from "./useHandleNewThread.logic";
 import { useClientSettings } from "./useSettings";
 
 interface NewThreadWorkspaceOptions {
@@ -48,6 +55,19 @@ function pickExplicitWorkspaceOptions(options: NewThreadWorkspaceOptions | undef
     ...(options?.envMode !== undefined ? { envMode: options.envMode } : {}),
     ...(options?.startFromOrigin !== undefined ? { startFromOrigin: options.startFromOrigin } : {}),
   };
+}
+
+function resolveStoredDraftReuse(threadRef: ScopedThreadRef | null): StoredDraftReuseDecision {
+  if (threadRef === null) {
+    return "mint";
+  }
+  const draftSession = useComposerDraftStore.getState().getDraftSessionByRef(threadRef);
+  return decideStoredDraftReuse({
+    storedDraftThreadRef: threadRef,
+    liveShellExists: readThreadShell(threadRef) !== null,
+    archivedShellExists: readArchivedThreadExists(threadRef),
+    promoted: draftSession?.promotedTo != null,
+  });
 }
 
 export function useNewThreadHandler() {
@@ -189,9 +209,7 @@ export function useNewThreadHandler() {
         ? scopeThreadRef(storedDraftThread.environmentId, storedDraftThread.threadId)
         : null;
       const reusableStoredDraftThread =
-        storedDraftThreadRef && readThreadShell(storedDraftThreadRef) !== null
-          ? null
-          : storedDraftThread;
+        resolveStoredDraftReuse(storedDraftThreadRef) === "reuse" ? storedDraftThread : null;
       if (storedDraftThreadRef && reusableStoredDraftThread === null) {
         markPromotedDraftThreadByRef(storedDraftThreadRef);
       }
@@ -247,7 +265,8 @@ export function useNewThreadHandler() {
               routeTargetNow?.kind === "draft" &&
               routeTargetNow.draftId === emptyStoredDraftThread.draftId;
             const promotedMeanwhile =
-              storedDraftThreadRef !== null && readThreadShell(storedDraftThreadRef) !== null;
+              storedDraftThreadRef !== null &&
+              resolveStoredDraftReuse(storedDraftThreadRef) === "mint";
             const remappedMeanwhile =
               getDraftSessionByLogicalProjectKey(logicalProjectKey)?.draftId !==
               emptyStoredDraftThread.draftId;
@@ -361,6 +380,9 @@ export function useNewThreadHandler() {
         // too would evict that draft while its navigation is in flight —
         // reuse the winner instead, like the synchronous path above does.
         const racedDraft = getDraftSessionByLogicalProjectKey(logicalProjectKey);
+        const racedDraftThreadRef = racedDraft
+          ? scopeThreadRef(racedDraft.environmentId, racedDraft.threadId)
+          : null;
         if (
           racedDraft &&
           // Only a draft REGISTERED during the await counts as a raced
@@ -368,7 +390,7 @@ export function useNewThreadHandler() {
           // to reuse is still mapped at this point — reusing it here would
           // silently undo mint-fresh semantics.
           racedDraft.draftId !== storedDraftThread?.draftId &&
-          readThreadShell(scopeThreadRef(racedDraft.environmentId, racedDraft.threadId)) === null
+          resolveStoredDraftReuse(racedDraftThreadRef) === "reuse"
         ) {
           // Same remap the reuse paths above perform: point the draft at the
           // caller's project member and apply explicit workspace options if

--- a/apps/web/src/hooks/useThreadActions.ts
+++ b/apps/web/src/hooks/useThreadActions.ts
@@ -14,7 +14,7 @@ import { useRouter } from "@tanstack/react-router";
 import { useCallback, useMemo, useRef } from "react";
 
 import { getFallbackThreadIdAfterDelete, pinOrderKeyBetween } from "../components/Sidebar.logic";
-import { useComposerDraftStore } from "../composerDraftStore";
+import { retireProjectDraftMappingForThread, useComposerDraftStore } from "../composerDraftStore";
 import { terminalEnvironment } from "../state/terminal";
 import { threadEnvironment } from "../state/threads";
 import { vcsEnvironment } from "../state/vcs";
@@ -238,6 +238,7 @@ export function useThreadActions() {
         markThreadVisited(scopedThreadKey(threadRef), wokeAt);
       }
       refreshArchivedThreadsForEnvironment(threadRef.environmentId);
+      retireProjectDraftMappingForThread(threadRef);
       opts.onArchived?.();
 
       if (shouldNavigateToDraft) {

--- a/apps/web/src/hooks/useThreadActions.ts
+++ b/apps/web/src/hooks/useThreadActions.ts
@@ -281,6 +281,7 @@ export function useThreadActions() {
         });
         if (result._tag === "Success") {
           refreshArchivedThreadsForEnvironment(target.environmentId);
+          retireProjectDraftMappingForThread(target);
         }
         return result;
       }
@@ -365,6 +366,7 @@ export function useThreadActions() {
         return deleteResult;
       }
       refreshArchivedThreadsForEnvironment(threadRef.environmentId);
+      retireProjectDraftMappingForThread(threadRef);
       clearComposerDraftForThread(threadRef);
       clearProjectDraftThreadById(
         scopeProjectRef(threadRef.environmentId, thread.projectId),

--- a/apps/web/src/lib/archivedThreadsState.ts
+++ b/apps/web/src/lib/archivedThreadsState.ts
@@ -4,7 +4,13 @@ import {
   createArchivedThreadSnapshotsAtomFamily,
   makeArchivedThreadsEnvironmentKey,
 } from "@t3tools/client-runtime/state/threads";
-import type { EnvironmentId } from "@t3tools/contracts";
+import type {
+  EnvironmentId,
+  OrchestrationShellSnapshot,
+  ScopedThreadRef,
+} from "@t3tools/contracts";
+import * as Option from "effect/Option";
+import { AsyncResult } from "effect/unstable/reactivity";
 import { useCallback, useMemo } from "react";
 
 import { orchestrationEnvironment } from "../state/orchestration";
@@ -15,6 +21,41 @@ function archivedSnapshotAtom(environmentId: EnvironmentId) {
     environmentId,
     input: {},
   });
+}
+
+function findRegistryNode(atom: Parameters<typeof appAtomRegistry.get>[0]) {
+  const nodes = appAtomRegistry.getNodes();
+  const direct = nodes.get(atom);
+  if (direct) {
+    return direct;
+  }
+  for (const node of nodes.values()) {
+    if (node.atom === atom) {
+      return node;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Peek an already-fetched archived snapshot. Returns null when the snapshot
+ * has never been loaded so new-thread does not pull the full archive list.
+ */
+export function readArchivedThreadExists(ref: ScopedThreadRef): boolean | null {
+  const atom = archivedSnapshotAtom(ref.environmentId);
+  const node = findRegistryNode(atom);
+  if (node === undefined || node.currentState() !== "valid") {
+    return null;
+  }
+  const snapshot = Option.getOrNull(
+    AsyncResult.value(
+      node.value() as AsyncResult.AsyncResult<OrchestrationShellSnapshot, unknown>,
+    ),
+  );
+  if (snapshot === null) {
+    return null;
+  }
+  return snapshot.threads.some((thread) => thread.id === ref.threadId);
 }
 
 const archivedSnapshotsAtom = createArchivedThreadSnapshotsAtomFamily({


### PR DESCRIPTION
Fixes #6128. New-thread no longer reuses a composer draft whose thread id was archived (or otherwise already created). Archiving the open thread retires that project draft mapping.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches composer draft persistence and new-thread routing; incorrect reuse could recreate wrong threads or drop drafts, but behavior is covered by new unit tests.
> 
> **Overview**
> Fixes new-thread reusing a project's stored draft thread id after that thread was archived, deleted, or already sent.
> 
> **`retireProjectDraftMappingForThread`** clears the project's `+` draft mapping when a thread is archived or deleted, without wiping composer text or attachments. Unpromoted draft sessions get a **new minted thread id** so the old id cannot be resurrected from the sidebar.
> 
> **`decideStoredDraftReuse`** centralizes when a stored id may be reused: mint if the id is live, archived, deleted, or promoted; reuse only when snapshots show it is unused and unpromoted. An unloaded archive snapshot is treated as unknown (still reusable for empty drafts). **`readArchivedThreadExists`** peeks already-fetched archive snapshots so new-thread does not trigger a full archive load.
> 
> **`useHandleNewThread`** replaces the old "live shell exists → mint" check with this logic for reuse, race detection, and promoted-draft marking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4a85070fba85cb13dc0a5a7635159cb68e8f0a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix reuse of archived or deleted thread IDs as new draft thread IDs
> - Adds `retireProjectDraftMappingForThread` to the composer draft store, which drops the logical project→draft mapping for a thread and remints the draft's thread ID (without clearing composer content) when a thread is archived or deleted.
> - Introduces `decideStoredDraftReuse` in [`useHandleNewThread.logic.ts`](https://github.com/pingdotgg/t3code/pull/7183/files#diff-1fbdf31efd024b9e0b7ca58372816a7c991cb5e8adc1e36b0d94f69ee98c409f) to decide whether a stored draft thread ID can be reused (`reuse`) or must be replaced (`mint`), based on live, archived, deleted, and promoted state.
> - Updates [`useNewThreadHandler`](https://github.com/pingdotgg/t3code/pull/7183/files#diff-4a13a04822f436fab695948f0596a6fd92885554e031426dac1954a343c98fef) to use this decision in all three draft-reuse paths: initial reuse, stale-check, and async race resolution.
> - Adds `readArchivedThreadExists` in [`archivedThreadsState.ts`](https://github.com/pingdotgg/t3code/pull/7183/files#diff-5d17e8a5507587ce4a9a6a4e6420d8c091134a8615a8fcb23acee13b593f13b1) to check cached archive snapshots without triggering a fetch.
> - Behavioral Change: archiving or deleting a thread now immediately invalidates its ID as the project's next draft thread ID.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d4a8507.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->