### PR TITLE
fix(server): exclude inherited Codex child usage

### DIFF
--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -1221,19 +1221,18 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
           },
         } satisfies ProviderEvent);
 
+      // Reasoning first appears on the resume frame. Its baseline must initialize then.
       const childAFirstTotal = {
         totalTokens: 5_800_000_100,
         inputTokens: 5_000_000_070,
         cachedInputTokens: 3_000_000_040,
         outputTokens: 800_000_030,
-        reasoningOutputTokens: 5,
       } satisfies RuntimeTaskUsage;
       const childAFirstLast = {
         totalTokens: 100,
         inputTokens: 70,
         cachedInputTokens: 40,
         outputTokens: 30,
-        reasoningOutputTokens: 5,
       } satisfies RuntimeTaskUsage;
       const childBZeroTotal = {
         totalTokens: 5_800_050_000,
@@ -1321,7 +1320,6 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
             inputTokens: 70,
             cachedInputTokens: 40,
             outputTokens: 30,
-            reasoningOutputTokens: 5,
           },
         },
         {
@@ -1351,6 +1349,16 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
             inputTokens: 90,
             cachedInputTokens: 50,
             outputTokens: 40,
+            reasoningOutputTokens: 5,
+          },
+        },
+        {
+          taskId: "child-a",
+          usage: {
+            totalTokens: 150,
+            inputTokens: 100,
+            cachedInputTokens: 55,
+            outputTokens: 50,
             reasoningOutputTokens: 10,
           },
         },
@@ -1361,17 +1369,7 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
             inputTokens: 100,
             cachedInputTokens: 55,
             outputTokens: 50,
-            reasoningOutputTokens: 15,
-          },
-        },
-        {
-          taskId: "child-a",
-          usage: {
-            totalTokens: 150,
-            inputTokens: 100,
-            cachedInputTokens: 55,
-            outputTokens: 50,
-            reasoningOutputTokens: 15,
+            reasoningOutputTokens: 10,
           },
         },
       ]);

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -15,6 +15,7 @@ import {
   type ProviderSession,
   type ProviderTurnStartResult,
   type ProviderUserInputAnswers,
+  type RuntimeTaskUsage,
   ThreadId,
   TurnId,
 } from "@t3tools/contracts";
@@ -1149,6 +1150,240 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
         lastReasoningOutputTokens: 0,
         compactsAutomatically: true,
       });
+    }),
+  );
+
+  it.effect("reports only child-generated usage for Codex collab agents", () =>
+    Effect.gen(function* () {
+      const { adapter, runtime } = yield* startLifecycleRuntime();
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) => event.type === "thread.token-usage.updated" || event.type === "task.progress",
+        ),
+        Stream.take(7),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const parentBaseline = 5_800_000_000;
+      yield* runtime.emit({
+        id: asEventId("evt-parent-usage-baseline"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        threadId: asThreadId("thread-1"),
+        turnId: asTurnId("turn-1"),
+        createdAt: "2026-01-01T00:00:00.000Z",
+        method: "thread/tokenUsage/updated",
+        payload: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          tokenUsage: {
+            total: {
+              inputTokens: parentBaseline - 100,
+              cachedInputTokens: 0,
+              outputTokens: 100,
+              reasoningOutputTokens: 0,
+              totalTokens: parentBaseline,
+            },
+            last: {
+              inputTokens: 20,
+              cachedInputTokens: 0,
+              outputTokens: 5,
+              reasoningOutputTokens: 0,
+              totalTokens: 25,
+            },
+            modelContextWindow: 258_400,
+          },
+        },
+      } satisfies ProviderEvent);
+
+      const emitChildUsage = (
+        eventId: string,
+        agentThreadId: string,
+        total: RuntimeTaskUsage,
+        last: RuntimeTaskUsage,
+      ) =>
+        runtime.emit({
+          id: asEventId(eventId),
+          kind: "notification",
+          provider: ProviderDriverKind.make("codex"),
+          threadId: asThreadId("thread-1"),
+          turnId: asTurnId("turn-1"),
+          createdAt: "2026-01-01T00:00:01.000Z",
+          method: "collabAgent/tokenUsage",
+          payload: {
+            agentThreadId,
+            tokenUsage: {
+              total,
+              last,
+              modelContextWindow: 258_400,
+            },
+          },
+        } satisfies ProviderEvent);
+
+      const childAFirstTotal = {
+        totalTokens: 5_800_000_100,
+        inputTokens: 5_000_000_070,
+        cachedInputTokens: 3_000_000_040,
+        outputTokens: 800_000_030,
+        reasoningOutputTokens: 5,
+      } satisfies RuntimeTaskUsage;
+      const childAFirstLast = {
+        totalTokens: 100,
+        inputTokens: 70,
+        cachedInputTokens: 40,
+        outputTokens: 30,
+        reasoningOutputTokens: 5,
+      } satisfies RuntimeTaskUsage;
+      const childBZeroTotal = {
+        totalTokens: 5_800_050_000,
+        inputTokens: 5_000_040_000,
+        cachedInputTokens: 3_000_030_000,
+        outputTokens: 800_010_000,
+        reasoningOutputTokens: 0,
+      } satisfies RuntimeTaskUsage;
+      const childBZeroLast = {
+        totalTokens: 0,
+        inputTokens: 0,
+        cachedInputTokens: 0,
+        outputTokens: 0,
+        reasoningOutputTokens: 0,
+      } satisfies RuntimeTaskUsage;
+      const childBWorkTotal = {
+        totalTokens: 5_800_050_050,
+        inputTokens: 5_000_040_035,
+        cachedInputTokens: 3_000_030_020,
+        outputTokens: 800_010_015,
+        reasoningOutputTokens: 5,
+      } satisfies RuntimeTaskUsage;
+      const childBWorkLast = {
+        totalTokens: 50,
+        inputTokens: 35,
+        cachedInputTokens: 20,
+        outputTokens: 15,
+        reasoningOutputTokens: 5,
+      } satisfies RuntimeTaskUsage;
+      const childAResumeTotal = {
+        totalTokens: 5_800_000_130,
+        inputTokens: 5_000_000_090,
+        cachedInputTokens: 3_000_000_050,
+        outputTokens: 800_000_040,
+        reasoningOutputTokens: 10,
+      } satisfies RuntimeTaskUsage;
+      const childAResumeLast = {
+        totalTokens: 30,
+        inputTokens: 20,
+        cachedInputTokens: 10,
+        outputTokens: 10,
+        reasoningOutputTokens: 5,
+      } satisfies RuntimeTaskUsage;
+      const childARetryTotal = {
+        totalTokens: 5_800_000_150,
+        inputTokens: 5_000_000_100,
+        cachedInputTokens: 3_000_000_055,
+        outputTokens: 800_000_050,
+        reasoningOutputTokens: 15,
+      } satisfies RuntimeTaskUsage;
+      const childARetryLast = {
+        totalTokens: 20,
+        inputTokens: 10,
+        cachedInputTokens: 5,
+        outputTokens: 10,
+        reasoningOutputTokens: 5,
+      } satisfies RuntimeTaskUsage;
+
+      yield* emitChildUsage("evt-child-a-first", "child-a", childAFirstTotal, childAFirstLast);
+      yield* emitChildUsage("evt-child-b-zero", "child-b", childBZeroTotal, childBZeroLast);
+      yield* emitChildUsage("evt-child-b-work", "child-b", childBWorkTotal, childBWorkLast);
+      yield* emitChildUsage("evt-child-a-resume", "child-a", childAResumeTotal, childAResumeLast);
+      yield* emitChildUsage("evt-child-a-retry", "child-a", childARetryTotal, childARetryLast);
+      yield* emitChildUsage("evt-child-a-duplicate", "child-a", childARetryTotal, childARetryLast);
+
+      const events = Array.from(yield* Fiber.join(eventsFiber));
+      const parentEvents = events.filter((event) => event.type === "thread.token-usage.updated");
+      NodeAssert.equal(parentEvents.length, 1);
+      NodeAssert.equal(parentEvents[0]?.payload.usage.totalProcessedTokens, parentBaseline);
+
+      const childUsage = events.flatMap((event) => {
+        if (event.type !== "task.progress") return [];
+        return [
+          {
+            taskId: event.payload.taskId,
+            usage: event.payload.typedUsage,
+          },
+        ];
+      });
+      NodeAssert.deepEqual(childUsage, [
+        {
+          taskId: "child-a",
+          usage: {
+            totalTokens: 100,
+            inputTokens: 70,
+            cachedInputTokens: 40,
+            outputTokens: 30,
+            reasoningOutputTokens: 5,
+          },
+        },
+        {
+          taskId: "child-b",
+          usage: {
+            totalTokens: 0,
+            inputTokens: 0,
+            cachedInputTokens: 0,
+            outputTokens: 0,
+            reasoningOutputTokens: 0,
+          },
+        },
+        {
+          taskId: "child-b",
+          usage: {
+            totalTokens: 50,
+            inputTokens: 35,
+            cachedInputTokens: 20,
+            outputTokens: 15,
+            reasoningOutputTokens: 5,
+          },
+        },
+        {
+          taskId: "child-a",
+          usage: {
+            totalTokens: 130,
+            inputTokens: 90,
+            cachedInputTokens: 50,
+            outputTokens: 40,
+            reasoningOutputTokens: 10,
+          },
+        },
+        {
+          taskId: "child-a",
+          usage: {
+            totalTokens: 150,
+            inputTokens: 100,
+            cachedInputTokens: 55,
+            outputTokens: 50,
+            reasoningOutputTokens: 15,
+          },
+        },
+        {
+          taskId: "child-a",
+          usage: {
+            totalTokens: 150,
+            inputTokens: 100,
+            cachedInputTokens: 55,
+            outputTokens: 50,
+            reasoningOutputTokens: 15,
+          },
+        },
+      ]);
+
+      const latestByChild = new Map<string, RuntimeTaskUsage>();
+      for (const child of childUsage) {
+        if (child.usage) latestByChild.set(child.taskId, child.usage);
+      }
+      NodeAssert.equal(
+        Array.from(latestByChild.values()).reduce((sum, usage) => sum + usage.totalTokens, 0),
+        200,
+      );
     }),
   );
 

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -705,34 +705,47 @@ function mapCollabAgentEvent(
       const lastCachedInputTokens = count(last?.cachedInputTokens);
       const lastOutputTokens = count(last?.outputTokens);
       const lastReasoningOutputTokens = count(last?.reasoningOutputTokens);
+      const existing = usageByAgent.get(agentThreadId);
       const baselineCount = (
+        offset: number | undefined,
         cumulative: number | undefined,
         currentTurn: number | undefined,
       ): number | undefined =>
-        cumulative !== undefined && currentTurn !== undefined
+        offset ??
+        (cumulative !== undefined && currentTurn !== undefined
           ? Math.max(cumulative - currentTurn, 0)
-          : undefined;
-      const existing = usageByAgent.get(agentThreadId);
-      const baselineInputTokens = baselineCount(inputTokens, lastInputTokens);
-      const baselineCachedInputTokens = baselineCount(cachedInputTokens, lastCachedInputTokens);
-      const baselineOutputTokens = baselineCount(outputTokens, lastOutputTokens);
+          : undefined);
+      const baselineInputTokens = baselineCount(
+        existing?.baseline.inputTokens,
+        inputTokens,
+        lastInputTokens,
+      );
+      const baselineCachedInputTokens = baselineCount(
+        existing?.baseline.cachedInputTokens,
+        cachedInputTokens,
+        lastCachedInputTokens,
+      );
+      const baselineOutputTokens = baselineCount(
+        existing?.baseline.outputTokens,
+        outputTokens,
+        lastOutputTokens,
+      );
       const baselineReasoningOutputTokens = baselineCount(
+        existing?.baseline.reasoningOutputTokens,
         reasoningOutputTokens,
         lastReasoningOutputTokens,
       );
-      const baseline =
-        existing?.baseline ??
-        ({
-          totalTokens: Math.max(totalTokens - lastTotalTokens, 0),
-          ...(baselineInputTokens !== undefined ? { inputTokens: baselineInputTokens } : {}),
-          ...(baselineCachedInputTokens !== undefined
-            ? { cachedInputTokens: baselineCachedInputTokens }
-            : {}),
-          ...(baselineOutputTokens !== undefined ? { outputTokens: baselineOutputTokens } : {}),
-          ...(baselineReasoningOutputTokens !== undefined
-            ? { reasoningOutputTokens: baselineReasoningOutputTokens }
-            : {}),
-        } satisfies RuntimeTaskUsage);
+      const baseline = {
+        totalTokens: existing?.baseline.totalTokens ?? Math.max(totalTokens - lastTotalTokens, 0),
+        ...(baselineInputTokens !== undefined ? { inputTokens: baselineInputTokens } : {}),
+        ...(baselineCachedInputTokens !== undefined
+          ? { cachedInputTokens: baselineCachedInputTokens }
+          : {}),
+        ...(baselineOutputTokens !== undefined ? { outputTokens: baselineOutputTokens } : {}),
+        ...(baselineReasoningOutputTokens !== undefined
+          ? { reasoningOutputTokens: baselineReasoningOutputTokens }
+          : {}),
+      } satisfies RuntimeTaskUsage;
       const normalizedCount = (
         cumulative: number | undefined,
         offset: number | undefined,

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -95,6 +95,11 @@ interface CodexAdapterSessionContext {
   stopped: boolean;
 }
 
+interface CodexCollabUsageState {
+  readonly baseline: RuntimeTaskUsage;
+  readonly latest: RuntimeTaskUsage;
+}
+
 function mapCodexRuntimeError(
   threadId: ThreadId,
   method: string,
@@ -507,6 +512,7 @@ function mapItemLifecycle(
 function mapCollabAgentEvent(
   event: ProviderEvent,
   canonicalThreadId: ThreadId,
+  usageByAgent: Map<string, CodexCollabUsageState>,
 ): ReadonlyArray<ProviderRuntimeEvent> {
   const payload =
     typeof event.payload === "object" && event.payload !== null
@@ -667,8 +673,8 @@ function mapCollabAgentEvent(
       return [];
     }
     case "collabAgent/tokenUsage": {
-      // Cumulative per child thread: always the `total` breakdown, never
-      // `last` (which shrinks on follow-ups). Client folds max-merge.
+      // Calibrate the first cumulative `total` with `last` to remove copied
+      // history. Later snapshots stay based on `total`; `last` resets per turn.
       const tokenUsage =
         typeof payload.tokenUsage === "object" && payload.tokenUsage !== null
           ? (payload.tokenUsage as Record<string, unknown>)
@@ -677,29 +683,100 @@ function mapCollabAgentEvent(
         typeof tokenUsage?.total === "object" && tokenUsage.total !== null
           ? (tokenUsage.total as Record<string, unknown>)
           : undefined;
+      const last =
+        typeof tokenUsage?.last === "object" && tokenUsage.last !== null
+          ? (tokenUsage.last as Record<string, unknown>)
+          : undefined;
       const count = (value: unknown): number | undefined =>
         typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
       // Same validation as every other field: RuntimeTaskUsage.totalTokens
       // is NonNegativeInt, so NaN/Infinity/negative wire values must miss.
       const totalTokens = count(total?.totalTokens);
-      if (totalTokens === undefined) {
+      const lastTotalTokens = count(last?.totalTokens);
+      if (totalTokens === undefined || lastTotalTokens === undefined) {
         return [];
       }
+
+      const inputTokens = count(total?.inputTokens);
+      const cachedInputTokens = count(total?.cachedInputTokens);
+      const outputTokens = count(total?.outputTokens);
+      const reasoningOutputTokens = count(total?.reasoningOutputTokens);
+      const lastInputTokens = count(last?.inputTokens);
+      const lastCachedInputTokens = count(last?.cachedInputTokens);
+      const lastOutputTokens = count(last?.outputTokens);
+      const lastReasoningOutputTokens = count(last?.reasoningOutputTokens);
+      const baselineCount = (
+        cumulative: number | undefined,
+        currentTurn: number | undefined,
+      ): number | undefined =>
+        cumulative !== undefined && currentTurn !== undefined
+          ? Math.max(cumulative - currentTurn, 0)
+          : undefined;
+      const existing = usageByAgent.get(agentThreadId);
+      const baselineInputTokens = baselineCount(inputTokens, lastInputTokens);
+      const baselineCachedInputTokens = baselineCount(cachedInputTokens, lastCachedInputTokens);
+      const baselineOutputTokens = baselineCount(outputTokens, lastOutputTokens);
+      const baselineReasoningOutputTokens = baselineCount(
+        reasoningOutputTokens,
+        lastReasoningOutputTokens,
+      );
+      const baseline =
+        existing?.baseline ??
+        ({
+          totalTokens: Math.max(totalTokens - lastTotalTokens, 0),
+          ...(baselineInputTokens !== undefined ? { inputTokens: baselineInputTokens } : {}),
+          ...(baselineCachedInputTokens !== undefined
+            ? { cachedInputTokens: baselineCachedInputTokens }
+            : {}),
+          ...(baselineOutputTokens !== undefined ? { outputTokens: baselineOutputTokens } : {}),
+          ...(baselineReasoningOutputTokens !== undefined
+            ? { reasoningOutputTokens: baselineReasoningOutputTokens }
+            : {}),
+        } satisfies RuntimeTaskUsage);
+      const normalizedCount = (
+        cumulative: number | undefined,
+        offset: number | undefined,
+        latest: number | undefined,
+      ): number | undefined =>
+        cumulative !== undefined && offset !== undefined
+          ? Math.max(cumulative - offset, latest ?? 0, 0)
+          : undefined;
+      const normalizedInputTokens = normalizedCount(
+        inputTokens,
+        baseline.inputTokens,
+        existing?.latest.inputTokens,
+      );
+      const normalizedCachedInputTokens = normalizedCount(
+        cachedInputTokens,
+        baseline.cachedInputTokens,
+        existing?.latest.cachedInputTokens,
+      );
+      const normalizedOutputTokens = normalizedCount(
+        outputTokens,
+        baseline.outputTokens,
+        existing?.latest.outputTokens,
+      );
+      const normalizedReasoningOutputTokens = normalizedCount(
+        reasoningOutputTokens,
+        baseline.reasoningOutputTokens,
+        existing?.latest.reasoningOutputTokens,
+      );
       const typedUsage: RuntimeTaskUsage = {
-        totalTokens,
-        ...(count(total?.inputTokens) !== undefined
-          ? { inputTokens: count(total?.inputTokens) }
+        totalTokens: Math.max(
+          totalTokens - baseline.totalTokens,
+          existing?.latest.totalTokens ?? 0,
+          0,
+        ),
+        ...(normalizedInputTokens !== undefined ? { inputTokens: normalizedInputTokens } : {}),
+        ...(normalizedCachedInputTokens !== undefined
+          ? { cachedInputTokens: normalizedCachedInputTokens }
           : {}),
-        ...(count(total?.cachedInputTokens) !== undefined
-          ? { cachedInputTokens: count(total?.cachedInputTokens) }
-          : {}),
-        ...(count(total?.outputTokens) !== undefined
-          ? { outputTokens: count(total?.outputTokens) }
-          : {}),
-        ...(count(total?.reasoningOutputTokens) !== undefined
-          ? { reasoningOutputTokens: count(total?.reasoningOutputTokens) }
+        ...(normalizedOutputTokens !== undefined ? { outputTokens: normalizedOutputTokens } : {}),
+        ...(normalizedReasoningOutputTokens !== undefined
+          ? { reasoningOutputTokens: normalizedReasoningOutputTokens }
           : {}),
       };
+      usageByAgent.set(agentThreadId, { baseline, latest: typedUsage });
       return [
         {
           ...base,
@@ -762,9 +839,10 @@ function mapCollabAgentEvent(
 function mapToRuntimeEvents(
   event: ProviderEvent,
   canonicalThreadId: ThreadId,
+  collabUsageByAgent: Map<string, CodexCollabUsageState>,
 ): ReadonlyArray<ProviderRuntimeEvent> {
   if (event.kind === "notification" && event.method.startsWith("collabAgent/")) {
-    return mapCollabAgentEvent(event, canonicalThreadId);
+    return mapCollabAgentEvent(event, canonicalThreadId, collabUsageByAgent);
   }
   if (event.kind === "error") {
     if (!event.message) {
@@ -1719,10 +1797,11 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
         // this a child of `startSession`, and Effect interrupts a fiber's
         // children when it completes, so the consumer died on return and every
         // runtime event the session emitted afterwards was dropped.
+        const collabUsageByAgent = new Map<string, CodexCollabUsageState>();
         const eventFiber = yield* Stream.runForEach(runtime.events, (event) =>
           Effect.gen(function* () {
             yield* writeNativeEvent(event);
-            const runtimeEvents = mapToRuntimeEvents(event, event.threadId);
+            const runtimeEvents = mapToRuntimeEvents(event, event.threadId, collabUsageByAgent);
             if (runtimeEvents.length === 0) {
               yield* Effect.logDebug("ignoring unhandled Codex provider event", {
                 method: event.method,


### PR DESCRIPTION
Closes #5793.

## Problem

Codex child usage events contain a cumulative `total` counter. A fork can copy prior cumulative history into that counter. `CodexAdapter` sent the raw total through the provider-neutral task-usage interface. The Agents panel then summed task snapshots that already contained parent history.

The client fold and Agents panel did not create the inflation. They correctly max-merge and sum the task totals supplied by the adapter.

## Change

- Normalize Codex child counters in `CodexAdapter` before runtime storage and UI consumption.
- Calculate one fixed baseline per child from its first valid `total - last` frame.
- Subtract that baseline from later cumulative totals.
- Keep total, input, cached input, output, and reasoning output values non-negative and non-decreasing.
- Leave parent usage and transcript-based usage analytics unchanged.

This keeps Codex counter rules inside the existing Codex adapter. It needs no contract, storage, or UI change.

## Regression coverage

The provider-free adapter regression covers:

- a nonzero parent baseline;
- two children with independent baselines;
- zero child usage;
- resume and retry frames;
- duplicate cumulative frames;
- every token breakdown field;
- unchanged parent usage;
- public `task.progress.typedUsage` output.

The test failed before the fix with inherited totals such as `5,800,000,100` instead of `100`.

## Verification

- `pnpm exec vp test run apps/server/src/provider/Layers/CodexAdapter.test.ts` — 27 passed
- adjacent runtime tests — 60 passed
- Codex collaboration integration tests — 3 passed
- server and client-runtime typechecks — passed
- touched-file lint and format checks — passed
- server bundle build — passed
- `git diff --check` — passed

Repo-wide checks were not run, as repository guidance assigns the full suite to CI.

## Compatibility

No public contract or stored shape changes. Existing inflated stored rows cannot be repaired from their stored shape alone. A later corrected snapshot replaces the active stable task-usage row.

Prepared with Codex. Luna Max subagents performed independent design and review checks.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Codex collab agent token usage to exclude inherited parent baseline
> - `mapCollabAgentEvent` in [CodexAdapter.ts](https://github.com/pingdotgg/t3code/pull/7238/files#diff-f37bcac225467446dcf6198df38d357c15304b19eebacbdcdea70047f507707d) now subtracts a per-agent baseline from cumulative token totals, so `task.progress` events reflect only child-generated usage rather than raw inherited totals.
> - On first observation of a child agent, the baseline is computed as `cumulative - current-turn` counts (clamped to zero); subsequent events normalize against this stored baseline and clamp to the previously emitted maximum.
> - A per-session `collabUsageByAgent` map is introduced in `adapter.startSession` to maintain baseline and latest state across events for each child agent.
> - Events are suppressed when either `total.totalTokens` or `last.totalTokens` is absent.
> - Behavioral Change: collab agent token usage events previously forwarded raw cumulative totals; they now emit baseline-subtracted values, which will be lower for agents that inherit parent thread history.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f9b6ed4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only Codex collab usage math in the server adapter; wrong baselines would skew agent token display/sums, but parent usage and public contracts are untouched and coverage is targeted.
> 
> **Overview**
> Fixes inflated token totals in the Agents panel when Codex collab children inherit cumulative usage from a forked parent thread.
> 
> **`CodexAdapter`** now normalizes `collabAgent/tokenUsage` before emitting `task.progress` `typedUsage`. It keeps per-child **`CodexCollabUsageState`** (baseline + latest) for the session event stream. The first valid frame sets baseline from **`total − last`** so copied history is stripped; later frames subtract that fixed baseline from cumulative **`total`** while clamping each breakdown field to stay non-negative and non-decreasing. Events missing **`total.totalTokens`** or **`last.totalTokens`** are dropped. Parent **`thread/tokenUsage/updated`** mapping is unchanged.
> 
> A lifecycle regression test drives parent baseline, two children, zero usage, resume/retry, duplicate frames, and asserts child **`typedUsage`** stays turn-scoped (e.g. ~100 tokens, not billions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9b6ed453427146e876d994d8fda139759ec7cfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->