### PR TITLE
fix(server): start Claude turns after idle session restart

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -59,6 +59,8 @@ class FakeClaudeQuery implements AsyncIterable<SDKMessage> {
   public readonly setModelCalls: Array<string | undefined> = [];
   public readonly setPermissionModeCalls: Array<string> = [];
   public readonly setMaxThinkingTokensCalls: Array<number | null> = [];
+  public hangSetModel = false;
+  public hangSetPermissionMode = false;
   public closeCalls = 0;
 
   emit(message: SDKMessage): void {
@@ -105,10 +107,16 @@ class FakeClaudeQuery implements AsyncIterable<SDKMessage> {
 
   readonly setModel = async (model?: string): Promise<void> => {
     this.setModelCalls.push(model);
+    if (this.hangSetModel) {
+      await new Promise<void>(() => undefined);
+    }
   };
 
   readonly setPermissionMode = async (mode: PermissionMode): Promise<void> => {
     this.setPermissionModeCalls.push(mode);
+    if (this.hangSetPermissionMode) {
+      await new Promise<void>(() => undefined);
+    }
   };
 
   readonly setMaxThinkingTokens = async (maxThinkingTokens: number | null): Promise<void> => {
@@ -162,7 +170,7 @@ function makeHarness(config?: {
   readonly claudeConfig?: Partial<ClaudeSettings>;
   readonly instanceId?: ProviderInstanceId;
 }) {
-  const query = new FakeClaudeQuery();
+  let query = new FakeClaudeQuery();
   let createInput:
     | {
         readonly prompt: AsyncIterable<SDKUserMessage>;
@@ -174,6 +182,7 @@ function makeHarness(config?: {
     ...(config?.instanceId ? { instanceId: config.instanceId } : {}),
     createQuery: (input) => {
       createInput = input;
+      query = new FakeClaudeQuery();
       return query;
     },
     ...(config?.nativeEventLogger
@@ -205,7 +214,9 @@ function makeHarness(config?: {
       Layer.provideMerge(ServerSettingsService.layerTest()),
       Layer.provideMerge(NodeServices.layer),
     ),
-    query,
+    get query() {
+      return query;
+    },
     getLastCreateQueryInput: () => createInput,
   };
 }
@@ -271,6 +282,33 @@ async function readFirstPromptMessage(
 
 const THREAD_ID = ThreadId.make("thread-claude-1");
 const RESUME_THREAD_ID = ThreadId.make("thread-claude-resume");
+const RESUME_SESSION_ID = "550e8400-e29b-41d4-a716-446655440000";
+const RESUME_CURSOR = {
+  threadId: "resume-thread-1",
+  resume: RESUME_SESSION_ID,
+  resumeSessionAt: "assistant-99",
+  turnCount: 3,
+} as const;
+
+function emitClaudeInit(query: FakeClaudeQuery, sessionId = RESUME_SESSION_ID): void {
+  query.emit({
+    type: "system",
+    subtype: "init",
+    apiKeySource: "none",
+    claude_code_version: "test",
+    cwd: "/tmp/claude-adapter-test",
+    tools: [],
+    mcp_servers: [],
+    model: "claude-sonnet-4-5",
+    permissionMode: "bypassPermissions",
+    slash_commands: [],
+    output_style: "default",
+    skills: [],
+    plugins: [],
+    session_id: sessionId,
+    uuid: "resume-init",
+  } as unknown as SDKMessage);
+}
 
 describe("ClaudeAdapterLive", () => {
   it.effect("returns validation error for non-claude provider on startSession", () => {
@@ -4016,6 +4054,161 @@ describe("ClaudeAdapterLive", () => {
       });
 
       assert.deepEqual(harness.query.setPermissionModeCalls, []);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect(
+    "starts a turn after idle session.exited without waiting on a hung setPermissionMode",
+    () => {
+      const harness = makeHarness();
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+        const turnStartedFiber = yield* Stream.filter(
+          adapter.streamEvents,
+          (event) => event.type === "turn.started",
+        ).pipe(Stream.runHead, Effect.forkChild);
+
+        yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          runtimeMode: "full-access",
+        });
+        yield* adapter.stopSession(THREAD_ID);
+
+        yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          resumeCursor: RESUME_CURSOR,
+          runtimeMode: "full-access",
+        });
+        harness.query.hangSetPermissionMode = true;
+        const turn = yield* adapter.sendTurn({
+          threadId: THREAD_ID,
+          input: "after idle",
+          interactionMode: "default",
+          attachments: [],
+        });
+
+        const turnStarted = yield* Fiber.join(turnStartedFiber);
+        assert.equal(turnStarted._tag, "Some");
+        if (turnStarted._tag === "Some" && turnStarted.value.type === "turn.started") {
+          assert.equal(String(turnStarted.value.turnId), String(turn.turnId));
+        }
+        assert.deepEqual(harness.query.setPermissionModeCalls, []);
+      }).pipe(
+        Effect.provideService(Random.Random, makeDeterministicRandomService()),
+        Effect.provide(harness.layer),
+      );
+    },
+  );
+
+  it.effect(
+    "skips setPermissionMode on startSession + immediate sendTurn when the query is not ready",
+    () => {
+      const harness = makeHarness();
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+        const turnStartedFiber = yield* Stream.filter(
+          adapter.streamEvents,
+          (event) => event.type === "turn.started",
+        ).pipe(Stream.runHead, Effect.forkChild);
+
+        yield* adapter.startSession({
+          threadId: RESUME_THREAD_ID,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          resumeCursor: RESUME_CURSOR,
+          runtimeMode: "full-access",
+        });
+        harness.query.hangSetPermissionMode = true;
+        const turnFiber = yield* adapter
+          .sendTurn({
+            threadId: RESUME_THREAD_ID,
+            input: "plan this",
+            interactionMode: "plan",
+            attachments: [],
+          })
+          .pipe(Effect.forkChild);
+
+        yield* TestClock.adjust("5 seconds");
+        const turn = yield* Fiber.join(turnFiber);
+        const turnStarted = yield* Fiber.join(turnStartedFiber);
+
+        assert.equal(String(turn.turnId).length > 0, true);
+        assert.equal(turnStarted._tag, "Some");
+        if (turnStarted._tag === "Some") {
+          assert.equal(turnStarted.value.type, "turn.started");
+        }
+        assert.deepEqual(harness.query.setPermissionModeCalls, []);
+      }).pipe(
+        Effect.provideService(Random.Random, makeDeterministicRandomService()),
+        Effect.provide(harness.layer),
+      );
+    },
+  );
+
+  it.effect("sets permission mode on an in-session sendTurn after the query becomes usable", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      yield* adapter.startSession({
+        threadId: RESUME_THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        resumeCursor: RESUME_CURSOR,
+        runtimeMode: "full-access",
+      });
+      yield* Stream.take(adapter.streamEvents, 3).pipe(Stream.runDrain);
+      emitClaudeInit(harness.query);
+      yield* Stream.take(adapter.streamEvents, 1).pipe(Stream.runDrain);
+
+      yield* adapter.sendTurn({
+        threadId: RESUME_THREAD_ID,
+        input: "plan this",
+        interactionMode: "plan",
+        attachments: [],
+      });
+
+      assert.deepEqual(harness.query.setPermissionModeCalls, ["plan"]);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("times out a hung in-session setPermissionMode and still starts the turn", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const turnStartedFiber = yield* Stream.filter(
+        adapter.streamEvents,
+        (event) => event.type === "turn.started",
+      ).pipe(Stream.runHead, Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      harness.query.hangSetPermissionMode = true;
+      const turnFiber = yield* adapter
+        .sendTurn({
+          threadId: THREAD_ID,
+          input: "plan this",
+          interactionMode: "plan",
+          attachments: [],
+        })
+        .pipe(Effect.forkChild);
+
+      yield* TestClock.adjust("5 seconds");
+      const turn = yield* Fiber.join(turnFiber);
+      const turnStarted = yield* Fiber.join(turnStartedFiber);
+
+      assert.equal(String(turn.turnId).length > 0, true);
+      assert.equal(turnStarted._tag, "Some");
+      assert.deepEqual(harness.query.setPermissionModeCalls, ["plan"]);
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -3972,6 +3972,108 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect(
+    "does not advertise a model on turn.started or the session when setModel times out",
+    () => {
+      const harness = makeHarness();
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+        const startedModel = createModelSelection(
+          ProviderInstanceId.make("claudeAgent"),
+          "claude-opus-4-6",
+          [{ id: "contextWindow", value: "200k" }],
+        );
+        const requestedModel = createModelSelection(
+          ProviderInstanceId.make("claudeAgent"),
+          "claude-opus-4-6",
+          [{ id: "contextWindow", value: "1m" }],
+        );
+
+        yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          modelSelection: startedModel,
+          runtimeMode: "full-access",
+        });
+
+        const turnStartedFiber = yield* Stream.filter(
+          adapter.streamEvents,
+          (event) => event.type === "turn.started",
+        ).pipe(Stream.runHead, Effect.forkChild);
+
+        harness.query.hangSetModel = true;
+        const turnFiber = yield* adapter
+          .sendTurn({
+            threadId: THREAD_ID,
+            input: "hello",
+            modelSelection: requestedModel,
+            attachments: [],
+          })
+          .pipe(Effect.forkChild);
+
+        yield* TestClock.adjust("5 seconds");
+        yield* Fiber.join(turnFiber);
+        const turnStarted = yield* Fiber.join(turnStartedFiber);
+
+        assert.equal(turnStarted._tag, "Some");
+        if (turnStarted._tag === "Some" && turnStarted.value.type === "turn.started") {
+          assert.deepEqual(turnStarted.value.payload, { model: "claude-opus-4-6" });
+        }
+        const sessions = yield* adapter.listSessions();
+        assert.equal(sessions[0]?.model, "claude-opus-4-6");
+        assert.deepEqual(harness.query.setModelCalls, ["claude-opus-4-6[1m]"]);
+      }).pipe(
+        Effect.provideService(Random.Random, makeDeterministicRandomService()),
+        Effect.provide(harness.layer),
+      );
+    },
+  );
+
+  it.effect("does not advertise a requested model when the resume query is not ready", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const turnStartedFiber = yield* Stream.filter(
+        adapter.streamEvents,
+        (event) => event.type === "turn.started",
+      ).pipe(Stream.runHead, Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId: RESUME_THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        resumeCursor: RESUME_CURSOR,
+        runtimeMode: "full-access",
+      });
+      const turnFiber = yield* adapter
+        .sendTurn({
+          threadId: RESUME_THREAD_ID,
+          input: "hello",
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("claudeAgent"),
+            "claude-opus-4-6",
+            [{ id: "contextWindow", value: "1m" }],
+          ),
+          attachments: [],
+        })
+        .pipe(Effect.forkChild);
+
+      yield* TestClock.adjust("5 seconds");
+      yield* Fiber.join(turnFiber);
+      const turnStarted = yield* Fiber.join(turnStartedFiber);
+
+      assert.equal(turnStarted._tag, "Some");
+      if (turnStarted._tag === "Some" && turnStarted.value.type === "turn.started") {
+        assert.deepEqual(turnStarted.value.payload, {});
+      }
+      const sessions = yield* adapter.listSessions();
+      assert.equal(sessions[0]?.model, undefined);
+      assert.deepEqual(harness.query.setModelCalls, []);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("sets plan permission mode on sendTurn when interactionMode is plan", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -61,12 +61,9 @@ class FakeClaudeQuery implements AsyncIterable<SDKMessage> {
   public readonly setMaxThinkingTokensCalls: Array<number | null> = [];
   public hangSetModel = false;
   public hangSetPermissionMode = false;
-  public ignorePermissionModeAbort = false;
-  public readonly permissionModeAborts: Array<PermissionMode> = [];
   private readonly permissionModeWaiters: Array<{
     readonly mode: PermissionMode;
     readonly resolve: () => void;
-    readonly reject: (reason: unknown) => void;
   }> = [];
   public closeCalls = 0;
 
@@ -112,52 +109,20 @@ class FakeClaudeQuery implements AsyncIterable<SDKMessage> {
     this.stopTaskCalls.push(taskId);
   };
 
-  readonly setModel = async (model?: string, signal?: AbortSignal): Promise<void> => {
+  readonly setModel = async (model?: string): Promise<void> => {
     this.setModelCalls.push(model);
     if (this.hangSetModel) {
-      await new Promise<void>((_resolve, reject) => {
-        if (signal?.aborted) {
-          reject(signal.reason ?? new Error("Aborted"));
-          return;
-        }
-        signal?.addEventListener(
-          "abort",
-          () => {
-            reject(signal.reason ?? new Error("Aborted"));
-          },
-          { once: true },
-        );
-      });
+      await new Promise<void>(() => undefined);
     }
   };
 
-  readonly setPermissionMode = async (
-    mode: PermissionMode,
-    signal?: AbortSignal,
-  ): Promise<void> => {
+  readonly setPermissionMode = async (mode: PermissionMode): Promise<void> => {
     this.setPermissionModeCalls.push(mode);
     if (!this.hangSetPermissionMode) {
       return;
     }
-    await new Promise<void>((resolve, reject) => {
-      const waiter = { mode, resolve, reject };
-      const abort = () => {
-        this.permissionModeAborts.push(mode);
-        if (this.ignorePermissionModeAbort) {
-          return;
-        }
-        const index = this.permissionModeWaiters.indexOf(waiter);
-        if (index >= 0) {
-          this.permissionModeWaiters.splice(index, 1);
-        }
-        reject(signal?.reason ?? new Error("Aborted"));
-      };
-      if (signal?.aborted) {
-        abort();
-        return;
-      }
-      signal?.addEventListener("abort", abort, { once: true });
-      this.permissionModeWaiters.push(waiter);
+    await new Promise<void>((resolve) => {
+      this.permissionModeWaiters.push({ mode, resolve });
     });
   };
 
@@ -4261,7 +4226,6 @@ describe("ClaudeAdapterLive", () => {
       assert.equal(String(turn.turnId).length > 0, true);
       assert.equal(turnStarted._tag, "Some");
       assert.deepEqual(harness.query.setPermissionModeCalls, ["plan"]);
-      assert.deepEqual(harness.query.permissionModeAborts, ["plan"]);
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),
@@ -4303,7 +4267,6 @@ describe("ClaudeAdapterLive", () => {
         yield* Fiber.join(firstCompletedFiber);
 
         harness.query.hangSetPermissionMode = true;
-        harness.query.ignorePermissionModeAbort = true;
         const restoreFiber = yield* adapter
           .sendTurn({
             threadId: THREAD_ID,
@@ -4315,7 +4278,23 @@ describe("ClaudeAdapterLive", () => {
         yield* TestClock.adjust("5 seconds");
         yield* Fiber.join(restoreFiber);
 
+        const restoreCompletedFiber = yield* Stream.filter(
+          adapter.streamEvents,
+          (event) => event.type === "turn.completed",
+        ).pipe(Stream.runHead, Effect.forkChild);
+        harness.query.emit({
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          errors: [],
+          session_id: "sdk-session-late-restore",
+          uuid: "result-restore",
+        } as unknown as SDKMessage);
+        yield* Fiber.join(restoreCompletedFiber);
+
         harness.query.hangSetPermissionMode = false;
+        assert.equal(harness.query.resolveHungPermissionMode("bypassPermissions"), true);
+
         yield* adapter.sendTurn({
           threadId: THREAD_ID,
           input: "plan again",
@@ -4326,18 +4305,6 @@ describe("ClaudeAdapterLive", () => {
         assert.deepEqual(harness.query.setPermissionModeCalls, [
           "plan",
           "bypassPermissions",
-          "plan",
-        ]);
-
-        assert.equal(harness.query.resolveHungPermissionMode("bypassPermissions"), true);
-        yield* Effect.yieldNow;
-        yield* Effect.yieldNow;
-        yield* Effect.yieldNow;
-
-        assert.deepEqual(harness.query.setPermissionModeCalls, [
-          "plan",
-          "bypassPermissions",
-          "plan",
           "plan",
         ]);
       }).pipe(

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -61,6 +61,13 @@ class FakeClaudeQuery implements AsyncIterable<SDKMessage> {
   public readonly setMaxThinkingTokensCalls: Array<number | null> = [];
   public hangSetModel = false;
   public hangSetPermissionMode = false;
+  public ignorePermissionModeAbort = false;
+  public readonly permissionModeAborts: Array<PermissionMode> = [];
+  private readonly permissionModeWaiters: Array<{
+    readonly mode: PermissionMode;
+    readonly resolve: () => void;
+    readonly reject: (reason: unknown) => void;
+  }> = [];
   public closeCalls = 0;
 
   emit(message: SDKMessage): void {
@@ -105,19 +112,64 @@ class FakeClaudeQuery implements AsyncIterable<SDKMessage> {
     this.stopTaskCalls.push(taskId);
   };
 
-  readonly setModel = async (model?: string): Promise<void> => {
+  readonly setModel = async (model?: string, signal?: AbortSignal): Promise<void> => {
     this.setModelCalls.push(model);
     if (this.hangSetModel) {
-      await new Promise<void>(() => undefined);
+      await new Promise<void>((_resolve, reject) => {
+        if (signal?.aborted) {
+          reject(signal.reason ?? new Error("Aborted"));
+          return;
+        }
+        signal?.addEventListener(
+          "abort",
+          () => {
+            reject(signal.reason ?? new Error("Aborted"));
+          },
+          { once: true },
+        );
+      });
     }
   };
 
-  readonly setPermissionMode = async (mode: PermissionMode): Promise<void> => {
+  readonly setPermissionMode = async (
+    mode: PermissionMode,
+    signal?: AbortSignal,
+  ): Promise<void> => {
     this.setPermissionModeCalls.push(mode);
-    if (this.hangSetPermissionMode) {
-      await new Promise<void>(() => undefined);
+    if (!this.hangSetPermissionMode) {
+      return;
     }
+    await new Promise<void>((resolve, reject) => {
+      const waiter = { mode, resolve, reject };
+      const abort = () => {
+        this.permissionModeAborts.push(mode);
+        if (this.ignorePermissionModeAbort) {
+          return;
+        }
+        const index = this.permissionModeWaiters.indexOf(waiter);
+        if (index >= 0) {
+          this.permissionModeWaiters.splice(index, 1);
+        }
+        reject(signal?.reason ?? new Error("Aborted"));
+      };
+      if (signal?.aborted) {
+        abort();
+        return;
+      }
+      signal?.addEventListener("abort", abort, { once: true });
+      this.permissionModeWaiters.push(waiter);
+    });
   };
+
+  resolveHungPermissionMode(mode?: PermissionMode): boolean {
+    const index =
+      mode === undefined
+        ? 0
+        : this.permissionModeWaiters.findIndex((waiter) => waiter.mode === mode);
+    const waiter = index >= 0 ? this.permissionModeWaiters.splice(index, 1)[0] : undefined;
+    waiter?.resolve();
+    return waiter !== undefined;
+  }
 
   readonly setMaxThinkingTokens = async (maxThinkingTokens: number | null): Promise<void> => {
     this.setMaxThinkingTokensCalls.push(maxThinkingTokens);
@@ -4209,11 +4261,91 @@ describe("ClaudeAdapterLive", () => {
       assert.equal(String(turn.turnId).length > 0, true);
       assert.equal(turnStarted._tag, "Some");
       assert.deepEqual(harness.query.setPermissionModeCalls, ["plan"]);
+      assert.deepEqual(harness.query.permissionModeAborts, ["plan"]);
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),
     );
   });
+
+  it.effect(
+    "re-sends plan after a timed-out restore so a late bypass cannot skip the next plan turn",
+    () => {
+      const harness = makeHarness();
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+
+        yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          runtimeMode: "full-access",
+        });
+
+        yield* adapter.sendTurn({
+          threadId: THREAD_ID,
+          input: "plan this",
+          interactionMode: "plan",
+          attachments: [],
+        });
+
+        const firstCompletedFiber = yield* Stream.filter(
+          adapter.streamEvents,
+          (event) => event.type === "turn.completed",
+        ).pipe(Stream.runHead, Effect.forkChild);
+        harness.query.emit({
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          errors: [],
+          session_id: "sdk-session-late-restore",
+          uuid: "result-plan",
+        } as unknown as SDKMessage);
+        yield* Fiber.join(firstCompletedFiber);
+
+        harness.query.hangSetPermissionMode = true;
+        harness.query.ignorePermissionModeAbort = true;
+        const restoreFiber = yield* adapter
+          .sendTurn({
+            threadId: THREAD_ID,
+            input: "now do it",
+            interactionMode: "default",
+            attachments: [],
+          })
+          .pipe(Effect.forkChild);
+        yield* TestClock.adjust("5 seconds");
+        yield* Fiber.join(restoreFiber);
+
+        harness.query.hangSetPermissionMode = false;
+        yield* adapter.sendTurn({
+          threadId: THREAD_ID,
+          input: "plan again",
+          interactionMode: "plan",
+          attachments: [],
+        });
+
+        assert.deepEqual(harness.query.setPermissionModeCalls, [
+          "plan",
+          "bypassPermissions",
+          "plan",
+        ]);
+
+        assert.equal(harness.query.resolveHungPermissionMode("bypassPermissions"), true);
+        yield* Effect.yieldNow;
+        yield* Effect.yieldNow;
+        yield* Effect.yieldNow;
+
+        assert.deepEqual(harness.query.setPermissionModeCalls, [
+          "plan",
+          "bypassPermissions",
+          "plan",
+          "plan",
+        ]);
+      }).pipe(
+        Effect.provideService(Random.Random, makeDeterministicRandomService()),
+        Effect.provide(harness.layer),
+      );
+    },
+  );
 
   it.effect("captures ExitPlanMode as a proposed plan and denies auto-exit", () => {
     const harness = makeHarness();

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -4417,20 +4417,6 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       yield* completeTurn(context, "completed");
     }
 
-    if (modelSelection?.model) {
-      context.session = {
-        ...context.session,
-        model: modelSelection.model,
-      };
-      const turnCaps = getClaudeModelCapabilities(modelSelection.model);
-      const turnEffort = resolveClaudeEffort(
-        turnCaps,
-        getModelSelectionStringOptionValue(modelSelection, "effort"),
-      );
-      context.currentEffort =
-        getEffectiveClaudeAgentEffort(turnEffort ?? null, modelSelection.model) ?? undefined;
-    }
-
     const nextApiModelId =
       modelSelection?.model !== undefined ? resolveClaudeApiModelId(modelSelection) : undefined;
     const needsModelUpdate =
@@ -4477,6 +4463,24 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       }
     }
 
+    const modelAppliedOnCli =
+      modelSelection?.model === undefined ||
+      !needsModelUpdate ||
+      context.currentApiModelId === nextApiModelId;
+    if (modelSelection?.model && modelAppliedOnCli) {
+      context.session = {
+        ...context.session,
+        model: modelSelection.model,
+      };
+      const turnCaps = getClaudeModelCapabilities(modelSelection.model);
+      const turnEffort = resolveClaudeEffort(
+        turnCaps,
+        getModelSelectionStringOptionValue(modelSelection, "effort"),
+      );
+      context.currentEffort =
+        getEffectiveClaudeAgentEffort(turnEffort ?? null, modelSelection.model) ?? undefined;
+    }
+
     if (context.stopped) {
       return yield* new ProviderAdapterSessionClosedError({
         provider: PROVIDER,
@@ -4513,7 +4517,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         createdAt: turnStartedStamp.createdAt,
         threadId: context.session.threadId,
         turnId,
-        payload: modelSelection?.model ? { model: modelSelection.model } : {},
+        payload: context.session.model ? { model: context.session.model } : {},
         providerRefs: {},
       });
     }

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -99,6 +99,10 @@ const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.fromJsonStri
 const decodeUnknownJsonStringExit = Schema.decodeUnknownExit(Schema.fromJsonString(Schema.Unknown));
 
 const PROVIDER = ProviderDriverKind.make("claudeAgent");
+// SDK setModel / setPermissionMode wait forever for a control reply. After an
+// idle restart the CLI may not answer until system/init, or at all.
+const QUERY_READY_TIMEOUT = "5 seconds";
+const QUERY_CONTROL_TIMEOUT = "5 seconds";
 type ClaudeTextStreamKind = Extract<RuntimeContentStreamKind, "assistant_text" | "reasoning_text">;
 type ClaudeToolResultStreamKind = Extract<
   RuntimeContentStreamKind,
@@ -248,6 +252,8 @@ interface ClaudeSessionContext {
   streamFiber: Fiber.Fiber<void, Error> | undefined;
   readonly startedAt: string;
   readonly basePermissionMode: PermissionMode | undefined;
+  currentPermissionMode: PermissionMode;
+  readonly queryReady: Deferred.Deferred<void>;
   currentApiModelId: string | undefined;
   /** Effective effort for the session's turns; subagents without an explicit
    * effort override inherit this. */
@@ -3103,6 +3109,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
     switch (message.subtype) {
       case "init":
+        yield* markQueryReady(context);
         yield* offerRuntimeEvent({
           ...base,
           type: "session.configured",
@@ -3637,6 +3644,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     if (context.stopped) return;
 
     context.stopped = true;
+    yield* markQueryReady(context);
 
     for (const [requestId, pending] of context.pendingApprovals) {
       yield* Deferred.succeed(pending.decision, "cancel");
@@ -3746,6 +3754,34 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     return Effect.succeed(context);
   };
 
+  const markQueryReady = (context: ClaudeSessionContext) =>
+    Deferred.succeed(context.queryReady, undefined).pipe(Effect.asVoid);
+
+  const awaitQueryReady = (context: ClaudeSessionContext) =>
+    Deferred.await(context.queryReady).pipe(
+      Effect.timeoutOption(QUERY_READY_TIMEOUT),
+      Effect.map((ready) => Option.isSome(ready) && !context.stopped),
+    );
+
+  const applyQueryControl = Effect.fn("applyQueryControl")(function* (
+    threadId: ThreadId,
+    method: string,
+    run: () => Promise<void>,
+  ) {
+    const completed = yield* Effect.tryPromise({
+      try: run,
+      catch: (cause) => toRequestError(threadId, method, cause),
+    }).pipe(Effect.timeoutOption(QUERY_CONTROL_TIMEOUT));
+    if (Option.isSome(completed)) {
+      return true;
+    }
+    yield* Effect.logWarning("claude.turn.query-control-timeout", {
+      threadId,
+      method,
+    });
+    return false;
+  });
+
   const startSession: ClaudeAdapterShape["startSession"] = Effect.fn("startSession")(
     function* (input) {
       if (input.provider !== undefined && input.provider !== PROVIDER) {
@@ -3783,6 +3819,12 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       const existingResumeSessionId = resumeState?.resume;
       const newSessionId = existingResumeSessionId === undefined ? yield* randomUUIDv4 : undefined;
       const sessionId = existingResumeSessionId ?? newSessionId;
+      const queryReady = yield* Deferred.make<void>();
+      // Fresh sessions can accept control RPCs immediately. Resume sessions
+      // must wait for system/init — setPermissionMode hangs until then.
+      if (existingResumeSessionId === undefined) {
+        yield* Deferred.succeed(queryReady, undefined);
+      }
 
       const runtimeContext = yield* Effect.context<never>();
       const runFork = Effect.runForkWith(runtimeContext);
@@ -4257,6 +4299,8 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         streamFiber: undefined,
         startedAt,
         basePermissionMode: permissionMode,
+        currentPermissionMode: permissionMode ?? "default",
+        queryReady,
         currentApiModelId: apiModelId,
         currentEffort: effectiveEffort ?? undefined,
         resumeSessionId: sessionId,
@@ -4372,14 +4416,6 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     }
 
     if (modelSelection?.model) {
-      const apiModelId = resolveClaudeApiModelId(modelSelection);
-      if (context.currentApiModelId !== apiModelId) {
-        yield* Effect.tryPromise({
-          try: () => context.query.setModel(apiModelId),
-          catch: (cause) => toRequestError(input.threadId, "turn/setModel", cause),
-        });
-        context.currentApiModelId = apiModelId;
-      }
       context.session = {
         ...context.session,
         model: modelSelection.model,
@@ -4393,19 +4429,60 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         getEffectiveClaudeAgentEffort(turnEffort ?? null, modelSelection.model) ?? undefined;
     }
 
-    // Apply interaction mode by switching the SDK's permission mode.
-    // "plan" maps directly to the SDK's "plan" permission mode;
-    // "default" restores the session's original permission mode.
-    // When interactionMode is absent we leave the current mode unchanged.
-    if (input.interactionMode === "plan") {
-      yield* Effect.tryPromise({
-        try: () => context.query.setPermissionMode("plan"),
-        catch: (cause) => toRequestError(input.threadId, "turn/setPermissionMode", cause),
-      });
-    } else if (input.interactionMode === "default") {
-      yield* Effect.tryPromise({
-        try: () => context.query.setPermissionMode(context.basePermissionMode ?? "default"),
-        catch: (cause) => toRequestError(input.threadId, "turn/setPermissionMode", cause),
+    const nextApiModelId =
+      modelSelection?.model !== undefined ? resolveClaudeApiModelId(modelSelection) : undefined;
+    const needsModelUpdate =
+      nextApiModelId !== undefined && context.currentApiModelId !== nextApiModelId;
+    // "plan" maps to the SDK's plan permission mode; "default" restores the
+    // session's original mode. Absent interactionMode leaves the mode as-is.
+    const desiredPermissionMode =
+      input.interactionMode === "plan"
+        ? "plan"
+        : input.interactionMode === "default"
+          ? (context.basePermissionMode ?? "default")
+          : undefined;
+    const needsPermissionUpdate =
+      desiredPermissionMode !== undefined &&
+      desiredPermissionMode !== context.currentPermissionMode;
+
+    if (needsModelUpdate || needsPermissionUpdate) {
+      const queryReady = yield* awaitQueryReady(context);
+      if (context.stopped) {
+        return yield* new ProviderAdapterSessionClosedError({
+          provider: PROVIDER,
+          threadId: input.threadId,
+        });
+      }
+      if (queryReady) {
+        if (needsModelUpdate && nextApiModelId !== undefined) {
+          const applied = yield* applyQueryControl(input.threadId, "turn/setModel", () =>
+            context.query.setModel(nextApiModelId),
+          );
+          if (applied) {
+            context.currentApiModelId = nextApiModelId;
+          }
+        }
+        if (needsPermissionUpdate && desiredPermissionMode !== undefined) {
+          const applied = yield* applyQueryControl(input.threadId, "turn/setPermissionMode", () =>
+            context.query.setPermissionMode(desiredPermissionMode),
+          );
+          if (applied) {
+            context.currentPermissionMode = desiredPermissionMode;
+          }
+        }
+      } else {
+        yield* Effect.logWarning("claude.turn.query-not-ready", {
+          threadId: input.threadId,
+          needsModelUpdate,
+          needsPermissionUpdate,
+        });
+      }
+    }
+
+    if (context.stopped) {
+      return yield* new ProviderAdapterSessionClosedError({
+        provider: PROVIDER,
+        threadId: input.threadId,
       });
     }
 

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -252,9 +252,13 @@ interface ClaudeSessionContext {
   streamFiber: Fiber.Fiber<void, Error> | undefined;
   readonly startedAt: string;
   readonly basePermissionMode: PermissionMode | undefined;
-  currentPermissionMode: PermissionMode;
+  currentPermissionMode: PermissionMode | undefined;
+  targetPermissionMode: PermissionMode | undefined;
+  permissionControlGeneration: number;
   readonly queryReady: Deferred.Deferred<void>;
   currentApiModelId: string | undefined;
+  targetApiModelId: string | undefined;
+  modelControlGeneration: number;
   /** Effective effort for the session's turns; subagents without an explicit
    * effort override inherit this. */
   currentEffort: string | undefined;
@@ -291,8 +295,8 @@ interface ClaudeQueryRuntime extends AsyncIterable<SDKMessage> {
   readonly interrupt: () => Promise<void>;
   /** SDK Query.stopTask — present on real queries; optional for test doubles. */
   readonly stopTask?: (taskId: string) => Promise<void>;
-  readonly setModel: (model?: string) => Promise<void>;
-  readonly setPermissionMode: (mode: PermissionMode) => Promise<void>;
+  readonly setModel: (model?: string, signal?: AbortSignal) => Promise<void>;
+  readonly setPermissionMode: (mode: PermissionMode, signal?: AbortSignal) => Promise<void>;
   readonly setMaxThinkingTokens: (maxThinkingTokens: number | null) => Promise<void>;
   readonly getContextUsage?: () => Promise<SDKControlGetContextUsageResponse>;
   readonly close: () => void;
@@ -3644,6 +3648,8 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     if (context.stopped) return;
 
     context.stopped = true;
+    context.permissionControlGeneration += 1;
+    context.modelControlGeneration += 1;
     yield* markQueryReady(context);
 
     for (const [requestId, pending] of context.pendingApprovals) {
@@ -3763,23 +3769,106 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       Effect.map((ready) => Option.isSome(ready) && !context.stopped),
     );
 
-  const applyQueryControl = Effect.fn("applyQueryControl")(function* (
-    threadId: ThreadId,
-    method: string,
-    run: () => Promise<void>,
-  ) {
+  const applyQueryControl = Effect.fn("applyQueryControl")(function* (input: {
+    readonly threadId: ThreadId;
+    readonly method: string;
+    readonly nextGeneration: () => number;
+    readonly isCurrentGeneration: (generation: number) => boolean;
+    readonly run: (signal: AbortSignal) => Promise<void>;
+    readonly onApplied: () => void;
+    readonly reassert: () => Effect.Effect<void>;
+  }) {
+    const generation = input.nextGeneration();
+    const controller = new AbortController();
+    const request = input.run(controller.signal);
     const completed = yield* Effect.tryPromise({
-      try: run,
-      catch: (cause) => toRequestError(threadId, method, cause),
+      try: () => request,
+      catch: (cause) => toRequestError(input.threadId, input.method, cause),
     }).pipe(Effect.timeoutOption(QUERY_CONTROL_TIMEOUT));
     if (Option.isSome(completed)) {
-      return true;
+      if (input.isCurrentGeneration(generation)) {
+        input.onApplied();
+        return true;
+      }
+      return false;
     }
+    controller.abort();
     yield* Effect.logWarning("claude.turn.query-control-timeout", {
-      threadId,
-      method,
+      threadId: input.threadId,
+      method: input.method,
     });
+    // The SDK may still complete after abort. Reconcile so a late restore
+    // cannot leave a later plan turn running with bypass permissions.
+    yield* Effect.promise(() => request).pipe(
+      Effect.flatMap(() =>
+        Effect.suspend(() =>
+          input.isCurrentGeneration(generation) ? Effect.sync(input.onApplied) : input.reassert(),
+        ),
+      ),
+      Effect.ignore,
+      Effect.forkDetach,
+    );
     return false;
+  });
+
+  const reassertPermissionMode = Effect.fn("reassertPermissionMode")(function* (
+    context: ClaudeSessionContext,
+    threadId: ThreadId,
+  ) {
+    if (context.stopped) {
+      return;
+    }
+    const permission = context.targetPermissionMode;
+    if (permission === undefined) {
+      return;
+    }
+    const applied = yield* applyQueryControl({
+      threadId,
+      method: "turn/setPermissionMode",
+      nextGeneration: () => {
+        context.permissionControlGeneration += 1;
+        return context.permissionControlGeneration;
+      },
+      isCurrentGeneration: (generation) => generation === context.permissionControlGeneration,
+      run: (signal) => context.query.setPermissionMode(permission, signal),
+      onApplied: () => {
+        context.currentPermissionMode = permission;
+      },
+      reassert: () => reassertPermissionMode(context, threadId),
+    });
+    if (!applied) {
+      context.currentPermissionMode = undefined;
+    }
+  });
+
+  const reassertModel = Effect.fn("reassertModel")(function* (
+    context: ClaudeSessionContext,
+    threadId: ThreadId,
+  ) {
+    if (context.stopped) {
+      return;
+    }
+    const model = context.targetApiModelId;
+    if (model === undefined) {
+      return;
+    }
+    const applied = yield* applyQueryControl({
+      threadId,
+      method: "turn/setModel",
+      nextGeneration: () => {
+        context.modelControlGeneration += 1;
+        return context.modelControlGeneration;
+      },
+      isCurrentGeneration: (generation) => generation === context.modelControlGeneration,
+      run: (signal) => context.query.setModel(model, signal),
+      onApplied: () => {
+        context.currentApiModelId = model;
+      },
+      reassert: () => reassertModel(context, threadId),
+    });
+    if (!applied) {
+      context.currentApiModelId = undefined;
+    }
   });
 
   const startSession: ClaudeAdapterShape["startSession"] = Effect.fn("startSession")(
@@ -4300,8 +4389,12 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         startedAt,
         basePermissionMode: permissionMode,
         currentPermissionMode: permissionMode ?? "default",
+        targetPermissionMode: permissionMode ?? "default",
+        permissionControlGeneration: 0,
         queryReady,
         currentApiModelId: apiModelId,
+        targetApiModelId: apiModelId,
+        modelControlGeneration: 0,
         currentEffort: effectiveEffort ?? undefined,
         resumeSessionId: sessionId,
         pendingApprovals,
@@ -4431,6 +4524,9 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
     const nextApiModelId =
       modelSelection?.model !== undefined ? resolveClaudeApiModelId(modelSelection) : undefined;
+    if (nextApiModelId !== undefined) {
+      context.targetApiModelId = nextApiModelId;
+    }
     const needsModelUpdate =
       nextApiModelId !== undefined && context.currentApiModelId !== nextApiModelId;
     // "plan" maps to the SDK's plan permission mode; "default" restores the
@@ -4441,6 +4537,9 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         : input.interactionMode === "default"
           ? (context.basePermissionMode ?? "default")
           : undefined;
+    if (desiredPermissionMode !== undefined) {
+      context.targetPermissionMode = desiredPermissionMode;
+    }
     const needsPermissionUpdate =
       desiredPermissionMode !== undefined &&
       desiredPermissionMode !== context.currentPermissionMode;
@@ -4455,19 +4554,41 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       }
       if (queryReady) {
         if (needsModelUpdate && nextApiModelId !== undefined) {
-          const applied = yield* applyQueryControl(input.threadId, "turn/setModel", () =>
-            context.query.setModel(nextApiModelId),
-          );
-          if (applied) {
-            context.currentApiModelId = nextApiModelId;
+          const applied = yield* applyQueryControl({
+            threadId: input.threadId,
+            method: "turn/setModel",
+            nextGeneration: () => {
+              context.modelControlGeneration += 1;
+              return context.modelControlGeneration;
+            },
+            isCurrentGeneration: (generation) => generation === context.modelControlGeneration,
+            run: (signal) => context.query.setModel(nextApiModelId, signal),
+            onApplied: () => {
+              context.currentApiModelId = nextApiModelId;
+            },
+            reassert: () => reassertModel(context, input.threadId),
+          });
+          if (!applied) {
+            context.currentApiModelId = undefined;
           }
         }
         if (needsPermissionUpdate && desiredPermissionMode !== undefined) {
-          const applied = yield* applyQueryControl(input.threadId, "turn/setPermissionMode", () =>
-            context.query.setPermissionMode(desiredPermissionMode),
-          );
-          if (applied) {
-            context.currentPermissionMode = desiredPermissionMode;
+          const applied = yield* applyQueryControl({
+            threadId: input.threadId,
+            method: "turn/setPermissionMode",
+            nextGeneration: () => {
+              context.permissionControlGeneration += 1;
+              return context.permissionControlGeneration;
+            },
+            isCurrentGeneration: (generation) => generation === context.permissionControlGeneration,
+            run: (signal) => context.query.setPermissionMode(desiredPermissionMode, signal),
+            onApplied: () => {
+              context.currentPermissionMode = desiredPermissionMode;
+            },
+            reassert: () => reassertPermissionMode(context, input.threadId),
+          });
+          if (!applied) {
+            context.currentPermissionMode = undefined;
           }
         }
       } else {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -100,7 +100,9 @@ const decodeUnknownJsonStringExit = Schema.decodeUnknownExit(Schema.fromJsonStri
 
 const PROVIDER = ProviderDriverKind.make("claudeAgent");
 // SDK setModel / setPermissionMode wait forever for a control reply. After an
-// idle restart the CLI may not answer until system/init, or at all.
+// idle restart the CLI may not answer until system/init, or at all. A timed-out
+// call can still apply later, so sendTurn forgets the cached mode/model and
+// re-issues on the next turn instead of treating the last request as current.
 const QUERY_READY_TIMEOUT = "5 seconds";
 const QUERY_CONTROL_TIMEOUT = "5 seconds";
 type ClaudeTextStreamKind = Extract<RuntimeContentStreamKind, "assistant_text" | "reasoning_text">;
@@ -253,12 +255,8 @@ interface ClaudeSessionContext {
   readonly startedAt: string;
   readonly basePermissionMode: PermissionMode | undefined;
   currentPermissionMode: PermissionMode | undefined;
-  targetPermissionMode: PermissionMode | undefined;
-  permissionControlGeneration: number;
   readonly queryReady: Deferred.Deferred<void>;
   currentApiModelId: string | undefined;
-  targetApiModelId: string | undefined;
-  modelControlGeneration: number;
   /** Effective effort for the session's turns; subagents without an explicit
    * effort override inherit this. */
   currentEffort: string | undefined;
@@ -295,8 +293,8 @@ interface ClaudeQueryRuntime extends AsyncIterable<SDKMessage> {
   readonly interrupt: () => Promise<void>;
   /** SDK Query.stopTask — present on real queries; optional for test doubles. */
   readonly stopTask?: (taskId: string) => Promise<void>;
-  readonly setModel: (model?: string, signal?: AbortSignal) => Promise<void>;
-  readonly setPermissionMode: (mode: PermissionMode, signal?: AbortSignal) => Promise<void>;
+  readonly setModel: (model?: string) => Promise<void>;
+  readonly setPermissionMode: (mode: PermissionMode) => Promise<void>;
   readonly setMaxThinkingTokens: (maxThinkingTokens: number | null) => Promise<void>;
   readonly getContextUsage?: () => Promise<SDKControlGetContextUsageResponse>;
   readonly close: () => void;
@@ -3648,8 +3646,6 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     if (context.stopped) return;
 
     context.stopped = true;
-    context.permissionControlGeneration += 1;
-    context.modelControlGeneration += 1;
     yield* markQueryReady(context);
 
     for (const [requestId, pending] of context.pendingApprovals) {
@@ -3769,106 +3765,23 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       Effect.map((ready) => Option.isSome(ready) && !context.stopped),
     );
 
-  const applyQueryControl = Effect.fn("applyQueryControl")(function* (input: {
-    readonly threadId: ThreadId;
-    readonly method: string;
-    readonly nextGeneration: () => number;
-    readonly isCurrentGeneration: (generation: number) => boolean;
-    readonly run: (signal: AbortSignal) => Promise<void>;
-    readonly onApplied: () => void;
-    readonly reassert: () => Effect.Effect<void>;
-  }) {
-    const generation = input.nextGeneration();
-    const controller = new AbortController();
-    const request = input.run(controller.signal);
+  const applyQueryControl = Effect.fn("applyQueryControl")(function* (
+    threadId: ThreadId,
+    method: string,
+    run: () => Promise<void>,
+  ) {
     const completed = yield* Effect.tryPromise({
-      try: () => request,
-      catch: (cause) => toRequestError(input.threadId, input.method, cause),
+      try: run,
+      catch: (cause) => toRequestError(threadId, method, cause),
     }).pipe(Effect.timeoutOption(QUERY_CONTROL_TIMEOUT));
     if (Option.isSome(completed)) {
-      if (input.isCurrentGeneration(generation)) {
-        input.onApplied();
-        return true;
-      }
-      return false;
+      return true;
     }
-    controller.abort();
     yield* Effect.logWarning("claude.turn.query-control-timeout", {
-      threadId: input.threadId,
-      method: input.method,
+      threadId,
+      method,
     });
-    // The SDK may still complete after abort. Reconcile so a late restore
-    // cannot leave a later plan turn running with bypass permissions.
-    yield* Effect.promise(() => request).pipe(
-      Effect.flatMap(() =>
-        Effect.suspend(() =>
-          input.isCurrentGeneration(generation) ? Effect.sync(input.onApplied) : input.reassert(),
-        ),
-      ),
-      Effect.ignore,
-      Effect.forkDetach,
-    );
     return false;
-  });
-
-  const reassertPermissionMode = Effect.fn("reassertPermissionMode")(function* (
-    context: ClaudeSessionContext,
-    threadId: ThreadId,
-  ) {
-    if (context.stopped) {
-      return;
-    }
-    const permission = context.targetPermissionMode;
-    if (permission === undefined) {
-      return;
-    }
-    const applied = yield* applyQueryControl({
-      threadId,
-      method: "turn/setPermissionMode",
-      nextGeneration: () => {
-        context.permissionControlGeneration += 1;
-        return context.permissionControlGeneration;
-      },
-      isCurrentGeneration: (generation) => generation === context.permissionControlGeneration,
-      run: (signal) => context.query.setPermissionMode(permission, signal),
-      onApplied: () => {
-        context.currentPermissionMode = permission;
-      },
-      reassert: () => reassertPermissionMode(context, threadId),
-    });
-    if (!applied) {
-      context.currentPermissionMode = undefined;
-    }
-  });
-
-  const reassertModel = Effect.fn("reassertModel")(function* (
-    context: ClaudeSessionContext,
-    threadId: ThreadId,
-  ) {
-    if (context.stopped) {
-      return;
-    }
-    const model = context.targetApiModelId;
-    if (model === undefined) {
-      return;
-    }
-    const applied = yield* applyQueryControl({
-      threadId,
-      method: "turn/setModel",
-      nextGeneration: () => {
-        context.modelControlGeneration += 1;
-        return context.modelControlGeneration;
-      },
-      isCurrentGeneration: (generation) => generation === context.modelControlGeneration,
-      run: (signal) => context.query.setModel(model, signal),
-      onApplied: () => {
-        context.currentApiModelId = model;
-      },
-      reassert: () => reassertModel(context, threadId),
-    });
-    if (!applied) {
-      context.currentApiModelId = undefined;
-    }
   });
 
   const startSession: ClaudeAdapterShape["startSession"] = Effect.fn("startSession")(
@@ -4389,12 +4302,8 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         startedAt,
         basePermissionMode: permissionMode,
         currentPermissionMode: permissionMode ?? "default",
-        targetPermissionMode: permissionMode ?? "default",
-        permissionControlGeneration: 0,
         queryReady,
         currentApiModelId: apiModelId,
-        targetApiModelId: apiModelId,
-        modelControlGeneration: 0,
         currentEffort: effectiveEffort ?? undefined,
         resumeSessionId: sessionId,
         pendingApprovals,
@@ -4524,9 +4433,6 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
     const nextApiModelId =
       modelSelection?.model !== undefined ? resolveClaudeApiModelId(modelSelection) : undefined;
-    if (nextApiModelId !== undefined) {
-      context.targetApiModelId = nextApiModelId;
-    }
     const needsModelUpdate =
       nextApiModelId !== undefined && context.currentApiModelId !== nextApiModelId;
     // "plan" maps to the SDK's plan permission mode; "default" restores the
@@ -4537,9 +4443,6 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         : input.interactionMode === "default"
           ? (context.basePermissionMode ?? "default")
           : undefined;
-    if (desiredPermissionMode !== undefined) {
-      context.targetPermissionMode = desiredPermissionMode;
-    }
     const needsPermissionUpdate =
       desiredPermissionMode !== undefined &&
       desiredPermissionMode !== context.currentPermissionMode;
@@ -4554,42 +4457,16 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       }
       if (queryReady) {
         if (needsModelUpdate && nextApiModelId !== undefined) {
-          const applied = yield* applyQueryControl({
-            threadId: input.threadId,
-            method: "turn/setModel",
-            nextGeneration: () => {
-              context.modelControlGeneration += 1;
-              return context.modelControlGeneration;
-            },
-            isCurrentGeneration: (generation) => generation === context.modelControlGeneration,
-            run: (signal) => context.query.setModel(nextApiModelId, signal),
-            onApplied: () => {
-              context.currentApiModelId = nextApiModelId;
-            },
-            reassert: () => reassertModel(context, input.threadId),
-          });
-          if (!applied) {
-            context.currentApiModelId = undefined;
-          }
+          const applied = yield* applyQueryControl(input.threadId, "turn/setModel", () =>
+            context.query.setModel(nextApiModelId),
+          );
+          context.currentApiModelId = applied ? nextApiModelId : undefined;
         }
         if (needsPermissionUpdate && desiredPermissionMode !== undefined) {
-          const applied = yield* applyQueryControl({
-            threadId: input.threadId,
-            method: "turn/setPermissionMode",
-            nextGeneration: () => {
-              context.permissionControlGeneration += 1;
-              return context.permissionControlGeneration;
-            },
-            isCurrentGeneration: (generation) => generation === context.permissionControlGeneration,
-            run: (signal) => context.query.setPermissionMode(desiredPermissionMode, signal),
-            onApplied: () => {
-              context.currentPermissionMode = desiredPermissionMode;
-            },
-            reassert: () => reassertPermissionMode(context, input.threadId),
-          });
-          if (!applied) {
-            context.currentPermissionMode = undefined;
-          }
+          const applied = yield* applyQueryControl(input.threadId, "turn/setPermissionMode", () =>
+            context.query.setPermissionMode(desiredPermissionMode),
+          );
+          context.currentPermissionMode = applied ? desiredPermissionMode : undefined;
         }
       } else {
         yield* Effect.logWarning("claude.turn.query-not-ready", {

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -1274,6 +1274,57 @@ routing.layer("ProviderServiceLive routing", (it) => {
     }),
   );
 
+  it.effect(
+    "reuses persisted Claude resume cursor when startSession follows an idle adapter stop",
+    () =>
+      Effect.gen(function* () {
+        const provider = yield* ProviderService.ProviderService;
+        const resumeCursor = {
+          threadId: asThreadId("thread-claude-idle"),
+          resume: "550e8400-e29b-41d4-a716-446655440000",
+          resumeSessionAt: "assistant-99",
+          turnCount: 3,
+        };
+
+        const initial = yield* provider.startSession(asThreadId("thread-claude-idle"), {
+          provider: ProviderDriverKind.make("claudeAgent"),
+          providerInstanceId: claudeAgentInstanceId,
+          threadId: asThreadId("thread-claude-idle"),
+          cwd: "/tmp/project-claude-idle",
+          resumeCursor,
+          runtimeMode: "full-access",
+        });
+
+        yield* routing.claude.stopSession(initial.threadId);
+        routing.claude.startSession.mockClear();
+        routing.claude.sendTurn.mockClear();
+
+        yield* provider.startSession(initial.threadId, {
+          provider: ProviderDriverKind.make("claudeAgent"),
+          providerInstanceId: claudeAgentInstanceId,
+          threadId: initial.threadId,
+          runtimeMode: "full-access",
+        });
+
+        assert.equal(routing.claude.startSession.mock.calls.length, 1);
+        const resumedStartInput = routing.claude.startSession.mock.calls[0]?.[0];
+        assert.equal(typeof resumedStartInput === "object" && resumedStartInput !== null, true);
+        if (resumedStartInput && typeof resumedStartInput === "object") {
+          const startPayload = resumedStartInput as {
+            resumeCursor?: unknown;
+          };
+          assert.deepEqual(startPayload.resumeCursor, resumeCursor);
+        }
+
+        yield* provider.sendTurn({
+          threadId: initial.threadId,
+          input: "after idle",
+          attachments: [],
+        });
+        assert.equal(routing.claude.sendTurn.mock.calls.length, 1);
+      }),
+  );
+
   it.effect("lists no sessions after adapter runtime clears", () =>
     Effect.gen(function* () {
       const provider = yield* ProviderService.ProviderService;


### PR DESCRIPTION
## Problem

After an idle `claudeAgent` session exits (`session.exited`, "Session stopped"), the next prompt on that thread is stored and never starts a turn. Messages land with a null `turn_id`. `/stop` is stored as another user message. A new thread in the same project still works.

`sendTurn` emits `turn.started` only after optional `query.setModel` / `query.setPermissionMode`. `interactionMode: "default"` always called `setPermissionMode`. After a fresh `startSession` those SDK control RPCs wait forever for a reply the resumed CLI may not send until `system/init` — or at all.

## Fix

- Skip `setPermissionMode` / `setModel` when the session already has that mode or model (the idle `default` path no longer blocks on a no-op control RPC).
- After a resume, wait for `system/init` before issuing those RPCs. If the query never becomes ready, skip them and still emit `turn.started` so the prompt is not stored with a null `turn_id`.
- Time out hung `setModel` / `setPermissionMode` calls and start the turn anyway.
- Stopping a session unblocks waiters so a later `/stop` can fail the pending start instead of hanging it.
- `ProviderService.startSession` already backfills the persisted Claude resume cursor after an idle adapter stop; a test now covers that path, including `resumeSessionAt`.

## Tests

- After `session.exited`, a new `sendTurn` on the same thread emits `turn.started` even when `setPermissionMode` would hang.
- `startSession` + immediate `sendTurn` does not invoke `setPermissionMode` until the query is usable (or skips it if not).
- In-session `sendTurn` still sets permission mode / model as before; a hung in-session `setPermissionMode` times out and still starts the turn.
- After an idle adapter stop, `startSession` without a resume cursor still passes the persisted Claude resume cursor through.

Fixes #7155

Made-with: Grok

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Claude turn startup and permission/model synchronization; behavior is well-covered by new tests but affects every sendTurn path.
> 
> **Overview**
> Fixes threads that stall after an idle `claudeAgent` session exits: **`sendTurn` no longer blocks on SDK `setModel` / `setPermissionMode` before emitting `turn.started`**, so prompts are not left with a null `turn_id`.
> 
> **`ClaudeAdapter`** adds a per-session `queryReady` gate (resolved on `system/init` for resume sessions, immediately for fresh ones, and on stop). Model and permission updates run only when the effective value changed; the adapter waits up to 5s for query readiness and 5s per control RPC, then proceeds anyway. Failed or skipped controls clear tracked state so the next turn retries—avoiding a late `bypassPermissions` after a timed-out restore. **`turn.started` and session model** reflect what actually applied (e.g. no requested model when resume query never becomes ready). Stopping a session unblocks readiness waiters.
> 
> Tests extend the fake Claude query (hung controls, resume `init`) and add **`ProviderService`** coverage that persisted resume cursor is passed through after an idle adapter stop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7a1ee2ed4cc7794a100124611413b45ca52e6ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Claude turn start after idle session restart by adding query readiness checks
> - Resumed Claude sessions now wait for the SDK's `system/init` message before issuing `setModel` or `setPermissionMode` control RPCs, preventing them from being sent before the query is ready.
> - Introduces `QUERY_READY_TIMEOUT` and `QUERY_CONTROL_TIMEOUT` (5 seconds each) so turns proceed even if the query never becomes ready or a control RPC hangs.
> - When a control RPC times out or the query isn't ready, the turn starts anyway and the model/permission change is not cached — so the next turn will retry.
> - `turn.started` and `listSessions` only advertise `model` once the CLI has confirmed it applied.
> - Behavioral Change: `sendTurn` no longer blocks indefinitely on `setModel`/`setPermissionMode`; failed or timed-out control RPCs cause the session's cached model/permission state to remain unchanged until a future turn succeeds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b7a1ee2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->