### PR TITLE
fix(web): merged PR threads settle without polling delay

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -146,7 +146,10 @@ import {
   selectThreadPreviewMiniPlayer,
   usePreviewMiniPlayerStore,
 } from "../previewMiniPlayerStore";
-import { isThreadOwnPullRequest } from "./pullRequest/pullRequestDetail.logic";
+import {
+  isThreadOwnPullRequest,
+  pullRequestActionNeedsVcsRefresh,
+} from "./pullRequest/pullRequestDetail.logic";
 import { PullRequestDetailPanel } from "./pullRequest/PullRequestDetailPanel";
 import { PullRequestDetailGhost } from "./pullRequest/PullRequestGhosts";
 import { PullRequestsUnavailableState } from "./pullRequest/PullRequestsUnavailableState";
@@ -1223,6 +1226,7 @@ function ChatViewContent(props: ChatViewProps) {
     reportFailure: false,
   });
   const switchGitRef = useAtomCommand(vcsEnvironment.switchRef, { reportFailure: false });
+  const refreshVcsStatus = useAtomCommand(vcsEnvironment.refreshStatus, { reportFailure: false });
   const setThreadRuntimeMode = useAtomCommand(threadEnvironment.setRuntimeMode, {
     reportFailure: false,
   });
@@ -6162,6 +6166,13 @@ function ChatViewContent(props: ChatViewProps) {
         }
         chromeVariant="collapse"
         composerDraftTarget={composerDraftTarget}
+        onActed={(action) => {
+          if (!pullRequestActionNeedsVcsRefresh(action) || gitStatusCwd === null) return;
+          void refreshVcsStatus({
+            environmentId: activeThread.environmentId,
+            input: { cwd: gitStatusCwd },
+          });
+        }}
         onStateChange={handlePullRequestTabStatusChange}
       />
     ) : activeRightPanelSurface?.kind === "agents" ? (

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -366,7 +366,7 @@ export function PullRequestDetailPanel({
    * An action changed this pull request on the host, so a list showing it is now out of date.
    * Told rather than assumed: only the page knows whether it is showing one.
    */
-  onActed?: () => void;
+  onActed?: (action: PullRequestAction) => void;
   /** Page-owned detail columns use this to clear the selected pull request. */
   onClose?: () => void;
   /** Keeps compact chrome, such as the right-panel tab, in step with refreshed host state. */
@@ -640,7 +640,7 @@ export function PullRequestDetailPanel({
     } else {
       refreshDetail();
     }
-    onActed?.();
+    onActed?.(action);
   };
 
   const saveTitle = async (next: string) => {

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
@@ -20,6 +20,7 @@ import {
   orderPullRequestComments,
   pullRequestActionMenuHasGroup,
   pullRequestActionNeedsHostRefresh,
+  pullRequestActionNeedsVcsRefresh,
   pullRequestComposerTarget,
   pullRequestFindingKey,
   pullRequestHandoffLabels,
@@ -935,5 +936,13 @@ describe("which actions need the host read again after they run", () => {
     ] as const) {
       expect(pullRequestActionNeedsHostRefresh(action)).toBe(false);
     }
+  });
+});
+
+describe("which actions change linked thread VCS status", () => {
+  it("refreshes VCS status only after a merge", () => {
+    expect(PullRequestAction.literals.map(pullRequestActionNeedsVcsRefresh)).toEqual(
+      PullRequestAction.literals.map((action) => action === "merge"),
+    );
   });
 });

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
@@ -772,3 +772,11 @@ const ACTION_NEEDS_HOST_REFRESH: Record<PullRequestAction, boolean> = {
 export function pullRequestActionNeedsHostRefresh(action: PullRequestAction): boolean {
   return ACTION_NEEDS_HOST_REFRESH[action];
 }
+
+/**
+ * A merge changes the VCS status that classifies linked threads in the sidebar. Other pull
+ * request actions either leave that classification alone or keep the pull request open.
+ */
+export function pullRequestActionNeedsVcsRefresh(action: PullRequestAction): boolean {
+  return action === "merge";
+}

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -41,6 +41,7 @@ T3 Code works with the platforms your team already uses:
 - Open several reviews from the **Pull requests** page as tabs in the right panel
 - While working in a thread, open linked reviews in the same compact right-panel tabs without
   leaving the conversation
+- Merging a linked review updates the thread immediately so it can move to the settled list
 - Open the review directly in your browser with one click
 - Command-click (Control-click on Windows and Linux) a pull request number in the sidebar to open it in your browser instead of in T3 Code
 - Check out a teammate's branch to review code locally


### PR DESCRIPTION
Closes #7224.

Merging a pull request from the thread PR panel refreshed the panel and PR lists, but left the thread sidebar waiting for its next VCS status poll.

Pass the completed action back to ChatView and explicitly refresh the active thread's exact checkout after a successful merge. The existing VCS status stream then publishes the merged state and the existing auto-settle classification moves the thread immediately. Other PR actions keep their current refresh behavior.

Verification:
- `pnpm exec vp test run apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts`
- `pnpm exec vp run --filter @t3tools/web typecheck`

Behavior-only change; there are no styling or layout changes.

Created by GPT-5.6-sol using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-only fix scoped to post-merge VCS refresh; no auth, data, or payment paths touched.
> 
> **Overview**
> **Merging a linked pull request from the thread panel no longer leaves the sidebar waiting for the next VCS poll** before the thread moves to the settled list.
> 
> Adds `pullRequestActionNeedsVcsRefresh` (true only for `merge`) and changes `PullRequestDetailPanel`'s `onActed` to pass the completed `PullRequestAction`. **ChatView** wires that into `vcsEnvironment.refreshStatus` for the active thread's checkout when a merge succeeds, so the existing VCS status stream can reclassify the thread right away. Other PR actions keep the same refresh behavior as before.
> 
> User docs note that merging a linked review updates the thread immediately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd4c4675c9feb8581da050a7c74a124dcb701051. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Trigger VCS status refresh immediately after merging a pull request
> - Adds `pullRequestActionNeedsVcsRefresh` in [pullRequestDetail.logic.ts](https://github.com/pingdotgg/t3code/pull/7227/files#diff-2c5f917dba9decc3bd48ec3231f7b0db073e8b642379cf000265960a03718c18) that returns `true` only for the `merge` action.
> - Updates `PullRequestDetailPanel` to pass the executed `PullRequestAction` to its `onActed` callback instead of calling it with no arguments.
> - In `ChatViewContent`, the new `onActed` handler calls `vcsEnvironment.refreshStatus` when the action requires a VCS refresh, so merged PR threads settle immediately without waiting for the next polling cycle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd4c467.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->