### PR TITLE
perf(ci): parallelize the test suite and split out Rust checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,9 +108,9 @@ jobs:
           cache: true
           run-install: true
 
-      - name: Ensure Electron runtime is installed
-        run: vp run --filter @t3tools/desktop ensure:electron
-
+      # No Electron setup here: `t3` (apps/server) has no Electron dependency
+      # and none of its tests touch the runtime. Only the non-server `test`
+      # job, which covers @t3tools/desktop, needs the download.
       - name: Test
         env:
           T3CODE_TRANSFER_BUDGET_REPORT_PATH: ${{ runner.temp }}/t3code-transfer-budget.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,6 @@ jobs:
           cache: true
           run-install: true
 
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
-
       - name: Ensure Electron runtime is installed
         run: vp run --filter @t3tools/desktop ensure:electron
 
@@ -44,9 +39,6 @@ jobs:
 
       - name: Typecheck
         run: vpr typecheck
-
-      - name: Check resource monitor formatting
-        run: cargo fmt --manifest-path native/resource-monitor/Cargo.toml -- --check
 
       - name: Build desktop pipeline
         run: vp run build:desktop
@@ -57,6 +49,11 @@ jobs:
           grep -nE "desktopBridge|getLocalEnvironmentBootstrap|PICK_FOLDER_CHANNEL|wsUrl" apps/desktop/dist-electron/preload.cjs
           grep -n "__clerk_internal_electron_passkeys" apps/desktop/dist-electron/preload.cjs
 
+  # Everything except `t3` (apps/server). `--parallel` drops the package
+  # dependency ordering that `vp run` applies by default: these `test` tasks
+  # declare no `dependsOn` and resolve workspace deps from source, so ordering
+  # only bought us idle runners between dependency layers. The concurrency
+  # limit stays at the default 4 so peak load per runner is unchanged.
   test:
     name: Test
     runs-on: blacksmith-8vcpu-ubuntu-2404
@@ -77,8 +74,39 @@ jobs:
           cache: true
           run-install: true
 
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+      - name: Ensure Electron runtime is installed
+        run: vp run --filter @t3tools/desktop ensure:electron
+
+      - name: Test
+        run: vp run --parallel --concurrency-limit 4 --filter '!t3' --filter '!@t3tools/monorepo' test
+
+  # apps/server sets `fileParallelism: false`, so its 239 files run strictly
+  # one at a time. Sharding spreads them over separate runners instead of
+  # separate workers, so no two server test files ever share a machine and the
+  # isolation that flag buys is preserved exactly.
+  test_server:
+    name: Test Server ${{ matrix.shard }}
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            /*
+            !/.repos/
+          sparse-checkout-cone-mode: false
+
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version-file: package.json
+          cache: true
+          run-install: true
 
       - name: Ensure Electron runtime is installed
         run: vp run --filter @t3tools/desktop ensure:electron
@@ -87,10 +115,24 @@ jobs:
         env:
           T3CODE_TRANSFER_BUDGET_REPORT_PATH: ${{ runner.temp }}/t3code-transfer-budget.md
           T3CODE_TRANSFER_BUDGET_RESULT_PATH: ${{ runner.temp }}/thread-transfer-result.json
-        run: vp run test
+        run: vp run --filter t3 test --shard ${{ matrix.shard }}/${{ strategy.job-total }}
+
+      # src/server.test.ts writes the budget report, so exactly one shard
+      # produces these files. Gating the upload on their presence keeps a
+      # single `thread-transfer-results` artifact per run, which is the name
+      # thread-transfer-report.yml resolves.
+      - name: Detect transfer budget report
+        id: transfer_budget
+        if: always()
+        run: |
+          if test -f "${{ runner.temp }}/thread-transfer-result.json"; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Publish transfer budget report
-        if: always()
+        if: always() && steps.transfer_budget.outputs.present == 'true'
         run: |
           if test -f "${{ runner.temp }}/t3code-transfer-budget.md"; then
             tee -a "$GITHUB_STEP_SUMMARY" < "${{ runner.temp }}/t3code-transfer-budget.md"
@@ -99,13 +141,36 @@ jobs:
           fi
 
       - name: Upload thread transfer result
-        if: always()
+        if: always() && steps.transfer_budget.outputs.present == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: thread-transfer-results
           path: ${{ runner.temp }}/thread-transfer-result.json
           if-no-files-found: ignore
           retention-days: 30
+
+  # Split out of Check and Test: both paid ~7-9s to install a Rust toolchain
+  # for checks that take under 3s, on the critical path of every PR.
+  rust:
+    name: Rust
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            /*
+            !/.repos/
+          sparse-checkout-cone-mode: false
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check resource monitor formatting
+        run: cargo fmt --manifest-path native/resource-monitor/Cargo.toml -- --check
 
       - name: Test resource monitor
         run: cargo test --locked --manifest-path native/resource-monitor/Cargo.toml


### PR DESCRIPTION
`CI / Test` is the critical path on every PR: ~200s, against ~78s for `Check`. Pulling the step timeline and VM metrics for a dozen recent runs shows why, and it is very consistent (123-124s in every sample).

`vp run -r test` walks the package dependency graph, so `apps/server` runs **last and alone** for 124s of the 161s test step. Everything else is done in ~37s. The CPU trace for that job shows the shape exactly:

```
01:45:54  86.35   <- 4 packages in parallel, 8 vCPU saturated
01:46:10  99.81
01:46:30  89.28
01:46:40  18.31   <- apps/server starts, alone
01:47:00  18.89
01:47:30  18.77
01:48:00  20.10
01:48:30  19.64   <- 115s pinned at ~1.5 of 8 cores
```

That 19% is not a tuning problem. `apps/server/vite.config.ts` sets `fileParallelism: false` on purpose, so its 239 test files run strictly one at a time in a single worker (`tests 66.43s, import 44.03s` ≈ the 124s wall). This PR does not touch that flag: the load-sensitive flakes it prevents are real.

Instead it gets the parallelism from separate runners, so no two server test files ever share a machine and the isolation the flag buys is preserved exactly:

```yaml
  test_server:
    name: Test Server ${{ matrix.shard }}
    strategy:
      fail-fast: false
      matrix:
        shard: [1, 2, 3]
    steps:
      - name: Test
        run: vp run --filter t3 test --shard ${{ matrix.shard }}/${{ strategy.job-total }}
```

Three other changes fall out of the same timeline:

- The remaining package tests move to `vp run --parallel --concurrency-limit 4 --filter '!t3' --filter '!@t3tools/monorepo' test`. No `test` task declares `dependsOn` and they resolve workspace deps from source, so the ordering only bought idle runners between dependency layers. The concurrency limit stays at the default 4, so peak load per runner is unchanged.
- `Setup Rust` cost 8.6s in `Test` and 6.6s in `Check` to support `cargo fmt --check` (0.002s) and `cargo test` (2.3s). Both move to a new `Rust` job that skips the Vite+ setup entirely and lands around 26s, off the critical path.
- Exactly one shard runs `src/server.test.ts`, the sole producer of the transfer budget report. A detection step gates the upload so the run still publishes a single `thread-transfer-results` artifact, which is the name `thread-transfer-report.yml` resolves by exact match. No change needed downstream.

Expected critical path: **~205s → ~79s**. Sharding stops at 3 because that puts `Test Server` (~79s) at parity with `Check` (~71s); a 4th shard would only buy ~10s for another full setup. The extra runners cost roughly +$190/month against a $2,591 bill.

Flags were verified against vite-plus 0.2.9 in a scratch workspace rather than assumed, which caught two things worth knowing: `--filter` is silently broken when combined with `-r` (every form errors), and `--filter '!t3'` alone still selects the workspace root, whose `test` script is `vp run -r test` and would have re-run the entire suite inside the "everything else" job. Hence the explicit second `--filter '!@t3tools/monorepo'`.

**Heads up:** `Test Server 1/2/3` and `Rust` are new job names. Branch protection required checks need updating, and `Test` no longer covers the server suite or the Rust crate on its own.

Model: Claude Sonnet 4.5, harness: [code]smith.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which jobs run which tests and branch-protection check names; misconfigured required checks or filter/shard mistakes could skip server or Rust validation until caught.
> 
> **Overview**
> **Restructures CI** so PR wall time drops by running work on more runners instead of one long sequential `test` step.
> 
> The main **`Test`** job now runs only non-server packages with `vp run --parallel` (concurrency 4), explicitly excluding `t3` and the monorepo root so the workspace root does not re-invoke the full suite.
> 
> **`apps/server` (`t3`)** moves to a new **`Test Server`** matrix (3 shards) with `--shard N/3`, preserving single-file isolation from `fileParallelism: false` by sharding across machines rather than workers. That job skips Electron setup and only uploads/publishes the thread-transfer budget artifact when the result JSON exists on that shard.
> 
> **Rust** (`cargo fmt --check` and `cargo test` for `native/resource-monitor`) is pulled out of **Check** and **Test** into a separate **`Rust`** job on a 4 vCPU runner without Vite+ install, so ~7–9s toolchain setup is no longer on every Node job’s critical path.
> 
> **Operational note:** required status checks must add `Test Server 1/2/3` and `Rust`; legacy **`Test`** alone no longer covers server or Rust.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e7039403edf97eff6bd3a0d18be37044831da1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parallelize CI test suite and split Rust checks into a dedicated job
> - Non-server workspace tests now run in parallel with `--concurrency-limit 4`, excluding `t3` and `@t3tools/monorepo`.
> - Server (`t3`) tests are sharded across 3 parallel CI jobs using the framework's shard mechanism; budget report publishing and artifact upload are gated to the shard that produces the files.
> - Rust formatting (`cargo fmt --check`) and tests for `native/resource-monitor` move to a dedicated job on a 4 vCPU runner, removed from the `check` and `test` jobs.
> - Behavioral Change: the `check` job no longer installs a Rust toolchain or validates Rust formatting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e70394.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->