### PR TITLE
feat(web): allow customizing topbar header controls visibility via context menu

### DIFF
--- a/apps/web/src/components/chat/ChatHeader.test.ts
+++ b/apps/web/src/components/chat/ChatHeader.test.ts
@@ -95,9 +95,9 @@ describe("buildHeaderControlsContextMenuItems", () => {
       git: true,
     });
     expect(items).toEqual([
-      { id: "scripts", label: "✓ Action scripts" },
-      { id: "openIn", label: "✓ Open in editor" },
-      { id: "git", label: "✓ Git source control" },
+      { id: "scripts", label: "✓\u00A0Action scripts" },
+      { id: "openIn", label: "✓\u00A0Open in editor" },
+      { id: "git", label: "✓\u00A0Git source control" },
     ]);
   });
 
@@ -108,9 +108,9 @@ describe("buildHeaderControlsContextMenuItems", () => {
       git: false,
     });
     expect(items).toEqual([
-      { id: "scripts", label: "   Action scripts" },
-      { id: "openIn", label: "✓ Open in editor" },
-      { id: "git", label: "   Git source control" },
+      { id: "scripts", label: "\u00A0\u00A0Action scripts" },
+      { id: "openIn", label: "✓\u00A0Open in editor" },
+      { id: "git", label: "\u00A0\u00A0Git source control" },
     ]);
   });
 });

--- a/apps/web/src/components/chat/ChatHeader.test.ts
+++ b/apps/web/src/components/chat/ChatHeader.test.ts
@@ -1,7 +1,11 @@
 import { EnvironmentId } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
-import { resolveRenameCommit, shouldShowOpenInPicker } from "./ChatHeader";
+import {
+  buildHeaderControlsContextMenuItems,
+  resolveRenameCommit,
+  shouldShowOpenInPicker,
+} from "./ChatHeader";
 
 describe("shouldShowOpenInPicker", () => {
   const primaryEnvironmentId = EnvironmentId.make("environment-primary");
@@ -80,5 +84,33 @@ describe("resolveRenameCommit", () => {
     expect(resolveRenameCommit({ title: " Old ", originalTitle: "Old" })).toEqual({
       action: "noop",
     });
+  });
+});
+
+describe("buildHeaderControlsContextMenuItems", () => {
+  it("formats checked state when all controls are visible", () => {
+    const items = buildHeaderControlsContextMenuItems({
+      scripts: true,
+      openIn: true,
+      git: true,
+    });
+    expect(items).toEqual([
+      { id: "scripts", label: "✓ Action scripts" },
+      { id: "openIn", label: "✓ Open in editor" },
+      { id: "git", label: "✓ Git source control" },
+    ]);
+  });
+
+  it("formats unchecked state when controls are hidden", () => {
+    const items = buildHeaderControlsContextMenuItems({
+      scripts: false,
+      openIn: true,
+      git: false,
+    });
+    expect(items).toEqual([
+      { id: "scripts", label: "   Action scripts" },
+      { id: "openIn", label: "✓ Open in editor" },
+      { id: "git", label: "   Git source control" },
+    ]);
   });
 });

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -361,21 +361,23 @@ export const ChatHeader = memo(function ChatHeader({
         data-chat-header-actions
         onContextMenu={handleHeaderActionsContextMenu}
         className={cn(
-          "flex shrink-0 items-center justify-end gap-2 @3xl/header-actions:gap-3",
+          "flex h-full min-w-6 shrink-0 items-center justify-end gap-2 @3xl/header-actions:gap-3",
           rightPanelOpen ? "pr-0" : "pr-16",
         )}
       >
-        {visibility.scripts && activeProjectScripts && (
-          <ProjectScriptsControl
-            scripts={activeProjectScripts}
-            fileScripts={fileScripts}
-            keybindings={keybindings}
-            preferredScriptId={preferredScriptId}
-            onRunScript={onRunProjectScript}
-            onAddScript={onAddProjectScript}
-            onUpdateScript={onUpdateProjectScript}
-            onDeleteScript={onDeleteProjectScript}
-          />
+        {activeProjectScripts && (
+          <div className={cn(!visibility.scripts && "hidden")}>
+            <ProjectScriptsControl
+              scripts={activeProjectScripts}
+              fileScripts={fileScripts}
+              keybindings={keybindings}
+              preferredScriptId={preferredScriptId}
+              onRunScript={onRunProjectScript}
+              onAddScript={onAddProjectScript}
+              onUpdateScript={onUpdateProjectScript}
+              onDeleteScript={onDeleteProjectScript}
+            />
+          </div>
         )}
         {showOpenInPicker && (
           <div className={cn(!visibility.openIn && "hidden")}>
@@ -387,13 +389,15 @@ export const ChatHeader = memo(function ChatHeader({
             />
           </div>
         )}
-        {visibility.git && activeProjectName && (
-          <GitActionsControl
-            gitCwd={gitCwd}
-            activeThreadRef={scopeThreadRef(activeThreadEnvironmentId, activeThreadId)}
-            onOpenPullRequest={onOpenPullRequest}
-            {...(draftId ? { draftId } : {})}
-          />
+        {activeProjectName && (
+          <div className={cn(!visibility.git && "hidden")}>
+            <GitActionsControl
+              gitCwd={gitCwd}
+              activeThreadRef={scopeThreadRef(activeThreadEnvironmentId, activeThreadId)}
+              onOpenPullRequest={onOpenPullRequest}
+              {...(draftId ? { draftId } : {})}
+            />
+          </div>
         )}
       </div>
     </div>

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -97,15 +97,15 @@ export function buildHeaderControlsContextMenuItems(
   return [
     {
       id: "scripts",
-      label: `${visibility.scripts ? "✓ " : "   "}Action scripts`,
+      label: `${visibility.scripts ? "✓\u00A0" : "\u00A0\u00A0"}Action scripts`,
     },
     {
       id: "openIn",
-      label: `${visibility.openIn ? "✓ " : "   "}Open in editor`,
+      label: `${visibility.openIn ? "✓\u00A0" : "\u00A0\u00A0"}Open in editor`,
     },
     {
       id: "git",
-      label: `${visibility.git ? "✓ " : "   "}Git source control`,
+      label: `${visibility.git ? "✓\u00A0" : "\u00A0\u00A0"}Git source control`,
     },
   ];
 }
@@ -246,22 +246,13 @@ export const ChatHeader = memo(function ChatHeader({
 
   const handleHeaderContextMenu = useCallback(
     (event: ReactMouseEvent) => {
-      const isActionsArea = Boolean(
-        (event.target as HTMLElement).closest("[data-chat-header-actions]"),
-      );
-      if (isActionsArea) {
+      if ((event.target as HTMLElement).closest("[data-chat-header-actions]")) {
         void handleHeaderActionsContextMenu(event);
         return;
       }
-      const isTitleArea = Boolean(
-        (event.target as HTMLElement).closest("[data-thread-title-anchor]"),
-      );
-      if (isServerThread && renamingTitle === null && isTitleArea) {
-        event.preventDefault();
-        openMenu({ x: event.clientX, y: event.clientY });
-        return;
-      }
-      void handleHeaderActionsContextMenu(event);
+      if (!isServerThread || renamingTitle !== null) return;
+      event.preventDefault();
+      openMenu({ x: event.clientX, y: event.clientY });
     },
     [handleHeaderActionsContextMenu, isServerThread, openMenu, renamingTitle],
   );
@@ -386,13 +377,15 @@ export const ChatHeader = memo(function ChatHeader({
             onDeleteScript={onDeleteProjectScript}
           />
         )}
-        {visibility.openIn && showOpenInPicker && (
-          <OpenInPicker
-            environmentId={activeThreadEnvironmentId}
-            keybindings={keybindings}
-            availableEditors={availableEditors}
-            openInCwd={openInCwd}
-          />
+        {showOpenInPicker && (
+          <div className={cn(!visibility.openIn && "hidden")}>
+            <OpenInPicker
+              environmentId={activeThreadEnvironmentId}
+              keybindings={keybindings}
+              availableEditors={availableEditors}
+              openInCwd={openInCwd}
+            />
+          </div>
         )}
         {visibility.git && activeProjectName && (
           <GitActionsControl

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -1,5 +1,6 @@
 import {
   type EnvironmentId,
+  type ContextMenuItem,
   type EditorId,
   type ProjectScript,
   type ResolvedKeybindingsConfig,
@@ -42,6 +43,8 @@ import {
   WorkspaceBreadcrumbItem,
   WorkspaceBreadcrumbSeparator,
 } from "../WorkspaceBreadcrumb";
+import { readLocalApi } from "~/localApi";
+import { type HeaderControlsVisibility, useHeaderControlsStore } from "~/headerControlsStore";
 import { cn } from "~/lib/utils";
 
 interface ChatHeaderProps {
@@ -86,6 +89,25 @@ export function resolveRenameCommit(input: {
   if (trimmed.length === 0) return { action: "reject-empty" };
   if (trimmed === input.originalTitle) return { action: "noop" };
   return { action: "commit", title: trimmed };
+}
+
+export function buildHeaderControlsContextMenuItems(
+  visibility: HeaderControlsVisibility,
+): readonly ContextMenuItem<keyof HeaderControlsVisibility>[] {
+  return [
+    {
+      id: "scripts",
+      label: `${visibility.scripts ? "✓ " : "   "}Action scripts`,
+    },
+    {
+      id: "openIn",
+      label: `${visibility.openIn ? "✓ " : "   "}Open in editor`,
+    },
+    {
+      id: "git",
+      label: `${visibility.git ? "✓ " : "   "}Git source control`,
+    },
+  ];
 }
 
 export function shouldShowOpenInPicker(input: {
@@ -200,16 +222,48 @@ export const ChatHeader = memo(function ChatHeader({
     if (!rect) return;
     openMenu({ x: rect.left, y: rect.bottom + 4 });
   }, [openMenu]);
+  const visibility = useHeaderControlsStore((state) => state.visibility);
+
+  const handleHeaderActionsContextMenu = useCallback(async (event: ReactMouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const api = readLocalApi();
+    if (!api) return;
+
+    const currentVisibility = useHeaderControlsStore.getState().visibility;
+    const items = buildHeaderControlsContextMenuItems(currentVisibility);
+
+    const selected = await api.contextMenu.show(items, {
+      x: event.clientX,
+      y: event.clientY,
+    });
+
+    if (selected) {
+      useHeaderControlsStore.getState().toggleControl(selected);
+    }
+  }, []);
+
   const handleHeaderContextMenu = useCallback(
     (event: ReactMouseEvent) => {
-      if (!isServerThread || renamingTitle !== null) return;
-      // The right-side controls (git, scripts, open-in) keep their own
-      // behavior; only the breadcrumb area opens the thread menu.
-      if ((event.target as HTMLElement).closest("[data-chat-header-actions]")) return;
-      event.preventDefault();
-      openMenu({ x: event.clientX, y: event.clientY });
+      const isActionsArea = Boolean(
+        (event.target as HTMLElement).closest("[data-chat-header-actions]"),
+      );
+      if (isActionsArea) {
+        void handleHeaderActionsContextMenu(event);
+        return;
+      }
+      const isTitleArea = Boolean(
+        (event.target as HTMLElement).closest("[data-thread-title-anchor]"),
+      );
+      if (isServerThread && renamingTitle === null && isTitleArea) {
+        event.preventDefault();
+        openMenu({ x: event.clientX, y: event.clientY });
+        return;
+      }
+      void handleHeaderActionsContextMenu(event);
     },
-    [isServerThread, openMenu, renamingTitle],
+    [handleHeaderActionsContextMenu, isServerThread, openMenu, renamingTitle],
   );
   const handleRenameKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLInputElement>) => {
@@ -282,6 +336,7 @@ export const ChatHeader = memo(function ChatHeader({
                   <button
                     ref={titleButtonRef}
                     type="button"
+                    data-thread-title-anchor=""
                     aria-label={`Thread actions for ${activeThreadTitle}`}
                     aria-haspopup="menu"
                     onClick={openMenuFromTitle}
@@ -313,12 +368,13 @@ export const ChatHeader = memo(function ChatHeader({
       </WorkspaceBreadcrumb>
       <div
         data-chat-header-actions
+        onContextMenu={handleHeaderActionsContextMenu}
         className={cn(
           "flex shrink-0 items-center justify-end gap-2 @3xl/header-actions:gap-3",
           rightPanelOpen ? "pr-0" : "pr-16",
         )}
       >
-        {activeProjectScripts && (
+        {visibility.scripts && activeProjectScripts && (
           <ProjectScriptsControl
             scripts={activeProjectScripts}
             fileScripts={fileScripts}
@@ -330,7 +386,7 @@ export const ChatHeader = memo(function ChatHeader({
             onDeleteScript={onDeleteProjectScript}
           />
         )}
-        {showOpenInPicker && (
+        {visibility.openIn && showOpenInPicker && (
           <OpenInPicker
             environmentId={activeThreadEnvironmentId}
             keybindings={keybindings}
@@ -338,7 +394,7 @@ export const ChatHeader = memo(function ChatHeader({
             openInCwd={openInCwd}
           />
         )}
-        {activeProjectName && (
+        {visibility.git && activeProjectName && (
           <GitActionsControl
             gitCwd={gitCwd}
             activeThreadRef={scopeThreadRef(activeThreadEnvironmentId, activeThreadId)}

--- a/apps/web/src/headerControlsStore.test.ts
+++ b/apps/web/src/headerControlsStore.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+import { useHeaderControlsStore } from "./headerControlsStore";
+
+describe("headerControlsStore", () => {
+  beforeEach(() => {
+    useHeaderControlsStore.getState().resetVisibility();
+  });
+
+  it("initializes with all controls visible by default", () => {
+    const { visibility } = useHeaderControlsStore.getState();
+    expect(visibility).toEqual({
+      scripts: true,
+      openIn: true,
+      git: true,
+    });
+  });
+
+  it("toggles individual control visibility", () => {
+    useHeaderControlsStore.getState().toggleControl("scripts");
+    expect(useHeaderControlsStore.getState().visibility.scripts).toBe(false);
+    expect(useHeaderControlsStore.getState().visibility.openIn).toBe(true);
+    expect(useHeaderControlsStore.getState().visibility.git).toBe(true);
+
+    useHeaderControlsStore.getState().toggleControl("scripts");
+    expect(useHeaderControlsStore.getState().visibility.scripts).toBe(true);
+  });
+
+  it("sets specific control visibility", () => {
+    useHeaderControlsStore.getState().setControlVisibility("openIn", false);
+    expect(useHeaderControlsStore.getState().visibility.openIn).toBe(false);
+
+    useHeaderControlsStore.getState().setControlVisibility("openIn", true);
+    expect(useHeaderControlsStore.getState().visibility.openIn).toBe(true);
+  });
+
+  it("resets visibility to defaults", () => {
+    useHeaderControlsStore.getState().setControlVisibility("scripts", false);
+    useHeaderControlsStore.getState().setControlVisibility("git", false);
+    expect(useHeaderControlsStore.getState().visibility.scripts).toBe(false);
+    expect(useHeaderControlsStore.getState().visibility.git).toBe(false);
+
+    useHeaderControlsStore.getState().resetVisibility();
+    expect(useHeaderControlsStore.getState().visibility).toEqual({
+      scripts: true,
+      openIn: true,
+      git: true,
+    });
+  });
+});

--- a/apps/web/src/headerControlsStore.ts
+++ b/apps/web/src/headerControlsStore.ts
@@ -1,0 +1,52 @@
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import { resolveStorage } from "./lib/storage";
+
+export interface HeaderControlsVisibility {
+  scripts: boolean;
+  openIn: boolean;
+  git: boolean;
+}
+
+export interface HeaderControlsStoreState {
+  visibility: HeaderControlsVisibility;
+  toggleControl: (control: keyof HeaderControlsVisibility) => void;
+  setControlVisibility: (control: keyof HeaderControlsVisibility, visible: boolean) => void;
+  resetVisibility: () => void;
+}
+
+const DEFAULT_VISIBILITY: HeaderControlsVisibility = {
+  scripts: true,
+  openIn: true,
+  git: true,
+};
+
+export const useHeaderControlsStore = create<HeaderControlsStoreState>()(
+  persist(
+    (set) => ({
+      visibility: DEFAULT_VISIBILITY,
+      toggleControl: (control) =>
+        set((state) => ({
+          visibility: {
+            ...state.visibility,
+            [control]: !state.visibility[control],
+          },
+        })),
+      setControlVisibility: (control, visible) =>
+        set((state) => ({
+          visibility: {
+            ...state.visibility,
+            [control]: visible,
+          },
+        })),
+      resetVisibility: () => set({ visibility: DEFAULT_VISIBILITY }),
+    }),
+    {
+      name: "t3code:header-controls:v1",
+      version: 1,
+      storage: createJSONStorage(() =>
+        resolveStorage(typeof window !== "undefined" ? window.localStorage : undefined),
+      ),
+    },
+  ),
+);


### PR DESCRIPTION
### Summary
Allows users to show or hide the topbar action controls (Action scripts, Open in editor, Git source control) by right-clicking on the header bar or buttons.

### Changes
- Created persistent `useHeaderControlsStore` with localStorage support for action visibility toggles.
- Added context menu on topbar header and action buttons to list and toggle visible controls with checkmarks.
- Conditionally render header action buttons based on user preferences.
- Added unit tests for store and menu helpers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI preference state in localStorage only; no auth, data, or API behavior changes beyond conditional header rendering.
> 
> **Overview**
> Adds a **right-click context menu** on the chat header actions strip so users can show or hide **Action scripts**, **Open in editor**, and **Git source control**. Choices are stored in a new persisted **`useHeaderControlsStore`** (`localStorage` key `t3code:header-controls:v1`); all three default to visible.
> 
> `ChatHeader` wires the menu through the local **`contextMenu.show`** API, toggles visibility on selection, and wraps each control in a container that uses **`hidden`** when turned off. Right-clicks inside **`[data-chat-header-actions]`** open this menu instead of being ignored; the breadcrumb/title area still opens the existing thread actions menu. **`buildHeaderControlsContextMenuItems`** builds checkmarked menu labels; unit tests cover the store and menu helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d2170454cbff3cabdcb87e646d75d3acdf1e9fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add context menu to chat header for toggling header controls visibility
> - Adds a right-click context menu on the header actions area that lets users toggle visibility of Scripts, Open in Editor, and Git controls.
> - Introduces `buildHeaderControlsContextMenuItems` in [ChatHeader.tsx](https://github.com/pingdotgg/t3code/pull/7204/files#diff-124f699b87245f05f11a8bf7ef3d0b17dbe34657c443a51e23125ce90e0fcf0c) to format menu items with checkmark/unchecked indicators based on current visibility.
> - Adds `useHeaderControlsStore` in [headerControlsStore.ts](https://github.com/pingdotgg/t3code/pull/7204/files#diff-d40bdb79016b77bc9de23a1e73a6e08894236b5a2c9eafa5bb43c8be4a081885), a Zustand store that persists visibility state to localStorage under the key `t3code:header-controls:v1`.
> - Behavioral Change: right-clicking within the header actions area now opens the visibility menu instead of the thread context menu.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9d21704.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->