### PR TITLE
fix(server): force-stop timed out login shell probes

### DIFF
--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -63,7 +63,11 @@ describe("readPathFromLoginShell", () => {
       (
         file: string,
         args: ReadonlyArray<string>,
-        options: { encoding: "utf8"; timeout: number },
+        options: {
+          encoding: "utf8";
+          timeout: number;
+          killSignal?: NodeJS.Signals | number;
+        },
       ) => string
     >(() => "__T3CODE_ENV_PATH_START__\n/a:/b\n__T3CODE_ENV_PATH_END__\n");
 
@@ -71,7 +75,15 @@ describe("readPathFromLoginShell", () => {
     expect(execFile).toHaveBeenCalledTimes(1);
 
     const firstCall = execFile.mock.calls[0] as
-      | [string, ReadonlyArray<string>, { encoding: "utf8"; timeout: number }]
+      | [
+          string,
+          ReadonlyArray<string>,
+          {
+            encoding: "utf8";
+            timeout: number;
+            killSignal?: NodeJS.Signals | number;
+          },
+        ]
       | undefined;
     expect(firstCall).toBeDefined();
     if (!firstCall) {
@@ -85,7 +97,7 @@ describe("readPathFromLoginShell", () => {
     expect(args?.[1]).toContain("printenv PATH || true");
     expect(args?.[1]).toContain("__T3CODE_ENV_PATH_START__");
     expect(args?.[1]).toContain("__T3CODE_ENV_PATH_END__");
-    expect(options).toEqual({ encoding: "utf8", timeout: 5000 });
+    expect(options).toEqual({ encoding: "utf8", timeout: 5000, killSignal: "SIGKILL" });
   });
 });
 

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -22,7 +22,7 @@ const WINDOWS_SHELL_CANDIDATES = ["pwsh.exe", "powershell.exe"] as const;
 type ExecFileSyncLike = (
   file: string,
   args: ReadonlyArray<string>,
-  options: { encoding: "utf8"; timeout: number },
+  options: { encoding: "utf8"; timeout: number; killSignal?: NodeJS.Signals | number },
 ) => string;
 
 function canExecuteFile(filePath: string): boolean {
@@ -315,6 +315,7 @@ export const readEnvironmentFromLoginShell: ShellEnvironmentReader = (
   const output = execFile(shell, ["-ilc", buildEnvironmentCaptureCommand(names)], {
     encoding: "utf8",
     timeout: 5000,
+    killSignal: "SIGKILL",
   });
 
   const environment: Partial<Record<string, string>> = {};


### PR DESCRIPTION
## What Changed

- Configure synchronous login-shell probes to use `SIGKILL` when their existing 5-second timeout expires.
- Cover the exact timeout and kill-signal options in the shared shell tests.

## Why

`execFileSync` waits for the child to exit after sending its timeout signal. A login-shell startup script that traps or ignores the default `SIGTERM` can therefore keep server startup blocked beyond the intended timeout. Using `SIGKILL` makes the existing timeout an effective upper bound without changing successful probe behavior.

## Verification

- Shared shell tests: 29 passed
- Shared package typecheck: passed
- Changed-file lint and formatting checks: passed

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] UI screenshots are not applicable

Prepared and validated with GPT-5.6 Sol through the T3 Code Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change to POSIX login-shell probing only; successful probes unchanged, with clearer shutdown on timeout.
> 
> **Overview**
> Login-shell environment probes (`readEnvironmentFromLoginShell`, including PATH via `readPathFromLoginShell`) now pass **`killSignal: "SIGKILL"`** to `execFileSync` alongside the existing **5s timeout**, so a child that traps or ignores the default timeout signal cannot block startup past that bound.
> 
> The shared **`ExecFileSyncLike`** type documents the optional `killSignal`, and the **`readPathFromLoginShell`** test asserts timeout and **`SIGKILL`** are forwarded. Windows PowerShell probes are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a12ed1c3200c01c90b967f3c5211331775f7865. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Force-kill timed-out login shell probes with SIGKILL
> Adds `killSignal: "SIGKILL"` to the `execFile` call in `readEnvironmentFromLoginShell` so that shell processes exceeding the 5-second timeout are forcefully terminated rather than receiving the default `SIGTERM`, which some shells may ignore.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a12ed1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->