### PR TITLE
fix(desktop): keep preview automation when leaving a thread

### DIFF
--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -3068,6 +3068,40 @@ describe("PreviewManager", () => {
       }),
     ),
   );
+
+  effectIt.effect("clears agent controller after a snapshot capture miss", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const preview = makeAutomationWebContents({
+          capturePage: () => new Promise(() => undefined),
+        });
+        fromId.mockReturnValue(preview.webContents);
+        const states: PreviewManager.PreviewTabState[] = [];
+        yield* manager.subscribeStateChanges((_tabId, state) =>
+          Effect.sync(() => {
+            states.push(state);
+          }),
+        );
+
+        yield* manager.createTab("tab_viz_controller");
+        yield* manager.registerWebview("tab_viz_controller", 42);
+        yield* Effect.yieldNow;
+
+        const fiber = yield* manager
+          .automationSnapshot("tab_viz_controller")
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Effect.yieldNow;
+        yield* TestClock.adjust(PreviewManager.AUTOMATION_CAPTURE_TIMEOUT_MS);
+        yield* Effect.yieldNow;
+        yield* TestClock.adjust(PreviewManager.AUTOMATION_CAPTURE_TIMEOUT_MS);
+        const exit = yield* Fiber.await(fiber);
+
+        expect(Exit.isFailure(exit)).toBe(true);
+        expect(states.some((state) => state.controller === "agent")).toBe(true);
+        expect(states.at(-1)?.controller).toBe("none");
+      }),
+    ),
+  );
 });
 
 describe("PreviewCaptureUnavailableError", () => {

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -186,6 +186,86 @@ const makeTestPreviewWebContents = (
     capturePage,
   }) as never;
 
+const SNAPSHOT_PAGE = {
+  url: "https://example.com",
+  title: "Example",
+  loading: false,
+  visibleText: "Hello",
+  interactiveElements: [],
+};
+
+const makeSnapshotImage = () => {
+  const image = {
+    getSize: () => ({ width: 800, height: 600 }),
+    resize: vi.fn(() => image),
+    toPNG: () => Buffer.from("png"),
+  };
+  return image;
+};
+
+const makeAutomationWebContents = (options?: {
+  readonly capturePage?: () => Promise<ReturnType<typeof makeSnapshotImage>>;
+  readonly id?: number;
+}) => {
+  const debuggerListeners = new Map<string, (...args: never[]) => void>();
+  let attached = false;
+  const attach = vi.fn(() => {
+    attached = true;
+  });
+  const detach = vi.fn(() => {
+    attached = false;
+    debuggerListeners.get("detach")?.();
+  });
+  const sendCommand = vi.fn(async (method: string) => {
+    if (method === "Runtime.evaluate") {
+      return { result: { value: SNAPSHOT_PAGE } };
+    }
+    if (method === "Accessibility.getFullAXTree") {
+      return { nodes: [] };
+    }
+    return undefined;
+  });
+  const capturePage = options?.capturePage ?? (async () => makeSnapshotImage());
+  const webContents = {
+    id: options?.id ?? 42,
+    isDestroyed: () => false,
+    isDevToolsOpened: () => false,
+    getType: () => "webview",
+    getURL: () => "https://example.com",
+    getTitle: () => "Example",
+    isLoading: () => false,
+    getZoomFactor: () => 1,
+    setZoomFactor: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+    ipc: { on: vi.fn(), off: vi.fn() },
+    send: webviewSend,
+    navigationHistory: { canGoBack: () => false, canGoForward: () => false },
+    setWindowOpenHandler: vi.fn(),
+    debugger: {
+      isAttached: () => attached,
+      attach,
+      detach,
+      sendCommand,
+      on: vi.fn((event: string, listener: (...args: never[]) => void) => {
+        debuggerListeners.set(event, listener);
+      }),
+      off: vi.fn((event: string) => {
+        debuggerListeners.delete(event);
+      }),
+    },
+    capturePage: vi.fn(capturePage),
+  };
+  return {
+    attach,
+    detach,
+    debuggerListeners,
+    sendCommand,
+    webContents: webContents as never,
+    capturePage: webContents.capturePage,
+  };
+};
+
 const TEST_FAVICON = "data:image/png;base64,cG5n";
 
 const makeSourcePng = (width = 1, height = 1): Buffer => {
@@ -2735,6 +2815,115 @@ describe("PreviewManager", () => {
           detailLength: text.length,
           cause: exceptionDetails,
         });
+      }),
+    ),
+  );
+
+  effectIt.effect("does not detach a live tab when the same webview re-registers", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const preview = makeAutomationWebContents();
+        fromId.mockReturnValue(preview.webContents);
+
+        yield* manager.createTab("tab_leave_reregister");
+        yield* manager.registerWebview("tab_leave_reregister", 42);
+        yield* Effect.yieldNow;
+        const attachesAfterRegister = preview.attach.mock.calls.length;
+        expect(attachesAfterRegister).toBeGreaterThan(0);
+
+        yield* manager.registerWebview("tab_leave_reregister", 42);
+        yield* Effect.yieldNow;
+
+        expect(preview.detach).not.toHaveBeenCalled();
+        expect(preview.attach).toHaveBeenCalledTimes(attachesAfterRegister);
+
+        const snapshot = yield* manager.automationSnapshot("tab_leave_reregister");
+        expect(snapshot).toMatchObject(SNAPSHOT_PAGE);
+        expect(preview.capturePage).toHaveBeenCalledOnce();
+        expect(preview.detach).not.toHaveBeenCalled();
+      }),
+    ),
+  );
+
+  effectIt.effect(
+    "restores the control session on the next snapshot after a hidden-tab detach",
+    () =>
+      withManager((manager) =>
+        Effect.gen(function* () {
+          const preview = makeAutomationWebContents();
+          fromId.mockReturnValue(preview.webContents);
+
+          yield* manager.createTab("tab_leave_reattach");
+          yield* manager.registerWebview("tab_leave_reattach", 42);
+          yield* Effect.yieldNow;
+          const attachesAfterRegister = preview.attach.mock.calls.length;
+
+          preview.debuggerListeners.get("detach")?.();
+          yield* Effect.yieldNow;
+
+          const snapshot = yield* manager.automationSnapshot("tab_leave_reattach");
+          expect(snapshot).toMatchObject(SNAPSHOT_PAGE);
+          expect(preview.attach.mock.calls.length).toBeGreaterThan(attachesAfterRegister);
+          expect(preview.capturePage).toHaveBeenCalledOnce();
+        }),
+      ),
+  );
+
+  effectIt.effect("retries snapshot after UnknownVizError by restoring the control session", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const preview = makeAutomationWebContents();
+        preview.capturePage.mockRejectedValueOnce(new Error("UnknownVizError"));
+        fromId.mockReturnValue(preview.webContents);
+
+        yield* manager.createTab("tab_viz_retry");
+        yield* manager.registerWebview("tab_viz_retry", 42);
+        yield* Effect.yieldNow;
+        const attachesAfterRegister = preview.attach.mock.calls.length;
+
+        const snapshot = yield* manager.automationSnapshot("tab_viz_retry");
+        expect(snapshot).toMatchObject(SNAPSHOT_PAGE);
+        expect(preview.capturePage).toHaveBeenCalledTimes(2);
+        expect(preview.attach.mock.calls.length).toBeGreaterThan(attachesAfterRegister);
+      }),
+    ),
+  );
+
+  effectIt.effect("fails a hung snapshot quickly instead of waiting minutes", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const preview = makeAutomationWebContents({
+          capturePage: () => new Promise(() => undefined),
+        });
+        fromId.mockReturnValue(preview.webContents);
+
+        yield* manager.createTab("tab_viz_timeout");
+        yield* manager.registerWebview("tab_viz_timeout", 42);
+        yield* Effect.yieldNow;
+
+        const fiber = yield* manager
+          .automationSnapshot("tab_viz_timeout")
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Effect.yieldNow;
+        yield* TestClock.adjust(PreviewManager.AUTOMATION_CAPTURE_TIMEOUT_MS);
+        yield* Effect.yieldNow;
+        yield* TestClock.adjust(PreviewManager.AUTOMATION_CAPTURE_TIMEOUT_MS);
+        const exit = yield* Fiber.await(fiber);
+
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isSuccess(exit)) return;
+        const error = Option.getOrThrow(Cause.findErrorOption(exit.cause));
+        expect(PreviewManager.isPreviewOperationError(error)).toBe(true);
+        if (!PreviewManager.isPreviewOperationError(error)) return;
+        expect(error).toMatchObject({
+          _tag: "PreviewOperationError",
+          operation: "automationSnapshot.capturePage",
+          tabId: "tab_viz_timeout",
+        });
+        expect(PreviewManager.PreviewOperationError.toTimelineMessage(error)).toBe(
+          "UnknownVizError",
+        );
+        expect(preview.capturePage.mock.calls.length).toBeLessThanOrEqual(2);
       }),
     ),
   );

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -2869,6 +2869,29 @@ describe("PreviewManager", () => {
       ),
   );
 
+  effectIt.effect("does not let a stale control-session finalizer detach its replacement", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const preview = makeAutomationWebContents();
+        fromId.mockReturnValue(preview.webContents);
+
+        yield* manager.createTab("tab_session_race");
+        yield* manager.registerWebview("tab_session_race", 42);
+        yield* Effect.yieldNow;
+
+        const inFlight = yield* manager
+          .automationSnapshot("tab_session_race")
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        preview.debuggerListeners.get("detach")?.();
+        const first = yield* Fiber.join(inFlight);
+        expect(first).toMatchObject(SNAPSHOT_PAGE);
+
+        const second = yield* manager.automationSnapshot("tab_session_race");
+        expect(second).toMatchObject(SNAPSHOT_PAGE);
+      }),
+    ),
+  );
+
   effectIt.effect("retries snapshot after UnknownVizError by restoring the control session", () =>
     withManager((manager) =>
       Effect.gen(function* () {
@@ -2913,20 +2936,40 @@ describe("PreviewManager", () => {
         expect(Exit.isFailure(exit)).toBe(true);
         if (Exit.isSuccess(exit)) return;
         const error = Option.getOrThrow(Cause.findErrorOption(exit.cause));
-        expect(PreviewManager.isPreviewOperationError(error)).toBe(true);
-        if (!PreviewManager.isPreviewOperationError(error)) return;
+        expect(PreviewManager.isPreviewCaptureUnavailableError(error)).toBe(true);
+        if (!PreviewManager.isPreviewCaptureUnavailableError(error)) return;
         expect(error).toMatchObject({
-          _tag: "PreviewOperationError",
-          operation: "automationSnapshot.capturePage",
+          _tag: "PreviewCaptureUnavailableError",
           tabId: "tab_viz_timeout",
+          webContentsId: 42,
         });
-        expect(PreviewManager.PreviewOperationError.toTimelineMessage(error)).toBe(
-          "UnknownVizError",
-        );
+        expect(Cause.isTimeoutError(error.cause)).toBe(true);
+        expect(error.message).not.toContain("UnknownVizError");
         expect(preview.capturePage.mock.calls.length).toBeLessThanOrEqual(2);
       }),
     ),
   );
+});
+
+describe("PreviewCaptureUnavailableError", () => {
+  it("keeps the real timeout as cause and retries from the tag", () => {
+    const cause = new Cause.TimeoutError();
+    const error = new PreviewManager.PreviewCaptureUnavailableError({
+      tabId: "tab_1",
+      webContentsId: 42,
+      cause,
+    });
+
+    expect(error._tag).toBe("PreviewCaptureUnavailableError");
+    expect(error.cause).toBe(cause);
+    expect(Cause.isTimeoutError(error.cause)).toBe(true);
+    expect(error.message).not.toContain("UnknownVizError");
+    expect(encodePreviewManagerError(error)).toMatchObject({
+      _tag: "PreviewCaptureUnavailableError",
+      tabId: "tab_1",
+      webContentsId: 42,
+    });
+  });
 });
 
 describe("PreviewOperationError", () => {

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -226,6 +226,10 @@ const makeAutomationWebContents = (options?: {
     return undefined;
   });
   const capturePage = options?.capturePage ?? (async () => makeSnapshotImage());
+  const emitDetach = () => {
+    attached = false;
+    debuggerListeners.get("detach")?.();
+  };
   const webContents = {
     id: options?.id ?? 42,
     isDestroyed: () => false,
@@ -259,6 +263,7 @@ const makeAutomationWebContents = (options?: {
   return {
     attach,
     detach,
+    emitDetach,
     debuggerListeners,
     sendCommand,
     webContents: webContents as never,
@@ -2858,7 +2863,7 @@ describe("PreviewManager", () => {
           yield* Effect.yieldNow;
           const attachesAfterRegister = preview.attach.mock.calls.length;
 
-          preview.debuggerListeners.get("detach")?.();
+          preview.emitDetach();
           yield* Effect.yieldNow;
 
           const snapshot = yield* manager.automationSnapshot("tab_leave_reattach");
@@ -2869,7 +2874,26 @@ describe("PreviewManager", () => {
       ),
   );
 
-  effectIt.effect("does not let a stale control-session finalizer detach its replacement", () =>
+  effectIt.effect("reattaches when Chromium has detached before the session is forgotten", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const preview = makeAutomationWebContents();
+        fromId.mockReturnValue(preview.webContents);
+
+        yield* manager.createTab("tab_stale_session");
+        yield* manager.registerWebview("tab_stale_session", 42);
+        yield* Effect.yieldNow;
+        const attachesAfterRegister = preview.attach.mock.calls.length;
+
+        preview.emitDetach();
+        const snapshot = yield* manager.automationSnapshot("tab_stale_session");
+        expect(snapshot).toMatchObject(SNAPSHOT_PAGE);
+        expect(preview.attach.mock.calls.length).toBeGreaterThan(attachesAfterRegister);
+      }),
+    ),
+  );
+
+  effectIt.effect("does not let a stale control-session detach tear down its replacement", () =>
     withManager((manager) =>
       Effect.gen(function* () {
         const preview = makeAutomationWebContents();
@@ -2878,16 +2902,19 @@ describe("PreviewManager", () => {
         yield* manager.createTab("tab_session_race");
         yield* manager.registerWebview("tab_session_race", 42);
         yield* Effect.yieldNow;
+        const staleDetach = preview.debuggerListeners.get("detach");
 
-        const inFlight = yield* manager
-          .automationSnapshot("tab_session_race")
-          .pipe(Effect.forkChild({ startImmediately: true }));
-        preview.debuggerListeners.get("detach")?.();
-        const first = yield* Fiber.join(inFlight);
-        expect(first).toMatchObject(SNAPSHOT_PAGE);
+        preview.emitDetach();
+        yield* Effect.yieldNow;
+        const restored = yield* manager.automationSnapshot("tab_session_race");
+        expect(restored).toMatchObject(SNAPSHOT_PAGE);
+        const attachesAfterRestore = preview.attach.mock.calls.length;
 
-        const second = yield* manager.automationSnapshot("tab_session_race");
-        expect(second).toMatchObject(SNAPSHOT_PAGE);
+        staleDetach?.();
+        yield* Effect.yieldNow;
+        const reused = yield* manager.automationSnapshot("tab_session_race");
+        expect(reused).toMatchObject(SNAPSHOT_PAGE);
+        expect(preview.attach.mock.calls.length).toBe(attachesAfterRestore);
       }),
     ),
   );
@@ -2908,6 +2935,54 @@ describe("PreviewManager", () => {
         expect(snapshot).toMatchObject(SNAPSHOT_PAGE);
         expect(preview.capturePage).toHaveBeenCalledTimes(2);
         expect(preview.attach.mock.calls.length).toBeGreaterThan(attachesAfterRegister);
+      }),
+    ),
+  );
+
+  effectIt.effect("holds the restored session lock across a snapshot retry", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        let captures = 0;
+        let resolveRetryStarted: (() => void) | undefined;
+        let resolveRetryRelease: (() => void) | undefined;
+        const retryStarted = new Promise<void>((resolve) => {
+          resolveRetryStarted = resolve;
+        });
+        const retryRelease = new Promise<void>((resolve) => {
+          resolveRetryRelease = resolve;
+        });
+        const preview = makeAutomationWebContents({
+          capturePage: async () => {
+            const n = ++captures;
+            if (n === 1) throw new Error("UnknownVizError");
+            if (n === 2) {
+              resolveRetryStarted?.();
+              await retryRelease;
+            }
+            return makeSnapshotImage();
+          },
+        });
+        fromId.mockReturnValue(preview.webContents);
+
+        yield* manager.createTab("tab_viz_mutex");
+        yield* manager.registerWebview("tab_viz_mutex", 42);
+        yield* Effect.yieldNow;
+
+        const first = yield* manager
+          .automationSnapshot("tab_viz_mutex")
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Effect.promise(() => retryStarted);
+
+        const second = yield* manager
+          .automationSnapshot("tab_viz_mutex")
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        for (let i = 0; i < 8; i++) yield* Effect.yieldNow;
+        expect(captures).toBe(2);
+
+        resolveRetryRelease?.();
+        expect(yield* Fiber.join(first)).toMatchObject(SNAPSHOT_PAGE);
+        expect(yield* Fiber.join(second)).toMatchObject(SNAPSHOT_PAGE);
+        expect(captures).toBe(3);
       }),
     ),
   );

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -2919,6 +2919,50 @@ describe("PreviewManager", () => {
     ),
   );
 
+  effectIt.effect("retries a snapshot against the live webview after the guest is replaced", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        let resolveCaptureStarted: (() => void) | undefined;
+        let resolveAllowFailure: (() => void) | undefined;
+        const captureStarted = new Promise<void>((resolve) => {
+          resolveCaptureStarted = resolve;
+        });
+        const allowFailure = new Promise<void>((resolve) => {
+          resolveAllowFailure = resolve;
+        });
+        const original = makeAutomationWebContents({
+          id: 42,
+          capturePage: async () => {
+            resolveCaptureStarted?.();
+            await allowFailure;
+            throw new Error("UnknownVizError");
+          },
+        });
+        const replacement = makeAutomationWebContents({ id: 43 });
+        fromId.mockImplementation((id) => {
+          if (id === 42) return original.webContents;
+          if (id === 43) return replacement.webContents;
+          return null;
+        });
+
+        yield* manager.createTab("tab_retry_replaced");
+        yield* manager.registerWebview("tab_retry_replaced", 42);
+        yield* Effect.yieldNow;
+
+        const snapshot = yield* manager
+          .automationSnapshot("tab_retry_replaced")
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Effect.promise(() => captureStarted);
+        yield* manager.registerWebview("tab_retry_replaced", 43);
+        resolveAllowFailure?.();
+
+        expect(yield* Fiber.join(snapshot)).toMatchObject(SNAPSHOT_PAGE);
+        expect(original.capturePage).toHaveBeenCalledOnce();
+        expect(replacement.capturePage).toHaveBeenCalledOnce();
+      }),
+    ),
+  );
+
   effectIt.effect("retries snapshot after UnknownVizError by restoring the control session", () =>
     withManager((manager) =>
       Effect.gen(function* () {

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -857,26 +857,26 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     webContentsId: number,
     expected?: BrowserControlSession,
   ) {
-    const control = yield* SynchronizedRef.modify(controlSessionsRef, (sessions) => {
-      const current = sessions.get(webContentsId);
-      if (!current || (expected !== undefined && current !== expected)) {
-        return [undefined, sessions] as const;
-      }
-      return [
-        current,
-        replaceMap(sessions, (copy) => {
+    // Close the scope while holding the session lock so a replacement cannot
+    // attach before this session's finalizer has detached the debugger.
+    yield* SynchronizedRef.modifyEffect(controlSessionsRef, (sessions) =>
+      Effect.gen(function* () {
+        const current = sessions.get(webContentsId);
+        if (!current || (expected !== undefined && current !== expected)) {
+          if (expected === undefined && current === undefined) {
+            yield* Ref.update(diagnosticsRef, (diagnostics) =>
+              replaceMap(diagnostics, (copy) => {
+                copy.delete(webContentsId);
+              }),
+            );
+          }
+          return [undefined, sessions] as const;
+        }
+        const next = replaceMap(sessions, (copy) => {
           copy.delete(webContentsId);
-        }),
-      ] as const;
-    });
-    if (control) {
-      yield* Scope.close(control.scope, Exit.void).pipe(Effect.ignore);
-      return;
-    }
-    if (expected !== undefined) return;
-    yield* Ref.update(diagnosticsRef, (diagnostics) =>
-      replaceMap(diagnostics, (copy) => {
-        copy.delete(webContentsId);
+        });
+        yield* Scope.close(current.scope, Exit.void).pipe(Effect.ignore);
+        return [undefined, next] as const;
       }),
     );
   });
@@ -891,156 +891,156 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       ): Effect.Effect<
         readonly [BrowserControlSession, ReadonlyMap<number, BrowserControlSession>],
         PreviewManagerError
-      > => {
-        const existing = sessions.get(wc.id);
-        if (existing) return Effect.succeed([existing, sessions] as const);
-        if (wc.isDevToolsOpened()) {
-          return Effect.fail(
-            new PreviewAutomationDevToolsOpenError({
-              webContentsId: wc.id,
-            }),
-          );
-        }
-        if (wc.debugger.isAttached()) {
-          return Effect.fail(
-            new PreviewAutomationDebuggerAttachedError({
-              webContentsId: wc.id,
-            }),
-          );
-        }
-        const createControlSession = Effect.fn("PreviewManager.createControlSession")(function* () {
-          const semaphore = yield* Semaphore.make(1);
-          const scope = yield* Scope.fork(parentScope, "sequential");
-          const handleDebuggerMessage = Effect.fnUntraced(function* (
-            method: string,
-            params: Record<string, unknown>,
-          ) {
-            if (method === "Page.screencastFrame") {
-              const sessionId = params["sessionId"];
-              if (typeof sessionId === "number") {
-                yield* attemptPromise(
-                  {
-                    operation: "ackScreencastFrame",
-                    webContentsId: wc.id,
-                  },
-                  () => wc.debugger.sendCommand("Page.screencastFrameAck", { sessionId }),
-                ).pipe(Effect.ignore);
-              }
-              const tabId = yield* tabIdForWebContents(wc.id);
-              const metadata =
-                typeof params["metadata"] === "object" && params["metadata"] !== null
-                  ? (params["metadata"] as Record<string, unknown>)
-                  : {};
-              if (tabId && typeof params["data"] === "string") {
-                const captureSession = (yield* SynchronizedRef.get(frameCaptureSessionsRef)).get(
-                  tabId,
-                );
-                if (captureSession?.consumers.has("recording")) {
-                  const receivedAt = yield* currentIso;
-                  const listeners = yield* Ref.get(recordingFrameListenersRef);
-                  const frame: DesktopPreviewRecordingFrame = {
-                    tabId,
-                    data: params["data"],
-                    width:
-                      typeof metadata["deviceWidth"] === "number" ? metadata["deviceWidth"] : 0,
-                    height:
-                      typeof metadata["deviceHeight"] === "number" ? metadata["deviceHeight"] : 0,
-                    receivedAt,
-                  };
-                  yield* Effect.forEach(
-                    listeners,
-                    (listener) =>
-                      deliverEvent("recording-frame", frame.tabId, () => listener(frame)),
-                    { discard: true },
-                  );
-                }
-              }
-            }
-            yield* captureDiagnosticMessage(wc.id, method, params);
-          });
-          const onMessage: BrowserControlSession["onMessage"] = (_event, method, params) => {
-            runFork(handleDebuggerMessage(method, params));
-          };
-          const control: BrowserControlSession = {
-            webContentsId: wc.id,
-            semaphore,
-            scope,
-            onMessage,
-          };
-          const onDetach = () => {
-            // Chromium can drop the debugger when a guest is hidden offscreen.
-            // Forget only this session so a replacement is not torn down.
-            runFork(detachControlSession(wc.id, control));
-          };
-          yield* Scope.addFinalizer(
-            scope,
-            Effect.gen(function* () {
-              // Hold the session lock across detach so a replacement that
-              // attaches after we left the map cannot be detached by this
-              // finalizer.
-              const ownsDebugger = yield* SynchronizedRef.modifyEffect(
-                controlSessionsRef,
-                (sessions) =>
-                  Effect.gen(function* () {
-                    const current = sessions.get(wc.id);
-                    const owns = current === undefined || current === control;
-                    yield* attempt(
-                      { operation: "detachControlSession", webContentsId: wc.id },
-                      () => {
-                        wc.debugger.off("message", onMessage);
-                        wc.debugger.off("detach", onDetach);
-                        if (owns && wc.debugger.isAttached()) wc.debugger.detach();
-                      },
-                    ).pipe(Effect.ignore);
-                    return [owns, sessions] as const;
-                  }),
-              );
-              if (!ownsDebugger) return;
-              yield* Ref.update(diagnosticsRef, (diagnostics) =>
-                replaceMap(diagnostics, (copy) => {
-                  copy.delete(wc.id);
-                }),
-              );
-            }),
-          );
-          const initialize = Effect.fn("PreviewManager.initializeControlSession")(function* () {
-            yield* Ref.update(diagnosticsRef, (diagnostics) =>
-              replaceMap(diagnostics, (copy) => {
-                copy.set(wc.id, {
-                  consoleEntries: [],
-                  networkEntries: [],
-                  requests: new Map(),
-                });
-              }),
-            );
-            yield* attempt({ operation: "attachDebuggerListeners", webContentsId: wc.id }, () => {
-              wc.debugger.on("message", onMessage);
-              wc.debugger.on("detach", onDetach);
-              wc.debugger.attach("1.3");
+      > =>
+        Effect.gen(function* () {
+          const existing = sessions.get(wc.id);
+          if (existing && wc.debugger.isAttached()) {
+            return [existing, sessions] as const;
+          }
+          let publishedSessions = sessions;
+          if (existing) {
+            publishedSessions = replaceMap(sessions, (copy) => {
+              copy.delete(wc.id);
             });
-            yield* Effect.all(
-              ["Runtime.enable", "Accessibility.enable", "Network.enable", "Log.enable"].map(
-                (method) =>
-                  attemptPromise(
-                    { operation: `initializeDebugger.${method}`, webContentsId: wc.id },
-                    () => wc.debugger.sendCommand(method),
+            yield* Scope.close(existing.scope, Exit.void).pipe(Effect.ignore);
+          }
+          if (wc.isDevToolsOpened()) {
+            return yield* new PreviewAutomationDevToolsOpenError({
+              webContentsId: wc.id,
+            });
+          }
+          if (wc.debugger.isAttached()) {
+            return yield* new PreviewAutomationDebuggerAttachedError({
+              webContentsId: wc.id,
+            });
+          }
+          const createControlSession = Effect.fn("PreviewManager.createControlSession")(
+            function* () {
+              const semaphore = yield* Semaphore.make(1);
+              const scope = yield* Scope.fork(parentScope, "sequential");
+              const handleDebuggerMessage = Effect.fnUntraced(function* (
+                method: string,
+                params: Record<string, unknown>,
+              ) {
+                if (method === "Page.screencastFrame") {
+                  const sessionId = params["sessionId"];
+                  if (typeof sessionId === "number") {
+                    yield* attemptPromise(
+                      {
+                        operation: "ackScreencastFrame",
+                        webContentsId: wc.id,
+                      },
+                      () => wc.debugger.sendCommand("Page.screencastFrameAck", { sessionId }),
+                    ).pipe(Effect.ignore);
+                  }
+                  const tabId = yield* tabIdForWebContents(wc.id);
+                  const metadata =
+                    typeof params["metadata"] === "object" && params["metadata"] !== null
+                      ? (params["metadata"] as Record<string, unknown>)
+                      : {};
+                  if (tabId && typeof params["data"] === "string") {
+                    const captureSession = (yield* SynchronizedRef.get(
+                      frameCaptureSessionsRef,
+                    )).get(tabId);
+                    if (captureSession?.consumers.has("recording")) {
+                      const receivedAt = yield* currentIso;
+                      const listeners = yield* Ref.get(recordingFrameListenersRef);
+                      const frame: DesktopPreviewRecordingFrame = {
+                        tabId,
+                        data: params["data"],
+                        width:
+                          typeof metadata["deviceWidth"] === "number" ? metadata["deviceWidth"] : 0,
+                        height:
+                          typeof metadata["deviceHeight"] === "number"
+                            ? metadata["deviceHeight"]
+                            : 0,
+                        receivedAt,
+                      };
+                      yield* Effect.forEach(
+                        listeners,
+                        (listener) =>
+                          deliverEvent("recording-frame", frame.tabId, () => listener(frame)),
+                        { discard: true },
+                      );
+                    }
+                  }
+                }
+                yield* captureDiagnosticMessage(wc.id, method, params);
+              });
+              const onMessage: BrowserControlSession["onMessage"] = (_event, method, params) => {
+                runFork(handleDebuggerMessage(method, params));
+              };
+              const control: BrowserControlSession = {
+                webContentsId: wc.id,
+                semaphore,
+                scope,
+                onMessage,
+              };
+              const onDetach = () => {
+                // Chromium can drop the debugger when a guest is hidden offscreen.
+                // Forget only this session so a replacement is not torn down.
+                runFork(detachControlSession(wc.id, control));
+              };
+              yield* Scope.addFinalizer(
+                scope,
+                Effect.all(
+                  [
+                    Ref.update(diagnosticsRef, (diagnostics) =>
+                      replaceMap(diagnostics, (copy) => {
+                        copy.delete(wc.id);
+                      }),
+                    ),
+                    attempt({ operation: "detachControlSession", webContentsId: wc.id }, () => {
+                      wc.debugger.off("message", onMessage);
+                      wc.debugger.off("detach", onDetach);
+                      if (wc.debugger.isAttached()) wc.debugger.detach();
+                    }).pipe(Effect.ignore),
+                  ],
+                  { discard: true },
+                ),
+              );
+              const initialize = Effect.fn("PreviewManager.initializeControlSession")(function* () {
+                yield* Ref.update(diagnosticsRef, (diagnostics) =>
+                  replaceMap(diagnostics, (copy) => {
+                    copy.set(wc.id, {
+                      consoleEntries: [],
+                      networkEntries: [],
+                      requests: new Map(),
+                    });
+                  }),
+                );
+                yield* attempt(
+                  { operation: "attachDebuggerListeners", webContentsId: wc.id },
+                  () => {
+                    wc.debugger.on("message", onMessage);
+                    wc.debugger.on("detach", onDetach);
+                    wc.debugger.attach("1.3");
+                  },
+                );
+                yield* Effect.all(
+                  ["Runtime.enable", "Accessibility.enable", "Network.enable", "Log.enable"].map(
+                    (method) =>
+                      attemptPromise(
+                        { operation: `initializeDebugger.${method}`, webContentsId: wc.id },
+                        () => wc.debugger.sendCommand(method),
+                      ),
                   ),
-              ),
-              { concurrency: "unbounded", discard: true },
-            );
-            return [
-              control,
-              replaceMap(sessions, (copy) => {
-                copy.set(wc.id, control);
-              }),
-            ] as const;
-          });
-          return yield* initialize().pipe(
-            Effect.onError(() => Scope.close(scope, Exit.void).pipe(Effect.ignore)),
+                  { concurrency: "unbounded", discard: true },
+                );
+                return [
+                  control,
+                  replaceMap(publishedSessions, (copy) => {
+                    copy.set(wc.id, control);
+                  }),
+                ] as const;
+              });
+              return yield* initialize().pipe(
+                Effect.onError(() => Scope.close(scope, Exit.void).pipe(Effect.ignore)),
+              );
+            },
           );
-        });
-        return createControlSession();
-      },
+          return yield* createControlSession();
+        }),
     );
   });
 

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -36,6 +36,7 @@ import * as Clock from "effect/Clock";
 import * as Context from "effect/Context";
 import * as DateTime from "effect/DateTime";
 import * as Deferred from "effect/Deferred";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
@@ -114,6 +115,9 @@ const DIAGNOSTIC_BUFFER_LIMIT = 200;
 const MAX_ARTIFACT_SITE_SLUG_LENGTH = 80;
 const AGENT_CURSOR_MOVE_MS = 160;
 const AGENT_CURSOR_CLICK_LEAD_MS = 40;
+// Hidden guests can stall capturePage for minutes after CDP detaches.
+// Bound the compositor grab so a poisoned tab fails fast and can reattach.
+export const AUTOMATION_CAPTURE_TIMEOUT_MS = 8_000;
 const encodeUnknownJson = Schema.encodeUnknownEffect(Schema.fromJsonString(Schema.Unknown));
 const DEFAULT_ANNOTATION_THEME: DesktopPreviewAnnotationTheme = {
   colorScheme: "light",
@@ -421,6 +425,13 @@ export const isPreviewRefreshShortcut = (input: Electron.Input): boolean =>
   !input.shift &&
   !input.alt;
 
+const isUnknownVizCause = (cause: unknown): boolean => {
+  if (cause instanceof Error) {
+    return cause.name === "UnknownVizError" || cause.message.includes("UnknownVizError");
+  }
+  return typeof cause === "string" && cause.includes("UnknownVizError");
+};
+
 const isPreviewInputSignal = (value: unknown): value is PreviewInputSignal => {
   if (typeof value !== "object" || value === null || !("kind" in value)) return false;
   if (value.kind === "pointer") {
@@ -676,7 +687,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       return yield* new PreviewWebviewNotInitializedError({ tabId });
     }
     const wc = webContents.fromId(tab.webContentsId);
-    if (!wc) {
+    if (!wc || wc.isDestroyed()) {
       return yield* new PreviewWebContentsNotFoundError({
         tabId,
         webContentsId: tab.webContentsId,
@@ -949,6 +960,12 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           const onMessage: BrowserControlSession["onMessage"] = (_event, method, params) => {
             runFork(handleDebuggerMessage(method, params));
           };
+          const onDetach = () => {
+            // Chromium can drop the debugger when a guest is hidden offscreen.
+            // Forget the stale session so the next automation call reattaches;
+            // do not restore here or a hidden guest can loop attach/detach.
+            runFork(detachControlSession(wc.id));
+          };
           yield* Scope.addFinalizer(
             scope,
             Effect.all(
@@ -960,6 +977,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
                 ),
                 attempt({ operation: "detachControlSession", webContentsId: wc.id }, () => {
                   wc.debugger.off("message", onMessage);
+                  wc.debugger.off("detach", onDetach);
                   if (wc.debugger.isAttached()) wc.debugger.detach();
                 }).pipe(Effect.ignore),
               ],
@@ -984,6 +1002,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
             );
             yield* attempt({ operation: "attachDebuggerListeners", webContentsId: wc.id }, () => {
               wc.debugger.on("message", onMessage);
+              wc.debugger.on("detach", onDetach);
               wc.debugger.attach("1.3");
             });
             yield* Effect.all(
@@ -1065,6 +1084,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     };
     yield* pushAction(tabId, actionEvent);
     const epoch = (yield* Ref.get(controlEpochRef)).get(tabId) ?? 0;
+    yield* restoreControlSession(tabId, wc);
     const control = yield* ensureControlSession(wc);
     const execute = Effect.fn("PreviewManager.executeControlAction")(function* () {
       yield* update(tabId, { controller: "agent" });
@@ -2180,10 +2200,10 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     );
   });
 
-  // Re-establish the control session after a detach, restoring any
-  // color-scheme override the tab carries. The scheme is read after the
-  // session attaches so a concurrent setColorScheme is not overwritten with
-  // a stale snapshot.
+  // Re-establish the control session after a detach (hidden-thread guest
+  // teardown, webview swap, DevTools close), restoring any color-scheme
+  // override the tab carries. The scheme is read after the session attaches
+  // so a concurrent setColorScheme is not overwritten with a stale snapshot.
   const restoreControlSession = (tabId: string, wc: Electron.WebContents) =>
     Effect.gen(function* () {
       const beforeAttach = (yield* SynchronizedRef.get(tabsRef)).get(tabId);
@@ -2919,6 +2939,18 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
             webContentsId: wc.id,
           },
           () => wc.capturePage(),
+        ).pipe(
+          Effect.timeout(Duration.millis(AUTOMATION_CAPTURE_TIMEOUT_MS)),
+          Effect.mapError((error) =>
+            Cause.isTimeoutError(error)
+              ? new PreviewOperationError({
+                  operation: "automationSnapshot.capturePage",
+                  tabId,
+                  webContentsId: wc.id,
+                  cause: new Error("UnknownVizError"),
+                })
+              : error,
+          ),
         ),
         Ref.get(diagnosticsRef),
         Ref.get(actionTimelineRef),
@@ -2951,7 +2983,18 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   ) {
     const wc = yield* requireWebContents(tabId);
     return yield* withControlSession(tabId, wc, "snapshot", (send) =>
-      captureAutomationSnapshot(tabId, wc, send),
+      captureAutomationSnapshot(tabId, wc, send).pipe(
+        Effect.catchIf(
+          (error): error is PreviewOperationError =>
+            isPreviewOperationError(error) && isUnknownVizCause(error.cause),
+          () =>
+            Effect.gen(function* () {
+              yield* detachControlSession(wc.id);
+              yield* restoreControlSession(tabId, wc);
+              return yield* captureAutomationSnapshot(tabId, wc, send);
+            }),
+        ),
+      ),
     );
   });
 

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -3003,17 +3003,20 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   const automationSnapshot = Effect.fn("PreviewManager.automationSnapshot")(function* (
     tabId: string,
   ) {
-    const wc = yield* requireWebContents(tabId);
-    return yield* withControlSession(tabId, wc, "snapshot", (send) =>
-      captureAutomationSnapshot(tabId, wc, send),
-    ).pipe(
+    const snapshotCurrentWebContents = Effect.fn("PreviewManager.snapshotCurrentWebContents")(
+      function* () {
+        const wc = yield* requireWebContents(tabId);
+        return yield* withControlSession(tabId, wc, "snapshot", (send) =>
+          captureAutomationSnapshot(tabId, wc, send),
+        );
+      },
+    );
+    return yield* snapshotCurrentWebContents().pipe(
       Effect.catchTags({
-        PreviewCaptureUnavailableError: () =>
+        PreviewCaptureUnavailableError: (error) =>
           Effect.gen(function* () {
-            yield* detachControlSession(wc.id);
-            return yield* withControlSession(tabId, wc, "snapshot", (send) =>
-              captureAutomationSnapshot(tabId, wc, send),
-            );
+            yield* detachControlSession(error.webContentsId);
+            return yield* snapshotCurrentWebContents();
           }),
       }),
     );

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -1170,13 +1170,10 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           // Retryable compositor miss: drop this attempt so a later success
           // is the only snapshot row in the action timeline.
           yield* dropAction(tabId, actionEvent.id);
-          return;
-        }
-        const interrupted = isPreviewAutomationControlInterruptedError(error);
-        const errorMessage = isPreviewOperationError(error)
-          ? PreviewOperationError.toTimelineMessage(error)
-          : isPreviewCaptureUnavailableError(error)
-            ? error.message
+        } else {
+          const interrupted = isPreviewAutomationControlInterruptedError(error);
+          const errorMessage = isPreviewOperationError(error)
+            ? PreviewOperationError.toTimelineMessage(error)
             : isPreviewAutomationEvaluationError(error)
               ? PreviewAutomationEvaluationError.toTimelineMessage(error)
               : isPreviewAutomationInvalidSelectorError(error)
@@ -1184,12 +1181,13 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
                 : error instanceof Error
                   ? error.message
                   : String(error);
-        yield* replaceAction(tabId, {
-          ...actionEvent,
-          status: interrupted ? "interrupted" : "failed",
-          completedAt,
-          error: errorMessage,
-        });
+          yield* replaceAction(tabId, {
+            ...actionEvent,
+            status: interrupted ? "interrupted" : "failed",
+            completedAt,
+            error: errorMessage,
+          });
+        }
       }
       const tabs = yield* SynchronizedRef.get(tabsRef);
       if (tabs.has(tabId)) yield* update(tabId, { controller: "none" });

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -1061,6 +1061,17 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         );
       });
     });
+  const dropAction = (tabId: string, actionId: string) =>
+    Ref.update(actionTimelineRef, (timelines) => {
+      const timeline = timelines.get(tabId);
+      if (!timeline) return timelines;
+      return replaceMap(timelines, (copy) => {
+        copy.set(
+          tabId,
+          timeline.filter((candidate) => candidate.id !== actionId),
+        );
+      });
+    });
 
   type SendCommand = (
     method: string,
@@ -1155,6 +1166,12 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         });
       } else {
         const error = Option.getOrNull(Cause.findErrorOption(exit.cause));
+        if (isPreviewCaptureUnavailableError(error)) {
+          // Retryable compositor miss: drop this attempt so a later success
+          // is the only snapshot row in the action timeline.
+          yield* dropAction(tabId, actionEvent.id);
+          return;
+        }
         const interrupted = isPreviewAutomationControlInterruptedError(error);
         const errorMessage = isPreviewOperationError(error)
           ? PreviewOperationError.toTimelineMessage(error)

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -425,13 +425,6 @@ export const isPreviewRefreshShortcut = (input: Electron.Input): boolean =>
   !input.shift &&
   !input.alt;
 
-const isUnknownVizCause = (cause: unknown): boolean => {
-  if (cause instanceof Error) {
-    return cause.name === "UnknownVizError" || cause.message.includes("UnknownVizError");
-  }
-  return typeof cause === "string" && cause.includes("UnknownVizError");
-};
-
 const isPreviewInputSignal = (value: unknown): value is PreviewInputSignal => {
   if (typeof value !== "object" || value === null || !("kind" in value)) return false;
   if (value.kind === "pointer") {
@@ -862,17 +855,25 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
 
   const detachControlSession = Effect.fn("PreviewManager.detachControlSession")(function* (
     webContentsId: number,
+    expected?: BrowserControlSession,
   ) {
-    const control = yield* SynchronizedRef.modify(controlSessionsRef, (sessions) => [
-      sessions.get(webContentsId),
-      replaceMap(sessions, (copy) => {
-        copy.delete(webContentsId);
-      }),
-    ]);
+    const control = yield* SynchronizedRef.modify(controlSessionsRef, (sessions) => {
+      const current = sessions.get(webContentsId);
+      if (!current || (expected !== undefined && current !== expected)) {
+        return [undefined, sessions] as const;
+      }
+      return [
+        current,
+        replaceMap(sessions, (copy) => {
+          copy.delete(webContentsId);
+        }),
+      ] as const;
+    });
     if (control) {
       yield* Scope.close(control.scope, Exit.void).pipe(Effect.ignore);
       return;
     }
+    if (expected !== undefined) return;
     yield* Ref.update(diagnosticsRef, (diagnostics) =>
       replaceMap(diagnostics, (copy) => {
         copy.delete(webContentsId);
@@ -960,36 +961,48 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           const onMessage: BrowserControlSession["onMessage"] = (_event, method, params) => {
             runFork(handleDebuggerMessage(method, params));
           };
-          const onDetach = () => {
-            // Chromium can drop the debugger when a guest is hidden offscreen.
-            // Forget the stale session so the next automation call reattaches;
-            // do not restore here or a hidden guest can loop attach/detach.
-            runFork(detachControlSession(wc.id));
-          };
-          yield* Scope.addFinalizer(
-            scope,
-            Effect.all(
-              [
-                Ref.update(diagnosticsRef, (diagnostics) =>
-                  replaceMap(diagnostics, (copy) => {
-                    copy.delete(wc.id);
-                  }),
-                ),
-                attempt({ operation: "detachControlSession", webContentsId: wc.id }, () => {
-                  wc.debugger.off("message", onMessage);
-                  wc.debugger.off("detach", onDetach);
-                  if (wc.debugger.isAttached()) wc.debugger.detach();
-                }).pipe(Effect.ignore),
-              ],
-              { discard: true },
-            ),
-          );
           const control: BrowserControlSession = {
             webContentsId: wc.id,
             semaphore,
             scope,
             onMessage,
           };
+          const onDetach = () => {
+            // Chromium can drop the debugger when a guest is hidden offscreen.
+            // Forget only this session so a replacement is not torn down.
+            runFork(detachControlSession(wc.id, control));
+          };
+          yield* Scope.addFinalizer(
+            scope,
+            Effect.gen(function* () {
+              // Hold the session lock across detach so a replacement that
+              // attaches after we left the map cannot be detached by this
+              // finalizer.
+              const ownsDebugger = yield* SynchronizedRef.modifyEffect(
+                controlSessionsRef,
+                (sessions) =>
+                  Effect.gen(function* () {
+                    const current = sessions.get(wc.id);
+                    const owns = current === undefined || current === control;
+                    yield* attempt(
+                      { operation: "detachControlSession", webContentsId: wc.id },
+                      () => {
+                        wc.debugger.off("message", onMessage);
+                        wc.debugger.off("detach", onDetach);
+                        if (owns && wc.debugger.isAttached()) wc.debugger.detach();
+                      },
+                    ).pipe(Effect.ignore);
+                    return [owns, sessions] as const;
+                  }),
+              );
+              if (!ownsDebugger) return;
+              yield* Ref.update(diagnosticsRef, (diagnostics) =>
+                replaceMap(diagnostics, (copy) => {
+                  copy.delete(wc.id);
+                }),
+              );
+            }),
+          );
           const initialize = Effect.fn("PreviewManager.initializeControlSession")(function* () {
             yield* Ref.update(diagnosticsRef, (diagnostics) =>
               replaceMap(diagnostics, (copy) => {
@@ -1145,13 +1158,15 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         const interrupted = isPreviewAutomationControlInterruptedError(error);
         const errorMessage = isPreviewOperationError(error)
           ? PreviewOperationError.toTimelineMessage(error)
-          : isPreviewAutomationEvaluationError(error)
-            ? PreviewAutomationEvaluationError.toTimelineMessage(error)
-            : isPreviewAutomationInvalidSelectorError(error)
-              ? PreviewAutomationInvalidSelectorError.toTimelineMessage(error)
-              : error instanceof Error
-                ? error.message
-                : String(error);
+          : isPreviewCaptureUnavailableError(error)
+            ? error.message
+            : isPreviewAutomationEvaluationError(error)
+              ? PreviewAutomationEvaluationError.toTimelineMessage(error)
+              : isPreviewAutomationInvalidSelectorError(error)
+                ? PreviewAutomationInvalidSelectorError.toTimelineMessage(error)
+                : error instanceof Error
+                  ? error.message
+                  : String(error);
         yield* replaceAction(tabId, {
           ...actionEvent,
           status: interrupted ? "interrupted" : "failed",
@@ -2862,6 +2877,32 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         };
   });
 
+  const captureAutomationPage = (
+    tabId: string,
+    wc: Electron.WebContents,
+  ): Effect.Effect<Electron.NativeImage, PreviewCaptureUnavailableError> =>
+    Effect.tryPromise({
+      try: () => wc.capturePage(),
+      catch: (cause) =>
+        new PreviewCaptureUnavailableError({
+          tabId,
+          webContentsId: wc.id,
+          cause,
+        }),
+    }).pipe(
+      Effect.timeout(Duration.millis(AUTOMATION_CAPTURE_TIMEOUT_MS)),
+      Effect.catchTags({
+        TimeoutError: (cause) =>
+          Effect.fail(
+            new PreviewCaptureUnavailableError({
+              tabId,
+              webContentsId: wc.id,
+              cause,
+            }),
+          ),
+      }),
+    );
+
   const captureAutomationSnapshot = Effect.fn("PreviewManager.captureAutomationSnapshot")(
     function* (tabId: string, wc: Electron.WebContents, send: SendCommand) {
       yield* Effect.all([send("Runtime.enable"), send("Accessibility.enable")], {
@@ -2932,26 +2973,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       );
       const [accessibility, sourceImage, diagnostics, timelines] = yield* Effect.all([
         send("Accessibility.getFullAXTree"),
-        attemptPromise(
-          {
-            operation: "automationSnapshot.capturePage",
-            tabId,
-            webContentsId: wc.id,
-          },
-          () => wc.capturePage(),
-        ).pipe(
-          Effect.timeout(Duration.millis(AUTOMATION_CAPTURE_TIMEOUT_MS)),
-          Effect.mapError((error) =>
-            Cause.isTimeoutError(error)
-              ? new PreviewOperationError({
-                  operation: "automationSnapshot.capturePage",
-                  tabId,
-                  webContentsId: wc.id,
-                  cause: new Error("UnknownVizError"),
-                })
-              : error,
-          ),
-        ),
+        captureAutomationPage(tabId, wc),
         Ref.get(diagnosticsRef),
         Ref.get(actionTimelineRef),
       ]);
@@ -2983,18 +3005,17 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   ) {
     const wc = yield* requireWebContents(tabId);
     return yield* withControlSession(tabId, wc, "snapshot", (send) =>
-      captureAutomationSnapshot(tabId, wc, send).pipe(
-        Effect.catchIf(
-          (error): error is PreviewOperationError =>
-            isPreviewOperationError(error) && isUnknownVizCause(error.cause),
-          () =>
-            Effect.gen(function* () {
-              yield* detachControlSession(wc.id);
-              yield* restoreControlSession(tabId, wc);
-              return yield* captureAutomationSnapshot(tabId, wc, send);
-            }),
-        ),
-      ),
+      captureAutomationSnapshot(tabId, wc, send),
+    ).pipe(
+      Effect.catchTags({
+        PreviewCaptureUnavailableError: () =>
+          Effect.gen(function* () {
+            yield* detachControlSession(wc.id);
+            return yield* withControlSession(tabId, wc, "snapshot", (send) =>
+              captureAutomationSnapshot(tabId, wc, send),
+            );
+          }),
+      }),
     );
   });
 
@@ -3634,6 +3655,21 @@ export class PreviewOperationError extends Schema.TaggedErrorClass<PreviewOperat
 
 export const isPreviewOperationError = Schema.is(PreviewOperationError);
 
+export class PreviewCaptureUnavailableError extends Schema.TaggedErrorClass<PreviewCaptureUnavailableError>()(
+  "PreviewCaptureUnavailableError",
+  {
+    tabId: Schema.String,
+    webContentsId: Schema.Number,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Preview snapshot could not capture tab ${this.tabId}; reattach the session or create a new preview tab`;
+  }
+}
+
+export const isPreviewCaptureUnavailableError = Schema.is(PreviewCaptureUnavailableError);
+
 export class PreviewArtifactPathOutsideDirectoryError extends Schema.TaggedErrorClass<PreviewArtifactPathOutsideDirectoryError>()(
   "PreviewArtifactPathOutsideDirectoryError",
   {
@@ -3815,6 +3851,7 @@ export const PreviewManagerError = Schema.Union([
   PreviewWebContentsNotFoundError,
   PreviewWebviewNotInitializedError,
   PreviewOperationError,
+  PreviewCaptureUnavailableError,
   PreviewArtifactPathOutsideDirectoryError,
   PreviewArtifactImageLoadError,
   PreviewAutomationDevToolsOpenError,

--- a/apps/desktop/src/preview/WebviewPreferences.ts
+++ b/apps/desktop/src/preview/WebviewPreferences.ts
@@ -32,11 +32,12 @@
  *   `contextIsolation="no"` is truthy → contextIsolation stays ENABLED →
  *   react-grab can't see the React DevTools hook.
  *
- * Defense in depth: `apps/desktop/src/main.ts` also runs a
- * `will-attach-webview` handler that force-sets `sandbox: true` and
- * `nodeIntegration*: false` on the actual webPreferences object, gated on
- * the preview partition, so even if this string is ever wrong, the
- * security-critical flags can't regress on preview tabs.
+ * Defense in depth: `apps/desktop/src/window/DesktopWindow.ts` also runs a
+ * `will-attach-webview` handler that force-sets `sandbox: true`,
+ * `nodeIntegration*: false`, and `backgroundThrottling: false` on the actual
+ * webPreferences object, gated on the preview partition, so even if this
+ * string is ever wrong, the security-critical flags can't regress on preview
+ * tabs and hidden-thread guests keep a usable compositor.
  */
 export const PREVIEW_WEBVIEW_PREFERENCES =
   "contextIsolation=false,sandbox=true,nodeIntegration=false";

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -470,6 +470,9 @@ export const make = Effect.gen(function* () {
       webPreferences.nodeIntegration = false;
       webPreferences.nodeIntegrationInSubFrames = false;
       webPreferences.contextIsolation = false;
+      // Keep offscreen/background thread guests composited so CDP and
+      // capturePage stay usable after the user leaves the thread.
+      webPreferences.backgroundThrottling = false;
     });
 
     window.webContents.on("context-menu", (event, params) => {


### PR DESCRIPTION
## Problem

Leaving a thread with an embedded browser preview can drop that tab's CDP control session. After returning, the old tab still exists, but `preview_snapshot` fails with `UnknownVizError` or hangs for ~76–320s. Reusing the tab does not recover; a fresh tab does. Background-agent browser work is poisoned even though the backend stays healthy.

## Fix

Do not treat a hidden thread as a closed tab.

- Drop a control session only after Chromium has already detached it. The next automation call (`snapshot` / click / evaluate) restores the session through the existing `restoreControlSession` path.
- Retry one snapshot after reattach when capture fails with `UnknownVizError`.
- Bound `capturePage` at 8s so a poisoned compositor fails fast instead of hanging for minutes.
- Disable `backgroundThrottling` on preview guests so offscreen/background-thread tabs keep a usable compositor.

## Tests

`apps/desktop/src/preview/Manager.test.ts`

- Re-registering a live webview (thread visible again) does not detach the control session, and snapshot still runs.
- A hidden-tab debugger detach restores on the next snapshot.
- `UnknownVizError` retries after reattach.
- A hung `capturePage` fails quickly with a recoverable `UnknownVizError` instead of waiting minutes.

## Residual risk

If Electron destroys the guest `WebContents` entirely when the panel is hidden, the next snapshot fails immediately with `PreviewWebContentsNotFoundError` until the webview remounts and re-registers. This change does not persist tabs across app quit.

Fixes #6355

Made with Grok.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CDP session lifecycle, snapshot retries, and Electron webPreferences for all preview guests; regressions could affect automation reliability or guest resource usage, but behavior is heavily tested.
> 
> **Overview**
> **Keeps preview browser automation alive when a thread (and its embedded preview) is hidden**, instead of leaving `preview_snapshot` stuck on `UnknownVizError` or multi-minute hangs.
> 
> The **CDP control session** now listens for Chromium `debugger` detach, forgets only that session (with an `expected` guard so a stale finalizer cannot tear down a replacement), and **reattaches** when automation runs again. **`ensureControlSession`** treats a map entry without an attached debugger as stale and recreates the session. **`detachControlSession`** closes the scope under the session lock so a new attach cannot race the old debugger teardown.
> 
> **Snapshots** wrap `capturePage` in an **8s** timeout, surface failures as **`PreviewCaptureUnavailableError`**, **retry once** after detaching the control session, and **drop** retryable capture misses from the action timeline instead of recording a failed snapshot row. Automation actions call **`restoreControlSession`** before acquiring the session. **`requireWebContents`** also rejects destroyed guests.
> 
> Preview **webviews** set **`backgroundThrottling: false`** in `DesktopWindow` (and docs in `WebviewPreferences`) so offscreen guests keep a usable compositor. **`Manager.test.ts`** adds broad coverage for re-register, detach/reattach, viz retry, timeout, and session races.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4fc245707953fb2d9da70beb8093ae70a4fd3cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix preview automation control sessions to persist when leaving a thread
> - Stale debugger detach events no longer tear down a replacement control session; `detachControlSession` now operates atomically and only removes the session it was given.
> - `ensureControlSession` re-establishes the CDP session automatically when Chromium detaches the debugger, avoiding a state where automation silently stops working.
> - `automationSnapshot` retries once after a compositor capture miss by detaching the stale session and re-snapshotting against the current webview.
> - Snapshot capture is now bounded by an 8s timeout (`AUTOMATION_CAPTURE_TIMEOUT_MS`); failures surface as the new `PreviewCaptureUnavailableError` and are dropped from the action timeline rather than recorded as failures.
> - Preview webviews now run with `backgroundThrottling=false` to keep the compositor and CDP responsive when the webview is hidden.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d4fc245.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->