### PR TITLE
feat(codex): add 1M context for supported models

### DIFF
--- a/apps/server/src/codexModelOptions.ts
+++ b/apps/server/src/codexModelOptions.ts
@@ -4,6 +4,17 @@ import {
   getModelSelectionStringOptionValue,
 } from "@t3tools/shared/model";
 
+const LONG_CONTEXT_CODEX_MODELS = new Set([
+  "gpt-5.4",
+  "gpt-5.6-luna",
+  "gpt-5.6-terra",
+  "gpt-5.6-sol",
+]);
+
+export function supportsCodexLongContext(model: string): boolean {
+  return LONG_CONTEXT_CODEX_MODELS.has(model);
+}
+
 export function getCodexServiceTierOptionValue(
   modelSelection: ModelSelection | null | undefined,
 ): string | undefined {

--- a/apps/server/src/codexModelOptions.ts
+++ b/apps/server/src/codexModelOptions.ts
@@ -4,6 +4,7 @@ import {
   getModelSelectionStringOptionValue,
 } from "@t3tools/shared/model";
 
+// `model/list` has no context-limit field; replace this allowlist when Codex exposes one.
 const LONG_CONTEXT_CODEX_MODELS = new Set([
   "gpt-5.4",
   "gpt-5.6-luna",

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -2111,6 +2111,61 @@ describe("ProviderCommandReactor", () => {
       ),
     });
   });
+  it("restarts codex sessions when the context window changes", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-codex-context-1"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-codex-context-1"),
+          role: "user",
+          text: "first codex turn",
+          attachments: [],
+        },
+        modelSelection: createModelSelection(ProviderInstanceId.make("codex"), "gpt-5-codex", [
+          { id: "contextWindow", value: "1m" },
+        ]),
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.startSession.mock.calls.length === 1);
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-codex-context-2"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-codex-context-2"),
+          role: "user",
+          text: "second codex turn",
+          attachments: [],
+        },
+        modelSelection: createModelSelection(ProviderInstanceId.make("codex"), "gpt-5-codex", [
+          { id: "contextWindow", value: "258k" },
+        ]),
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.startSession.mock.calls.length === 2);
+    expect(harness.startSession.mock.calls[1]?.[1]).toMatchObject({
+      resumeCursor: { opaque: "resume-1" },
+      modelSelection: createModelSelection(ProviderInstanceId.make("codex"), "gpt-5-codex", [
+        { id: "contextWindow", value: "258k" },
+      ]),
+    });
+  });
 
   it("restarts the provider session when runtime mode is updated on the thread", async () => {
     const harness = await createHarness();

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -2985,6 +2985,14 @@ describe("ProviderCommandReactor", () => {
         },
         createdAt: now,
       });
+      yield* harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.make("cmd-meta-update-codex-context-recovered"),
+        threadId,
+        modelSelection: createModelSelection(providerInstanceId, "gpt-5-codex", [
+          { id: "contextWindow", value: "1m" },
+        ]),
+      });
 
       yield* harness.engine.dispatch({
         type: "thread.turn.start",

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -2111,61 +2111,6 @@ describe("ProviderCommandReactor", () => {
       ),
     });
   });
-  it("restarts codex sessions when the context window changes", async () => {
-    const harness = await createHarness();
-    const now = "2026-01-01T00:00:00.000Z";
-
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.turn.start",
-        commandId: CommandId.make("cmd-turn-start-codex-context-1"),
-        threadId: ThreadId.make("thread-1"),
-        message: {
-          messageId: asMessageId("user-message-codex-context-1"),
-          role: "user",
-          text: "first codex turn",
-          attachments: [],
-        },
-        modelSelection: createModelSelection(ProviderInstanceId.make("codex"), "gpt-5-codex", [
-          { id: "contextWindow", value: "1m" },
-        ]),
-        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
-        runtimeMode: "approval-required",
-        createdAt: now,
-      }),
-    );
-
-    await waitFor(() => harness.startSession.mock.calls.length === 1);
-    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
-
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.turn.start",
-        commandId: CommandId.make("cmd-turn-start-codex-context-2"),
-        threadId: ThreadId.make("thread-1"),
-        message: {
-          messageId: asMessageId("user-message-codex-context-2"),
-          role: "user",
-          text: "second codex turn",
-          attachments: [],
-        },
-        modelSelection: createModelSelection(ProviderInstanceId.make("codex"), "gpt-5-codex", [
-          { id: "contextWindow", value: "258k" },
-        ]),
-        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
-        runtimeMode: "approval-required",
-        createdAt: now,
-      }),
-    );
-
-    await waitFor(() => harness.startSession.mock.calls.length === 2);
-    expect(harness.startSession.mock.calls[1]?.[1]).toMatchObject({
-      resumeCursor: { opaque: "resume-1" },
-      modelSelection: createModelSelection(ProviderInstanceId.make("codex"), "gpt-5-codex", [
-        { id: "contextWindow", value: "258k" },
-      ]),
-    });
-  });
 
   it("restarts the provider session when runtime mode is updated on the thread", async () => {
     const harness = await createHarness();
@@ -2998,4 +2943,74 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.session?.providerInstanceId).toBe(ProviderInstanceId.make("codex_work"));
     expect(thread?.session?.activeTurnId).toBeNull();
   });
+
+  effectIt.effect("restarts a recovered codex session when context window changes", () =>
+    Effect.gen(function* () {
+      const now = "2026-01-01T00:00:00.000Z";
+      const threadId = ThreadId.make("thread-1");
+      const providerInstanceId = ProviderInstanceId.make("codex");
+      const harness = yield* Effect.promise(() =>
+        createHarness({
+          threadModelSelection: createModelSelection(providerInstanceId, "gpt-5-codex", [
+            { id: "contextWindow", value: "258k" },
+          ]),
+        }),
+      );
+
+      harness.runtimeSessions.push({
+        provider: ProviderDriverKind.make("codex"),
+        providerInstanceId,
+        status: "ready",
+        runtimeMode: "approval-required",
+        model: "gpt-5-codex",
+        cwd: "/tmp/provider-project",
+        threadId,
+        resumeCursor: { opaque: "resume-258k" },
+        createdAt: now,
+        updatedAt: now,
+      });
+      yield* harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("cmd-session-set-codex-context-recovered"),
+        threadId,
+        session: {
+          threadId,
+          status: "ready",
+          providerName: "codex",
+          providerInstanceId,
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: now,
+        },
+        createdAt: now,
+      });
+
+      yield* harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-codex-context-recovered"),
+        threadId,
+        message: {
+          messageId: asMessageId("user-message-codex-context-recovered"),
+          role: "user",
+          text: "use the larger context window",
+          attachments: [],
+        },
+        modelSelection: createModelSelection(providerInstanceId, "gpt-5-codex", [
+          { id: "contextWindow", value: "1m" },
+        ]),
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      });
+
+      yield* Effect.promise(() => waitFor(() => harness.startSession.mock.calls.length === 1));
+      expect(harness.startSession.mock.calls[0]?.[1]).toMatchObject({
+        resumeCursor: { opaque: "resume-258k" },
+        modelSelection: createModelSelection(providerInstanceId, "gpt-5-codex", [
+          { id: "contextWindow", value: "1m" },
+        ]),
+      });
+    }),
+  );
 });

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -664,7 +664,7 @@ const make = Effect.gen(function* () {
         requestedModelSelection !== undefined &&
         activeSession?.providerInstanceId !== requestedModelSelection.instanceId;
       const shouldRestartForModelChange = modelChanged && sessionModelSwitch === "unsupported";
-      const previousModelSelection = threadModelSelections.get(threadId);
+      const previousModelSelection = threadModelSelections.get(threadId) ?? thread.modelSelection;
       const codexContextWindowChanged =
         preferredProvider === "codex" &&
         requestedModelSelection !== undefined &&

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -664,12 +664,13 @@ const make = Effect.gen(function* () {
         requestedModelSelection !== undefined &&
         activeSession?.providerInstanceId !== requestedModelSelection.instanceId;
       const shouldRestartForModelChange = modelChanged && sessionModelSwitch === "unsupported";
-      const previousModelSelection = threadModelSelections.get(threadId) ?? thread.modelSelection;
+      const previousModelSelection = threadModelSelections.get(threadId);
       const codexContextWindowChanged =
         preferredProvider === "codex" &&
         requestedModelSelection !== undefined &&
-        (getModelSelectionStringOptionValue(previousModelSelection, "contextWindow") ?? "1m") !==
-          (getModelSelectionStringOptionValue(requestedModelSelection, "contextWindow") ?? "1m");
+        (previousModelSelection === undefined ||
+          (getModelSelectionStringOptionValue(previousModelSelection, "contextWindow") ?? "1m") !==
+            (getModelSelectionStringOptionValue(requestedModelSelection, "contextWindow") ?? "1m"));
       const shouldRestartForModelSelectionChange =
         (preferredProvider === "claudeAgent" &&
           requestedModelSelection !== undefined &&

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -13,6 +13,7 @@ import {
   type TurnId,
 } from "@t3tools/contracts";
 import { isTemporaryWorktreeBranch, WORKTREE_BRANCH_PREFIX } from "@t3tools/shared/git";
+import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
 import * as Cache from "effect/Cache";
 import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
@@ -664,10 +665,16 @@ const make = Effect.gen(function* () {
         activeSession?.providerInstanceId !== requestedModelSelection.instanceId;
       const shouldRestartForModelChange = modelChanged && sessionModelSwitch === "unsupported";
       const previousModelSelection = threadModelSelections.get(threadId);
-      const shouldRestartForModelSelectionChange =
-        preferredProvider === "claudeAgent" &&
+      const codexContextWindowChanged =
+        preferredProvider === "codex" &&
         requestedModelSelection !== undefined &&
-        !Equal.equals(previousModelSelection, requestedModelSelection);
+        (getModelSelectionStringOptionValue(previousModelSelection, "contextWindow") ?? "1m") !==
+          (getModelSelectionStringOptionValue(requestedModelSelection, "contextWindow") ?? "1m");
+      const shouldRestartForModelSelectionChange =
+        (preferredProvider === "claudeAgent" &&
+          requestedModelSelection !== undefined &&
+          !Equal.equals(previousModelSelection, requestedModelSelection)) ||
+        codexContextWindowChanged;
 
       if (
         !runtimeModeChanged &&

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -282,7 +282,7 @@ validationLayer("CodexAdapterLive validation", (it) => {
         binaryPath: "codex",
         cwd: process.cwd(),
         launchArgs: "",
-        appServerArgs: ["-c", "model_context_window=258400"],
+        appServerArgs: [],
         model: "gpt-5.3-codex",
         providerInstanceId: ProviderInstanceId.make("codex"),
         serviceTier: "priority",
@@ -394,6 +394,8 @@ sessionErrorLayer("CodexAdapterLive session errors", (it) => {
       NodeAssert.deepStrictEqual(runtime.options.appServerArgs, [
         "-c",
         "model_context_window=1000000",
+        "-c",
+        "model_auto_compact_token_limit=900000",
       ]);
     }).pipe(Effect.provide(layer));
   });

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -271,7 +271,7 @@ validationLayer("CodexAdapterLive validation", (it) => {
       yield* adapter.startSession({
         provider: ProviderDriverKind.make("codex"),
         threadId: asThreadId("thread-1"),
-        modelSelection: createModelSelection(ProviderInstanceId.make("codex"), "gpt-5.3-codex", [
+        modelSelection: createModelSelection(ProviderInstanceId.make("codex"), "gpt-5.6-sol", [
           { id: "serviceTier", value: "priority" },
           { id: "contextWindow", value: "258k" },
         ]),
@@ -283,12 +283,33 @@ validationLayer("CodexAdapterLive validation", (it) => {
         cwd: process.cwd(),
         launchArgs: "",
         appServerArgs: [],
-        model: "gpt-5.3-codex",
+        model: "gpt-5.6-sol",
         providerInstanceId: ProviderInstanceId.make("codex"),
         serviceTier: "priority",
         threadId: asThreadId("thread-1"),
         runtimeMode: "full-access",
       });
+    }),
+  );
+
+  it.effect("ignores 1m context for unsupported codex models", () =>
+    Effect.gen(function* () {
+      validationRuntimeFactory.factory.mockClear();
+      const adapter = yield* CodexAdapter;
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("codex"),
+        threadId: asThreadId("thread-unsupported-context"),
+        modelSelection: createModelSelection(ProviderInstanceId.make("codex"), "gpt-5.5", [
+          { id: "contextWindow", value: "1m" },
+        ]),
+        runtimeMode: "full-access",
+      });
+
+      NodeAssert.deepStrictEqual(
+        validationRuntimeFactory.factory.mock.calls[0]?.[0]?.appServerArgs,
+        [],
+      );
     }),
   );
 });
@@ -385,6 +406,7 @@ sessionErrorLayer("CodexAdapterLive session errors", (it) => {
       yield* adapter.startSession({
         provider: ProviderDriverKind.make("codex"),
         threadId: asThreadId("sess-launch-args"),
+        modelSelection: createModelSelection(ProviderInstanceId.make("codex"), "gpt-5.6-sol", []),
         runtimeMode: "full-access",
       });
 

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -273,6 +273,7 @@ validationLayer("CodexAdapterLive validation", (it) => {
         threadId: asThreadId("thread-1"),
         modelSelection: createModelSelection(ProviderInstanceId.make("codex"), "gpt-5.3-codex", [
           { id: "serviceTier", value: "priority" },
+          { id: "contextWindow", value: "258k" },
         ]),
         runtimeMode: "full-access",
       });
@@ -281,6 +282,7 @@ validationLayer("CodexAdapterLive validation", (it) => {
         binaryPath: "codex",
         cwd: process.cwd(),
         launchArgs: "",
+        appServerArgs: ["-c", "model_context_window=258400"],
         model: "gpt-5.3-codex",
         providerInstanceId: ProviderInstanceId.make("codex"),
         serviceTier: "priority",
@@ -361,7 +363,7 @@ sessionErrorLayer("CodexAdapterLive session errors", (it) => {
     }),
   );
 
-  it.effect("passes configured launch args into the session runtime", () => {
+  it.effect("passes launch args and default context into the session runtime", () => {
     const runtimeFactory = makeRuntimeFactory();
     const layer = Layer.effect(
       CodexAdapter,
@@ -389,6 +391,10 @@ sessionErrorLayer("CodexAdapterLive session errors", (it) => {
       const runtime = runtimeFactory.lastRuntime;
       NodeAssert.ok(runtime);
       NodeAssert.equal(runtime.options.launchArgs, "--strict-config --enable foo");
+      NodeAssert.deepStrictEqual(runtime.options.appServerArgs, [
+        "-c",
+        "model_context_window=1000000",
+      ]);
     }).pipe(Effect.provide(layer));
   });
 

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1668,8 +1668,14 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
             : undefined;
         const mcpSession = McpProviderSession.readMcpProviderSession(input.threadId);
         const appServerArgs = [
-          "-c",
-          `model_context_window=${contextWindow === "258k" ? 258_400 : 1_000_000}`,
+          ...(contextWindow === "258k"
+            ? []
+            : [
+                "-c",
+                "model_context_window=1000000",
+                "-c",
+                "model_auto_compact_token_limit=900000",
+              ]),
           ...(mcpSession
             ? [
                 "-c",

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1662,13 +1662,30 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           input.modelSelection?.instanceId === boundInstanceId
             ? getCodexServiceTierOptionValue(input.modelSelection)
             : undefined;
+        const contextWindow =
+          input.modelSelection?.instanceId === boundInstanceId
+            ? getModelSelectionStringOptionValue(input.modelSelection, "contextWindow")
+            : undefined;
         const mcpSession = McpProviderSession.readMcpProviderSession(input.threadId);
+        const appServerArgs = [
+          "-c",
+          `model_context_window=${contextWindow === "258k" ? 258_400 : 1_000_000}`,
+          ...(mcpSession
+            ? [
+                "-c",
+                `mcp_servers.t3-code.url=${mcpSession.endpoint}`,
+                "-c",
+                'mcp_servers.t3-code.bearer_token_env_var="T3_MCP_BEARER_TOKEN"',
+              ]
+            : []),
+        ];
         const runtimeInput: CodexSessionRuntimeOptions = {
           threadId: input.threadId,
           providerInstanceId: boundInstanceId,
           cwd: input.cwd ?? process.cwd(),
           binaryPath: codexConfig.binaryPath,
           launchArgs: resolveCodexLaunchArgs(codexConfig.launchArgs, options?.environment),
+          appServerArgs,
           ...(options?.environment ? { environment: options.environment } : {}),
           ...(codexConfig.homePath ? { homePath: codexConfig.homePath } : {}),
           ...(isCodexResumeCursorSchema(input.resumeCursor)
@@ -1685,12 +1702,6 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
                   ...(options?.environment ?? process.env),
                   T3_MCP_BEARER_TOKEN: mcpSession.authorizationHeader.replace(/^Bearer\s+/, ""),
                 },
-                appServerArgs: [
-                  "-c",
-                  `mcp_servers.t3-code.url=${mcpSession.endpoint}`,
-                  "-c",
-                  'mcp_servers.t3-code.bearer_token_env_var="T3_MCP_BEARER_TOKEN"',
-                ],
               }
             : {}),
         };

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -40,7 +40,10 @@ import * as CodexErrors from "effect-codex-app-server/errors";
 import * as EffectCodexSchema from "effect-codex-app-server/schema";
 
 import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
-import { getCodexServiceTierOptionValue } from "../../codexModelOptions.ts";
+import {
+  getCodexServiceTierOptionValue,
+  supportsCodexLongContext,
+} from "../../codexModelOptions.ts";
 import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
 
 import {
@@ -1662,20 +1665,15 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           input.modelSelection?.instanceId === boundInstanceId
             ? getCodexServiceTierOptionValue(input.modelSelection)
             : undefined;
-        const contextWindow =
-          input.modelSelection?.instanceId === boundInstanceId
-            ? getModelSelectionStringOptionValue(input.modelSelection, "contextWindow")
-            : undefined;
+        const useLongContext =
+          input.modelSelection?.instanceId === boundInstanceId &&
+          supportsCodexLongContext(input.modelSelection.model) &&
+          getModelSelectionStringOptionValue(input.modelSelection, "contextWindow") !== "258k";
         const mcpSession = McpProviderSession.readMcpProviderSession(input.threadId);
         const appServerArgs = [
-          ...(contextWindow === "258k"
-            ? []
-            : [
-                "-c",
-                "model_context_window=1000000",
-                "-c",
-                "model_auto_compact_token_limit=900000",
-              ]),
+          ...(useLongContext
+            ? ["-c", "model_context_window=1000000", "-c", "model_auto_compact_token_limit=900000"]
+            : []),
           ...(mcpSession
             ? [
                 "-c",

--- a/apps/server/src/provider/Layers/CodexProvider.test.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.test.ts
@@ -1,10 +1,23 @@
 import { assert, it } from "@effect/vitest";
 
+import { supportsCodexLongContext } from "../../codexModelOptions.ts";
 import {
+  appendCustomCodexModels,
   applyPreferredCodexDefaultModel,
   isLegacyCodexModel,
   mapCodexModelCapabilities,
 } from "./CodexProvider.ts";
+
+it.each([
+  ["gpt-5.4", true],
+  ["gpt-5.6-luna", true],
+  ["gpt-5.6-terra", true],
+  ["gpt-5.6-sol", true],
+  ["gpt-5.5", false],
+  ["custom-model", false],
+] as const)("maps long context support for %s", (model, expected) => {
+  assert.equal(supportsCodexLongContext(model), expected);
+});
 
 it("keeps only the GPT-5.6 Codex family out of legacy models", () => {
   assert.deepStrictEqual(
@@ -172,4 +185,33 @@ it("ignores custom models that shadow a preferred slug", () => {
   ]);
 
   assert.deepStrictEqual(models.find((model) => model.isDefault)?.slug, "gpt-5.4");
+});
+
+it("keeps long context off custom models", () => {
+  const models = appendCustomCodexModels(
+    [
+      {
+        slug: "gpt-5.6-sol",
+        name: "GPT-5.6-Sol",
+        isCustom: false,
+        capabilities: {
+          optionDescriptors: [
+            {
+              id: "contextWindow",
+              label: "Context Window",
+              type: "select",
+              options: [],
+            },
+            { id: "serviceTier", label: "Service Tier", type: "select", options: [] },
+          ],
+        },
+      },
+    ],
+    ["custom-model"],
+  );
+
+  assert.deepStrictEqual(
+    models[1]?.capabilities?.optionDescriptors?.map(({ id }) => id),
+    ["serviceTier"],
+  );
 });

--- a/apps/server/src/provider/Layers/CodexProvider.test.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.test.ts
@@ -28,9 +28,9 @@ it("maps current Codex model capability fields", () => {
     description: "Test model",
     displayName: "GPT Test",
     hidden: false,
-    id: "gpt-test",
+    id: "gpt-5.6-luna",
     isDefault: true,
-    model: "gpt-test",
+    model: "gpt-5.6-luna",
     defaultServiceTier: "flex",
     serviceTiers: [
       {
@@ -101,9 +101,9 @@ it("uses standard routing when the catalog has no default service tier", () => {
     description: "Test model",
     displayName: "GPT Test",
     hidden: false,
-    id: "gpt-test",
+    id: "gpt-5.5",
     isDefault: true,
-    model: "gpt-test",
+    model: "gpt-5.5",
     serviceTiers: [
       {
         id: "priority",
@@ -128,16 +128,6 @@ it("uses standard routing when the catalog has no default service tier", () => {
         },
       ],
       currentValue: "default",
-    },
-    {
-      id: "contextWindow",
-      label: "Context Window",
-      type: "select",
-      options: [
-        { id: "258k", label: "258k" },
-        { id: "1m", label: "1M", isDefault: true },
-      ],
-      currentValue: "1m",
     },
   ]);
 });

--- a/apps/server/src/provider/Layers/CodexProvider.test.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.test.ts
@@ -80,6 +80,16 @@ it("maps current Codex model capability fields", () => {
       ],
       currentValue: "flex",
     },
+    {
+      id: "contextWindow",
+      label: "Context Window",
+      type: "select",
+      options: [
+        { id: "258k", label: "258k" },
+        { id: "1m", label: "1M", isDefault: true },
+      ],
+      currentValue: "1m",
+    },
   ]);
 });
 
@@ -118,6 +128,16 @@ it("uses standard routing when the catalog has no default service tier", () => {
         },
       ],
       currentValue: "default",
+    },
+    {
+      id: "contextWindow",
+      label: "Context Window",
+      type: "select",
+      options: [
+        { id: "258k", label: "258k" },
+        { id: "1m", label: "1M", isDefault: true },
+      ],
+      currentValue: "1m",
     },
   ]);
 });

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -238,7 +238,7 @@ export function applyPreferredCodexDefaultModel(
   });
 }
 
-function appendCustomCodexModels(
+export function appendCustomCodexModels(
   models: ReadonlyArray<ServerProviderModel>,
   customModels: ReadonlyArray<string>,
 ): ReadonlyArray<ServerProviderModel> {
@@ -248,6 +248,14 @@ function appendCustomCodexModels(
 
   const seen = new Set(models.map((model) => model.slug));
   const fallbackCapabilities = models.find((model) => model.capabilities)?.capabilities ?? null;
+  const customCapabilities = fallbackCapabilities
+    ? {
+        ...fallbackCapabilities,
+        optionDescriptors: fallbackCapabilities.optionDescriptors?.filter(
+          (descriptor) => descriptor.id !== "contextWindow",
+        ),
+      }
+    : null;
   const customEntries: ServerProviderModel[] = [];
   for (const rawModel of customModels) {
     const slug = rawModel.trim();
@@ -259,7 +267,7 @@ function appendCustomCodexModels(
       slug,
       name: slug,
       isCustom: true,
-      capabilities: fallbackCapabilities,
+      capabilities: customCapabilities,
     });
   }
   return customEntries.length === 0 ? models : [...models, ...customEntries];

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -26,6 +26,7 @@ import { PREFERRED_DEFAULT_CODEX_MODELS, ServerSettingsError } from "@t3tools/co
 
 import { createModelCapabilities } from "@t3tools/shared/model";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
+import { supportsCodexLongContext } from "../../codexModelOptions.ts";
 import { codexAppServerArgs, resolveCodexLaunchArgs } from "./codexLaunchArgs.ts";
 import {
   AUTH_PROBE_TIMEOUT_MS,
@@ -174,16 +175,18 @@ export function mapCodexModelCapabilities(
       currentValue: defaultServiceTier,
     });
   }
-  optionDescriptors.push({
-    id: "contextWindow",
-    label: "Context Window",
-    type: "select",
-    options: [
-      { id: "258k", label: "258k" },
-      { id: "1m", label: "1M", isDefault: true },
-    ],
-    currentValue: "1m",
-  });
+  if (supportsCodexLongContext(model.model)) {
+    optionDescriptors.push({
+      id: "contextWindow",
+      label: "Context Window",
+      type: "select",
+      options: [
+        { id: "258k", label: "258k" },
+        { id: "1m", label: "1M", isDefault: true },
+      ],
+      currentValue: "1m",
+    });
+  }
 
   return createModelCapabilities({
     optionDescriptors,

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -174,6 +174,16 @@ export function mapCodexModelCapabilities(
       currentValue: defaultServiceTier,
     });
   }
+  optionDescriptors.push({
+    id: "contextWindow",
+    label: "Context Window",
+    type: "select",
+    options: [
+      { id: "258k", label: "258k" },
+      { id: "1m", label: "1M", isDefault: true },
+    ],
+    currentValue: "1m",
+  });
 
   return createModelCapabilities({
     optionDescriptors,


### PR DESCRIPTION
## What changed

- Added a Codex context-window selector with 258k and 1M choices for GPT-5.4 and GPT-5.6 Luna, Terra, and Sol.
- Made 1M the default for those supported models.
- Started 1M sessions with model_context_window=1000000 and model_auto_compact_token_limit=900000.
- Kept unsupported and custom models on native Codex context settings with no context selector.
- Restarted and resumed recovered Codex sessions when the context choice changes.

The existing model-option UI renders this on web, desktop, and mobile. No client component, layout, style, or motion changed.

## Why

T3 Code had no Codex context choice and could keep supported models on the native 258k window. Applying 1M to every Codex model would also expose a control that some models cannot honor.

## Verification

- 87 focused server tests passed.
- Server typecheck passed.
- Changed files pass lint and format checks.
- Regression coverage includes all supported slugs, unsupported models, custom models, launch flags, and recovered sessions.
- Independent read-only review found no remaining issues.

Built with GPT-5.6 Sol in the Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 1M context window support for Codex models
> - Introduces `LONG_CONTEXT_CODEX_MODELS` allowlist and `supportsCodexLongContext()` in [codexModelOptions.ts](https://github.com/pingdotgg/t3code/pull/7190/files#diff-b5ac87e07f91806c157713a1a298d8bf691586b63cb0503b3fb6b5114c60f273) to identify models that support long context (`gpt-5.4`, `gpt-5.6-luna`, `gpt-5.6-terra`, `gpt-5.6-sol`).
> - Adds a `contextWindow` select option (choices: `258k` / `1m`, default `1m`) to capability responses for supported models in [CodexProvider.ts](https://github.com/pingdotgg/t3code/pull/7190/files#diff-c0fb5ae851f722b7ec74cc0b9dab393a72637319c70756f8532c0a4e73ccae53); custom models are excluded.
> - Passes `model_context_window=1000000` and `model_auto_compact_token_limit=900000` as `appServerArgs` when starting a session with a supported model unless `258k` is explicitly selected in [CodexAdapter.ts](https://github.com/pingdotgg/t3code/pull/7190/files#diff-f37bcac225467446dcf6198df38d357c15304b19eebacbdcdea70047f507707d).
> - `ProviderCommandReactor` now restarts an existing Codex session when the `contextWindow` option changes between `258k` and `1m`.
> - Behavioral Change: supported Codex models default to 1M context; sessions will restart if the context window value changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8577655.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->