### PR TITLE
fix(web): render persisted bash tool output in expanded turns

### DIFF
--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -324,6 +324,58 @@ describe("buildThreadFeed", () => {
     expect(group.activities[0]?.getFullDetail()).toContain("repository.search");
   });
 
+  it("includes persisted Claude Bash result content in the expanded work row", () => {
+    const turnId = TurnId.make("turn-bash");
+    const output = "hello from bash\nsecond line";
+    const thread = makeThread({
+      id: ThreadId.make("thread-bash"),
+      projectId: ProjectId.make("project-1"),
+      title: "Bash output",
+      latestTurn: {
+        turnId,
+        state: "completed",
+        requestedAt: "2026-04-01T00:00:00.000Z",
+        startedAt: "2026-04-01T00:00:01.000Z",
+        completedAt: "2026-04-01T00:00:03.000Z",
+        assistantMessageId: null,
+      },
+      activities: [
+        makeActivity({
+          id: EventId.make("bash-completed"),
+          kind: "tool.completed",
+          tone: "tool",
+          summary: "Command run",
+          createdAt: "2026-04-01T00:00:02.000Z",
+          turnId,
+          payload: {
+            title: "Command run",
+            itemType: "command_execution",
+            detail: "Bash: printf hello",
+            status: "completed",
+            data: {
+              toolName: "Bash",
+              input: { command: "printf hello" },
+              result: {
+                type: "tool_result",
+                content: output,
+                is_error: false,
+              },
+            },
+          },
+        }),
+      ],
+    });
+
+    const group = buildThreadFeed(thread)[0];
+    expect(group).toMatchObject({ type: "activity-group" });
+    if (!group || group.type !== "activity-group") {
+      return;
+    }
+
+    expect(group.activities[0]?.detail).toBe("printf hello");
+    expect(group.activities[0]?.getFullDetail()).toBe(`printf hello\n\n${output}`);
+  });
+
   it("defers large tool output expansion until a work row is opened or copied", () => {
     let serializedToolOutputs = 0;
     const activities = Array.from({ length: 5_000 }, (_, index) =>

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -376,6 +376,105 @@ describe("buildThreadFeed", () => {
     expect(group.activities[0]?.getFullDetail()).toBe(`printf hello\n\n${output}`);
   });
 
+  it("does not duplicate MCP summarized result as a separate output block", () => {
+    const turnId = TurnId.make("turn-mcp-result");
+    const item = {
+      server: "repository",
+      tool: "search",
+      arguments: { query: "work log" },
+      result: { content: "first line of output" },
+    };
+    const thread = makeThread({
+      id: ThreadId.make("thread-mcp-result"),
+      projectId: ProjectId.make("project-1"),
+      title: "MCP result",
+      latestTurn: {
+        turnId,
+        state: "completed",
+        requestedAt: "2026-04-01T00:00:00.000Z",
+        startedAt: "2026-04-01T00:00:01.000Z",
+        completedAt: "2026-04-01T00:00:03.000Z",
+        assistantMessageId: null,
+      },
+      activities: [
+        makeActivity({
+          id: EventId.make("mcp-result-completed"),
+          kind: "tool.completed",
+          tone: "tool",
+          summary: "Call repository tool",
+          createdAt: "2026-04-01T00:00:02.000Z",
+          turnId,
+          payload: {
+            title: "Call repository tool",
+            itemType: "mcp_tool_call",
+            detail: "repository.search",
+            status: "completed",
+            data: { item },
+          },
+        }),
+      ],
+    });
+
+    const group = buildThreadFeed(thread)[0];
+    expect(group).toMatchObject({ type: "activity-group" });
+    if (!group || group.type !== "activity-group") {
+      return;
+    }
+
+    expect(group.activities[0]?.getFullDetail()).toBe(
+      `MCP call\n${JSON.stringify(item, null, 2)}\n\nrepository.search`,
+    );
+    expect(group.activities[0]?.status).toBe("success");
+  });
+
+  it("does not mark completed commands failed from stdout phrases", () => {
+    const turnId = TurnId.make("turn-stdout-phrases");
+    const output = "this tutorial mentions command not found, ENOENT, and exit code 1";
+    const thread = makeThread({
+      id: ThreadId.make("thread-stdout-phrases"),
+      projectId: ProjectId.make("project-1"),
+      title: "Stdout phrases",
+      latestTurn: {
+        turnId,
+        state: "completed",
+        requestedAt: "2026-04-01T00:00:00.000Z",
+        startedAt: "2026-04-01T00:00:01.000Z",
+        completedAt: "2026-04-01T00:00:03.000Z",
+        assistantMessageId: null,
+      },
+      activities: [
+        makeActivity({
+          id: EventId.make("bash-stdout-phrases"),
+          kind: "tool.completed",
+          tone: "tool",
+          summary: "Command run",
+          createdAt: "2026-04-01T00:00:02.000Z",
+          turnId,
+          payload: {
+            title: "Command run",
+            itemType: "command_execution",
+            detail: "cat notes.txt",
+            status: "completed",
+            data: {
+              toolName: "Bash",
+              input: { command: "cat notes.txt" },
+              result: { content: output, is_error: false },
+            },
+          },
+        }),
+      ],
+    });
+
+    const group = buildThreadFeed(thread)[0];
+    expect(group).toMatchObject({ type: "activity-group" });
+    if (!group || group.type !== "activity-group") {
+      return;
+    }
+
+    expect(group.activities[0]?.status).toBe("success");
+    expect(group.activities[0]?.getFullDetail()).toBe(`cat notes.txt\n\n${output}`);
+  });
+
   it("defers large tool output expansion until a work row is opened or copied", () => {
     let serializedToolOutputs = 0;
     const activities = Array.from({ length: 5_000 }, (_, index) =>

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -409,7 +409,7 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   if (commandPreview.rawCommand) {
     entry.rawCommand = commandPreview.rawCommand;
   }
-  const output = extractPersistedToolResult(payload);
+  const output = itemType === "mcp_tool_call" ? null : extractPersistedToolResult(payload);
   if (output && output !== entry.detail && output !== commandPreview.command) {
     entry.output = output;
   }
@@ -736,8 +736,12 @@ function asTrimmedString(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+function asPersistedResultText(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
 function extractToolResultText(result: unknown): string | null {
-  const direct = asTrimmedString(result);
+  const direct = asPersistedResultText(result);
   if (direct) {
     return direct;
   }
@@ -748,7 +752,7 @@ function extractToolResultText(result: unknown): string | null {
   }
 
   const content = record.content;
-  const contentText = asTrimmedString(content);
+  const contentText = asPersistedResultText(content);
   if (contentText) {
     return contentText;
   }
@@ -759,7 +763,8 @@ function extractToolResultText(result: unknown): string | null {
 
   const chunks: string[] = [];
   for (const entryValue of content) {
-    const text = asTrimmedString(entryValue) ?? asTrimmedString(asRecord(entryValue)?.text);
+    const text =
+      asPersistedResultText(entryValue) ?? asPersistedResultText(asRecord(entryValue)?.text);
     if (text) {
       chunks.push(text);
     }
@@ -773,12 +778,8 @@ function extractPersistedToolResult(payload: Record<string, unknown> | null): st
   const candidates = [data?.result, item?.result];
   for (const candidate of candidates) {
     const text = extractToolResultText(candidate);
-    if (!text) {
-      continue;
-    }
-    const output = stripTrailingExitCode(text).output;
-    if (output) {
-      return output;
+    if (text && text.trim().length > 0) {
+      return text;
     }
   }
   return null;

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -68,6 +68,7 @@ interface WorkLogEntry {
   detail?: string;
   command?: string;
   rawCommand?: string;
+  output?: string;
   changedFiles?: ReadonlyArray<string>;
   tone: "thinking" | "tool" | "info" | "error";
   toolTitle?: string;
@@ -408,6 +409,10 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   if (commandPreview.rawCommand) {
     entry.rawCommand = commandPreview.rawCommand;
   }
+  const output = extractPersistedToolResult(payload);
+  if (output && output !== entry.detail && output !== commandPreview.command) {
+    entry.output = output;
+  }
   if (changedFiles.length > 0) {
     entry.changedFiles = changedFiles;
   }
@@ -497,6 +502,7 @@ function mergeDerivedWorkLogEntries(
   const detail = next.detail ?? previous.detail;
   const command = next.command ?? previous.command;
   const rawCommand = next.rawCommand ?? previous.rawCommand;
+  const output = next.output ?? previous.output;
   const toolTitle = next.toolTitle ?? previous.toolTitle;
   const itemType = next.itemType ?? previous.itemType;
   const requestKind = next.requestKind ?? previous.requestKind;
@@ -509,6 +515,7 @@ function mergeDerivedWorkLogEntries(
     ...(detail ? { detail } : {}),
     ...(command ? { command } : {}),
     ...(rawCommand ? { rawCommand } : {}),
+    ...(output ? { output } : {}),
     ...(changedFiles.length > 0 ? { changedFiles } : {}),
     ...(toolTitle ? { toolTitle } : {}),
     ...(itemType ? { itemType } : {}),
@@ -659,7 +666,7 @@ function buildWorkEntryExpandedBody(entry: WorkLogEntry): string | null {
     appendUniqueBlock(`MCP call\n${JSON.stringify(entry.toolData, null, 2)}`);
   }
   appendUniqueBlock(entry.rawCommand ?? entry.command);
-  appendUniqueBlock(entry.detail);
+  appendUniqueBlock(entry.output ?? entry.detail);
   if ((entry.changedFiles?.length ?? 0) > 0) {
     appendUniqueBlock(entry.changedFiles!.join("\n"));
   }
@@ -671,6 +678,7 @@ function workEntryHasExpandedBody(entry: WorkLogEntry): boolean {
   return (
     (entry.itemType === "mcp_tool_call" && entry.toolData !== undefined) ||
     Boolean((entry.rawCommand ?? entry.command)?.trim()) ||
+    Boolean(entry.output?.trim()) ||
     Boolean(entry.detail?.trim()) ||
     (entry.changedFiles?.some((path) => path.trim().length > 0) ?? false)
   );
@@ -726,6 +734,54 @@ function asTrimmedString(value: unknown): string | null {
   }
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
+}
+
+function extractToolResultText(result: unknown): string | null {
+  const direct = asTrimmedString(result);
+  if (direct) {
+    return direct;
+  }
+
+  const record = asRecord(result);
+  if (!record) {
+    return null;
+  }
+
+  const content = record.content;
+  const contentText = asTrimmedString(content);
+  if (contentText) {
+    return contentText;
+  }
+
+  if (!Array.isArray(content)) {
+    return null;
+  }
+
+  const chunks: string[] = [];
+  for (const entryValue of content) {
+    const text = asTrimmedString(entryValue) ?? asTrimmedString(asRecord(entryValue)?.text);
+    if (text) {
+      chunks.push(text);
+    }
+  }
+  return chunks.length > 0 ? chunks.join("\n") : null;
+}
+
+function extractPersistedToolResult(payload: Record<string, unknown> | null): string | null {
+  const data = asRecord(payload?.data);
+  const item = asRecord(data?.item);
+  const candidates = [data?.result, item?.result];
+  for (const candidate of candidates) {
+    const text = extractToolResultText(candidate);
+    if (!text) {
+      continue;
+    }
+    const output = stripTrailingExitCode(text).output;
+    if (output) {
+      return output;
+    }
+  }
+  return null;
 }
 
 function trimMatchingOuterQuotes(value: string): string {
@@ -886,11 +942,13 @@ function extractToolCommand(payload: Record<string, unknown> | null): {
   const itemInput = asRecord(item?.input);
   const itemType = asTrimmedString(payload?.itemType);
   const detail = asTrimmedString(payload?.detail);
+  const dataInput = asRecord(data?.input);
   const candidates: unknown[] = [
     item?.command,
     itemInput?.command,
     itemResult?.command,
     data?.command,
+    dataInput?.command,
     itemType === "command_execution" && detail ? stripTrailingExitCode(detail).output : null,
   ];
 

--- a/apps/server/src/orchestration/ActivityPayloadProjection.test.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.test.ts
@@ -174,6 +174,42 @@ describe("projectActivityPayload agent-field survival", () => {
     expect(data.toolName).toBeUndefined();
   });
 
+  it("does not attach result bodies for Read/Grep dynamic tools", () => {
+    const projected = projectActivityPayload(
+      activity({
+        itemType: "dynamic_tool_call",
+        data: {
+          toolName: "Read",
+          input: { file_path: "README.md" },
+          result: {
+            type: "tool_result",
+            content: `file body\n${"x".repeat(10_000)}`,
+            is_error: false,
+          },
+        },
+      }),
+    );
+    const data = (projected.payload as Record<string, unknown>).data as Record<string, unknown>;
+    expect(data.result).toBeUndefined();
+    expect(data.toolName).toBeUndefined();
+  });
+
+  it("still attaches Bash-like dynamic tool result content", () => {
+    const output = "hello from bash";
+    const projected = projectActivityPayload(
+      activity({
+        itemType: "dynamic_tool_call",
+        data: {
+          toolName: "Bash",
+          input: { command: "printf hello" },
+          result: { content: output, is_error: false },
+        },
+      }),
+    );
+    const data = (projected.payload as Record<string, unknown>).data as Record<string, unknown>;
+    expect(data.result).toEqual({ content: output });
+  });
+
   it("bounds huge Claude Bash result content instead of dropping it", () => {
     const output = `first line\n${"y".repeat(40_000)}`;
     const projected = projectActivityPayload(

--- a/apps/server/src/orchestration/ActivityPayloadProjection.test.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.test.ts
@@ -151,6 +151,49 @@ describe("projectActivityPayload agent-field survival", () => {
     expect(JSON.stringify(projected.payload).length).toBeLessThan(500);
   });
 
+  it("keeps Claude Bash result content for the expanded command-run row", () => {
+    const output = `hello from bash\n${"x".repeat(200)}`;
+    const projected = projectActivityPayload(
+      activity({
+        itemType: "command_execution",
+        data: {
+          toolName: "Bash",
+          input: { command: "printf hello && cat huge.txt" },
+          result: {
+            type: "tool_result",
+            tool_use_id: "toolu_1",
+            content: output,
+            is_error: false,
+          },
+        },
+      }),
+    );
+    const data = (projected.payload as Record<string, unknown>).data as Record<string, unknown>;
+    expect(data.command).toBe("printf hello && cat huge.txt");
+    expect(data.result).toEqual({ content: output });
+    expect(data.toolName).toBeUndefined();
+  });
+
+  it("bounds huge Claude Bash result content instead of dropping it", () => {
+    const output = `first line\n${"y".repeat(40_000)}`;
+    const projected = projectActivityPayload(
+      activity({
+        itemType: "command_execution",
+        data: {
+          toolName: "Bash",
+          input: { command: "cat huge.txt" },
+          result: { content: output, is_error: false },
+        },
+      }),
+    );
+    const data = (projected.payload as Record<string, unknown>).data as Record<string, unknown>;
+    const result = data.result as { content: string };
+    expect(result.content.startsWith("first line\n")).toBe(true);
+    expect(result.content.endsWith("…")).toBe(true);
+    expect(result.content.length).toBeLessThan(output.length);
+    expect(result.content.length).toBeGreaterThan(30_000);
+  });
+
   it("passes task lifecycle payloads (no data field) through untouched", () => {
     const source = activity({
       taskId: "task-9",

--- a/apps/server/src/orchestration/ActivityPayloadProjection.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.ts
@@ -125,6 +125,9 @@ function projectCommandData(data: Record<string, unknown>): Record<string, unkno
   return Object.keys(projectedItem).length > 0 ? projectedItem : undefined;
 }
 
+/** Expanded Command-run rows render this; keep it bounded for the wire. */
+const MAX_PROJECTED_COMMAND_RESULT_CHARS = 32_768;
+
 function summarizeToolTextOutput(value: string): string | null {
   const lines: string[] = [];
   for (const rawLine of value.split(/\r?\n/u)) {
@@ -252,6 +255,18 @@ function projectMcpToolCallData(data: Record<string, unknown>): Record<string, u
   return projectedData;
 }
 
+function projectCommandResult(result: unknown): Record<string, unknown> | undefined {
+  const text = extractMcpResultText(result);
+  if (!text) {
+    return undefined;
+  }
+  const content =
+    text.length > MAX_PROJECTED_COMMAND_RESULT_CHARS
+      ? `${text.slice(0, MAX_PROJECTED_COMMAND_RESULT_CHARS).trimEnd()}\n…`
+      : text;
+  return { content };
+}
+
 function projectRawOutput(value: unknown): Record<string, unknown> | undefined {
   const direct = asTrimmedString(value);
   if (direct) {
@@ -341,6 +356,16 @@ export function projectActivityPayload(
   }
   if ("command" in data) {
     projectedData.command = data.command;
+  } else {
+    const inputCommand = asRecord(data.input)?.command;
+    if (inputCommand !== undefined) {
+      projectedData.command = inputCommand;
+    }
+  }
+
+  const commandResult = projectCommandResult(data.result);
+  if (commandResult) {
+    projectedData.result = commandResult;
   }
 
   const changedFiles: string[] = [];

--- a/apps/server/src/orchestration/ActivityPayloadProjection.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.ts
@@ -255,6 +255,29 @@ function projectMcpToolCallData(data: Record<string, unknown>): Record<string, u
   return projectedData;
 }
 
+function isCommandLikeTool(
+  payload: Record<string, unknown>,
+  data: Record<string, unknown>,
+): boolean {
+  if (payload.itemType === "command_execution") {
+    return true;
+  }
+  const kind = asTrimmedString(data.kind)?.toLowerCase();
+  if (kind === "execute") {
+    return true;
+  }
+  const toolName = asTrimmedString(data.toolName)?.toLowerCase();
+  if (!toolName) {
+    return false;
+  }
+  return (
+    toolName.includes("bash") ||
+    toolName.includes("shell") ||
+    toolName.includes("terminal") ||
+    toolName.includes("command")
+  );
+}
+
 function projectCommandResult(result: unknown): Record<string, unknown> | undefined {
   const text = extractMcpResultText(result);
   if (!text) {
@@ -363,9 +386,11 @@ export function projectActivityPayload(
     }
   }
 
-  const commandResult = projectCommandResult(data.result);
-  if (commandResult) {
-    projectedData.result = commandResult;
+  if (isCommandLikeTool(payload, data)) {
+    const commandResult = projectCommandResult(data.result);
+    if (commandResult) {
+      projectedData.result = commandResult;
+    }
   }
 
   const changedFiles: string[] = [];

--- a/apps/server/test/ActivityPayloadProjection.test.ts
+++ b/apps/server/test/ActivityPayloadProjection.test.ts
@@ -184,6 +184,29 @@ describe("projectActivityPayload", () => {
     });
   });
 
+  it("projects Claude Bash result content so the work-log can render it", () => {
+    const output = `hello from bash\n${"x".repeat(200)}`;
+    const source = makeActivity("claude-bash", "command_execution", {
+      toolName: "Bash",
+      input: { command: "printf hello && cat huge.txt" },
+      result: {
+        type: "tool_result",
+        tool_use_id: "toolu_1",
+        content: output,
+        is_error: false,
+      },
+    });
+    const projected = projectActivityPayload(source);
+    const data = (projected.payload as Record<string, unknown>).data as Record<string, unknown>;
+    expect(data.command).toBe("printf hello && cat huge.txt");
+    expect(data.result).toEqual({ content: output });
+    expect(deriveWorkLogEntries([projected])).toEqual(deriveWorkLogEntries([source]));
+    expect(deriveWorkLogEntries([projected])[0]).toMatchObject({
+      command: "printf hello && cat huge.txt",
+      output,
+    });
+  });
+
   it("slims MCP tool data to the fields the expanded row renders", () => {
     expect(projectActivityPayload(fixtures[4]!).payload).toEqual({
       itemType: "mcp_tool_call",

--- a/apps/server/test/ActivityPayloadProjection.test.ts
+++ b/apps/server/test/ActivityPayloadProjection.test.ts
@@ -184,6 +184,22 @@ describe("projectActivityPayload", () => {
     });
   });
 
+  it("does not attach result bodies for Read/Grep dynamic tools", () => {
+    const source = makeActivity("read", "dynamic_tool_call", {
+      toolName: "Read",
+      input: { file_path: "README.md" },
+      result: {
+        type: "tool_result",
+        content: `file body\n${"x".repeat(8_000)}`,
+        is_error: false,
+      },
+    });
+    const projected = projectActivityPayload(source);
+    const data = (projected.payload as Record<string, unknown>).data as Record<string, unknown>;
+    expect(data.result).toBeUndefined();
+    expect(deriveWorkLogEntries([projected])[0]?.output).toBeUndefined();
+  });
+
   it("projects Claude Bash result content so the work-log can render it", () => {
     const output = `hello from bash\n${"x".repeat(200)}`;
     const source = makeActivity("claude-bash", "command_execution", {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -4,9 +4,29 @@ import {
   computeMessageDurationStart,
   deriveMessagesTimelineRows,
   normalizeCompactToolLabel,
+  presentExpandedToolOutput,
   resolveAssistantMessageCopyState,
   shouldPreserveAssistantLineBreaks,
+  TOOL_OUTPUT_PREVIEW_MAX_CHARS,
 } from "./MessagesTimeline.logic";
+
+describe("presentExpandedToolOutput", () => {
+  it("leaves short output intact and truncates huge output until expanded", () => {
+    expect(presentExpandedToolOutput("hello", false)).toEqual({
+      text: "hello",
+      truncated: false,
+    });
+
+    const huge = `${"x".repeat(TOOL_OUTPUT_PREVIEW_MAX_CHARS + 20)}\nmore`;
+    const collapsed = presentExpandedToolOutput(huge, false);
+    expect(collapsed.truncated).toBe(true);
+    expect(collapsed.text.length).toBeLessThan(huge.length);
+    expect(collapsed.text.endsWith("…")).toBe(true);
+
+    const expanded = presentExpandedToolOutput(huge, true);
+    expect(expanded).toEqual({ text: huge, truncated: true });
+  });
+});
 
 describe("shouldPreserveAssistantLineBreaks", () => {
   it("preserves Claude insight formatting without changing regular markdown", () => {
@@ -648,6 +668,99 @@ describe("deriveMessagesTimelineRows", () => {
     // User message (00:00:00) → trailing work entry (00:00:12).
     expect(foldRow?.turnId).toBe("turn-1");
     expect(foldRow?.label).toBe("Worked for 12s");
+  });
+
+  it("keeps a tool-only completed turn expandable and includes the tool activity", () => {
+    const timelineEntries = [
+      {
+        id: "user-entry",
+        kind: "message" as const,
+        createdAt: "2026-01-01T00:00:00Z",
+        message: {
+          id: "user-1" as never,
+          role: "user" as const,
+          text: "run it",
+          turnId: null,
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-01-01T00:00:00Z",
+          streaming: false,
+        },
+      },
+      {
+        id: "work-entry-1",
+        kind: "work" as const,
+        createdAt: "2026-01-01T00:00:08Z",
+        entry: {
+          id: "work-1",
+          createdAt: "2026-01-01T00:00:08Z",
+          turnId: "turn-1" as never,
+          label: "Command run",
+          command: "printf hello",
+          output: "hello",
+          tone: "tool" as const,
+          itemType: "command_execution" as const,
+        },
+      },
+    ];
+
+    const collapsedRows = deriveMessagesTimelineRows({
+      timelineEntries,
+      latestTurn: {
+        turnId: "turn-1" as never,
+        state: "completed",
+        startedAt: "2026-01-01T00:00:00Z",
+        completedAt: "2026-01-01T00:00:12Z",
+      },
+      isWorking: false,
+      activeTurnStartedAt: null,
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(collapsedRows.map((row) => row.id)).toEqual(["user-entry", "turn-fold:turn-1"]);
+    const foldRow = collapsedRows.find(
+      (row): row is Extract<(typeof collapsedRows)[number], { kind: "turn-fold" }> =>
+        row.kind === "turn-fold",
+    );
+    expect(foldRow).toMatchObject({
+      turnId: "turn-1",
+      expanded: false,
+      label: "Worked for 12s",
+    });
+
+    const expandedRows = deriveMessagesTimelineRows({
+      timelineEntries,
+      latestTurn: {
+        turnId: "turn-1" as never,
+        state: "completed",
+        startedAt: "2026-01-01T00:00:00Z",
+        completedAt: "2026-01-01T00:00:12Z",
+      },
+      expandedTurnIds: new Set(["turn-1" as never]),
+      isWorking: false,
+      activeTurnStartedAt: null,
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(expandedRows.map((row) => row.id)).toEqual([
+      "user-entry",
+      "turn-fold:turn-1",
+      "work-entry-1",
+    ]);
+    const workRow = expandedRows.find(
+      (row): row is Extract<(typeof expandedRows)[number], { kind: "work" }> => row.kind === "work",
+    );
+    expect(workRow?.groupedEntries).toEqual([
+      expect.objectContaining({
+        id: "work-1",
+        command: "printf hello",
+        output: "hello",
+      }),
+    ]);
+    expect(
+      expandedRows.find((row) => row.kind === "turn-fold" && row.expanded === true),
+    ).toBeDefined();
   });
 
   it("uses latest-turn timings and the stopped label for an interrupted latest turn", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -11,6 +11,25 @@ import { type ChatMessage, type ProposedPlan, type TurnDiffSummary } from "../..
 import { type MessageId, type OrchestrationLatestTurn, type TurnId } from "@t3tools/contracts";
 
 export const MAX_VISIBLE_WORK_LOG_ENTRIES = 1;
+/** First-paint cap for an expanded Command-run body; the full string stays on the entry. */
+export const TOOL_OUTPUT_PREVIEW_MAX_CHARS = 4_000;
+
+export function presentExpandedToolOutput(
+  output: string,
+  expanded: boolean,
+): { text: string; truncated: boolean } {
+  if (expanded || output.length <= TOOL_OUTPUT_PREVIEW_MAX_CHARS) {
+    return {
+      text: output,
+      truncated: output.length > TOOL_OUTPUT_PREVIEW_MAX_CHARS,
+    };
+  }
+  return {
+    text: `${output.slice(0, TOOL_OUTPUT_PREVIEW_MAX_CHARS).trimEnd()}\n…`,
+    truncated: true,
+  };
+}
+
 export const TIMELINE_MINIMAP_ITEM_SPACING = 8;
 export const TIMELINE_MINIMAP_MIN_ITEMS = 2;
 export const TIMELINE_MINIMAP_MAX_HEIGHT_CSS = "calc(100vh - 18rem)";
@@ -318,6 +337,10 @@ function deriveUnsettledTurnId(
  * Settled turns fold their commentary and tool activity behind a
  * "Worked for ..." row anchored at the turn's first foldable entry; the
  * terminal assistant message stays visible below the fold.
+ *
+ * Tool-only turns have no terminal message, so every work entry is hidden
+ * while collapsed. Expanding the fold must still reveal those entries —
+ * hiding them is only a collapsed-state concern, not a deletion.
  */
 function deriveTurnFolds(input: {
   timelineEntries: ReadonlyArray<TimelineEntry>;
@@ -387,9 +410,10 @@ function deriveTurnFolds(input: {
     if (group.hasStreamingMessage) {
       continue;
     }
+    const terminalEntryId = group.terminalEntry?.id ?? null;
     const hiddenEntryIds = new Set<string>();
     for (const entry of group.entries) {
-      if (entry.id === group.terminalEntry?.id) {
+      if (terminalEntryId !== null && entry.id === terminalEntryId) {
         continue;
       }
       // Agent-spawn CTA rows never fold: workflows outlive their launching

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -33,6 +33,7 @@ import { LegendList, type LegendListRef } from "@legendapp/list/react";
 import { FileDiff } from "@pierre/diffs/react";
 import {
   deriveTimelineEntries,
+  selectWorkLogToolOutput,
   workEntryIndicatesToolFailure,
   workEntryIndicatesToolNeutralStatus,
   workEntryIndicatesToolSuccess,
@@ -75,6 +76,7 @@ import {
   computeStableMessagesTimelineRows,
   deriveMessagesTimelineRows,
   normalizeCompactToolLabel,
+  presentExpandedToolOutput,
   resolveAssistantMessageCopyState,
   resolveTimelineIsAtEnd,
   resolveTimelineMinimapHasPersistentGutter,
@@ -2035,32 +2037,47 @@ function workEntryRawCommand(
   return rawCommand === workEntry.command.trim() ? null : rawCommand;
 }
 
-function buildToolCallExpandedBody(
+function buildToolCallExpandedSections(
   workEntry: TimelineWorkEntry,
   workspaceRoot: string | undefined,
-): string | null {
-  const blocks: string[] = [];
+): {
+  preamble: string | null;
+  output: string | null;
+  files: string | null;
+} {
+  const preambleBlocks: string[] = [];
   if (workEntry.itemType === "mcp_tool_call" && workEntry.toolData !== undefined) {
-    blocks.push(`MCP call\n${JSON.stringify(workEntry.toolData, null, 2)}`);
+    preambleBlocks.push(`MCP call\n${JSON.stringify(workEntry.toolData, null, 2)}`);
   }
   const raw = workEntryRawCommand(workEntry);
   if (raw?.trim()) {
-    blocks.push(raw.trim());
+    preambleBlocks.push(raw.trim());
   } else if (workEntry.command?.trim()) {
-    blocks.push(workEntry.command.trim());
+    preambleBlocks.push(workEntry.command.trim());
   }
-  if (workEntry.detail?.trim()) {
-    blocks.push(workEntry.detail.trim());
+
+  const output = selectWorkLogToolOutput(workEntry);
+  const commandText = (raw ?? workEntry.command)?.trim() ?? null;
+  if (!output) {
+    const detail = workEntry.detail?.trim();
+    if (detail && detail !== commandText) {
+      preambleBlocks.push(detail);
+    }
   }
+
   const changedFiles = workEntry.changedFiles ?? [];
-  if (changedFiles.length > 0) {
-    blocks.push(
-      changedFiles
-        .map((filePath) => formatWorkspaceRelativePath(filePath, workspaceRoot))
-        .join("\n"),
-    );
-  }
-  return blocks.length > 0 ? blocks.join("\n\n") : null;
+  const files =
+    changedFiles.length > 0
+      ? changedFiles
+          .map((filePath) => formatWorkspaceRelativePath(filePath, workspaceRoot))
+          .join("\n")
+      : null;
+
+  return {
+    preamble: preambleBlocks.length > 0 ? preambleBlocks.join("\n\n") : null,
+    output,
+    files,
+  };
 }
 
 const toolCallExpandedBodyClassName =
@@ -2119,6 +2136,33 @@ function toolWorkEntryHeading(workEntry: TimelineWorkEntry): string {
 }
 
 const stopRowToggle = (e: { stopPropagation: () => void }) => e.stopPropagation();
+
+const ToolCallOutputBlock = memo(function ToolCallOutputBlock(props: {
+  output: string;
+  expanded: boolean;
+  onToggleExpanded: () => void;
+}) {
+  const presented = presentExpandedToolOutput(props.output, props.expanded);
+  return (
+    <div className="mt-1">
+      <div className="mb-0.5 flex items-center justify-end gap-1">
+        {presented.truncated ? (
+          <Button
+            type="button"
+            size="xs"
+            variant="ghost"
+            className="h-5 px-1.5 text-[11px] text-muted-foreground"
+            onClick={props.onToggleExpanded}
+          >
+            {props.expanded ? "Show less" : "Show more"}
+          </Button>
+        ) : null}
+        <MessageCopyButton text={props.output} size="icon-xs" variant="ghost" />
+      </div>
+      <pre className={toolCallExpandedBodyClassName}>{presented.text}</pre>
+    </div>
+  );
+});
 
 /**
  * A1 spawn CTA: one anchored row per workflow run (or per-turn direct-spawn
@@ -2233,6 +2277,7 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
   const { workEntry, workspaceRoot } = props;
   const activity = use(TimelineRowActivityCtx);
   const [expanded, setExpanded] = useState(false);
+  const [outputExpanded, setOutputExpanded] = useState(false);
   const iconConfig = workToneIcon(workEntry.tone);
   const showWarningIndicator = workEntry.sourceActivityKind === "runtime.warning";
   const entryIconName = showWarningIndicator ? "x" : workEntryIconName(workEntry);
@@ -2245,8 +2290,11 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
       ? null
       : rawPreview;
   const displayText = preview ? `${heading} - ${preview}` : heading;
-  const expandedBody = buildToolCallExpandedBody(workEntry, workspaceRoot);
-  const canExpand = expandedBody !== null;
+  const expandedSections = buildToolCallExpandedSections(workEntry, workspaceRoot);
+  const canExpand =
+    expandedSections.preamble !== null ||
+    expandedSections.output !== null ||
+    expandedSections.files !== null;
   const showFailedIndicator = workEntryIndicatesToolFailure(workEntry);
   const showDestructiveRowStyle =
     showFailedIndicator &&
@@ -2370,13 +2418,25 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
           </div>
         </div>
       </div>
-      {expanded && canExpand && expandedBody ? (
+      {expanded && canExpand ? (
         <div
           className="mt-1 ms-7 cursor-default border-s border-border/45 ps-3 pt-0.5"
           onClick={stopRowToggle}
           onPointerDown={stopRowToggle}
         >
-          <pre className={toolCallExpandedBodyClassName}>{expandedBody}</pre>
+          {expandedSections.preamble ? (
+            <pre className={toolCallExpandedBodyClassName}>{expandedSections.preamble}</pre>
+          ) : null}
+          {expandedSections.output ? (
+            <ToolCallOutputBlock
+              output={expandedSections.output}
+              expanded={outputExpanded}
+              onToggleExpanded={() => setOutputExpanded((value) => !value)}
+            />
+          ) : null}
+          {expandedSections.files ? (
+            <pre className={toolCallExpandedBodyClassName}>{expandedSections.files}</pre>
+          ) : null}
         </div>
       ) : null}
     </div>

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -2150,8 +2150,8 @@ const ToolCallOutputBlock = memo(function ToolCallOutputBlock(props: {
           <Button
             type="button"
             size="xs"
-            variant="ghost"
-            className="h-5 px-1.5 text-[11px] text-muted-foreground"
+            variant="ghost-muted"
+            className="h-5 px-1.5 text-[11px]"
             onClick={props.onToggleExpanded}
           >
             {props.expanded ? "Show less" : "Show more"}
@@ -2423,6 +2423,7 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
           className="mt-1 ms-7 cursor-default border-s border-border/45 ps-3 pt-0.5"
           onClick={stopRowToggle}
           onPointerDown={stopRowToggle}
+          onKeyDown={stopRowToggle}
         >
           {expandedSections.preamble ? (
             <pre className={toolCallExpandedBodyClassName}>{expandedSections.preamble}</pre>
@@ -2435,7 +2436,9 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
             />
           ) : null}
           {expandedSections.files ? (
-            <pre className={toolCallExpandedBodyClassName}>{expandedSections.files}</pre>
+            <pre className={cn(toolCallExpandedBodyClassName, "mt-2")}>
+              {expandedSections.files}
+            </pre>
           ) : null}
         </div>
       ) : null}

--- a/apps/web/src/session-logic.command-output.test.ts
+++ b/apps/web/src/session-logic.command-output.test.ts
@@ -95,6 +95,55 @@ describe("deriveWorkLogEntries command output", () => {
     expect(selectWorkLogToolOutput({ detail: entry!.detail, command: entry!.command })).toBeNull();
   });
 
+  it("keeps a trailing <exited with exit code 0> line in persisted output", () => {
+    const output = "hello\n<exited with exit code 0>";
+    const [entry] = deriveWorkLogEntries([
+      makeCommandActivity("claude-bash-exit-line", {
+        itemType: "command_execution",
+        title: "Command run",
+        detail: "Bash: printf hello",
+        data: {
+          toolName: "Bash",
+          input: { command: "printf hello" },
+          result: {
+            type: "tool_result",
+            content: output,
+            is_error: false,
+          },
+        },
+      }),
+    ]);
+
+    expect(entry?.output).toBe(output);
+    expect(selectWorkLogToolOutput(entry!)).toBe(output);
+  });
+
+  it("does not copy MCP summarized result onto output", () => {
+    const [entry] = deriveWorkLogEntries([
+      makeCommandActivity("mcp-result", {
+        itemType: "mcp_tool_call",
+        title: "Call repository tool",
+        detail: "repository.search",
+        data: {
+          item: {
+            server: "repository",
+            tool: "search",
+            arguments: { query: "work log" },
+            result: { content: "first line of output" },
+          },
+        },
+      }),
+    ]);
+
+    expect(entry?.output).toBeUndefined();
+    expect(entry?.toolData).toEqual({
+      server: "repository",
+      tool: "search",
+      arguments: { query: "work log" },
+      result: { content: "first line of output" },
+    });
+  });
+
   it("reads Claude tool_result content blocks as output", () => {
     const [entry] = deriveWorkLogEntries([
       makeCommandActivity("claude-bash-blocks", {

--- a/apps/web/src/session-logic.command-output.test.ts
+++ b/apps/web/src/session-logic.command-output.test.ts
@@ -1,7 +1,7 @@
 import { EventId, TurnId, type OrchestrationThreadActivity } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
-import { deriveWorkLogEntries } from "./session-logic";
+import { deriveWorkLogEntries, selectWorkLogToolOutput } from "./session-logic";
 
 function makeCommandActivity(
   id: string,
@@ -64,6 +64,56 @@ describe("deriveWorkLogEntries command output", () => {
       command: "printf hello",
       detail: "hello from claude",
     });
+  });
+
+  it("passes persisted Claude Bash result content through as output, not the short detail", () => {
+    const output = `first line of stdout\n${"x".repeat(200)}`;
+    const [entry] = deriveWorkLogEntries([
+      makeCommandActivity("claude-bash-result", {
+        itemType: "command_execution",
+        title: "Command run",
+        detail: "Bash: printf hello && cat huge.txt",
+        data: {
+          toolName: "Bash",
+          input: { command: "printf hello && cat huge.txt" },
+          result: {
+            type: "tool_result",
+            tool_use_id: "toolu_1",
+            content: output,
+            is_error: false,
+          },
+        },
+      }),
+    ]);
+
+    expect(entry).toMatchObject({
+      command: "printf hello && cat huge.txt",
+      detail: "Bash: printf hello && cat huge.txt",
+      output,
+    });
+    expect(selectWorkLogToolOutput(entry!)).toBe(output);
+    expect(selectWorkLogToolOutput({ detail: entry!.detail, command: entry!.command })).toBeNull();
+  });
+
+  it("reads Claude tool_result content blocks as output", () => {
+    const [entry] = deriveWorkLogEntries([
+      makeCommandActivity("claude-bash-blocks", {
+        itemType: "command_execution",
+        title: "Command run",
+        detail: "Bash: ls",
+        data: {
+          toolName: "Bash",
+          input: { command: "ls" },
+          result: {
+            type: "tool_result",
+            content: [{ type: "text", text: "README.md\npackage.json" }],
+            is_error: false,
+          },
+        },
+      }),
+    ]);
+
+    expect(selectWorkLogToolOutput(entry!)).toBe("README.md\npackage.json");
   });
 
   it("drops duplicated command detail when the command has no output", () => {

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -673,6 +673,20 @@ describe("workEntryIndicatesToolFailure", () => {
     ).toBe(false);
   });
 
+  it("does not treat completed-success stdout phrases as failure", () => {
+    expect(
+      workEntryIndicatesToolFailure({
+        ...base,
+        label: "Bash",
+        tone: "tool",
+        itemType: "command_execution",
+        toolLifecycleStatus: "completed",
+        command: "cat notes.txt",
+        output: "this tutorial mentions command not found, ENOENT, and exit code 1",
+      }),
+    ).toBe(false);
+  });
+
   it("treats successful tool rows as success candidates", () => {
     expect(
       workEntryIndicatesToolSuccess({

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -244,9 +244,6 @@ export function workEntryIndicatesToolFailure(entry: WorkLogEntry): boolean {
   if (entry.detail) {
     parts.push(entry.detail);
   }
-  if (entry.output) {
-    parts.push(entry.output);
-  }
   if (entry.command) {
     parts.push(entry.command);
   }
@@ -864,7 +861,7 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   if (commandPreview.rawCommand) {
     entry.rawCommand = commandPreview.rawCommand;
   }
-  const output = extractPersistedToolResult(payload);
+  const output = itemType === "mcp_tool_call" ? null : extractPersistedToolResult(payload);
   if (output && output !== detail && output !== commandPreview.command) {
     entry.output = output;
   }
@@ -1398,8 +1395,12 @@ function summarizeToolRawOutput(payload: Record<string, unknown> | null): string
   return null;
 }
 
+function asPersistedResultText(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
 function extractToolResultText(result: unknown): string | null {
-  const direct = asTrimmedString(result);
+  const direct = asPersistedResultText(result);
   if (direct) {
     return direct;
   }
@@ -1410,7 +1411,7 @@ function extractToolResultText(result: unknown): string | null {
   }
 
   const content = record.content;
-  const contentText = asTrimmedString(content);
+  const contentText = asPersistedResultText(content);
   if (contentText) {
     return contentText;
   }
@@ -1421,7 +1422,8 @@ function extractToolResultText(result: unknown): string | null {
 
   const chunks: string[] = [];
   for (const entryValue of content) {
-    const text = asTrimmedString(entryValue) ?? asTrimmedString(asRecord(entryValue)?.text);
+    const text =
+      asPersistedResultText(entryValue) ?? asPersistedResultText(asRecord(entryValue)?.text);
     if (text) {
       chunks.push(text);
     }
@@ -1435,12 +1437,8 @@ function extractPersistedToolResult(payload: Record<string, unknown> | null): st
   const candidates = [data?.result, item?.result];
   for (const candidate of candidates) {
     const text = extractToolResultText(candidate);
-    if (!text) {
-      continue;
-    }
-    const output = stripTrailingExitCode(text).output;
-    if (output) {
-      return output;
+    if (text && text.trim().length > 0) {
+      return text;
     }
   }
   return null;
@@ -1453,7 +1451,7 @@ function extractPersistedToolResult(payload: Record<string, unknown> | null): st
 export function selectWorkLogToolOutput(
   entry: Pick<WorkLogEntry, "output" | "detail" | "command">,
 ): string | null {
-  return asTrimmedString(entry.output);
+  return typeof entry.output === "string" && entry.output.trim().length > 0 ? entry.output : null;
 }
 
 function extractAcpTextContent(value: unknown): string | null {

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -69,6 +69,11 @@ export interface WorkLogEntry {
   detail?: string;
   command?: string;
   rawCommand?: string;
+  /**
+   * Persisted tool result (stdout / `data.result.content`). Shown in the
+   * expanded Command-run row; never used as the collapsed preview.
+   */
+  output?: string;
   changedFiles?: ReadonlyArray<string>;
   tone: "thinking" | "tool" | "info" | "error";
   toolTitle?: string;
@@ -238,6 +243,9 @@ export function workEntryIndicatesToolFailure(entry: WorkLogEntry): boolean {
   const parts: string[] = [];
   if (entry.detail) {
     parts.push(entry.detail);
+  }
+  if (entry.output) {
+    parts.push(entry.output);
   }
   if (entry.command) {
     parts.push(entry.command);
@@ -856,6 +864,10 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   if (commandPreview.rawCommand) {
     entry.rawCommand = commandPreview.rawCommand;
   }
+  const output = extractPersistedToolResult(payload);
+  if (output && output !== detail && output !== commandPreview.command) {
+    entry.output = output;
+  }
   if (changedFiles.length > 0) {
     entry.changedFiles = changedFiles;
   }
@@ -1036,6 +1048,7 @@ function mergeDerivedWorkLogEntries(
   const detail = next.detail ?? previous.detail;
   const command = next.command ?? previous.command;
   const rawCommand = next.rawCommand ?? previous.rawCommand;
+  const output = next.output ?? previous.output;
   const toolTitle = next.toolTitle ?? previous.toolTitle;
   const itemType = next.itemType ?? previous.itemType;
   const requestKind = next.requestKind ?? previous.requestKind;
@@ -1049,6 +1062,7 @@ function mergeDerivedWorkLogEntries(
     ...(detail ? { detail } : {}),
     ...(command ? { command } : {}),
     ...(rawCommand ? { rawCommand } : {}),
+    ...(output ? { output } : {}),
     ...(changedFiles.length > 0 ? { changedFiles } : {}),
     ...(toolTitle ? { toolTitle } : {}),
     ...(itemType ? { itemType } : {}),
@@ -1285,11 +1299,13 @@ function extractToolCommand(payload: Record<string, unknown> | null): {
   const itemInput = asRecord(item?.input);
   const itemType = asTrimmedString(payload?.itemType);
   const detail = asTrimmedString(payload?.detail);
+  const dataInput = asRecord(data?.input);
   const candidates: unknown[] = [
     item?.command,
     itemInput?.command,
     itemResult?.command,
     data?.command,
+    dataInput?.command,
     itemType === "command_execution" && detail ? stripTrailingExitCode(detail).output : null,
   ];
 
@@ -1380,6 +1396,64 @@ function summarizeToolRawOutput(payload: Record<string, unknown> | null): string
   }
 
   return null;
+}
+
+function extractToolResultText(result: unknown): string | null {
+  const direct = asTrimmedString(result);
+  if (direct) {
+    return direct;
+  }
+
+  const record = asRecord(result);
+  if (!record) {
+    return null;
+  }
+
+  const content = record.content;
+  const contentText = asTrimmedString(content);
+  if (contentText) {
+    return contentText;
+  }
+
+  if (!Array.isArray(content)) {
+    return null;
+  }
+
+  const chunks: string[] = [];
+  for (const entryValue of content) {
+    const text = asTrimmedString(entryValue) ?? asTrimmedString(asRecord(entryValue)?.text);
+    if (text) {
+      chunks.push(text);
+    }
+  }
+  return chunks.length > 0 ? chunks.join("\n") : null;
+}
+
+function extractPersistedToolResult(payload: Record<string, unknown> | null): string | null {
+  const data = asRecord(payload?.data);
+  const item = asRecord(data?.item);
+  const candidates = [data?.result, item?.result];
+  for (const candidate of candidates) {
+    const text = extractToolResultText(candidate);
+    if (!text) {
+      continue;
+    }
+    const output = stripTrailingExitCode(text).output;
+    if (output) {
+      return output;
+    }
+  }
+  return null;
+}
+
+/**
+ * Full persisted tool result for the expanded Command-run body. Collapsed
+ * previews keep using `command` / `detail` and must not receive this string.
+ */
+export function selectWorkLogToolOutput(
+  entry: Pick<WorkLogEntry, "output" | "detail" | "command">,
+): string | null {
+  return asTrimmedString(entry.output);
 }
 
 function extractAcpTextContent(value: unknown): string | null {


### PR DESCRIPTION
Fixes #6388. Expanded Command-run entries now show the persisted tool output, and tool-only turns keep their tool entries behind the Worked-for fold.

Claude Bash `tool.completed` payloads store stdout on `data.result.content`. The snapshot mapper dropped that field (no `data.item` / `data.rawOutput`), and the work-log model had no `output` slot — so expanding a Command-run row only showed the command line and short `detail`.

- Project `data.input.command` and a bounded `data.result.content` on the wire
- Copy the persisted result onto `WorkLogEntry.output` and render it when the row is expanded (preview + show more / copy; collapsed rows still show the command)
- Keep tool-only settled turns expandable so the tool activity is visible behind "Worked for …"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared activity projection and work-log derivation across server, web, and mobile; payload size and fold behavior change user-visible timelines, but changes are bounded and covered by extensive tests.
> 
> **Overview**
> **Expanded Command-run rows now show real tool stdout** instead of only the command line and short `detail`. The server projection forwards `data.input.command` and a **bounded** `data.result.content` (32k cap) for command-like tools—including Claude Bash—while still **stripping** large Read/Grep dynamic-tool bodies. Web and mobile work-log derivation adds an **`output`** field from persisted `data.result`, keeps MCP summaries out of a duplicate output block, and resolves commands from `data.input.command`.
> 
> On **web**, expanded tool rows split preamble, output, and changed files; **`ToolCallOutputBlock`** previews huge output at 4k with show more/less and copy. **`deriveTurnFolds`** treats tool-only completed turns as expandable so work entries stay behind “Worked for …”. Completed commands are no longer marked failed when **stdout** merely mentions phrases like “command not found” or “exit code 1”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddb2bce454aee00d4cf7873deed03c3e305ef066. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render persisted bash tool output in expanded work log turns
> - Adds an `output` field to `WorkLogEntry` populated from persisted tool results (e.g. Claude Bash) via new `extractPersistedToolResult` helpers in [`session-logic.ts`](https://github.com/pingdotgg/t3code/pull/7184/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) and [`threadActivity.ts`](https://github.com/pingdotgg/t3code/pull/7184/files#diff-a18e8ed6aa4a9d6b3d9e32ea2fa3034dfd7621b6af3d640ec1b95a8564c97eb5).
> - Projected activity payloads for command-like tools now include a bounded `data.result.content` field (capped at 32,768 chars) in [`ActivityPayloadProjection.ts`](https://github.com/pingdotgg/t3code/pull/7184/files#diff-debcaf6e868575f9d95bb6918b9983c3a8929d664039039b54e9e1c7ea3b4130).
> - Expanded work rows in [`MessagesTimeline.tsx`](https://github.com/pingdotgg/t3code/pull/7184/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) render output via a new `ToolCallOutputBlock` component with Show more/less toggle (preview capped at 4,000 chars) and a copy button.
> - Fixes tool-only completed turns so they remain expandable and reveal their work entries instead of being hidden.
> - MCP summarized results are excluded from the `output` field to avoid duplication with existing `toolData` rendering.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ddb2bce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->