### PR TITLE
fix(web): align Windows update confirmation copy

### DIFF
--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -3585,7 +3585,7 @@ export default function LegacySidebar() {
       let confirmed = false;
       try {
         confirmed = await ensureLocalApi().dialogs.confirm(
-          getDesktopUpdateInstallConfirmationMessage(desktopUpdateState, navigator.platform),
+          getDesktopUpdateInstallConfirmationMessage(desktopUpdateState),
         );
       } catch (error) {
         setDesktopUpdateActionPending(false);

--- a/apps/web/src/components/desktopUpdate.logic.test.ts
+++ b/apps/web/src/components/desktopUpdate.logic.test.ts
@@ -244,30 +244,15 @@ describe("desktop update UI helpers", () => {
     ).toContain("Install update and restart T3 Code?");
   });
 
-  it("warns Windows users that a silent installation can take several minutes", () => {
-    const message = getDesktopUpdateInstallConfirmationMessage(
-      {
+  it("keeps the same install confirmation copy across desktop platforms", () => {
+    expect(
+      getDesktopUpdateInstallConfirmationMessage({
         availableVersion: "1.1.0",
         downloadedVersion: "1.1.0",
-      },
-      "Win32",
+      }),
+    ).toBe(
+      "Install update 1.1.0 and restart T3 Code?\n\nAny running tasks will be interrupted. Make sure you're ready before continuing.",
     );
-
-    expect(message).toContain("may remain closed for several minutes");
-    expect(message).toContain("no installer window may appear");
-    expect(message).toContain("will reopen automatically");
-  });
-
-  it("keeps the additional silent installation warning Windows-specific", () => {
-    const message = getDesktopUpdateInstallConfirmationMessage(
-      {
-        availableVersion: "1.1.0",
-        downloadedVersion: "1.1.0",
-      },
-      "MacIntel",
-    );
-
-    expect(message).not.toContain("may remain closed for several minutes");
   });
 });
 

--- a/apps/web/src/components/desktopUpdate.logic.ts
+++ b/apps/web/src/components/desktopUpdate.logic.ts
@@ -1,5 +1,4 @@
 import type { DesktopUpdateActionResult, DesktopUpdateState } from "@t3tools/contracts";
-import { isWindowsPlatform } from "../lib/utils";
 
 export type DesktopUpdateButtonAction = "download" | "install" | "none";
 
@@ -97,13 +96,9 @@ export function getDesktopUpdateButtonTooltip(state: DesktopUpdateState): string
 
 export function getDesktopUpdateInstallConfirmationMessage(
   state: Pick<DesktopUpdateState, "availableVersion" | "downloadedVersion">,
-  platform = "",
 ): string {
   const version = state.downloadedVersion ?? state.availableVersion;
-  const windowsInstallWarning = isWindowsPlatform(platform)
-    ? "\n\nOn Windows, T3 Code may remain closed for several minutes while the update installs, and no installer window may appear. T3 Code will reopen automatically when installation finishes."
-    : "";
-  return `Install update${version ? ` ${version}` : ""} and restart T3 Code?\n\nAny running tasks will be interrupted. Make sure you're ready before continuing.${windowsInstallWarning}`;
+  return `Install update${version ? ` ${version}` : ""} and restart T3 Code?\n\nAny running tasks will be interrupted. Make sure you're ready before continuing.`;
 }
 
 export function getDesktopUpdateActionError(result: DesktopUpdateActionResult): string | null {

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -284,7 +284,6 @@ function AboutVersionSection() {
         confirmed = await ensureLocalApi().dialogs.confirm(
           getDesktopUpdateInstallConfirmationMessage(
             updateState ?? { availableVersion: null, downloadedVersion: null },
-            navigator.platform,
           ),
         );
       } catch (error) {

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -222,7 +222,7 @@ function SidebarUpdateControl() {
       let confirmed = false;
       try {
         confirmed = await ensureLocalApi().dialogs.confirm(
-          getDesktopUpdateInstallConfirmationMessage(state, navigator.platform),
+          getDesktopUpdateInstallConfirmationMessage(state),
         );
       } catch (error) {
         setIsActionPending(false);


### PR DESCRIPTION
Windows update confirmations still warned that T3 Code could remain closed for several minutes, even though install times have improved and other desktop platforms already use the shorter shared message.

This removes the stale Windows-only warning and its platform-specific helper branch, so Windows now uses the existing Mac/Linux confirmation copy across all three update entry points. Focused coverage now asserts the shared confirmation text.

Tests: `pnpm exec vp test run apps/web/src/components/desktopUpdate.logic.test.ts`; `pnpm exec vp fmt --check ...`; `pnpm exec vp lint --report-unused-disable-directives ...`; `pnpm --filter @t3tools/web typecheck`.

Model/harness: GPT-5.6 Luna via the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to desktop update confirmation dialogs with no auth, data, or updater behavior changes.
> 
> **Overview**
> Removes the **Windows-only** extra text in the desktop update install confirmation dialog (long silent-install warning) so **all platforms** use the same short message about restarting and interrupting tasks.
> 
> `getDesktopUpdateInstallConfirmationMessage` no longer takes a platform argument or branches on Windows; **LegacySidebar**, **SettingsPanels**, and **SidebarUpdatePill** call it with update state only. Tests now assert one shared confirmation string instead of separate Windows vs Mac expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6120bd1d1c0f7c0acbff40c8f610e19e002b3c81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove Windows-specific copy from desktop update confirmation dialog
> The `getDesktopUpdateInstallConfirmationMessage` function previously appended a Windows-specific silent installation warning based on `navigator.platform`. It now returns a single, platform-agnostic confirmation message on all platforms. Callers in [LegacySidebar.tsx](https://github.com/pingdotgg/t3code/pull/7208/files#diff-ef6c49faf62e0e2403f09772084537ac313e826ae0f90db230a898204f3bdd86), [SidebarUpdatePill.tsx](https://github.com/pingdotgg/t3code/pull/7208/files#diff-9c449dd05c2249718ddff617b46ddb0eb834d90aef4a2ac4927f765784adb7bf), and [SettingsPanels.tsx](https://github.com/pingdotgg/t3code/pull/7208/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18) no longer pass a platform argument.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6120bd1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->