### PR TITLE
fix(web): protect account profile details

### DIFF
--- a/apps/web/src/components/clerk/T3ConnectSidebarSignIn.tsx
+++ b/apps/web/src/components/clerk/T3ConnectSidebarSignIn.tsx
@@ -1,5 +1,6 @@
-import { UserButton, useAuth } from "@clerk/react";
+import { UserButton, useAuth, useUser } from "@clerk/react";
 import { LogInIcon, ServerIcon, SmartphoneIcon } from "lucide-react";
+import { useRef } from "react";
 
 import { hasCloudPublicConfig } from "../../cloud/publicConfig";
 import { SidebarMenu, SidebarMenuButton, SidebarMenuItem } from "../ui/sidebar";
@@ -21,33 +22,53 @@ export function T3ConnectSidebarAvatar() {
 
 function ConfiguredT3ConnectSidebarAvatar() {
   const { isLoaded, isSignedIn } = useAuth();
+  const { user } = useUser();
+  const profileRefreshRef = useRef<Promise<unknown> | null>(null);
+
+  const refreshAccountProfile = () => {
+    if (!user || profileRefreshRef.current) return;
+
+    const refresh = user
+      .reload()
+      .catch(() => undefined)
+      .finally(() => {
+        if (profileRefreshRef.current === refresh) profileRefreshRef.current = null;
+      });
+    profileRefreshRef.current = refresh;
+  };
 
   if (!isLoaded || !isSignedIn) return null;
 
   return (
-    <UserButton
-      appearance={{
-        elements: {
-          avatarBox: "size-7",
-          userButtonTrigger: "rounded-lg p-1 hover:bg-sidebar-row-hover",
-        },
-      }}
+    <span
+      className="inline-flex"
+      onFocus={refreshAccountProfile}
+      onPointerDown={refreshAccountProfile}
     >
-      <UserButton.UserProfilePage
-        label="Mobile clients"
-        labelIcon={<SmartphoneIcon className="size-4" />}
-        url="mobile-clients"
+      <UserButton
+        appearance={{
+          elements: {
+            avatarBox: "size-7",
+            userButtonTrigger: "rounded-lg p-1 hover:bg-sidebar-row-hover",
+          },
+        }}
       >
-        <MobileClientsUserProfilePage />
-      </UserButton.UserProfilePage>
-      <UserButton.UserProfilePage
-        label="T3 Connect"
-        labelIcon={<ServerIcon className="size-4" />}
-        url="t3-connect"
-      >
-        <T3ConnectUserProfilePage />
-      </UserButton.UserProfilePage>
-    </UserButton>
+        <UserButton.UserProfilePage
+          label="Mobile clients"
+          labelIcon={<SmartphoneIcon className="size-4" />}
+          url="mobile-clients"
+        >
+          <MobileClientsUserProfilePage />
+        </UserButton.UserProfilePage>
+        <UserButton.UserProfilePage
+          label="T3 Connect"
+          labelIcon={<ServerIcon className="size-4" />}
+          url="t3-connect"
+        >
+          <T3ConnectUserProfilePage />
+        </UserButton.UserProfilePage>
+      </UserButton>
+    </span>
   );
 }
 

--- a/apps/web/src/components/clerk/clerkAppearance.test.ts
+++ b/apps/web/src/components/clerk/clerkAppearance.test.ts
@@ -75,6 +75,20 @@ describe("clerkAppearance", () => {
         otpCodeFieldErrorText: { color: "var(--error-foreground)" },
         otpCodeFieldSuccessText: { color: "var(--success-foreground)" },
       },
+      userButton: {
+        elements: {
+          userPreviewMainIdentifier: {
+            "&:not(:has(~ .cl-userPreviewSecondaryIdentifier))": {
+              filter: "blur(2px)",
+              userSelect: "none",
+            },
+          },
+          userPreviewSecondaryIdentifier: {
+            filter: "blur(2px)",
+            userSelect: "none",
+          },
+        },
+      },
     });
   });
 

--- a/apps/web/src/components/clerk/clerkAppearance.ts
+++ b/apps/web/src/components/clerk/clerkAppearance.ts
@@ -31,4 +31,18 @@ export const clerkAppearance = {
     otpCodeFieldErrorText: { color: "var(--error-foreground)" },
     otpCodeFieldSuccessText: { color: "var(--success-foreground)" },
   },
+  userButton: {
+    elements: {
+      userPreviewMainIdentifier: {
+        "&:not(:has(~ .cl-userPreviewSecondaryIdentifier))": {
+          filter: "blur(2px)",
+          userSelect: "none",
+        },
+      },
+      userPreviewSecondaryIdentifier: {
+        filter: "blur(2px)",
+        userSelect: "none",
+      },
+    },
+  },
 } satisfies NonNullable<ClerkProviderProps["appearance"]>;

--- a/apps/web/src/components/clerk/clerkAppearance.ts
+++ b/apps/web/src/components/clerk/clerkAppearance.ts
@@ -31,6 +31,8 @@ export const clerkAppearance = {
     otpCodeFieldErrorText: { color: "var(--error-foreground)" },
     otpCodeFieldSuccessText: { color: "var(--success-foreground)" },
   },
+  // Clerk owns these non-interactive nodes. Keep their redaction permanent
+  // because revealing on hover can expose an identifier during screen sharing.
   userButton: {
     elements: {
       userPreviewMainIdentifier: {


### PR DESCRIPTION
The account dropdown exposed the signed-in identifier during screen sharing and could keep a stale username after the profile name changed in Clerk Settings.

This change applies the account-menu privacy treatment to both Clerk identifier layouts. It also refreshes the Clerk user on focus or pointer-down so the menu reads the current first and last name while preserving Clerk's account actions and custom T3 profile pages.

Checks:

- `pnpm exec vp test run apps/web/src/components/clerk/clerkAppearance.test.ts`
- `pnpm exec vp run --filter @t3tools/web typecheck`
- `pnpm exec vp lint apps/web/src/components/clerk/T3ConnectSidebarSignIn.tsx apps/web/src/components/clerk/clerkAppearance.ts apps/web/src/components/clerk/clerkAppearance.test.ts`
- Independent read-only review by Claude Opus 5: clean after fixes

Visuals:

- Before: supplied with the task
- After: pending the required real-client pass and image upload

Implemented with GPT 5.6 Sol through the Codex harness in T3 Code. Reviewed with Claude Opus 5 through Claude Code.

Implemented-by: GPT 5.6 Sol <noreply@openai.com>
Reviewed-by: Claude Opus 5 <noreply@anthropic.com>
Reviewed-by: Macroscope <noreply@ai-agent.invalid>
Co-Authored-By: GPT 5.6 Sol <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only Clerk UI styling and a best-effort `user.reload()` on menu interaction; no server auth or data-path changes.
> 
> **Overview**
> Hardens the Clerk account dropdown for screen sharing by **permanently blurring** email/username preview text in shared `clerkAppearance` (main and secondary identifier layouts), with tests updated to lock in the styling.
> 
> The sidebar **UserButton** now **reloads the Clerk user** on focus or pointer-down (single in-flight refresh) so the menu shows an up-to-date name after changes in Clerk Settings, without altering custom profile pages or sign-in flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ffe906c050c2aa0beca9f82239f317f6a00eacb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Blur account profile identifiers and refresh user on sidebar avatar interaction
> - Adds CSS blur and `userSelect: none` to the Clerk `UserButton`'s preview identifiers in [clerkAppearance.ts](https://github.com/pingdotgg/t3code/pull/7217/files#diff-6071582417608661c1becf50a6e2d3be51a404d1ec7e7a0788c3f110e910e9d5), protecting account details from casual visibility. The main identifier is only blurred when no secondary identifier is present.
> - Triggers a single in-flight `user.reload()` on `onFocus` or `onPointerDown` of the sidebar avatar in [T3ConnectSidebarSignIn.tsx](https://github.com/pingdotgg/t3code/pull/7217/files#diff-36cbbf6163af20007352723b636dbbb278cf71e11771e659b08199e43b3085e2), ensuring profile data is fresh when the user opens the account menu. Concurrent refresh calls are suppressed until the active one resolves.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ffe906.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->