### PR TITLE
fix(web): keep windows drive paths clickable in chat markdown

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -73,11 +73,13 @@ import {
   serializeTableElementToMarkdown,
 } from "../markdown-clipboard";
 import { remarkNormalizeListItemIndentation } from "../markdown-list-indentation";
+import { remarkFilesystemLinkDestinations } from "../markdown-filesystem-links";
 import {
   normalizeMarkdownLinkDestination,
   resolveInlineCodeFileLinkMeta,
   resolveMarkdownFileLinkMeta,
   rewriteMarkdownFileUriHref,
+  toFilesystemLinkUrl,
   type MarkdownFileLinkMeta,
 } from "../markdown-links";
 import { readLocalApi } from "../localApi";
@@ -175,7 +177,7 @@ export function orderedListGutterStyle(
   return { "--list-gutter": `${digits + 1}ch` };
 }
 
-const CHAT_MARKDOWN_SANITIZE_SCHEMA = {
+export const CHAT_MARKDOWN_SANITIZE_SCHEMA: NonNullable<Parameters<typeof rehypeSanitize>[0]> = {
   ...defaultSchema,
   attributes: {
     ...defaultSchema.attributes,
@@ -187,12 +189,13 @@ const CHAT_MARKDOWN_SANITIZE_SCHEMA = {
     ...defaultSchema.protocols,
     href: [...(defaultSchema.protocols?.href ?? []), "file"],
   },
-} satisfies Parameters<typeof rehypeSanitize>[0];
+};
 
 const CHAT_MARKDOWN_REMARK_PLUGINS = [
   remarkGfm,
   remarkGithubAlerts,
   remarkNormalizeListItemIndentation,
+  remarkFilesystemLinkDestinations,
   remarkPreserveCodeMeta,
   remarkTagInlineCode,
 ] satisfies NonNullable<ReactMarkdownOptions["remarkPlugins"]>;
@@ -202,6 +205,7 @@ const CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS = [
   remarkGithubAlerts,
   remarkNormalizeListItemIndentation,
   remarkBreaks,
+  remarkFilesystemLinkDestinations,
   remarkPreserveCodeMeta,
   remarkTagInlineCode,
 ] satisfies NonNullable<ReactMarkdownOptions["remarkPlugins"]>;
@@ -915,7 +919,10 @@ function extractMarkdownLinkHrefs(text: string): string[] {
 }
 
 function normalizeMarkdownLinkHrefKey(href: string): string {
-  const normalizedHref = normalizeMarkdownLinkDestination(href);
+  // Drive destinations are keyed through the same `file:` form the remark plugin
+  // rewrites them to, so a `M:\dir\file.md` in the source text and the
+  // `M:/dir/file.md` the renderer receives resolve to one key.
+  const normalizedHref = toFilesystemLinkUrl(href) ?? normalizeMarkdownLinkDestination(href);
   return rewriteMarkdownFileUriHref(normalizedHref) ?? normalizedHref;
 }
 
@@ -1627,7 +1634,16 @@ function ChatMarkdown({
       },
       a({ node, href, children, title: _title, ...props }) {
         const normalizedHref = href ? normalizeMarkdownLinkHrefKey(href) : "";
-        const fileLinkMeta = normalizedHref ? markdownFileLinkMetaByHref.get(normalizedHref) : null;
+        // The map is keyed off a scan of the message text, which only reads
+        // inline links with a plain destination. A drive path is resolved here
+        // when that scan missed it, so a link shape the scan cannot read still
+        // opens the file rather than rendering as an ordinary dead link.
+        const fileLinkMeta = normalizedHref
+          ? (markdownFileLinkMetaByHref.get(normalizedHref) ??
+            (toFilesystemLinkUrl(normalizedHref)
+              ? resolveMarkdownFileLinkMeta(normalizedHref, cwd)
+              : null))
+          : null;
         if (!fileLinkMeta) {
           const faviconHost = resolveExternalWebLinkHost(href);
           const isSameDocumentLink = href?.startsWith("#") ?? false;

--- a/apps/web/src/markdown-filesystem-links.test.tsx
+++ b/apps/web/src/markdown-filesystem-links.test.tsx
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vite-plus/test";
+import { renderToStaticMarkup } from "react-dom/server";
+import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
+import rehypeRaw from "rehype-raw";
+import rehypeSanitize from "rehype-sanitize";
+import remarkGfm from "remark-gfm";
+
+import { CHAT_MARKDOWN_SANITIZE_SCHEMA } from "./components/ChatMarkdown";
+import { remarkFilesystemLinkDestinations } from "./markdown-filesystem-links";
+import { rewriteMarkdownFileUriHref } from "./markdown-links";
+
+/**
+ * Renders through the same two pipelines the chat does: assistant messages parse
+ * raw HTML and therefore run `rehype-sanitize`, user messages do not.
+ */
+function renderChatMarkdown(markdown: string, options: { readonly parseRawHtml: boolean }): string {
+  return renderToStaticMarkup(
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm, remarkFilesystemLinkDestinations]}
+      rehypePlugins={
+        options.parseRawHtml
+          ? [rehypeRaw, [rehypeSanitize, CHAT_MARKDOWN_SANITIZE_SCHEMA]]
+          : undefined
+      }
+      skipHtml={false}
+      // Mirrors the component's own transform, so an unsafe scheme is still
+      // rejected by React Markdown exactly as it is in the app.
+      urlTransform={(href) => rewriteMarkdownFileUriHref(href) ?? defaultUrlTransform(href)}
+    >
+      {markdown}
+    </ReactMarkdown>,
+  );
+}
+
+describe("remarkFilesystemLinkDestinations", () => {
+  // #6418: both pipelines dropped the destination, so the anchor rendered
+  // without an href and could not be matched to a resolved file link.
+  for (const parseRawHtml of [true, false]) {
+    it(`keeps a drive destination with parseRawHtml=${parseRawHtml}`, () => {
+      expect(renderChatMarkdown("[Open](D:/tmp/example.md)", { parseRawHtml })).toContain(
+        'href="D:/tmp/example.md"',
+      );
+    });
+
+    it(`keeps a backslash drive destination with parseRawHtml=${parseRawHtml}`, () => {
+      expect(
+        renderChatMarkdown("[Open](M:\\batches\\docs\\prompt.md)", { parseRawHtml }),
+      ).toContain('href="M:/batches/docs/prompt.md"');
+    });
+
+    it(`keeps a reference definition destination with parseRawHtml=${parseRawHtml}`, () => {
+      expect(
+        renderChatMarkdown("[Open][ref]\n\n[ref]: D:/tmp/example.md", { parseRawHtml }),
+      ).toContain('href="D:/tmp/example.md"');
+    });
+
+    // Link shapes the metadata scan's regex cannot read - balanced parentheses,
+    // nested brackets, a bracketed destination with spaces. The anchor resolves
+    // these itself, so the destination still has to survive the pipeline.
+    it(`keeps destinations the metadata scan misses with parseRawHtml=${parseRawHtml}`, () => {
+      expect(renderChatMarkdown("[Open](D:/tmp/example(1).md)", { parseRawHtml })).toContain(
+        'href="D:/tmp/example(1).md"',
+      );
+      // A space survives percent-encoded, the form the `file:` URL carries it
+      // in; `resolveMarkdownFileLinkTarget` decodes it again when it resolves.
+      expect(
+        renderChatMarkdown("[Open](<D:/Program Files/example.md>)", { parseRawHtml }),
+      ).toContain('href="D:/Program%20Files/example.md"');
+    });
+
+    it(`still drops an unsafe scheme with parseRawHtml=${parseRawHtml}`, () => {
+      const html = renderChatMarkdown("[Click](javascript:alert(1))", { parseRawHtml });
+      expect(html).not.toContain("javascript:");
+    });
+
+    it(`leaves ordinary destinations alone with parseRawHtml=${parseRawHtml}`, () => {
+      expect(renderChatMarkdown("[Docs](https://example.com/docs)", { parseRawHtml })).toContain(
+        'href="https://example.com/docs"',
+      );
+    });
+  }
+});

--- a/apps/web/src/markdown-filesystem-links.ts
+++ b/apps/web/src/markdown-filesystem-links.ts
@@ -1,0 +1,38 @@
+import { toFilesystemLinkUrl } from "./markdown-links";
+
+interface MarkdownAstNode {
+  readonly type: string;
+  url?: unknown;
+  children?: MarkdownAstNode[];
+}
+
+/**
+ * Rewrite Windows drive link destinations to the `file:` URLs they can survive
+ * the rest of the pipeline as.
+ *
+ * `[open](D:/src/main.ts)` renders as styled but dead text otherwise: with raw
+ * HTML parsing on, `rehype-sanitize` reads `D:` as an unknown protocol and
+ * removes the href before `urlTransform` ever sees it, and with it off
+ * `defaultUrlTransform` returns an empty string for the same reason. Rewriting
+ * at the syntax-tree stage covers both, because remark plugins run either way.
+ *
+ * The renderer still receives a plain path: `rewriteMarkdownFileUriHref` maps
+ * the `file:` URL back on the way out, which is the form the resolved file
+ * links are keyed by.
+ */
+export function remarkFilesystemLinkDestinations() {
+  return (tree: MarkdownAstNode): void => {
+    const visit = (node: MarkdownAstNode): void => {
+      // Reference definitions carry a destination too, so `[a][ref]` behaves the
+      // same as the inline form.
+      if ((node.type === "link" || node.type === "definition") && typeof node.url === "string") {
+        const fileUrl = toFilesystemLinkUrl(node.url);
+        if (fileUrl !== null) {
+          node.url = fileUrl;
+        }
+      }
+      node.children?.forEach(visit);
+    };
+    visit(tree);
+  };
+}

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -5,6 +5,7 @@ import {
   resolveMarkdownFileLinkMeta,
   resolveMarkdownFileLinkTarget,
   rewriteMarkdownFileUriHref,
+  toFilesystemLinkUrl,
 } from "./markdown-links";
 
 describe("rewriteMarkdownFileUriHref", () => {
@@ -32,6 +33,60 @@ describe("rewriteMarkdownFileUriHref", () => {
     expect(
       rewriteMarkdownFileUriHref(" <file:///D:/Programme/t3code/apps/web/src/markdown-links.ts> "),
     ).toBe("D:/Programme/t3code/apps/web/src/markdown-links.ts");
+  });
+});
+
+describe("toFilesystemLinkUrl", () => {
+  it("maps a drive destination to a file url", () => {
+    expect(toFilesystemLinkUrl("D:/tmp/example.md")).toBe("file:///D:/tmp/example.md");
+  });
+
+  it("normalizes separators so backslash and slash forms share one key", () => {
+    expect(toFilesystemLinkUrl("M:\\batches\\docs\\prompt.md")).toBe(
+      "file:///M:/batches/docs/prompt.md",
+    );
+    expect(toFilesystemLinkUrl("M:\\batches\\docs\\prompt.md")).toBe(
+      toFilesystemLinkUrl("M:/batches/docs/prompt.md"),
+    );
+  });
+
+  it("round-trips back to the path the renderer receives", () => {
+    const fileUrl = toFilesystemLinkUrl("D:/tmp/example.md");
+    expect(fileUrl).not.toBeNull();
+    expect(rewriteMarkdownFileUriHref(fileUrl!)).toBe("D:/tmp/example.md");
+  });
+
+  it("unwraps angle-bracketed drive destinations", () => {
+    expect(toFilesystemLinkUrl(" <D:/Programme/t3code/AGENTS.md> ")).toBe(
+      "file:///D:/Programme/t3code/AGENTS.md",
+    );
+  });
+
+  it("leaves everything that is not a drive destination alone", () => {
+    expect(toFilesystemLinkUrl("https://example.com")).toBeNull();
+    expect(toFilesystemLinkUrl("./relative.md")).toBeNull();
+    expect(toFilesystemLinkUrl("/Users/julius/project/AGENTS.md")).toBeNull();
+    expect(toFilesystemLinkUrl("file:///D:/tmp/example.md")).toBeNull();
+    expect(toFilesystemLinkUrl(undefined)).toBeNull();
+  });
+
+  it("resolves the shapes the link scan misses, which the anchor falls back to", () => {
+    // Balanced parentheses and spaced destinations never reach the metadata map,
+    // so the anchor resolves them directly; that only works if these resolve.
+    expect(resolveMarkdownFileLinkMeta("D:/tmp/example(1).md")).toMatchObject({
+      basename: "example(1).md",
+    });
+    expect(resolveMarkdownFileLinkMeta("D:/Program Files/example.md")).toMatchObject({
+      basename: "example.md",
+    });
+  });
+
+  it("does not take a multi-letter scheme", () => {
+    // A drive letter is one character, so nothing that could carry script
+    // matches; those stay with the transform that already rejects them.
+    expect(toFilesystemLinkUrl("javascript:alert(1)")).toBeNull();
+    expect(toFilesystemLinkUrl("data:text/html,<script>")).toBeNull();
+    expect(toFilesystemLinkUrl("D:alert(1)")).toBeNull();
   });
 });
 

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -108,6 +108,25 @@ export function rewriteMarkdownFileUriHref(href: string | undefined): string | n
   return `${target.path}${target.hash}`;
 }
 
+/**
+ * The `file:` URL for a Windows drive destination, or null for anything else.
+ *
+ * A destination like `D:/src/main.ts` cannot reach the anchor renderer as
+ * written: `D:` reads as an unknown protocol, so `rehype-sanitize` drops the
+ * href and React Markdown's `defaultUrlTransform` blanks it. Both already allow
+ * `file:`, and `rewriteMarkdownFileUriHref` turns that back into a plain path,
+ * so this is the one form a drive path can travel in.
+ *
+ * Separators are normalized because a `file:` URL cannot carry backslashes;
+ * link keys go through here too, so both sides of the lookup agree.
+ */
+export function toFilesystemLinkUrl(destination: string | undefined): string | null {
+  if (!destination) return null;
+  const normalized = normalizeMarkdownLinkDestination(destination);
+  if (!WINDOWS_DRIVE_PATH_PATTERN.test(normalized)) return null;
+  return `file:///${normalized.replaceAll("\\", "/")}`;
+}
+
 function looksLikePosixFilesystemPath(path: string): boolean {
   if (!path.startsWith("/")) return false;
   if (POSIX_FILE_ROOT_PREFIXES.some((prefix) => path.startsWith(prefix))) return true;


### PR DESCRIPTION
A markdown link whose destination is an absolute Windows path renders as styled text with nothing behind it (#6418).

## What changed

Both chat render paths drop the destination before the anchor can use it:

- **Assistant messages** leave `parseRawHtml` at its default of `true`, so `rehype-sanitize` runs, reads `D:` as an unknown protocol, and removes the href — before `urlTransform` is reached.
- **User messages** pass `false`, skip the sanitizer, and React Markdown's `defaultUrlTransform` blanks the same destination for the same reason.

Either way the anchor arrives without an href, so it cannot match an entry in `markdownFileLinkMetaByHref` even though that map has already resolved the path from the raw message text.

Both pipelines run remark, so the destination is normalized there: `toFilesystemLinkUrl` maps a drive path to the `file:` URL the sanitize schema already allows, and the existing `rewriteMarkdownFileUriHref` maps it back on the way out. `resolveMarkdownFileLinkTarget` already handled these paths, so this is only about getting them that far.

Two smaller pieces come with it:

- Link keys go through the same function, so `M:\dir\file.md` in the source and the `M:/dir/file.md` the renderer receives resolve to one key rather than missing each other on the separator.
- The anchor resolves a drive destination itself when the metadata map misses. That map is built by scanning the message text for inline links with a plain destination, so balanced parentheses, nested brackets and bracketed destinations with spaces are absent from it; without the fallback those would render as ordinary anchors pointing at a drive path with no file action.

`CHAT_MARKDOWN_SANITIZE_SCHEMA` is exported so the tests can render both pipelines with the real configuration; that needs an explicit type annotation because its inferred type is not nameable outside the module.

## Before / after

![Before and after rendering of a Windows drive markdown link](https://raw.githubusercontent.com/CDVolvik/t3code/pr-assets/6418-before-after.png)

Rendered from the real `ChatMarkdown` component with the app's built stylesheet. "Before" is the same component with this PR's source hunks reverted to `origin/main`. The file-type glyph inside the chip is a runtime SVG sprite the offline render does not load, so it shows as blank space.

Emitted markup for `See [Open](D:/tmp/example.md) for the notes.`:

| pipeline | before | after |
| --- | --- | --- |
| assistant (`parseRawHtml: true`) | `<a target="_blank" rel="noopener noreferrer">Open</a>` | `<a href="D:/tmp/example.md" class="… chat-markdown-file-link">… example.md</a>` |
| user (`parseRawHtml: false`) | `<a href="" target="_blank" rel="noopener noreferrer">Open</a>` | same as above |

## Scope

Markdown destinations only. A bare `M:\dir\file.md` written as plain text is still not linked, because GFM does not autolink filesystem paths and adding that is a separate change. If you read #6418 to include the bare-path case, this does not close it outright.

## Testing

- `apps/web` unit project: **2574 tests across 262 files pass**
- **63 tests** in the three touched files, including new tests that render both pipelines through `renderToStaticMarkup` with the real sanitize schema, and that assert an unsafe scheme is still dropped
- `tsgo --noEmit` clean; `vp lint` 0 warnings / 0 errors on the changed files; `vp fmt --check` clean
- Rebased on `origin/main` @ `4cb676cc1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized markdown rendering and URL handling for Windows drive paths; unsafe schemes remain rejected and behavior is covered by pipeline tests for both assistant and user render modes.
> 
> **Overview**
> Fixes **#6418**: markdown links like `[Open](D:/tmp/example.md)` used to render without a usable `href` because `D:` was treated as an unknown protocol—**assistant** messages lost it in `rehype-sanitize`, and **user** messages got a blank href from `defaultUrlTransform`.
> 
> A new **`remarkFilesystemLinkDestinations`** plugin runs on both chat pipelines and rewrites drive (and reference-definition) destinations to allowed **`file:`** URLs; existing **`rewriteMarkdownFileUriHref`** still turns them back into plain paths on output. **`toFilesystemLinkUrl`** centralizes that mapping and normalizes `\` vs `/` so metadata keys match what the renderer sees.
> 
> **`ChatMarkdown`** wires the plugin in, keys link metadata through the same helper, and **falls back** to `resolveMarkdownFileLinkMeta` at render time when the message-text regex scan missed the destination (parentheses, spaced `<...>` paths, etc.). **`CHAT_MARKDOWN_SANITIZE_SCHEMA`** is exported (with an explicit type) so tests can mirror both `parseRawHtml` paths; new unit tests assert drive links work, `javascript:` stays dropped, and https links are unchanged.
> 
> **Scope:** markdown link destinations only—not autolinking bare paths in plain text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ddc78670eff4905d268dadea2f78198953025fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Windows drive paths to remain clickable as file links in chat markdown
> - Adds a new remark plugin, `remarkFilesystemLinkDestinations` in [markdown-filesystem-links.ts](https://github.com/pingdotgg/t3code/pull/7189/files#diff-8e1bbe40206dff44d051563aa22cde9021714be313a5e4257933be170ab4f9c0), that rewrites Windows drive-style link destinations (e.g. `D:/path/file.md`, backslash variants) to `file:///` URLs before sanitization strips them.
> - Adds `toFilesystemLinkUrl` in [markdown-links.ts](https://github.com/pingdotgg/t3code/pull/7189/files#diff-010f94b966be6604cb228ce225d1f3ce41b15470b641a970ec5ed07cd2ed2040) to convert Windows drive paths to `file:` URLs and normalize path separators.
> - Updates `normalizeMarkdownLinkHrefKey` in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/7189/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05) to key drive destinations via their `file:` form so lookups into the pre-scanned metadata map succeed for both slash and backslash variants.
> - The anchor renderer in `ChatMarkdown` now falls back to resolving file link metadata on the fly when the pre-scan misses a link shape.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ddc786.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->