### PR TITLE
fix(server): a provider probe timeout no longer marks the provider broken

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -38,6 +38,7 @@ import {
   providerModelsFromSettings,
   spawnAndCollect,
   type ServerProviderDraft,
+  ProviderProbeTimeoutError,
 } from "../providerSnapshot.ts";
 import { resolveClaudeSdkExecutablePath } from "../Drivers/ClaudeExecutable.ts";
 import { makeClaudeEnvironment } from "../Drivers/ClaudeHome.ts";
@@ -813,7 +814,7 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
   cwd?: string,
 ): Effect.fn.Return<
   ServerProviderDraft,
-  never,
+  ProviderProbeTimeoutError,
   ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
 > {
   const resolvedEnvironment = environment ?? process.env;
@@ -869,19 +870,11 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
   }
 
   if (Option.isNone(versionProbe.success)) {
-    return buildServerProvider({
-      presentation: CLAUDE_PRESENTATION,
-      enabled: claudeSettings.enabled,
-      checkedAt,
-      models: allModels,
-      probe: {
-        installed: true,
-        version: null,
-        status: "error",
-        auth: { status: "unknown" },
-        message:
-          "Claude Agent CLI is installed but failed to run. Timed out while running command.",
-      },
+    return yield* new ProviderProbeTimeoutError({
+      provider: "Claude Agent",
+      probe: "version",
+      timeoutMs: DEFAULT_TIMEOUT_MS,
+      installed: true,
     });
   }
 

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -31,6 +31,7 @@ import {
   AUTH_PROBE_TIMEOUT_MS,
   buildServerProvider,
   type ServerProviderDraft,
+  ProviderProbeTimeoutError,
 } from "../providerSnapshot.ts";
 import { expandHomePath } from "../../pathExpansion.ts";
 import packageJson from "../../../package.json" with { type: "json" };
@@ -517,7 +518,7 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
   environment?: NodeJS.ProcessEnv,
 ): Effect.fn.Return<
   ServerProviderDraft,
-  ServerSettingsError,
+  ServerSettingsError | ProviderProbeTimeoutError,
   ChildProcessSpawner.ChildProcessSpawner
 > {
   const resolvedEnvironment = environment ?? process.env;
@@ -576,19 +577,11 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
   }
 
   if (Option.isNone(probeResult.success)) {
-    return buildServerProvider({
-      presentation: CODEX_PRESENTATION,
-      enabled: codexSettings.enabled,
-      checkedAt,
-      models: emptyModels,
-      skills: [],
-      probe: {
-        installed: true,
-        version: null,
-        status: "error",
-        auth: { status: "unknown" },
-        message: "Timed out while checking Codex app-server provider status.",
-      },
+    return yield* new ProviderProbeTimeoutError({
+      provider: "Codex",
+      probe: "app-server status",
+      timeoutMs: AUTH_PROBE_TIMEOUT_MS,
+      installed: true,
     });
   }
 

--- a/apps/server/src/provider/Layers/CursorProvider.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.ts
@@ -39,6 +39,7 @@ import {
   providerModelsFromSettings,
   type CommandResult,
   type ServerProviderDraft,
+  ProviderProbeTimeoutError,
 } from "../providerSnapshot.ts";
 import {
   enrichProviderSnapshotWithVersionAdvisory,
@@ -989,7 +990,7 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
   environment?: NodeJS.ProcessEnv,
 ): Effect.fn.Return<
   ServerProviderDraft,
-  never,
+  ProviderProbeTimeoutError,
   ChildProcessSpawner.ChildProcessSpawner | Crypto.Crypto | FileSystem.FileSystem | Path.Path
 > {
   const checkedAt = DateTime.formatIso(yield* DateTime.now);
@@ -1040,18 +1041,11 @@ export const checkCursorProviderStatus = Effect.fn("checkCursorProviderStatus")(
   }
 
   if (Option.isNone(aboutProbe.success)) {
-    return buildServerProvider({
-      presentation: CURSOR_PRESENTATION,
-      enabled: cursorSettings.enabled,
-      checkedAt,
-      models: fallbackModels,
-      probe: {
-        installed: true,
-        version: null,
-        status: "error",
-        auth: { status: "unknown" },
-        message: "Cursor Agent CLI is installed but timed out while running `agent about`.",
-      },
+    return yield* new ProviderProbeTimeoutError({
+      provider: "Cursor Agent",
+      probe: "agent about",
+      timeoutMs: ABOUT_TIMEOUT_MS,
+      installed: true,
     });
   }
 

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -273,6 +273,8 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
       probe: "ACP model discovery",
       timeoutMs: GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS,
       installed: true,
+      // `grok --version` already answered, so keep what it told us.
+      ...(version ? { version } : {}),
     });
   }
   const discoveredModels = discoveryExit.value.value;

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -24,6 +24,7 @@ import {
   providerModelsFromSettings,
   spawnAndCollect,
   type ServerProviderDraft,
+  ProviderProbeTimeoutError,
 } from "../providerSnapshot.ts";
 import {
   enrichProviderSnapshotWithVersionAdvisory,
@@ -163,7 +164,7 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
   environment: NodeJS.ProcessEnv = process.env,
 ): Effect.fn.Return<
   ServerProviderDraft,
-  never,
+  ProviderProbeTimeoutError,
   ChildProcessSpawner.ChildProcessSpawner | Crypto.Crypto
 > {
   const checkedAt = DateTime.formatIso(yield* DateTime.now);
@@ -213,18 +214,11 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
   }
 
   if (Option.isNone(versionResult.success)) {
-    return buildServerProvider({
-      presentation: GROK_PRESENTATION,
-      enabled: grokSettings.enabled,
-      checkedAt,
-      models: fallbackModels,
-      probe: {
-        installed: true,
-        version: null,
-        status: "error",
-        auth: { status: "unknown" },
-        message: "Grok CLI is installed but timed out while running `grok --version`.",
-      },
+    return yield* new ProviderProbeTimeoutError({
+      provider: "Grok",
+      probe: "grok --version",
+      timeoutMs: VERSION_PROBE_TIMEOUT_MS,
+      installed: true,
     });
   }
 
@@ -274,21 +268,11 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
     });
   }
   if (Option.isNone(discoveryExit.value)) {
-    yield* Effect.logWarning(
-      `Grok ACP model discovery timed out after ${GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS}ms.`,
-    );
-    return buildServerProvider({
-      presentation: GROK_PRESENTATION,
-      enabled: grokSettings.enabled,
-      checkedAt,
-      models: fallbackModels,
-      probe: {
-        installed: true,
-        version,
-        status: "error",
-        auth: { status: "unknown" },
-        message: `Grok CLI is installed but ACP startup timed out after ${GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS}ms.`,
-      },
+    return yield* new ProviderProbeTimeoutError({
+      provider: "Grok",
+      probe: "ACP model discovery",
+      timeoutMs: GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS,
+      installed: true,
     });
   }
   const discoveredModels = discoveryExit.value.value;

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -7,6 +7,7 @@ import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as PubSub from "effect/PubSub";
 import * as Ref from "effect/Ref";
+import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 import * as Sink from "effect/Sink";
@@ -506,6 +507,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           const killCalls = yield* Ref.make(0);
           const statusFiber = yield* checkCodexProviderStatus(defaultCodexSettings).pipe(
             Effect.provide(hangingScopedSpawnerLayer(killCalls)),
+            Effect.result,
             Effect.forkChild,
           );
 
@@ -513,11 +515,15 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           yield* TestClock.adjust("11 seconds");
           yield* Effect.yieldNow;
 
+          // A timeout is reported as a failure rather than an `error` snapshot,
+          // so the caller can keep the last known status instead of publishing
+          // a verdict the probe never reached. The spawned child is still
+          // killed on the way out.
           const status = yield* Fiber.join(statusFiber);
-          assert.strictEqual(status.status, "error");
+          assert.strictEqual(Result.isFailure(status), true);
           assert.strictEqual(
-            status.message,
-            "Timed out while checking Codex app-server provider status.",
+            Result.isFailure(status) ? status.failure._tag : null,
+            "ProviderProbeTimeoutError",
           );
           assert.strictEqual(yield* Ref.get(killCalls), 1);
         }),

--- a/apps/server/src/provider/makeManagedServerProvider.test.ts
+++ b/apps/server/src/provider/makeManagedServerProvider.test.ts
@@ -94,6 +94,15 @@ const enrichedSnapshot: ServerProvider = {
   ],
 };
 
+const missingCliSnapshot: ServerProvider = {
+  ...refreshedSnapshot,
+  installed: false,
+  version: null,
+  status: "error",
+  auth: { status: "unknown" },
+  message: "Codex CLI (`codex`) is not installed or not on PATH.",
+};
+
 const probeTimeout = new ProviderProbeTimeoutError({
   provider: "Codex",
   probe: "app-server status",
@@ -542,6 +551,76 @@ describe("makeManagedServerProvider", () => {
         // both learn the check was attempted and did not finish.
         assert.notStrictEqual(updates[1]!.checkedAt, refreshedSnapshot.checkedAt);
         assert.match(updates[1]!.message ?? "", /timed out after 10000ms/);
+      }),
+    ).pipe(Effect.provide(AlwaysRunTestLayer)),
+  );
+
+  it.effect("does not let stale enrichment publish over a probe timeout", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const publishCallbacks: Array<(snapshot: ServerProvider) => Effect.Effect<void>> = [];
+        const enrichmentReady = yield* Deferred.make<void>();
+        const checkCalls = yield* Ref.make(0);
+        const provider = yield* makeManagedServerProvider<TestSettings>({
+          maintenanceCapabilities,
+          getSettings: Effect.succeed({ enabled: true }),
+          streamSettings: Stream.empty,
+          haveSettingsChanged: (previous, next) => previous.enabled !== next.enabled,
+          initialSnapshot: () => Effect.succeed(initialSnapshot),
+          checkProvider: Ref.updateAndGet(checkCalls, (count) => count + 1).pipe(
+            Effect.flatMap((count) =>
+              count === 1 ? Effect.succeed(refreshedSnapshot) : Effect.fail(probeTimeout),
+            ),
+          ),
+          enrichSnapshot: ({ publishSnapshot }) =>
+            Effect.gen(function* () {
+              publishCallbacks.push(publishSnapshot);
+              yield* Deferred.succeed(enrichmentReady, undefined).pipe(Effect.ignore);
+            }),
+          refreshInterval: "1 hour",
+        });
+
+        yield* Deferred.await(enrichmentReady);
+        const afterTimeout = yield* provider.refresh;
+
+        // Enrichment started against the pre-timeout snapshot. Publishing now
+        // would restore the old checkedAt and drop the timeout message, which
+        // is how a manual refresh became a silent no-op in the first place.
+        yield* publishCallbacks[0]!(enrichedSnapshot);
+
+        assert.deepStrictEqual(yield* provider.getSnapshot, afterTimeout);
+        assert.match(afterTimeout.message ?? "", /timed out after 10000ms/);
+      }),
+    ).pipe(Effect.provide(AlwaysRunTestLayer)),
+  );
+
+  it.effect("does not carry a failed check forward as if it were a known good status", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const checkCalls = yield* Ref.make(0);
+        const provider = yield* makeManagedServerProvider<TestSettings>({
+          maintenanceCapabilities,
+          getSettings: Effect.succeed({ enabled: true }),
+          streamSettings: Stream.empty,
+          haveSettingsChanged: (previous, next) => previous.enabled !== next.enabled,
+          initialSnapshot: () => Effect.succeed(initialSnapshot),
+          checkProvider: Ref.updateAndGet(checkCalls, (count) => count + 1).pipe(
+            Effect.flatMap((count) =>
+              count === 1 ? Effect.succeed(missingCliSnapshot) : Effect.fail(probeTimeout),
+            ),
+          ),
+          refreshInterval: "1 hour",
+        });
+
+        yield* Effect.yieldNow;
+        // The CLI was missing last time and may since have been installed. The
+        // timeout knows the probe got far enough to spawn, so keeping the old
+        // "not installed" verdict would be the more wrong of the two answers.
+        const afterTimeout = yield* provider.refresh;
+
+        assert.strictEqual(afterTimeout.installed, true);
+        assert.match(afterTimeout.message ?? "", /timed out after 10000ms/);
+        assert.notMatch(afterTimeout.message ?? "", /last known status/);
       }),
     ).pipe(Effect.provide(AlwaysRunTestLayer)),
   );

--- a/apps/server/src/provider/makeManagedServerProvider.test.ts
+++ b/apps/server/src/provider/makeManagedServerProvider.test.ts
@@ -20,6 +20,7 @@ import { TestClock } from "effect/testing";
 import * as BackgroundPolicy from "../background/BackgroundPolicy.ts";
 import { ServerSettingsService } from "../serverSettings.ts";
 import { makeManagedServerProvider } from "./makeManagedServerProvider.ts";
+import { ProviderProbeTimeoutError } from "./providerSnapshot.ts";
 
 const emptyCapabilities = createModelCapabilities({ optionDescriptors: [] });
 const TEST_EPOCH = DateTime.makeUnsafe("1970-01-01T00:00:00.000Z");
@@ -92,6 +93,13 @@ const enrichedSnapshot: ServerProvider = {
     },
   ],
 };
+
+const probeTimeout = new ProviderProbeTimeoutError({
+  provider: "Codex",
+  probe: "app-server status",
+  timeoutMs: 10_000,
+  installed: true,
+});
 
 const refreshedSnapshotSecond: ServerProvider = {
   ...refreshedSnapshot,
@@ -450,6 +458,115 @@ describe("makeManagedServerProvider", () => {
           enrichedSnapshotSecond,
         ]);
         assert.deepStrictEqual(latest, enrichedSnapshotSecond);
+      }),
+    ).pipe(Effect.provide(AlwaysRunTestLayer)),
+  );
+
+  it.effect("keeps the last known status when a provider status probe times out", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const checkCalls = yield* Ref.make(0);
+        const releaseFirstCheck = yield* Deferred.make<void>();
+        const provider = yield* makeManagedServerProvider<TestSettings>({
+          maintenanceCapabilities,
+          getSettings: Effect.succeed({ enabled: true }),
+          streamSettings: Stream.empty,
+          haveSettingsChanged: (previous, next) => previous.enabled !== next.enabled,
+          initialSnapshot: () => Effect.succeed(initialSnapshot),
+          checkProvider: Ref.updateAndGet(checkCalls, (count) => count + 1).pipe(
+            Effect.flatMap((count) =>
+              count === 1
+                ? Deferred.await(releaseFirstCheck).pipe(Effect.as(refreshedSnapshot))
+                : Effect.fail(probeTimeout),
+            ),
+          ),
+          refreshInterval: "1 hour",
+        });
+
+        const updatesFiber = yield* Stream.take(provider.streamChanges, 1).pipe(
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+        yield* Effect.yieldNow;
+        yield* Deferred.succeed(releaseFirstCheck, undefined);
+        assert.deepStrictEqual(Array.from(yield* Fiber.join(updatesFiber)), [refreshedSnapshot]);
+
+        // Reporting an error would hide a working provider and write that error
+        // to the status cache, so everything the check established is carried
+        // forward. Only the timestamp and the message move.
+        const afterTimeout = yield* provider.refresh;
+
+        assert.strictEqual(yield* Ref.get(checkCalls), 2);
+        assert.strictEqual(afterTimeout.status, "ready");
+        assert.strictEqual(afterTimeout.installed, true);
+        assert.strictEqual(afterTimeout.version, refreshedSnapshot.version);
+        assert.deepStrictEqual(afterTimeout.auth, refreshedSnapshot.auth);
+        assert.deepStrictEqual(afterTimeout.models, refreshedSnapshot.models);
+        assert.deepStrictEqual(yield* provider.getSnapshot, afterTimeout);
+      }),
+    ).pipe(Effect.provide(AlwaysRunTestLayer)),
+  );
+
+  it.effect("publishes a timeout so a manual refresh is never a silent no-op", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const releaseFirstCheck = yield* Deferred.make<void>();
+        const checkCalls = yield* Ref.make(0);
+        const provider = yield* makeManagedServerProvider<TestSettings>({
+          maintenanceCapabilities,
+          getSettings: Effect.succeed({ enabled: true }),
+          streamSettings: Stream.empty,
+          haveSettingsChanged: (previous, next) => previous.enabled !== next.enabled,
+          initialSnapshot: () => Effect.succeed(initialSnapshot),
+          checkProvider: Ref.updateAndGet(checkCalls, (count) => count + 1).pipe(
+            Effect.flatMap((count) =>
+              count === 1
+                ? Deferred.await(releaseFirstCheck).pipe(Effect.as(refreshedSnapshot))
+                : Effect.fail(probeTimeout),
+            ),
+          ),
+          refreshInterval: "1 hour",
+        });
+
+        const updatesFiber = yield* Stream.take(provider.streamChanges, 2).pipe(
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+        yield* Effect.yieldNow;
+        yield* Deferred.succeed(releaseFirstCheck, undefined);
+        yield* provider.refresh;
+
+        const updates = Array.from(yield* Fiber.join(updatesFiber));
+        assert.strictEqual(updates.length, 2);
+        // Second update carries the timeout, so clients and the status cache
+        // both learn the check was attempted and did not finish.
+        assert.notStrictEqual(updates[1]!.checkedAt, refreshedSnapshot.checkedAt);
+        assert.match(updates[1]!.message ?? "", /timed out after 10000ms/);
+      }),
+    ).pipe(Effect.provide(AlwaysRunTestLayer)),
+  );
+
+  it.effect("reports the timeout plainly when no check has ever succeeded", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const provider = yield* makeManagedServerProvider<TestSettings>({
+          maintenanceCapabilities,
+          getSettings: Effect.succeed({ enabled: true }),
+          streamSettings: Stream.empty,
+          haveSettingsChanged: (previous, next) => previous.enabled !== next.enabled,
+          initialSnapshot: () => Effect.succeed(initialSnapshot),
+          checkProvider: Effect.fail(probeTimeout),
+          refreshInterval: "1 hour",
+        });
+
+        // There is no known status to keep, and the pending placeholder claims
+        // the check has not run yet. Saying it timed out is the honest answer.
+        const afterTimeout = yield* provider.refresh;
+
+        assert.strictEqual(afterTimeout.status, "error");
+        assert.strictEqual(afterTimeout.installed, true);
+        assert.match(afterTimeout.message ?? "", /timed out after 10000ms/);
+        assert.notMatch(afterTimeout.message ?? "", /last known status/);
       }),
     ).pipe(Effect.provide(AlwaysRunTestLayer)),
   );

--- a/apps/server/src/provider/makeManagedServerProvider.ts
+++ b/apps/server/src/provider/makeManagedServerProvider.ts
@@ -4,6 +4,7 @@ import {
   ServerSettingsError,
 } from "@t3tools/contracts";
 import { resolveServerBackgroundActivitySettings } from "@t3tools/shared/backgroundActivitySettings";
+import * as DateTime from "effect/DateTime";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Equal from "effect/Equal";
@@ -11,13 +12,17 @@ import * as Fiber from "effect/Fiber";
 import * as PubSub from "effect/PubSub";
 import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import * as Semaphore from "effect/Semaphore";
 
 import * as BackgroundPolicy from "../background/BackgroundPolicy.ts";
 import { ServerSettingsService } from "../serverSettings.ts";
+import { ProviderProbeTimeoutError } from "./providerSnapshot.ts";
 import type { ServerProviderShape } from "./Services/ServerProvider.ts";
+
+const isProviderProbeTimeoutError = Schema.is(ProviderProbeTimeoutError);
 
 interface ProviderSnapshotState {
   readonly snapshot: ServerProvider;
@@ -32,7 +37,10 @@ export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(
   readonly streamSettings: Stream.Stream<Settings>;
   readonly haveSettingsChanged: (previous: Settings, next: Settings) => boolean;
   readonly initialSnapshot: (settings: Settings) => Effect.Effect<ServerProvider>;
-  readonly checkProvider: Effect.Effect<ServerProvider, ServerSettingsError>;
+  readonly checkProvider: Effect.Effect<
+    ServerProvider,
+    ServerSettingsError | ProviderProbeTimeoutError
+  >;
   readonly enrichSnapshot?: (input: {
     readonly settings: Settings;
     readonly snapshot: ServerProvider;
@@ -59,6 +67,9 @@ export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(
     enrichmentGeneration: 0,
   });
   const settingsRef = yield* Ref.make(initialSettings);
+  // Gates the "keep what we knew" path: before the first successful check there
+  // is no known status, only the pending placeholder.
+  const hasCompletedCheck = yield* Ref.make(false);
   const enrichmentFiberRef = yield* Ref.make<Fiber.Fiber<void, unknown> | null>(null);
   const scope = yield* Effect.scope;
 
@@ -110,6 +121,47 @@ export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(
     yield* Ref.set(enrichmentFiberRef, fiber);
   });
 
+  /**
+   * Decide what a provider looks like after a probe misses its deadline.
+   *
+   * Once a check has succeeded, reporting `error` would replace a working
+   * provider with a verdict the probe never reached, and `ProviderRegistry`
+   * persists that snapshot to the status cache, so one busy moment would
+   * outlive itself and keep the provider unusable for new sessions. Status,
+   * auth, version, and models are carried forward; only `checkedAt` and
+   * `message` move. That is still a change, so the snapshot reaches clients and
+   * the cache, a manual refresh visibly does something, and the timeout is
+   * stated rather than leaving the provider silently frozen.
+   *
+   * Before the first successful check there is nothing worth carrying forward.
+   * The pending snapshot describes a check that has not run, not one that ran
+   * out of time, so the timeout is reported plainly instead.
+   */
+  const snapshotAfterProbeTimeout = Effect.fn("snapshotAfterProbeTimeout")(function* (
+    error: ProviderProbeTimeoutError,
+  ) {
+    const checkedAt = DateTime.formatIso(yield* DateTime.now);
+    const checkedBefore = yield* Ref.get(hasCompletedCheck);
+    const next = yield* Ref.modify(snapshotStateRef, (state) => {
+      const snapshot: ServerProvider = checkedBefore
+        ? {
+            ...state.snapshot,
+            checkedAt,
+            message: `${error.message} Showing the last known status.`,
+          }
+        : {
+            ...state.snapshot,
+            checkedAt,
+            installed: error.installed,
+            status: "error",
+            message: error.message,
+          };
+      return [snapshot, { ...state, snapshot }] as const;
+    });
+    yield* PubSub.publish(changesPubSub, next);
+    return next;
+  });
+
   const applySnapshotBase = Effect.fn("applySnapshot")(function* (
     nextSettings: Settings,
     options?: { readonly forceRefresh?: boolean },
@@ -121,7 +173,26 @@ export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(
       return yield* Ref.get(snapshotStateRef).pipe(Effect.map((state) => state.snapshot));
     }
 
-    const nextSnapshot = yield* input.checkProvider;
+    const checkOutcome = yield* input.checkProvider.pipe(
+      Effect.tap(() => Ref.set(hasCompletedCheck, true)),
+      Effect.catchTag("ProviderProbeTimeoutError", (error) =>
+        Effect.logWarning("Provider status probe timed out.").pipe(
+          Effect.annotateLogs({
+            "provider.name": error.provider,
+            "provider.probe": error.probe,
+            "provider.probe.timeout_ms": error.timeoutMs,
+          }),
+          Effect.as(error),
+        ),
+      ),
+    );
+    if (isProviderProbeTimeoutError(checkOutcome)) {
+      // `settingsRef` deliberately stays on the previous value: these settings
+      // were never applied to a snapshot, so the next emission must still count
+      // as a change and re-probe rather than short-circuiting above.
+      return yield* snapshotAfterProbeTimeout(checkOutcome);
+    }
+    const nextSnapshot = checkOutcome;
     const nextGeneration = yield* Ref.modify(snapshotStateRef, (state) => {
       const generation = input.enrichSnapshot
         ? state.enrichmentGeneration + 1

--- a/apps/server/src/provider/makeManagedServerProvider.ts
+++ b/apps/server/src/provider/makeManagedServerProvider.ts
@@ -9,10 +9,10 @@ import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Equal from "effect/Equal";
 import * as Fiber from "effect/Fiber";
+import * as Option from "effect/Option";
 import * as PubSub from "effect/PubSub";
 import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
-import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import * as Semaphore from "effect/Semaphore";
@@ -21,8 +21,6 @@ import * as BackgroundPolicy from "../background/BackgroundPolicy.ts";
 import { ServerSettingsService } from "../serverSettings.ts";
 import { ProviderProbeTimeoutError } from "./providerSnapshot.ts";
 import type { ServerProviderShape } from "./Services/ServerProvider.ts";
-
-const isProviderProbeTimeoutError = Schema.is(ProviderProbeTimeoutError);
 
 interface ProviderSnapshotState {
   readonly snapshot: ServerProvider;
@@ -67,9 +65,9 @@ export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(
     enrichmentGeneration: 0,
   });
   const settingsRef = yield* Ref.make(initialSettings);
-  // Gates the "keep what we knew" path: before the first successful check there
-  // is no known status, only the pending placeholder.
-  const hasCompletedCheck = yield* Ref.make(false);
+  // Gates the "keep what we knew" path: set once a check produces a status the
+  // UI can act on, cleared again if a later check reports the provider broken.
+  const hasUsableStatus = yield* Ref.make(false);
   const enrichmentFiberRef = yield* Ref.make<Fiber.Fiber<void, unknown> | null>(null);
   const scope = yield* Effect.scope;
 
@@ -133,17 +131,18 @@ export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(
    * the cache, a manual refresh visibly does something, and the timeout is
    * stated rather than leaving the provider silently frozen.
    *
-   * Before the first successful check there is nothing worth carrying forward.
-   * The pending snapshot describes a check that has not run, not one that ran
-   * out of time, so the timeout is reported plainly instead.
+   * Without a usable status there is nothing worth carrying forward. The
+   * pending snapshot describes a check that has not run, and a failed one
+   * describes a provider that was already broken, so the timeout is reported
+   * plainly along with whatever the probe did establish before it gave up.
    */
   const snapshotAfterProbeTimeout = Effect.fn("snapshotAfterProbeTimeout")(function* (
     error: ProviderProbeTimeoutError,
   ) {
     const checkedAt = DateTime.formatIso(yield* DateTime.now);
-    const checkedBefore = yield* Ref.get(hasCompletedCheck);
+    const carryForward = yield* Ref.get(hasUsableStatus);
     const next = yield* Ref.modify(snapshotStateRef, (state) => {
-      const snapshot: ServerProvider = checkedBefore
+      const snapshot: ServerProvider = carryForward
         ? {
             ...state.snapshot,
             checkedAt,
@@ -153,11 +152,21 @@ export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(
             ...state.snapshot,
             checkedAt,
             installed: error.installed,
+            version: error.version ?? state.snapshot.version,
             status: "error",
             message: error.message,
           };
-      return [snapshot, { ...state, snapshot }] as const;
+      // Bumping the generation retires any enrichment still running against the
+      // superseded snapshot, so it cannot publish over this timeout later.
+      return [
+        snapshot,
+        { snapshot, enrichmentGeneration: state.enrichmentGeneration + 1 },
+      ] as const;
     });
+    const staleEnrichment = yield* Ref.getAndSet(enrichmentFiberRef, null);
+    if (staleEnrichment) {
+      yield* Fiber.interrupt(staleEnrichment).pipe(Effect.ignore);
+    }
     yield* PubSub.publish(changesPubSub, next);
     return next;
   });
@@ -173,26 +182,32 @@ export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(
       return yield* Ref.get(snapshotStateRef).pipe(Effect.map((state) => state.snapshot));
     }
 
-    const checkOutcome = yield* input.checkProvider.pipe(
-      Effect.tap(() => Ref.set(hasCompletedCheck, true)),
-      Effect.catchTag("ProviderProbeTimeoutError", (error) =>
-        Effect.logWarning("Provider status probe timed out.").pipe(
-          Effect.annotateLogs({
-            "provider.name": error.provider,
-            "provider.probe": error.probe,
-            "provider.probe.timeout_ms": error.timeoutMs,
-          }),
-          Effect.as(error),
-        ),
-      ),
+    const checked = yield* input.checkProvider.pipe(
+      // Only a status the UI can act on is worth protecting from a later
+      // timeout. A verdict of "broken" is not, or a provider that was missing
+      // when last checked would stay missing after it is installed.
+      Effect.tap((snapshot) => Ref.set(hasUsableStatus, snapshot.status !== "error")),
+      Effect.map(Option.some),
+      Effect.catchTags({
+        ProviderProbeTimeoutError: (error) =>
+          Effect.logWarning("Provider status probe timed out.").pipe(
+            Effect.annotateLogs({
+              "provider.name": error.provider,
+              "provider.probe": error.probe,
+              "provider.probe.timeout_ms": error.timeoutMs,
+            }),
+            Effect.andThen(snapshotAfterProbeTimeout(error)),
+            Effect.as(Option.none<ServerProvider>()),
+          ),
+      }),
     );
-    if (isProviderProbeTimeoutError(checkOutcome)) {
+    if (Option.isNone(checked)) {
       // `settingsRef` deliberately stays on the previous value: these settings
       // were never applied to a snapshot, so the next emission must still count
       // as a change and re-probe rather than short-circuiting above.
-      return yield* snapshotAfterProbeTimeout(checkOutcome);
+      return yield* Ref.get(snapshotStateRef).pipe(Effect.map((state) => state.snapshot));
     }
-    const nextSnapshot = checkOutcome;
+    const nextSnapshot = checked.value;
     const nextGeneration = yield* Ref.modify(snapshotStateRef, (state) => {
       const generation = input.enrichSnapshot
         ? state.enrichmentGeneration + 1

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -61,9 +61,10 @@ export class ProviderProbeTimeoutError extends Schema.TaggedErrorClass<ProviderP
     /**
      * What the probe had established about the CLI before it ran out of time.
      * Only consulted when there is no earlier status to fall back on, so the
-     * first-ever check still reports something truthful.
+     * first-ever check still reports everything it did manage to learn.
      */
     installed: Schema.Boolean,
+    version: Schema.optionalKey(Schema.String),
   },
 ) {
   override get message(): string {

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -44,6 +44,33 @@ export class ProviderCommandNotFoundError extends Schema.TaggedErrorClass<Provid
 
 const isProviderCommandNotFoundError = Schema.is(ProviderCommandNotFoundError);
 
+/**
+ * Raised when a provider status probe misses its deadline.
+ *
+ * A timeout means the host was too busy to answer in time, which is not the
+ * same as the provider being broken. Status checks fail with this instead of
+ * reporting an `error` snapshot so `makeManagedServerProvider` can keep the
+ * last known snapshot rather than overwriting it with a guess.
+ */
+export class ProviderProbeTimeoutError extends Schema.TaggedErrorClass<ProviderProbeTimeoutError>()(
+  "ProviderProbeTimeoutError",
+  {
+    provider: Schema.String,
+    probe: Schema.String,
+    timeoutMs: Schema.Number,
+    /**
+     * What the probe had established about the CLI before it ran out of time.
+     * Only consulted when there is no earlier status to fall back on, so the
+     * first-ever check still reports something truthful.
+     */
+    installed: Schema.Boolean,
+  },
+) {
+  override get message(): string {
+    return `${this.provider} ${this.probe} probe timed out after ${this.timeoutMs}ms.`;
+  }
+}
+
 export interface ProviderProbeResult {
   readonly installed: boolean;
   readonly version: string | null;

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -39,6 +39,29 @@ directory to route session and turn operations for a thread, so callers name a t
 Adding a driver means writing the driver plus adapter and adding it to `BUILT_IN_DRIVERS`. No
 orchestration, contract, or client change is required for the common case.
 
+### Status probes and timeouts
+
+Each instance runs its own health refresh through `makeManagedServerProvider`, which calls the
+driver's `checkProvider`. Those checks spawn CLI subprocesses under short deadlines, so on a busy
+host several instances can miss their deadlines at once.
+
+A status check must not report `error` when it merely ran out of time. Reporting `error` empties the
+snapshot and `ProviderRegistry` persists it to the on-disk status cache, so one busy moment would
+outlive itself and keep the provider unusable for new sessions. Instead, a probe that hits its
+deadline fails with `ProviderProbeTimeoutError`, and `makeManagedServerProvider` decides what to
+publish:
+
+- After at least one successful check, the last known status, auth, version, and models are carried
+  forward. Only `checkedAt` and `message` move, which is still a change, so clients and the cache
+  both see it and a manual refresh is never a silent no-op.
+- Before the first successful check there is nothing to carry forward, so the timeout is reported as
+  an `error` with the probe's own message.
+
+A definite failure, including a missing CLI, is unaffected and still reports `error` immediately.
+New drivers with a probe deadline should raise `ProviderProbeTimeoutError` rather than building a
+failure snapshot. A probe that reaches a real verdict, such as an unreachable configured server,
+should keep reporting that verdict.
+
 ## How provider work is requested
 
 Clients never call a provider directly. They dispatch orchestration commands over the RPC method


### PR DESCRIPTION
Fixes #7230.

## Problem

Provider status checks spawn CLI subprocesses on short fixed deadlines (4s for version probes, 10s for the Codex auth probe, 8s for `cursor agent about`, 4s and 15s for Grok). When the host is busy, a check misses its deadline and the timeout branch reports `status: "error"` with no version, and for Codex no models.

That snapshot is then treated as authoritative. `makeManagedServerProvider` publishes it, `ProviderRegistry` writes it to the per-instance status cache on disk, and the next boot hydrates from that cache. So one busy moment is persisted, survives a restart, and keeps the provider out of the new-session picker until a later check happens to win.

Hosts with several configured instances hit this most, because each instance refreshes on its own loop and the probes compete with each other for the same busy machine.

## Fix

A timeout means the host was too busy to answer. That is not the same fact as the provider being broken, so the probes stop reporting it as one.

Codex, Claude, Cursor, and Grok status checks now fail with `ProviderProbeTimeoutError`, and `makeManagedServerProvider` decides what to publish:

- **After at least one successful check**, the last known status, auth, version, and models are carried forward. Only `checkedAt` and `message` move. That still counts as a change, so the snapshot reaches clients and the cache, and a manual refresh is never a silent no-op.
- **Before the first successful check** there is nothing worth carrying forward, so the timeout is reported plainly. Holding the pending placeholder instead would claim the check had not run, and for Codex that placeholder carries `installed: false`, which the settings panel renders as "Not found" — a worse and less true answer than the one it replaced.

Definite failures, including a missing CLI, are unchanged.

## Per-provider decisions

Grok has two deadlines and both are converted. The 15s ACP one spawns a full ACP session and is the likelier of the pair to be missed, so converting only the cheap `--version` probe would have left the real problem in place.

**OpenCode is deliberately unchanged.** Its probe failure is an unreachable configured server (`ECONNREFUSED`, `fetch failed`, and similar), which is a real verdict about a remote endpoint rather than a local deadline, so reporting `error` is correct. If #6577 lands and gives OpenCode genuine spawn deadlines, those should raise `ProviderProbeTimeoutError` too.

The Claude capabilities probe (25s) and the Cursor ACP discovery probe (15s) already degrade without clobbering the snapshot, so they need no change.

## Relationship to #5794

#5794 raises the Windows probe deadlines. It reduces how often the race is lost and is worth having on its own. It does not change what happens when a probe does time out, which is what this PR addresses. They compose: longer deadlines mean fewer timeouts, and a timeout that still happens no longer erases a working provider.

## Testing

- `makeManagedServerProvider.test.ts`: three new tests covering the carry-forward path, the publish-so-refresh-is-visible path, and the first-boot path.
- Reworked the Codex probe-scope test, which asserted the old error snapshot. Its check that the spawned child is still killed on timeout is preserved.
- `vp run --filter t3 typecheck` clean, `vp lint apps/server/src/provider` clean.
- The Windows server suite has 74 pre-existing failures from shell escaping in the test harness (`Unexpected args: ^"--version^"`). I ran a baseline on untouched `main` and diffed failing test names; this change adds none. The only delta across runs is `persists authoritative OpenCode removals...`, which is flaky on Windows independently of this change (passes 2 of 3 runs on both).

Docs: `docs/internals/providers.md` gains a "Status probes and timeouts" section stating the contract for new drivers.

Model: Claude Opus 5; harness: Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provider health and persistence behavior across multiple drivers; mistakes could leave stale “ready” status or confuse first-boot UX, but scope is localized to probe timeout handling with extensive tests.
> 
> **Overview**
> Provider health checks that **miss their deadline** no longer publish an `error` snapshot that gets cached and hides a working provider.
> 
> **`ProviderProbeTimeoutError`** is introduced so Claude, Codex, Cursor, and Grok probes signal a timeout instead of returning `status: "error"`. **`makeManagedServerProvider`** catches it: after at least one successful non-error check it **carries forward** status, auth, version, and models and only updates `checkedAt` plus a timeout message (so refresh and the on-disk cache still move). With no usable prior status it reports an error using what the probe learned (`installed`, optional `version`). Stale enrichment is invalidated so late publishes cannot undo the timeout. Real failures (e.g. missing CLI) are unchanged.
> 
> Tests and **`docs/internals/providers.md`** document the contract for new drivers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41bbb0a2b285deb8bf9dbf229f200ed4a4d976f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix provider probe timeouts to preserve last known status instead of marking provider broken
> - Introduces `ProviderProbeTimeoutError` in [providerSnapshot.ts](https://github.com/pingdotgg/t3code/pull/7232/files#diff-62373f674410fb63637739f0efeb07b9ef79b579393ae2adf51567de0b812b26) as a structured error for probe timeouts, replacing the previous behavior of returning an error snapshot directly from each provider's status check function.
> - Updates `ClaudeProvider`, `CodexProvider`, `CursorProvider`, and `GrokProvider` to fail with `ProviderProbeTimeoutError` on timeout instead of building error snapshots internally.
> - `makeManagedServerProvider` now intercepts `ProviderProbeTimeoutError`: if a prior usable status exists, it carries that snapshot forward with an updated timestamp and a 'last known status' message; otherwise it emits an error snapshot reflecting what the probe established before timing out.
> - Stale enrichment fibers are cancelled on timeout to prevent them from overwriting the timeout outcome.
> - Behavioral Change: providers that previously became 'broken' on a slow probe now retain their last good status until the next successful check.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 41bbb0a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->