### PR TITLE
fix(mobile): rotate snoozed and settled shelf chevrons

### DIFF
--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -135,10 +135,11 @@ export const ThreadListV2SnoozedShelfHeader = memo(function ThreadListV2SnoozedS
       </Text>
       <View className="h-px flex-1 bg-blue-500/20 dark:bg-blue-400/15" />
       <SymbolView
-        name={props.expanded ? "chevron.up" : "chevron.down"}
+        name="chevron.down"
         size={10}
         tintColor={colorScheme === "dark" ? SNOOZE_ACCENT_DARK : SNOOZE_ACCENT_LIGHT}
         type="monochrome"
+        style={{ transform: [{ rotate: props.expanded ? "180deg" : "0deg" }] }}
       />
     </Pressable>
   );
@@ -171,10 +172,11 @@ export const ThreadListV2SettledShelfHeader = memo(function ThreadListV2SettledS
       </Text>
       <View className="h-px flex-1 bg-border" />
       <SymbolView
-        name={props.expanded ? "chevron.up" : "chevron.down"}
+        name="chevron.down"
         size={10}
         tintColor={mutedColor}
         type="monochrome"
+        style={{ transform: [{ rotate: props.expanded ? "180deg" : "0deg" }] }}
       />
     </Pressable>
   );


### PR DESCRIPTION
The Snoozed and Settled shelf chevrons on the mobile threads list never moved and pointed in opposite directions: both headers swapped between the `chevron.up`/`chevron.down` SF Symbols based on expanded state, but the native symbol view does not redraw when only the symbol name changes, so each chevron stayed frozen at whatever direction it first rendered.

Fixed by matching the disclosure-chevron convention already shipped in `ConnectionEnvironmentRow` and `CloudEnvironmentRows`: keep a single `chevron.down` symbol and rotate it 180° with a state-driven style transform. Both headers now follow the same rule (down when collapsed, up when expanded) and give feedback on every tap. No continuous animation — the transform only changes with the expanded state.

Before: the issue's screenshots (fig1–fig3 at https://t3code-chevron-shots.pages.dev/) show Snoozed open pointing down while Settled closed points up. After-screenshots were not captured — this change was made without simulator access; happy to add them on request.

Verification: `vp run typecheck` in `apps/mobile` (exit 0) and `vp lint` on the changed file (0 warnings). No test exists for this presentational component and no behavior contract changed, so none was added.

Fixes #7121

Claude Fable 5 via Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentational-only change to two shelf header icons; no logic, API, or data handling.
> 
> **Overview**
> **Snoozed** and **Settled** thread-list shelf headers now show chevrons that actually flip when you expand or collapse the section.
> 
> Both headers used to swap SF Symbol names (`chevron.up` / `chevron.down`) with `expanded`, but the native `SymbolView` does not reliably redraw when only the name changes, so the icons stayed stuck on their first render (and could point the wrong way).
> 
> The fix matches **ConnectionEnvironmentRow** and **CloudEnvironmentRows**: always use `chevron.down` and drive direction with a style `transform` rotate (`0deg` collapsed, `180deg` expanded). No animation—only the transform updates with state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8d1176c0da205d108f38d21666d4a536ae244c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rotate snoozed and settled shelf chevrons on expand instead of swapping glyphs
> Replaces the conditional `chevron.up`/`chevron.down` glyph swap in `ThreadListV2SnoozedShelfHeader` and `ThreadListV2SettledShelfHeader` with a CSS transform that rotates a fixed `chevron.down` icon 180° when expanded. This produces a smoother visual transition and removes the need for conditional icon names.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8d1176.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->