### PR TITLE
fix(server): attach explicit Codex $skill invocations

### DIFF
--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -252,7 +252,7 @@ function appendCustomCodexModels(
   return customEntries.length === 0 ? models : [...models, ...customEntries];
 }
 
-function parseCodexSkillsListResponse(
+export function parseCodexSkillsListResponse(
   response: CodexSchema.V2SkillsListResponse,
   cwd: string,
 ): ReadonlyArray<ServerProviderSkill> {

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -17,12 +17,15 @@ import {
 import { codexSessionAppServerArgs } from "./codexLaunchArgs.ts";
 import {
   buildTurnStartParams,
+  CodexSessionRuntimeUnknownSkillError,
   hasConfiguredMcpServer,
   isRecoverableThreadResumeError,
   makeMemoryConsolidationNotificationFilter,
   openCodexThread,
 } from "./CodexSessionRuntime.ts";
 const isCodexAppServerRequestError = Schema.is(CodexErrors.CodexAppServerRequestError);
+const isCodexAppServerProtocolParseError = Schema.is(CodexErrors.CodexAppServerProtocolParseError);
+const isCodexSessionRuntimeUnknownSkillError = Schema.is(CodexSessionRuntimeUnknownSkillError);
 
 describe("CodexSessionRuntimeIdentifierGenerationError", () => {
   it("retains identifier purpose and the random source failure", () => {
@@ -79,6 +82,10 @@ describe("buildTurnStartParams", () => {
         ],
       }).pipe(Effect.flip),
     );
+    if (!isCodexAppServerProtocolParseError(error)) {
+      NodeAssert.fail("expected CodexAppServerProtocolParseError");
+      return;
+    }
     const { cause, ...directDiagnostics } = error;
 
     NodeAssert.equal(error.operation, "decode-request-payload");
@@ -219,6 +226,83 @@ describe("buildTurnStartParams", () => {
           },
         ],
       });
+    }),
+  );
+
+  it.effect("attaches explicit $skill tokens as Codex skill user input", () =>
+    Effect.gen(function* () {
+      const params = yield* buildTurnStartParams({
+        threadId: "provider-thread-1",
+        runtimeMode: "full-access",
+        prompt: "$grill-with-docs explain why this skill is not in the list",
+        availableSkills: [
+          {
+            name: "grill-with-docs",
+            path: "/Users/me/.agents/skills/grill-with-docs/SKILL.md",
+            enabled: true,
+          },
+        ],
+      });
+
+      NodeAssert.deepStrictEqual(params.input, [
+        {
+          type: "text",
+          text: "$grill-with-docs explain why this skill is not in the list",
+        },
+        {
+          type: "skill",
+          name: "grill-with-docs",
+          path: "/Users/me/.agents/skills/grill-with-docs/SKILL.md",
+        },
+      ]);
+    }),
+  );
+
+  it.effect("fails instead of sending an unknown $skill token", () =>
+    Effect.gen(function* () {
+      const error = yield* buildTurnStartParams({
+        threadId: "provider-thread-1",
+        runtimeMode: "full-access",
+        prompt: "$missing-skill do this",
+        availableSkills: [
+          {
+            name: "grill-with-docs",
+            path: "/Users/me/.agents/skills/grill-with-docs/SKILL.md",
+            enabled: true,
+          },
+        ],
+      }).pipe(Effect.flip);
+
+      if (!isCodexSessionRuntimeUnknownSkillError(error)) {
+        NodeAssert.fail("expected CodexSessionRuntimeUnknownSkillError");
+        return;
+      }
+      NodeAssert.deepStrictEqual(error.names, ["missing-skill"]);
+      NodeAssert.equal(error.message, "Unknown Codex skill $missing-skill.");
+    }),
+  );
+
+  it.effect("leaves a message without $skill tokens unchanged", () =>
+    Effect.gen(function* () {
+      const params = yield* buildTurnStartParams({
+        threadId: "provider-thread-1",
+        runtimeMode: "full-access",
+        prompt: "Review this change",
+        availableSkills: [
+          {
+            name: "grill-with-docs",
+            path: "/Users/me/.agents/skills/grill-with-docs/SKILL.md",
+            enabled: true,
+          },
+        ],
+      });
+
+      NodeAssert.deepStrictEqual(params.input, [
+        {
+          type: "text",
+          text: "Review this change",
+        },
+      ]);
     }),
   );
 

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -16,8 +16,9 @@ import {
   ThreadId,
   TurnId,
 } from "@t3tools/contracts";
-import { resolveSpawnCommand } from "@t3tools/shared/shell";
+import { collectComposerSkillInvocations } from "@t3tools/shared/composerInlineTokens";
 import { normalizeModelSlug } from "@t3tools/shared/model";
+import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Deferred from "effect/Deferred";
@@ -35,7 +36,8 @@ import * as CodexErrors from "effect-codex-app-server/errors";
 import * as CodexRpc from "effect-codex-app-server/rpc";
 import * as EffectCodexSchema from "effect-codex-app-server/schema";
 
-import { buildCodexInitializeParams } from "./CodexProvider.ts";
+import { buildCodexInitializeParams, parseCodexSkillsListResponse } from "./CodexProvider.ts";
+import { bindCodexSkillInvocations } from "./codexSkillInvocations.ts";
 import { codexSessionAppServerArgs } from "./codexLaunchArgs.ts";
 import { expandHomePath } from "../../pathExpansion.ts";
 import { buildCodexDeveloperInstructions } from "../CodexDeveloperInstructions.ts";
@@ -159,7 +161,8 @@ export type CodexSessionRuntimeError =
   | CodexSessionRuntimePendingApprovalNotFoundError
   | CodexSessionRuntimePendingUserInputNotFoundError
   | CodexSessionRuntimeInvalidUserInputAnswersError
-  | CodexSessionRuntimeThreadIdMissingError;
+  | CodexSessionRuntimeThreadIdMissingError
+  | CodexSessionRuntimeUnknownSkillError;
 
 export class CodexSessionRuntimePendingApprovalNotFoundError extends Schema.TaggedErrorClass<CodexSessionRuntimePendingApprovalNotFoundError>()(
   "CodexSessionRuntimePendingApprovalNotFoundError",
@@ -202,6 +205,21 @@ export class CodexSessionRuntimeThreadIdMissingError extends Schema.TaggedErrorC
 ) {
   override get message(): string {
     return `Codex session is missing a provider thread id for ${this.threadId}`;
+  }
+}
+
+export class CodexSessionRuntimeUnknownSkillError extends Schema.TaggedErrorClass<CodexSessionRuntimeUnknownSkillError>()(
+  "CodexSessionRuntimeUnknownSkillError",
+  {
+    names: Schema.Array(Schema.String),
+  },
+) {
+  override get message(): string {
+    const listed = this.names.map((name) => `$${name}`).join(", ");
+    if (this.names.length === 1) {
+      return `Unknown Codex skill ${listed}.`;
+    }
+    return `Unknown Codex skills ${listed}.`;
   }
 }
 
@@ -367,20 +385,33 @@ export function buildTurnStartParams(input: {
     readonly type: "image";
     readonly url: string;
   }>;
+  readonly availableSkills?: ReadonlyArray<{
+    readonly name: string;
+    readonly path: string;
+    readonly enabled: boolean;
+  }>;
   readonly model?: string;
   readonly serviceTier?: CodexServiceTier;
   readonly effort?: EffectCodexSchema.V2TurnStartParams__ReasoningEffort;
   readonly interactionMode?: ProviderInteractionMode;
 }): Effect.Effect<
   CodexTurnStartParamsWithCollaborationMode,
-  CodexErrors.CodexAppServerProtocolParseError
+  CodexErrors.CodexAppServerProtocolParseError | CodexSessionRuntimeUnknownSkillError
 > {
+  const boundSkills = bindCodexSkillInvocations(input.prompt, input.availableSkills ?? []);
+  if (!boundSkills.ok) {
+    return Effect.fail(new CodexSessionRuntimeUnknownSkillError({ names: boundSkills.names }));
+  }
+
   const turnInput: Array<EffectCodexSchema.V2TurnStartParams__UserInput> = [];
   if (input.prompt) {
     turnInput.push({
       type: "text",
       text: input.prompt,
     });
+  }
+  for (const skill of boundSkills.inputs) {
+    turnInput.push(skill);
   }
   for (const attachment of input.attachments ?? []) {
     turnInput.push(attachment);
@@ -1813,11 +1844,20 @@ export const makeCodexSessionRuntime = (
           const normalizedModel = normalizeCodexModelSlug(
             input.model ?? (yield* Ref.get(sessionRef)).model,
           );
+          const skillInvocations = collectComposerSkillInvocations(input.input ?? "");
+          let availableSkills: ReturnType<typeof parseCodexSkillsListResponse> = [];
+          if (skillInvocations.length > 0) {
+            const session = yield* Ref.get(sessionRef);
+            const cwd = session.cwd ?? options.cwd;
+            const skillsResponse = yield* client.request("skills/list", { cwds: [cwd] });
+            availableSkills = parseCodexSkillsListResponse(skillsResponse, cwd);
+          }
           const params = yield* buildTurnStartParams({
             threadId: providerThreadId,
             runtimeMode: options.runtimeMode,
             ...(input.input ? { prompt: input.input } : {}),
             ...(input.attachments ? { attachments: input.attachments } : {}),
+            ...(skillInvocations.length > 0 ? { availableSkills } : {}),
             ...(normalizedModel ? { model: normalizedModel } : {}),
             ...(input.serviceTier ? { serviceTier: input.serviceTier } : {}),
             ...(input.effort ? { effort: input.effort } : {}),

--- a/apps/server/src/provider/Layers/codexSkillInvocations.test.ts
+++ b/apps/server/src/provider/Layers/codexSkillInvocations.test.ts
@@ -83,6 +83,71 @@ describe("bindCodexSkillInvocations", () => {
     });
   });
 
+  it("prefers an exact name match over an enabled case-insensitive skill", () => {
+    expect(
+      bindCodexSkillInvocations("$Foo go", [
+        { name: "foo", path: "/skills/foo/SKILL.md", enabled: true },
+        { name: "Foo", path: "/skills/Foo/SKILL.md", enabled: false },
+      ]),
+    ).toEqual({
+      ok: true,
+      inputs: [
+        {
+          type: "skill",
+          name: "Foo",
+          path: "/skills/Foo/SKILL.md",
+        },
+      ],
+    });
+  });
+
+  it("falls back to a case-insensitive match when no exact name exists", () => {
+    expect(
+      bindCodexSkillInvocations("$Foo go", [
+        { name: "foo", path: "/skills/foo/SKILL.md", enabled: true },
+      ]),
+    ).toEqual({
+      ok: true,
+      inputs: [
+        {
+          type: "skill",
+          name: "foo",
+          path: "/skills/foo/SKILL.md",
+        },
+      ],
+    });
+  });
+
+  it("attaches a skill invoked with trailing punctuation", () => {
+    expect(bindCodexSkillInvocations("Use $grill-with-docs.", [grillWithDocs])).toEqual({
+      ok: true,
+      inputs: [
+        {
+          type: "skill",
+          name: "grill-with-docs",
+          path: grillWithDocs.path,
+        },
+      ],
+    });
+  });
+
+  it("attaches one skill item when case variants resolve to the same path", () => {
+    expect(
+      bindCodexSkillInvocations("$Foo then $foo", [
+        { name: "foo", path: "/skills/foo/SKILL.md", enabled: true },
+      ]),
+    ).toEqual({
+      ok: true,
+      inputs: [
+        {
+          type: "skill",
+          name: "foo",
+          path: "/skills/foo/SKILL.md",
+        },
+      ],
+    });
+  });
+
   it("attaches each distinct skill once and keeps list order", () => {
     expect(
       bindCodexSkillInvocations("$grill-with-docs then $grilling then $grill-with-docs", [

--- a/apps/server/src/provider/Layers/codexSkillInvocations.test.ts
+++ b/apps/server/src/provider/Layers/codexSkillInvocations.test.ts
@@ -136,6 +136,10 @@ describe("bindCodexSkillInvocations", () => {
       ok: true,
       inputs: [],
     });
+    expect(bindCodexSkillInvocations("read $FOO/bar", [grillWithDocs])).toEqual({
+      ok: true,
+      inputs: [],
+    });
   });
 
   it("attaches one skill item when case variants resolve to the same path", () => {

--- a/apps/server/src/provider/Layers/codexSkillInvocations.test.ts
+++ b/apps/server/src/provider/Layers/codexSkillInvocations.test.ts
@@ -131,6 +131,13 @@ describe("bindCodexSkillInvocations", () => {
     });
   });
 
+  it("does not treat shell paths as unknown skills", () => {
+    expect(bindCodexSkillInvocations("check $HOME/.config", [grillWithDocs])).toEqual({
+      ok: true,
+      inputs: [],
+    });
+  });
+
   it("attaches one skill item when case variants resolve to the same path", () => {
     expect(
       bindCodexSkillInvocations("$Foo then $foo", [

--- a/apps/server/src/provider/Layers/codexSkillInvocations.test.ts
+++ b/apps/server/src/provider/Layers/codexSkillInvocations.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { bindCodexSkillInvocations } from "./codexSkillInvocations.ts";
+
+const grillWithDocs = {
+  name: "grill-with-docs",
+  path: "/Users/me/.agents/skills/grill-with-docs/SKILL.md",
+  enabled: true,
+};
+
+const grilling = {
+  name: "grilling",
+  path: "/Users/me/.agents/skills/grilling/SKILL.md",
+  enabled: true,
+};
+
+describe("bindCodexSkillInvocations", () => {
+  it("attaches a known enabled skill as a structured skill item", () => {
+    expect(
+      bindCodexSkillInvocations("$grill-with-docs explain why this skill is not in the list", [
+        grillWithDocs,
+        grilling,
+      ]),
+    ).toEqual({
+      ok: true,
+      inputs: [
+        {
+          type: "skill",
+          name: "grill-with-docs",
+          path: grillWithDocs.path,
+        },
+      ],
+    });
+  });
+
+  it("attaches a user-invoked-only skill when it is enabled in the list", () => {
+    expect(bindCodexSkillInvocations("Use $grill-with-docs please", [grillWithDocs])).toEqual({
+      ok: true,
+      inputs: [
+        {
+          type: "skill",
+          name: "grill-with-docs",
+          path: grillWithDocs.path,
+        },
+      ],
+    });
+  });
+
+  it("attaches an explicit token even when the listed skill is disabled", () => {
+    expect(
+      bindCodexSkillInvocations("$grill-with-docs go", [{ ...grillWithDocs, enabled: false }]),
+    ).toEqual({
+      ok: true,
+      inputs: [
+        {
+          type: "skill",
+          name: "grill-with-docs",
+          path: grillWithDocs.path,
+        },
+      ],
+    });
+  });
+
+  it("returns unknown names instead of attaching a silent token", () => {
+    expect(bindCodexSkillInvocations("$missing-skill do this", [grillWithDocs])).toEqual({
+      ok: false,
+      names: ["missing-skill"],
+    });
+  });
+
+  it("leaves messages without $skill tokens unchanged", () => {
+    expect(bindCodexSkillInvocations("explain this change", [grillWithDocs])).toEqual({
+      ok: true,
+      inputs: [],
+    });
+    expect(bindCodexSkillInvocations("costs $100 please", [grillWithDocs])).toEqual({
+      ok: true,
+      inputs: [],
+    });
+    expect(bindCodexSkillInvocations(undefined, [grillWithDocs])).toEqual({
+      ok: true,
+      inputs: [],
+    });
+  });
+
+  it("attaches each distinct skill once and keeps list order", () => {
+    expect(
+      bindCodexSkillInvocations("$grill-with-docs then $grilling then $grill-with-docs", [
+        grillWithDocs,
+        grilling,
+      ]),
+    ).toEqual({
+      ok: true,
+      inputs: [
+        {
+          type: "skill",
+          name: "grill-with-docs",
+          path: grillWithDocs.path,
+        },
+        {
+          type: "skill",
+          name: "grilling",
+          path: grilling.path,
+        },
+      ],
+    });
+  });
+});

--- a/apps/server/src/provider/Layers/codexSkillInvocations.ts
+++ b/apps/server/src/provider/Layers/codexSkillInvocations.ts
@@ -1,0 +1,54 @@
+import type { ServerProviderSkill } from "@t3tools/contracts";
+import { collectComposerSkillInvocations } from "@t3tools/shared/composerInlineTokens";
+
+export type CodexSkillUserInput = {
+  readonly type: "skill";
+  readonly name: string;
+  readonly path: string;
+};
+
+export type BindCodexSkillInvocationsResult =
+  | { readonly ok: true; readonly inputs: ReadonlyArray<CodexSkillUserInput> }
+  | { readonly ok: false; readonly names: readonly string[] };
+
+function findCodexSkill(
+  name: string,
+  skills: ReadonlyArray<Pick<ServerProviderSkill, "name" | "path" | "enabled">>,
+): Pick<ServerProviderSkill, "name" | "path" | "enabled"> | undefined {
+  const lower = name.toLowerCase();
+  const matches = skills.filter(
+    (skill) => skill.name === name || skill.name.toLowerCase() === lower,
+  );
+  return matches.find((skill) => skill.enabled) ?? matches[0];
+}
+
+export function bindCodexSkillInvocations(
+  prompt: string | undefined,
+  skills: ReadonlyArray<Pick<ServerProviderSkill, "name" | "path" | "enabled">>,
+): BindCodexSkillInvocationsResult {
+  const invocations = collectComposerSkillInvocations(prompt ?? "");
+  if (invocations.length === 0) {
+    return { ok: true, inputs: [] };
+  }
+
+  const inputs: CodexSkillUserInput[] = [];
+  const unknown: string[] = [];
+
+  for (const name of invocations) {
+    const skill = findCodexSkill(name, skills);
+    if (!skill) {
+      unknown.push(name);
+      continue;
+    }
+    inputs.push({
+      type: "skill",
+      name: skill.name,
+      path: skill.path,
+    });
+  }
+
+  if (unknown.length > 0) {
+    return { ok: false, names: unknown };
+  }
+  return { ok: true, inputs };
+}

--- a/apps/server/src/provider/Layers/codexSkillInvocations.ts
+++ b/apps/server/src/provider/Layers/codexSkillInvocations.ts
@@ -15,10 +15,12 @@ function findCodexSkill(
   name: string,
   skills: ReadonlyArray<Pick<ServerProviderSkill, "name" | "path" | "enabled">>,
 ): Pick<ServerProviderSkill, "name" | "path" | "enabled"> | undefined {
+  const exact = skills.find((skill) => skill.name === name);
+  if (exact) {
+    return exact;
+  }
   const lower = name.toLowerCase();
-  const matches = skills.filter(
-    (skill) => skill.name === name || skill.name.toLowerCase() === lower,
-  );
+  const matches = skills.filter((skill) => skill.name.toLowerCase() === lower);
   return matches.find((skill) => skill.enabled) ?? matches[0];
 }
 
@@ -33,6 +35,7 @@ export function bindCodexSkillInvocations(
 
   const inputs: CodexSkillUserInput[] = [];
   const unknown: string[] = [];
+  const seenPaths = new Set<string>();
 
   for (const name of invocations) {
     const skill = findCodexSkill(name, skills);
@@ -40,6 +43,10 @@ export function bindCodexSkillInvocations(
       unknown.push(name);
       continue;
     }
+    if (seenPaths.has(skill.path)) {
+      continue;
+    }
+    seenPaths.add(skill.path);
     inputs.push({
       type: "skill",
       name: skill.name,

--- a/packages/shared/src/composerInlineTokens.test.ts
+++ b/packages/shared/src/composerInlineTokens.test.ts
@@ -158,6 +158,13 @@ describe("collectComposerInlineTokens", () => {
     expect(collectComposerSkillInvocations("Use $review.")).toEqual(["review"]);
     expect(collectComposerSkillInvocations("$review, then continue")).toEqual(["review"]);
     expect(collectComposerSkillInvocations("call $skill-name.")).toEqual(["skill-name"]);
+    expect(collectComposerSkillInvocations("try $review!")).toEqual(["review"]);
+  });
+
+  it("does not treat shell paths or filenames as skill invocations", () => {
+    expect(collectComposerSkillInvocations("check $HOME/.config")).toEqual([]);
+    expect(collectComposerSkillInvocations("open $review.md")).toEqual([]);
+    expect(collectComposerSkillInvocations("$PATH/bin then $review.")).toEqual(["review"]);
   });
 
   it("ignores non-skill dollar text and empty prompts", () => {

--- a/packages/shared/src/composerInlineTokens.test.ts
+++ b/packages/shared/src/composerInlineTokens.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { collectComposerInlineTokens } from "./composerInlineTokens.ts";
+import {
+  collectComposerInlineTokens,
+  collectComposerSkillInvocations,
+} from "./composerInlineTokens.ts";
 
 describe("collectComposerInlineTokens", () => {
   it("collects file links, mentions, and skills with source ranges", () => {
@@ -141,6 +144,21 @@ describe("collectComposerInlineTokens", () => {
   it("leaves a file link past the label cap as plain text", () => {
     const label = `${"a".repeat(509)}.tsx`;
     expect(collectComposerInlineTokens(`see [${label}](src/${label}) ok`)).toEqual([]);
+  });
+
+  it("collects complete submitted skill invocations including a trailing token", () => {
+    expect(collectComposerSkillInvocations("$grill-with-docs explain this")).toEqual([
+      "grill-with-docs",
+    ]);
+    expect(collectComposerSkillInvocations("Use $grill-with-docs")).toEqual(["grill-with-docs"]);
+    expect(collectComposerSkillInvocations("$ui then $ui again $review")).toEqual(["ui", "review"]);
+  });
+
+  it("ignores non-skill dollar text and empty prompts", () => {
+    expect(collectComposerSkillInvocations("")).toEqual([]);
+    expect(collectComposerSkillInvocations("plain text")).toEqual([]);
+    expect(collectComposerSkillInvocations("costs $100 please")).toEqual([]);
+    expect(collectComposerSkillInvocations("foo$bar baz")).toEqual([]);
   });
 
   it("stays fast on unterminated bracket runs", () => {

--- a/packages/shared/src/composerInlineTokens.test.ts
+++ b/packages/shared/src/composerInlineTokens.test.ts
@@ -154,6 +154,12 @@ describe("collectComposerInlineTokens", () => {
     expect(collectComposerSkillInvocations("$ui then $ui again $review")).toEqual(["ui", "review"]);
   });
 
+  it("collects skill invocations terminated by punctuation", () => {
+    expect(collectComposerSkillInvocations("Use $review.")).toEqual(["review"]);
+    expect(collectComposerSkillInvocations("$review, then continue")).toEqual(["review"]);
+    expect(collectComposerSkillInvocations("call $skill-name.")).toEqual(["skill-name"]);
+  });
+
   it("ignores non-skill dollar text and empty prompts", () => {
     expect(collectComposerSkillInvocations("")).toEqual([]);
     expect(collectComposerSkillInvocations("plain text")).toEqual([]);

--- a/packages/shared/src/composerInlineTokens.test.ts
+++ b/packages/shared/src/composerInlineTokens.test.ts
@@ -163,7 +163,10 @@ describe("collectComposerInlineTokens", () => {
 
   it("does not treat shell paths or filenames as skill invocations", () => {
     expect(collectComposerSkillInvocations("check $HOME/.config")).toEqual([]);
+    expect(collectComposerSkillInvocations("read $FOO/bar")).toEqual([]);
     expect(collectComposerSkillInvocations("open $review.md")).toEqual([]);
+    expect(collectComposerSkillInvocations("open $review.配置")).toEqual([]);
+    expect(collectComposerSkillInvocations("open $review.é")).toEqual([]);
     expect(collectComposerSkillInvocations("$PATH/bin then $review.")).toEqual(["review"]);
   });
 

--- a/packages/shared/src/composerInlineTokens.ts
+++ b/packages/shared/src/composerInlineTokens.ts
@@ -22,11 +22,12 @@ const SKILL_NAME_PATTERN = "[a-zA-Z][a-zA-Z0-9:_-]*";
 // Trailing whitespace is required while typing so `$partial` does not become a chip.
 const SKILL_TOKEN_REGEX = new RegExp(`(^|\\s)\\$(${SKILL_NAME_PATTERN})(?=\\s)`, "g");
 // Submitted messages also accept sentence punctuation so `$review.` / `$review,`
-// bind. A period only terminates when it is not an extension (`$review.md`).
-// Path-like `$HOME/.config` stays plain text — `/` is not a terminator.
+// bind. A period only terminates when it is not an extension (`$review.md`,
+// `$review.配置`). Path-like `$HOME/.config` stays plain text — `/` is not a
+// terminator.
 const COMPLETE_SKILL_INVOCATION_REGEX = new RegExp(
-  `(^|\\s)\\$(${SKILL_NAME_PATTERN})(?=\\s|$|[,!?;)"']|\\.(?![a-zA-Z0-9]))`,
-  "g",
+  `(^|\\s)\\$(${SKILL_NAME_PATTERN})(?=\\s|$|[,!?;)"'\\]]|\\.(?![\\p{L}\\p{N}]))`,
+  "gu",
 );
 const MENTION_TOKEN_REGEX = /(^|\s)@(?:"((?:\\.|[^"\\])*)"|([^\s@"]+))(?=\s)/g;
 /**

--- a/packages/shared/src/composerInlineTokens.ts
+++ b/packages/shared/src/composerInlineTokens.ts
@@ -21,10 +21,11 @@ export interface CollectComposerInlineTokensOptions {
 const SKILL_NAME_PATTERN = "[a-zA-Z][a-zA-Z0-9:_-]*";
 // Trailing whitespace is required while typing so `$partial` does not become a chip.
 const SKILL_TOKEN_REGEX = new RegExp(`(^|\\s)\\$(${SKILL_NAME_PATTERN})(?=\\s)`, "g");
-// Submitted messages treat a token as complete when the next character is not
-// part of a skill name, so `$review.` and `$review,` still bind.
+// Submitted messages also accept sentence punctuation so `$review.` / `$review,`
+// bind. A period only terminates when it is not an extension (`$review.md`).
+// Path-like `$HOME/.config` stays plain text — `/` is not a terminator.
 const COMPLETE_SKILL_INVOCATION_REGEX = new RegExp(
-  `(^|\\s)\\$(${SKILL_NAME_PATTERN})(?![a-zA-Z0-9:_-])`,
+  `(^|\\s)\\$(${SKILL_NAME_PATTERN})(?=\\s|$|[,!?;)"']|\\.(?![a-zA-Z0-9]))`,
   "g",
 );
 const MENTION_TOKEN_REGEX = /(^|\s)@(?:"((?:\\.|[^"\\])*)"|([^\s@"]+))(?=\s)/g;

--- a/packages/shared/src/composerInlineTokens.ts
+++ b/packages/shared/src/composerInlineTokens.ts
@@ -18,7 +18,14 @@ export interface CollectComposerInlineTokensOptions {
   readonly preserveTrailingFrom?: ReadonlyArray<ComposerInlineToken>;
 }
 
-const SKILL_TOKEN_REGEX = /(^|\s)\$([a-zA-Z][a-zA-Z0-9:_-]*)(?=\s)/g;
+const SKILL_NAME_PATTERN = "[a-zA-Z][a-zA-Z0-9:_-]*";
+// Trailing whitespace is required while typing so `$partial` does not become a chip.
+const SKILL_TOKEN_REGEX = new RegExp(`(^|\\s)\\$(${SKILL_NAME_PATTERN})(?=\\s)`, "g");
+// Submitted messages treat a token at end-of-input as complete.
+const COMPLETE_SKILL_INVOCATION_REGEX = new RegExp(
+  `(^|\\s)\\$(${SKILL_NAME_PATTERN})(?=\\s|$)`,
+  "g",
+);
 const MENTION_TOKEN_REGEX = /(^|\s)@(?:"((?:\\.|[^"\\])*)"|([^\s@"]+))(?=\s)/g;
 /**
  * The label body is bounded rather than `*`. Unbounded, every whitespace in
@@ -132,4 +139,26 @@ export function collectComposerInlineTokens(
   }
 
   return [...matches].sort((left, right) => left.start - right.start);
+}
+
+/**
+ * Distinct complete `$skill` names in submitted composer text, including a
+ * trailing token at end of input. Used for send-time Codex skill binding.
+ */
+export function collectComposerSkillInvocations(text: string): readonly string[] {
+  if (!text) {
+    return [];
+  }
+
+  const names: string[] = [];
+  const seen = new Set<string>();
+  for (const match of text.matchAll(COMPLETE_SKILL_INVOCATION_REGEX)) {
+    const name = match[2] ?? "";
+    if (!name || seen.has(name)) {
+      continue;
+    }
+    seen.add(name);
+    names.push(name);
+  }
+  return names;
 }

--- a/packages/shared/src/composerInlineTokens.ts
+++ b/packages/shared/src/composerInlineTokens.ts
@@ -21,9 +21,10 @@ export interface CollectComposerInlineTokensOptions {
 const SKILL_NAME_PATTERN = "[a-zA-Z][a-zA-Z0-9:_-]*";
 // Trailing whitespace is required while typing so `$partial` does not become a chip.
 const SKILL_TOKEN_REGEX = new RegExp(`(^|\\s)\\$(${SKILL_NAME_PATTERN})(?=\\s)`, "g");
-// Submitted messages treat a token at end-of-input as complete.
+// Submitted messages treat a token as complete when the next character is not
+// part of a skill name, so `$review.` and `$review,` still bind.
 const COMPLETE_SKILL_INVOCATION_REGEX = new RegExp(
-  `(^|\\s)\\$(${SKILL_NAME_PATTERN})(?=\\s|$)`,
+  `(^|\\s)\\$(${SKILL_NAME_PATTERN})(?![a-zA-Z0-9:_-])`,
   "g",
 );
 const MENTION_TOKEN_REGEX = /(^|\s)@(?:"((?:\\.|[^"\\])*)"|([^\s@"]+))(?=\s)/g;


### PR DESCRIPTION
## Problem

T3 recognizes `$skill` tokens in the composer, but a Codex turn received only that literal text. Skills with `disable-model-invocation: true` / `allow_implicit_invocation: false` then never loaded `SKILL.md`, so explicit `$grill-with-docs` style entry points failed silently.

## Fix

On Codex `turn/start`, resolve complete `$skill` tokens against the live `skills/list` for the session cwd and attach Codex `SkillUserInput` items (`{ type: "skill", name, path }`). The user text is unchanged, so `$` chips still render. Unknown tokens fail the turn with `Unknown Codex skill $name.` instead of being sent inert.

Picker inventory and implicit invocation are unchanged. Web, desktop, and mobile all go through this send path.

Fixes #6095

Made-with: Grok / T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Codex turn input construction and adds a hard failure path for unresolved `$skill` tokens; behavior is localized to the Codex send path with broad test coverage.
> 
> **Overview**
> Codex turns now **bind composer `$skill` tokens** to real skills instead of sending inert literal text, so user-invoked-only skills (e.g. `disable-model-invocation`) actually load `SKILL.md`.
> 
> On send, **`collectComposerSkillInvocations`** parses complete tokens (including end-of-message and punctuation-terminated forms, while ignoring `$HOME/.config`, `$review.md`, etc.). When the prompt has any `$skill`, the runtime calls **`skills/list`** for the session cwd, **`bindCodexSkillInvocations`** resolves names (exact, then case-insensitive; deduped by path), and **`buildTurnStartParams`** appends Codex `{ type: "skill", name, path }` inputs after the unchanged text. Unknown names fail the turn with **`CodexSessionRuntimeUnknownSkillError`** instead of silently continuing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f44f09c335802ad8da93344ed34f3c29942f535f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Attach explicit `$skill` invocations as structured inputs in `CodexSessionRuntime`
> - Adds `collectComposerSkillInvocations` to [`composerInlineTokens.ts`](https://github.com/pingdotgg/t3code/pull/7196/files#diff-5cffe3270b732b403f881278a2c54291483129bca7ee5cdb8c14f1cc6aac666c) to extract distinct `$skill` names from submitted text, excluding shell paths and filenames.
> - Adds [`codexSkillInvocations.ts`](https://github.com/pingdotgg/t3code/pull/7196/files#diff-00272da229723a141e1cb86d079dc63e3fbe895fc1cef3fb840094b0614a9f20) with `bindCodexSkillInvocations`, which resolves `$skill` tokens against available skills (exact match first, then case-insensitive with enabled preference) and returns structured `{type,name,path}` inputs or a list of unknown names.
> - When the user input contains `$skill` tokens, `makeCodexSessionRuntime` now fetches `skills/list` from the Codex app server and passes results to `buildTurnStartParams`, which appends the resolved skill inputs to the turn payload.
> - Introduces `CodexSessionRuntimeUnknownSkillError` — thrown when any referenced `$skill` is not found — with a formatted message showing the unrecognized `$name` tokens.
> - Risk: turns referencing unknown `$skill` names now fail explicitly with `CodexSessionRuntimeUnknownSkillError` instead of passing silently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f44f09c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->