### PR TITLE
fix(mobile): Local Network permission sheet leaves pairing stuck

### DIFF
--- a/apps/mobile/src/connection/app-state-wakeups.test.ts
+++ b/apps/mobile/src/connection/app-state-wakeups.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "@effect/vitest";
 import {
   MOBILE_BACKGROUND_RECONNECT_AFTER_MS,
   mobileApplicationActiveWakeup,
+  mobileSuspensionStartedAtMs,
 } from "./app-state-wakeups";
 
 describe("mobileApplicationActiveWakeup", () => {
@@ -17,5 +18,25 @@ describe("mobileApplicationActiveWakeup", () => {
     expect(
       mobileApplicationActiveWakeup(20_000, 20_000 + MOBILE_BACKGROUND_RECONNECT_AFTER_MS),
     ).toBe("application-active-reconnect");
+  });
+});
+
+describe("mobileSuspensionStartedAtMs", () => {
+  it("starts the clock on inactive so a short permission sheet stays a probe", () => {
+    const startedAtMs = mobileSuspensionStartedAtMs(null, "inactive", 20_000);
+    expect(startedAtMs).toBe(20_000);
+    expect(mobileApplicationActiveWakeup(startedAtMs, 20_500)).toBe("application-active-probe");
+  });
+
+  it("starts the clock on background and keeps the first stamp through inactive", () => {
+    const afterBackground = mobileSuspensionStartedAtMs(null, "background", 20_000);
+    expect(afterBackground).toBe(20_000);
+    expect(mobileSuspensionStartedAtMs(afterBackground, "inactive", 25_000)).toBe(20_000);
+  });
+
+  it("clears the clock on active and ignores unknown states", () => {
+    expect(mobileSuspensionStartedAtMs(20_000, "active", 25_000)).toBeNull();
+    expect(mobileSuspensionStartedAtMs(20_000, "unknown", 25_000)).toBe(20_000);
+    expect(mobileSuspensionStartedAtMs(null, "active", 20_000)).toBeNull();
   });
 });

--- a/apps/mobile/src/connection/app-state-wakeups.ts
+++ b/apps/mobile/src/connection/app-state-wakeups.ts
@@ -16,3 +16,17 @@ export function mobileApplicationActiveWakeup(
     ? "application-active-reconnect"
     : "application-active-probe";
 }
+
+export function mobileSuspensionStartedAtMs(
+  startedAtMs: number | null,
+  appState: string,
+  nowMs: number,
+): number | null {
+  if (appState === "background" || appState === "inactive") {
+    return startedAtMs ?? nowMs;
+  }
+  if (appState === "active") {
+    return null;
+  }
+  return startedAtMs;
+}

--- a/apps/mobile/src/connection/platform.ts
+++ b/apps/mobile/src/connection/platform.ts
@@ -30,7 +30,7 @@ import * as MobileStorage from "../persistence/mobile-storage";
 import { appAtomRegistry } from "../state/atom-registry";
 import { clearThreadOutboxEnvironment } from "../state/thread-outbox";
 import { clearComposerDraftsEnvironment } from "../state/use-composer-drafts";
-import { mobileApplicationActiveWakeup } from "./app-state-wakeups";
+import { mobileApplicationActiveWakeup, mobileSuspensionStartedAtMs } from "./app-state-wakeups";
 import { connectionStorageLayer } from "./storage";
 
 function networkStatus(state: Network.NetworkState): "unknown" | "offline" | "online" {
@@ -90,16 +90,16 @@ const wakeupsLayer = Wakeups.layer({
     Stream.callback<"application-active-probe" | "application-active-reconnect">((queue) =>
       Effect.acquireRelease(
         Effect.sync(() => {
-          let backgroundedAtMs = AppState.currentState === "background" ? Date.now() : null;
+          let backgroundedAtMs = mobileSuspensionStartedAtMs(
+            null,
+            AppState.currentState,
+            Date.now(),
+          );
           return AppState.addEventListener("change", (state) => {
-            if (state === "background") {
-              backgroundedAtMs = Date.now();
-              return;
-            }
             if (state === "active") {
               Queue.offerUnsafe(queue, mobileApplicationActiveWakeup(backgroundedAtMs, Date.now()));
-              backgroundedAtMs = null;
             }
+            backgroundedAtMs = mobileSuspensionStartedAtMs(backgroundedAtMs, state, Date.now());
           });
         }),
         (subscription) => Effect.sync(() => subscription.remove()),

--- a/docs/internals/connection-runtime.md
+++ b/docs/internals/connection-runtime.md
@@ -61,13 +61,12 @@ The supervisor is the only retry owner.
 
 Wakeup handling differs by phase, in [supervisor.ts][supervisor]:
 
-- During establishment, `waitForEstablishmentInterrupt` consumes and **ignores**
-  plain application activation. Restarting an in-flight attempt because the app
-  came to the foreground would only delay it. The exception is
-  `application-active-reconnect`, which mobile emits after a meaningful
-  background suspension; it interrupts establishment and resets the retry
-  ladder, because the OS may have silently killed the socket underneath the
-  attempt.
+- During establishment, `waitForEstablishmentInterrupt` interrupts and resets
+  the retry ladder on any application-active wakeup (`application-active`,
+  `application-active-probe`, or `application-active-reconnect`). A short
+  inactive blip such as an iOS Local Network permission sheet can leave the
+  in-flight attempt on a doomed socket; restarting from attempt 1 is cheaper
+  than waiting out the rest of the ladder.
 - Credential changes interrupt establishment only for relay targets, where a new
   credential changes what is being established.
 - Explicit disconnect, explicit retry, and going offline interrupt establishment

--- a/packages/client-runtime/src/connection/supervisor.test.ts
+++ b/packages/client-runtime/src/connection/supervisor.test.ts
@@ -646,7 +646,7 @@ describe("EnvironmentSupervisor", () => {
     }),
   );
 
-  it.effect("does not let platform wakeups reset an in-flight attempt", () =>
+  it.effect("does not let credential wakeups reset an in-flight primary attempt", () =>
     Effect.gen(function* () {
       const firstAttemptStarted = yield* Deferred.make<void>();
       const harness = yield* makeHarness({
@@ -659,11 +659,7 @@ describe("EnvironmentSupervisor", () => {
 
       yield* Deferred.await(firstAttemptStarted);
       yield* Effect.all(
-        [
-          harness.wake("credentials-changed"),
-          harness.wake("application-active"),
-          harness.wake("credentials-changed"),
-        ],
+        [harness.wake("credentials-changed"), harness.wake("credentials-changed")],
         { concurrency: "unbounded" },
       );
       yield* Effect.yieldNow;
@@ -841,6 +837,35 @@ describe("EnvironmentSupervisor", () => {
       );
 
       yield* harness.wake("application-active-reconnect");
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 2 && state.attempt === 1,
+      );
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+
+  it.effect("restarts the retry ladder when a short resume interrupts connection setup", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({
+        prepare: (attempt) => (attempt === 2 ? Effect.never : Effect.succeed(PREPARED_CONNECTION)),
+      });
+      const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(supervisor.state, (state) => state.phase === "connected");
+      yield* harness.closeLatestSession();
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "backoff" && state.attempt === 1,
+      );
+      yield* TestClock.adjust("3 seconds");
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "connecting" && state.attempt === 2,
+      );
+
+      yield* harness.wake("application-active-probe");
       yield* awaitState(
         supervisor.state,
         (state) => state.phase === "connected" && state.generation === 2 && state.attempt === 1,

--- a/packages/client-runtime/src/connection/supervisor.ts
+++ b/packages/client-runtime/src/connection/supervisor.ts
@@ -381,7 +381,7 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
         case "ConnectRequested":
           break;
         case "Wakeup":
-          if (next.reason === "application-active-reconnect") {
+          if (ConnectionWakeups.isApplicationActiveWakeup(next.reason)) {
             return true;
           }
           if (next.reason === "credentials-changed" && target._tag === "RelayConnectionTarget") {


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

Fixes #5061

## What Changed

`waitForEstablishmentInterrupt` now returns `true` for any `isApplicationActiveWakeup` (`application-active`, `application-active-probe`, or `application-active-reconnect`), so a short resume during connection setup resets the retry ladder the same way a long resume already did. `mobileSuspensionStartedAtMs` starts that clock on AppState `inactive` as well as `background` (`??=` keeps the earlier stamp; `active` clears it). The Wakeups paragraph in `docs/internals/connection-runtime.md` no longer says establishment ignores probe.

## Why

First-time iOS LAN pairing: user taps **Allow** on the Local Network sheet, the environment stays on `Failed to connect. Reconnecting…` until force-quit. The sheet is `active → inactive → active`; that resume is an `application-active-probe`. Establishment consumed the probe and left the doomed attempt on the retry ladder. The mobile adapter never started the suspension clock on `inactive`, so a permission sheet could not be classified as a real resume.

`waitForEstablishmentInterrupt` already returned `resetRetry` for `application-active-reconnect`. Extending that predicate is the existing seam — same interface, more behaviour. `mobileApplicationActiveWakeup` still classifies short inactive as probe; web/desktop inherit the supervisor change via `isApplicationActiveWakeup`. Connected-phase `monitorConnectedLease` still probes on probe and only replaces the lease on reconnect.

## Test

- `restarts the retry ladder when a short resume interrupts connection setup` timed out at 60000ms on `upstream/main` (`waitForEstablishmentInterrupt` swallowed `application-active-probe`; hanging prepare on attempt 2 never reset). After the fix the same assertion reached `phase === "connected" && generation === 2 && attempt === 1`.
- `starts the clock on inactive so a short permission sheet stays a probe` covers the AppState `inactive` stamp that the supervisor test cannot see.
- `vp test run packages/client-runtime/src/connection/supervisor.test.ts apps/mobile/src/connection/app-state-wakeups.test.ts` — 36 + 5 passed.
- `vp lint` on the touched source and test files: 0 errors.
- Did not pair on a device or simulator. Did not run web, desktop, or server suites.

## UI Changes

No UI change.

## Deliberately not included

- Connected-phase probe stays a probe (`supervisor.ts:421-427`). `monitorConnectedLease` still calls `lease.session.probe` for `application-active` / `application-active-probe` and only replaces the lease on `application-active-reconnect`.
- No new `ConnectionWakeup` reason (`wakeups.ts:5-9`). A new reason would widen the interface and collide with #5154.
- `mobileApplicationActiveWakeup` duration rule unchanged. Short inactive remains probe; only the stamp helper now treats `inactive` like `background`.
- Web visibility adapter (`apps/web/src/connection/platform.ts:93-99`) still emits plain `application-active`.
- `connectivityLayer` AppState network re-read (`apps/mobile/src/connection/platform.ts:63-70`) — #4528 / #5597 resume network refresh.
- #5154 `network-path-changed` — not in this tree; hunks kept off that path.
- #5198 / #7233 connected probe timeout tolerance (`supervisor.ts:34-35`, `supervisor.ts:425-427`; tests at `supervisor.test.ts:1021` and `:1044`).
- #5179 Android background connection (`background-activity.ts:30-34`).
- #6642 thread-feed resubscribe (`threads.ts:548-557`). `shouldResubscribeAfterWakeup` is unchanged.
- Distinguishing Control Center from the Local Network sheet: both are AppState `inactive`; there is no API to tell them apart.
- contracts.
- UI copy (`presentation.ts:68-81`).
- Pairing UI (`ConnectionsNewRouteScreen.tsx:150-155`, `onboarding.ts:13-20`).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Implemented with grok-4.6 in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared `EnvironmentSupervisor` establishment interrupts for all platforms; scope is narrow and connected-phase probing is unchanged, but any platform can now restart setup on short foreground wakeups.
> 
> **Overview**
> Fixes iOS first-time LAN pairing getting stuck on **Reconnecting…** after the Local Network permission sheet (`active → inactive → active`).
> 
> **Shared supervisor:** During connection establishment, `waitForEstablishmentInterrupt` now interrupts and **resets the retry ladder** for any application-active wakeup (`application-active`, `application-active-probe`, or `application-active-reconnect`), not only long-background `application-active-reconnect`. Short resumes during setup therefore abandon a doomed in-flight attempt instead of waiting through backoff. Connected-phase behavior is unchanged (probe vs full reconnect).
> 
> **Mobile wakeups:** New `mobileSuspensionStartedAtMs` starts the background suspension clock on AppState **`inactive`** as well as **`background`** (first timestamp is kept through `inactive`; **`active`** clears it). The mobile wakeup layer uses this so a brief permission sheet still classifies as a short `application-active-probe` with correct timing.
> 
> Docs and tests cover the new establishment and AppState behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf7995ed0e6baebc95e5a98841d00a1422ab91c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix mobile pairing getting stuck when Local Network permission sheet appears
> - Introduces `mobileSuspensionStartedAtMs` to track suspension start across both `inactive` and `background` app states, preserving the earliest timestamp and clearing it on `active`.
> - Updates `EnvironmentSupervisor` so that any application-active wakeup (`application-active`, `application-active-probe`, or `application-active-reconnect`) interrupts an in-flight connection attempt and resets the retry ladder — previously only `application-active-reconnect` did this.
> - The Local Network permission sheet briefly moves the app to `inactive` before returning to `active`; without this fix, that transition was not recognized as a suspension, leaving the pairing flow stuck waiting for a retry.
> - Behavioral Change: short `inactive` blips now emit `application-active-probe` wakeups and reset the retry ladder, which may cause more reconnect attempts after transient interruptions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf7995e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->