### PR TITLE
feat(web): navigate files from the file preview breadcrumbs

### DIFF
--- a/apps/web/src/components/files/FileBreadcrumbMenu.tsx
+++ b/apps/web/src/components/files/FileBreadcrumbMenu.tsx
@@ -1,0 +1,151 @@
+import type { EnvironmentId, ProjectEntry } from "@t3tools/contracts";
+import { useMemo } from "react";
+
+import {
+  Menu,
+  MenuItem,
+  MenuPopup,
+  MenuSub,
+  MenuSubPopup,
+  MenuSubTrigger,
+  MenuTrigger,
+} from "~/components/ui/menu";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
+import { cn } from "~/lib/utils";
+
+import { useProjectEntriesQuery } from "./projectFilesQueryState";
+
+interface FileBreadcrumbMenuProps {
+  environmentId: EnvironmentId;
+  cwd: string;
+  /** Directory the menu lists; the empty string is the project root. */
+  directoryPath: string;
+  label: string;
+  /** Tooltip text, kept as the full path the crumb points at. */
+  title: string;
+  className?: string;
+  onOpenFile: (relativePath: string) => void;
+}
+
+type FileBreadcrumbMenuItemsProps = Pick<
+  FileBreadcrumbMenuProps,
+  "environmentId" | "cwd" | "directoryPath" | "onOpenFile"
+>;
+
+function entryName(path: string): string {
+  return path.slice(path.lastIndexOf("/") + 1);
+}
+
+/**
+ * Immediate children of `directoryPath` out of the flat workspace listing,
+ * directories first so the menu reads like the file tree.
+ */
+function directoryChildren(
+  entries: ReadonlyArray<ProjectEntry>,
+  directoryPath: string,
+): ProjectEntry[] {
+  const prefix = directoryPath ? `${directoryPath}/` : "";
+  return entries
+    .filter(
+      (entry) => entry.path.startsWith(prefix) && !entry.path.slice(prefix.length).includes("/"),
+    )
+    .toSorted((left, right) =>
+      left.kind === right.kind
+        ? entryName(left.path).localeCompare(entryName(right.path))
+        : left.kind === "directory"
+          ? -1
+          : 1,
+    );
+}
+
+function FileBreadcrumbMenuItems({
+  environmentId,
+  cwd,
+  directoryPath,
+  onOpenFile,
+}: FileBreadcrumbMenuItemsProps) {
+  const entriesQuery = useProjectEntriesQuery(environmentId, cwd);
+  const entries = entriesQuery.data?.entries;
+  const children = useMemo(
+    () => (entries ? directoryChildren(entries, directoryPath) : []),
+    [directoryPath, entries],
+  );
+
+  if (children.length === 0) {
+    return <MenuItem disabled>{entries ? "No files" : "Loading files…"}</MenuItem>;
+  }
+
+  return (
+    <>
+      {children.map((entry) =>
+        entry.kind === "directory" ? (
+          <MenuSub key={entry.path}>
+            <MenuSubTrigger>{entryName(entry.path)}</MenuSubTrigger>
+            <MenuSubPopup className="min-w-40 max-w-72">
+              <FileBreadcrumbMenuItems
+                environmentId={environmentId}
+                cwd={cwd}
+                directoryPath={entry.path}
+                onOpenFile={onOpenFile}
+              />
+            </MenuSubPopup>
+          </MenuSub>
+        ) : (
+          <MenuItem key={entry.path} onClick={() => onOpenFile(entry.path)}>
+            {entryName(entry.path)}
+          </MenuItem>
+        ),
+      )}
+    </>
+  );
+}
+
+/**
+ * Breadcrumb crumb that opens the directory it points at, so a file can be
+ * swapped without opening the file explorer. Entries are only queried once the
+ * menu opens, since the popup mounts lazily.
+ */
+export function FileBreadcrumbMenu({
+  environmentId,
+  cwd,
+  directoryPath,
+  label,
+  title,
+  className,
+  onOpenFile,
+}: FileBreadcrumbMenuProps) {
+  return (
+    <Menu>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <MenuTrigger
+              render={
+                <button
+                  type="button"
+                  className={cn(
+                    "max-w-40 cursor-pointer truncate rounded px-1 py-0.5 hover:bg-accent hover:text-accent-foreground data-popup-open:bg-accent data-popup-open:text-accent-foreground",
+                    className,
+                  )}
+                />
+              }
+            />
+          }
+        >
+          {label}
+        </TooltipTrigger>
+        <TooltipPopup side="top" className="max-w-80">
+          {title}
+        </TooltipPopup>
+      </Tooltip>
+      <MenuPopup align="start" sideOffset={6} className="min-w-40 max-w-72">
+        <FileBreadcrumbMenuItems
+          environmentId={environmentId}
+          cwd={cwd}
+          directoryPath={directoryPath}
+          onOpenFile={onOpenFile}
+        />
+      </MenuPopup>
+    </Menu>
+  );
+}

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -42,6 +42,7 @@ import { useAtomCommand } from "~/state/use-atom-command";
 import { useAtomQueryRunner } from "~/state/use-atom-query-runner";
 
 import FileBrowserPanel from "./FileBrowserPanel";
+import { FileBreadcrumbMenu } from "./FileBreadcrumbMenu";
 import {
   type FileCommentAnnotationEntry,
   type FileCommentAnnotationGroup,
@@ -878,27 +879,27 @@ export default function FilePreviewPanel({
                   data-current-file-crumb={crumb.kind === "file"}
                 >
                   {index > 0 ? (
-                    <ChevronRight className="mx-1 size-3.5 shrink-0 text-muted-foreground/60" />
+                    <ChevronRight className="mx-0.5 size-3.5 shrink-0 text-muted-foreground/60" />
                   ) : null}
-                  <Tooltip>
-                    <TooltipTrigger
-                      render={
-                        <span
-                          className={cn(
-                            "max-w-40 truncate",
-                            crumb.kind === "file"
-                              ? "font-medium text-foreground"
-                              : "text-muted-foreground",
-                          )}
-                        />
-                      }
-                    >
-                      {crumb.label}
-                    </TooltipTrigger>
-                    <TooltipPopup side="top" className="max-w-80">
-                      {crumb.path || projectName}
-                    </TooltipPopup>
-                  </Tooltip>
+                  <FileBreadcrumbMenu
+                    environmentId={environmentId}
+                    cwd={cwd}
+                    // A file crumb browses the directory that contains it, so
+                    // the last crumb offers the sibling files of what's open.
+                    directoryPath={
+                      crumb.kind === "file"
+                        ? crumb.path.slice(0, Math.max(0, crumb.path.lastIndexOf("/")))
+                        : crumb.path
+                    }
+                    label={crumb.label}
+                    title={crumb.path || projectName}
+                    className={
+                      crumb.kind === "file"
+                        ? "font-medium text-foreground"
+                        : "text-muted-foreground"
+                    }
+                    onOpenFile={onOpenFile}
+                  />
                 </div>
               ))}
             </div>


### PR DESCRIPTION
Placeholder — description to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only navigation reusing existing file listing and open handlers; no auth or persistence changes.
> 
> **Overview**
> **File preview breadcrumbs are now interactive** so you can switch files without opening the file explorer.
> 
> Each crumb is a `FileBreadcrumbMenu` that opens a nested menu of that segment’s directory (directories first, like the tree). Choosing a file calls the existing `onOpenFile` handler. The **file** crumb lists **siblings** in its parent folder; path segments still list that folder’s children. Tooltips and styling for the current file vs path segments are unchanged.
> 
> Listing uses `useProjectEntriesQuery` (same source as the explorer) and loads when the menu opens via the lazy popup mount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dcbc12e3083dd57337c2cd345c74c591699cc21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add clickable breadcrumb menus to file preview panel for directory navigation
> - Adds a `FileBreadcrumbMenu` component to [FilePreviewPanel.tsx](https://github.com/pingdotgg/t3code/pull/7275/files#diff-776fa2f4352bbbf118206cfd39f4cf95c38e47b1629aa20a6c8c028cadf458ea) that replaces static breadcrumb segments with clickable menus.
> - Each breadcrumb opens a popup listing the immediate children of the represented directory; subdirectories expand as nested submenus, and files can be opened directly from the menu.
> - Directory children are lazily fetched via `useProjectEntriesQuery` and sorted with directories first, then alphabetically.
> - Slightly reduces the `ChevronRight` separator margin from `mx-1` to `mx-0.5`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4dcbc12. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->