### PR TITLE
feat(server): relink projects after folder moves

### DIFF
--- a/apps/server/src/bin.test.ts
+++ b/apps/server/src/bin.test.ts
@@ -468,52 +468,127 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
     }),
   );
 
-  it.effect("adds, renames, and removes projects offline through the orchestration engine", () =>
-    Effect.gen(function* () {
-      const baseDir = NodeFS.mkdtempSync(
-        NodePath.join(NodeOS.tmpdir(), "t3-cli-projects-offline-test-"),
-      );
-      const workspaceRoot = NodeFS.mkdtempSync(
-        NodePath.join(NodeOS.tmpdir(), "t3-cli-projects-workspace-"),
-      );
+  it.effect(
+    "adds, renames, relinks, and removes projects offline through the orchestration engine",
+    () =>
+      Effect.gen(function* () {
+        const baseDir = NodeFS.mkdtempSync(
+          NodePath.join(NodeOS.tmpdir(), "t3-cli-projects-offline-test-"),
+        );
+        const workspaceParent = NodeFS.mkdtempSync(
+          NodePath.join(NodeOS.tmpdir(), "t3-cli-projects-workspace-"),
+        );
+        const workspaceRoot = NodePath.join(workspaceParent, "Alpha");
+        const relinkedWorkspaceRoot = NodePath.join(workspaceParent, "Beta");
+        NodeFS.mkdirSync(workspaceRoot);
+        const duplicateWorkspaceRoot = NodeFS.mkdtempSync(
+          NodePath.join(NodeOS.tmpdir(), "t3-cli-projects-duplicate-workspace-"),
+        );
+        const missingWorkspaceRoot = NodePath.join(
+          NodeOS.tmpdir(),
+          "t3-cli-projects-missing-workspace",
+        );
 
-      yield* runCliWithRuntime([
-        "project",
-        "add",
-        workspaceRoot,
-        "--title",
-        "Alpha",
-        "--base-dir",
-        baseDir,
-      ]);
-      const afterAdd = yield* readPersistedSnapshot(baseDir);
-      const addedProject = afterAdd.projects.find(
-        (project) => project.workspaceRoot === workspaceRoot && project.deletedAt === null,
-      );
-      assert.isTrue(addedProject !== undefined);
-      assert.equal(addedProject?.title, "Alpha");
+        yield* runCliWithRuntime([
+          "project",
+          "add",
+          workspaceRoot,
+          "--title",
+          "Alpha",
+          "--base-dir",
+          baseDir,
+        ]);
+        const afterAdd = yield* readPersistedSnapshot(baseDir);
+        const addedProject = afterAdd.projects.find(
+          (project) => project.workspaceRoot === workspaceRoot && project.deletedAt === null,
+        );
+        assert.isTrue(addedProject !== undefined);
+        assert.equal(addedProject?.title, "Alpha");
 
-      yield* runCliWithRuntime(["project", "rename", workspaceRoot, "Beta", "--base-dir", baseDir]);
-      const afterRename = yield* readPersistedSnapshot(baseDir);
-      const renamedProject = afterRename.projects.find(
-        (project) => project.id === addedProject?.id,
-      );
-      assert.equal(renamedProject?.title, "Beta");
-      assert.equal(renamedProject?.deletedAt, null);
+        yield* runCliWithRuntime([
+          "project",
+          "add",
+          duplicateWorkspaceRoot,
+          "--title",
+          "Duplicate",
+          "--base-dir",
+          baseDir,
+        ]);
 
-      yield* runCliWithRuntime([
-        "project",
-        "remove",
-        addedProject?.id ?? "",
-        "--base-dir",
-        baseDir,
-      ]);
-      const afterRemove = yield* readPersistedSnapshot(baseDir);
-      const removedProject = afterRemove.projects.find(
-        (project) => project.id === addedProject?.id,
-      );
-      assert.isTrue((removedProject?.deletedAt ?? null) !== null);
-    }),
+        yield* runCliWithRuntime([
+          "project",
+          "rename",
+          workspaceRoot,
+          "Beta",
+          "--base-dir",
+          baseDir,
+        ]);
+        const afterRename = yield* readPersistedSnapshot(baseDir);
+        const renamedProject = afterRename.projects.find(
+          (project) => project.id === addedProject?.id,
+        );
+        assert.equal(renamedProject?.title, "Beta");
+        assert.equal(renamedProject?.deletedAt, null);
+
+        NodeFS.renameSync(workspaceRoot, relinkedWorkspaceRoot);
+        yield* runCliWithRuntime([
+          "project",
+          "relink",
+          addedProject?.id ?? "",
+          relinkedWorkspaceRoot,
+          "--base-dir",
+          baseDir,
+        ]);
+        const afterRelink = yield* readPersistedSnapshot(baseDir);
+        const relinkedProject = afterRelink.projects.find(
+          (project) => project.id === addedProject?.id,
+        );
+        assert.equal(relinkedProject?.workspaceRoot, relinkedWorkspaceRoot);
+        assert.equal(relinkedProject?.title, "Beta");
+        assert.equal(relinkedProject?.deletedAt, null);
+        yield* runCliWithRuntime([
+          "project",
+          "relink",
+          addedProject?.id ?? "",
+          missingWorkspaceRoot,
+          "--base-dir",
+          baseDir,
+        ]).pipe(Effect.flip);
+        const afterMissingRelink = yield* readPersistedSnapshot(baseDir);
+        assert.equal(
+          afterMissingRelink.projects.find((project) => project.id === addedProject?.id)
+            ?.workspaceRoot,
+          relinkedWorkspaceRoot,
+        );
+
+        yield* runCliWithRuntime([
+          "project",
+          "relink",
+          addedProject?.id ?? "",
+          duplicateWorkspaceRoot,
+          "--base-dir",
+          baseDir,
+        ]).pipe(Effect.flip);
+        const afterDuplicateRelink = yield* readPersistedSnapshot(baseDir);
+        assert.equal(
+          afterDuplicateRelink.projects.find((project) => project.id === addedProject?.id)
+            ?.workspaceRoot,
+          relinkedWorkspaceRoot,
+        );
+
+        yield* runCliWithRuntime([
+          "project",
+          "remove",
+          addedProject?.id ?? "",
+          "--base-dir",
+          baseDir,
+        ]);
+        const afterRemove = yield* readPersistedSnapshot(baseDir);
+        const removedProject = afterRemove.projects.find(
+          (project) => project.id === addedProject?.id,
+        );
+        assert.isTrue((removedProject?.deletedAt ?? null) !== null);
+      }),
   );
 
   it.effect("force removes projects that still contain threads", () =>

--- a/apps/server/src/bin.test.ts
+++ b/apps/server/src/bin.test.ts
@@ -534,7 +534,7 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
         yield* runCliWithRuntime([
           "project",
           "relink",
-          addedProject?.id ?? "",
+          workspaceRoot,
           relinkedWorkspaceRoot,
           "--base-dir",
           baseDir,

--- a/apps/server/src/bin.test.ts
+++ b/apps/server/src/bin.test.ts
@@ -531,10 +531,11 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
         assert.equal(renamedProject?.deletedAt, null);
 
         NodeFS.renameSync(workspaceRoot, relinkedWorkspaceRoot);
+        const staleWorkspaceRoot = NodePath.relative(process.cwd(), workspaceRoot);
         yield* runCliWithRuntime([
           "project",
           "relink",
-          workspaceRoot,
+          staleWorkspaceRoot,
           relinkedWorkspaceRoot,
           "--base-dir",
           baseDir,

--- a/apps/server/src/cli/project.ts
+++ b/apps/server/src/cli/project.ts
@@ -7,7 +7,6 @@ import {
   ProjectId,
   type ClientOrchestrationCommand,
 } from "@t3tools/contracts";
-import * as NodeOS from "node:os";
 import * as Console from "effect/Console";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
@@ -26,6 +25,7 @@ import * as HttpApiClient from "effect/unstable/httpapi/HttpApiClient";
 import * as EnvironmentAuth from "../auth/EnvironmentAuth.ts";
 
 import * as ServerConfig from "../config.ts";
+import { expandHomePathWith } from "../pathExpansion.ts";
 import * as OrchestrationEngine from "../orchestration/Services/OrchestrationEngine.ts";
 import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSnapshotQuery.ts";
 import { OrchestrationLayerLive } from "../orchestration/runtimeLayer.ts";
@@ -236,13 +236,7 @@ const normalizeWorkspaceRootForProjectCommand = Effect.fn(
 });
 
 function resolveWorkspaceRootIdentifier(identifier: string, path: Path.Path): string {
-  const expandedIdentifier =
-    identifier === "~"
-      ? NodeOS.homedir()
-      : identifier.startsWith("~/") || identifier.startsWith("~\\")
-        ? path.join(NodeOS.homedir(), identifier.slice(2))
-        : identifier;
-  return path.resolve(expandedIdentifier);
+  return path.resolve(expandHomePathWith(identifier, path));
 }
 
 const resolveProjectTitle = Effect.fn("resolveProjectTitle")(function* (

--- a/apps/server/src/cli/project.ts
+++ b/apps/server/src/cli/project.ts
@@ -568,7 +568,55 @@ const projectRenameCommand = Command.make("rename", {
   ),
 );
 
+const projectRelinkCommand = Command.make("relink", {
+  ...projectLocationFlags,
+  project: Argument.string("project").pipe(
+    Argument.withDescription("Project id or workspace root to relink."),
+  ),
+  workspaceRoot: Argument.string("path").pipe(
+    Argument.withDescription("New workspace root for the project."),
+  ),
+}).pipe(
+  Command.withDescription("Relink a project to a new workspace root."),
+  Command.withHandler((flags) =>
+    runProjectMutation(
+      flags,
+      Effect.fn("projectRelinkMutation")(function* ({
+        snapshot,
+        dispatch,
+      }: {
+        readonly snapshot: OrchestrationReadModel;
+        readonly dispatch: (
+          command: ProjectCliDispatchCommand,
+        ) => Effect.Effect<void, Error, FileSystem.FileSystem | HttpClient.HttpClient | Path.Path>;
+      }) {
+        const project = yield* findActiveProjectTarget({
+          snapshot,
+          identifier: flags.project,
+        });
+        const workspaceRoot = yield* normalizeWorkspaceRootForProjectCommand(flags.workspaceRoot);
+        if (workspaceRoot === project.workspaceRoot) {
+          return `Project ${project.id} is already linked to ${workspaceRoot}.`;
+        }
+
+        yield* dispatch({
+          type: "project.meta.update",
+          commandId: CommandId.make(yield* projectCommandUuid),
+          projectId: project.id,
+          workspaceRoot,
+        });
+        return `Relinked project ${project.id} to ${workspaceRoot}.`;
+      }),
+    ),
+  ),
+);
+
 export const projectCommand = Command.make("project").pipe(
   Command.withDescription("Manage projects."),
-  Command.withSubcommands([projectAddCommand, projectRemoveCommand, projectRenameCommand]),
+  Command.withSubcommands([
+    projectAddCommand,
+    projectRemoveCommand,
+    projectRenameCommand,
+    projectRelinkCommand,
+  ]),
 );

--- a/apps/server/src/cli/project.ts
+++ b/apps/server/src/cli/project.ts
@@ -276,6 +276,19 @@ const findActiveProjectTarget = Effect.fn("findActiveProjectTarget")(function* (
     } satisfies ProjectMutationTarget;
   }
 
+  // A relink may be the first command run after the workspace moved, so the
+  // stored root can be valid project identity even though it no longer exists.
+  const staleWorkspaceRootMatch = activeProjects.find(
+    (project) => project.workspaceRoot === trimmedIdentifier,
+  );
+  if (staleWorkspaceRootMatch) {
+    return {
+      id: staleWorkspaceRootMatch.id,
+      title: staleWorkspaceRootMatch.title,
+      workspaceRoot: staleWorkspaceRootMatch.workspaceRoot,
+    } satisfies ProjectMutationTarget;
+  }
+
   const normalizedWorkspaceRootResult = yield* Effect.result(
     normalizeWorkspaceRootForProjectCommand(trimmedIdentifier),
   );

--- a/apps/server/src/cli/project.ts
+++ b/apps/server/src/cli/project.ts
@@ -7,6 +7,7 @@ import {
   ProjectId,
   type ClientOrchestrationCommand,
 } from "@t3tools/contracts";
+import * as NodeOS from "node:os";
 import * as Console from "effect/Console";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
@@ -234,6 +235,16 @@ const normalizeWorkspaceRootForProjectCommand = Effect.fn(
   return yield* workspacePaths.normalizeWorkspaceRoot(workspaceRoot);
 });
 
+function resolveWorkspaceRootIdentifier(identifier: string, path: Path.Path): string {
+  const expandedIdentifier =
+    identifier === "~"
+      ? NodeOS.homedir()
+      : identifier.startsWith("~/") || identifier.startsWith("~\\")
+        ? path.join(NodeOS.homedir(), identifier.slice(2))
+        : identifier;
+  return path.resolve(expandedIdentifier);
+}
+
 const resolveProjectTitle = Effect.fn("resolveProjectTitle")(function* (
   workspaceRoot: string,
   explicitTitle?: string,
@@ -278,8 +289,10 @@ const findActiveProjectTarget = Effect.fn("findActiveProjectTarget")(function* (
 
   // A relink may be the first command run after the workspace moved, so the
   // stored root can be valid project identity even though it no longer exists.
+  const path = yield* Path.Path;
+  const resolvedWorkspaceRootIdentifier = resolveWorkspaceRootIdentifier(trimmedIdentifier, path);
   const staleWorkspaceRootMatch = activeProjects.find(
-    (project) => project.workspaceRoot === trimmedIdentifier,
+    (project) => project.workspaceRoot === resolvedWorkspaceRootIdentifier,
   );
   if (staleWorkspaceRootMatch) {
     return {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -1157,6 +1157,108 @@ describe("ProviderCommandReactor", () => {
       expect(runningThread?.session?.status).toBe("running");
     }),
   );
+  effectIt.effect(
+    "uses a relinked project cwd for new Claude sessions without restarting existing sessions",
+    () =>
+      Effect.gen(function* () {
+        const modelSelection = {
+          instanceId: ProviderInstanceId.make("claudeAgent"),
+          model: "claude-sonnet-4-5",
+        } satisfies ModelSelection;
+        const harness = yield* Effect.promise(() =>
+          createHarness({ threadModelSelection: modelSelection }),
+        );
+        const now = "2026-01-01T00:00:00.000Z";
+
+        yield* harness.engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.make("cmd-turn-start-existing-claude-thread"),
+          threadId: ThreadId.make("thread-1"),
+          message: {
+            messageId: asMessageId("user-message-existing-claude-thread"),
+            role: "user",
+            text: "start the existing Claude thread",
+            attachments: [],
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          createdAt: now,
+        });
+        yield* Effect.promise(() => harness.drain());
+
+        expect(harness.startSession).toHaveBeenCalledTimes(1);
+        expect(harness.startSession.mock.calls[0]?.[0]).toEqual(ThreadId.make("thread-1"));
+        expect(harness.startSession.mock.calls[0]?.[1]).toMatchObject({
+          cwd: "/tmp/provider-project",
+          provider: "claudeAgent",
+        });
+        expect(harness.sendTurn).toHaveBeenCalledTimes(1);
+
+        yield* harness.engine.dispatch({
+          type: "project.meta.update",
+          commandId: CommandId.make("cmd-project-relink-claude"),
+          projectId: asProjectId("project-1"),
+          workspaceRoot: "/tmp/provider-project-relocated",
+        });
+        yield* Effect.promise(() => harness.drain());
+
+        yield* harness.engine.dispatch({
+          type: "thread.create",
+          commandId: CommandId.make("cmd-thread-create-new-claude-thread"),
+          threadId: ThreadId.make("thread-2"),
+          projectId: asProjectId("project-1"),
+          title: "New Claude thread",
+          modelSelection,
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          branch: null,
+          worktreePath: null,
+          createdAt: "2026-01-01T00:00:01.000Z",
+        });
+        yield* harness.engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.make("cmd-turn-start-new-claude-thread"),
+          threadId: ThreadId.make("thread-2"),
+          message: {
+            messageId: asMessageId("user-message-new-claude-thread"),
+            role: "user",
+            text: "start a new Claude thread after relinking",
+            attachments: [],
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          createdAt: "2026-01-01T00:00:01.000Z",
+        });
+        yield* Effect.promise(() => harness.drain());
+
+        expect(harness.startSession).toHaveBeenCalledTimes(2);
+        expect(harness.startSession.mock.calls[1]?.[0]).toEqual(ThreadId.make("thread-2"));
+        expect(harness.startSession.mock.calls[1]?.[1]).toMatchObject({
+          cwd: "/tmp/provider-project-relocated",
+          provider: "claudeAgent",
+        });
+        expect(
+          harness.startSession.mock.calls.filter(
+            ([threadId]) => threadId === ThreadId.make("thread-1"),
+          ),
+        ).toHaveLength(1);
+        expect(harness.sendTurn).toHaveBeenCalledTimes(2);
+        expect(
+          harness.runtimeSessions.find(
+            (session) => session.threadId === ThreadId.make("thread-1"),
+          ),
+        ).toMatchObject({ cwd: "/tmp/provider-project" });
+
+        const readModel = yield* Effect.promise(() => harness.readModel());
+        for (const threadId of [ThreadId.make("thread-1"), ThreadId.make("thread-2")]) {
+          const thread = readModel.threads.find((entry) => entry.id === threadId);
+          expect(
+            thread?.activities.some((activity) => activity.kind === "provider.turn.start.failed"),
+          ).toBe(false);
+        }
+      }),
+  );
+
   effectIt.effect("projects starting before a slow provider session finishes", () =>
     Effect.gen(function* () {
       const releaseStart = yield* Deferred.make<void>();

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -3732,7 +3732,7 @@ describe("ProviderCommandReactor", () => {
       ),
     );
 
-    await Effect.runPromise(
+    await harness.runEffect(
       harness.engine.dispatch({
         type: "thread.session.set",
         commandId: CommandId.make("cmd-session-set-for-approval-error"),
@@ -3827,7 +3827,7 @@ describe("ProviderCommandReactor", () => {
       ),
     );
 
-    await Effect.runPromise(
+    await harness.runEffect(
       harness.engine.dispatch({
         type: "thread.session.set",
         commandId: CommandId.make("cmd-session-set-for-user-input-error"),
@@ -3845,7 +3845,7 @@ describe("ProviderCommandReactor", () => {
       }),
     );
 
-    await Effect.runPromise(
+    await harness.runEffect(
       harness.engine.dispatch({
         type: "thread.activity.append",
         commandId: CommandId.make("cmd-user-input-requested"),
@@ -3878,7 +3878,7 @@ describe("ProviderCommandReactor", () => {
       }),
     );
 
-    await Effect.runPromise(
+    await harness.runEffect(
       harness.engine.dispatch({
         type: "thread.user-input.respond",
         commandId: CommandId.make("cmd-user-input-respond-stale"),

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -1184,7 +1184,8 @@ describe("ProviderCommandReactor", () => {
           runtimeMode: "approval-required",
           createdAt: now,
         });
-        yield* Effect.promise(() => harness.drain());
+        yield* Effect.promise(() => waitFor(() => harness.startSession.mock.calls.length === 1));
+        yield* Effect.promise(() => waitFor(() => harness.sendTurn.mock.calls.length === 1));
 
         expect(harness.startSession).toHaveBeenCalledTimes(1);
         expect(harness.startSession.mock.calls[0]?.[0]).toEqual(ThreadId.make("thread-1"));
@@ -1229,7 +1230,8 @@ describe("ProviderCommandReactor", () => {
           runtimeMode: "approval-required",
           createdAt: "2026-01-01T00:00:01.000Z",
         });
-        yield* Effect.promise(() => harness.drain());
+        yield* Effect.promise(() => waitFor(() => harness.startSession.mock.calls.length === 2));
+        yield* Effect.promise(() => waitFor(() => harness.sendTurn.mock.calls.length === 2));
 
         expect(harness.startSession).toHaveBeenCalledTimes(2);
         expect(harness.startSession.mock.calls[1]?.[0]).toEqual(ThreadId.make("thread-2"));
@@ -1244,9 +1246,7 @@ describe("ProviderCommandReactor", () => {
         ).toHaveLength(1);
         expect(harness.sendTurn).toHaveBeenCalledTimes(2);
         expect(
-          harness.runtimeSessions.find(
-            (session) => session.threadId === ThreadId.make("thread-1"),
-          ),
+          harness.runtimeSessions.find((session) => session.threadId === ThreadId.make("thread-1")),
         ).toMatchObject({ cwd: "/tmp/provider-project" });
 
         const readModel = yield* Effect.promise(() => harness.readModel());


### PR DESCRIPTION
Partially addresses #4940. #7156 was closed as a duplicate.

Rename a project's folder and the next new thread dies with a fake "Claude Code native binary not found" error. Claude is installed. Old threads on that project keep working. Re-adding the project is the only workaround.

The stored workspace path was left pointing at the old directory. `t3 project relink` updates that path. New sessions use the new cwd. Existing sessions keep theirs.

Verification:

- `vp test run apps/server/src/bin.test.ts apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts` (79 tests passed)
- Targeted formatting and lint
- `vp run --filter t3 typecheck`
- `git diff --check origin/main...HEAD`

Updated with GPT-5.6 Sol through Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared `findActiveProjectTarget` resolution used by multiple project mutations; incorrect stale-root matching could target the wrong project, though relink still normalizes and rejects invalid/duplicate destinations in tests.
> 
> **Overview**
> Adds **`t3 project relink <project> <path>`** so a project’s persisted workspace root can be updated after the folder moves, via **`project.meta.update`** with a new `workspaceRoot` (no-op message when unchanged).
> 
> **Project lookup** now resolves identifiers with **`~`/home expansion** and can match an active project by its **stored absolute workspace root** even when that path no longer exists—so relink/rename/remove still work when the old directory is gone.
> 
> Integration tests cover offline add/rename/relink/remove (stale path, missing target, duplicate workspace failures) and provider behavior: **new Claude sessions use the relinked `cwd`** while **existing sessions keep the original `cwd`**. Provider reactor tests also switch some harness calls from **`Effect.runPromise`** to **`harness.runEffect`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bee3f05b46f3173eac7a704ecc3c013772e29ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `project relink` CLI subcommand to update project workspace roots after folder moves
> - Adds a `project relink` subcommand that accepts a project id or workspace root plus a new workspace path, normalizes the new root, and dispatches `project.meta.update` when the root has changed
> - Adds `resolveWorkspaceRootIdentifier` to expand `~` notation and resolve to absolute paths before comparing with stored roots, and `findActiveProjectTarget` to match a project from a stale stored root even when the folder no longer exists on disk
> - Existing Claude sessions keep their original cwd; only new sessions created after relinking use the updated root
> - Risk: `findActiveProjectTarget` in [project.ts](https://github.com/pingdotgg/t3code/pull/7216/files#diff-44f1264ca9e5b2f3994c44291b5616390842fc6345021ca54e8447fd8dbbc1cd) now resolves projects from stale roots before filesystem normalization, so a moved-but-not-relinked project can still be targeted by its old root — reviewers should confirm this does not shadow other project lookups by id or title
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6bee3f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->