### PR TITLE
fix(server): keep new Codex SQLite state shadow-local

### DIFF
--- a/apps/server/src/provider/Drivers/CodexHomeLayout.test.ts
+++ b/apps/server/src/provider/Drivers/CodexHomeLayout.test.ts
@@ -210,6 +210,57 @@ it.layer(NodeServices.layer)("CodexHomeLayout", (it) => {
       }),
     );
 
+    it.effect("keeps a SQLite family local when Codex creates it between passes", () =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const sharedHome = yield* makeTempDir("t3code-codex-shared-");
+        const shadowRoot = yield* makeTempDir("t3code-codex-shadow-root-");
+        const shadowHome = path.join(shadowRoot, "shadow");
+        const layout = yield* resolveCodexHomeLayout(
+          decodeCodexSettings({
+            homePath: sharedHome,
+            shadowHomePath: shadowHome,
+          }),
+        );
+
+        yield* materializeCodexShadowHome(layout);
+
+        for (const suffix of ["", "-wal", "-shm"]) {
+          yield* writeTextFile(path.join(sharedHome, `queue_1.sqlite${suffix}`), `shared${suffix}`);
+          yield* writeTextFile(path.join(shadowHome, `queue_1.sqlite${suffix}`), `shadow${suffix}`);
+          yield* writeTextFile(
+            path.join(sharedHome, `future_runtime.sqlite${suffix}`),
+            `future-shared${suffix}`,
+          );
+        }
+        yield* writeTextFile(path.join(shadowHome, "future_runtime.sqlite"), "future-shadow");
+
+        yield* materializeCodexShadowHome(layout);
+        yield* materializeCodexShadowHome(layout);
+
+        for (const suffix of ["", "-wal", "-shm"]) {
+          const entryName = `queue_1.sqlite${suffix}`;
+          const sharedPath = path.join(sharedHome, entryName);
+          const shadowPath = path.join(shadowHome, entryName);
+
+          expect(yield* fileSystem.readFileString(sharedPath)).toBe(`shared${suffix}`);
+          expect(yield* fileSystem.readFileString(shadowPath)).toBe(`shadow${suffix}`);
+          expect((yield* fileSystem.readLink(shadowPath).pipe(Effect.result))._tag).toBe("Failure");
+        }
+
+        expect(
+          yield* fileSystem.readFileString(path.join(shadowHome, "future_runtime.sqlite")),
+        ).toBe("future-shadow");
+        expect(yield* fileSystem.exists(path.join(shadowHome, "future_runtime.sqlite-wal"))).toBe(
+          false,
+        );
+        expect(yield* fileSystem.exists(path.join(shadowHome, "future_runtime.sqlite-shm"))).toBe(
+          false,
+        );
+      }),
+    );
+
     it.effect("rejects shadow homes that point at the shared home", () =>
       Effect.gen(function* () {
         const sharedHome = yield* makeTempDir("t3code-codex-shared-");
@@ -235,6 +286,7 @@ it.layer(NodeServices.layer)("CodexHomeLayout", (it) => {
 
     it.effect("rejects shared entries that already exist in the shadow home as real files", () =>
       Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
         const path = yield* Path.Path;
         const sharedHome = yield* makeTempDir("t3code-codex-shared-");
         const shadowRoot = yield* makeTempDir("t3code-codex-shadow-root-");
@@ -261,6 +313,19 @@ it.layer(NodeServices.layer)("CodexHomeLayout", (it) => {
         });
         expect(error.message).toBe(
           `Cannot create Codex shadow home entry 'config.toml' because '${path.join(shadowHome, "config.toml")}' already exists and is not a symlink.`,
+        );
+        expect(yield* fileSystem.readFileString(path.join(sharedHome, "config.toml"))).toBe(
+          'model = "gpt-5-codex"\n',
+        );
+        expect(yield* fileSystem.readFileString(path.join(shadowHome, "config.toml"))).toBe(
+          'model = "local"\n',
+        );
+
+        yield* fileSystem.remove(path.join(shadowHome, "config.toml"));
+        yield* materializeCodexShadowHome(layout);
+
+        expect(yield* fileSystem.readLink(path.join(shadowHome, "config.toml"))).toBe(
+          path.join(sharedHome, "config.toml"),
         );
       }),
     );

--- a/apps/server/src/provider/Drivers/CodexHomeLayout.ts
+++ b/apps/server/src/provider/Drivers/CodexHomeLayout.ts
@@ -32,6 +32,12 @@ const KNOWN_SHARED_DIRECTORIES = [
 const PRIVATE_ENTRY_NAMES = new Set(["auth.json", "models_cache.json"]);
 const SHADOW_LOCAL_ENTRY_NAMES = new Set(["log", "memories", "tmp"]);
 const REPLACEABLE_SHARED_RUNTIME_DIRECTORIES = new Set(["mcp-oauth-locks"]);
+const SQLITE_FAMILY_SUFFIXES = ["", "-wal", "-shm"] as const;
+
+function sqliteFamilyBaseName(entryName: string): string | undefined {
+  const baseName = entryName.replace(/-(?:wal|shm)$/, "");
+  return baseName.endsWith(".sqlite") ? baseName : undefined;
+}
 
 function resolveHomePath(path: Path.Path, value: string | undefined): string {
   const expanded =
@@ -184,27 +190,27 @@ const readLinkState = Effect.fn("CodexHomeLayout.readLinkState")(function* (inpu
   );
 });
 
-const removePrivateSymlink = Effect.fn("CodexHomeLayout.removePrivateSymlink")(function* (input: {
+const removeSymlink = Effect.fn("CodexHomeLayout.removeSymlink")(function* (input: {
   readonly fileSystem: FileSystem.FileSystem;
   readonly sharedHomePath: string;
   readonly effectiveHomePath: string;
   readonly entryName: string;
 }): Effect.fn.Return<void, CodexShadowHomeError, Path.Path> {
   const path = yield* Path.Path;
-  const privatePath = path.join(input.effectiveHomePath, input.entryName);
+  const entryPath = path.join(input.effectiveHomePath, input.entryName);
   const state = yield* readLinkState({
     ...input,
-    linkPath: privatePath,
+    linkPath: entryPath,
   });
   if (state._tag === "Symlink") {
-    yield* input.fileSystem.remove(privatePath).pipe(
+    yield* input.fileSystem.remove(entryPath).pipe(
       Effect.catchTags({
         PlatformError: (cause) =>
           new CodexShadowHomeFileSystemError({
             sharedHomePath: input.sharedHomePath,
             effectiveHomePath: input.effectiveHomePath,
             operation: "remove",
-            path: privatePath,
+            path: entryPath,
             entryName: input.entryName,
             cause,
           }),
@@ -377,12 +383,44 @@ export const materializeCodexShadowHome = Effect.fn("materializeCodexShadowHome"
     }
   }
 
+  const shadowLocalSqliteFamilies = new Set<string>();
+  for (const entryName of entries) {
+    const familyBaseName = sqliteFamilyBaseName(entryName);
+    if (familyBaseName === undefined || shadowLocalSqliteFamilies.has(familyBaseName)) {
+      continue;
+    }
+
+    const familyBaseState = yield* readLinkState({
+      fileSystem,
+      sharedHomePath: layout.sharedHomePath,
+      effectiveHomePath,
+      entryName: familyBaseName,
+      linkPath: path.join(effectiveHomePath, familyBaseName),
+    });
+    if (familyBaseState._tag !== "NotSymlink") {
+      continue;
+    }
+
+    shadowLocalSqliteFamilies.add(familyBaseName);
+    yield* Effect.forEach(
+      SQLITE_FAMILY_SUFFIXES,
+      (suffix) =>
+        removeSymlink({
+          fileSystem,
+          sharedHomePath: layout.sharedHomePath,
+          effectiveHomePath,
+          entryName: `${familyBaseName}${suffix}`,
+        }),
+      { discard: true },
+    );
+  }
+
   yield* Effect.forEach(
     PRIVATE_ENTRY_NAMES,
     (entryName) =>
       entryName === "auth.json"
         ? Effect.void
-        : removePrivateSymlink({
+        : removeSymlink({
             fileSystem,
             sharedHomePath: layout.sharedHomePath,
             effectiveHomePath,
@@ -395,6 +433,10 @@ export const materializeCodexShadowHome = Effect.fn("materializeCodexShadowHome"
     entries,
     (entryName) => {
       if (PRIVATE_ENTRY_NAMES.has(entryName)) {
+        return Effect.void;
+      }
+      const familyBaseName = sqliteFamilyBaseName(entryName);
+      if (familyBaseName !== undefined && shadowLocalSqliteFamilies.has(familyBaseName)) {
         return Effect.void;
       }
       return ensureSymlink({


### PR DESCRIPTION
## Problem

Codex can add a top-level SQLite runtime database after a shadow home was first materialized. If Codex creates regular copies in both homes, the next materialization rejects the shadow copy and disables that provider.

## Root cause

The home layout treated each shared-home entry separately. It had no ownership rule for a new SQLite base file and its WAL and SHM sidecars.

## Fix

Treat each top-level `.sqlite` base name, `-wal`, and `-shm` sidecar as one family. A regular shadow database keeps the complete family local. Both homes retain their files, and repeated materialization stays idempotent. Unrelated regular-file conflicts still return the existing typed error.

## Tests

- Added a regression that materializes once, creates `queue_1.sqlite`, WAL, and SHM files in both homes, then materializes twice.
- Added a future SQLite filename case and verified missing shadow sidecars do not become shared links.
- Extended the unrelated-file conflict test to prove both copies remain unchanged and the layout can recover after the conflict is removed.
- Focused test: 9 passed.
- Focused format and lint: passed.
- Server typecheck: passed with no errors.

The regression test fails on the pinned base with `CodexShadowHomeEntryConflictError` for `queue_1.sqlite`.

## Risks

Low. The rule applies only to top-level SQLite families whose shadow base is already a regular entry. It removes only family symlinks when local ownership is selected. Shared targets and regular files remain unchanged. Non-SQLite conflict behavior is unchanged.

## Release note

Codex shadow-home providers no longer disable when new SQLite runtime databases appear.

Fixes #5817

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] UI screenshots are not applicable
- [x] Animation or interaction video is not applicable

Implemented with GPT 5.6 Sol via Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve shadow-local SQLite file families in `materializeCodexShadowHome`
> - When Codex creates a new SQLite database in the shadow home between materialization passes, `materializeCodexShadowHome` now detects the base `.sqlite` file as a real (non-symlink) file and marks the entire family (base, `-wal`, `-shm`) as local.
> - Any existing symlinks for the family are removed, and symlink creation is skipped for all family members, keeping the shadow-local database intact.
> - Adds a `sqliteFamilyBaseName` helper in [CodexHomeLayout.ts](https://github.com/pingdotgg/t3code/pull/7201/files#diff-17973143128131a5e3f30fc3e32012a3a86aee719917b08d60615a47558fb8d5) that strips `-wal`/`-shm` suffixes to resolve the base name of a SQLite file family.
> - `removePrivateSymlink` is renamed to `removeSymlink` with generalized parameter naming to support both auth and SQLite family entries.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 979c487.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to auth-overlay shadow homes when a shadow `.sqlite` base is already a regular file; only removes symlinks for that family and leaves non-SQLite conflict behavior unchanged.
> 
> **Overview**
> **Codex shadow-home materialization** no longer fails when Codex adds a top-level SQLite runtime database (and WAL/SHM sidecars) in the shadow home after the first pass.
> 
> `materializeCodexShadowHome` now treats each top-level `*.sqlite` name plus `-wal` and `-shm` as one **SQLite family**. If the shadow base file is already a real file (not a symlink), the whole family stays **shadow-local**: existing family symlinks are removed and symlink creation is skipped for those entries, while shared-home copies are untouched. Unrelated real-file conflicts (e.g. `config.toml`) still raise `CodexShadowHomeEntryConflictError`.
> 
> Adds regression coverage for inter-pass SQLite creation, partial sidecars, and recovery after a non-SQLite conflict; `removePrivateSymlink` is renamed to `removeSymlink` for reuse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 979c48787dd8cf0500140dc7abea5e850813f1cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->