### PR TITLE
fix(server): point Claude resume cursor at reverted transcript

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -3995,6 +3995,79 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("replaceQueryAfterRollback keeps mid-session model and permission mode", () => {
+    const harness = makeHarness();
+    const durableSessionId = "550e8400-e29b-41d4-a716-446655440333";
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "first",
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("claudeAgent"),
+          model: "claude-opus-4-6",
+        },
+        interactionMode: "plan",
+        attachments: [],
+      });
+      const firstCompletedFiber = yield* Stream.filter(
+        adapter.streamEvents,
+        (event) => event.type === "turn.completed",
+      ).pipe(Stream.runHead, Effect.forkChild);
+      emitSuccessfulTurn(harness, {
+        sessionId: durableSessionId,
+        assistantUuid: "assistant-keep-options",
+        resultUuid: "result-keep-options",
+      });
+      yield* Fiber.join(firstCompletedFiber);
+      assert.deepEqual(harness.query.setModelCalls, ["claude-opus-4-6[1m]"]);
+      assert.deepEqual(harness.query.setPermissionModeCalls, ["plan"]);
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "second",
+        attachments: [],
+      });
+      const secondCompletedFiber = yield* Stream.filter(
+        adapter.streamEvents,
+        (event) => event.type === "turn.completed",
+      ).pipe(Stream.runHead, Effect.forkChild);
+      emitSuccessfulTurn(harness, {
+        sessionId: durableSessionId,
+        assistantUuid: "assistant-revert-options",
+        resultUuid: "result-revert-options",
+      });
+      yield* Fiber.join(secondCompletedFiber);
+
+      yield* adapter.rollbackThread(session.threadId, 1);
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "after revert",
+        attachments: [],
+      });
+
+      const restarted = harness.getLastCreateQueryInput();
+      assert.equal(restarted?.options.resumeSessionAt, "assistant-keep-options");
+      assert.equal(restarted?.options.model, "claude-opus-4-6[1m]");
+      assert.equal(restarted?.options.permissionMode, "plan");
+      assert.equal(restarted?.options.allowDangerouslySkipPermissions, undefined);
+      // Recreated query already has the mid-session options; sendTurn must
+      // not skip-apply by assuming the new process inherited them implicitly.
+      assert.deepEqual(harness.query.setModelCalls, []);
+      assert.deepEqual(harness.query.setPermissionModeCalls, []);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("restarts a fresh Claude query after rollback when no assistant uuid remains", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -4057,7 +4057,7 @@ describe("ClaudeAdapterLive", () => {
       assert.equal(restarted?.options.resumeSessionAt, "assistant-keep-options");
       assert.equal(restarted?.options.model, "claude-opus-4-6[1m]");
       assert.equal(restarted?.options.permissionMode, "plan");
-      assert.equal(restarted?.options.allowDangerouslySkipPermissions, undefined);
+      assert.equal(restarted?.options.allowDangerouslySkipPermissions, true);
       // Recreated query already has the mid-session options; sendTurn must
       // not skip-apply by assuming the new process inherited them implicitly.
       assert.deepEqual(harness.query.setModelCalls, []);

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -3913,6 +3913,174 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("ignores late assistant frames from the discarded query after rollback", () => {
+    const harness = makeHarness();
+    const durableSessionId = "550e8400-e29b-41d4-a716-446655440222";
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "first",
+        attachments: [],
+      });
+      const firstCompletedFiber = yield* Stream.filter(
+        adapter.streamEvents,
+        (event) => event.type === "turn.completed",
+      ).pipe(Stream.runHead, Effect.forkChild);
+      emitSuccessfulTurn(harness, {
+        sessionId: durableSessionId,
+        assistantUuid: "assistant-keep",
+        resultUuid: "result-keep",
+      });
+      yield* Fiber.join(firstCompletedFiber);
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "second",
+        attachments: [],
+      });
+      const secondCompletedFiber = yield* Stream.filter(
+        adapter.streamEvents,
+        (event) => event.type === "turn.completed",
+      ).pipe(Stream.runHead, Effect.forkChild);
+      emitSuccessfulTurn(harness, {
+        sessionId: durableSessionId,
+        assistantUuid: "assistant-revert",
+        resultUuid: "result-revert",
+      });
+      yield* Fiber.join(secondCompletedFiber);
+
+      yield* adapter.rollbackThread(session.threadId, 1);
+
+      harness.query.emit({
+        type: "assistant",
+        session_id: durableSessionId,
+        uuid: "assistant-late-discarded",
+        parent_tool_use_id: null,
+        message: {
+          id: "assistant-late-discarded",
+          content: [{ type: "text", text: "should not become the resume cursor" }],
+        },
+      } as unknown as SDKMessage);
+      yield* Effect.yieldNow;
+
+      const afterLateFrame = yield* adapter.listSessions();
+      const resumeCursor = afterLateFrame[0]?.resumeCursor as
+        | {
+            readonly resumeSessionAt?: string;
+            readonly pinResumeSessionAt?: boolean;
+          }
+        | undefined;
+      assert.equal(resumeCursor?.resumeSessionAt, "assistant-keep");
+      assert.equal(resumeCursor?.pinResumeSessionAt, true);
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "after late frame",
+        attachments: [],
+      });
+      const restarted = harness.getLastCreateQueryInput();
+      assert.equal(restarted?.options.resumeSessionAt, "assistant-keep");
+      assert.notEqual(restarted?.options.resumeSessionAt, "assistant-late-discarded");
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("restarts a fresh Claude query after rollback when no assistant uuid remains", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      const originalResume = (session.resumeCursor as { resume?: string } | undefined)?.resume;
+      assert.equal(typeof originalResume, "string");
+
+      const firstTurn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "first",
+        attachments: [],
+      });
+      const firstCompletedFiber = yield* Stream.filter(
+        adapter.streamEvents,
+        (event) => event.type === "turn.completed",
+      ).pipe(Stream.runHead, Effect.forkChild);
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "sdk-session-rollback-fresh",
+        uuid: "result-first",
+      } as unknown as SDKMessage);
+      yield* Fiber.join(firstCompletedFiber);
+
+      const secondTurn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "second",
+        attachments: [],
+      });
+      const secondCompletedFiber = yield* Stream.filter(
+        adapter.streamEvents,
+        (event) => event.type === "turn.completed",
+      ).pipe(Stream.runHead, Effect.forkChild);
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "sdk-session-rollback-fresh",
+        uuid: "result-second",
+      } as unknown as SDKMessage);
+      yield* Fiber.join(secondCompletedFiber);
+
+      const rolledBack = yield* adapter.rollbackThread(session.threadId, 1);
+      assert.equal(rolledBack.turns.length, 1);
+      assert.equal(rolledBack.turns[0]?.id, firstTurn.turnId);
+      assert.notEqual(rolledBack.turns[0]?.id, secondTurn.turnId);
+
+      const afterRollback = yield* adapter.listSessions();
+      const resumeCursor = afterRollback[0]?.resumeCursor as
+        | {
+            readonly resume?: string;
+            readonly resumeSessionAt?: string;
+            readonly pinResumeSessionAt?: boolean;
+            readonly turnCount?: number;
+          }
+        | undefined;
+      assert.equal(resumeCursor?.resume, undefined);
+      assert.equal(resumeCursor?.resumeSessionAt, undefined);
+      assert.equal(resumeCursor?.pinResumeSessionAt, undefined);
+      assert.equal(resumeCursor?.turnCount, 1);
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "after revert without checkpoint",
+        attachments: [],
+      });
+      const restarted = harness.getLastCreateQueryInput();
+      assert.equal(restarted?.options.resume, undefined);
+      assert.equal(restarted?.options.resumeSessionAt, undefined);
+      assert.equal(typeof restarted?.options.sessionId, "string");
+      assert.notEqual(restarted?.options.sessionId, originalResume);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("updates model on sendTurn when model override is provided", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -162,7 +162,7 @@ function makeHarness(config?: {
   readonly claudeConfig?: Partial<ClaudeSettings>;
   readonly instanceId?: ProviderInstanceId;
 }) {
-  const query = new FakeClaudeQuery();
+  let query = new FakeClaudeQuery();
   let createInput:
     | {
         readonly prompt: AsyncIterable<SDKUserMessage>;
@@ -174,6 +174,7 @@ function makeHarness(config?: {
     ...(config?.instanceId ? { instanceId: config.instanceId } : {}),
     createQuery: (input) => {
       createInput = input;
+      query = new FakeClaudeQuery();
       return query;
     },
     ...(config?.nativeEventLogger
@@ -205,7 +206,9 @@ function makeHarness(config?: {
       Layer.provideMerge(ServerSettingsService.layerTest()),
       Layer.provideMerge(NodeServices.layer),
     ),
-    query,
+    get query() {
+      return query;
+    },
     getLastCreateQueryInput: () => createInput,
   };
 }
@@ -3783,6 +3786,132 @@ describe("ClaudeAdapterLive", () => {
       );
     },
   );
+
+  const emitSuccessfulTurn = (
+    harness: ReturnType<typeof makeHarness>,
+    input: {
+      readonly sessionId: string;
+      readonly assistantUuid: string;
+      readonly resultUuid: string;
+    },
+  ) => {
+    harness.query.emit({
+      type: "assistant",
+      session_id: input.sessionId,
+      uuid: input.assistantUuid,
+      parent_tool_use_id: null,
+      message: {
+        id: input.assistantUuid,
+        content: [{ type: "text", text: input.assistantUuid }],
+      },
+    } as unknown as SDKMessage);
+    harness.query.emit({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      errors: [],
+      session_id: input.sessionId,
+      uuid: input.resultUuid,
+    } as unknown as SDKMessage);
+  };
+
+  it.effect("rollbackThread pins the resume cursor at the last retained assistant uuid", () => {
+    const harness = makeHarness();
+    const durableSessionId = "550e8400-e29b-41d4-a716-446655440111";
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      const firstTurn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "first",
+        attachments: [],
+      });
+      const firstCompletedFiber = yield* Stream.filter(
+        adapter.streamEvents,
+        (event) => event.type === "turn.completed",
+      ).pipe(Stream.runHead, Effect.forkChild);
+      emitSuccessfulTurn(harness, {
+        sessionId: durableSessionId,
+        assistantUuid: "assistant-keep",
+        resultUuid: "result-keep",
+      });
+      const firstCompleted = yield* Fiber.join(firstCompletedFiber);
+      assert.equal(firstCompleted._tag, "Some");
+      if (firstCompleted._tag === "Some" && firstCompleted.value.type === "turn.completed") {
+        assert.equal(String(firstCompleted.value.turnId), String(firstTurn.turnId));
+      }
+
+      const secondTurn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "second",
+        attachments: [],
+      });
+      const secondCompletedFiber = yield* Stream.filter(
+        adapter.streamEvents,
+        (event) => event.type === "turn.completed",
+      ).pipe(Stream.runHead, Effect.forkChild);
+      emitSuccessfulTurn(harness, {
+        sessionId: durableSessionId,
+        assistantUuid: "assistant-revert",
+        resultUuid: "result-revert",
+      });
+      const secondCompleted = yield* Fiber.join(secondCompletedFiber);
+      assert.equal(secondCompleted._tag, "Some");
+      if (secondCompleted._tag === "Some" && secondCompleted.value.type === "turn.completed") {
+        assert.equal(String(secondCompleted.value.turnId), String(secondTurn.turnId));
+      }
+
+      const rolledBack = yield* adapter.rollbackThread(session.threadId, 1);
+      assert.equal(rolledBack.turns.length, 1);
+      assert.equal(rolledBack.turns[0]?.id, firstTurn.turnId);
+
+      const afterRollback = yield* adapter.listSessions();
+      const resumeCursor = afterRollback[0]?.resumeCursor as
+        | {
+            readonly resume?: string;
+            readonly resumeSessionAt?: string;
+            readonly pinResumeSessionAt?: boolean;
+            readonly turnCount?: number;
+          }
+        | undefined;
+      assert.equal(resumeCursor?.resume, durableSessionId);
+      assert.equal(resumeCursor?.resumeSessionAt, "assistant-keep");
+      assert.equal(resumeCursor?.pinResumeSessionAt, true);
+      assert.equal(resumeCursor?.turnCount, 1);
+      assert.notEqual(resumeCursor?.resumeSessionAt, "assistant-revert");
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "after revert",
+        attachments: [],
+      });
+      const liveRestart = harness.getLastCreateQueryInput();
+      assert.equal(liveRestart?.options.resumeSessionAt, "assistant-keep");
+      assert.notEqual(liveRestart?.options.resumeSessionAt, "assistant-revert");
+
+      yield* adapter.stopSession(session.threadId);
+      yield* adapter.startSession({
+        threadId: session.threadId,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        resumeCursor,
+        runtimeMode: "full-access",
+      });
+
+      const resumed = harness.getLastCreateQueryInput();
+      assert.equal(resumed?.options.resume, resumeCursor?.resume);
+      assert.equal(resumed?.options.resumeSessionAt, "assistant-keep");
+      assert.notEqual(resumed?.options.resumeSessionAt, "assistant-revert");
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
 
   it.effect("updates model on sendTurn when model override is provided", () => {
     const harness = makeHarness();

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -124,7 +124,27 @@ interface ClaudeResumeState {
   readonly threadId?: ThreadId;
   readonly resume?: string;
   readonly resumeSessionAt?: string;
+  /** Set after rollback so the next start/resume may pin `resumeSessionAt`. */
+  readonly pinResumeSessionAt?: boolean;
   readonly turnCount?: number;
+}
+
+interface ClaudeCompletedTurn {
+  readonly id: TurnId;
+  readonly items: Array<unknown>;
+  readonly lastAssistantUuid?: string;
+}
+
+function lastRetainedAssistantUuid(
+  turns: ReadonlyArray<ClaudeCompletedTurn>,
+): string | undefined {
+  for (let index = turns.length - 1; index >= 0; index--) {
+    const uuid = turns[index]?.lastAssistantUuid;
+    if (typeof uuid === "string" && uuid.length > 0) {
+      return uuid;
+    }
+  }
+  return undefined;
 }
 
 interface ClaudeTurnState {
@@ -142,6 +162,7 @@ interface ClaudeTurnState {
   readonly assistantTextBlockOrder: Array<AssistantTextBlockState>;
   readonly capturedProposedPlanKeys: Set<string>;
   nextSyntheticAssistantBlockIndex: number;
+  lastAssistantUuid?: string;
 }
 
 interface AssistantTextBlockState {
@@ -243,8 +264,9 @@ interface ClaudeTaskAgentState {
 
 interface ClaudeSessionContext {
   session: ProviderSession;
-  readonly promptQueue: Queue.Queue<PromptQueueItem>;
-  readonly query: ClaudeQueryRuntime;
+  promptQueue: Queue.Queue<PromptQueueItem>;
+  query: ClaudeQueryRuntime;
+  queryOptions: ClaudeQueryOptions;
   streamFiber: Fiber.Fiber<void, Error> | undefined;
   readonly startedAt: string;
   readonly basePermissionMode: PermissionMode | undefined;
@@ -255,10 +277,7 @@ interface ClaudeSessionContext {
   resumeSessionId: string | undefined;
   readonly pendingApprovals: Map<ApprovalRequestId, PendingApproval>;
   readonly pendingUserInputs: Map<ApprovalRequestId, PendingUserInput>;
-  readonly turns: Array<{
-    id: TurnId;
-    items: Array<unknown>;
-  }>;
+  readonly turns: Array<ClaudeCompletedTurn>;
   readonly inFlightTools: Map<number, ToolInFlight>;
   readonly claudeTasks: Map<string, ClaudeTaskState>;
   readonly taskAgents: Map<string, ClaudeTaskAgentState>;
@@ -277,6 +296,11 @@ interface ClaudeSessionContext {
   lastKnownTokenUsage: ThreadTokenUsageSnapshot | undefined;
   lastKnownTotalProcessedTokens: number | undefined;
   lastAssistantUuid: string | undefined;
+  /** After rollback, the next start/resume may pass `resumeSessionAt` to the SDK. */
+  pinResumeSessionAt: boolean;
+  /** Live query still includes reverted transcript until it is recreated. */
+  needsPinnedQueryRestart: boolean;
+  replacingQuery: boolean;
   lastThreadStartedId: string | undefined;
   stopped: boolean;
 }
@@ -665,6 +689,7 @@ function readClaudeResumeState(resumeCursor: unknown): ClaudeResumeState | undef
     resume?: unknown;
     sessionId?: unknown;
     resumeSessionAt?: unknown;
+    pinResumeSessionAt?: unknown;
     turnCount?: unknown;
   };
 
@@ -682,12 +707,14 @@ function readClaudeResumeState(resumeCursor: unknown): ClaudeResumeState | undef
   const resume = resumeCandidate && isUuid(resumeCandidate) ? resumeCandidate : undefined;
   const resumeSessionAt =
     typeof cursor.resumeSessionAt === "string" ? cursor.resumeSessionAt : undefined;
+  const pinResumeSessionAt = cursor.pinResumeSessionAt === true;
   const turnCountValue = typeof cursor.turnCount === "number" ? cursor.turnCount : undefined;
 
   return {
     ...(threadId ? { threadId } : {}),
     ...(resume ? { resume } : {}),
     ...(resumeSessionAt ? { resumeSessionAt } : {}),
+    ...(pinResumeSessionAt ? { pinResumeSessionAt: true } : {}),
     ...(turnCountValue !== undefined && Number.isInteger(turnCountValue) && turnCountValue >= 0
       ? { turnCount: turnCountValue }
       : {}),
@@ -1776,6 +1803,9 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       threadId,
       ...(context.resumeSessionId ? { resume: context.resumeSessionId } : {}),
       ...(context.lastAssistantUuid ? { resumeSessionAt: context.lastAssistantUuid } : {}),
+      ...(context.pinResumeSessionAt && context.lastAssistantUuid
+        ? { pinResumeSessionAt: true }
+        : {}),
       turnCount: context.turns.length,
     };
 
@@ -2348,6 +2378,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     context.turns.push({
       id: turnState.turnId,
       items: [...turnState.items],
+      ...(turnState.lastAssistantUuid ? { lastAssistantUuid: turnState.lastAssistantUuid } : {}),
     });
 
     yield* emitThreadTokenUsage(context, usageSnapshot, {
@@ -2882,6 +2913,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         owningAgent.model = snapshotModel;
       }
       context.lastAssistantUuid = message.uuid;
+      context.pinResumeSessionAt = false;
       yield* updateResumeCursor(context);
       return;
     }
@@ -2958,11 +2990,13 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     }
 
     if (context.turnState) {
+      context.turnState.lastAssistantUuid = message.uuid;
       context.turnState.items.push(message.message);
       yield* backfillAssistantTextBlocksFromSnapshot(context, message);
     }
 
     context.lastAssistantUuid = message.uuid;
+    context.pinResumeSessionAt = false;
     yield* updateResumeCursor(context);
   });
 
@@ -3601,7 +3635,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     context: ClaudeSessionContext,
     exit: Exit.Exit<void, ProviderAdapterProcessError>,
   ) {
-    if (context.stopped) {
+    if (context.stopped || context.replacingQuery) {
       return;
     }
 
@@ -3746,6 +3780,114 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     return Effect.succeed(context);
   };
 
+  const makePromptIterable = (promptQueue: Queue.Queue<PromptQueueItem>) =>
+    Stream.fromQueue(promptQueue).pipe(
+      Stream.filter((item) => item.type === "message"),
+      Stream.map((item) => item.message),
+      Stream.catchCause((cause) =>
+        Cause.hasInterruptsOnly(cause) ? Stream.empty : Stream.failCause(cause),
+      ),
+      Stream.toAsyncIterable,
+    );
+
+  const forkSdkStream = (
+    context: ClaudeSessionContext,
+    runFork: (effect: Effect.Effect<void, never>) => Fiber.Fiber<void, never>,
+  ) => {
+    let streamFiber: Fiber.Fiber<void, never>;
+    streamFiber = runFork(
+      Effect.exit(runSdkStream(context)).pipe(
+        Effect.flatMap((exit) => {
+          if (context.stopped || context.replacingQuery) {
+            return Effect.void;
+          }
+          if (context.streamFiber === streamFiber) {
+            context.streamFiber = undefined;
+          }
+          return handleStreamExit(context, exit).pipe(
+            Effect.catch((cause) =>
+              Effect.logError("Failed to close Claude runtime stream.", { cause }),
+            ),
+          );
+        }),
+      ),
+    );
+    context.streamFiber = streamFiber;
+    streamFiber.addObserver(() => {
+      if (context.streamFiber === streamFiber) {
+        context.streamFiber = undefined;
+      }
+    });
+  };
+
+  const replaceQueryAfterRollback = Effect.fn("replaceQueryAfterRollback")(function* (
+    context: ClaudeSessionContext,
+  ) {
+    const threadId = context.session.threadId;
+    context.replacingQuery = true;
+    const streamFiber = context.streamFiber;
+    context.streamFiber = undefined;
+    if (streamFiber && streamFiber.pollUnsafe() === undefined) {
+      yield* Fiber.interrupt(streamFiber);
+    }
+    yield* Queue.shutdown(context.promptQueue);
+    yield* Effect.try({
+      try: () => context.query.close(),
+      catch: (cause) =>
+        new ProviderAdapterProcessError({
+          provider: PROVIDER,
+          threadId,
+          detail: "Failed to close Claude runtime query for rollback.",
+          cause,
+        }),
+    }).pipe(Effect.ignore);
+
+    const promptQueue = yield* Queue.unbounded<PromptQueueItem>();
+    const {
+      sessionId: _ignoredSessionId,
+      resume: _ignoredResume,
+      resumeSessionAt: _ignoredResumeSessionAt,
+      ...baseQueryOptions
+    } = context.queryOptions;
+    const nextOptions: ClaudeQueryOptions =
+      context.lastAssistantUuid && context.resumeSessionId
+        ? {
+            ...baseQueryOptions,
+            resume: context.resumeSessionId,
+            resumeSessionAt: context.lastAssistantUuid,
+          }
+        : {
+            ...baseQueryOptions,
+            sessionId: yield* randomUUIDv4,
+          };
+    if (nextOptions.sessionId) {
+      context.resumeSessionId = nextOptions.sessionId;
+    }
+
+    const queryRuntime = yield* Effect.try({
+      try: () =>
+        createQuery({
+          prompt: makePromptIterable(promptQueue),
+          options: nextOptions,
+        }),
+      catch: (cause) =>
+        new ProviderAdapterProcessError({
+          provider: PROVIDER,
+          threadId,
+          detail: "Failed to restart Claude runtime session after rollback.",
+          cause,
+        }),
+    }).pipe(Effect.onExit(() => Effect.sync(() => (context.replacingQuery = false))));
+
+    context.promptQueue = promptQueue;
+    context.query = queryRuntime;
+    context.queryOptions = nextOptions;
+    yield* updateResumeCursor(context);
+
+    const runtimeContext = yield* Effect.context<never>();
+    forkSdkStream(context, Effect.runForkWith(runtimeContext));
+  });
+
   const startSession: ClaudeAdapterShape["startSession"] = Effect.fn("startSession")(
     function* (input) {
       if (input.provider !== undefined && input.provider !== PROVIDER) {
@@ -3789,14 +3931,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       const runPromise = Effect.runPromiseWith(runtimeContext);
 
       const promptQueue = yield* Queue.unbounded<PromptQueueItem>();
-      const prompt = Stream.fromQueue(promptQueue).pipe(
-        Stream.filter((item) => item.type === "message"),
-        Stream.map((item) => item.message),
-        Stream.catchCause((cause) =>
-          Cause.hasInterruptsOnly(cause) ? Stream.empty : Stream.failCause(cause),
-        ),
-        Stream.toAsyncIterable,
-      );
+      const prompt = makePromptIterable(promptQueue);
 
       const pendingApprovals = new Map<ApprovalRequestId, PendingApproval>();
       const pendingUserInputs = new Map<ApprovalRequestId, PendingUserInput>();
@@ -4170,6 +4305,14 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           : {}),
         ...(Object.keys(settings).length > 0 ? { settings } : {}),
         ...(existingResumeSessionId ? { resume: existingResumeSessionId } : {}),
+        // Ordinary resume omits resumeSessionAt so a stale last-assistant
+        // checkpoint cannot truncate a live session. After rollback the
+        // cursor is explicitly pinned to the last retained assistant uuid.
+        ...(existingResumeSessionId &&
+        resumeState?.pinResumeSessionAt === true &&
+        resumeState.resumeSessionAt
+          ? { resumeSessionAt: resumeState.resumeSessionAt }
+          : {}),
         ...(newSessionId ? { sessionId: newSessionId } : {}),
         includePartialMessages: true,
         canUseTool,
@@ -4244,6 +4387,9 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           ...(threadId ? { threadId } : {}),
           ...(sessionId ? { resume: sessionId } : {}),
           ...(resumeState?.resumeSessionAt ? { resumeSessionAt: resumeState.resumeSessionAt } : {}),
+          ...(resumeState?.pinResumeSessionAt === true && resumeState.resumeSessionAt
+            ? { pinResumeSessionAt: true }
+            : {}),
           turnCount: resumeState?.turnCount ?? 0,
         },
         createdAt: startedAt,
@@ -4254,6 +4400,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         session,
         promptQueue,
         query: queryRuntime,
+        queryOptions,
         streamFiber: undefined,
         startedAt,
         basePermissionMode: permissionMode,
@@ -4273,6 +4420,9 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         lastKnownTokenUsage: undefined,
         lastKnownTotalProcessedTokens: undefined,
         lastAssistantUuid: resumeState?.resumeSessionAt,
+        pinResumeSessionAt: resumeState?.pinResumeSessionAt === true,
+        needsPinnedQueryRestart: false,
+        replacingQuery: false,
         lastThreadStartedId: undefined,
         stopped: false,
       };
@@ -4322,30 +4472,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         providerRefs: {},
       });
 
-      let streamFiber: Fiber.Fiber<void, never>;
-      streamFiber = runFork(
-        Effect.exit(runSdkStream(context)).pipe(
-          Effect.flatMap((exit) => {
-            if (context.stopped) {
-              return Effect.void;
-            }
-            if (context.streamFiber === streamFiber) {
-              context.streamFiber = undefined;
-            }
-            return handleStreamExit(context, exit).pipe(
-              Effect.catch((cause) =>
-                Effect.logError("Failed to close Claude runtime stream.", { cause }),
-              ),
-            );
-          }),
-        ),
-      );
-      context.streamFiber = streamFiber;
-      streamFiber.addObserver(() => {
-        if (context.streamFiber === streamFiber) {
-          context.streamFiber = undefined;
-        }
-      });
+      forkSdkStream(context, runFork);
 
       return {
         ...session,
@@ -4355,6 +4482,10 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
   const sendTurn: ClaudeAdapterShape["sendTurn"] = Effect.fn("sendTurn")(function* (input) {
     const context = yield* requireSession(input.threadId);
+    if (context.needsPinnedQueryRestart) {
+      yield* replaceQueryAfterRollback(context);
+      context.needsPinnedQueryRestart = false;
+    }
     const modelSelection =
       input.modelSelection !== undefined && input.modelSelection.instanceId === boundInstanceId
         ? input.modelSelection
@@ -4537,6 +4668,18 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       const context = yield* requireSession(threadId);
       const nextLength = Math.max(0, context.turns.length - numTurns);
       context.turns.splice(nextLength);
+      context.lastAssistantUuid = lastRetainedAssistantUuid(context.turns);
+      if (context.lastAssistantUuid) {
+        context.pinResumeSessionAt = true;
+        context.needsPinnedQueryRestart = true;
+      } else if (context.turns.length === 0) {
+        context.resumeSessionId = undefined;
+        context.pinResumeSessionAt = false;
+        context.needsPinnedQueryRestart = true;
+      } else {
+        context.pinResumeSessionAt = false;
+        context.needsPinnedQueryRestart = false;
+      }
       yield* updateResumeCursor(context);
       return yield* snapshotThread(context);
     },

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -3875,7 +3875,11 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       ...baseQueryOptions,
       ...(liveModelId !== undefined ? { model: liveModelId } : {}),
       ...(livePermissionMode !== undefined ? { permissionMode: livePermissionMode } : {}),
-      ...(livePermissionMode === "bypassPermissions"
+      // The SDK only honors setPermissionMode("bypassPermissions") if the
+      // query was created with this flag. Keep it whenever the session's
+      // base mode is bypass, even if the live mode is currently plan.
+      ...(context.basePermissionMode === "bypassPermissions" ||
+      livePermissionMode === "bypassPermissions"
         ? { allowDangerouslySkipPermissions: true }
         : {}),
       ...(pinnedLastAssistantUuid && pinnedResumeSessionId

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -277,6 +277,7 @@ interface ClaudeSessionContext {
   streamFiber: Fiber.Fiber<void, Error> | undefined;
   readonly startedAt: string;
   readonly basePermissionMode: PermissionMode | undefined;
+  currentPermissionMode: PermissionMode | undefined;
   currentApiModelId: string | undefined;
   /** Effective effort for the session's turns; subagents without an explicit
    * effort override inherit this. */
@@ -3865,19 +3866,27 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       sessionId: _ignoredSessionId,
       resume: _ignoredResume,
       resumeSessionAt: _ignoredResumeSessionAt,
+      allowDangerouslySkipPermissions: _ignoredSkip,
       ...baseQueryOptions
     } = context.queryOptions;
-    const nextOptions: ClaudeQueryOptions =
-      pinnedLastAssistantUuid && pinnedResumeSessionId
+    const liveModelId = context.currentApiModelId;
+    const livePermissionMode = context.currentPermissionMode;
+    const nextOptions: ClaudeQueryOptions = {
+      ...baseQueryOptions,
+      ...(liveModelId !== undefined ? { model: liveModelId } : {}),
+      ...(livePermissionMode !== undefined ? { permissionMode: livePermissionMode } : {}),
+      ...(livePermissionMode === "bypassPermissions"
+        ? { allowDangerouslySkipPermissions: true }
+        : {}),
+      ...(pinnedLastAssistantUuid && pinnedResumeSessionId
         ? {
-            ...baseQueryOptions,
             resume: pinnedResumeSessionId,
             resumeSessionAt: pinnedLastAssistantUuid,
           }
         : {
-            ...baseQueryOptions,
             sessionId: yield* randomUUIDv4,
-          };
+          }),
+    };
     if (nextOptions.sessionId) {
       context.resumeSessionId = nextOptions.sessionId;
     }
@@ -4424,6 +4433,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         streamFiber: undefined,
         startedAt,
         basePermissionMode: permissionMode,
+        currentPermissionMode: permissionMode,
         currentApiModelId: apiModelId,
         currentEffort: effectiveEffort ?? undefined,
         resumeSessionId: sessionId,
@@ -4531,6 +4541,10 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         });
         context.currentApiModelId = apiModelId;
       }
+      context.queryOptions = {
+        ...context.queryOptions,
+        model: apiModelId,
+      };
       context.session = {
         ...context.session,
         model: modelSelection.model,
@@ -4553,11 +4567,25 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         try: () => context.query.setPermissionMode("plan"),
         catch: (cause) => toRequestError(input.threadId, "turn/setPermissionMode", cause),
       });
+      context.currentPermissionMode = "plan";
+      context.queryOptions = {
+        ...context.queryOptions,
+        permissionMode: "plan",
+      };
     } else if (input.interactionMode === "default") {
+      const restoredPermissionMode = context.basePermissionMode ?? "default";
       yield* Effect.tryPromise({
-        try: () => context.query.setPermissionMode(context.basePermissionMode ?? "default"),
+        try: () => context.query.setPermissionMode(restoredPermissionMode),
         catch: (cause) => toRequestError(input.threadId, "turn/setPermissionMode", cause),
       });
+      context.currentPermissionMode = restoredPermissionMode;
+      context.queryOptions = {
+        ...context.queryOptions,
+        permissionMode: restoredPermissionMode,
+        ...(restoredPermissionMode === "bypassPermissions"
+          ? { allowDangerouslySkipPermissions: true }
+          : {}),
+      };
     }
 
     const turnId = steeringTurnState?.turnId ?? TurnId.make(yield* randomUUIDv4);

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -147,6 +147,13 @@ function lastRetainedAssistantUuid(
   return undefined;
 }
 
+function isStaleRollbackQuery(context: {
+  readonly needsPinnedQueryRestart: boolean;
+  readonly replacingQuery: boolean;
+}): boolean {
+  return context.needsPinnedQueryRestart || context.replacingQuery;
+}
+
 interface ClaudeTurnState {
   readonly turnId: TurnId;
   readonly startedAt: string;
@@ -2896,6 +2903,9 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     if (message.type !== "assistant") {
       return;
     }
+    if (isStaleRollbackQuery(context)) {
+      return;
+    }
 
     // Subagent-owned assistant snapshots (parent_tool_use_id set) are the
     // subagent's own conversation, not the parent's. Emitting them created
@@ -3555,6 +3565,12 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     message: SDKMessage,
   ) {
     yield* logNativeSdkMessage(context, message);
+    // Rollback leaves the old SDK stream running until sendTurn replaces it.
+    // Late assistant/result frames from that stream must not move the cursor
+    // back onto discarded transcript.
+    if (isStaleRollbackQuery(context)) {
+      return;
+    }
     yield* ensureThreadId(context, message);
 
     // Wire-only command bookkeeping has no user-facing T3 lifecycle.
@@ -3635,7 +3651,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     context: ClaudeSessionContext,
     exit: Exit.Exit<void, ProviderAdapterProcessError>,
   ) {
-    if (context.stopped || context.replacingQuery) {
+    if (context.stopped || isStaleRollbackQuery(context)) {
       return;
     }
 
@@ -3798,7 +3814,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     streamFiber = runFork(
       Effect.exit(runSdkStream(context)).pipe(
         Effect.flatMap((exit) => {
-          if (context.stopped || context.replacingQuery) {
+          if (context.stopped || isStaleRollbackQuery(context)) {
             return Effect.void;
           }
           if (context.streamFiber === streamFiber) {
@@ -3824,6 +3840,8 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     context: ClaudeSessionContext,
   ) {
     const threadId = context.session.threadId;
+    const pinnedResumeSessionId = context.resumeSessionId;
+    const pinnedLastAssistantUuid = context.lastAssistantUuid;
     context.replacingQuery = true;
     const streamFiber = context.streamFiber;
     context.streamFiber = undefined;
@@ -3850,11 +3868,11 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       ...baseQueryOptions
     } = context.queryOptions;
     const nextOptions: ClaudeQueryOptions =
-      context.lastAssistantUuid && context.resumeSessionId
+      pinnedLastAssistantUuid && pinnedResumeSessionId
         ? {
             ...baseQueryOptions,
-            resume: context.resumeSessionId,
-            resumeSessionAt: context.lastAssistantUuid,
+            resume: pinnedResumeSessionId,
+            resumeSessionAt: pinnedLastAssistantUuid,
           }
         : {
             ...baseQueryOptions,
@@ -3882,6 +3900,8 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     context.promptQueue = promptQueue;
     context.query = queryRuntime;
     context.queryOptions = nextOptions;
+    context.lastAssistantUuid = pinnedLastAssistantUuid;
+    context.pinResumeSessionAt = pinnedLastAssistantUuid !== undefined;
     yield* updateResumeCursor(context);
 
     const runtimeContext = yield* Effect.context<never>();
@@ -4669,16 +4689,14 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       const nextLength = Math.max(0, context.turns.length - numTurns);
       context.turns.splice(nextLength);
       context.lastAssistantUuid = lastRetainedAssistantUuid(context.turns);
+      context.needsPinnedQueryRestart = true;
       if (context.lastAssistantUuid) {
         context.pinResumeSessionAt = true;
-        context.needsPinnedQueryRestart = true;
-      } else if (context.turns.length === 0) {
+      } else {
+        // No retained assistant checkpoint: a resume would replay discarded
+        // turns, so the replacement query must start a fresh session.
         context.resumeSessionId = undefined;
         context.pinResumeSessionAt = false;
-        context.needsPinnedQueryRestart = true;
-      } else {
-        context.pinResumeSessionAt = false;
-        context.needsPinnedQueryRestart = false;
       }
       yield* updateResumeCursor(context);
       return yield* snapshotThread(context);

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -1050,6 +1050,16 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         "provider.rollback_turns": input.numTurns,
       });
       yield* routed.adapter.rollbackThread(routed.threadId, input.numTurns);
+      const activeSessions = yield* routed.adapter.listSessions();
+      const rolledBackSession = activeSessions.find(
+        (session) => session.threadId === routed.threadId,
+      );
+      if (rolledBackSession) {
+        yield* upsertSessionBinding(
+          { ...rolledBackSession, providerInstanceId: routed.instanceId },
+          routed.threadId,
+        );
+      }
       yield* analytics.record("provider.conversation.rolled_back", {
         provider: routed.adapter.provider,
         turns: input.numTurns,


### PR DESCRIPTION
Fixes #6127

## What changed

Revert already restored files and trimmed the visible timeline, but the next Claude turn still saw the discarded prompts. `rollbackThread` left `lastAssistantUuid` on the reverted leaf, `updateResumeCursor` wrote that leaf back as `resumeSessionAt`, and the SDK query was started with `resume` only.

After rollback the adapter now:

- recomputes `lastAssistantUuid` from the last retained parent assistant uuid (or clears it when nothing remains)
- persists that cursor, with `pinResumeSessionAt` set only for the post-revert resume
- passes `resumeSessionAt` to the SDK on the next start, and recreates the live query on the next `sendTurn`, so the model resumes at the retained transcript

Ordinary resume is unchanged: a cursor that still carries `resumeSessionAt` without the pin still starts with `options.resumeSessionAt === undefined`, which is the stale-checkpoint guard.

## Verification

```
CI=true vp test run apps/server/src/provider/Layers/ClaudeAdapter.test.ts   # 71 passed
CI=true vp test run apps/server/src/provider/Layers/ProviderService.test.ts # 29 passed
```

Model: grok-4. Harness: T3 Code / Grok Build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes conversation rollback and SDK resume semantics in the Claude provider path; behavior is well-covered by new tests but affects core thread continuity after revert.
> 
> **Overview**
> Fixes a bug where **conversation rollback** trimmed the UI timeline but the next Claude turn still resumed from discarded transcript state.
> 
> **Claude adapter:** `rollbackThread` now recomputes `lastAssistantUuid` from retained turns (per-turn `lastAssistantUuid`), sets `pinResumeSessionAt` on the resume cursor, and defers replacing the live SDK query until the next `sendTurn` via `replaceQueryAfterRollback`. That restart passes `resume` + `resumeSessionAt` only when a checkpoint remains; otherwise it starts a **fresh** `sessionId`. Late frames from the old query are ignored while the query is stale. Recreated queries carry current model/permission options from stored `queryOptions`. Normal resume still omits `resumeSessionAt` unless `pinResumeSessionAt` is set.
> 
> **Provider service:** After rollback, session bindings are upserted from `listSessions` so persisted state matches the new cursor.
> 
> Tests extend the Claude adapter harness (fresh query per `createQuery`) and add rollback/resume coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0c6b93a800eb73b0a4c2010d6a19d5b6632d732. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Claude resume cursor to point at the last retained assistant turn after rollback
> - After `rollbackThread`, the adapter now pins the resume cursor to the `lastAssistantUuid` of the last retained completed turn, so subsequent `sendTurn`/`startSession` calls resume at the correct checkpoint.
> - Introduces `replaceQueryAfterRollback` in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/7198/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc), which shuts down the old prompt queue and query, then either resumes at the pinned assistant uuid or starts a fresh session when no checkpoint remains.
> - Mid-session model and permission mode are preserved across rollback-induced query replacement via new `queryOptions` and `currentPermissionMode` fields on `ClaudeSessionContext`.
> - Late SDK messages and assistant frames from a discarded post-rollback stream are ignored via the new `isStaleRollbackQuery` predicate, preventing stale frames from corrupting session state.
> - `ProviderService.rollbackConversation` now upserts the updated session binding (including the new resume cursor) into the directory after rollback.
> - Behavioral Change: the first `sendTurn` after a rollback triggers a query restart rather than continuing on the old stream.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d0c6b93.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->