### PR TITLE
fix(server): persist late Claude tool results after turn finalize

### DIFF
--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -338,6 +338,89 @@ describe("buildThreadFeed", () => {
     expect(group.activities[0]?.id).toBe("tool-late-updated");
   });
 
+  it("merges a late tool result onto a non-adjacent completed work-log row", () => {
+    const thread = makeThread({
+      id: ThreadId.make("thread-late-multi-tool"),
+      projectId: ProjectId.make("project-1"),
+      title: "Late multi-tool result",
+      latestTurn: {
+        turnId: TurnId.make("turn-1"),
+        state: "completed",
+        requestedAt: "2026-04-01T00:00:00.000Z",
+        startedAt: "2026-04-01T00:00:01.000Z",
+        completedAt: "2026-04-01T00:00:04.000Z",
+        assistantMessageId: null,
+      },
+      activities: [
+        makeActivity({
+          id: EventId.make("tool-a-complete"),
+          kind: "tool.completed",
+          tone: "tool",
+          summary: "Grep",
+          createdAt: "2026-04-01T00:00:01.000Z",
+          turnId: TurnId.make("turn-1"),
+          payload: {
+            title: "Grep",
+            itemType: "dynamic_tool_call",
+            data: {
+              toolCallId: "tool-a",
+              toolName: "Grep",
+              input: { pattern: "foo" },
+            },
+          },
+        }),
+        makeActivity({
+          id: EventId.make("tool-b-complete"),
+          kind: "tool.completed",
+          tone: "tool",
+          summary: "Read File",
+          createdAt: "2026-04-01T00:00:02.000Z",
+          turnId: TurnId.make("turn-1"),
+          payload: {
+            title: "Read File",
+            itemType: "dynamic_tool_call",
+            data: {
+              toolCallId: "tool-b",
+              toolName: "Read",
+              input: { path: "/tmp/a.ts" },
+            },
+          },
+        }),
+        makeActivity({
+          id: EventId.make("tool-a-late"),
+          kind: "tool.updated",
+          tone: "tool",
+          summary: "Grep",
+          createdAt: "2026-04-01T00:00:03.000Z",
+          turnId: TurnId.make("turn-1"),
+          payload: {
+            title: "Grep",
+            itemType: "dynamic_tool_call",
+            status: "completed",
+            data: {
+              toolCallId: "tool-a",
+              toolName: "Grep",
+              input: { pattern: "foo" },
+              result: { content: "src/example.ts:1:foo" },
+            },
+          },
+        }),
+      ],
+    });
+
+    const feed = buildThreadFeed(thread);
+    const group = feed[0];
+    expect(group).toMatchObject({ type: "activity-group" });
+    if (!group || group.type !== "activity-group") {
+      return;
+    }
+
+    expect(group.activities).toHaveLength(2);
+    expect(new Set(group.activities.map((activity) => activity.id))).toEqual(
+      new Set(["tool-a-late", "tool-b-complete"]),
+    );
+  });
+
   it("keeps MCP inputs available to expanded mobile work rows", () => {
     const turnId = TurnId.make("turn-mcp");
     const thread = makeThread({

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -415,10 +415,11 @@ describe("buildThreadFeed", () => {
       return;
     }
 
-    expect(group.activities).toHaveLength(2);
-    expect(new Set(group.activities.map((activity) => activity.id))).toEqual(
-      new Set(["tool-a-late", "tool-b-complete"]),
-    );
+    expect(group.activities.map((activity) => activity.id)).toEqual([
+      "tool-a-late",
+      "tool-b-complete",
+    ]);
+    expect(group.activities[0]?.createdAt).toBe("2026-04-01T00:00:01.000Z");
   });
 
   it("keeps MCP inputs available to expanded mobile work rows", () => {

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -274,6 +274,70 @@ describe("buildThreadFeed", () => {
     );
   });
 
+  it("merges a late tool result into the completed work-log row", () => {
+    const thread = makeThread({
+      id: ThreadId.make("thread-late-tool"),
+      projectId: ProjectId.make("project-1"),
+      title: "Late tool result",
+      latestTurn: {
+        turnId: TurnId.make("turn-1"),
+        state: "completed",
+        requestedAt: "2026-04-01T00:00:00.000Z",
+        startedAt: "2026-04-01T00:00:01.000Z",
+        completedAt: "2026-04-01T00:00:03.000Z",
+        assistantMessageId: null,
+      },
+      activities: [
+        makeActivity({
+          id: EventId.make("tool-force-complete"),
+          kind: "tool.completed",
+          tone: "tool",
+          summary: "Grep",
+          createdAt: "2026-04-01T00:00:01.000Z",
+          turnId: TurnId.make("turn-1"),
+          payload: {
+            title: "Grep",
+            itemType: "dynamic_tool_call",
+            data: {
+              toolCallId: "tool-late-1",
+              toolName: "Grep",
+              input: { pattern: "foo" },
+            },
+          },
+        }),
+        makeActivity({
+          id: EventId.make("tool-late-updated"),
+          kind: "tool.updated",
+          tone: "tool",
+          summary: "Grep",
+          createdAt: "2026-04-01T00:00:02.000Z",
+          turnId: TurnId.make("turn-1"),
+          payload: {
+            title: "Grep",
+            itemType: "dynamic_tool_call",
+            status: "completed",
+            data: {
+              toolCallId: "tool-late-1",
+              toolName: "Grep",
+              input: { pattern: "foo" },
+              result: { content: "src/example.ts:1:foo" },
+            },
+          },
+        }),
+      ],
+    });
+
+    const feed = buildThreadFeed(thread);
+    const group = feed[0];
+    expect(group).toMatchObject({ type: "activity-group" });
+    if (!group || group.type !== "activity-group") {
+      return;
+    }
+
+    expect(group.activities).toHaveLength(1);
+    expect(group.activities[0]?.id).toBe("tool-late-updated");
+  });
+
   it("keeps MCP inputs available to expanded mobile work rows", () => {
     const turnId = TurnId.make("turn-mcp");
     const thread = makeThread({

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -80,6 +80,7 @@ interface WorkLogEntry {
 interface DerivedWorkLogEntry extends WorkLogEntry {
   activityKind: OrchestrationThreadActivity["kind"];
   collapseKey?: string;
+  toolCallId?: string;
   /** Grouping key for subagent lifecycle rows (one row per agent). */
   taskId?: string;
 }
@@ -426,6 +427,10 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   if (requestKind) {
     entry.requestKind = requestKind;
   }
+  const toolCallId = extractToolCallId(payload);
+  if (toolCallId) {
+    entry.toolCallId = toolCallId;
+  }
   let toolLifecycleStatus = extractWorkLogToolLifecycleStatus(payload);
   if (!toolLifecycleStatus && activity.kind === "tool.completed") {
     toolLifecycleStatus = "completed";
@@ -484,7 +489,8 @@ function shouldCollapseToolLifecycleEntries(
     return false;
   }
   if (previous.activityKind === "tool.completed") {
-    return false;
+    // Same toolCallId after complete is a late result amendment, not a new call.
+    return previous.toolCallId !== undefined && previous.toolCallId === next.toolCallId;
   }
   return previous.collapseKey !== undefined && previous.collapseKey === next.collapseKey;
 }
@@ -533,6 +539,9 @@ function mergeChangedFiles(
 function deriveToolLifecycleCollapseKey(entry: DerivedWorkLogEntry): string | undefined {
   if (entry.activityKind !== "tool.updated" && entry.activityKind !== "tool.completed") {
     return undefined;
+  }
+  if (entry.toolCallId) {
+    return `tool:${entry.toolCallId}`;
   }
   const normalizedLabel = normalizeCompactToolLabel(entry.toolTitle ?? entry.label);
   const detail = entry.detail?.trim() ?? "";
@@ -913,6 +922,11 @@ function extractToolCommand(payload: Record<string, unknown> | null): {
 
 function extractToolTitle(payload: Record<string, unknown> | null): string | null {
   return asTrimmedString(payload?.title);
+}
+
+function extractToolCallId(payload: Record<string, unknown> | null): string | null {
+  const data = asRecord(payload?.data);
+  return asTrimmedString(data?.toolCallId);
 }
 
 function extractWorkLogToolLifecycleStatus(

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -478,7 +478,13 @@ function collapseDerivedWorkLogEntries(
     if (toolCallId !== undefined) {
       const existingIndex = toolRowIndex.get(toolCallId);
       if (existingIndex !== undefined) {
-        collapsed[existingIndex] = mergeDerivedWorkLogEntries(collapsed[existingIndex]!, entry);
+        const existing = collapsed[existingIndex]!;
+        // Keep the first row's createdAt so a late result does not sort
+        // past intervening tools or the assistant reply.
+        collapsed[existingIndex] = {
+          ...mergeDerivedWorkLogEntries(existing, entry),
+          createdAt: existing.createdAt,
+        };
         continue;
       }
     }

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -452,6 +452,7 @@ function collapseDerivedWorkLogEntries(
   // Subagent rows collapse by identity, not adjacency (quiet-timeline
   // guarantee; mirrors web's session-logic).
   const taskRowIndex = new Map<string, number>();
+  const toolRowIndex = new Map<string, number>();
   for (const entry of entries) {
     const isTaskRow =
       entry.taskId !== undefined &&
@@ -468,12 +469,32 @@ function collapseDerivedWorkLogEntries(
       collapsed.push(entry);
       continue;
     }
+    // Late tool_result after completeTurn force-completes every in-flight
+    // tool is not adjacent to its row. Merge by toolCallId, not adjacency.
+    const toolCallId =
+      entry.activityKind === "tool.updated" || entry.activityKind === "tool.completed"
+        ? entry.toolCallId
+        : undefined;
+    if (toolCallId !== undefined) {
+      const existingIndex = toolRowIndex.get(toolCallId);
+      if (existingIndex !== undefined) {
+        collapsed[existingIndex] = mergeDerivedWorkLogEntries(collapsed[existingIndex]!, entry);
+        continue;
+      }
+    }
     const previous = collapsed.at(-1);
     if (previous && shouldCollapseToolLifecycleEntries(previous, entry)) {
-      collapsed[collapsed.length - 1] = mergeDerivedWorkLogEntries(previous, entry);
+      const merged = mergeDerivedWorkLogEntries(previous, entry);
+      collapsed[collapsed.length - 1] = merged;
+      if (merged.toolCallId !== undefined) {
+        toolRowIndex.set(merged.toolCallId, collapsed.length - 1);
+      }
       continue;
     }
     collapsed.push(entry);
+    if (toolCallId !== undefined) {
+      toolRowIndex.set(toolCallId, collapsed.length - 1);
+    }
   }
   return collapsed;
 }

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.activity.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.activity.test.ts
@@ -122,6 +122,35 @@ describe("runtimeEventToActivities tool streaming persistence", () => {
     expect(JSON.stringify(data).length).toBeLessThan(1_000);
   });
 
+  it("persists the full payload on a late terminal tool.updated", () => {
+    const event = {
+      ...base,
+      type: "item.updated",
+      eventId: EventId.make("evt-tool-late-updated"),
+      payload: {
+        itemType: "command_execution",
+        status: "completed",
+        title: "Grep",
+        data: {
+          toolName: "Grep",
+          input: { pattern: "foo" },
+          result: { type: "tool_result", tool_use_id: "tool-late-1", content: "src/a.ts:1:foo" },
+        },
+      },
+    } satisfies ProviderRuntimeEvent;
+
+    const activities = runtimeEventToActivities(event);
+
+    expect(activities).toHaveLength(1);
+    const payload = activities[0]?.payload as Record<string, unknown>;
+    expect(payload.status).toBe("completed");
+    expect(payload.data).toEqual({
+      toolName: "Grep",
+      input: { pattern: "foo" },
+      result: { type: "tool_result", tool_use_id: "tool-late-1", content: "src/a.ts:1:foo" },
+    });
+  });
+
   it("persists the full terminal payload on tool.completed", () => {
     const event = {
       ...base,

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -792,29 +792,32 @@ export function runtimeEventToActivities(
       // per chunk, so persisting `data` verbatim writes O(N²) bytes per tool
       // call into both the event store and the projection table. No reader
       // needs it: ws.ts and http.ts apply `projectActivityPayload` before any
-      // payload reaches a client. Persist the projected form for non-terminal
-      // updates; `item.completed` below still persists the full payload.
-      return [
-        projectActivityPayload({
-          id: event.eventId,
-          createdAt: event.createdAt,
-          tone: "tool",
-          kind: "tool.updated",
-          summary: event.payload.title ?? "Tool updated",
-          payload: {
-            itemType: event.payload.itemType,
-            ...(event.payload.status ? { status: event.payload.status } : {}),
-            ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
-            ...(event.payload.data !== undefined ? { data: event.payload.data } : {}),
-            ...(event.payload.agentId ? { agentId: event.payload.agentId } : {}),
-            ...(event.payload.parentToolUseId
-              ? { parentToolUseId: event.payload.parentToolUseId }
-              : {}),
-          },
-          turnId: toTurnId(event.turnId) ?? null,
-          ...maybeSequence,
-        }),
-      ];
+      // payload reaches a client. Persist the projected form for in-progress
+      // updates. A late terminal `item.updated` (status completed/failed after
+      // `completeTurn` already force-completed the item) is the only place the
+      // result exists — persist that payload in full, like `item.completed`.
+      const activity = {
+        id: event.eventId,
+        createdAt: event.createdAt,
+        tone: "tool" as const,
+        kind: "tool.updated" as const,
+        summary: event.payload.title ?? "Tool updated",
+        payload: {
+          itemType: event.payload.itemType,
+          ...(event.payload.status ? { status: event.payload.status } : {}),
+          ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
+          ...(event.payload.data !== undefined ? { data: event.payload.data } : {}),
+          ...(event.payload.agentId ? { agentId: event.payload.agentId } : {}),
+          ...(event.payload.parentToolUseId
+            ? { parentToolUseId: event.payload.parentToolUseId }
+            : {}),
+        },
+        turnId: toTurnId(event.turnId) ?? null,
+        ...maybeSequence,
+      };
+      const isTerminalUpdate =
+        event.payload.status === "completed" || event.payload.status === "failed";
+      return [isTerminalUpdate ? activity : projectActivityPayload(activity)];
     }
 
     case "item.completed": {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1267,6 +1267,7 @@ describe("ClaudeAdapterLive", () => {
             pattern: "foo",
             path: "src",
           },
+          toolCallId: "tool-grep-1",
         });
       }
 
@@ -1365,7 +1366,9 @@ describe("ClaudeAdapterLive", () => {
       harness.query.finish();
 
       const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
-      const turnCompletedIndex = runtimeEvents.findIndex((event) => event.type === "turn.completed");
+      const turnCompletedIndex = runtimeEvents.findIndex(
+        (event) => event.type === "turn.completed",
+      );
       assert.equal(turnCompletedIndex >= 0, true);
       assert.equal(
         runtimeEvents.some(
@@ -1375,8 +1378,7 @@ describe("ClaudeAdapterLive", () => {
       );
 
       const toolCompletions = runtimeEvents.filter(
-        (event) =>
-          event.type === "item.completed" && String(event.itemId) === "tool-late-1",
+        (event) => event.type === "item.completed" && String(event.itemId) === "tool-late-1",
       );
       assert.equal(toolCompletions.length, 1);
 
@@ -1390,6 +1392,7 @@ describe("ClaudeAdapterLive", () => {
             pattern: "foo",
             path: "src",
           },
+          toolCallId: "tool-late-1",
         });
       }
 
@@ -1407,6 +1410,10 @@ describe("ClaudeAdapterLive", () => {
         assert.equal(
           (lateUpdated.payload.data as { result?: { content?: string } }).result?.content,
           "src/example.ts:1:foo",
+        );
+        assert.equal(
+          (lateUpdated.payload.data as { toolCallId?: string }).toolCallId,
+          "tool-late-1",
         );
       }
 
@@ -1496,7 +1503,9 @@ describe("ClaudeAdapterLive", () => {
       harness.query.finish();
 
       const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
-      const turnCompletedIndex = runtimeEvents.findIndex((event) => event.type === "turn.completed");
+      const turnCompletedIndex = runtimeEvents.findIndex(
+        (event) => event.type === "turn.completed",
+      );
       const lateDelta = runtimeEvents.find(
         (event, index) =>
           index > turnCompletedIndex &&
@@ -1601,7 +1610,9 @@ describe("ClaudeAdapterLive", () => {
       harness.query.finish();
 
       const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
-      const turnCompletedIndex = runtimeEvents.findIndex((event) => event.type === "turn.completed");
+      const turnCompletedIndex = runtimeEvents.findIndex(
+        (event) => event.type === "turn.completed",
+      );
       const planUpdated = runtimeEvents.find(
         (event, index) => index > turnCompletedIndex && event.type === "turn.plan.updated",
       );
@@ -1616,183 +1627,189 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
-  it.effect("does not throw when a tool_result arrives for an unknown toolUseId after finalize", () => {
-    const harness = makeHarness();
-    return Effect.gen(function* () {
-      const adapter = yield* ClaudeAdapter;
+  it.effect(
+    "does not throw when a tool_result arrives for an unknown toolUseId after finalize",
+    () => {
+      const harness = makeHarness();
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
 
-      const runtimeEventsFiber = yield* adapter.streamEvents.pipe(
-        Stream.takeUntil((event) => event.type === "session.exited"),
-        Stream.runCollect,
-        Effect.forkChild,
+        const runtimeEventsFiber = yield* adapter.streamEvents.pipe(
+          Stream.takeUntil((event) => event.type === "session.exited"),
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+
+        const session = yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          runtimeMode: "full-access",
+        });
+
+        yield* adapter.sendTurn({
+          threadId: session.threadId,
+          input: "hello",
+          attachments: [],
+        });
+
+        harness.query.emit({
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          errors: [],
+          session_id: "sdk-session-unknown-tool-result",
+          uuid: "result-unknown-tool",
+        } as unknown as SDKMessage);
+
+        harness.query.emit({
+          type: "user",
+          session_id: "sdk-session-unknown-tool-result",
+          uuid: "user-unknown-tool-result",
+          parent_tool_use_id: null,
+          message: {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "tool-unknown-1",
+                content: "should not be attached",
+              },
+            ],
+          },
+        } as unknown as SDKMessage);
+
+        harness.query.finish();
+
+        const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+        assert.equal(
+          runtimeEvents.some(
+            (event) =>
+              (event.type === "item.started" ||
+                event.type === "item.updated" ||
+                event.type === "item.completed") &&
+              String(event.itemId) === "tool-unknown-1",
+          ),
+          false,
+        );
+        assert.equal(
+          runtimeEvents.some(
+            (event) =>
+              event.type === "item.completed" &&
+              (event.payload.data as { result?: { tool_use_id?: string } } | undefined)?.result
+                ?.tool_use_id === "tool-unknown-1",
+          ),
+          false,
+        );
+      }).pipe(
+        Effect.provideService(Random.Random, makeDeterministicRandomService()),
+        Effect.provide(harness.layer),
       );
+    },
+  );
 
-      const session = yield* adapter.startSession({
-        threadId: THREAD_ID,
-        provider: ProviderDriverKind.make("claudeAgent"),
-        runtimeMode: "full-access",
-      });
+  it.effect(
+    "still completes an in-flight tool when tool_result arrives before completeTurn",
+    () => {
+      const harness = makeHarness();
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
 
-      yield* adapter.sendTurn({
-        threadId: session.threadId,
-        input: "hello",
-        attachments: [],
-      });
+        const runtimeEventsFiber = yield* adapter.streamEvents.pipe(
+          Stream.takeUntil((event) => event.type === "session.exited"),
+          Stream.runCollect,
+          Effect.forkChild,
+        );
 
-      harness.query.emit({
-        type: "result",
-        subtype: "success",
-        is_error: false,
-        errors: [],
-        session_id: "sdk-session-unknown-tool-result",
-        uuid: "result-unknown-tool",
-      } as unknown as SDKMessage);
+        const session = yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          runtimeMode: "full-access",
+        });
 
-      harness.query.emit({
-        type: "user",
-        session_id: "sdk-session-unknown-tool-result",
-        uuid: "user-unknown-tool-result",
-        parent_tool_use_id: null,
-        message: {
-          role: "user",
-          content: [
-            {
-              type: "tool_result",
-              tool_use_id: "tool-unknown-1",
-              content: "should not be attached",
-            },
-          ],
-        },
-      } as unknown as SDKMessage);
+        const turn = yield* adapter.sendTurn({
+          threadId: session.threadId,
+          input: "hello",
+          attachments: [],
+        });
 
-      harness.query.finish();
-
-      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
-      assert.equal(
-        runtimeEvents.some(
-          (event) =>
-            (event.type === "item.started" ||
-              event.type === "item.updated" ||
-              event.type === "item.completed") &&
-            String(event.itemId) === "tool-unknown-1",
-        ),
-        false,
-      );
-      assert.equal(
-        runtimeEvents.some(
-          (event) =>
-            event.type === "item.completed" &&
-            (event.payload.data as { result?: { tool_use_id?: string } } | undefined)?.result
-              ?.tool_use_id === "tool-unknown-1",
-        ),
-        false,
-      );
-    }).pipe(
-      Effect.provideService(Random.Random, makeDeterministicRandomService()),
-      Effect.provide(harness.layer),
-    );
-  });
-
-  it.effect("still completes an in-flight tool when tool_result arrives before completeTurn", () => {
-    const harness = makeHarness();
-    return Effect.gen(function* () {
-      const adapter = yield* ClaudeAdapter;
-
-      const runtimeEventsFiber = yield* adapter.streamEvents.pipe(
-        Stream.takeUntil((event) => event.type === "session.exited"),
-        Stream.runCollect,
-        Effect.forkChild,
-      );
-
-      const session = yield* adapter.startSession({
-        threadId: THREAD_ID,
-        provider: ProviderDriverKind.make("claudeAgent"),
-        runtimeMode: "full-access",
-      });
-
-      const turn = yield* adapter.sendTurn({
-        threadId: session.threadId,
-        input: "hello",
-        attachments: [],
-      });
-
-      harness.query.emit({
-        type: "stream_event",
-        session_id: "sdk-session-happy-tool-result",
-        uuid: "stream-happy-tool-start",
-        parent_tool_use_id: null,
-        event: {
-          type: "content_block_start",
-          index: 0,
-          content_block: {
-            type: "tool_use",
-            id: "tool-happy-1",
-            name: "Grep",
-            input: {
-              pattern: "bar",
-              path: "src",
+        harness.query.emit({
+          type: "stream_event",
+          session_id: "sdk-session-happy-tool-result",
+          uuid: "stream-happy-tool-start",
+          parent_tool_use_id: null,
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: {
+              type: "tool_use",
+              id: "tool-happy-1",
+              name: "Grep",
+              input: {
+                pattern: "bar",
+                path: "src",
+              },
             },
           },
-        },
-      } as unknown as SDKMessage);
+        } as unknown as SDKMessage);
 
-      harness.query.emit({
-        type: "user",
-        session_id: "sdk-session-happy-tool-result",
-        uuid: "user-happy-tool-result",
-        parent_tool_use_id: null,
-        message: {
-          role: "user",
-          content: [
-            {
-              type: "tool_result",
-              tool_use_id: "tool-happy-1",
-              content: "src/example.ts:1:bar",
-            },
-          ],
-        },
-      } as unknown as SDKMessage);
+        harness.query.emit({
+          type: "user",
+          session_id: "sdk-session-happy-tool-result",
+          uuid: "user-happy-tool-result",
+          parent_tool_use_id: null,
+          message: {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "tool-happy-1",
+                content: "src/example.ts:1:bar",
+              },
+            ],
+          },
+        } as unknown as SDKMessage);
 
-      harness.query.emit({
-        type: "result",
-        subtype: "success",
-        is_error: false,
-        errors: [],
-        session_id: "sdk-session-happy-tool-result",
-        uuid: "result-happy-tool",
-      } as unknown as SDKMessage);
+        harness.query.emit({
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          errors: [],
+          session_id: "sdk-session-happy-tool-result",
+          uuid: "result-happy-tool",
+        } as unknown as SDKMessage);
 
-      harness.query.finish();
+        harness.query.finish();
 
-      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
-      const toolCompletions = runtimeEvents.filter(
-        (event) =>
-          event.type === "item.completed" && String(event.itemId) === "tool-happy-1",
-      );
-      assert.equal(toolCompletions.length, 1);
-
-      const toolCompleted = toolCompletions[0];
-      assert.equal(toolCompleted?.type, "item.completed");
-      if (toolCompleted?.type === "item.completed") {
-        assert.equal(String(toolCompleted.turnId), String(turn.turnId));
-        assert.equal(toolCompleted.payload.status, "completed");
-        assert.equal(
-          (toolCompleted.payload.data as { result?: { content?: string } }).result?.content,
-          "src/example.ts:1:bar",
+        const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+        const toolCompletions = runtimeEvents.filter(
+          (event) => event.type === "item.completed" && String(event.itemId) === "tool-happy-1",
         );
-      }
+        assert.equal(toolCompletions.length, 1);
 
-      const turnCompletedIndex = runtimeEvents.findIndex((event) => event.type === "turn.completed");
-      const toolCompletedIndex = runtimeEvents.findIndex(
-        (event) =>
-          event.type === "item.completed" && String(event.itemId) === "tool-happy-1",
+        const toolCompleted = toolCompletions[0];
+        assert.equal(toolCompleted?.type, "item.completed");
+        if (toolCompleted?.type === "item.completed") {
+          assert.equal(String(toolCompleted.turnId), String(turn.turnId));
+          assert.equal(toolCompleted.payload.status, "completed");
+          assert.equal(
+            (toolCompleted.payload.data as { result?: { content?: string } }).result?.content,
+            "src/example.ts:1:bar",
+          );
+        }
+
+        const turnCompletedIndex = runtimeEvents.findIndex(
+          (event) => event.type === "turn.completed",
+        );
+        const toolCompletedIndex = runtimeEvents.findIndex(
+          (event) => event.type === "item.completed" && String(event.itemId) === "tool-happy-1",
+        );
+        assert.equal(turnCompletedIndex > toolCompletedIndex, true);
+      }).pipe(
+        Effect.provideService(Random.Random, makeDeterministicRandomService()),
+        Effect.provide(harness.layer),
       );
-      assert.equal(turnCompletedIndex > toolCompletedIndex, true);
-    }).pipe(
-      Effect.provideService(Random.Random, makeDeterministicRandomService()),
-      Effect.provide(harness.layer),
-    );
-  });
+    },
+  );
 
   it.effect("falls back to a default plan step label for blank TodoWrite content", () => {
     const harness = makeHarness();

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1293,6 +1293,316 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("applies a late tool_result after completeTurn drains the in-flight tool", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const runtimeEventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "session.exited"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      const turn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "stream_event",
+        session_id: "sdk-session-late-tool-result",
+        uuid: "stream-late-tool-start",
+        parent_tool_use_id: null,
+        event: {
+          type: "content_block_start",
+          index: 0,
+          content_block: {
+            type: "tool_use",
+            id: "tool-late-1",
+            name: "Grep",
+            input: {
+              pattern: "foo",
+              path: "src",
+            },
+          },
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "sdk-session-late-tool-result",
+        uuid: "result-late-tool",
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "user",
+        session_id: "sdk-session-late-tool-result",
+        uuid: "user-late-tool-result",
+        parent_tool_use_id: null,
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool-late-1",
+              content: "src/example.ts:1:foo",
+            },
+          ],
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.finish();
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      const turnCompletedIndex = runtimeEvents.findIndex((event) => event.type === "turn.completed");
+      assert.equal(turnCompletedIndex >= 0, true);
+      assert.equal(
+        runtimeEvents.some(
+          (event, index) => event.type === "turn.started" && index > turnCompletedIndex,
+        ),
+        false,
+      );
+
+      const toolCompletions = runtimeEvents.filter(
+        (event) =>
+          event.type === "item.completed" && String(event.itemId) === "tool-late-1",
+      );
+      assert.equal(toolCompletions.length, 2);
+
+      const forceCompleted = toolCompletions[0];
+      assert.equal(forceCompleted?.type, "item.completed");
+      if (forceCompleted?.type === "item.completed") {
+        assert.equal(String(forceCompleted.turnId), String(turn.turnId));
+        assert.deepEqual(forceCompleted.payload.data, {
+          toolName: "Grep",
+          input: {
+            pattern: "foo",
+            path: "src",
+          },
+        });
+      }
+
+      const lateUpdated = runtimeEvents.find(
+        (event, index) =>
+          index > turnCompletedIndex &&
+          event.type === "item.updated" &&
+          (event.payload.data as { result?: { tool_use_id?: string } } | undefined)?.result
+            ?.tool_use_id === "tool-late-1",
+      );
+      assert.equal(lateUpdated?.type, "item.updated");
+      if (lateUpdated?.type === "item.updated") {
+        assert.equal(String(lateUpdated.turnId), String(turn.turnId));
+        assert.equal(
+          (lateUpdated.payload.data as { result?: { content?: string } }).result?.content,
+          "src/example.ts:1:foo",
+        );
+      }
+
+      const lateCompleted = toolCompletions[1];
+      assert.equal(lateCompleted?.type, "item.completed");
+      if (lateCompleted?.type === "item.completed") {
+        assert.equal(String(lateCompleted.turnId), String(turn.turnId));
+        assert.equal(lateCompleted.payload.status, "completed");
+        assert.equal(
+          (lateCompleted.payload.data as { result?: { content?: string } }).result?.content,
+          "src/example.ts:1:foo",
+        );
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("does not throw when a tool_result arrives for an unknown toolUseId after finalize", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const runtimeEventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "session.exited"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "sdk-session-unknown-tool-result",
+        uuid: "result-unknown-tool",
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "user",
+        session_id: "sdk-session-unknown-tool-result",
+        uuid: "user-unknown-tool-result",
+        parent_tool_use_id: null,
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool-unknown-1",
+              content: "should not be attached",
+            },
+          ],
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.finish();
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      assert.equal(
+        runtimeEvents.some(
+          (event) =>
+            (event.type === "item.started" ||
+              event.type === "item.updated" ||
+              event.type === "item.completed") &&
+            String(event.itemId) === "tool-unknown-1",
+        ),
+        false,
+      );
+      assert.equal(
+        runtimeEvents.some(
+          (event) =>
+            event.type === "item.completed" &&
+            (event.payload.data as { result?: { tool_use_id?: string } } | undefined)?.result
+              ?.tool_use_id === "tool-unknown-1",
+        ),
+        false,
+      );
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("still completes an in-flight tool when tool_result arrives before completeTurn", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const runtimeEventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "session.exited"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      const turn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "stream_event",
+        session_id: "sdk-session-happy-tool-result",
+        uuid: "stream-happy-tool-start",
+        parent_tool_use_id: null,
+        event: {
+          type: "content_block_start",
+          index: 0,
+          content_block: {
+            type: "tool_use",
+            id: "tool-happy-1",
+            name: "Grep",
+            input: {
+              pattern: "bar",
+              path: "src",
+            },
+          },
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "user",
+        session_id: "sdk-session-happy-tool-result",
+        uuid: "user-happy-tool-result",
+        parent_tool_use_id: null,
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool-happy-1",
+              content: "src/example.ts:1:bar",
+            },
+          ],
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "sdk-session-happy-tool-result",
+        uuid: "result-happy-tool",
+      } as unknown as SDKMessage);
+
+      harness.query.finish();
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      const toolCompletions = runtimeEvents.filter(
+        (event) =>
+          event.type === "item.completed" && String(event.itemId) === "tool-happy-1",
+      );
+      assert.equal(toolCompletions.length, 1);
+
+      const toolCompleted = toolCompletions[0];
+      assert.equal(toolCompleted?.type, "item.completed");
+      if (toolCompleted?.type === "item.completed") {
+        assert.equal(String(toolCompleted.turnId), String(turn.turnId));
+        assert.equal(toolCompleted.payload.status, "completed");
+        assert.equal(
+          (toolCompleted.payload.data as { result?: { content?: string } }).result?.content,
+          "src/example.ts:1:bar",
+        );
+      }
+
+      const turnCompletedIndex = runtimeEvents.findIndex((event) => event.type === "turn.completed");
+      const toolCompletedIndex = runtimeEvents.findIndex(
+        (event) =>
+          event.type === "item.completed" && String(event.itemId) === "tool-happy-1",
+      );
+      assert.equal(turnCompletedIndex > toolCompletedIndex, true);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("falls back to a default plan step label for blank TodoWrite content", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1378,7 +1378,7 @@ describe("ClaudeAdapterLive", () => {
         (event) =>
           event.type === "item.completed" && String(event.itemId) === "tool-late-1",
       );
-      assert.equal(toolCompletions.length, 2);
+      assert.equal(toolCompletions.length, 1);
 
       const forceCompleted = toolCompletions[0];
       assert.equal(forceCompleted?.type, "item.completed");
@@ -1403,21 +1403,212 @@ describe("ClaudeAdapterLive", () => {
       assert.equal(lateUpdated?.type, "item.updated");
       if (lateUpdated?.type === "item.updated") {
         assert.equal(String(lateUpdated.turnId), String(turn.turnId));
+        assert.equal(lateUpdated.payload.status, "completed");
         assert.equal(
           (lateUpdated.payload.data as { result?: { content?: string } }).result?.content,
           "src/example.ts:1:foo",
         );
       }
 
-      const lateCompleted = toolCompletions[1];
-      assert.equal(lateCompleted?.type, "item.completed");
-      if (lateCompleted?.type === "item.completed") {
-        assert.equal(String(lateCompleted.turnId), String(turn.turnId));
-        assert.equal(lateCompleted.payload.status, "completed");
-        assert.equal(
-          (lateCompleted.payload.data as { result?: { content?: string } }).result?.content,
-          "src/example.ts:1:foo",
-        );
+      assert.equal(
+        runtimeEvents.some(
+          (event, index) =>
+            index > turnCompletedIndex &&
+            event.type === "item.completed" &&
+            String(event.itemId) === "tool-late-1",
+        ),
+        false,
+      );
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("attributes late command output to the finalized tool's turn", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const runtimeEventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "session.exited"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      const turn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "stream_event",
+        session_id: "sdk-session-late-bash-result",
+        uuid: "stream-late-bash-start",
+        parent_tool_use_id: null,
+        event: {
+          type: "content_block_start",
+          index: 0,
+          content_block: {
+            type: "tool_use",
+            id: "tool-late-bash-1",
+            name: "Bash",
+            input: {
+              command: "ls",
+            },
+          },
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "sdk-session-late-bash-result",
+        uuid: "result-late-bash",
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "user",
+        session_id: "sdk-session-late-bash-result",
+        uuid: "user-late-bash-result",
+        parent_tool_use_id: null,
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool-late-bash-1",
+              content: "README.md",
+            },
+          ],
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.finish();
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      const turnCompletedIndex = runtimeEvents.findIndex((event) => event.type === "turn.completed");
+      const lateDelta = runtimeEvents.find(
+        (event, index) =>
+          index > turnCompletedIndex &&
+          event.type === "content.delta" &&
+          event.payload.streamKind === "command_output",
+      );
+      assert.equal(lateDelta?.type, "content.delta");
+      if (lateDelta?.type === "content.delta") {
+        assert.equal(String(lateDelta.turnId), String(turn.turnId));
+        assert.equal(String(lateDelta.itemId), "tool-late-bash-1");
+        assert.equal(lateDelta.payload.delta, "README.md");
+      }
+      assert.equal(
+        runtimeEvents.some(
+          (event, index) =>
+            index > turnCompletedIndex &&
+            event.type === "item.completed" &&
+            String(event.itemId) === "tool-late-bash-1",
+        ),
+        false,
+      );
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("attributes a late TaskCreate plan update to the finalized tool's turn", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const runtimeEventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "session.exited"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      const turn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "stream_event",
+        session_id: "sdk-session-late-task-create",
+        uuid: "stream-late-task-create-start",
+        parent_tool_use_id: null,
+        event: {
+          type: "content_block_start",
+          index: 0,
+          content_block: {
+            type: "tool_use",
+            id: "tool-late-task-1",
+            name: "TaskCreate",
+            input: {
+              subject: "Ship the fix",
+            },
+          },
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "sdk-session-late-task-create",
+        uuid: "result-late-task-create",
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "user",
+        session_id: "sdk-session-late-task-create",
+        uuid: "user-late-task-create-result",
+        parent_tool_use_id: null,
+        tool_use_result: {
+          task: {
+            id: "task-1",
+            subject: "Ship the fix",
+          },
+        },
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool-late-task-1",
+              content: "created",
+            },
+          ],
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.finish();
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      const turnCompletedIndex = runtimeEvents.findIndex((event) => event.type === "turn.completed");
+      const planUpdated = runtimeEvents.find(
+        (event, index) => index > turnCompletedIndex && event.type === "turn.plan.updated",
+      );
+      assert.equal(planUpdated?.type, "turn.plan.updated");
+      if (planUpdated?.type === "turn.plan.updated") {
+        assert.equal(String(planUpdated.turnId), String(turn.turnId));
+        assert.deepEqual(planUpdated.payload.plan, [{ step: "Ship the fix", status: "pending" }]);
       }
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -1467,6 +1467,18 @@ function toolResultStreamKind(itemType: CanonicalItemType): ClaudeToolResultStre
   }
 }
 
+function claudeToolEventData(
+  tool: Pick<ToolInFlight, "itemId" | "toolName" | "input">,
+  extra?: { readonly result?: Record<string, unknown> },
+): Record<string, unknown> {
+  return {
+    toolName: tool.toolName,
+    input: tool.input,
+    toolCallId: tool.itemId,
+    ...(extra?.result !== undefined ? { result: extra.result } : {}),
+  };
+}
+
 function rememberFinalizedToolAwaitingResult(
   tools: Map<string, FinalizedToolAwaitingResult>,
   entry: FinalizedToolAwaitingResult,
@@ -2345,10 +2357,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           status: status === "completed" ? "completed" : "failed",
           title: tool.title,
           ...(tool.detail ? { detail: tool.detail } : {}),
-          data: {
-            toolName: tool.toolName,
-            input: tool.input,
-          },
+          data: claudeToolEventData(tool),
         },
         providerRefs: nativeProviderRefs(context, {
           providerItemId: tool.itemId,
@@ -2583,10 +2592,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
             ...(nextTool.detail ? { detail: nextTool.detail } : {}),
             ...(nextTool.agentId ? { agentId: nextTool.agentId } : {}),
             ...(nextTool.parentToolUseId ? { parentToolUseId: nextTool.parentToolUseId } : {}),
-            data: {
-              toolName: nextTool.toolName,
-              input: nextTool.input,
-            },
+            data: claudeToolEventData(nextTool),
           },
           providerRefs: nativeProviderRefs(context, {
             providerItemId: nextTool.itemId,
@@ -2690,10 +2696,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           ...(tool.detail ? { detail: tool.detail } : {}),
           ...(tool.agentId ? { agentId: tool.agentId } : {}),
           ...(tool.parentToolUseId ? { parentToolUseId: tool.parentToolUseId } : {}),
-          data: {
-            toolName: tool.toolName,
-            input: toolInput,
-          },
+          data: claudeToolEventData(tool),
         },
         providerRefs: nativeProviderRefs(context, {
           providerItemId: tool.itemId,
@@ -2762,11 +2765,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         : finalized?.turnId;
       const itemStatus = toolResult.isError ? "failed" : "completed";
       const toolUseResult = readClaudeToolUseResult(message);
-      const toolData = {
-        toolName: tool.toolName,
-        input: tool.input,
-        result: toolResult.block,
-      };
+      const toolData = claudeToolEventData(tool, { result: toolResult.block });
 
       const updatedStamp = yield* makeEventStamp();
       yield* offerRuntimeEvent({

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -212,6 +212,14 @@ interface ToolInFlight {
   readonly parentToolUseId?: string;
 }
 
+/** Force-completed by completeTurn before the matching SDK tool_result arrived. */
+interface FinalizedToolAwaitingResult {
+  readonly tool: ToolInFlight;
+  readonly turnId: TurnId;
+}
+
+const MAX_FINALIZED_TOOLS_AWAITING_RESULT = 64;
+
 interface ClaudeTaskState {
   readonly id: string;
   subject: string;
@@ -260,6 +268,8 @@ interface ClaudeSessionContext {
     items: Array<unknown>;
   }>;
   readonly inFlightTools: Map<number, ToolInFlight>;
+  /** Late tool_result lookup after completeTurn drains inFlightTools. */
+  readonly finalizedToolsAwaitingResult: Map<string, FinalizedToolAwaitingResult>;
   readonly claudeTasks: Map<string, ClaudeTaskState>;
   readonly taskAgents: Map<string, ClaudeTaskAgentState>;
   /**
@@ -1457,6 +1467,21 @@ function toolResultStreamKind(itemType: CanonicalItemType): ClaudeToolResultStre
   }
 }
 
+function rememberFinalizedToolAwaitingResult(
+  tools: Map<string, FinalizedToolAwaitingResult>,
+  entry: FinalizedToolAwaitingResult,
+): void {
+  tools.delete(entry.tool.itemId);
+  tools.set(entry.tool.itemId, entry);
+  while (tools.size > MAX_FINALIZED_TOOLS_AWAITING_RESULT) {
+    const oldestKey = tools.keys().next().value;
+    if (oldestKey === undefined) {
+      return;
+    }
+    tools.delete(oldestKey);
+  }
+}
+
 function toolResultBlocksFromUserMessage(message: SDKMessage): Array<{
   readonly toolUseId: string;
   readonly block: Record<string, unknown>;
@@ -2303,7 +2328,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       return;
     }
 
-    for (const [index, tool] of context.inFlightTools.entries()) {
+    for (const tool of context.inFlightTools.values()) {
       const toolStamp = yield* makeEventStamp();
       yield* offerRuntimeEvent({
         type: "item.completed",
@@ -2332,7 +2357,10 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           payload: result ?? { status },
         },
       });
-      context.inFlightTools.delete(index);
+      rememberFinalizedToolAwaitingResult(context.finalizedToolsAwaitingResult, {
+        tool,
+        turnId: turnState.turnId,
+      });
     }
     // Clear any remaining stale entries (e.g. from interrupted content blocks)
     context.inFlightTools.clear();
@@ -2711,11 +2739,24 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       const toolEntry = Array.from(context.inFlightTools.entries()).find(
         ([, tool]) => tool.itemId === toolResult.toolUseId,
       );
-      if (!toolEntry) {
+      const finalized = toolEntry
+        ? undefined
+        : context.finalizedToolsAwaitingResult.get(toolResult.toolUseId);
+      const tool = toolEntry?.[1] ?? finalized?.tool;
+      if (!tool) {
+        yield* Effect.logWarning("claude.tool_result.unknown-tool-use", {
+          threadId: context.session.threadId,
+          toolUseId: toolResult.toolUseId,
+        });
         continue;
       }
 
-      const [index, tool] = toolEntry;
+      const index = toolEntry?.[0];
+      const eventTurnId = toolEntry
+        ? context.turnState
+          ? asCanonicalTurnId(context.turnState.turnId)
+          : undefined
+        : finalized?.turnId;
       const itemStatus = toolResult.isError ? "failed" : "completed";
       const toolUseResult = readClaudeToolUseResult(message);
       const toolData = {
@@ -2731,7 +2772,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         provider: PROVIDER,
         createdAt: updatedStamp.createdAt,
         threadId: context.session.threadId,
-        ...(context.turnState ? { turnId: asCanonicalTurnId(context.turnState.turnId) } : {}),
+        ...(eventTurnId ? { turnId: eventTurnId } : {}),
         itemId: asRuntimeItemId(tool.itemId),
         payload: {
           itemType: tool.itemType,
@@ -2785,7 +2826,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         provider: PROVIDER,
         createdAt: completedStamp.createdAt,
         threadId: context.session.threadId,
-        ...(context.turnState ? { turnId: asCanonicalTurnId(context.turnState.turnId) } : {}),
+        ...(eventTurnId ? { turnId: eventTurnId } : {}),
         itemId: asRuntimeItemId(tool.itemId),
         payload: {
           itemType: tool.itemType,
@@ -2854,7 +2895,10 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         });
       }
 
-      context.inFlightTools.delete(index);
+      if (index !== undefined) {
+        context.inFlightTools.delete(index);
+      }
+      context.finalizedToolsAwaitingResult.delete(tool.itemId);
     }
   });
 
@@ -3720,6 +3764,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       });
     }
 
+    context.finalizedToolsAwaitingResult.clear();
     sessions.delete(context.session.threadId);
   });
 
@@ -3801,6 +3846,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       const pendingApprovals = new Map<ApprovalRequestId, PendingApproval>();
       const pendingUserInputs = new Map<ApprovalRequestId, PendingUserInput>();
       const inFlightTools = new Map<number, ToolInFlight>();
+      const finalizedToolsAwaitingResult = new Map<string, FinalizedToolAwaitingResult>();
       const claudeTasks = new Map<string, ClaudeTaskState>();
       const taskAgents = new Map<string, ClaudeTaskAgentState>();
       const workflowMemberFingerprints = new Map<string, string>();
@@ -4264,6 +4310,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         pendingUserInputs,
         turns: [],
         inFlightTools,
+        finalizedToolsAwaitingResult,
         claudeTasks,
         taskAgents,
         workflowMemberFingerprints,

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -2193,6 +2193,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       readonly toolUseId: string;
       readonly rawMethod: string;
       readonly rawPayload: unknown;
+      readonly turnId?: TurnId;
     },
   ) {
     const plan = planStepsFromClaudeTasks(context.claudeTasks);
@@ -2200,6 +2201,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       return;
     }
 
+    const planTurnId = input.turnId ?? context.turnState?.turnId;
     const stamp = yield* makeEventStamp();
     yield* offerRuntimeEvent({
       type: "turn.plan.updated",
@@ -2207,7 +2209,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       provider: PROVIDER,
       createdAt: stamp.createdAt,
       threadId: context.session.threadId,
-      ...(context.turnState ? { turnId: asCanonicalTurnId(context.turnState.turnId) } : {}),
+      ...(planTurnId ? { turnId: asCanonicalTurnId(planTurnId) } : {}),
       payload: {
         explanation: "Claude Tasks",
         plan,
@@ -2752,6 +2754,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       }
 
       const index = toolEntry?.[0];
+      const alreadyCompleted = finalized !== undefined;
       const eventTurnId = toolEntry
         ? context.turnState
           ? asCanonicalTurnId(context.turnState.turnId)
@@ -2776,7 +2779,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         itemId: asRuntimeItemId(tool.itemId),
         payload: {
           itemType: tool.itemType,
-          status: toolResult.isError ? "failed" : "inProgress",
+          status: alreadyCompleted || toolResult.isError ? itemStatus : "inProgress",
           title: tool.title,
           ...(tool.detail ? { detail: tool.detail } : {}),
           ...(tool.agentId ? { agentId: tool.agentId } : {}),
@@ -2794,7 +2797,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       });
 
       const streamKind = toolResultStreamKind(tool.itemType);
-      if (streamKind && toolResult.text.length > 0 && context.turnState) {
+      if (streamKind && toolResult.text.length > 0 && eventTurnId) {
         const deltaStamp = yield* makeEventStamp();
         yield* offerRuntimeEvent({
           type: "content.delta",
@@ -2802,7 +2805,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           provider: PROVIDER,
           createdAt: deltaStamp.createdAt,
           threadId: context.session.threadId,
-          turnId: context.turnState.turnId,
+          turnId: eventTurnId,
           itemId: asRuntimeItemId(tool.itemId),
           payload: {
             streamKind,
@@ -2819,33 +2822,35 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         });
       }
 
-      const completedStamp = yield* makeEventStamp();
-      yield* offerRuntimeEvent({
-        type: "item.completed",
-        eventId: completedStamp.eventId,
-        provider: PROVIDER,
-        createdAt: completedStamp.createdAt,
-        threadId: context.session.threadId,
-        ...(eventTurnId ? { turnId: eventTurnId } : {}),
-        itemId: asRuntimeItemId(tool.itemId),
-        payload: {
-          itemType: tool.itemType,
-          status: itemStatus,
-          title: tool.title,
-          ...(tool.detail ? { detail: tool.detail } : {}),
-          ...(tool.agentId ? { agentId: tool.agentId } : {}),
-          ...(tool.parentToolUseId ? { parentToolUseId: tool.parentToolUseId } : {}),
-          data: toolData,
-        },
-        providerRefs: nativeProviderRefs(context, {
-          providerItemId: tool.itemId,
-        }),
-        raw: {
-          source: "claude.sdk.message",
-          method: "claude/user",
-          payload: message,
-        },
-      });
+      if (!alreadyCompleted) {
+        const completedStamp = yield* makeEventStamp();
+        yield* offerRuntimeEvent({
+          type: "item.completed",
+          eventId: completedStamp.eventId,
+          provider: PROVIDER,
+          createdAt: completedStamp.createdAt,
+          threadId: context.session.threadId,
+          ...(eventTurnId ? { turnId: eventTurnId } : {}),
+          itemId: asRuntimeItemId(tool.itemId),
+          payload: {
+            itemType: tool.itemType,
+            status: itemStatus,
+            title: tool.title,
+            ...(tool.detail ? { detail: tool.detail } : {}),
+            ...(tool.agentId ? { agentId: tool.agentId } : {}),
+            ...(tool.parentToolUseId ? { parentToolUseId: tool.parentToolUseId } : {}),
+            data: toolData,
+          },
+          providerRefs: nativeProviderRefs(context, {
+            providerItemId: tool.itemId,
+          }),
+          raw: {
+            source: "claude.sdk.message",
+            method: "claude/user",
+            payload: message,
+          },
+        });
+      }
 
       // The Workflow tool's result carries the run handles (runId, scriptPath,
       // transcriptDir, sessionUrl). Attach them to the workflow's task agent so
@@ -2892,6 +2897,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           toolUseId: tool.itemId,
           rawMethod: "claude/user",
           rawPayload: message,
+          ...(eventTurnId ? { turnId: eventTurnId } : {}),
         });
       }
 

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -1479,6 +1479,47 @@ describe("deriveWorkLogEntries", () => {
     expect(entries.map((entry) => entry.id)).toEqual(["tool-1-complete", "tool-2-complete"]);
   });
 
+  it("merges a late result into the completed row when toolCallId matches", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "tool-force-complete",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "tool.completed",
+        summary: "Grep",
+        payload: {
+          itemType: "dynamic_tool_call",
+          title: "Grep",
+          data: {
+            toolCallId: "tool-late-1",
+            toolName: "Grep",
+            input: { pattern: "foo" },
+          },
+        },
+      }),
+      makeActivity({
+        id: "tool-late-updated",
+        createdAt: "2026-02-23T00:00:03.000Z",
+        kind: "tool.updated",
+        summary: "Grep",
+        payload: {
+          itemType: "dynamic_tool_call",
+          title: "Grep",
+          status: "completed",
+          data: {
+            toolCallId: "tool-late-1",
+            toolName: "Grep",
+            input: { pattern: "foo" },
+            result: { content: "src/example.ts:1:foo" },
+          },
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.id).toBe("tool-late-updated");
+  });
+
   it("collapses same-timestamp lifecycle rows even when completed sorts before updated by id", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -1573,6 +1573,8 @@ describe("deriveWorkLogEntries", () => {
 
     const entries = deriveWorkLogEntries(activities);
     expect(entries.map((entry) => entry.id)).toEqual(["tool-a-late", "tool-b-complete"]);
+    expect(entries[0]?.createdAt).toBe("2026-02-23T00:00:02.000Z");
+    expect(entries[1]?.createdAt).toBe("2026-02-23T00:00:03.000Z");
   });
 
   it("collapses same-timestamp lifecycle rows even when completed sorts before updated by id", () => {

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -1520,6 +1520,61 @@ describe("deriveWorkLogEntries", () => {
     expect(entries[0]?.id).toBe("tool-late-updated");
   });
 
+  it("merges a late result onto a non-adjacent completed row when toolCallId matches", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "tool-a-complete",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "tool.completed",
+        summary: "Grep",
+        payload: {
+          itemType: "dynamic_tool_call",
+          title: "Grep",
+          data: {
+            toolCallId: "tool-a",
+            toolName: "Grep",
+            input: { pattern: "foo" },
+          },
+        },
+      }),
+      makeActivity({
+        id: "tool-b-complete",
+        createdAt: "2026-02-23T00:00:03.000Z",
+        kind: "tool.completed",
+        summary: "Read File",
+        payload: {
+          itemType: "dynamic_tool_call",
+          title: "Read File",
+          data: {
+            toolCallId: "tool-b",
+            toolName: "Read",
+            input: { path: "/tmp/a.ts" },
+          },
+        },
+      }),
+      makeActivity({
+        id: "tool-a-late",
+        createdAt: "2026-02-23T00:00:04.000Z",
+        kind: "tool.updated",
+        summary: "Grep",
+        payload: {
+          itemType: "dynamic_tool_call",
+          title: "Grep",
+          status: "completed",
+          data: {
+            toolCallId: "tool-a",
+            toolName: "Grep",
+            input: { pattern: "foo" },
+            result: { content: "src/example.ts:1:foo" },
+          },
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities);
+    expect(entries.map((entry) => entry.id)).toEqual(["tool-a-late", "tool-b-complete"]);
+  });
+
   it("collapses same-timestamp lifecycle rows even when completed sorts before updated by id", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -1003,7 +1003,13 @@ function collapseDerivedWorkLogEntries(
     if (toolCallId !== undefined) {
       const existingIndex = toolRowIndex.get(toolCallId);
       if (existingIndex !== undefined) {
-        collapsed[existingIndex] = mergeDerivedWorkLogEntries(collapsed[existingIndex]!, entry);
+        const existing = collapsed[existingIndex]!;
+        // Keep the first row's createdAt so a late result does not sort
+        // past intervening tools or the assistant reply.
+        collapsed[existingIndex] = {
+          ...mergeDerivedWorkLogEntries(existing, entry),
+          createdAt: existing.createdAt,
+        };
         continue;
       }
     }

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -943,6 +943,7 @@ function collapseDerivedWorkLogEntries(
   // contains or how their progress rows interleave (quiet-timeline
   // guarantee).
   const spawnRowIndex = new Map<string, number>();
+  const toolRowIndex = new Map<string, number>();
   // Batch membership is decided once, at the FIRST row seen for a taskId.
   // Claude background subagents settle between turns, so their completion
   // rows carry fresh synthetic turn ids (or none) — keying each row by its
@@ -993,12 +994,32 @@ function collapseDerivedWorkLogEntries(
       });
       continue;
     }
+    // Late tool_result after completeTurn force-completes every in-flight
+    // tool is not adjacent to its row. Merge by toolCallId, not adjacency.
+    const toolCallId =
+      entry.activityKind === "tool.updated" || entry.activityKind === "tool.completed"
+        ? entry.toolCallId
+        : undefined;
+    if (toolCallId !== undefined) {
+      const existingIndex = toolRowIndex.get(toolCallId);
+      if (existingIndex !== undefined) {
+        collapsed[existingIndex] = mergeDerivedWorkLogEntries(collapsed[existingIndex]!, entry);
+        continue;
+      }
+    }
     const previous = collapsed.at(-1);
     if (previous && shouldCollapseToolLifecycleEntries(previous, entry)) {
-      collapsed[collapsed.length - 1] = mergeDerivedWorkLogEntries(previous, entry);
+      const merged = mergeDerivedWorkLogEntries(previous, entry);
+      collapsed[collapsed.length - 1] = merged;
+      if (merged.toolCallId !== undefined) {
+        toolRowIndex.set(merged.toolCallId, collapsed.length - 1);
+      }
       continue;
     }
     collapsed.push(entry);
+    if (toolCallId !== undefined) {
+      toolRowIndex.set(toolCallId, collapsed.length - 1);
+    }
   }
   return collapsed;
 }

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -1014,7 +1014,8 @@ function shouldCollapseToolLifecycleEntries(
     return false;
   }
   if (previous.activityKind === "tool.completed") {
-    return false;
+    // Same toolCallId after complete is a late result amendment, not a new call.
+    return previous.toolCallId !== undefined && previous.toolCallId === next.toolCallId;
   }
   if (previous.collapseKey !== undefined && previous.collapseKey === next.collapseKey) {
     return true;


### PR DESCRIPTION
Fixes #6389

`ClaudeAdapter.completeTurn` force-completes any still-in-flight tools without a result, then clears `inFlightTools`. If the matching SDK `tool_result` arrives afterwards — the SDK `result` landing first, or finalize from interrupt, stream exit, session stop, or a non-steering turn handoff — `handleUserMessage` misses the lookup and drops the output with no warning. The persisted `item.completed` then has only `toolName` and `input`.

This keeps a bounded per-session map of those finalized tools, keyed by `toolUseId`. A late `tool_result` now emits the same `item.updated` + `item.completed` events as the happy path, including `data.result`, attributed to the original turn. It does not start a new turn or mark a completed turn as running.

Unknown `toolUseId` values after finalize do not throw. They log `claude.tool_result.unknown-tool-use` and are ignored. Map entries are removed when the late result is applied, evicted after 64 pending tools, and cleared on session teardown.

Coverage in `ClaudeAdapter.test.ts`:
- late `tool_result` after `completeTurn` still emits completed with `data.result`
- unknown `toolUseId` after finalize is a no-op
- happy-path `tool_result` before `completeTurn` still works

Grok / T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Claude adapter turn/tool lifecycle and activity persistence; behavior is well covered by tests but ordering and duplicate-event edge cases matter for the thread timeline.
> 
> **Overview**
> Fixes a race where Claude’s turn can finish before a `tool_result` arrives, leaving force-completed tools without output in storage and the UI.
> 
> **Server:** `ClaudeAdapter` keeps force-completed tools in a bounded `finalizedToolsAwaitingResult` map (keyed by tool use id). Late `tool_result` messages emit a terminal `item.updated` (with full `data.result`) on the original turn, plus `content.delta` when needed, and skip a second `item.completed`. Tool event payloads now include `toolCallId`. `ProviderRuntimeIngestion` persists the full payload for terminal `item.updated` events (not only the trimmed projection used for in-progress streaming).
> 
> **Clients:** Web and mobile work-log collapse merges `tool.updated` / `tool.completed` rows by `toolCallId` even when they are not adjacent, preserving the first row’s `createdAt` so ordering stays correct.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16ba7a6eff17048c75d0dd20fe3c877c453e0fca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist late Claude tool results after turn finalization and merge them in the thread feed
> - Claude tool calls force-completed by `completeTurn` are now tracked in a bounded `finalizedToolsAwaitingResult` map so that `tool_result` messages arriving after turn finalization are matched to the correct turn.
> - Late terminal `tool_result` events emit an `item.updated` with status `completed`/`failed` (attributed to the finalized turn) without re-emitting `item.completed`; unknown `tool_use_id` values are ignored with a warning.
> - All tool lifecycle events now include `toolCallId` in their payload; terminal `item.updated` events persist the full payload (including result) instead of a size-limited projection.
> - The thread feed (`collapseDerivedWorkLogEntries` in both web and mobile) merges non-adjacent late `tool.updated` entries into their corresponding completed rows by `toolCallId`, preserving the original `createdAt`.
> - Behavioral Change: previously, all `item.updated` payloads were projected/truncated; terminal updates now bypass projection to retain the full result.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 16ba7a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->