### PR TITLE
fix(web): center the context usage meter

### DIFF
--- a/apps/web/src/components/chat/ContextWindowMeter.tsx
+++ b/apps/web/src/components/chat/ContextWindowMeter.tsx
@@ -50,7 +50,7 @@ export function ContextWindowMeter(props: {
             <span className="relative flex size-5 items-center justify-center">
               <svg
                 viewBox="0 0 24 24"
-                className="-rotate-90 absolute inset-0 size-full transform-gpu"
+                className="-rotate-90 absolute inset-0 size-full transform-gpu mx-0!"
                 aria-hidden="true"
               >
                 <circle


### PR DESCRIPTION
The context usage ring was shifted two pixels left inside its button because the shared button icon margin also applied to its nested, absolutely positioned SVG.

This cancels that inherited margin on the meter SVG so the button, wrapper, and ring share the same center without changing normal button icons.

## Before / after

| Before | After |
| --- | --- |
| <img src="https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/57819d5a-b07d-4f57-a650-df21bb4366db/usage-meter-before.png" alt="Usage meter shifted left" width="112"> | <img src="https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/c0130049-627c-40c7-8163-385772e1fbef/usage-meter-after.png" alt="Usage meter centered" width="112"> |

## Verification

- Playwright against an isolated T3 Code environment: the button, wrapper, and SVG centers all resolve to `(1161, 815)` with `0px` horizontal SVG margins
- `pnpm exec vp fmt --check apps/web/src/components/chat/ContextWindowMeter.tsx`
- `pnpm exec vp lint apps/web/src/components/chat/ContextWindowMeter.tsx`
- `pnpm exec vp run @t3tools/web#typecheck`
- `git diff --check`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change
- [x] No animation or timing changes require a video

Implemented with GPT-5.6 Sol through the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-class visual fix in chat UI with no logic, auth, or data changes.
> 
> **Overview**
> The context usage ring in the chat UI was visually off-center (~2px left) because **Button** applies horizontal margin to descendant SVGs, which also affected the absolutely positioned meter SVG.
> 
> Adds **`mx-0!`** on that SVG in `ContextWindowMeter` to zero out the inherited margin so the ring aligns with the icon button—same approach already used in `BranchToolbar` for nested SVGs inside buttons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ea1eae0724dad9a4c85f258b9c383bf56be4da4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Center the context usage meter in `ContextWindowMeter`
> Adds `mx-0!` to the SVG element's class list in [ContextWindowMeter.tsx](https://github.com/pingdotgg/t3code/pull/7296/files#diff-aea829de2db7f11cd97477231090fa3f2bc72e2b46a5275ed82fd29b0825d2fd) to force zero horizontal margin, fixing the misaligned circular meter inside the button.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ea1eae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->