### PR TITLE
fix(server): start Claude full access without forbidden permission modes (#4927)

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -37,7 +37,11 @@ import { ServerConfig } from "../../config.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import { ProviderAdapterProcessError, ProviderAdapterValidationError } from "../Errors.ts";
 import type { ClaudeAdapterShape } from "../Services/ClaudeAdapter.ts";
-import { makeClaudeAdapter, type ClaudeAdapterLiveOptions } from "./ClaudeAdapter.ts";
+import {
+  makeClaudeAdapter,
+  ClaudeSettingsResolveError,
+  type ClaudeAdapterLiveOptions,
+} from "./ClaudeAdapter.ts";
 const decodeClaudeSettings = Schema.decodeSync(ClaudeSettings);
 
 // Test-local service tag so the rest of the file can keep using `yield* ClaudeAdapter`.
@@ -154,6 +158,15 @@ class FakeClaudeQuery implements AsyncIterable<SDKMessage> {
   }
 }
 
+const PERMISSIVE_CLAUDE_SETTINGS = { effective: {} } as const;
+const BYPASS_DISABLED_CLAUDE_SETTINGS = {
+  effective: {
+    permissions: {
+      disableBypassPermissionsMode: "disable",
+    },
+  },
+} as const;
+
 function makeHarness(config?: {
   readonly nativeEventLogPath?: string;
   readonly nativeEventLogger?: ClaudeAdapterLiveOptions["nativeEventLogger"];
@@ -161,6 +174,7 @@ function makeHarness(config?: {
   readonly baseDir?: string;
   readonly claudeConfig?: Partial<ClaudeSettings>;
   readonly instanceId?: ProviderInstanceId;
+  readonly resolveSettings?: ClaudeAdapterLiveOptions["resolveSettings"];
 }) {
   const query = new FakeClaudeQuery();
   let createInput:
@@ -176,6 +190,7 @@ function makeHarness(config?: {
       createInput = input;
       return query;
     },
+    resolveSettings: config?.resolveSettings ?? (() => Effect.succeed(PERMISSIVE_CLAUDE_SETTINGS)),
     ...(config?.nativeEventLogger
       ? {
           nativeEventLogger: config.nativeEventLogger,
@@ -313,6 +328,7 @@ describe("ClaudeAdapterLive", () => {
           createQuery: () => {
             throw cause;
           },
+          resolveSettings: () => Effect.succeed(PERMISSIVE_CLAUDE_SETTINGS),
         });
       }),
     ).pipe(
@@ -413,6 +429,210 @@ describe("ClaudeAdapterLive", () => {
       const createInput = harness.getLastCreateQueryInput();
       assert.equal(createInput?.options.permissionMode, "bypassPermissions");
       assert.equal(createInput?.options.allowDangerouslySkipPermissions, true);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect(
+    "does not request bypassPermissions when resolved policy disables it for full access",
+    () => {
+      const resolveCalls: Array<{
+        readonly cwd?: string;
+        readonly settingSources: ReadonlyArray<string>;
+      }> = [];
+      const harness = makeHarness({
+        resolveSettings: (input) => {
+          resolveCalls.push({
+            ...(input.cwd ? { cwd: input.cwd } : {}),
+            settingSources: [...input.settingSources],
+          });
+          return Effect.succeed(BYPASS_DISABLED_CLAUDE_SETTINGS);
+        },
+      });
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+        const session = yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          cwd: "/tmp/claude-policy-project",
+          runtimeMode: "full-access",
+        });
+
+        const createInput = harness.getLastCreateQueryInput();
+        assert.equal(session.runtimeMode, "full-access");
+        assert.equal(createInput?.options.permissionMode, "auto");
+        assert.equal(createInput?.options.allowDangerouslySkipPermissions, undefined);
+        assert.deepEqual(resolveCalls, [
+          {
+            cwd: "/tmp/claude-policy-project",
+            settingSources: ["user", "project", "local"],
+          },
+        ]);
+      }).pipe(
+        Effect.provideService(Random.Random, makeDeterministicRandomService()),
+        Effect.provide(harness.layer),
+      );
+    },
+  );
+
+  it.effect("keeps auto permission mode when policy disables bypass permissions", () => {
+    const harness = makeHarness({
+      resolveSettings: () => Effect.succeed(BYPASS_DISABLED_CLAUDE_SETTINGS),
+    });
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "auto",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.permissionMode, "auto");
+      assert.equal(createInput?.options.allowDangerouslySkipPermissions, undefined);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("keeps acceptEdits when policy disables bypass permissions", () => {
+    const harness = makeHarness({
+      resolveSettings: () => Effect.succeed(BYPASS_DISABLED_CLAUDE_SETTINGS),
+    });
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "auto-accept-edits",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.permissionMode, "acceptEdits");
+      assert.equal(createInput?.options.allowDangerouslySkipPermissions, undefined);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("keeps default approval mode when policy disables bypass permissions", () => {
+    const harness = makeHarness({
+      resolveSettings: () => Effect.succeed(BYPASS_DISABLED_CLAUDE_SETTINGS),
+    });
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "approval-required",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.permissionMode, undefined);
+      assert.equal(createInput?.options.allowDangerouslySkipPermissions, undefined);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("treats settings resolution failure as bypass disabled for full access", () => {
+    const harness = makeHarness({
+      resolveSettings: () => Effect.fail(new ClaudeSettingsResolveError({})),
+    });
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(session.runtimeMode, "full-access");
+      assert.equal(createInput?.options.permissionMode, "auto");
+      assert.equal(createInput?.options.allowDangerouslySkipPermissions, undefined);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("still requests bypass when disableBypassPermissionsMode is not disable", () => {
+    const harness = makeHarness({
+      resolveSettings: () =>
+        Effect.succeed({
+          effective: {
+            permissions: {
+              disableBypassPermissionsMode: "allow",
+            },
+          },
+        }),
+    });
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.permissionMode, "bypassPermissions");
+      assert.equal(createInput?.options.allowDangerouslySkipPermissions, true);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("restores auto after plan when full access was policy-downgraded", () => {
+    const harness = makeHarness({
+      resolveSettings: () => Effect.succeed(BYPASS_DISABLED_CLAUDE_SETTINGS),
+    });
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "plan this",
+        interactionMode: "plan",
+        attachments: [],
+      });
+
+      const turnCompletedFiber = yield* Stream.filter(
+        adapter.streamEvents,
+        (event) => event.type === "turn.completed",
+      ).pipe(Stream.runHead, Effect.forkChild);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "sdk-session-policy-auto",
+        uuid: "result-policy-auto",
+      } as unknown as SDKMessage);
+
+      yield* Fiber.join(turnCompletedFiber);
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "now do it",
+        interactionMode: "default",
+        attachments: [],
+      });
+
+      assert.deepEqual(harness.query.setPermissionModeCalls, ["plan", "auto"]);
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),
@@ -1960,6 +2180,7 @@ describe("ClaudeAdapterLive", () => {
             queries.push(query);
             return query;
           },
+          resolveSettings: () => Effect.succeed(PERMISSIVE_CLAUDE_SETTINGS),
         });
       }),
     ).pipe(
@@ -2051,6 +2272,7 @@ describe("ClaudeAdapterLive", () => {
             })();
             return query;
           },
+          resolveSettings: () => Effect.succeed(PERMISSIVE_CLAUDE_SETTINGS),
         });
       }),
     ).pipe(

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -166,6 +166,23 @@ const BYPASS_DISABLED_CLAUDE_SETTINGS = {
     },
   },
 } as const;
+const AUTO_DISABLED_CLAUDE_SETTINGS = {
+  effective: {
+    disableAutoMode: "disable",
+    permissions: {
+      disableAutoMode: "disable",
+    },
+  },
+} as const;
+const BYPASS_AND_AUTO_DISABLED_CLAUDE_SETTINGS = {
+  effective: {
+    disableAutoMode: "disable",
+    permissions: {
+      disableBypassPermissionsMode: "disable",
+      disableAutoMode: "disable",
+    },
+  },
+} as const;
 
 function makeHarness(config?: {
   readonly nativeEventLogPath?: string;
@@ -175,6 +192,7 @@ function makeHarness(config?: {
   readonly claudeConfig?: Partial<ClaudeSettings>;
   readonly instanceId?: ProviderInstanceId;
   readonly resolveSettings?: ClaudeAdapterLiveOptions["resolveSettings"];
+  readonly resolveSdkSettings?: ClaudeAdapterLiveOptions["resolveSdkSettings"];
 }) {
   const query = new FakeClaudeQuery();
   let createInput:
@@ -190,7 +208,12 @@ function makeHarness(config?: {
       createInput = input;
       return query;
     },
-    resolveSettings: config?.resolveSettings ?? (() => Effect.succeed(PERMISSIVE_CLAUDE_SETTINGS)),
+    ...(config?.resolveSdkSettings
+      ? { resolveSdkSettings: config.resolveSdkSettings }
+      : {
+          resolveSettings:
+            config?.resolveSettings ?? (() => Effect.succeed(PERMISSIVE_CLAUDE_SETTINGS)),
+        }),
     ...(config?.nativeEventLogger
       ? {
           nativeEventLogger: config.nativeEventLogger,
@@ -540,6 +563,28 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("starts supervised when policy disables both bypass and auto for full access", () => {
+    const harness = makeHarness({
+      resolveSettings: () => Effect.succeed(BYPASS_AND_AUTO_DISABLED_CLAUDE_SETTINGS),
+    });
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(session.runtimeMode, "full-access");
+      assert.equal(createInput?.options.permissionMode, undefined);
+      assert.equal(createInput?.options.allowDangerouslySkipPermissions, undefined);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("treats settings resolution failure as bypass disabled for full access", () => {
     const harness = makeHarness({
       resolveSettings: () => Effect.fail(new ClaudeSettingsResolveError({})),
@@ -633,6 +678,210 @@ describe("ClaudeAdapterLive", () => {
       });
 
       assert.deepEqual(harness.query.setPermissionModeCalls, ["plan", "auto"]);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("starts supervised when policy disables auto for auto runtime", () => {
+    const harness = makeHarness({
+      resolveSettings: () => Effect.succeed(AUTO_DISABLED_CLAUDE_SETTINGS),
+    });
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "auto",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(session.runtimeMode, "auto");
+      assert.equal(createInput?.options.permissionMode, undefined);
+      assert.equal(createInput?.options.allowDangerouslySkipPermissions, undefined);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("honors permissions.disableAutoMode without the top-level copy", () => {
+    const harness = makeHarness({
+      resolveSettings: () =>
+        Effect.succeed({
+          effective: {
+            permissions: {
+              disableAutoMode: "disable",
+            },
+          },
+        }),
+    });
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "auto",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.permissionMode, undefined);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("honors top-level disableAutoMode without the permissions copy", () => {
+    const harness = makeHarness({
+      resolveSettings: () =>
+        Effect.succeed({
+          effective: {
+            disableAutoMode: "disable",
+          },
+        }),
+    });
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "auto",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.permissionMode, undefined);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("keeps bypass when auto is locked but bypass is allowed", () => {
+    const harness = makeHarness({
+      resolveSettings: () => Effect.succeed(AUTO_DISABLED_CLAUDE_SETTINGS),
+    });
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.permissionMode, "bypassPermissions");
+      assert.equal(createInput?.options.allowDangerouslySkipPermissions, true);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect(
+    "restores default after plan when full access was policy-downgraded to supervised",
+    () => {
+      const harness = makeHarness({
+        resolveSettings: () => Effect.succeed(BYPASS_AND_AUTO_DISABLED_CLAUDE_SETTINGS),
+      });
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+        const session = yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          runtimeMode: "full-access",
+        });
+
+        yield* adapter.sendTurn({
+          threadId: session.threadId,
+          input: "plan this",
+          interactionMode: "plan",
+          attachments: [],
+        });
+
+        const turnCompletedFiber = yield* Stream.filter(
+          adapter.streamEvents,
+          (event) => event.type === "turn.completed",
+        ).pipe(Stream.runHead, Effect.forkChild);
+
+        harness.query.emit({
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          errors: [],
+          session_id: "sdk-session-policy-default",
+          uuid: "result-policy-default",
+        } as unknown as SDKMessage);
+
+        yield* Fiber.join(turnCompletedFiber);
+
+        yield* adapter.sendTurn({
+          threadId: session.threadId,
+          input: "now do it",
+          interactionMode: "default",
+          attachments: [],
+        });
+
+        assert.deepEqual(harness.query.setPermissionModeCalls, ["plan", "default"]);
+      }).pipe(
+        Effect.provideService(Random.Random, makeDeterministicRandomService()),
+        Effect.provide(harness.layer),
+      );
+    },
+  );
+
+  it.effect("resolves Claude settings with the instance CLAUDE_CONFIG_DIR", () => {
+    const homePath = "/tmp/claude-policy-home-test";
+    const seenConfigDirs: Array<string | undefined> = [];
+    const previousConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    const harness = makeHarness({
+      claudeConfig: { homePath },
+      resolveSdkSettings: async () => {
+        seenConfigDirs.push(process.env.CLAUDE_CONFIG_DIR);
+        return BYPASS_DISABLED_CLAUDE_SETTINGS;
+      },
+    });
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(session.runtimeMode, "full-access");
+      assert.equal(createInput?.options.permissionMode, "auto");
+      assert.equal(createInput?.options.allowDangerouslySkipPermissions, undefined);
+      assert.deepEqual(seenConfigDirs, [homePath]);
+      assert.equal(process.env.CLAUDE_CONFIG_DIR, previousConfigDir);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("restores CLAUDE_CONFIG_DIR when settings resolution throws", () => {
+    const homePath = "/tmp/claude-policy-home-throw";
+    const previousConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    const harness = makeHarness({
+      claudeConfig: { homePath },
+      resolveSdkSettings: async () => {
+        throw new Error("sdk resolve boom");
+      },
+    });
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.permissionMode, "auto");
+      assert.equal(process.env.CLAUDE_CONFIG_DIR, previousConfigDir);
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -587,7 +587,13 @@ describe("ClaudeAdapterLive", () => {
 
   it.effect("treats settings resolution failure as bypass disabled for full access", () => {
     const harness = makeHarness({
-      resolveSettings: () => Effect.fail(new ClaudeSettingsResolveError({})),
+      resolveSettings: () =>
+        Effect.fail(
+          new ClaudeSettingsResolveError({
+            settingSources: ["user", "project", "local"],
+            cause: new Error("settings resolve failed"),
+          }),
+        ),
     });
     return Effect.gen(function* () {
       const adapter = yield* ClaudeAdapter;
@@ -882,6 +888,142 @@ describe("ClaudeAdapterLive", () => {
       const createInput = harness.getLastCreateQueryInput();
       assert.equal(createInput?.options.permissionMode, "auto");
       assert.equal(process.env.CLAUDE_CONFIG_DIR, previousConfigDir);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("serializes CLAUDE_CONFIG_DIR swaps across Claude adapter instances", () => {
+    let active = 0;
+    let maxActive = 0;
+    const makeResolver =
+      (): NonNullable<ClaudeAdapterLiveOptions["resolveSdkSettings"]> => async () =>
+        Effect.runPromise(
+          Effect.gen(function* () {
+            active += 1;
+            maxActive = Math.max(maxActive, active);
+            yield* Effect.sleep("25 millis");
+            active -= 1;
+            return BYPASS_DISABLED_CLAUDE_SETTINGS;
+          }),
+        );
+    const first = makeHarness({
+      claudeConfig: { homePath: "/tmp/claude-policy-home-a" },
+      resolveSdkSettings: makeResolver(),
+    });
+    const second = makeHarness({
+      instanceId: ProviderInstanceId.make("claudeAgent-work"),
+      claudeConfig: { homePath: "/tmp/claude-policy-home-b" },
+      resolveSdkSettings: makeResolver(),
+    });
+    const start = (harness: ReturnType<typeof makeHarness>, threadId: ThreadId) =>
+      Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+        yield* adapter.startSession({
+          threadId,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          runtimeMode: "full-access",
+        });
+      }).pipe(
+        Effect.provideService(Random.Random, makeDeterministicRandomService()),
+        Effect.provide(harness.layer),
+      );
+
+    return Effect.gen(function* () {
+      yield* Effect.all(
+        [start(first, THREAD_ID), start(second, ThreadId.make("thread-claude-2"))],
+        { concurrency: "unbounded" },
+      );
+      assert.equal(maxActive, 1);
+    });
+  });
+
+  it.effect("auto-allows tools when effective Claude mode is still bypass", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      const canUseTool = harness.getLastCreateQueryInput()?.options.canUseTool;
+      assert.equal(typeof canUseTool, "function");
+      if (!canUseTool) {
+        return;
+      }
+
+      const permissionResult = yield* Effect.promise(() =>
+        canUseTool(
+          "Bash",
+          { command: "pwd" },
+          {
+            signal: new AbortController().signal,
+            toolUseID: "tool-use-bypass",
+          },
+        ),
+      );
+      assert.equal(permissionResult.behavior, "allow");
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("does not auto-allow tools when full access is policy-downgraded to supervised", () => {
+    const harness = makeHarness({
+      resolveSettings: () => Effect.succeed(BYPASS_AND_AUTO_DISABLED_CLAUDE_SETTINGS),
+    });
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      yield* Stream.take(adapter.streamEvents, 3).pipe(Stream.runDrain);
+
+      const canUseTool = harness.getLastCreateQueryInput()?.options.canUseTool;
+      assert.equal(typeof canUseTool, "function");
+      if (!canUseTool) {
+        return;
+      }
+
+      const permissionPromise = canUseTool(
+        "Bash",
+        { command: "pwd" },
+        {
+          signal: new AbortController().signal,
+          toolUseID: "tool-use-supervised",
+        },
+      );
+
+      const requested = yield* Stream.runHead(adapter.streamEvents);
+      assert.equal(requested._tag, "Some");
+      if (requested._tag !== "Some") {
+        return;
+      }
+      assert.equal(requested.value.type, "request.opened");
+      if (requested.value.type !== "request.opened") {
+        return;
+      }
+      const runtimeRequestId = requested.value.requestId;
+      assert.equal(typeof runtimeRequestId, "string");
+      if (runtimeRequestId === undefined) {
+        return;
+      }
+
+      yield* adapter.respondToRequest(
+        session.threadId,
+        ApprovalRequestId.make(runtimeRequestId),
+        "decline",
+      );
+
+      const permissionResult = yield* Effect.promise(() => permissionPromise);
+      assert.equal(permissionResult.behavior, "deny");
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -296,7 +296,9 @@ interface ClaudeQueryRuntime extends AsyncIterable<SDKMessage> {
 
 export interface ClaudeResolvedSettingsSnapshot {
   readonly effective?: {
+    readonly disableAutoMode?: unknown;
     readonly permissions?: {
+      readonly disableAutoMode?: unknown;
       readonly disableBypassPermissionsMode?: unknown;
     };
   };
@@ -320,14 +322,24 @@ export interface ClaudeAdapterLiveOptions {
   readonly nativeEventLogger?: EventNdjsonLogger;
   /**
    * Optional settings snapshot used to honor Claude's
-   * `permissions.disableBypassPermissionsMode` policy before requesting
-   * `bypassPermissions`. Production uses the SDK's `resolveSettings()` with
-   * the same filesystem sources as the session. Tests inject fixtures.
+   * `permissions.disableBypassPermissionsMode` and `disableAutoMode` policy
+   * before requesting those modes. Production uses the SDK's
+   * `resolveSettings()` with the same filesystem sources as the session.
+   * Tests inject fixtures.
    */
   readonly resolveSettings?: (input: {
     readonly cwd?: string;
     readonly settingSources: ReadonlyArray<SettingSource>;
   }) => Effect.Effect<ClaudeResolvedSettingsSnapshot, ClaudeSettingsResolveError>;
+  /**
+   * Optional inner `resolveSettings()` used when `resolveSettings` is omitted.
+   * Production calls the SDK. Tests inject this to observe `CLAUDE_CONFIG_DIR`
+   * without hitting disk or managed policy.
+   */
+  readonly resolveSdkSettings?: (input: {
+    readonly cwd?: string;
+    readonly settingSources: ReadonlyArray<SettingSource>;
+  }) => Promise<ClaudeResolvedSettingsSnapshot>;
 }
 
 function isUuid(value: string): boolean {
@@ -1233,7 +1245,6 @@ const CLAUDE_SETTING_SOURCES = [
   "project",
   "local",
 ] as const satisfies ReadonlyArray<SettingSource>;
-const CLAUDE_BYPASS_DISABLED_FALLBACK_MODE = "auto" satisfies PermissionMode;
 const CLAUDE_BYPASS_DISABLED_SETTINGS = {
   effective: {
     permissions: {
@@ -1242,8 +1253,33 @@ const CLAUDE_BYPASS_DISABLED_SETTINGS = {
   },
 } as const satisfies ClaudeResolvedSettingsSnapshot;
 
+function isClaudePolicyDisabled(value: unknown): boolean {
+  return value === "disable";
+}
+
 function isClaudeBypassPermissionsDisabled(settings: ClaudeResolvedSettingsSnapshot): boolean {
-  return settings.effective?.permissions?.disableBypassPermissionsMode === "disable";
+  return isClaudePolicyDisabled(settings.effective?.permissions?.disableBypassPermissionsMode);
+}
+
+function isClaudeAutoModeDisabled(settings: ClaudeResolvedSettingsSnapshot): boolean {
+  return (
+    isClaudePolicyDisabled(settings.effective?.disableAutoMode) ||
+    isClaudePolicyDisabled(settings.effective?.permissions?.disableAutoMode)
+  );
+}
+
+function effectiveClaudePermissionMode(
+  requested: PermissionMode | undefined,
+  settings: ClaudeResolvedSettingsSnapshot,
+): PermissionMode | undefined {
+  const autoDisabled = isClaudeAutoModeDisabled(settings);
+  if (requested === "bypassPermissions" && isClaudeBypassPermissionsDisabled(settings)) {
+    return autoDisabled ? undefined : "auto";
+  }
+  if (requested === "auto" && autoDisabled) {
+    return undefined;
+  }
+  return requested;
 }
 
 function withProcessClaudeConfigDir<A, E, R>(
@@ -1254,6 +1290,8 @@ function withProcessClaudeConfigDir<A, E, R>(
     return effect;
   }
 
+  // acquire/release are uninterruptible; keep `use` interruptible so a hung
+  // SDK resolve cannot pin CLAUDE_CONFIG_DIR or block later session starts.
   return Effect.acquireUseRelease(
     Effect.sync(() => {
       const previous = process.env.CLAUDE_CONFIG_DIR;
@@ -1753,6 +1791,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         options: input.options,
       }) as ClaudeQueryRuntime);
   const settingsResolveLock = yield* Semaphore.make(1);
+  const resolveSdkSettings = options?.resolveSdkSettings ?? resolveClaudeSdkSettings;
   const resolveSettings =
     options?.resolveSettings ??
     ((input) =>
@@ -1761,7 +1800,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           claudeEnvironment.CLAUDE_CONFIG_DIR,
           Effect.tryPromise({
             try: () =>
-              resolveClaudeSdkSettings({
+              resolveSdkSettings({
                 ...(input.cwd ? { cwd: input.cwd } : {}),
                 settingSources: [...input.settingSources],
               }),
@@ -4219,28 +4258,30 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         "full-access": "bypassPermissions",
       };
       const requestedPermissionMode = runtimeModeToPermission[input.runtimeMode];
-      let permissionMode = requestedPermissionMode;
-      if (permissionMode === "bypassPermissions") {
-        const resolvedSettings = yield* resolveSettings({
-          ...(input.cwd ? { cwd: input.cwd } : {}),
-          settingSources: CLAUDE_SETTING_SOURCES,
-        }).pipe(
-          Effect.tapError(() =>
-            Effect.logWarning("claude.settings.resolve-failed", {
-              threadId,
-            }),
-          ),
-          Effect.orElseSucceed(() => CLAUDE_BYPASS_DISABLED_SETTINGS),
-        );
-        if (isClaudeBypassPermissionsDisabled(resolvedSettings)) {
-          permissionMode = CLAUDE_BYPASS_DISABLED_FALLBACK_MODE;
-          yield* Effect.logWarning("claude.permission.bypass-disabled", {
-            threadId,
-            requestedRuntimeMode: input.runtimeMode,
-            requestedPermissionMode,
-            effectivePermissionMode: permissionMode,
-          });
-        }
+      const permissionMode =
+        requestedPermissionMode === "bypassPermissions" || requestedPermissionMode === "auto"
+          ? effectiveClaudePermissionMode(
+              requestedPermissionMode,
+              yield* resolveSettings({
+                ...(input.cwd ? { cwd: input.cwd } : {}),
+                settingSources: CLAUDE_SETTING_SOURCES,
+              }).pipe(
+                Effect.tapError(() =>
+                  Effect.logWarning("claude.settings.resolve-failed", {
+                    threadId,
+                  }),
+                ),
+                Effect.orElseSucceed(() => CLAUDE_BYPASS_DISABLED_SETTINGS),
+              ),
+            )
+          : requestedPermissionMode;
+      if (permissionMode !== requestedPermissionMode) {
+        yield* Effect.logWarning("claude.permission.mode-downgraded", {
+          threadId,
+          requestedRuntimeMode: input.runtimeMode,
+          requestedPermissionMode,
+          effectivePermissionMode: permissionMode ?? "default",
+        });
       }
       const settings = {
         ...(typeof thinking === "boolean" ? { alwaysThinkingEnabled: thinking } : {}),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -307,7 +307,9 @@ export interface ClaudeResolvedSettingsSnapshot {
 export class ClaudeSettingsResolveError extends Schema.TaggedErrorClass<ClaudeSettingsResolveError>()(
   "ClaudeSettingsResolveError",
   {
-    cause: Schema.optional(Schema.Defect()),
+    cwd: Schema.optional(Schema.String),
+    settingSources: Schema.Array(Schema.String),
+    cause: Schema.Defect(),
   },
 ) {}
 
@@ -1245,6 +1247,12 @@ const CLAUDE_SETTING_SOURCES = [
   "project",
   "local",
 ] as const satisfies ReadonlyArray<SettingSource>;
+const CLAUDE_RUNTIME_MODE_TO_PERMISSION: Record<string, PermissionMode> = {
+  "auto-accept-edits": "acceptEdits",
+  auto: "auto",
+  "full-access": "bypassPermissions",
+};
+const claudeConfigDirLock = Semaphore.makeUnsafe(1);
 const CLAUDE_BYPASS_DISABLED_SETTINGS = {
   effective: {
     permissions: {
@@ -1790,12 +1798,11 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         prompt: input.prompt,
         options: input.options,
       }) as ClaudeQueryRuntime);
-  const settingsResolveLock = yield* Semaphore.make(1);
   const resolveSdkSettings = options?.resolveSdkSettings ?? resolveClaudeSdkSettings;
   const resolveSettings =
     options?.resolveSettings ??
     ((input) =>
-      settingsResolveLock.withPermits(1)(
+      claudeConfigDirLock.withPermits(1)(
         withProcessClaudeConfigDir(
           claudeEnvironment.CLAUDE_CONFIG_DIR,
           Effect.tryPromise({
@@ -1804,7 +1811,12 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
                 ...(input.cwd ? { cwd: input.cwd } : {}),
                 settingSources: [...input.settingSources],
               }),
-            catch: (cause) => new ClaudeSettingsResolveError({ cause }),
+            catch: (cause) =>
+              new ClaudeSettingsResolveError({
+                ...(input.cwd ? { cwd: input.cwd } : {}),
+                settingSources: [...input.settingSources],
+                cause,
+              }),
           }),
         ),
       ));
@@ -3929,6 +3941,33 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
       const contextRef = yield* Ref.make<ClaudeSessionContext | undefined>(undefined);
 
+      const requestedPermissionMode = CLAUDE_RUNTIME_MODE_TO_PERMISSION[input.runtimeMode];
+      const permissionMode =
+        requestedPermissionMode === "bypassPermissions" || requestedPermissionMode === "auto"
+          ? effectiveClaudePermissionMode(
+              requestedPermissionMode,
+              yield* resolveSettings({
+                ...(input.cwd ? { cwd: input.cwd } : {}),
+                settingSources: CLAUDE_SETTING_SOURCES,
+              }).pipe(
+                Effect.tapError(() =>
+                  Effect.logWarning("claude.settings.resolve-failed", {
+                    threadId,
+                  }),
+                ),
+                Effect.orElseSucceed(() => CLAUDE_BYPASS_DISABLED_SETTINGS),
+              ),
+            )
+          : requestedPermissionMode;
+      if (permissionMode !== requestedPermissionMode) {
+        yield* Effect.logWarning("claude.permission.mode-downgraded", {
+          threadId,
+          requestedRuntimeMode: input.runtimeMode,
+          requestedPermissionMode,
+          effectivePermissionMode: permissionMode ?? "default",
+        });
+      }
+
       /**
        * Handle AskUserQuestion tool calls by emitting a `user-input.requested`
        * runtime event and waiting for the user to respond via `respondToUserInput`.
@@ -4109,8 +4148,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           } satisfies PermissionResult;
         }
 
-        const runtimeMode = input.runtimeMode ?? "full-access";
-        if (runtimeMode === "full-access") {
+        if (permissionMode === "bypassPermissions") {
           return {
             behavior: "allow",
             updatedInput: toolInput,
@@ -4252,37 +4290,6 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         : undefined;
       const ultracode = isClaudeUltracodeEffort(effort);
       const effectiveEffort = getEffectiveClaudeAgentEffort(effort, modelSelection?.model);
-      const runtimeModeToPermission: Record<string, PermissionMode> = {
-        "auto-accept-edits": "acceptEdits",
-        auto: "auto",
-        "full-access": "bypassPermissions",
-      };
-      const requestedPermissionMode = runtimeModeToPermission[input.runtimeMode];
-      const permissionMode =
-        requestedPermissionMode === "bypassPermissions" || requestedPermissionMode === "auto"
-          ? effectiveClaudePermissionMode(
-              requestedPermissionMode,
-              yield* resolveSettings({
-                ...(input.cwd ? { cwd: input.cwd } : {}),
-                settingSources: CLAUDE_SETTING_SOURCES,
-              }).pipe(
-                Effect.tapError(() =>
-                  Effect.logWarning("claude.settings.resolve-failed", {
-                    threadId,
-                  }),
-                ),
-                Effect.orElseSucceed(() => CLAUDE_BYPASS_DISABLED_SETTINGS),
-              ),
-            )
-          : requestedPermissionMode;
-      if (permissionMode !== requestedPermissionMode) {
-        yield* Effect.logWarning("claude.permission.mode-downgraded", {
-          threadId,
-          requestedRuntimeMode: input.runtimeMode,
-          requestedPermissionMode,
-          effectivePermissionMode: permissionMode ?? "default",
-        });
-      }
       const settings = {
         ...(typeof thinking === "boolean" ? { alwaysThinkingEnabled: thinking } : {}),
         ...(fastMode ? { fastMode: true } : {}),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -13,6 +13,7 @@ import {
   type PermissionMode,
   type PermissionResult,
   type PermissionUpdate,
+  resolveSettings as resolveClaudeSdkSettings,
   type SDKMessage,
   type SDKControlGetContextUsageResponse,
   type SDKResultMessage,
@@ -70,6 +71,7 @@ import * as Path from "effect/Path";
 import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
+import * as Semaphore from "effect/Semaphore";
 import * as Stream from "effect/Stream";
 
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
@@ -292,6 +294,21 @@ interface ClaudeQueryRuntime extends AsyncIterable<SDKMessage> {
   readonly close: () => void;
 }
 
+export interface ClaudeResolvedSettingsSnapshot {
+  readonly effective?: {
+    readonly permissions?: {
+      readonly disableBypassPermissionsMode?: unknown;
+    };
+  };
+}
+
+export class ClaudeSettingsResolveError extends Schema.TaggedErrorClass<ClaudeSettingsResolveError>()(
+  "ClaudeSettingsResolveError",
+  {
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
+
 export interface ClaudeAdapterLiveOptions {
   readonly instanceId?: ProviderInstanceId;
   readonly environment?: NodeJS.ProcessEnv;
@@ -301,6 +318,16 @@ export interface ClaudeAdapterLiveOptions {
   }) => ClaudeQueryRuntime;
   readonly nativeEventLogPath?: string;
   readonly nativeEventLogger?: EventNdjsonLogger;
+  /**
+   * Optional settings snapshot used to honor Claude's
+   * `permissions.disableBypassPermissionsMode` policy before requesting
+   * `bypassPermissions`. Production uses the SDK's `resolveSettings()` with
+   * the same filesystem sources as the session. Tests inject fixtures.
+   */
+  readonly resolveSettings?: (input: {
+    readonly cwd?: string;
+    readonly settingSources: ReadonlyArray<SettingSource>;
+  }) => Effect.Effect<ClaudeResolvedSettingsSnapshot, ClaudeSettingsResolveError>;
 }
 
 function isUuid(value: string): boolean {
@@ -1206,6 +1233,44 @@ const CLAUDE_SETTING_SOURCES = [
   "project",
   "local",
 ] as const satisfies ReadonlyArray<SettingSource>;
+const CLAUDE_BYPASS_DISABLED_FALLBACK_MODE = "auto" satisfies PermissionMode;
+const CLAUDE_BYPASS_DISABLED_SETTINGS = {
+  effective: {
+    permissions: {
+      disableBypassPermissionsMode: "disable",
+    },
+  },
+} as const satisfies ClaudeResolvedSettingsSnapshot;
+
+function isClaudeBypassPermissionsDisabled(settings: ClaudeResolvedSettingsSnapshot): boolean {
+  return settings.effective?.permissions?.disableBypassPermissionsMode === "disable";
+}
+
+function withProcessClaudeConfigDir<A, E, R>(
+  configDir: string | undefined,
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> {
+  if (configDir === undefined) {
+    return effect;
+  }
+
+  return Effect.acquireUseRelease(
+    Effect.sync(() => {
+      const previous = process.env.CLAUDE_CONFIG_DIR;
+      process.env.CLAUDE_CONFIG_DIR = configDir;
+      return previous;
+    }),
+    () => effect,
+    (previous) =>
+      Effect.sync(() => {
+        if (previous === undefined) {
+          delete process.env.CLAUDE_CONFIG_DIR;
+        } else {
+          process.env.CLAUDE_CONFIG_DIR = previous;
+        }
+      }),
+  );
+}
 
 function buildPromptText(
   input: ProviderSendTurnInput,
@@ -1687,6 +1752,23 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         prompt: input.prompt,
         options: input.options,
       }) as ClaudeQueryRuntime);
+  const settingsResolveLock = yield* Semaphore.make(1);
+  const resolveSettings =
+    options?.resolveSettings ??
+    ((input) =>
+      settingsResolveLock.withPermits(1)(
+        withProcessClaudeConfigDir(
+          claudeEnvironment.CLAUDE_CONFIG_DIR,
+          Effect.tryPromise({
+            try: () =>
+              resolveClaudeSdkSettings({
+                ...(input.cwd ? { cwd: input.cwd } : {}),
+                settingSources: [...input.settingSources],
+              }),
+            catch: (cause) => new ClaudeSettingsResolveError({ cause }),
+          }),
+        ),
+      ));
 
   const sessions = new Map<ThreadId, ClaudeSessionContext>();
   const runtimeEventQueue = yield* Queue.unbounded<ProviderRuntimeEvent>();
@@ -4136,7 +4218,30 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         auto: "auto",
         "full-access": "bypassPermissions",
       };
-      const permissionMode = runtimeModeToPermission[input.runtimeMode];
+      const requestedPermissionMode = runtimeModeToPermission[input.runtimeMode];
+      let permissionMode = requestedPermissionMode;
+      if (permissionMode === "bypassPermissions") {
+        const resolvedSettings = yield* resolveSettings({
+          ...(input.cwd ? { cwd: input.cwd } : {}),
+          settingSources: CLAUDE_SETTING_SOURCES,
+        }).pipe(
+          Effect.tapError(() =>
+            Effect.logWarning("claude.settings.resolve-failed", {
+              threadId,
+            }),
+          ),
+          Effect.orElseSucceed(() => CLAUDE_BYPASS_DISABLED_SETTINGS),
+        );
+        if (isClaudeBypassPermissionsDisabled(resolvedSettings)) {
+          permissionMode = CLAUDE_BYPASS_DISABLED_FALLBACK_MODE;
+          yield* Effect.logWarning("claude.permission.bypass-disabled", {
+            threadId,
+            requestedRuntimeMode: input.runtimeMode,
+            requestedPermissionMode,
+            effectivePermissionMode: permissionMode,
+          });
+        }
+      }
       const settings = {
         ...(typeof thinking === "boolean" ? { alwaysThinkingEnabled: thinking } : {}),
         ...(fastMode ? { fastMode: true } : {}),
@@ -4195,6 +4300,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         "provider.kind": PROVIDER,
         "provider.thread_id": threadId,
         "provider.runtime_mode": input.runtimeMode,
+        "claude.query.requested_permission_mode": requestedPermissionMode ?? "",
         "claude.resume.source":
           existingResumeSessionId !== undefined ? "resume-session" : "generated-session",
         "claude.resume.thread_id": resumeState?.threadId ?? "",

--- a/docs/user/providers-claude.md
+++ b/docs/user/providers-claude.md
@@ -215,3 +215,9 @@ If the preset needs different Claude files, give it a different `CLAUDE_CONFIG_D
 different API keys, base URLs, or router settings, use Environment variables.
 
 Do not put environment variable assignments in `Launch arguments`.
+
+## Full Access When Bypass Permissions Are Locked
+
+Some Claude setups, including organization policy, forbid bypass-permissions mode. If you pick
+**Full access** there, T3 Code keeps the thread on Full access but starts Claude in **Auto** so the
+session can run. Pick Auto yourself if you want the composer to match what Claude will enforce.

--- a/docs/user/providers-claude.md
+++ b/docs/user/providers-claude.md
@@ -220,4 +220,6 @@ Do not put environment variable assignments in `Launch arguments`.
 
 Some Claude setups, including organization policy, forbid bypass-permissions mode. If you pick
 **Full access** there, T3 Code keeps the thread on Full access but starts Claude in **Auto** so the
-session can run. Pick Auto yourself if you want the composer to match what Claude will enforce.
+session can run. If Auto is also locked — or you pick Auto while Auto is locked — the session starts
+in **Supervised** instead. Pick the composer mode that matches what Claude will enforce if you want
+the label to stay in sync.


### PR DESCRIPTION
Fixes #4927

## What Changed

Claude `startSession` now resolves the same filesystem settings cascade as the SDK session (`user`, `project`, `local`; managed policy still loads regardless) before requesting `bypassPermissions` or `auto`.

If resolved policy forbids the requested mode, the adapter:

- keeps the thread's requested runtime mode
- starts Claude in the next allowed mode: Auto if only bypass is locked, Supervised if Auto is locked too
- omits `allowDangerouslySkipPermissions` unless effective mode is still bypass
- records requested vs effective mode on the session span
- logs a warning without settings contents, paths, or credentials

Existing Full access behavior is unchanged when policy allows bypass. Auto-accept-edits and supervised keep their current mappings.

Settings resolve for isolated Claude homes temporarily sets `CLAUDE_CONFIG_DIR` under a process-wide mutex and always restores it, including when resolve throws. Tool auto-allow follows the effective Claude permission mode, not the requested Full access label.

## Why

### Verified root cause

On `origin/main` (`bab4b6f02`), `ClaudeAdapter.startSession` mapped `"full-access"` straight to `permissionMode: "bypassPermissions"` plus `allowDangerouslySkipPermissions: true`. It never read Claude's resolved policy. Current Claude docs say `permissions.disableBypassPermissionsMode: "disable"` (user settings or managed policy) forbids that mode. The adapter still sent it, so the Claude CLI/SDK rejected the session.

The first draft only remapped Full access to Auto. Claude also accepts `disableAutoMode: "disable"` (top-level or `permissions.disableAutoMode`). Sending Auto in that case is the same class of bug. Claude docs say a session that would start in Auto then starts in default / Manual instead.

### Why this seam

| Option | Verdict |
| --- | --- |
| UI-only disable of Full access | Rejected. Chat, compact menu, mobile sheets, command palette, and RPC can all still request the mode. |
| Shared server+UI policy contract | Rejected for this bug. No existing provider-state field for "bypass locked", and it would expand contracts/web/mobile. |
| Hard error instead of Auto | Weaker than the issue's working workaround. Auto already starts cleanly when it is allowed. |
| Server-side check in the Claude adapter | Selected. One Claude-only seam, same `startSession` public interface, strongest policy guarantee, UI can still be added later. |

## Requested vs effective mode

- **Requested:** `session.runtimeMode` stays what the client asked for (`full-access` or `auto`).
- **Effective:** `claude.query.permission_mode` is the allowed mode (`bypassPermissions`, `auto`, or omitted for Supervised); `claude.query.requested_permission_mode` keeps the original mapping.
- Plan-mode restore uses the effective base mode (`auto`, or `default` when Supervised).
- `canUseTool` auto-allows only when the effective mode is still `bypassPermissions`.

## Tests and commands

```bash
vp test run apps/server/src/provider/Layers/ClaudeAdapter.test.ts
vp run --filter t3 typecheck
vp lint apps/server/src/provider/Layers/ClaudeAdapter.ts apps/server/src/provider/Layers/ClaudeAdapter.test.ts
```

88 tests passed. Typecheck passed. No new lint on the changed logic. No real Claude account, credentials, or managed policy required. Policy tests inject settings fixtures. `CLAUDE_CONFIG_DIR` tests inject the inner SDK resolve so they observe the env swap without hitting disk or MDM.

Covered matrix: permissive + full access; bypass locked + full access → Auto; bypass and Auto locked + full access → Supervised; Auto locked + Auto runtime → Supervised; Auto locked + full access still bypass; top-level and `permissions.disableAutoMode`; non-`"disable"` policy values; settings resolution failure (fail closed to Auto); plan restore after Auto or Supervised downgrade; resolve call uses cwd + `["user","project","local"]`; instance `CLAUDE_CONFIG_DIR` is visible during resolve and restored after success or throw; process-wide config-dir lock; tools are not auto-allowed after a Supervised downgrade.

## Risk, compatibility, and rollout

- Server-only safety backstop. Web, desktop, and mobile still offer Full access; the session no longer dies.
- `resolveSettings()` is an alpha Claude Agent SDK API. We call it with the same sources as `query()`.
- Custom `CLAUDE_CONFIG_DIR` is applied around the in-process resolve call under a process-wide mutex so user settings from isolated Claude homes are visible. The SDK call itself stays interruptible; acquire/release restore the previous env.
- Resolve failure still fail-closes to Auto (the issue author's working workaround), not Supervised.
- No credentials or policy JSON are logged.

## UI Changes

None. Composer, compact menu, and mobile still show Full access. A later change can grey it out once provider state surfaces "bypass locked".

## Remaining uncertainty

- Current Claude CLI may silently remap bypass to default in some versions rather than hard-failing. Either way, T3 must not send the forbidden request.
- Whether Full access should snap the visible thread mode to Auto, stay as Full access, or become a hard picker error still needs a product call.
- UI disable across web, mobile, command palette, and defaults is intentionally out of scope.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Model: Cursor Grok 4.6. Harness: Cursor cloud agent.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Claude full-access sessions to start without forbidden permission modes
> - When full-access mode requests `bypassPermissions` but policy has disabled it, the adapter now downgrades to `auto`; if `auto` is also disabled, it falls back to supervised (undefined) mode.
> - Settings resolution uses a semaphore-guarded `CLAUDE_CONFIG_DIR` swap to safely serialize concurrent environment mutations.
> - Resolution failures are treated as if bypass is disabled, falling back to `CLAUDE_BYPASS_DISABLED_SETTINGS`.
> - Tool calls are auto-allowed only when the effective `permissionMode` is `bypassPermissions`; otherwise they require approval.
> - Behavioral Change: `startSession` now resolves Claude policy settings and may silently downgrade the requested permission mode, logging a warning and annotating the span with both requested and effective modes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7278ed4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->