### PR TITLE
ci(swift-ios): right-size native test runner to 12 vCPU macOS

### DIFF
--- a/.github/workflows/swift-ios.yml
+++ b/.github/workflows/swift-ios.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   test:
     name: Contract fixtures and native tests
-    runs-on: blacksmith-6vcpu-macos-26
+    runs-on: blacksmith-12vcpu-macos-26
     timeout-minutes: 25
     steps:
       - name: Checkout


### PR DESCRIPTION
The `SwiftUI iOS` workflow only exists on `t3code/rebuild-mobile-app-swift`, so this targets that branch rather than `main`. It is the remaining row from the right-sizing card that could not be applied in #7284.

```yaml
  test:
    name: Contract fixtures and native tests
-    runs-on: blacksmith-6vcpu-macos-26
+    runs-on: blacksmith-12vcpu-macos-26
```

## Apply for speed

**`SwiftUI iOS / Contract fixtures and native tests`** (`.github/workflows/swift-ios.yml`): `blacksmith-6vcpu-macos-26` -> `blacksmith-12vcpu-macos-26`, high confidence.
This is the most clearly CPU-bound job in the repo: average CPU is 95% and it sits above 80% CPU for 91% of its runtime across all 6 cores, with peak memory at 58%. Doubling cores projects p50 down from 139s to 87s (-37%) and p95 from 229s to 152s (-34%), measured over 269 runs in the last 30 days. Runtime-adjusted spend rises about $61/month, the best wall-time-per-dollar row on the card. [Median run](https://app.blacksmith.sh/pingdotgg/runs/31347832415/jobs/93332985136?tab=metrics) - [Slow run (p95)](https://app.blacksmith.sh/pingdotgg/runs/31303595075/jobs/93220235437?tab=metrics)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only runner label change with no application or security impact; cost and queue behavior may shift slightly.
> 
> **Overview**
> **Right-sizes the SwiftUI iOS CI runner** for the **Contract fixtures and native tests** job by changing `runs-on` from `blacksmith-6vcpu-macos-26` to `blacksmith-12vcpu-macos-26`.
> 
> No workflow steps, paths, or timeouts change—only the Blacksmith runner size. This aligns the job with other CPU-heavy macOS workflows (e.g. release builds and mobile showcase screenshots) that already use 12 vCPU.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41505329f474944c56a8501c152f3a1761ffdf88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Increase native test runner to 12 vCPU macOS in swift-ios CI
> Updates the `runs-on` label for the 'Contract fixtures and native tests' job in [swift-ios.yml](.github/workflows/swift-ios.yml) from `blacksmith-6vcpu-macos-26` to `blacksmith-12vcpu-macos-26`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4150532.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->