### PR TITLE
fix(web): refresh T3 Connect switch after startup reconcile

### DIFF
--- a/apps/web/src/cloud/connectOnboarding.test.ts
+++ b/apps/web/src/cloud/connectOnboarding.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  resolveOnboardingReconcileDesired,
+  shouldSyncOnboardingToggleFromLinkState,
+} from "./connectOnboarding";
+
+describe("shouldSyncOnboardingToggleFromLinkState", () => {
+  it("resyncs an untouched toggle for the account being onboarded", () => {
+    expect(
+      shouldSyncOnboardingToggleFromLinkState({
+        touched: false,
+        openForAccount: "user-1",
+        linked: true,
+        cloudUserId: "user-1",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not overwrite a toggle the user has already changed", () => {
+    expect(
+      shouldSyncOnboardingToggleFromLinkState({
+        touched: true,
+        openForAccount: "user-1",
+        linked: true,
+        cloudUserId: "user-1",
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores link state from another account", () => {
+    expect(
+      shouldSyncOnboardingToggleFromLinkState({
+        touched: false,
+        openForAccount: "user-1",
+        linked: true,
+        cloudUserId: "user-2",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("resolveOnboardingReconcileDesired", () => {
+  it("does not tear down an active tunnel after a stale inactive prefill", () => {
+    expect(
+      resolveOnboardingReconcileDesired({
+        exposeEnvironment: false,
+        publishAgentActivity: true,
+        managedTunnelActive: true,
+      }),
+    ).toEqual({ managedTunnel: true, publish: true });
+  });
+
+  it("skips reconcile when nothing would be enabled", () => {
+    expect(
+      resolveOnboardingReconcileDesired({
+        exposeEnvironment: false,
+        publishAgentActivity: false,
+        managedTunnelActive: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("keeps an explicit request to enable the managed tunnel", () => {
+    expect(
+      resolveOnboardingReconcileDesired({
+        exposeEnvironment: true,
+        publishAgentActivity: false,
+        managedTunnelActive: false,
+      }),
+    ).toEqual({ managedTunnel: true, publish: false });
+  });
+});

--- a/apps/web/src/cloud/connectOnboarding.test.ts
+++ b/apps/web/src/cloud/connectOnboarding.test.ts
@@ -38,6 +38,25 @@ describe("shouldSyncOnboardingToggleFromLinkState", () => {
       }),
     ).toBe(false);
   });
+
+  it("does not sync when the wizard is closed or the environment is unlinked", () => {
+    expect(
+      shouldSyncOnboardingToggleFromLinkState({
+        touched: false,
+        openForAccount: null,
+        linked: true,
+        cloudUserId: "user-1",
+      }),
+    ).toBe(false);
+    expect(
+      shouldSyncOnboardingToggleFromLinkState({
+        touched: false,
+        openForAccount: "user-1",
+        linked: false,
+        cloudUserId: "user-1",
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("resolveOnboardingReconcileDesired", () => {
@@ -57,6 +76,16 @@ describe("resolveOnboardingReconcileDesired", () => {
         exposeEnvironment: false,
         publishAgentActivity: false,
         managedTunnelActive: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("does not rewrite publish when both toggles are off and a tunnel is already active", () => {
+    expect(
+      resolveOnboardingReconcileDesired({
+        exposeEnvironment: false,
+        publishAgentActivity: false,
+        managedTunnelActive: true,
       }),
     ).toBeNull();
   });

--- a/apps/web/src/cloud/connectOnboarding.test.ts
+++ b/apps/web/src/cloud/connectOnboarding.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  resolveOnboardingManagedTunnelActive,
   resolveOnboardingReconcileDesired,
   shouldSyncOnboardingToggleFromLinkState,
 } from "./connectOnboarding";
@@ -56,6 +57,39 @@ describe("shouldSyncOnboardingToggleFromLinkState", () => {
         cloudUserId: "user-1",
       }),
     ).toBe(false);
+  });
+});
+
+describe("resolveOnboardingManagedTunnelActive", () => {
+  it("uses the current tunnel only when the cached link belongs to this account", () => {
+    expect(
+      resolveOnboardingManagedTunnelActive({
+        managedTunnelActive: true,
+        cloudUserId: "user-1",
+        openForAccount: "user-1",
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores a previous account's active tunnel after an account switch", () => {
+    expect(
+      resolveOnboardingManagedTunnelActive({
+        managedTunnelActive: true,
+        cloudUserId: "user-1",
+        openForAccount: "user-2",
+      }),
+    ).toBe(false);
+    expect(
+      resolveOnboardingReconcileDesired({
+        exposeEnvironment: false,
+        publishAgentActivity: true,
+        managedTunnelActive: resolveOnboardingManagedTunnelActive({
+          managedTunnelActive: true,
+          cloudUserId: "user-1",
+          openForAccount: "user-2",
+        }),
+      }),
+    ).toEqual({ managedTunnel: false, publish: true });
   });
 });
 

--- a/apps/web/src/cloud/connectOnboarding.ts
+++ b/apps/web/src/cloud/connectOnboarding.ts
@@ -31,17 +31,19 @@ export function shouldSyncOnboardingToggleFromLinkState(input: {
   );
 }
 
-// The wizard only ever enables. A stale prefill of expose=false after
-// startup reconcile must not submit publish_only and tear the tunnel down.
+// The wizard only ever enables. Both toggles off means skip — do not unlink,
+// downgrade, or rewrite publish. A stale expose=false after startup
+// reconcile must also not submit publish_only and tear the tunnel down.
 export function resolveOnboardingReconcileDesired(input: {
   readonly exposeEnvironment: boolean;
   readonly publishAgentActivity: boolean;
   readonly managedTunnelActive: boolean;
 }): { readonly managedTunnel: boolean; readonly publish: boolean } | null {
-  const managedTunnel = input.exposeEnvironment || input.managedTunnelActive;
-  const publish = input.publishAgentActivity;
-  if (!managedTunnel && !publish) {
+  if (!input.exposeEnvironment && !input.publishAgentActivity) {
     return null;
   }
-  return { managedTunnel, publish };
+  return {
+    managedTunnel: input.exposeEnvironment || input.managedTunnelActive,
+    publish: input.publishAgentActivity,
+  };
 }

--- a/apps/web/src/cloud/connectOnboarding.ts
+++ b/apps/web/src/cloud/connectOnboarding.ts
@@ -16,3 +16,32 @@ export type ConnectOnboardingOptOutState = typeof ConnectOnboardingOptOutSchema.
 export const EMPTY_CONNECT_ONBOARDING_OPT_OUT_STATE: ConnectOnboardingOptOutState = {
   optOutAccounts: [],
 };
+
+export function shouldSyncOnboardingToggleFromLinkState(input: {
+  readonly touched: boolean;
+  readonly openForAccount: string | null;
+  readonly linked: boolean;
+  readonly cloudUserId: string | null;
+}): boolean {
+  return (
+    !input.touched &&
+    input.openForAccount !== null &&
+    input.linked &&
+    input.cloudUserId === input.openForAccount
+  );
+}
+
+// The wizard only ever enables. A stale prefill of expose=false after
+// startup reconcile must not submit publish_only and tear the tunnel down.
+export function resolveOnboardingReconcileDesired(input: {
+  readonly exposeEnvironment: boolean;
+  readonly publishAgentActivity: boolean;
+  readonly managedTunnelActive: boolean;
+}): { readonly managedTunnel: boolean; readonly publish: boolean } | null {
+  const managedTunnel = input.exposeEnvironment || input.managedTunnelActive;
+  const publish = input.publishAgentActivity;
+  if (!managedTunnel && !publish) {
+    return null;
+  }
+  return { managedTunnel, publish };
+}

--- a/apps/web/src/cloud/connectOnboarding.ts
+++ b/apps/web/src/cloud/connectOnboarding.ts
@@ -31,6 +31,17 @@ export function shouldSyncOnboardingToggleFromLinkState(input: {
   );
 }
 
+// controller.managedTunnelActive is environment-global. After an account
+// switch the cached link can still belong to the previous user — only treat
+// it as this wizard's tunnel when the linked user matches.
+export function resolveOnboardingManagedTunnelActive(input: {
+  readonly managedTunnelActive: boolean;
+  readonly cloudUserId: string | null | undefined;
+  readonly openForAccount: string | null;
+}): boolean {
+  return input.cloudUserId === input.openForAccount ? input.managedTunnelActive : false;
+}
+
 // The wizard only ever enables. Both toggles off means skip — do not unlink,
 // downgrade, or rewrite publish. A stale expose=false after startup
 // reconcile must also not submit publish_only and tear the tunnel down.

--- a/apps/web/src/cloud/primaryCloudLinkState.test.ts
+++ b/apps/web/src/cloud/primaryCloudLinkState.test.ts
@@ -3,9 +3,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 import type { CloudLinkTarget } from "./linkEnvironment";
 import {
   __resetStartupCloudLinkRefreshForTests,
+  CONNECTIONS_CLOUD_LINK_RETRY_BUDGET_MS,
   resolveManagedTunnelActive,
   scheduleStartupReconcileLinkStateRefresh,
-  STARTUP_CLOUD_LINK_RECONCILE_REFRESH_MS,
+  shouldContinueConnectionsCloudLinkRetry,
+  STARTUP_CLOUD_LINK_RECONCILE_REFRESH_DELAYS_MS,
+  stopStartupReconcileLinkStateRefresh,
 } from "./primaryCloudLinkState";
 
 const TARGET: CloudLinkTarget = {
@@ -31,6 +34,22 @@ describe("resolveManagedTunnelActive", () => {
   });
 });
 
+describe("shouldContinueConnectionsCloudLinkRetry", () => {
+  it("stops once the managed tunnel is active", () => {
+    expect(shouldContinueConnectionsCloudLinkRetry(0, true)).toBe(false);
+  });
+
+  it("retries while inactive inside the budget and stops after it", () => {
+    expect(shouldContinueConnectionsCloudLinkRetry(0, false)).toBe(true);
+    expect(
+      shouldContinueConnectionsCloudLinkRetry(CONNECTIONS_CLOUD_LINK_RETRY_BUDGET_MS - 1, false),
+    ).toBe(true);
+    expect(
+      shouldContinueConnectionsCloudLinkRetry(CONNECTIONS_CLOUD_LINK_RETRY_BUDGET_MS, false),
+    ).toBe(false);
+  });
+});
+
 describe("scheduleStartupReconcileLinkStateRefresh", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -42,33 +61,62 @@ describe("scheduleStartupReconcileLinkStateRefresh", () => {
     __resetStartupCloudLinkRefreshForTests();
   });
 
-  it("replaces a startup-stale inactive switch after the follow-up refresh", () => {
+  it("replaces a startup-stale inactive switch across the bounded refresh series", () => {
     let state: { linked: boolean; managedTunnelActive?: boolean } = {
       linked: true,
       managedTunnelActive: false,
     };
     const refresh = vi.fn(() => {
-      state = { linked: true, managedTunnelActive: true };
+      if (refresh.mock.calls.length >= 2) {
+        state = { linked: true, managedTunnelActive: true };
+      }
     });
 
     expect(resolveManagedTunnelActive(state)).toBe(false);
     expect(scheduleStartupReconcileLinkStateRefresh(TARGET, refresh)).toBe(true);
     expect(scheduleStartupReconcileLinkStateRefresh(TARGET, refresh)).toBe(false);
 
-    vi.advanceTimersByTime(STARTUP_CLOUD_LINK_RECONCILE_REFRESH_MS - 1);
+    vi.advanceTimersByTime(STARTUP_CLOUD_LINK_RECONCILE_REFRESH_DELAYS_MS[0] - 1);
     expect(refresh).not.toHaveBeenCalled();
     expect(resolveManagedTunnelActive(state)).toBe(false);
 
     vi.advanceTimersByTime(1);
     expect(refresh).toHaveBeenCalledTimes(1);
-    expect(refresh).toHaveBeenCalledWith(TARGET);
+    expect(resolveManagedTunnelActive(state)).toBe(false);
+
+    vi.advanceTimersByTime(
+      STARTUP_CLOUD_LINK_RECONCILE_REFRESH_DELAYS_MS[1] -
+        STARTUP_CLOUD_LINK_RECONCILE_REFRESH_DELAYS_MS[0],
+    );
+    expect(refresh).toHaveBeenCalledTimes(2);
     expect(resolveManagedTunnelActive(state)).toBe(true);
+
+    vi.advanceTimersByTime(
+      STARTUP_CLOUD_LINK_RECONCILE_REFRESH_DELAYS_MS[2] -
+        STARTUP_CLOUD_LINK_RECONCILE_REFRESH_DELAYS_MS[1],
+    );
+    expect(refresh).toHaveBeenCalledTimes(3);
+    expect(refresh).toHaveBeenNthCalledWith(1, TARGET);
+    expect(refresh).toHaveBeenNthCalledWith(2, TARGET);
+    expect(refresh).toHaveBeenNthCalledWith(3, TARGET);
+  });
+
+  it("cancels remaining startup refreshes once the tunnel is active", () => {
+    const refresh = vi.fn();
+    expect(scheduleStartupReconcileLinkStateRefresh(TARGET, refresh)).toBe(true);
+
+    vi.advanceTimersByTime(STARTUP_CLOUD_LINK_RECONCILE_REFRESH_DELAYS_MS[0]);
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    stopStartupReconcileLinkStateRefresh(TARGET);
+    vi.advanceTimersByTime(STARTUP_CLOUD_LINK_RECONCILE_REFRESH_DELAYS_MS[2]);
+    expect(refresh).toHaveBeenCalledTimes(1);
   });
 
   it("does not schedule without a target", () => {
     const refresh = vi.fn();
     expect(scheduleStartupReconcileLinkStateRefresh(null, refresh)).toBe(false);
-    vi.advanceTimersByTime(STARTUP_CLOUD_LINK_RECONCILE_REFRESH_MS);
+    vi.advanceTimersByTime(STARTUP_CLOUD_LINK_RECONCILE_REFRESH_DELAYS_MS[2]);
     expect(refresh).not.toHaveBeenCalled();
   });
 
@@ -79,7 +127,7 @@ describe("scheduleStartupReconcileLinkStateRefresh", () => {
     expect(scheduleStartupReconcileLinkStateRefresh(TARGET, refresh)).toBe(true);
     expect(scheduleStartupReconcileLinkStateRefresh(otherTarget, refresh)).toBe(true);
 
-    vi.advanceTimersByTime(STARTUP_CLOUD_LINK_RECONCILE_REFRESH_MS);
+    vi.advanceTimersByTime(STARTUP_CLOUD_LINK_RECONCILE_REFRESH_DELAYS_MS[0]);
     expect(refresh).toHaveBeenCalledTimes(2);
     expect(refresh).toHaveBeenNthCalledWith(1, TARGET);
     expect(refresh).toHaveBeenNthCalledWith(2, otherTarget);

--- a/apps/web/src/cloud/primaryCloudLinkState.test.ts
+++ b/apps/web/src/cloud/primaryCloudLinkState.test.ts
@@ -111,6 +111,7 @@ describe("scheduleStartupReconcileLinkStateRefresh", () => {
     stopStartupReconcileLinkStateRefresh(TARGET);
     vi.advanceTimersByTime(STARTUP_CLOUD_LINK_RECONCILE_REFRESH_DELAYS_MS[2]);
     expect(refresh).toHaveBeenCalledTimes(1);
+    expect(scheduleStartupReconcileLinkStateRefresh(TARGET, refresh)).toBe(false);
   });
 
   it("does not schedule without a target", () => {

--- a/apps/web/src/cloud/primaryCloudLinkState.test.ts
+++ b/apps/web/src/cloud/primaryCloudLinkState.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import type { CloudLinkTarget } from "./linkEnvironment";
+import {
+  __resetStartupCloudLinkRefreshForTests,
+  resolveManagedTunnelActive,
+  scheduleStartupReconcileLinkStateRefresh,
+  STARTUP_CLOUD_LINK_RECONCILE_REFRESH_MS,
+} from "./primaryCloudLinkState";
+
+const TARGET: CloudLinkTarget = {
+  environmentId: "environment-1",
+  label: "Desktop",
+  httpBaseUrl: "http://127.0.0.1:3000",
+  wsBaseUrl: "ws://127.0.0.1:3000",
+};
+
+describe("resolveManagedTunnelActive", () => {
+  it("falls back to linked when older servers omit managedTunnelActive", () => {
+    expect(resolveManagedTunnelActive({ linked: true })).toBe(true);
+    expect(resolveManagedTunnelActive({ linked: false })).toBe(false);
+  });
+
+  it("does not treat a publish-only or pre-reconcile link as an active tunnel", () => {
+    expect(resolveManagedTunnelActive({ linked: true, managedTunnelActive: false })).toBe(false);
+  });
+
+  it("is inactive when link state has not loaded", () => {
+    expect(resolveManagedTunnelActive(null)).toBe(false);
+    expect(resolveManagedTunnelActive(undefined)).toBe(false);
+  });
+});
+
+describe("scheduleStartupReconcileLinkStateRefresh", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    __resetStartupCloudLinkRefreshForTests();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    __resetStartupCloudLinkRefreshForTests();
+  });
+
+  it("replaces a startup-stale inactive switch after the follow-up refresh", () => {
+    let state: { linked: boolean; managedTunnelActive?: boolean } = {
+      linked: true,
+      managedTunnelActive: false,
+    };
+    const refresh = vi.fn(() => {
+      state = { linked: true, managedTunnelActive: true };
+    });
+
+    expect(resolveManagedTunnelActive(state)).toBe(false);
+    expect(scheduleStartupReconcileLinkStateRefresh(TARGET, refresh)).toBe(true);
+    expect(scheduleStartupReconcileLinkStateRefresh(TARGET, refresh)).toBe(false);
+
+    vi.advanceTimersByTime(STARTUP_CLOUD_LINK_RECONCILE_REFRESH_MS - 1);
+    expect(refresh).not.toHaveBeenCalled();
+    expect(resolveManagedTunnelActive(state)).toBe(false);
+
+    vi.advanceTimersByTime(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(refresh).toHaveBeenCalledWith(TARGET);
+    expect(resolveManagedTunnelActive(state)).toBe(true);
+  });
+
+  it("does not schedule without a target", () => {
+    const refresh = vi.fn();
+    expect(scheduleStartupReconcileLinkStateRefresh(null, refresh)).toBe(false);
+    vi.advanceTimersByTime(STARTUP_CLOUD_LINK_RECONCILE_REFRESH_MS);
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("schedules a separate follow-up for a different environment", () => {
+    const refresh = vi.fn();
+    const otherTarget = { ...TARGET, environmentId: "environment-2" };
+
+    expect(scheduleStartupReconcileLinkStateRefresh(TARGET, refresh)).toBe(true);
+    expect(scheduleStartupReconcileLinkStateRefresh(otherTarget, refresh)).toBe(true);
+
+    vi.advanceTimersByTime(STARTUP_CLOUD_LINK_RECONCILE_REFRESH_MS);
+    expect(refresh).toHaveBeenCalledTimes(2);
+    expect(refresh).toHaveBeenNthCalledWith(1, TARGET);
+    expect(refresh).toHaveBeenNthCalledWith(2, otherTarget);
+  });
+});

--- a/apps/web/src/cloud/primaryCloudLinkState.ts
+++ b/apps/web/src/cloud/primaryCloudLinkState.ts
@@ -57,11 +57,25 @@ export function resolveManagedTunnelActive(
 }
 
 // Startup reconcile applies relay config after routes are already live. The
-// first link-state read can cache `managedTunnelActive: false`; one delayed
-// refresh replaces that once reconcile has had a chance to finish.
-export const STARTUP_CLOUD_LINK_RECONCILE_REFRESH_MS = 2_000;
+// first link-state read can cache `managedTunnelActive: false`; a short
+// bounded series of refreshes replaces that once reconcile has had a chance
+// to finish. Delays are from first settlement, then we stop.
+export const STARTUP_CLOUD_LINK_RECONCILE_REFRESH_DELAYS_MS = [2_000, 5_000, 10_000] as const;
+export const CONNECTIONS_CLOUD_LINK_RETRY_INTERVAL_MS = 2_000;
+export const CONNECTIONS_CLOUD_LINK_RETRY_BUDGET_MS = 15_000;
 
 const scheduledStartupReconcileRefreshKeys = new Set<string>();
+const pendingStartupReconcileRefreshTimers = new Map<
+  string,
+  Array<ReturnType<typeof setTimeout>>
+>();
+
+export function shouldContinueConnectionsCloudLinkRetry(
+  elapsedMs: number,
+  managedTunnelActive: boolean,
+): boolean {
+  return !managedTunnelActive && elapsedMs < CONNECTIONS_CLOUD_LINK_RETRY_BUDGET_MS;
+}
 
 export function scheduleStartupReconcileLinkStateRefresh(
   target: CloudLinkTarget | null,
@@ -75,13 +89,40 @@ export function scheduleStartupReconcileLinkStateRefresh(
     return false;
   }
   scheduledStartupReconcileRefreshKeys.add(key);
-  setTimeout(() => {
-    refresh(target);
-  }, STARTUP_CLOUD_LINK_RECONCILE_REFRESH_MS);
+  pendingStartupReconcileRefreshTimers.set(
+    key,
+    STARTUP_CLOUD_LINK_RECONCILE_REFRESH_DELAYS_MS.map((delayMs) =>
+      setTimeout(() => {
+        refresh(target);
+      }, delayMs),
+    ),
+  );
   return true;
 }
 
+export function stopStartupReconcileLinkStateRefresh(target: CloudLinkTarget | null): void {
+  if (!target) {
+    return;
+  }
+  const key = targetKey(target);
+  scheduledStartupReconcileRefreshKeys.add(key);
+  const timers = pendingStartupReconcileRefreshTimers.get(key);
+  if (!timers) {
+    return;
+  }
+  for (const timer of timers) {
+    clearTimeout(timer);
+  }
+  pendingStartupReconcileRefreshTimers.delete(key);
+}
+
 export function __resetStartupCloudLinkRefreshForTests(): void {
+  for (const timers of pendingStartupReconcileRefreshTimers.values()) {
+    for (const timer of timers) {
+      clearTimeout(timer);
+    }
+  }
+  pendingStartupReconcileRefreshTimers.clear();
   scheduledStartupReconcileRefreshKeys.clear();
 }
 
@@ -107,12 +148,21 @@ export function usePrimaryCloudLinkState() {
     refreshPrimaryCloudLinkState(target);
   }, [target]);
   const settled = result._tag === "Success" || result._tag === "Failure";
+  const data = Option.getOrNull(AsyncResult.value(result));
+  const managedTunnelActive = resolveManagedTunnelActive(data);
   useEffect(() => {
+    if (!target) {
+      return;
+    }
+    if (managedTunnelActive) {
+      stopStartupReconcileLinkStateRefresh(target);
+      return;
+    }
     if (!settled) {
       return;
     }
     scheduleStartupReconcileLinkStateRefresh(target);
-  }, [settled, target]);
+  }, [managedTunnelActive, settled, target]);
   let error: string | null = null;
   if (result._tag === "Failure") {
     const cause = Cause.squash(result.cause);
@@ -120,7 +170,7 @@ export function usePrimaryCloudLinkState() {
   }
 
   return {
-    data: Option.getOrNull(AsyncResult.value(result)),
+    data,
     error,
     isPending: result.waiting,
     refresh,

--- a/apps/web/src/cloud/primaryCloudLinkState.ts
+++ b/apps/web/src/cloud/primaryCloudLinkState.ts
@@ -7,7 +7,7 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
 import { HttpClient } from "effect/unstable/http";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 
 import { usePrimaryEnvironment } from "../state/environments";
 import { runtime } from "../lib/runtime";
@@ -48,6 +48,43 @@ export function refreshPrimaryCloudLinkState(target: CloudLinkTarget | null): vo
   }
 }
 
+// Older environment servers predate the managedTunnelActive field; for them a
+// link always implies a managed tunnel, so fall back to `linked`.
+export function resolveManagedTunnelActive(
+  state: Pick<EnvironmentCloudLinkStateResult, "managedTunnelActive" | "linked"> | null | undefined,
+): boolean {
+  return state?.managedTunnelActive ?? state?.linked ?? false;
+}
+
+// Startup reconcile applies relay config after routes are already live. The
+// first link-state read can cache `managedTunnelActive: false`; one delayed
+// refresh replaces that once reconcile has had a chance to finish.
+export const STARTUP_CLOUD_LINK_RECONCILE_REFRESH_MS = 2_000;
+
+const scheduledStartupReconcileRefreshKeys = new Set<string>();
+
+export function scheduleStartupReconcileLinkStateRefresh(
+  target: CloudLinkTarget | null,
+  refresh: (target: CloudLinkTarget | null) => void = refreshPrimaryCloudLinkState,
+): boolean {
+  if (!target) {
+    return false;
+  }
+  const key = targetKey(target);
+  if (scheduledStartupReconcileRefreshKeys.has(key)) {
+    return false;
+  }
+  scheduledStartupReconcileRefreshKeys.add(key);
+  setTimeout(() => {
+    refresh(target);
+  }, STARTUP_CLOUD_LINK_RECONCILE_REFRESH_MS);
+  return true;
+}
+
+export function __resetStartupCloudLinkRefreshForTests(): void {
+  scheduledStartupReconcileRefreshKeys.clear();
+}
+
 export function usePrimaryCloudLinkState() {
   const primary = usePrimaryEnvironment();
   const target = useMemo(
@@ -69,6 +106,13 @@ export function usePrimaryCloudLinkState() {
   const refresh = useCallback(() => {
     refreshPrimaryCloudLinkState(target);
   }, [target]);
+  const settled = result._tag === "Success" || result._tag === "Failure";
+  useEffect(() => {
+    if (!settled) {
+      return;
+    }
+    scheduleStartupReconcileLinkStateRefresh(target);
+  }, [settled, target]);
   let error: string | null = null;
   if (result._tag === "Failure") {
     const cause = Cause.squash(result.cause);

--- a/apps/web/src/cloud/useCloudLinkController.ts
+++ b/apps/web/src/cloud/useCloudLinkController.ts
@@ -15,7 +15,7 @@ import {
   unlinkPrimaryEnvironment as unlinkPrimaryEnvironmentAtom,
   updatePrimaryEnvironmentPreferences as updatePrimaryEnvironmentPreferencesAtom,
 } from "./linkEnvironmentAtoms";
-import { usePrimaryCloudLinkState } from "./primaryCloudLinkState";
+import { resolveManagedTunnelActive, usePrimaryCloudLinkState } from "./primaryCloudLinkState";
 import { resolveRelayClerkTokenOptions } from "./publicConfig";
 
 export interface CloudLinkDesiredState {
@@ -70,10 +70,7 @@ export function useCloudLinkController() {
     });
   };
 
-  // Older environment servers predate the managedTunnelActive field; for them a
-  // link always implies a managed tunnel, so fall back to `linked`.
-  const managedTunnelActive =
-    primaryCloudLinkState.data?.managedTunnelActive ?? primaryCloudLinkState.data?.linked ?? false;
+  const managedTunnelActive = resolveManagedTunnelActive(primaryCloudLinkState.data);
   const publishAgentActivity = primaryCloudLinkState.data?.publishAgentActivity ?? false;
   const linked = primaryCloudLinkState.data?.linked ?? false;
 

--- a/apps/web/src/components/cloud/ConnectOnboardingDialog.tsx
+++ b/apps/web/src/components/cloud/ConnectOnboardingDialog.tsx
@@ -7,6 +7,7 @@ import {
   CONNECT_ONBOARDING_OPT_OUT_STORAGE_KEY,
   ConnectOnboardingOptOutSchema,
   EMPTY_CONNECT_ONBOARDING_OPT_OUT_STATE,
+  resolveOnboardingManagedTunnelActive,
   resolveOnboardingReconcileDesired,
   shouldSyncOnboardingToggleFromLinkState,
 } from "~/cloud/connectOnboarding";
@@ -208,7 +209,11 @@ function ConfiguredConnectOnboardingDialog() {
     const desired = resolveOnboardingReconcileDesired({
       exposeEnvironment,
       publishAgentActivity,
-      managedTunnelActive: controller.managedTunnelActive,
+      managedTunnelActive: resolveOnboardingManagedTunnelActive({
+        managedTunnelActive: controller.managedTunnelActive,
+        cloudUserId: linkStateData?.cloudUserId,
+        openForAccount,
+      }),
     });
     if (desired === null) {
       setStep("devices");

--- a/apps/web/src/components/cloud/ConnectOnboardingDialog.tsx
+++ b/apps/web/src/components/cloud/ConnectOnboardingDialog.tsx
@@ -8,6 +8,7 @@ import {
   ConnectOnboardingOptOutSchema,
   EMPTY_CONNECT_ONBOARDING_OPT_OUT_STATE,
 } from "~/cloud/connectOnboarding";
+import { resolveManagedTunnelActive } from "~/cloud/primaryCloudLinkState";
 import { hasCloudPublicConfig } from "~/cloud/publicConfig";
 import { useCloudLinkController } from "~/cloud/useCloudLinkController";
 import { usePrimarySessionState } from "~/environments/primary";
@@ -164,7 +165,7 @@ function ConfiguredConnectOnboardingDialog() {
     }
     prefilledFromLinkStateRef.current = true;
     if (linkStateData.linked && linkStateData.cloudUserId === openForAccount) {
-      setExposeEnvironment(linkStateData.managedTunnelActive ?? linkStateData.linked);
+      setExposeEnvironment(resolveManagedTunnelActive(linkStateData));
       setPublishAgentActivity(linkStateData.publishAgentActivity);
     }
   }, [linkStateData, openForAccount]);

--- a/apps/web/src/components/cloud/ConnectOnboardingDialog.tsx
+++ b/apps/web/src/components/cloud/ConnectOnboardingDialog.tsx
@@ -7,6 +7,8 @@ import {
   CONNECT_ONBOARDING_OPT_OUT_STORAGE_KEY,
   ConnectOnboardingOptOutSchema,
   EMPTY_CONNECT_ONBOARDING_OPT_OUT_STATE,
+  resolveOnboardingReconcileDesired,
+  shouldSyncOnboardingToggleFromLinkState,
 } from "~/cloud/connectOnboarding";
 import { resolveManagedTunnelActive } from "~/cloud/primaryCloudLinkState";
 import { hasCloudPublicConfig } from "~/cloud/publicConfig";
@@ -87,7 +89,8 @@ function ConfiguredConnectOnboardingDialog() {
   const [publishAgentActivity, setPublishAgentActivity] = useState(true);
   const [dontShowAgain, setDontShowAgain] = useState(false);
   const [isApplying, setIsApplying] = useState(false);
-  const prefilledFromLinkStateRef = useRef(false);
+  const exposeTouchedRef = useRef(false);
+  const publishTouchedRef = useRef(false);
   const observedAccountRef = useRef<string | null | undefined>(undefined);
 
   const optOutAccounts = optOutState.optOutAccounts;
@@ -126,7 +129,8 @@ function ConfiguredConnectOnboardingDialog() {
     }
     if (!sessionScopesKnown || !publishStepDecided) return;
     setRequestedAccount(null);
-    prefilledFromLinkStateRef.current = false;
+    exposeTouchedRef.current = false;
+    publishTouchedRef.current = false;
     setExposeEnvironment(true);
     setPublishAgentActivity(true);
     setDontShowAgain(false);
@@ -155,17 +159,29 @@ function ConfiguredConnectOnboardingDialog() {
 
   // Toggles default on, but an environment that is already linked should show
   // its actual configuration instead of silently proposing to rewrite it.
+  // Keep resyncing from link state until the user touches a control — a
+  // startup-stale inactive snapshot must not stick after reconcile.
   // Only when the link belongs to the account being onboarded, though — after
   // an account switch the cached link state can still describe the previous
   // account's setup.
   const linkStateData = controller.linkState.data;
   useEffect(() => {
-    if (openForAccount === null || prefilledFromLinkStateRef.current || linkStateData === null) {
+    if (openForAccount === null || linkStateData === null) {
       return;
     }
-    prefilledFromLinkStateRef.current = true;
-    if (linkStateData.linked && linkStateData.cloudUserId === openForAccount) {
+    const syncInput = {
+      openForAccount,
+      linked: linkStateData.linked,
+      cloudUserId: linkStateData.cloudUserId,
+    };
+    if (
+      shouldSyncOnboardingToggleFromLinkState({ ...syncInput, touched: exposeTouchedRef.current })
+    ) {
       setExposeEnvironment(resolveManagedTunnelActive(linkStateData));
+    }
+    if (
+      shouldSyncOnboardingToggleFromLinkState({ ...syncInput, touched: publishTouchedRef.current })
+    ) {
       setPublishAgentActivity(linkStateData.publishAgentActivity);
     }
   }, [linkStateData, openForAccount]);
@@ -187,22 +203,25 @@ function ConfiguredConnectOnboardingDialog() {
 
   const applyPublishSelection = async () => {
     // The wizard only ever enables — with both toggles off there is nothing to
-    // apply, and an existing link must not be torn down from onboarding.
-    if (!exposeEnvironment && !publishAgentActivity) {
+    // apply, and an existing managed tunnel must not be torn down from
+    // onboarding if a later link-state refresh showed it active.
+    const desired = resolveOnboardingReconcileDesired({
+      exposeEnvironment,
+      publishAgentActivity,
+      managedTunnelActive: controller.managedTunnelActive,
+    });
+    if (desired === null) {
       setStep("devices");
       return;
     }
     setIsApplying(true);
-    const ok = await controller.reconcileCloudState({
-      managedTunnel: exposeEnvironment,
-      publish: publishAgentActivity,
-    });
+    const ok = await controller.reconcileCloudState(desired);
     setIsApplying(false);
     if (!ok) return;
     toastManager.add({
       type: "success",
       title: "T3 Connect enabled",
-      description: exposeEnvironment
+      description: desired.managedTunnel
         ? "This environment is available to your other devices through T3 Connect."
         : "This environment publishes agent activity to your mobile clients.",
     });
@@ -241,8 +260,14 @@ function ConfiguredConnectOnboardingDialog() {
               publishAgentActivity={publishAgentActivity}
               disabled={isApplying}
               operationError={controller.operationError}
-              onExposeEnvironmentChange={setExposeEnvironment}
-              onPublishAgentActivityChange={setPublishAgentActivity}
+              onExposeEnvironmentChange={(enabled) => {
+                exposeTouchedRef.current = true;
+                setExposeEnvironment(enabled);
+              }}
+              onPublishAgentActivityChange={(enabled) => {
+                publishTouchedRef.current = true;
+                setPublishAgentActivity(enabled);
+              }}
             />
           ) : (
             <DevicesStep />

--- a/apps/web/src/components/settings/ConnectionsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/ConnectionsSettings.logic.test.ts
@@ -2,6 +2,7 @@ import type { AdvertisedEndpoint, DesktopWslState } from "@t3tools/contracts";
 import { describe, expect, it, vi } from "vite-plus/test";
 import {
   applyWslEnableSelection,
+  isInitialCloudLinkStatePending,
   isQrShareableEndpoint,
   selectQrEndpointOption,
 } from "./ConnectionsSettings.logic";
@@ -14,6 +15,20 @@ const baseWslState: DesktopWslState = {
   distros: [],
   preflightError: null,
 };
+
+describe("isInitialCloudLinkStatePending", () => {
+  it("treats SWR revalidation of a cached snapshot as ready", () => {
+    expect(isInitialCloudLinkStatePending({ isPending: true, data: { linked: true } })).toBe(false);
+    expect(isInitialCloudLinkStatePending({ isPending: false, data: { linked: true } })).toBe(
+      false,
+    );
+  });
+
+  it("is pending only before the first link-state value arrives", () => {
+    expect(isInitialCloudLinkStatePending({ isPending: true, data: null })).toBe(true);
+    expect(isInitialCloudLinkStatePending({ isPending: false, data: null })).toBe(false);
+  });
+});
 
 describe("applyWslEnableSelection", () => {
   it("clears WSL-only and updates the distro before enabling both backends", async () => {

--- a/apps/web/src/components/settings/ConnectionsSettings.logic.ts
+++ b/apps/web/src/components/settings/ConnectionsSettings.logic.ts
@@ -2,6 +2,15 @@ import type { AdvertisedEndpoint, DesktopBridge, DesktopWslState } from "@t3tool
 
 type WslEnableBridge = Pick<DesktopBridge, "setWslBackendEnabled" | "setWslDistro" | "setWslOnly">;
 
+// SWR `waiting` is true on every refresh. Disable the T3 Connect switches
+// only for the first load, not while a cached value is being revalidated.
+export function isInitialCloudLinkStatePending(input: {
+  readonly isPending: boolean;
+  readonly data: unknown;
+}): boolean {
+  return input.isPending && input.data === null;
+}
+
 /**
  * A QR code encoding a loopback URL makes the scanning device dial itself, so
  * loopback endpoints stay copyable from the endpoint menu but are never

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -6,7 +6,7 @@ import {
   TerminalIcon,
 } from "lucide-react";
 import { useAtomValue } from "@effect/atom-react";
-import { type ReactNode, memo, useCallback, useId, useMemo, useState } from "react";
+import { type ReactNode, memo, useCallback, useEffect, useId, useMemo, useState } from "react";
 import {
   AuthAccessReadScope,
   AuthAccessWriteScope,
@@ -1600,6 +1600,11 @@ function ConfiguredCloudLinkRow({ canManageRelay }: { readonly canManageRelay: b
     operationError,
     reconcileCloudState,
   } = useCloudLinkController();
+  // Opening Connections can race startup reconcile: the shared SWR atom may
+  // still hold managedTunnelActive: false from a pre-reconcile read.
+  useEffect(() => {
+    primaryCloudLinkState.refresh();
+  }, [primaryCloudLinkState.refresh]);
   const [isUpdating, setIsUpdating] = useState(false);
   const [isUpdatingPreference, setIsUpdatingPreference] = useState(false);
 

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -104,6 +104,10 @@ import {
   resolveServerConfigVersionMismatch,
   resolveServerSelfUpdateCapability,
 } from "~/versionSkew";
+import {
+  CONNECTIONS_CLOUD_LINK_RETRY_INTERVAL_MS,
+  shouldContinueConnectionsCloudLinkRetry,
+} from "~/cloud/primaryCloudLinkState";
 import { hasCloudPublicConfig } from "~/cloud/publicConfig";
 import { useCloudLinkController } from "~/cloud/useCloudLinkController";
 import { authEnvironment } from "~/state/auth";
@@ -1601,10 +1605,28 @@ function ConfiguredCloudLinkRow({ canManageRelay }: { readonly canManageRelay: b
     reconcileCloudState,
   } = useCloudLinkController();
   // Opening Connections can race startup reconcile: the shared SWR atom may
-  // still hold managedTunnelActive: false from a pre-reconcile read.
+  // still hold managedTunnelActive: false from a pre-reconcile read. Refresh
+  // on open, then retry on a short budget while this page stays mounted.
   useEffect(() => {
     primaryCloudLinkState.refresh();
   }, [primaryCloudLinkState.refresh]);
+  useEffect(() => {
+    if (managedTunnelActive) {
+      return;
+    }
+    const startedAt = Date.now();
+    const intervalId = window.setInterval(() => {
+      const elapsedMs = Date.now() - startedAt;
+      if (!shouldContinueConnectionsCloudLinkRetry(elapsedMs, managedTunnelActive)) {
+        window.clearInterval(intervalId);
+        return;
+      }
+      primaryCloudLinkState.refresh();
+    }, CONNECTIONS_CLOUD_LINK_RETRY_INTERVAL_MS);
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [managedTunnelActive, primaryCloudLinkState.refresh]);
   const [isUpdating, setIsUpdating] = useState(false);
   const [isUpdatingPreference, setIsUpdatingPreference] = useState(false);
 

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -1606,12 +1606,14 @@ function ConfiguredCloudLinkRow({ canManageRelay }: { readonly canManageRelay: b
   } = useCloudLinkController();
   // Opening Connections can race startup reconcile: the shared SWR atom may
   // still hold managedTunnelActive: false from a pre-reconcile read. Refresh
-  // on open, then retry on a short budget while this page stays mounted.
+  // on open, then retry on a short budget while a linked tunnel still looks
+  // inactive and this page stays mounted.
+  const linked = primaryCloudLinkState.data?.linked ?? false;
   useEffect(() => {
     primaryCloudLinkState.refresh();
   }, [primaryCloudLinkState.refresh]);
   useEffect(() => {
-    if (managedTunnelActive) {
+    if (managedTunnelActive || !linked) {
       return;
     }
     const startedAt = Date.now();
@@ -1626,7 +1628,7 @@ function ConfiguredCloudLinkRow({ canManageRelay }: { readonly canManageRelay: b
     return () => {
       window.clearInterval(intervalId);
     };
-  }, [managedTunnelActive, primaryCloudLinkState.refresh]);
+  }, [linked, managedTunnelActive, primaryCloudLinkState.refresh]);
   const [isUpdating, setIsUpdating] = useState(false);
   const [isUpdatingPreference, setIsUpdatingPreference] = useState(false);
 

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -42,6 +42,7 @@ import { formatElapsedDurationLabel, formatExpiresInLabel } from "../../timestam
 import { resolveDesktopPairingUrl, resolveHostedPairingUrl } from "./pairingUrls";
 import {
   applyWslEnableSelection,
+  isInitialCloudLinkStatePending,
   isQrShareableEndpoint,
   selectQrEndpointOption,
 } from "./ConnectionsSettings.logic";
@@ -1638,6 +1639,7 @@ function ConfiguredCloudLinkRow({ canManageRelay }: { readonly canManageRelay: b
       ? "Your session does not have permission to manage T3 Connect access."
       : null;
   const isBusy = isUpdating || isUpdatingPreference;
+  const isInitialLinkStatePending = isInitialCloudLinkStatePending(primaryCloudLinkState);
 
   const updateManagedTunnel = async (enabled: boolean) => {
     setIsUpdating(true);
@@ -1691,7 +1693,7 @@ function ConfiguredCloudLinkRow({ canManageRelay }: { readonly canManageRelay: b
           control={
             <CloudLinkSwitch
               checked={managedTunnelActive}
-              disabled={!canManageRelay || !isSignedIn || primaryCloudLinkState.isPending || isBusy}
+              disabled={!canManageRelay || !isSignedIn || isInitialLinkStatePending || isBusy}
               disabledReason={disabledReason}
               onCheckedChange={(enabled) => void updateManagedTunnel(enabled)}
             />
@@ -1705,7 +1707,7 @@ function ConfiguredCloudLinkRow({ canManageRelay }: { readonly canManageRelay: b
           <CloudLinkSwitch
             ariaLabel="Publish agent activity to mobile clients"
             checked={publishAgentActivity}
-            disabled={!canManageRelay || !isSignedIn || primaryCloudLinkState.isPending || isBusy}
+            disabled={!canManageRelay || !isSignedIn || isInitialLinkStatePending || isBusy}
             disabledReason={disabledReason}
             onCheckedChange={(enabled) => void updatePublishAgentActivity(enabled)}
           />


### PR DESCRIPTION
## Problem

Startup reconciliation applies T3 Connect relay config after routes are already live. Settings reads `managedTunnelActive` from `useCloudLinkController` → a shared SWR atom (`staleTime: 5s`). If the first read lands before `applyRelayConfig`, the atom caches `managedTunnelActive: false` and nothing invalidates it when the background reconcile finishes. The switch stays off even though the tunnel is up. Toggling later refreshes via the mutation path.

The always-mounted T3 Connect onboarding dialog keeps this atom subscribed from app start, so `revalidateOnMount` never runs again.

## Fix

Display refresh only — no auto-link, no protocol change, and the `managedTunnelActive ?? linked` fallback for older servers is unchanged.

- After the first settled link-state read, schedule one delayed refresh so a startup-stale inactive value can be replaced once reconcile has had a chance to finish.
- Force-refresh when Settings → Connections opens, so a later visit also converges on post-reconcile server state.

## Tests

- `apps/web/src/cloud/primaryCloudLinkState.test.ts` — stale inactive snapshot becomes active after the follow-up refresh; one-shot per target; no schedule without a target
- Existing `linkEnvironment.test.ts` still passes (read/reconcile mapping unchanged)

Fixes #6628

Model: grok-4
Harness: T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes T3 Connect reconcile and toggle sync paths in onboarding and Connections; display-only refresh logic but incorrect reconcile could affect tunnel/publish state if helpers are wrong.
> 
> **Overview**
> Fixes **stale `managedTunnelActive: false`** in the shared cloud link SWR cache when startup reconcile finishes after the first read, so the T3 Connect switch and onboarding UI can catch up without a manual toggle.
> 
> **Link-state refresh:** After the first settled read with an inactive tunnel, `usePrimaryCloudLinkState` schedules bounded follow-up refreshes (2s / 5s / 10s) and cancels them once the tunnel is active. **Connections** forces a refresh on mount and retries every 2s for up to 15s while linked but still inactive.
> 
> **Derived behavior:** `resolveManagedTunnelActive` centralizes the `managedTunnelActive ?? linked` fallback (moved out of `useCloudLinkController`). `isInitialCloudLinkStatePending` only disables switches before the first snapshot, not during background revalidation.
> 
> **Onboarding hardening:** Toggles keep syncing from link state until the user touches them; reconcile uses `resolveOnboardingReconcileDesired` so stale prefill cannot tear down an active tunnel or submit publish-only when both toggles are off. Account-scoped helpers avoid applying another account’s cached tunnel state after a switch.
> 
> Unit tests cover the new helpers and refresh scheduling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee96d97bea90483a9862da7ddd53e20964f52725. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refresh T3 Connect switch state after startup reconcile to fix stale inactive tunnel snapshots
> - After `usePrimaryCloudLinkState` settles, link state is refreshed at 2s, 5s, and 10s delays to correct a startup-stale `managedTunnelActive=false` snapshot left before reconcile completes.
> - The onboarding dialog in `ConnectOnboardingDialog.tsx` now continuously re-syncs toggles from link state until the user manually changes them, scoped to the current account only.
> - Reconcile submissions skip when both toggles are off, and no longer tear down an already-active tunnel when the expose toggle is turned off.
> - The T3 Connect switches on the Connections settings page are disabled only during the initial load, not during SWR revalidation of cached data, using the new `isInitialCloudLinkStatePending` helper.
> - Behavioral Change: `ConnectionsSettings` now also starts a periodic retry loop on mount to refresh link state while a linked tunnel appears inactive, stopping when the tunnel becomes active or a time budget elapses.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee96d97.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->