### PR TITLE
fix(preview): name hidden, disabled, and ambiguous click failures

### DIFF
--- a/apps/desktop/src/ipc/methods/preview.test.ts
+++ b/apps/desktop/src/ipc/methods/preview.test.ts
@@ -121,6 +121,24 @@ describe("preview IPC methods", () => {
     }),
   );
 
+  effectIt.effect("returns typed click outcomes across the preview IPC handler", () =>
+    Effect.gen(function* () {
+      const result = {
+        _tag: "NotSent",
+        reason: "target-disabled",
+      } as const;
+      const manager = PreviewManager.PreviewManager.of({
+        automationClick: () => Effect.succeed(result),
+      } as unknown as PreviewManager.PreviewManager["Service"]);
+
+      expect(
+        yield* PreviewIpc.automationClick
+          .handler({ tabId: "tab-1", input: { locator: "role=button[name='Send']" } })
+          .pipe(Effect.provideService(PreviewManager.PreviewManager, manager)),
+      ).toEqual(result);
+    }),
+  );
+
   it("keeps the public automation status tab id limit", () => {
     const encode = Schema.encodeUnknownSync(PreviewAutomationStatus);
     const tabId = "t".repeat(129);

--- a/apps/desktop/src/ipc/methods/preview.ts
+++ b/apps/desktop/src/ipc/methods/preview.ts
@@ -2,6 +2,7 @@ import {
   DesktopPreviewAnnotationThemeInputSchema,
   DesktopPreviewArtifactInputSchema,
   DesktopPreviewAutomationClickInputSchema,
+  DesktopPreviewAutomationClickResultSchema,
   DesktopPreviewAutomationEvaluateInputSchema,
   DesktopPreviewAutomationPressInputSchema,
   DesktopPreviewAutomationScrollInputSchema,
@@ -357,10 +358,10 @@ export const automationSnapshot = DesktopIpc.makeIpcMethod({
 export const automationClick = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_AUTOMATION_CLICK_CHANNEL,
   payload: DesktopPreviewAutomationClickInputSchema,
-  result: Schema.Void,
+  result: DesktopPreviewAutomationClickResultSchema,
   handler: Effect.fn("desktop.ipc.preview.automationClick")(function* ({ tabId, input }) {
     const manager = yield* PreviewManager.PreviewManager;
-    yield* manager.automationClick(tabId, input);
+    return yield* manager.automationClick(tabId, input);
   }),
 });
 

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -3906,44 +3906,62 @@ describe("Preview automation diagnostics", () => {
     expect("locator" in error).toBe(false);
   });
 
-  it("names hidden, disabled, and ambiguous click failures without leaking the locator", () => {
-    const selector = "role=button[name='target-secret']";
-    const hidden = new PreviewManager.PreviewAutomationTargetHiddenError({
-      operation: "click",
-      tabId: "tab_1",
-      selectorKind: "locator",
-      selectorLength: selector.length,
-    });
-    const disabled = new PreviewManager.PreviewAutomationTargetDisabledError({
-      operation: "click",
-      tabId: "tab_1",
-      selectorKind: "locator",
-      selectorLength: selector.length,
-    });
-    const ambiguous = new PreviewManager.PreviewAutomationTargetAmbiguousError({
-      operation: "click",
-      tabId: "tab_1",
-      selectorKind: "locator",
-      selectorLength: selector.length,
-      matchCount: 3,
-    });
-    expect(hidden.message).toContain("not visible");
-    expect(disabled.message).toContain("disabled");
-    expect(ambiguous.message).toContain("matched 3 elements");
-    expect(hidden.message).not.toContain("secret");
-    expect(disabled.message).not.toContain("secret");
-    expect(ambiguous.message).not.toContain("secret");
+  effectIt.effect("returns typed click lookup failures without dispatching input", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const selector = "role=button[name='target-secret']";
+        let lookupResult: unknown = { notFound: true, failureKind: "missing" };
+        const sendCommand = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+          if (method !== "Runtime.evaluate") return undefined;
+          const expression = String(params?.["expression"] ?? "");
+          return expression.includes("const parsed = injected.parseSelector")
+            ? { result: { value: lookupResult } }
+            : { result: { value: true } };
+        });
+        fromId.mockReturnValue({
+          ...makeTestPreviewWebContents(
+            vi.fn(async () => ({
+              toJPEG: () => Buffer.from("unused-click-frame"),
+              toPNG: () => Buffer.from("unused-click-frame"),
+              getSize: () => ({ width: 1280, height: 720 }),
+            })),
+          ),
+          isDevToolsOpened: () => false,
+          debugger: {
+            isAttached: () => false,
+            attach: vi.fn(),
+            sendCommand,
+            on: vi.fn(),
+            off: vi.fn(),
+          },
+        } as never);
 
-    const fromAmbiguous = PreviewManager.PreviewAutomationTargetNotFoundError.fromLookupFailure({
-      operation: "click",
-      tabId: "tab_1",
-      selectorKind: "locator",
-      selectorLength: selector.length,
-      failureKind: "ambiguous",
-      matchCount: 3,
-    });
-    expect(fromAmbiguous).toBeInstanceOf(PreviewManager.PreviewAutomationTargetAmbiguousError);
-    expect(fromAmbiguous.message).toContain("matched 3 elements");
-    expect(fromAmbiguous.message).not.toContain("secret");
-  });
+        yield* manager.createTab("tab_lookup");
+        yield* manager.registerWebview("tab_lookup", 42);
+
+        const missing = yield* manager.automationClick("tab_lookup", { locator: selector });
+        lookupResult = { notFound: true, failureKind: "hidden" };
+        const hidden = yield* manager.automationClick("tab_lookup", { locator: selector });
+        lookupResult = { notFound: true, failureKind: "disabled" };
+        const disabled = yield* manager.automationClick("tab_lookup", { locator: selector });
+        lookupResult = { notFound: true, failureKind: "ambiguous", matchCount: 3 };
+        const ambiguous = yield* manager.automationClick("tab_lookup", { locator: selector });
+        const snapshot = yield* manager.automationSnapshot("tab_lookup");
+
+        expect([missing, hidden, disabled, ambiguous]).toEqual([
+          { _tag: "NotSent", reason: "target-missing" },
+          { _tag: "NotSent", reason: "target-hidden" },
+          { _tag: "NotSent", reason: "target-disabled" },
+          { _tag: "NotSent", reason: "target-ambiguous", matchCount: 3 },
+        ]);
+        expect(snapshot.actionTimeline.filter((action) => action.action === "click")).toEqual([
+          expect.objectContaining({ status: "failed" }),
+          expect.objectContaining({ status: "failed" }),
+          expect.objectContaining({ status: "failed" }),
+          expect.objectContaining({ status: "failed" }),
+        ]);
+        expect(sendCommand).not.toHaveBeenCalledWith("Input.dispatchMouseEvent", expect.anything());
+      }),
+    ),
+  );
 });

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -3906,6 +3906,20 @@ describe("Preview automation diagnostics", () => {
     expect("locator" in error).toBe(false);
   });
 
+  it("does not invent an ambiguous target match count", () => {
+    const error = new PreviewManager.PreviewAutomationTargetLookupError({
+      operation: "click",
+      tabId: "tab_1",
+      selectorKind: "locator",
+      selectorLength: 12,
+      failureKind: "ambiguous",
+    });
+
+    expect(error.message).toBe(
+      "Preview automation click matched multiple elements for locator (12 characters)",
+    );
+  });
+
   effectIt.effect("returns typed click lookup failures without dispatching input", () =>
     withManager((manager) =>
       Effect.gen(function* () {

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -3905,4 +3905,33 @@ describe("Preview automation diagnostics", () => {
     expect(JSON.stringify(error)).not.toContain(selector);
     expect("locator" in error).toBe(false);
   });
+
+  it("names hidden, disabled, and ambiguous click failures without leaking the locator", () => {
+    const selector = "role=button[name='target-secret']";
+    const hidden = new PreviewManager.PreviewAutomationTargetHiddenError({
+      operation: "click",
+      tabId: "tab_1",
+      selectorKind: "locator",
+      selectorLength: selector.length,
+    });
+    const disabled = new PreviewManager.PreviewAutomationTargetDisabledError({
+      operation: "click",
+      tabId: "tab_1",
+      selectorKind: "locator",
+      selectorLength: selector.length,
+    });
+    const ambiguous = new PreviewManager.PreviewAutomationTargetAmbiguousError({
+      operation: "click",
+      tabId: "tab_1",
+      selectorKind: "locator",
+      selectorLength: selector.length,
+      matchCount: 3,
+    });
+    expect(hidden.message).toContain("not visible");
+    expect(disabled.message).toContain("disabled");
+    expect(ambiguous.message).toContain("matched 3 elements");
+    expect(hidden.message).not.toContain("secret");
+    expect(disabled.message).not.toContain("secret");
+    expect(ambiguous.message).not.toContain("secret");
+  });
 });

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -2,6 +2,7 @@ import { it as effectIt } from "@effect/vitest";
 import { DESKTOP_PREVIEW_RECORDING_CAPTURE_TRIGGER } from "@t3tools/contracts";
 import type { DesktopPreviewRecordingFrame } from "@t3tools/contracts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import * as NodeVM from "node:vm";
 import * as Cause from "effect/Cause";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
@@ -3925,12 +3926,15 @@ describe("Preview automation diagnostics", () => {
       Effect.gen(function* () {
         const selector = "role=button[name='target-secret']";
         let lookupResult: unknown = { notFound: true, failureKind: "missing" };
+        let lookupExpression = "";
         const sendCommand = vi.fn(async (method: string, params?: Record<string, unknown>) => {
           if (method !== "Runtime.evaluate") return undefined;
           const expression = String(params?.["expression"] ?? "");
-          return expression.includes("const parsed = injected.parseSelector")
-            ? { result: { value: lookupResult } }
-            : { result: { value: true } };
+          if (expression.includes("const parsed = injected.parseSelector")) {
+            lookupExpression = expression;
+            return { result: { value: lookupResult } };
+          }
+          return { result: { value: true } };
         });
         fromId.mockReturnValue({
           ...makeTestPreviewWebContents(
@@ -3975,6 +3979,58 @@ describe("Preview automation diagnostics", () => {
           expect.objectContaining({ status: "failed" }),
         ]);
         expect(sendCommand).not.toHaveBeenCalledWith("Input.dispatchMouseEvent", expect.anything());
+
+        const element = {
+          scrollIntoView: vi.fn(),
+          getBoundingClientRect: () => ({ left: 20, top: 10, width: 40, height: 20 }),
+        };
+        const runLookup = (
+          matches: ReadonlyArray<typeof element>,
+          state: { readonly visible: boolean; readonly enabled: boolean },
+        ) => {
+          const querySelectorAll = vi.fn(() => matches);
+          const elementState = vi.fn((_element: typeof element, name: keyof typeof state) => ({
+            matches: state[name],
+          }));
+          const result = NodeVM.runInNewContext(lookupExpression, {
+            document: {},
+            globalThis: {
+              __t3PlaywrightInjected: {
+                parseSelector: vi.fn(() => ({ parts: [] })),
+                querySelectorAll,
+                elementState,
+              },
+            },
+          });
+          return { result, querySelectorAll, elementState };
+        };
+
+        const missingLookup = runLookup([], { visible: true, enabled: true });
+        expect(missingLookup.result).toEqual({ notFound: true, failureKind: "missing" });
+        expect(missingLookup.querySelectorAll).toHaveBeenCalledOnce();
+
+        const ambiguousLookup = runLookup([element, element, element], {
+          visible: true,
+          enabled: true,
+        });
+        expect(ambiguousLookup.result).toEqual({
+          notFound: true,
+          failureKind: "ambiguous",
+          matchCount: 3,
+        });
+        expect(ambiguousLookup.querySelectorAll).toHaveBeenCalledOnce();
+
+        const hiddenLookup = runLookup([element], { visible: false, enabled: true });
+        expect(hiddenLookup.result).toEqual({ notFound: true, failureKind: "hidden" });
+        expect(hiddenLookup.elementState).toHaveBeenCalledWith(element, "visible");
+
+        const disabledLookup = runLookup([element], { visible: true, enabled: false });
+        expect(disabledLookup.result).toEqual({ notFound: true, failureKind: "disabled" });
+        expect(disabledLookup.elementState).toHaveBeenCalledWith(element, "enabled");
+
+        const visibleLookup = runLookup([element], { visible: true, enabled: true });
+        expect(visibleLookup.result).toEqual({ x: 40, y: 20 });
+        expect(element.scrollIntoView).toHaveBeenCalledWith({ block: "center", inline: "center" });
       }),
     ),
   );

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -3933,5 +3933,17 @@ describe("Preview automation diagnostics", () => {
     expect(hidden.message).not.toContain("secret");
     expect(disabled.message).not.toContain("secret");
     expect(ambiguous.message).not.toContain("secret");
+
+    const fromAmbiguous = PreviewManager.PreviewAutomationTargetNotFoundError.fromLookupFailure({
+      operation: "click",
+      tabId: "tab_1",
+      selectorKind: "locator",
+      selectorLength: selector.length,
+      failureKind: "ambiguous",
+      matchCount: 3,
+    });
+    expect(fromAmbiguous).toBeInstanceOf(PreviewManager.PreviewAutomationTargetAmbiguousError);
+    expect(fromAmbiguous.message).toContain("matched 3 elements");
+    expect(fromAmbiguous.message).not.toContain("secret");
   });
 });

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -3625,20 +3625,12 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           try {
             const injected = globalThis.__t3PlaywrightInjected;
             const parsed = injected.parseSelector(${locatorJson});
-            let element;
-            try {
-              element = injected.querySelector(parsed, document, true);
-            } catch (error) {
-              const message = String(error);
-              if (message.toLowerCase().includes("strict mode")) {
-                const matches = injected.querySelectorAll
-                  ? injected.querySelectorAll(parsed, document)
-                  : [];
-                return { notFound: true, failureKind: "ambiguous", matchCount: matches.length || 2 };
-              }
-              throw error;
+            const matches = injected.querySelectorAll(parsed, document);
+            if (matches.length === 0) return { notFound: true, failureKind: "missing" };
+            if (matches.length > 1) {
+              return { notFound: true, failureKind: "ambiguous", matchCount: matches.length };
             }
-            if (!element) return { notFound: true, failureKind: "missing" };
+            const element = matches[0];
             const visible = injected.elementState(element, "visible");
             const enabled = injected.elementState(element, "enabled");
             if (!visible.matches) return { notFound: true, failureKind: "hidden" };

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -3606,7 +3606,13 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       locator,
     );
     const point = yield* evaluateWithDebugger<
-      { x: number; y: number } | { invalidSelector: true; message: string } | { notFound: true }
+      | { x: number; y: number }
+      | { invalidSelector: true; message: string }
+      | {
+          notFound: true;
+          failureKind: "missing" | "hidden" | "disabled" | "ambiguous";
+          matchCount?: number;
+        }
     >(
       tabId,
       send,
@@ -3614,11 +3620,24 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           try {
             const injected = globalThis.__t3PlaywrightInjected;
             const parsed = injected.parseSelector(${locatorJson});
-            const element = injected.querySelector(parsed, document, true);
-            if (!element) return { notFound: true };
+            let element;
+            try {
+              element = injected.querySelector(parsed, document, true);
+            } catch (error) {
+              const message = String(error);
+              if (message.toLowerCase().includes("strict mode")) {
+                const matches = injected.querySelectorAll
+                  ? injected.querySelectorAll(parsed, document)
+                  : [];
+                return { notFound: true, failureKind: "ambiguous", matchCount: matches.length || 2 };
+              }
+              throw error;
+            }
+            if (!element) return { notFound: true, failureKind: "missing" };
             const visible = injected.elementState(element, "visible");
             const enabled = injected.elementState(element, "enabled");
-            if (!visible.matches || !enabled.matches) return { notFound: true };
+            if (!visible.matches) return { notFound: true, failureKind: "hidden" };
+            if (!enabled.matches) return { notFound: true, failureKind: "disabled" };
             element.scrollIntoView({ block: "center", inline: "center" });
             const rect = element.getBoundingClientRect();
             return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
@@ -3638,10 +3657,12 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       });
     }
     if ("notFound" in point) {
-      return yield* new PreviewAutomationTargetNotFoundError({
+      return yield* raiseAutomationTargetLookupError({
         operation: "click",
         tabId,
         ...automationSelectorDiagnostics(input),
+        failureKind: point.failureKind,
+        ...(point.matchCount === undefined ? {} : { matchCount: point.matchCount }),
       });
     }
     return point;
@@ -4319,20 +4340,84 @@ export class PreviewAutomationEvaluationError extends Schema.TaggedErrorClass<Pr
   }
 }
 
+const PreviewAutomationTargetLookupFields = {
+  operation: Schema.String,
+  tabId: Schema.String,
+  selectorKind: PreviewAutomationSelectorKind,
+  selectorLength: Schema.optionalKey(Schema.Number),
+};
+
 export class PreviewAutomationTargetNotFoundError extends Schema.TaggedErrorClass<PreviewAutomationTargetNotFoundError>()(
   "PreviewAutomationTargetNotFoundError",
-  {
-    operation: Schema.String,
-    tabId: Schema.String,
-    selectorKind: PreviewAutomationSelectorKind,
-    selectorLength: Schema.optionalKey(Schema.Number),
-  },
+  PreviewAutomationTargetLookupFields,
 ) {
   override get message(): string {
     const target = previewAutomationTargetLabel(this.selectorKind, this.selectorLength);
     return `Preview automation ${this.operation} could not find ${target} in tab ${this.tabId}`;
   }
 }
+
+export class PreviewAutomationTargetHiddenError extends Schema.TaggedErrorClass<PreviewAutomationTargetHiddenError>()(
+  "PreviewAutomationTargetHiddenError",
+  PreviewAutomationTargetLookupFields,
+) {
+  override get message(): string {
+    const target = previewAutomationTargetLabel(this.selectorKind, this.selectorLength);
+    return `Preview automation ${this.operation} found ${target} in tab ${this.tabId}, but it is not visible`;
+  }
+}
+
+export class PreviewAutomationTargetDisabledError extends Schema.TaggedErrorClass<PreviewAutomationTargetDisabledError>()(
+  "PreviewAutomationTargetDisabledError",
+  PreviewAutomationTargetLookupFields,
+) {
+  override get message(): string {
+    const target = previewAutomationTargetLabel(this.selectorKind, this.selectorLength);
+    return `Preview automation ${this.operation} found ${target} in tab ${this.tabId}, but it is disabled`;
+  }
+}
+
+export class PreviewAutomationTargetAmbiguousError extends Schema.TaggedErrorClass<PreviewAutomationTargetAmbiguousError>()(
+  "PreviewAutomationTargetAmbiguousError",
+  {
+    ...PreviewAutomationTargetLookupFields,
+    matchCount: Schema.Number,
+  },
+) {
+  override get message(): string {
+    const target = previewAutomationTargetLabel(this.selectorKind, this.selectorLength);
+    return `Preview automation ${this.operation} matched ${this.matchCount} elements for ${target} in tab ${this.tabId}`;
+  }
+}
+
+const raiseAutomationTargetLookupError = (input: {
+  readonly operation: string;
+  readonly tabId: string;
+  readonly selectorKind: PreviewAutomationSelectorKind;
+  readonly selectorLength?: number;
+  readonly failureKind?: "missing" | "hidden" | "disabled" | "ambiguous";
+  readonly matchCount?: number;
+}) => {
+  const shared = {
+    operation: input.operation,
+    tabId: input.tabId,
+    selectorKind: input.selectorKind,
+    ...(input.selectorLength === undefined ? {} : { selectorLength: input.selectorLength }),
+  };
+  if (input.failureKind === "hidden") {
+    return new PreviewAutomationTargetHiddenError(shared);
+  }
+  if (input.failureKind === "disabled") {
+    return new PreviewAutomationTargetDisabledError(shared);
+  }
+  if (input.failureKind === "ambiguous") {
+    return new PreviewAutomationTargetAmbiguousError({
+      ...shared,
+      matchCount: input.matchCount ?? 0,
+    });
+  }
+  return new PreviewAutomationTargetNotFoundError(shared);
+};
 
 export class PreviewAutomationTargetNotEditableError extends Schema.TaggedErrorClass<PreviewAutomationTargetNotEditableError>()(
   "PreviewAutomationTargetNotEditableError",
@@ -4452,6 +4537,9 @@ export const PreviewManagerError = Schema.Union([
   PreviewAutomationDebuggerAttachedError,
   PreviewAutomationEvaluationError,
   PreviewAutomationTargetNotFoundError,
+  PreviewAutomationTargetHiddenError,
+  PreviewAutomationTargetDisabledError,
+  PreviewAutomationTargetAmbiguousError,
   PreviewAutomationTargetNotEditableError,
   PreviewAutomationCoordinatesOutsideViewportError,
   PreviewAutomationInvalidSelectorError,

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -3752,9 +3752,8 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       );
       return { _tag: "Dispatched" } satisfies DesktopPreviewAutomationClickResult;
     }).pipe(
-      Effect.catchTag(
-        "PreviewAutomationTargetLookupError",
-        (
+      Effect.catchTags({
+        PreviewAutomationTargetLookupError: (
           error,
         ): Effect.Effect<
           DesktopPreviewAutomationClickResult,
@@ -3773,7 +3772,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
             reason: `target-${error.failureKind}`,
           });
         },
-      ),
+      }),
     );
   });
 
@@ -4406,7 +4405,9 @@ export class PreviewAutomationTargetLookupError extends Schema.TaggedErrorClass<
       return `Preview automation ${this.operation} found ${target}, but it is disabled`;
     }
     if (this.failureKind === "ambiguous") {
-      return `Preview automation ${this.operation} matched ${this.matchCount ?? 0} elements for ${target}`;
+      return this.matchCount === undefined
+        ? `Preview automation ${this.operation} matched multiple elements for ${target}`
+        : `Preview automation ${this.operation} matched ${this.matchCount} elements for ${target}`;
     }
     return `Preview automation ${this.operation} could not find ${target}`;
   }

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -3610,8 +3610,12 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       | { invalidSelector: true; message: string }
       | {
           notFound: true;
-          failureKind: "missing" | "hidden" | "disabled" | "ambiguous";
-          matchCount?: number;
+          failureKind: "missing" | "hidden" | "disabled";
+        }
+      | {
+          notFound: true;
+          failureKind: "ambiguous";
+          matchCount: number;
         }
     >(
       tabId,
@@ -3657,12 +3661,13 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       });
     }
     if ("notFound" in point) {
-      return yield* raiseAutomationTargetLookupError({
+      return yield* PreviewAutomationTargetNotFoundError.fromLookupFailure({
         operation: "click",
         tabId,
         ...automationSelectorDiagnostics(input),
-        failureKind: point.failureKind,
-        ...(point.matchCount === undefined ? {} : { matchCount: point.matchCount }),
+        ...(point.failureKind === "ambiguous"
+          ? { failureKind: "ambiguous", matchCount: point.matchCount }
+          : { failureKind: point.failureKind }),
       });
     }
     return point;
@@ -4351,6 +4356,38 @@ export class PreviewAutomationTargetNotFoundError extends Schema.TaggedErrorClas
   "PreviewAutomationTargetNotFoundError",
   PreviewAutomationTargetLookupFields,
 ) {
+  static fromLookupFailure(
+    input: {
+      readonly operation: string;
+      readonly tabId: string;
+      readonly selectorKind: PreviewAutomationSelectorKind;
+      readonly selectorLength?: number;
+    } & (
+      | { readonly failureKind: "ambiguous"; readonly matchCount: number }
+      | { readonly failureKind?: "missing" | "hidden" | "disabled" }
+    ),
+  ) {
+    const shared = {
+      operation: input.operation,
+      tabId: input.tabId,
+      selectorKind: input.selectorKind,
+      ...(input.selectorLength === undefined ? {} : { selectorLength: input.selectorLength }),
+    };
+    if (input.failureKind === "hidden") {
+      return new PreviewAutomationTargetHiddenError(shared);
+    }
+    if (input.failureKind === "disabled") {
+      return new PreviewAutomationTargetDisabledError(shared);
+    }
+    if (input.failureKind === "ambiguous") {
+      return new PreviewAutomationTargetAmbiguousError({
+        ...shared,
+        matchCount: input.matchCount,
+      });
+    }
+    return new PreviewAutomationTargetNotFoundError(shared);
+  }
+
   override get message(): string {
     const target = previewAutomationTargetLabel(this.selectorKind, this.selectorLength);
     return `Preview automation ${this.operation} could not find ${target} in tab ${this.tabId}`;
@@ -4389,35 +4426,6 @@ export class PreviewAutomationTargetAmbiguousError extends Schema.TaggedErrorCla
     return `Preview automation ${this.operation} matched ${this.matchCount} elements for ${target} in tab ${this.tabId}`;
   }
 }
-
-const raiseAutomationTargetLookupError = (input: {
-  readonly operation: string;
-  readonly tabId: string;
-  readonly selectorKind: PreviewAutomationSelectorKind;
-  readonly selectorLength?: number;
-  readonly failureKind?: "missing" | "hidden" | "disabled" | "ambiguous";
-  readonly matchCount?: number;
-}) => {
-  const shared = {
-    operation: input.operation,
-    tabId: input.tabId,
-    selectorKind: input.selectorKind,
-    ...(input.selectorLength === undefined ? {} : { selectorLength: input.selectorLength }),
-  };
-  if (input.failureKind === "hidden") {
-    return new PreviewAutomationTargetHiddenError(shared);
-  }
-  if (input.failureKind === "disabled") {
-    return new PreviewAutomationTargetDisabledError(shared);
-  }
-  if (input.failureKind === "ambiguous") {
-    return new PreviewAutomationTargetAmbiguousError({
-      ...shared,
-      matchCount: input.matchCount ?? 0,
-    });
-  }
-  return new PreviewAutomationTargetNotFoundError(shared);
-};
 
 export class PreviewAutomationTargetNotEditableError extends Schema.TaggedErrorClass<PreviewAutomationTargetNotEditableError>()(
   "PreviewAutomationTargetNotEditableError",

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -8,6 +8,7 @@
 import { DESKTOP_PREVIEW_RECORDING_CAPTURE_TRIGGER } from "@t3tools/contracts";
 import type {
   DesktopPreviewAnnotationTheme,
+  DesktopPreviewAutomationClickResult,
   DesktopPreviewAutomationStatus,
   DesktopPreviewColorScheme,
   DesktopPreviewFavicon,
@@ -3661,13 +3662,12 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       });
     }
     if ("notFound" in point) {
-      return yield* PreviewAutomationTargetNotFoundError.fromLookupFailure({
+      return yield* new PreviewAutomationTargetLookupError({
         operation: "click",
         tabId,
         ...automationSelectorDiagnostics(input),
-        ...(point.failureKind === "ambiguous"
-          ? { failureKind: "ambiguous", matchCount: point.matchCount }
-          : { failureKind: point.failureKind }),
+        failureKind: point.failureKind,
+        ...(point.failureKind === "ambiguous" ? { matchCount: point.matchCount } : {}),
       });
     }
     return point;
@@ -3746,8 +3746,34 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     input: PreviewAutomationClickInput,
   ) {
     const wc = yield* requireWebContents(tabId);
-    yield* withControlSession(tabId, wc, "click", (send) =>
-      performAutomationClick(tabId, input, send),
+    return yield* Effect.gen(function* () {
+      yield* withControlSession(tabId, wc, "click", (send) =>
+        performAutomationClick(tabId, input, send),
+      );
+      return { _tag: "Dispatched" } satisfies DesktopPreviewAutomationClickResult;
+    }).pipe(
+      Effect.catchTag(
+        "PreviewAutomationTargetLookupError",
+        (
+          error,
+        ): Effect.Effect<
+          DesktopPreviewAutomationClickResult,
+          PreviewAutomationTargetLookupError
+        > => {
+          if (error.failureKind === "ambiguous") {
+            if (error.matchCount === undefined) return Effect.fail(error);
+            return Effect.succeed<DesktopPreviewAutomationClickResult>({
+              _tag: "NotSent",
+              reason: "target-ambiguous",
+              matchCount: error.matchCount,
+            });
+          }
+          return Effect.succeed<DesktopPreviewAutomationClickResult>({
+            _tag: "NotSent",
+            reason: `target-${error.failureKind}`,
+          });
+        },
+      ),
     );
   });
 
@@ -4345,85 +4371,44 @@ export class PreviewAutomationEvaluationError extends Schema.TaggedErrorClass<Pr
   }
 }
 
-const PreviewAutomationTargetLookupFields = {
-  operation: Schema.String,
-  tabId: Schema.String,
-  selectorKind: PreviewAutomationSelectorKind,
-  selectorLength: Schema.optionalKey(Schema.Number),
-};
-
 export class PreviewAutomationTargetNotFoundError extends Schema.TaggedErrorClass<PreviewAutomationTargetNotFoundError>()(
   "PreviewAutomationTargetNotFoundError",
-  PreviewAutomationTargetLookupFields,
+  {
+    operation: Schema.String,
+    tabId: Schema.String,
+    selectorKind: PreviewAutomationSelectorKind,
+    selectorLength: Schema.optionalKey(Schema.Number),
+  },
 ) {
-  static fromLookupFailure(
-    input: {
-      readonly operation: string;
-      readonly tabId: string;
-      readonly selectorKind: PreviewAutomationSelectorKind;
-      readonly selectorLength?: number;
-    } & (
-      | { readonly failureKind: "ambiguous"; readonly matchCount: number }
-      | { readonly failureKind?: "missing" | "hidden" | "disabled" }
-    ),
-  ) {
-    const shared = {
-      operation: input.operation,
-      tabId: input.tabId,
-      selectorKind: input.selectorKind,
-      ...(input.selectorLength === undefined ? {} : { selectorLength: input.selectorLength }),
-    };
-    if (input.failureKind === "hidden") {
-      return new PreviewAutomationTargetHiddenError(shared);
-    }
-    if (input.failureKind === "disabled") {
-      return new PreviewAutomationTargetDisabledError(shared);
-    }
-    if (input.failureKind === "ambiguous") {
-      return new PreviewAutomationTargetAmbiguousError({
-        ...shared,
-        matchCount: input.matchCount,
-      });
-    }
-    return new PreviewAutomationTargetNotFoundError(shared);
-  }
-
   override get message(): string {
     const target = previewAutomationTargetLabel(this.selectorKind, this.selectorLength);
     return `Preview automation ${this.operation} could not find ${target} in tab ${this.tabId}`;
   }
 }
 
-export class PreviewAutomationTargetHiddenError extends Schema.TaggedErrorClass<PreviewAutomationTargetHiddenError>()(
-  "PreviewAutomationTargetHiddenError",
-  PreviewAutomationTargetLookupFields,
-) {
-  override get message(): string {
-    const target = previewAutomationTargetLabel(this.selectorKind, this.selectorLength);
-    return `Preview automation ${this.operation} found ${target} in tab ${this.tabId}, but it is not visible`;
-  }
-}
-
-export class PreviewAutomationTargetDisabledError extends Schema.TaggedErrorClass<PreviewAutomationTargetDisabledError>()(
-  "PreviewAutomationTargetDisabledError",
-  PreviewAutomationTargetLookupFields,
-) {
-  override get message(): string {
-    const target = previewAutomationTargetLabel(this.selectorKind, this.selectorLength);
-    return `Preview automation ${this.operation} found ${target} in tab ${this.tabId}, but it is disabled`;
-  }
-}
-
-export class PreviewAutomationTargetAmbiguousError extends Schema.TaggedErrorClass<PreviewAutomationTargetAmbiguousError>()(
-  "PreviewAutomationTargetAmbiguousError",
+export class PreviewAutomationTargetLookupError extends Schema.TaggedErrorClass<PreviewAutomationTargetLookupError>()(
+  "PreviewAutomationTargetLookupError",
   {
-    ...PreviewAutomationTargetLookupFields,
-    matchCount: Schema.Number,
+    operation: Schema.String,
+    tabId: Schema.String,
+    selectorKind: PreviewAutomationSelectorKind,
+    selectorLength: Schema.optionalKey(Schema.Number),
+    failureKind: Schema.Literals(["missing", "hidden", "disabled", "ambiguous"]),
+    matchCount: Schema.optionalKey(Schema.Int.check(Schema.isGreaterThan(0))),
   },
 ) {
   override get message(): string {
     const target = previewAutomationTargetLabel(this.selectorKind, this.selectorLength);
-    return `Preview automation ${this.operation} matched ${this.matchCount} elements for ${target} in tab ${this.tabId}`;
+    if (this.failureKind === "hidden") {
+      return `Preview automation ${this.operation} found ${target}, but it is not visible`;
+    }
+    if (this.failureKind === "disabled") {
+      return `Preview automation ${this.operation} found ${target}, but it is disabled`;
+    }
+    if (this.failureKind === "ambiguous") {
+      return `Preview automation ${this.operation} matched ${this.matchCount ?? 0} elements for ${target}`;
+    }
+    return `Preview automation ${this.operation} could not find ${target}`;
   }
 }
 
@@ -4545,9 +4530,7 @@ export const PreviewManagerError = Schema.Union([
   PreviewAutomationDebuggerAttachedError,
   PreviewAutomationEvaluationError,
   PreviewAutomationTargetNotFoundError,
-  PreviewAutomationTargetHiddenError,
-  PreviewAutomationTargetDisabledError,
-  PreviewAutomationTargetAmbiguousError,
+  PreviewAutomationTargetLookupError,
   PreviewAutomationTargetNotEditableError,
   PreviewAutomationCoordinatesOutsideViewportError,
   PreviewAutomationInvalidSelectorError,
@@ -4646,7 +4629,7 @@ export class PreviewManager extends Context.Service<
     readonly automationClick: (
       tabId: string,
       input: PreviewAutomationClickInput,
-    ) => Effect.Effect<void, PreviewManagerError>;
+    ) => Effect.Effect<DesktopPreviewAutomationClickResult, PreviewManagerError>;
     readonly automationType: (
       tabId: string,
       input: PreviewAutomationTypeInput,

--- a/apps/server/src/mcp/McpHttpServer.test.ts
+++ b/apps/server/src/mcp/McpHttpServer.test.ts
@@ -97,6 +97,51 @@ it.effect("returns bounded structural preview snapshot failures", () =>
   ).pipe(Effect.provide(TestLayer)),
 );
 
+it.effect("returns a typed click lookup reason through the MCP tool", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const locator = "role=button[name='request-secret']";
+      const server = yield* McpServer.McpServer;
+      const broker = yield* PreviewAutomationBroker.PreviewAutomationBroker;
+      const events = yield* broker.connect({
+        clientId: "mcp-click-failure-client",
+        environmentId,
+      });
+      yield* Stream.runForEach(events, (event) =>
+        event.type === "connected"
+          ? Effect.void
+          : broker.respond({
+              clientId: "mcp-click-failure-client",
+              connectionId: event.connectionId,
+              requestId: event.request.requestId,
+              ok: false,
+              error: {
+                _tag: "PreviewAutomationTargetLookupError",
+                message: "The preview click target is disabled.",
+                detail: { failureKind: "disabled" },
+              },
+            }),
+      ).pipe(Effect.forkScoped);
+      yield* Effect.yieldNow;
+
+      const result = yield* server
+        .callTool({ name: "preview_click", arguments: { locator } })
+        .pipe(
+          Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
+          Effect.provideService(McpSchema.McpServerClient, client),
+        );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: `Preview automation click found locator (${locator.length} characters), but it is disabled.`,
+        },
+      ]);
+    }),
+  ).pipe(Effect.provide(TestLayer)),
+);
+
 it.effect("terminates HTTP MCP sessions with DELETE", () =>
   Effect.scoped(
     Effect.gen(function* () {

--- a/apps/server/src/mcp/PreviewAutomationBroker.test.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.test.ts
@@ -6,6 +6,7 @@ import {
   PreviewAutomationInvalidSelectorError,
   PreviewAutomationMalformedResponseError,
   PreviewAutomationNoAvailableHostError,
+  PreviewAutomationTargetLookupError,
   PreviewAutomationTargetNotEditableError,
   PreviewTabId,
   ProviderInstanceId,
@@ -400,6 +401,55 @@ it.effect("classifies a remote non-editable target without collapsing it to exec
         remoteTag: "PreviewAutomationTargetNotEditableError",
       });
       expect(error.message).toBe("Preview automation type requires an editable focused element.");
+    }),
+  );
+});
+
+it.effect("preserves a remote click lookup reason without exposing the locator", () => {
+  const locator = "role=button[name='request-secret']";
+  const remoteError = {
+    _tag: "PreviewAutomationTargetLookupError",
+    message: "The preview click target is not visible.",
+    detail: { failureKind: "hidden" },
+  } as const;
+
+  return Effect.scoped(
+    Effect.gen(function* () {
+      const broker = yield* makeBroker;
+      const requests = requestsFrom(yield* broker.connect(makeHost()));
+      yield* Stream.runForEach(requests, (request) =>
+        broker.respond({
+          clientId: "client-1",
+          connectionId: request.connectionId,
+          requestId: request.requestId,
+          ok: false,
+          error: remoteError,
+        }),
+      ).pipe(Effect.forkScoped);
+      yield* Effect.yieldNow;
+
+      const error = yield* broker
+        .invoke<void>({
+          scope,
+          operation: "click",
+          input: { locator },
+          tabId: PreviewTabId.make("tab-1"),
+        })
+        .pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(PreviewAutomationTargetLookupError);
+      expect(error).toMatchObject({
+        operation: "click",
+        failureKind: "hidden",
+        selectorKind: "locator",
+        selectorLength: locator.length,
+        remoteTag: "PreviewAutomationTargetLookupError",
+      });
+      expect(error.message).toBe(
+        `Preview automation click found locator (${locator.length} characters), but it is not visible.`,
+      );
+      expect(error.message).not.toContain("request-secret");
+      expect(error.cause).toBe(remoteError);
     }),
   );
 });

--- a/apps/server/src/mcp/PreviewAutomationBroker.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.ts
@@ -10,6 +10,8 @@ import {
   PreviewAutomationRequestQueueClosedError,
   PreviewAutomationResultTooLargeError,
   PreviewAutomationTabNotFoundError,
+  PreviewAutomationTargetLookupError,
+  PreviewAutomationTargetLookupFailureKind,
   PreviewAutomationTargetNotEditableError,
   PreviewAutomationTimeoutError,
   PreviewAutomationUnsupportedClientError,
@@ -183,6 +185,14 @@ function remoteDetailKind(detail: unknown): RemoteDetailKind {
   }
 }
 
+const PreviewAutomationTargetLookupRemoteDetail = Schema.Struct({
+  failureKind: PreviewAutomationTargetLookupFailureKind,
+  matchCount: Schema.optional(Schema.Int.check(Schema.isGreaterThan(0))),
+});
+const isPreviewAutomationTargetLookupRemoteDetail = Schema.is(
+  PreviewAutomationTargetLookupRemoteDetail,
+);
+
 const classifyResponseError = (
   context: PreviewAutomationRequestErrorContext,
   error: NonNullable<PreviewAutomationResponse["error"]>,
@@ -255,6 +265,16 @@ const classifyResponseError = (
           : { selectorLength: remoteSelectorLength ?? context.selectorLength }),
       });
     }
+    case "PreviewAutomationTargetLookupError": {
+      if (!isPreviewAutomationTargetLookupRemoteDetail(error.detail)) break;
+      if (error.detail.failureKind === "ambiguous" && error.detail.matchCount === undefined) break;
+      return new PreviewAutomationTargetLookupError({
+        ...context,
+        ...remoteDiagnostics,
+        failureKind: error.detail.failureKind,
+        ...(error.detail.matchCount === undefined ? {} : { matchCount: error.detail.matchCount }),
+      });
+    }
     case "PreviewAutomationResultTooLargeError": {
       const detail =
         typeof error.detail === "object" && error.detail !== null ? error.detail : undefined;
@@ -278,11 +298,12 @@ const classifyResponseError = (
         ...remoteDiagnostics,
       });
     default:
-      return new PreviewAutomationExecutionError({
-        ...context,
-        ...remoteDiagnostics,
-      });
+      break;
   }
+  return new PreviewAutomationExecutionError({
+    ...context,
+    ...remoteDiagnostics,
+  });
 };
 
 export const make = Effect.gen(function* PreviewAutomationBrokerMake() {

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -52,6 +52,7 @@ import { useAtomCommand } from "~/state/use-atom-command";
 
 import { previewBridge } from "./previewBridge";
 import {
+  confirmPreviewAutomationClickTarget,
   PreviewAutomationOperationError,
   PreviewAutomationOverlayTimeoutError,
   PreviewAutomationRecordingNotActiveError,
@@ -595,9 +596,18 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
           }
           case "click": {
             const ready = await requireReadyTab();
-            return await ready.bridge.automation.click(
-              ready.runtimeTabId,
-              request.input as Parameters<typeof ready.bridge.automation.click>[1],
+            return confirmPreviewAutomationClickTarget(
+              await ready.bridge.automation.click(
+                ready.runtimeTabId,
+                request.input as Parameters<typeof ready.bridge.automation.click>[1],
+              ),
+              {
+                requestId: request.requestId,
+                operation: "click",
+                environmentId,
+                threadId: request.threadId,
+                tabId: ready.tabId,
+              },
             );
           }
           case "type": {

--- a/apps/web/src/components/preview/previewAutomationErrors.test.ts
+++ b/apps/web/src/components/preview/previewAutomationErrors.test.ts
@@ -25,17 +25,14 @@ describe("PreviewAutomationOperationError", () => {
       ...context,
       cause: { _tag: "PreviewAutomationTargetAmbiguousError", matchCount: 3 },
     });
-    const legacyHidden = PreviewAutomationOperationError.fromCause({
+    const missing = PreviewAutomationOperationError.fromCause({
       ...context,
-      cause: {
-        _tag: "PreviewAutomationTargetNotFoundError",
-        failureKind: "hidden",
-      },
+      cause: { _tag: "PreviewAutomationTargetNotFoundError" },
     });
     expect(hidden.message).toContain("not visible");
     expect(disabled.message).toContain("disabled");
     expect(ambiguous.message).toContain("matched 3 elements");
-    expect(legacyHidden.message).toContain("not visible");
+    expect(missing.message).toContain("could not find a target");
     expect(hidden.message).not.toContain("secret");
     expect(disabled.message).not.toContain("secret");
     expect(ambiguous.message).not.toContain("secret");

--- a/apps/web/src/components/preview/previewAutomationErrors.test.ts
+++ b/apps/web/src/components/preview/previewAutomationErrors.test.ts
@@ -1,10 +1,17 @@
-import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import {
+  type DesktopPreviewAutomationClickResult,
+  EnvironmentId,
+  ThreadId,
+} from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
 import {
   confirmPreviewAutomationClickTarget,
+  PreviewAutomationOperationError,
   PreviewAutomationTargetLookupHostError,
 } from "./previewAutomationErrors";
+
+type NotSentClickResult = Extract<DesktopPreviewAutomationClickResult, { _tag: "NotSent" }>;
 
 describe("confirmPreviewAutomationClickTarget", () => {
   const context = {
@@ -52,5 +59,34 @@ describe("confirmPreviewAutomationClickTarget", () => {
     expect(hidden.message).not.toContain("secret");
     expect(disabled.message).not.toContain("secret");
     expect(ambiguous.message).not.toContain("secret");
+  });
+
+  it("fails every NotSent outcome and preserves successful results", () => {
+    const results = [
+      { _tag: "NotSent", reason: "tab-not-visible" },
+      { _tag: "NotSent", reason: "timeout", timeoutMs: 5_000 },
+      { _tag: "NotSent", reason: "target-missing" },
+      { _tag: "NotSent", reason: "target-hidden" },
+      { _tag: "NotSent", reason: "target-disabled" },
+      { _tag: "NotSent", reason: "target-ambiguous", matchCount: 3 },
+    ] satisfies ReadonlyArray<NotSentClickResult>;
+
+    for (const result of results) {
+      expect(() => confirmPreviewAutomationClickTarget(result, context)).toThrow();
+    }
+
+    for (const result of results.slice(0, 2)) {
+      try {
+        confirmPreviewAutomationClickTarget(result, context);
+        throw new Error("Expected click target confirmation to fail");
+      } catch (error) {
+        expect(error).toBeInstanceOf(PreviewAutomationOperationError);
+        expect((error as PreviewAutomationOperationError).cause).toEqual(result);
+      }
+    }
+
+    const dispatched = { _tag: "Dispatched" } as const;
+    expect(confirmPreviewAutomationClickTarget(dispatched, context)).toBe(dispatched);
+    expect(confirmPreviewAutomationClickTarget(undefined, context)).toBeUndefined();
   });
 });

--- a/apps/web/src/components/preview/previewAutomationErrors.test.ts
+++ b/apps/web/src/components/preview/previewAutomationErrors.test.ts
@@ -1,0 +1,43 @@
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { PreviewAutomationOperationError } from "./previewAutomationErrors";
+
+describe("PreviewAutomationOperationError", () => {
+  const context = {
+    requestId: "request-1",
+    operation: "click" as const,
+    environmentId: EnvironmentId.make("environment-1"),
+    threadId: ThreadId.make("thread-1"),
+    tabId: "tab-1",
+  };
+
+  it("maps typed not-found failures to a visible/disabled/ambiguous reason", () => {
+    const hidden = PreviewAutomationOperationError.fromCause({
+      ...context,
+      cause: { _tag: "PreviewAutomationTargetHiddenError" },
+    });
+    const disabled = PreviewAutomationOperationError.fromCause({
+      ...context,
+      cause: { _tag: "PreviewAutomationTargetDisabledError" },
+    });
+    const ambiguous = PreviewAutomationOperationError.fromCause({
+      ...context,
+      cause: { _tag: "PreviewAutomationTargetAmbiguousError", matchCount: 3 },
+    });
+    const legacyHidden = PreviewAutomationOperationError.fromCause({
+      ...context,
+      cause: {
+        _tag: "PreviewAutomationTargetNotFoundError",
+        failureKind: "hidden",
+      },
+    });
+    expect(hidden.message).toContain("not visible");
+    expect(disabled.message).toContain("disabled");
+    expect(ambiguous.message).toContain("matched 3 elements");
+    expect(legacyHidden.message).toContain("not visible");
+    expect(hidden.message).not.toContain("secret");
+    expect(disabled.message).not.toContain("secret");
+    expect(ambiguous.message).not.toContain("secret");
+  });
+});

--- a/apps/web/src/components/preview/previewAutomationErrors.test.ts
+++ b/apps/web/src/components/preview/previewAutomationErrors.test.ts
@@ -1,9 +1,12 @@
 import { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
-import { PreviewAutomationOperationError } from "./previewAutomationErrors";
+import {
+  confirmPreviewAutomationClickTarget,
+  PreviewAutomationTargetLookupHostError,
+} from "./previewAutomationErrors";
 
-describe("PreviewAutomationOperationError", () => {
+describe("confirmPreviewAutomationClickTarget", () => {
   const context = {
     requestId: "request-1",
     operation: "click" as const,
@@ -12,27 +15,40 @@ describe("PreviewAutomationOperationError", () => {
     tabId: "tab-1",
   };
 
-  it("maps typed not-found failures to a visible/disabled/ambiguous reason", () => {
-    const hidden = PreviewAutomationOperationError.fromCause({
-      ...context,
-      cause: { _tag: "PreviewAutomationTargetHiddenError" },
+  const lookupError = (
+    result:
+      | { readonly _tag: "NotSent"; readonly reason: "target-missing" }
+      | { readonly _tag: "NotSent"; readonly reason: "target-hidden" }
+      | { readonly _tag: "NotSent"; readonly reason: "target-disabled" }
+      | {
+          readonly _tag: "NotSent";
+          readonly reason: "target-ambiguous";
+          readonly matchCount: number;
+        },
+  ) => {
+    try {
+      confirmPreviewAutomationClickTarget(result, context);
+      throw new Error("Expected click target confirmation to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(PreviewAutomationTargetLookupHostError);
+      return error as PreviewAutomationTargetLookupHostError;
+    }
+  };
+
+  it("maps typed IPC outcomes to visible, disabled, ambiguous, and missing reasons", () => {
+    const hidden = lookupError({ _tag: "NotSent", reason: "target-hidden" });
+    const disabled = lookupError({ _tag: "NotSent", reason: "target-disabled" });
+    const ambiguous = lookupError({
+      _tag: "NotSent",
+      reason: "target-ambiguous",
+      matchCount: 3,
     });
-    const disabled = PreviewAutomationOperationError.fromCause({
-      ...context,
-      cause: { _tag: "PreviewAutomationTargetDisabledError" },
-    });
-    const ambiguous = PreviewAutomationOperationError.fromCause({
-      ...context,
-      cause: { _tag: "PreviewAutomationTargetAmbiguousError", matchCount: 3 },
-    });
-    const missing = PreviewAutomationOperationError.fromCause({
-      ...context,
-      cause: { _tag: "PreviewAutomationTargetNotFoundError" },
-    });
+    const missing = lookupError({ _tag: "NotSent", reason: "target-missing" });
+
     expect(hidden.message).toContain("not visible");
     expect(disabled.message).toContain("disabled");
     expect(ambiguous.message).toContain("matched 3 elements");
-    expect(missing.message).toContain("could not find a target");
+    expect(missing.message).toContain("not found");
     expect(hidden.message).not.toContain("secret");
     expect(disabled.message).not.toContain("secret");
     expect(ambiguous.message).not.toContain("secret");

--- a/apps/web/src/components/preview/previewAutomationErrors.ts
+++ b/apps/web/src/components/preview/previewAutomationErrors.ts
@@ -1,4 +1,5 @@
 import {
+  type DesktopPreviewAutomationClickResult,
   EnvironmentId,
   type PreviewAutomationHost,
   PreviewAutomationOperation,
@@ -140,86 +141,61 @@ const PreviewAutomationTargetHostFields = {
   environmentId: EnvironmentId,
   threadId: ThreadId,
   tabId: Schema.NullOr(PreviewTabId),
-  cause: Schema.Defect(),
 };
 
-const readTargetLookupKind = (
-  cause: unknown,
-): "missing" | "hidden" | "disabled" | "ambiguous" | null => {
-  if (typeof cause !== "object" || cause === null || !("_tag" in cause)) return null;
-  if (cause._tag === "PreviewAutomationTargetHiddenError") return "hidden";
-  if (cause._tag === "PreviewAutomationTargetDisabledError") return "disabled";
-  if (cause._tag === "PreviewAutomationTargetAmbiguousError") return "ambiguous";
-  if (cause._tag === "PreviewAutomationTargetNotFoundError") return "missing";
-  return null;
-};
-
-const readAmbiguousMatchCount = (cause: unknown): number => {
-  if (
-    typeof cause === "object" &&
-    cause !== null &&
-    "matchCount" in cause &&
-    typeof cause.matchCount === "number" &&
-    Number.isInteger(cause.matchCount) &&
-    cause.matchCount >= 0
-  ) {
-    return cause.matchCount;
-  }
-  return 0;
-};
-
-export class PreviewAutomationTargetNotFoundHostError extends Schema.TaggedErrorClass<PreviewAutomationTargetNotFoundHostError>()(
-  "PreviewAutomationTargetNotFoundHostError",
-  PreviewAutomationTargetHostFields,
-) {
-  get responseTag() {
-    return "PreviewAutomationExecutionError" as const;
-  }
-
-  override get message(): string {
-    return `Preview automation ${this.operation} request ${this.requestId} could not find a target in tab ${this.tabId ?? "unassigned"}.`;
-  }
-}
-
-export class PreviewAutomationTargetHiddenHostError extends Schema.TaggedErrorClass<PreviewAutomationTargetHiddenHostError>()(
-  "PreviewAutomationTargetHiddenHostError",
-  PreviewAutomationTargetHostFields,
-) {
-  get responseTag() {
-    return "PreviewAutomationExecutionError" as const;
-  }
-
-  override get message(): string {
-    return `Preview automation ${this.operation} request ${this.requestId} found a target in tab ${this.tabId ?? "unassigned"}, but it is not visible.`;
-  }
-}
-
-export class PreviewAutomationTargetDisabledHostError extends Schema.TaggedErrorClass<PreviewAutomationTargetDisabledHostError>()(
-  "PreviewAutomationTargetDisabledHostError",
-  PreviewAutomationTargetHostFields,
-) {
-  get responseTag() {
-    return "PreviewAutomationExecutionError" as const;
-  }
-
-  override get message(): string {
-    return `Preview automation ${this.operation} request ${this.requestId} found a target in tab ${this.tabId ?? "unassigned"}, but it is disabled.`;
-  }
-}
-
-export class PreviewAutomationTargetAmbiguousHostError extends Schema.TaggedErrorClass<PreviewAutomationTargetAmbiguousHostError>()(
-  "PreviewAutomationTargetAmbiguousHostError",
+export class PreviewAutomationTargetLookupHostError extends Schema.TaggedErrorClass<PreviewAutomationTargetLookupHostError>()(
+  "PreviewAutomationTargetLookupHostError",
   {
     ...PreviewAutomationTargetHostFields,
-    matchCount: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+    failureKind: Schema.Literals(["missing", "hidden", "disabled", "ambiguous"]),
+    matchCount: Schema.optional(Schema.Int.check(Schema.isGreaterThan(0))),
   },
 ) {
   get responseTag() {
-    return "PreviewAutomationExecutionError" as const;
+    return "PreviewAutomationTargetLookupError" as const;
   }
 
   override get message(): string {
-    return `Preview automation ${this.operation} request ${this.requestId} matched ${this.matchCount} elements in tab ${this.tabId ?? "unassigned"}.`;
+    if (this.failureKind === "hidden") return "The preview click target is not visible.";
+    if (this.failureKind === "disabled") return "The preview click target is disabled.";
+    if (this.failureKind === "ambiguous") {
+      return this.matchCount === undefined
+        ? "The preview click target matched multiple elements."
+        : `The preview click target matched ${this.matchCount} elements.`;
+    }
+    return "The preview click target was not found.";
+  }
+}
+
+export function confirmPreviewAutomationClickTarget(
+  result: DesktopPreviewAutomationClickResult | void,
+  context: PreviewAutomationOperationContext & { readonly operation: "click" },
+): DesktopPreviewAutomationClickResult | void {
+  if (result?._tag !== "NotSent") return result;
+  switch (result.reason) {
+    case "target-missing":
+      throw new PreviewAutomationTargetLookupHostError({
+        ...context,
+        failureKind: "missing",
+      });
+    case "target-hidden":
+      throw new PreviewAutomationTargetLookupHostError({
+        ...context,
+        failureKind: "hidden",
+      });
+    case "target-disabled":
+      throw new PreviewAutomationTargetLookupHostError({
+        ...context,
+        failureKind: "disabled",
+      });
+    case "target-ambiguous":
+      throw new PreviewAutomationTargetLookupHostError({
+        ...context,
+        failureKind: "ambiguous",
+        matchCount: result.matchCount,
+      });
+    default:
+      return result;
   }
 }
 
@@ -272,26 +248,6 @@ export class PreviewAutomationOperationError extends Schema.TaggedErrorClass<Pre
     input: PreviewAutomationOperationContext & { readonly cause: unknown },
   ): PreviewAutomationHostError {
     if (isPreviewAutomationHostError(input.cause)) return input.cause;
-    const lookupKind = readTargetLookupKind(input.cause);
-    if (lookupKind) {
-      const shared = {
-        requestId: input.requestId,
-        operation: input.operation,
-        environmentId: input.environmentId,
-        threadId: input.threadId,
-        tabId: input.tabId,
-        cause: input.cause,
-      };
-      if (lookupKind === "hidden") return new PreviewAutomationTargetHiddenHostError(shared);
-      if (lookupKind === "disabled") return new PreviewAutomationTargetDisabledHostError(shared);
-      if (lookupKind === "ambiguous") {
-        return new PreviewAutomationTargetAmbiguousHostError({
-          ...shared,
-          matchCount: readAmbiguousMatchCount(input.cause),
-        });
-      }
-      return new PreviewAutomationTargetNotFoundHostError(shared);
-    }
     const diagnostics = targetNotEditableDiagnostics(input.cause);
     return diagnostics
       ? new PreviewAutomationTargetNotEditableHostError({
@@ -320,10 +276,7 @@ export const PreviewAutomationHostError = Schema.Union([
   PreviewAutomationViewportTimeoutError,
   PreviewAutomationTargetUnavailableError,
   PreviewAutomationRecordingNotActiveError,
-  PreviewAutomationTargetNotFoundHostError,
-  PreviewAutomationTargetHiddenHostError,
-  PreviewAutomationTargetDisabledHostError,
-  PreviewAutomationTargetAmbiguousHostError,
+  PreviewAutomationTargetLookupHostError,
   PreviewAutomationTargetNotEditableHostError,
   PreviewAutomationOperationError,
 ]);

--- a/apps/web/src/components/preview/previewAutomationErrors.ts
+++ b/apps/web/src/components/preview/previewAutomationErrors.ts
@@ -134,6 +134,103 @@ export class PreviewAutomationTargetNotEditableHostError extends Schema.TaggedEr
   }
 }
 
+const PreviewAutomationTargetHostFields = {
+  requestId: TrimmedNonEmptyString,
+  operation: PreviewAutomationOperation,
+  environmentId: EnvironmentId,
+  threadId: ThreadId,
+  tabId: Schema.NullOr(PreviewTabId),
+  cause: Schema.Defect(),
+};
+
+const readTargetLookupKind = (
+  cause: unknown,
+): "missing" | "hidden" | "disabled" | "ambiguous" | null => {
+  if (typeof cause !== "object" || cause === null || !("_tag" in cause)) return null;
+  if (cause._tag === "PreviewAutomationTargetHiddenError") return "hidden";
+  if (cause._tag === "PreviewAutomationTargetDisabledError") return "disabled";
+  if (cause._tag === "PreviewAutomationTargetAmbiguousError") return "ambiguous";
+  if (cause._tag !== "PreviewAutomationTargetNotFoundError") return null;
+  if (
+    "failureKind" in cause &&
+    (cause.failureKind === "hidden" ||
+      cause.failureKind === "disabled" ||
+      cause.failureKind === "ambiguous")
+  ) {
+    return cause.failureKind;
+  }
+  return "missing";
+};
+
+const readAmbiguousMatchCount = (cause: unknown): number => {
+  if (
+    typeof cause === "object" &&
+    cause !== null &&
+    "matchCount" in cause &&
+    typeof cause.matchCount === "number" &&
+    Number.isInteger(cause.matchCount) &&
+    cause.matchCount >= 0
+  ) {
+    return cause.matchCount;
+  }
+  return 0;
+};
+
+export class PreviewAutomationTargetNotFoundHostError extends Schema.TaggedErrorClass<PreviewAutomationTargetNotFoundHostError>()(
+  "PreviewAutomationTargetNotFoundHostError",
+  PreviewAutomationTargetHostFields,
+) {
+  get responseTag() {
+    return "PreviewAutomationExecutionError" as const;
+  }
+
+  override get message(): string {
+    return `Preview automation ${this.operation} request ${this.requestId} could not find a target in tab ${this.tabId ?? "unassigned"}.`;
+  }
+}
+
+export class PreviewAutomationTargetHiddenHostError extends Schema.TaggedErrorClass<PreviewAutomationTargetHiddenHostError>()(
+  "PreviewAutomationTargetHiddenHostError",
+  PreviewAutomationTargetHostFields,
+) {
+  get responseTag() {
+    return "PreviewAutomationExecutionError" as const;
+  }
+
+  override get message(): string {
+    return `Preview automation ${this.operation} request ${this.requestId} found a target in tab ${this.tabId ?? "unassigned"}, but it is not visible.`;
+  }
+}
+
+export class PreviewAutomationTargetDisabledHostError extends Schema.TaggedErrorClass<PreviewAutomationTargetDisabledHostError>()(
+  "PreviewAutomationTargetDisabledHostError",
+  PreviewAutomationTargetHostFields,
+) {
+  get responseTag() {
+    return "PreviewAutomationExecutionError" as const;
+  }
+
+  override get message(): string {
+    return `Preview automation ${this.operation} request ${this.requestId} found a target in tab ${this.tabId ?? "unassigned"}, but it is disabled.`;
+  }
+}
+
+export class PreviewAutomationTargetAmbiguousHostError extends Schema.TaggedErrorClass<PreviewAutomationTargetAmbiguousHostError>()(
+  "PreviewAutomationTargetAmbiguousHostError",
+  {
+    ...PreviewAutomationTargetHostFields,
+    matchCount: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+  },
+) {
+  get responseTag() {
+    return "PreviewAutomationExecutionError" as const;
+  }
+
+  override get message(): string {
+    return `Preview automation ${this.operation} request ${this.requestId} matched ${this.matchCount} elements in tab ${this.tabId ?? "unassigned"}.`;
+  }
+}
+
 const targetNotEditableDiagnostics = (
   cause: unknown,
 ): {
@@ -183,6 +280,26 @@ export class PreviewAutomationOperationError extends Schema.TaggedErrorClass<Pre
     input: PreviewAutomationOperationContext & { readonly cause: unknown },
   ): PreviewAutomationHostError {
     if (isPreviewAutomationHostError(input.cause)) return input.cause;
+    const lookupKind = readTargetLookupKind(input.cause);
+    if (lookupKind) {
+      const shared = {
+        requestId: input.requestId,
+        operation: input.operation,
+        environmentId: input.environmentId,
+        threadId: input.threadId,
+        tabId: input.tabId,
+        cause: input.cause,
+      };
+      if (lookupKind === "hidden") return new PreviewAutomationTargetHiddenHostError(shared);
+      if (lookupKind === "disabled") return new PreviewAutomationTargetDisabledHostError(shared);
+      if (lookupKind === "ambiguous") {
+        return new PreviewAutomationTargetAmbiguousHostError({
+          ...shared,
+          matchCount: readAmbiguousMatchCount(input.cause),
+        });
+      }
+      return new PreviewAutomationTargetNotFoundHostError(shared);
+    }
     const diagnostics = targetNotEditableDiagnostics(input.cause);
     return diagnostics
       ? new PreviewAutomationTargetNotEditableHostError({
@@ -211,6 +328,10 @@ export const PreviewAutomationHostError = Schema.Union([
   PreviewAutomationViewportTimeoutError,
   PreviewAutomationTargetUnavailableError,
   PreviewAutomationRecordingNotActiveError,
+  PreviewAutomationTargetNotFoundHostError,
+  PreviewAutomationTargetHiddenHostError,
+  PreviewAutomationTargetDisabledHostError,
+  PreviewAutomationTargetAmbiguousHostError,
   PreviewAutomationTargetNotEditableHostError,
   PreviewAutomationOperationError,
 ]);

--- a/apps/web/src/components/preview/previewAutomationErrors.ts
+++ b/apps/web/src/components/preview/previewAutomationErrors.ts
@@ -195,7 +195,7 @@ export function confirmPreviewAutomationClickTarget(
         matchCount: result.matchCount,
       });
     default:
-      return result;
+      throw new PreviewAutomationOperationError({ ...context, cause: result });
   }
 }
 

--- a/apps/web/src/components/preview/previewAutomationErrors.ts
+++ b/apps/web/src/components/preview/previewAutomationErrors.ts
@@ -150,16 +150,8 @@ const readTargetLookupKind = (
   if (cause._tag === "PreviewAutomationTargetHiddenError") return "hidden";
   if (cause._tag === "PreviewAutomationTargetDisabledError") return "disabled";
   if (cause._tag === "PreviewAutomationTargetAmbiguousError") return "ambiguous";
-  if (cause._tag !== "PreviewAutomationTargetNotFoundError") return null;
-  if (
-    "failureKind" in cause &&
-    (cause.failureKind === "hidden" ||
-      cause.failureKind === "disabled" ||
-      cause.failureKind === "ambiguous")
-  ) {
-    return cause.failureKind;
-  }
-  return "missing";
+  if (cause._tag === "PreviewAutomationTargetNotFoundError") return "missing";
+  return null;
 };
 
 const readAmbiguousMatchCount = (cause: unknown): number => {

--- a/apps/web/src/components/preview/previewAutomationRequestConsumer.test.ts
+++ b/apps/web/src/components/preview/previewAutomationRequestConsumer.test.ts
@@ -10,6 +10,7 @@ import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity";
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
+  confirmPreviewAutomationClickTarget,
   PreviewAutomationRecordingNotActiveError,
   PreviewAutomationTargetUnavailableError,
   PreviewAutomationViewportTimeoutError,
@@ -292,49 +293,34 @@ describe("previewAutomationRequestConsumer", () => {
   });
 
   it("maps hidden click targets to a named execution failure without leaking the locator", () => {
-    expect(
-      serializePreviewAutomationError(
-        {
-          _tag: "PreviewAutomationTargetHiddenError",
-          selector: "role=button[name='target-secret']",
-        },
-        {
-          requestId: "request-click",
-          operation: "click",
-          environmentId,
-          threadId,
-          tabId,
-        },
-      ),
-    ).toEqual({
-      _tag: "PreviewAutomationExecutionError",
-      message:
-        "Preview automation click request request-click found a target in tab tab-1, but it is not visible.",
+    const context = {
+      requestId: "request-click",
+      operation: "click" as const,
+      environmentId,
+      threadId,
+      tabId,
+    };
+    let error: unknown;
+    try {
+      confirmPreviewAutomationClickTarget({ _tag: "NotSent", reason: "target-hidden" }, context);
+    } catch (cause) {
+      error = cause;
+    }
+
+    const response = serializePreviewAutomationError(error, context);
+    expect(response).toEqual({
+      _tag: "PreviewAutomationTargetLookupError",
+      message: "The preview click target is not visible.",
       detail: {
         requestId: "request-click",
         operation: "click",
         environmentId: "environment-1",
         threadId: "thread-1",
         tabId: "tab-1",
+        failureKind: "hidden",
       },
     });
-    expect(
-      JSON.stringify(
-        serializePreviewAutomationError(
-          {
-            _tag: "PreviewAutomationTargetHiddenError",
-            selector: "role=button[name='target-secret']",
-          },
-          {
-            requestId: "request-click",
-            operation: "click",
-            environmentId,
-            threadId,
-            tabId,
-          },
-        ),
-      ),
-    ).not.toContain("secret");
+    expect(JSON.stringify(response)).not.toContain("target-secret");
   });
 
   it("maps desktop non-editable targets to the public typed response", () => {

--- a/apps/web/src/components/preview/previewAutomationRequestConsumer.test.ts
+++ b/apps/web/src/components/preview/previewAutomationRequestConsumer.test.ts
@@ -322,8 +322,7 @@ describe("previewAutomationRequestConsumer", () => {
       JSON.stringify(
         serializePreviewAutomationError(
           {
-            _tag: "PreviewAutomationTargetNotFoundError",
-            failureKind: "hidden",
+            _tag: "PreviewAutomationTargetHiddenError",
             selector: "role=button[name='target-secret']",
           },
           {

--- a/apps/web/src/components/preview/previewAutomationRequestConsumer.test.ts
+++ b/apps/web/src/components/preview/previewAutomationRequestConsumer.test.ts
@@ -291,6 +291,53 @@ describe("previewAutomationRequestConsumer", () => {
     });
   });
 
+  it("maps hidden click targets to a named execution failure without leaking the locator", () => {
+    expect(
+      serializePreviewAutomationError(
+        {
+          _tag: "PreviewAutomationTargetHiddenError",
+          selector: "role=button[name='target-secret']",
+        },
+        {
+          requestId: "request-click",
+          operation: "click",
+          environmentId,
+          threadId,
+          tabId,
+        },
+      ),
+    ).toEqual({
+      _tag: "PreviewAutomationExecutionError",
+      message:
+        "Preview automation click request request-click found a target in tab tab-1, but it is not visible.",
+      detail: {
+        requestId: "request-click",
+        operation: "click",
+        environmentId: "environment-1",
+        threadId: "thread-1",
+        tabId: "tab-1",
+      },
+    });
+    expect(
+      JSON.stringify(
+        serializePreviewAutomationError(
+          {
+            _tag: "PreviewAutomationTargetNotFoundError",
+            failureKind: "hidden",
+            selector: "role=button[name='target-secret']",
+          },
+          {
+            requestId: "request-click",
+            operation: "click",
+            environmentId,
+            threadId,
+            tabId,
+          },
+        ),
+      ),
+    ).not.toContain("secret");
+  });
+
   it("maps desktop non-editable targets to the public typed response", () => {
     expect(
       serializePreviewAutomationError(

--- a/packages/contracts/src/ipc.test.ts
+++ b/packages/contracts/src/ipc.test.ts
@@ -1,7 +1,10 @@
 import * as Schema from "effect/Schema";
 import { describe, expect, it } from "vite-plus/test";
 
-import { DesktopEnvironmentBootstrapSchema } from "./ipc.ts";
+import {
+  DesktopEnvironmentBootstrapSchema,
+  DesktopPreviewAutomationClickResultSchema,
+} from "./ipc.ts";
 
 describe("DesktopEnvironmentBootstrapSchema", () => {
   const decode = Schema.decodeUnknownSync(DesktopEnvironmentBootstrapSchema);
@@ -34,5 +37,25 @@ describe("DesktopEnvironmentBootstrapSchema", () => {
         wsBaseUrl: null,
       }).runningDistro,
     ).toBeNull();
+  });
+});
+
+describe("DesktopPreviewAutomationClickResultSchema", () => {
+  const decode = Schema.decodeUnknownSync(DesktopPreviewAutomationClickResultSchema);
+
+  it.each([
+    { _tag: "Dispatched" },
+    { _tag: "NotSent", reason: "tab-not-visible" },
+    { _tag: "NotSent", reason: "timeout", timeoutMs: 50 },
+    { _tag: "NotSent", reason: "target-missing" },
+    { _tag: "NotSent", reason: "target-hidden" },
+    { _tag: "NotSent", reason: "target-disabled" },
+    { _tag: "NotSent", reason: "target-ambiguous", matchCount: 2 },
+  ] as const)("decodes $reason", (result) => {
+    expect(decode(result)).toEqual(result);
+  });
+
+  it("rejects an ambiguous target without a positive match count", () => {
+    expect(() => decode({ _tag: "NotSent", reason: "target-ambiguous", matchCount: 0 })).toThrow();
   });
 });

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1022,6 +1022,32 @@ export const DesktopPreviewAutomationClickInputSchema = Schema.Struct({
   input: PreviewAutomationClickInput,
 });
 
+export const DesktopPreviewAutomationClickResultSchema = Schema.Union([
+  Schema.TaggedStruct("Dispatched", {}),
+  Schema.TaggedStruct("NotSent", {
+    reason: Schema.Literal("tab-not-visible"),
+  }),
+  Schema.TaggedStruct("NotSent", {
+    reason: Schema.Literal("timeout"),
+    timeoutMs: Schema.Int.check(Schema.isGreaterThan(0)),
+  }),
+  Schema.TaggedStruct("NotSent", {
+    reason: Schema.Literal("target-missing"),
+  }),
+  Schema.TaggedStruct("NotSent", {
+    reason: Schema.Literal("target-hidden"),
+  }),
+  Schema.TaggedStruct("NotSent", {
+    reason: Schema.Literal("target-disabled"),
+  }),
+  Schema.TaggedStruct("NotSent", {
+    reason: Schema.Literal("target-ambiguous"),
+    matchCount: Schema.Int.check(Schema.isGreaterThan(0)),
+  }),
+]);
+export type DesktopPreviewAutomationClickResult =
+  typeof DesktopPreviewAutomationClickResultSchema.Type;
+
 export const DesktopPreviewAutomationTypeInputSchema = Schema.Struct({
   tabId: DesktopPreviewTabIdSchema,
   input: PreviewAutomationTypeInput,
@@ -1220,7 +1246,10 @@ export interface DesktopPreviewBridge {
   automation: {
     status: (tabId: string) => Promise<DesktopPreviewAutomationStatus>;
     snapshot: (tabId: string) => Promise<PreviewAutomationSnapshot>;
-    click: (tabId: string, input: PreviewAutomationClickInput) => Promise<void>;
+    click: (
+      tabId: string,
+      input: PreviewAutomationClickInput,
+    ) => Promise<DesktopPreviewAutomationClickResult | void>;
     type: (tabId: string, input: PreviewAutomationTypeInput) => Promise<void>;
     press: (tabId: string, input: PreviewAutomationPressInput) => Promise<void>;
     scroll: (tabId: string, input: PreviewAutomationScrollInput) => Promise<void>;

--- a/packages/contracts/src/previewAutomation.ts
+++ b/packages/contracts/src/previewAutomation.ts
@@ -800,6 +800,46 @@ export class PreviewAutomationTargetNotEditableError extends Schema.TaggedErrorC
   }
 }
 
+export const PreviewAutomationTargetLookupFailureKind = Schema.Literals([
+  "missing",
+  "hidden",
+  "disabled",
+  "ambiguous",
+]);
+export type PreviewAutomationTargetLookupFailureKind =
+  typeof PreviewAutomationTargetLookupFailureKind.Type;
+
+export class PreviewAutomationTargetLookupError extends Schema.TaggedErrorClass<PreviewAutomationTargetLookupError>()(
+  "PreviewAutomationTargetLookupError",
+  {
+    ...PreviewAutomationRequestErrorFields,
+    ...PreviewAutomationRemoteDiagnosticFields,
+    failureKind: PreviewAutomationTargetLookupFailureKind,
+    matchCount: Schema.optional(Schema.Int.check(Schema.isGreaterThan(0))),
+    selectorKind: Schema.optional(Schema.Literals(["locator", "selector"])),
+    selectorLength: Schema.optional(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))),
+  },
+) {
+  override get message(): string {
+    const target =
+      this.selectorKind === undefined || this.selectorLength === undefined
+        ? "target"
+        : `${this.selectorKind} (${this.selectorLength} characters)`;
+    if (this.failureKind === "hidden") {
+      return `Preview automation ${this.operation} found ${target}, but it is not visible.`;
+    }
+    if (this.failureKind === "disabled") {
+      return `Preview automation ${this.operation} found ${target}, but it is disabled.`;
+    }
+    if (this.failureKind === "ambiguous") {
+      return this.matchCount === undefined
+        ? `Preview automation ${this.operation} matched multiple elements for ${target}.`
+        : `Preview automation ${this.operation} matched ${this.matchCount} elements for ${target}.`;
+    }
+    return `Preview automation ${this.operation} could not find ${target}.`;
+  }
+}
+
 export class PreviewAutomationResultTooLargeError extends Schema.TaggedErrorClass<PreviewAutomationResultTooLargeError>()(
   "PreviewAutomationResultTooLargeError",
   {
@@ -866,6 +906,7 @@ export const PreviewAutomationError = Schema.Union([
   PreviewAutomationExecutionError,
   PreviewAutomationInvalidSelectorError,
   PreviewAutomationTargetNotEditableError,
+  PreviewAutomationTargetLookupError,
   PreviewAutomationResultTooLargeError,
   PreviewAutomationClientDisconnectedError,
   PreviewAutomationRequestQueueClosedError,


### PR DESCRIPTION
`preview_click` identified hidden, disabled, and ambiguous targets in the desktop process, but Electron IPC did not preserve the custom error fields. The MCP caller then received a generic client failure.

This change sends a typed click outcome across Electron IPC. The web host returns only the exact lookup reason and optional match count. The broker combines that response with the selector kind and length from the original request, so the MCP error is useful without returning the locator text.

The desktop action timeline still records target lookup failures as failed clicks.

Related to #3714. Does not close it.

Tests:

- `vp test run packages/contracts/src/ipc.test.ts`
- `vp test run apps/desktop/src/preview/Manager.test.ts apps/desktop/src/ipc/methods/preview.test.ts`
- `vp test run apps/web/src/components/preview/previewAutomationErrors.test.ts apps/web/src/components/preview/previewAutomationRequestConsumer.test.ts`
- `vp test run apps/server/src/mcp/PreviewAutomationBroker.test.ts apps/server/src/mcp/McpHttpServer.test.ts`

Original implementation by @gbarros-dev with Grok 4.6 through Grok CLI.

Made with GPT-5.6 Sol using Codex for modernization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes preview automation click semantics and error propagation across desktop IPC, web host, and MCP; callers that assumed silent success on lookup failure now get typed failures, but successful clicks still dispatch input as before.
> 
> **Overview**
> Preview automation **clicks** now return a typed `DesktopPreviewAutomationClickResult` over Electron IPC (`Dispatched` or `NotSent` with reasons like `target-missing`, `target-hidden`, `target-disabled`, `target-ambiguous`) instead of `void`, so lookup failure details are not lost before they reach MCP callers.
> 
> On the desktop side, locator resolution uses **all matches** and classifies missing, hidden, disabled, and ambiguous targets; failed lookups yield `NotSent` **without** dispatching mouse input, while the action timeline still records failed clicks. New `PreviewAutomationTargetLookupError` types (contracts, desktop manager, web host) carry `failureKind` and optional `matchCount`, with messages that avoid leaking locator text.
> 
> The web preview host wraps IPC results with `confirmPreviewAutomationClickTarget`, turning target `NotSent` outcomes into `PreviewAutomationTargetLookupHostError` for the automation broker/MCP path. The server broker maps remote lookup errors from response `detail.failureKind`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30f017dfb0ac2ed132b20cdcb98584cfa77d16cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Return typed click outcomes for preview automation clicks
> - Preview automation clicks now return `DesktopPreviewAutomationClickResult` with `Dispatched` or `NotSent` variants (`target-missing`, `target-hidden`, `target-disabled`, `target-ambiguous`) instead of `void`
> - `PreviewManager` locator lookup switches from single-element to all-matches query so ambiguous targets with multiple matches are detected; only a single visible enabled match is clicked
> - New schema-backed error classes (`PreviewAutomationTargetLookupError`, `PreviewAutomationTargetLookupHostError`) carry the lookup failure kind and optional positive match count, with sanitized messages that omit selector/locator values
> - The web preview host converts every `NotSent` click result into a named host automation error via `confirmPreviewAutomationClickTarget`
> - Behavioral Change: `DesktopPreviewBridge.automation.click` return type changes from `Promise<void>` to `Promise<DesktopPreviewAutomationClickResult | void>`; callers that ignored the result are unaffected, but the broker and host layers now reject `NotSent` outcomes as errors rather than silently succeeding
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30f017d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->