### PR TITLE
fix(web): resolve sidebar provider icons from the thread's own environment

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -164,11 +164,10 @@ import { ProjectFavicon } from "./ProjectFavicon";
 import { ProviderInstanceIcon } from "./chat/ProviderInstanceIcon";
 import { getTriggerDisplayModelLabel } from "./chat/providerIconUtils";
 import {
-  deriveProviderInstanceEntries,
+  deriveProviderEntriesByEnvironment,
   shouldShowInstanceBadge,
   type ProviderInstanceEntry,
 } from "../providerInstances";
-import { primaryServerProvidersAtom } from "../state/server";
 import { useThreadRunningTerminalIds } from "../state/terminalSessions";
 import { stackedThreadToast, toastManager } from "./ui/toast";
 import { Button } from "./ui/button";
@@ -245,6 +244,8 @@ function WorkingDuration(props: { startedAt: string | null }) {
     </span>
   );
 }
+
+const EMPTY_PROVIDER_ENTRIES: ReadonlyMap<string, ProviderInstanceEntry> = new Map();
 
 function terminalProcessLabel(count: number): string {
   return `${count} terminal ${count === 1 ? "process" : "processes"} running`;
@@ -1860,15 +1861,18 @@ export default function Sidebar() {
     () => sortLogicalProjectsForSidebar(unsortedProjectGroups, threads, sidebarProjectSortOrder),
     [sidebarProjectSortOrder, threads, unsortedProjectGroups],
   );
-  const serverProviders = useAtomValue(primaryServerProvidersAtom);
-  const providerEntryByInstanceId = useMemo(
+  const serverConfigs = useAtomValue(environmentServerConfigsAtom);
+  // Threads on non-primary environments (T3 Connect, hosted) resolve their
+  // provider entry from their own environment's config: default instance ids
+  // are driver slugs, so a flat map would collide across environments.
+  const providerEntriesByEnvironment = useMemo(
     () =>
-      new Map(
-        deriveProviderInstanceEntries(serverProviders).map(
-          (entry) => [entry.instanceId as string, entry] as const,
+      deriveProviderEntriesByEnvironment(
+        [...serverConfigs].map(
+          ([environmentId, config]) => [environmentId, config.providers] as const,
         ),
       ),
-    [serverProviders],
+    [serverConfigs],
   );
   const projectCwdByKey = useMemo(
     () =>
@@ -1989,7 +1993,6 @@ export default function Sidebar() {
   // the partition works directly off live shells: no archived-snapshot
   // merging, no optimistic holds. Archived threads remain hidden here —
   // archive keeps its original "remove from sidebar" meaning.
-  const serverConfigs = useAtomValue(environmentServerConfigsAtom);
   const {
     pinnedThreads,
     reorderablePinnedKeys,
@@ -3596,7 +3599,10 @@ export default function Sidebar() {
                           ) ?? null
                         }
                         environmentLabel={environmentLabelById.get(thread.environmentId) ?? null}
-                        providerEntryByInstanceId={providerEntryByInstanceId}
+                        providerEntryByInstanceId={
+                          providerEntriesByEnvironment.get(thread.environmentId) ??
+                          EMPTY_PROVIDER_ENTRIES
+                        }
                         isHighlighted={activeSearchResultIndex === index}
                         isRouteActive={routeThreadKey === threadKey}
                         resultId={`sidebar-thread-search-result-${index}`}
@@ -3705,7 +3711,10 @@ export default function Sidebar() {
                             `${thread.environmentId}:${thread.projectId}`,
                           ) ?? null
                         }
-                        providerEntryByInstanceId={providerEntryByInstanceId}
+                        providerEntryByInstanceId={
+                          providerEntriesByEnvironment.get(thread.environmentId) ??
+                          EMPTY_PROVIDER_ENTRIES
+                        }
                         timestampFormat={timestampFormat}
                         onThreadClick={handleThreadClick}
                         onThreadActivate={navigateToThread}

--- a/apps/web/src/providerInstances.test.ts
+++ b/apps/web/src/providerInstances.test.ts
@@ -2,6 +2,7 @@ import { ProviderDriverKind, ProviderInstanceId, type ServerProvider } from "@t3
 import { describe, expect, it } from "vite-plus/test";
 import {
   applyProviderInstanceSettings,
+  deriveProviderEntriesByEnvironment,
   deriveProviderInstanceEntries,
   getDefaultProviderInstanceModel,
   isProviderInstancePickerReady,
@@ -17,6 +18,7 @@ function provider(input: {
   enabled?: boolean;
   availability?: ServerProvider["availability"];
   displayName?: string;
+  accentColor?: string;
   status?: ServerProvider["status"];
   models?: ServerProvider["models"];
 }): ServerProvider {
@@ -24,6 +26,7 @@ function provider(input: {
     instanceId: ProviderInstanceId.make(input.instanceId),
     driver: input.provider,
     ...(input.displayName ? { displayName: input.displayName } : {}),
+    ...(input.accentColor ? { accentColor: input.accentColor } : {}),
     enabled: input.enabled ?? true,
     installed: true,
     version: null,
@@ -129,6 +132,52 @@ describe("deriveProviderInstanceEntries", () => {
     expect(entry?.instanceId).toBe("codex_personal");
     expect(entry?.driverKind).toBe("codex");
     expect(entry?.isDefault).toBe(false);
+  });
+});
+
+describe("deriveProviderEntriesByEnvironment", () => {
+  it("keeps same-id default instances distinct per environment", () => {
+    const byEnvironment = deriveProviderEntriesByEnvironment([
+      [
+        "local",
+        [
+          provider({
+            provider: ProviderDriverKind.make("claude"),
+            instanceId: "claude",
+            displayName: "Claude Local",
+            accentColor: "#112233",
+          }),
+        ],
+      ],
+      [
+        "remote",
+        [
+          provider({
+            provider: ProviderDriverKind.make("claude"),
+            instanceId: "claude",
+            displayName: "Claude Remote",
+            accentColor: "#445566",
+          }),
+        ],
+      ],
+    ]);
+
+    expect(byEnvironment.get("local")?.get("claude")?.displayName).toBe("Claude Local");
+    expect(byEnvironment.get("local")?.get("claude")?.accentColor).toBe("#112233");
+    expect(byEnvironment.get("remote")?.get("claude")?.displayName).toBe("Claude Remote");
+    expect(byEnvironment.get("remote")?.get("claude")?.accentColor).toBe("#445566");
+  });
+
+  it("never falls back to another environment's instances", () => {
+    const byEnvironment = deriveProviderEntriesByEnvironment([
+      ["local", [provider({ provider: ProviderDriverKind.make("codex"), instanceId: "codex" })]],
+      ["empty", []],
+    ]);
+
+    expect(byEnvironment.get("empty")?.get("codex")).toBeUndefined();
+    // Every environment gets its own bucket, so an absent lookup is a real
+    // "this environment has no such instance", not a missing key.
+    expect(byEnvironment.get("empty")?.size).toBe(0);
   });
 });
 

--- a/apps/web/src/providerInstances.ts
+++ b/apps/web/src/providerInstances.ts
@@ -201,6 +201,33 @@ export function deriveProviderInstanceEntries(
 }
 
 /**
+ * Project several environments' `ServerProvider[]` into a nested
+ * `environmentId → instanceId → entry` lookup.
+ *
+ * Instance ids are per-environment routing keys, and `defaultInstanceIdForDriver`
+ * makes the default id literally the driver slug, so every environment running
+ * the same driver reports the same id. Flattening across environments would
+ * clobber entries and mis-resolve accent colors; lookups must stay scoped to
+ * the thread's own environment.
+ */
+export function deriveProviderEntriesByEnvironment(
+  providersByEnvironment: Iterable<readonly [string, ReadonlyArray<ServerProvider>]>,
+): ReadonlyMap<string, ReadonlyMap<string, ProviderInstanceEntry>> {
+  const byEnvironment = new Map<string, ReadonlyMap<string, ProviderInstanceEntry>>();
+  for (const [environmentId, providers] of providersByEnvironment) {
+    byEnvironment.set(
+      environmentId,
+      new Map(
+        deriveProviderInstanceEntries(providers).map(
+          (entry) => [entry.instanceId as string, entry] as const,
+        ),
+      ),
+    );
+  }
+  return byEnvironment;
+}
+
+/**
  * Overlay the current settings configuration onto streamed provider snapshots.
  * Provider probes can briefly retain their previous `enabled` value after a
  * settings write, so picker visibility must follow settings rather than waiting


### PR DESCRIPTION
## What Changed

Sidebar v2 now resolves each thread's provider identity from **that thread's own environment** instead of a single flat map built from `primaryServerProvidersAtom`:

- New pure helper `deriveProviderEntriesByEnvironment` in `providerInstances.ts` builds a nested map (`environmentId → instanceId → ProviderInstanceEntry`) — with a doc note that default instance ids are driver slugs, so lookups must never cross environments.
- `Sidebar.tsx` feeds it from `environmentServerConfigsAtom` (already read in the component for capability flags — now read once), and the two render sites pass each row `providerEntriesByEnvironment.get(thread.environmentId)` — the same per-thread lookup idiom the file already uses for `projectCwdByKey` and `environmentLabelById`. `SidebarThreadRow`, `SidebarSearchResultRow`, and the hover card are unchanged; they keep receiving the same flat per-environment map as before, now scoped correctly. The account-badge heuristic from #5980 therefore counts duplicate accounts within one environment only.
- Focused unit tests cover the collision case: two environments both carrying instance id `claude` with different accent colors resolve independently, and an environment with no providers yields no entries rather than falling back across environments.

One deliberate trade: a thread on an environment whose config hasn't streamed yet (still connecting, or offline) now renders no provider icon until the config arrives, instead of borrowing a colliding entry from the primary environment — no icon is honest; the wrong account is not. This also aligns web with mobile, which already resolves the driver per environment and renders nothing when that environment's config is absent (`apps/mobile/src/features/home/HomeScreen.tsx`, `ThreadNavigationSidebar.tsx`).

## Why

Fixes #5289. The flat primary-only map fails non-primary environments (T3 Connect, hosted app.t3.codes, multi-environment) in two ways:

1. **No primary set** → the map is empty → provider icon, account accent badge (#5977/#5980), and the hover card's provider line vanish for every row — the symptom in #5289.
2. **Primary set + id collision** → `defaultInstanceIdForDriver` makes default instance ids literally the driver slug (`"claude"`), so remote threads resolve the **primary environment's** entry and render the wrong account's color and name — the sidebar misattributes which account/quota a remote thread burns.

#5300 attempted this with a flat merged map across environments; that shape silently clobbers colliding default ids (last environment wins), which is why this PR scopes the map per environment instead — the same pattern `CommandPalette.tsx` already ships for its own thread list.

## UI Changes

Reproduced with a real two-environment setup: a primary dev environment plus a second headless server paired via Settings → Connections, seeded with the same threads but distinct account accent colors (`envB-*` accounts in red/amber). Remote rows carry the server glyph.

| | Before | After |
|---|---|---|
| Sidebar rows | <img src="https://gist.githubusercontent.com/vitalyiegorov/e643fa28477c035bf155d43c3fa11a5f/raw/env-before-sidebar.png" width="290" alt="Remote rows borrow the primary environment's badges (purple VI, blue W1)" /> | <img src="https://gist.githubusercontent.com/vitalyiegorov/e643fa28477c035bf155d43c3fa11a5f/raw/env-after-sidebar.png" width="290" alt="Remote rows show their own environment's badges (amber EW, red EV) while primary rows keep VI" /> |
| Hover details card (remote thread) | <img src="https://gist.githubusercontent.com/vitalyiegorov/e643fa28477c035bf155d43c3fa11a5f/raw/env-before-tooltip.png" width="420" alt="Hover card claims the primary account work-1@example.com for a remote thread" /> | <img src="https://gist.githubusercontent.com/vitalyiegorov/e643fa28477c035bf155d43c3fa11a5f/raw/env-after-tooltip.png" width="420" alt="Hover card shows the thread's real account envB-work-1@example.com with its own accent" /> |

Before: remote rows either render **no icon at all** (no primary set — the #5289 report) or the **wrong account** (collision, shown above: purple "VI"/blue "W1" borrowed from the primary). After: each row wears its own environment's identity — same thread titles visible side by side with primary "VI" (purple) vs remote "EV" (red). No motion changes, so no video.

To verify locally: run a dev client, start a second server (`node apps/server/src/bin.ts serve --port <p> --base-dir <tmp>`) with different provider accent colors in its `settings.json`, pair it via Settings → Connections → Add environment, and compare the remote rows' badges and hover card before/after this change.

Verified with: new unit tests (`vp test run apps/web/src/providerInstances.test.ts`, 29 pass), `vp fmt --check`, `vp lint --report-unused-disable-directives` on the changed files, `vp run --filter @t3tools/web typecheck`, and the integrated two-environment pass above. Primary-environment rendering is unchanged (re-captured locally to confirm).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes (n/a — no motion changes)

Made by Claude Fable 5 in Claude Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sidebar provider icons to resolve from each thread's own environment
> - Previously, the sidebar used a single flat provider map shared across all environments, causing icon lookups to potentially resolve from the wrong environment.
> - Adds `deriveProviderEntriesByEnvironment` in [providerInstances.ts](https://github.com/pingdotgg/t3code/pull/7292/files#diff-366ee4ff966b3b9fefcc872cdc0d10484ac52c174b5ed0e8ed59e84e97f58d5b), which builds a nested `ReadonlyMap` of `environmentId → instanceId → ProviderInstanceEntry`.
> - [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/7292/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) now passes `providerEntriesByEnvironment.get(thread.environmentId)` to each thread item, scoping icon lookups to the thread's own environment with a fallback to an empty map.
> - Behavioral Change: provider entries are now strictly scoped per environment — icons will not fall back to entries from other environments.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a84833a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI lookup change with a pure helper and tests; no auth or server behavior changes, only slightly different icon display while an environment config is still loading.
> 
> **Overview**
> **Fixes multi-environment sidebar provider identity** (#5289): thread rows, search results, and hover cards no longer build provider metadata from `primaryServerProvidersAtom` alone.
> 
> Adds **`deriveProviderEntriesByEnvironment`** — a nested `environmentId → instanceId → ProviderInstanceEntry` map — because default instance ids are driver slugs and flattening across environments clobbered entries (wrong accent/name) or left remote rows with no icon when the primary map was empty.
> 
> **`Sidebar.tsx`** now derives that map from `environmentServerConfigsAtom` and passes `providerEntriesByEnvironment.get(thread.environmentId)` (with an empty-map fallback) into each row. **Trade-off:** until an environment's config streams in, a thread shows no provider icon rather than borrowing a colliding primary entry.
> 
> Unit tests cover same-id instances across two environments and no cross-environment fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a84833affcad9d4908e149d0a05f1cfcdb7092ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->