### PR TITLE
fix(server): refresh PR status from agent links

### DIFF
--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -285,6 +285,7 @@ describe("CheckpointReactor", () => {
     readonly providerSessionCwd?: string;
     readonly providerName?: ProviderDriverKind;
     readonly gitStatusRefreshCalls?: Array<string>;
+    readonly changeRequestRefreshCalls?: Array<string>;
   }) {
     const cwd = createGitRepository();
     tempDirs.push(cwd);
@@ -330,7 +331,23 @@ describe("CheckpointReactor", () => {
             workingTree: { files: [], insertions: 0, deletions: 0 },
           }),
         ),
-      refreshStatus: () => Effect.die("refreshStatus should not be called in this test"),
+      refreshStatus: (cwd: string) =>
+        Effect.sync(() => {
+          options?.changeRequestRefreshCalls?.push(cwd);
+          return {
+            isRepo: true,
+            hasPrimaryRemote: false,
+            isDefaultRef: true,
+            refName: "main",
+            hasWorkingTreeChanges: false,
+            workingTree: { files: [], insertions: 0, deletions: 0 },
+            hasUpstream: false,
+            aheadCount: 0,
+            behindCount: 0,
+            aheadOfDefaultCount: 0,
+            pr: null,
+          };
+        }),
       streamStatus: () => Stream.empty,
     });
 
@@ -452,6 +469,41 @@ describe("CheckpointReactor", () => {
       drain,
     };
   }
+
+  it("refreshes remote status when a completed assistant message contains a change request URL", async () => {
+    const changeRequestRefreshCalls: Array<string> = [];
+    const harness = await createHarness({
+      seedFilesystemCheckpoints: false,
+      changeRequestRefreshCalls,
+    });
+    const messageId = MessageId.make("assistant-change-request-link");
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.message.assistant.delta",
+        commandId: CommandId.make("cmd-assistant-change-request-link"),
+        threadId: ThreadId.make("thread-1"),
+        messageId,
+        delta: "Opened https://bitbucket.org/pingdotgg/t3code/pull-requests/42",
+        createdAt: "2026-01-01T00:00:01.000Z",
+      }),
+    );
+    await harness.drain();
+    expect(changeRequestRefreshCalls).toEqual([]);
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.message.assistant.complete",
+        commandId: CommandId.make("cmd-assistant-change-request-link-complete"),
+        threadId: ThreadId.make("thread-1"),
+        messageId,
+        createdAt: "2026-01-01T00:00:02.000Z",
+      }),
+    );
+    await harness.drain();
+
+    expect(changeRequestRefreshCalls).toEqual([harness.cwd]);
+  });
 
   it("captures pre-turn baseline on turn.started and post-turn checkpoint on turn.completed", async () => {
     const harness = await createHarness({ seedFilesystemCheckpoints: false });

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -20,6 +20,7 @@ import type * as PlatformError from "effect/PlatformError";
 import * as Stream from "effect/Stream";
 import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
 import { isTemporaryWorktreeBranch } from "@t3tools/shared/git";
+import { containsChangeRequestUrl } from "@t3tools/shared/sourceControl";
 
 import { parseTurnDiffFilesFromUnifiedDiff } from "../../checkpointing/Diffs.ts";
 import {
@@ -687,6 +688,41 @@ const make = Effect.gen(function* () {
     });
   });
 
+  const refreshChangeRequestFromAssistantMessage = Effect.fn(
+    "refreshChangeRequestFromAssistantMessage",
+  )(function* (event: Extract<OrchestrationEvent, { type: "thread.message-sent" }>) {
+    if (event.payload.role !== "assistant" || event.payload.streaming) {
+      return;
+    }
+
+    const thread = yield* resolveThreadDetail(event.payload.threadId);
+    const message = thread?.messages.find((entry) => entry.id === event.payload.messageId);
+    if (!thread || !message || !containsChangeRequestUrl(message.text)) {
+      return;
+    }
+
+    const projects = yield* resolveThreadProjects(thread.projectId);
+    const cwd = yield* resolveCheckpointCwd({
+      threadId: thread.id,
+      thread,
+      projects,
+      preferSessionRuntime: true,
+    });
+    if (!cwd) {
+      return;
+    }
+
+    yield* vcsStatusBroadcaster.refreshStatus(cwd).pipe(
+      Effect.catchCause((cause) =>
+        Effect.logWarning("failed to refresh change request status from assistant message", {
+          threadId: thread.id,
+          cwd,
+          cause: Cause.pretty(cause),
+        }),
+      ),
+    );
+  });
+
   const handleRevertRequested = Effect.fn("handleRevertRequested")(function* (
     event: Extract<OrchestrationEvent, { type: "thread.checkpoint-revert-requested" }>,
   ) {
@@ -820,6 +856,9 @@ const make = Effect.gen(function* () {
   const processDomainEvent = Effect.fn("processDomainEvent")(function* (event: OrchestrationEvent) {
     if (event.type === "thread.turn-start-requested" || event.type === "thread.message-sent") {
       yield* ensurePreTurnBaselineFromDomainTurnStart(event);
+      if (event.type === "thread.message-sent") {
+        yield* refreshChangeRequestFromAssistantMessage(event);
+      }
       return;
     }
 

--- a/packages/shared/src/sourceControl.test.ts
+++ b/packages/shared/src/sourceControl.test.ts
@@ -1,11 +1,31 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  containsChangeRequestUrl,
   detectSourceControlProviderFromRemoteUrl,
   getChangeRequestTerminologyForKind,
   isSshRemoteUrl,
   resolveChangeRequestPresentation,
 } from "./sourceControl.ts";
+
+describe("containsChangeRequestUrl", () => {
+  it.each([
+    "Opened https://github.com/pingdotgg/t3code/pull/42",
+    "Opened https://gitlab.example.com/group/project/-/merge_requests/42.",
+    "Opened https://dev.azure.com/acme/project/_git/t3code/pullrequest/42",
+    "Opened https://bitbucket.org/pingdotgg/t3code/pull-requests/42",
+  ])("accepts supported change request URLs in agent text", (text) => {
+    expect(containsChangeRequestUrl(text)).toBe(true);
+  });
+
+  it.each([
+    "I will open a pull request next.",
+    "https://github.com/pingdotgg/t3code/issues/42",
+    "https://example.com/pull/not-a-number",
+  ])("rejects text without a supported change request URL", (text) => {
+    expect(containsChangeRequestUrl(text)).toBe(false);
+  });
+});
 
 describe("source control presentation", () => {
   it("uses merge request terminology for GitLab", () => {

--- a/packages/shared/src/sourceControl.ts
+++ b/packages/shared/src/sourceControl.ts
@@ -21,6 +21,18 @@ export const DEFAULT_CHANGE_REQUEST_TERMINOLOGY: ChangeRequestTerminology = {
   singular: "pull request",
 };
 
+const CHANGE_REQUEST_URL_PATTERNS = [
+  /https:\/\/[^\s<>()]+\/[^/\s<>()]+\/[^/\s<>()]+\/pull\/\d+(?:[/?#][^\s<>()]*)?/i,
+  /https:\/\/[^\s<>()]+\/[^\s<>()]+\/-\/merge_requests\/\d+(?:[/?#][^\s<>()]*)?/i,
+  /https:\/\/[^\s<>()]+\/[^\s<>()]+\/_git\/[^/\s<>()]+\/pullrequest\/\d+(?:[/?#][^\s<>()]*)?/i,
+  /https:\/\/[^\s<>()]+\/[^/\s<>()]+\/[^/\s<>()]+\/pull-requests\/\d+(?:[/?#][^\s<>()]*)?/i,
+] as const;
+
+/** Detects a source-control change request URL embedded in agent-authored text. */
+export function containsChangeRequestUrl(text: string): boolean {
+  return CHANGE_REQUEST_URL_PATTERNS.some((pattern) => pattern.test(text));
+}
+
 const GITHUB_CHANGE_REQUEST_PRESENTATION: ChangeRequestPresentation = {
   icon: "github",
   providerName: "GitHub",


### PR DESCRIPTION
## What Changed

- detect completed assistant messages containing GitHub, GitLab, Azure DevOps, or Bitbucket change request URLs
- refresh the authoritative remote VCS status immediately after detection so subscribed sidebars update without waiting for the polling interval
- avoid refreshes for streaming message chunks and cover URL detection plus reactor behavior with focused tests

## Why

Remote pull request and merge request metadata normally refreshes on a 30-second interval. When an agent creates a change request and posts its URL, the sidebar can therefore remain stale even though T3 already has a reliable signal that remote state changed. The URL is used only as a refresh hint; the configured source-control provider remains the source of truth.

Closes #7228

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Before/after screenshots are not applicable; this changes refresh timing without changing UI
- [x] A video is not applicable; this changes refresh timing without changing interaction behavior

Implemented with gpt-5.6-sol via the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an opportunistic VCS refresh on message completion with guarded regex matching and swallowed refresh errors; no auth or data-model changes.
> 
> **Overview**
> When an agent finishes a **non-streaming** assistant message that includes a PR/MR URL, the sidebar can refresh remote VCS status right away instead of waiting on the ~30s poll.
> 
> **Shared:** adds `containsChangeRequestUrl` in `@t3tools/shared/sourceControl` with regexes for GitHub, GitLab, Azure DevOps, and Bitbucket change-request links, plus unit tests.
> 
> **Server:** `CheckpointReactor` handles `thread.message-sent` for completed assistant messages: if the message text matches, it resolves the thread workspace CWD and calls `VcsStatusBroadcaster.refreshStatus` (failures are logged, not thrown). Streaming deltas are ignored. A reactor test asserts refresh runs only after `assistant.complete`, not on delta alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 515e2ca79c68e434b0ad0c9a4ec381721138602f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refresh PR status when a completed assistant message contains a change request URL
> - Adds `containsChangeRequestUrl` to [`packages/shared/src/sourceControl.ts`](https://github.com/pingdotgg/t3code/pull/7229/files#diff-cb400671e313566c053c016f281d8ebad90db5adcec2fee1dea13d296d8b789d), which matches GitHub, GitLab, Azure DevOps, and Bitbucket change request URLs using provider-specific regex patterns.
> - Adds `refreshChangeRequestFromAssistantMessage` in [`CheckpointReactor.ts`](https://github.com/pingdotgg/t3code/pull/7229/files#diff-79dc41615f79575ae1404bd102df915797fb24ba34989557f80e229d305521fb) that triggers a VCS status refresh via `vcsStatusBroadcaster.refreshStatus(cwd)` when a non-streaming assistant message contains a change request URL.
> - Refresh is only triggered on `thread.message-sent` events where the message role is `assistant` and streaming has completed — delta events are ignored.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 515e2ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->