### PR TITLE
fix(desktop): cap macOS shell startup probe

### DIFF
--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -1,12 +1,15 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, describe, it } from "@effect/vitest";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Logger from "effect/Logger";
 import * as PlatformError from "effect/PlatformError";
 import * as Schema from "effect/Schema";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
+import * as TestClock from "effect/testing/TestClock";
 import * as ChildProcess from "effect/unstable/process/ChildProcess";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
@@ -46,6 +49,22 @@ function makeProcess(output: string): ChildProcessSpawner.ChildProcessHandle {
   });
 }
 
+function makeHangingProcess(): ChildProcessSpawner.ChildProcessHandle {
+  return ChildProcessSpawner.makeHandle({
+    pid: ChildProcessSpawner.ProcessId(124),
+    stdout: Stream.never,
+    stderr: Stream.never,
+    all: Stream.never,
+    exitCode: Effect.never,
+    isRunning: Effect.succeed(true),
+    kill: () => Effect.void,
+    stdin: Sink.drain,
+    getInputFd: () => Sink.drain,
+    getOutputFd: () => Stream.empty,
+    unref: Effect.succeed(Effect.void),
+  });
+}
+
 function withProcessEnv<A, E, R>(
   env: NodeJS.ProcessEnv,
   effect: Effect.Effect<A, E, R>,
@@ -67,7 +86,9 @@ function withProcessEnv<A, E, R>(
 function runShellEnvironment(input: {
   readonly env: NodeJS.ProcessEnv;
   readonly platform: NodeJS.Platform;
-  readonly handler: (command: ChildProcess.Command) => string;
+  readonly handler: (
+    command: ChildProcess.Command,
+  ) => string | ChildProcessSpawner.ChildProcessHandle;
   readonly failure?: PlatformError.PlatformError;
 }) {
   const environmentLayer = Layer.succeed(
@@ -78,11 +99,11 @@ function runShellEnvironment(input: {
   );
   const spawnerLayer = Layer.succeed(
     ChildProcessSpawner.ChildProcessSpawner,
-    ChildProcessSpawner.make((command) =>
-      input.failure === undefined
-        ? Effect.succeed(makeProcess(input.handler(command)))
-        : Effect.fail(input.failure),
-    ),
+    ChildProcessSpawner.make((command) => {
+      if (input.failure !== undefined) return Effect.fail(input.failure);
+      const result = input.handler(command);
+      return Effect.succeed(typeof result === "string" ? makeProcess(result) : result);
+    }),
   );
 
   const program = Effect.gen(function* () {
@@ -123,6 +144,7 @@ describe("DesktopShellEnvironment", () => {
 
       assert.equal(commands.length, 1);
       assert.equal(commands[0]?._tag === "StandardCommand" ? commands[0].command : "", "/bin/zsh");
+      assert.equal(commands[0]?._tag === "StandardCommand" ? commands[0].args[0] : "", "-lc");
       assert.equal(env.PATH, "/opt/homebrew/bin:/usr/bin:/Users/test/.local/bin");
       assert.equal(env.SSH_AUTH_SOCK, "/tmp/secretive.sock");
       assert.equal(env.HOMEBREW_PREFIX, "/opt/homebrew");
@@ -261,16 +283,20 @@ describe("DesktopShellEnvironment", () => {
         PATH: "/usr/bin",
       };
 
+      const commands: ChildProcess.Command[] = [];
       yield* runShellEnvironment({
         env,
         platform: "linux",
-        handler: () =>
-          envOutput({
+        handler: (command) => {
+          commands.push(command);
+          return envOutput({
             PATH: "/home/linuxbrew/.linuxbrew/bin:/usr/bin",
             SSH_AUTH_SOCK: "/tmp/secretive.sock",
-          }),
+          });
+        },
       });
 
+      assert.equal(commands[0]?._tag === "StandardCommand" ? commands[0].args[0] : "", "-ilc");
       assert.equal(env.PATH, "/home/linuxbrew/.linuxbrew/bin:/usr/bin");
       assert.equal(env.SSH_AUTH_SOCK, "/tmp/secretive.sock");
     }),
@@ -298,6 +324,47 @@ describe("DesktopShellEnvironment", () => {
       assert.equal(env.PATH, "/opt/homebrew/bin:/usr/bin");
     }),
   );
+
+  it.effect("caps a hanging macOS login shell before falling back to launchctl PATH", () => {
+    const env: NodeJS.ProcessEnv = {
+      SHELL: "/bin/zsh",
+      PATH: "/usr/bin",
+    };
+    const commands: string[] = [];
+    const testClockLayer = TestClock.layer();
+
+    return Effect.gen(function* () {
+      const fiber = yield* runShellEnvironment({
+        env,
+        platform: "darwin",
+        handler: (command) => {
+          if (command._tag !== "StandardCommand") return "";
+          commands.push(command.command);
+          if (command.command === "/bin/launchctl") {
+            return "/opt/homebrew/bin:/usr/bin";
+          }
+          assert.equal(
+            Duration.toMillis(Duration.fromInputUnsafe(command.options.forceKillAfter ?? 0)),
+            100,
+          );
+          return makeHangingProcess();
+        },
+      }).pipe(Effect.forkScoped);
+
+      yield* Effect.yieldNow;
+      assert.deepEqual(commands, ["/bin/zsh"]);
+
+      yield* TestClock.adjust(Duration.millis(749));
+      yield* Effect.yieldNow;
+      assert.deepEqual(commands, ["/bin/zsh"]);
+
+      yield* TestClock.adjust(Duration.millis(1));
+      yield* Fiber.join(fiber);
+
+      assert.deepEqual(commands, ["/bin/zsh", "/bin/launchctl"]);
+      assert.equal(env.PATH, "/opt/homebrew/bin:/usr/bin");
+    }).pipe(Effect.provide(testClockLayer));
+  });
 
   it.effect("loads PowerShell profile environment on Windows", () =>
     Effect.gen(function* () {

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -91,8 +91,10 @@ const LOCALE_ENV_NAMES = ["LANG", "LC_ALL", "LC_CTYPE"] as const;
 const FALLBACK_LC_CTYPE = "en_US.UTF-8";
 const WINDOWS_SHELL_CANDIDATES = ["pwsh.exe", "powershell.exe"] as const;
 const LOGIN_SHELL_TIMEOUT = Duration.seconds(5);
+const MACOS_LOGIN_SHELL_TIMEOUT = Duration.millis(750);
 const LAUNCHCTL_TIMEOUT = Duration.seconds(2);
 const PROCESS_TERMINATE_GRACE = Duration.seconds(1);
+const MACOS_LOGIN_SHELL_TERMINATE_GRACE = Duration.millis(100);
 
 const trimNonEmpty = (value: string | null | undefined): Option.Option<string> =>
   Option.fromNullishOr(value).pipe(
@@ -284,6 +286,7 @@ const runCommandOutput = Effect.fn("desktop.shellEnvironment.runCommandOutput")(
   readonly command: string;
   readonly args: ReadonlyArray<string>;
   readonly timeout: Duration.Duration;
+  readonly forceKillAfter?: Duration.Duration;
   readonly shell?: boolean;
 }): Effect.fn.Return<string, never, ChildProcessSpawner.ChildProcessSpawner> {
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
@@ -295,7 +298,7 @@ const runCommandOutput = Effect.fn("desktop.shellEnvironment.runCommandOutput")(
         stdout: "pipe",
         stderr: "pipe",
         killSignal: "SIGTERM",
-        forceKillAfter: PROCESS_TERMINATE_GRACE,
+        forceKillAfter: input.forceKillAfter ?? PROCESS_TERMINATE_GRACE,
       }),
     )
     .pipe(
@@ -331,14 +334,16 @@ const runCommandOutput = Effect.fn("desktop.shellEnvironment.runCommandOutput")(
 const readLoginShellEnvironment = (
   shell: string,
   names: ReadonlyArray<string>,
+  platform: NodeJS.Platform,
 ): Effect.Effect<EnvironmentPatch, never, ChildProcessSpawner.ChildProcessSpawner> =>
   names.length === 0
     ? Effect.succeed({})
     : runCommandOutput({
         probe: "login-shell",
         command: shell,
-        args: ["-ilc", capturePosixEnvironmentCommand(names)],
-        timeout: LOGIN_SHELL_TIMEOUT,
+        args: [platform === "darwin" ? "-lc" : "-ilc", capturePosixEnvironmentCommand(names)],
+        timeout: platform === "darwin" ? MACOS_LOGIN_SHELL_TIMEOUT : LOGIN_SHELL_TIMEOUT,
+        ...(platform === "darwin" ? { forceKillAfter: MACOS_LOGIN_SHELL_TERMINATE_GRACE } : {}),
       }).pipe(Effect.map((output) => extractEnvironment(output, names)));
 
 const readLaunchctlPath = runCommandOutput({
@@ -429,7 +434,7 @@ const installPosixEnvironment = Effect.fn("desktop.shellEnvironment.installPosix
     for (const shell of listLoginShellCandidates(config)) {
       Object.assign(
         shellEnvironment,
-        yield* readLoginShellEnvironment(shell, LOGIN_SHELL_ENV_NAMES),
+        yield* readLoginShellEnvironment(shell, LOGIN_SHELL_ENV_NAMES, config.platform),
       );
       if (shellEnvironment.PATH) break;
     }


### PR DESCRIPTION
## What Changed

- Run macOS environment discovery through a non-interactive login shell.
- Limit each macOS login-shell probe to 750ms, with a 100ms forced-termination grace period.
- Preserve the existing interactive login-shell behavior and 5-second timeout on Linux.
- Add deterministic coverage for shell arguments, timeout timing, forced termination, and the `launchctl` fallback.

## Why

Desktop startup waits for shell environment discovery before continuing. Interactive macOS shell configuration can initialize prompt frameworks or other startup hooks that are slow or never finish, leaving the app stuck during launch. The desktop only needs login environment values, so a non-interactive login shell plus a bounded probe keeps startup responsive while retaining the existing `launchctl` PATH fallback.

## Verification

- Targeted shell-environment tests: 15 passed
- Desktop test suite: 547 passed across 60 files
- Desktop package typecheck: passed
- Changed-file lint and formatting checks: passed

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] UI screenshots are not applicable

Prepared and validated with GPT-5.6 Sol through the T3 Code Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes desktop startup PATH/SSH env hydration on macOS with shorter probes and different shell flags; mis-tuning could miss env vars on some setups, though launchctl PATH fallback remains.
> 
> **Overview**
> **macOS login-shell environment probing** is tightened so desktop startup does not block on slow or hung interactive shell init.
> 
> On **darwin**, probes now run `zsh` (etc.) with **`-lc`** instead of **`-ilc`**, use a **750ms** timeout and **100ms** `forceKillAfter` grace (overriding the default 1s terminate grace via an optional `forceKillAfter` on `runCommandOutput`). **Linux** still uses **`-ilc`** and the **5s** login-shell timeout.
> 
> When a macOS probe times out without `PATH`, behavior unchanged: fall through to **`launchctl getenv PATH`**. Tests assert platform-specific shell args and add a **TestClock** case for a hanging shell that triggers the cap then `launchctl` fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d29c618bc36ee9e154e91bb4d41267fcf56844a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cap macOS login shell startup probe with shorter timeouts and force-kill grace
> - On macOS, `readLoginShellEnvironment` now uses `-lc` instead of `-ilc`, a 750ms timeout (`MACOS_LOGIN_SHELL_TIMEOUT`), and a 100ms force-kill grace (`MACOS_LOGIN_SHELL_TERMINATE_GRACE`) to prevent hanging shell probes from blocking startup.
> - On other platforms, the existing `-ilc` flag and `LOGIN_SHELL_TIMEOUT` are retained unchanged.
> - `runCommandOutput` accepts an optional `forceKillAfter` duration to allow per-call override of the termination grace period.
> - Tests use a new `makeHangingProcess` helper and `TestClock` to verify the timeout/kill behavior and the launchctl PATH fallback on macOS.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d29c61.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->