### PR TITLE
fix(client): a busy backend no longer looks like a disconnect

### DIFF
--- a/docs/internals/connection-runtime.md
+++ b/docs/internals/connection-runtime.md
@@ -76,10 +76,19 @@ Wakeup handling differs by phase, in [supervisor.ts][supervisor]:
   foregrounded app reconnects immediately instead of serving the remaining
   delay.
 - Once connected, `monitorConnectedLease` handles plain activation by probing
-  the existing session (`lease.session.probe`, with a shorter timeout for
-  mobile's `application-active-probe`) rather than reconnecting; a healthy
-  session survives foregrounding. `application-active-reconnect` skips the probe
-  and replaces the lease outright.
+  the existing session (`lease.session.probe`) rather than reconnecting; a
+  healthy session survives foregrounding. `application-active-reconnect` skips
+  the probe and replaces the lease outright.
+- A desktop or web probe that misses its 15s deadline does not replace the
+  lease. The socket is still open and no close arrived, so a missed deadline
+  says the backend is busy, not gone, and tearing the lease down would disable
+  the composer over a stall. The supervisor waits 5s and probes once more; only
+  a second miss is treated as a failure. A definite probe failure still acts
+  immediately, and a genuinely dead transport is caught independently by the RPC
+  pinger through `session.closed`.
+- Mobile's `application-active-probe` keeps its short 3s deadline and does not
+  retry. After a background suspension the socket usually is dead, so waiting
+  longer would only delay recovery.
 
 The UI derives `available`, `offline`, `connecting`, `reconnecting`,
 `connected`, and `error` from supervisor state plus explicit data-sync state.

--- a/packages/client-runtime/src/connection/supervisor.test.ts
+++ b/packages/client-runtime/src/connection/supervisor.test.ts
@@ -993,7 +993,42 @@ describe("EnvironmentSupervisor", () => {
     }).pipe(Effect.provide(TestClock.layer())),
   );
 
-  it.effect("uses the full tolerance window for a stalled desktop foreground probe", () =>
+  it.effect("stays connected when a stalled desktop foreground probe answers on retry", () =>
+    Effect.gen(function* () {
+      const probeAttempts = yield* Ref.make(0);
+      const harness = yield* makeHarness({
+        probe: (attempt) =>
+          attempt === 1
+            ? Effect.gen(function* () {
+                const probeAttempt = yield* Ref.updateAndGet(probeAttempts, (count) => count + 1);
+                if (probeAttempt === 1) {
+                  return yield* Effect.never;
+                }
+              })
+            : Effect.void,
+      });
+      const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(supervisor.state, (state) => state.phase === "connected");
+      yield* harness.wake("application-active");
+      yield* TestClock.adjust("15 seconds");
+      yield* TestClock.adjust("5 seconds");
+
+      // The retry answers, so a busy backend never becomes a visible
+      // disconnect and the composer is never disabled.
+      yield* eventuallyState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 1,
+      );
+      expect(yield* Ref.get(probeAttempts)).toBe(2);
+      expect(yield* Ref.get(harness.sessionCount)).toBe(1);
+      expect(yield* Ref.get(harness.releaseCount)).toBe(0);
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+
+  it.effect("reconnects when the retried desktop foreground probe also stalls", () =>
     Effect.gen(function* () {
       const harness = yield* makeHarness({
         probe: (attempt) => (attempt === 1 ? Effect.never : Effect.void),
@@ -1004,6 +1039,11 @@ describe("EnvironmentSupervisor", () => {
 
       yield* awaitState(supervisor.state, (state) => state.phase === "connected");
       yield* harness.wake("application-active");
+      yield* TestClock.adjust("15 seconds");
+      yield* TestClock.adjust("5 seconds");
+      expect(yield* Ref.get(harness.sessionCount)).toBe(1);
+
+      // The retry gets the full desktop window before the lease is replaced.
       yield* TestClock.adjust("14999 millis");
       expect(yield* Ref.get(harness.sessionCount)).toBe(1);
       yield* TestClock.adjust("1 milli");

--- a/packages/client-runtime/src/connection/supervisor.ts
+++ b/packages/client-runtime/src/connection/supervisor.ts
@@ -34,6 +34,10 @@ const CONNECTION_ESTABLISHMENT_TIMEOUT = "15 seconds";
 const CONNECTION_PROBE_TIMEOUT = "15 seconds";
 const MOBILE_CONNECTION_PROBE_TIMEOUT = "3 seconds";
 const BACKOFF_RESET_AFTER_MS = 30_000;
+// How long a stalled desktop/web foreground probe waits before asking again.
+// Long enough for a burst of agent work to clear, short enough that a genuinely
+// wedged backend is still replaced promptly.
+const CONNECTION_PROBE_RETRY_DELAY = "5 seconds";
 
 interface SupervisorIntent {
   readonly desired: boolean;
@@ -419,22 +423,53 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
             return true;
           }
           if (next.reason === "application-active" || next.reason === "application-active-probe") {
-            const probe = yield* lease.session.probe.pipe(
-              Effect.timeoutOrElse({
-                duration:
-                  next.reason === "application-active-probe"
-                    ? MOBILE_CONNECTION_PROBE_TIMEOUT
-                    : CONNECTION_PROBE_TIMEOUT,
-                orElse: () =>
-                  Effect.fail(
-                    new ConnectionTransientError({
-                      reason: "timeout",
-                      detail: `${target.label} did not respond to a connection health check.`,
-                    }),
-                  ),
+            const probeTimedOut = Effect.fail(
+              new ConnectionTransientError({
+                reason: "timeout",
+                detail: `${target.label} did not respond to a connection health check.`,
               }),
-              Effect.forkChild,
             );
+            const probe = yield* (
+              next.reason === "application-active-probe"
+                ? // Mobile resume: the OS commonly suspends the socket without
+                  // delivering a close, so a stalled probe really does mean a
+                  // dead transport and waiting longer only delays recovery.
+                  lease.session.probe.pipe(
+                    Effect.timeoutOrElse({
+                      duration: MOBILE_CONNECTION_PROBE_TIMEOUT,
+                      orElse: () => probeTimedOut,
+                    }),
+                  )
+                : // Desktop and web: the socket is still open and no close
+                  // arrived, so a missed deadline says the backend is busy, not
+                  // gone. Replacing the lease on that evidence turns a stall
+                  // into a visible disconnect and disables the composer. Wait,
+                  // then ask once more; a second miss is a real failure.
+                  lease.session.probe.pipe(
+                    Effect.timeoutOption(CONNECTION_PROBE_TIMEOUT),
+                    Effect.flatMap((answered) =>
+                      Option.isSome(answered)
+                        ? Effect.void
+                        : Effect.logWarning(
+                            "Environment health check timed out; retrying before reconnecting.",
+                          ).pipe(
+                            Effect.annotateLogs({
+                              "environment.id": target.environmentId,
+                              "environment.label": target.label,
+                            }),
+                            Effect.andThen(Effect.sleep(CONNECTION_PROBE_RETRY_DELAY)),
+                            Effect.andThen(
+                              lease.session.probe.pipe(
+                                Effect.timeoutOption(CONNECTION_PROBE_TIMEOUT),
+                              ),
+                            ),
+                            Effect.flatMap((retried) =>
+                              Option.isSome(retried) ? Effect.void : probeTimedOut,
+                            ),
+                          ),
+                    ),
+                  )
+            ).pipe(Effect.forkChild);
             for (;;) {
               const probeEvent = yield* Effect.raceFirst(
                 Fiber.await(probe).pipe(


### PR DESCRIPTION
Fixes #7231.

## Problem

When the app comes to the foreground, the supervisor probes the live session with a 15s deadline. A probe that misses that deadline was treated exactly like a definite failure: the lease was replaced and the environment dropped to "Failed to connect. Reconnecting...".

The socket was still open and no close event had arrived. The backend was busy, not gone. The visible cost is the composer, which is disabled while the client recovers, and it lands precisely when someone has returned to the app to send a message.

## Fix

On desktop and web, a missed deadline now waits 5s and probes once more. Only a second miss replaces the lease.

The retry lives inside the forked probe effect rather than in the signal loop, which matters for two reasons:

- Disconnect, explicit retry, going offline, and resume signals still interrupt it exactly as before, through the existing `Fiber.interrupt(probe)` paths.
- Recovery stays bounded. An earlier version of this fix tolerated a timeout and waited for the *next* `application-active` wakeup to decide. On desktop that wakeup only fires on `visibilitychange`, so a user who stays in the window would never produce one, and a backend wedged at the RPC layer (socket healthy, pings answered, handler deadlocked) would have sat at "connected" indefinitely with every request hanging. Doing the retry inline caps that at roughly 35s instead.

Switching the desktop path to `Effect.timeoutOption` also removes the guesswork about whether a given failure was our own deadline: a missed deadline arrives as `None` on the success channel, and every real probe failure still fails immediately. That matches the idiom already used by the provider probes on the server side.

**Mobile is unchanged.** `application-active-probe` keeps its 3s fail-fast and does not retry. After a background suspension the OS has usually killed the socket for real, so waiting longer would only delay recovery. Mobile cannot emit the bare `application-active` reason, so the retry path is unreachable from it.

Worth noting for reviewers: a genuinely dead transport is still detected independently of this path by the RPC pinger through `session.closed`, so nothing here is the sole defence against a dropped socket.

## Relationship to #3553, #4137, and #5198

#3553 reported this and was closed by #4137, which made the probe itself lightweight (`serverProbe` rather than `serverGetConfig`). That was the right fix for probe cost. It did not change the teardown rule, and on a host that is starved rather than merely doing extra work a cheap probe misses its deadline too.

#5198 proposed tolerating a transient timeout and had the right instinct. It has carried merge conflicts since 1 Aug. This PR takes the same starting point and adds the retry, without which tolerance alone can strand a wedged backend.

Backend starvation itself is tracked in #4773. This is the client's reaction to it, which is worth fixing separately because the client cannot assume the server will ever be fast.

## Testing

- Reworked the existing "stalled desktop foreground probe" test, which asserted teardown on the first timeout. Its 14999ms / 1ms deadline-boundary assertions are preserved on the retry.
- Added a test that the retry answering keeps the session, the generation, and the composer path untouched.
- 36/36 supervisor tests pass, over 5 consecutive runs.
- `typecheck` and `vp lint packages/client-runtime/src/connection` clean.

Docs: `docs/internals/connection-runtime.md` "Wakeups" section now states the retry, the bound, and the mobile exclusion.

Model: Claude Opus 5; harness: Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes connection supervisor wake/probe policy on desktop/web, which affects when sessions are replaced and the composer is disabled; behavior is well-tested but touches core connectivity logic.
> 
> **Overview**
> **Desktop/web foreground health checks** no longer tear down the live session on a single 15s probe timeout. A miss is treated as a busy backend (socket still open); the supervisor waits **5s**, runs **one** more probe, and only then fails and replaces the lease. Real probe failures still reconnect immediately; mobile `application-active-probe` stays **3s fail-fast** with no retry.
> 
> `monitorConnectedLease` switches the desktop path to `Effect.timeoutOption` and runs the retry inside the forked probe effect so disconnect/offline/resume signals still interrupt via existing `Fiber.interrupt` paths, with worst-case recovery bounded (~35s).
> 
> Docs and supervisor tests cover retry success (stay connected), double stall (reconnect), and preserved mobile behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1164990084f04e6d6cb37f9ddd6894ca0a722b04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix desktop/web foreground probe to retry once before treating a stall as a disconnect
> - A single missed 15s probe on desktop/web no longer immediately reconnects; the supervisor now waits 5s (`CONNECTION_PROBE_RETRY_DELAY`) and issues a second probe before treating the timeout as a failure.
> - Mobile (`application-active-probe`) retains the original behavior: 3s deadline, no retry, immediate failure on timeout.
> - Behavioral Change: desktop/web clients on a slow/busy backend will stay in the current session instead of re-establishing a new lease on the first stalled probe.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1164990.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->