### PR TITLE
fix(mobile): allow terminal paste from the device clipboard

### DIFF
--- a/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
+++ b/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
@@ -5,7 +5,7 @@ import { SymbolView } from "../../components/AppSymbol";
 import { NativeHeaderToolbar, NativeStackScreenOptions } from "../../native/StackHeader";
 import { StackActions, useNavigation, type StaticScreenProps } from "@react-navigation/native";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Platform, Pressable, View } from "react-native";
+import { Alert, Platform, Pressable, View } from "react-native";
 import {
   KeyboardController,
   KeyboardEvents,
@@ -44,6 +44,7 @@ import { useSelectedThreadDetail } from "../../state/use-thread-detail";
 import { EnvironmentConnectionNotice } from "../connection/EnvironmentConnectionNotice";
 import { useAdaptiveWorkspaceLayout } from "../layout/AdaptiveWorkspaceLayout";
 import { TerminalSurface } from "./NativeTerminalSurface";
+import { readTerminalClipboardText } from "./terminalClipboard";
 import { getMobileTerminalTheme } from "./terminalTheme";
 import { terminalDebugLog } from "./terminalDebugLog";
 import {
@@ -78,6 +79,7 @@ type HostPlatform = "mac" | "linux" | "windows" | "unknown";
 type TerminalToolbarAction =
   | { readonly kind: "send"; readonly key: string; readonly label: string; readonly data: string }
   | { readonly kind: "clear"; readonly key: string; readonly label: string }
+  | { readonly kind: "paste"; readonly key: string; readonly label: string }
   | {
       readonly kind: "modifier";
       readonly key: string;
@@ -488,6 +490,7 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
       { kind: "send", key: "esc", label: "esc", data: "\u001b" },
       ...modifierActions,
       { kind: "send", key: "tab", label: "tab", data: "\t" },
+      { kind: "paste", key: "paste", label: "paste" },
       { kind: "clear", key: "clear", label: "clear" },
       { kind: "send", key: "up", label: "↑", data: "\u001b[A" },
       { kind: "send", key: "down", label: "↓", data: "\u001b[B" },
@@ -927,11 +930,39 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
     setTerminalFontSize(stepTerminalFontSize(fontSize, 1));
   }, [fontSize, setTerminalFontSize]);
 
+  const handlePasteTerminal = useCallback(() => {
+    if (!isRunning) {
+      return;
+    }
+
+    void readTerminalClipboardText().then((result) => {
+      switch (result._tag) {
+        case "text":
+          setPendingModifierState({ terminalId, value: null });
+          writeInput(result.text);
+          return;
+        case "empty":
+          Alert.alert("Nothing to paste", "The clipboard does not contain text.");
+          return;
+        case "unavailable":
+          console.warn("[terminal] clipboard paste failed", result.cause);
+          Alert.alert("Could not paste", "The clipboard is unavailable right now.");
+          return;
+      }
+    });
+  }, [isRunning, terminalId, writeInput]);
+
   // Android mirror of the iOS NativeHeaderToolbar terminal menu below: text
   // size, session switching, and "Open new terminal", rendered through the
   // token-styled anchored menu (the native header items are iOS-only).
   const androidTerminalMenuActions = useMemo<MenuAction[]>(
     () => [
+      {
+        id: "terminal-paste",
+        title: "Paste",
+        image: "doc.on.clipboard",
+        attributes: !isRunning ? { disabled: true } : undefined,
+      },
       {
         id: "text-size",
         title: "Text size",
@@ -965,7 +996,7 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
         subtitle: `Start another shell in ${basename(selectedThreadProject?.workspaceRoot ?? null) ?? "this workspace"}`,
       },
     ],
-    [fontSize, selectedThreadProject?.workspaceRoot, terminalId, terminalMenuSessions],
+    [fontSize, isRunning, selectedThreadProject?.workspaceRoot, terminalId, terminalMenuSessions],
   );
 
   const handleAndroidTerminalMenuAction = useCallback(
@@ -973,6 +1004,10 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
       const id = event.nativeEvent.event;
       if (id === "font-decrease") {
         handleDecreaseFontSize();
+        return;
+      }
+      if (id === "terminal-paste") {
+        handlePasteTerminal();
         return;
       }
       if (id === "font-increase") {
@@ -987,7 +1022,13 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
         handleSelectTerminal(id.slice("terminal-session:".length));
       }
     },
-    [handleDecreaseFontSize, handleIncreaseFontSize, handleOpenNewTerminal, handleSelectTerminal],
+    [
+      handleDecreaseFontSize,
+      handleIncreaseFontSize,
+      handleOpenNewTerminal,
+      handlePasteTerminal,
+      handleSelectTerminal,
+    ],
   );
 
   const handleClearTerminal = useCallback(() => {
@@ -1023,6 +1064,11 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
         return;
       }
 
+      if (action.kind === "paste") {
+        handlePasteTerminal();
+        return;
+      }
+
       setPendingModifierState({ terminalId, value: null });
       if (pendingModifier === "ctrl") {
         writeInput(applyCtrlModifier(action.data));
@@ -1032,7 +1078,7 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
         writeInput(action.data);
       }
     },
-    [handleClearTerminal, pendingModifier, terminalId, writeInput],
+    [handleClearTerminal, handlePasteTerminal, pendingModifier, terminalId, writeInput],
   );
 
   const handleDismissKeyboard = useCallback(() => {
@@ -1155,6 +1201,13 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
                 hasRunningSubprocess: terminal.hasRunningSubprocess,
               })}
             </NativeHeaderToolbar.Label>
+            <NativeHeaderToolbar.MenuAction
+              disabled={!isRunning}
+              icon="doc.on.clipboard"
+              onPress={handlePasteTerminal}
+            >
+              <NativeHeaderToolbar.Label>Paste</NativeHeaderToolbar.Label>
+            </NativeHeaderToolbar.MenuAction>
             <NativeHeaderToolbar.Menu icon="textformat.size" inline title="Text size">
               <NativeHeaderToolbar.Label>Text size</NativeHeaderToolbar.Label>
               <NativeHeaderToolbar.MenuAction
@@ -1266,7 +1319,9 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
                             onPress={() => handleToolbarActionPress(action)}
                             showChevron={false}
                             textTransform={
-                              action.kind === "modifier" || action.kind === "clear"
+                              action.kind === "modifier" ||
+                              action.kind === "clear" ||
+                              action.kind === "paste"
                                 ? "uppercase"
                                 : "none"
                             }

--- a/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
+++ b/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
@@ -4,7 +4,7 @@ import type { MenuAction } from "@react-native-menu/menu";
 import { SymbolView } from "../../components/AppSymbol";
 import { NativeHeaderToolbar, NativeStackScreenOptions } from "../../native/StackHeader";
 import { StackActions, useNavigation, type StaticScreenProps } from "@react-navigation/native";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Alert, Platform, Pressable, View } from "react-native";
 import {
   KeyboardController,
@@ -257,6 +257,7 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
   const firstNonEmptyBufferLoggedRef = useRef(false);
   const lastBufferReplayKeyRef = useRef<string | null>(null);
   const sentInitialInputKeyRef = useRef<string | null>(null);
+  const activePasteTargetRef = useRef<string | null>(null);
   const [readyBufferReplayKey, setReadyBufferReplayKey] = useState<string | null>(null);
   /** Default grid is always valid for attach; onResize refines cols/rows. Requiring a cached size blocked bootstrap for new terminal routes. */
   const [hasMeasuredSurface, setHasMeasuredSurface] = useState(true);
@@ -355,6 +356,15 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
     readyReplayKey: readyBufferReplayKey,
   });
   const isRunning = terminal.status === "running" || terminal.status === "starting";
+
+  useLayoutEffect(() => {
+    activePasteTargetRef.current = isRunning ? terminalKey : null;
+    return () => {
+      if (activePasteTargetRef.current === terminalKey) {
+        activePasteTargetRef.current = null;
+      }
+    };
+  }, [isRunning, terminalKey]);
 
   // When the process ends while this screen is attached (e.g. typing `exit`),
   // close the session and leave the screen, mirroring the web drawer's
@@ -935,7 +945,11 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
       return;
     }
 
+    const pasteTargetKey = terminalKey;
     void readTerminalClipboardText().then((result) => {
+      if (activePasteTargetRef.current !== pasteTargetKey) {
+        return;
+      }
       switch (result._tag) {
         case "text":
           setPendingModifierState({ terminalId, value: null });
@@ -950,7 +964,7 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
           return;
       }
     });
-  }, [isRunning, terminalId, writeInput]);
+  }, [isRunning, terminalId, terminalKey, writeInput]);
 
   // Android mirror of the iOS NativeHeaderToolbar terminal menu below: text
   // size, session switching, and "Open new terminal", rendered through the

--- a/apps/mobile/src/features/terminal/terminalClipboard.test.ts
+++ b/apps/mobile/src/features/terminal/terminalClipboard.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const mocks = vi.hoisted(() => ({
+  hasStringAsync: vi.fn(),
+  getStringAsync: vi.fn(),
+}));
+
+vi.mock("expo-clipboard", () => ({
+  hasStringAsync: mocks.hasStringAsync,
+  getStringAsync: mocks.getStringAsync,
+}));
+
+import { readTerminalClipboardText } from "./terminalClipboard";
+
+describe("terminal clipboard", () => {
+  beforeEach(() => {
+    mocks.hasStringAsync.mockReset();
+    mocks.getStringAsync.mockReset();
+  });
+
+  it("returns clipboard text", async () => {
+    mocks.hasStringAsync.mockResolvedValue(true);
+    mocks.getStringAsync.mockResolvedValue("pnpm test\n");
+
+    await expect(readTerminalClipboardText()).resolves.toEqual({
+      _tag: "text",
+      text: "pnpm test\n",
+    });
+  });
+
+  it("does not read non-text clipboard content", async () => {
+    mocks.hasStringAsync.mockResolvedValue(false);
+
+    await expect(readTerminalClipboardText()).resolves.toEqual({ _tag: "empty" });
+    expect(mocks.getStringAsync).not.toHaveBeenCalled();
+  });
+
+  it("reports clipboard failures without throwing from the terminal action", async () => {
+    const cause = new Error("clipboard unavailable");
+    mocks.hasStringAsync.mockRejectedValue(cause);
+
+    await expect(readTerminalClipboardText()).resolves.toEqual({
+      _tag: "unavailable",
+      cause,
+    });
+  });
+});

--- a/apps/mobile/src/features/terminal/terminalClipboard.ts
+++ b/apps/mobile/src/features/terminal/terminalClipboard.ts
@@ -1,0 +1,24 @@
+import * as Clipboard from "expo-clipboard";
+
+export type TerminalClipboardReadResult =
+  | { readonly _tag: "text"; readonly text: string }
+  | { readonly _tag: "empty" }
+  | { readonly _tag: "unavailable"; readonly cause: unknown };
+
+/**
+ * Reads text only after an explicit terminal paste action. Keeping clipboard
+ * access behind the button avoids surprising iOS paste prompts while still
+ * giving both native terminal surfaces the same behavior.
+ */
+export async function readTerminalClipboardText(): Promise<TerminalClipboardReadResult> {
+  try {
+    if (!(await Clipboard.hasStringAsync())) {
+      return { _tag: "empty" };
+    }
+
+    const text = await Clipboard.getStringAsync();
+    return text.length === 0 ? { _tag: "empty" } : { _tag: "text", text };
+  } catch (cause) {
+    return { _tag: "unavailable", cause };
+  }
+}


### PR DESCRIPTION
### What?

Adds an explicit **Paste** action to the mobile terminal shortcut bar and the iOS and Android terminal menus.

### Why?

The custom terminal surface does not expose the phone's native text-selection menu, so users controlling a remote terminal from mobile could copy commands but had no reliable way to paste them into the session.

### How?

Clipboard text is read only after the user presses Paste, then sent through the existing terminal input path. Empty and unavailable clipboards produce a user-facing alert instead of an unhandled rejection, and pasting clears any pending terminal modifier before writing the text.

The clipboard read is isolated behind a small result-based helper so the success, non-text, and failure paths are covered without a native runtime.

### Verification

- `pnpm exec vp test run apps/mobile/src/features/terminal/terminalClipboard.test.ts`
- `pnpm --filter @t3tools/mobile typecheck`
- changed-file formatting and `git diff --check`

A native screenshot was not captured because this machine has no compatible T3 Code Dev client or reusable app artifact installed. The repository mobile-test workflow explicitly avoids rebuilding native code for a TypeScript-only change.

Generated with GPT-5.6 Sol via the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-initiated clipboard read and terminal input only; no auth or server changes, with tests on the helper.
> 
> **Overview**
> Adds **Paste** to the mobile thread terminal so clipboard text can reach the remote shell without the native text-selection menu.
> 
> A new `readTerminalClipboardText` helper reads from `expo-clipboard` only when the user taps Paste (to limit surprise iOS paste prompts). It returns `text`, `empty`, or `unavailable` instead of throwing. Successful paste clears any pending ctrl/meta modifier and sends the string through the existing terminal `writeInput` path.
> 
> Paste is wired in three places: the keyboard accessory toolbar, the iOS terminal header menu, and the Android terminal overflow menu. It is disabled while the session is not running. Empty or failed reads show an alert; an `activePasteTargetRef` drops stale async results if the user leaves the screen before the read finishes.
> 
> Unit tests cover the clipboard helper’s success, non-text, and error paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3669e8e8ae9ccd75b6885c6d970778338da4d69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add clipboard paste action to the mobile terminal screen
> - Adds a Paste toolbar button and menu item to `ThreadTerminalRouteScreen` for both iOS and Android; paste is disabled when the terminal session is not running.
> - Introduces [`terminalClipboard.ts`](https://github.com/pingdotgg/t3code/pull/7239/files#diff-31a1e682b41afb21faf6f79326bf04c26c983d8529b780b0adefa1b222120fb4) with `readTerminalClipboardText`, which wraps `expo-clipboard` and returns a tagged result (`text`, `empty`, or `unavailable`) instead of throwing.
> - Shows an alert when the clipboard is empty or unavailable, and logs a warning for unavailable cases.
> - Uses a ref to track the active terminal instance so that async clipboard reads are discarded if the screen has changed before the result returns.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f3669e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->