### PR TITLE
fix(grok): stop Working after 10 minutes of silence

### DIFF
--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -19,7 +19,12 @@ const emitInterleavedAssistantToolCalls =
 const emitGenericToolPlaceholders = process.env.T3_ACP_EMIT_GENERIC_TOOL_PLACEHOLDERS === "1";
 const emitAskQuestion = process.env.T3_ACP_EMIT_ASK_QUESTION === "1";
 const emitXAiAskUserQuestion = process.env.T3_ACP_EMIT_XAI_ASK_USER_QUESTION === "1";
+const emitXAiAskUserQuestionThenHang =
+  process.env.T3_ACP_EMIT_XAI_ASK_USER_QUESTION_THEN_HANG === "1";
 const emitXAiPromptCompleteThenHang = process.env.T3_ACP_EMIT_XAI_PROMPT_COMPLETE_THEN_HANG === "1";
+const emitContentThenHang = process.env.T3_ACP_EMIT_CONTENT_THEN_HANG === "1";
+const emitPlanThenHang = process.env.T3_ACP_EMIT_PLAN_THEN_HANG === "1";
+const emitActiveToolThenHang = process.env.T3_ACP_EMIT_ACTIVE_TOOL_THEN_HANG === "1";
 const emitForeignSessionUpdates = process.env.T3_ACP_EMIT_FOREIGN_SESSION_UPDATES === "1";
 const hangPromptForever = process.env.T3_ACP_HANG_PROMPT_FOREVER === "1";
 const hangFirstPromptForever = process.env.T3_ACP_HANG_FIRST_PROMPT_FOREVER === "1";
@@ -522,6 +527,58 @@ const program = Effect.gen(function* () {
         return yield* Effect.never;
       }
 
+      if (emitContentThenHang) {
+        yield* agent.client.sessionUpdate({
+          sessionId: requestedSessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "partial before stall" },
+          },
+        });
+        return yield* Effect.never;
+      }
+
+      if (emitPlanThenHang) {
+        yield* agent.client.sessionUpdate({
+          sessionId: requestedSessionId,
+          update: {
+            sessionUpdate: "plan",
+            entries: [
+              {
+                content: "Wait for more ACP progress",
+                priority: "high",
+                status: "in_progress",
+              },
+            ],
+          },
+        });
+        return yield* Effect.never;
+      }
+
+      if (emitActiveToolThenHang) {
+        const toolCallId = "tool-call-long-running-1";
+        yield* agent.client.sessionUpdate({
+          sessionId: requestedSessionId,
+          update: {
+            sessionUpdate: "tool_call",
+            toolCallId,
+            title: "Long-running tool",
+            kind: "execute",
+            status: "pending",
+            rawInput: { command: ["long-running-tool"] },
+          },
+        });
+        yield* agent.client.sessionUpdate({
+          sessionId: requestedSessionId,
+          update: {
+            sessionUpdate: "tool_call_update",
+            toolCallId,
+            status: "in_progress",
+          },
+        });
+        return yield* Effect.never;
+      }
+
       if (emitXAiPromptCompleteThenHang) {
         writeJsonRpcNotification("session/update", {
           sessionId: requestedSessionId,
@@ -773,7 +830,7 @@ const program = Effect.gen(function* () {
         return { stopReason: "end_turn" };
       }
 
-      if (emitXAiAskUserQuestion) {
+      if (emitXAiAskUserQuestion || emitXAiAskUserQuestionThenHang) {
         const result = yield* agent.client.extRequest("_x.ai/ask_user_question", {
           method: "x.ai/ask_user_question",
           params: {
@@ -805,6 +862,10 @@ const program = Effect.gen(function* () {
           result.answers === null
         ) {
           throw new Error("Expected accepted _x.ai/ask_user_question response answers.");
+        }
+
+        if (emitXAiAskUserQuestionThenHang) {
+          return yield* Effect.never;
         }
 
         return { stopReason: "end_turn" };

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -418,6 +418,362 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
     }),
   );
 
+  it.effect("does not time out a Grok turn before ACP emits progress", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-watchdog-silent-turn");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({
+          T3_ACP_HANG_PROMPT_FOREVER: "1",
+        }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath, {
+        turnInactivityTimeoutMs: 1_000,
+      });
+      const runtimeEvents: ProviderRuntimeEvent[] = [];
+      const turnStarted = yield* Deferred.make<void>();
+      const turnCompleted =
+        yield* Deferred.make<Extract<ProviderRuntimeEvent, { type: "turn.completed" }>>();
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.gen(function* () {
+          if (String(event.threadId) !== String(threadId)) {
+            return;
+          }
+          runtimeEvents.push(event);
+          if (event.type === "turn.started") {
+            yield* Deferred.succeed(turnStarted, undefined).pipe(Effect.ignore);
+          }
+          if (event.type === "turn.completed") {
+            yield* Deferred.succeed(turnCompleted, event).pipe(Effect.ignore);
+          }
+        }),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("grok"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+
+      const sendTurnFiber = yield* adapter
+        .sendTurn({ threadId, input: "silence forever", attachments: [] })
+        .pipe(Effect.forkChild);
+      yield* Deferred.await(turnStarted);
+
+      yield* TestClock.adjust("5 seconds");
+      yield* Effect.yieldNow;
+      const steerSendTurnFiber = yield* adapter
+        .sendTurn({ threadId, input: "keep reasoning", attachments: [] })
+        .pipe(Effect.forkChild);
+      for (let yieldAttempt = 0; yieldAttempt < 12; yieldAttempt += 1) {
+        yield* Effect.yieldNow;
+      }
+      yield* TestClock.adjust("5 seconds");
+      yield* Effect.yieldNow;
+      assert.lengthOf(
+        runtimeEvents.filter(
+          (event) => event.type === "turn.completed" && String(event.threadId) === String(threadId),
+        ),
+        0,
+      );
+
+      yield* adapter.interruptTurn(threadId);
+      const completed = yield* Deferred.await(turnCompleted).pipe(
+        Effect.timeout("2 seconds"),
+        TestClock.withLive,
+      );
+      yield* Fiber.join(sendTurnFiber);
+      yield* Fiber.interrupt(steerSendTurnFiber);
+
+      assert.equal(completed.payload.state, "cancelled");
+      const session = (yield* adapter.listSessions()).find(
+        (candidate) => candidate.threadId === threadId,
+      );
+      assert.equal(session?.status, "ready");
+      assert.isUndefined(session?.activeTurnId);
+
+      yield* Fiber.interrupt(runtimeEventsFiber);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("fails a Grok turn that stalls after ACP content begins", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-watchdog-content-stall");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({
+          T3_ACP_EMIT_CONTENT_THEN_HANG: "1",
+        }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath, {
+        turnInactivityTimeoutMs: 1_000,
+      });
+      const contentDelta = yield* Deferred.make<void>();
+      const turnCompleted =
+        yield* Deferred.make<Extract<ProviderRuntimeEvent, { type: "turn.completed" }>>();
+      const runtimeEvents: ProviderRuntimeEvent[] = [];
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.gen(function* () {
+          if (String(event.threadId) !== String(threadId)) {
+            return;
+          }
+          runtimeEvents.push(event);
+          if (event.type === "content.delta") {
+            yield* Deferred.succeed(contentDelta, undefined).pipe(Effect.ignore);
+          }
+          if (event.type === "turn.completed") {
+            yield* Deferred.succeed(turnCompleted, event).pipe(Effect.ignore);
+          }
+        }),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("grok"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+      const sendTurnFiber = yield* adapter
+        .sendTurn({ threadId, input: "start then stall", attachments: [] })
+        .pipe(Effect.forkChild);
+      yield* Deferred.await(contentDelta).pipe(Effect.timeout("2 seconds"), TestClock.withLive);
+
+      yield* TestClock.adjust("999 millis");
+      yield* Effect.yieldNow;
+      assert.lengthOf(
+        runtimeEvents.filter(
+          (event) => event.type === "turn.completed" && String(event.threadId) === String(threadId),
+        ),
+        0,
+      );
+
+      yield* TestClock.adjust("1 millis");
+      for (let yieldAttempt = 0; yieldAttempt < 4; yieldAttempt += 1) {
+        yield* Effect.yieldNow;
+      }
+      const completed = yield* Deferred.await(turnCompleted).pipe(
+        Effect.timeout("2 seconds"),
+        TestClock.withLive,
+      );
+      yield* Fiber.join(sendTurnFiber);
+
+      assert.equal(completed.payload.state, "failed");
+      assert.equal(
+        runtimeEvents.filter(
+          (event) => event.type === "turn.completed" && String(event.threadId) === String(threadId),
+        ).length,
+        1,
+      );
+
+      yield* Fiber.interrupt(runtimeEventsFiber);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("refreshes Grok liveness when a turn is steered", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-watchdog-steer");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({
+          T3_ACP_EMIT_CONTENT_THEN_HANG: "1",
+        }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath, {
+        turnInactivityTimeoutMs: 1_000,
+      });
+      const contentDelta = yield* Deferred.make<void>();
+      const turnCompleted =
+        yield* Deferred.make<Extract<ProviderRuntimeEvent, { type: "turn.completed" }>>();
+      const runtimeEvents: ProviderRuntimeEvent[] = [];
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.gen(function* () {
+          if (String(event.threadId) !== String(threadId)) {
+            return;
+          }
+          runtimeEvents.push(event);
+          if (event.type === "content.delta") {
+            yield* Deferred.succeed(contentDelta, undefined).pipe(Effect.ignore);
+          }
+          if (event.type === "turn.completed") {
+            yield* Deferred.succeed(turnCompleted, event).pipe(Effect.ignore);
+          }
+        }),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("grok"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+      const firstSendTurnFiber = yield* adapter
+        .sendTurn({ threadId, input: "start then steer", attachments: [] })
+        .pipe(Effect.forkChild);
+      yield* Deferred.await(contentDelta).pipe(Effect.timeout("2 seconds"), TestClock.withLive);
+
+      yield* TestClock.adjust("999 millis");
+      const steerSendTurnFiber = yield* adapter
+        .sendTurn({ threadId, input: "continue working", attachments: [] })
+        .pipe(Effect.forkChild);
+      for (let yieldAttempt = 0; yieldAttempt < 12; yieldAttempt += 1) {
+        yield* Effect.yieldNow;
+      }
+
+      yield* TestClock.adjust("1 millis");
+      for (let yieldAttempt = 0; yieldAttempt < 4; yieldAttempt += 1) {
+        yield* Effect.yieldNow;
+      }
+      assert.lengthOf(
+        runtimeEvents.filter(
+          (event) => event.type === "turn.completed" && String(event.threadId) === String(threadId),
+        ),
+        0,
+      );
+
+      yield* Fiber.interrupt(steerSendTurnFiber);
+      yield* adapter.interruptTurn(threadId);
+      const completed = yield* Deferred.await(turnCompleted).pipe(
+        Effect.timeout("2 seconds"),
+        TestClock.withLive,
+      );
+      yield* Fiber.join(firstSendTurnFiber);
+      assert.equal(completed.payload.state, "cancelled");
+
+      yield* Fiber.interrupt(runtimeEventsFiber);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("refreshes Grok liveness when ACP updates its plan", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-watchdog-plan-stall");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({
+          T3_ACP_EMIT_PLAN_THEN_HANG: "1",
+        }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath, {
+        turnInactivityTimeoutMs: 1_000,
+      });
+      const planUpdated = yield* Deferred.make<void>();
+      const turnCompleted =
+        yield* Deferred.make<Extract<ProviderRuntimeEvent, { type: "turn.completed" }>>();
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.gen(function* () {
+          if (String(event.threadId) !== String(threadId)) {
+            return;
+          }
+          if (event.type === "turn.plan.updated") {
+            yield* Deferred.succeed(planUpdated, undefined).pipe(Effect.ignore);
+          }
+          if (event.type === "turn.completed") {
+            yield* Deferred.succeed(turnCompleted, event).pipe(Effect.ignore);
+          }
+        }),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("grok"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+      const sendTurnFiber = yield* adapter
+        .sendTurn({ threadId, input: "update plan then stall", attachments: [] })
+        .pipe(Effect.forkChild);
+      yield* Deferred.await(planUpdated).pipe(Effect.timeout("2 seconds"), TestClock.withLive);
+
+      yield* TestClock.adjust("1 second");
+      for (let yieldAttempt = 0; yieldAttempt < 4; yieldAttempt += 1) {
+        yield* Effect.yieldNow;
+      }
+      const completed = yield* Deferred.await(turnCompleted).pipe(
+        Effect.timeout("2 seconds"),
+        TestClock.withLive,
+      );
+      yield* Fiber.join(sendTurnFiber);
+
+      assert.equal(completed.payload.state, "failed");
+      yield* Fiber.interrupt(runtimeEventsFiber);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("settles a stalled Grok turn after the active-tool deadline", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-watchdog-active-tool");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({
+          T3_ACP_EMIT_ACTIVE_TOOL_THEN_HANG: "1",
+        }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath, {
+        turnInactivityTimeoutMs: 1_000,
+        activeToolInactivityTimeoutMs: 5_000,
+      });
+      const activeTool = yield* Deferred.make<void>();
+      const turnCompleted =
+        yield* Deferred.make<Extract<ProviderRuntimeEvent, { type: "turn.completed" }>>();
+      const runtimeEvents: ProviderRuntimeEvent[] = [];
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.gen(function* () {
+          if (String(event.threadId) !== String(threadId)) {
+            return;
+          }
+          runtimeEvents.push(event);
+          if (event.type === "item.updated") {
+            yield* Deferred.succeed(activeTool, undefined).pipe(Effect.ignore);
+          }
+          if (event.type === "turn.completed") {
+            yield* Deferred.succeed(turnCompleted, event).pipe(Effect.ignore);
+          }
+        }),
+      ).pipe(Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("grok"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+      const sendTurnFiber = yield* adapter
+        .sendTurn({ threadId, input: "run a long tool", attachments: [] })
+        .pipe(Effect.forkChild);
+      yield* Deferred.await(activeTool).pipe(Effect.timeout("2 seconds"), TestClock.withLive);
+      for (let yieldAttempt = 0; yieldAttempt < 4; yieldAttempt += 1) {
+        yield* Effect.yieldNow;
+      }
+
+      yield* TestClock.adjust("4999 millis");
+      yield* Effect.yieldNow;
+      assert.lengthOf(
+        runtimeEvents.filter(
+          (event) => event.type === "turn.completed" && String(event.threadId) === String(threadId),
+        ),
+        0,
+      );
+      assert.equal(
+        (yield* adapter.listSessions()).find((candidate) => candidate.threadId === threadId)
+          ?.status,
+        "running",
+      );
+
+      yield* TestClock.adjust("1 millis");
+      for (let yieldAttempt = 0; yieldAttempt < 4; yieldAttempt += 1) {
+        yield* Effect.yieldNow;
+      }
+      const completed = yield* Deferred.await(turnCompleted).pipe(
+        Effect.timeout("2 seconds"),
+        TestClock.withLive,
+      );
+      yield* Fiber.join(sendTurnFiber);
+      assert.equal(completed.payload.state, "failed");
+
+      yield* Fiber.interrupt(runtimeEventsFiber);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("retains turn transcript when sendTurn is interrupted after prompt success", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-send-turn-interrupt-after-prompt");
@@ -1097,17 +1453,21 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
     }),
   );
 
-  it.effect("handles xAI ask_user_question extension requests", () =>
+  it.effect("settles a stalled Grok turn after its first activity is user input", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-xai-ask-user-question");
       const wrapperPath = yield* Effect.promise(() =>
-        makeMockGrokWrapper({ T3_ACP_EMIT_XAI_ASK_USER_QUESTION: "1" }),
+        makeMockGrokWrapper({ T3_ACP_EMIT_XAI_ASK_USER_QUESTION_THEN_HANG: "1" }),
       );
-      const adapter = yield* makeTestAdapter(wrapperPath);
+      const adapter = yield* makeTestAdapter(wrapperPath, {
+        turnInactivityTimeoutMs: 1_000,
+      });
       const requested =
         yield* Deferred.make<Extract<ProviderRuntimeEvent, { type: "user-input.requested" }>>();
       const resolved =
         yield* Deferred.make<Extract<ProviderRuntimeEvent, { type: "user-input.resolved" }>>();
+      const completed =
+        yield* Deferred.make<Extract<ProviderRuntimeEvent, { type: "turn.completed" }>>();
 
       const eventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) => {
         if (String(event.threadId) !== String(threadId)) {
@@ -1118,6 +1478,9 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
         }
         if (event.type === "user-input.resolved") {
           return Deferred.succeed(resolved, event).pipe(Effect.ignore);
+        }
+        if (event.type === "turn.completed") {
+          return Deferred.succeed(completed, event).pipe(Effect.ignore);
         }
         return Effect.void;
       }).pipe(Effect.forkChild);
@@ -1152,6 +1515,13 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
         "Which scope should Grok use?": "Workspace",
       });
       assert.equal(String(resolvedEvent.turnId), String(requestedEvent.turnId));
+
+      yield* TestClock.adjust("1 second");
+      const completedEvent = yield* Deferred.await(completed).pipe(
+        Effect.timeout("2 seconds"),
+        TestClock.withLive,
+      );
+      assert.equal(completedEvent.payload.state, "failed");
       yield* Fiber.join(sendTurnFiber);
 
       yield* Fiber.interrupt(eventsFiber);

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -12,9 +12,11 @@ import {
   type ThreadId,
   TurnId,
 } from "@t3tools/contracts";
+import * as Clock from "effect/Clock";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Deferred from "effect/Deferred";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
@@ -22,6 +24,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as PubSub from "effect/PubSub";
+import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
@@ -73,6 +76,15 @@ const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.fromJsonStri
 
 const PROVIDER = ProviderDriverKind.make("grok");
 const GROK_RESUME_VERSION = 1 as const;
+const NANOS_PER_MILLI = 1_000_000n;
+// ACP does not expose Grok's private `streaming_reasoning` phase. Once it has
+// emitted standard ACP progress, ten silent minutes is long enough to avoid
+// treating legitimate reasoning as a stalled stream.
+const DEFAULT_GROK_TURN_INACTIVITY_TIMEOUT_MS = 10 * 60 * 1_000;
+// A tool can legitimately run without emitting text for much longer than
+// reasoning. It still needs a deadline so a lost tool update cannot leave the
+// turn working forever.
+const DEFAULT_GROK_ACTIVE_TOOL_INACTIVITY_TIMEOUT_MS = 30 * 60 * 1_000;
 
 function encodeJsonStringForDiagnostics(input: unknown): string | undefined {
   const result = encodeUnknownJsonStringExit(input);
@@ -84,6 +96,10 @@ export interface GrokAdapterLiveOptions {
   readonly nativeEventLogPath?: string;
   readonly nativeEventLogger?: EventNdjsonLogger;
   readonly instanceId?: ProviderInstanceId;
+  /** Override the conservative ACP turn liveness timeout in focused tests. */
+  readonly turnInactivityTimeoutMs?: number;
+  /** Override the longer active-tool liveness timeout in focused tests. */
+  readonly activeToolInactivityTimeoutMs?: number;
 }
 
 interface PendingApproval {
@@ -96,6 +112,10 @@ type PendingUserInputResolution =
 
 interface PendingUserInput {
   readonly resolution: Deferred.Deferred<PendingUserInputResolution>;
+}
+
+interface GrokTurnLivenessSignal {
+  readonly turnId: TurnId;
 }
 
 interface GrokSessionContext {
@@ -116,6 +136,13 @@ interface GrokSessionContext {
    * >0 means a turn is actively running, so a new sendTurn is a steer that
    * continues it, and only the last remaining prompt settles the turn. */
   promptsInFlight: number;
+  readonly livenessSignals: Queue.Queue<GrokTurnLivenessSignal>;
+  livenessTurnId: TurnId | undefined;
+  lastTurnActivityAtNanos: bigint | undefined;
+  readonly activeToolCallIds: Set<string>;
+  livenessUpdatesInFlight: number;
+  /** Prompt RPCs that returned before their turn settlement acquired the lock. */
+  promptResponsesReady: number;
   currentModelId: string | undefined;
   stopped: boolean;
 }
@@ -244,6 +271,21 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
     const sessions = new Map<ThreadId, GrokSessionContext>();
     const threadLocksRef = yield* SynchronizedRef.make(new Map<string, Semaphore.Semaphore>());
     const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
+    const requestedTurnInactivityTimeoutMs = options?.turnInactivityTimeoutMs;
+    const turnInactivityTimeoutMs =
+      typeof requestedTurnInactivityTimeoutMs === "number" &&
+      Number.isFinite(requestedTurnInactivityTimeoutMs)
+        ? Math.max(1, Math.floor(requestedTurnInactivityTimeoutMs))
+        : DEFAULT_GROK_TURN_INACTIVITY_TIMEOUT_MS;
+    const turnInactivityTimeoutNanos = BigInt(turnInactivityTimeoutMs) * NANOS_PER_MILLI;
+    const requestedActiveToolInactivityTimeoutMs = options?.activeToolInactivityTimeoutMs;
+    const activeToolInactivityTimeoutMs =
+      typeof requestedActiveToolInactivityTimeoutMs === "number" &&
+      Number.isFinite(requestedActiveToolInactivityTimeoutMs)
+        ? Math.max(1, Math.floor(requestedActiveToolInactivityTimeoutMs))
+        : DEFAULT_GROK_ACTIVE_TOOL_INACTIVITY_TIMEOUT_MS;
+    const activeToolInactivityTimeoutNanos =
+      BigInt(activeToolInactivityTimeoutMs) * NANOS_PER_MILLI;
 
     const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
     const randomUUIDv4 = crypto.randomUUIDv4.pipe(
@@ -293,6 +335,143 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
 
     const withThreadLock = <A, E, R>(threadId: string, effect: Effect.Effect<A, E, R>) =>
       Effect.flatMap(getThreadSemaphore(threadId), (semaphore) => semaphore.withPermit(effect));
+
+    const signalTurnLiveness = (ctx: GrokSessionContext, turnId: TurnId) =>
+      Queue.offer(ctx.livenessSignals, { turnId }).pipe(Effect.asVoid);
+
+    const beginTurnLiveness = (ctx: GrokSessionContext, turnId: TurnId) =>
+      Effect.sync(() => {
+        ctx.livenessTurnId = turnId;
+        // Do not start a deadline until ACP has made observable progress.
+        // Grok's private reasoning phase is not present in the ACP stream.
+        ctx.lastTurnActivityAtNanos = undefined;
+        ctx.activeToolCallIds.clear();
+      });
+
+    const clearTurnLiveness = (ctx: GrokSessionContext) => {
+      const turnId = ctx.livenessTurnId;
+      ctx.livenessTurnId = undefined;
+      ctx.lastTurnActivityAtNanos = undefined;
+      ctx.activeToolCallIds.clear();
+      ctx.livenessUpdatesInFlight = 0;
+      ctx.promptResponsesReady = 0;
+      return turnId === undefined ? Effect.void : signalTurnLiveness(ctx, turnId);
+    };
+
+    const recordTurnActivity = Effect.fn("GrokAdapter.recordTurnActivity")(function* (
+      ctx: GrokSessionContext,
+      turnId: TurnId,
+      event: Extract<
+        AcpSessionRuntime.AcpSessionRuntimeEvent,
+        {
+          _tag:
+            | "AssistantItemStarted"
+            | "AssistantItemCompleted"
+            | "PlanUpdated"
+            | "ToolCallUpdated"
+            | "ContentDelta";
+        }
+      >,
+    ) {
+      if (
+        ctx.livenessTurnId !== turnId ||
+        (event._tag === "ContentDelta" && event.text.length === 0)
+      ) {
+        return;
+      }
+      ctx.livenessUpdatesInFlight += 1;
+      try {
+        const activityAtNanos = yield* Clock.currentTimeNanos;
+        if (ctx.livenessTurnId !== turnId || ctx.interruptedTurnIds.has(turnId)) {
+          return;
+        }
+        if (event._tag === "ToolCallUpdated") {
+          if (event.toolCall.status === "completed" || event.toolCall.status === "failed") {
+            ctx.activeToolCallIds.delete(event.toolCall.toolCallId);
+          } else {
+            // A tool update without a terminal status receives a longer
+            // deadline so a long-running tool is not mistaken for a stall.
+            ctx.activeToolCallIds.add(event.toolCall.toolCallId);
+          }
+        }
+        ctx.lastTurnActivityAtNanos = activityAtNanos;
+        yield* signalTurnLiveness(ctx, turnId);
+      } finally {
+        ctx.livenessUpdatesInFlight = Math.max(0, ctx.livenessUpdatesInFlight - 1);
+      }
+    });
+
+    const hasLivenessPause = (ctx: GrokSessionContext) =>
+      ctx.pendingApprovals.size > 0 ||
+      ctx.pendingUserInputs.size > 0 ||
+      ctx.livenessUpdatesInFlight > 0;
+
+    const livenessTimeoutFor = (ctx: GrokSessionContext) =>
+      ctx.activeToolCallIds.size > 0
+        ? {
+            milliseconds: activeToolInactivityTimeoutMs,
+            nanos: activeToolInactivityTimeoutNanos,
+          }
+        : { milliseconds: turnInactivityTimeoutMs, nanos: turnInactivityTimeoutNanos };
+
+    const signalSessionTurnLiveness = (threadId: ThreadId, turnId: TurnId | undefined) => {
+      const ctx = sessions.get(threadId);
+      return ctx && turnId !== undefined ? signalTurnLiveness(ctx, turnId) : Effect.void;
+    };
+
+    const resumeSessionTurnLiveness = Effect.fn("GrokAdapter.resumeSessionTurnLiveness")(function* (
+      threadId: ThreadId,
+      turnId: TurnId | undefined,
+    ) {
+      const ctx = sessions.get(threadId);
+      if (!ctx || turnId === undefined || ctx.livenessTurnId !== turnId) {
+        return;
+      }
+      // An approval or user-input wait can last longer than the watchdog.
+      // Its resolution gives the provider a fresh window to resume output.
+      ctx.lastTurnActivityAtNanos = yield* Clock.currentTimeNanos;
+      yield* signalTurnLiveness(ctx, turnId);
+    });
+
+    const refreshSessionTurnLiveness = Effect.fn("GrokAdapter.refreshSessionTurnLiveness")(
+      function* (threadId: ThreadId, turnId: TurnId | undefined) {
+        const ctx = sessions.get(threadId);
+        if (
+          !ctx ||
+          turnId === undefined ||
+          ctx.livenessTurnId !== turnId ||
+          ctx.lastTurnActivityAtNanos === undefined
+        ) {
+          return;
+        }
+        ctx.lastTurnActivityAtNanos = yield* Clock.currentTimeNanos;
+        yield* signalTurnLiveness(ctx, turnId);
+      },
+    );
+
+    const markPromptResponseReady = Effect.fn("GrokAdapter.markPromptResponseReady")(function* (
+      threadId: ThreadId,
+      acpSessionId: string,
+      turnId: TurnId,
+    ) {
+      const ctx = sessions.get(threadId);
+      if (
+        ctx &&
+        ctx.acpSessionId === acpSessionId &&
+        !ctx.stopped &&
+        !ctx.interruptedTurnIds.has(turnId) &&
+        ctx.livenessTurnId === turnId &&
+        ctx.activeTurnId === turnId &&
+        ctx.session.activeTurnId === turnId
+      ) {
+        ctx.promptResponsesReady += 1;
+        yield* signalTurnLiveness(ctx, turnId);
+      }
+    });
+
+    const consumePromptResponseReady = (ctx: GrokSessionContext) => {
+      ctx.promptResponsesReady = Math.max(0, ctx.promptResponsesReady - 1);
+    };
 
     const settlePromptInFlight = (
       threadId: ThreadId,
@@ -373,6 +552,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                   updatedAt,
                 };
               }
+              yield* clearTurnLiveness(liveCtx);
               return;
             }
             settleTurnId = fallbackTurnId;
@@ -389,6 +569,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
           }
           liveCtx.promptsInFlight = remainingPrompts;
         }
+        yield* clearTurnLiveness(liveCtx);
         const updatedAt = yield* nowIso;
         const canEmitTurnCompletion =
           liveCtx.session.status === "running" || liveCtx.session.status === "connecting";
@@ -431,6 +612,104 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
           });
         }
       });
+
+    const isLiveTurn = (ctx: GrokSessionContext, turnId: TurnId) =>
+      ctx.promptsInFlight > 0 &&
+      ctx.promptsInFlight > ctx.promptResponsesReady &&
+      ctx.activeTurnId === turnId &&
+      ctx.session.activeTurnId === turnId &&
+      (ctx.session.status === "running" || ctx.session.status === "connecting");
+
+    const settleStalledTurn = Effect.fn("GrokAdapter.settleStalledTurn")(function* (
+      ctx: GrokSessionContext,
+      turnId: TurnId,
+    ) {
+      return yield* withThreadLock(
+        ctx.threadId,
+        Effect.gen(function* () {
+          const liveCtx = sessions.get(ctx.threadId);
+          if (
+            liveCtx !== ctx ||
+            ctx.stopped ||
+            !isLiveTurn(ctx, turnId) ||
+            ctx.interruptedTurnIds.has(turnId) ||
+            hasLivenessPause(ctx)
+          ) {
+            return;
+          }
+          const lastActivityAtNanos = ctx.lastTurnActivityAtNanos;
+          if (lastActivityAtNanos === undefined) {
+            return;
+          }
+          const nowNanos = yield* Clock.currentTimeNanos;
+          if (
+            ctx.interruptedTurnIds.has(turnId) ||
+            !isLiveTurn(ctx, turnId) ||
+            hasLivenessPause(ctx) ||
+            nowNanos - lastActivityAtNanos < livenessTimeoutFor(ctx).nanos
+          ) {
+            return;
+          }
+
+          // Mark before cancel/drain so notifications already in flight finish
+          // before the terminal event, while late notifications are dropped.
+          ctx.interruptedTurnIds.add(turnId);
+          yield* Effect.ignore(
+            ctx.acp.cancel.pipe(
+              Effect.mapError((error) =>
+                mapAcpToAdapterError(PROVIDER, ctx.threadId, "session/cancel", error),
+              ),
+            ),
+          );
+          yield* Effect.ignore(ctx.acp.drainEvents);
+          yield* settlePromptInFlight(ctx.threadId, turnId, ctx.acpSessionId, {
+            errorMessage: `Grok ACP turn stalled without content or tool progress for ${livenessTimeoutFor(ctx).milliseconds}ms.`,
+            settleAllPrompts: true,
+          });
+        }),
+      );
+    });
+
+    const runTurnLivenessWatchdog = Effect.fn("GrokAdapter.runTurnLivenessWatchdog")(
+      function* (ctx: GrokSessionContext) {
+        while (true) {
+          if (ctx.stopped) {
+            return;
+          }
+          const turnId = ctx.livenessTurnId;
+          if (
+            turnId === undefined ||
+            ctx.interruptedTurnIds.has(turnId) ||
+            !isLiveTurn(ctx, turnId) ||
+            hasLivenessPause(ctx)
+          ) {
+            yield* Queue.take(ctx.livenessSignals);
+            continue;
+          }
+
+          const lastActivityAtNanos = ctx.lastTurnActivityAtNanos;
+          if (lastActivityAtNanos === undefined) {
+            yield* Queue.take(ctx.livenessSignals);
+            continue;
+          }
+          const nowNanos = yield* Clock.currentTimeNanos;
+          const remainingNanos = livenessTimeoutFor(ctx).nanos - (nowNanos - lastActivityAtNanos);
+          if (remainingNanos <= 0n) {
+            yield* settleStalledTurn(ctx, turnId);
+            continue;
+          }
+
+          const wakeReason = yield* Effect.raceFirst(
+            Effect.sleep(Duration.nanos(remainingNanos)).pipe(Effect.as("timeout" as const)),
+            Queue.take(ctx.livenessSignals).pipe(Effect.as("activity" as const)),
+          );
+          if (wakeReason === "timeout") {
+            yield* settleStalledTurn(ctx, turnId);
+          }
+        }
+      },
+      Effect.catch(() => Effect.void),
+    );
 
     const logNative = (threadId: ThreadId, method: string, payload: unknown) =>
       Effect.gen(function* () {
@@ -621,6 +900,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                       const resolution = yield* Deferred.make<PendingUserInputResolution>();
                       const turnId = resolveSessionCallbackTurnId(sessions, input.threadId);
                       pendingUserInputs.set(requestId, { resolution });
+                      yield* signalSessionTurnLiveness(input.threadId, turnId);
                       yield* offerRuntimeEvent({
                         type: "user-input.requested",
                         ...(yield* makeEventStamp()),
@@ -637,6 +917,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                       });
                       const resolved = yield* Deferred.await(resolution);
                       pendingUserInputs.delete(requestId);
+                      yield* resumeSessionTurnLiveness(input.threadId, turnId);
                       const resolvedAnswers = resolved._tag === "answered" ? resolved.answers : {};
                       yield* offerRuntimeEvent({
                         type: "user-input.resolved",
@@ -684,6 +965,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                   const decision = yield* Deferred.make<ProviderApprovalDecision>();
                   const turnId = resolveSessionCallbackTurnId(sessions, input.threadId);
                   pendingApprovals.set(requestId, { decision });
+                  yield* signalSessionTurnLiveness(input.threadId, turnId);
                   yield* offerRuntimeEvent(
                     makeAcpRequestOpenedEvent({
                       stamp: yield* makeEventStamp(),
@@ -704,6 +986,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                   );
                   const resolved = yield* Deferred.await(decision);
                   pendingApprovals.delete(requestId);
+                  yield* resumeSessionTurnLiveness(input.threadId, turnId);
                   yield* offerRuntimeEvent(
                     makeAcpRequestResolvedEvent({
                       stamp: yield* makeEventStamp(),
@@ -777,6 +1060,12 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
             activeTurnId: undefined,
             interruptedTurnIds: new Set(),
             promptsInFlight: 0,
+            livenessSignals: yield* Queue.sliding<GrokTurnLivenessSignal>(1),
+            livenessTurnId: undefined,
+            lastTurnActivityAtNanos: undefined,
+            activeToolCallIds: new Set(),
+            livenessUpdatesInFlight: 0,
+            promptResponsesReady: 0,
             currentModelId: boundModelId,
             stopped: false,
           };
@@ -806,6 +1095,15 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                   ctx.interruptedTurnIds.has(notificationTurnId)
                 ) {
                   return;
+                }
+                if (
+                  event._tag === "AssistantItemStarted" ||
+                  event._tag === "AssistantItemCompleted" ||
+                  event._tag === "PlanUpdated" ||
+                  event._tag === "ToolCallUpdated" ||
+                  event._tag === "ContentDelta"
+                ) {
+                  yield* recordTurnActivity(ctx, notificationTurnId, event);
                 }
                 const stamp = yield* makeEventStamp();
 
@@ -887,6 +1185,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
 
           ctx.notificationFiber = nf;
           sessions.set(input.threadId, ctx);
+          yield* runTurnLivenessWatchdog(ctx).pipe(Effect.forkIn(ctx.scope), Effect.asVoid);
           sessionScopeTransferred = true;
 
           yield* offerRuntimeEvent({
@@ -1032,6 +1331,11 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 updatedAt: yield* nowIso,
                 ...(displayModel ? { model: displayModel } : {}),
               };
+              if (steeringTurnId === undefined) {
+                yield* beginTurnLiveness(ctx, turnId);
+              } else {
+                yield* refreshSessionTurnLiveness(input.threadId, turnId);
+              }
 
               if (steeringTurnId === undefined) {
                 yield* offerRuntimeEvent({
@@ -1082,10 +1386,14 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
             })
             .pipe(
               Effect.tap((promptResult) =>
-                Effect.all([
-                  Ref.set(promptRpcSucceeded, true),
-                  Ref.set(promptResultRef, promptResult),
-                ]),
+                Effect.all(
+                  [
+                    Ref.set(promptRpcSucceeded, true),
+                    Ref.set(promptResultRef, promptResult),
+                    markPromptResponseReady(input.threadId, prepared.acpSessionId, prepared.turnId),
+                  ],
+                  { discard: true },
+                ),
               ),
               Effect.tapError((error) =>
                 Ref.set(
@@ -1126,6 +1434,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 yield* Effect.yieldNow;
               }
               yield* prepared.acp.drainEvents;
+              consumePromptResponseReady(ctx);
               if (ctx.interruptedTurnIds.has(prepared.turnId)) {
                 yield* Ref.set(promptSettled, true);
                 return {
@@ -1184,6 +1493,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                   updatedAt: completedAt,
                   ...(prepared.displayModel ? { model: prepared.displayModel } : {}),
                 };
+                yield* clearTurnLiveness(ctx);
                 const completedStopReason = completedStopReasonFromPromptResponse(result);
                 yield* offerRuntimeEvent({
                   type: "turn.completed",
@@ -1240,6 +1550,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                     if (ctx.interruptedTurnIds.has(prepared.turnId)) {
                       return;
                     }
+                    consumePromptResponseReady(ctx);
                     if (
                       ctx.promptsInFlight <= 0 ||
                       ctx.activeTurnId !== prepared.turnId ||
@@ -1356,6 +1667,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 status: "ready",
                 updatedAt,
               };
+              yield* clearTurnLiveness(ctx);
             }
           }),
         );


### PR DESCRIPTION
Fixes #7210.

A Grok turn sat on Working for 74 minutes after the last tool finished. The stream died mid-reasoning. No `turn_ended`. The UI never gave up.

After ten minutes with no tokens, tools, or terminal events, the turn now fails and Working stops. The timer does not run during tools, approvals, or user input. Existing threads and other clients already share that turn state.

Most of the diff is the watchdog plus tests.

Validation: `vp test run apps/server/src/provider/Layers/GrokAdapter.test.ts` (25 passed).

Created with GPT-5.6 Luna via Codex CLI, reviewed and finalized in the T3 Code Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stalled ACP turns in `GrokAdapter` by adding a liveness watchdog
> - Adds a liveness watchdog to [`GrokAdapter.ts`](https://github.com/pingdotgg/t3code/pull/7215/files#diff-1a00c5b795ace1b6633f05c6d3b900dc8d4778afd1879ebdbdf3fb41d04ed521) that monitors turn activity and fails stalled turns after an inactivity deadline, but only after ACP has emitted observable progress (content, plan update, tool activity, or user input resolution).
> - Pauses the watchdog during pending approvals and user-input requests, and resumes it on resolution; refreshes the liveness window on steering turns and plan updates.
> - Uses a longer inactivity timeout while tool calls are in progress, tracked via an active tool call set.
> - Extends [`acp-mock-agent.ts`](https://github.com/pingdotgg/t3code/pull/7215/files#diff-8a006152e281284d31dee6c6726df790c3c486b6899a0746f334a8d0663fabc7) with env-controlled stall modes to simulate hangs after content, plan updates, active tools, or `ask_user_question` responses for testing.
> - Behavioral Change: turns that stall after emitting any progress will now be failed with a turn completion event after the inactivity deadline; turns silent before any ACP progress are not timed out.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa5736c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->