### PR TITLE
fix(web): let Escape reach nvim in the terminal drawer

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -193,6 +193,7 @@ import { useNowMinute } from "../hooks/useNowMinute";
 import { useNewThreadHandler } from "../hooks/useHandleNewThread";
 import { resolveAppModelSelectionForInstance } from "../modelSelection";
 import { getTerminalFocusOwner } from "../lib/terminalFocus";
+import { isBareEscapeKey } from "../lib/terminalBeforeKey";
 import { preventRepeatedTerminalCloseShortcut } from "../lib/terminalCloseShortcut";
 import { resolveNewDraftStartFromOrigin } from "../lib/chatThreadActions";
 import {
@@ -4691,6 +4692,11 @@ function ChatViewContent(props: ChatViewProps) {
 
   useEffect(() => {
     const handler = (event: globalThis.KeyboardEvent) => {
+      // Bare Escape is for the PTY (vim/nvim). Close stays mod+w.
+      // Command palette / dialogs still claim Escape when they are actually open.
+      if (isBareEscapeKey(event) && getTerminalFocusOwner() !== null && !isCommandPaletteOpen()) {
+        return;
+      }
       if (preventRepeatedTerminalCloseShortcut(event, keybindings)) {
         event.stopPropagation();
         return;

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -44,16 +44,6 @@ import { type GhosttyColor, type GhosttyTheme } from "~/terminal/ghostty/core";
 import { useOpenInPreferredEditor } from "../editorPreferences";
 import { isTerminalLinkActivation, resolvePathLinkTarget } from "../terminal-links";
 import {
-  isDiffToggleShortcut,
-  isTerminalClearShortcut,
-  isTerminalNewShortcut,
-  isTerminalSplitShortcut,
-  isTerminalSplitVerticalShortcut,
-  isTerminalToggleShortcut,
-  terminalDeleteShortcutData,
-  terminalNavigationShortcutData,
-} from "../keybindings";
-import {
   DEFAULT_THREAD_TERMINAL_HEIGHT,
   MAX_TERMINALS_PER_GROUP,
   type ThreadTerminalGroup,
@@ -67,7 +57,7 @@ import { previewEnvironment } from "../state/preview";
 import { terminalEnvironment } from "../state/terminal";
 import { openTerminalLinkInPreview } from "./preview/openTerminalLinkInPreview";
 import { useAtomCommand } from "../state/use-atom-command";
-import { preventTerminalCloseShortcut } from "../lib/terminalCloseShortcut";
+import { decideTerminalBeforeKey } from "../lib/terminalBeforeKey";
 import {
   resolveTerminalFontPreference,
   resolveTerminalFontSizePreference,
@@ -706,41 +696,14 @@ export function TerminalViewport({
       };
 
       function handleBeforeKey(event: KeyboardEvent): boolean {
-        const currentKeybindings = keybindingsRef.current;
-        const options = { context: { terminalFocus: true, terminalOpen: true } };
-        if (preventTerminalCloseShortcut(event, currentKeybindings)) {
-          return false;
+        const decision = decideTerminalBeforeKey(event, keybindingsRef.current);
+        if (decision.action === "encode") {
+          return true;
         }
-        if (
-          isTerminalToggleShortcut(event, currentKeybindings, options) ||
-          isTerminalSplitShortcut(event, currentKeybindings, options) ||
-          isTerminalSplitVerticalShortcut(event, currentKeybindings, options) ||
-          isTerminalNewShortcut(event, currentKeybindings, options) ||
-          isDiffToggleShortcut(event, currentKeybindings, options)
-        ) {
-          return false;
-        }
-
-        const navigationData = terminalNavigationShortcutData(event);
-        if (navigationData !== null) {
-          event.preventDefault();
+        if (decision.action === "send") {
           event.stopPropagation();
-          void sendTerminalInput(navigationData, "Failed to move cursor");
-          return false;
+          void sendTerminalInput(decision.data, decision.error);
         }
-
-        const deleteData = terminalDeleteShortcutData(event);
-        if (deleteData !== null) {
-          event.preventDefault();
-          event.stopPropagation();
-          void sendTerminalInput(deleteData, "Failed to delete terminal input");
-          return false;
-        }
-
-        if (!isTerminalClearShortcut(event)) return true;
-        event.preventDefault();
-        event.stopPropagation();
-        void sendTerminalInput("\u000c", "Failed to clear terminal");
         return false;
       }
 

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -248,6 +248,12 @@ describe("split/new/close terminal shortcuts", () => {
         context: { terminalFocus: true },
       }),
     );
+    assert.isFalse(
+      isTerminalCloseShortcut(event({ key: "Escape" }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: true, terminalOpen: true },
+      }),
+    );
   });
 
   it("supports when expressions", () => {

--- a/apps/web/src/lib/terminalBeforeKey.test.ts
+++ b/apps/web/src/lib/terminalBeforeKey.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import type { ResolvedKeybindingsConfig } from "@t3tools/contracts";
+
+import {
+  decideTerminalBeforeKey,
+  isBareEscapeKey,
+  type TerminalBeforeKeyEvent,
+} from "./terminalBeforeKey";
+
+const defaultKeybindings = [
+  {
+    command: "terminal.close",
+    shortcut: {
+      key: "w",
+      metaKey: false,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      modKey: true,
+    },
+    whenAst: { type: "identifier", name: "terminalFocus" },
+  },
+  {
+    command: "terminal.toggle",
+    shortcut: {
+      key: "j",
+      metaKey: false,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      modKey: true,
+    },
+  },
+  {
+    command: "terminal.split",
+    shortcut: {
+      key: "d",
+      metaKey: false,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      modKey: true,
+    },
+    whenAst: { type: "identifier", name: "terminalFocus" },
+  },
+] satisfies ResolvedKeybindingsConfig;
+
+const escapeCloseKeybindings = [
+  {
+    command: "terminal.close",
+    shortcut: {
+      key: "escape",
+      metaKey: false,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      modKey: false,
+    },
+    whenAst: { type: "identifier", name: "terminalFocus" },
+  },
+] satisfies ResolvedKeybindingsConfig;
+
+type KeyboardEventOverrides = Partial<
+  Pick<
+    TerminalBeforeKeyEvent,
+    "key" | "code" | "metaKey" | "ctrlKey" | "shiftKey" | "altKey" | "type"
+  >
+>;
+
+function keyboardEvent(
+  overrides: KeyboardEventOverrides = {},
+): TerminalBeforeKeyEvent & { readonly defaultPrevented: boolean } {
+  let defaultPrevented = false;
+  return {
+    key: "Escape",
+    code: "Escape",
+    type: "keydown",
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    ...overrides,
+    preventDefault: () => {
+      defaultPrevented = true;
+    },
+    get defaultPrevented() {
+      return defaultPrevented;
+    },
+  };
+}
+
+describe("isBareEscapeKey", () => {
+  it("matches Escape and esc with no modifiers", () => {
+    expect(isBareEscapeKey(keyboardEvent())).toBe(true);
+    expect(isBareEscapeKey(keyboardEvent({ key: "esc" }))).toBe(true);
+  });
+
+  it("rejects modified Escape", () => {
+    expect(isBareEscapeKey(keyboardEvent({ metaKey: true }))).toBe(false);
+    expect(isBareEscapeKey(keyboardEvent({ ctrlKey: true }))).toBe(false);
+    expect(isBareEscapeKey(keyboardEvent({ shiftKey: true }))).toBe(false);
+    expect(isBareEscapeKey(keyboardEvent({ altKey: true }))).toBe(false);
+  });
+});
+
+describe("decideTerminalBeforeKey", () => {
+  it("lets bare Escape reach the PTY and does not treat it as close", () => {
+    const event = keyboardEvent();
+
+    expect(decideTerminalBeforeKey(event, defaultKeybindings, "MacIntel")).toEqual({
+      action: "encode",
+    });
+    expect(event.defaultPrevented).toBe(false);
+
+    const remapped = keyboardEvent();
+    expect(decideTerminalBeforeKey(remapped, escapeCloseKeybindings, "MacIntel")).toEqual({
+      action: "encode",
+    });
+    expect(remapped.defaultPrevented).toBe(false);
+  });
+
+  it("still suppresses the default close shortcut", () => {
+    const event = keyboardEvent({ key: "w", code: "KeyW", ctrlKey: true });
+
+    expect(decideTerminalBeforeKey(event, defaultKeybindings, "Linux x86_64")).toEqual({
+      action: "suppress",
+    });
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("still suppresses split and toggle shortcuts", () => {
+    const split = keyboardEvent({ key: "d", code: "KeyD", metaKey: true });
+    expect(decideTerminalBeforeKey(split, defaultKeybindings, "MacIntel")).toEqual({
+      action: "suppress",
+    });
+
+    const toggle = keyboardEvent({ key: "j", code: "KeyJ", ctrlKey: true });
+    expect(decideTerminalBeforeKey(toggle, defaultKeybindings, "Linux x86_64")).toEqual({
+      action: "suppress",
+    });
+  });
+
+  it("still sends navigation, delete, and clear shortcuts", () => {
+    const wordLeft = keyboardEvent({ key: "ArrowLeft", altKey: true });
+    expect(decideTerminalBeforeKey(wordLeft, defaultKeybindings, "MacIntel")).toEqual({
+      action: "send",
+      data: "\u001bb",
+      error: "Failed to move cursor",
+    });
+    expect(wordLeft.defaultPrevented).toBe(true);
+
+    const deleteToStart = keyboardEvent({ key: "Backspace", metaKey: true });
+    expect(decideTerminalBeforeKey(deleteToStart, defaultKeybindings, "MacIntel")).toEqual({
+      action: "send",
+      data: "\u0015",
+      error: "Failed to delete terminal input",
+    });
+    expect(deleteToStart.defaultPrevented).toBe(true);
+
+    const clear = keyboardEvent({ key: "l", code: "KeyL", ctrlKey: true });
+    expect(decideTerminalBeforeKey(clear, defaultKeybindings, "Linux x86_64")).toEqual({
+      action: "send",
+      data: "\u000c",
+      error: "Failed to clear terminal",
+    });
+    expect(clear.defaultPrevented).toBe(true);
+  });
+});

--- a/apps/web/src/lib/terminalBeforeKey.ts
+++ b/apps/web/src/lib/terminalBeforeKey.ts
@@ -1,0 +1,84 @@
+import type { ResolvedKeybindingsConfig } from "@t3tools/contracts";
+
+import {
+  isDiffToggleShortcut,
+  isTerminalClearShortcut,
+  isTerminalNewShortcut,
+  isTerminalSplitShortcut,
+  isTerminalSplitVerticalShortcut,
+  isTerminalToggleShortcut,
+  terminalDeleteShortcutData,
+  terminalNavigationShortcutData,
+  type ShortcutEventLike,
+} from "../keybindings";
+import { preventTerminalCloseShortcut } from "./terminalCloseShortcut";
+
+export interface TerminalBeforeKeyEvent extends ShortcutEventLike {
+  readonly preventDefault: () => void;
+}
+
+export type TerminalBeforeKeyDecision =
+  | { readonly action: "encode" }
+  | { readonly action: "suppress" }
+  | { readonly action: "send"; readonly data: string; readonly error: string };
+
+const TERMINAL_SHORTCUT_CONTEXT = { terminalFocus: true, terminalOpen: true } as const;
+
+/** Escape with no modifiers. Close is `mod+w`; this must reach the PTY for vim/nvim. */
+export function isBareEscapeKey(
+  event: Pick<ShortcutEventLike, "key" | "metaKey" | "ctrlKey" | "shiftKey" | "altKey">,
+): boolean {
+  const key = event.key.toLowerCase();
+  if (key !== "escape" && key !== "esc") return false;
+  return !event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey;
+}
+
+/**
+ * Decides whether Ghostty should encode a key into the PTY.
+ * Returning `encode` means `beforeKey` is true so the surface does not swallow it.
+ */
+export function decideTerminalBeforeKey(
+  event: TerminalBeforeKeyEvent,
+  keybindings: ResolvedKeybindingsConfig,
+  platform?: string,
+): TerminalBeforeKeyDecision {
+  if (isBareEscapeKey(event)) {
+    return { action: "encode" };
+  }
+
+  const options = {
+    ...(platform === undefined ? {} : { platform }),
+    context: TERMINAL_SHORTCUT_CONTEXT,
+  };
+  if (preventTerminalCloseShortcut(event, keybindings, platform)) {
+    return { action: "suppress" };
+  }
+  if (
+    isTerminalToggleShortcut(event, keybindings, options) ||
+    isTerminalSplitShortcut(event, keybindings, options) ||
+    isTerminalSplitVerticalShortcut(event, keybindings, options) ||
+    isTerminalNewShortcut(event, keybindings, options) ||
+    isDiffToggleShortcut(event, keybindings, options)
+  ) {
+    return { action: "suppress" };
+  }
+
+  const resolvedPlatform = platform ?? navigator.platform;
+  const navigationData = terminalNavigationShortcutData(event, resolvedPlatform);
+  if (navigationData !== null) {
+    event.preventDefault();
+    return { action: "send", data: navigationData, error: "Failed to move cursor" };
+  }
+
+  const deleteData = terminalDeleteShortcutData(event, resolvedPlatform);
+  if (deleteData !== null) {
+    event.preventDefault();
+    return { action: "send", data: deleteData, error: "Failed to delete terminal input" };
+  }
+
+  if (!isTerminalClearShortcut(event, resolvedPlatform)) {
+    return { action: "encode" };
+  }
+  event.preventDefault();
+  return { action: "send", data: "\u000c", error: "Failed to clear terminal" };
+}

--- a/apps/web/src/lib/terminalCloseShortcut.test.ts
+++ b/apps/web/src/lib/terminalCloseShortcut.test.ts
@@ -77,6 +77,13 @@ describe("terminal close shortcut guards", () => {
     );
   });
 
+  it("does not treat bare Escape as terminal close", () => {
+    const event = keyboardEvent({ key: "Escape", code: "Escape", ctrlKey: false });
+
+    expect(preventTerminalCloseShortcut(event, keybindings, "MacIntel")).toBe(false);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
   it("leaves a non-repeated window close and unrelated repeats alone", () => {
     const deliberateWindowClose = keyboardEvent({ repeat: false });
     const unrelatedRepeat = keyboardEvent({ key: "q", code: "KeyQ", repeat: true });

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -72,6 +72,7 @@ function ChatRouteGlobalShortcuts() {
       }
 
       if (event.key === "Escape" && selectedThreadKeysSize > 0) {
+        if (isTerminalFocused()) return;
         event.preventDefault();
         clearSelection();
         return;

--- a/apps/web/src/terminal/ghostty/runtimeAbi.test.ts
+++ b/apps/web/src/terminal/ghostty/runtimeAbi.test.ts
@@ -631,4 +631,63 @@ describe("vendored libghostty-vt WebAssembly", () => {
     call("ghostty_wasm_free_opaque", terminalSlot);
     free(terminalOptions, 8);
   });
+
+  it("encodes Escape as a C0 ESC byte", async () => {
+    const result = await WebAssembly.instantiate(
+      decodeWasmDataUrl(wasmDataUrl).buffer as ArrayBuffer,
+      { env: { log: () => {} } },
+    );
+    const instance = result instanceof WebAssembly.Instance ? result : result.instance;
+    const memory = instance.exports.memory as WebAssembly.Memory;
+    const call = (name: string, ...args: number[]) =>
+      (instance.exports[name] as WasmFunction)(...args);
+    const alloc = (size: number) => call("ghostty_wasm_alloc_u8_array", size);
+    const free = (pointer: number, size: number) =>
+      call("ghostty_wasm_free_u8_array", pointer, size);
+
+    const terminalOptions = alloc(8);
+    const terminalOptionsView = new DataView(memory.buffer, terminalOptions, 8);
+    terminalOptionsView.setUint16(0, 80, true);
+    terminalOptionsView.setUint16(2, 24, true);
+    const terminalSlot = call("ghostty_wasm_alloc_opaque");
+    expect(call("ghostty_terminal_new", 0, terminalSlot, terminalOptions)).toBe(0);
+    const terminal = new DataView(memory.buffer).getUint32(terminalSlot, true);
+
+    const encoderSlot = call("ghostty_wasm_alloc_opaque");
+    const eventSlot = call("ghostty_wasm_alloc_opaque");
+    expect(call("ghostty_key_encoder_new", 0, encoderSlot)).toBe(0);
+    expect(call("ghostty_key_event_new", 0, eventSlot)).toBe(0);
+    const view = new DataView(memory.buffer);
+    const keyEncoder = view.getUint32(encoderSlot, true);
+    const keyEvent = view.getUint32(eventSlot, true);
+    call("ghostty_key_encoder_setopt_from_terminal", keyEncoder, terminal);
+    call("ghostty_key_event_set_action", keyEvent, 1);
+    call("ghostty_key_event_set_key", keyEvent, ghosttyKeyForCode("Escape"));
+    call("ghostty_key_event_set_mods", keyEvent, 0);
+    call("ghostty_key_event_set_consumed_mods", keyEvent, 0);
+    call("ghostty_key_event_set_composing", keyEvent, 0);
+    call("ghostty_key_event_set_unshifted_codepoint", keyEvent, 0);
+
+    const written = call("ghostty_wasm_alloc_usize");
+    expect(call("ghostty_key_encoder_encode", keyEncoder, keyEvent, 0, 0, written)).toBe(-3);
+    const outputSize = new DataView(memory.buffer, written, 4).getUint32(0, true);
+    const output = alloc(outputSize);
+    expect(
+      call("ghostty_key_encoder_encode", keyEncoder, keyEvent, output, outputSize, written),
+    ).toBe(0);
+    const outputLength = new DataView(memory.buffer, written, 4).getUint32(0, true);
+    expect(new TextDecoder().decode(new Uint8Array(memory.buffer, output, outputLength))).toBe(
+      "\u001b",
+    );
+
+    free(output, outputSize);
+    call("ghostty_wasm_free_usize", written);
+    call("ghostty_key_event_free", keyEvent);
+    call("ghostty_key_encoder_free", keyEncoder);
+    call("ghostty_wasm_free_opaque", eventSlot);
+    call("ghostty_wasm_free_opaque", encoderSlot);
+    call("ghostty_terminal_free", terminal);
+    call("ghostty_wasm_free_opaque", terminalSlot);
+    free(terminalOptions, 8);
+  });
 });


### PR DESCRIPTION
Fixes #6362

Escape in the terminal drawer never reached the PTY, so vim/nvim stayed in insert mode and `:q` could not be entered. Default close is still `mod+w`.

When the terminal has focus and no overlay (command palette, dialog) is open, bare Escape is no longer treated as a close/dismiss chord. `beforeKey` returns true so Ghostty encodes ESC. `mod+w`, split/toggle, and navigation/delete/clear shortcuts are unchanged.

Grok / T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Keyboard routing and terminal UX only; no auth, data, or API changes, with broad unit test coverage.
> 
> **Overview**
> Fixes **bare Escape** being swallowed before it reaches the PTY in the thread terminal, so vim/nvim can use Escape normally; **terminal close stays on `mod+w`**.
> 
> A shared **`decideTerminalBeforeKey`** path now treats unmodified Escape as **encode** (not close), while keeping existing behavior for close, split/toggle, navigation, delete, and clear. **ChatView** and **`_chat`** skip their Escape handlers when the terminal has focus and the command palette is closed, so overlays still own Escape when open. **Thread selection** is no longer cleared by Escape while the terminal is focused.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6248904cdd58ca67b142ed10ab42daf7d6614759. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix bare Escape key pass-through to nvim in the terminal drawer
> - Adds `isBareEscapeKey` and `decideTerminalBeforeKey` utilities in [`terminalBeforeKey.ts`](https://github.com/pingdotgg/t3code/pull/7203/files#diff-a8cfd442e6511e42464c2278ffb8bea0bf73066f126b49084554268ce0073cc9) to consolidate terminal key-handling decisions (encode, suppress, or send a control sequence).
> - Updates the global keydown handler in [`ChatView.tsx`](https://github.com/pingdotgg/t3code/pull/7203/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to skip shortcut processing when a bare Escape is pressed while a terminal has focus and the command palette is closed.
> - Updates [`ThreadTerminalDrawer.tsx`](https://github.com/pingdotgg/t3code/pull/7203/files#diff-09ca7578f1aa1d1aaf5c36202aad25ecde8fb131a58b0c251fd9c03323eb5636) to use `decideTerminalBeforeKey` instead of inline shortcut checks, letting bare Escape reach the PTY.
> - Adds a guard in [`_chat.tsx`](https://github.com/pingdotgg/t3code/pull/7203/files#diff-57ccd85378cde777d8acfd2c8581caf212ad22cf0d96b993b064a9a9f2c77691) so pressing Escape while the terminal is focused no longer clears selected threads.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6248904.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->