### PR TITLE
fix(swift-ios): grow composer within available viewport

### DIFF
--- a/apps/swift-ios/Features/Chat/FeatureComposerView.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerView.swift
@@ -200,7 +200,7 @@ struct FeatureComposerView: View {
                 axis: .vertical
             )
                 .font(T3Typography.composer)
-                .lineLimit(1...7)
+                .modifier(FeatureComposerGrowingTextInput())
                 .focused(focused)
                 // Return is always editing input. Sending is deliberately button-only.
                 .submitLabel(.return)
@@ -447,6 +447,14 @@ struct FeatureComposerView: View {
                   canSend {
             onSend()
         }
+    }
+}
+
+struct FeatureComposerGrowingTextInput: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .lineLimit(1...)
+            .layoutPriority(1)
     }
 }
 

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -63,7 +63,7 @@ public struct NewThreadView: View {
                     hero
                         .padding(.top, 82)
                 }
-                Spacer(minLength: 140)
+                Spacer(minLength: 0)
             }
         }
         .safeAreaInset(edge: .bottom, spacing: 0) {

--- a/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
@@ -1,8 +1,52 @@
+import SwiftUI
 import Testing
+import UIKit
 @testable import T3Code
 
 @Suite("Composer power features")
 struct FeatureComposerPowerTests {
+    @MainActor
+    @Test(
+        "Composer input grows past the former seven-line cap",
+        .bug("https://github.com/saphid/t3code-personal/issues/105")
+    )
+    func composerTextInputGrowsBeyondSevenLines() {
+        let sevenLineHeight = composerTextInputHeight(lineCount: 7)
+        let thirtyLineHeight = composerTextInputHeight(lineCount: 30)
+
+        #expect(thirtyLineHeight > sevenLineHeight + 300)
+    }
+
+    @MainActor
+    @Test(
+        "A very tall composer input yields to its viewport",
+        .bug("https://github.com/saphid/t3code-personal/issues/105")
+    )
+    func composerTextInputYieldsToAvailableViewport() {
+        let viewportHeight: CGFloat = 500
+
+        #expect(composerTextInputHeight(lineCount: 100, maximumHeight: viewportHeight) <= viewportHeight)
+    }
+
+    @MainActor
+    private func composerTextInputHeight(
+        lineCount: Int,
+        maximumHeight: CGFloat = .greatestFiniteMagnitude
+    ) -> CGFloat {
+        let text = Array(repeating: "A full visible prompt line", count: lineCount)
+            .joined(separator: "\n")
+        let controller = UIHostingController(
+            rootView: TextField("Ask anything…", text: .constant(text), axis: .vertical)
+                .font(T3Typography.composer)
+                .modifier(FeatureComposerGrowingTextInput())
+                .frame(width: 320)
+        )
+
+        return controller.sizeThatFits(
+            in: CGSize(width: 320, height: maximumHeight)
+        ).height
+    }
+
     @Test
     func detectsCommandsModelsSkillsAndPathsAtTheCursor() {
         #expect(

--- a/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
@@ -1,5 +1,7 @@
 import Foundation
+import SwiftUI
 import Testing
+import UIKit
 @testable import T3Code
 
 @MainActor
@@ -641,6 +643,85 @@ struct FeatureRootModelTests {
         #expect(model.snapshot.threads == [created])
     }
 
+    @Test(
+        "New-task composer grows beyond two lines with a software-keyboard viewport",
+        .bug("https://github.com/saphid/t3code-personal/issues/105")
+    )
+    func newTaskComposerGrowsWithSoftwareKeyboardViewport() async throws {
+        let project = FeatureProject(
+            id: "project-1",
+            environmentID: "environment-1",
+            name: "Native",
+            path: "/native"
+        )
+        let client = FeatureClientStub()
+        client.snapshot = FeatureSnapshot(
+            connection: .init(state: .connected),
+            environments: [
+                .init(
+                    id: "environment-1",
+                    name: "Studio",
+                    endpoint: "https://studio.example",
+                    isActive: true,
+                    connectionState: .connected
+                ),
+            ],
+            projects: [project],
+            providersByEnvironment: [
+                "environment-1": [
+                    .init(
+                        id: "codex",
+                        name: "Codex",
+                        models: [.init(id: "gpt-5.6-sol", name: "Sol")]
+                    ),
+                ],
+            ]
+        )
+        let model = testRootModel(client: client)
+        await model.reload()
+
+        let draftURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-new-task-keyboard-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: draftURL) }
+        let draftStore = FeatureComposerDraftStore(fileURL: draftURL)
+        let longDraft = (1...20).map { "Composer keyboard proof line \($0)" }
+            .joined(separator: "\n")
+        try await draftStore.setDraft(
+            FeatureComposerDraft(text: longDraft),
+            for: FeatureComposerDraftStore.newTaskKey(project: project)
+        )
+
+        let controller = UIHostingController(
+            rootView: NewThreadView(
+                model: model,
+                submit: { _ in nil },
+                onCreated: { _ in },
+                initialProjectID: project.id,
+                draftStore: draftStore
+            )
+        )
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 402, height: 540))
+        window.rootViewController = controller
+        window.isHidden = false
+        defer { window.isHidden = true }
+
+        var textInput: UIView?
+        for _ in 0..<30 {
+            controller.view.setNeedsLayout()
+            controller.view.layoutIfNeeded()
+            textInput = firstMultilineTextInput(in: controller.view)
+            if textInputText(textInput) == longDraft { break }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        let input = try #require(textInput)
+        #expect(textInputText(input) == longDraft)
+        #expect(
+            input.bounds.height >= 100,
+            "Expected room for more than two visible lines; got \(input.bounds.height) points"
+        )
+    }
+
     @Test
     func testArchiveAndDeleteKeepLocalListsConsistent() async {
         let client = FeatureClientStub()
@@ -1142,6 +1223,30 @@ struct FeatureRootModelTests {
         #expect(reduction.result == .refresh)
         #expect(reduction.renderMutation == .full)
     }
+}
+
+@MainActor
+private func firstMultilineTextInput(in view: UIView) -> UIView? {
+    if view is UITextView || view is UITextField {
+        return view
+    }
+    for subview in view.subviews {
+        if let input = firstMultilineTextInput(in: subview) {
+            return input
+        }
+    }
+    return nil
+}
+
+@MainActor
+private func textInputText(_ view: UIView?) -> String? {
+    if let textView = view as? UITextView {
+        return textView.text
+    }
+    if let textField = view as? UITextField {
+        return textField.text
+    }
+    return nil
 }
 
 @MainActor


### PR DESCRIPTION
<!-- swiftui-delivery:start -->
Delivery: direct
Validated against Theo commit: f6b2005e38a66a2f547e42f94b6a619565ae5af5
Depends on: none
Merge order: this PR only
Validation status: 53 focused native tests passed; approved SwiftUI Test build 81 behavior reproduced exactly
<!-- swiftui-delivery:end -->

## What Changed

The native SwiftUI composer now grows through the height its current viewport offers instead of stopping at seven lines. Once the viewport is full, long drafts scroll inside the text input, leaving the attachment, model, and send controls visible and reachable.

The new-task screen also lets its decorative spacer yield under keyboard pressure, so the composer can use the available height rather than being held near two visible lines.

This is scoped to SwiftUI mobile only. It does not change React Native mobile, web, desktop, providers, wire contracts, app identity, signing, or build numbers.

## Why

With the software keyboard open, the old seven-line cap and the new-task screen's 140-point minimum spacer prevented long prompts from using the available viewport. The approved behavior is about seven visible lines on the tested phone, followed by internal scrolling while the controls remain usable.

This is the feature-only reconstruction of the human-approved SwiftUI Test 0.1.0 build 81 generation. Its stable patch ID matches the approved feature slice, and comparing this head with the approved generation leaves only the excluded Test identity/signing/build overlay.

## Verification

- `FeatureRootModelTests`, `FeatureComposerPowerTests`, and `PlatformDeepLinkTests`: 53 passed, 0 failed, 0 skipped with `xcodebuild` exit 0.
- The focused run includes `newTaskComposerGrowsWithSoftwareKeyboardViewport` and `composerTextInputYieldsToAvailableViewport`.
- Result bundle: `focused-20260817T071154Z.xcresult` (retained with the delivery evidence).
- Stable patch ID: `a641194885381f754bd4781685aeb0cb21fc9ba4`.
- Read-only cross-provider review ran as `claude-opus-5` with Read/Grep/Glob only and exited 0. It noted keyboard-dismissed sizing and test-hardening follow-ups; no changes were applied because the suggested cap/priority changes would diverge from the exact phone-approved generation.

## UI Changes

Before — compact composer:

![Compact composer before growth](https://raw.githubusercontent.com/saphid/t3code/2ee258dd17a4d38ba5f0531b8982ead21009b329/pr-media/swiftui-composer-growth/new-thread-compact.jpg)

After — expanded long-draft composer:

![Expanded composer with a long draft](https://raw.githubusercontent.com/saphid/t3code/2ee258dd17a4d38ba5f0531b8982ead21009b329/pr-media/swiftui-composer-growth/new-thread-seven-line-cap.jpg)

Interaction reference: [composer growth video (MP4)](https://raw.githubusercontent.com/saphid/t3code/2ee258dd17a4d38ba5f0531b8982ead21009b329/pr-media/swiftui-composer-growth/composer-growth.mp4) · [GIF fallback](https://raw.githubusercontent.com/saphid/t3code/2ee258dd17a4d38ba5f0531b8982ead21009b329/pr-media/swiftui-composer-growth/composer-growth.gif)

These existing visuals show the compact-to-growing interaction. The exact keyboard-visible Build 81 behavior was separately approved on a physical phone.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Built with GPT-5.6 Sol high in the Codex harness through T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized SwiftUI layout and test-only changes; no API, auth, or data-path impact.
> 
> **Overview**
> The SwiftUI composer **no longer stops at seven lines**. It uses a new `FeatureComposerGrowingTextInput` modifier (unbounded vertical growth with layout priority) instead of `.lineLimit(1...7)`, so long drafts expand until the viewport is full and then scroll inside the field while footer controls stay reachable.
> 
> On **new-task**, the hero area’s bottom `Spacer` minimum drops from **140pt to 0**, freeing vertical space when the keyboard is up so the bottom composer can grow past ~two visible lines.
> 
> **Tests** add `UIHostingController` sizing checks for growth past seven lines and height caps, plus a `NewThreadView` integration test with a long restored draft and a phone-sized window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd62fdbc4eb75c346f423c037baba63fc3b0767a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow the iOS chat composer to grow beyond seven lines within the viewport
> - Replaces the fixed `.lineLimit(1...7)` on the composer `TextField` with a new `FeatureComposerGrowingTextInput` modifier that sets an unbounded line limit and `.layoutPriority(1)`, letting the input expand to fill available space.
> - Reduces the minimum `Spacer` length above the composer in [`NewThreadView`](https://github.com/pingdotgg/t3code/pull/7299/files#diff-b6ba9c0744007ccd1dd2c30b31fc66ec800d601a0a3153404e3ee2917cda96c5) from 140pt to 0, reclaiming vertical space for the input.
> - Adds UI tests in [`FeatureComposerPowerTests`](https://github.com/pingdotgg/t3code/pull/7299/files#diff-350e83f86e57eb36ff75519830fab71b6851389935337c9b49655cbec9414328) and [`FeatureRootModelTests`](https://github.com/pingdotgg/t3code/pull/7299/files#diff-1e4ac0ac4ebcb0caa93c349c4c0975c383f3a6f20e87fbff4435dc204530c325) to assert the composer grows beyond fixed line counts and stays within the viewport height.
> - Behavioral Change: the composer no longer caps at seven lines — long inputs will expand until constrained by the container rather than scrolling in place.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd62fdb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


Coordination trace: T3 thread A5CAFEFD-DE38-4B12-9BB1-63DB6DD4D221 · saphid/t3code-personal#105
