### PR TITLE
fix(web): keep large composer prompts responsive

### DIFF
--- a/apps/web/src/composer-editor-mentions.test.ts
+++ b/apps/web/src/composer-editor-mentions.test.ts
@@ -1,12 +1,79 @@
-import { describe, expect, it } from "vite-plus/test";
+import { ThreadId } from "@t3tools/contracts";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+const { collectComposerInlineTokensSpy } = vi.hoisted(() => ({
+  collectComposerInlineTokensSpy: vi.fn(),
+}));
+
+vi.mock("@t3tools/shared/composerInlineTokens", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@t3tools/shared/composerInlineTokens")>();
+  return {
+    ...original,
+    collectComposerInlineTokens: (
+      ...args: Parameters<typeof original.collectComposerInlineTokens>
+    ) => {
+      collectComposerInlineTokensSpy();
+      return original.collectComposerInlineTokens(...args);
+    },
+  };
+});
 
 import {
   selectionTouchesMentionBoundary,
   splitPromptIntoComposerSegments,
 } from "./composer-editor-mentions";
-import { INLINE_TERMINAL_CONTEXT_PLACEHOLDER } from "./lib/terminalContext";
+import {
+  INLINE_TERMINAL_CONTEXT_PLACEHOLDER,
+  type TerminalContextDraft,
+} from "./lib/terminalContext";
 
 describe("splitPromptIntoComposerSegments", () => {
+  it("scans an unchanged large prompt only once", () => {
+    const largePrompt =
+      '2026-08-16T12:00:00.000Z ERROR path=/api/workspaces message="operation failed"\n'.repeat(
+        1_000,
+      );
+    collectComposerInlineTokensSpy.mockClear();
+
+    const first = splitPromptIntoComposerSegments(largePrompt);
+    const second = splitPromptIntoComposerSegments(largePrompt);
+
+    expect(first).toEqual([{ type: "text", text: largePrompt }]);
+    expect(second).toEqual(first);
+    expect(second).not.toBe(first);
+    expect(collectComposerInlineTokensSpy).toHaveBeenCalledOnce();
+
+    splitPromptIntoComposerSegments("");
+    splitPromptIntoComposerSegments(largePrompt);
+    expect(collectComposerInlineTokensSpy).toHaveBeenCalledTimes(2);
+
+    splitPromptIntoComposerSegments(`${largePrompt}next`);
+    expect(collectComposerInlineTokensSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it("keeps terminal context segments outside the prompt cache", () => {
+    const context = {
+      id: "context-1",
+      threadId: ThreadId.make("thread-1"),
+      terminalId: "default",
+      terminalLabel: "Terminal 1",
+      lineStart: 1,
+      lineEnd: 1,
+      text: "first",
+      createdAt: "2026-08-16T12:00:00.000Z",
+    } satisfies TerminalContextDraft;
+    const prompt = `${INLINE_TERMINAL_CONTEXT_PLACEHOLDER} inspect`;
+
+    expect(splitPromptIntoComposerSegments(prompt, [context])[0]).toEqual({
+      type: "terminal-context",
+      context,
+    });
+    expect(splitPromptIntoComposerSegments(prompt, [{ ...context, text: "second" }])[0]).toEqual({
+      type: "terminal-context",
+      context: { ...context, text: "second" },
+    });
+  });
+
   it("splits mention tokens followed by whitespace into mention segments", () => {
     expect(splitPromptIntoComposerSegments("Inspect @AGENTS.md please")).toEqual([
       { type: "text", text: "Inspect " },

--- a/apps/web/src/composer-editor-mentions.ts
+++ b/apps/web/src/composer-editor-mentions.ts
@@ -26,6 +26,9 @@ export type ComposerPromptSegment =
       context: TerminalContextDraft | null;
     };
 
+let cachedPrompt = "";
+let cachedSegments: ComposerPromptSegment[] = [];
+
 function rangeIncludesIndex(start: number, end: number, index: number): boolean {
   return start <= index && index < end;
 }
@@ -200,7 +203,12 @@ export function splitPromptIntoComposerSegments(
   terminalContexts: ReadonlyArray<TerminalContextDraft> = [],
 ): ComposerPromptSegment[] {
   if (!prompt) {
+    cachedPrompt = "";
+    cachedSegments = [];
     return [];
+  }
+  if (terminalContexts.length === 0 && prompt === cachedPrompt) {
+    return cachedSegments.map((segment) => ({ ...segment }));
   }
 
   const segments: ComposerPromptSegment[] = [];
@@ -219,5 +227,9 @@ export function splitPromptIntoComposerSegments(
     return false;
   });
 
+  if (terminalContexts.length === 0) {
+    cachedPrompt = prompt;
+    cachedSegments = segments.map((segment) => ({ ...segment }));
+  }
   return segments;
 }


### PR DESCRIPTION
## What Changed

- Reuse composer prompt segments when the full prompt is unchanged.
- Keep terminal-context parsing uncached and return fresh segment objects.
- Add a 79 KB regression case that bounds full-document scans.

## Why

Large prompts repeatedly ran the full inline-token scan during render, caret, and selection work. A fixed 75,529-byte reproduction made 391 full-prompt scans.

The change keeps one exact-prompt result inside the existing parser. Prompt changes invalidate it. Empty prompts clear it. The composer interface and input timing stay unchanged.

## Performance

The fixed sequence performs one paste, 30 keypresses, 10 caret moves, two selection changes, and two scrolls.

| Measurement | Before | After | Change |
| --- | ---: | ---: | ---: |
| Full-prompt scans | 391 | 45 | -88.5% |
| Scan self time | 57.2 ms | 8.9 ms | -84.4% |
| 30 keypresses | 346.6 ms | 283.1 ms | -18.3% |
| Main-thread task time | 516.3 ms | 434.5 ms | -15.8% |

The bounded scan count is the stable regression gate. Local timing provides supporting evidence.

## UI Changes

There is no visual change. This PR changes composer interaction performance.

https://github.com/user-attachments/assets/41124e0c-6b0d-4a9a-8eb1-69d383f3dd43

## Verification

- Focused composer tests: 5 files passed, 156 tests passed.
- Web typecheck passed.
- Targeted lint passed.
- Targeted format check passed.
- `git diff --check` passed.
- Chromium 151 on macOS arm64 preserved text, selection, scroll, undo, redo, send state, and draft restoration.
- Mention, command, path, skill, paste, composition, keyboard, and controlled-state tests passed.

Safari automation was unavailable. The change uses repository parsing only and no browser API.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No visual change; screenshots do not apply
- [x] I included a video for the interaction change

Fixes #5626

Built with GPT 5.6 Sol in the Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Memoize `splitPromptIntoComposerSegments` to avoid rescanning large unchanged prompts
> Adds module-level memoization to [`splitPromptIntoComposerSegments`](https://github.com/pingdotgg/t3code/pull/7197/files#diff-fe3b0266af75d6e06d8819ee307b1048dd163e07bfc6758027f84a441c92be3c) so repeated calls with the same prompt skip the inline token scan and return a cached copy. Prompts containing terminal contexts are always recomputed and never cached. The cache is cleared when the prompt becomes empty.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a983113.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized parsing optimization with explicit cache bypass for terminal contexts; behavior covered by new regression tests.
> 
> **Overview**
> **Adds module-level memoization** to `splitPromptIntoComposerSegments` so repeated calls with the same prompt string skip the full inline-token scan and return a fresh shallow copy of cached segments.
> 
> Caching applies only when `terminalContexts` is empty; prompts with terminal context placeholders always re-parse so attached context drafts stay current. Empty prompts clear the cache.
> 
> **Tests** spy on `collectComposerInlineTokens` to assert one scan per unchanged large prompt, cache invalidation on empty or edited prompts, and that terminal-context calls are never served from the prompt cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a983113dc32d0cd8ceffcf1855addb6309be2b94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->