### PR TITLE
fix(mobile): show structured input option descriptions

### DIFF
--- a/apps/mobile/src/features/threads/PendingUserInputCard.tsx
+++ b/apps/mobile/src/features/threads/PendingUserInputCard.tsx
@@ -277,16 +277,23 @@ export function PendingUserInputCard(props: PendingUserInputCardProps) {
                         )
                       }
                     >
-                      <Text
-                        className={cn(
-                          "font-t3-bold text-sm",
-                          selected
-                            ? "text-sky-700 dark:text-sky-300"
-                            : "text-neutral-600 dark:text-neutral-300",
-                        )}
-                      >
-                        {option.label}
-                      </Text>
+                      <View className="gap-0.5">
+                        <Text
+                          className={cn(
+                            "font-t3-bold text-sm",
+                            selected
+                              ? "text-sky-700 dark:text-sky-300"
+                              : "text-neutral-600 dark:text-neutral-300",
+                          )}
+                        >
+                          {option.label}
+                        </Text>
+                        {option.description && option.description !== option.label ? (
+                          <Text className="font-sans text-xs text-neutral-500 dark:text-neutral-400">
+                            {option.description}
+                          </Text>
+                        ) : null}
+                      </View>
                     </Pressable>
                   );
                 })}


### PR DESCRIPTION
## Summary

Fixes #7304.

The mobile structured user-input card now renders each option's description below its label, matching the existing web client behavior. Descriptions equal to the label remain hidden to avoid duplicate text.

## Validation

- `git diff --check` passed.
- The mobile workspace dependency install was attempted with the checked-in lockfile, but npm downloads were too slow to complete, so the mobile test suite and typecheck could not run locally.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show option descriptions in structured input multiple-choice cards
> In [PendingUserInputCard.tsx](https://github.com/pingdotgg/t3code/pull/7306/files#diff-7e638162740719ba1f11003bf9376f0b089c32c5b55bedd73929281fc98ff7bf), each multiple-choice option now renders a description line below the label when `option.description` is present and differs from `option.label`. The description uses smaller, subtler typography and is wrapped in a `gap-0.5` View alongside the label.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b015f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized mobile UI presentation change with no API, selection, or submission logic touched.
> 
> **Overview**
> **Structured user-input options on mobile** now show a secondary description line under each choice label in `PendingUserInputCard`, aligning with web behavior.
> 
> Each option pill wraps label and optional description in a vertical stack. A description renders only when `option.description` is set and is not identical to `option.label`, using smaller muted text so duplicate copy is avoided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b015f23fef1de4ecb03a884747d574cd51f7d33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->