### PR TITLE
fix(build): identify cross-architecture probe by executable

### DIFF
--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -598,6 +598,7 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
 
     return Effect.scoped(
       Effect.gen(function* () {
+        const path = yield* Path.Path;
         const fixture = yield* makeWindowsPayloadFixture({ copyUnpackedNatives: true });
         yield* validateWindowsPackagedPayload({
           stageDistDir: fixture.stageDistDir,
@@ -606,7 +607,11 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         });
 
         assert.isFalse(
-          commands.some((command) => command.options.env?.ELECTRON_RUN_AS_NODE === "1"),
+          commands.some(
+            (command) =>
+              command.command === path.join(fixture.packagedAppDir, fixture.appExecutableName) &&
+              command.options.env?.ELECTRON_RUN_AS_NODE === "1",
+          ),
         );
         assert.isTrue(
           commands.some(


### PR DESCRIPTION
The cross-architecture Windows payload test treats any child command carrying ELECTRON_RUN_AS_NODE=1 as the packaged primary probe. When tests are launched from Electron, that variable is inherited by the ordinary Node self-containment check, so the assertion fails even though the primary probe was correctly skipped.

Identify the primary probe by both its packaged executable path and Electron runtime flag. This keeps the assertion scoped to the behavior it intends to test and makes it independent of ambient Electron environment variables.

Downstream port: https://github.com/lastobelus/lastCode/pull/18

Validation: vp test run build-desktop-artifact.test.ts (46 passed).

Implemented with GPT-5.6-Sol through the Codex harness in T3 Code.