### PR TITLE
feat(web): show server versions on remote connections

### DIFF
--- a/apps/web/src/components/settings/ConnectionsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/ConnectionsSettings.logic.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vite-plus/test";
 import {
   applyWslEnableSelection,
   isQrShareableEndpoint,
+  remoteEnvironmentVersionLabel,
   selectQrEndpointOption,
 } from "./ConnectionsSettings.logic";
 
@@ -14,6 +15,22 @@ const baseWslState: DesktopWslState = {
   distros: [],
   preflightError: null,
 };
+
+describe("remoteEnvironmentVersionLabel", () => {
+  it("shows the complete connected server version, including nightly suffixes", () => {
+    expect(remoteEnvironmentVersionLabel("0.0.33-nightly.20260816", true)).toBe(
+      "v0.0.33-nightly.20260816",
+    );
+  });
+
+  it("marks a cached disconnected version as last seen", () => {
+    expect(remoteEnvironmentVersionLabel("0.0.32", false)).toBe("Last seen v0.0.32");
+  });
+
+  it("omits the label before a server version is known", () => {
+    expect(remoteEnvironmentVersionLabel(null, true)).toBeNull();
+  });
+});
 
 describe("applyWslEnableSelection", () => {
   it("clears WSL-only and updates the distro before enabling both backends", async () => {

--- a/apps/web/src/components/settings/ConnectionsSettings.logic.ts
+++ b/apps/web/src/components/settings/ConnectionsSettings.logic.ts
@@ -2,6 +2,15 @@ import type { AdvertisedEndpoint, DesktopBridge, DesktopWslState } from "@t3tool
 
 type WslEnableBridge = Pick<DesktopBridge, "setWslBackendEnabled" | "setWslDistro" | "setWslOnly">;
 
+export function remoteEnvironmentVersionLabel(
+  serverVersion: string | null,
+  isConnected: boolean,
+): string | null {
+  if (serverVersion === null) return null;
+  const version = `v${serverVersion}`;
+  return isConnected ? version : `Last seen ${version}`;
+}
+
 /**
  * A QR code encoding a loopback URL makes the scanning device dial itself, so
  * loopback endpoints stay copyable from the endpoint menu but are never

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -43,6 +43,7 @@ import { resolveDesktopPairingUrl, resolveHostedPairingUrl } from "./pairingUrls
 import {
   applyWslEnableSelection,
   isQrShareableEndpoint,
+  remoteEnvironmentVersionLabel,
   selectQrEndpointOption,
 } from "./ConnectionsSettings.logic";
 import {
@@ -1413,6 +1414,10 @@ function SavedBackendListRow({
   const metadataBits = [
     sshTarget ? `SSH ${formatDesktopSshTarget(sshTarget)}` : null,
     environment.relayManaged ? "T3 Connect" : null,
+    remoteEnvironmentVersionLabel(
+      environment.serverConfig?.environment.serverVersion ?? null,
+      isConnected,
+    ),
   ].filter((value): value is string => value !== null);
 
   // The WSL backend is a desktop-managed local backend (it surfaces as a bearer


### PR DESCRIPTION
Hello, just added the version in the connections page because i just forgot in what version my remote machines are. This helps me to quickly see and identified which ones i should update
<img width="1042" height="233" alt="image" src="https://github.com/user-attachments/assets/52b0049f-12d8-4f41-8481-63500d94f8c3" />
<img width="589" height="165" alt="image" src="https://github.com/user-attachments/assets/a6a6a1c6-483d-4359-89f6-a9c208eddbcb" />


# AI GENERATED FROM HERE

## What Changed

Remote environment rows now show the connected server version alongside their existing metadata. The full package version is preserved, including nightly suffixes.

When a disconnected environment still has cached server configuration, the row labels that value as `Last seen v…`. Environments that have never reported a version remain unchanged.

## Why

A client can connect to servers running different T3 Code versions, but Settings only surfaced the exact version when there was a mismatch. Showing the version on every known remote connection makes the environment state obvious without adding a new request or changing any wire contracts.

## UI Changes

Before: remote connection metadata only showed the connection type, such as `T3 Connect` or an SSH target.

After: connected rows append the exact version, such as `T3 Connect · v0.0.33-nightly.20260816`; disconnected rows with cached configuration show `Last seen v…`.

Screenshot pending attachment from the verified local fixture.

## Verification

- `pnpm --filter @t3tools/web exec vp test run src/components/settings/ConnectionsSettings.logic.test.ts --project unit` — 11 tests passed
- `pnpm --filter @t3tools/web typecheck`
- targeted lint and format checks passed
- `git diff --check`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for the UI change
- [x] No video is needed; there is no animation or interaction change

Model/harness: GPT-5.6 Sol via the Codex harness in T3 Code.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change in settings UI, reusing cached server config with covered formatting logic and no auth or connection behavior changes.
> 
> **Overview**
> Remote environment rows in **Settings → Connections** now include a server version in the metadata line (alongside SSH target and T3 Connect), using existing `serverConfig.environment.serverVersion`—no new API or contract changes.
> 
> A new **`remoteEnvironmentVersionLabel`** helper formats the string: connected backends show **`v{version}`** (full semver, including nightly suffixes); disconnected backends with cached config show **`Last seen v{version}`**; unknown versions add nothing. Unit tests cover those three cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ccd39624ebe12dd75856e389db71e78d4295860. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show server version labels on remote connections in settings
> Adds a `remoteEnvironmentVersionLabel` utility in [ConnectionsSettings.logic.ts](https://github.com/pingdotgg/t3code/pull/7271/files#diff-a7a170d2c0884c270c94cda8b4f4498c1488857ae1c1cfda21e6233e15ec0110) that formats a server version string as `v{version}` when connected or `Last seen v{version}` when disconnected, returning null when no version is available. Each saved backend row in [ConnectionsSettings.tsx](https://github.com/pingdotgg/t3code/pull/7271/files#diff-8d3463be4371da0f55c5b65bb143b023e8c0ea0ee1db0816b2a21f11f3a1fce9) now includes this label in its metadata display.
> >
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ccd396.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->