### PR TITLE
fix(web): wrap phase rail dots and center the context meter ring

### DIFF
--- a/apps/web/src/components/AgentsPanel.tsx
+++ b/apps/web/src/components/AgentsPanel.tsx
@@ -217,13 +217,13 @@ function PhaseRail({ group }: { group: AgentPanelWorkflowGroup }) {
   return (
     <div className="flex flex-wrap items-center gap-x-1 gap-y-1 px-1.5 pb-1 pt-1.5">
       {group.phases.map((phase, index) => (
-        <div key={phase.index} className="flex items-center gap-1">
+        <div key={phase.index} className="flex min-w-0 max-w-full items-center gap-1">
           {index > 0 ? (
-            <ChevronRight aria-hidden className="size-3 text-muted-foreground/40" />
+            <ChevronRight aria-hidden className="size-3 shrink-0 text-muted-foreground/40" />
           ) : null}
           <div
             className={cn(
-              "flex items-center gap-1 rounded-sm border px-1.5 py-0.5",
+              "flex min-w-0 items-center gap-1 rounded-sm border px-1.5 py-0.5",
               phase.state === "running"
                 ? "border-info/40"
                 : phase.state === "done"
@@ -233,7 +233,7 @@ function PhaseRail({ group }: { group: AgentPanelWorkflowGroup }) {
           >
             <span
               className={cn(
-                "font-mono text-[.65rem]",
+                "shrink-0 font-mono text-[.65rem]",
                 phase.state === "running"
                   ? "text-info-foreground"
                   : phase.state === "done"
@@ -244,7 +244,7 @@ function PhaseRail({ group }: { group: AgentPanelWorkflowGroup }) {
               {phase.state === "done" ? "✓ " : ""}
               {phase.title}
             </span>
-            <span className="flex items-center gap-0.5">
+            <span className="flex min-w-0 flex-wrap items-center gap-0.5">
               {phase.members.length === 0 ? (
                 <span className="font-mono text-[.6rem] text-muted-foreground/50">–</span>
               ) : (

--- a/apps/web/src/components/chat/ContextWindowMeter.tsx
+++ b/apps/web/src/components/chat/ContextWindowMeter.tsx
@@ -47,10 +47,10 @@ export function ContextWindowMeter(props: {
                 : `Context window ${formatContextWindowTokens(usage.usedTokens)} tokens used`
             }
           >
-            <span className="relative flex size-5 items-center justify-center">
+            <span className="flex size-5 items-center justify-center">
               <svg
                 viewBox="0 0 24 24"
-                className="-rotate-90 absolute inset-0 size-full transform-gpu"
+                className="-rotate-90 size-full shrink-0 transform-gpu"
                 aria-hidden="true"
               >
                 <circle


### PR DESCRIPTION
## Problem

Two small layout bugs in the web client:

1. **Agents panel phase rail overflows.** The rail draws one status dot per member on a single line. A phase with many agents (here, a Verify phase with 56 agents) pushes past the right edge of the panel.
2. **Context window meter ring is off center.** The ring SVG sits 2px left of the button center, visible on hover.

## Fix

- `AgentsPanel.tsx` (`PhaseRail`): the phase wrapper and pill get `min-w-0` / `max-w-full`, the chevron and title get `shrink-0`, and the dot cluster gets `flex-wrap`. Dots now wrap inside the pill instead of overflowing. One dot per member is preserved.
- `ContextWindowMeter.tsx`: the ring SVG was `absolute inset-0` inside `Button`, whose base class applies `[&_svg]:-mx-0.5` to every svg. With left/right anchors that negative margin becomes a 2px left shift. The SVG is now a plain flex child of the centered wrapper, so the margins stay symmetric and the ring is centered. No visual size change.

## Before / after

Phase rail (before):

![Before: Verify phase rail overflows the Agents panel](https://files.team-nfa.org/f/432e0b627e6778d6275b4a32152ece16-28f71cf261b9fa54a4a7efe2b4e02cf04559876af3d39c0d4d2df7b4b2e561d3.png)

Phase rail (after):

![After: Verify phase dots wrap inside the pill](https://files.team-nfa.org/f/1bc0cc47e70f100466dcf9ae4b3650a7-6fe6885d6c41cbfad4c5c44a9537f7c0f6a5a7aedc3b554389b8820f23ea3929.png)

Context meter (before, right one shows the hover box):

![Before: context meter ring sits left of center](https://files.team-nfa.org/f/2324dc685e9f86fa97a273af303ca0f8-ba02027d445d092329edc951fffb276590a7b1658ed704420afc6c192f5008f6.png)

Context meter (after):

![After: context meter ring centered](https://files.team-nfa.org/f/19f3eefe48d3625936172364bcca15da-a6d68c2255ef6563068e1e0f74392fe1a1d054a90e7cffbc19d194955029bccf.png)

## Verification

- Rendered both components in a throwaway Vite harness with a 56 member phase and measured in the DOM: rail `scrollWidth === clientWidth`, ring center offset `dx: 0, dy: 0` (was `dx: -2`).
- `vp lint`, `vp fmt --check`, and `tsgo --noEmit` on `apps/web` are clean.
- Surfaces: web only (desktop wraps web). Mobile has its own agents UI and is untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tailwind-only presentation tweaks in two components; no logic, API, or data changes.
> 
> **Overview**
> Fixes two **web-only layout bugs** in the agents panel and chat context meter.
> 
> **Agents panel `PhaseRail`:** Phases with many member status dots no longer overflow the panel. Wrappers get `min-w-0` / `max-w-full`, chevrons and phase titles get `shrink-0`, and the dot row uses `flex-wrap` so dots stay inside each phase pill (still one dot per member).
> 
> **`ContextWindowMeter`:** The ring SVG is no longer `absolute inset-0` inside `Button`. That layout interacted with the button’s `[&_svg]:-mx-0.5` rule and shifted the ring ~2px left; the SVG is now a normal flex child in the centered wrapper so the ring aligns with the icon button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81d3d9f3fbd05fd5d2b4f3f6bd9931d8240fa2ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix phase rail dot wrapping and center the context meter ring
> - Updates flex layout in [AgentsPanel.tsx](https://github.com/pingdotgg/t3code/pull/7243/files#diff-10464442e3a11a770b2b1a5718e7a452453347c492f6aa0533f267063e2c6494): the chevron and phase title no longer shrink, the members container gains `flex-wrap` and `min-w-0`, and outer containers enforce `min-w-0`/`max-w-full` to prevent overflow.
> - Fixes SVG positioning in [ContextWindowMeter.tsx](https://github.com/pingdotgg/t3code/pull/7243/files#diff-aea829de2db7f11cd97477231090fa3f2bc72e2b46a5275ed82fd29b0825d2fd) by replacing `absolute inset-0` with normal flow and `shrink-0`, centering the ring icon correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 81d3d9f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->