### PR TITLE
fix(codex): recover turns after usage limits

### DIFF
--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -59,8 +59,37 @@ const asTurnId = (value: string): TurnId => TurnId.make(value);
 const asEventId = (value: string): EventId => EventId.make(value);
 const asItemId = (value: string): ProviderItemId => ProviderItemId.make(value);
 
+class TestQueue<A> {
+  private readonly values: Array<A> = [];
+  private readonly waiters: Array<(value: A) => void> = [];
+
+  offer(value: A): void {
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter(value);
+      return;
+    }
+    this.values.push(value);
+  }
+
+  take(): Effect.Effect<A> {
+    return Effect.promise(
+      () =>
+        new Promise<A>((resolve) => {
+          const value = this.values.shift();
+          if (value !== undefined) {
+            resolve(value);
+            return;
+          }
+          this.waiters.push(resolve);
+        }),
+    );
+  }
+}
+
 class FakeCodexRuntime implements CodexSessionRuntimeShape {
-  private readonly eventQueue = Effect.runSync(Queue.unbounded<ProviderEvent>());
+  public readonly closed = new TestQueue<true>();
+  public readonly sentTurns = new TestQueue<CodexSessionRuntimeSendTurnInput>();
   private readonly now = "2026-01-01T00:00:00.000Z";
 
   public readonly startImpl = vi.fn(() =>
@@ -71,6 +100,7 @@ class FakeCodexRuntime implements CodexSessionRuntimeShape {
       threadId: this.options.threadId,
       cwd: this.options.cwd,
       ...(this.options.model ? { model: this.options.model } : {}),
+      resumeCursor: this.options.resumeCursor ?? { threadId: "provider-thread-1" },
       createdAt: this.now,
       updatedAt: this.now,
     } satisfies ProviderSession),
@@ -114,12 +144,17 @@ class FakeCodexRuntime implements CodexSessionRuntimeShape {
       Promise.resolve(undefined),
   );
 
-  public readonly closeImpl = vi.fn(() => Promise.resolve(undefined));
+  public readonly closeImpl = vi.fn(() => {
+    this.closed.offer(true);
+    return Promise.resolve(undefined);
+  });
 
   readonly options: CodexSessionRuntimeOptions;
+  private readonly eventQueue: Queue.Queue<ProviderEvent>;
 
-  constructor(options: CodexSessionRuntimeOptions) {
+  constructor(options: CodexSessionRuntimeOptions, eventQueue: Queue.Queue<ProviderEvent>) {
     this.options = options;
+    this.eventQueue = eventQueue;
   }
 
   start() {
@@ -129,6 +164,7 @@ class FakeCodexRuntime implements CodexSessionRuntimeShape {
   getSession = Effect.promise(() => this.startImpl());
 
   sendTurn(input: CodexSessionRuntimeSendTurnInput) {
+    this.sentTurns.offer(input);
     return Effect.promise(() => this.sendTurnImpl(input));
   }
 
@@ -161,16 +197,26 @@ class FakeCodexRuntime implements CodexSessionRuntimeShape {
   }
 }
 
-function makeRuntimeFactory() {
+function makeRuntimeFactory(configure?: (runtime: FakeCodexRuntime, index: number) => void) {
   const runtimes: Array<FakeCodexRuntime> = [];
-  const factory = vi.fn((options: CodexSessionRuntimeOptions) => {
-    const runtime = new FakeCodexRuntime(options);
-    runtimes.push(runtime);
-    return Effect.succeed(runtime);
-  });
+  const created = new TestQueue<FakeCodexRuntime>();
+  const factory = vi.fn((options: CodexSessionRuntimeOptions) =>
+    Effect.gen(function* () {
+      const eventQueue = yield* Queue.unbounded<ProviderEvent>();
+      const runtime = new FakeCodexRuntime(options, eventQueue);
+      runtimes.push(runtime);
+      configure?.(runtime, runtimes.length - 1);
+      created.offer(runtime);
+      return runtime;
+    }),
+  );
 
   return {
     factory,
+    created,
+    get runtimes(): ReadonlyArray<FakeCodexRuntime> {
+      return runtimes;
+    },
     get lastRuntime(): FakeCodexRuntime | undefined {
       return runtimes.at(-1);
     },
@@ -197,7 +243,8 @@ function makeScopedRuntimeFactory(options?: { readonly failConstruction?: boolea
         });
       }
 
-      const runtime = new FakeCodexRuntime(runtimeOptions);
+      const eventQueue = yield* Queue.unbounded<ProviderEvent>();
+      const runtime = new FakeCodexRuntime(runtimeOptions, eventQueue);
       runtimes.push(runtime);
       return runtime;
     }),
@@ -511,6 +558,268 @@ function startLifecycleRuntime() {
     return { adapter, runtime };
   });
 }
+
+function usageLimitCompletionEvent(input?: {
+  readonly turnId?: string;
+  readonly items?: ReadonlyArray<unknown>;
+}): ProviderEvent {
+  const turnId = input?.turnId ?? "turn-1";
+  return {
+    id: asEventId(`evt-usage-limit-${turnId}`),
+    kind: "notification",
+    provider: ProviderDriverKind.make("codex"),
+    createdAt: "2026-01-01T00:00:00.000Z",
+    method: "turn/completed",
+    threadId: asThreadId("thread-1"),
+    turnId: asTurnId(turnId),
+    payload: {
+      threadId: "provider-thread-1",
+      turn: {
+        id: turnId,
+        status: "failed",
+        items: input?.items ?? [],
+        itemsView: "notLoaded",
+        error: {
+          message: "Usage limit exceeded",
+          codexErrorInfo: "usageLimitExceeded",
+        },
+      },
+    },
+  } satisfies ProviderEvent;
+}
+
+function itemLifecycleEvent(
+  method: "item/started" | "item/completed",
+  item: { readonly id: string; readonly type: string; readonly [key: string]: unknown },
+): ProviderEvent {
+  return {
+    id: asEventId(`evt-${method}-${item.id}`),
+    kind: "notification",
+    provider: ProviderDriverKind.make("codex"),
+    createdAt: "2026-01-01T00:00:00.000Z",
+    method,
+    threadId: asThreadId("thread-1"),
+    turnId: asTurnId("turn-1"),
+    itemId: asItemId(item.id),
+    payload: {
+      threadId: "provider-thread-1",
+      turnId: "turn-1",
+      item,
+      ...(method === "item/started" ? { startedAtMs: 1 } : { completedAtMs: 2 }),
+    },
+  } satisfies ProviderEvent;
+}
+
+function makeRecoveryTestLayer(runtimeFactory: ReturnType<typeof makeRuntimeFactory>) {
+  return Layer.effect(
+    CodexAdapter,
+    Effect.gen(function* () {
+      const codexConfig = decodeCodexSettings({ binaryPath: "codex-balanced" });
+      return yield* makeCodexAdapter(codexConfig, {
+        makeRuntime: runtimeFactory.factory,
+      });
+    }),
+  ).pipe(
+    Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
+    Layer.provideMerge(ServerSettingsService.layerTest()),
+    Layer.provideMerge(providerSessionDirectoryTestLayer),
+    Layer.provideMerge(NodeServices.layer),
+  );
+}
+
+function startRecoveryTurn(
+  adapter: CodexAdapterShape,
+  runtimeFactory: ReturnType<typeof makeRuntimeFactory>,
+) {
+  return Effect.gen(function* () {
+    yield* adapter.startSession({
+      provider: ProviderDriverKind.make("codex"),
+      threadId: asThreadId("thread-1"),
+      modelSelection: createModelSelection(ProviderInstanceId.make("codex"), "gpt-5.3-codex"),
+      runtimeMode: "full-access",
+    });
+    const runtime = yield* runtimeFactory.created.take();
+    yield* adapter.sendTurn({
+      threadId: asThreadId("thread-1"),
+      input: "continue this exact conversation",
+      attachments: [],
+      modelSelection: createModelSelection(ProviderInstanceId.make("codex"), "gpt-5.3-codex"),
+    });
+    yield* runtime.sentTurns.take();
+    return runtime;
+  });
+}
+
+it.effect("restarts, resumes, and retries an empty Codex usage-limit turn once", () => {
+  const runtimeFactory = makeRuntimeFactory((runtime, index) => {
+    if (index !== 1) return;
+    runtime.readThreadImpl.mockResolvedValue({
+      threadId: "provider-thread-1",
+      turns: [
+        {
+          id: asTurnId("turn-1"),
+          items: [
+            {
+              id: "user-message-1",
+              type: "userMessage",
+              content: [{ type: "text", text: "continue this exact conversation" }],
+            },
+          ],
+        },
+      ],
+    });
+  });
+  const layer = makeRecoveryTestLayer(runtimeFactory);
+
+  return Effect.gen(function* () {
+    const adapter = yield* CodexAdapter;
+    const firstRuntime = yield* startRecoveryTurn(adapter, runtimeFactory);
+    const eventsFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 3)).pipe(
+      Effect.forkChild,
+    );
+
+    const userMessage = {
+      id: "user-message-1",
+      type: "userMessage",
+      content: [{ type: "text", text: "continue this exact conversation" }],
+    };
+    yield* firstRuntime.emit(itemLifecycleEvent("item/started", userMessage));
+    yield* firstRuntime.emit(itemLifecycleEvent("item/completed", userMessage));
+    yield* firstRuntime.emit(usageLimitCompletionEvent());
+    yield* Fiber.join(eventsFiber);
+
+    const recoveredRuntime = yield* runtimeFactory.created.take();
+    const retriedInput = yield* recoveredRuntime.sentTurns.take();
+
+    NodeAssert.equal(firstRuntime.closeImpl.mock.calls.length, 1);
+    NodeAssert.equal(recoveredRuntime.options.binaryPath, "codex-balanced");
+    NodeAssert.equal(recoveredRuntime.options.requireResume, true);
+    NodeAssert.deepStrictEqual(recoveredRuntime.options.resumeCursor, {
+      threadId: "provider-thread-1",
+    });
+    NodeAssert.equal(recoveredRuntime.rollbackThreadImpl.mock.calls.length, 1);
+    NodeAssert.deepStrictEqual(retriedInput, {
+      input: "continue this exact conversation",
+      model: "gpt-5.3-codex",
+    });
+  }).pipe(Effect.provide(layer));
+});
+
+it.effect("does not replace a session started while usage-limit recovery is opening", () => {
+  let releaseRecoveryStart: (() => void) | undefined;
+  const recoveryStartGate = new Promise<void>((resolve) => {
+    releaseRecoveryStart = resolve;
+  });
+  const runtimeFactory = makeRuntimeFactory((runtime, index) => {
+    if (index !== 1) return;
+    const start = runtime.startImpl.getMockImplementation();
+    if (!start) throw new Error("Expected the fake runtime start implementation");
+    runtime.startImpl.mockImplementation(async () => {
+      await recoveryStartGate;
+      return start();
+    });
+  });
+  const layer = makeRecoveryTestLayer(runtimeFactory);
+
+  return Effect.gen(function* () {
+    const adapter = yield* CodexAdapter;
+    const firstRuntime = yield* startRecoveryTurn(adapter, runtimeFactory);
+    const completedFiber = yield* Stream.runHead(adapter.streamEvents).pipe(Effect.forkChild);
+    yield* firstRuntime.emit(usageLimitCompletionEvent());
+    yield* Fiber.join(completedFiber);
+
+    const recoveringRuntime = yield* runtimeFactory.created.take();
+    yield* adapter.startSession({
+      provider: ProviderDriverKind.make("codex"),
+      threadId: asThreadId("thread-1"),
+      modelSelection: createModelSelection(ProviderInstanceId.make("codex"), "gpt-5.3-codex"),
+      runtimeMode: "full-access",
+    });
+    const userStartedRuntime = yield* runtimeFactory.created.take();
+
+    releaseRecoveryStart?.();
+    yield* recoveringRuntime.closed.take();
+
+    yield* adapter.sendTurn({
+      threadId: asThreadId("thread-1"),
+      input: "use the session I started",
+      attachments: [],
+      modelSelection: createModelSelection(ProviderInstanceId.make("codex"), "gpt-5.3-codex"),
+    });
+    const sentInput = yield* userStartedRuntime.sentTurns.take();
+    NodeAssert.equal(sentInput.input, "use the session I started");
+    NodeAssert.equal(userStartedRuntime.closeImpl.mock.calls.length, 0);
+  }).pipe(Effect.provide(layer));
+});
+
+it.effect("does not retry a usage-limit turn that emits provider activity", () => {
+  const runtimeFactory = makeRuntimeFactory();
+  const layer = makeRecoveryTestLayer(runtimeFactory);
+
+  return Effect.gen(function* () {
+    const adapter = yield* CodexAdapter;
+    const runtime = yield* startRecoveryTurn(adapter, runtimeFactory);
+    const eventsFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 2)).pipe(
+      Effect.forkChild,
+    );
+
+    yield* runtime.emit(
+      itemLifecycleEvent("item/started", {
+        id: "msg-1",
+        type: "agentMessage",
+        text: "partial output",
+      }),
+    );
+    yield* runtime.emit(usageLimitCompletionEvent());
+    yield* Fiber.join(eventsFiber);
+
+    NodeAssert.equal(runtimeFactory.factory.mock.calls.length, 1);
+    NodeAssert.equal(runtime.closeImpl.mock.calls.length, 0);
+  }).pipe(Effect.provide(layer));
+});
+
+it.effect("does not retry provider output reported only by turn completion", () => {
+  const runtimeFactory = makeRuntimeFactory();
+  const layer = makeRecoveryTestLayer(runtimeFactory);
+
+  return Effect.gen(function* () {
+    const adapter = yield* CodexAdapter;
+    const runtime = yield* startRecoveryTurn(adapter, runtimeFactory);
+    const completedFiber = yield* Stream.runHead(adapter.streamEvents).pipe(Effect.forkChild);
+
+    yield* runtime.emit(
+      usageLimitCompletionEvent({
+        items: [{ id: "msg-1", type: "agentMessage", text: "partial output" }],
+      }),
+    );
+    yield* Fiber.join(completedFiber);
+
+    NodeAssert.equal(runtimeFactory.factory.mock.calls.length, 1);
+    NodeAssert.equal(runtime.closeImpl.mock.calls.length, 0);
+  }).pipe(Effect.provide(layer));
+});
+
+it.effect("does not restart again when the retried turn also exhausts usage", () => {
+  const runtimeFactory = makeRuntimeFactory();
+  const layer = makeRecoveryTestLayer(runtimeFactory);
+
+  return Effect.gen(function* () {
+    const adapter = yield* CodexAdapter;
+    const firstRuntime = yield* startRecoveryTurn(adapter, runtimeFactory);
+    const firstCompletedFiber = yield* Stream.runHead(adapter.streamEvents).pipe(Effect.forkChild);
+    yield* firstRuntime.emit(usageLimitCompletionEvent());
+    yield* Fiber.join(firstCompletedFiber);
+
+    const recoveredRuntime = yield* runtimeFactory.created.take();
+    yield* recoveredRuntime.sentTurns.take();
+    const secondCompletedFiber = yield* Stream.runHead(adapter.streamEvents).pipe(Effect.forkChild);
+    yield* recoveredRuntime.emit(usageLimitCompletionEvent());
+    yield* Fiber.join(secondCompletedFiber);
+
+    NodeAssert.equal(runtimeFactory.factory.mock.calls.length, 2);
+    NodeAssert.equal(recoveredRuntime.closeImpl.mock.calls.length, 0);
+  }).pipe(Effect.provide(layer));
+});
 
 lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
   it.effect("maps completed agent message items to canonical item.completed events", () =>

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -16,6 +16,8 @@ import {
   ProviderInstanceId,
   type ProviderRuntimeEvent,
   type ProviderRequestKind,
+  type ProviderSession,
+  type ProviderTurnStartResult,
   type ThreadTokenUsageSnapshot,
   type ProviderUserInputAnswers,
   RuntimeItemId,
@@ -24,6 +26,7 @@ import {
   type RuntimeTaskUsage,
   ProviderApprovalDecision,
   ThreadId,
+  type TurnId,
   ProviderSendTurnInput,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
@@ -39,7 +42,7 @@ import { ChildProcessSpawner } from "effect/unstable/process";
 import * as CodexErrors from "effect-codex-app-server/errors";
 import * as EffectCodexSchema from "effect-codex-app-server/schema";
 
-import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
+import { getModelSelectionStringOptionValue, normalizeModelSlug } from "@t3tools/shared/model";
 import { getCodexServiceTierOptionValue } from "../../codexModelOptions.ts";
 import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
 
@@ -60,7 +63,9 @@ import {
   makeCodexSessionRuntime,
   type CodexSessionRuntimeError,
   type CodexSessionRuntimeOptions,
+  type CodexSessionRuntimeSendTurnInput,
   type CodexSessionRuntimeShape,
+  type CodexThreadSnapshot,
 } from "./CodexSessionRuntime.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
 import { resolveCodexLaunchArgs } from "./codexLaunchArgs.ts";
@@ -87,12 +92,83 @@ export interface CodexAdapterLiveOptions {
   readonly nativeEventLogger?: EventNdjsonLogger;
 }
 
+interface CodexPendingTurn {
+  readonly input: CodexSessionRuntimeSendTurnInput;
+  readonly restartInput: Parameters<CodexAdapterShape["startSession"]>[0];
+  readonly retryCount: number;
+}
+
 interface CodexAdapterSessionContext {
   readonly threadId: ThreadId;
   readonly scope: Scope.Closeable;
   readonly runtime: CodexSessionRuntimeShape;
   readonly eventFiber: Fiber.Fiber<void, never>;
+  readonly startInput: Parameters<CodexAdapterShape["startSession"]>[0];
+  readonly providerSession: ProviderSession;
+  readonly pendingTurns: Map<TurnId, CodexPendingTurn>;
+  readonly deferredTurnCompletions: Map<TurnId, ProviderEvent>;
+  readonly unsafeTurnIds: Set<TurnId>;
+  readonly recoveryToken?: symbol;
+  recovering: boolean;
   stopped: boolean;
+}
+
+function isRetryableUsageLimitCompletion(event: ProviderEvent): boolean {
+  if (event.method !== "turn/completed") {
+    return false;
+  }
+  const payload = readPayload(EffectCodexSchema.V2TurnCompletedNotification, event.payload);
+  return (
+    payload?.turn.status === "failed" &&
+    payload.turn.error?.codexErrorInfo === "usageLimitExceeded" &&
+    payload.turn.items.every((item) => item.type === "userMessage")
+  );
+}
+
+function isUnsafeUsageLimitRetryEvent(event: ProviderEvent): boolean {
+  if (event.turnId === undefined) {
+    return false;
+  }
+  if (event.method === "item/started") {
+    const payload = readPayload(EffectCodexSchema.V2ItemStartedNotification, event.payload);
+    return payload?.item.type !== "userMessage";
+  }
+  if (event.method === "item/completed") {
+    const payload = readPayload(EffectCodexSchema.V2ItemCompletedNotification, event.payload);
+    return payload?.item.type !== "userMessage";
+  }
+  return (
+    event.itemId !== undefined ||
+    event.requestId !== undefined ||
+    event.method.startsWith("item/") ||
+    event.method.startsWith("rawResponseItem/") ||
+    event.method.startsWith("hook/") ||
+    event.method.startsWith("turn/diff/") ||
+    event.method.startsWith("turn/plan/") ||
+    event.method.startsWith("collabAgent/")
+  );
+}
+
+function requiresFailedTurnRollback(
+  snapshot: CodexThreadSnapshot,
+  failedTurnId: TurnId,
+): boolean | undefined {
+  const lastTurn = snapshot.turns.at(-1);
+  if (!lastTurn || lastTurn.id !== failedTurnId) {
+    return false;
+  }
+  return lastTurn.items.every((item) => item.type === "userMessage") ? true : undefined;
+}
+
+function resumedRequestedModel(
+  requestedModel: string | undefined,
+  resumedModel: string | undefined,
+): boolean {
+  const requested = normalizeModelSlug(requestedModel);
+  if (!requested) {
+    return true;
+  }
+  return requested === normalizeModelSlug(resumedModel);
 }
 
 function mapCodexRuntimeError(
@@ -1639,10 +1715,18 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
       : undefined);
   const managedNativeEventLogger =
     options?.nativeEventLogger === undefined ? nativeEventLogger : undefined;
+  const adapterScope = yield* Scope.Scope;
   const runtimeEventQueue = yield* Queue.unbounded<ProviderRuntimeEvent>();
   const sessions = new Map<ThreadId, CodexAdapterSessionContext>();
+  const recoveryTokens = new Map<ThreadId, symbol>();
 
-  const startSession: CodexAdapterShape["startSession"] = (input) =>
+  const startSessionInternal: (
+    input: Parameters<CodexAdapterShape["startSession"]>[0],
+    internalOptions?: {
+      readonly requireResume?: boolean;
+      readonly recoveryToken?: symbol;
+    },
+  ) => Effect.Effect<ProviderSession, ProviderAdapterError> = (input, internalOptions) =>
     Effect.scoped(
       Effect.gen(function* () {
         if (input.provider !== undefined && input.provider !== PROVIDER) {
@@ -1674,6 +1758,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           ...(isCodexResumeCursorSchema(input.resumeCursor)
             ? { resumeCursor: input.resumeCursor }
             : {}),
+          ...(internalOptions?.requireResume === true ? { requireResume: true } : {}),
           runtimeMode: input.runtimeMode,
           ...(input.modelSelection?.instanceId === boundInstanceId
             ? { model: input.modelSelection.model }
@@ -1700,6 +1785,10 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           sessionScopeTransferred ? Effect.void : Scope.close(sessionScope, Exit.void),
         );
         const createRuntime = options?.makeRuntime ?? makeCodexSessionRuntime;
+        const pendingTurns = new Map<TurnId, CodexPendingTurn>();
+        const deferredTurnCompletions = new Map<TurnId, ProviderEvent>();
+        const unsafeTurnIds = new Set<TurnId>();
+        let sessionContext: CodexAdapterSessionContext | undefined;
         const runtime = yield* createRuntime(runtimeInput).pipe(
           Effect.provideService(Scope.Scope, sessionScope),
           Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner),
@@ -1722,6 +1811,9 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
         const eventFiber = yield* Stream.runForEach(runtime.events, (event) =>
           Effect.gen(function* () {
             yield* writeNativeEvent(event);
+            if (event.turnId !== undefined && isUnsafeUsageLimitRetryEvent(event)) {
+              unsafeTurnIds.add(event.turnId);
+            }
             const runtimeEvents = mapToRuntimeEvents(event, event.threadId);
             if (runtimeEvents.length === 0) {
               yield* Effect.logDebug("ignoring unhandled Codex provider event", {
@@ -1730,9 +1822,12 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
                 turnId: event.turnId,
                 itemId: event.itemId,
               });
-              return;
+            } else {
+              yield* Queue.offerAll(runtimeEventQueue, runtimeEvents);
             }
-            yield* Queue.offerAll(runtimeEventQueue, runtimeEvents);
+            if (sessionContext !== undefined) {
+              yield* scheduleUsageLimitRecovery(sessionContext, event);
+            }
           }),
         ).pipe(Effect.forkIn(sessionScope));
 
@@ -1755,17 +1850,46 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           ),
         );
 
-        sessions.set(input.threadId, {
+        if (
+          internalOptions?.recoveryToken !== undefined &&
+          recoveryTokens.get(input.threadId) !== internalOptions.recoveryToken
+        ) {
+          sessionScopeTransferred = true;
+          yield* runtime.close.pipe(
+            Effect.andThen(Effect.ignore(Scope.close(sessionScope, Exit.void))),
+            Effect.andThen(Fiber.interrupt(eventFiber)),
+            Effect.ignore,
+          );
+          return started;
+        }
+
+        const context: CodexAdapterSessionContext = {
           threadId: input.threadId,
           scope: sessionScope,
           runtime,
           eventFiber,
+          startInput: input,
+          providerSession: started,
+          pendingTurns,
+          deferredTurnCompletions,
+          unsafeTurnIds,
+          ...(internalOptions?.recoveryToken !== undefined
+            ? { recoveryToken: internalOptions.recoveryToken }
+            : {}),
+          recovering: false,
           stopped: false,
-        });
+        };
+        sessionContext = context;
+        sessions.set(input.threadId, context);
         sessionScopeTransferred = true;
 
         return started;
       }),
+    );
+
+  const startSession: CodexAdapterShape["startSession"] = (input) =>
+    Effect.sync(() => recoveryTokens.delete(input.threadId)).pipe(
+      Effect.andThen(startSessionInternal(input)),
     );
 
   const resolveAttachment = Effect.fn("resolveAttachment")(function* (
@@ -1800,6 +1924,188 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     };
   });
 
+  const sendMappedTurn = Effect.fn("CodexAdapter.sendMappedTurn")(function* (
+    session: CodexAdapterSessionContext,
+    input: CodexSessionRuntimeSendTurnInput,
+    restartInput: Parameters<CodexAdapterShape["startSession"]>[0],
+    retryCount: number,
+  ): Effect.fn.Return<ProviderTurnStartResult, ProviderAdapterError> {
+    const result = yield* session.runtime
+      .sendTurn(input)
+      .pipe(
+        Effect.mapError((cause) => mapCodexRuntimeError(session.threadId, "turn/start", cause)),
+      );
+    session.pendingTurns.set(result.turnId, {
+      input,
+      restartInput,
+      retryCount,
+    });
+    const deferredCompletion = session.deferredTurnCompletions.get(result.turnId);
+    if (deferredCompletion !== undefined) {
+      yield* scheduleUsageLimitRecovery(session, deferredCompletion);
+    }
+    return result;
+  });
+
+  const recoverUsageLimitTurn = Effect.fn("CodexAdapter.recoverUsageLimitTurn")(function* (input: {
+    readonly sourceSession: CodexAdapterSessionContext;
+    readonly failedTurnId: TurnId;
+    readonly pendingTurn: CodexPendingTurn;
+    readonly token: symbol;
+  }): Effect.fn.Return<void, ProviderAdapterError | CodexSessionRuntimeError> {
+    const resumeCursor = input.sourceSession.providerSession.resumeCursor;
+    if (!isCodexResumeCursorSchema(resumeCursor)) {
+      yield* Effect.logWarning("codex usage-limit recovery skipped without a resume cursor", {
+        threadId: input.sourceSession.threadId,
+        failedTurnId: input.failedTurnId,
+      });
+      return;
+    }
+
+    const resumedSession = yield* startSessionInternal(
+      {
+        ...input.pendingTurn.restartInput,
+        resumeCursor,
+      },
+      { requireResume: true, recoveryToken: input.token },
+    );
+    const recoveredContext = sessions.get(input.sourceSession.threadId);
+    if (
+      recoveryTokens.get(input.sourceSession.threadId) !== input.token ||
+      recoveredContext === undefined ||
+      recoveredContext.stopped
+    ) {
+      if (
+        recoveredContext?.recoveryToken === input.token &&
+        !recoveredContext.stopped &&
+        sessions.get(input.sourceSession.threadId) === recoveredContext
+      ) {
+        yield* stopSessionInternal(recoveredContext);
+      }
+      return;
+    }
+
+    if (
+      !isCodexResumeCursorSchema(resumedSession.resumeCursor) ||
+      resumedSession.resumeCursor.threadId !== resumeCursor.threadId
+    ) {
+      yield* Effect.logWarning("codex usage-limit recovery resumed a different thread", {
+        threadId: input.sourceSession.threadId,
+        expectedProviderThreadId: resumeCursor.threadId,
+      });
+      yield* stopSessionInternal(recoveredContext);
+      return;
+    }
+
+    if (!resumedRequestedModel(input.pendingTurn.input.model, resumedSession.model)) {
+      yield* Effect.logWarning("codex usage-limit recovery resumed with a different model", {
+        threadId: input.sourceSession.threadId,
+        requestedModel: input.pendingTurn.input.model,
+        resumedModel: resumedSession.model,
+      });
+      yield* stopSessionInternal(recoveredContext);
+      return;
+    }
+
+    const snapshot = yield* recoveredContext.runtime.readThread;
+    const rollbackFailedTurn = requiresFailedTurnRollback(snapshot, input.failedTurnId);
+    if (rollbackFailedTurn === undefined) {
+      yield* Effect.logWarning(
+        "codex usage-limit recovery found provider activity in failed turn",
+        {
+          threadId: input.sourceSession.threadId,
+          failedTurnId: input.failedTurnId,
+        },
+      );
+      return;
+    }
+    if (rollbackFailedTurn) {
+      yield* recoveredContext.runtime.rollbackThread(1);
+    }
+
+    if (recoveryTokens.get(input.sourceSession.threadId) !== input.token) {
+      yield* stopSessionInternal(recoveredContext);
+      return;
+    }
+
+    yield* sendMappedTurn(
+      recoveredContext,
+      input.pendingTurn.input,
+      input.pendingTurn.restartInput,
+      input.pendingTurn.retryCount + 1,
+    );
+  });
+
+  const scheduleUsageLimitRecovery = Effect.fn("CodexAdapter.scheduleUsageLimitRecovery")(
+    function* (session: CodexAdapterSessionContext, event: ProviderEvent): Effect.fn.Return<void> {
+      if (event.method !== "turn/completed" || event.turnId === undefined) {
+        return;
+      }
+
+      const failedTurnId = event.turnId;
+      const pendingTurn = session.pendingTurns.get(failedTurnId);
+      if (pendingTurn === undefined) {
+        session.deferredTurnCompletions.set(failedTurnId, event);
+        return;
+      }
+
+      if (!isRetryableUsageLimitCompletion(event)) {
+        session.pendingTurns.delete(failedTurnId);
+        session.deferredTurnCompletions.delete(failedTurnId);
+        session.unsafeTurnIds.delete(failedTurnId);
+        return;
+      }
+
+      const hadQueuedTurns = session.pendingTurns.size !== 1;
+      const safeToRetry =
+        pendingTurn.retryCount === 0 &&
+        !hadQueuedTurns &&
+        !session.unsafeTurnIds.has(failedTurnId) &&
+        !session.recovering &&
+        !session.stopped &&
+        sessions.get(session.threadId) === session;
+      session.pendingTurns.delete(failedTurnId);
+      session.deferredTurnCompletions.delete(failedTurnId);
+      session.unsafeTurnIds.delete(failedTurnId);
+      if (hadQueuedTurns) {
+        for (const queuedTurnId of session.pendingTurns.keys()) {
+          session.unsafeTurnIds.add(queuedTurnId);
+        }
+      }
+      if (!safeToRetry) {
+        return;
+      }
+
+      const token = Symbol("codex-usage-limit-recovery");
+      recoveryTokens.set(session.threadId, token);
+      session.recovering = true;
+      yield* recoverUsageLimitTurn({
+        sourceSession: session,
+        failedTurnId,
+        pendingTurn,
+        token,
+      }).pipe(
+        Effect.catchCause((cause) =>
+          Effect.logWarning("codex usage-limit recovery failed", {
+            threadId: session.threadId,
+            failedTurnId,
+            cause,
+          }),
+        ),
+        Effect.ensuring(
+          Effect.sync(() => {
+            if (recoveryTokens.get(session.threadId) === token) {
+              recoveryTokens.delete(session.threadId);
+            }
+            session.recovering = false;
+          }),
+        ),
+        Effect.forkIn(adapterScope),
+        Effect.asVoid,
+      );
+    },
+  );
+
   const sendTurn: CodexAdapterShape["sendTurn"] = Effect.fn("sendTurn")(function* (input) {
     const codexAttachments = yield* Effect.forEach(
       input.attachments ?? [],
@@ -1808,6 +2114,13 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     );
 
     const session = yield* requireSession(input.threadId);
+    if (session.recovering || recoveryTokens.has(input.threadId)) {
+      return yield* new ProviderAdapterRequestError({
+        provider: PROVIDER,
+        method: "turn/start",
+        detail: "Codex is recovering this conversation after reaching its usage limit.",
+      });
+    }
     const reasoningEffort =
       input.modelSelection?.instanceId === boundInstanceId
         ? getModelSelectionStringOptionValue(input.modelSelection, "reasoningEffort")
@@ -1816,22 +2129,25 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
       input.modelSelection?.instanceId === boundInstanceId
         ? getCodexServiceTierOptionValue(input.modelSelection)
         : undefined;
-    return yield* session.runtime
-      .sendTurn({
-        ...(input.input !== undefined ? { input: input.input } : {}),
-        ...(input.modelSelection?.instanceId === boundInstanceId
-          ? { model: input.modelSelection.model }
-          : {}),
-        ...(reasoningEffort
-          ? {
-              effort: reasoningEffort as EffectCodexSchema.V2TurnStartParams__ReasoningEffort,
-            }
-          : {}),
-        ...(serviceTier ? { serviceTier } : {}),
-        ...(input.interactionMode !== undefined ? { interactionMode: input.interactionMode } : {}),
-        ...(codexAttachments.length > 0 ? { attachments: codexAttachments } : {}),
-      })
-      .pipe(Effect.mapError((cause) => mapCodexRuntimeError(input.threadId, "turn/start", cause)));
+    const mappedInput: CodexSessionRuntimeSendTurnInput = {
+      ...(input.input !== undefined ? { input: input.input } : {}),
+      ...(input.modelSelection?.instanceId === boundInstanceId
+        ? { model: input.modelSelection.model }
+        : {}),
+      ...(reasoningEffort
+        ? {
+            effort: reasoningEffort as EffectCodexSchema.V2TurnStartParams__ReasoningEffort,
+          }
+        : {}),
+      ...(serviceTier ? { serviceTier } : {}),
+      ...(input.interactionMode !== undefined ? { interactionMode: input.interactionMode } : {}),
+      ...(codexAttachments.length > 0 ? { attachments: codexAttachments } : {}),
+    };
+    const restartInput = {
+      ...session.startInput,
+      ...(input.modelSelection !== undefined ? { modelSelection: input.modelSelection } : {}),
+    };
+    return yield* sendMappedTurn(session, mappedInput, restartInput, 0);
   });
 
   const requireSession = Effect.fn("requireSession")(function* (threadId: ThreadId) {
@@ -1846,7 +2162,8 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
   });
 
   const interruptTurn: CodexAdapterShape["interruptTurn"] = (threadId, turnId) =>
-    requireSession(threadId).pipe(
+    Effect.sync(() => recoveryTokens.delete(threadId)).pipe(
+      Effect.andThen(requireSession(threadId)),
       Effect.flatMap((session) => session.runtime.interruptTurn(turnId)),
       Effect.mapError((cause) =>
         cause._tag === "ProviderAdapterSessionNotFoundError"
@@ -1932,7 +2249,9 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
       return;
     }
     session.stopped = true;
-    sessions.delete(session.threadId);
+    if (sessions.get(session.threadId) === session) {
+      sessions.delete(session.threadId);
+    }
     yield* session.runtime.close.pipe(Effect.ignore);
     yield* Effect.ignore(Scope.close(session.scope, Exit.void));
     yield* Fiber.interrupt(session.eventFiber).pipe(Effect.ignore);
@@ -1940,6 +2259,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
 
   const stopSession: CodexAdapterShape["stopSession"] = (threadId) =>
     Effect.gen(function* () {
+      recoveryTokens.delete(threadId);
       const session = sessions.get(threadId);
       if (!session) {
         return;
@@ -1958,10 +2278,15 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     Effect.succeed(Boolean(sessions.get(threadId) && !sessions.get(threadId)?.stopped));
 
   const stopAll: CodexAdapterShape["stopAll"] = () =>
-    Effect.forEach(Array.from(sessions.values()), stopSessionInternal, {
-      concurrency: 1,
-      discard: true,
-    }).pipe(Effect.asVoid);
+    Effect.sync(() => recoveryTokens.clear()).pipe(
+      Effect.andThen(
+        Effect.forEach(Array.from(sessions.values()), stopSessionInternal, {
+          concurrency: 1,
+          discard: true,
+        }),
+      ),
+      Effect.asVoid,
+    );
 
   yield* Effect.acquireRelease(Effect.void, () =>
     stopAll().pipe(

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -571,6 +571,45 @@ describe("isRecoverableThreadResumeError", () => {
 });
 
 describe("openCodexThread", () => {
+  it.effect("does not fall back to a fresh thread when exact resume is required", () =>
+    Effect.gen(function* () {
+      const calls: Array<"thread/start" | "thread/resume"> = [];
+      const client = {
+        request: <M extends "thread/start" | "thread/resume">(
+          method: M,
+          _payload: CodexRpc.ClientRequestParamsByMethod[M],
+        ) => {
+          calls.push(method);
+          if (method === "thread/resume") {
+            return Effect.fail(
+              new CodexErrors.CodexAppServerRequestError({
+                code: -32603,
+                errorMessage: "thread not found",
+              }),
+            );
+          }
+          return Effect.succeed(
+            makeThreadOpenResponse("fresh-thread") as CodexRpc.ClientRequestResponsesByMethod[M],
+          );
+        },
+      };
+
+      const error = yield* openCodexThread({
+        client,
+        threadId: ThreadId.make("thread-1"),
+        runtimeMode: "full-access",
+        cwd: "/tmp/project",
+        requestedModel: "gpt-5.3-codex",
+        serviceTier: undefined,
+        resumeThreadId: "missing-thread",
+        requireResume: true,
+      }).pipe(Effect.flip);
+
+      NodeAssert.ok(isCodexAppServerRequestError(error));
+      NodeAssert.deepStrictEqual(calls, ["thread/resume"]);
+    }),
+  );
+
   it.effect("falls back to thread/start when resume fails recoverably", () =>
     Effect.gen(function* () {
       const calls: Array<{ method: "thread/start" | "thread/resume"; payload: unknown }> = [];

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -106,6 +106,7 @@ export interface CodexSessionRuntimeOptions {
   readonly model?: string;
   readonly serviceTier?: CodexServiceTier | undefined;
   readonly resumeCursor?: CodexResumeCursor;
+  readonly requireResume?: boolean;
   readonly appServerArgs?: ReadonlyArray<string>;
 }
 
@@ -468,6 +469,7 @@ export const openCodexThread = (input: {
   readonly requestedModel: string | undefined;
   readonly serviceTier: CodexServiceTier | undefined;
   readonly resumeThreadId: string | undefined;
+  readonly requireResume?: boolean;
 }): Effect.Effect<CodexThreadOpenResponse, CodexErrors.CodexAppServerError> => {
   const resumeThreadId = input.resumeThreadId;
   const startParams = buildThreadStartParams({
@@ -481,22 +483,25 @@ export const openCodexThread = (input: {
     return input.client.request("thread/start", startParams);
   }
 
-  return input.client
-    .request("thread/resume", {
-      threadId: resumeThreadId,
-      ...startParams,
-    })
-    .pipe(
-      Effect.catchIf(isRecoverableThreadResumeError, (error) =>
-        Effect.logWarning("codex app-server thread resume fell back to fresh start", {
-          threadId: input.threadId,
-          requestedRuntimeMode: input.runtimeMode,
-          resumeThreadId,
-          recoverable: true,
-          cause: error,
-        }).pipe(Effect.andThen(input.client.request("thread/start", startParams))),
-      ),
-    );
+  const resume = input.client.request("thread/resume", {
+    threadId: resumeThreadId,
+    ...startParams,
+  });
+  if (input.requireResume === true) {
+    return resume;
+  }
+
+  return resume.pipe(
+    Effect.catchIf(isRecoverableThreadResumeError, (error) =>
+      Effect.logWarning("codex app-server thread resume fell back to fresh start", {
+        threadId: input.threadId,
+        requestedRuntimeMode: input.runtimeMode,
+        resumeThreadId,
+        recoverable: true,
+        cause: error,
+      }).pipe(Effect.andThen(input.client.request("thread/start", startParams))),
+    ),
+  );
 };
 
 function readNotificationThreadId(notification: CodexServerNotification): string | undefined {
@@ -1753,6 +1758,7 @@ export const makeCodexSessionRuntime = (
         requestedModel,
         serviceTier: options.serviceTier,
         resumeThreadId: readResumeCursorThreadId(options.resumeCursor),
+        ...(options.requireResume === true ? { requireResume: true } : {}),
       });
 
       const providerThreadId = opened.thread.id;

--- a/docs/user/providers-codex.md
+++ b/docs/user/providers-codex.md
@@ -100,6 +100,17 @@ This is useful when a Codex-compatible setup needs account-specific variables. A
 the provider instance that should receive them, and mark API keys or tokens as sensitive. Sensitive
 values are stored as server secrets and are not sent back to the app after saving.
 
+## Automatic Recovery From Usage Limits
+
+If your configured Codex executable can select another account when it starts, T3 Code gives it one
+chance to do that automatically. When Codex reports a usage-limit failure before producing any
+output or starting any tool, T3 Code restarts the executable, resumes the same Codex thread, and
+retries the prompt once.
+
+T3 Code does not retry after output or tool activity because that could repeat commands or file
+changes. It also stops if the original thread cannot be resumed exactly. In either case, the original
+failure remains visible so you can switch accounts manually.
+
 ## Can I Switch Accounts In An Existing Thread?
 
 Yes, when both Codex providers share the same `CODEX_HOME path`.


### PR DESCRIPTION
## Decision

Codex App Server keeps one account per process, so a T3 thread stops when that account runs out. This change restarts the configured executable, strictly resumes the same provider thread, and retries a safe failed turn once. Account-selecting launchers can then continue the conversation with available quota. Other providers, contracts, clients, and UI behavior do not change.

## What Changed

- Retain each in-flight Codex turn's mapped input and launch settings in the adapter.
- Detect the structured `usageLimitExceeded` completion emitted by Codex App Server.
- Restart the configured executable and require the original provider thread. Never fall back to a fresh thread during recovery.
- Read the resumed thread. Roll back only a failed user-only turn, then retry the exact input once.
- Preserve normal event forwarding, including the original usage-limit failure.
- Document automatic Codex recovery for account-selecting executables.

## Production Behavior And Risk

The recovery path runs only for the first usage-limit failure. It refuses to retry after assistant output, tool requests, commands, hooks, diffs, plans, collaboration activity, or queued turns. It verifies the resumed provider thread and requested model before retrying.

Manual session starts, stops, and interrupts cancel an in-flight recovery. A recovery process cannot overwrite a newer user-started session. A second usage-limit failure remains visible and does not launch a third process.

The worst case is a configured executable that restarts but cannot resume the original provider thread. T3 Code closes that recovery session and exposes the existing failure. It never creates a disconnected conversation. T3 Code adds no migrations or new persistent state. Its only provider mutation is rolling back the failed user-only turn before retrying it.

## Reviewer Focus

- Verify event ordering when `turn/completed` arrives before the `turn/start` response.
- Verify that the side-effect guard is fail-closed for provider activity while allowing Codex's user-message lifecycle events.
- Verify cancellation when manual session replacement races automatic recovery.

## Test Plan

- `vp test run apps/server/src/provider/Layers/CodexAdapter.test.ts apps/server/src/provider/Layers/CodexSessionRuntime.test.ts` — 57 tests passed.
- Targeted `vp lint` for the four changed TypeScript files.
- `vp run --filter t3 typecheck` — passed with existing suggestions in unrelated files.
- `vp fmt --check` for all five changed files.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

Built with GPT-5.6 Sol in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Codex session lifecycle (process restart, thread resume, rollback, and async recovery) on a critical provider path, but scope is narrow with fail-closed guards and extensive tests.
> 
> **Overview**
> **Codex** now handles `usageLimitExceeded` turn failures by giving account-selecting launchers one automatic retry without leaving the conversation.
> 
> When a turn fails with that error and produced **no assistant/tool activity** (only user-message lifecycle events are allowed), the adapter **restarts** the configured Codex process, opens the session with **`requireResume`** so `thread/resume` cannot fall back to a fresh thread, verifies the **same provider thread and model**, optionally **rolls back** a user-only failed turn, then **re-sends the exact prompt once**. The original failure still flows through the event stream; a second limit hit is not retried again.
> 
> **Guards and races:** pending-turn tracking handles `turn/completed` arriving before `turn/start`; `unsafeTurnIds` blocks retry after any real provider output (including items only on completion); queued turns, manual `startSession`/`stopSession`/`interruptTurn`, and in-flight recovery use **recovery tokens** so recovery cannot replace a newer user session. `sendTurn` is rejected while recovery is active.
> 
> **Tests** cover happy path, race with manual session start, no-retry with activity, and strict resume behavior. **User docs** describe when auto-recovery runs and when it stops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92a148c73cb6b39ca1411ea24824a55f7fc8e425. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add automatic recovery from usage-limit failures in `CodexAdapter`
> - When a Codex turn fails with `usageLimitExceeded` and no provider activity has occurred in that turn, the adapter automatically restarts the runtime, resumes the same thread, and retries the turn exactly once.
> - A new `requireResume` flag in `CodexSessionRuntimeOptions` prevents fallback to a fresh thread when strict resume is required; recoverable resume errors are surfaced instead of silently starting over.
> - `sendTurn` is blocked while recovery is in progress or a recovery token is active; tokens are cleared on explicit starts, interrupts, and stops.
> - New tests in [CodexAdapter.test.ts](https://github.com/pingdotgg/t3code/pull/7308/files#diff-663e3d780fd51d280579d76e348513d7a984c58fa267fb77a31ea2bd72821087) verify recovery semantics using observable `TestQueue` utilities for deterministic event ordering.
> - Risk: Any provider activity (non-userMessage items, tool calls, hooks, diffs) disables retry for that turn, aborting recovery silently.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 92a148c. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->