### PR TITLE
fix(web): fix subagent row left border being cut off

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -2195,7 +2195,7 @@ const AgentSpawnCtaRow = memo(function AgentSpawnCtaRow(props: { workEntry: Time
     <button
       type="button"
       onClick={onOpenAgents}
-      className="-mx-1 flex w-full items-center gap-2 rounded-md border border-border/60 bg-card/50 px-2.5 py-1.5 text-left text-[13px] transition hover:bg-accent/50"
+      className="flex w-full items-center gap-2 rounded-md border border-border/60 bg-card/50 px-2.5 py-1.5 text-left text-[13px] transition hover:bg-accent/50"
     >
       <span aria-hidden className={cn("size-1.5 shrink-0 rounded-full", dotClass)} />
       <WorkEntryIconSvg name="bot" className="size-3.5 shrink-0 text-muted-foreground" />


### PR DESCRIPTION
## What Changed

The subagent spawn summary no longer shifts outside the clipped chat timeline. Removing its redundant negative horizontal margin keeps the rounded left border visible while preserving the full-width row.

## Why

The surrounding work-group layout already balances its negative margin with matching padding. The nested `-mx-1` moved the subagent row four pixels past the timeline boundary, where horizontal overflow clipping hid its left edge.

## UI Changes

| Before | After |
| --- | --- |
| ![Before: the subagent row's left edge is clipped](https://raw.githubusercontent.com/sameerr03/t3code/pr-assets-agent-row-left-edge/.github/pr-assets/agent-row-left-edge-before.png) | ![After: the subagent row's complete rounded border is visible](https://raw.githubusercontent.com/sameerr03/t3code/pr-assets-agent-row-left-edge/.github/pr-assets/agent-row-left-edge-after.jpg) |

## Validation

- `vp fmt --check apps/web/src/components/chat/MessagesTimeline.tsx`
- `vp lint apps/web/src/components/chat/MessagesTimeline.tsx`
- `vp test run apps/web/src/components/chat/MessagesTimeline.test.tsx` (20 tests)
- `git diff --check`
- Reproduced before the change and verified after hot reload in a real `vp run dev` thread

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change
- [x] A video is not applicable because this is a static layout fix

Implemented with GPT-5.6-sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class change on a chat UI row; no logic, API, or data impact.
> 
> **Overview**
> Fixes a **chat timeline layout bug** where the subagent spawn summary row’s **left rounded border was clipped**.
> 
> The `AgentSpawnCtaRow` button no longer uses `-mx-1`. That extra negative horizontal margin stacked with the parent work-group’s `-mx-1` / `px-1` and pushed the row past the timeline’s `overflow-x-clip` boundary, hiding the left edge. The row still spans full width inside the group with the rest of its styling unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a75d43d3600a270e54c319845ccd7357bb3d9cbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `AgentSpawnCtaRow` border visibility by removing negative horizontal margin
> Removes the `-mx-1` Tailwind class from the CTA button in [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/7207/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588), restoring the subagent row border visibility that was being clipped by the negative margin.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a75d43d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->