### PR TITLE
fix(web): label nested agent models from spawn/response

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1781,8 +1781,9 @@ describe("ClaudeAdapterLive", () => {
         attachments: [],
       });
 
-      // No explicit model/effort on the launch input: the task inherits the
-      // session's selection.
+      // No explicit model on the launch: leave it unlabeled. Effort still
+      // inherits the session selection. Inventing the session model here is
+      // what mislabeled nested Agent-tool children (#6026).
       harness.query.emit({
         type: "system",
         subtype: "task_started",
@@ -1819,7 +1820,7 @@ describe("ClaudeAdapterLive", () => {
       const started = taskEvents[0];
       assert.equal(started?.type, "task.started");
       if (started?.type === "task.started") {
-        assert.equal(started.payload.model, "claude-opus-4-6");
+        assert.equal(started.payload.model, undefined);
         assert.equal(started.payload.effort, "max");
       }
       const progress = taskEvents[1];
@@ -1827,6 +1828,175 @@ describe("ClaudeAdapterLive", () => {
       if (progress?.type === "task.progress") {
         assert.equal(progress.payload.model, "claude-sonnet-5[1m]");
         assert.equal(progress.payload.effort, "max");
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("depth-2 nested agent uses the child model, never the session default", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      // parent start + omitted start/progress + named start
+      const taskEventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.type.startsWith("task.")),
+        Stream.take(4),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("claudeAgent"),
+          "claude-fable-5",
+          [{ id: "effort", value: "high" }],
+        ),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "spawn nested agents",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "system",
+        subtype: "task_started",
+        task_id: "task-parent",
+        description: "codex-sol",
+        task_type: "local_agent",
+        subagent_type: "codex-sol",
+        tool_use_id: "toolu_parent",
+        uuid: "task-parent-uuid",
+        session_id: "sdk-session",
+      } as unknown as SDKMessage);
+
+      // Depth-2 Agent tool: no model on the spawn input (frontmatter pin
+      // lives on the agent definition, not the tool call).
+      harness.query.emit({
+        type: "stream_event",
+        parent_tool_use_id: "toolu_parent",
+        event: {
+          type: "content_block_start",
+          index: 0,
+          content_block: {
+            type: "tool_use",
+            id: "toolu_nested_omitted",
+            name: "Agent",
+            input: {
+              description: "Explore the repo",
+              prompt: "Find auth usage",
+              subagent_type: "Explore",
+            },
+          },
+        },
+        uuid: "stream-nested-omitted",
+        session_id: "sdk-session",
+      } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "system",
+        subtype: "task_started",
+        task_id: "task-nested-omitted",
+        description: "Explore the repo",
+        task_type: "local_agent",
+        subagent_type: "Explore",
+        tool_use_id: "toolu_nested_omitted",
+        uuid: "task-nested-omitted-uuid",
+        session_id: "sdk-session",
+      } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "assistant",
+        parent_tool_use_id: "toolu_nested_omitted",
+        message: {
+          model: "gpt-5.6-sol",
+          content: [],
+        },
+        uuid: "nested-snapshot-uuid",
+        session_id: "sdk-session",
+      } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "system",
+        subtype: "task_progress",
+        task_id: "task-nested-omitted",
+        description: "Explore the repo",
+        usage: { total_tokens: 40, tool_uses: 1, duration_ms: 8 },
+        uuid: "task-nested-omitted-progress",
+        session_id: "sdk-session",
+      } as unknown as SDKMessage);
+
+      // Sibling spawn whose SDK task record names the child model.
+      harness.query.emit({
+        type: "stream_event",
+        parent_tool_use_id: "toolu_parent",
+        event: {
+          type: "content_block_start",
+          index: 1,
+          content_block: {
+            type: "tool_use",
+            id: "toolu_nested_named",
+            name: "Agent",
+            input: {
+              description: "Explore tests",
+              prompt: "Scan tests",
+              subagent_type: "Explore",
+              model: "gpt-5.6-sol",
+            },
+          },
+        },
+        uuid: "stream-nested-named",
+        session_id: "sdk-session",
+      } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "system",
+        subtype: "task_started",
+        task_id: "task-nested-named",
+        description: "Explore tests",
+        task_type: "local_agent",
+        subagent_type: "Explore",
+        tool_use_id: "toolu_nested_named",
+        model: "gpt-5.6-sol",
+        uuid: "task-nested-named-uuid",
+        session_id: "sdk-session",
+      } as unknown as SDKMessage);
+
+      const taskEvents = Array.from(yield* Fiber.join(taskEventsFiber));
+      const omittedStarted = taskEvents.find(
+        (event) =>
+          event.type === "task.started" &&
+          (event.payload as { taskId?: string }).taskId === "task-nested-omitted",
+      );
+      assert.equal(omittedStarted?.type, "task.started");
+      if (omittedStarted?.type === "task.started") {
+        assert.equal(omittedStarted.payload.model, undefined);
+        assert.equal(omittedStarted.payload.agentId, "task-parent");
+        assert.equal(omittedStarted.payload.role, "Explore");
+        assert.notEqual(omittedStarted.payload.model, "claude-fable-5");
+      }
+      const omittedProgress = taskEvents.find(
+        (event) =>
+          event.type === "task.progress" &&
+          (event.payload as { taskId?: string }).taskId === "task-nested-omitted",
+      );
+      assert.equal(omittedProgress?.type, "task.progress");
+      if (omittedProgress?.type === "task.progress") {
+        assert.equal(omittedProgress.payload.model, "gpt-5.6-sol");
+        assert.notEqual(omittedProgress.payload.model, "claude-fable-5");
+      }
+
+      const namedStarted = taskEvents.find(
+        (event) =>
+          event.type === "task.started" &&
+          (event.payload as { taskId?: string }).taskId === "task-nested-named",
+      );
+      assert.equal(namedStarted?.type, "task.started");
+      if (namedStarted?.type === "task.started") {
+        assert.equal(namedStarted.payload.model, "gpt-5.6-sol");
+        assert.equal(namedStarted.payload.agentId, "task-parent");
       }
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -1039,6 +1039,45 @@ function taskLinkageFor(
   };
 }
 
+/**
+ * A model the spawn or SDK actually named. `"inherit"` is an instruction,
+ * not an id — treating it as a label would invent the parent session model.
+ */
+function explicitTaskModel(value: unknown): string | undefined {
+  const model = trimmedString(value);
+  return model === undefined || model === "inherit" ? undefined : model;
+}
+
+/** Authoritative API model on an assistant snapshot or its stream open. */
+function servingModelFromSdkMessage(message: SDKMessage): string | undefined {
+  if (message.type === "assistant") {
+    return explicitTaskModel(message.message.model);
+  }
+  if (message.type === "stream_event" && message.event.type === "message_start") {
+    return explicitTaskModel(message.event.message.model);
+  }
+  return undefined;
+}
+
+/**
+ * Bind a serving model onto the task whose Task/Agent tool_use_id is
+ * `parentToolUseId`. Used when the start row had no model of its own.
+ */
+function rememberTaskAgentServingModel(
+  agents: Map<string, ClaudeTaskAgentState>,
+  parentToolUseId: string | null | undefined,
+  model: string | undefined,
+): void {
+  if (!model) {
+    return;
+  }
+  const taskId = agentIdForParentToolUse(agents, parentToolUseId);
+  const agent = taskId ? agents.get(taskId) : undefined;
+  if (agent) {
+    agent.model = model;
+  }
+}
+
 const WORKFLOW_PHASE_CAP = 64;
 const WORKFLOW_AGENT_CAP = 100;
 
@@ -2407,6 +2446,13 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     // re-homed by the quiet-timeline filter.
     const streamParentToolUseId = (message as { parent_tool_use_id?: string | null })
       .parent_tool_use_id;
+    // Nested Agent-tool children often omit model on task_started.
+    // message_start.model is the id that actually served the response.
+    rememberTaskAgentServingModel(
+      context.taskAgents,
+      streamParentToolUseId,
+      servingModelFromSdkMessage(message),
+    );
     if (streamParentToolUseId !== null && streamParentToolUseId !== undefined) {
       // Drop only the subagent's narration (text/thinking); tool_use blocks
       // and their input_json_delta frames must flow so attributed tool items
@@ -2874,13 +2920,12 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       .parent_tool_use_id;
     if (assistantParentToolUseId !== null && assistantParentToolUseId !== undefined) {
       // The snapshot's message.model is the authoritative API model the
-      // subagent actually ran on — refine the seeded launch-time value.
-      const owningTaskId = agentIdForParentToolUse(context.taskAgents, assistantParentToolUseId);
-      const snapshotModel = trimmedString(message.message.model);
-      const owningAgent = owningTaskId ? context.taskAgents.get(owningTaskId) : undefined;
-      if (owningAgent && snapshotModel) {
-        owningAgent.model = snapshotModel;
-      }
+      // subagent actually ran on — refine a missing or launch-time value.
+      rememberTaskAgentServingModel(
+        context.taskAgents,
+        assistantParentToolUseId,
+        servingModelFromSdkMessage(message),
+      );
       context.lastAssistantUuid = message.uuid;
       yield* updateResumeCursor(context);
       return;
@@ -3191,14 +3236,16 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
             )
           : undefined;
         const owningAgentId = launchingTool?.agentId;
-        // Model/effort: the Agent tool's input carries explicit overrides;
-        // absent ones inherit the session's selection (SDK behavior).
-        // Subagent assistant snapshots later refine model with the
-        // authoritative API id. AgentInput.effort may be a named level or an
+        // Model: only what the spawn or SDK named. Nested Agent-tool children
+        // resolve their own frontmatter model; copying the session default
+        // labeled them as the parent model (#6026). Assistant / message_start
+        // snapshots refine later. Effort still inherits the session when the
+        // launch input omits it. AgentInput.effort may be a named level or an
         // integer.
         const launchInput = launchingTool?.input;
         const model =
-          trimmedString(launchInput?.model) ?? trimmedString(context.session.model ?? undefined);
+          explicitTaskModel(launchInput?.model) ??
+          explicitTaskModel((message as { model?: unknown }).model);
         const rawLaunchEffort = launchInput?.effort;
         const effort =
           trimmedString(rawLaunchEffort) ??

--- a/packages/client-runtime/src/state/subagentRuntime.test.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.test.ts
@@ -603,6 +603,48 @@ describe("model and effort attribution", () => {
     expect(agents[0]!.effort).toBe("high");
   });
 
+  it("nested spawn without a model stays unlabeled until a later payload names one", () => {
+    const unlabeled = fold([
+      activity("task.started", {
+        taskId: "parent-1",
+        title: "codex-sol",
+        role: "codex-sol",
+        model: "gpt-5.6-sol",
+        effort: "high",
+      }),
+      activity("task.started", {
+        taskId: "child-1",
+        title: "Explore the repo",
+        role: "Explore",
+        agentId: "parent-1",
+        taskType: "local_agent",
+        effort: "high",
+      }),
+    ]);
+    const child = unlabeled.find((agent) => agent.id === "child-1");
+    expect(child?.model).toBeNull();
+    expect(formatSubagentModelLabel(child?.model ?? null, child?.effort ?? null)).toBeNull();
+
+    const refined = fold([
+      activity("task.started", {
+        taskId: "child-2",
+        title: "Explore the repo",
+        role: "Explore",
+        agentId: "parent-1",
+        taskType: "local_agent",
+        effort: "high",
+      }),
+      activity("task.progress", { taskId: "child-2", model: "gpt-5.6-sol" }),
+      // A later row without model must not revert to inherited/null.
+      activity("task.progress", { taskId: "child-2", lastToolName: "Read" }),
+    ]);
+    expect(refined).toHaveLength(1);
+    expect(refined[0]!.model).toBe("gpt-5.6-sol");
+    expect(formatSubagentModelLabel(refined[0]!.model, refined[0]!.effort)).toBe(
+      "gpt-5.6-sol · high",
+    );
+  });
+
   it("formatSubagentModelLabel compacts ids and appends effort", () => {
     expect(formatSubagentModelLabel("claude-sonnet-5[1m]", "high")).toBe("sonnet-5[1m] · high");
     expect(formatSubagentModelLabel("claude-opus-4-20250514", null)).toBe("opus-4");


### PR DESCRIPTION
## Problem

Depth-2 Agent-tool spawns were labeled with the parent session model (`fable-5`) even when every response was served by the child's frontmatter model (`gpt-5.6-sol`). `task_started` copied `session.model` whenever the spawn omitted a model, and that invented id rode on every later `task.*` linkage row.

## Fix

Persist only a model the spawn or SDK actually named. Nested children stay unlabeled until the first assistant / `message_start` serving model arrives; later `task.*` rows carry that id. `formatSubagentModelLabel` is unchanged. A later payload without a model never clears a known one.

Fixes #6026

Model: grok-4
Harness: T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task lifecycle model attribution in ClaudeAdapter, which affects UI labels for nested agents; behavior is covered by new adapter and client-runtime tests.
> 
> **Overview**
> Fixes **#6026**: nested Agent-tool tasks were shown with the **parent session model** when the spawn omitted an explicit model.
> 
> **ClaudeAdapter** now seeds `task.*` model only from the Agent launch input, the SDK `task_started` row, or later **assistant** / **`message_start`** serving ids—via `explicitTaskModel` (ignores `"inherit"`) and `rememberTaskAgentServingModel`. It **no longer copies `session.model`** on `task_started`. **Effort** still inherits from the session when the launch omits it.
> 
> **Tests** assert unlabeled starts until a serving model arrives, depth-2 nesting never uses the session default, and the client-runtime fold keeps model unset until a payload names one without clearing a known model later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ae6af1b348553ae7262c3fcb5c910c5c3d35803. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix nested agent task model attribution to use child model instead of session default
> - Nested Agent tool tasks started without an explicit model no longer inherit the session's default model; `payload.model` remains `undefined` until an SDK `message_start` or assistant message names one.
> - Adds `explicitTaskModel`, `servingModelFromSdkMessage`, and `rememberTaskAgentServingModel` helpers in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/7199/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc) to centralize model extraction and attribution logic.
> - Model refinement from SDK stream frames now updates the owning nested task consistently, replacing bespoke inline trimming logic.
> - Behavioral Change: tasks previously labeled with the session default model at start will now show `undefined` until the serving model is confirmed from SDK traffic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ae6af1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->