### PR TITLE
fix(preview): failed tabs no longer sit as a blank floating panel

### DIFF
--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -558,7 +558,7 @@ describe("PreviewManager", () => {
           available: false,
           visible: true,
           tabId: "tab_failed",
-          url: "chrome-error://chromewebdata/",
+          url: "http://localhost:5173/",
           title: "ERR_CONNECTION_REFUSED",
           loading: false,
         });

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -501,6 +501,71 @@ describe("PreviewManager", () => {
     ),
   );
 
+  effectIt.effect("reports a failed navigation as unavailable automation", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const listeners = new Map<string, (...args: never[]) => void>();
+        let url = "http://localhost:5173/";
+        fromId.mockReturnValue({
+          id: 42,
+          isDestroyed: () => false,
+          getType: () => "webview",
+          getURL: () => url,
+          getTitle: () => "localhost:5173",
+          isLoading: () => false,
+          getZoomFactor: () => 1,
+          setZoomFactor: vi.fn(),
+          loadURL: vi.fn(async () => undefined),
+          on: vi.fn((event: string, listener: (...args: never[]) => void) => {
+            listeners.set(event, listener);
+          }),
+          off: vi.fn(),
+          ipc: { on: vi.fn(), off: vi.fn() },
+          send: webviewSend,
+          navigationHistory: { canGoBack: () => false, canGoForward: () => false },
+          setWindowOpenHandler: vi.fn(),
+          debugger: {
+            isAttached: () => false,
+            attach: vi.fn(),
+            sendCommand: vi.fn(async () => undefined),
+            on: vi.fn(),
+            off: vi.fn(),
+          },
+        } as never);
+
+        yield* manager.createTab("tab_failed");
+        yield* manager.registerWebview("tab_failed", 42);
+        listeners.get("did-fail-load")?.(
+          {},
+          -102,
+          "ERR_CONNECTION_REFUSED",
+          "http://localhost:5173/",
+          true,
+        );
+        yield* Effect.yieldNow;
+
+        expect(yield* manager.automationStatus("tab_failed")).toEqual({
+          available: false,
+          visible: true,
+          tabId: "tab_failed",
+          url: "http://localhost:5173/",
+          title: "ERR_CONNECTION_REFUSED",
+          loading: false,
+        });
+
+        url = "chrome-error://chromewebdata/";
+        expect(yield* manager.automationStatus("tab_failed")).toEqual({
+          available: false,
+          visible: true,
+          tabId: "tab_failed",
+          url: "chrome-error://chromewebdata/",
+          title: "ERR_CONNECTION_REFUSED",
+          loading: false,
+        });
+      }),
+    ),
+  );
+
   effectIt.effect("rejects a destroyed webview during registration", () =>
     withManager((manager) =>
       Effect.gen(function* () {

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -515,6 +515,8 @@ describe("PreviewManager", () => {
           isLoading: () => false,
           getZoomFactor: () => 1,
           setZoomFactor: vi.fn(),
+          setAudioMuted: vi.fn(),
+          isCurrentlyAudible: () => false,
           loadURL: vi.fn(async () => undefined),
           on: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
             listeners.set(event, listener);

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -508,13 +508,14 @@ describe("PreviewManager", () => {
       Effect.gen(function* () {
         const listeners = new Map<string, (...args: unknown[]) => void>();
         let url = "http://localhost:5173/";
+        let loading = false;
         fromId.mockReturnValue({
           id: 42,
           isDestroyed: () => false,
           getType: () => "webview",
           getURL: () => url,
           getTitle: () => "localhost:5173",
-          isLoading: () => false,
+          isLoading: () => loading,
           getZoomFactor: () => 1,
           setZoomFactor: vi.fn(),
           setAudioMuted: vi.fn(),
@@ -559,13 +560,14 @@ describe("PreviewManager", () => {
         });
 
         url = "chrome-error://chromewebdata/";
+        loading = true;
         expect(yield* manager.automationStatus("tab_failed")).toEqual({
           available: false,
           visible: true,
           tabId: "tab_failed",
           url: "http://localhost:5173/",
           title: "ERR_CONNECTION_REFUSED",
-          loading: false,
+          loading: true,
           attached: true,
         });
       }),

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -484,6 +484,7 @@ describe("PreviewManager", () => {
           url: null,
           title: null,
           loading: false,
+          attached: false,
         });
 
         yield* manager.createTab("tab_1");
@@ -495,6 +496,7 @@ describe("PreviewManager", () => {
           url: null,
           title: null,
           loading: false,
+          attached: false,
         });
         expect(fromId).not.toHaveBeenCalled();
       }),
@@ -553,6 +555,7 @@ describe("PreviewManager", () => {
           url: "http://localhost:5173/",
           title: "ERR_CONNECTION_REFUSED",
           loading: false,
+          attached: true,
         });
 
         url = "chrome-error://chromewebdata/";
@@ -563,6 +566,29 @@ describe("PreviewManager", () => {
           url: "http://localhost:5173/",
           title: "ERR_CONNECTION_REFUSED",
           loading: false,
+          attached: true,
+        });
+      }),
+    ),
+  );
+
+  effectIt.effect("reports a destroyed guest as detached even when webContentsId remains", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const preview = makeFaviconWebContents();
+        fromId.mockReturnValue(preview.webContents);
+        yield* manager.createTab("tab_destroyed_status");
+        yield* manager.registerWebview("tab_destroyed_status", 42);
+        preview.setDestroyed(true);
+
+        expect(yield* manager.automationStatus("tab_destroyed_status")).toEqual({
+          available: false,
+          visible: true,
+          tabId: "tab_destroyed_status",
+          url: "http://localhost:3200/",
+          title: null,
+          loading: false,
+          attached: false,
         });
       }),
     ),
@@ -703,6 +729,7 @@ describe("PreviewManager", () => {
           url: "http://localhost:3200/",
           title: "",
           loading: true,
+          attached: false,
         });
 
         yield* manager.registerWebview("tab_pending", 42);

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -504,7 +504,7 @@ describe("PreviewManager", () => {
   effectIt.effect("reports a failed navigation as unavailable automation", () =>
     withManager((manager) =>
       Effect.gen(function* () {
-        const listeners = new Map<string, (...args: never[]) => void>();
+        const listeners = new Map<string, (...args: unknown[]) => void>();
         let url = "http://localhost:5173/";
         fromId.mockReturnValue({
           id: 42,
@@ -516,7 +516,7 @@ describe("PreviewManager", () => {
           getZoomFactor: () => 1,
           setZoomFactor: vi.fn(),
           loadURL: vi.fn(async () => undefined),
-          on: vi.fn((event: string, listener: (...args: never[]) => void) => {
+          on: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
             listeners.set(event, listener);
           }),
           off: vi.fn(),

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -3469,6 +3469,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
               ? null
               : navStatus.title,
         loading: navStatus?.kind === "Loading",
+        attached: false,
       };
     }
     const wc = webContents.fromId(tab.webContentsId);
@@ -3483,6 +3484,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
             ? tab.navStatus.description || tab.navStatus.title
             : null,
         loading: false,
+        attached: false,
       };
     }
     if (tab.navStatus.kind === "LoadFailed") {
@@ -3493,6 +3495,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         url: tab.navStatus.url,
         title: tab.navStatus.description || wc.getTitle() || tab.navStatus.title,
         loading: false,
+        attached: true,
       };
     }
     return {
@@ -3502,6 +3505,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       url: wc.getURL() || null,
       title: wc.getTitle() || null,
       loading: wc.isLoading(),
+      attached: true,
     };
   });
 

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -3494,7 +3494,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         tabId,
         url: tab.navStatus.url,
         title: tab.navStatus.description || wc.getTitle() || tab.navStatus.title,
-        loading: false,
+        loading: wc.isLoading(),
         attached: true,
       };
     }

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -3462,28 +3462,48 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         visible: true,
         tabId,
         url: !navStatus || navStatus.kind === "Idle" ? null : navStatus.url,
-        title: !navStatus || navStatus.kind === "Idle" ? null : navStatus.title,
+        title:
+          navStatus?.kind === "LoadFailed"
+            ? navStatus.description || navStatus.title
+            : !navStatus || navStatus.kind === "Idle"
+              ? null
+              : navStatus.title,
         loading: navStatus?.kind === "Loading",
       };
     }
     const wc = webContents.fromId(tab.webContentsId);
-    return !wc || wc.isDestroyed()
-      ? {
-          available: false,
-          visible: true,
-          tabId,
-          url: null,
-          title: null,
-          loading: false,
-        }
-      : {
-          available: true,
-          visible: true,
-          tabId,
-          url: wc.getURL() || null,
-          title: wc.getTitle() || null,
-          loading: wc.isLoading(),
-        };
+    if (!wc || wc.isDestroyed()) {
+      return {
+        available: false,
+        visible: true,
+        tabId,
+        url: tab.navStatus.kind === "Idle" ? null : tab.navStatus.url,
+        title:
+          tab.navStatus.kind === "LoadFailed"
+            ? tab.navStatus.description || tab.navStatus.title
+            : null,
+        loading: false,
+      };
+    }
+    if (tab.navStatus.kind === "LoadFailed") {
+      const guestUrl = wc.getURL() || null;
+      return {
+        available: false,
+        visible: true,
+        tabId,
+        url: guestUrl?.startsWith("chrome-error:") ? guestUrl : tab.navStatus.url,
+        title: tab.navStatus.description || wc.getTitle() || tab.navStatus.title,
+        loading: false,
+      };
+    }
+    return {
+      available: true,
+      visible: true,
+      tabId,
+      url: wc.getURL() || null,
+      title: wc.getTitle() || null,
+      loading: wc.isLoading(),
+    };
   });
 
   const captureAutomationSnapshot = Effect.fn("PreviewManager.captureAutomationSnapshot")(

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -3486,12 +3486,11 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       };
     }
     if (tab.navStatus.kind === "LoadFailed") {
-      const guestUrl = wc.getURL() || null;
       return {
         available: false,
         visible: true,
         tabId,
-        url: guestUrl?.startsWith("chrome-error:") ? guestUrl : tab.navStatus.url,
+        url: tab.navStatus.url,
         title: tab.navStatus.description || wc.getTitle() || tab.navStatus.title,
         loading: false,
       };

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -71,6 +71,7 @@ import {
 } from "./previewNavigationReadiness";
 import { createPreviewAutomationRequestConsumerAtom } from "./previewAutomationRequestConsumer";
 import { createPreviewAutomationClientId } from "./previewAutomationClientId";
+import { applyPreviewLoadFailureToAutomationStatus } from "./previewAutomationStatus";
 import {
   needsPreviewAutomationSessionSync,
   resolvePreviewAutomationOpenTab,
@@ -234,18 +235,24 @@ const currentStatus = async (
   };
   if (runtimeTabId && tabId && previewBridge && state.desktopByTabId[tabId]) {
     const status = await previewBridge.automation.status(runtimeTabId);
-    return { ...status, tabId, visible, ...viewportStatus };
+    return applyPreviewLoadFailureToAutomationStatus(
+      { ...status, tabId, visible, ...viewportStatus },
+      snapshot?.navStatus,
+    );
   }
   const navStatus = snapshot?.navStatus;
-  return {
-    available: Boolean(previewBridge?.automation),
-    visible,
-    tabId,
-    url: navStatus && navStatus._tag !== "Idle" ? navStatus.url : null,
-    title: navStatus && navStatus._tag !== "Idle" ? navStatus.title : null,
-    loading: navStatus?._tag === "Loading",
-    ...viewportStatus,
-  };
+  return applyPreviewLoadFailureToAutomationStatus(
+    {
+      available: Boolean(previewBridge?.automation),
+      visible,
+      tabId,
+      url: navStatus && navStatus._tag !== "Idle" ? navStatus.url : null,
+      title: navStatus && navStatus._tag !== "Idle" ? navStatus.title : null,
+      loading: navStatus?._tag === "Loading",
+      ...viewportStatus,
+    },
+    navStatus,
+  );
 };
 
 const raiseAtomCommandFailure = (result: Parameters<typeof squashAtomCommandFailure>[0]): never => {

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -238,6 +238,7 @@ const currentStatus = async (
     return applyPreviewLoadFailureToAutomationStatus(
       { ...status, tabId, visible, ...viewportStatus },
       snapshot?.navStatus,
+      { preferLiveAvailability: true },
     );
   }
   const navStatus = snapshot?.navStatus;

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -238,7 +238,15 @@ const currentStatus = async (
   if (runtimeTabId && tabId && previewBridge && state.desktopByTabId[tabId]) {
     const status = await previewBridge.automation.status(runtimeTabId);
     return applyPreviewLoadFailureToAutomationStatus(
-      { ...status, tabId, visible, ...viewportStatus },
+      {
+        available: status.available,
+        visible,
+        tabId,
+        url: status.url,
+        title: status.title,
+        loading: status.loading,
+        ...viewportStatus,
+      },
       snapshot?.navStatus,
       { preferLiveAvailability: true },
     );

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -106,9 +106,21 @@ const waitForDesktopOverlay = async (
     });
     // Attachment only. LoadFailed still has a live guest and must stay
     // reachable so navigate/retry can recover. Page health is reported by
-    // preview_status, not this wait.
+    // preview_status, not this wait. Re-read the main-process attachment bit
+    // because a stale overlay snapshot can retain hasWebContents after destroy.
     if (state.desktopByTabId[tabId]?.hasWebContents && previewBridge) {
-      return;
+      const status = await previewBridge.automation.status(runtimeTabId).catch(() => null);
+      if (status?.attached === false) {
+        throw new PreviewAutomationTargetUnavailableError({
+          requestId,
+          operation,
+          environmentId: threadRef.environmentId,
+          threadId: threadRef.threadId,
+          tabId,
+          bridgeAvailable: true,
+        });
+      }
+      if (status) return;
     }
     await new Promise<void>((resolve) => window.setTimeout(resolve, 50));
   }

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -260,7 +260,7 @@ const currentStatus = async (
         ...viewportStatus,
       },
       snapshot?.navStatus,
-      { preferLiveAvailability: true },
+      { preferLiveStatus: true },
     );
   }
   const navStatus = snapshot?.navStatus;

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -104,9 +104,11 @@ const waitForDesktopOverlay = async (
       operation,
       requestId,
     });
-    if (state.desktopByTabId[tabId] && previewBridge && isPreviewWebviewRendering(runtimeTabId)) {
-      const status = await previewBridge.automation.status(runtimeTabId);
-      if (status.available) return;
+    // Attachment only. LoadFailed still has a live guest and must stay
+    // reachable so navigate/retry can recover. Page health is reported by
+    // preview_status, not this wait.
+    if (state.desktopByTabId[tabId]?.hasWebContents && previewBridge) {
+      return;
     }
     await new Promise<void>((resolve) => window.setTimeout(resolve, 50));
   }

--- a/apps/web/src/components/preview/PreviewMiniPlayerUnreachable.test.tsx
+++ b/apps/web/src/components/preview/PreviewMiniPlayerUnreachable.test.tsx
@@ -17,5 +17,6 @@ describe("PreviewMiniPlayerUnreachable", () => {
     expect(html).toContain("Retry");
     expect(html).toContain("Close");
     expect(html).toContain("Connection refused");
+    expect(html).toContain("pointer-events-auto");
   });
 });

--- a/apps/web/src/components/preview/PreviewMiniPlayerUnreachable.test.tsx
+++ b/apps/web/src/components/preview/PreviewMiniPlayerUnreachable.test.tsx
@@ -18,5 +18,18 @@ describe("PreviewMiniPlayerUnreachable", () => {
     expect(html).toContain("Close");
     expect(html).toContain("Connection refused");
     expect(html).toContain("pointer-events-auto");
+    expect(html).toContain("truncate");
+  });
+
+  it("falls back to the raw URL when there is no host", () => {
+    const html = renderToStaticMarkup(
+      <PreviewMiniPlayerUnreachable
+        url="file:///missing.html"
+        description="ERR_FILE_NOT_FOUND"
+        onRetry={() => undefined}
+        onClose={() => undefined}
+      />,
+    );
+    expect(html).toContain("file:///missing.html");
   });
 });

--- a/apps/web/src/components/preview/PreviewMiniPlayerUnreachable.test.tsx
+++ b/apps/web/src/components/preview/PreviewMiniPlayerUnreachable.test.tsx
@@ -1,0 +1,21 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import { PreviewMiniPlayerUnreachable } from "./PreviewMiniPlayerUnreachable";
+
+describe("PreviewMiniPlayerUnreachable", () => {
+  it("shows the failed host with Retry and Close", () => {
+    const html = renderToStaticMarkup(
+      <PreviewMiniPlayerUnreachable
+        url="http://localhost:5173/app"
+        description="ERR_CONNECTION_REFUSED"
+        onRetry={() => undefined}
+        onClose={() => undefined}
+      />,
+    );
+    expect(html).toContain("localhost:5173");
+    expect(html).toContain("Retry");
+    expect(html).toContain("Close");
+    expect(html).toContain("Connection refused");
+  });
+});

--- a/apps/web/src/components/preview/PreviewMiniPlayerUnreachable.tsx
+++ b/apps/web/src/components/preview/PreviewMiniPlayerUnreachable.tsx
@@ -1,0 +1,39 @@
+import { Button } from "~/components/ui/button";
+
+import { describePreviewError } from "./errorCodeMessages";
+
+interface Props {
+  readonly url: string;
+  readonly description: string;
+  readonly onRetry: () => void;
+  readonly onClose: () => void;
+}
+
+/** Compact failed-navigation overlay for the floating mini-player. */
+export function PreviewMiniPlayerUnreachable({ url, description, onRetry, onClose }: Props) {
+  const host = safeHost(url) ?? url;
+  const friendly = describePreviewError(description);
+
+  return (
+    <div className="absolute inset-0 z-[49] flex flex-col items-center justify-center gap-3 rounded-xl bg-background px-4 text-center">
+      <p className="text-xs font-medium text-foreground">Can&apos;t reach {host}</p>
+      <p className="text-[11px] leading-snug text-muted-foreground">{friendly}</p>
+      <div className="flex items-center gap-2">
+        <Button type="button" size="sm" onClick={onRetry}>
+          Retry
+        </Button>
+        <Button type="button" size="sm" variant="outline" onClick={onClose}>
+          Close
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function safeHost(url: string): string | null {
+  try {
+    return new URL(url).host;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/components/preview/PreviewMiniPlayerUnreachable.tsx
+++ b/apps/web/src/components/preview/PreviewMiniPlayerUnreachable.tsx
@@ -15,7 +15,7 @@ export function PreviewMiniPlayerUnreachable({ url, description, onRetry, onClos
   const friendly = describePreviewError(description);
 
   return (
-    <div className="absolute inset-0 z-[49] flex flex-col items-center justify-center gap-3 rounded-xl bg-background px-4 text-center">
+    <div className="pointer-events-auto absolute inset-0 z-[49] flex flex-col items-center justify-center gap-3 rounded-xl bg-background px-4 text-center">
       <p className="text-xs font-medium text-foreground">Can&apos;t reach {host}</p>
       <p className="text-[11px] leading-snug text-muted-foreground">{friendly}</p>
       <div className="flex items-center gap-2">

--- a/apps/web/src/components/preview/PreviewMiniPlayerUnreachable.tsx
+++ b/apps/web/src/components/preview/PreviewMiniPlayerUnreachable.tsx
@@ -19,7 +19,9 @@ export function PreviewMiniPlayerUnreachable({ url, description, onRetry, onClos
       <p className="min-w-0 max-w-full truncate text-xs font-medium text-foreground">
         Can&apos;t reach {host}
       </p>
-      <p className="min-w-0 max-w-full text-[11px] leading-snug text-muted-foreground">{friendly}</p>
+      <p className="min-w-0 max-w-full text-[11px] leading-snug text-muted-foreground">
+        {friendly}
+      </p>
       <div className="flex items-center gap-2">
         <Button type="button" size="sm" onClick={onRetry}>
           Retry

--- a/apps/web/src/components/preview/PreviewMiniPlayerUnreachable.tsx
+++ b/apps/web/src/components/preview/PreviewMiniPlayerUnreachable.tsx
@@ -15,9 +15,11 @@ export function PreviewMiniPlayerUnreachable({ url, description, onRetry, onClos
   const friendly = describePreviewError(description);
 
   return (
-    <div className="pointer-events-auto absolute inset-0 z-[49] flex flex-col items-center justify-center gap-3 rounded-xl bg-background px-4 text-center">
-      <p className="text-xs font-medium text-foreground">Can&apos;t reach {host}</p>
-      <p className="text-[11px] leading-snug text-muted-foreground">{friendly}</p>
+    <div className="pointer-events-auto absolute inset-0 z-[49] flex min-w-0 flex-col items-center justify-center gap-3 overflow-hidden rounded-xl bg-background px-4 text-center">
+      <p className="min-w-0 max-w-full truncate text-xs font-medium text-foreground">
+        Can&apos;t reach {host}
+      </p>
+      <p className="min-w-0 max-w-full text-[11px] leading-snug text-muted-foreground">{friendly}</p>
       <div className="flex items-center gap-2">
         <Button type="button" size="sm" onClick={onRetry}>
           Retry
@@ -32,7 +34,7 @@ export function PreviewMiniPlayerUnreachable({ url, description, onRetry, onClos
 
 function safeHost(url: string): string | null {
   try {
-    return new URL(url).host;
+    return new URL(url).host || null;
   } catch {
     return null;
   }

--- a/apps/web/src/components/preview/ThreadPreviewMiniPlayer.tsx
+++ b/apps/web/src/components/preview/ThreadPreviewMiniPlayer.tsx
@@ -257,7 +257,7 @@ export function ThreadPreviewMiniPlayer({ threadRef, tabId, bottomInset }: Props
             }
       }
     >
-      <div className="group pointer-events-auto absolute right-2 top-2 z-[49] size-3">
+      <div className="group pointer-events-auto absolute right-2 top-2 z-[50] size-3">
         <div
           aria-hidden="true"
           className="absolute right-0 top-0 size-2 rounded-full bg-foreground/25 shadow-sm ring-1 ring-background/70 transition-opacity group-hover:opacity-0 group-focus-within:opacity-0"

--- a/apps/web/src/components/preview/ThreadPreviewMiniPlayer.tsx
+++ b/apps/web/src/components/preview/ThreadPreviewMiniPlayer.tsx
@@ -289,7 +289,10 @@ export function ThreadPreviewMiniPlayer({ threadRef, tabId, bottomInset }: Props
                       ? "Close popped-out preview"
                       : "Pop preview into separate window"
                   }
-                  disabled={!desktopOverlay?.hasWebContents || isUnreachable}
+                  disabled={
+                    !desktopOverlay?.hasWebContents ||
+                    (isUnreachable && !desktopOverlay.pictureInPicture)
+                  }
                   onPointerDown={(event) => event.stopPropagation()}
                   onClick={toggleNativePictureInPicture}
                 />

--- a/apps/web/src/components/preview/ThreadPreviewMiniPlayer.tsx
+++ b/apps/web/src/components/preview/ThreadPreviewMiniPlayer.tsx
@@ -286,31 +286,33 @@ export function ThreadPreviewMiniPlayer({ threadRef, tabId, bottomInset }: Props
             <TooltipPopup side="top">Open in right panel</TooltipPopup>
           </Tooltip>
           <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button
-                  variant={desktopOverlay?.pictureInPicture ? "secondary" : "ghost"}
-                  size="icon-xs"
-                  aria-label={
-                    desktopOverlay?.pictureInPicture
-                      ? "Close popped-out preview"
-                      : "Pop preview into separate window"
-                  }
-                  disabled={
-                    !desktopOverlay?.hasWebContents ||
-                    (isUnreachable && !desktopOverlay.pictureInPicture)
-                  }
-                  onPointerDown={(event) => event.stopPropagation()}
-                  onClick={toggleNativePictureInPicture}
-                />
-              }
-            >
-              <PictureInPicture2 />
+            <TooltipTrigger render={<span className="flex shrink-0" />}>
+              <Button
+                variant={desktopOverlay?.pictureInPicture ? "secondary" : "ghost"}
+                size="icon-xs"
+                aria-label={
+                  desktopOverlay?.pictureInPicture
+                    ? "Close popped-out preview"
+                    : "Pop preview into separate window"
+                }
+                disabled={
+                  !desktopOverlay?.hasWebContents ||
+                  (isUnreachable && !desktopOverlay.pictureInPicture)
+                }
+                onPointerDown={(event) => event.stopPropagation()}
+                onClick={toggleNativePictureInPicture}
+              >
+                <PictureInPicture2 />
+              </Button>
             </TooltipTrigger>
             <TooltipPopup side="top">
               {desktopOverlay?.pictureInPicture
                 ? "Close separate window"
-                : "Pop into separate window"}
+                : isUnreachable
+                  ? "Retry preview before popping out"
+                  : !desktopOverlay?.hasWebContents
+                    ? "Preview is reconnecting"
+                    : "Pop into separate window"}
             </TooltipPopup>
           </Tooltip>
           <Tooltip>
@@ -348,7 +350,7 @@ export function ThreadPreviewMiniPlayer({ threadRef, tabId, bottomInset }: Props
           className="absolute inset-0"
         />
         <div className="pointer-events-none absolute inset-0 z-[49] rounded-xl ring-1 ring-inset ring-border/80" />
-        {isUnreachable && navStatus._tag === "LoadFailed" ? (
+        {isUnreachable && navStatus._tag === "LoadFailed" && desktopOverlay?.hasWebContents ? (
           <PreviewMiniPlayerUnreachable
             url={navStatus.url}
             description={navStatus.description}

--- a/apps/web/src/components/preview/ThreadPreviewMiniPlayer.tsx
+++ b/apps/web/src/components/preview/ThreadPreviewMiniPlayer.tsx
@@ -70,7 +70,14 @@ export function ThreadPreviewMiniPlayer({ threadRef, tabId, bottomInset }: Props
     usePreviewMiniPlayerStore.getState().close(threadRef);
   };
   const retry = () => {
-    if (previewBridge && runtimeTabId) void previewBridge.refresh(runtimeTabId);
+    if (!previewBridge || !runtimeTabId || !desktopOverlay?.hasWebContents) return;
+    void previewBridge.refresh(runtimeTabId).catch((error) => {
+      toastManager.add({
+        type: "error",
+        title: "Unable to retry preview",
+        description: error instanceof Error ? error.message : "An error occurred.",
+      });
+    });
   };
 
   const openInPanel = () => {

--- a/apps/web/src/components/preview/ThreadPreviewMiniPlayer.tsx
+++ b/apps/web/src/components/preview/ThreadPreviewMiniPlayer.tsx
@@ -14,6 +14,7 @@ import { selectThreadPreviewMiniPlayer, usePreviewMiniPlayerStore } from "~/prev
 import { useRightPanelStore } from "~/rightPanelStore";
 
 import { previewBridge } from "./previewBridge";
+import { PreviewMiniPlayerUnreachable } from "./PreviewMiniPlayerUnreachable";
 import {
   clampPreviewMiniPlayerPosition,
   clampPreviewMiniPlayerSize,
@@ -63,8 +64,13 @@ export function ThreadPreviewMiniPlayer({ threadRef, tabId, bottomInset }: Props
     miniPlayer?.tabId === tabId && miniPlayer.size
       ? miniPlayer.size
       : PREVIEW_MINI_PLAYER_DEFAULT_SIZE;
+  const navStatus = snapshot?.navStatus ?? { _tag: "Idle" as const };
+  const isUnreachable = navStatus._tag === "LoadFailed";
   const close = () => {
     usePreviewMiniPlayerStore.getState().close(threadRef);
+  };
+  const retry = () => {
+    if (previewBridge && runtimeTabId) void previewBridge.refresh(runtimeTabId);
   };
 
   const openInPanel = () => {
@@ -320,7 +326,7 @@ export function ThreadPreviewMiniPlayer({ threadRef, tabId, bottomInset }: Props
         <div className="absolute inset-0 z-[47] rounded-xl bg-muted shadow-2xl/35" />
         <BrowserSurfaceSlot
           tabId={runtimeTabId}
-          visible={Boolean(desktopOverlay?.hasWebContents)}
+          visible={Boolean(desktopOverlay?.hasWebContents) && !isUnreachable}
           cornerRadius={12}
           zIndex={PREVIEW_MINI_PLAYER_WEBVIEW_Z_INDEX}
           fitSourceContent
@@ -332,7 +338,14 @@ export function ThreadPreviewMiniPlayer({ threadRef, tabId, bottomInset }: Props
           className="absolute inset-0"
         />
         <div className="pointer-events-none absolute inset-0 z-[49] rounded-xl ring-1 ring-inset ring-border/80" />
-        {!desktopOverlay?.hasWebContents ? (
+        {isUnreachable && navStatus._tag === "LoadFailed" ? (
+          <PreviewMiniPlayerUnreachable
+            url={navStatus.url}
+            description={navStatus.description}
+            onRetry={retry}
+            onClose={close}
+          />
+        ) : !desktopOverlay?.hasWebContents ? (
           <div className="pointer-events-none absolute inset-0 z-[49] flex items-center justify-center rounded-xl bg-muted text-xs text-muted-foreground">
             Reconnecting preview…
           </div>

--- a/apps/web/src/components/preview/ThreadPreviewMiniPlayer.tsx
+++ b/apps/web/src/components/preview/ThreadPreviewMiniPlayer.tsx
@@ -289,7 +289,7 @@ export function ThreadPreviewMiniPlayer({ threadRef, tabId, bottomInset }: Props
                       ? "Close popped-out preview"
                       : "Pop preview into separate window"
                   }
-                  disabled={!desktopOverlay?.hasWebContents}
+                  disabled={!desktopOverlay?.hasWebContents || isUnreachable}
                   onPointerDown={(event) => event.stopPropagation()}
                   onClick={toggleNativePictureInPicture}
                 />

--- a/apps/web/src/components/preview/previewAutomationStatus.test.ts
+++ b/apps/web/src/components/preview/previewAutomationStatus.test.ts
@@ -73,4 +73,26 @@ describe("previewAutomationStatus", () => {
       ),
     ).toEqual(healthy);
   });
+
+  it("does not let a stale LoadFailed snapshot hide an in-flight load", () => {
+    const attaching = {
+      ...healthy,
+      available: false,
+      loading: true,
+      title: null,
+    };
+    expect(
+      applyPreviewLoadFailureToAutomationStatus(
+        attaching,
+        {
+          _tag: "LoadFailed",
+          url: "http://localhost:5173/",
+          title: "localhost:5173",
+          code: -102,
+          description: "ERR_CONNECTION_REFUSED",
+        },
+        { preferLiveAvailability: true },
+      ),
+    ).toEqual(attaching);
+  });
 });

--- a/apps/web/src/components/preview/previewAutomationStatus.test.ts
+++ b/apps/web/src/components/preview/previewAutomationStatus.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  applyPreviewLoadFailureToAutomationStatus,
+  isChromeErrorPreviewUrl,
+} from "./previewAutomationStatus";
+
+const healthy = {
+  available: true,
+  visible: false,
+  tabId: "tab_2",
+  url: "http://localhost:5173/",
+  title: "App",
+  loading: false,
+} as const;
+
+describe("previewAutomationStatus", () => {
+  it("detects chromium error interstitial URLs", () => {
+    expect(isChromeErrorPreviewUrl("chrome-error://chromewebdata/")).toBe(true);
+    expect(isChromeErrorPreviewUrl("http://localhost:5173/")).toBe(false);
+    expect(isChromeErrorPreviewUrl(null)).toBe(false);
+  });
+
+  it("leaves a successful navigation unchanged", () => {
+    expect(
+      applyPreviewLoadFailureToAutomationStatus(healthy, {
+        _tag: "Success",
+        url: "http://localhost:5173/",
+        title: "App",
+      }),
+    ).toEqual(healthy);
+  });
+
+  it("marks a failed navigation unavailable and reports the requested URL", () => {
+    expect(
+      applyPreviewLoadFailureToAutomationStatus(healthy, {
+        _tag: "LoadFailed",
+        url: "http://localhost:5173/",
+        title: "localhost:5173",
+        code: -102,
+        description: "ERR_CONNECTION_REFUSED",
+      }),
+    ).toEqual({
+      ...healthy,
+      available: false,
+      title: "ERR_CONNECTION_REFUSED",
+    });
+  });
+
+  it("prefers the chrome-error interstitial when the guest already landed there", () => {
+    expect(
+      applyPreviewLoadFailureToAutomationStatus(
+        { ...healthy, url: "chrome-error://chromewebdata/" },
+        {
+          _tag: "LoadFailed",
+          url: "http://localhost:5173/",
+          title: "localhost:5173",
+          code: -105,
+          description: "ERR_NAME_NOT_RESOLVED",
+        },
+      ),
+    ).toEqual({
+      ...healthy,
+      available: false,
+      url: "chrome-error://chromewebdata/",
+      title: "ERR_NAME_NOT_RESOLVED",
+    });
+  });
+});

--- a/apps/web/src/components/preview/previewAutomationStatus.test.ts
+++ b/apps/web/src/components/preview/previewAutomationStatus.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import {
-  applyPreviewLoadFailureToAutomationStatus,
-  isChromeErrorPreviewUrl,
-} from "./previewAutomationStatus";
+import { applyPreviewLoadFailureToAutomationStatus } from "./previewAutomationStatus";
 
 const healthy = {
   available: true,
@@ -15,12 +12,6 @@ const healthy = {
 } as const;
 
 describe("previewAutomationStatus", () => {
-  it("detects chromium error interstitial URLs", () => {
-    expect(isChromeErrorPreviewUrl("chrome-error://chromewebdata/")).toBe(true);
-    expect(isChromeErrorPreviewUrl("http://localhost:5173/")).toBe(false);
-    expect(isChromeErrorPreviewUrl(null)).toBe(false);
-  });
-
   it("leaves a successful navigation unchanged", () => {
     expect(
       applyPreviewLoadFailureToAutomationStatus(healthy, {
@@ -47,7 +38,7 @@ describe("previewAutomationStatus", () => {
     });
   });
 
-  it("prefers the chrome-error interstitial when the guest already landed there", () => {
+  it("keeps the requested URL when the guest landed on a chrome-error interstitial", () => {
     expect(
       applyPreviewLoadFailureToAutomationStatus(
         { ...healthy, url: "chrome-error://chromewebdata/" },
@@ -62,7 +53,7 @@ describe("previewAutomationStatus", () => {
     ).toEqual({
       ...healthy,
       available: false,
-      url: "chrome-error://chromewebdata/",
+      url: "http://localhost:5173/",
       title: "ERR_NAME_NOT_RESOLVED",
     });
   });

--- a/apps/web/src/components/preview/previewAutomationStatus.test.ts
+++ b/apps/web/src/components/preview/previewAutomationStatus.test.ts
@@ -57,4 +57,20 @@ describe("previewAutomationStatus", () => {
       title: "ERR_NAME_NOT_RESOLVED",
     });
   });
+
+  it("does not let a stale LoadFailed snapshot override a live available guest", () => {
+    expect(
+      applyPreviewLoadFailureToAutomationStatus(
+        healthy,
+        {
+          _tag: "LoadFailed",
+          url: "http://localhost:5173/",
+          title: "localhost:5173",
+          code: -102,
+          description: "ERR_CONNECTION_REFUSED",
+        },
+        { preferLiveAvailability: true },
+      ),
+    ).toEqual(healthy);
+  });
 });

--- a/apps/web/src/components/preview/previewAutomationStatus.test.ts
+++ b/apps/web/src/components/preview/previewAutomationStatus.test.ts
@@ -69,7 +69,7 @@ describe("previewAutomationStatus", () => {
           code: -102,
           description: "ERR_CONNECTION_REFUSED",
         },
-        { preferLiveAvailability: true },
+        { preferLiveStatus: true },
       ),
     ).toEqual(healthy);
   });
@@ -91,8 +91,30 @@ describe("previewAutomationStatus", () => {
           code: -102,
           description: "ERR_CONNECTION_REFUSED",
         },
-        { preferLiveAvailability: true },
+        { preferLiveStatus: true },
       ),
     ).toEqual(attaching);
+  });
+
+  it("keeps a newer live failure instead of the stale snapshot", () => {
+    const liveFailure = {
+      ...healthy,
+      available: false,
+      url: "http://localhost:4173/",
+      title: "ERR_NAME_NOT_RESOLVED",
+    };
+    expect(
+      applyPreviewLoadFailureToAutomationStatus(
+        liveFailure,
+        {
+          _tag: "LoadFailed",
+          url: "http://localhost:5173/",
+          title: "localhost:5173",
+          code: -102,
+          description: "ERR_CONNECTION_REFUSED",
+        },
+        { preferLiveStatus: true },
+      ),
+    ).toEqual(liveFailure);
   });
 });

--- a/apps/web/src/components/preview/previewAutomationStatus.ts
+++ b/apps/web/src/components/preview/previewAutomationStatus.ts
@@ -4,12 +4,17 @@ import type { PreviewAutomationStatus, PreviewNavStatus } from "@t3tools/contrac
  * preview_status must not report a failed guest as a healthy automation target.
  * Keep the requested URL so Retry/navigate still have something useful; the
  * chrome-error interstitial is not a navigable address.
+ *
+ * When a live desktop status already says the guest is available, keep it.
+ * A stale LoadFailed snapshot can lag a successful retry.
  */
 export function applyPreviewLoadFailureToAutomationStatus(
   status: PreviewAutomationStatus,
   navStatus: PreviewNavStatus | undefined,
+  options?: { readonly preferLiveAvailability?: boolean },
 ): PreviewAutomationStatus {
   if (navStatus?._tag !== "LoadFailed") return status;
+  if (options?.preferLiveAvailability && status.available) return status;
   return {
     ...status,
     available: false,

--- a/apps/web/src/components/preview/previewAutomationStatus.ts
+++ b/apps/web/src/components/preview/previewAutomationStatus.ts
@@ -1,0 +1,25 @@
+import type { PreviewAutomationStatus, PreviewNavStatus } from "@t3tools/contracts";
+
+/** Chromium interstitials such as chrome-error://chromewebdata/. */
+export function isChromeErrorPreviewUrl(url: string | null | undefined): boolean {
+  return typeof url === "string" && url.startsWith("chrome-error:");
+}
+
+/**
+ * preview_status must not report a failed guest as a healthy automation target.
+ * Prefer the chrome-error URL when the guest landed on one; otherwise keep the
+ * requested URL so Retry/navigate still have something useful.
+ */
+export function applyPreviewLoadFailureToAutomationStatus(
+  status: PreviewAutomationStatus,
+  navStatus: PreviewNavStatus | undefined,
+): PreviewAutomationStatus {
+  if (navStatus?._tag !== "LoadFailed") return status;
+  return {
+    ...status,
+    available: false,
+    loading: false,
+    url: isChromeErrorPreviewUrl(status.url) ? status.url : navStatus.url,
+    title: navStatus.description || status.title,
+  };
+}

--- a/apps/web/src/components/preview/previewAutomationStatus.ts
+++ b/apps/web/src/components/preview/previewAutomationStatus.ts
@@ -1,14 +1,9 @@
 import type { PreviewAutomationStatus, PreviewNavStatus } from "@t3tools/contracts";
 
-/** Chromium interstitials such as chrome-error://chromewebdata/. */
-export function isChromeErrorPreviewUrl(url: string | null | undefined): boolean {
-  return typeof url === "string" && url.startsWith("chrome-error:");
-}
-
 /**
  * preview_status must not report a failed guest as a healthy automation target.
- * Prefer the chrome-error URL when the guest landed on one; otherwise keep the
- * requested URL so Retry/navigate still have something useful.
+ * Keep the requested URL so Retry/navigate still have something useful; the
+ * chrome-error interstitial is not a navigable address.
  */
 export function applyPreviewLoadFailureToAutomationStatus(
   status: PreviewAutomationStatus,
@@ -19,7 +14,7 @@ export function applyPreviewLoadFailureToAutomationStatus(
     ...status,
     available: false,
     loading: false,
-    url: isChromeErrorPreviewUrl(status.url) ? status.url : navStatus.url,
+    url: navStatus.url,
     title: navStatus.description || status.title,
   };
 }

--- a/apps/web/src/components/preview/previewAutomationStatus.ts
+++ b/apps/web/src/components/preview/previewAutomationStatus.ts
@@ -5,8 +5,9 @@ import type { PreviewAutomationStatus, PreviewNavStatus } from "@t3tools/contrac
  * Keep the requested URL so Retry/navigate still have something useful; the
  * chrome-error interstitial is not a navigable address.
  *
- * When a live desktop status already says the guest is available, keep it.
- * A stale LoadFailed snapshot can lag a successful retry.
+ * When a live desktop status already says the guest is available or still
+ * loading, keep it. A stale LoadFailed snapshot can lag a retry that is
+ * attaching or already in flight.
  */
 export function applyPreviewLoadFailureToAutomationStatus(
   status: PreviewAutomationStatus,
@@ -14,7 +15,7 @@ export function applyPreviewLoadFailureToAutomationStatus(
   options?: { readonly preferLiveAvailability?: boolean },
 ): PreviewAutomationStatus {
   if (navStatus?._tag !== "LoadFailed") return status;
-  if (options?.preferLiveAvailability && status.available) return status;
+  if (options?.preferLiveAvailability && (status.available || status.loading)) return status;
   return {
     ...status,
     available: false,

--- a/apps/web/src/components/preview/previewAutomationStatus.ts
+++ b/apps/web/src/components/preview/previewAutomationStatus.ts
@@ -5,17 +5,16 @@ import type { PreviewAutomationStatus, PreviewNavStatus } from "@t3tools/contrac
  * Keep the requested URL so Retry/navigate still have something useful; the
  * chrome-error interstitial is not a navigable address.
  *
- * When a live desktop status already says the guest is available or still
- * loading, keep it. A stale LoadFailed snapshot can lag a retry that is
- * attaching or already in flight.
+ * Keep a live desktop status intact. A stale LoadFailed snapshot can lag a
+ * retry or a newer failed navigation.
  */
 export function applyPreviewLoadFailureToAutomationStatus(
   status: PreviewAutomationStatus,
   navStatus: PreviewNavStatus | undefined,
-  options?: { readonly preferLiveAvailability?: boolean },
+  options?: { readonly preferLiveStatus?: boolean },
 ): PreviewAutomationStatus {
   if (navStatus?._tag !== "LoadFailed") return status;
-  if (options?.preferLiveAvailability && (status.available || status.loading)) return status;
+  if (options?.preferLiveStatus) return status;
   return {
     ...status,
     available: false,

--- a/apps/web/src/components/preview/previewNavigationReadiness.test.ts
+++ b/apps/web/src/components/preview/previewNavigationReadiness.test.ts
@@ -55,6 +55,44 @@ describe("waitForNavigationReadiness", () => {
     ).rejects.toBeInstanceOf(PreviewAutomationTargetUnavailableError);
   });
 
+  it("falls back to a fresh overlay read when attached is absent", async () => {
+    const threadRef = {
+      environmentId: EnvironmentId.make("environment-2"),
+      threadId: ThreadId.make("thread-1"),
+    };
+    const tabId = "tab_1";
+    const runtimeTabId = previewRuntimeTabId(threadRef, "epoch-1", tabId);
+    mocks.readThreadPreviewState.mockReturnValue({
+      serverEpoch: "epoch-1",
+      sessions: {
+        [tabId]: { tabId },
+      },
+      desktopByTabId: {
+        [tabId]: { hasWebContents: true },
+      },
+    });
+    vi.mocked(previewBridge!.automation.status).mockResolvedValue({
+      available: false,
+      visible: true,
+      tabId,
+      url: "http://localhost:5173/",
+      title: "ERR_CONNECTION_REFUSED",
+      loading: false,
+    });
+
+    await expect(
+      waitForNavigationReadiness(
+        threadRef,
+        "request-1",
+        tabId,
+        runtimeTabId,
+        "navigate",
+        "load",
+        2_000,
+      ),
+    ).resolves.toBeUndefined();
+  });
+
   it("settles a failed navigation instead of waiting for availability", async () => {
     const threadRef = {
       environmentId: EnvironmentId.make("environment-2"),
@@ -78,6 +116,7 @@ describe("waitForNavigationReadiness", () => {
       url: "http://localhost:5173/",
       title: "ERR_CONNECTION_REFUSED",
       loading: false,
+      attached: true,
     });
 
     await expect(
@@ -116,6 +155,7 @@ describe("waitForNavigationReadiness", () => {
       url: "http://localhost:5173/",
       title: null,
       loading: false,
+      attached: false,
     });
 
     await expect(
@@ -129,5 +169,83 @@ describe("waitForNavigationReadiness", () => {
         2_000,
       ),
     ).rejects.toBeInstanceOf(PreviewAutomationTargetUnavailableError);
+  });
+
+  it("rejects a destroyed guest even when the overlay still reports webContents", async () => {
+    const threadRef = {
+      environmentId: EnvironmentId.make("environment-2"),
+      threadId: ThreadId.make("thread-1"),
+    };
+    const tabId = "tab_1";
+    const runtimeTabId = previewRuntimeTabId(threadRef, "epoch-1", tabId);
+    mocks.readThreadPreviewState.mockReturnValue({
+      serverEpoch: "epoch-1",
+      sessions: {
+        [tabId]: { tabId },
+      },
+      desktopByTabId: {
+        [tabId]: { hasWebContents: true },
+      },
+    });
+    vi.mocked(previewBridge!.automation.status).mockResolvedValue({
+      available: false,
+      visible: true,
+      tabId,
+      url: "http://localhost:5173/",
+      title: "ERR_CONNECTION_REFUSED",
+      loading: false,
+      attached: false,
+    });
+
+    await expect(
+      waitForNavigationReadiness(
+        threadRef,
+        "request-1",
+        tabId,
+        runtimeTabId,
+        "navigate",
+        "load",
+        2_000,
+      ),
+    ).rejects.toBeInstanceOf(PreviewAutomationTargetUnavailableError);
+  });
+
+  it("settles a failed navigation from attached even if the overlay lags", async () => {
+    const threadRef = {
+      environmentId: EnvironmentId.make("environment-2"),
+      threadId: ThreadId.make("thread-1"),
+    };
+    const tabId = "tab_1";
+    const runtimeTabId = previewRuntimeTabId(threadRef, "epoch-1", tabId);
+    mocks.readThreadPreviewState.mockReturnValue({
+      serverEpoch: "epoch-1",
+      sessions: {
+        [tabId]: { tabId },
+      },
+      desktopByTabId: {
+        [tabId]: { hasWebContents: false },
+      },
+    });
+    vi.mocked(previewBridge!.automation.status).mockResolvedValue({
+      available: false,
+      visible: true,
+      tabId,
+      url: "http://localhost:5173/",
+      title: "ERR_CONNECTION_REFUSED",
+      loading: false,
+      attached: true,
+    });
+
+    await expect(
+      waitForNavigationReadiness(
+        threadRef,
+        "request-1",
+        tabId,
+        runtimeTabId,
+        "navigate",
+        "load",
+        2_000,
+      ),
+    ).resolves.toBeUndefined();
   });
 });

--- a/apps/web/src/components/preview/previewNavigationReadiness.test.ts
+++ b/apps/web/src/components/preview/previewNavigationReadiness.test.ts
@@ -67,6 +67,9 @@ describe("waitForNavigationReadiness", () => {
       sessions: {
         [tabId]: { tabId },
       },
+      desktopByTabId: {
+        [tabId]: { hasWebContents: true },
+      },
     });
     vi.mocked(previewBridge!.automation.status).mockResolvedValue({
       available: false,
@@ -88,5 +91,43 @@ describe("waitForNavigationReadiness", () => {
         2_000,
       ),
     ).resolves.toBeUndefined();
+  });
+
+  it("rejects a detached guest instead of treating it as a finished load", async () => {
+    const threadRef = {
+      environmentId: EnvironmentId.make("environment-2"),
+      threadId: ThreadId.make("thread-1"),
+    };
+    const tabId = "tab_1";
+    const runtimeTabId = previewRuntimeTabId(threadRef, "epoch-1", tabId);
+    mocks.readThreadPreviewState.mockReturnValue({
+      serverEpoch: "epoch-1",
+      sessions: {
+        [tabId]: { tabId },
+      },
+      desktopByTabId: {
+        [tabId]: { hasWebContents: false },
+      },
+    });
+    vi.mocked(previewBridge!.automation.status).mockResolvedValue({
+      available: false,
+      visible: true,
+      tabId,
+      url: "http://localhost:5173/",
+      title: null,
+      loading: false,
+    });
+
+    await expect(
+      waitForNavigationReadiness(
+        threadRef,
+        "request-1",
+        tabId,
+        runtimeTabId,
+        "navigate",
+        "load",
+        2_000,
+      ),
+    ).rejects.toBeInstanceOf(PreviewAutomationTargetUnavailableError);
   });
 });

--- a/apps/web/src/components/preview/previewNavigationReadiness.test.ts
+++ b/apps/web/src/components/preview/previewNavigationReadiness.test.ts
@@ -23,6 +23,7 @@ vi.mock("./previewBridge", () => ({
 
 import { previewRuntimeTabId } from "~/browser/previewRuntimeTabId";
 
+import { previewBridge } from "./previewBridge";
 import { PreviewAutomationTargetUnavailableError } from "./previewAutomationErrors";
 import { waitForNavigationReadiness } from "./previewNavigationReadiness";
 
@@ -52,5 +53,40 @@ describe("waitForNavigationReadiness", () => {
         100,
       ),
     ).rejects.toBeInstanceOf(PreviewAutomationTargetUnavailableError);
+  });
+
+  it("settles a failed navigation instead of waiting for availability", async () => {
+    const threadRef = {
+      environmentId: EnvironmentId.make("environment-2"),
+      threadId: ThreadId.make("thread-1"),
+    };
+    const tabId = "tab_1";
+    const runtimeTabId = previewRuntimeTabId(threadRef, "epoch-1", tabId);
+    mocks.readThreadPreviewState.mockReturnValue({
+      serverEpoch: "epoch-1",
+      sessions: {
+        [tabId]: { tabId },
+      },
+    });
+    vi.mocked(previewBridge!.automation.status).mockResolvedValue({
+      available: false,
+      visible: true,
+      tabId,
+      url: "http://localhost:5173/",
+      title: "ERR_CONNECTION_REFUSED",
+      loading: false,
+    });
+
+    await expect(
+      waitForNavigationReadiness(
+        threadRef,
+        "request-1",
+        tabId,
+        runtimeTabId,
+        "navigate",
+        "load",
+        2_000,
+      ),
+    ).resolves.toBeUndefined();
   });
 });

--- a/apps/web/src/components/preview/previewNavigationReadiness.ts
+++ b/apps/web/src/components/preview/previewNavigationReadiness.ts
@@ -59,7 +59,11 @@ export async function waitForNavigationReadiness(
       if (readyState === "interactive" || readyState === "complete") return;
     } else {
       const status = await previewBridge.automation.status(runtimeTabId);
-      if (status.available && !status.loading) return;
+      if (!status.loading) {
+        // LoadFailed reports available:false with a live guest. Attachment is
+        // waitForDesktopOverlay's job; this wait is page-load completion.
+        return;
+      }
     }
     await new Promise<void>((resolve) => window.setTimeout(resolve, 50));
   }

--- a/apps/web/src/components/preview/previewNavigationReadiness.ts
+++ b/apps/web/src/components/preview/previewNavigationReadiness.ts
@@ -51,7 +51,10 @@ export async function waitForNavigationReadiness(
   if (targetReadiness === "none") return;
   const deadline = Date.now() + timeoutMs;
   while (Date.now() <= deadline) {
-    assertPreviewRuntimeCurrent(threadRef, tabId, runtimeTabId, { operation, requestId });
+    const state = assertPreviewRuntimeCurrent(threadRef, tabId, runtimeTabId, {
+      operation,
+      requestId,
+    });
     if (targetReadiness === "domContentLoaded") {
       const readyState = await previewBridge.automation.evaluate(runtimeTabId, {
         expression: "document.readyState",
@@ -60,9 +63,18 @@ export async function waitForNavigationReadiness(
     } else {
       const status = await previewBridge.automation.status(runtimeTabId);
       if (!status.loading) {
-        // LoadFailed reports available:false with a live guest. Attachment is
-        // waitForDesktopOverlay's job; this wait is page-load completion.
-        return;
+        if (status.available) return;
+        // LoadFailed reports available:false with a live guest. A detached
+        // webContents is not a finished load.
+        if (state.desktopByTabId[tabId]?.hasWebContents) return;
+        throw new PreviewAutomationTargetUnavailableError({
+          requestId,
+          operation,
+          environmentId: threadRef.environmentId,
+          threadId: threadRef.threadId,
+          tabId,
+          bridgeAvailable: Boolean(previewBridge),
+        });
       }
     }
     await new Promise<void>((resolve) => window.setTimeout(resolve, 50));

--- a/apps/web/src/components/preview/previewNavigationReadiness.ts
+++ b/apps/web/src/components/preview/previewNavigationReadiness.ts
@@ -51,7 +51,7 @@ export async function waitForNavigationReadiness(
   if (targetReadiness === "none") return;
   const deadline = Date.now() + timeoutMs;
   while (Date.now() <= deadline) {
-    const state = assertPreviewRuntimeCurrent(threadRef, tabId, runtimeTabId, {
+    assertPreviewRuntimeCurrent(threadRef, tabId, runtimeTabId, {
       operation,
       requestId,
     });
@@ -64,9 +64,13 @@ export async function waitForNavigationReadiness(
       const status = await previewBridge.automation.status(runtimeTabId);
       if (!status.loading) {
         if (status.available) return;
-        // LoadFailed reports available:false with a live guest. A detached
-        // webContents is not a finished load.
-        if (state.desktopByTabId[tabId]?.hasWebContents) return;
+        // LoadFailed reports available:false with a live guest. A destroyed
+        // webContents is not a finished load. Prefer the main-process
+        // `attached` bit; fall back to a fresh overlay read for older hosts.
+        const attached =
+          status.attached ??
+          readThreadPreviewState(threadRef).desktopByTabId[tabId]?.hasWebContents;
+        if (attached) return;
         throw new PreviewAutomationTargetUnavailableError({
           requestId,
           operation,

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -591,6 +591,12 @@ export const DesktopPreviewTabIdSchema = Schema.String.check(Schema.isTrimmed())
 export const DesktopPreviewAutomationStatusSchema = Schema.Struct({
   ...PreviewAutomationStatus.fields,
   tabId: Schema.NullOr(DesktopPreviewTabIdSchema),
+  /**
+   * Live guest process, not the renderer overlay. Optional for desktop hosts
+   * that predate this field. `webContentsId !== null` can stay true after
+   * destroy; this is the main-process check.
+   */
+  attached: Schema.optional(Schema.Boolean),
 });
 export type DesktopPreviewAutomationStatus = typeof DesktopPreviewAutomationStatusSchema.Type;
 


### PR DESCRIPTION
A dead preview URL still counted as a live tab. The floating mini-player stayed a white rectangle, and `preview_status` told the agent the page was healthy.

The mini-player now shows Retry and Close on a failed load. Status reports `available: false` with the URL the agent actually tried, not `chrome-error://`.

Closes #7212.

Verification:

- 82 desktop preview-manager tests
- 14 focused web preview tests
- 2 IPC contract tests
- web, desktop, and contracts typechecks
- targeted lint, formatting, and `git diff --check`

Originally implemented with Grok 4.6 through Grok CLI. Rebased and updated with GPT-5.6 Luna in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes preview automation readiness and status semantics across desktop IPC and the web host, which can affect agent navigate/retry behavior but stays within preview UI and automation—not auth or data paths.
> 
> **Overview**
> Failed preview navigations no longer look like a healthy, blank mini-player or automation target. **LoadFailed** tabs show a **Retry/Close** overlay instead of an empty webview, and agents get **`available: false`** with the **requested URL** and error text—not `chrome-error://`.
> 
> Desktop **`PreviewManager.automationStatus`** now exposes an optional **`attached`** flag (live guest vs stale overlay), treats **LoadFailed** as unavailable while keeping the guest reachable for retry, and preserves failure metadata when web contents are destroyed. Web-side **`applyPreviewLoadFailureToAutomationStatus`** merges snapshot failures into **`preview_status`** without letting stale **`LoadFailed`** state override a live healthy or loading guest.
> 
> **`waitForNavigationReadiness`** and overlay waiting stop treating **`available: false`** as an infinite wait: attached failed loads settle, detached/destroyed guests fail fast. Picture-in-picture is blocked on unreachable previews unless PiP is already open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ef66d5701bc4ac4c5624d856dabc9222af4a8e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix failed preview tabs showing blank floating panel with unreachable overlay
> - Adds `PreviewMiniPlayerUnreachable` overlay that displays a parsed host, friendly error description, and Retry/Close actions when a preview navigation fails
> - Adds an optional `attached` boolean to `DesktopPreviewAutomationStatusSchema` so the main process reports whether the guest webContents is still alive, distinguishing live guests from destroyed or missing ones
> - Updates `previewNavigationReadiness` and `preview.waitForDesktopOverlay` to resolve readiness after a failed load when the guest is attached, and to reject with target-unavailable when the guest is detached or destroyed
> - Transforms snapshot-only `LoadFailed` states into unavailable automation status, preserving the requested navigation URL and failure title instead of a chrome-error interstitial URL
> - **Behavioral Change:** `PreviewManager.automationStatus` no longer replaces failed navigation details with chrome-error URLs or in-flight loading state; callers that do not pass live-status precedence will now see `unavailable` with the original requested URL. `ThreadPreviewMiniPlayer` disables popping out a failed preview unless already popped out.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9ef66d5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
