### PR TITLE
ci: only boot the macOS native lint runner when native sources change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,8 +175,9 @@ jobs:
           paths=$(tr '\t' '\n' <<< "$rows")
 
           # Sources scripts/mobile-native-static-check.ts lints, plus the tool
-          # and rule configuration that decides how it lints them.
-          pattern='^apps/mobile/.*\.(swift|kt|kts)$|^apps/mobile/(\.swiftlint\.yml|detekt\.yml|\.editorconfig|Brewfile)$|^scripts/mobile-native-static-check\.ts$|^\.github/workflows/ci\.yml$'
+          # and rule configuration that decides how it lints them, plus the
+          # root package.json that defines the lint:mobile command.
+          pattern='^apps/mobile/.*\.(swift|kt|kts)$|^apps/mobile/(\.swiftlint\.yml|detekt\.yml|\.editorconfig|Brewfile)$|^scripts/mobile-native-static-check\.ts$|^package\.json$|^\.github/workflows/ci\.yml$'
 
           if grep -qE "$pattern" <<< "$paths"; then
             echo "Native sources or lint configuration changed:"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,8 +110,60 @@ jobs:
       - name: Test resource monitor
         run: cargo test --locked --manifest-path native/resource-monitor/Cargo.toml
 
+  # The static analysis below needs a macOS runner, which bills ~6.7x a Linux
+  # minute, so gate it on the native sources it actually lints instead of paying
+  # for it on every push. Detection is API-only (no checkout) and fails open: if
+  # the diff cannot be resolved, the lint runs.
+  mobile_native_changes:
+    name: Mobile Native Changes
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      changed: ${{ steps.detect.outputs.changed }}
+    steps:
+      - name: Detect mobile native changes
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -uo pipefail
+
+          if [[ -n "${PR_NUMBER}" ]]; then
+            files=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
+            status=$?
+          else
+            files=$(gh api "repos/${GITHUB_REPOSITORY}/compare/${BEFORE_SHA}...${GITHUB_SHA}" --paginate --jq '.files[].filename')
+            status=$?
+          fi
+
+          if [[ "$status" -ne 0 ]]; then
+            echo "Could not resolve changed files; running native static analysis."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Sources scripts/mobile-native-static-check.ts lints, plus the tool
+          # and rule configuration that decides how it lints them.
+          pattern='^apps/mobile/.*\.(swift|kt|kts)$|^apps/mobile/(\.swiftlint\.yml|detekt\.yml|\.editorconfig|Brewfile)$|^scripts/mobile-native-static-check\.ts$|^\.github/workflows/ci\.yml$'
+
+          if grep -qE "$pattern" <<< "$files"; then
+            echo "Native sources or lint configuration changed:"
+            grep -E "$pattern" <<< "$files"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No mobile native sources or lint configuration changed."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
   mobile_native_static_analysis:
     name: Mobile Native Static Analysis
+    needs: mobile_native_changes
+    if: needs.mobile_native_changes.outputs.changed == 'true'
     runs-on: blacksmith-6vcpu-macos-26
     timeout-minutes: 10
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,27 +133,54 @@ jobs:
         run: |
           set -uo pipefail
 
-          if [[ -n "${PR_NUMBER}" ]]; then
-            files=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
-            status=$?
-          else
-            files=$(gh api "repos/${GITHUB_REPOSITORY}/compare/${BEFORE_SHA}...${GITHUB_SHA}" --paginate --jq '.files[].filename')
-            status=$?
-          fi
-
-          if [[ "$status" -ne 0 ]]; then
-            echo "Could not resolve changed files; running native static analysis."
+          fail_open() {
+            echo "$* Running native static analysis."
             echo "changed=true" >> "$GITHUB_OUTPUT"
             exit 0
+          }
+
+          count_rows() {
+            printf '%s\n' "$1" | grep -c . || true
+          }
+
+          # One row per changed file, holding the new path and, for a rename,
+          # the path it replaced: renaming a matched file out of the matched
+          # paths removes a lint input just like editing it.
+          row='[.filename, (.previous_filename // empty)] | @tsv'
+
+          if [[ -n "${PR_NUMBER}" ]]; then
+            # The PR files endpoint stops at 3000 files and pagination cannot
+            # extend it, so cross-check against the count the PR itself reports.
+            expected=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.changed_files') \
+              || fail_open "Could not read the pull request."
+            rows=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --paginate --jq ".[] | ${row}") \
+              || fail_open "Could not resolve changed files."
+
+            listed=$(count_rows "$rows")
+            if [[ "$listed" -lt "$expected" ]]; then
+              fail_open "GitHub listed only ${listed} of ${expected} changed files."
+            fi
+          else
+            rows=$(gh api "repos/${GITHUB_REPOSITORY}/compare/${BEFORE_SHA}...${GITHUB_SHA}" --jq ".files[]? | ${row}") \
+              || fail_open "Could not resolve changed files."
+
+            # The compare endpoint reports at most 300 files and pagination does
+            # not extend that list, so a full list may be hiding native changes.
+            listed=$(count_rows "$rows")
+            if [[ "$listed" -ge 300 ]]; then
+              fail_open "GitHub listed ${listed} changed files, the compare endpoint maximum."
+            fi
           fi
+
+          paths=$(tr '\t' '\n' <<< "$rows")
 
           # Sources scripts/mobile-native-static-check.ts lints, plus the tool
           # and rule configuration that decides how it lints them.
           pattern='^apps/mobile/.*\.(swift|kt|kts)$|^apps/mobile/(\.swiftlint\.yml|detekt\.yml|\.editorconfig|Brewfile)$|^scripts/mobile-native-static-check\.ts$|^\.github/workflows/ci\.yml$'
 
-          if grep -qE "$pattern" <<< "$files"; then
+          if grep -qE "$pattern" <<< "$paths"; then
             echo "Native sources or lint configuration changed:"
-            grep -E "$pattern" <<< "$files"
+            grep -E "$pattern" <<< "$paths"
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "No mobile native sources or lint configuration changed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,9 @@ jobs:
   mobile_native_static_analysis:
     name: Mobile Native Static Analysis
     needs: mobile_native_changes
-    if: needs.mobile_native_changes.outputs.changed == 'true'
+    # Skip only on an explicit "no": a gate job that failed or errored leaves the
+    # output empty, and that must run the lint rather than silently skip it.
+    if: ${{ !cancelled() && needs.mobile_native_changes.outputs.changed != 'false' }}
     runs-on: blacksmith-6vcpu-macos-26
     timeout-minutes: 10
     steps:

--- a/docs/internals/ci.md
+++ b/docs/internals/ci.md
@@ -2,8 +2,8 @@
 
 > For maintainers. Using T3 Code? See [docs/user](../user/).
 
-[`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) runs four jobs on pull requests and
-pushes to `main`:
+[`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) runs these quality gates on pull requests
+and pushes to `main`:
 
 - **Check**: `vp check` (format and lint; this repo sets `typeCheck: false` in its lint options),
   then `vpr typecheck` for the workspace type check. The same job
@@ -13,10 +13,11 @@ pushes to `main`:
 - **Mobile Native Static Analysis**: `vp run lint:mobile` on macOS, wrapping
   `scripts/mobile-native-static-check.ts`. A cheap Linux **Mobile Native Changes** job gates it:
   the macOS runner only boots when the diff touches `apps/mobile` Swift/Kotlin sources, the
-  SwiftLint/detekt/ktlint configuration, the `Brewfile`, the check script, or `ci.yml`. Otherwise
-  the job is skipped, which GitHub reports as success for the required check. Renames are matched on
-  both their old and new path. If the changed-file list cannot be resolved, or GitHub truncates it,
-  the gate fails open and the lint runs.
+  SwiftLint/detekt/ktlint configuration, the `Brewfile`, the check script, the root `package.json`
+  that defines `lint:mobile`, or `ci.yml`. Otherwise the job is skipped, which GitHub reports as
+  success for the required check. Renames are matched on both their old and new path. If the
+  changed-file list cannot be resolved, or GitHub truncates it, the gate fails open and the lint
+  runs.
 - **Release Smoke**: exercises release-only workflow steps through `scripts/release-smoke.ts`, so
   release breakage surfaces on PRs rather than at tag time.
 

--- a/docs/internals/ci.md
+++ b/docs/internals/ci.md
@@ -15,9 +15,9 @@ and pushes to `main`:
   the macOS runner only boots when the diff touches `apps/mobile` Swift/Kotlin sources, the
   SwiftLint/detekt/ktlint configuration, the `Brewfile`, the check script, the root `package.json`
   that defines `lint:mobile`, or `ci.yml`. Otherwise the job is skipped, which GitHub reports as
-  success for the required check. Renames are matched on both their old and new path. If the
-  changed-file list cannot be resolved, or GitHub truncates it, the gate fails open and the lint
-  runs.
+  success for the required check. Renames are matched on both their old and new path. The gate fails
+  open in every other case: if the changed-file list cannot be resolved, GitHub truncates it, or the
+  gate job itself fails, the lint runs.
 - **Release Smoke**: exercises release-only workflow steps through `scripts/release-smoke.ts`, so
   release breakage surfaces on PRs rather than at tag time.
 

--- a/docs/internals/ci.md
+++ b/docs/internals/ci.md
@@ -11,7 +11,11 @@ pushes to `main`:
   still exports its expected symbols.
 - **Test**: `vp run test` across the workspace.
 - **Mobile Native Static Analysis**: `vp run lint:mobile` on macOS, wrapping
-  `scripts/mobile-native-static-check.ts`.
+  `scripts/mobile-native-static-check.ts`. A cheap Linux **Mobile Native Changes** job gates it:
+  the macOS runner only boots when the diff touches `apps/mobile` Swift/Kotlin sources, the
+  SwiftLint/detekt/ktlint configuration, the `Brewfile`, the check script, or `ci.yml`. Otherwise
+  the job is skipped, which GitHub reports as success for the required check. If the changed-file
+  list cannot be resolved, the gate fails open and the lint runs.
 - **Release Smoke**: exercises release-only workflow steps through `scripts/release-smoke.ts`, so
   release breakage surfaces on PRs rather than at tag time.
 

--- a/docs/internals/ci.md
+++ b/docs/internals/ci.md
@@ -14,8 +14,9 @@ pushes to `main`:
   `scripts/mobile-native-static-check.ts`. A cheap Linux **Mobile Native Changes** job gates it:
   the macOS runner only boots when the diff touches `apps/mobile` Swift/Kotlin sources, the
   SwiftLint/detekt/ktlint configuration, the `Brewfile`, the check script, or `ci.yml`. Otherwise
-  the job is skipped, which GitHub reports as success for the required check. If the changed-file
-  list cannot be resolved, the gate fails open and the lint runs.
+  the job is skipped, which GitHub reports as success for the required check. Renames are matched on
+  both their old and new path. If the changed-file list cannot be resolved, or GitHub truncates it,
+  the gate fails open and the lint runs.
 - **Release Smoke**: exercises release-only workflow steps through `scripts/release-smoke.ts`, so
   release breakage surfaces on PRs rather than at tag time.
 


### PR DESCRIPTION
`Mobile Native Static Analysis` runs `swiftlint`/`ktlint`/`detekt` over 19 files under `apps/mobile/modules/*/{ios,android}`, and it runs on every PR push and every merge to `main`. It needs a macOS runner, which bills at ~6.7x a Linux minute, so those 40-second lint runs added up to **$1,131 of the org's $2,591 Blacksmith bill over the last 30 days: 44% of all CI spend, for the single cheapest check we run**. In the same window only 6 of 658 commits on `main` touched a `.swift`, `.kt`, or `.kts` file, so ~99% of those macOS boots linted an unchanged tree.

This adds a ~15-second Linux gate job that resolves the changed-file list from the API (no checkout) and gates the macOS job on it:

```yaml
  mobile_native_static_analysis:
    name: Mobile Native Static Analysis
    needs: mobile_native_changes
    if: ${{ !cancelled() && needs.mobile_native_changes.outputs.changed != 'false' }}
    runs-on: blacksmith-6vcpu-macos-26
```

The gate trips on `apps/mobile` Swift/Kotlin sources, the SwiftLint/detekt/ktlint configuration, the `Brewfile`, `scripts/mobile-native-static-check.ts`, and `ci.yml` itself. If the diff cannot be resolved (API error, odd force-push) it fails open and the lint runs.

`Mobile Native Static Analysis` is a required check in the `Passing CI on main` ruleset. The job name is unchanged and it still reports on every run: when the gate says no, GitHub reports the skipped job as success, which [does not block merging](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks) even for a required check. No ruleset edit is needed. Coverage is unchanged: any diff that can affect the lint result still runs it on macOS.

Expected saving is roughly $1.1k/month, ~40% of total CI spend, with no loss of signal.

Written by [code]smith (Claude Opus 4.6).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow and documentation only; fail-open design preserves lint coverage when detection is uncertain.
> 
> **Overview**
> Adds a cheap Linux **`Mobile Native Changes`** job that uses the GitHub API (no checkout) to decide whether **`Mobile Native Static Analysis`** should run on macOS, avoiding ~6.7× billing when the diff does not touch mobile native work.
> 
> The detector matches `apps/mobile` `.swift`/`.kt`/`.kts` files, related lint config (`SwiftLint`, detekt, `.editorconfig`, `Brewfile`), `scripts/mobile-native-static-check.ts`, root `package.json`, and `ci.yml`, including rename old/new paths. It **fails open** when file lists cannot be trusted (API errors, PR/compare truncation vs. reported counts, or ≥300 compare files). The macOS job uses `needs` and only skips when `changed` is explicitly `false`; empty output after a gate failure still runs lint.
> 
> **`docs/internals/ci.md`** documents the gate, skip-as-success behavior for required checks, and fail-open rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cdce5612dc273224562fb75f789bcc16e3a58dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip macOS native lint runner when no native sources change
> - Adds a `mobile_native_changes` Linux gate job that detects whether Swift/Kotlin sources or lint configuration changed, using the GitHub API to enumerate changed files for both PR and push contexts.
> - The `mobile_native_static_analysis` macOS job now depends on this gate and is skipped when the gate outputs `changed=false`.
> - The gate fails open to `true` when the changed-file list is unresolvable or potentially truncated, ensuring analysis is never incorrectly skipped.
> - Updates [ci.md](https://github.com/pingdotgg/t3code/pull/7283/files#diff-d88698dc5909f010b1462a8ad36a3f429f191b627825e2acac8214ba2ec254b3) to document the new gate, its trigger paths, rename handling, and fail-open behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0cdce56.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->