### PR TITLE
fix(desktop): --version segfaults without a display

### DIFF
--- a/apps/desktop/src/app/DesktopPreReadyPlatform.test.ts
+++ b/apps/desktop/src/app/DesktopPreReadyPlatform.test.ts
@@ -88,6 +88,27 @@ describe("DesktopPreReadyPlatform", () => {
     assert.isFalse(DesktopPreReadyPlatform.isVersionRequest([]));
   });
 
+  it("writes a version line to stdout synchronously and swallows EPIPE", () => {
+    const writes: Array<{ fd: number; data: string }> = [];
+    DesktopPreReadyPlatform.writeStdoutLineSync("1.2.3", (fd, data) => {
+      writes.push({ fd, data });
+    });
+    assert.deepEqual(writes, [{ fd: 1, data: "1.2.3\n" }]);
+
+    DesktopPreReadyPlatform.writeStdoutLineSync("1.2.3", () => {
+      throw Object.assign(new Error("broken pipe"), { code: "EPIPE" });
+    });
+
+    try {
+      DesktopPreReadyPlatform.writeStdoutLineSync("1.2.3", () => {
+        throw Object.assign(new Error("bad fd"), { code: "EBADF" });
+      });
+      assert.fail("expected EBADF to propagate");
+    } catch (error) {
+      assert.equal((error as NodeJS.ErrnoException).code, "EBADF");
+    }
+  });
+
   it.effect(
     "acquires a synchronous pre-ready layer before an asynchronous Clerk-shaped layer",
     () =>

--- a/apps/desktop/src/app/DesktopPreReadyPlatform.test.ts
+++ b/apps/desktop/src/app/DesktopPreReadyPlatform.test.ts
@@ -78,6 +78,16 @@ describe("DesktopPreReadyPlatform", () => {
     assert.isNull(value);
   });
 
+  it("detects --version and -V as whole-token version requests", () => {
+    assert.isTrue(DesktopPreReadyPlatform.isVersionRequest(["--version"]));
+    assert.isTrue(DesktopPreReadyPlatform.isVersionRequest(["-V"]));
+    assert.isFalse(DesktopPreReadyPlatform.isVersionRequest(["--no-sandbox"]));
+    assert.isFalse(DesktopPreReadyPlatform.isVersionRequest(["--version=1"]));
+    assert.isFalse(DesktopPreReadyPlatform.isVersionRequest(["--version-foo"]));
+    assert.isFalse(DesktopPreReadyPlatform.isVersionRequest(["-v"]));
+    assert.isFalse(DesktopPreReadyPlatform.isVersionRequest([]));
+  });
+
   it.effect(
     "acquires a synchronous pre-ready layer before an asynchronous Clerk-shaped layer",
     () =>

--- a/apps/desktop/src/app/DesktopPreReadyPlatform.ts
+++ b/apps/desktop/src/app/DesktopPreReadyPlatform.ts
@@ -29,6 +29,10 @@ export function readCommandLineSwitchValue(
   return value.length > 0 ? value : null;
 }
 
+export function isVersionRequest(argv: ReadonlyArray<string>): boolean {
+  return argv.includes("--version") || argv.includes("-V");
+}
+
 export const resolveEarlyLinuxElectronOptionsFromProcess =
   (): DesktopEarlyElectronStartup.EarlyLinuxElectronOptions =>
     DesktopEarlyElectronStartup.resolveEarlyLinuxElectronOptions({

--- a/apps/desktop/src/app/DesktopPreReadyPlatform.ts
+++ b/apps/desktop/src/app/DesktopPreReadyPlatform.ts
@@ -33,6 +33,20 @@ export function isVersionRequest(argv: ReadonlyArray<string>): boolean {
   return argv.includes("--version") || argv.includes("-V");
 }
 
+export function writeStdoutLineSync(
+  line: string,
+  writeSync: (fd: number, data: string) => void = (fd, data) => {
+    NodeFS.writeSync(fd, data);
+  },
+): void {
+  try {
+    writeSync(1, `${line}\n`);
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code !== "EPIPE") throw error;
+  }
+}
+
 export const resolveEarlyLinuxElectronOptionsFromProcess =
   (): DesktopEarlyElectronStartup.EarlyLinuxElectronOptions =>
     DesktopEarlyElectronStartup.resolveEarlyLinuxElectronOptions({

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -217,8 +217,7 @@ const desktopRuntimeLayer = desktopClerkLayer.pipe(
 );
 
 if (DesktopPreReadyPlatform.isVersionRequest(process.argv)) {
-  // @effect-diagnostics-next-line globalConsole:off - print and exit before the Effect runtime exists.
-  console.log(Electron.app.getVersion());
+  DesktopPreReadyPlatform.writeStdoutLineSync(Electron.app.getVersion());
   process.exit(0);
 }
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -216,4 +216,10 @@ const desktopRuntimeLayer = desktopClerkLayer.pipe(
   Layer.provideMerge(DesktopPreReadyPlatform.layer),
 );
 
+if (DesktopPreReadyPlatform.isVersionRequest(process.argv)) {
+  // @effect-diagnostics-next-line globalConsole:off - print and exit before the Effect runtime exists.
+  console.log(Electron.app.getVersion());
+  process.exit(0);
+}
+
 DesktopApp.program.pipe(Effect.provide(desktopRuntimeLayer), NodeRuntime.runMain);


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

Fixes #5474

## What Changed

`DesktopPreReadyPlatform.isVersionRequest` returns true only for the whole tokens `--version` and `-V`. `main.ts` checks that predicate immediately before `DesktopApp.program` and, on a match, writes the version with `writeStdoutLineSync` (fd 1, swallows EPIPE) then `process.exit(0)`. Layers and `whenReady` never run on that path. `console.log` then `process.exit` can drop piped stdout on Electron before ready.

## Why

`env -u DISPLAY -u WAYLAND_DISPLAY t3code --version` printed Ozone "Missing X server" and exited 139. Packagers and headless scripts expect a version string and exit 0. `--no-sandbox` still never printed the version (it only avoided the SIGSEGV on teardown).

`DesktopApp.startup` always awaits `electronApp.whenReady`, which initializes Ozone. `DesktopPreReadyPlatform` already owns pre-ready command-line reads. A one-function argv predicate there hides token matching; print+exit stays at the `main.ts` call site so `app.exit` teardown cannot still fault without a display. Handling version after ElectronApp/DesktopApp services exist still walks the ready path unless it special-cases before `whenReady`.

The server CLI already prints a version (`apps/server/src/bin.ts:65`). This is the desktop binary.

## Test

- `detects --version and -V as whole-token version requests` failed on `upstream/main` before the fix: `TypeError: isVersionRequest is not a function` (1 failed | 4 passed). It passes once the pure predicate exists.
- `writes a version line to stdout synchronously and swallows EPIPE` covers the flush path Bugbot flagged.
- `vp test run apps/desktop/src/app/DesktopPreReadyPlatform.test.ts apps/desktop/src/app/DesktopEarlyElectronStartup.test.ts` — 13 passed (6 + 7).
- `vp lint` on the three files: 0 warnings/errors.
- `vp run --filter @t3tools/desktop typecheck`: our files clean (pre-existing suggestions remain in `DesktopBackendPool.test.ts` and `DesktopWslEnvironment.ts`).
- Did not launch a packaged Linux binary with `DISPLAY` unset. Did not run web, mobile, or server suites.

## UI Changes

No UI change.

## Deliberately not included

- `-v` (`DesktopPreReadyPlatform.ts:33`, asserted false at `DesktopPreReadyPlatform.test.ts:88`): the issue workaround mentioned it; Chromium also uses `-v` for verbosity.
- AUR/AppImage wrapper (`packaging/aur/t3code-bin/PKGBUILD:76-79`): still just `exec AppRun "$@"`.
- Headless GUI launch still dies without a display (`DesktopApp.ts:275-278`). `--no-sandbox` only changes teardown, not version printing.
- Chromium's built-in `--version` after Ozone starts.
- `ElectronApp.whenReady` still requires a display for normal launches (`ElectronApp.ts:133-139`).
- `DesktopApp.startup` still always awaits `whenReady` for normal launches (`DesktopApp.ts:275`).
- Server CLI version (`apps/server/src/bin.ts:65`).
- contracts / web / mobile.
- `Electron.app.exit` teardown (`ElectronApp.ts:143-146`).
- Linux password-store / WM-class (`DesktopPreReadyPlatform.ts:70-80`).
- Open file-touch PRs #6250 #6274 #6308 #6374 #6668 #7115 — nearby desktop files, not this bug.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Implemented with grok-4.5 in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, early-exit path with unit tests; normal GUI startup is unchanged.
> 
> **Overview**
> Fixes headless **`t3code --version`** (no display) exiting with Ozone errors or a segfault instead of printing the version and exiting 0.
> 
> **`DesktopPreReadyPlatform`** gains **`isVersionRequest`** (whole argv tokens **`--version`** and **`-V`** only—not **`-v`**, **`--version=…`**, or similar) and **`writeStdoutLineSync`**, which writes one line to stdout and ignores **`EPIPE`**.
> 
> In **`main.ts`**, that check runs **after** the runtime layer is defined but **before** **`DesktopApp.program`** starts, so the Effect stack and **`whenReady`** / display init never run on the version path. A match prints **`Electron.app.getVersion()`** and **`process.exit(0)`**.
> 
> Tests cover argv matching and stdout/EPIPE behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69817a1c8d66e9ef219c1f9388f0e66ce0f88095. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `--version` segfault by handling version flag before display initialization
> When the desktop app is invoked with `--version` or `-V`, it previously tried to initialize a display before printing the version, causing a segfault in headless environments.
>
> - Adds `isVersionRequest` in [DesktopPreReadyPlatform.ts](https://github.com/pingdotgg/t3code/pull/7256/files#diff-7454e838d3cfc6fda6f70d9fc7822f86e63f5ed93b81cee57ea922b3c95972a4) to detect whole-token `--version` or `-V` flags (ignoring variants like `--version=1` or `-v`).
> - Adds `writeStdoutLineSync` to write the version string to stdout synchronously, suppressing `EPIPE` errors.
> - In [main.ts](https://github.com/pingdotgg/t3code/pull/7256/files#diff-31a471f6ef958ceff6e87ee910f4bc4f7bbc4986f797f159353b328a5916f7cb), checks for the version flag before app startup, prints the Electron app version, and exits with code 0.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 69817a1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->