### PR TITLE
feat(web): scroll the chat with arrow keys when the chat input is empty

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -510,6 +510,8 @@ function formatOutgoingPrompt(params: {
   const promptEffort = resolvePromptInjectedEffort(caps, params.effort);
   return applyClaudePromptEffortPrefix(params.text, promptEffort);
 }
+// Roughly one line of transcript per arrow press, matching native key scroll.
+const TIMELINE_ARROW_SCROLL_STEP_PX = 40;
 const SCRIPT_TERMINAL_COLS = 120;
 const SCRIPT_TERMINAL_ROWS = 30;
 
@@ -3777,6 +3779,26 @@ function ChatViewContent(props: ChatViewProps) {
       void legendListRef.current?.scrollToEnd?.({ animated });
     });
   }, []);
+  // Arrow keys the composer cannot use scroll the transcript by roughly a
+  // line, the same as if the list itself held focus. Returns false when the
+  // transcript is already at that edge so the key falls through untouched.
+  const scrollTimelineByArrowKey = useCallback(
+    (direction: "up" | "down") => {
+      const scrollNode = legendListRef.current?.getScrollableNode();
+      if (!(scrollNode instanceof HTMLElement)) return false;
+      const maxScrollTop = Math.max(0, scrollNode.scrollHeight - scrollNode.clientHeight);
+      const delta =
+        direction === "up" ? -TIMELINE_ARROW_SCROLL_STEP_PX : TIMELINE_ARROW_SCROLL_STEP_PX;
+      const nextScrollTop = Math.max(0, Math.min(maxScrollTop, scrollNode.scrollTop + delta));
+      if (Math.abs(nextScrollTop - scrollNode.scrollTop) < 1) return false;
+      if (direction === "up") {
+        cancelTimelineLiveFollowForUserNavigation();
+      }
+      scrollNode.scrollTop = nextScrollTop;
+      return true;
+    },
+    [cancelTimelineLiveFollowForUserNavigation],
+  );
   useEffect(() => {
     let removeListeners: (() => void) | null = null;
     let frame: number | null = null;
@@ -6487,6 +6509,7 @@ function ChatViewContent(props: ChatViewProps) {
                             handleInteractionModeChange={handleInteractionModeChange}
                             focusComposer={focusComposer}
                             scheduleComposerFocus={scheduleComposerFocus}
+                            scrollTimelineByArrowKey={scrollTimelineByArrowKey}
                             setThreadError={setThreadError}
                             onExpandImage={onExpandTimelineImage}
                           />

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -59,6 +59,7 @@ import {
   collapseExpandedComposerCursor,
   expandCollapsedComposerCursor,
   isCollapsedCursorAdjacentToInlineToken,
+  shouldForwardComposerArrowToTimeline,
 } from "~/composer-logic";
 import {
   selectionTouchesMentionBoundary,
@@ -897,6 +898,12 @@ interface ComposerPromptEditorProps {
     key: "ArrowDown" | "ArrowUp" | "Enter" | "Tab",
     event: KeyboardEvent,
   ) => boolean;
+  /**
+   * Called for an Arrow Up/Down that the composer itself cannot act on (caret
+   * already at the edge, composer scrolled to its own limit). Return true to
+   * claim the key — the chat uses it to scroll the transcript.
+   */
+  onArrowBeyondEdge?: (direction: "up" | "down") => boolean;
   onPaste: React.ClipboardEventHandler<HTMLElement>;
   editorRef: React.RefObject<ComposerPromptEditorHandle | null>;
 }
@@ -959,6 +966,64 @@ function ComposerCommandKeyPlugin(props: {
       unregisterTab();
     };
   }, [editor, props]);
+
+  return null;
+}
+
+/**
+ * Hands Arrow Up/Down to the host when the caret is already at the composer's
+ * first/last offset and the composer is scrolled to that same edge. Runs at low
+ * priority so menus and the command-key plugin still get the key first.
+ */
+function ComposerEdgeArrowPlugin(props: {
+  onArrowBeyondEdge: (direction: "up" | "down") => boolean;
+}) {
+  const [editor] = useLexicalComposerContext();
+  const onArrowBeyondEdge = useEffectEvent(props.onArrowBeyondEdge);
+
+  useEffect(() => {
+    const handle = (direction: "up" | "down", event: KeyboardEvent | null): boolean => {
+      if (!event || event.shiftKey || event.metaKey || event.ctrlKey || event.altKey) {
+        return false;
+      }
+      const rootElement = editor.getRootElement();
+      if (!rootElement) return false;
+      let shouldForward = false;
+      editor.getEditorState().read(() => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) return;
+        shouldForward = shouldForwardComposerArrowToTimeline({
+          direction,
+          hasModifier: false,
+          isCollapsed: selection.isCollapsed(),
+          cursor: $readSelectionOffsetFromEditorState(0),
+          length: $getComposerRootLength(),
+          editorScrollTop: rootElement.scrollTop,
+          editorScrollHeight: rootElement.scrollHeight,
+          editorClientHeight: rootElement.clientHeight,
+        });
+      });
+      if (!shouldForward || !onArrowBeyondEdge(direction)) return false;
+      event.preventDefault();
+      event.stopPropagation();
+      return true;
+    };
+
+    const unregisterUp = editor.registerCommand(
+      KEY_ARROW_UP_COMMAND,
+      (event) => handle("up", event),
+      COMMAND_PRIORITY_LOW,
+    );
+    const unregisterDown = editor.registerCommand(
+      KEY_ARROW_DOWN_COMMAND,
+      (event) => handle("down", event),
+      COMMAND_PRIORITY_LOW,
+    );
+    return () => {
+      unregisterUp();
+      unregisterDown();
+    };
+  }, [editor]);
 
   return null;
 }
@@ -1537,6 +1602,7 @@ function ComposerPromptEditorInner({
   onRemoveTerminalContext,
   onChange,
   onCommandKeyDown,
+  onArrowBeyondEdge,
   onPaste,
   editorRef,
 }: ComposerPromptEditorProps) {
@@ -1774,6 +1840,9 @@ function ComposerPromptEditorInner({
         />
         <OnChangePlugin onChange={handleEditorChange} />
         <ComposerCommandKeyPlugin {...(onCommandKeyDown ? { onCommandKeyDown } : {})} />
+        {onArrowBeyondEdge ? (
+          <ComposerEdgeArrowPlugin onArrowBeyondEdge={onArrowBeyondEdge} />
+        ) : null}
         <ComposerSurroundSelectionPlugin terminalContexts={terminalContexts} skills={skills} />
         <ComposerHomeEndKeyPlugin />
         <ComposerInlineTokenArrowPlugin />
@@ -1798,6 +1867,7 @@ export function ComposerPromptEditor({
   onRemoveTerminalContext,
   onChange,
   onCommandKeyDown,
+  onArrowBeyondEdge,
   onPaste,
   editorRef,
 }: ComposerPromptEditorProps) {
@@ -1837,6 +1907,7 @@ export function ComposerPromptEditor({
         onPaste={onPaste}
         editorRef={editorRef}
         {...(onCommandKeyDown ? { onCommandKeyDown } : {})}
+        {...(onArrowBeyondEdge ? { onArrowBeyondEdge } : {})}
         {...(className ? { className } : {})}
       />
     </LexicalComposer>

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -602,6 +602,11 @@ export interface ChatComposerProps {
 
   focusComposer: () => void;
   scheduleComposerFocus: () => void;
+  /**
+   * Scrolls the transcript one step. Used for Arrow Up/Down the composer
+   * cannot act on; returns false when the transcript cannot move either.
+   */
+  scrollTimelineByArrowKey: (direction: "up" | "down") => boolean;
   setThreadError: (threadId: ThreadId | null, error: string | null) => void;
   onExpandImage: (preview: ExpandedImagePreview) => void;
 }
@@ -673,6 +678,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     handleInteractionModeChange,
     focusComposer,
     scheduleComposerFocus,
+    scrollTimelineByArrowKey,
     setThreadError,
     onExpandImage,
   } = props;
@@ -1946,6 +1952,17 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     return false;
   };
 
+  // An arrow the composer cannot act on (caret parked at its first/last
+  // offset) scrolls the transcript instead of doing nothing — the common case
+  // after a keyboard thread switch, which focuses the composer. Menus own the
+  // arrows while they are open.
+  const onComposerArrowBeyondEdge = (direction: "up" | "down") => {
+    if (composerMenuOpenRef.current || resolveActiveComposerTrigger().trigger !== null) {
+      return false;
+    }
+    return scrollTimelineByArrowKey(direction);
+  };
+
   // ------------------------------------------------------------------
   // Prompt stash (⌘S)
   // ------------------------------------------------------------------
@@ -3062,6 +3079,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                 onRemoveTerminalContext={removeComposerTerminalContextFromDraft}
                 onChange={onPromptChange}
                 onCommandKeyDown={onComposerCommandKey}
+                onArrowBeyondEdge={onComposerArrowBeyondEdge}
                 onPaste={onComposerPaste}
                 placeholder={
                   isComposerApprovalState

--- a/apps/web/src/composer-logic.test.ts
+++ b/apps/web/src/composer-logic.test.ts
@@ -8,6 +8,7 @@ import {
   isCollapsedCursorAdjacentToInlineToken,
   parseStandaloneComposerSlashCommand,
   replaceTextRange,
+  shouldForwardComposerArrowToTimeline,
   shouldSubmitComposerOnEnter,
 } from "./composer-logic";
 import { INLINE_TERMINAL_CONTEXT_PLACEHOLDER } from "./lib/terminalContext";
@@ -370,5 +371,70 @@ describe("parseStandaloneComposerSlashCommand", () => {
 
   it("ignores slash commands with extra message text", () => {
     expect(parseStandaloneComposerSlashCommand("/plan explain this")).toBeNull();
+  });
+});
+
+describe("shouldForwardComposerArrowToTimeline", () => {
+  // Empty composer, nothing scrolled: the state a keyboard thread switch lands in.
+  const atRest = {
+    hasModifier: false,
+    isCollapsed: true,
+    cursor: 0,
+    length: 0,
+    editorScrollTop: 0,
+    editorScrollHeight: 100,
+    editorClientHeight: 100,
+  };
+
+  it("forwards both arrows from an empty composer", () => {
+    expect(shouldForwardComposerArrowToTimeline({ ...atRest, direction: "up" })).toBe(true);
+    expect(shouldForwardComposerArrowToTimeline({ ...atRest, direction: "down" })).toBe(true);
+  });
+
+  it("keeps arrows that still move the caret", () => {
+    expect(
+      shouldForwardComposerArrowToTimeline({
+        ...atRest,
+        direction: "up",
+        cursor: 3,
+        length: 10,
+      }),
+    ).toBe(false);
+    expect(
+      shouldForwardComposerArrowToTimeline({
+        ...atRest,
+        direction: "down",
+        cursor: 3,
+        length: 10,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps arrows while the composer can still scroll itself", () => {
+    expect(
+      shouldForwardComposerArrowToTimeline({
+        ...atRest,
+        direction: "up",
+        editorScrollTop: 20,
+        editorScrollHeight: 400,
+      }),
+    ).toBe(false);
+    expect(
+      shouldForwardComposerArrowToTimeline({
+        ...atRest,
+        direction: "down",
+        editorScrollTop: 20,
+        editorScrollHeight: 400,
+      }),
+    ).toBe(false);
+  });
+
+  it("leaves modified and selecting arrows alone", () => {
+    expect(
+      shouldForwardComposerArrowToTimeline({ ...atRest, direction: "up", hasModifier: true }),
+    ).toBe(false);
+    expect(
+      shouldForwardComposerArrowToTimeline({ ...atRest, direction: "up", isCollapsed: false }),
+    ).toBe(false);
   });
 });

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -18,6 +18,31 @@ export function shouldSubmitComposerOnEnter(input: {
   return !input.isMobileViewport && !input.shiftKey;
 }
 
+/**
+ * True when an Arrow Up/Down press in the composer cannot move the caret or
+ * scroll the composer itself, so the transcript should take the key instead.
+ * Keyboard thread switches focus the composer, and without this the arrows
+ * silently do nothing.
+ */
+export function shouldForwardComposerArrowToTimeline(input: {
+  direction: "up" | "down";
+  hasModifier: boolean;
+  isCollapsed: boolean;
+  cursor: number;
+  length: number;
+  editorScrollTop: number;
+  editorScrollHeight: number;
+  editorClientHeight: number;
+}): boolean {
+  if (input.hasModifier || !input.isCollapsed) return false;
+  if (input.direction === "up") {
+    if (input.cursor > 0) return false;
+    return input.editorScrollTop <= 0;
+  }
+  if (input.cursor < input.length) return false;
+  return input.editorScrollTop >= input.editorScrollHeight - input.editorClientHeight - 1;
+}
+
 const isInlineTokenSegment = (
   segment:
     | { type: "text"; text: string }


### PR DESCRIPTION
When the chat input is empty I think it would be nice UX to scroll the chat itself when pressing up/down arrow keys. Especially useful when you just switch sessions with your keyboard and want to read back what the agent said without having to pick up the mouse.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized chat keyboard/scroll UX with guarded forwarding and tests; no auth, data, or API changes.
> 
> **Overview**
> **Arrow Up/Down** can scroll the chat transcript when the composer is focused but cannot use the key (caret at the top/bottom, composer already at its scroll limit, collapsed selection with no modifiers).
> 
> A new **`shouldForwardComposerArrowToTimeline`** helper decides when forwarding is appropriate; **`ComposerEdgeArrowPlugin`** handles arrows at low Lexical priority so command/menus keep precedence. **`ChatView`** exposes **`scrollTimelineByArrowKey`** (~40px per press); scrolling up cancels timeline live-follow like other manual navigation. **`ChatComposer`** skips forwarding while composer menus or triggers are open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ba752518375d54a5adba601db7e4bc150ce2378. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix arrow keys to scroll the transcript when the chat composer is idle
> - Adds `shouldForwardComposerArrowToTimeline` in [composer-logic.ts](https://github.com/pingdotgg/t3code/pull/7235/files#diff-d8bf01d2c2c41e34161141355950c042b07686d185ea476beb91213ecf6466a6) to detect when the composer caret is at its edge and the editor cannot scroll further, forwarding the arrow key to the timeline instead.
> - Adds `ComposerEdgeArrowPlugin` in [ComposerPromptEditor.tsx](https://github.com/pingdotgg/t3code/pull/7235/files#diff-12fcb05b3e147eba955638d8df57440b8cf7f796941af0989c9bfa57b5b4f4a4) as a Lexical plugin that invokes a new `onArrowBeyondEdge` callback when the composer cannot act on Arrow Up/Down.
> - Scrolls the transcript by 40px per key press via `scrollTimelineByArrowKey` in [ChatViewContent](https://github.com/pingdotgg/t3code/pull/7235/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e); upward scroll cancels live-follow.
> - Arrow forwarding is suppressed when composer menus or triggers are active.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ba7525.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->