### PR TITLE
fix(vcs): share in-flight status refreshes per repository

### DIFF
--- a/apps/server/integration/OrchestrationEngineHarness.integration.ts
+++ b/apps/server/integration/OrchestrationEngineHarness.integration.ts
@@ -351,6 +351,7 @@ export const makeOrchestrationIntegrationHarness = (
               hasWorkingTreeChanges: false,
               workingTree: { files: [], insertions: 0, deletions: 0 },
             }),
+          invalidateStatus: () => Effect.void,
           refreshStatus: () => Effect.die("refreshStatus should not be called in this test"),
           streamStatus: () => Stream.empty,
         }),

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -330,6 +330,7 @@ describe("CheckpointReactor", () => {
             workingTree: { files: [], insertions: 0, deletions: 0 },
           }),
         ),
+      invalidateStatus: () => Effect.void,
       refreshStatus: () => Effect.die("refreshStatus should not be called in this test"),
       streamStatus: () => Stream.empty,
     });

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -402,6 +402,7 @@ describe("ProviderCommandReactor", () => {
           getStatus: () => Effect.die("getStatus should not be called in this test"),
           refreshLocalStatus: () =>
             Effect.die("refreshLocalStatus should not be called in this test"),
+          invalidateStatus: () => Effect.void,
           refreshStatus,
           streamStatus: () => Stream.die("streamStatus should not be called in this test"),
         }),

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -829,7 +829,12 @@ const make = Effect.gen(function* () {
         branch: renamed.branch,
         worktreePath: cwd,
       });
-      yield* vcsStatusBroadcaster.refreshStatus(cwd).pipe(Effect.ignoreCause({ log: true }));
+      yield* vcsStatusBroadcaster
+        .invalidateStatus(cwd)
+        .pipe(
+          Effect.andThen(vcsStatusBroadcaster.refreshStatus(cwd)),
+          Effect.ignoreCause({ log: true }),
+        );
     }).pipe(
       Effect.catchCause((cause) =>
         Effect.logWarning("provider command reactor failed to generate or rename worktree branch", {

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -5273,6 +5273,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
             switchRef: (input) => Effect.succeed({ refName: input.refName }),
           },
           vcsStatusBroadcaster: {
+            invalidateStatus: () => Effect.void,
             refreshStatus: () =>
               Effect.succeed({
                 isRepo: true,
@@ -7380,6 +7381,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
               createWorktree,
             },
             vcsStatusBroadcaster: {
+              invalidateStatus: () => Effect.void,
               refreshStatus,
             },
             orchestrationEngine: {

--- a/apps/server/src/vcs/VcsStatusBroadcaster.test.ts
+++ b/apps/server/src/vcs/VcsStatusBroadcaster.test.ts
@@ -146,20 +146,22 @@ function makeGatedRefreshLayer(state: GatedRefreshState, gates: GatedRefreshGate
           Effect.suspend(() => {
             state.seenCwds?.push(input.cwd);
             state.localStatusCalls += 1;
+            const local = state.currentLocalStatus;
             return (
               gates.started === null || state.localStatusCalls < startedAfter
                 ? Effect.void
                 : Deferred.succeed(gates.started, undefined).pipe(Effect.ignore)
             ).pipe(
               Effect.andThen(gates.release === null ? Effect.void : Deferred.await(gates.release)),
-              Effect.as(state.currentLocalStatus),
+              Effect.as(local),
             );
           }),
         remoteStatus: () =>
           Effect.suspend(() => {
             state.remoteStatusCalls += 1;
+            const remote = state.currentRemoteStatus;
             return (gates.release === null ? Effect.void : Deferred.await(gates.release)).pipe(
-              Effect.as(state.currentRemoteStatus),
+              Effect.as(remote),
             );
           }),
         invalidateLocalStatus: () =>
@@ -1010,6 +1012,63 @@ describe("VcsStatusBroadcaster", () => {
       assert.equal(state.localInvalidationCalls, 2);
       assert.equal(state.remoteInvalidationCalls, 2);
       assert.deepStrictEqual([...state.seenCwds].toSorted(), ["/repo-a", "/repo-b"]);
+    }).pipe(Effect.provide(makeGatedRefreshLayer(state, gates)));
+  });
+
+  it.effect("does not reuse a pre-invalidation in-flight status refresh", () => {
+    const firstLocal = baseLocalStatus;
+    const firstRemote = baseRemoteStatus;
+    const nextLocal = {
+      ...baseLocalStatus,
+      refName: "feature/after-mutation",
+    };
+    const nextRemote = {
+      ...baseRemoteStatus,
+      aheadCount: 4,
+    };
+    const state = {
+      currentLocalStatus: firstLocal,
+      currentRemoteStatus: firstRemote,
+      localStatusCalls: 0,
+      remoteStatusCalls: 0,
+      localInvalidationCalls: 0,
+      remoteInvalidationCalls: 0,
+    };
+    const gates: GatedRefreshGates = { started: null, release: null };
+
+    return Effect.gen(function* () {
+      gates.started = yield* Deferred.make<void>();
+      gates.release = yield* Deferred.make<void>();
+      const broadcaster = yield* VcsStatusBroadcaster.VcsStatusBroadcaster;
+
+      const first = yield* broadcaster
+        .refreshStatus("/repo")
+        .pipe(Effect.forkChild({ startImmediately: true }));
+
+      yield* Deferred.await(gates.started);
+      state.currentLocalStatus = nextLocal;
+      state.currentRemoteStatus = nextRemote;
+      yield* broadcaster.invalidateStatus("/repo");
+      const afterMutation = yield* broadcaster
+        .refreshStatus("/repo")
+        .pipe(Effect.forkChild({ startImmediately: true }));
+
+      yield* Effect.yieldNow;
+      yield* Deferred.succeed(gates.release, undefined);
+
+      const firstResult = yield* Fiber.join(first);
+      const afterMutationResult = yield* Fiber.join(afterMutation);
+      const cached = yield* broadcaster.getStatus({ cwd: "/repo" });
+      const nextStatus = {
+        ...nextLocal,
+        ...nextRemote,
+      };
+
+      assert.deepStrictEqual(afterMutationResult, nextStatus);
+      assert.deepStrictEqual(cached, nextStatus);
+      assert.deepStrictEqual(firstResult, nextStatus);
+      assert.equal(state.localStatusCalls, 2);
+      assert.equal(state.remoteStatusCalls, 2);
     }).pipe(Effect.provide(makeGatedRefreshLayer(state, gates)));
   });
 });

--- a/apps/server/src/vcs/VcsStatusBroadcaster.test.ts
+++ b/apps/server/src/vcs/VcsStatusBroadcaster.test.ts
@@ -6,6 +6,7 @@ import * as DateTime from "effect/DateTime";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Logger from "effect/Logger";
@@ -91,6 +92,75 @@ function makeTestLayer(state: {
             state.remoteStatusCalls += 1;
             state.remoteStatusRefreshUpstreamValues?.push(options?.refreshUpstream);
             return state.currentRemoteStatus;
+          }),
+        invalidateLocalStatus: () =>
+          Effect.sync(() => {
+            state.localInvalidationCalls += 1;
+          }),
+        invalidateRemoteStatus: () =>
+          Effect.sync(() => {
+            state.remoteInvalidationCalls += 1;
+          }),
+        invalidateStatus: () =>
+          Effect.sync(() => {
+            state.localInvalidationCalls += 1;
+            state.remoteInvalidationCalls += 1;
+          }),
+      }),
+    ),
+  );
+}
+
+interface GatedRefreshState {
+  currentLocalStatus: VcsStatusLocalResult;
+  currentRemoteStatus: VcsStatusRemoteResult | null;
+  localStatusCalls: number;
+  remoteStatusCalls: number;
+  localInvalidationCalls: number;
+  remoteInvalidationCalls: number;
+  seenCwds?: Array<string>;
+}
+
+interface GatedRefreshGates {
+  started: Deferred.Deferred<void> | null;
+  release: Deferred.Deferred<void> | null;
+  startedAfter?: number;
+}
+
+function makeGatedRefreshLayer(state: GatedRefreshState, gates: GatedRefreshGates) {
+  const startedAfter = gates.startedAfter ?? 1;
+  const identityRealPath = Layer.effect(
+    FileSystem.FileSystem,
+    Effect.map(FileSystem.FileSystem, (fs) => ({
+      ...fs,
+      realPath: (path: string) => Effect.succeed(path),
+    })),
+  );
+  return VcsStatusBroadcaster.layer.pipe(
+    Layer.provide(identityRealPath),
+    Layer.provideMerge(NodeServices.layer),
+    Layer.provide(makeBackgroundPolicyLayer(() => true)),
+    Layer.provide(
+      Layer.mock(GitWorkflowService.GitWorkflowService)({
+        localStatus: (input) =>
+          Effect.suspend(() => {
+            state.seenCwds?.push(input.cwd);
+            state.localStatusCalls += 1;
+            return (
+              gates.started === null || state.localStatusCalls < startedAfter
+                ? Effect.void
+                : Deferred.succeed(gates.started, undefined).pipe(Effect.ignore)
+            ).pipe(
+              Effect.andThen(gates.release === null ? Effect.void : Deferred.await(gates.release)),
+              Effect.as(state.currentLocalStatus),
+            );
+          }),
+        remoteStatus: () =>
+          Effect.suspend(() => {
+            state.remoteStatusCalls += 1;
+            return (gates.release === null ? Effect.void : Deferred.await(gates.release)).pipe(
+              Effect.as(state.currentRemoteStatus),
+            );
           }),
         invalidateLocalStatus: () =>
           Effect.sync(() => {
@@ -816,5 +886,130 @@ describe("VcsStatusBroadcaster", () => {
       yield* Deferred.await(remoteInterrupted);
       assert.isTrue(Option.isSome(yield* Deferred.poll(remoteInterrupted)));
     }).pipe(Effect.provide(testLayer));
+  });
+
+  it.effect("shares one in-flight explicit refresh per repository", () => {
+    const state = {
+      currentLocalStatus: baseLocalStatus,
+      currentRemoteStatus: baseRemoteStatus,
+      localStatusCalls: 0,
+      remoteStatusCalls: 0,
+      localInvalidationCalls: 0,
+      remoteInvalidationCalls: 0,
+    };
+    const gates: GatedRefreshGates = { started: null, release: null };
+
+    return Effect.gen(function* () {
+      gates.started = yield* Deferred.make<void>();
+      gates.release = yield* Deferred.make<void>();
+      const broadcaster = yield* VcsStatusBroadcaster.VcsStatusBroadcaster;
+
+      const first = yield* broadcaster
+        .refreshStatus("/repo")
+        .pipe(Effect.forkChild({ startImmediately: true }));
+      const second = yield* broadcaster
+        .refreshStatus("/repo")
+        .pipe(Effect.forkChild({ startImmediately: true }));
+
+      yield* Deferred.await(gates.started);
+      assert.equal(state.localStatusCalls, 1);
+      assert.equal(state.localInvalidationCalls, 1);
+      assert.equal(state.remoteInvalidationCalls, 1);
+
+      yield* Deferred.succeed(gates.release, undefined);
+      const firstResult = yield* Fiber.join(first);
+      const secondResult = yield* Fiber.join(second);
+
+      assert.deepStrictEqual(firstResult, baseStatus);
+      assert.deepStrictEqual(secondResult, baseStatus);
+      assert.equal(state.localStatusCalls, 1);
+      assert.equal(state.remoteStatusCalls, 1);
+      assert.equal(state.localInvalidationCalls, 1);
+      assert.equal(state.remoteInvalidationCalls, 1);
+
+      const later = yield* broadcaster.refreshStatus("/repo");
+      assert.deepStrictEqual(later, baseStatus);
+      assert.equal(state.localStatusCalls, 2);
+      assert.equal(state.remoteStatusCalls, 2);
+      assert.equal(state.localInvalidationCalls, 2);
+      assert.equal(state.remoteInvalidationCalls, 2);
+    }).pipe(Effect.provide(makeGatedRefreshLayer(state, gates)));
+  });
+
+  it.effect("keeps a shared refresh running after one waiter is interrupted", () => {
+    const state = {
+      currentLocalStatus: baseLocalStatus,
+      currentRemoteStatus: baseRemoteStatus,
+      localStatusCalls: 0,
+      remoteStatusCalls: 0,
+      localInvalidationCalls: 0,
+      remoteInvalidationCalls: 0,
+    };
+    const gates: GatedRefreshGates = { started: null, release: null };
+
+    return Effect.gen(function* () {
+      gates.started = yield* Deferred.make<void>();
+      gates.release = yield* Deferred.make<void>();
+      const broadcaster = yield* VcsStatusBroadcaster.VcsStatusBroadcaster;
+
+      const interruptedWaiter = yield* broadcaster
+        .refreshStatus("/repo")
+        .pipe(Effect.forkChild({ startImmediately: true }));
+      const remainingWaiter = yield* broadcaster
+        .refreshStatus("/repo")
+        .pipe(Effect.forkChild({ startImmediately: true }));
+
+      yield* Deferred.await(gates.started);
+      yield* Fiber.interrupt(interruptedWaiter);
+      const interruptedExit = yield* Fiber.await(interruptedWaiter);
+      assert.isTrue(Exit.hasInterrupts(interruptedExit));
+      assert.equal(state.localStatusCalls, 1);
+      assert.equal(state.localInvalidationCalls, 1);
+
+      yield* Deferred.succeed(gates.release, undefined);
+      const remaining = yield* Fiber.join(remainingWaiter);
+
+      assert.deepStrictEqual(remaining, baseStatus);
+      assert.equal(state.localStatusCalls, 1);
+      assert.equal(state.remoteStatusCalls, 1);
+      assert.equal(state.localInvalidationCalls, 1);
+      assert.equal(state.remoteInvalidationCalls, 1);
+    }).pipe(Effect.provide(makeGatedRefreshLayer(state, gates)));
+  });
+
+  it.effect("does not share explicit refreshes across different repositories", () => {
+    const state = {
+      currentLocalStatus: baseLocalStatus,
+      currentRemoteStatus: baseRemoteStatus,
+      localStatusCalls: 0,
+      remoteStatusCalls: 0,
+      localInvalidationCalls: 0,
+      remoteInvalidationCalls: 0,
+      seenCwds: [] as Array<string>,
+    };
+    const gates: GatedRefreshGates = { started: null, release: null, startedAfter: 2 };
+
+    return Effect.gen(function* () {
+      gates.started = yield* Deferred.make<void>();
+      gates.release = yield* Deferred.make<void>();
+      const broadcaster = yield* VcsStatusBroadcaster.VcsStatusBroadcaster;
+
+      const first = yield* broadcaster
+        .refreshStatus("/repo-a")
+        .pipe(Effect.forkChild({ startImmediately: true }));
+      const second = yield* broadcaster
+        .refreshStatus("/repo-b")
+        .pipe(Effect.forkChild({ startImmediately: true }));
+
+      yield* Deferred.await(gates.started);
+      yield* Deferred.succeed(gates.release, undefined);
+      assert.deepStrictEqual(yield* Fiber.join(first), baseStatus);
+      assert.deepStrictEqual(yield* Fiber.join(second), baseStatus);
+      assert.equal(state.localStatusCalls, 2);
+      assert.equal(state.remoteStatusCalls, 2);
+      assert.equal(state.localInvalidationCalls, 2);
+      assert.equal(state.remoteInvalidationCalls, 2);
+      assert.deepStrictEqual([...state.seenCwds].toSorted(), ["/repo-a", "/repo-b"]);
+    }).pipe(Effect.provide(makeGatedRefreshLayer(state, gates)));
   });
 });

--- a/apps/server/src/vcs/VcsStatusBroadcaster.ts
+++ b/apps/server/src/vcs/VcsStatusBroadcaster.ts
@@ -495,11 +495,17 @@ export const make = Effect.gen(function* () {
           }),
         );
       });
-      const result = yield* Fiber.join(inFlight.fiber);
+      const exit = yield* Fiber.await(inFlight.fiber);
       const latestGeneration = yield* invalidateGenerationOf(cwd);
-      if (inFlight.startedGeneration >= latestGeneration) {
-        return result;
+      // A stale run's failure must not surface: settleRefreshFiber may already
+      // have started the post-invalidation rerun this waiter should join.
+      if (inFlight.startedGeneration < latestGeneration) {
+        continue;
       }
+      if (Exit.isFailure(exit)) {
+        return yield* Effect.failCause(exit.cause);
+      }
+      return exit.value;
     }
   });
 

--- a/apps/server/src/vcs/VcsStatusBroadcaster.ts
+++ b/apps/server/src/vcs/VcsStatusBroadcaster.ts
@@ -193,6 +193,9 @@ export const make = Effect.gen(function* () {
   );
   const cacheRef = yield* Ref.make(new Map<string, CachedVcsStatus>());
   const pollersRef = yield* SynchronizedRef.make(new Map<string, ActiveRemotePoller>());
+  const inFlightRefreshesRef = yield* SynchronizedRef.make(
+    new Map<string, Fiber.Fiber<VcsStatusResult, GitManagerServiceError>>(),
+  );
 
   const getCachedStatus = Effect.fn("VcsStatusBroadcaster.getCachedStatus")(function* (
     cwd: string,
@@ -365,10 +368,9 @@ export const make = Effect.gen(function* () {
     return yield* updateCachedRemoteStatus(cwd, remote, { publish: true });
   });
 
-  const refreshStatus: VcsStatusBroadcaster["Service"]["refreshStatus"] = Effect.fn(
-    "VcsStatusBroadcaster.refreshStatus",
-  )(function* (rawCwd) {
-    const cwd = yield* withFileSystem(normalizeCwd(rawCwd));
+  const refreshStatusCore = Effect.fn("VcsStatusBroadcaster.refreshStatusCore")(function* (
+    cwd: string,
+  ) {
     // invalidateStatus (not the two partial invalidations) so an explicit
     // refresh also bypasses GitManager's slow PR-lookup cache.
     yield* workflow.invalidateStatus(cwd);
@@ -377,6 +379,37 @@ export const make = Effect.gen(function* () {
       { concurrency: "unbounded" },
     );
     return yield* updateCachedStatus(cwd, local, remote, { publish: true });
+  });
+
+  const refreshStatus: VcsStatusBroadcaster["Service"]["refreshStatus"] = Effect.fn(
+    "VcsStatusBroadcaster.refreshStatus",
+  )(function* (rawCwd) {
+    const cwd = yield* withFileSystem(normalizeCwd(rawCwd));
+    // Overlapping callers share one invalidate+recompute. The work is forked
+    // into the broadcaster scope so interrupting a waiter cannot cancel it.
+    const fiber = yield* SynchronizedRef.modifyEffect(inFlightRefreshesRef, (inFlight) => {
+      const existing = inFlight.get(cwd);
+      if (existing) {
+        return Effect.succeed([existing, inFlight] as const);
+      }
+
+      return refreshStatusCore(cwd).pipe(
+        Effect.ensuring(
+          SynchronizedRef.update(inFlightRefreshesRef, (current) => {
+            const next = new Map(current);
+            next.delete(cwd);
+            return next;
+          }),
+        ),
+        Effect.forkIn(broadcasterScope),
+        Effect.map((started) => {
+          const next = new Map(inFlight);
+          next.set(cwd, started);
+          return [started, next] as const;
+        }),
+      );
+    });
+    return yield* Fiber.join(fiber);
   });
 
   const makeRemoteRefreshLoop = (

--- a/apps/server/src/vcs/VcsStatusBroadcaster.ts
+++ b/apps/server/src/vcs/VcsStatusBroadcaster.ts
@@ -135,6 +135,12 @@ interface ActiveRemotePoller {
   readonly demandCwds: Ref.Ref<ReadonlyMap<string, number>>;
 }
 
+interface InFlightRefresh {
+  readonly fiber: Fiber.Fiber<VcsStatusResult, GitManagerServiceError>;
+  readonly startedGeneration: number;
+  readonly pendingRerun: boolean;
+}
+
 interface StreamStatusOptions {
   readonly automaticRemoteRefreshInterval?: Effect.Effect<Duration.Duration, never>;
 }
@@ -162,6 +168,7 @@ export class VcsStatusBroadcaster extends Context.Service<
     readonly refreshLocalStatus: (
       cwd: string,
     ) => Effect.Effect<VcsStatusLocalResult, GitManagerServiceError>;
+    readonly invalidateStatus: (cwd: string) => Effect.Effect<void>;
     readonly refreshStatus: (cwd: string) => Effect.Effect<VcsStatusResult, GitManagerServiceError>;
     readonly streamStatus: (
       input: VcsStatusInput,
@@ -193,9 +200,8 @@ export const make = Effect.gen(function* () {
   );
   const cacheRef = yield* Ref.make(new Map<string, CachedVcsStatus>());
   const pollersRef = yield* SynchronizedRef.make(new Map<string, ActiveRemotePoller>());
-  const inFlightRefreshesRef = yield* SynchronizedRef.make(
-    new Map<string, Fiber.Fiber<VcsStatusResult, GitManagerServiceError>>(),
-  );
+  const inFlightRefreshesRef = yield* SynchronizedRef.make(new Map<string, InFlightRefresh>());
+  const invalidateGenerationsRef = yield* Ref.make(new Map<string, number>());
 
   const getCachedStatus = Effect.fn("VcsStatusBroadcaster.getCachedStatus")(function* (
     cwd: string,
@@ -381,35 +387,120 @@ export const make = Effect.gen(function* () {
     return yield* updateCachedStatus(cwd, local, remote, { publish: true });
   });
 
+  const invalidateGenerationOf = (cwd: string) =>
+    Ref.get(invalidateGenerationsRef).pipe(Effect.map((generations) => generations.get(cwd) ?? 0));
+
+  function startRefreshFiber(
+    cwd: string,
+    startedGeneration: number,
+  ): Effect.Effect<Fiber.Fiber<VcsStatusResult, GitManagerServiceError>> {
+    return refreshStatusCore(cwd).pipe(
+      Effect.ensuring(settleRefreshFiber(cwd, startedGeneration)),
+      Effect.forkIn(broadcasterScope),
+    );
+  }
+
+  function settleRefreshFiber(cwd: string, startedGeneration: number) {
+    return Effect.gen(function* () {
+      const shouldRerun = yield* SynchronizedRef.modify(inFlightRefreshesRef, (inFlight) => {
+        const existing = inFlight.get(cwd);
+        if (existing === undefined || existing.startedGeneration !== startedGeneration) {
+          return [false, inFlight] as const;
+        }
+        if (!existing.pendingRerun) {
+          const next = new Map(inFlight);
+          next.delete(cwd);
+          return [false, next] as const;
+        }
+        const next = new Map(inFlight);
+        next.set(cwd, { ...existing, pendingRerun: false });
+        return [true, next] as const;
+      });
+      if (!shouldRerun) {
+        return;
+      }
+
+      const nextGeneration = yield* invalidateGenerationOf(cwd);
+      const nextFiber = yield* startRefreshFiber(cwd, nextGeneration);
+      yield* SynchronizedRef.update(inFlightRefreshesRef, (inFlight) => {
+        const existing = inFlight.get(cwd);
+        if (existing === undefined || existing.startedGeneration !== startedGeneration) {
+          return inFlight;
+        }
+        const next = new Map(inFlight);
+        next.set(cwd, {
+          fiber: nextFiber,
+          startedGeneration: nextGeneration,
+          pendingRerun: existing.pendingRerun,
+        });
+        return next;
+      });
+    });
+  }
+
+  const invalidateStatus: VcsStatusBroadcaster["Service"]["invalidateStatus"] = Effect.fn(
+    "VcsStatusBroadcaster.invalidateStatus",
+  )(function* (rawCwd) {
+    const cwd = yield* withFileSystem(normalizeCwd(rawCwd));
+    yield* workflow.invalidateStatus(cwd);
+    yield* Ref.update(invalidateGenerationsRef, (generations) => {
+      const next = new Map(generations);
+      next.set(cwd, (generations.get(cwd) ?? 0) + 1);
+      return next;
+    });
+    // A mutation after an in-flight refresh started must not reuse that run.
+    yield* SynchronizedRef.update(inFlightRefreshesRef, (inFlight) => {
+      const existing = inFlight.get(cwd);
+      if (existing === undefined || existing.pendingRerun) {
+        return inFlight;
+      }
+      const next = new Map(inFlight);
+      next.set(cwd, { ...existing, pendingRerun: true });
+      return next;
+    });
+  });
+
   const refreshStatus: VcsStatusBroadcaster["Service"]["refreshStatus"] = Effect.fn(
     "VcsStatusBroadcaster.refreshStatus",
   )(function* (rawCwd) {
     const cwd = yield* withFileSystem(normalizeCwd(rawCwd));
-    // Overlapping callers share one invalidate+recompute. The work is forked
-    // into the broadcaster scope so interrupting a waiter cannot cancel it.
-    const fiber = yield* SynchronizedRef.modifyEffect(inFlightRefreshesRef, (inFlight) => {
-      const existing = inFlight.get(cwd);
-      if (existing) {
-        return Effect.succeed([existing, inFlight] as const);
-      }
+    // Same-generation callers share one invalidate+recompute. The work is
+    // forked into the broadcaster scope so interrupting a waiter cannot
+    // cancel it. A later invalidate marks that run stale and this waiter
+    // joins one follow-up refresh after it completes.
+    while (true) {
+      const requestGeneration = yield* invalidateGenerationOf(cwd);
+      const inFlight = yield* SynchronizedRef.modifyEffect(inFlightRefreshesRef, (current) => {
+        const existing = current.get(cwd);
+        if (existing) {
+          if (existing.startedGeneration >= requestGeneration) {
+            return Effect.succeed([existing, current] as const);
+          }
+          const joined = { ...existing, pendingRerun: true };
+          const next = new Map(current);
+          next.set(cwd, joined);
+          return Effect.succeed([joined, next] as const);
+        }
 
-      return refreshStatusCore(cwd).pipe(
-        Effect.ensuring(
-          SynchronizedRef.update(inFlightRefreshesRef, (current) => {
+        return startRefreshFiber(cwd, requestGeneration).pipe(
+          Effect.map((started) => {
+            const created: InFlightRefresh = {
+              fiber: started,
+              startedGeneration: requestGeneration,
+              pendingRerun: false,
+            };
             const next = new Map(current);
-            next.delete(cwd);
-            return next;
+            next.set(cwd, created);
+            return [created, next] as const;
           }),
-        ),
-        Effect.forkIn(broadcasterScope),
-        Effect.map((started) => {
-          const next = new Map(inFlight);
-          next.set(cwd, started);
-          return [started, next] as const;
-        }),
-      );
-    });
-    return yield* Fiber.join(fiber);
+        );
+      });
+      const result = yield* Fiber.join(inFlight.fiber);
+      const latestGeneration = yield* invalidateGenerationOf(cwd);
+      if (inFlight.startedGeneration >= latestGeneration) {
+        return result;
+      }
+    }
   });
 
   const makeRemoteRefreshLoop = (
@@ -621,6 +712,7 @@ export const make = Effect.gen(function* () {
   return VcsStatusBroadcaster.of({
     getStatus,
     refreshLocalStatus,
+    invalidateStatus,
     refreshStatus,
     streamStatus,
   });

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1036,8 +1036,13 @@ const makeWsRpcLayer = (
 
       const refreshGitStatus = (cwd: string) =>
         vcsStatusBroadcaster
-          .refreshStatus(cwd)
-          .pipe(Effect.ignoreCause({ log: true }), Effect.forkDetach, Effect.asVoid);
+          .invalidateStatus(cwd)
+          .pipe(
+            Effect.andThen(vcsStatusBroadcaster.refreshStatus(cwd)),
+            Effect.ignoreCause({ log: true }),
+            Effect.forkDetach,
+            Effect.asVoid,
+          );
 
       return WsRpcGroup.of({
         [ORCHESTRATION_WS_METHODS.dispatchCommand]: (command) =>


### PR DESCRIPTION
Fixes #7076. Concurrent `vcs.refreshStatus` calls for the same cwd share one local+remote refresh. Interrupting one waiter does not cancel the shared work.

Overlapping explicit refreshes each invalidated the repo status cache and started another local+remote Git computation. Concurrent windows/clients stacked 15–24s refreshes.

`VcsStatusBroadcaster.refreshStatus` now keeps one in-flight fiber per normalized working directory. Later callers join that fiber instead of starting another invalidate+recompute. The work is forked into the broadcaster scope, so cancelling one waiter does not abort the shared refresh. A request that starts after that work completes still runs a new refresh.

Client-side `vcs.refreshStatus` stays on the shared serial VCS command lane. That queue is not refresh-only (pull/worktree/ref mutations share it), and window-focus already debounce-coalesces. The server-side single-flight is what stops concurrent environments from stacking Git work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core VCS refresh/coalescing semantics and WS-triggered git status updates; behavior changes around interruption and post-mutation freshness, though heavily covered by new unit tests.
> 
> **Overview**
> Fixes stacked concurrent Git status work by **deduplicating `refreshStatus` per normalized cwd** in `VcsStatusBroadcaster`: one in-flight fiber runs in the broadcaster scope, concurrent callers await it, and **interrupting a waiter no longer cancels** the shared refresh.
> 
> Adds **`invalidateStatus(cwd)`**, which invalidates workflow caches, bumps a per-repo **generation**, and marks any in-flight refresh stale so waiters **join a follow-up refresh** instead of reusing pre-mutation results. Post-mutation paths in **`ws.ts`** (`refreshGitStatus`) and **`ProviderCommandReactor`** (worktree branch rename) now call **`invalidateStatus` then `refreshStatus`**.
> 
> New **`VcsStatusBroadcaster` tests** cover single-flight sharing, survival after waiter interrupt, isolation across repos, and invalidation during an in-flight refresh; test mocks gain **`invalidateStatus`** stubs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09083c355c4ed096bbdcf74e482f175d023b1716. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Share in-flight VCS status refreshes per repository and add `invalidateStatus` API
> - `VcsStatusBroadcaster.refreshStatus` now shares a single in-flight fiber per repository path, so concurrent callers join the same refresh rather than triggering duplicate work.
> - A new `invalidateStatus(cwd)` method invalidates cached workflow status and increments a generation counter; if called mid-refresh, the in-flight refresh is flagged to rerun after completion.
> - `ProviderCommandReactor` and the WebSocket RPC layer ([ws.ts](https://github.com/pingdotgg/t3code/pull/7185/files#diff-7f2100e8ffa23a58d9bf425c5b3ceafc39239911ae33bc569291a00ecb8e9125)) are updated to call `invalidateStatus` before `refreshStatus` after branch renames and manual refresh requests.
> - Waiter interruption is handled safely: failures from stale in-flight runs are not surfaced to late joiners.
> - Behavioral Change: `refreshStatus` callers now share results from an in-progress refresh rather than each starting their own, which may reduce latency but changes the timing of cache updates under concurrent load.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 09083c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->