### PR TITLE
fix(server): pass project root to JetBrains editor launches

### DIFF
--- a/apps/server/src/process/externalLauncher.test.ts
+++ b/apps/server/src/process/externalLauncher.test.ts
@@ -281,6 +281,146 @@ it.effect("rescans after an interrupted discovery instead of caching the interru
   );
 });
 
+function launchEditorAndCapture(input: {
+  readonly editor: "idea" | "clion" | "vscode" | "zed";
+  readonly cwd: string;
+  readonly projectRoot?: string;
+  readonly binaries: ReadonlyArray<string>;
+}) {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const binDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-editors-" });
+    for (const binary of input.binaries) {
+      const binaryPath = path.join(binDir, binary);
+      yield* fileSystem.writeFileString(binaryPath, "#!/bin/sh\n");
+      yield* fileSystem.chmod(binaryPath, 0o755);
+    }
+
+    let spawned: ChildProcess.StandardCommand | undefined;
+    yield* Effect.gen(function* () {
+      const launcher = yield* ExternalLauncher.ExternalLauncher;
+      yield* launcher.launchEditor({
+        editor: input.editor,
+        cwd: input.cwd,
+        ...(input.projectRoot === undefined ? {} : { projectRoot: input.projectRoot }),
+      });
+    }).pipe(
+      Effect.provide(
+        testLayer({
+          platform: "linux",
+          env: { PATH: binDir },
+          onSpawn: (command) => {
+            spawned = command;
+          },
+        }),
+      ),
+    );
+
+    assert.ok(spawned);
+    return spawned;
+  });
+}
+
+it.effect("intellij positioned file includes project root before --line", () =>
+  Effect.gen(function* () {
+    const spawned = yield* launchEditorAndCapture({
+      editor: "idea",
+      cwd: "/abs/worktree-b/src/File.java:168:4",
+      projectRoot: "/abs/worktree-b",
+      binaries: ["idea"],
+    });
+
+    assert.equal(spawned.command, "idea");
+    assert.deepEqual(spawned.args, [
+      "/abs/worktree-b",
+      "--line",
+      "168",
+      "--column",
+      "4",
+      "/abs/worktree-b/src/File.java",
+    ]);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
+it.effect("clion positioned file includes project root and omits --column when absent", () =>
+  Effect.gen(function* () {
+    const spawned = yield* launchEditorAndCapture({
+      editor: "clion",
+      cwd: "/abs/worktree-b/src/main.cpp:42",
+      projectRoot: "/abs/worktree-b",
+      binaries: ["clion"],
+    });
+
+    assert.equal(spawned.command, "clion");
+    assert.deepEqual(spawned.args, [
+      "/abs/worktree-b",
+      "--line",
+      "42",
+      "/abs/worktree-b/src/main.cpp",
+    ]);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
+it.effect("jetbrains positioned file without project root keeps the old arg shape", () =>
+  Effect.gen(function* () {
+    const spawned = yield* launchEditorAndCapture({
+      editor: "idea",
+      cwd: "/abs/worktree-b/src/File.java:168:4",
+      binaries: ["idea"],
+    });
+
+    assert.deepEqual(spawned.args, [
+      "--line",
+      "168",
+      "--column",
+      "4",
+      "/abs/worktree-b/src/File.java",
+    ]);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
+it.effect("jetbrains unpositioned targets stay a single path argument", () =>
+  Effect.gen(function* () {
+    const spawned = yield* launchEditorAndCapture({
+      editor: "idea",
+      cwd: "/abs/worktree-b",
+      projectRoot: "/abs/worktree-b",
+      binaries: ["idea"],
+    });
+
+    assert.deepEqual(spawned.args, ["/abs/worktree-b"]);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
+it.effect("vscode goto launches stay --goto even when a project root is known", () =>
+  Effect.gen(function* () {
+    const spawned = yield* launchEditorAndCapture({
+      editor: "vscode",
+      cwd: "/abs/worktree-b/src/index.ts:12:4",
+      projectRoot: "/abs/worktree-b",
+      binaries: ["code"],
+    });
+
+    assert.equal(spawned.command, "code");
+    assert.deepEqual(spawned.args, ["--goto", "/abs/worktree-b/src/index.ts:12:4"]);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
+it.effect("zed direct-path launches stay a single path argument", () =>
+  Effect.gen(function* () {
+    const spawned = yield* launchEditorAndCapture({
+      editor: "zed",
+      cwd: "/abs/worktree-b/src/lib.rs:10:2",
+      projectRoot: "/abs/worktree-b",
+      binaries: ["zed"],
+    });
+
+    assert.equal(spawned.command, "zed");
+    assert.deepEqual(spawned.args, ["/abs/worktree-b/src/lib.rs:10:2"]);
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+);
+
 it.effect("rejects unknown editors through the service API", () =>
   Effect.gen(function* () {
     const launcher = yield* ExternalLauncher.ExternalLauncher;

--- a/apps/server/src/process/externalLauncher.ts
+++ b/apps/server/src/process/externalLauncher.ts
@@ -127,6 +127,7 @@ function parseTargetPathAndPosition(target: string): Option.Option<TargetPathAnd
 function resolveCommandEditorArgs(
   editor: (typeof EDITORS)[number],
   target: string,
+  projectRoot: string | undefined,
 ): ReadonlyArray<string> {
   const parsedTarget = parseTargetPathAndPosition(target);
 
@@ -139,6 +140,7 @@ function resolveCommandEditorArgs(
       return Option.match(parsedTarget, {
         onNone: () => [target],
         onSome: ({ path, line, column }) => [
+          ...(projectRoot === undefined ? [] : [projectRoot]),
           "--line",
           line,
           ...Option.match(column, {
@@ -154,9 +156,10 @@ function resolveCommandEditorArgs(
 function resolveEditorArgs(
   editor: (typeof EDITORS)[number],
   target: string,
+  projectRoot: string | undefined,
 ): ReadonlyArray<string> {
   const baseArgs = "baseArgs" in editor ? editor.baseArgs : [];
-  return [...baseArgs, ...resolveCommandEditorArgs(editor, target)];
+  return [...baseArgs, ...resolveCommandEditorArgs(editor, target, projectRoot)];
 }
 
 const resolveAvailableCommand = Effect.fn("externalLauncher.resolveAvailableCommand")(function* (
@@ -352,6 +355,7 @@ const resolveEditorLaunch = Effect.fn("resolveEditorLaunch")(function* (
   yield* Effect.annotateCurrentSpan({
     "externalLauncher.editor": input.editor,
     "externalLauncher.cwd": input.cwd,
+    "externalLauncher.projectRoot": input.projectRoot,
     "externalLauncher.platform": platform,
   });
   const editorDef = EDITORS.find((editor) => editor.id === input.editor);
@@ -368,7 +372,7 @@ const resolveEditorLaunch = Effect.fn("resolveEditorLaunch")(function* (
       editor: editorDef.id,
       target: input.cwd,
       command,
-      args: resolveEditorArgs(editorDef, input.cwd),
+      args: resolveEditorArgs(editorDef, input.cwd, input.projectRoot),
     };
   }
 

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1380,6 +1380,7 @@ function ChatMarkdown({
   const openInPreferredEditor = useOpenInPreferredEditor(
     environmentId,
     serverConfig?.availableEditors ?? [],
+    cwd,
   );
   const diffThemeName = resolveDiffThemeName(resolvedTheme);
   const markdownFileLinkMetaByHref = useMemo(() => {

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -143,6 +143,7 @@ export default function DiffPanel({
   const openInPreferredEditor = useOpenInPreferredEditor(
     activeThread?.environmentId ?? null,
     serverConfig?.availableEditors ?? [],
+    activeCwd,
   );
   const getDiffFileContents = useAtomCommand(reviewEnvironment.diffFileContents);
   const gitStatusQuery = useEnvironmentQuery(

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -990,6 +990,7 @@ export default function GitActionsControl({
   const openInPreferredEditor = useOpenInPreferredEditor(
     activeEnvironmentId,
     serverConfig?.availableEditors ?? [],
+    gitCwd,
   );
   const threadToastData = useMemo(
     () => (activeThreadRef ? { threadRef: activeThreadRef } : undefined),

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -357,6 +357,7 @@ export function TerminalViewport({
   const openInPreferredEditor = useOpenInPreferredEditor(
     environmentId,
     serverConfig?.availableEditors ?? [],
+    worktreePath ?? cwd,
   );
   const openTerminalPath = useEffectEvent((target: string) => openInPreferredEditor(target));
   const openPreview = useAtomCommand(previewEnvironment.open, {

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -336,6 +336,7 @@ export const ChatHeader = memo(function ChatHeader({
             keybindings={keybindings}
             availableEditors={availableEditors}
             openInCwd={openInCwd}
+            projectRoot={openInCwd}
           />
         )}
         {activeProjectName && (

--- a/apps/web/src/components/chat/OpenInPicker.tsx
+++ b/apps/web/src/components/chat/OpenInPicker.tsx
@@ -200,6 +200,7 @@ export const OpenInPicker = memo(function OpenInPicker({
   keybindings,
   availableEditors,
   openInCwd,
+  projectRoot,
   compact = false,
   enableShortcut = true,
 }: {
@@ -207,6 +208,7 @@ export const OpenInPicker = memo(function OpenInPicker({
   keybindings: ResolvedKeybindingsConfig;
   availableEditors: ReadonlyArray<EditorId>;
   openInCwd: string | null;
+  projectRoot?: string | null;
   compact?: boolean;
   enableShortcut?: boolean;
 }) {
@@ -252,6 +254,7 @@ export const OpenInPicker = memo(function OpenInPicker({
         input: {
           cwd: openInCwd,
           editor,
+          ...(projectRoot ? { projectRoot } : {}),
         },
       });
       setPreferredEditor(editor);
@@ -263,6 +266,7 @@ export const OpenInPicker = memo(function OpenInPicker({
       openInCwd,
       openInEditorMutation,
       preferredEditor,
+      projectRoot,
       remote,
       setPreferredEditor,
     ],

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -902,6 +902,7 @@ export default function FilePreviewPanel({
               keybindings={keybindings}
               availableEditors={availableEditors}
               openInCwd={absolutePath}
+              projectRoot={cwd}
               compact
               enableShortcut={false}
             />

--- a/apps/web/src/editorPreferences.ts
+++ b/apps/web/src/editorPreferences.ts
@@ -63,6 +63,7 @@ export function resolveAndPersistPreferredEditor(
 export function useOpenInPreferredEditor(
   environmentId: EnvironmentId | null,
   availableEditors: readonly EditorId[],
+  projectRoot?: string | null,
 ) {
   const openInEditor = useAtomCommand(shellEnvironment.openInEditor, {
     reportFailure: false,
@@ -106,10 +107,11 @@ export function useOpenInPreferredEditor(
         input: {
           cwd: targetPath,
           editor,
+          ...(projectRoot ? { projectRoot } : {}),
         },
       });
       return mapAtomCommandResult(result, () => editor);
     },
-    [availableEditors, environmentId, openInEditor],
+    [availableEditors, environmentId, openInEditor, projectRoot],
   );
 }

--- a/packages/contracts/src/editor.ts
+++ b/packages/contracts/src/editor.ts
@@ -72,6 +72,11 @@ export type EditorId = typeof EditorId.Type;
 export const LaunchEditorInput = Schema.Struct({
   cwd: TrimmedNonEmptyString,
   editor: EditorId,
+  /**
+   * Thread workspace root already known to T3. JetBrains CLIs use this as the
+   * project to open or reuse; never inferred from the file path.
+   */
+  projectRoot: Schema.optionalKey(TrimmedNonEmptyString),
 });
 export type LaunchEditorInput = typeof LaunchEditorInput.Type;
 


### PR DESCRIPTION
JetBrains CLIs were launched as `idea --line 168 --column 4 /abs/worktree-b/src/File.java`. Without the project/worktree root, IntelliJ can reuse the wrong window, open LightEdit, or fail when another checkout of the same repo is already open.

`LaunchEditorInput` now carries an optional `projectRoot` from the thread's known workspace cwd (chat links, diffs, git file actions, terminal links, file preview). Line-column launches become:

```
idea /abs/worktree-b --line 168 --column 4 /abs/worktree-b/src/File.java
```

If the root is missing, the previous arg shape is unchanged. `--column` is still omitted when no column is present. VS Code `--goto` and Zed direct-path launches are unchanged. The root is never inferred from the file path.

Fixes #5885

Made with Grok (T3 Code).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to optional editor launch args and UI plumbing; backward-compatible when projectRoot is omitted, with regression tests for JetBrains CLI shapes.
> 
> **Overview**
> Fixes JetBrains **line-column** launches opening the wrong project window when multiple checkouts exist by threading an optional **`projectRoot`** through **`LaunchEditorInput`** and the web “open in editor” paths.
> 
> When **`projectRoot`** is set, **`externalLauncher`** prepends it before **`--line`** / **`--column`** and the file path (e.g. `idea /abs/worktree-b --line 168 --column 4 …`). Without it, JetBrains args stay the old shape. **VS Code** (`--goto`) and **Zed** direct-path launches are unchanged.
> 
> The UI passes the thread/workspace **`cwd`** as **`projectRoot`** from chat markdown links, diff panel, git file actions, terminal links, file preview, and **`OpenInPicker`** / **`useOpenInPreferredEditor`**. New server tests lock in the arg shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5325a42281886674b25c2e95140adf0e00335d46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pass project root to JetBrains editor launches
> - Adds an optional `projectRoot` field to `LaunchEditorInput` in [editor.ts](https://github.com/pingdotgg/t3code/pull/7194/files#diff-952d09e8dcc92b201e44f8f0b5edc71af952e9af9479b5853c41ce6e93d636f7) and threads it through `resolveCommandEditorArgs` in [externalLauncher.ts](https://github.com/pingdotgg/t3code/pull/7194/files#diff-157ca66b5181820e0a628ef443d244577cda2329dd1d88fe5f2aff441da05e56)
> - For `line-column` launch style (e.g. JetBrains CLIs), `projectRoot` is prepended to the args before `--line` when a file position is present
> - All web components that trigger editor opens (`ChatMarkdown`, `DiffPanel`, `GitActionsControl`, `OpenInPicker`, etc.) now pass their local `cwd` or equivalent as `projectRoot`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5325a42.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->