### PR TITLE
feat(web): support PDF message attachments

### DIFF
--- a/apps/server/src/attachmentStore.test.ts
+++ b/apps/server/src/attachmentStore.test.ts
@@ -6,12 +6,25 @@ import * as NodePath from "node:path";
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  attachmentRelativePath,
   createAttachmentId,
   parseThreadSegmentFromAttachmentId,
   resolveAttachmentPathById,
 } from "./attachmentStore.ts";
 
 describe("attachmentStore", () => {
+  it("stores PDF attachments with a stable PDF extension", () => {
+    expect(
+      attachmentRelativePath({
+        type: "pdf",
+        id: "thread-1-attachment",
+        name: "spec.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: 4,
+      }),
+    ).toBe("thread-1-attachment.pdf");
+  });
+
   it("sanitizes thread ids when creating attachment ids", () => {
     const attachmentId = createAttachmentId("thread.folder/unsafe space");
     expect(attachmentId).toBeTruthy();

--- a/apps/server/src/attachmentStore.ts
+++ b/apps/server/src/attachmentStore.ts
@@ -10,7 +10,7 @@ import {
 } from "./attachmentPaths.ts";
 import { inferImageExtension, SAFE_IMAGE_FILE_EXTENSIONS } from "./imageMime.ts";
 
-const ATTACHMENT_FILENAME_EXTENSIONS = [...SAFE_IMAGE_FILE_EXTENSIONS, ".bin"];
+const ATTACHMENT_FILENAME_EXTENSIONS = [...SAFE_IMAGE_FILE_EXTENSIONS, ".pdf", ".bin"];
 const ATTACHMENT_ID_THREAD_SEGMENT_MAX_CHARS = 80;
 const ATTACHMENT_ID_THREAD_SEGMENT_PATTERN = "[a-z0-9_]+(?:-[a-z0-9_]+)*";
 const ATTACHMENT_ID_UUID_PATTERN = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
@@ -63,6 +63,8 @@ export function attachmentRelativePath(attachment: ChatAttachment): string {
       });
       return `${attachment.id}${extension}`;
     }
+    case "pdf":
+      return `${attachment.id}.pdf`;
   }
 }
 

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -799,6 +799,7 @@ it.layer(
       const threadId = ThreadId.make("Thread Revert.Files");
       const keepAttachmentId = "thread-revert-files-00000000-0000-4000-8000-000000000001";
       const removeAttachmentId = "thread-revert-files-00000000-0000-4000-8000-000000000002";
+      const removePdfAttachmentId = "thread-revert-files-00000000-0000-4000-8000-000000000004";
       const otherThreadAttachmentId =
         "thread-revert-files-extra-00000000-0000-4000-8000-000000000003";
 
@@ -952,6 +953,13 @@ it.layer(
               mimeType: "image/png",
               sizeBytes: 5,
             },
+            {
+              type: "pdf",
+              id: removePdfAttachmentId,
+              name: "remove.pdf",
+              mimeType: "application/pdf",
+              sizeBytes: 5,
+            },
           ],
           turnId: TurnId.make("turn-remove"),
           streaming: false,
@@ -962,9 +970,11 @@ it.layer(
 
       const keepPath = path.join(attachmentsDir, `${keepAttachmentId}.png`);
       const removePath = path.join(attachmentsDir, `${removeAttachmentId}.png`);
+      const removePdfPath = path.join(attachmentsDir, `${removePdfAttachmentId}.pdf`);
       yield* fileSystem.makeDirectory(attachmentsDir, { recursive: true });
       yield* fileSystem.writeFileString(keepPath, "keep");
       yield* fileSystem.writeFileString(removePath, "remove");
+      yield* fileSystem.writeFileString(removePdfPath, "remove pdf");
       const otherThreadPath = path.join(attachmentsDir, `${otherThreadAttachmentId}.png`);
       yield* fileSystem.writeFileString(otherThreadPath, "other");
       assert.isTrue(yield* exists(keepPath));
@@ -989,6 +999,7 @@ it.layer(
 
       assert.isTrue(yield* exists(keepPath));
       assert.isFalse(yield* exists(removePath));
+      assert.isFalse(yield* exists(removePdfPath));
       assert.isTrue(yield* exists(otherThreadPath));
     }),
   );

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -338,9 +338,6 @@ function collectThreadAttachmentRelativePaths(
   const relativePaths = new Set<string>();
   for (const message of messages) {
     for (const attachment of message.attachments ?? []) {
-      if (attachment.type !== "image") {
-        continue;
-      }
       const attachmentThreadSegment = parseThreadSegmentFromAttachmentId(attachment.id);
       if (!attachmentThreadSegment || attachmentThreadSegment !== threadSegment) {
         continue;

--- a/apps/server/src/orchestration/Normalizer.test.ts
+++ b/apps/server/src/orchestration/Normalizer.test.ts
@@ -1,4 +1,10 @@
-import { describe, expect, it } from "vite-plus/test";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { describe, expect } from "vite-plus/test";
+import { it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
 import {
   CommandId,
   type ClientOrchestrationCommand,
@@ -8,10 +14,18 @@ import {
   ThreadId,
 } from "@t3tools/contracts";
 
-import { canonicalizeClientCommandTimestamps } from "./Normalizer.ts";
+import { attachmentRelativePath } from "../attachmentStore.ts";
+import { ServerConfig } from "../config.ts";
+import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
+import { canonicalizeClientCommandTimestamps, normalizeDispatchCommand } from "./Normalizer.ts";
 
 const clientCreatedAt = "2031-01-01T00:00:00.000Z";
 const serverReceivedAt = "2026-07-18T00:00:00.000Z";
+
+const normalizeTestLayer = Layer.mergeAll(
+  ServerConfig.layerTest(process.cwd(), { prefix: "t3-normalizer-attachment-" }),
+  WorkspacePaths.layer,
+).pipe(Layer.provideMerge(NodeServices.layer));
 
 describe("canonicalizeClientCommandTimestamps", () => {
   it("replaces a client command timestamp with the server receipt timestamp", () => {
@@ -70,4 +84,55 @@ describe("canonicalizeClientCommandTimestamps", () => {
     expect(result.createdAt).toBe(serverReceivedAt);
     expect(result.bootstrap?.createThread?.createdAt).toBe(serverReceivedAt);
   });
+
+  it.effect("persists PDF turn attachments with PDF metadata and extension", () =>
+    Effect.gen(function* () {
+      const command: ClientOrchestrationCommand = {
+        type: "thread.turn.start",
+        commandId: CommandId.make("normalizer-pdf-command"),
+        threadId: ThreadId.make("normalizer-pdf-thread"),
+        message: {
+          messageId: MessageId.make("normalizer-pdf-message"),
+          role: "user",
+          text: "Read this document",
+          attachments: [
+            {
+              type: "pdf",
+              name: "spec.pdf",
+              mimeType: "application/pdf",
+              sizeBytes: 6,
+              dataUrl: "data:application/pdf;base64,JVBERi0x",
+            },
+          ],
+        },
+        runtimeMode: "full-access",
+        interactionMode: "default",
+        createdAt: clientCreatedAt,
+      };
+
+      const result = yield* normalizeDispatchCommand(command);
+      expect(result.type).toBe("thread.turn.start");
+      if (result.type !== "thread.turn.start") {
+        return;
+      }
+
+      const attachment = result.message.attachments[0];
+      if (!attachment) {
+        throw new Error("Expected a persisted PDF attachment");
+      }
+      expect(attachment).toMatchObject({
+        type: "pdf",
+        name: "spec.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: 6,
+      });
+      const config = yield* ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const info = yield* fileSystem.stat(
+        path.join(config.attachmentsDir, attachmentRelativePath(attachment)),
+      );
+      expect(info.type).toBe("File");
+    }).pipe(Effect.provide(normalizeTestLayer)),
+  );
 });

--- a/apps/server/src/orchestration/Normalizer.ts
+++ b/apps/server/src/orchestration/Normalizer.ts
@@ -7,7 +7,7 @@ import {
   type IsoDateTime,
   type OrchestrationCommand,
   OrchestrationDispatchCommandError,
-  PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
+  PROVIDER_SEND_TURN_MAX_ATTACHMENT_BYTES,
 } from "@t3tools/contracts";
 
 import { createAttachmentId, resolveAttachmentPath } from "../attachmentStore.ts";
@@ -109,16 +109,24 @@ export const normalizeDispatchCommand = (command: ClientOrchestrationCommand) =>
       (attachment) =>
         Effect.gen(function* () {
           const parsed = parseBase64DataUrl(attachment.dataUrl);
-          if (!parsed || !parsed.mimeType.startsWith("image/")) {
+          const isValidPayload =
+            parsed !== null &&
+            (attachment.type === "image"
+              ? parsed.mimeType.startsWith("image/")
+              : parsed.mimeType === "application/pdf");
+          if (!isValidPayload || !parsed) {
             return yield* new OrchestrationDispatchCommandError({
-              message: `Invalid image attachment payload for '${attachment.name}'.`,
+              message: `Invalid ${attachment.type} attachment payload for '${attachment.name}'.`,
             });
           }
 
           const bytes = Buffer.from(parsed.base64, "base64");
-          if (bytes.byteLength === 0 || bytes.byteLength > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES) {
+          if (
+            bytes.byteLength === 0 ||
+            bytes.byteLength > PROVIDER_SEND_TURN_MAX_ATTACHMENT_BYTES
+          ) {
             return yield* new OrchestrationDispatchCommandError({
-              message: `Image attachment '${attachment.name}' is empty or too large.`,
+              message: `${attachment.type === "pdf" ? "PDF" : "Image"} attachment '${attachment.name}' is empty or too large.`,
             });
           }
 
@@ -129,13 +137,22 @@ export const normalizeDispatchCommand = (command: ClientOrchestrationCommand) =>
             });
           }
 
-          const persistedAttachment = {
-            type: "image" as const,
-            id: attachmentId,
-            name: attachment.name,
-            mimeType: parsed.mimeType.toLowerCase(),
-            sizeBytes: bytes.byteLength,
-          };
+          const persistedAttachment =
+            attachment.type === "pdf"
+              ? {
+                  type: "pdf" as const,
+                  id: attachmentId,
+                  name: attachment.name,
+                  mimeType: "application/pdf" as const,
+                  sizeBytes: bytes.byteLength,
+                }
+              : {
+                  type: "image" as const,
+                  id: attachmentId,
+                  name: attachment.name,
+                  mimeType: parsed.mimeType.toLowerCase(),
+                  sizeBytes: bytes.byteLength,
+                };
 
           const attachmentPath = resolveAttachmentPath({
             attachmentsDir: serverConfig.attachmentsDir,

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -736,7 +736,7 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
-  it.effect("embeds image attachments in Claude user messages", () => {
+  it.effect("embeds image and PDF attachments in Claude user messages", () => {
     const baseDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "claude-attachments-"));
     const harness = makeHarness({
       cwd: "/tmp/project-claude-attachments",
@@ -762,9 +762,21 @@ describe("ClaudeAdapterLive", () => {
         mimeType: "image/png",
         sizeBytes: 4,
       };
+      const pdfAttachment = {
+        type: "pdf" as const,
+        id: "thread-claude-pdf-12345678-1234-1234-1234-123456789abc",
+        name: "spec.pdf",
+        mimeType: "application/pdf" as const,
+        sizeBytes: 4,
+      };
       const attachmentPath = NodePath.join(attachmentsDir, attachmentRelativePath(attachment));
+      const pdfAttachmentPath = NodePath.join(
+        attachmentsDir,
+        attachmentRelativePath(pdfAttachment),
+      );
       NodeFS.mkdirSync(NodePath.dirname(attachmentPath), { recursive: true });
       NodeFS.writeFileSync(attachmentPath, Uint8Array.from([1, 2, 3, 4]));
+      NodeFS.writeFileSync(pdfAttachmentPath, Uint8Array.from([5, 6, 7, 8]));
 
       const session = yield* adapter.startSession({
         threadId: THREAD_ID,
@@ -775,7 +787,7 @@ describe("ClaudeAdapterLive", () => {
       yield* adapter.sendTurn({
         threadId: session.threadId,
         input: "What's in this image?",
-        attachments: [attachment],
+        attachments: [attachment, pdfAttachment],
       });
 
       const createInput = harness.getLastCreateQueryInput();
@@ -792,6 +804,14 @@ describe("ClaudeAdapterLive", () => {
             type: "base64",
             media_type: "image/png",
             data: "AQIDBA==",
+          },
+        },
+        {
+          type: "document",
+          source: {
+            type: "base64",
+            media_type: "application/pdf",
+            data: "BQYHCA==",
           },
         },
       ]);

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -1251,6 +1251,19 @@ function buildClaudeImageContentBlock(input: {
   };
 }
 
+function buildClaudePdfContentBlock(input: {
+  readonly bytes: Uint8Array;
+}): Record<string, unknown> {
+  return {
+    type: "document",
+    source: {
+      type: "base64",
+      media_type: "application/pdf",
+      data: Buffer.from(input.bytes).toString("base64"),
+    },
+  };
+}
+
 const buildUserMessageEffect = Effect.fn("buildUserMessageEffect")(function* (
   input: ProviderSendTurnInput,
   dependencies: {
@@ -1267,11 +1280,10 @@ const buildUserMessageEffect = Effect.fn("buildUserMessageEffect")(function* (
   }
 
   for (const attachment of input.attachments ?? []) {
-    if (attachment.type !== "image") {
-      continue;
-    }
-
-    if (!SUPPORTED_CLAUDE_IMAGE_MIME_TYPES.has(attachment.mimeType)) {
+    if (
+      attachment.type === "image" &&
+      !SUPPORTED_CLAUDE_IMAGE_MIME_TYPES.has(attachment.mimeType)
+    ) {
       return yield* new ProviderAdapterRequestError({
         provider: PROVIDER,
         method: "turn/start",
@@ -1304,10 +1316,9 @@ const buildUserMessageEffect = Effect.fn("buildUserMessageEffect")(function* (
     );
 
     sdkContent.push(
-      buildClaudeImageContentBlock({
-        mimeType: attachment.mimeType,
-        bytes,
-      }),
+      attachment.type === "pdf"
+        ? buildClaudePdfContentBlock({ bytes })
+        : buildClaudeImageContentBlock({ mimeType: attachment.mimeType, bytes }),
     );
   }
 

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -328,6 +328,32 @@ sessionErrorLayer("CodexAdapterLive session errors", (it) => {
     }),
   );
 
+  it.effect("rejects PDF attachments before invoking the Codex runtime", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CodexAdapter;
+      const result = yield* adapter
+        .sendTurn({
+          threadId: asThreadId("sess-pdf"),
+          input: "read this",
+          attachments: [
+            {
+              type: "pdf",
+              id: "sess-pdf-attachment",
+              name: "spec.pdf",
+              mimeType: "application/pdf",
+              sizeBytes: 4,
+            },
+          ],
+        })
+        .pipe(Effect.result);
+
+      NodeAssert.equal(result._tag, "Failure");
+      NodeAssert.equal(result.failure._tag, "ProviderAdapterRequestError");
+      NodeAssert.match(result.failure.detail, /does not support PDF attachments/);
+      NodeAssert.equal(sessionRuntimeFactory.factory.mock.calls.length, 0);
+    }),
+  );
+
   it.effect("maps codex model options before sending a turn", () =>
     Effect.gen(function* () {
       const adapter = yield* CodexAdapter;

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1772,6 +1772,14 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     input: ProviderSendTurnInput,
     attachment: NonNullable<ProviderSendTurnInput["attachments"]>[number],
   ) {
+    if (attachment.type === "pdf") {
+      return yield* new ProviderAdapterRequestError({
+        provider: PROVIDER,
+        method: "turn/start",
+        detail:
+          "Codex does not support PDF attachments yet. Use Claude, Cursor, Grok, or OpenCode for PDF messages.",
+      });
+    }
     const attachmentPath = resolveAttachmentPath({
       attachmentsDir: serverConfig.attachmentsDir,
       attachment,

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -49,7 +49,11 @@ import {
   ProviderAdapterSessionNotFoundError,
   ProviderAdapterValidationError,
 } from "../Errors.ts";
-import { acpPermissionOutcome, mapAcpToAdapterError } from "../acp/AcpAdapterSupport.ts";
+import {
+  acpPermissionOutcome,
+  makeAcpFileResourceLink,
+  mapAcpToAdapterError,
+} from "../acp/AcpAdapterSupport.ts";
 import type * as AcpSessionRuntime from "../acp/AcpSessionRuntime.ts";
 import {
   makeAcpAssistantItemEvent,
@@ -982,6 +986,17 @@ export function makeCursorAdapter(
                   method: "session/prompt",
                   detail: `Invalid attachment id '${attachment.id}'.`,
                 });
+              }
+              if (attachment.type === "pdf") {
+                promptParts.push(
+                  makeAcpFileResourceLink({
+                    path: attachmentPath,
+                    name: attachment.name,
+                    mimeType: attachment.mimeType,
+                    sizeBytes: attachment.sizeBytes,
+                  }),
+                );
+                continue;
               }
               const bytes = yield* fileSystem.readFile(attachmentPath).pipe(
                 Effect.mapError(

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -41,7 +41,7 @@ import {
   ProviderAdapterSessionNotFoundError,
   ProviderAdapterValidationError,
 } from "../Errors.ts";
-import { mapAcpToAdapterError } from "../acp/AcpAdapterSupport.ts";
+import { makeAcpFileResourceLink, mapAcpToAdapterError } from "../acp/AcpAdapterSupport.ts";
 import type * as AcpSessionRuntime from "../acp/AcpSessionRuntime.ts";
 import {
   makeAcpAssistantItemEvent,
@@ -957,7 +957,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
               });
 
               const text = input.input?.trim();
-              const imagePromptParts = yield* Effect.forEach(
+              const attachmentPromptParts = yield* Effect.forEach(
                 input.attachments ?? [],
                 (attachment) =>
                   Effect.gen(function* () {
@@ -971,6 +971,14 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                         method: "session/prompt",
                         detail: `Invalid attachment id '${attachment.id}'.`,
                       });
+                    }
+                    if (attachment.type === "pdf") {
+                      return makeAcpFileResourceLink({
+                        path: attachmentPath,
+                        name: attachment.name,
+                        mimeType: attachment.mimeType,
+                        sizeBytes: attachment.sizeBytes,
+                      }) satisfies EffectAcpSchema.ContentBlock;
                     }
                     const bytes = yield* fileSystem.readFile(attachmentPath).pipe(
                       Effect.mapError(
@@ -992,7 +1000,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
               );
               const promptParts: Array<EffectAcpSchema.ContentBlock> = [
                 ...(text ? [{ type: "text" as const, text }] : []),
-                ...imagePromptParts,
+                ...attachmentPromptParts,
               ];
 
               if (promptParts.length === 0) {

--- a/apps/server/src/provider/acp/AcpAdapterSupport.test.ts
+++ b/apps/server/src/provider/acp/AcpAdapterSupport.test.ts
@@ -2,13 +2,34 @@ import { describe, expect, it } from "vite-plus/test";
 import * as EffectAcpErrors from "effect-acp/errors";
 import { ProviderDriverKind } from "@t3tools/contracts";
 
-import { acpPermissionOutcome, mapAcpToAdapterError } from "./AcpAdapterSupport.ts";
+import {
+  acpPermissionOutcome,
+  makeAcpFileResourceLink,
+  mapAcpToAdapterError,
+} from "./AcpAdapterSupport.ts";
 
 describe("AcpAdapterSupport", () => {
   it("maps ACP approval decisions to permission outcomes", () => {
     expect(acpPermissionOutcome("accept")).toBe("allow-once");
     expect(acpPermissionOutcome("acceptForSession")).toBe("allow-always");
     expect(acpPermissionOutcome("decline")).toBe("reject-once");
+  });
+
+  it("builds file resource links for non-image attachments", () => {
+    expect(
+      makeAcpFileResourceLink({
+        path: "/tmp/spec.pdf",
+        name: "spec.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: 42,
+      }),
+    ).toEqual({
+      type: "resource_link",
+      name: "spec.pdf",
+      mimeType: "application/pdf",
+      size: 42,
+      uri: "file:///tmp/spec.pdf",
+    });
   });
 
   it("maps ACP request errors to provider adapter request errors", () => {

--- a/apps/server/src/provider/acp/AcpAdapterSupport.ts
+++ b/apps/server/src/provider/acp/AcpAdapterSupport.ts
@@ -3,6 +3,7 @@ import {
   type ProviderDriverKind,
   type ThreadId,
 } from "@t3tools/contracts";
+import * as NodeURL from "node:url";
 import * as Schema from "effect/Schema";
 import * as EffectAcpErrors from "effect-acp/errors";
 
@@ -13,6 +14,21 @@ import {
 } from "../Errors.ts";
 const isAcpProcessExitedError = Schema.is(EffectAcpErrors.AcpProcessExitedError);
 const isAcpRequestError = Schema.is(EffectAcpErrors.AcpRequestError);
+
+export function makeAcpFileResourceLink(input: {
+  readonly path: string;
+  readonly name: string;
+  readonly mimeType: string;
+  readonly sizeBytes: number;
+}) {
+  return {
+    type: "resource_link" as const,
+    name: input.name,
+    mimeType: input.mimeType,
+    size: input.sizeBytes,
+    uri: NodeURL.pathToFileURL(input.path).href,
+  };
+}
 
 export function mapAcpToAdapterError(
   provider: ProviderDriverKind,

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -16,6 +16,7 @@ import {
   buildExpiredTerminalContextToastCopy,
   buildLoadingThreadFromShell,
   buildThreadTurnInterruptInput,
+  collectUserMessageBlobPreviewUrls,
   createLocalDispatchSnapshot,
   deriveComposerSendState,
   dismissBranchMismatchForSession,
@@ -38,6 +39,40 @@ const environmentId = EnvironmentId.make("environment-local");
 const projectId = ProjectId.make("project-1");
 const threadId = ThreadId.make("thread-1");
 const now = "2026-03-29T00:00:00.000Z";
+
+describe("attachment preview handoff", () => {
+  it("keeps image and PDF blob previews alive until server assets are ready", () => {
+    const message = {
+      id: MessageId.make("message-attachments"),
+      role: "user" as const,
+      text: "",
+      attachments: [
+        {
+          type: "image" as const,
+          id: "image-attachment",
+          name: "diagram.png",
+          mimeType: "image/png",
+          sizeBytes: 4,
+          previewUrl: "blob:image",
+        },
+        {
+          type: "pdf" as const,
+          id: "pdf-attachment",
+          name: "spec.pdf",
+          mimeType: "application/pdf" as const,
+          sizeBytes: 4,
+          previewUrl: "blob:pdf",
+        },
+      ],
+      turnId: null,
+      streaming: false,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    expect(collectUserMessageBlobPreviewUrls(message)).toEqual(["blob:image", "blob:pdf"]);
+  });
+});
 
 describe("environment reconnect warning grace", () => {
   afterEach(() => vi.useRealTimers());

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -208,9 +208,6 @@ export function revokeUserMessagePreviewUrls(message: ChatMessage): void {
     return;
   }
   for (const attachment of message.attachments) {
-    if (attachment.type !== "image") {
-      continue;
-    }
     revokeBlobPreviewUrl(attachment.previewUrl);
   }
 }
@@ -221,7 +218,6 @@ export function collectUserMessageBlobPreviewUrls(message: ChatMessage): string[
   }
   const previewUrls: string[] = [];
   for (const attachment of message.attachments) {
-    if (attachment.type !== "image") continue;
     if (!attachment.previewUrl || !attachment.previewUrl.startsWith("blob:")) continue;
     previewUrls.push(attachment.previewUrl);
   }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5,6 +5,7 @@ import {
   type EnvironmentId,
   type MessageId,
   type ModelSelection,
+  type UploadChatAttachment,
   type ProjectScript,
   type ProjectId,
   type ProviderApprovalDecision,
@@ -113,6 +114,7 @@ import {
   DEFAULT_THREAD_TERMINAL_ID,
   MAX_TERMINALS_PER_GROUP,
   type ChatMessage,
+  type ChatAttachment,
   type SessionPhase,
   type Thread,
   type TurnDiffSummary,
@@ -204,6 +206,7 @@ import { buildPhysicalToLogicalProjectKeyMap } from "../sidebarProjectGrouping";
 import { buildDraftThreadRouteParams } from "../threadRoutes";
 import {
   type ComposerImageAttachment,
+  type ComposerPdfAttachment,
   type DraftThreadEnvMode,
   useComposerDraftStore,
   type DraftId,
@@ -352,8 +355,8 @@ import {
 } from "../versionSkew";
 import { useAssetUrls } from "../assets/assetUrls";
 
-const IMAGE_ONLY_BOOTSTRAP_PROMPT =
-  "[User attached one or more images without additional text. Respond using the conversation context and the attached image(s).]";
+const ATTACHMENT_ONLY_BOOTSTRAP_PROMPT =
+  "[User attached one or more files without additional text. Respond using the conversation context and the attached file(s).]";
 const EMPTY_ACTIVITIES: OrchestrationThreadActivity[] = [];
 const EMPTY_PROVIDERS: ServerProvider[] = [];
 const EMPTY_PROVIDER_SKILLS: ServerProvider["skills"] = [];
@@ -1311,6 +1314,7 @@ function ChatViewContent(props: ChatViewProps) {
   );
   const setComposerDraftPrompt = useComposerDraftStore((store) => store.setPrompt);
   const addComposerDraftImages = useComposerDraftStore((store) => store.addImages);
+  const addComposerDraftPdfs = useComposerDraftStore((store) => store.addPdfs);
   const setComposerDraftTerminalContexts = useComposerDraftStore(
     (store) => store.setTerminalContexts,
   );
@@ -1337,6 +1341,7 @@ function ChatViewContent(props: ChatViewProps) {
   );
   const promptRef = useRef("");
   const composerImagesRef = useRef<ComposerImageAttachment[]>([]);
+  const composerPdfsRef = useRef<ComposerPdfAttachment[]>([]);
   const composerTerminalContextsRef = useRef<TerminalContextDraft[]>([]);
   const composerElementContextsRef = useRef<ElementContextDraft[]>([]);
   const localComposerRef = useRef<ChatComposerHandle | null>(null);
@@ -2453,10 +2458,9 @@ function ChatViewContent(props: ChatViewProps) {
       }
 
       const serverPreviewUrls = serverMessage.attachments.flatMap((attachment) =>
-        attachment.type === "image" && attachment.previewUrl ? [attachment.previewUrl] : [],
+        attachment.previewUrl ? [attachment.previewUrl] : [],
       );
       if (
-        serverPreviewUrls.length === 0 ||
         serverPreviewUrls.length !== handoffPreviewUrls.length ||
         serverPreviewUrls.some((previewUrl) => previewUrl.startsWith("blob:"))
       ) {
@@ -2468,8 +2472,11 @@ function ChatViewContent(props: ChatViewProps) {
       let cancelled = false;
       const imageInstances: HTMLImageElement[] = [];
 
+      const serverImagePreviewUrls = serverMessage.attachments.flatMap((attachment) =>
+        attachment.type === "image" && attachment.previewUrl ? [attachment.previewUrl] : [],
+      );
       const preloadServerPreviews = Promise.all(
-        serverPreviewUrls.map(
+        serverImagePreviewUrls.map(
           (previewUrl) =>
             new Promise<void>((resolve, reject) => {
               const image = new Image();
@@ -2534,13 +2541,10 @@ function ChatViewContent(props: ChatViewProps) {
             }
 
             let changed = false;
-            let imageIndex = 0;
+            let attachmentIndex = 0;
             const attachments = message.attachments.map((attachment) => {
-              if (attachment.type !== "image") {
-                return attachment;
-              }
-              const handoffPreviewUrl = handoffPreviewUrls[imageIndex];
-              imageIndex += 1;
+              const handoffPreviewUrl = handoffPreviewUrls[attachmentIndex];
+              attachmentIndex += 1;
               if (!handoffPreviewUrl || attachment.previewUrl === handoffPreviewUrl) {
                 return attachment;
               }
@@ -4291,6 +4295,7 @@ function ChatViewContent(props: ChatViewProps) {
       draft &&
       (draft.prompt.trim().length > 0 ||
         draft.images.length > 0 ||
+        draft.pdfs.length > 0 ||
         draft.terminalContexts.length > 0 ||
         draft.elementContexts.length > 0 ||
         draft.previewAnnotations.length > 0 ||
@@ -4959,6 +4964,7 @@ function ChatViewContent(props: ChatViewProps) {
     }
     const {
       images: sendContextImages,
+      pdfs: sendContextPdfs,
       terminalContexts: composerTerminalContexts,
       elementContexts: composerElementContexts,
       previewAnnotations: sendContextPreviewAnnotations,
@@ -4974,6 +4980,15 @@ function ChatViewContent(props: ChatViewProps) {
       !sendContextImages.some((image) => image.id === directAnnotation.image?.id)
         ? [...sendContextImages, directAnnotation.image]
         : sendContextImages;
+    const composerPdfs = sendContextPdfs;
+    if (ctxSelectedProvider === "codex" && composerPdfs.length > 0) {
+      toastManager.add({
+        type: "error",
+        title: "PDF attachments are unavailable with Codex",
+        description: "Choose Claude, Cursor, Grok, or OpenCode before sending this message.",
+      });
+      return;
+    }
     const composerPreviewAnnotations =
       directAnnotation &&
       !sendContextPreviewAnnotations.some(
@@ -4997,7 +5012,7 @@ function ChatViewContent(props: ChatViewProps) {
       hasSendableContent,
     } = deriveComposerSendState({
       prompt: promptForSend,
-      imageCount: composerImages.length,
+      imageCount: composerImages.length + composerPdfs.length,
       terminalContexts: composerTerminalContexts,
       elementContextCount:
         composerElementContexts.length +
@@ -5033,6 +5048,7 @@ function ChatViewContent(props: ChatViewProps) {
     const standaloneSlashCommand =
       settings.planModeEnabled &&
       composerImages.length === 0 &&
+      composerPdfs.length === 0 &&
       sendableComposerTerminalContexts.length === 0 &&
       composerElementContexts.length === 0 &&
       composerPreviewAnnotations.length === 0 &&
@@ -5089,6 +5105,7 @@ function ChatViewContent(props: ChatViewProps) {
     }
 
     const composerImagesSnapshot = [...composerImages];
+    const composerPdfsSnapshot = [...composerPdfs];
     const composerTerminalContextsSnapshot = [...sendableComposerTerminalContexts];
     const composerElementContextsSnapshot = [...composerElementContexts];
     const composerPreviewAnnotationsSnapshot = [...composerPreviewAnnotations];
@@ -5110,7 +5127,7 @@ function ChatViewContent(props: ChatViewProps) {
       model: ctxSelectedModel,
       models: ctxSelectedProviderModels,
       effort: ctxSelectedPromptEffort,
-      text: messageTextForSend || IMAGE_ONLY_BOOTSTRAP_PROMPT,
+      text: messageTextForSend || ATTACHMENT_ONLY_BOOTSTRAP_PROMPT,
     });
     if (composerRef.current?.validateProviderInput(outgoingMessageText) === false) {
       return;
@@ -5137,22 +5154,51 @@ function ChatViewContent(props: ChatViewProps) {
     const messageIdForSend = newMessageId();
     const messageCreatedAt = new Date().toISOString();
     const turnAttachmentsPromise = Promise.all(
-      composerImagesSnapshot.map(async (image) => ({
-        type: "image" as const,
-        name: image.name,
-        mimeType: image.mimeType,
-        sizeBytes: image.sizeBytes,
-        dataUrl: await readFileAsDataUrl(image.file),
-      })),
+      [...composerImagesSnapshot, ...composerPdfsSnapshot].map(
+        async (attachment): Promise<UploadChatAttachment> => {
+          const dataUrl = await readFileAsDataUrl(attachment.file);
+          if (attachment.type === "pdf") {
+            return {
+              type: "pdf",
+              name: attachment.name,
+              mimeType: "application/pdf",
+              sizeBytes: attachment.sizeBytes,
+              dataUrl,
+            };
+          }
+          return {
+            type: "image",
+            name: attachment.name,
+            mimeType: attachment.mimeType,
+            sizeBytes: attachment.sizeBytes,
+            dataUrl,
+          };
+        },
+      ),
     );
-    const optimisticAttachments = composerImagesSnapshot.map((image) => ({
-      type: "image" as const,
-      id: image.id,
-      name: image.name,
-      mimeType: image.mimeType,
-      sizeBytes: image.sizeBytes,
-      previewUrl: image.previewUrl,
-    }));
+    const optimisticAttachments: ChatAttachment[] = [
+      ...composerImagesSnapshot,
+      ...composerPdfsSnapshot,
+    ].map((attachment) => {
+      if (attachment.type === "pdf") {
+        return {
+          type: "pdf",
+          id: attachment.id,
+          name: attachment.name,
+          mimeType: "application/pdf",
+          sizeBytes: attachment.sizeBytes,
+          previewUrl: attachment.previewUrl,
+        };
+      }
+      return {
+        type: "image",
+        id: attachment.id,
+        name: attachment.name,
+        mimeType: attachment.mimeType,
+        sizeBytes: attachment.sizeBytes,
+        previewUrl: attachment.previewUrl,
+      };
+    });
     // Sending always returns to the live edge. The new row becomes the
     // anchored end-space target so it lands near the top while the response
     // streams into the reserved space below it.
@@ -5199,17 +5245,18 @@ function ChatViewContent(props: ChatViewProps) {
     clearComposerDraftContent(composerDraftTarget);
     composerRef.current?.resetCursorState();
 
-    let firstComposerImageName: string | null = null;
-    if (composerImagesSnapshot.length > 0) {
-      const firstComposerImage = composerImagesSnapshot[0];
-      if (firstComposerImage) {
-        firstComposerImageName = firstComposerImage.name;
+    let firstComposerAttachment: { readonly type: "image" | "pdf"; readonly name: string } | null =
+      null;
+    if (composerImagesSnapshot.length > 0 || composerPdfsSnapshot.length > 0) {
+      const firstAttachment = [...composerImagesSnapshot, ...composerPdfsSnapshot][0];
+      if (firstAttachment) {
+        firstComposerAttachment = { type: firstAttachment.type, name: firstAttachment.name };
       }
     }
     let titleSeed = trimmed;
     if (!titleSeed) {
-      if (firstComposerImageName) {
-        titleSeed = `Image: ${firstComposerImageName}`;
+      if (firstComposerAttachment) {
+        titleSeed = `${firstComposerAttachment.type === "pdf" ? "PDF" : "Image"}: ${firstComposerAttachment.name}`;
       } else if (composerTerminalContextsSnapshot.length > 0) {
         titleSeed = formatTerminalContextLabel(composerTerminalContextsSnapshot[0]!);
       } else if (composerElementContextsSnapshot.length > 0) {
@@ -5324,6 +5371,7 @@ function ChatViewContent(props: ChatViewProps) {
       if (
         promptRef.current.length === 0 &&
         composerImagesRef.current.length === 0 &&
+        composerPdfsRef.current.length === 0 &&
         composerTerminalContextsRef.current.length === 0 &&
         composerElementContextsRef.current.length === 0 &&
         (useComposerDraftStore.getState().getComposerDraft(composerDraftTarget)?.previewAnnotations
@@ -5341,11 +5389,19 @@ function ChatViewContent(props: ChatViewProps) {
         });
         promptRef.current = promptForSend;
         const retryComposerImages = composerImagesSnapshot.map(cloneComposerImageForRetry);
+        const retryComposerPdfs = composerPdfsSnapshot.map((pdf) => ({
+          ...pdf,
+          previewUrl: pdf.previewUrl.startsWith("blob:")
+            ? URL.createObjectURL(pdf.file)
+            : pdf.previewUrl,
+        }));
         composerImagesRef.current = retryComposerImages;
+        composerPdfsRef.current = retryComposerPdfs;
         composerTerminalContextsRef.current = composerTerminalContextsSnapshot;
         composerElementContextsRef.current = composerElementContextsSnapshot;
         setComposerDraftPrompt(composerDraftTarget, promptForSend);
         addComposerDraftImages(composerDraftTarget, retryComposerImages);
+        addComposerDraftPdfs(composerDraftTarget, retryComposerPdfs);
         setComposerDraftTerminalContexts(composerDraftTarget, composerTerminalContextsSnapshot);
         setComposerDraftElementContexts(composerDraftTarget, composerElementContextsSnapshot);
         setComposerDraftPreviewAnnotations(composerDraftTarget, composerPreviewAnnotationsSnapshot);
@@ -6463,6 +6519,7 @@ function ChatViewContent(props: ChatViewProps) {
                             gitCwd={gitCwd}
                             promptRef={promptRef}
                             composerImagesRef={composerImagesRef}
+                            composerPdfsRef={composerPdfsRef}
                             composerTerminalContextsRef={composerTerminalContextsRef}
                             composerElementContextsRef={composerElementContextsRef}
                             onSend={onSend}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -15,8 +15,8 @@ import {
   isProviderSendTurnSupportedImageMimeType,
   ProviderDriverKind,
   ProviderInstanceId,
+  PROVIDER_SEND_TURN_MAX_ATTACHMENT_BYTES,
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
-  PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
 } from "@t3tools/contracts";
 import type { EnvironmentConnectionPresentation } from "@t3tools/client-runtime/connection";
 import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
@@ -49,6 +49,7 @@ import {
 } from "./composerMentionDrag";
 import {
   type ComposerImageAttachment,
+  type ComposerPdfAttachment,
   type DraftId,
   type PersistedComposerImageAttachment,
   hydrateImagesFromPersisted,
@@ -202,6 +203,7 @@ import { toastManager } from "../ui/toast";
 import {
   BotIcon,
   CircleAlertIcon,
+  FileTextIcon,
   PencilRulerIcon,
   type LucideIcon,
   LockIcon,
@@ -480,6 +482,7 @@ export interface ChatComposerHandle {
   getSendContext: () => {
     prompt: string;
     images: ComposerImageAttachment[];
+    pdfs: ComposerPdfAttachment[];
     terminalContexts: TerminalContextDraft[];
     elementContexts: ElementContextDraft[];
     previewAnnotations: PreviewAnnotationPayload[];
@@ -571,6 +574,7 @@ export interface ChatComposerProps {
   // Refs the parent needs kept in sync
   promptRef: React.RefObject<string>;
   composerImagesRef: React.RefObject<ComposerImageAttachment[]>;
+  composerPdfsRef: React.RefObject<ComposerPdfAttachment[]>;
   composerTerminalContextsRef: React.RefObject<TerminalContextDraft[]>;
   composerElementContextsRef: React.RefObject<ElementContextDraft[]>;
   composerRef: React.RefObject<ChatComposerHandle | null>;
@@ -656,6 +660,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     promptRef,
     composerRef,
     composerImagesRef,
+    composerPdfsRef,
     composerTerminalContextsRef,
     composerElementContextsRef,
     onSend,
@@ -684,16 +689,20 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const composerDraft = useComposerThreadDraft(composerDraftTarget);
   const prompt = composerDraft.prompt;
   const composerImages = composerDraft.images;
+  const composerPdfs = composerDraft.pdfs;
   const composerTerminalContexts = composerDraft.terminalContexts;
   const composerElementContexts = composerDraft.elementContexts;
   const composerPreviewAnnotations = composerDraft.previewAnnotations;
   const composerReviewComments = composerDraft.reviewComments;
   const nonPersistedComposerImageIds = composerDraft.nonPersistedImageIds;
+  const nonPersistedComposerPdfIds = composerDraft.nonPersistedPdfIds;
 
   const setComposerDraftPrompt = useComposerDraftStore((store) => store.setPrompt);
   const addComposerDraftImage = useComposerDraftStore((store) => store.addImage);
   const addComposerDraftImages = useComposerDraftStore((store) => store.addImages);
   const removeComposerDraftImage = useComposerDraftStore((store) => store.removeImage);
+  const addComposerDraftPdfs = useComposerDraftStore((store) => store.addPdfs);
+  const removeComposerDraftPdf = useComposerDraftStore((store) => store.removePdf);
   const insertComposerDraftTerminalContext = useComposerDraftStore(
     (store) => store.insertTerminalContext,
   );
@@ -1003,7 +1012,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     () =>
       deriveComposerSendState({
         prompt,
-        imageCount: composerImages.length,
+        imageCount: composerImages.length + composerPdfs.length,
         terminalContexts: composerTerminalContexts,
         elementContextCount:
           composerElementContexts.length +
@@ -1013,6 +1022,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     [
       composerElementContexts.length,
       composerImages.length,
+      composerPdfs.length,
       composerPreviewAnnotations.length,
       composerReviewComments.length,
       composerTerminalContexts,
@@ -1283,6 +1293,20 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     [composerDraftTarget, removeComposerDraftImage],
   );
 
+  const addComposerPdfsToDraft = useCallback(
+    (pdfs: ComposerPdfAttachment[]) => {
+      addComposerDraftPdfs(composerDraftTarget, pdfs);
+    },
+    [addComposerDraftPdfs, composerDraftTarget],
+  );
+
+  const removeComposerPdfFromDraft = useCallback(
+    (pdfId: string) => {
+      removeComposerDraftPdf(composerDraftTarget, pdfId);
+    },
+    [composerDraftTarget, removeComposerDraftPdf],
+  );
+
   const removeComposerTerminalContextFromDraft = useCallback(
     (contextId: string) => {
       const contextIndex = composerTerminalContexts.findIndex(
@@ -1338,6 +1362,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   useEffect(() => {
     composerImagesRef.current = composerImages;
   }, [composerImages, composerImagesRef]);
+
+  useEffect(() => {
+    composerPdfsRef.current = composerPdfs;
+  }, [composerPdfs, composerPdfsRef]);
 
   useEffect(() => {
     composerTerminalContextsRef.current = composerTerminalContexts;
@@ -1485,7 +1513,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   useEffect(() => {
     let cancelled = false;
     void (async () => {
-      if (composerImages.length === 0) {
+      const composerAttachments = [...composerImages, ...composerPdfs];
+      if (composerAttachments.length === 0) {
         clearComposerDraftPersistedAttachments(composerDraftTarget);
         return;
       }
@@ -1498,20 +1527,21 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         );
         const stagedAttachmentById = new Map<string, PersistedComposerImageAttachment>();
         await Promise.all(
-          composerImages.map(async (image) => {
+          composerAttachments.map(async (attachment) => {
             try {
-              const dataUrl = await readFileAsDataUrl(image.file);
-              stagedAttachmentById.set(image.id, {
-                id: image.id,
-                name: image.name,
-                mimeType: image.mimeType,
-                sizeBytes: image.sizeBytes,
+              const dataUrl = await readFileAsDataUrl(attachment.file);
+              stagedAttachmentById.set(attachment.id, {
+                id: attachment.id,
+                type: attachment.type,
+                name: attachment.name,
+                mimeType: attachment.mimeType,
+                sizeBytes: attachment.sizeBytes,
                 dataUrl,
               });
             } catch {
-              const existingPersisted = existingPersistedById.get(image.id);
+              const existingPersisted = existingPersistedById.get(attachment.id);
               if (existingPersisted) {
-                stagedAttachmentById.set(image.id, existingPersisted);
+                stagedAttachmentById.set(attachment.id, existingPersisted);
               }
             }
           }),
@@ -1520,11 +1550,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         if (cancelled) return;
         syncComposerDraftPersistedAttachments(composerDraftTarget, serialized);
       } catch {
-        const currentImageIds = new Set(composerImages.map((image) => image.id));
+        const currentAttachmentIds = new Set(
+          composerAttachments.map((attachment) => attachment.id),
+        );
         const fallbackPersistedAttachments = getPersistedAttachmentsForThread();
         const fallbackPersistedIds: Array<string> = [];
         for (const attachment of fallbackPersistedAttachments) {
-          if (currentImageIds.has(attachment.id)) {
+          if (currentAttachmentIds.has(attachment.id)) {
             fallbackPersistedIds.push(attachment.id);
           }
         }
@@ -1543,6 +1575,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     composerDraftTarget,
     clearComposerDraftPersistedAttachments,
     composerImages,
+    composerPdfs,
     getComposerDraft,
     syncComposerDraftPersistedAttachments,
   ]);
@@ -2114,6 +2147,16 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     // round-trip, so they are stripped from the stashed prompt.
     const prompt = promptRef.current.split(INLINE_TERMINAL_CONTEXT_PLACEHOLDER).join("").trim();
     const images = [...composerImagesRef.current];
+    const pdfs = [...composerPdfsRef.current];
+    if (pdfs.length > 0) {
+      toastManager.add({
+        type: "warning",
+        title: "PDFs cannot be stashed yet",
+        description:
+          "Send the PDF message directly, or remove the PDF before stashing this prompt.",
+      });
+      return;
+    }
     if (prompt.length === 0 && images.length === 0) {
       setIsStashMenuOpen((open) => !open);
       return;
@@ -2321,14 +2364,14 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   ]);
 
   // ------------------------------------------------------------------
-  // Callbacks: images
+  // Callbacks: attachments
   // ------------------------------------------------------------------
   const addComposerImages = async (files: File[]) => {
     if (!activeThreadId || files.length === 0) return;
     if (pendingUserInputs.length > 0) {
       toastManager.add({
         type: "error",
-        title: "Attach images after answering plan questions.",
+        title: "Attach files after answering plan questions.",
       });
       return;
     }
@@ -2341,12 +2384,19 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     // accepted files reserve their attachment slots (via the pending counter)
     // before the first await, keeping the total under the limit.
     const pendingCount = pendingImageCompressionsRef.current.get(threadId) ?? 0;
-    let reservedCount = composerImagesRef.current.length + pendingCount;
+    let reservedCount =
+      composerImagesRef.current.length + composerPdfsRef.current.length + pendingCount;
     const acceptedFiles: File[] = [];
     let error: string | null = null;
     for (const file of files) {
-      if (!file.type.startsWith("image/")) {
-        error = `Unsupported file type for '${file.name}'. Please attach image files only.`;
+      const mimeType = file.type.toLowerCase();
+      const isPdf = mimeType === "application/pdf" || file.name.toLowerCase().endsWith(".pdf");
+      if (isPdf && selectedProvider === "codex") {
+        error = "Codex does not support PDF attachments. Choose another provider for this file.";
+        continue;
+      }
+      if (!mimeType.startsWith("image/") && !isPdf) {
+        error = `Unsupported file type for '${file.name}'. Please attach image or PDF files only.`;
         continue;
       }
       if (!isProviderSendTurnSupportedImageMimeType(file.type)) {
@@ -2354,7 +2404,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         continue;
       }
       if (reservedCount >= PROVIDER_SEND_TURN_MAX_ATTACHMENTS) {
-        error = `You can attach up to ${PROVIDER_SEND_TURN_MAX_ATTACHMENTS} images per message.`;
+        error = `You can attach up to ${PROVIDER_SEND_TURN_MAX_ATTACHMENTS} files per message.`;
         break;
       }
       acceptedFiles.push(file);
@@ -2366,11 +2416,37 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     pendingImageCompressionsRef.current.set(threadId, pendingCount + acceptedFiles.length);
     try {
       const nextImages: ComposerImageAttachment[] = [];
+      const nextPdfs: ComposerPdfAttachment[] = [];
       let compressionError: string | null = null;
       for (const file of acceptedFiles) {
+        const isPdf =
+          file.type.toLowerCase() === "application/pdf" || file.name.toLowerCase().endsWith(".pdf");
+        if (isPdf) {
+          if (file.size <= 0 || file.size > PROVIDER_SEND_TURN_MAX_ATTACHMENT_BYTES) {
+            compressionError = `'${file.name}' is empty or exceeds the 10 MB PDF attachment limit.`;
+            continue;
+          }
+          const attachmentFile =
+            file.type.toLowerCase() === "application/pdf"
+              ? file
+              : new File([file], file.name, { type: "application/pdf" });
+          nextPdfs.push({
+            type: "pdf",
+            id: randomUUID(),
+            name: attachmentFile.name || "document.pdf",
+            mimeType: "application/pdf",
+            sizeBytes: attachmentFile.size,
+            previewUrl: URL.createObjectURL(attachmentFile),
+            file: attachmentFile,
+          });
+          continue;
+        }
         // Images over the wire cap are downscaled to fit rather than
         // refused; files already within it pass through byte-for-byte.
-        const compressed = await compressImageToByteLimit(file, PROVIDER_SEND_TURN_MAX_IMAGE_BYTES);
+        const compressed = await compressImageToByteLimit(
+          file,
+          PROVIDER_SEND_TURN_MAX_ATTACHMENT_BYTES,
+        );
         if (!compressed.ok) {
           compressionError =
             compressed.reason === "unreadable"
@@ -2395,6 +2471,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       } else if (nextImages.length > 1) {
         addComposerImagesToDraft(nextImages);
       }
+      if (nextPdfs.length > 0) {
+        addComposerPdfsToDraft(nextPdfs);
+      }
       // Only failures are reported here. Success must not pass `null`: by
       // now other work (a failed send, an overlapping paste) may have set a
       // thread error this call knows nothing about, and clearing it would
@@ -2417,16 +2496,25 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     removeComposerImageFromDraft(imageId);
   };
 
+  const removeComposerPdf = (pdfId: string) => {
+    removeComposerPdfFromDraft(pdfId);
+  };
+
   // ------------------------------------------------------------------
   // Callbacks: paste / drag
   // ------------------------------------------------------------------
   const onComposerPaste = (event: React.ClipboardEvent<HTMLElement>) => {
     const files = Array.from(event.clipboardData.files);
     if (files.length === 0) return;
-    const imageFiles = files.filter((file) => file.type.startsWith("image/"));
-    if (imageFiles.length === 0) return;
+    const attachmentFiles = files.filter(
+      (file) =>
+        file.type.toLowerCase().startsWith("image/") ||
+        file.type.toLowerCase() === "application/pdf" ||
+        file.name.toLowerCase().endsWith(".pdf"),
+    );
+    if (attachmentFiles.length === 0) return;
     event.preventDefault();
-    void addComposerImages(imageFiles);
+    void addComposerImages(attachmentFiles);
   };
 
   const insertComposerTextAtEnd = (
@@ -2621,6 +2709,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       getSendContext: () => ({
         prompt: promptRef.current,
         images: composerImagesRef.current,
+        pdfs: composerPdfsRef.current,
         terminalContexts: composerTerminalContextsRef.current,
         elementContexts: composerElementContextsRef.current,
         previewAnnotations: composerPreviewAnnotations,
@@ -2653,6 +2742,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       insertComposerDraftTerminalContext,
       promptRef,
       composerImagesRef,
+      composerPdfsRef,
       composerTerminalContextsRef,
       composerElementContextsRef,
       composerPreviewAnnotations,
@@ -3041,6 +3131,40 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                 </div>
               )}
 
+            {!isComposerCollapsedMobile &&
+              !isComposerApprovalState &&
+              pendingUserInputs.length === 0 &&
+              composerPdfs.length > 0 && (
+                <div className="mb-3 flex flex-wrap gap-2">
+                  {composerPdfs.map((pdf) => (
+                    <div
+                      key={pdf.id}
+                      className="relative flex h-16 max-w-56 items-center gap-2 rounded-lg border border-border/80 bg-background px-3 pr-8"
+                    >
+                      <FileTextIcon className="size-5 shrink-0 text-red-500" />
+                      <span className="truncate text-xs" title={pdf.name}>
+                        {pdf.name}
+                      </span>
+                      {nonPersistedComposerPdfIds.includes(pdf.id) && (
+                        <CircleAlertIcon
+                          className="absolute left-1 top-1 size-3 text-amber-600"
+                          aria-label="Draft PDF may not persist"
+                        />
+                      )}
+                      <Button
+                        variant="ghost"
+                        size="icon-xs"
+                        className="absolute right-1 top-1"
+                        onClick={() => removeComposerPdf(pdf.id)}
+                        aria-label={`Remove ${pdf.name}`}
+                      >
+                        <XIcon />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
+
             <div className="relative">
               <ComposerPromptEditor
                 editorRef={composerEditorRef}
@@ -3075,7 +3199,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                           : noProviderAvailable
                             ? "Enable a provider in Settings to send a message"
                             : phase === "disconnected"
-                              ? "Ask for follow-up changes or attach images"
+                              ? "Ask for follow-up changes or attach files"
                               : "Ask anything, @tag files/folders, $use skills, or / for commands"
                 }
                 disabled={isConnecting || isComposerApprovalState || projectSelectionRequired}

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -52,6 +52,7 @@ import {
   ChevronRightIcon,
   CircleAlertIcon,
   EyeIcon,
+  FileTextIcon,
   GlobeIcon,
   HammerIcon,
   MessageCircleIcon,
@@ -955,7 +956,7 @@ const TimelineRowContent = memo(function TimelineRowContent({ row }: { row: Time
 
 function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" }> }) {
   const ctx = use(TimelineRowCtx);
-  const userImages = row.message.attachments ?? [];
+  const userAttachments = row.message.attachments ?? [];
   const displayedUserMessage = deriveDisplayedUserMessageState(row.message.text);
   const terminalContexts = displayedUserMessage.contexts;
   const previewAnnotations: ParsedPreviewAnnotation[] = [];
@@ -971,8 +972,15 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
     ...displayedUserMessage.elementContexts,
     ...elementContextState.contexts,
   ];
-  const previewImages = userImages.filter((image) => image.name.startsWith("preview-annotation-"));
-  const regularImages = userImages.filter((image) => !image.name.startsWith("preview-annotation-"));
+  const previewImages = userAttachments.filter(
+    (attachment) =>
+      attachment.type === "image" && attachment.name.startsWith("preview-annotation-"),
+  );
+  const regularImages = userAttachments.filter(
+    (attachment) =>
+      attachment.type === "image" && !attachment.name.startsWith("preview-annotation-"),
+  );
+  const pdfs = userAttachments.filter((attachment) => attachment.type === "pdf");
   const canRevertAgentWork = typeof row.revertTurnCount === "number";
 
   return (
@@ -1011,6 +1019,25 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
             ))}
           </div>
         )}
+        {pdfs.length > 0 ? (
+          <div className="mb-2 flex max-w-[420px] flex-wrap gap-2">
+            {pdfs.map((pdf) => (
+              <a
+                key={pdf.id}
+                href={pdf.previewUrl}
+                download={pdf.name}
+                target="_blank"
+                rel="noreferrer"
+                className="flex min-w-0 max-w-full items-center gap-2 rounded-lg border border-border/80 bg-background/70 px-3 py-2 text-xs hover:bg-background"
+              >
+                <FileTextIcon className="size-5 shrink-0 text-red-500" />
+                <span className="truncate" title={pdf.name}>
+                  {pdf.name}
+                </span>
+              </a>
+            ))}
+          </div>
+        ) : null}
         {previewAnnotations.map((annotation, index) => (
           <UserMessagePreviewAnnotationCard
             key={annotation.id}
@@ -1105,6 +1132,7 @@ function TurnFoldTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "turn-
 function AssistantTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" }> }) {
   const ctx = use(TimelineRowCtx);
   const messageText = row.message.text || (row.message.streaming ? "" : "(empty response)");
+  const pdfs = (row.message.attachments ?? []).filter((attachment) => attachment.type === "pdf");
 
   return (
     <>
@@ -1117,6 +1145,25 @@ function AssistantTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "mess
           lineBreaks={shouldPreserveAssistantLineBreaks(messageText)}
           skills={ctx.skills}
         />
+        {pdfs.length > 0 ? (
+          <div className="mt-2 flex flex-wrap gap-2">
+            {pdfs.map((pdf) => (
+              <a
+                key={pdf.id}
+                href={pdf.previewUrl}
+                download={pdf.name}
+                target="_blank"
+                rel="noreferrer"
+                className="flex min-w-0 max-w-full items-center gap-2 rounded-lg border border-border/80 bg-background/70 px-3 py-2 text-xs hover:bg-background"
+              >
+                <FileTextIcon className="size-5 shrink-0 text-red-500" />
+                <span className="truncate" title={pdf.name}>
+                  {pdf.name}
+                </span>
+              </a>
+            ))}
+          </div>
+        ) : null}
         <AssistantChangedFilesSection
           turnSummary={row.assistantTurnDiffSummary}
           routeThreadKey={ctx.routeThreadKey}

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -66,6 +66,7 @@ import {
   markPromotedDraftThreads,
   markPromotedDraftThreadsByRef,
   type ComposerImageAttachment,
+  type ComposerPdfAttachment,
   useComposerDraftStore,
   DraftId,
 } from "./composerDraftStore";
@@ -98,6 +99,20 @@ function makeImage(input: {
     id: input.id,
     name,
     mimeType,
+    sizeBytes: file.size,
+    previewUrl: input.previewUrl,
+    file,
+  };
+}
+
+function makePdf(input: { id: string; previewUrl: string; name?: string }): ComposerPdfAttachment {
+  const name = input.name ?? "document.pdf";
+  const file = new File([new Uint8Array([1, 2, 3, 4])], name, { type: "application/pdf" });
+  return {
+    type: "pdf",
+    id: input.id,
+    name,
+    mimeType: "application/pdf",
     sizeBytes: file.size,
     previewUrl: input.previewUrl,
     file,
@@ -254,6 +269,24 @@ describe("composerDraftStore addImages", () => {
     const draft = draftFor(threadId, TEST_ENVIRONMENT_ID);
     expect(draft?.images.map((image) => image.id)).toEqual(["img-shared"]);
     expect(revokeSpy).not.toHaveBeenCalledWith("blob:shared");
+  });
+});
+
+describe("composerDraftStore addPdfs", () => {
+  const threadId = ThreadId.make("thread-pdf");
+  const threadRef = scopeThreadRef(TEST_ENVIRONMENT_ID, threadId);
+
+  beforeEach(() => {
+    resetComposerDraftStore();
+  });
+
+  it("keeps PDF attachments in the composer draft", () => {
+    const pdf = makePdf({ id: "pdf-1", previewUrl: "blob:pdf" });
+
+    useComposerDraftStore.getState().addPdfs(threadRef, [pdf]);
+
+    expect(draftFor(threadId, TEST_ENVIRONMENT_ID)?.pdfs).toEqual([pdf]);
+    expect(draftFor(threadId, TEST_ENVIRONMENT_ID)?.images).toEqual([]);
   });
 });
 

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -33,7 +33,12 @@ import { createModelSelection, normalizeModelSlug } from "@t3tools/shared/model"
 import { useMemo } from "react";
 import { getLocalStorageItem } from "./hooks/useLocalStorage";
 import { resolveAppModelSelection, resolveAppModelSelectionForInstance } from "./modelSelection";
-import { DEFAULT_INTERACTION_MODE, DEFAULT_RUNTIME_MODE, type ChatImageAttachment } from "./types";
+import {
+  DEFAULT_INTERACTION_MODE,
+  DEFAULT_RUNTIME_MODE,
+  type ChatImageAttachment,
+  type ChatPdfAttachment,
+} from "./types";
 import {
   type TerminalContextDraft,
   ensureInlineTerminalContextPlaceholders,
@@ -81,17 +86,27 @@ if (typeof window !== "undefined" && typeof window.addEventListener === "functio
 
 export const PersistedComposerImageAttachment = Schema.Struct({
   id: Schema.String,
+  type: Schema.optional(Schema.Literals(["image", "pdf"])),
   name: Schema.String,
   mimeType: Schema.String,
   sizeBytes: Schema.Number,
   dataUrl: Schema.String,
 });
 export type PersistedComposerImageAttachment = typeof PersistedComposerImageAttachment.Type;
+export type PersistedComposerAttachment = PersistedComposerImageAttachment;
 
-export interface ComposerImageAttachment extends Omit<ChatImageAttachment, "previewUrl"> {
+interface ComposerAttachmentPreviewState {
   previewUrl: string;
   file: File;
 }
+
+export interface ComposerImageAttachment
+  extends Omit<ChatImageAttachment, "previewUrl">, ComposerAttachmentPreviewState {}
+
+export interface ComposerPdfAttachment
+  extends Omit<ChatPdfAttachment, "previewUrl">, ComposerAttachmentPreviewState {}
+
+type ComposerAttachment = ComposerImageAttachment | ComposerPdfAttachment;
 
 const PersistedTerminalContextDraft = Schema.Struct({
   id: Schema.String,
@@ -251,7 +266,9 @@ const PersistedComposerDraftStoreStorage = Schema.Struct({
 export interface ComposerThreadDraftState {
   prompt: string;
   images: ComposerImageAttachment[];
+  pdfs: ComposerPdfAttachment[];
   nonPersistedImageIds: string[];
+  nonPersistedPdfIds: string[];
   persistedAttachments: PersistedComposerImageAttachment[];
   terminalContexts: TerminalContextDraft[];
   /**
@@ -472,6 +489,8 @@ interface ComposerDraftStoreState {
   addImage: (threadRef: ComposerThreadTarget, image: ComposerImageAttachment) => void;
   addImages: (threadRef: ComposerThreadTarget, images: ComposerImageAttachment[]) => void;
   removeImage: (threadRef: ComposerThreadTarget, imageId: string) => void;
+  addPdfs: (threadRef: ComposerThreadTarget, pdfs: ComposerPdfAttachment[]) => void;
+  removePdf: (threadRef: ComposerThreadTarget, pdfId: string) => void;
   insertTerminalContext: (
     threadRef: ComposerThreadTarget,
     prompt: string,
@@ -603,6 +622,7 @@ const EMPTY_PERSISTED_DRAFT_STORE_STATE = Object.freeze<PersistedComposerDraftSt
 });
 
 const EMPTY_IMAGES: ComposerImageAttachment[] = [];
+const EMPTY_PDFS: ComposerPdfAttachment[] = [];
 const EMPTY_IDS: string[] = [];
 const EMPTY_PERSISTED_ATTACHMENTS: PersistedComposerImageAttachment[] = [];
 const EMPTY_TERMINAL_CONTEXTS: TerminalContextDraft[] = [];
@@ -610,6 +630,7 @@ const EMPTY_ELEMENT_CONTEXTS: ElementContextDraft[] = [];
 const EMPTY_PREVIEW_ANNOTATIONS: PreviewAnnotationPayload[] = [];
 const EMPTY_REVIEW_COMMENTS: ReviewCommentContext[] = [];
 Object.freeze(EMPTY_IMAGES);
+Object.freeze(EMPTY_PDFS);
 Object.freeze(EMPTY_IDS);
 Object.freeze(EMPTY_PERSISTED_ATTACHMENTS);
 Object.freeze(EMPTY_ELEMENT_CONTEXTS);
@@ -625,7 +646,9 @@ const EMPTY_COMPOSER_DRAFT_MODEL_STATE = Object.freeze<ComposerDraftModelState>(
 const EMPTY_THREAD_DRAFT = Object.freeze<ComposerThreadDraftState>({
   prompt: "",
   images: EMPTY_IMAGES,
+  pdfs: EMPTY_PDFS,
   nonPersistedImageIds: EMPTY_IDS,
+  nonPersistedPdfIds: EMPTY_IDS,
   persistedAttachments: EMPTY_PERSISTED_ATTACHMENTS,
   terminalContexts: EMPTY_TERMINAL_CONTEXTS,
   elementContexts: EMPTY_ELEMENT_CONTEXTS,
@@ -647,7 +670,9 @@ export function createEmptyThreadDraft(): ComposerThreadDraftState {
   return {
     prompt: "",
     images: [],
+    pdfs: [],
     nonPersistedImageIds: [],
+    nonPersistedPdfIds: [],
     persistedAttachments: [],
     terminalContexts: [],
     elementContexts: [],
@@ -660,10 +685,14 @@ export function createEmptyThreadDraft(): ComposerThreadDraftState {
   };
 }
 
-function composerImageDedupKey(image: ComposerImageAttachment): string {
+function composerAttachmentDedupKey(attachment: {
+  readonly mimeType: string;
+  readonly sizeBytes: number;
+  readonly name: string;
+}): string {
   // Keep this independent from File.lastModified so dedupe is stable for hydrated
-  // images reconstructed from localStorage (which get a fresh lastModified value).
-  return `${image.mimeType}\u0000${image.sizeBytes}\u0000${image.name}`;
+  // attachments reconstructed from localStorage (which get a fresh lastModified value).
+  return `${attachment.mimeType}\u0000${attachment.sizeBytes}\u0000${attachment.name}`;
 }
 
 function terminalContextDedupKey(context: TerminalContextDraft): string {
@@ -721,6 +750,7 @@ function shouldRemoveDraft(draft: ComposerThreadDraftState): boolean {
   return (
     draft.prompt.length === 0 &&
     draft.images.length === 0 &&
+    draft.pdfs.length === 0 &&
     draft.persistedAttachments.length === 0 &&
     draft.terminalContexts.length === 0 &&
     draft.elementContexts.length === 0 &&
@@ -1079,12 +1109,41 @@ function revokeObjectPreviewUrl(previewUrl: string): void {
   URL.revokeObjectURL(previewUrl);
 }
 
+function dedupeComposerAttachments<T extends ComposerAttachment>(
+  existing: ReadonlyArray<T>,
+  incoming: ReadonlyArray<T>,
+): T[] {
+  const existingIds = new Set(existing.map((attachment) => attachment.id));
+  const existingDedupKeys = new Set(
+    existing.map((attachment) => composerAttachmentDedupKey(attachment)),
+  );
+  const acceptedPreviewUrls = new Set(existing.map((attachment) => attachment.previewUrl));
+  const dedupedIncoming: T[] = [];
+  for (const attachment of incoming) {
+    const dedupKey = composerAttachmentDedupKey(attachment);
+    if (existingIds.has(attachment.id) || existingDedupKeys.has(dedupKey)) {
+      if (!acceptedPreviewUrls.has(attachment.previewUrl)) {
+        revokeObjectPreviewUrl(attachment.previewUrl);
+      }
+      continue;
+    }
+    dedupedIncoming.push(attachment);
+    existingIds.add(attachment.id);
+    existingDedupKeys.add(dedupKey);
+    acceptedPreviewUrls.add(attachment.previewUrl);
+  }
+  return dedupedIncoming;
+}
+
 function revokeDraftThreadPreviewUrls(draft: ComposerThreadDraftState | undefined): void {
   if (!draft) {
     return;
   }
   for (const image of draft.images) {
     revokeObjectPreviewUrl(image.previewUrl);
+  }
+  for (const pdf of draft.pdfs) {
+    revokeObjectPreviewUrl(pdf.previewUrl);
   }
 }
 
@@ -1094,6 +1153,7 @@ function normalizePersistedAttachment(value: unknown): PersistedComposerImageAtt
   }
   const candidate = value as Record<string, unknown>;
   const id = candidate.id;
+  const type = candidate.type;
   const name = candidate.name;
   const mimeType = candidate.mimeType;
   const sizeBytes = candidate.sizeBytes;
@@ -1112,6 +1172,10 @@ function normalizePersistedAttachment(value: unknown): PersistedComposerImageAtt
   }
   return {
     id,
+    type:
+      type === "pdf" || mimeType === "application/pdf" || name.toLowerCase().endsWith(".pdf")
+        ? "pdf"
+        : "image",
     name,
     mimeType,
     sizeBytes,
@@ -2105,20 +2169,30 @@ function verifyPersistedAttachments(
     if (!current) {
       return state;
     }
-    const imageIdSet = new Set(current.images.map((image) => image.id));
+    const attachmentIdSet = new Set([
+      ...current.images.map((image) => image.id),
+      ...current.pdfs.map((pdf) => pdf.id),
+    ]);
     const persistedAttachments = attachments.filter(
-      (attachment) => imageIdSet.has(attachment.id) && persistedIdSet.has(attachment.id),
+      (attachment) => attachmentIdSet.has(attachment.id) && persistedIdSet.has(attachment.id),
     );
     const nonPersistedImageIds: string[] = [];
+    const nonPersistedPdfIds: string[] = [];
     for (const image of current.images) {
       if (!persistedIdSet.has(image.id)) {
         nonPersistedImageIds.push(image.id);
+      }
+    }
+    for (const pdf of current.pdfs) {
+      if (!persistedIdSet.has(pdf.id)) {
+        nonPersistedPdfIds.push(pdf.id);
       }
     }
     const nextDraft: ComposerThreadDraftState = {
       ...current,
       persistedAttachments,
       nonPersistedImageIds,
+      nonPersistedPdfIds,
     };
     const nextDraftsByThreadKey = { ...state.draftsByThreadKey };
     if (shouldRemoveDraft(nextDraft)) {
@@ -2162,25 +2236,53 @@ function hydratePersistedComposerImageAttachment(
   }
 }
 
-export function hydrateImagesFromPersisted(
+function hydrateComposerAttachmentsFromPersisted(
   attachments: ReadonlyArray<PersistedComposerImageAttachment>,
-): ComposerImageAttachment[] {
-  return attachments.flatMap((attachment) => {
+): Array<ComposerImageAttachment | ComposerPdfAttachment> {
+  const hydrated: Array<ComposerImageAttachment | ComposerPdfAttachment> = [];
+  for (const attachment of attachments) {
     const file = hydratePersistedComposerImageAttachment(attachment);
-    if (!file) return [];
+    if (!file) continue;
 
-    return [
-      {
-        type: "image" as const,
+    if (attachment.type === "pdf" || attachment.mimeType === "application/pdf") {
+      hydrated.push({
+        type: "pdf",
         id: attachment.id,
         name: attachment.name,
-        mimeType: attachment.mimeType,
+        mimeType: "application/pdf",
         sizeBytes: attachment.sizeBytes,
         previewUrl: attachment.dataUrl,
         file,
-      } satisfies ComposerImageAttachment,
-    ];
-  });
+      });
+      continue;
+    }
+    hydrated.push({
+      type: "image",
+      id: attachment.id,
+      name: attachment.name,
+      mimeType: attachment.mimeType,
+      sizeBytes: attachment.sizeBytes,
+      previewUrl: attachment.dataUrl,
+      file,
+    });
+  }
+  return hydrated;
+}
+
+export function hydrateImagesFromPersisted(
+  attachments: ReadonlyArray<PersistedComposerImageAttachment>,
+): ComposerImageAttachment[] {
+  return hydrateComposerAttachmentsFromPersisted(attachments).filter(
+    (attachment): attachment is ComposerImageAttachment => attachment.type === "image",
+  );
+}
+
+export function hydratePdfsFromPersisted(
+  attachments: ReadonlyArray<PersistedComposerImageAttachment>,
+): ComposerPdfAttachment[] {
+  return hydrateComposerAttachmentsFromPersisted(attachments).filter(
+    (attachment): attachment is ComposerPdfAttachment => attachment.type === "pdf",
+  );
 }
 
 function toHydratedThreadDraft(
@@ -2194,7 +2296,9 @@ function toHydratedThreadDraft(
   return {
     prompt: persistedDraft.prompt,
     images: hydrateImagesFromPersisted(persistedDraft.attachments),
+    pdfs: hydratePdfsFromPersisted(persistedDraft.attachments),
     nonPersistedImageIds: [],
+    nonPersistedPdfIds: [],
     persistedAttachments: [...persistedDraft.attachments],
     terminalContexts:
       persistedDraft.terminalContexts?.map((context) => ({
@@ -2970,26 +3074,7 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
           }
           set((state) => {
             const existing = state.draftsByThreadKey[threadKey] ?? createEmptyThreadDraft();
-            const existingIds = new Set(existing.images.map((image) => image.id));
-            const existingDedupKeys = new Set(
-              existing.images.map((image) => composerImageDedupKey(image)),
-            );
-            const acceptedPreviewUrls = new Set(existing.images.map((image) => image.previewUrl));
-            const dedupedIncoming: ComposerImageAttachment[] = [];
-            for (const image of images) {
-              const dedupKey = composerImageDedupKey(image);
-              if (existingIds.has(image.id) || existingDedupKeys.has(dedupKey)) {
-                // Avoid revoking a blob URL that's still referenced by an accepted image.
-                if (!acceptedPreviewUrls.has(image.previewUrl)) {
-                  revokeObjectPreviewUrl(image.previewUrl);
-                }
-                continue;
-              }
-              dedupedIncoming.push(image);
-              existingIds.add(image.id);
-              existingDedupKeys.add(dedupKey);
-              acceptedPreviewUrls.add(image.previewUrl);
-            }
+            const dedupedIncoming = dedupeComposerAttachments(existing.images, images);
             if (dedupedIncoming.length === 0) {
               return state;
             }
@@ -2999,6 +3084,28 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
                 [threadKey]: {
                   ...existing,
                   images: [...existing.images, ...dedupedIncoming],
+                },
+              },
+            };
+          });
+        },
+        addPdfs: (threadRef, pdfs) => {
+          const threadKey = resolveComposerDraftKey(get(), threadRef) ?? "";
+          if (threadKey.length === 0 || pdfs.length === 0) {
+            return;
+          }
+          set((state) => {
+            const existing = state.draftsByThreadKey[threadKey] ?? createEmptyThreadDraft();
+            const dedupedIncoming = dedupeComposerAttachments(existing.pdfs, pdfs);
+            if (dedupedIncoming.length === 0) {
+              return state;
+            }
+            return {
+              draftsByThreadKey: {
+                ...state.draftsByThreadKey,
+                [threadKey]: {
+                  ...existing,
+                  pdfs: [...existing.pdfs, ...dedupedIncoming],
                 },
               },
             };
@@ -3028,6 +3135,41 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
               nonPersistedImageIds: current.nonPersistedImageIds.filter((id) => id !== imageId),
               persistedAttachments: current.persistedAttachments.filter(
                 (attachment) => attachment.id !== imageId,
+              ),
+            };
+            const nextDraftsByThreadKey = { ...state.draftsByThreadKey };
+            if (shouldRemoveDraft(nextDraft)) {
+              delete nextDraftsByThreadKey[threadKey];
+            } else {
+              nextDraftsByThreadKey[threadKey] = nextDraft;
+            }
+            return { draftsByThreadKey: nextDraftsByThreadKey };
+          });
+        },
+        removePdf: (threadRef, pdfId) => {
+          const threadKey = resolveComposerDraftKey(get(), threadRef) ?? "";
+          if (threadKey.length === 0) {
+            return;
+          }
+          const existing = get().draftsByThreadKey[threadKey];
+          if (!existing) {
+            return;
+          }
+          const removedPdf = existing.pdfs.find((pdf) => pdf.id === pdfId);
+          if (removedPdf) {
+            revokeObjectPreviewUrl(removedPdf.previewUrl);
+          }
+          set((state) => {
+            const current = state.draftsByThreadKey[threadKey];
+            if (!current) {
+              return state;
+            }
+            const nextDraft: ComposerThreadDraftState = {
+              ...current,
+              pdfs: current.pdfs.filter((pdf) => pdf.id !== pdfId),
+              nonPersistedPdfIds: current.nonPersistedPdfIds.filter((id) => id !== pdfId),
+              persistedAttachments: current.persistedAttachments.filter(
+                (attachment) => attachment.id !== pdfId,
               ),
             };
             const nextDraftsByThreadKey = { ...state.draftsByThreadKey };
@@ -3384,6 +3526,7 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
               ...current,
               persistedAttachments: [],
               nonPersistedImageIds: [],
+              nonPersistedPdfIds: [],
             };
             const nextDraftsByThreadKey = { ...state.draftsByThreadKey };
             if (shouldRemoveDraft(nextDraft)) {
@@ -3410,6 +3553,9 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
               // Stage attempted attachments so persist middleware can try writing them.
               persistedAttachments: attachments,
               nonPersistedImageIds: current.nonPersistedImageIds.filter(
+                (id) => !attachmentIdSet.has(id),
+              ),
+              nonPersistedPdfIds: current.nonPersistedPdfIds.filter(
                 (id) => !attachmentIdSet.has(id),
               ),
             };
@@ -3439,7 +3585,9 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
               ...current,
               prompt: "",
               images: [],
+              pdfs: [],
               nonPersistedImageIds: [],
+              nonPersistedPdfIds: [],
               persistedAttachments: [],
               terminalContexts: [],
               elementContexts: [],
@@ -3468,11 +3616,16 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             for (const image of current.images) {
               revokeObjectPreviewUrl(image.previewUrl);
             }
+            for (const pdf of current.pdfs) {
+              revokeObjectPreviewUrl(pdf.previewUrl);
+            }
             const nextDraft: ComposerThreadDraftState = {
               ...current,
               prompt: ensureInlineTerminalContextPlaceholders("", current.terminalContexts.length),
               images: [],
+              pdfs: [],
               nonPersistedImageIds: [],
+              nonPersistedPdfIds: [],
               persistedAttachments: [],
             };
             const nextDraftsByThreadKey = { ...state.draftsByThreadKey };

--- a/apps/web/src/historyBootstrap.ts
+++ b/apps/web/src/historyBootstrap.ts
@@ -19,17 +19,17 @@ function messageRoleLabel(message: ChatMessage): "USER" | "ASSISTANT" {
 }
 
 function attachmentSummary(message: ChatMessage): string | null {
-  const imageAttachments = message.attachments?.filter((attachment) => attachment.type === "image");
-  const count = imageAttachments?.length ?? 0;
+  const attachments = message.attachments ?? [];
+  const count = attachments.length;
   if (count === 0) {
     return null;
   }
 
-  const names = imageAttachments?.slice(0, 3).map((image) => image.name) ?? [];
+  const names = attachments.slice(0, 3).map((attachment) => attachment.name);
   const namesSummary = names.join(", ");
   const extraCount = count - names.length;
   const extraSummary = extraCount > 0 ? ` (+${extraCount} more)` : "";
-  return `[Attached image${count === 1 ? "" : "s"}: ${namesSummary}${extraSummary}]`;
+  return `[Attached file${count === 1 ? "" : "s"}: ${namesSummary}${extraSummary}]`;
 }
 
 function buildMessageBlock(message: ChatMessage): string {

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -1,5 +1,6 @@
 import type {
   ChatImageAttachment as ContractChatImageAttachment,
+  ChatPdfAttachment as ContractChatPdfAttachment,
   OrchestrationCheckpointFile,
   OrchestrationCheckpointSummary,
   OrchestrationLatestTurn,
@@ -35,7 +36,11 @@ export interface ChatImageAttachment extends ContractChatImageAttachment {
   readonly previewUrl?: string;
 }
 
-export type ChatAttachment = ChatImageAttachment;
+export interface ChatPdfAttachment extends ContractChatPdfAttachment {
+  readonly previewUrl?: string;
+}
+
+export type ChatAttachment = ChatImageAttachment | ChatPdfAttachment;
 
 export interface ChatMessage extends Omit<OrchestrationMessage, "attachments"> {
   readonly attachments?: ReadonlyArray<ChatAttachment> | undefined;

--- a/docs/user/attachments.md
+++ b/docs/user/attachments.md
@@ -1,0 +1,5 @@
+# Attachments
+
+You can attach images and PDF files from the message composer by pasting or dropping them into the input. Attachments must be no larger than 10 MB each.
+
+PDF attachments are available with Claude, Cursor, Grok, and OpenCode. Codex currently supports image attachments only.

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -227,6 +227,39 @@ it.effect("decodes thread.turn.start defaults for provider and runtime mode", ()
   }),
 );
 
+it.effect("decodes PDF attachments in thread.turn.start", () =>
+  Effect.gen(function* () {
+    const parsed = yield* decodeThreadTurnStartCommand({
+      type: "thread.turn.start",
+      commandId: "cmd-turn-pdf",
+      threadId: "thread-1",
+      message: {
+        messageId: "msg-pdf",
+        role: "user",
+        text: "Review this document",
+        attachments: [
+          {
+            type: "pdf",
+            id: "thread-pdf-12345678-1234-1234-1234-123456789abc",
+            name: "spec.pdf",
+            mimeType: "application/pdf",
+            sizeBytes: 4,
+            dataUrl: "data:application/pdf;base64,JVBERg==",
+          },
+        ],
+      },
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    assert.deepStrictEqual(parsed.message.attachments[0], {
+      type: "pdf",
+      id: "thread-pdf-12345678-1234-1234-1234-123456789abc",
+      name: "spec.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 4,
+    });
+  }),
+);
+
 it.effect("preserves explicit provider and runtime mode in thread.turn.start", () =>
   Effect.gen(function* () {
     const parsed = yield* decodeThreadTurnStartCommand({

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -143,7 +143,9 @@ export type ProviderUserInputAnswers = typeof ProviderUserInputAnswers.Type;
 
 export const PROVIDER_SEND_TURN_MAX_INPUT_CHARS = 120_000;
 export const PROVIDER_SEND_TURN_MAX_ATTACHMENTS = 8;
-export const PROVIDER_SEND_TURN_MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+export const PROVIDER_SEND_TURN_MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+/** @deprecated Use PROVIDER_SEND_TURN_MAX_ATTACHMENT_BYTES. */
+export const PROVIDER_SEND_TURN_MAX_IMAGE_BYTES = PROVIDER_SEND_TURN_MAX_ATTACHMENT_BYTES;
 export const PROVIDER_SEND_TURN_SUPPORTED_IMAGE_MIME_TYPES = [
   "image/gif",
   "image/jpeg",
@@ -175,24 +177,52 @@ export const ChatImageAttachment = Schema.Struct({
   id: ChatAttachmentId,
   name: TrimmedNonEmptyString.check(Schema.isMaxLength(255)),
   mimeType: TrimmedNonEmptyString.check(Schema.isMaxLength(100), Schema.isPattern(/^image\//i)),
-  sizeBytes: NonNegativeInt.check(Schema.isLessThanOrEqualTo(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES)),
+  sizeBytes: NonNegativeInt.check(
+    Schema.isLessThanOrEqualTo(PROVIDER_SEND_TURN_MAX_ATTACHMENT_BYTES),
+  ),
 });
 export type ChatImageAttachment = typeof ChatImageAttachment.Type;
+
+export const ChatPdfAttachment = Schema.Struct({
+  type: Schema.Literal("pdf"),
+  id: ChatAttachmentId,
+  name: TrimmedNonEmptyString.check(Schema.isMaxLength(255)),
+  mimeType: Schema.Literal("application/pdf"),
+  sizeBytes: NonNegativeInt.check(
+    Schema.isLessThanOrEqualTo(PROVIDER_SEND_TURN_MAX_ATTACHMENT_BYTES),
+  ),
+});
+export type ChatPdfAttachment = typeof ChatPdfAttachment.Type;
 
 const UploadChatImageAttachment = Schema.Struct({
   type: Schema.Literal("image"),
   name: TrimmedNonEmptyString.check(Schema.isMaxLength(255)),
   mimeType: TrimmedNonEmptyString.check(Schema.isMaxLength(100), Schema.isPattern(/^image\//i)),
-  sizeBytes: NonNegativeInt.check(Schema.isLessThanOrEqualTo(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES)),
+  sizeBytes: NonNegativeInt.check(
+    Schema.isLessThanOrEqualTo(PROVIDER_SEND_TURN_MAX_ATTACHMENT_BYTES),
+  ),
   dataUrl: TrimmedNonEmptyString.check(
     Schema.isMaxLength(PROVIDER_SEND_TURN_MAX_IMAGE_DATA_URL_CHARS),
   ),
 });
 export type UploadChatImageAttachment = typeof UploadChatImageAttachment.Type;
 
-export const ChatAttachment = Schema.Union([ChatImageAttachment]);
+const UploadChatPdfAttachment = Schema.Struct({
+  type: Schema.Literal("pdf"),
+  name: TrimmedNonEmptyString.check(Schema.isMaxLength(255)),
+  mimeType: Schema.Literal("application/pdf"),
+  sizeBytes: NonNegativeInt.check(
+    Schema.isLessThanOrEqualTo(PROVIDER_SEND_TURN_MAX_ATTACHMENT_BYTES),
+  ),
+  dataUrl: TrimmedNonEmptyString.check(
+    Schema.isMaxLength(PROVIDER_SEND_TURN_MAX_IMAGE_DATA_URL_CHARS),
+  ),
+});
+export type UploadChatPdfAttachment = typeof UploadChatPdfAttachment.Type;
+
+export const ChatAttachment = Schema.Union([ChatImageAttachment, ChatPdfAttachment]);
 export type ChatAttachment = typeof ChatAttachment.Type;
-const UploadChatAttachment = Schema.Union([UploadChatImageAttachment]);
+const UploadChatAttachment = Schema.Union([UploadChatImageAttachment, UploadChatPdfAttachment]);
 export type UploadChatAttachment = typeof UploadChatAttachment.Type;
 
 export const ProjectScriptIcon = Schema.Literals([


### PR DESCRIPTION
## Summary

- Add PDF attachments to the web message composer, including paste/drop, draft persistence, optimistic/history rendering, and previews.
- Validate and store PDFs server-side, route them to Claude, Cursor, Grok, and OpenCode, and reject unsupported Codex PDF sends before dispatch.
- Keep mobile out of scope, add focused coverage, and document attachment behavior.

## Verification

- Focused contracts, web, and server attachment/provider tests pass.
- `git diff --check` passes.
- Package typechecks currently report unrelated upstream baseline errors in web theme dependencies and mobile toolbar prop types.

Generated by GPT-5.6 Luna in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches turn dispatch, attachment persistence, and multiple provider adapters; incorrect MIME validation or provider mapping could drop or mis-send files, though Codex is guarded on client and server.
> 
> **Overview**
> Adds **PDF attachments** end-to-end alongside existing images: contracts define `ChatPdfAttachment` / upload variants and rename the size cap to `PROVIDER_SEND_TURN_MAX_ATTACHMENT_BYTES`.
> 
> The **web composer** accepts paste/drop PDFs, shows chips in the draft, persists them with images, sends `UploadChatAttachment` PDF payloads, blocks Codex sends with a toast, and renders PDF links in the timeline. Blob preview handoff and revoke logic now cover all attachment types, not only images.
> 
> **Server** paths use `.pdf` filenames; the normalizer validates `application/pdf` data URLs and writes files; projection cleanup includes PDFs on revert. **Providers**: Claude embeds base64 `document` blocks; Cursor/Grok use new ACP `resource_link` helpers; Codex fails fast with a clear error. Stashing PDFs is explicitly unsupported for now.
> 
> User docs note the 10 MB limit and which providers accept PDFs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bb44606d5ee2a7279c69246bddc257af72bce3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add PDF attachment support to chat composer, timeline, and provider adapters
> - Extends the composer to accept PDF files via paste or file picker; PDFs count toward the shared attachment limit (10 MB each) and are blocked for the Codex provider with a warning toast.
> - Adds `ChatPdfAttachment` and `UploadChatPdfAttachment` schemas to contracts and a unified `PROVIDER_SEND_TURN_MAX_ATTACHMENT_BYTES` constant that replaces the image-only limit.
> - Server-side normalizer persists PDF attachments to disk; Claude adapter embeds PDFs as `document` content blocks; Cursor and Grok adapters attach PDFs as ACP `resource_link` entries; Codex adapter rejects PDFs with a `ProviderAdapterRequestError`.
> - PDF attachments render as downloadable chips in both user and assistant timeline rows, and draft state tracks PDFs with deduplication and blob URL cleanup.
> - Risk: stashing a prompt that includes PDFs is disallowed; any existing code that assumes `ChatAttachment` is always an image will need updating.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7bb4460. 17 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->