### PR TITLE
fix(web): allow new threads when unsettled env is offline

### DIFF
--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -92,6 +92,7 @@ import { isPreviewFocused } from "../lib/previewFocus";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { selectActiveRightPanel, useRightPanelStore } from "../rightPanelStore";
 import { getLatestThreadForProject, sortThreads } from "../lib/threadSort";
+import { shouldOpenLatestThreadForProject } from "../session-logic";
 import { cn, isMacPlatform, isWindowsPlatform, newProjectId } from "../lib/utils";
 import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../terminalUiStateStore";
 import { buildThreadRouteParams, resolveThreadRouteTarget } from "../threadRoutes";
@@ -965,7 +966,19 @@ function OpenCommandPaletteDialog(props: {
             project.id,
             clientSettings.sidebarThreadSortOrder,
           );
-      if (latestThread) {
+      const latestThreadConnectionPhase = latestThread
+        ? environments.find(
+            (environment) => environment.environmentId === latestThread.environmentId,
+          )?.connection.phase
+        : undefined;
+      if (
+        latestThread &&
+        shouldOpenLatestThreadForProject(
+          latestThread.latestTurn,
+          latestThread.session,
+          latestThreadConnectionPhase,
+        )
+      ) {
         await navigate({
           to: "/$environmentId/$threadId",
           params: buildThreadRouteParams(
@@ -979,6 +992,7 @@ function OpenCommandPaletteDialog(props: {
     },
     [
       clientSettings.sidebarThreadSortOrder,
+      environments,
       handleNewThread,
       navigate,
       projectGroupByTargetKey,
@@ -1683,7 +1697,19 @@ function OpenCommandPaletteDialog(props: {
           existing.id,
           clientSettings.sidebarThreadSortOrder,
         );
-        if (latestThread) {
+        const latestThreadConnectionPhase = latestThread
+          ? environments.find(
+              (environment) => environment.environmentId === latestThread.environmentId,
+            )?.connection.phase
+          : undefined;
+        if (
+          latestThread &&
+          shouldOpenLatestThreadForProject(
+            latestThread.latestTurn,
+            latestThread.session,
+            latestThreadConnectionPhase,
+          )
+        ) {
           await navigate({
             to: "/$environmentId/$threadId",
             params: buildThreadRouteParams(

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -29,6 +29,7 @@ import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments"
 import {
   resolveAvailableNewThreadProjectRef,
   resolveNewDraftStartFromOrigin,
+  resolveWorkspaceOptionsAfterEnvironmentRetarget,
 } from "../lib/chatThreadActions";
 import { readT3ProjectFileDefaultThreadEnvMode } from "../lib/t3ProjectFileDefaults";
 import { shouldReadProjectFileForNewThreadDefaults } from "../session-logic";
@@ -198,6 +199,11 @@ export function useNewThreadHandler() {
             candidate.id === projectRef.projectId &&
             candidate.environmentId === projectRef.environmentId,
         ) ?? requestedProject;
+      const workspaceOptions = resolveWorkspaceOptionsAfterEnvironmentRetarget({
+        requestedEnvironmentId: requestedProjectRef.environmentId,
+        targetEnvironmentId: projectRef.environmentId,
+        options,
+      });
       // The shared resolver owns the priority order. The t3.json read is
       // skipped entirely when a higher-priority source decides or the
       // environment cannot serve: executeAtomQuery waits on a live RPC, so
@@ -223,10 +229,10 @@ export function useNewThreadHandler() {
       const logicalProjectKey = project
         ? deriveLogicalProjectKeyFromSettings(project, projectGroupingSettings)
         : scopedProjectKey(projectRef);
-      const hasBranchOption = options?.branch !== undefined;
-      const hasWorktreePathOption = options?.worktreePath !== undefined;
-      const hasEnvModeOption = options?.envMode !== undefined;
-      const hasStartFromOriginOption = options?.startFromOrigin !== undefined;
+      const hasBranchOption = workspaceOptions?.branch !== undefined;
+      const hasWorktreePathOption = workspaceOptions?.worktreePath !== undefined;
+      const hasEnvModeOption = workspaceOptions?.envMode !== undefined;
+      const hasStartFromOriginOption = workspaceOptions?.startFromOrigin !== undefined;
       const storedDraftThread = getDraftSessionByLogicalProjectKey(logicalProjectKey);
       const storedDraftThreadRef = storedDraftThread
         ? scopeThreadRef(storedDraftThread.environmentId, storedDraftThread.threadId)
@@ -273,7 +279,7 @@ export function useNewThreadHandler() {
           // the user may have just picked a branch in the composer.
           let workspaceContext: NewThreadWorkspaceOptions | null = null;
           if (hasExplicitWorkspaceOption) {
-            workspaceContext = pickExplicitWorkspaceOptions(options);
+            workspaceContext = pickExplicitWorkspaceOptions(workspaceOptions);
           } else if (!isDraftAlreadyOpen) {
             const defaultEnvMode = await resolveDefaultEnvMode();
             // The await yields. If the draft was opened (a concurrent
@@ -379,14 +385,17 @@ export function useNewThreadHandler() {
           hasEnvModeOption ||
           hasStartFromOriginOption
         ) {
-          setDraftThreadContext(currentRouteTarget.draftId, pickExplicitWorkspaceOptions(options));
+          setDraftThreadContext(
+            currentRouteTarget.draftId,
+            pickExplicitWorkspaceOptions(workspaceOptions),
+          );
         }
         setLogicalProjectDraftThreadId(logicalProjectKey, projectRef, currentRouteTarget.draftId, {
           threadId: latestActiveDraftThread.threadId,
           createdAt: latestActiveDraftThread.createdAt,
           runtimeMode: latestActiveDraftThread.runtimeMode,
           interactionMode: latestActiveDraftThread.interactionMode,
-          ...pickExplicitWorkspaceOptions(options),
+          ...pickExplicitWorkspaceOptions(workspaceOptions),
         });
         return Promise.resolve({
           draftId: currentRouteTarget.draftId,
@@ -398,7 +407,7 @@ export function useNewThreadHandler() {
       const threadId = newThreadId();
       const createdAt = new Date().toISOString();
       return (async () => {
-        const initialEnvMode = options?.envMode ?? (await resolveDefaultEnvMode());
+        const initialEnvMode = workspaceOptions?.envMode ?? (await resolveDefaultEnvMode());
         // The await yields, so a concurrent invocation may have registered a
         // draft for this logical project in the meantime. Registering ours
         // too would evict that draft while its navigation is in flight —
@@ -426,7 +435,7 @@ export function useNewThreadHandler() {
             createdAt: racedDraft.createdAt,
             runtimeMode: racedDraft.runtimeMode,
             interactionMode: racedDraft.interactionMode,
-            ...pickExplicitWorkspaceOptions(options),
+            ...pickExplicitWorkspaceOptions(workspaceOptions),
           });
           carryComposerContentTo(racedDraft.draftId);
           await router.navigate({
@@ -439,11 +448,11 @@ export function useNewThreadHandler() {
         setLogicalProjectDraftThreadId(logicalProjectKey, projectRef, draftId, {
           threadId,
           createdAt,
-          branch: options?.branch ?? null,
-          worktreePath: options?.worktreePath ?? null,
+          branch: workspaceOptions?.branch ?? null,
+          worktreePath: workspaceOptions?.worktreePath ?? null,
           envMode: initialEnvMode,
           startFromOrigin:
-            options?.startFromOrigin ??
+            workspaceOptions?.startFromOrigin ??
             resolveNewDraftStartFromOrigin({
               envMode: initialEnvMode,
               newWorktreesStartFromOrigin: primaryServerSettings.newWorktreesStartFromOrigin,

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -4,6 +4,7 @@ import {
   scopeProjectRef,
   scopeThreadRef,
 } from "@t3tools/client-runtime/environment";
+import { canCreateProjectInEnvironment } from "@t3tools/client-runtime/operations/projects";
 import { DEFAULT_RUNTIME_MODE, type ScopedProjectRef, type ThreadId } from "@t3tools/contracts";
 import { useParams, useRouter } from "@tanstack/react-router";
 import { useCallback, useMemo } from "react";
@@ -24,8 +25,13 @@ import {
 } from "../logicalProject";
 import { resolveDefaultThreadEnvMode } from "@t3tools/shared/threadEnvMode";
 import { readThreadShell, useProjects, useThread } from "../state/entities";
-import { resolveNewDraftStartFromOrigin } from "../lib/chatThreadActions";
+import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
+import {
+  resolveAvailableNewThreadProjectRef,
+  resolveNewDraftStartFromOrigin,
+} from "../lib/chatThreadActions";
 import { readT3ProjectFileDefaultThreadEnvMode } from "../lib/t3ProjectFileDefaults";
+import { shouldReadProjectFileForNewThreadDefaults } from "../session-logic";
 import { primaryServerSettingsAtom } from "../state/server";
 import { resolveThreadRouteTarget } from "../threadRoutes";
 import { legacyProjectCwdPreferenceKey, useUiStateStore } from "../uiStateStore";
@@ -52,6 +58,8 @@ function pickExplicitWorkspaceOptions(options: NewThreadWorkspaceOptions | undef
 
 export function useNewThreadHandler() {
   const projects = useProjects();
+  const { environments } = useEnvironments();
+  const primaryEnvironmentId = usePrimaryEnvironmentId();
   // New-thread defaults are a user preference, and the settings UI only ever
   // edits the primary environment's settings.json. Reading the target
   // environment's own settings here would silently reset remote projects to
@@ -67,7 +75,7 @@ export function useNewThreadHandler() {
 
   return useCallback(
     (
-      projectRef: ScopedProjectRef,
+      requestedProjectRef: ScopedProjectRef,
       options?: {
         branch?: string | null;
         worktreePath?: string | null;
@@ -156,16 +164,51 @@ export function useNewThreadHandler() {
           moveComposerPromptAndImages(carryContentSourceDraftId, destinationDraftId);
         }
       };
-      const project = projects.find(
+      const requestedProject = projects.find(
         (candidate) =>
-          candidate.id === projectRef.projectId &&
-          candidate.environmentId === projectRef.environmentId,
+          candidate.id === requestedProjectRef.projectId &&
+          candidate.environmentId === requestedProjectRef.environmentId,
       );
+      const requestedLogicalProjectKey = requestedProject
+        ? deriveLogicalProjectKeyFromSettings(requestedProject, projectGroupingSettings)
+        : scopedProjectKey(requestedProjectRef);
+      const siblingProjects = requestedProject
+        ? projects.filter(
+            (candidate) =>
+              deriveLogicalProjectKeyFromSettings(candidate, projectGroupingSettings) ===
+              requestedLogicalProjectKey,
+          )
+        : [];
+      const projectRef = resolveAvailableNewThreadProjectRef({
+        requested: requestedProjectRef,
+        members: siblingProjects.map((candidate) => ({
+          environmentId: candidate.environmentId,
+          projectId: candidate.id,
+          isPrimary: candidate.environmentId === primaryEnvironmentId,
+        })),
+        isEnvironmentReachable: (environmentId) =>
+          canCreateProjectInEnvironment(
+            environments.find((environment) => environment.environmentId === environmentId)
+              ?.connection.phase,
+          ),
+      });
+      const project =
+        projects.find(
+          (candidate) =>
+            candidate.id === projectRef.projectId &&
+            candidate.environmentId === projectRef.environmentId,
+        ) ?? requestedProject;
       // The shared resolver owns the priority order. The t3.json read is
-      // skipped entirely when a higher-priority source decides, and its
-      // query atom caches per project after the first call.
+      // skipped entirely when a higher-priority source decides or the
+      // environment cannot serve: executeAtomQuery waits on a live RPC, so
+      // a down machine would leave New Thread hanging.
       const resolveDefaultEnvMode = async (): Promise<DraftThreadEnvMode> => {
-        const consultProjectFile = project !== undefined && project.defaultThreadEnvMode == null;
+        const connectionPhase = environments.find(
+          (environment) => environment.environmentId === projectRef.environmentId,
+        )?.connection.phase;
+        const consultProjectFile =
+          project !== undefined &&
+          shouldReadProjectFileForNewThreadDefaults(project.defaultThreadEnvMode, connectionPhase);
         return resolveDefaultThreadEnvMode({
           projectSetting: project?.defaultThreadEnvMode,
           projectFile: consultProjectFile
@@ -427,7 +470,15 @@ export function useNewThreadHandler() {
         return { draftId, threadId };
       })();
     },
-    [getCurrentRouteTarget, primaryServerSettings, projectGroupingSettings, projects, router],
+    [
+      environments,
+      getCurrentRouteTarget,
+      primaryEnvironmentId,
+      primaryServerSettings,
+      projectGroupingSettings,
+      projects,
+      router,
+    ],
   );
 }
 

--- a/apps/web/src/lib/chatThreadActions.test.ts
+++ b/apps/web/src/lib/chatThreadActions.test.ts
@@ -5,6 +5,7 @@ import {
   resolveAvailableNewThreadProjectRef,
   resolveThreadActionProjectRef,
   resolveNewDraftStartFromOrigin,
+  resolveWorkspaceOptionsAfterEnvironmentRetarget,
   startNewThreadFromContext,
   type ChatThreadActionContext,
 } from "./chatThreadActions";
@@ -160,5 +161,47 @@ describe("chatThreadActions", () => {
         isEnvironmentReachable: () => false,
       }),
     ).toEqual(requested);
+  });
+
+  it("keeps explicit workspace options when the draft stays on the requested environment", () => {
+    expect(
+      resolveWorkspaceOptionsAfterEnvironmentRetarget({
+        requestedEnvironmentId: ENVIRONMENT_ID,
+        targetEnvironmentId: ENVIRONMENT_ID,
+        options: {
+          branch: "feat/checkout",
+          worktreePath: "/dead/machine/worktree",
+          envMode: "worktree",
+          startFromOrigin: false,
+        },
+      }),
+    ).toEqual({
+      branch: "feat/checkout",
+      worktreePath: "/dead/machine/worktree",
+      envMode: "worktree",
+      startFromOrigin: false,
+    });
+  });
+
+  it("clears machine-specific workspace options when retargeting to another environment", () => {
+    const targetEnvironmentId = EnvironmentId.make("environment-2");
+
+    expect(
+      resolveWorkspaceOptionsAfterEnvironmentRetarget({
+        requestedEnvironmentId: ENVIRONMENT_ID,
+        targetEnvironmentId,
+        options: {
+          branch: "feat/checkout",
+          worktreePath: "/dead/machine/worktree",
+          envMode: "worktree",
+          startFromOrigin: false,
+        },
+      }),
+    ).toEqual({
+      branch: null,
+      worktreePath: null,
+      envMode: "worktree",
+      startFromOrigin: false,
+    });
   });
 });

--- a/apps/web/src/lib/chatThreadActions.test.ts
+++ b/apps/web/src/lib/chatThreadActions.test.ts
@@ -2,6 +2,7 @@ import { scopeProjectRef } from "@t3tools/client-runtime/environment";
 import { EnvironmentId, ProjectId } from "@t3tools/contracts";
 import { describe, expect, it, vi } from "vite-plus/test";
 import {
+  resolveAvailableNewThreadProjectRef,
   resolveThreadActionProjectRef,
   resolveNewDraftStartFromOrigin,
   startNewThreadFromContext,
@@ -103,5 +104,61 @@ describe("chatThreadActions", () => {
 
     expect(didStart).toBe(false);
     expect(handleNewThread).not.toHaveBeenCalled();
+  });
+
+  it("keeps the requested project when its environment is reachable", () => {
+    const otherEnvironmentId = EnvironmentId.make("environment-2");
+    const requested = scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID);
+
+    expect(
+      resolveAvailableNewThreadProjectRef({
+        requested,
+        members: [
+          { environmentId: ENVIRONMENT_ID, projectId: PROJECT_ID, isPrimary: false },
+          { environmentId: otherEnvironmentId, projectId: FALLBACK_PROJECT_ID, isPrimary: true },
+        ],
+        isEnvironmentReachable: () => true,
+      }),
+    ).toEqual(requested);
+  });
+
+  it("retargets an unreachable requested environment to a reachable sibling, preferring primary", () => {
+    const reachableEnvironmentId = EnvironmentId.make("environment-2");
+    const otherEnvironmentId = EnvironmentId.make("environment-3");
+
+    expect(
+      resolveAvailableNewThreadProjectRef({
+        requested: scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID),
+        members: [
+          { environmentId: ENVIRONMENT_ID, projectId: PROJECT_ID, isPrimary: false },
+          {
+            environmentId: otherEnvironmentId,
+            projectId: ProjectId.make("project-3"),
+            isPrimary: false,
+          },
+          {
+            environmentId: reachableEnvironmentId,
+            projectId: FALLBACK_PROJECT_ID,
+            isPrimary: true,
+          },
+        ],
+        isEnvironmentReachable: (environmentId) => environmentId !== ENVIRONMENT_ID,
+      }),
+    ).toEqual(scopeProjectRef(reachableEnvironmentId, FALLBACK_PROJECT_ID));
+  });
+
+  it("keeps the requested project when no sibling environment is reachable", () => {
+    const requested = scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID);
+
+    expect(
+      resolveAvailableNewThreadProjectRef({
+        requested,
+        members: [
+          { environmentId: ENVIRONMENT_ID, projectId: PROJECT_ID },
+          { environmentId: EnvironmentId.make("environment-2"), projectId: FALLBACK_PROJECT_ID },
+        ],
+        isEnvironmentReachable: () => false,
+      }),
+    ).toEqual(requested);
   });
 });

--- a/apps/web/src/lib/chatThreadActions.ts
+++ b/apps/web/src/lib/chatThreadActions.ts
@@ -49,6 +49,25 @@ export function resolveThreadActionProjectRef(
   return context.defaultProjectRef;
 }
 
+export function resolveAvailableNewThreadProjectRef(input: {
+  requested: ScopedProjectRef;
+  members: ReadonlyArray<{
+    environmentId: EnvironmentId;
+    projectId: ProjectId;
+    isPrimary?: boolean;
+  }>;
+  isEnvironmentReachable: (environmentId: EnvironmentId) => boolean;
+}): ScopedProjectRef {
+  if (input.isEnvironmentReachable(input.requested.environmentId)) {
+    return input.requested;
+  }
+  const reachable = input.members
+    .filter((member) => input.isEnvironmentReachable(member.environmentId))
+    .toSorted((left, right) => Number(Boolean(right.isPrimary)) - Number(Boolean(left.isPrimary)));
+  const next = reachable[0];
+  return next ? scopeProjectRef(next.environmentId, next.projectId) : input.requested;
+}
+
 // New threads inherit only the *project* from the current context. Branch,
 // worktree, and env mode always come from the user's configured defaults —
 // carrying them over from the viewed thread meant "new thread" silently

--- a/apps/web/src/lib/chatThreadActions.ts
+++ b/apps/web/src/lib/chatThreadActions.ts
@@ -68,6 +68,25 @@ export function resolveAvailableNewThreadProjectRef(input: {
   return next ? scopeProjectRef(next.environmentId, next.projectId) : input.requested;
 }
 
+export function resolveWorkspaceOptionsAfterEnvironmentRetarget<
+  TOptions extends {
+    branch?: string | null;
+    worktreePath?: string | null;
+  },
+>(input: {
+  requestedEnvironmentId: EnvironmentId;
+  targetEnvironmentId: EnvironmentId;
+  options: TOptions | undefined;
+}): TOptions | undefined {
+  if (input.options === undefined) return undefined;
+  if (input.requestedEnvironmentId === input.targetEnvironmentId) return input.options;
+  return {
+    ...input.options,
+    ...(input.options.branch !== undefined ? { branch: null } : {}),
+    ...(input.options.worktreePath !== undefined ? { worktreePath: null } : {}),
+  };
+}
+
 // New threads inherit only the *project* from the current context. Branch,
 // worktree, and env mode always come from the user's configured defaults —
 // carrying them over from the viewed thread meant "new thread" silently

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -1708,6 +1708,11 @@ describe("offline environment escape for unsettled latest turns", () => {
     ).toBe(false);
   });
 
+  it("does not treat a never-started thread as an unsettled trap when the environment is offline", () => {
+    expect(shouldEscapeUnsettledThreadOnOfflineEnvironment(null, null, "offline")).toBe(false);
+    expect(shouldOpenLatestThreadForProject(null, null, "offline")).toBe(true);
+  });
+
   it("does not consult t3.json for new-thread defaults unless the environment is connected", () => {
     expect(shouldReadProjectFileForNewThreadDefaults(null, "connected")).toBe(true);
     expect(shouldReadProjectFileForNewThreadDefaults(null, "offline")).toBe(false);

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -19,6 +19,9 @@ import {
   findLatestProposedPlan,
   hasActionableProposedPlan,
   isLatestTurnSettled,
+  shouldEscapeUnsettledThreadOnOfflineEnvironment,
+  shouldOpenLatestThreadForProject,
+  shouldReadProjectFileForNewThreadDefaults,
   workEntryIndicatesToolFailure,
   workEntryIndicatesToolNeutralStatus,
   workEntryIndicatesToolSuccess,
@@ -1654,6 +1657,61 @@ describe("isLatestTurnSettled", () => {
         null,
       ),
     ).toBe(false);
+  });
+});
+
+describe("offline environment escape for unsettled latest turns", () => {
+  const settledTurn = {
+    turnId: TurnId.make("turn-1"),
+    startedAt: "2026-02-27T21:10:00.000Z",
+    completedAt: "2026-02-27T21:10:06.000Z",
+  } as const;
+  const inFlightTurn = {
+    turnId: TurnId.make("turn-1"),
+    startedAt: "2026-02-27T21:10:00.000Z",
+    completedAt: null,
+  } as const;
+  const runningSession = {
+    status: "running" as const,
+    activeTurnId: TurnId.make("turn-1"),
+  };
+  const readySession = {
+    status: "ready" as const,
+    activeTurnId: null,
+  };
+
+  it("still opens the latest thread when the owning environment is reachable and the turn is unsettled", () => {
+    expect(shouldOpenLatestThreadForProject(inFlightTurn, runningSession, "connected")).toBe(true);
+    expect(
+      shouldEscapeUnsettledThreadOnOfflineEnvironment(inFlightTurn, runningSession, "connected"),
+    ).toBe(false);
+  });
+
+  it("does not open an unsettled latest thread when the owning environment is offline", () => {
+    expect(shouldOpenLatestThreadForProject(inFlightTurn, runningSession, "offline")).toBe(false);
+    expect(
+      shouldEscapeUnsettledThreadOnOfflineEnvironment(inFlightTurn, runningSession, "offline"),
+    ).toBe(true);
+  });
+
+  it("does not open an unsettled latest thread when the owning environment is reconnecting or unknown", () => {
+    expect(shouldOpenLatestThreadForProject(inFlightTurn, runningSession, "reconnecting")).toBe(
+      false,
+    );
+    expect(shouldOpenLatestThreadForProject(inFlightTurn, runningSession, undefined)).toBe(false);
+  });
+
+  it("still opens a settled latest thread even if the owning environment is offline", () => {
+    expect(shouldOpenLatestThreadForProject(settledTurn, readySession, "offline")).toBe(true);
+    expect(
+      shouldEscapeUnsettledThreadOnOfflineEnvironment(settledTurn, readySession, "offline"),
+    ).toBe(false);
+  });
+
+  it("does not consult t3.json for new-thread defaults unless the environment is connected", () => {
+    expect(shouldReadProjectFileForNewThreadDefaults(null, "connected")).toBe(true);
+    expect(shouldReadProjectFileForNewThreadDefaults(null, "offline")).toBe(false);
+    expect(shouldReadProjectFileForNewThreadDefaults("worktree", "connected")).toBe(false);
   });
 });
 

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -347,7 +347,7 @@ export function shouldEscapeUnsettledThreadOnOfflineEnvironment(
   connectionPhase: EnvironmentConnectionPhase | null | undefined,
 ): boolean {
   if (canCreateProjectInEnvironment(connectionPhase)) return false;
-  return !isLatestTurnSettled(latestTurn, session);
+  return latestTurn !== null && !isLatestTurnSettled(latestTurn, session);
 }
 
 export function shouldOpenLatestThreadForProject(

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -1,6 +1,8 @@
 import * as Option from "effect/Option";
 import * as Arr from "effect/Array";
 import { isBackgroundTaskActivity } from "@t3tools/client-runtime/state/subagentRuntime";
+import { canCreateProjectInEnvironment } from "@t3tools/client-runtime/operations/projects";
+import type { EnvironmentConnectionPhase } from "@t3tools/client-runtime/connection";
 import {
   ApprovalRequestId,
   isToolLifecycleItemType,
@@ -331,6 +333,36 @@ export function isLatestTurnSettled(
   if (!session) return true;
   if (session.status === "running") return false;
   return true;
+}
+
+/**
+ * Opening a project still lands on an unsettled latest thread when its
+ * environment can serve (settle / send). When that machine is down, landing
+ * there traps the user: settle and the t3.json new-thread read both wait on
+ * the dead host.
+ */
+export function shouldEscapeUnsettledThreadOnOfflineEnvironment(
+  latestTurn: LatestTurnTiming | null,
+  session: SessionActivityState | null,
+  connectionPhase: EnvironmentConnectionPhase | null | undefined,
+): boolean {
+  if (canCreateProjectInEnvironment(connectionPhase)) return false;
+  return !isLatestTurnSettled(latestTurn, session);
+}
+
+export function shouldOpenLatestThreadForProject(
+  latestTurn: LatestTurnTiming | null,
+  session: SessionActivityState | null,
+  connectionPhase: EnvironmentConnectionPhase | null | undefined,
+): boolean {
+  return !shouldEscapeUnsettledThreadOnOfflineEnvironment(latestTurn, session, connectionPhase);
+}
+
+export function shouldReadProjectFileForNewThreadDefaults(
+  projectDefaultThreadEnvMode: string | null | undefined,
+  connectionPhase: EnvironmentConnectionPhase | null | undefined,
+): boolean {
+  return projectDefaultThreadEnvMode == null && canCreateProjectInEnvironment(connectionPhase);
 }
 
 export function deriveActiveWorkStartedAt(


### PR DESCRIPTION
Fixes #6358.

If machine A dies mid-turn, opening project P auto-opens that unsettled thread. Settle cannot run while A is down, and New Thread waited on a `t3.json` read against the dead host, so the user was trapped until `t3 serve` came back.

**Product rule**
- Reachable environment + unsettled latest turn: still land on that thread so it can be settled. New Thread was never blocked in this case and is not newly blocked.
- Unreachable/offline environment + unsettled latest turn: do not land on that thread. Open a new draft instead.
- Settled latest turn: unchanged (still opened).
- Do not fake-settle the remote turn.

**Fix**
- Skip auto-open of an unsettled latest thread when its environment is not connected (command palette / existing-project open).
- New Thread no longer consults `t3.json` unless the target environment is connected (`executeAtomQuery` would otherwise hang).
- If the requested environment is down and the same logical project exists on a connected machine, the draft retargets there (primary preferred).

Grok 4.5 (T3 Code worktree).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default navigation and new-thread targeting across multi-environment projects; behavior is covered by new unit tests but wrong reachability checks could send drafts to the wrong machine.
> 
> **Overview**
> Fixes a trap when a machine dies mid-turn: opening a project or starting **New Thread** could land on an unsettled thread or block on RPC/`t3.json` against the offline host.
> 
> **Project open (command palette / existing path):** Auto-navigation to the latest thread now goes through `shouldOpenLatestThreadForProject`. Unsettled latest threads on offline, reconnecting, or unknown environments are skipped so the flow falls through to **New Thread**; settled threads and reachable unsettled threads behave as before.
> 
> **New Thread (`useHandleNewThread`):** Before creating a draft, the handler resolves a reachable project via `resolveAvailableNewThreadProjectRef` (sibling logical projects, preferring primary). `shouldReadProjectFileForNewThreadDefaults` gates `t3.json` reads to connected environments only. After retargeting, `resolveWorkspaceOptionsAfterEnvironmentRetarget` clears machine-specific `branch` and `worktreePath` while keeping other options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38dcec389f8905716184dbe043054c7386e16525. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow new thread creation when the target environment is offline by retargeting to a reachable sibling
> - When opening a project from the command palette, navigation to the latest thread is skipped if the environment is offline and the latest turn is unsettled; a new thread is created instead, using new `shouldOpenLatestThreadForProject` in [session-logic.ts](https://github.com/pingdotgg/t3code/pull/7195/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6).
> - New thread creation in [useHandleNewThread.ts](https://github.com/pingdotgg/t3code/pull/7195/files#diff-4a13a04822f436fab695948f0596a6fd92885554e031426dac1954a343c98fef) retargets to a reachable sibling environment (preferring the primary) when the requested environment is unreachable, via `resolveAvailableNewThreadProjectRef` in [chatThreadActions.ts](https://github.com/pingdotgg/t3code/pull/7195/files#diff-6e655e056adaf8605b1381f1a37651405db18539fe8abe8eb1e810e5f95608e1).
> - When retargeted, machine-specific options (`branch`, `worktreePath`) are cleared via `resolveWorkspaceOptionsAfterEnvironmentRetarget`.
> - Reading project file defaults (`t3.json`) is skipped when the environment is offline, avoiding blocked RPC calls.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 38dcec3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->