### PR TITLE
test(server): cover desktop-origin CORS on environment descriptor GET

### DIFF
--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -1530,6 +1530,46 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
+  it.effect(
+    "includes CORS headers on desktop-origin environment descriptor GET with Accept-Encoding",
+    () =>
+      Effect.gen(function* () {
+        yield* buildAppUnderTest();
+
+        const url = yield* getHttpServerUrl("/.well-known/t3/environment");
+        const response = yield* fetchEffect(url, {
+          headers: {
+            origin: "t3code://app",
+            "accept-encoding": "gzip, deflate, br",
+          },
+        });
+        const body = yield* responseJsonEffect<typeof testEnvironmentDescriptor>(response);
+
+        assert.equal(response.status, 200);
+        assertBrowserApiCorsResponseHeaders(response.headers);
+        assert.deepEqual(body, testEnvironmentDescriptor);
+      }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("includes CORS headers on desktop-origin environment descriptor OPTIONS", () =>
+    Effect.gen(function* () {
+      yield* buildAppUnderTest();
+
+      const url = yield* getHttpServerUrl("/.well-known/t3/environment");
+      const response = yield* fetchEffect(url, {
+        method: "OPTIONS",
+        headers: {
+          origin: "t3code://app",
+          "access-control-request-method": "GET",
+          "access-control-request-headers": "content-type",
+        },
+      });
+
+      assert.equal(response.status, 204);
+      assertBrowserApiCorsPreflightHeaders(response.headers);
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
   it.effect("reports unauthenticated session state without requiring auth", () =>
     Effect.gen(function* () {
       yield* buildAppUnderTest();


### PR DESCRIPTION
## What Changed

Adds two tests on the real `makeRoutesLayer` descriptor route:

- `GET /.well-known/t3/environment` from `t3code://app` with Chromium `Accept-Encoding`
- matching `OPTIONS` preflight from that origin

No production code change. Packaged CORS stays wildcard ACAO without credentials.

## Why

#7102 reported that a packaged nightly returned 200 JSON for the environment descriptor without `Access-Control-Allow-Origin` on the GET, while OPTIONS 204 included it. Desktop pairing to remote environments then failed in Chromium.

On current `main` the packaged server already returns ACAO on that GET. The existing test used a generic origin and no `Accept-Encoding`, so it did not lock the desktop Chromium request shape. These tests do. Re-implementing #2594 would duplicate a fix that is already present.

Fixes #7102

## Validation

- `vp test run apps/server/src/server.test.ts -t "includes CORS headers on desktop-origin"`
- `vp test run apps/server/src/server.test.ts -t "includes CORS headers on public environment descriptor"`
- `vp fmt` / `vp lint` on `apps/server/src/server.test.ts`

## UI Changes

None.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes — no UI changes
- [ ] I included a video for animation/interaction changes — no animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in `server.test.ts` with no runtime behavior modifications.
> 
> **Overview**
> Adds **test-only** coverage so desktop Chromium cannot regress on CORS for `/.well-known/t3/environment`.
> 
> Two integration tests hit the real server routes: a **GET** with origin `t3code://app` and `Accept-Encoding: gzip, deflate, br` (matching packaged desktop), asserting 200, JSON body, and browser API CORS response headers; and an **OPTIONS** preflight from the same origin with `access-control-request-method` / `access-control-request-headers`, asserting 204 and preflight CORS headers.
> 
> No production or CORS policy changes—the prior public-descriptor CORS test used a generic origin and omitted `Accept-Encoding`, so it did not pin the desktop request shape reported in #7102.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0db7dff83b13356935a372a76697384ea7e580d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CORS tests for desktop-origin requests to the environment descriptor endpoint
> Adds two tests in [server.test.ts](https://github.com/pingdotgg/t3code/pull/7248/files#diff-311d34bc81e1c9cdae991c24771a5c0b8f02084dc94251982be7466403965b9f) to verify CORS behavior for requests from `t3code://app` to `/.well-known/t3/environment`: one for a GET request (asserts 200, correct body, and CORS response headers) and one for an OPTIONS preflight (asserts 204 and preflight headers).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0db7dff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->