### PR TITLE
fix(preview): open local environment ports on localhost

### DIFF
--- a/apps/web/src/browser/browserTargetResolver.test.ts
+++ b/apps/web/src/browser/browserTargetResolver.test.ts
@@ -173,7 +173,19 @@ describe("browser target resolver", () => {
         kind: "environment-port",
         port: 5173,
       }).resolvedUrl,
-    ).toBe("http://[::1]:5173/");
+    ).toBe("http://localhost:5173/");
+  });
+
+  it("maps local IPv4 environment ports onto localhost for dual-stack guests", async () => {
+    readPreparedConnection.mockReturnValue({ httpBaseUrl: "http://127.0.0.1:3773" });
+    const { resolveBrowserNavigationTarget } = await import("./browserTargetResolver");
+    expect(
+      resolveBrowserNavigationTarget(EnvironmentId.make("environment-1"), {
+        kind: "environment-port",
+        port: 5173,
+        path: "/app",
+      }).resolvedUrl,
+    ).toBe("http://localhost:5173/app");
   });
 
   it("leaves malformed input for the normal navigation error path", async () => {

--- a/apps/web/src/browser/browserTargetResolver.ts
+++ b/apps/web/src/browser/browserTargetResolver.ts
@@ -178,9 +178,13 @@ const resolveEnvironmentPortTarget = (
   const protocol = target.protocol ?? "http";
   const path = target.path?.startsWith("/") ? target.path : `/${target.path ?? ""}`;
   const normalizedEnvironmentHost = environmentUrl.hostname.replace(/^\[|\]$/g, "");
-  const resolvedHost = normalizedEnvironmentHost.includes(":")
-    ? `[${normalizedEnvironmentHost}]`
-    : normalizedEnvironmentHost;
+  // Local loopback environments should advertise `localhost` so Chromium
+  // dual-stack lookup can reach a Vite server bound only to ::1 or 127.0.0.1.
+  const resolvedHost = isLocalLoopbackHost(normalizedEnvironmentHost)
+    ? "localhost"
+    : normalizedEnvironmentHost.includes(":")
+      ? `[${normalizedEnvironmentHost}]`
+      : normalizedEnvironmentHost;
   const resolved = sourceUrl
     ? new URL(sourceUrl)
     : new URL(path, `${protocol}://${resolvedHost}:${target.port}`);


### PR DESCRIPTION
A Vite server bound to `::1` or `127.0.0.1` was advertised as that exact host. A dual-stack Chromium guest often failed to load the other stack.

Environment-port URLs now resolve to `localhost` so the guest can reach either bind.

Split out of closed #7127.

Tests: `vp test run apps/web/src/browser/browserTargetResolver.test.ts`

Implemented with Grok 4.6 through Grok CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to preview URL resolution for local dev; no auth or data-path impact.
> 
> **Overview**
> **Environment-port preview URLs** for loopback-backed environments (`127.0.0.1`, `::1`, etc.) now resolve to **`http://localhost:<port>/...`** instead of keeping the literal loopback host in `resolvedUrl`.
> 
> In `resolveEnvironmentPortTarget`, loopback detection via `isLocalLoopbackHost` drives that host rewrite so Chromium’s dual-stack resolution can reach dev servers bound only on `::1` or `127.0.0.1`. Remote private hosts (e.g. Tailscale/LAN) are unchanged.
> 
> Tests expect `localhost` for IPv6 `::1` and IPv4 `127.0.0.1` environment bases, including paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 694d783402f8df8faf98033721ed5c1d47ae4478. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix local environment ports to resolve to `localhost` instead of loopback IP
> In `resolveEnvironmentPortTarget`, when the environment host is a loopback address (e.g. `127.0.0.1` or `::1`), the resolved URL now uses `localhost` as the host. Previously, the literal loopback address was used, which could cause issues with dual-stack environments. Behavioral Change: loopback-hosted environments that previously resolved to `http://127.0.0.1:<port>/...` or `http://[::1]:<port>/...` now resolve to `http://localhost:<port>/...`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 694d783.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->