### PR TITLE
feat(web): allow reordering provider icons via drag-and-drop in model picker

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -86,6 +86,7 @@ import {
 } from "../composerFooterLayout";
 import { type ComposerPromptEditorHandle, ComposerPromptEditor } from "../ComposerPromptEditor";
 import { ProviderModelPicker } from "./ProviderModelPicker";
+import { useUiStateStore } from "~/uiStateStore";
 import { type ComposerCommandItem, ComposerCommandMenu } from "./ComposerCommandMenu";
 import { ComposerPendingApprovalActions } from "./ComposerPendingApprovalActions";
 import { CompactComposerControlsMenu } from "./CompactComposerControlsMenu";
@@ -726,15 +727,14 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // ------------------------------------------------------------------
   // Model state
   // ------------------------------------------------------------------
-  // Instance-aware projection of the wire provider list. One entry per
-  // configured instance (default built-in + any custom `providerInstances.*`),
-  // sorted default-first per driver kind for a stable picker order.
+  const providerOrder = useUiStateStore((state) => state.providerOrder);
   const providerInstanceEntries = useMemo<ReadonlyArray<ProviderInstanceEntry>>(
     () =>
       sortProviderInstanceEntries(
         applyProviderInstanceSettings(deriveProviderInstanceEntries(providerStatuses), settings),
+        providerOrder,
       ),
-    [providerStatuses, settings],
+    [providerStatuses, settings, providerOrder],
   );
   const selectedProviderByThreadId = composerDraft.activeProvider ?? null;
   const threadProvider =

--- a/apps/web/src/components/chat/ModelPickerSidebar.tsx
+++ b/apps/web/src/components/chat/ModelPickerSidebar.tsx
@@ -1,9 +1,17 @@
 import { type ProviderInstanceId } from "@t3tools/contracts";
-import { memo, useLayoutEffect, useRef, useState } from "react";
+import {
+  memo,
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type DragEvent as ReactDragEvent,
+} from "react";
 import { SparklesIcon, StarIcon } from "lucide-react";
 import { ProviderInstanceIcon } from "./ProviderInstanceIcon";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { cn } from "~/lib/utils";
+import { useUiStateStore } from "~/uiStateStore";
 import {
   isProviderInstancePickerReady,
   shouldShowInstanceBadge,
@@ -67,6 +75,45 @@ export const ModelPickerSidebar = memo(function ModelPickerSidebar(props: {
   };
   const showFavorites = props.showFavorites ?? true;
   const [hoveredInstanceId, setHoveredInstanceId] = useState<ProviderInstanceId | null>(null);
+  const [draggedInstanceId, setDraggedInstanceId] = useState<ProviderInstanceId | null>(null);
+  const [dragOverInstanceId, setDragOverInstanceId] = useState<ProviderInstanceId | null>(null);
+  const providerOrder = useUiStateStore((state) => state.providerOrder);
+  const reorderProviders = useUiStateStore((state) => state.reorderProviders);
+
+  const handleDragStart = useCallback((e: ReactDragEvent, instanceId: ProviderInstanceId) => {
+    e.dataTransfer.setData("text/plain", instanceId);
+    e.dataTransfer.effectAllowed = "move";
+    setDraggedInstanceId(instanceId);
+  }, []);
+
+  const handleDragOver = useCallback((e: ReactDragEvent, instanceId: ProviderInstanceId) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+    setDragOverInstanceId(instanceId);
+  }, []);
+
+  const handleDragLeave = useCallback((instanceId: ProviderInstanceId) => {
+    setDragOverInstanceId((current) => (current === instanceId ? null : current));
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: ReactDragEvent, targetInstanceId: ProviderInstanceId) => {
+      e.preventDefault();
+      if (draggedInstanceId && draggedInstanceId !== targetInstanceId) {
+        const allInstanceIds = props.instanceEntries.map((entry) => entry.instanceId);
+        reorderProviders(providerOrder, allInstanceIds, draggedInstanceId, targetInstanceId);
+      }
+      setDraggedInstanceId(null);
+      setDragOverInstanceId(null);
+    },
+    [draggedInstanceId, props.instanceEntries, providerOrder, reorderProviders],
+  );
+
+  const handleDragEnd = useCallback(() => {
+    setDraggedInstanceId(null);
+    setDragOverInstanceId(null);
+  }, []);
+
   const sidebarContentRef = useRef<HTMLDivElement>(null);
   const [selectedIndicatorTop, setSelectedIndicatorTop] = useState<number | null>(null);
   useLayoutEffect(() => {
@@ -207,11 +254,24 @@ export const ModelPickerSidebar = memo(function ModelPickerSidebar(props: {
               button
             );
 
+            const isDragged = draggedInstanceId === entry.instanceId;
+            const isDragOver = dragOverInstanceId === entry.instanceId;
+
             return (
               <div
                 key={entry.instanceId}
-                className="relative w-full"
+                className={cn(
+                  "relative w-full transition-all duration-150",
+                  isDragged && "opacity-40 scale-95",
+                  isDragOver && !isDragged && "ring-2 ring-primary/80 rounded-md",
+                )}
                 data-model-picker-provider={entry.instanceId}
+                draggable={!isDisabled}
+                onDragStart={(e) => handleDragStart(e, entry.instanceId)}
+                onDragOver={(e) => handleDragOver(e, entry.instanceId)}
+                onDragLeave={() => handleDragLeave(entry.instanceId)}
+                onDrop={(e) => handleDrop(e, entry.instanceId)}
+                onDragEnd={handleDragEnd}
               >
                 <Tooltip>
                   <TooltipTrigger render={trigger} />

--- a/apps/web/src/providerInstances.test.ts
+++ b/apps/web/src/providerInstances.test.ts
@@ -9,7 +9,9 @@ import {
   resolveDefaultProviderModelSelection,
   resolveSelectableProviderInstance,
   resolveProviderDriverKindForInstanceSelection,
+  sortProviderInstanceEntries,
 } from "./providerInstances";
+import { reorderProviders } from "./uiStateStore";
 
 function provider(input: {
   provider: ProviderDriverKind;
@@ -458,5 +460,39 @@ describe("resolveDefaultProviderModelSelection", () => {
         null,
       ),
     ).toBeNull();
+  });
+});
+
+describe("sortProviderInstanceEntries and reorderProviders", () => {
+  it("sorts entries according to customOrder while preserving unlisted entries", () => {
+    const entries = deriveProviderInstanceEntries([
+      provider({ provider: ProviderDriverKind.make("codex"), instanceId: "codex" }),
+      provider({ provider: ProviderDriverKind.make("claudeAgent"), instanceId: "claudeAgent" }),
+      provider({ provider: ProviderDriverKind.make("antigravity"), instanceId: "antigravity" }),
+    ]);
+
+    const sorted = sortProviderInstanceEntries(entries, ["antigravity", "codex"]);
+    expect(sorted.map((e) => e.instanceId)).toEqual(["antigravity", "codex", "claudeAgent"]);
+  });
+
+  it("reorders provider order correctly when dragged to new target position", () => {
+    const allIds = ["codex", "claudeAgent", "antigravity"];
+    const initialOrder = ["codex", "claudeAgent", "antigravity"];
+    const reordered = reorderProviders(
+      {
+        projectExpandedById: {},
+        projectOrder: [],
+        providerOrder: initialOrder,
+        threadLastVisitedAtById: {},
+        threadChangedFilesExpandedById: {},
+        defaultAdvertisedEndpointKey: null,
+      },
+      initialOrder,
+      allIds,
+      "antigravity",
+      "codex",
+    );
+
+    expect(reordered.providerOrder).toEqual(["antigravity", "codex", "claudeAgent"]);
   });
 });

--- a/apps/web/src/providerInstances.ts
+++ b/apps/web/src/providerInstances.ts
@@ -237,11 +237,8 @@ export function applyProviderInstanceSettings(
  */
 export function sortProviderInstanceEntries(
   entries: ReadonlyArray<ProviderInstanceEntry>,
+  customOrder?: ReadonlyArray<string>,
 ): ReadonlyArray<ProviderInstanceEntry> {
-  // Group by driver kind preserving first-appearance order, then emit
-  // default-first within each kind. Using a Map keeps the "first-seen"
-  // semantics for kinds whose default instance is absent (unusual but
-  // possible during the migration).
   const byKind = new Map<ProviderDriverKind, ProviderInstanceEntry[]>();
   for (const entry of entries) {
     const bucket = byKind.get(entry.driverKind);
@@ -251,13 +248,37 @@ export function sortProviderInstanceEntries(
       byKind.set(entry.driverKind, [entry]);
     }
   }
-  const sorted: ProviderInstanceEntry[] = [];
+  const defaultSorted: ProviderInstanceEntry[] = [];
   for (const bucket of byKind.values()) {
     const defaults = bucket.filter((entry) => entry.isDefault);
     const customs = bucket.filter((entry) => !entry.isDefault);
-    sorted.push(...defaults, ...customs);
+    defaultSorted.push(...defaults, ...customs);
   }
-  return sorted;
+
+  if (!customOrder || customOrder.length === 0) {
+    return defaultSorted;
+  }
+
+  const ordered: ProviderInstanceEntry[] = [];
+  const remaining = new Set(defaultSorted);
+
+  for (const key of customOrder) {
+    const match = defaultSorted.find(
+      (entry) => remaining.has(entry) && (entry.instanceId === key || entry.driverKind === key),
+    );
+    if (match) {
+      ordered.push(match);
+      remaining.delete(match);
+    }
+  }
+
+  for (const entry of defaultSorted) {
+    if (remaining.has(entry)) {
+      ordered.push(entry);
+    }
+  }
+
+  return ordered;
 }
 
 /**

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -20,6 +20,7 @@ const LEGACY_PERSISTED_STATE_KEYS = [
 export interface PersistedUiState {
   projectExpandedById?: Record<string, boolean>;
   projectOrder?: string[];
+  providerOrder?: string[];
   threadLastVisitedAtById?: Record<string, string>;
   collapsedProjectCwds?: string[];
   expandedProjectCwds?: string[];
@@ -34,6 +35,10 @@ export interface UiProjectState {
   projectOrder: string[];
 }
 
+export interface UiProviderState {
+  providerOrder: string[];
+}
+
 export interface UiThreadState {
   threadLastVisitedAtById: Record<string, string>;
   threadChangedFilesExpandedById: Record<string, Record<string, boolean>>;
@@ -43,11 +48,12 @@ export interface UiEndpointState {
   defaultAdvertisedEndpointKey: string | null;
 }
 
-export interface UiState extends UiProjectState, UiThreadState, UiEndpointState {}
+export interface UiState extends UiProjectState, UiProviderState, UiThreadState, UiEndpointState {}
 
 const initialState: UiState = {
   projectExpandedById: {},
   projectOrder: [],
+  providerOrder: [],
   threadLastVisitedAtById: {},
   threadChangedFilesExpandedById: {},
   defaultAdvertisedEndpointKey: null,
@@ -125,6 +131,7 @@ export function parsePersistedState(parsed: PersistedUiState): UiState {
   return {
     projectExpandedById,
     projectOrder,
+    providerOrder: sanitizeStringArray(parsed.providerOrder),
     threadLastVisitedAtById: sanitizeTimestampRecord(parsed.threadLastVisitedAtById),
     threadChangedFilesExpandedById:
       parsed.threadChangedFilesExpansionVersion === THREAD_CHANGED_FILES_EXPANSION_VERSION
@@ -203,6 +210,7 @@ export function persistState(state: UiState): void {
       JSON.stringify({
         projectExpandedById,
         projectOrder: state.projectOrder,
+        providerOrder: state.providerOrder,
         threadLastVisitedAtById: state.threadLastVisitedAtById,
         defaultAdvertisedEndpointKey: state.defaultAdvertisedEndpointKey,
         threadChangedFilesExpansionVersion: THREAD_CHANGED_FILES_EXPANSION_VERSION,
@@ -381,6 +389,37 @@ export function reorderProjects(
   };
 }
 
+export function reorderProviders(
+  state: UiState,
+  currentProviderOrder: readonly string[],
+  allInstanceIds: readonly string[],
+  draggedInstanceId: string,
+  targetInstanceId: string,
+): UiState {
+  if (!draggedInstanceId || !targetInstanceId || draggedInstanceId === targetInstanceId) {
+    return state;
+  }
+  const base = currentProviderOrder.length > 0 ? [...currentProviderOrder] : [...allInstanceIds];
+  for (const id of allInstanceIds) {
+    if (!base.includes(id)) {
+      base.push(id);
+    }
+  }
+  const draggedIndex = base.indexOf(draggedInstanceId);
+  const targetIndex = base.indexOf(targetInstanceId);
+  if (draggedIndex < 0 || targetIndex < 0 || draggedIndex === targetIndex) {
+    return state;
+  }
+  const [removed] = base.splice(draggedIndex, 1);
+  if (removed) {
+    base.splice(targetIndex, 0, removed);
+  }
+  return {
+    ...state,
+    providerOrder: base,
+  };
+}
+
 interface UiStateStore extends UiState {
   markThreadVisited: (threadId: string, visitedAt: string) => void;
   markThreadUnread: (threadId: string, latestTurnCompletedAt: string | null | undefined) => void;
@@ -391,6 +430,12 @@ interface UiStateStore extends UiState {
     currentProjectOrder: readonly string[],
     draggedProjectIds: readonly string[],
     targetProjectIds: readonly string[],
+  ) => void;
+  reorderProviders: (
+    currentProviderOrder: readonly string[],
+    allInstanceIds: readonly string[],
+    draggedInstanceId: string,
+    targetInstanceId: string,
   ) => void;
 }
 
@@ -409,6 +454,16 @@ export const useUiStateStore = create<UiStateStore>((set) => ({
   reorderProjects: (currentProjectOrder, draggedProjectIds, targetProjectIds) =>
     set((state) =>
       reorderProjects(state, currentProjectOrder, draggedProjectIds, targetProjectIds),
+    ),
+  reorderProviders: (currentProviderOrder, allInstanceIds, draggedInstanceId, targetInstanceId) =>
+    set((state) =>
+      reorderProviders(
+        state,
+        currentProviderOrder,
+        allInstanceIds,
+        draggedInstanceId,
+        targetInstanceId,
+      ),
     ),
 }));
 


### PR DESCRIPTION
### Problem

In the model picker popover, providers are rendered in a fixed order with no intuitive way for users to reorder them to match their preferred workflow or prioritize specific providers at the top.

### Solution

- Added drag-and-drop support to provider icons in `ModelPickerSidebar` with visual feedback during drag.
- Added `providerOrder` and `reorderProviders` in `useUiStateStore` with local storage persistence.
- Updated `sortProviderInstanceEntries` to honor custom provider order across the composer and model picker.

Gemini 3.7 Flash via Antigravity CLI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only UI preference persisted in localStorage; no server, auth, or model-selection logic changes beyond display order.
> 
> **Overview**
> Users can **reorder provider icons** in the model picker sidebar with HTML5 drag-and-drop (opacity/ring feedback; disabled providers are not draggable). Drops update persisted **`providerOrder`** in `useUiStateStore` (localStorage, same pattern as project order).
> 
> **`sortProviderInstanceEntries`** now takes an optional custom order: it still default-sorts by driver kind, then reorders entries to match saved keys (`instanceId` or `driverKind`), appending any providers not in the list. **`ChatComposer`** passes `providerOrder` so the composer model list matches the picker rail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49f1387be8ce9d8f759b4e2f3919bb6eba9a3279. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add drag-and-drop provider icon reordering to the model picker sidebar
> - Provider icons in `ModelPickerSidebar` are now draggable; dropping one icon onto another reorders the list with immediate visual feedback (opacity/scale on drag, ring on drag-over).
> - The new order is persisted to `localStorage` via `providerOrder` in `uiStateStore` and restored on reload.
> - `sortProviderInstanceEntries` in [providerInstances.ts](https://github.com/pingdotgg/t3code/pull/7214/files#diff-366ee4ff966b3b9fefcc872cdc0d10484ac52c174b5ed0e8ed59e84e97f58d5b) accepts an optional `customOrder` array; unlisted entries are appended after ordered ones in their prior relative order.
> - `ChatComposer` reads `providerOrder` from UI state and passes it to `sortProviderInstanceEntries` so the picker respects the saved order.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 49f1387. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->