### PR TITLE
fix(web): hide thread jump hints while the terminal is focused

### DIFF
--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -3397,7 +3397,7 @@ export default function LegacySidebar() {
     [threadJumpCommandByKey],
   );
   const sidebarShortcutContext = {
-    terminalFocus: false,
+    terminalFocus: isTerminalFocused(),
     terminalOpen: routeTerminalOpen,
     modelPickerOpen: isModelPickerOpen(),
   };

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -73,6 +73,7 @@ import {
 import { isDesktopLocalConnectionTarget } from "../connection/desktopLocal";
 import { useDesktopLocalBootstraps } from "../connection/useDesktopLocalBootstraps";
 import { isElectron } from "../env";
+import { useTerminalFocus } from "../hooks/useTerminalFocus";
 import { useOpenPrLink } from "../lib/openPullRequestLink";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { isMacPlatform } from "../lib/utils";
@@ -3075,6 +3076,7 @@ export default function LegacySidebar() {
   const setSelectionAnchor = useThreadSelectionStore((s) => s.setAnchor);
   const platform = navigator.platform;
   const shortcutModifiers = useShortcutModifierState();
+  const terminalFocused = useTerminalFocus();
   const { environments } = useEnvironments();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
   const environmentLabelById = useMemo(
@@ -3397,7 +3399,7 @@ export default function LegacySidebar() {
     [threadJumpCommandByKey],
   );
   const sidebarShortcutContext = {
-    terminalFocus: isTerminalFocused(),
+    terminalFocus: terminalFocused,
     terminalOpen: routeTerminalOpen,
     modelPickerOpen: isModelPickerOpen(),
   };

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3308,7 +3308,10 @@ export default function Sidebar() {
   const shouldShowJumpHintsNow = shouldShowThreadJumpHintsForModifiers(
     shortcutModifiers,
     keybindings,
-    { platform: navigator.platform },
+    {
+      platform: navigator.platform,
+      context: { terminalFocus: isTerminalFocused() },
+    },
   );
   useEffect(() => {
     setShowJumpHints(shouldShowJumpHintsNow);

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -83,6 +83,7 @@ import {
   threadTraversalDirectionFromCommand,
 } from "../keybindings";
 import { useShortcutModifierState } from "../shortcutModifierState";
+import { useTerminalFocus } from "../hooks/useTerminalFocus";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { isModelPickerOpen } from "../modelPickerVisibility";
 import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../terminalUiStateStore";
@@ -3305,13 +3306,14 @@ export default function Sidebar() {
   // match a thread-jump binding. Adding Shift (screenshots) or Alt no
   // longer matches ⌘1..9, so the overlay hides for chords like ⌘⇧4.
   const shortcutModifiers = useShortcutModifierState();
+  const terminalFocused = useTerminalFocus();
   const shouldShowJumpHintsNow = shouldShowThreadJumpHintsForModifiers(
     shortcutModifiers,
     keybindings,
     {
       platform: navigator.platform,
       context: {
-        terminalFocus: isTerminalFocused(),
+        terminalFocus: terminalFocused,
         terminalOpen: routeTerminalOpen,
         modelPickerOpen: isModelPickerOpen(),
       },

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3310,7 +3310,11 @@ export default function Sidebar() {
     keybindings,
     {
       platform: navigator.platform,
-      context: { terminalFocus: isTerminalFocused() },
+      context: {
+        terminalFocus: isTerminalFocused(),
+        terminalOpen: routeTerminalOpen,
+        modelPickerOpen: isModelPickerOpen(),
+      },
     },
   );
   useEffect(() => {

--- a/apps/web/src/hooks/useTerminalFocus.test.ts
+++ b/apps/web/src/hooks/useTerminalFocus.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from "vite-plus/test";
+
+import { subscribeToTerminalFocusChanges } from "./useTerminalFocus";
+
+const originalWindow = globalThis.window;
+
+afterEach(() => {
+  if (originalWindow === undefined) {
+    delete (globalThis as { window?: Window }).window;
+  } else {
+    globalThis.window = originalWindow;
+  }
+});
+
+describe("subscribeToTerminalFocusChanges", () => {
+  it("notifies on focus transitions until unsubscribed", () => {
+    const listeners = new Map<string, Set<() => void>>();
+    globalThis.window = {
+      addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => {
+        const callbacks = listeners.get(type) ?? new Set<() => void>();
+        callbacks.add(listener as () => void);
+        listeners.set(type, callbacks);
+      },
+      removeEventListener: (type: string, listener: EventListenerOrEventListenerObject) => {
+        listeners.get(type)?.delete(listener as () => void);
+      },
+    } as unknown as Window & typeof globalThis;
+    let notifications = 0;
+
+    const unsubscribe = subscribeToTerminalFocusChanges(() => {
+      notifications += 1;
+    });
+
+    for (const listener of listeners.get("focusin") ?? []) listener();
+    for (const listener of listeners.get("focusout") ?? []) listener();
+    expect(notifications).toBe(2);
+
+    unsubscribe();
+    for (const listener of listeners.get("focusin") ?? []) listener();
+    expect(notifications).toBe(2);
+  });
+});

--- a/apps/web/src/hooks/useTerminalFocus.ts
+++ b/apps/web/src/hooks/useTerminalFocus.ts
@@ -1,0 +1,16 @@
+import { useSyncExternalStore } from "react";
+
+import { isTerminalFocused } from "../lib/terminalFocus";
+
+export function subscribeToTerminalFocusChanges(listener: () => void): () => void {
+  window.addEventListener("focusin", listener, true);
+  window.addEventListener("focusout", listener, true);
+  return () => {
+    window.removeEventListener("focusin", listener, true);
+    window.removeEventListener("focusout", listener, true);
+  };
+}
+
+export function useTerminalFocus(): boolean {
+  return useSyncExternalStore(subscribeToTerminalFocusChanges, isTerminalFocused, () => false);
+}

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -451,6 +451,21 @@ describe("thread navigation helpers", () => {
       }),
     );
   });
+
+  it("never shows jump hints while the terminal is focused, even with an unrestricted binding", () => {
+    assert.isFalse(
+      shouldShowThreadJumpHints(event({ metaKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: true },
+      }),
+    );
+    assert.isTrue(
+      shouldShowThreadJumpHints(event({ metaKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: false },
+      }),
+    );
+  });
 });
 
 describe("model picker navigation helpers", () => {

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -301,8 +301,8 @@ export function shouldShowThreadJumpHintsForModifiers(
   keybindings: ResolvedKeybindingsConfig,
   options?: ShortcutMatchOptions,
 ): boolean {
-  // The embedded terminal owns keystrokes while it has focus: xterm.js
-  // consumes the keydown and can write the pressed key into the shell
+  // The embedded terminal owns keystrokes while it has focus: the Ghostty
+  // surface encodes the keydown and can write the pressed key into the shell
   // before our window-level shortcut handling ever runs, regardless of any
   // configured `when` clause on the jump command. Advertising jump hints
   // here would promise a shortcut that instead types into the terminal, so

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -301,6 +301,16 @@ export function shouldShowThreadJumpHintsForModifiers(
   keybindings: ResolvedKeybindingsConfig,
   options?: ShortcutMatchOptions,
 ): boolean {
+  // The embedded terminal owns keystrokes while it has focus: xterm.js
+  // consumes the keydown and can write the pressed key into the shell
+  // before our window-level shortcut handling ever runs, regardless of any
+  // configured `when` clause on the jump command. Advertising jump hints
+  // here would promise a shortcut that instead types into the terminal, so
+  // never show them while the terminal is focused.
+  if (resolveContext(options).terminalFocus) {
+    return false;
+  }
+
   const platform = resolvePlatform(options);
 
   for (const command of THREAD_JUMP_KEYBINDING_COMMANDS) {


### PR DESCRIPTION
Holding ⌘ with the embedded terminal focused showed the sidebar's thread-jump hint overlay, but pressing a shown key typed the character into the terminal instead of navigating: xterm.js consumes the keydown before the window-level shortcut handler runs, regardless of the binding's `when` clause. The overlay advertised shortcuts that could not fire.

Fixed by suppressing jump hints whenever the terminal has focus, in the shared `shouldShowThreadJumpHintsForModifiers` predicate so the event-based delegate and the direct callers in both the current and legacy sidebars are all covered. This matches the existing `when: "!terminalFocus"` convention other terminal-aware commands already use; making the shortcuts execute through the terminal instead would have required new coupling between the terminal drawer's key handler and sidebar navigation, so the smaller honest fix won. The actual navigation path is untouched.

Verification: `vp test run apps/web/src/keybindings.test.ts` (48/48 passing, including a new case asserting suppression with `terminalFocus: true` and visibility with `false`), `tsgo --noEmit` for apps/web (exit 0), `vp lint` on the changed files (clean). No live desktop run was performed — that requires explicit permission in this repo and wasn't requested.

Fixes #7223

Claude Fable 5 via Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only shortcut-hint gating with a small reactive hook; no changes to navigation, auth, or data paths.
> 
> **Overview**
> Fixes misleading sidebar **thread-jump hint overlays** when the embedded terminal has focus: holding ⌘ could still show ⌘1–9 badges even though those keys are consumed by the terminal, not navigation.
> 
> **`shouldShowThreadJumpHintsForModifiers`** now bails out when shortcut context has **`terminalFocus: true`**, so hint visibility matches the reality that jump shortcuts cannot fire from the terminal surface. **`Sidebar`** and **`LegacySidebar`** supply live focus via a new **`useTerminalFocus`** hook (`useSyncExternalStore` on window `focusin`/`focusout`, backed by **`isTerminalFocused`**).
> 
> Thread-jump **navigation** behavior is unchanged; only when hints are shown is affected. Tests cover the new predicate and subscription lifecycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2880f4ba8a312c79859330473d21b8a8a2e23b14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide thread jump hints in the sidebar while the terminal is focused
> - Adds a `useTerminalFocus` hook using `useSyncExternalStore` that tracks terminal focus state via window `focusin`/`focusout` events.
> - Updates `shouldShowThreadJumpHintsForModifiers` in [keybindings.ts](https://github.com/pingdotgg/t3code/pull/7277/files#diff-0c56a39781768a3ed42f3d306e35b87e9d2426ccb4a81010bc2c4fe735001385) to return `false` immediately when `context.terminalFocus` is true.
> - Passes live terminal focus state from `useTerminalFocus` into the hint visibility check in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/7277/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) and [LegacySidebar.tsx](https://github.com/pingdotgg/t3code/pull/7277/files#diff-ef6c49faf62e0e2403f09772084537ac313e826ae0f90db230a898204f3bdd86).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2880f4b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->