### PR TITLE
fix(web): show all usage breakdown periods

### DIFF
--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -61,8 +61,10 @@ export function UsagePage() {
         : enumerateHourStarts(window.sinceTime, window.untilTime),
     [window.sinceTime, window.untilTime],
   );
-  const recentPeriods = useMemo<readonly (DailyTotals | HourlyTotals)[]>(
-    () => (isPast24Hours ? merged.hourly : merged.daily).toReversed().slice(0, 8),
+  // Newest first: the window can run 90 periods, so the interesting end
+  // belongs at the top of the table.
+  const breakdownPeriods = useMemo<readonly (DailyTotals | HourlyTotals)[]>(
+    () => (isPast24Hours ? merged.hourly : merged.daily).toReversed(),
     [isPast24Hours, merged.daily, merged.hourly],
   );
 
@@ -393,14 +395,14 @@ export function UsagePage() {
                         </tr>
                       </thead>
                       <tbody>
-                        {recentPeriods.length === 0 ? (
+                        {breakdownPeriods.length === 0 ? (
                           <tr>
                             <td colSpan={5} className="py-6 text-center text-muted-foreground">
                               No activity in this window.
                             </td>
                           </tr>
                         ) : (
-                          recentPeriods.map((period) => (
+                          breakdownPeriods.map((period) => (
                             <tr
                               key={"hourStart" in period ? period.hourStart : period.day}
                               className="border-b border-border/50"


### PR DESCRIPTION
## What changed

On the Usage page, the "Breakdown → day" table was hard-capped at the 8 most recent periods. Switching to the 30- or 90-day window still showed only the last 8 days, even though the chart and totals above correctly cover the whole window. This removes the `.slice(0, 8)` truncation so the table lists every day/hour in the selected window, newest first.

## Why

The table is the only per-period readout on the page, and it silently disagreed with the window selector. Small, focused bug fix: one file, ~10 changed lines.

## Testing

- `tsgo --noEmit` clean on `@t3tools/web`
- `vp lint` clean on the changed file

Harness: opencode / big-pickle

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file UI fix with no API, auth, or data-handling changes; only affects how many rows render in an existing table.
> 
> **Overview**
> The Usage page **Breakdown → day/hour** table no longer stops at the eight newest periods. It now lists **every** day or hour in the selected window (up to 90), still **newest first**, so the table matches the window selector and the chart/totals above.
> 
> The data hook was renamed from `recentPeriods` to `breakdownPeriods` and the `.slice(0, 8)` cap was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8fa6bc8999625ab6c62ee36df8295a8aa936ec5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show all periods in the usage breakdown table instead of limiting to 8
> The breakdown table in [UsagePage.tsx](https://github.com/pingdotgg/t3code/pull/7219/files#diff-e076db2611ea0a07e1c8ec8571cc21103a2a4c7fc0feb865192fc12c8a18dead) previously capped the displayed periods at the 8 most recent. It now renders the full hourly or daily array in newest-first order without truncation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8fa6bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->