### PR TITLE
feat(web): terminal link context menu actions

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -824,6 +824,7 @@ interface PersistentThreadTerminalDrawerProps {
   closeShortcutLabel: string | undefined;
   keybindings: ResolvedKeybindingsConfig;
   onAddTerminalContext: (selection: TerminalContextSelection) => void;
+  onAddTerminalLink: (link: string) => void;
 }
 
 const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDrawer({
@@ -838,6 +839,7 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
   closeShortcutLabel,
   keybindings,
   onAddTerminalContext,
+  onAddTerminalLink,
 }: PersistentThreadTerminalDrawerProps) {
   const openTerminal = useAtomCommand(terminalEnvironment.open, "terminal open");
   const writeTerminal = useAtomCommand(terminalEnvironment.write, "terminal write");
@@ -1137,6 +1139,13 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
     },
     [onAddTerminalContext, visible],
   );
+  const handleAddTerminalLink = useCallback(
+    (link: string) => {
+      if (!visible) return;
+      onAddTerminalLink(link);
+    },
+    [onAddTerminalLink, visible],
+  );
 
   if (!project || (!terminalUiState.terminalOpen && !active) || !cwd) {
     return null;
@@ -1179,6 +1188,7 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
           onCloseTerminal={closeTerminal}
           onHeightChange={setTerminalHeight}
           onAddTerminalContext={handleAddTerminalContext}
+          onAddTerminalLink={handleAddTerminalLink}
           terminalLabelsById={terminalLabelsById}
           terminalLaunchLocationsById={terminalLaunchLocationsById}
         />
@@ -1195,6 +1205,7 @@ interface PersistentThreadTerminalPanelProps {
   focusRequestId: number;
   keybindings: ResolvedKeybindingsConfig;
   onAddTerminalContext: (selection: TerminalContextSelection) => void;
+  onAddTerminalLink: (link: string) => void;
   onSplitTerminal: () => void;
   onSplitTerminalVertical: () => void;
   onNewTerminal: () => void;
@@ -1214,6 +1225,7 @@ const PersistentThreadTerminalPanel = memo(function PersistentThreadTerminalPane
   focusRequestId,
   keybindings,
   onAddTerminalContext,
+  onAddTerminalLink,
   onSplitTerminal,
   onSplitTerminalVertical,
   onNewTerminal,
@@ -1352,6 +1364,7 @@ const PersistentThreadTerminalPanel = memo(function PersistentThreadTerminalPane
       onCloseTerminal={onCloseTerminal}
       onHeightChange={() => undefined}
       onAddTerminalContext={onAddTerminalContext}
+      onAddTerminalLink={onAddTerminalLink}
       terminalLabelsById={terminalLabelsById}
       terminalLaunchLocationsById={terminalLaunchLocationsById}
       keybindings={keybindings}
@@ -3613,6 +3626,21 @@ export default function ChatView(props: ChatViewProps) {
   const addTerminalContextToDraft = useCallback(
     (selection: TerminalContextSelection) => {
       composerRef.current?.addTerminalContext(selection);
+    },
+    [composerRef],
+  );
+  const addTerminalLinkToDraft = useCallback(
+    (text: string) => {
+      const inserted =
+        composerRef.current?.insertTextAtEnd(`${text} `, {
+          ensureLeadingBoundary: true,
+        }) ?? false;
+      if (inserted) return;
+      toastManager.add({
+        type: "error",
+        title: "Unable to add to chat",
+        description: "The chat isn't ready to accept input right now.",
+      });
     },
     [composerRef],
   );
@@ -8019,6 +8047,7 @@ export default function ChatView(props: ChatViewProps) {
         focusRequestId={terminalFocusRequestId}
         keybindings={keybindings}
         onAddTerminalContext={addTerminalContextToDraft}
+        onAddTerminalLink={addTerminalLinkToDraft}
         onSplitTerminal={splitPanelTerminal}
         onSplitTerminalVertical={splitPanelTerminalVertical}
         onNewTerminal={addTerminalSurface}
@@ -8624,6 +8653,7 @@ export default function ChatView(props: ChatViewProps) {
             closeShortcutLabel={closeTerminalShortcutLabel ?? undefined}
             keybindings={keybindings}
             onAddTerminalContext={addTerminalContextToDraft}
+            onAddTerminalLink={addTerminalLinkToDraft}
           />
         ))}
       </div>

--- a/apps/web/src/components/ThreadTerminalDrawer.test.ts
+++ b/apps/web/src/components/ThreadTerminalDrawer.test.ts
@@ -4,9 +4,31 @@ import {
   shouldClearTerminalSelectionAction,
   shouldHandleTerminalExit,
   terminalContextMenuItems,
+  terminalFileManagerPath,
   terminalLinkChatText,
+  terminalLinkCopyText,
   terminalSelectionLineRange,
 } from "./ThreadTerminalDrawer";
+
+describe("terminalFileManagerPath", () => {
+  it("resolves relative paths and removes terminal positions", () => {
+    expect(terminalFileManagerPath("src/index.ts:12:3", "/Users/olive/project")).toBe(
+      "/Users/olive/project/src/index.ts",
+    );
+  });
+});
+
+describe("terminalLinkCopyText", () => {
+  it("removes terminal positions from paths", () => {
+    expect(terminalLinkCopyText("src/index.ts:12:3")).toBe("src/index.ts");
+  });
+
+  it("leaves URLs intact", () => {
+    expect(terminalLinkCopyText("https://t3.codes/docs#terminal")).toBe(
+      "https://t3.codes/docs#terminal",
+    );
+  });
+});
 
 describe("terminalLinkChatText", () => {
   it("resolves relative paths against the terminal cwd", () => {
@@ -42,12 +64,13 @@ describe("terminalContextMenuItems", () => {
       hasSelection: false,
       link: "src/components/ThreadTerminalDrawer.tsx",
       canOpenInPreview: false,
-      openLabel: "Open in editor",
-      revealLabel: null,
+      openLabel: "Open in Zed",
+      revealLabel: "Reveal in Finder",
     };
 
     expect(terminalContextMenuItems(options)).toEqual([
-      { id: "open-link", label: "Open in editor" },
+      { id: "open-link", label: "Open in Zed" },
+      { id: "reveal-link", label: "Reveal in Finder" },
       { id: "add-link-to-chat", label: "Add path to chat" },
       { id: "copy-link", label: "Copy path", icon: "copy" },
       { id: "add-to-chat", label: "Add to chat", disabled: true },
@@ -72,6 +95,25 @@ describe("terminalContextMenuItems", () => {
       { id: "copy-link", label: "Copy link", icon: "copy" },
       { id: "add-to-chat", label: "Add to chat", disabled: false },
       { id: "copy", label: "Copy", disabled: false },
+      { id: "paste", label: "Paste" },
+    ]);
+  });
+
+  it("omits file-manager actions when reveal is unavailable", () => {
+    expect(
+      terminalContextMenuItems({
+        hasSelection: false,
+        link: "src/index.ts",
+        canOpenInPreview: false,
+        openLabel: "Open in editor",
+        revealLabel: null,
+      }),
+    ).toEqual([
+      { id: "open-link", label: "Open in editor" },
+      { id: "add-link-to-chat", label: "Add path to chat" },
+      { id: "copy-link", label: "Copy path", icon: "copy" },
+      { id: "add-to-chat", label: "Add to chat", disabled: true },
+      { id: "copy", label: "Copy", disabled: true },
       { id: "paste", label: "Paste" },
     ]);
   });

--- a/apps/web/src/components/ThreadTerminalDrawer.test.ts
+++ b/apps/web/src/components/ThreadTerminalDrawer.test.ts
@@ -143,6 +143,25 @@ describe("terminalContextMenuItems", () => {
       { id: "paste", label: "Paste" },
     ]);
   });
+
+  it("omits link chat actions when no chat target is available", () => {
+    expect(
+      terminalContextMenuItems({
+        hasSelection: false,
+        link: "https://t3.codes",
+        canAddLinkToChat: false,
+        canOpenInPreview: false,
+        openLabel: "Open in editor",
+        revealLabel: null,
+      }),
+    ).toEqual([
+      { id: "open-link-external", label: "Open in system browser" },
+      { id: "copy-link", label: "Copy link", icon: "copy" },
+      { id: "add-to-chat", label: "Add to chat", disabled: true },
+      { id: "copy", label: "Copy", disabled: true },
+      { id: "paste", label: "Paste" },
+    ]);
+  });
 });
 
 describe("terminal selection actions", () => {

--- a/apps/web/src/components/ThreadTerminalDrawer.test.ts
+++ b/apps/web/src/components/ThreadTerminalDrawer.test.ts
@@ -51,6 +51,16 @@ describe("terminalLinkChatText", () => {
     );
   });
 
+  it("keeps a Windows drive root intact", () => {
+    const separator = String.fromCharCode(92);
+    expect(
+      terminalLinkChatText(
+        `C:${separator}`,
+        `C:${separator}Users${separator}olive${separator}project`,
+      ),
+    ).toBe("[](C:%5C)");
+  });
+
   it("leaves URLs intact regardless of scheme casing", () => {
     expect(terminalLinkChatText("HTTPS://t3.codes/docs", "/Users/olive/project")).toBe(
       "HTTPS://t3.codes/docs",
@@ -114,6 +124,22 @@ describe("terminalContextMenuItems", () => {
       { id: "copy-link", label: "Copy path", icon: "copy" },
       { id: "add-to-chat", label: "Add to chat", disabled: true },
       { id: "copy", label: "Copy", disabled: true },
+      { id: "paste", label: "Paste" },
+    ]);
+  });
+
+  it("omits selection chat actions when no chat target is available", () => {
+    expect(
+      terminalContextMenuItems({
+        hasSelection: true,
+        link: null,
+        canOpenInPreview: false,
+        openLabel: "Open in editor",
+        revealLabel: null,
+        canAddToChat: false,
+      }),
+    ).toEqual([
+      { id: "copy", label: "Copy", disabled: false },
       { id: "paste", label: "Paste" },
     ]);
   });

--- a/apps/web/src/components/ThreadTerminalDrawer.test.ts
+++ b/apps/web/src/components/ThreadTerminalDrawer.test.ts
@@ -1,95 +1,79 @@
-import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { describe, expect, it } from "vite-plus/test";
 
 import {
   shouldClearTerminalSelectionAction,
   shouldHandleTerminalExit,
   terminalContextMenuItems,
+  terminalLinkChatText,
   terminalSelectionLineRange,
-  terminalSelectionMenuItems,
-  terminalThemeFromApp,
 } from "./ThreadTerminalDrawer";
 
-describe("terminal selection menus", () => {
-  it("omits Add to chat when the terminal has no chat target", () => {
-    expect(terminalSelectionMenuItems().map(({ id }) => id)).toEqual(["add-to-chat", "copy"]);
-    expect(terminalContextMenuItems({ hasSelection: true }).map(({ id }) => id)).toEqual([
-      "add-to-chat",
-      "copy",
-      "paste",
-    ]);
-
-    expect(terminalSelectionMenuItems({ canAddToChat: false }).map(({ id }) => id)).toEqual([
-      "copy",
-    ]);
+describe("terminalLinkChatText", () => {
+  it("resolves relative paths against the terminal cwd", () => {
     expect(
-      terminalContextMenuItems({ hasSelection: true, canAddToChat: false }).map(({ id }) => id),
-    ).toEqual(["copy", "paste"]);
+      terminalLinkChatText("src/components/ThreadTerminalDrawer.tsx", "/Users/olive/project"),
+    ).toBe(
+      "[ThreadTerminalDrawer.tsx](/Users/olive/project/src/components/ThreadTerminalDrawer.tsx)",
+    );
+  });
+
+  it("removes terminal positions before serializing a file link", () => {
+    expect(terminalLinkChatText("src/index.ts:12:3", "/Users/olive/project")).toBe(
+      "[index.ts](/Users/olive/project/src/index.ts)",
+    );
+  });
+
+  it("trims trailing separators before serializing a directory link", () => {
+    expect(terminalLinkChatText("/Users/olive/project/dist/", "/Users/olive/project")).toBe(
+      "[dist](/Users/olive/project/dist)",
+    );
+  });
+
+  it("leaves URLs intact regardless of scheme casing", () => {
+    expect(terminalLinkChatText("HTTPS://t3.codes/docs", "/Users/olive/project")).toBe(
+      "HTTPS://t3.codes/docs",
+    );
   });
 });
 
-describe("terminalThemeFromApp", () => {
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
-  it("uses terminal colors inherited by the mount instead of a light document theme", () => {
-    const root = { classList: { contains: () => false } };
-    const body = {};
-    const drawer = {};
-    let canvasColor = "#000";
-    const colors: Record<string, [number, number, number, number]> = {
-      "#000": [0, 0, 0, 255],
-      "#fff": [255, 255, 255, 255],
-      "#ddd": [221, 221, 221, 255],
-      "#111": [17, 17, 17, 255],
+describe("terminalContextMenuItems", () => {
+  it("offers path actions for a detected terminal path", () => {
+    const options = {
+      hasSelection: false,
+      link: "src/components/ThreadTerminalDrawer.tsx",
+      canOpenInPreview: false,
+      openLabel: "Open in editor",
+      revealLabel: null,
     };
 
-    vi.stubGlobal("document", {
-      documentElement: root,
-      body,
-      querySelector: () => drawer,
-      createElement: () => ({
-        width: 0,
-        height: 0,
-        getContext: () => ({
-          clearRect: () => undefined,
-          fillRect: () => undefined,
-          get fillStyle() {
-            return canvasColor;
-          },
-          set fillStyle(value: string) {
-            canvasColor = value;
-          },
-          getImageData: () => ({ data: colors[canvasColor] ?? [0, 0, 0, 0] }),
-        }),
-      }),
-    });
-    vi.stubGlobal("getComputedStyle", (element: object) => {
-      const local = element === drawer;
-      const values = local
-        ? {
-            "--terminal-background": "#000",
-            "--terminal-foreground": "#fff",
-            "--terminal-cursor": "#ddd",
-            "--terminal-selection-background": "rgba(255, 255, 255, 0.2)",
-          }
-        : {
-            "--terminal-background": "#fff",
-            "--terminal-foreground": "#111",
-          };
-      return {
-        backgroundColor: local ? "#000" : "#fff",
-        color: local ? "#fff" : "#111",
-        colorScheme: local ? "dark" : "light",
-        getPropertyValue: (name: string) => values[name as keyof typeof values] ?? "",
-      };
-    });
+    expect(terminalContextMenuItems(options)).toEqual([
+      { id: "open-link", label: "Open in editor" },
+      { id: "add-link-to-chat", label: "Add path to chat" },
+      { id: "copy-link", label: "Copy path", icon: "copy" },
+      { id: "add-to-chat", label: "Add to chat", disabled: true },
+      { id: "copy", label: "Copy", disabled: true },
+      { id: "paste", label: "Paste" },
+    ]);
+  });
 
-    const theme = terminalThemeFromApp();
+  it("offers URL actions while preserving enabled selection actions", () => {
+    const options = {
+      hasSelection: true,
+      link: "https://t3.codes",
+      canOpenInPreview: true,
+      openLabel: "Open in editor",
+      revealLabel: null,
+    };
 
-    expect(theme.background).toEqual({ r: 0, g: 0, b: 0 });
-    expect(theme.foreground).toEqual({ r: 255, g: 255, b: 255 });
-    expect(theme.cursor).toEqual({ r: 221, g: 221, b: 221 });
+    expect(terminalContextMenuItems(options)).toEqual([
+      { id: "open-link-in-preview", label: "Open in integrated browser" },
+      { id: "open-link-external", label: "Open in system browser" },
+      { id: "add-link-to-chat", label: "Add link to chat" },
+      { id: "copy-link", label: "Copy link", icon: "copy" },
+      { id: "add-to-chat", label: "Add to chat", disabled: false },
+      { id: "copy", label: "Copy", disabled: false },
+      { id: "paste", label: "Paste" },
+    ]);
   });
 });
 

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -290,7 +290,7 @@ export function terminalLinkCopyText(link: string): string {
 }
 
 /** Post-selection popup actions. Add to chat is available when a chat target exists. */
-export function terminalSelectionMenuItems(options?: {
+function terminalSelectionMenuItems(options?: {
   canAddToChat?: boolean;
 }): ContextMenuItem<"add-to-chat" | "copy">[] {
   return [

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -310,6 +310,7 @@ export function terminalContextMenuItems(options: {
   hasSelection: boolean;
   link: string | null;
   canAddToChat?: boolean;
+  canAddLinkToChat?: boolean;
   canOpenInPreview: boolean;
   openLabel: string;
   revealLabel: string | null;
@@ -321,7 +322,9 @@ export function terminalContextMenuItems(options: {
             ? [{ id: "open-link-in-preview" as const, label: "Open in integrated browser" }]
             : []),
           { id: "open-link-external", label: "Open in system browser" },
-          { id: "add-link-to-chat", label: "Add link to chat" },
+          ...(options.canAddLinkToChat === false
+            ? []
+            : [{ id: "add-link-to-chat" as const, label: "Add link to chat" }]),
           { id: "copy-link", label: "Copy link", icon: "copy" },
         ]
       : [
@@ -329,7 +332,9 @@ export function terminalContextMenuItems(options: {
           ...(options.revealLabel
             ? [{ id: "reveal-link" as const, label: options.revealLabel }]
             : []),
-          { id: "add-link-to-chat", label: "Add path to chat" },
+          ...(options.canAddLinkToChat === false
+            ? []
+            : [{ id: "add-link-to-chat" as const, label: "Add path to chat" }]),
           { id: "copy-link", label: "Copy path", icon: "copy" },
         ]
     : [];
@@ -456,6 +461,7 @@ export function TerminalViewport({
     onAddTerminalContext?.(selection);
   });
   const canAddSelectionToChat = useEffectEvent(() => onAddTerminalContext !== undefined);
+  const canAddLinkToChat = useEffectEvent(() => onAddTerminalLink !== undefined);
   const handleAddTerminalLink = useEffectEvent((link: string) => {
     onAddTerminalLink?.(terminalLinkChatText(link, cwd));
   });
@@ -771,6 +777,7 @@ export function TerminalViewport({
               hasSelection: selectionAction !== null,
               link,
               canAddToChat: canAddSelectionToChat(),
+              canAddLinkToChat: canAddLinkToChat(),
               openLabel: openInEditorMenuLabel(editorAtMenuOpen),
               canOpenInPreview:
                 link !== null &&
@@ -795,7 +802,7 @@ export function TerminalViewport({
             }
             return;
           case "add-link-to-chat":
-            if (link) handleAddTerminalLink(link);
+            if (link && canAddLinkToChat()) handleAddTerminalLink(link);
             return;
           case "copy":
             if (selectionAction) await copySelection(selectionAction.clipboardText, requestId);
@@ -944,6 +951,14 @@ export function TerminalViewport({
           threadRef,
           openPreview,
           fallbackToBrowser: () => openTerminalUrlInBrowser(text),
+        }).catch((error: unknown) => {
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Unable to open link",
+              description: error instanceof Error ? error.message : "An error occurred.",
+            }),
+          );
         });
       }
 

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -1865,4 +1865,19 @@ export default function ThreadTerminalDrawer({
                                 onClick={() => onActiveTerminalChange(terminalId)}
                               >
                                 <span className="truncate">{terminalLabel}</span>
-                
+                              </button>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </aside>
+          )}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -279,17 +279,24 @@ export function terminalFileManagerPath(link: string, cwd: string): string {
 export function terminalLinkChatText(link: string, cwd: string): string {
   if (isTerminalUrl(link)) return link;
   const path = terminalFileManagerPath(link, cwd);
-  return serializeComposerFileLink(path.replace(/(?!^)[/\\]+$/u, ""));
+  const trimmedPath = path.replace(/(?!^)[/\\]+$/u, "");
+  const normalizedPath =
+    /^[A-Za-z]:$/u.test(trimmedPath) && /^[A-Za-z]:[\\/]+$/u.test(path) ? path : trimmedPath;
+  return serializeComposerFileLink(normalizedPath);
 }
 
 export function terminalLinkCopyText(link: string): string {
   return isTerminalUrl(link) ? link : splitFilePathPosition(link).path;
 }
 
-/** Post-selection popup: available selection actions, always enabled. */
-export function terminalSelectionMenuItems(): ContextMenuItem<"add-to-chat" | "copy">[] {
+/** Post-selection popup actions. Add to chat is available when a chat target exists. */
+export function terminalSelectionMenuItems(options?: {
+  canAddToChat?: boolean;
+}): ContextMenuItem<"add-to-chat" | "copy">[] {
   return [
-    { id: "add-to-chat", label: "Add to chat" },
+    ...(options?.canAddToChat === false
+      ? []
+      : ([{ id: "add-to-chat", label: "Add to chat" }] satisfies ContextMenuItem<"add-to-chat">[])),
     { id: "copy", label: "Copy" },
   ];
 }
@@ -302,6 +309,7 @@ export function terminalSelectionMenuItems(): ContextMenuItem<"add-to-chat" | "c
 export function terminalContextMenuItems(options: {
   hasSelection: boolean;
   link: string | null;
+  canAddToChat?: boolean;
   canOpenInPreview: boolean;
   openLabel: string;
   revealLabel: string | null;
@@ -327,7 +335,9 @@ export function terminalContextMenuItems(options: {
     : [];
   return [
     ...linkItems,
-    ...terminalSelectionMenuItems().map((item) => ({
+    ...terminalSelectionMenuItems(
+      options.canAddToChat === undefined ? undefined : { canAddToChat: options.canAddToChat },
+    ).map((item) => ({
       ...item,
       disabled: !options.hasSelection,
     })),
@@ -372,7 +382,7 @@ interface TerminalViewportProps {
   providerInstanceId?: ProviderInstanceId;
   onSessionExited: () => void;
   onAddTerminalContext?: (selection: TerminalContextSelection) => void;
-  onAddTerminalLink: (link: string) => void;
+  onAddTerminalLink?: (link: string) => void;
   focusRequestId: number;
   autoFocus: boolean;
   visible: boolean;
@@ -445,8 +455,9 @@ export function TerminalViewport({
   const handleAddTerminalContext = useEffectEvent((selection: TerminalContextSelection) => {
     onAddTerminalContext?.(selection);
   });
+  const canAddSelectionToChat = useEffectEvent(() => onAddTerminalContext !== undefined);
   const handleAddTerminalLink = useEffectEvent((link: string) => {
-    onAddTerminalLink(terminalLinkChatText(link, cwd));
+    onAddTerminalLink?.(terminalLinkChatText(link, cwd));
   });
   const fileManagerRevealLabel =
     remoteOpen.isResolved &&
@@ -623,7 +634,9 @@ export function TerminalViewport({
       synchronizedStatusRef.current = "closed";
       synchronizeTerminalStatus(terminal, latestSession.status);
       // Startup may finish after the user has returned to the composer.
-      if (autoFocus && visibleRef.current) window.requestAnimationFrame(() => terminal.focus());
+      if (visibleRef.current && mount.contains(document.activeElement)) {
+        terminal.focus();
+      }
 
       const dismissSelectionAction = (supersede = false) => {
         const ownsMenu =
@@ -757,6 +770,7 @@ export function TerminalViewport({
             terminalContextMenuItems({
               hasSelection: selectionAction !== null,
               link,
+              canAddToChat: canAddSelectionToChat(),
               openLabel: openInEditorMenuLabel(editorAtMenuOpen),
               canOpenInPreview:
                 link !== null &&
@@ -776,7 +790,9 @@ export function TerminalViewport({
         }
         switch (clicked) {
           case "add-to-chat":
-            if (selectionAction) addSelectionToChat(selectionAction.selection);
+            if (selectionAction && canAddSelectionToChat()) {
+              addSelectionToChat(selectionAction.selection);
+            }
             return;
           case "add-link-to-chat":
             if (link) handleAddTerminalLink(link);
@@ -829,7 +845,10 @@ export function TerminalViewport({
         const requestId = ++selectionActionRequestIdRef.current;
         openSelectionMenuRequestIdRef.current = requestId;
         const clicked = await localApi.contextMenu
-          .show(terminalSelectionMenuItems(), nextAction.position)
+          .show(
+            terminalSelectionMenuItems({ canAddToChat: canAddSelectionToChat() }),
+            nextAction.position,
+          )
           .finally(() => {
             if (openSelectionMenuRequestIdRef.current === requestId) {
               openSelectionMenuRequestIdRef.current = null;
@@ -840,7 +859,7 @@ export function TerminalViewport({
         }
         switch (clicked) {
           case "add-to-chat":
-            addSelectionToChat(nextAction.selection);
+            if (canAddSelectionToChat()) addSelectionToChat(nextAction.selection);
             return;
           case "copy":
             await copySelection(nextAction.clipboardText, requestId);
@@ -1072,10 +1091,10 @@ export function TerminalViewport({
 
     return () => {
       cancelled = true;
+      const hadFocus = mount.contains(document.activeElement);
       teardown?.();
+      if (hadFocus && mount.isConnected) mount.focus({ preventScroll: true });
     };
-    // autoFocus is intentionally omitted;
-    // it is only read at mount time and must not trigger terminal teardown/recreation.
   }, [cwd, environmentId, runtimeEnvKey, terminalId, threadId, worktreePath]);
 
   useEffect(() => {
@@ -1106,24 +1125,14 @@ export function TerminalViewport({
       writeSystemMessage(terminal, current.error);
     }
 
-    if (previous.version === 0 && autoFocus && visibleRef.current) {
-      window.requestAnimationFrame(() => {
-        terminal.focus();
-      });
-    }
     previousSessionRef.current = current;
-  }, [autoFocus, terminalOutput, terminalError, terminalStatus, terminalVersion]);
+  }, [terminalOutput, terminalError, terminalStatus, terminalVersion]);
 
   useEffect(() => {
     if (!autoFocus || !visible) return;
-    const terminal = terminalRef.current;
-    if (!terminal) return;
-    const frame = window.requestAnimationFrame(() => {
-      terminal.focus();
-    });
-    return () => {
-      window.cancelAnimationFrame(frame);
-    };
+    // Claim focus when requested, then hand it to the terminal once ready only
+    // if the user has not focused something else in the meantime.
+    (terminalRef.current ?? containerRef.current)?.focus();
   }, [autoFocus, focusRequestId, visible]);
 
   useEffect(() => {
@@ -1146,6 +1155,7 @@ export function TerminalViewport({
   return (
     <div
       ref={containerRef}
+      tabIndex={-1}
       className="relative h-full w-full overflow-hidden bg-[var(--terminal-background)]"
     />
   );

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -10,6 +10,7 @@ import {
   type TerminalOutputUpdate,
   type TerminalSessionState,
 } from "@t3tools/client-runtime/state/terminal";
+import { splitFilePathPosition } from "@t3tools/client-runtime/markdown-links";
 import {
   Plus,
   Square,
@@ -20,12 +21,14 @@ import {
 } from "lucide-react";
 import {
   type ContextMenuItem,
+  type EditorId,
   type ProviderInstanceId,
   type ResolvedKeybindingsConfig,
   type ScopedThreadRef,
   type ThreadId,
 } from "@t3tools/contracts";
 import { getTerminalLabel } from "@t3tools/shared/terminalLabels";
+import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
 import * as Schema from "effect/Schema";
 import {
   type PointerEvent as ReactPointerEvent,
@@ -56,7 +59,12 @@ import {
   type GhosttyTerminalSurfaceOptions,
 } from "~/terminal/ghostty/surface";
 import { type GhosttyColor, type GhosttyTheme } from "~/terminal/ghostty/core";
-import { useOpenInPreferredEditor } from "../editorPreferences";
+import { useOpenInPreferredEditor, usePreferredEditor } from "../editorPreferences";
+import { openInEditorMenuLabel } from "../editorLabels";
+import {
+  revealInFileExplorerLabelForKind,
+  revealInFileExplorerLabelForOs,
+} from "./preview/fileExplorerLabel";
 import { isTerminalUrl, resolvePathLinkTarget } from "../terminal-links";
 import {
   isDiffToggleShortcut,
@@ -80,8 +88,14 @@ import { useLocalStorage } from "../hooks/useLocalStorage";
 import { useAttachedTerminalSession } from "../state/terminalSessions";
 import { serverEnvironment } from "../state/server";
 import { previewEnvironment } from "../state/preview";
+import { shellEnvironment } from "../state/shell";
 import { terminalEnvironment } from "../state/terminal";
-import { openTerminalLinkInPreview } from "./preview/openTerminalLinkInPreview";
+import { useRemoteOpenResolution } from "../remoteOpen";
+import {
+  canOpenTerminalLinkInPreview,
+  openTerminalLinkInIntegratedBrowser,
+  openTerminalLinkInPreview,
+} from "./preview/openTerminalLinkInPreview";
 import { useAtomCommand } from "../state/use-atom-command";
 import { preventTerminalCloseShortcut } from "../lib/terminalCloseShortcut";
 import {
@@ -247,35 +261,75 @@ export function terminalSelectionLineRange(position: {
   };
 }
 
-export type TerminalContextMenuAction = "add-to-chat" | "copy" | "paste";
+export type TerminalContextMenuAction =
+  | "add-to-chat"
+  | "add-link-to-chat"
+  | "copy"
+  | "copy-link"
+  | "open-link"
+  | "open-link-external"
+  | "open-link-in-preview"
+  | "reveal-link"
+  | "paste";
+
+export function terminalFileManagerPath(link: string, cwd: string): string {
+  return splitFilePathPosition(resolvePathLinkTarget(link, cwd)).path;
+}
+
+export function terminalLinkChatText(link: string, cwd: string): string {
+  if (isTerminalUrl(link)) return link;
+  const path = terminalFileManagerPath(link, cwd);
+  return serializeComposerFileLink(path.replace(/(?!^)[/\\]+$/u, ""));
+}
+
+export function terminalLinkCopyText(link: string): string {
+  return isTerminalUrl(link) ? link : splitFilePathPosition(link).path;
+}
 
 /** Post-selection popup: available selection actions, always enabled. */
-export function terminalSelectionMenuItems(options?: {
-  canAddToChat?: boolean;
-}): ContextMenuItem<"add-to-chat" | "copy">[] {
+export function terminalSelectionMenuItems(): ContextMenuItem<"add-to-chat" | "copy">[] {
   return [
-    ...(options?.canAddToChat === false
-      ? []
-      : ([{ id: "add-to-chat", label: "Add to chat" }] satisfies ContextMenuItem<"add-to-chat">[])),
+    { id: "add-to-chat", label: "Add to chat" },
     { id: "copy", label: "Copy" },
   ];
 }
 
 /**
- * Right-click menu for the terminal canvas: the selection actions (disabled
- * until a selection exists) plus Paste. Paste is always offered: the browser
- * (and Electron's default editing menu) can only paste into an editable
- * element, so a canvas terminal never gets a usable entry from them.
+ * Right-click menu for the terminal canvas: link actions when the pointer is
+ * over a link, selection actions, and Paste. Paste stays available because
+ * browser and Electron menus cannot paste into the terminal canvas.
  */
 export function terminalContextMenuItems(options: {
   hasSelection: boolean;
-  canAddToChat?: boolean;
+  link: string | null;
+  canOpenInPreview: boolean;
+  openLabel: string;
+  revealLabel: string | null;
 }): ContextMenuItem<TerminalContextMenuAction>[] {
-  const { hasSelection, canAddToChat = true } = options;
+  const linkItems: ContextMenuItem<TerminalContextMenuAction>[] = options.link
+    ? isTerminalUrl(options.link)
+      ? [
+          ...(options.canOpenInPreview
+            ? [{ id: "open-link-in-preview" as const, label: "Open in integrated browser" }]
+            : []),
+          { id: "open-link-external", label: "Open in system browser" },
+          { id: "add-link-to-chat", label: "Add link to chat" },
+          { id: "copy-link", label: "Copy link", icon: "copy" },
+        ]
+      : [
+          { id: "open-link", label: options.openLabel },
+          ...(options.revealLabel
+            ? [{ id: "reveal-link" as const, label: options.revealLabel }]
+            : []),
+          { id: "add-link-to-chat", label: "Add path to chat" },
+          { id: "copy-link", label: "Copy path", icon: "copy" },
+        ]
+    : [];
   return [
-    ...terminalSelectionMenuItems({ canAddToChat }).map((item) => ({
+    ...linkItems,
+    ...terminalSelectionMenuItems().map((item) => ({
       ...item,
-      disabled: !hasSelection,
+      disabled: !options.hasSelection,
     })),
     { id: "paste", label: "Paste" },
   ];
@@ -318,6 +372,7 @@ interface TerminalViewportProps {
   providerInstanceId?: ProviderInstanceId;
   onSessionExited: () => void;
   onAddTerminalContext?: (selection: TerminalContextSelection) => void;
+  onAddTerminalLink: (link: string) => void;
   focusRequestId: number;
   autoFocus: boolean;
   visible: boolean;
@@ -344,6 +399,7 @@ export function TerminalViewport({
   providerInstanceId,
   onSessionExited,
   onAddTerminalContext,
+  onAddTerminalLink,
   focusRequestId,
   autoFocus,
   visible,
@@ -356,12 +412,17 @@ export function TerminalViewport({
   const visibleRef = useRef(visible);
   const environmentId = threadRef.environmentId;
   const serverConfig = useAtomValue(serverEnvironment.configValueAtom(environmentId));
-  const openInPreferredEditor = useOpenInPreferredEditor(
-    environmentId,
-    serverConfig?.availableEditors ?? [],
+  const remoteOpen = useRemoteOpenResolution(environmentId);
+  const availableEditors = serverConfig?.availableEditors ?? [];
+  const [preferredEditor] = usePreferredEditor(availableEditors);
+  const openInPreferredEditor = useOpenInPreferredEditor(environmentId, availableEditors);
+  const openTerminalPath = useEffectEvent((target: string, editorOverride?: EditorId | null) =>
+    openInPreferredEditor(target, editorOverride),
   );
-  const openTerminalPath = useEffectEvent((target: string) => openInPreferredEditor(target));
   const openPreview = useAtomCommand(previewEnvironment.open, {
+    reportFailure: false,
+  });
+  const revealInFileManager = useAtomCommand(shellEnvironment.openInEditor, {
     reportFailure: false,
   });
   const runTerminalWrite = useAtomCommand(terminalEnvironment.write, {
@@ -384,7 +445,26 @@ export function TerminalViewport({
   const handleAddTerminalContext = useEffectEvent((selection: TerminalContextSelection) => {
     onAddTerminalContext?.(selection);
   });
-  const canAddSelectionToChat = useEffectEvent(() => onAddTerminalContext !== undefined);
+  const handleAddTerminalLink = useEffectEvent((link: string) => {
+    onAddTerminalLink(terminalLinkChatText(link, cwd));
+  });
+  const fileManagerRevealLabel =
+    remoteOpen.isResolved &&
+    remoteOpen.state.mode === "local-exec" &&
+    serverConfig?.shellRevealInFileManager === true &&
+    serverConfig.availableEditors.includes("file-manager")
+      ? serverConfig.shellRevealInFileManagerKind === undefined
+        ? revealInFileExplorerLabelForOs(serverConfig.environment.platform.os)
+        : revealInFileExplorerLabelForKind(serverConfig.shellRevealInFileManagerKind)
+      : null;
+  const readFileManagerRevealLabel = useEffectEvent(() => fileManagerRevealLabel);
+  const runFileManagerReveal = useEffectEvent((target: string) =>
+    revealInFileManager({
+      environmentId,
+      input: { cwd: target, editor: "file-manager", reveal: true },
+    }),
+  );
+  const readPreferredEditor = useEffectEvent(() => preferredEditor);
   const readTerminalLabel = useEffectEvent(() => terminalLabel);
   const terminalFontFamily = useClientSettings((settings) =>
     resolveTerminalFontPreference({
@@ -504,9 +584,8 @@ export function TerminalViewport({
         // The surface listens from construction, so a right-click can land
         // while `create` is still awaiting WASM — before the handler below it
         // exists. The ref is only assigned once that setup has run.
-        onContextMenu: (event) => {
-          if (terminalRef.current) void showTerminalContextMenu(event);
-        },
+        onContextMenu: (event, linkText) =>
+          terminalRef.current ? showTerminalContextMenu(event, linkText) : undefined,
       };
       const terminal = await GhosttyTerminalSurface.create(mount, terminalOptions);
       if (cancelled) {
@@ -544,9 +623,7 @@ export function TerminalViewport({
       synchronizedStatusRef.current = "closed";
       synchronizeTerminalStatus(terminal, latestSession.status);
       // Startup may finish after the user has returned to the composer.
-      if (visibleRef.current && mount.contains(document.activeElement)) {
-        terminal.focus();
-      }
+      if (autoFocus && visibleRef.current) window.requestAnimationFrame(() => terminal.focus());
 
       const dismissSelectionAction = (supersede = false) => {
         const ownsMenu =
@@ -622,14 +699,27 @@ export function TerminalViewport({
         }
       };
 
-      const copySelection = async (text: string, requestId: number) => {
+      const copyTerminalText = async (
+        text: string,
+        description: string,
+        fallbackError: string,
+        requestId: number,
+      ) => {
         try {
-          await writeTextToClipboard(text, "terminal selection");
+          await writeTextToClipboard(text, description);
         } catch (error) {
-          reportIfCurrent(requestId, error, "Unable to copy terminal selection");
+          reportIfCurrent(requestId, error, fallbackError);
         }
         focusIfCurrent(requestId);
       };
+
+      const copySelection = (text: string, requestId: number) =>
+        copyTerminalText(
+          text,
+          "terminal selection",
+          "Unable to copy terminal selection",
+          requestId,
+        );
 
       const pasteFromClipboard = async (requestId: number) => {
         const activeTerminal = terminalRef.current;
@@ -649,7 +739,7 @@ export function TerminalViewport({
         focusIfCurrent(requestId);
       };
 
-      const showTerminalContextMenu = async (event: MouseEvent) => {
+      const showTerminalContextMenu = async (event: MouseEvent, link: string | null) => {
         if (!localApi || !terminalRef.current) return;
         // Own the gesture before anything async: leaving the default alive lets
         // the browser (or Electron's editing menu) answer with a Paste entry
@@ -659,12 +749,20 @@ export function TerminalViewport({
         clearSelectionAction();
         const selectionAction = readSelectionAction();
         const requestId = selectionActionRequestIdRef.current;
+        const editorAtMenuOpen = readPreferredEditor();
+        const revealLabelAtMenuOpen = readFileManagerRevealLabel();
         let clicked: TerminalContextMenuAction | null;
         try {
           clicked = await localApi.contextMenu.show(
             terminalContextMenuItems({
               hasSelection: selectionAction !== null,
-              canAddToChat: canAddSelectionToChat(),
+              link,
+              openLabel: openInEditorMenuLabel(editorAtMenuOpen),
+              canOpenInPreview:
+                link !== null &&
+                isTerminalUrl(link) &&
+                canOpenTerminalLinkInPreview(link, threadRef),
+              revealLabel: revealLabelAtMenuOpen,
             }),
             { x: event.clientX, y: event.clientY },
           );
@@ -678,12 +776,36 @@ export function TerminalViewport({
         }
         switch (clicked) {
           case "add-to-chat":
-            if (selectionAction && canAddSelectionToChat()) {
-              addSelectionToChat(selectionAction.selection);
-            }
+            if (selectionAction) addSelectionToChat(selectionAction.selection);
+            return;
+          case "add-link-to-chat":
+            if (link) handleAddTerminalLink(link);
             return;
           case "copy":
             if (selectionAction) await copySelection(selectionAction.clipboardText, requestId);
+            return;
+          case "copy-link": {
+            if (!link) return;
+            const isUrl = isTerminalUrl(link);
+            await copyTerminalText(
+              terminalLinkCopyText(link),
+              isUrl ? "terminal link" : "terminal path",
+              isUrl ? "Unable to copy terminal link" : "Unable to copy terminal path",
+              requestId,
+            );
+            return;
+          }
+          case "open-link":
+            if (link) openTerminalLink(link, editorAtMenuOpen);
+            return;
+          case "open-link-external":
+            if (link) openTerminalUrlInBrowser(link);
+            return;
+          case "open-link-in-preview":
+            if (link) openTerminalUrlInPreview(link);
+            return;
+          case "reveal-link":
+            if (link && revealLabelAtMenuOpen !== null) revealTerminalPath(link);
             return;
           case "paste":
             await pasteFromClipboard(requestId);
@@ -707,10 +829,7 @@ export function TerminalViewport({
         const requestId = ++selectionActionRequestIdRef.current;
         openSelectionMenuRequestIdRef.current = requestId;
         const clicked = await localApi.contextMenu
-          .show(
-            terminalSelectionMenuItems({ canAddToChat: canAddSelectionToChat() }),
-            nextAction.position,
-          )
+          .show(terminalSelectionMenuItems(), nextAction.position)
           .finally(() => {
             if (openSelectionMenuRequestIdRef.current === requestId) {
               openSelectionMenuRequestIdRef.current = null;
@@ -721,7 +840,7 @@ export function TerminalViewport({
         }
         switch (clicked) {
           case "add-to-chat":
-            if (canAddSelectionToChat()) addSelectionToChat(nextAction.selection);
+            addSelectionToChat(nextAction.selection);
             return;
           case "copy":
             await copySelection(nextAction.clipboardText, requestId);
@@ -782,6 +901,38 @@ export function TerminalViewport({
       }
 
       function handleLinkActivate(text: string, event: MouseEvent): void {
+        openTerminalLink(text, undefined, event.metaKey || event.ctrlKey);
+      }
+
+      function openTerminalUrlInBrowser(text: string): void {
+        const latestTerminal = terminalRef.current;
+        if (!latestTerminal) return;
+        if (!localApi) {
+          writeSystemMessage(latestTerminal, "Opening links is unavailable in this browser.");
+          return;
+        }
+        void localApi.shell.openExternal(text).catch((error: unknown) => {
+          writeSystemMessage(
+            latestTerminal,
+            error instanceof Error ? error.message : "Unable to open link",
+          );
+        });
+      }
+
+      function openTerminalUrlInPreview(text: string): void {
+        void openTerminalLinkInIntegratedBrowser({
+          url: text,
+          threadRef,
+          openPreview,
+          fallbackToBrowser: () => openTerminalUrlInBrowser(text),
+        });
+      }
+
+      function openTerminalLink(
+        text: string,
+        editorOverride?: EditorId | null,
+        forceBrowser = false,
+      ): void {
         const latestTerminal = terminalRef.current;
         if (!latestTerminal) return;
         if (isTerminalUrl(text)) {
@@ -789,20 +940,12 @@ export function TerminalViewport({
             writeSystemMessage(latestTerminal, "Opening links is unavailable in this browser.");
             return;
           }
-          const fallbackToBrowser = () => {
-            void localApi.shell.openExternal(text).catch((error: unknown) => {
-              writeSystemMessage(
-                latestTerminal,
-                error instanceof Error ? error.message : "Unable to open link",
-              );
-            });
-          };
           void openTerminalLinkInPreview({
             url: text,
             threadRef,
             openPreview,
-            fallbackToBrowser,
-            forceBrowser: event.metaKey || event.ctrlKey,
+            fallbackToBrowser: () => openTerminalUrlInBrowser(text),
+            forceBrowser,
           }).catch((error: unknown) => {
             toastManager.add(
               stackedThreadToast({
@@ -816,7 +959,7 @@ export function TerminalViewport({
         }
         const target = resolvePathLinkTarget(text, cwd);
         void (async () => {
-          const result = await openTerminalPath(target);
+          const result = await openTerminalPath(target, editorOverride);
           if (result._tag === "Success" || isAtomCommandInterrupted(result)) {
             return;
           }
@@ -824,6 +967,19 @@ export function TerminalViewport({
           writeSystemMessage(
             latestTerminal,
             error instanceof Error ? error.message : "Unable to open path",
+          );
+        })();
+      }
+
+      function revealTerminalPath(text: string): void {
+        const target = terminalFileManagerPath(text, cwd);
+        void (async () => {
+          const result = await runFileManagerReveal(target);
+          if (result._tag === "Success" || isAtomCommandInterrupted(result)) return;
+          const error = squashAtomCommandFailure(result);
+          writeSystemMessage(
+            terminal,
+            error instanceof Error ? error.message : "Unable to reveal path",
           );
         })();
       }
@@ -916,10 +1072,10 @@ export function TerminalViewport({
 
     return () => {
       cancelled = true;
-      const hadFocus = mount.contains(document.activeElement);
       teardown?.();
-      if (hadFocus && mount.isConnected) mount.focus({ preventScroll: true });
     };
+    // autoFocus is intentionally omitted;
+    // it is only read at mount time and must not trigger terminal teardown/recreation.
   }, [cwd, environmentId, runtimeEnvKey, terminalId, threadId, worktreePath]);
 
   useEffect(() => {
@@ -950,14 +1106,24 @@ export function TerminalViewport({
       writeSystemMessage(terminal, current.error);
     }
 
+    if (previous.version === 0 && autoFocus && visibleRef.current) {
+      window.requestAnimationFrame(() => {
+        terminal.focus();
+      });
+    }
     previousSessionRef.current = current;
-  }, [terminalOutput, terminalError, terminalStatus, terminalVersion]);
+  }, [autoFocus, terminalOutput, terminalError, terminalStatus, terminalVersion]);
 
   useEffect(() => {
     if (!autoFocus || !visible) return;
-    // Claim focus when requested, then hand it to the terminal once ready only
-    // if the user has not focused something else in the meantime.
-    (terminalRef.current ?? containerRef.current)?.focus();
+    const terminal = terminalRef.current;
+    if (!terminal) return;
+    const frame = window.requestAnimationFrame(() => {
+      terminal.focus();
+    });
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
   }, [autoFocus, focusRequestId, visible]);
 
   useEffect(() => {
@@ -980,7 +1146,6 @@ export function TerminalViewport({
   return (
     <div
       ref={containerRef}
-      tabIndex={-1}
       className="relative h-full w-full overflow-hidden bg-[var(--terminal-background)]"
     />
   );
@@ -1011,6 +1176,7 @@ interface ThreadTerminalDrawerProps {
   onCloseTerminal: (terminalId: string) => void;
   onHeightChange: (height: number) => void;
   onAddTerminalContext: (selection: TerminalContextSelection) => void;
+  onAddTerminalLink: (link: string) => void;
   keybindings: ResolvedKeybindingsConfig;
   /** Prefer server-provided tab titles when present (e.g. active subprocess name). */
   terminalLabelsById?: ReadonlyMap<string, string>;
@@ -1072,6 +1238,7 @@ export default function ThreadTerminalDrawer({
   onCloseTerminal,
   onHeightChange,
   onAddTerminalContext,
+  onAddTerminalLink,
   keybindings,
   terminalLabelsById,
   terminalLaunchLocationsById,
@@ -1542,6 +1709,7 @@ export default function ThreadTerminalDrawer({
                             : {})}
                           onSessionExited={() => onCloseTerminal(terminalId)}
                           onAddTerminalContext={onAddTerminalContext}
+                          onAddTerminalLink={onAddTerminalLink}
                           focusRequestId={focusRequestId}
                           autoFocus={terminalId === resolvedActiveTerminalId}
                           visible={visible}
@@ -1572,6 +1740,7 @@ export default function ThreadTerminalDrawer({
                     : {})}
                   onSessionExited={() => onCloseTerminal(resolvedActiveTerminalId)}
                   onAddTerminalContext={onAddTerminalContext}
+                  onAddTerminalLink={onAddTerminalLink}
                   focusRequestId={focusRequestId}
                   autoFocus
                   visible={visible}
@@ -1696,19 +1865,4 @@ export default function ThreadTerminalDrawer({
                                 onClick={() => onActiveTerminalChange(terminalId)}
                               >
                                 <span className="truncate">{terminalLabel}</span>
-                              </button>
-                            </div>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            </aside>
-          )}
-        </div>
-      </div>
-    </aside>
-  );
-}
+                

--- a/apps/web/src/components/preview/openTerminalLinkInPreview.test.ts
+++ b/apps/web/src/components/preview/openTerminalLinkInPreview.test.ts
@@ -4,6 +4,7 @@ import { AsyncResult } from "effect/unstable/reactivity";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import {
+  openTerminalLinkInIntegratedBrowser,
   openTerminalLinkInPreview,
   TerminalLinkPreviewOpenError,
 } from "./openTerminalLinkInPreview";
@@ -111,6 +112,22 @@ describe("openTerminalLinkInPreview", () => {
 
     expect(fallbackToBrowser).toHaveBeenCalledOnce();
     expect(openPreview).not.toHaveBeenCalled();
+  });
+
+  it("honors an explicit integrated-browser action regardless of the default", async () => {
+    linkTargetMocks.preference.mockReturnValue("system");
+    const fallbackToBrowser = vi.fn();
+    const openPreview = vi.fn(async () => AsyncResult.success(snapshot));
+
+    await openTerminalLinkInIntegratedBrowser({
+      url: "http://localhost:3000/",
+      threadRef,
+      openPreview,
+      fallbackToBrowser,
+    });
+
+    expect(openPreview).toHaveBeenCalledOnce();
+    expect(fallbackToBrowser).not.toHaveBeenCalled();
   });
 
   it("opens public URLs in-app too, not only local servers", async () => {

--- a/apps/web/src/components/preview/openTerminalLinkInPreview.ts
+++ b/apps/web/src/components/preview/openTerminalLinkInPreview.ts
@@ -35,7 +35,7 @@ interface OpenTerminalLinkInPreviewInput<E> {
   readonly openPreview: OpenPreviewMutation<E>;
   readonly fallbackToBrowser: () => void;
   /** Cmd/Ctrl-click bypasses the preference and opens in the system browser. */
-  readonly forceBrowser?: boolean;
+  readonly forceBrowser: boolean;
 }
 
 export function canOpenTerminalLinkInPreview(url: string, threadRef: ScopedThreadRef): boolean {

--- a/apps/web/src/components/preview/openTerminalLinkInPreview.ts
+++ b/apps/web/src/components/preview/openTerminalLinkInPreview.ts
@@ -35,24 +35,34 @@ interface OpenTerminalLinkInPreviewInput<E> {
   readonly openPreview: OpenPreviewMutation<E>;
   readonly fallbackToBrowser: () => void;
   /** Cmd/Ctrl-click bypasses the preference and opens in the system browser. */
-  readonly forceBrowser: boolean;
+  readonly forceBrowser?: boolean;
 }
 
-/**
- * Opens a terminal hyperlink where the "Open links in" setting says, unless a
- * Cmd/Ctrl-click explicitly requests the system browser.
- */
+export function canOpenTerminalLinkInPreview(url: string, threadRef: ScopedThreadRef): boolean {
+  return isWebUrl(url) && isPreviewSupportedInRuntime() && threadRef.threadId.length > 0;
+}
+
+/** Opens a terminal URL according to the configured browser-link target. */
 export async function openTerminalLinkInPreview<E>(
   input: OpenTerminalLinkInPreviewInput<E>,
 ): Promise<void> {
   const supportsPreview =
     !input.forceBrowser &&
-    isWebUrl(input.url) &&
-    isPreviewSupportedInRuntime() &&
-    input.threadRef.threadId.length > 0 &&
+    canOpenTerminalLinkInPreview(input.url, input.threadRef) &&
     (await resolveBrowserLinkTargetPreference()) === "app";
-
   if (!supportsPreview) {
+    input.fallbackToBrowser();
+    return;
+  }
+
+  await openTerminalLinkInIntegratedBrowser(input);
+}
+
+/** Opens a terminal URL in the integrated browser for an explicit menu action. */
+export async function openTerminalLinkInIntegratedBrowser<E>(
+  input: Omit<OpenTerminalLinkInPreviewInput<E>, "forceBrowser">,
+): Promise<void> {
+  if (!canOpenTerminalLinkInPreview(input.url, input.threadRef)) {
     input.fallbackToBrowser();
     return;
   }

--- a/apps/web/src/editorPreferences.test.ts
+++ b/apps/web/src/editorPreferences.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+afterEach(() => {
+  vi.resetModules();
+  vi.unstubAllGlobals();
+});
+
+describe("resolveAndPersistPreferredEditor", () => {
+  it("keeps an explicitly captured editor from falling back", async () => {
+    const values = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+    };
+    vi.stubGlobal("window", { localStorage: storage, dispatchEvent: vi.fn() });
+    vi.stubGlobal("localStorage", storage);
+    const { resolveAndPersistPreferredEditor } = await import("./editorPreferences");
+
+    expect(resolveAndPersistPreferredEditor(["zed", "vscode"], "zed")).toBe("zed");
+    expect(resolveAndPersistPreferredEditor(["vscode"], "zed")).toBeNull();
+  });
+});

--- a/apps/web/src/editorPreferences.ts
+++ b/apps/web/src/editorPreferences.ts
@@ -7,7 +7,11 @@ import {
 import * as Cause from "effect/Cause";
 import * as Schema from "effect/Schema";
 import { AsyncResult } from "effect/unstable/reactivity";
-import { getLocalStorageItem, setLocalStorageItem, useLocalStorage } from "./hooks/useLocalStorage";
+import {
+  getLocalStorageItem,
+  setLocalStorageItemAndNotify,
+  useLocalStorage,
+} from "./hooks/useLocalStorage";
 import { useCallback, useMemo } from "react";
 import { shellEnvironment } from "./state/shell";
 import { useAtomCommand } from "./state/use-atom-command";
@@ -51,12 +55,21 @@ export function usePreferredEditor(availableEditors: ReadonlyArray<EditorId>) {
 
 export function resolveAndPersistPreferredEditor(
   availableEditors: readonly EditorId[],
+  editorOverride?: EditorId | null,
 ): EditorId | null {
   const availableEditorIds = new Set(availableEditors);
   const stored = getLocalStorageItem(LAST_EDITOR_KEY, EditorId);
-  if (stored && availableEditorIds.has(stored)) return stored;
-  const editor = EDITORS.find((editor) => availableEditorIds.has(editor.id))?.id ?? null;
-  if (editor) setLocalStorageItem(LAST_EDITOR_KEY, editor, EditorId);
+  const editor =
+    editorOverride === undefined
+      ? stored && availableEditorIds.has(stored)
+        ? stored
+        : (EDITORS.find((candidate) => availableEditorIds.has(candidate.id))?.id ?? null)
+      : editorOverride !== null && availableEditorIds.has(editorOverride)
+        ? editorOverride
+        : null;
+  if (editor && editor !== stored) {
+    setLocalStorageItemAndNotify(LAST_EDITOR_KEY, editor, EditorId);
+  }
   return editor ?? null;
 }
 
@@ -72,6 +85,7 @@ export function useOpenInPreferredEditor(
   return useCallback(
     async (
       targetPath: string,
+      editorOverride?: EditorId | null,
     ): Promise<
       AtomCommandResult<
         EditorId,
@@ -89,7 +103,7 @@ export function useOpenInPreferredEditor(
           ),
         );
       }
-      const editor = resolveAndPersistPreferredEditor(availableEditors);
+      const editor = resolveAndPersistPreferredEditor(availableEditors, editorOverride);
       if (!editor) {
         return AsyncResult.failure(
           Cause.fail(

--- a/apps/web/src/hooks/useLocalStorage.test.ts
+++ b/apps/web/src/hooks/useLocalStorage.test.ts
@@ -138,22 +138,3 @@ describe("local storage errors", () => {
     }
   });
 });
-
-describe("local storage notifications", () => {
-  it("notifies same-window subscribers when an imperative value is written", async () => {
-    const storage = createStorage();
-    const dispatchEvent = vi.fn();
-    vi.stubGlobal("window", { localStorage: storage, dispatchEvent });
-    vi.stubGlobal("localStorage", storage);
-    const { setLocalStorageItemAndNotify } = await import("./useLocalStorage");
-
-    setLocalStorageItemAndNotify("changed-key", "value", Schema.String);
-
-    expect(dispatchEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "t3code:local_storage_change",
-        detail: { key: "changed-key" },
-      }),
-    );
-  });
-});

--- a/apps/web/src/hooks/useLocalStorage.test.ts
+++ b/apps/web/src/hooks/useLocalStorage.test.ts
@@ -138,3 +138,22 @@ describe("local storage errors", () => {
     }
   });
 });
+
+describe("local storage notifications", () => {
+  it("notifies same-window subscribers when an imperative value is written", async () => {
+    const storage = createStorage();
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal("window", { localStorage: storage, dispatchEvent });
+    vi.stubGlobal("localStorage", storage);
+    const { setLocalStorageItemAndNotify } = await import("./useLocalStorage");
+
+    setLocalStorageItemAndNotify("changed-key", "value", Schema.String);
+
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "t3code:local_storage_change",
+        detail: { key: "changed-key" },
+      }),
+    );
+  });
+});

--- a/apps/web/src/hooks/useLocalStorage.ts
+++ b/apps/web/src/hooks/useLocalStorage.ts
@@ -97,6 +97,15 @@ function dispatchLocalStorageChange(key: string) {
   }
 }
 
+export const setLocalStorageItemAndNotify = <T, E>(
+  key: string,
+  value: T,
+  schema: Schema.Codec<T, E>,
+) => {
+  setLocalStorageItem(key, value, schema);
+  dispatchLocalStorageChange(key);
+};
+
 export function useLocalStorage<T, E>(
   key: string,
   initialValue: T,

--- a/apps/web/src/pierre-icons.test.ts
+++ b/apps/web/src/pierre-icons.test.ts
@@ -1,6 +1,7 @@
 import { assert, describe, it } from "vite-plus/test";
 
 import {
+  basenameOfPath,
   hasSpecificPierreIconForFileName,
   resolvePierreIconForEntry,
   syntheticFileNameForLanguageId,
@@ -8,6 +9,10 @@ import {
 } from "./pierre-icons";
 
 describe("Pierre file icons", () => {
+  it("labels the POSIX filesystem root", () => {
+    assert.equal(basenameOfPath("/"), "/");
+  });
+
   it("uses Pierre exact filename and complete-set extension mappings", () => {
     assert.equal(resolvePierreIconForEntry("Dockerfile", "file")?.token, "docker");
     assert.equal(resolvePierreIconForEntry("src/Button.tsx", "file")?.token, "react");

--- a/apps/web/src/pierre-icons.ts
+++ b/apps/web/src/pierre-icons.ts
@@ -86,6 +86,7 @@ const LANGUAGE_EXTENSION_ALIASES: Record<string, string> = {
 };
 
 export function basenameOfPath(pathValue: string): string {
+  if (pathValue === "/") return "/";
   const slashIndex = pathValue.lastIndexOf("/");
   return slashIndex === -1 ? pathValue : pathValue.slice(slashIndex + 1);
 }

--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -17,6 +17,8 @@ import {
   primeTerminalCopyInput,
   resolveTerminalMouseData,
   resolveTerminalMouseTrackingState,
+  mapTerminalLinkRange,
+  runTerminalLinkContextMenu,
   shouldBlinkTerminalCursor,
   shouldReportTerminalMouse,
   terminalGridCellAt,
@@ -873,6 +875,96 @@ describe("application mouse reporting", () => {
       tracking: false,
       motionData: "\u001b[<35;8;4M",
     });
+  });
+
+  it("pins a right-clicked link highlight until its context menu closes", async () => {
+    const link = {
+      text: "src/terminal.ts",
+      range: {
+        start: { x: 3, y: 2 },
+        end: { x: 17, y: 2 },
+      },
+    };
+    const highlights: Array<typeof link | null> = [];
+    let closeMenu = () => {};
+    const menuClosed = new Promise<void>((resolve) => {
+      closeMenu = resolve;
+    });
+
+    const contextMenu = runTerminalLinkContextMenu({
+      link,
+      setContextMenuLink: (nextLink) => highlights.push(nextLink),
+      showContextMenu: () => menuClosed,
+    });
+
+    expect(highlights).toEqual([link]);
+    closeMenu();
+    await contextMenu;
+    expect(highlights).toEqual([link, null]);
+  });
+
+  it("reprojects a pinned link range into the current viewport", () => {
+    const link = {
+      text: "src/terminal.ts",
+      range: {
+        start: { x: 3, y: 12 },
+        end: { x: 17, y: 12 },
+      },
+    };
+
+    expect(mapTerminalLinkRange(link, ({ x, y }) => ({ x, y: y - 10 }))).toEqual({
+      text: link.text,
+      range: {
+        start: { x: 3, y: 2 },
+        end: { x: 17, y: 2 },
+      },
+    });
+  });
+
+  it("does not let an older context menu clear a newer link highlight", async () => {
+    const firstLink = {
+      text: "src/first.ts",
+      range: {
+        start: { x: 3, y: 2 },
+        end: { x: 14, y: 2 },
+      },
+    };
+    const secondLink = {
+      text: "src/second.ts",
+      range: {
+        start: { x: 5, y: 4 },
+        end: { x: 17, y: 4 },
+      },
+    };
+    const highlights: Array<typeof firstLink | null> = [];
+    let activeRequest = 0;
+    let closeFirst = () => {};
+    let closeSecond = () => {};
+    const firstClosed = new Promise<void>((resolve) => {
+      closeFirst = resolve;
+    });
+    const secondClosed = new Promise<void>((resolve) => {
+      closeSecond = resolve;
+    });
+    const openMenu = (link: typeof firstLink, menuClosed: Promise<void>) => {
+      const request = ++activeRequest;
+      return runTerminalLinkContextMenu({
+        link,
+        setContextMenuLink: (nextLink) => highlights.push(nextLink),
+        showContextMenu: () => menuClosed,
+        isCurrent: () => request === activeRequest,
+      });
+    };
+
+    const firstMenu = openMenu(firstLink, firstClosed);
+    const secondMenu = openMenu(secondLink, secondClosed);
+    closeFirst();
+    await firstMenu;
+    expect(highlights).toEqual([firstLink, secondLink]);
+
+    closeSecond();
+    await secondMenu;
+    expect(highlights).toEqual([firstLink, secondLink, null]);
   });
 });
 

--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -17,7 +17,6 @@ import {
   primeTerminalCopyInput,
   resolveTerminalMouseData,
   resolveTerminalMouseTrackingState,
-  mapTerminalLinkRange,
   runTerminalLinkContextMenu,
   shouldBlinkTerminalCursor,
   shouldReportTerminalMouse,
@@ -901,24 +900,6 @@ describe("application mouse reporting", () => {
     closeMenu();
     await contextMenu;
     expect(highlights).toEqual([link, null]);
-  });
-
-  it("reprojects a pinned link range into the current viewport", () => {
-    const link = {
-      text: "src/terminal.ts",
-      range: {
-        start: { x: 3, y: 12 },
-        end: { x: 17, y: 12 },
-      },
-    };
-
-    expect(mapTerminalLinkRange(link, ({ x, y }) => ({ x, y: y - 10 }))).toEqual({
-      text: link.text,
-      range: {
-        start: { x: 3, y: 2 },
-        end: { x: 17, y: 2 },
-      },
-    });
   });
 
   it("does not let an older context menu clear a newer link highlight", async () => {

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -260,6 +260,8 @@ function isSameTerminalLink(
     right.range.end.x === left.range.end.x &&
     right.range.end.y === left.range.end.y
   );
+}
+
 function mapTerminalLinkRange(
   link: TerminalLinkWithRange,
   mapPoint: (point: GhosttyCellRange["start"]) => GhosttyCellRange["start"] | null,

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -260,9 +260,7 @@ function isSameTerminalLink(
     right.range.end.x === left.range.end.x &&
     right.range.end.y === left.range.end.y
   );
-}
-
-export function mapTerminalLinkRange(
+function mapTerminalLinkRange(
   link: TerminalLinkWithRange,
   mapPoint: (point: GhosttyCellRange["start"]) => GhosttyCellRange["start"] | null,
 ): TerminalLinkWithRange | null {

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -262,6 +262,15 @@ function isSameTerminalLink(
   );
 }
 
+export function mapTerminalLinkRange(
+  link: TerminalLinkWithRange,
+  mapPoint: (point: GhosttyCellRange["start"]) => GhosttyCellRange["start"] | null,
+): TerminalLinkWithRange | null {
+  const start = mapPoint(link.range.start);
+  const end = mapPoint(link.range.end);
+  return start && end ? { text: link.text, range: { start, end } } : null;
+}
+
 function terminalColumnAtOffset(row: GhosttySnapshot["rowData"][number], offset: number): number {
   for (let column = 0; column < row.cells.length; column += 1) {
     const nextOffset = terminalColumnOffset(row, column + 1);
@@ -489,6 +498,24 @@ export function terminalWheelArrowData(rows: number, applicationCursorKeys: bool
   return sequence.repeat(Math.abs(rows));
 }
 
+export async function runTerminalLinkContextMenu({
+  link,
+  setContextMenuLink,
+  showContextMenu,
+  isCurrent = () => true,
+}: {
+  readonly link: TerminalLinkWithRange | null;
+  readonly setContextMenuLink: (link: TerminalLinkWithRange | null) => void;
+  readonly showContextMenu: (linkText: string | null) => void | Promise<void>;
+  readonly isCurrent?: () => boolean;
+}): Promise<void> {
+  setContextMenuLink(link);
+  try {
+    await showContextMenu(link?.text ?? null);
+  } finally {
+    if (isCurrent()) setContextMenuLink(null);
+  }
+}
 export function ghosttyMouseButton(button: number): number | null {
   switch (button) {
     case 0:
@@ -552,7 +579,7 @@ export interface GhosttyTerminalSurfaceOptions {
    * reporting. The host owns the menu, so it also owns preventing the browser
    * default — whose Paste entry can never reach a canvas terminal.
    */
-  readonly onContextMenu?: (event: MouseEvent) => void;
+  readonly onContextMenu?: (event: MouseEvent, linkText: string | null) => void | Promise<void>;
 }
 
 export class GhosttyTerminalSurface {
@@ -615,6 +642,8 @@ export class GhosttyTerminalSurface {
     clickCount: number;
   } | null = null;
   private hoveredLink: TerminalLinkWithRange | null = null;
+  private contextMenuLink: TerminalLinkWithRange | null = null;
+  private contextMenuRequest = 0;
   private hoverPointer: { x: number; y: number } | null = null;
   private selectionClickSequence: TerminalSelectionClickSequence | null = null;
   private selectionMoved = false;
@@ -1398,8 +1427,8 @@ export class GhosttyTerminalSurface {
       this.hoverPointer = { x: event.clientX, y: event.clientY };
       // A drag whose press was already sent to the terminal application cannot
       // turn into link activation midway through, so link feedback would lie.
-      this.setHoveredLink(null);
-      this.canvas.style.cursor = "default";
+      this.setHoveredLink(this.contextMenuLinkInViewport());
+      if (this.contextMenuLink === null) this.canvas.style.cursor = "default";
       this.sendMouse("motion", this.buttonFromButtons(event.buttons), event);
       return;
     }
@@ -1480,14 +1509,35 @@ export class GhosttyTerminalSurface {
 
   private clearHoveredLink(cursor = ""): void {
     this.hoverPointer = null;
-    this.setHoveredLink(null);
-    this.canvas.style.cursor = cursor;
+    this.setHoveredLink(this.contextMenuLinkInViewport());
+    if (this.contextMenuLink === null) this.canvas.style.cursor = cursor;
   }
 
   private refreshHoveredLink(): void {
     const pointer = this.hoverPointer;
-    const link = pointer ? this.linkAt(pointer.x, pointer.y) : null;
+    const link =
+      this.contextMenuLink !== null
+        ? this.contextMenuLinkInViewport()
+        : pointer
+          ? this.linkAt(pointer.x, pointer.y)
+          : null;
     this.setHoveredLink(link);
+  }
+
+  private setContextMenuLink(link: TerminalLinkWithRange | null): void {
+    if (this.disposed) return;
+    this.contextMenuLink = link
+      ? mapTerminalLinkRange(link, ({ x, y }) => this.core.viewportPointToScreen(x, y))
+      : null;
+    this.refreshHoveredLink();
+  }
+
+  private contextMenuLinkInViewport(): TerminalLinkWithRange | null {
+    return this.contextMenuLink
+      ? mapTerminalLinkRange(this.contextMenuLink, ({ x, y }) =>
+          this.core.screenPointToViewport(x, y),
+        )
+      : null;
   }
 
   private setHoveredLink(link: TerminalLinkWithRange | null): void {
@@ -1606,7 +1656,16 @@ export class GhosttyTerminalSurface {
       event.preventDefault();
       return;
     }
-    this.options.onContextMenu?.(event);
+    const showContextMenu = this.options.onContextMenu;
+    if (!showContextMenu) return;
+    const link = this.linkAt(event.clientX, event.clientY);
+    const request = ++this.contextMenuRequest;
+    void runTerminalLinkContextMenu({
+      link,
+      setContextMenuLink: (nextLink) => this.setContextMenuLink(nextLink),
+      showContextMenu: (linkText) => showContextMenu(event, linkText),
+      isCurrent: () => request === this.contextMenuRequest,
+    });
   };
 
   private readonly onScrollbarPointerDown = (event: PointerEvent) => {


### PR DESCRIPTION
> [!NOTE]
> 🤖 **GPT-6 on behalf of Oliver**

## What Changed

Right-clicking a terminal path or URL now offers Open, Add to chat, and Copy for the target under the pointer. The highlight stays for as long as the menu is open. Local filesystem paths also offer the environment's file-manager reveal action when supported; URLs and remote environments do not.

Add to chat inserts paths with the file chip appearance and URLs as plain text.

## Why

Right-clicking threw away the detected target and offered only the selection actions and Paste, so you couldn't open or copy the path or link you were pointing at. Putting this in the context menu is a natural addition.

## Behavior precedent

Ghostty-based terminals do the same thing: right-click offers actions for the target under the pointer and pins the highlight while the menu is open.

## UI Changes

### Before

<img width="1058" height="534" alt="image" src="https://github.com/user-attachments/assets/bdd95003-38f9-4e4b-bb0f-2eaa4595a647"  alt="Before: the terminal context menu only contains disabled selection actions and Paste">

### After

<img width="860" height="414" alt="image" src="https://github.com/user-attachments/assets/e28e5527-ab81-46a4-83c2-bec407216c54" alt="After: the right-clicked terminal URL stays highlighted and has Open, Add to chat, and Copy actions"> 

https://github.com/user-attachments/assets/6690ff54-caed-4ff7-b99b-9c7e57489481

## Verification

- 95 tests passed across terminal paths, URL opening, platform labels, editor selection, local storage, and Ghostty context-menu lifecycle.
- Web typecheck passed.
- Targeted lint and `git diff --check` passed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes

---

Implemented by GPT-5.6 Sol and Fable 5 via Codex and T3 Code. Rebase and file-manager reveal by GPT-5.6 Sol; review, test trimming, and this description by GPT-6 through Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add terminal link context menu actions to web terminal drawer
> - Adds a right-click context menu for terminal links in the web terminal drawer, offering actions to open in an editor, reveal in a file manager, open URLs in the integrated or system browser, copy, or send to chat.
> - `ChatView` inserts serialized file links into the chat composer, showing an error toast if insertion fails.
> - `GhosttyTerminalSurface` keeps the right-clicked link highlighted while the menu is open and prevents stale menu completions from clearing newer highlights.
> - Extracts `canOpenTerminalLinkInPreview` and adds an explicit `openTerminalLinkInIntegratedBrowser` opener in [openTerminalLinkInPreview.ts](https://github.com/pingdotgg/t3code/pull/7280/files#diff-d58b6a4e00743c1aac26eb420f0aad1607fe1c8927eb299fb428bcccec4b8162).
> - Risk: `resolveAndPersistPreferredEditor` in [editorPreferences.ts](https://github.com/pingdotgg/t3code/pull/7280/files#diff-b95642bd2ec02008455dc34d764b6b380dc3cb63bf4eb8fc249e0a105220efdd) now returns null for an unavailable explicit editor override instead of falling back to the stored or default editor.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f46aa75.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added terminal link actions for opening, copying, revealing files, and adding links or paths to chat.
  - Terminal links remain highlighted while their context menu is open.
  - Added support for opening eligible terminal links in the integrated browser.
  - Added editor selection controls when opening terminal paths.

- **Bug Fixes**
  - Improved terminal link handling across platforms and browser preferences.
  - Added clearer fallback behavior when integrated-browser or file-reveal actions are unavailable.
  - Corrected display of the POSIX filesystem root path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->