### PR TITLE
fix(swift-ios): preserve live updates during thread loading

### DIFF
--- a/apps/swift-ios/Features/Root/FeatureRootModel.swift
+++ b/apps/swift-ios/Features/Root/FeatureRootModel.swift
@@ -46,6 +46,8 @@ public final class FeatureRootModel {
     private var pendingCompletionSubmissionIDs: Set<String> = []
     private var pendingDiscardSubmissionIDs: Set<String> = []
     private var detailRecency: [String] = []
+    private var detailLoadGeneration: UInt64 = 0
+    private var detailLoadRevisions: [String: UInt64] = [:]
     private var outboxDrainTask: Task<Void, Never>?
     private var outboxRetryAttempt = 0
     private var outboxGeneration: UInt64 = 0
@@ -385,14 +387,21 @@ public final class FeatureRootModel {
             return cached
         }
         let environment = currentEnvironmentIdentity
-        let revisionBeforeLoad = detailRevisions[id]
+        let loadGenerationBeforeLoad = detailLoadGeneration
+        let loadRevisionBeforeLoad = detailLoadRevisions[id]
+        let threadBeforeLoad = snapshot.threads.first { $0.id == id }
         do {
-            let detail = try await client.loadThread(id: id)
+            var detail = try await client.loadThread(id: id)
             guard currentEnvironmentIdentity == environment else {
                 return details[id]
             }
-            if detailRevisions[id] != revisionBeforeLoad {
+            if detailLoadGeneration != loadGenerationBeforeLoad
+                || detailLoadRevisions[id] != loadRevisionBeforeLoad {
                 return details[id]
+            }
+            if let currentThread = snapshot.threads.first(where: { $0.id == id }),
+               currentThread != threadBeforeLoad {
+                detail.thread = currentThread
             }
             store(detail)
             upsert(detail.thread)
@@ -770,6 +779,7 @@ public final class FeatureRootModel {
         guard details[id] != next else { return }
         details[id] = next
         markDetailRecentlyUsed(id)
+        bumpDetailLoadRevision(id: id)
         bumpDetailRevision(id: id, change: .full)
     }
 
@@ -780,6 +790,7 @@ public final class FeatureRootModel {
         let next = addingPendingMessages(to: incoming)
         details[id] = next
         markDetailRecentlyUsed(id)
+        bumpDetailLoadRevision(id: id)
         let appended = next.messages.dropFirst(incoming.messages.count).map(\.id)
         let pendingDelta = FeatureDetailDelta(
             changedMessages: delta.changedMessages + next.messages.dropFirst(incoming.messages.count),
@@ -806,16 +817,23 @@ public final class FeatureRootModel {
         if details.removeValue(forKey: id) != nil {
             detailRecency.removeAll { $0 == id }
         }
+        bumpDetailLoadRevision(id: id)
         bumpDetailRevision(id: id, change: .full)
     }
 
     private func clearDetails() {
+        detailLoadGeneration &+= 1
+        detailLoadRevisions.removeAll()
         guard !details.isEmpty else { return }
         details.removeAll()
         detailRecency.removeAll()
         detailRevision &+= 1
         detailRevisions.removeAll()
         detailRenderUpdates.removeAll()
+    }
+
+    private func bumpDetailLoadRevision(id: String) {
+        detailLoadRevisions[id] = (detailLoadRevisions[id] ?? 0) &+ 1
     }
 
     private func markDetailRecentlyUsed(_ id: String) {

--- a/apps/swift-ios/Features/Root/FeatureRootModel.swift
+++ b/apps/swift-ios/Features/Root/FeatureRootModel.swift
@@ -48,6 +48,7 @@ public final class FeatureRootModel {
     private var detailRecency: [String] = []
     private var detailLoadGeneration: UInt64 = 0
     private var detailLoadRevisions: [String: UInt64] = [:]
+    private var detailMetadataRevisions: [String: UInt64] = [:]
     private var outboxDrainTask: Task<Void, Never>?
     private var outboxRetryAttempt = 0
     private var outboxGeneration: UInt64 = 0
@@ -389,6 +390,7 @@ public final class FeatureRootModel {
         let environment = currentEnvironmentIdentity
         let loadGenerationBeforeLoad = detailLoadGeneration
         let loadRevisionBeforeLoad = detailLoadRevisions[id]
+        let metadataRevisionBeforeLoad = detailMetadataRevisions[id]
         let threadBeforeLoad = snapshot.threads.first { $0.id == id }
         do {
             var detail = try await client.loadThread(id: id)
@@ -399,8 +401,12 @@ public final class FeatureRootModel {
                 || detailLoadRevisions[id] != loadRevisionBeforeLoad {
                 return details[id]
             }
-            if let currentThread = snapshot.threads.first(where: { $0.id == id }),
-               currentThread != threadBeforeLoad {
+            let currentThread = snapshot.threads.first { $0.id == id }
+            if detailMetadataRevisions[id] != metadataRevisionBeforeLoad {
+                if let currentThread = details[id]?.thread ?? currentThread {
+                    detail.thread = currentThread
+                }
+            } else if let currentThread, currentThread != threadBeforeLoad {
                 detail.thread = currentThread
             }
             store(detail)
@@ -659,10 +665,12 @@ public final class FeatureRootModel {
             upsert(value)
             mutateDetail(
                 id: value.id,
-                change: .delta(FeatureDetailDelta(changedMessages: []))
+                change: .delta(FeatureDetailDelta(changedMessages: [])),
+                invalidatesInFlightLoad: false
             ) {
                 $0.thread = value
             }
+            bumpDetailMetadataRevision(id: value.id)
         case let .threadRemoved(id):
             removeThread(id: id)
             removeDetail(id: id)
@@ -721,6 +729,26 @@ public final class FeatureRootModel {
             }
         }
 
+        let previousThreads = snapshot.threads.reduce(into: [String: FeatureThread]()) {
+            $0[$1.id] = $1
+        }
+        let nextThreads = value.threads.reduce(into: [String: FeatureThread]()) {
+            $0[$1.id] = $1
+        }
+        for id in previousThreads.keys where nextThreads[id] == nil {
+            removeDetail(id: id)
+        }
+        for thread in value.threads where previousThreads[thread.id] != thread {
+            mutateDetail(
+                id: thread.id,
+                change: .delta(FeatureDetailDelta(changedMessages: [])),
+                invalidatesInFlightLoad: false
+            ) {
+                $0.thread = thread
+            }
+            bumpDetailMetadataRevision(id: thread.id)
+        }
+
         if snapshot.connection != value.connection
             || snapshot.environments != value.environments
             || snapshot.projects != value.projects
@@ -744,19 +772,25 @@ public final class FeatureRootModel {
         id: String,
         _ mutation: (inout FeatureThread) -> Void
     ) {
+        var metadataChanged = false
         if let index = snapshot.threads.firstIndex(where: { $0.id == id }) {
             let previous = snapshot.threads[index]
             mutation(&snapshot.threads[index])
             if snapshot.threads[index] != previous {
+                metadataChanged = true
                 threadCollectionRevision &+= 1
                 homePresentationRevision &+= 1
             }
         }
-        mutateDetail(
+        let detailChanged = mutateDetail(
             id: id,
-            change: .delta(FeatureDetailDelta(changedMessages: []))
+            change: .delta(FeatureDetailDelta(changedMessages: [])),
+            invalidatesInFlightLoad: false
         ) {
             mutation(&$0.thread)
+        }
+        if metadataChanged || detailChanged {
+            bumpDetailMetadataRevision(id: id)
         }
     }
 
@@ -799,18 +833,24 @@ public final class FeatureRootModel {
         bumpDetailRevision(id: id, change: .delta(pendingDelta))
     }
 
+    @discardableResult
     private func mutateDetail(
         id: String,
         change: FeatureDetailRenderChange = .full,
+        invalidatesInFlightLoad: Bool = true,
         _ mutation: (inout FeatureThreadDetail) -> Void
-    ) {
-        guard var detail = details[id] else { return }
+    ) -> Bool {
+        guard var detail = details[id] else { return false }
         let previous = detail
         mutation(&detail)
-        guard detail != previous else { return }
+        guard detail != previous else { return false }
         details[id] = detail
         markDetailRecentlyUsed(id)
+        if invalidatesInFlightLoad {
+            bumpDetailLoadRevision(id: id)
+        }
         bumpDetailRevision(id: id, change: change)
+        return true
     }
 
     private func removeDetail(id: String) {
@@ -824,16 +864,23 @@ public final class FeatureRootModel {
     private func clearDetails() {
         detailLoadGeneration &+= 1
         detailLoadRevisions.removeAll()
-        guard !details.isEmpty else { return }
+        detailMetadataRevisions.removeAll()
+        let hadDetails = !details.isEmpty
         details.removeAll()
         detailRecency.removeAll()
-        detailRevision &+= 1
+        if hadDetails {
+            detailRevision &+= 1
+        }
         detailRevisions.removeAll()
         detailRenderUpdates.removeAll()
     }
 
     private func bumpDetailLoadRevision(id: String) {
         detailLoadRevisions[id] = (detailLoadRevisions[id] ?? 0) &+ 1
+    }
+
+    private func bumpDetailMetadataRevision(id: String) {
+        detailMetadataRevisions[id] = (detailMetadataRevisions[id] ?? 0) &+ 1
     }
 
     private func markDetailRecentlyUsed(_ id: String) {

--- a/apps/swift-ios/Features/Root/FeatureRootModel.swift
+++ b/apps/swift-ios/Features/Root/FeatureRootModel.swift
@@ -391,8 +391,8 @@ public final class FeatureRootModel {
             guard currentEnvironmentIdentity == environment else {
                 return details[id]
             }
-            if detailRevisions[id] != revisionBeforeLoad, let liveDetail = details[id] {
-                return liveDetail
+            if detailRevisions[id] != revisionBeforeLoad {
+                return details[id]
             }
             store(detail)
             upsert(detail.thread)
@@ -803,8 +803,9 @@ public final class FeatureRootModel {
     }
 
     private func removeDetail(id: String) {
-        guard details.removeValue(forKey: id) != nil else { return }
-        detailRecency.removeAll { $0 == id }
+        if details.removeValue(forKey: id) != nil {
+            detailRecency.removeAll { $0 == id }
+        }
         bumpDetailRevision(id: id, change: .full)
     }
 

--- a/apps/swift-ios/Features/Root/FeatureRootModel.swift
+++ b/apps/swift-ios/Features/Root/FeatureRootModel.swift
@@ -48,6 +48,8 @@ public final class FeatureRootModel {
     private var detailRecency: [String] = []
     private var detailLoadGeneration: UInt64 = 0
     private var detailLoadRevisions: [String: UInt64] = [:]
+    private var detailLoadRequestRevision: UInt64 = 0
+    private var storedDetailLoadRequestRevisions: [String: UInt64] = [:]
     private var detailMetadataRevisions: [String: UInt64] = [:]
     private var outboxDrainTask: Task<Void, Never>?
     private var outboxRetryAttempt = 0
@@ -392,6 +394,8 @@ public final class FeatureRootModel {
         let loadRevisionBeforeLoad = detailLoadRevisions[id]
         let metadataRevisionBeforeLoad = detailMetadataRevisions[id]
         let threadBeforeLoad = snapshot.threads.first { $0.id == id }
+        detailLoadRequestRevision &+= 1
+        let loadRequestRevision = detailLoadRequestRevision
         do {
             var detail = try await client.loadThread(id: id)
             guard currentEnvironmentIdentity == environment else {
@@ -399,6 +403,10 @@ public final class FeatureRootModel {
             }
             if detailLoadGeneration != loadGenerationBeforeLoad
                 || detailLoadRevisions[id] != loadRevisionBeforeLoad {
+                return details[id]
+            }
+            if let storedLoadRequestRevision = storedDetailLoadRequestRevisions[id],
+               loadRequestRevision < storedLoadRequestRevision {
                 return details[id]
             }
             let currentThread = snapshot.threads.first { $0.id == id }
@@ -409,7 +417,8 @@ public final class FeatureRootModel {
             } else if let currentThread, currentThread != threadBeforeLoad {
                 detail.thread = currentThread
             }
-            store(detail)
+            store(detail, invalidatesInFlightLoad: false)
+            storedDetailLoadRequestRevisions[id] = loadRequestRevision
             upsert(detail.thread)
             return detail
         } catch {
@@ -427,7 +436,7 @@ public final class FeatureRootModel {
         do {
             guard let detail = try await client.loadEarlierThreadTurns(id: id),
                   currentEnvironmentIdentity == environment else { return }
-            store(detail)
+            store(detail, invalidatesInFlightLoad: false)
         } catch {
             if !Self.isBenignCancellation(error) {
                 errorMessage = error.localizedDescription
@@ -802,7 +811,10 @@ public final class FeatureRootModel {
         }
     }
 
-    private func store(_ incoming: FeatureThreadDetail) {
+    private func store(
+        _ incoming: FeatureThreadDetail,
+        invalidatesInFlightLoad: Bool = true
+    ) {
         let incoming = retainingLocalAttachmentPreviews(in: incoming)
         let id = incoming.thread.id
         acknowledgeDeliveredMessages(incoming.messages)
@@ -821,7 +833,9 @@ public final class FeatureRootModel {
         guard details[id] != next else { return }
         details[id] = next
         markDetailRecentlyUsed(id)
-        bumpDetailLoadRevision(id: id)
+        if invalidatesInFlightLoad {
+            bumpDetailLoadRevision(id: id)
+        }
         bumpDetailRevision(id: id, change: .full)
     }
 
@@ -865,6 +879,7 @@ public final class FeatureRootModel {
         if details.removeValue(forKey: id) != nil {
             detailRecency.removeAll { $0 == id }
         }
+        storedDetailLoadRequestRevisions.removeValue(forKey: id)
         bumpDetailLoadRevision(id: id)
         bumpDetailRevision(id: id, change: .full)
     }
@@ -872,6 +887,7 @@ public final class FeatureRootModel {
     private func clearDetails() {
         detailLoadGeneration &+= 1
         detailLoadRevisions.removeAll()
+        storedDetailLoadRequestRevisions.removeAll()
         detailMetadataRevisions.removeAll()
         let hadDetails = !details.isEmpty
         details.removeAll()

--- a/apps/swift-ios/Features/Root/FeatureRootModel.swift
+++ b/apps/swift-ios/Features/Root/FeatureRootModel.swift
@@ -663,14 +663,6 @@ public final class FeatureRootModel {
         case let .thread(value):
             acknowledgeAuthoritativeThread(value.id)
             upsert(value)
-            mutateDetail(
-                id: value.id,
-                change: .delta(FeatureDetailDelta(changedMessages: [])),
-                invalidatesInFlightLoad: false
-            ) {
-                $0.thread = value
-            }
-            bumpDetailMetadataRevision(id: value.id)
         case let .threadRemoved(id):
             removeThread(id: id)
             removeDetail(id: id)
@@ -686,20 +678,36 @@ public final class FeatureRootModel {
     }
 
     private func upsert(_ thread: FeatureThread) {
+        var metadataChanged = false
         if let index = snapshot.threads.firstIndex(where: { $0.id == thread.id }) {
             let previous = snapshot.threads[index]
-            guard previous != thread else { return }
-            snapshot.threads[index] = thread
-            if previous.projectID != thread.projectID {
-                adjustProjectCount(id: previous.projectID, by: -1)
-                adjustProjectCount(id: thread.projectID, by: 1)
+            if previous != thread {
+                snapshot.threads[index] = thread
+                metadataChanged = true
+                if previous.projectID != thread.projectID {
+                    adjustProjectCount(id: previous.projectID, by: -1)
+                    adjustProjectCount(id: thread.projectID, by: 1)
+                }
             }
         } else {
             snapshot.threads.append(thread)
             adjustProjectCount(id: thread.projectID, by: 1)
+            metadataChanged = true
         }
-        threadCollectionRevision &+= 1
-        homePresentationRevision &+= 1
+        if metadataChanged {
+            threadCollectionRevision &+= 1
+            homePresentationRevision &+= 1
+        }
+        let detailChanged = mutateDetail(
+            id: thread.id,
+            change: .delta(FeatureDetailDelta(changedMessages: [])),
+            invalidatesInFlightLoad: false
+        ) {
+            $0.thread = thread
+        }
+        if metadataChanged || detailChanged {
+            bumpDetailMetadataRevision(id: thread.id)
+        }
     }
 
     private func removeThread(id: String) {

--- a/apps/swift-ios/Features/Root/FeatureRootModel.swift
+++ b/apps/swift-ios/Features/Root/FeatureRootModel.swift
@@ -385,10 +385,14 @@ public final class FeatureRootModel {
             return cached
         }
         let environment = currentEnvironmentIdentity
+        let revisionBeforeLoad = detailRevisions[id]
         do {
             let detail = try await client.loadThread(id: id)
             guard currentEnvironmentIdentity == environment else {
                 return details[id]
+            }
+            if detailRevisions[id] != revisionBeforeLoad, let liveDetail = details[id] {
+                return liveDetail
             }
             store(detail)
             upsert(detail.thread)

--- a/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
@@ -924,6 +924,37 @@ struct FeatureRootModelTests {
     }
 
     @Test
+    func initialDetailLoadDoesNotRestoreRemovedThread() async {
+        let client = FeatureClientStub()
+        let thread = FeatureThread(id: "thread-1", projectID: "project-1", title: "Thread")
+        client.snapshot = FeatureSnapshot(threads: [thread])
+        client.threadDetail = FeatureThreadDetail(
+            thread: thread,
+            messages: [FeatureMessage(id: "message-1", role: .assistant, text: "Initial")]
+        )
+        let model = testRootModel(client: client)
+        let run = Task { await model.start() }
+        client.beforeLoadThreadReturn = {
+            await withCheckedContinuation { continuation in
+                withObservationTracking {
+                    _ = model.detailRevisions[thread.id]
+                } onChange: {
+                    continuation.resume()
+                }
+                client.emit(.threadRemoved(id: thread.id))
+            }
+        }
+
+        let loaded = await model.detail(for: thread.id, force: true)
+        client.finishEvents()
+        await run.value
+
+        #expect(loaded == nil)
+        #expect(model.details[thread.id] == nil)
+        #expect(model.snapshot.threads.isEmpty)
+    }
+
+    @Test
     func environmentScopedCatalogAndPreferencesInvalidateHomePresentation() async {
         let client = FeatureClientStub()
         let model = testRootModel(client: client)

--- a/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
@@ -955,20 +955,20 @@ struct FeatureRootModelTests {
     }
 
     @Test
-    func initialDetailLoadMergesNewerThreadMetadata() async {
+    func initialDetailLoadMergesLatestThreadMetadata() async {
         let client = FeatureClientStub()
         let thread = FeatureThread(id: "thread-1", projectID: "project-1", title: "Original")
-        let updatedThread = FeatureThread(
+        let intermediateThread = FeatureThread(
             id: thread.id,
             projectID: thread.projectID,
-            title: "Updated"
+            title: "Intermediate"
         )
         let cached = FeatureThreadDetail(
             thread: thread,
             messages: [FeatureMessage(id: "message-1", role: .assistant, text: "Cached")]
         )
         let refreshed = FeatureThreadDetail(
-            thread: thread,
+            thread: intermediateThread,
             messages: [FeatureMessage(id: "message-2", role: .assistant, text: "Refreshed")]
         )
         client.snapshot = FeatureSnapshot(threads: [thread])
@@ -984,7 +984,15 @@ struct FeatureRootModelTests {
                 } onChange: {
                     continuation.resume()
                 }
-                client.emit(.thread(updatedThread))
+                client.emit(.thread(intermediateThread))
+            }
+            await withCheckedContinuation { continuation in
+                withObservationTracking {
+                    _ = model.details[thread.id]?.thread
+                } onChange: {
+                    continuation.resume()
+                }
+                client.emit(.thread(thread))
             }
         }
 
@@ -992,10 +1000,118 @@ struct FeatureRootModelTests {
         client.finishEvents()
         await run.value
 
-        #expect(loaded?.thread == updatedThread)
+        #expect(loaded?.thread == thread)
         #expect(loaded?.messages == refreshed.messages)
         #expect(model.details[thread.id] == loaded)
-        #expect(model.snapshot.threads == [updatedThread])
+        #expect(model.snapshot.threads == [thread])
+    }
+
+    @Test
+    func initialDetailLoadDoesNotRestoreResolvedApproval() async {
+        let client = FeatureClientStub()
+        let thread = FeatureThread(id: "thread-1", projectID: "project-1", title: "Thread")
+        let approval = FeatureApproval(
+            id: "approval-1",
+            threadID: thread.id,
+            kind: .command,
+            title: "Run command",
+            detail: "swift test"
+        )
+        let stale = FeatureThreadDetail(thread: thread, approvals: [approval])
+        client.threadDetail = stale
+        let model = testRootModel(client: client)
+        _ = await model.detail(for: thread.id)
+        client.beforeLoadThreadReturn = {
+            await model.resolveApproval(approval.id, decision: .allowOnce)
+        }
+
+        let loaded = await model.detail(for: thread.id, force: true)
+
+        #expect(loaded?.approvals.isEmpty == true)
+        #expect(model.details[thread.id]?.approvals.isEmpty == true)
+    }
+
+    @Test
+    func initialDetailLoadDoesNotRestoreThreadRemovedBySnapshot() async {
+        let client = FeatureClientStub()
+        let thread = FeatureThread(id: "thread-1", projectID: "project-1", title: "Thread")
+        client.snapshot = FeatureSnapshot(threads: [thread])
+        client.threadDetail = FeatureThreadDetail(
+            thread: thread,
+            messages: [FeatureMessage(id: "message-1", role: .assistant, text: "Initial")]
+        )
+        let model = testRootModel(client: client)
+        let run = Task { await model.start() }
+        client.beforeLoadThreadReturn = {
+            await withCheckedContinuation { continuation in
+                withObservationTracking {
+                    _ = model.detailRevisions[thread.id]
+                } onChange: {
+                    continuation.resume()
+                }
+                client.emit(.snapshot(FeatureSnapshot()))
+            }
+        }
+
+        let loaded = await model.detail(for: thread.id, force: true)
+        client.finishEvents()
+        await run.value
+
+        #expect(loaded == nil)
+        #expect(model.details[thread.id] == nil)
+        #expect(model.snapshot.threads.isEmpty)
+    }
+
+    @Test
+    func initialDetailLoadMergesLatestSnapshotMetadata() async {
+        let client = FeatureClientStub()
+        let thread = FeatureThread(id: "thread-1", projectID: "project-1", title: "Original")
+        let intermediateThread = FeatureThread(
+            id: thread.id,
+            projectID: thread.projectID,
+            title: "Intermediate"
+        )
+        let cached = FeatureThreadDetail(
+            thread: thread,
+            messages: [FeatureMessage(id: "message-1", role: .assistant, text: "Cached")]
+        )
+        let refreshed = FeatureThreadDetail(
+            thread: intermediateThread,
+            messages: [FeatureMessage(id: "message-2", role: .assistant, text: "Refreshed")]
+        )
+        client.snapshot = FeatureSnapshot(threads: [thread])
+        client.threadDetail = cached
+        let model = testRootModel(client: client)
+        _ = await model.detail(for: thread.id)
+        client.threadDetail = refreshed
+        let run = Task { await model.start() }
+        client.beforeLoadThreadReturn = {
+            await withCheckedContinuation { continuation in
+                withObservationTracking {
+                    _ = model.details[thread.id]?.thread
+                } onChange: {
+                    continuation.resume()
+                }
+                client.emit(.snapshot(FeatureSnapshot(threads: [intermediateThread])))
+            }
+            await withCheckedContinuation { continuation in
+                withObservationTracking {
+                    _ = model.details[thread.id]?.thread
+                } onChange: {
+                    continuation.resume()
+                }
+                client.emit(.snapshot(FeatureSnapshot(threads: [thread])))
+            }
+        }
+
+        let loaded = await model.detail(for: thread.id, force: true)
+        client.finishEvents()
+        await run.value
+
+        #expect(loaded?.thread == thread)
+        #expect(loaded?.messages == refreshed.messages)
+        #expect(model.details[thread.id] == loaded)
+        #expect(model.snapshot.threads == [thread])
     }
 
     @Test

--- a/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Observation
 import SwiftUI
 import Testing
 import UIKit
@@ -889,6 +890,40 @@ struct FeatureRootModelTests {
     }
 
     @Test
+    func initialDetailLoadDoesNotOverwriteNewerLiveUpdate() async {
+        let client = FeatureClientStub()
+        let thread = FeatureThread(id: "thread-1", projectID: "project-1", title: "Thread")
+        let initial = FeatureThreadDetail(
+            thread: thread,
+            messages: [FeatureMessage(id: "message-1", role: .assistant, text: "Initial")]
+        )
+        let live = FeatureThreadDetail(
+            thread: thread,
+            messages: [FeatureMessage(id: "message-2", role: .assistant, text: "Live")]
+        )
+        client.threadDetail = initial
+        let model = testRootModel(client: client)
+        let run = Task { await model.start() }
+        client.beforeLoadThreadReturn = {
+            await withCheckedContinuation { continuation in
+                withObservationTracking {
+                    _ = model.details[thread.id]
+                } onChange: {
+                    continuation.resume()
+                }
+                client.emit(.detail(live))
+            }
+        }
+
+        let loaded = await model.detail(for: thread.id, force: true)
+        client.finishEvents()
+        await run.value
+
+        #expect(loaded == live)
+        #expect(model.details[thread.id] == live)
+    }
+
+    @Test
     func environmentScopedCatalogAndPreferencesInvalidateHomePresentation() async {
         let client = FeatureClientStub()
         let model = testRootModel(client: client)
@@ -1336,6 +1371,7 @@ private final class FeatureClientStub: FeatureClient {
     var removedEnvironmentID: String?
     var beforeSendMessage: (() throws -> Void)?
     var loadThreadError: (any Error)?
+    var beforeLoadThreadReturn: (() async -> Void)?
     var loadEarlierCallCount = 0
     var resolvedInputID: String?
     var resolvedInputAnswers: [String: FeatureInputAnswer]?
@@ -1445,6 +1481,7 @@ private final class FeatureClientStub: FeatureClient {
         if let loadThreadError {
             throw loadThreadError
         }
+        await beforeLoadThreadReturn?()
         if let threadDetail {
             return threadDetail
         }

--- a/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
@@ -955,6 +955,50 @@ struct FeatureRootModelTests {
     }
 
     @Test
+    func initialDetailLoadMergesNewerThreadMetadata() async {
+        let client = FeatureClientStub()
+        let thread = FeatureThread(id: "thread-1", projectID: "project-1", title: "Original")
+        let updatedThread = FeatureThread(
+            id: thread.id,
+            projectID: thread.projectID,
+            title: "Updated"
+        )
+        let cached = FeatureThreadDetail(
+            thread: thread,
+            messages: [FeatureMessage(id: "message-1", role: .assistant, text: "Cached")]
+        )
+        let refreshed = FeatureThreadDetail(
+            thread: thread,
+            messages: [FeatureMessage(id: "message-2", role: .assistant, text: "Refreshed")]
+        )
+        client.snapshot = FeatureSnapshot(threads: [thread])
+        client.threadDetail = cached
+        let model = testRootModel(client: client)
+        _ = await model.detail(for: thread.id)
+        client.threadDetail = refreshed
+        let run = Task { await model.start() }
+        client.beforeLoadThreadReturn = {
+            await withCheckedContinuation { continuation in
+                withObservationTracking {
+                    _ = model.details[thread.id]?.thread
+                } onChange: {
+                    continuation.resume()
+                }
+                client.emit(.thread(updatedThread))
+            }
+        }
+
+        let loaded = await model.detail(for: thread.id, force: true)
+        client.finishEvents()
+        await run.value
+
+        #expect(loaded?.thread == updatedThread)
+        #expect(loaded?.messages == refreshed.messages)
+        #expect(model.details[thread.id] == loaded)
+        #expect(model.snapshot.threads == [updatedThread])
+    }
+
+    @Test
     func environmentScopedCatalogAndPreferencesInvalidateHomePresentation() async {
         let client = FeatureClientStub()
         let model = testRootModel(client: client)

--- a/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
@@ -923,6 +923,120 @@ struct FeatureRootModelTests {
         #expect(model.details[thread.id] == live)
     }
 
+    @Test(
+        "Later overlapping detail load wins for either completion order",
+        .bug("https://github.com/pingdotgg/t3code/pull/7206#discussion_r3816827717"),
+        arguments: [[1, 2], [2, 1]]
+    )
+    func laterOverlappingDetailLoadWins(completionOrder: [Int]) async throws {
+        let client = FeatureClientStub()
+        let thread = FeatureThread(id: "thread-1", projectID: "project-1", title: "Thread")
+        let initial = FeatureThreadDetail(
+            thread: thread,
+            messages: [FeatureMessage(id: "message-1", role: .assistant, text: "Initial")]
+        )
+        let refreshed = FeatureThreadDetail(
+            thread: thread,
+            messages: [FeatureMessage(id: "message-2", role: .assistant, text: "Refreshed")]
+        )
+        let loadStarted = AsyncStream<Int>.makeStream()
+        var loadIndex = 0
+        var loadContinuations: [Int: CheckedContinuation<FeatureThreadDetail, Never>] = [:]
+        defer {
+            loadStarted.continuation.finish()
+            for continuation in loadContinuations.values {
+                continuation.resume(returning: refreshed)
+            }
+        }
+        client.loadThreadHandler = { _ in
+            loadIndex += 1
+            let index = loadIndex
+            loadStarted.continuation.yield(index)
+            return await withCheckedContinuation { continuation in
+                loadContinuations[index] = continuation
+            }
+        }
+        let model = testRootModel(client: client)
+        var starts = loadStarted.stream.makeAsyncIterator()
+
+        let initialLoad = Task { await model.detail(for: thread.id, force: true) }
+        let firstStart = await starts.next()
+        #expect(firstStart == 1)
+        let refresh = Task { await model.detail(for: thread.id, force: true) }
+        let secondStart = await starts.next()
+        #expect(secondStart == 2)
+
+        for index in completionOrder {
+            let pendingContinuation = loadContinuations.removeValue(forKey: index)
+            let continuation = try #require(pendingContinuation)
+            continuation.resume(returning: index == 1 ? initial : refreshed)
+            if index == 1 {
+                _ = await initialLoad.value
+            } else {
+                _ = await refresh.value
+            }
+        }
+
+        let expectedInitialResult = completionOrder.first == 1 ? initial : refreshed
+        #expect(await initialLoad.value == expectedInitialResult)
+        #expect(await refresh.value == refreshed)
+        #expect(model.details[thread.id] == refreshed)
+    }
+
+    @Test(
+        "Pagination does not cancel an overlapping detail refresh",
+        .bug("https://github.com/pingdotgg/t3code/pull/7206#discussion_r3816827717")
+    )
+    func paginationDoesNotCancelOverlappingDetailRefresh() async throws {
+        let client = FeatureClientStub()
+        let thread = FeatureThread(id: "thread-1", projectID: "project-1", title: "Thread")
+        let cached = FeatureThreadDetail(
+            thread: thread,
+            messages: [FeatureMessage(id: "message-2", role: .assistant, text: "Cached")],
+            page: FeatureThreadPage(beforeCursor: "cursor-1", hasMore: true)
+        )
+        let paginated = FeatureThreadDetail(
+            thread: thread,
+            messages: [
+                FeatureMessage(id: "message-1", role: .user, text: "Earlier"),
+                cached.messages[0],
+            ],
+            page: FeatureThreadPage(beforeCursor: nil, hasMore: false)
+        )
+        let refreshed = FeatureThreadDetail(
+            thread: thread,
+            messages: [FeatureMessage(id: "message-3", role: .assistant, text: "Refreshed")]
+        )
+        client.threadDetail = cached
+        client.earlierThreadDetail = paginated
+        let model = testRootModel(client: client)
+        _ = await model.detail(for: thread.id)
+
+        let loadStarted = AsyncStream<Void>.makeStream()
+        var refreshContinuation: CheckedContinuation<FeatureThreadDetail, Never>?
+        defer {
+            loadStarted.continuation.finish()
+            refreshContinuation?.resume(returning: refreshed)
+        }
+        client.loadThreadHandler = { _ in
+            loadStarted.continuation.yield(())
+            return await withCheckedContinuation { continuation in
+                refreshContinuation = continuation
+            }
+        }
+        var starts = loadStarted.stream.makeAsyncIterator()
+
+        let refresh = Task { await model.detail(for: thread.id, force: true) }
+        _ = await starts.next()
+        await model.loadEarlierTurns(for: thread.id)
+        let continuation = try #require(refreshContinuation)
+        refreshContinuation = nil
+        continuation.resume(returning: refreshed)
+
+        #expect(await refresh.value == refreshed)
+        #expect(model.details[thread.id]?.messages == refreshed.messages)
+    }
+
     @Test
     func initialDetailLoadDoesNotRestoreRemovedThread() async {
         let client = FeatureClientStub()
@@ -1627,6 +1741,7 @@ private final class FeatureClientStub: FeatureClient {
     var removedEnvironmentID: String?
     var beforeSendMessage: (() throws -> Void)?
     var loadThreadError: (any Error)?
+    var loadThreadHandler: ((String) async throws -> FeatureThreadDetail)?
     var beforeLoadThreadReturn: (() async -> Void)?
     var loadEarlierCallCount = 0
     var resolvedInputID: String?
@@ -1736,6 +1851,9 @@ private final class FeatureClientStub: FeatureClient {
     func loadThread(id: String) async throws -> FeatureThreadDetail {
         if let loadThreadError {
             throw loadThreadError
+        }
+        if let loadThreadHandler {
+            return try await loadThreadHandler(id)
         }
         await beforeLoadThreadReturn?()
         if let threadDetail {

--- a/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
@@ -1007,6 +1007,71 @@ struct FeatureRootModelTests {
     }
 
     @Test
+    func initialDetailLoadKeepsMetadataFromThreadCreatedDuringLoad() async {
+        let client = FeatureClientStub()
+        let original = FeatureThread(id: "thread-1", projectID: "project-1", title: "Original")
+        let live = FeatureThread(id: original.id, projectID: original.projectID, title: "Live")
+        let created = FeatureThread(id: original.id, projectID: original.projectID, title: "Created")
+        client.snapshot = FeatureSnapshot(threads: [original])
+        client.threadDetail = FeatureThreadDetail(thread: original)
+        let model = testRootModel(client: client)
+        _ = await model.detail(for: original.id)
+        let run = Task { await model.start() }
+        client.createdThread = created
+        client.beforeLoadThreadReturn = {
+            await withCheckedContinuation { continuation in
+                withObservationTracking {
+                    _ = model.details[original.id]?.thread
+                } onChange: {
+                    continuation.resume()
+                }
+                client.emit(.thread(live))
+            }
+            _ = await model.createThread(projectID: original.projectID, title: nil, selection: nil)
+        }
+
+        let loaded = await model.detail(for: original.id, force: true)
+        client.finishEvents()
+        await run.value
+
+        #expect(loaded?.thread == created)
+        #expect(model.details[original.id]?.thread == created)
+        #expect(model.snapshot.threads == [created])
+    }
+
+    @Test
+    func duplicateThreadEventDuringRefreshDoesNotDiscardLoadedMetadata() async {
+        let client = FeatureClientStub()
+        let original = FeatureThread(id: "thread-1", projectID: "project-1", title: "Original")
+        let refreshed = FeatureThread(id: original.id, projectID: original.projectID, title: "Refreshed")
+        client.snapshot = FeatureSnapshot(threads: [original])
+        client.threadDetail = FeatureThreadDetail(thread: original)
+        let model = testRootModel(client: client)
+        _ = await model.detail(for: original.id)
+        client.threadDetail = FeatureThreadDetail(thread: refreshed)
+        let run = Task { await model.start() }
+        client.beforeLoadThreadReturn = {
+            await withCheckedContinuation { continuation in
+                withObservationTracking {
+                    _ = model.snapshot.connection
+                } onChange: {
+                    continuation.resume()
+                }
+                client.emit(.thread(original))
+                client.emit(.connection(.init(state: .connected)))
+            }
+        }
+
+        let loaded = await model.detail(for: original.id, force: true)
+        client.finishEvents()
+        await run.value
+
+        #expect(loaded?.thread == refreshed)
+        #expect(model.details[original.id]?.thread == refreshed)
+        #expect(model.snapshot.threads == [refreshed])
+    }
+
+    @Test
     func initialDetailLoadDoesNotRestoreResolvedApproval() async {
         let client = FeatureClientStub()
         let thread = FeatureThread(id: "thread-1", projectID: "project-1", title: "Thread")


### PR DESCRIPTION
## What Changed

Prevent an initial or forced SwiftUI thread-detail load from overwriting a newer live detail received while that request is in flight.

The model separately tracks detail changes that invalidate an in-flight load and metadata changes that can be merged into a refreshed result. Late loads cannot restore removed threads, resolved requests, or superseded live detail; accepted refreshes retain the latest thread metadata.

## Why

A slower history response could arrive after a newer live thread event and replace the current messages with stale content. The revision check resolves that race at the model boundary without changing the server or UI.

## Validation

- `FeatureRootModelTests` on iPhone 17 Simulator / iOS 26.5: **39 passed, 0 failed**.
- Eight race regressions passed, including live-detail preservation, granular and snapshot removal, resolved approval preservation, granular and snapshot metadata ABA handling, snapshot/detail synchronization, and duplicate-event handling.
- The original feature commit retains the stable patch ID of the approved personal Commit 1 patch.
- Frozen-diff standards review: no actionable findings.
- Frozen-diff behavior/spec review: no actionable findings.
- Swift concurrency and Swift Testing review: no actionable findings.
- Automated review findings were resolved by `2c56001bc`, `6491c5da2`, `81d5b27e6`, and `dbd6396fc``, with a fresh frozen-diff review after each correction.
- Independent Claude Opus 5 review was attempted but unavailable because the weekly quota was exhausted; no Claude review is claimed.

Delivery: **direct**

Validated against Theo commit: `f6b2005e38a66a2f547e42f94b6a619565ae5af5`

Depends on: **None**

Merge order: **This PR only**

Validation status: **Local 39/39 passed; required upstream checks, Cursor, and Macroscope correctness pass on dbd6396fc; Macroscope approvability is neutral/not eligible and the fork-only Vercel preview requires authorization; cross-provider review unavailable due quota**

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] UI screenshots are not applicable; this changes model behavior only
- [x] Video is not applicable; this changes no motion or interaction UI

Built with GPT-5.6 Sol (high reasoning) in T3 Code’s Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core iOS thread-detail state and in-flight load races. Logic is local to FeatureRootModel and covered by new race tests, but incorrect revision handling could still show stale or dropped transcript content.
> 
> **Overview**
> Prevents a slower `detail(for:)` (or pagination) response from replacing newer live thread content that arrived while the request was in flight.
> 
> `FeatureRootModel` now tracks load vs metadata revisions separately. Live detail/delta stores still invalidate in-flight loads; metadata-only upserts, snapshot thread merges, and pagination do not. A completed load is dropped if generation/load revision changed, a later overlapping load already stored, or the thread was removed. Accepted refreshes keep the latest in-memory thread metadata instead of restoring stale titles.
> 
> Tests cover live-update wins, overlapping load completion order, pagination vs refresh, removal/snapshot races, resolved approvals, and ABA metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4371014edd54a1f978596bd7110e739d57b6f941. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `FeatureRootModel` to preserve live updates during thread loading
> - Adds per-thread and global load-generation/revision tracking so `FeatureRootModel.detail(for:force:)` can detect stale loads after `client.loadThread(id:)` completes and early-return instead of overwriting newer state
> - Introduces `invalidatesInFlightLoad` parameter on `store(detail:)`, `mutateDetail(id:change:invalidatesInFlightLoad:)`, and related paths; `loadEarlierTurns(for:)`, `upsert`, `mutateThread`, and snapshot processing now push metadata into stored details without canceling concurrent refreshes
> - `detail(for:force:)` merges the latest thread metadata from events/snapshots into the loaded detail before storing; `removeDetail(id:)` and `clearDetails` bump generations to invalidate overlapping loads
> - Adds tests in [FeatureRootModelTests.swift](https://github.com/pingdotgg/t3code/pull/7206/files#diff-1e4ac0ac4ebcb0caa93c349c4c0975c383f3a6f20e87fbff4435dc204530c325) covering load ordering, metadata merging, pagination vs refresh, and removal semantics
> - Behavioral Change: `mutateDetail` now returns a `Bool` (was `Void`) and `store(detail:)` accepts an extra `invalidatesInFlightLoad` parameter with a default of `true`; out-of-tree callers passing positional arguments after the first may need adjustment
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4371014.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


Coordination trace: saphid/t3code-personal#83 · babysat by coordinator T3 thread 59B2463D-00DF-45D3-86C7-3765AEFEA109 (PR predates the per-thread trace protocol)
