### PR TITLE
fix(server): Claude plan mode never shows Implement

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -4159,6 +4159,449 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("prefers result text over assistant text when ExitPlanMode is skipped", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      yield* Stream.take(adapter.streamEvents, 3).pipe(Stream.runDrain);
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "plan this",
+        interactionMode: "plan",
+        attachments: [],
+      });
+      yield* Stream.take(adapter.streamEvents, 1).pipe(Stream.runDrain);
+
+      const completedFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      harness.query.emit({
+        type: "assistant",
+        session_id: "sdk-session-plan-text",
+        uuid: "assistant-plan-text",
+        parent_tool_use_id: null,
+        message: {
+          model: "claude-opus-4-6",
+          id: "msg-plan-text",
+          type: "message",
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "# Draft notes",
+            },
+          ],
+          stop_reason: null,
+          stop_sequence: null,
+          usage: {},
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        result: "# Ship it\n\n- one\n- two",
+        session_id: "sdk-session-plan-text",
+        uuid: "result-plan-text",
+      } as unknown as SDKMessage);
+
+      const runtimeEvents = Array.from(yield* Fiber.join(completedFiber));
+      const proposedEvent = runtimeEvents.find((event) => event.type === "turn.proposed.completed");
+      assert.equal(proposedEvent?.type, "turn.proposed.completed");
+      if (proposedEvent?.type !== "turn.proposed.completed") {
+        return;
+      }
+      assert.equal(proposedEvent.payload.planMarkdown, "# Ship it\n\n- one\n- two");
+      assert.equal(proposedEvent.raw?.source, "claude.sdk.message");
+      assert.equal(proposedEvent.raw?.method, "claude/result/plan-text");
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect.each<{
+    title: string;
+    interactionMode?: "plan" | "default";
+    assistantText?: string;
+    resultExtras?: Record<string, unknown>;
+  }>([
+    {
+      title: "does not emit proposed plan outside plan mode",
+      assistantText: "# Ship it\n\n- one\n- two",
+      resultExtras: { result: "# Ship it\n\n- one\n- two" },
+    },
+    {
+      title: "does not emit proposed plan when result and assistant text are empty",
+      interactionMode: "plan",
+    },
+    {
+      title: "does not emit proposed plan when the result is a refusal",
+      interactionMode: "plan",
+      assistantText: "# Ship it\n\n- one\n- two",
+      resultExtras: { result: "# Ship it\n\n- one\n- two", stop_reason: "refusal" },
+    },
+  ])("$title", ({ interactionMode, assistantText, resultExtras }) => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      yield* Stream.take(adapter.streamEvents, 3).pipe(Stream.runDrain);
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "plan this",
+        ...(interactionMode ? { interactionMode } : {}),
+        attachments: [],
+      });
+      yield* Stream.take(adapter.streamEvents, 1).pipe(Stream.runDrain);
+
+      const completedFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      if (assistantText !== undefined) {
+        harness.query.emit({
+          type: "assistant",
+          session_id: "sdk-session-plan-text-skip",
+          uuid: "assistant-plan-text-skip",
+          parent_tool_use_id: null,
+          message: {
+            model: "claude-opus-4-6",
+            id: "msg-plan-text-skip",
+            type: "message",
+            role: "assistant",
+            content: [{ type: "text", text: assistantText }],
+            stop_reason: null,
+            stop_sequence: null,
+            usage: {},
+          },
+        } as unknown as SDKMessage);
+      }
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "sdk-session-plan-text-skip",
+        uuid: "result-plan-text-skip",
+        ...resultExtras,
+      } as unknown as SDKMessage);
+
+      const runtimeEvents = Array.from(yield* Fiber.join(completedFiber));
+      assert.equal(
+        runtimeEvents.some((event) => event.type === "turn.proposed.completed"),
+        false,
+      );
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("does not emit a second proposed plan after ExitPlanMode", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      yield* Stream.take(adapter.streamEvents, 3).pipe(Stream.runDrain);
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "plan this",
+        interactionMode: "plan",
+        attachments: [],
+      });
+      yield* Stream.take(adapter.streamEvents, 1).pipe(Stream.runDrain);
+
+      const completedFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      harness.query.emit({
+        type: "assistant",
+        session_id: "sdk-session-exit-then-result",
+        uuid: "assistant-exit-then-result",
+        parent_tool_use_id: null,
+        message: {
+          model: "claude-opus-4-6",
+          id: "msg-exit-then-result",
+          type: "message",
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "# Final plan\n\n- capture it",
+            },
+            {
+              type: "tool_use",
+              id: "tool-exit-dedupe",
+              name: "ExitPlanMode",
+              input: {
+                plan: "# Final plan\n\n- capture it",
+              },
+            },
+          ],
+          stop_reason: null,
+          stop_sequence: null,
+          usage: {},
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        result: "# Final plan\n\n- capture it",
+        session_id: "sdk-session-exit-then-result",
+        uuid: "result-exit-then-result",
+      } as unknown as SDKMessage);
+
+      const runtimeEvents = Array.from(yield* Fiber.join(completedFiber));
+      const proposedEvents = runtimeEvents.filter(
+        (event) => event.type === "turn.proposed.completed",
+      );
+      assert.equal(proposedEvents.length, 1);
+      assert.equal(proposedEvents[0]?.raw?.method, "claude/assistant");
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("does not emit proposed plan from a later synthetic turn", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      yield* Stream.take(adapter.streamEvents, 3).pipe(Stream.runDrain);
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "plan this",
+        interactionMode: "plan",
+        attachments: [],
+      });
+      yield* Stream.take(adapter.streamEvents, 1).pipe(Stream.runDrain);
+
+      const firstCompletedFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      harness.query.emit({
+        type: "assistant",
+        session_id: "sdk-session-plan-then-synthetic",
+        uuid: "assistant-plan-then-synthetic",
+        parent_tool_use_id: null,
+        message: {
+          model: "claude-opus-4-6",
+          id: "msg-plan-then-synthetic",
+          type: "message",
+          role: "assistant",
+          content: [{ type: "text", text: "# Ship it\n\n- one\n- two" }],
+          stop_reason: null,
+          stop_sequence: null,
+          usage: {},
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        result: "# Ship it\n\n- one\n- two",
+        session_id: "sdk-session-plan-then-synthetic",
+        uuid: "result-plan-then-synthetic",
+      } as unknown as SDKMessage);
+
+      const firstEvents = Array.from(yield* Fiber.join(firstCompletedFiber));
+      assert.equal(
+        firstEvents.some((event) => event.type === "turn.proposed.completed"),
+        true,
+      );
+
+      const secondCompletedFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      harness.query.emit({
+        type: "assistant",
+        session_id: "sdk-session-plan-then-synthetic",
+        uuid: "assistant-synthetic-followup",
+        parent_tool_use_id: null,
+        message: {
+          model: "claude-opus-4-6",
+          id: "msg-synthetic-followup",
+          type: "message",
+          role: "assistant",
+          content: [{ type: "text", text: "background agent notes" }],
+          stop_reason: null,
+          stop_sequence: null,
+          usage: {},
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        result: "background agent notes",
+        session_id: "sdk-session-plan-then-synthetic",
+        uuid: "result-synthetic-followup",
+      } as unknown as SDKMessage);
+
+      const secondEvents = Array.from(yield* Fiber.join(secondCompletedFiber));
+      assert.equal(
+        secondEvents.some((event) => event.type === "turn.proposed.completed"),
+        false,
+      );
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("does not emit proposed plan while user input is pending", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      yield* Stream.take(adapter.streamEvents, 3).pipe(Stream.runDrain);
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "plan this",
+        interactionMode: "plan",
+        attachments: [],
+      });
+      yield* Stream.take(adapter.streamEvents, 1).pipe(Stream.runDrain);
+
+      const canUseTool = harness.getLastCreateQueryInput()?.options.canUseTool;
+      assert.equal(typeof canUseTool, "function");
+      if (!canUseTool) {
+        return;
+      }
+
+      const permissionPromise = canUseTool(
+        "AskUserQuestion",
+        {
+          questions: [
+            {
+              question: "Which framework?",
+              header: "Framework",
+              options: [{ label: "React", description: "React.js" }],
+              multiSelect: false,
+            },
+          ],
+        },
+        {
+          signal: new AbortController().signal,
+          toolUseID: "tool-ask-pending-plan",
+        },
+      );
+
+      const requestedEvent = yield* Stream.runHead(adapter.streamEvents);
+      assert.equal(requestedEvent._tag, "Some");
+      if (requestedEvent._tag !== "Some" || requestedEvent.value.type !== "user-input.requested") {
+        return;
+      }
+
+      const completedFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      harness.query.emit({
+        type: "assistant",
+        session_id: "sdk-session-pending-input",
+        uuid: "assistant-pending-input",
+        parent_tool_use_id: null,
+        message: {
+          model: "claude-opus-4-6",
+          id: "msg-pending-input",
+          type: "message",
+          role: "assistant",
+          content: [{ type: "text", text: "# Ship it\n\n- one\n- two" }],
+          stop_reason: null,
+          stop_sequence: null,
+          usage: {},
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        result: "# Ship it\n\n- one\n- two",
+        session_id: "sdk-session-pending-input",
+        uuid: "result-pending-input",
+      } as unknown as SDKMessage);
+
+      const runtimeEvents = Array.from(yield* Fiber.join(completedFiber));
+      assert.equal(
+        runtimeEvents.some((event) => event.type === "turn.proposed.completed"),
+        false,
+      );
+
+      yield* adapter.stopSession(session.threadId);
+      yield* Effect.promise(() => permissionPromise);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("handles AskUserQuestion via user-input.requested/resolved lifecycle", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -279,6 +279,11 @@ interface ClaudeSessionContext {
   lastAssistantUuid: string | undefined;
   lastThreadStartedId: string | undefined;
   stopped: boolean;
+  /**
+   * Set only from sendTurn's interactionMode plan/default branches.
+   * Absent interactionMode leaves the previous value unchanged.
+   */
+  inPlanMode: boolean;
 }
 
 interface ClaudeQueryRuntime extends AsyncIterable<SDKMessage> {
@@ -1422,6 +1427,20 @@ function extractExitPlanModePlan(value: unknown): string | undefined {
     : undefined;
 }
 
+function planMarkdownFromSkippedExit(turnState: ClaudeTurnState, result: SDKResultMessage): string {
+  if (result.subtype === "success" && typeof result.result === "string") {
+    const fromResult = result.result.trim();
+    if (fromResult.length > 0) {
+      return fromResult;
+    }
+  }
+
+  return turnState.assistantTextBlockOrder
+    .map((block) => block.fallbackText)
+    .join("")
+    .trim();
+}
+
 function exitPlanCaptureKey(input: {
   readonly toolUseId?: string | undefined;
   readonly planMarkdown: string;
@@ -2343,6 +2362,33 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         rawMethod: "claude/result",
         rawPayload: result ?? { status },
       });
+    }
+
+    // Plan-mode turns that skip ExitPlanMode still captured the plan on
+    // the success result (assistant text is the fallback). Arm Implement
+    // through the existing emit helper.
+    // capturedProposedPlanKeys.size (not the helper's capture key) is the
+    // double-emit gate: ExitPlanMode stores tool:${id}, this path would
+    // store plan:${markdown}. Skip synthetic auto-started turns — they
+    // inherit session inPlanMode after a real plan turn.
+    if (
+      result !== undefined &&
+      status === "completed" &&
+      result.stop_reason !== "refusal" &&
+      context.inPlanMode &&
+      turnState.synthetic !== true &&
+      turnState.capturedProposedPlanKeys.size === 0 &&
+      context.pendingUserInputs.size === 0
+    ) {
+      const planMarkdown = planMarkdownFromSkippedExit(turnState, result);
+      if (planMarkdown.length > 0) {
+        yield* emitProposedPlanCompleted(context, {
+          planMarkdown,
+          rawSource: "claude.sdk.message",
+          rawMethod: "claude/result/plan-text",
+          rawPayload: result,
+        });
+      }
     }
 
     context.turns.push({
@@ -4275,6 +4321,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         lastAssistantUuid: resumeState?.resumeSessionAt,
         lastThreadStartedId: undefined,
         stopped: false,
+        inPlanMode: false,
       };
       yield* Ref.set(contextRef, context);
       sessions.set(threadId, context);
@@ -4402,11 +4449,13 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         try: () => context.query.setPermissionMode("plan"),
         catch: (cause) => toRequestError(input.threadId, "turn/setPermissionMode", cause),
       });
+      context.inPlanMode = true;
     } else if (input.interactionMode === "default") {
       yield* Effect.tryPromise({
         try: () => context.query.setPermissionMode(context.basePermissionMode ?? "default"),
         catch: (cause) => toRequestError(input.threadId, "turn/setPermissionMode", cause),
       });
+      context.inPlanMode = false;
     }
 
     const turnId = steeringTurnState?.turnId ?? TurnId.make(yield* randomUUIDv4);


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

Fixes #2519

## What Changed

`ClaudeAdapter.sendTurn` sets `inPlanMode` on the existing `interactionMode` plan/default branches. Absent `interactionMode` leaves the previous value unchanged.

`completeTurn` then calls the existing `emitProposedPlanCompleted` helper when the SDK result is present, status is `completed`, it is not a refusal, `inPlanMode` is true, the turn is not synthetic, `capturedProposedPlanKeys` is empty, and no user input is pending. Plan text comes from `result.result`, then assistant `fallbackText`. Raw source stays `claude.sdk.message`; the method is `claude/result/plan-text`.

## Why

Claude Opus in plan mode often writes the plan as markdown and skips `ExitPlanMode`. `proposedPlans` stays empty, so the Implement control never arms. Users type "go". Confirmed on the issue through 2026-08-05.

Implement already renders once `turn.proposed.completed` lands (`ChatView.tsx:2301`, `hasActionableProposedPlan` at `session-logic.ts:678`). Claude only filled that event from `ExitPlanMode` (`canUseTool` at `ClaudeAdapter.ts:3997`, assistant snapshot at `:2978`). `completeTurn` already owns successful turn end. One extra call through the existing helper, gated by `capturedProposedPlanKeys.size` (ExitPlanMode keys are `tool:${id}`, so the helper's markdown key would not collide), is the smallest way to arm the same control. Codex already emits this from a native plan item (`CodexAdapter.ts:1117`); Cursor from `cursor/create_plan` (`CursorAdapter.ts:626`).

Synthetic auto-close, interrupt, failed turns, refusals, pending AskUserQuestion, and later background turns stay out.

## Test

- `prefers result text over assistant text when ExitPlanMode is skipped` failed on `upstream/main` before the fix (`AssertionError: expected undefined to equal 'turn.proposed.completed'`). It passes once `completeTurn` emits through the existing helper.
- Skip cases: not plan mode, empty result and assistant text, `stop_reason: "refusal"`, ExitPlanMode already captured, pending user input, later synthetic turn.
- `vp test run apps/server/src/provider/Layers/ClaudeAdapter.test.ts` — 77 passed.
- Targeted lint on the two planned files: 0 errors (pre-existing `no-useless-spread` warning at `ClaudeAdapter.ts:3708`, untouched).
- `vp run --filter t3 typecheck`: ok (pre-existing suggestions in unrelated files).
- Did not run web, mobile, desktop, or other adapter suites.

## UI Changes

No UI change.

## Deliberately not included

- Promote/revert commands and composer UI from closed #2597. Implement already lives in `ComposerPrimaryActions.tsx:191` and `ChatView.tsx:5718`.
- A new `claude.sdk.text-fallback` `RuntimeEventRawSource` (`packages/contracts/src/providerRuntime.ts:21`). Existing `claude.sdk.message` plus `rawMethod` is enough.
- English `looksLikePlan` heading/list scoring. The gate is plan mode plus non-empty result/assistant text (`ClaudeAdapter.ts:2373`).
- `startSession` permission mapping (`ClaudeAdapter.ts:4134`, #7246).
- Assistant text-block identity (`ClaudeAdapter.ts:1802`, #7143).
- Stalled-stream backfill (`ClaudeAdapter.ts:1920`, #7142).
- Compact meter (`ClaudeAdapter.ts:3125`, #7249).
- Resume cursor (`ClaudeAdapter.ts:659`, #7198).
- Late tool results (`ClaudeAdapter.ts:1488`, #7192).
- Web/mobile Implement UI (`session-logic.ts:678`, `threadPresentation.ts:112`).
- Other adapters (`CodexAdapter.ts:1117`, `CursorAdapter.ts:626`). Grok and OpenCode have no `turn.proposed` path.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Implemented with grok-4.6 in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Claude plan mode to emit proposed plan when `ExitPlanMode` tool-use is skipped
> - In plan mode turns that complete without an `ExitPlanMode` tool-use, the adapter now emits a `turn.proposed.completed` event using result text (falling back to assistant text) via a new `planMarkdownFromSkippedExit` helper in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/7263/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc).
> - A new `inPlanMode` flag on `ClaudeSessionContext` tracks whether the current turn is in plan mode, set by `sendTurn` based on `interactionMode`.
> - Emission is skipped for refusals, synthetic turns, turns where a plan was already captured via `ExitPlanMode`, and turns with pending user input.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 92ec3da.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Claude adapter turn completion and plan-mode gating; reuses existing emit helper with dedupe guards and no UI or API contract changes.
> 
> **Overview**
> Fixes plan mode where **Implement** never appeared because Claude often finished with markdown in the SDK **result** instead of calling **ExitPlanMode**.
> 
> **ClaudeAdapter** now tracks **`inPlanMode`** on the session (set from `sendTurn` when `interactionMode` is `plan` or `default`). On a successful turn completion, if the turn is in plan mode and no plan was already captured from **ExitPlanMode**, it emits **`turn.proposed.completed`** through the existing helper, using **`planMarkdownFromSkippedExit`** (SDK **`result`** text first, then assistant text fallback) with raw method **`claude/result/plan-text`**.
> 
> Emission is skipped for non–plan-mode turns, refusals, empty text, duplicate capture after **ExitPlanMode**, pending **AskUserQuestion**, and synthetic follow-up turns. Tests cover the happy path and these guardrails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92ec3daab8055a1df85d2c2f3c04103e2619dca6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->