### PR TITLE
fix(server): settle orphaned provider sessions at startup

### DIFF
--- a/apps/server/src/provider/Layers/SessionStartupReconciler.test.ts
+++ b/apps/server/src/provider/Layers/SessionStartupReconciler.test.ts
@@ -57,14 +57,16 @@ describe("SessionStartupReconciler", () => {
       dispatched.push(command);
       return input.dispatchImplementation
         ? input.dispatchImplementation()
-        : (Effect.void as ReturnType<OrchestrationEngineService["Service"]["dispatch"]>);
+        : (Effect.succeed({ sequence: dispatched.length }) as ReturnType<
+            OrchestrationEngineService["Service"]["dispatch"]
+          >);
     });
 
     const providerService: Partial<ProviderServiceShape> = {
       listSessions: () =>
         Effect.succeed(
           (input.liveSessionThreadIds ?? []).map((threadId) => ({ threadId })),
-        ) as ReturnType<ProviderServiceShape["listSessions"]>,
+        ) as unknown as ReturnType<ProviderServiceShape["listSessions"]>,
       startSession: () => unsupported(),
       sendTurn: () => unsupported(),
       interruptTurn: () => unsupported(),
@@ -86,9 +88,7 @@ describe("SessionStartupReconciler", () => {
           latestSequence: Effect.succeed(0),
         } as unknown as OrchestrationEngineService["Service"]),
       ),
-      Layer.provideMerge(
-        Layer.succeed(ProviderService, providerService as ProviderServiceShape),
-      ),
+      Layer.provideMerge(Layer.succeed(ProviderService, providerService as ProviderServiceShape)),
       Layer.provideMerge(
         Layer.succeed(ProjectionSnapshotQuery, {
           getShellSnapshot: () =>
@@ -173,7 +173,10 @@ describe("SessionStartupReconciler", () => {
 
     await runReconcile();
 
-    expect(harness.dispatched.map((command) => command.threadId)).toEqual([activeId, archivedId]);
+    const settledThreadIds = harness.dispatched.flatMap((command) =>
+      command.type === "thread.session.set" ? [command.threadId] : [],
+    );
+    expect(settledThreadIds).toEqual([activeId, archivedId]);
   });
 
   it("skips settled sessions and sessions with a live provider process", async () => {
@@ -227,13 +230,16 @@ describe("SessionStartupReconciler", () => {
         makeThreadShell(secondId, session(secondId)),
       ],
       dispatchImplementation: () =>
-        Effect.fail(new Error("dispatch rejected")) as ReturnType<
+        Effect.die(new Error("dispatch rejected")) as ReturnType<
           OrchestrationEngineService["Service"]["dispatch"]
         >,
     });
 
     await runReconcile();
 
-    expect(harness.dispatched.map((command) => command.threadId)).toEqual([firstId, secondId]);
+    const attemptedThreadIds = harness.dispatched.flatMap((command) =>
+      command.type === "thread.session.set" ? [command.threadId] : [],
+    );
+    expect(attemptedThreadIds).toEqual([firstId, secondId]);
   });
 });

--- a/apps/server/src/provider/Layers/SessionStartupReconciler.test.ts
+++ b/apps/server/src/provider/Layers/SessionStartupReconciler.test.ts
@@ -1,0 +1,239 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { ThreadId, TurnId, type OrchestrationCommand } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as ManagedRuntime from "effect/ManagedRuntime";
+import * as Stream from "effect/Stream";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { OrchestrationEngineService } from "../../orchestration/Services/OrchestrationEngine.ts";
+import { ProjectionSnapshotQuery } from "../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import { ProviderService, type ProviderServiceShape } from "../Services/ProviderService.ts";
+import { SessionStartupReconciler } from "../Services/SessionStartupReconciler.ts";
+import { SessionStartupReconcilerLive } from "./SessionStartupReconciler.ts";
+
+const unsupported = () => Effect.die(new Error("Unsupported call in test")) as never;
+
+const now = "2026-01-01T00:00:00.000Z";
+
+interface TestSession {
+  readonly threadId: ThreadId;
+  readonly status: "starting" | "running" | "ready" | "interrupted" | "stopped" | "error";
+  readonly providerName: "codex" | "claudeAgent";
+  readonly runtimeMode: "approval-required" | "full-access" | "auto-accept-edits";
+  readonly activeTurnId: TurnId | null;
+  readonly lastError: string | null;
+  readonly updatedAt: string;
+}
+
+function makeThreadShell(id: ThreadId, session: TestSession | null) {
+  return {
+    id,
+    title: `Thread ${id}`,
+    session,
+  };
+}
+
+describe("SessionStartupReconciler", () => {
+  let runtime: ManagedRuntime.ManagedRuntime<SessionStartupReconciler, unknown> | null = null;
+
+  afterEach(async () => {
+    if (runtime) {
+      await runtime.dispose();
+    }
+    runtime = null;
+  });
+
+  function createHarness(input: {
+    readonly threads: ReadonlyArray<ReturnType<typeof makeThreadShell>>;
+    readonly archivedThreads?: ReadonlyArray<ReturnType<typeof makeThreadShell>>;
+    readonly liveSessionThreadIds?: ReadonlyArray<ThreadId>;
+    readonly dispatchImplementation?: () => ReturnType<
+      OrchestrationEngineService["Service"]["dispatch"]
+    >;
+  }) {
+    const dispatched: Array<OrchestrationCommand> = [];
+    const dispatch = vi.fn((command: OrchestrationCommand) => {
+      dispatched.push(command);
+      return input.dispatchImplementation
+        ? input.dispatchImplementation()
+        : (Effect.void as ReturnType<OrchestrationEngineService["Service"]["dispatch"]>);
+    });
+
+    const providerService: Partial<ProviderServiceShape> = {
+      listSessions: () =>
+        Effect.succeed(
+          (input.liveSessionThreadIds ?? []).map((threadId) => ({ threadId })),
+        ) as ReturnType<ProviderServiceShape["listSessions"]>,
+      startSession: () => unsupported(),
+      sendTurn: () => unsupported(),
+      interruptTurn: () => unsupported(),
+      respondToRequest: () => unsupported(),
+      respondToUserInput: () => unsupported(),
+      stopSession: () => unsupported(),
+      getCapabilities: () => unsupported(),
+      getInstanceInfo: () => unsupported(),
+      rollbackConversation: () => unsupported(),
+      streamEvents: Stream.empty,
+    };
+
+    const layer = SessionStartupReconcilerLive.pipe(
+      Layer.provideMerge(
+        Layer.succeed(OrchestrationEngineService, {
+          readEvents: () => unsupported(),
+          dispatch,
+          streamDomainEvents: Stream.empty,
+          latestSequence: Effect.succeed(0),
+        } as unknown as OrchestrationEngineService["Service"]),
+      ),
+      Layer.provideMerge(
+        Layer.succeed(ProviderService, providerService as ProviderServiceShape),
+      ),
+      Layer.provideMerge(
+        Layer.succeed(ProjectionSnapshotQuery, {
+          getShellSnapshot: () =>
+            Effect.succeed({ snapshotSequence: 0, updatedAt: now, threads: input.threads }),
+          getArchivedShellSnapshot: () =>
+            Effect.succeed({
+              snapshotSequence: 0,
+              updatedAt: now,
+              threads: input.archivedThreads ?? [],
+            }),
+        } as unknown as ProjectionSnapshotQuery["Service"]),
+      ),
+      Layer.provideMerge(NodeServices.layer),
+    );
+
+    runtime = ManagedRuntime.make(layer);
+    return { dispatch, dispatched };
+  }
+
+  async function runReconcile() {
+    const reconciler = await runtime!.runPromise(Effect.service(SessionStartupReconciler));
+    await runtime!.runPromise(reconciler.reconcile());
+  }
+
+  it("settles running sessions with no live provider process as errors", async () => {
+    const threadId = ThreadId.make("thread-orphan-running");
+    const harness = createHarness({
+      threads: [
+        makeThreadShell(threadId, {
+          threadId,
+          status: "running",
+          providerName: "claudeAgent",
+          runtimeMode: "full-access",
+          activeTurnId: TurnId.make("turn-orphaned"),
+          lastError: null,
+          updatedAt: now,
+        }),
+      ],
+    });
+
+    await runReconcile();
+
+    expect(harness.dispatched).toHaveLength(1);
+    const command = harness.dispatched[0]!;
+    expect(command.type).toBe("thread.session.set");
+    if (command.type === "thread.session.set") {
+      expect(command.threadId).toBe(threadId);
+      expect(command.session.status).toBe("error");
+      expect(command.session.activeTurnId).toBeNull();
+      expect(command.session.providerName).toBe("claudeAgent");
+      expect(command.session.lastError).toContain("did not survive");
+    }
+  });
+
+  it("settles archived threads and sessions stuck in starting", async () => {
+    const activeId = ThreadId.make("thread-orphan-starting");
+    const archivedId = ThreadId.make("thread-orphan-archived");
+    const harness = createHarness({
+      threads: [
+        makeThreadShell(activeId, {
+          threadId: activeId,
+          status: "starting",
+          providerName: "codex",
+          runtimeMode: "full-access",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: now,
+        }),
+      ],
+      archivedThreads: [
+        makeThreadShell(archivedId, {
+          threadId: archivedId,
+          status: "running",
+          providerName: "codex",
+          runtimeMode: "full-access",
+          activeTurnId: TurnId.make("turn-archived"),
+          lastError: null,
+          updatedAt: now,
+        }),
+      ],
+    });
+
+    await runReconcile();
+
+    expect(harness.dispatched.map((command) => command.threadId)).toEqual([activeId, archivedId]);
+  });
+
+  it("skips settled sessions and sessions with a live provider process", async () => {
+    const settledId = ThreadId.make("thread-settled");
+    const liveId = ThreadId.make("thread-live");
+    const harness = createHarness({
+      threads: [
+        makeThreadShell(settledId, {
+          threadId: settledId,
+          status: "ready",
+          providerName: "codex",
+          runtimeMode: "full-access",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: now,
+        }),
+        makeThreadShell(liveId, {
+          threadId: liveId,
+          status: "running",
+          providerName: "codex",
+          runtimeMode: "full-access",
+          activeTurnId: TurnId.make("turn-live"),
+          lastError: null,
+          updatedAt: now,
+        }),
+        makeThreadShell(ThreadId.make("thread-no-session"), null),
+      ],
+      liveSessionThreadIds: [liveId],
+    });
+
+    await runReconcile();
+
+    expect(harness.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("continues past dispatch failures without failing startup", async () => {
+    const firstId = ThreadId.make("thread-orphan-first");
+    const secondId = ThreadId.make("thread-orphan-second");
+    const session = (threadId: ThreadId): TestSession => ({
+      threadId,
+      status: "running",
+      providerName: "codex",
+      runtimeMode: "full-access",
+      activeTurnId: TurnId.make(`turn-${threadId}`),
+      lastError: null,
+      updatedAt: now,
+    });
+    const harness = createHarness({
+      threads: [
+        makeThreadShell(firstId, session(firstId)),
+        makeThreadShell(secondId, session(secondId)),
+      ],
+      dispatchImplementation: () =>
+        Effect.fail(new Error("dispatch rejected")) as ReturnType<
+          OrchestrationEngineService["Service"]["dispatch"]
+        >,
+    });
+
+    await runReconcile();
+
+    expect(harness.dispatched.map((command) => command.threadId)).toEqual([firstId, secondId]);
+  });
+});

--- a/apps/server/src/provider/Layers/SessionStartupReconciler.ts
+++ b/apps/server/src/provider/Layers/SessionStartupReconciler.ts
@@ -1,0 +1,116 @@
+import * as Clock from "effect/Clock";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { CommandId, type OrchestrationThreadShell } from "@t3tools/contracts";
+
+import { OrchestrationEngineService } from "../../orchestration/Services/OrchestrationEngine.ts";
+import { ProjectionSnapshotQuery } from "../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import { ProviderService } from "../Services/ProviderService.ts";
+import {
+  SessionStartupReconciler,
+  type SessionStartupReconcilerShape,
+} from "../Services/SessionStartupReconciler.ts";
+
+const ORPHANED_SESSION_ERROR =
+  "Provider session did not survive a server restart. Send a new message to continue.";
+
+// A session in either of these states claims a live provider process. After a
+// restart no provider process exists yet, so any such claim is stale unless
+// ProviderService already tracks the thread again.
+const isOrphanCandidate = (thread: OrchestrationThreadShell): boolean =>
+  thread.session !== null &&
+  (thread.session.status === "running" ||
+    thread.session.status === "starting" ||
+    thread.session.activeTurnId !== null);
+
+const makeSessionStartupReconciler = Effect.gen(function* () {
+  const orchestrationEngine = yield* OrchestrationEngineService;
+  const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
+  const providerService = yield* ProviderService;
+
+  const settleOrphan = (thread: OrchestrationThreadShell, now: string, nowMillis: number) =>
+    orchestrationEngine
+      .dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make(`startup-reconcile-${thread.id}-${nowMillis}`),
+        threadId: thread.id,
+        session: {
+          threadId: thread.id,
+          status: "error",
+          providerName: thread.session?.providerName ?? null,
+          ...(thread.session?.providerInstanceId !== undefined
+            ? { providerInstanceId: thread.session.providerInstanceId }
+            : {}),
+          runtimeMode: thread.session?.runtimeMode ?? "full-access",
+          activeTurnId: null,
+          lastError: ORPHANED_SESSION_ERROR,
+          updatedAt: now,
+        },
+        createdAt: now,
+      })
+      .pipe(
+        Effect.tap(() =>
+          Effect.logInfo("session.startup-reconciler.settled-orphan", {
+            threadId: thread.id,
+            previousStatus: thread.session?.status,
+            previousActiveTurnId: thread.session?.activeTurnId,
+          }),
+        ),
+        Effect.as(true),
+        Effect.catchCause((cause) =>
+          Effect.logWarning("session.startup-reconciler.settle-failed", {
+            threadId: thread.id,
+            cause,
+          }).pipe(Effect.as(false)),
+        ),
+      );
+
+  const sweep = Effect.gen(function* () {
+    const [shell, archived] = yield* Effect.all([
+      projectionSnapshotQuery.getShellSnapshot(),
+      projectionSnapshotQuery.getArchivedShellSnapshot(),
+    ]);
+    const liveSessions = yield* providerService.listSessions();
+    const liveThreadIds = new Set(liveSessions.map((session) => session.threadId));
+
+    const orphans = [...shell.threads, ...archived.threads].filter(
+      (thread) => isOrphanCandidate(thread) && !liveThreadIds.has(thread.id),
+    );
+    if (orphans.length === 0) {
+      return;
+    }
+
+    const nowMillis = yield* Clock.currentTimeMillis;
+    const now = new Date(nowMillis).toISOString();
+    let settledCount = 0;
+    for (const thread of orphans) {
+      if (yield* settleOrphan(thread, now, nowMillis)) {
+        settledCount += 1;
+      }
+    }
+
+    yield* Effect.logInfo("session.startup-reconciler.complete", {
+      orphanCount: orphans.length,
+      settledCount,
+    });
+  });
+
+  const reconcile: SessionStartupReconcilerShape["reconcile"] = () =>
+    sweep.pipe(
+      Effect.catch((error: unknown) =>
+        Effect.logWarning("session.startup-reconciler.failed", { error }),
+      ),
+      Effect.catchDefect((defect: unknown) =>
+        Effect.logWarning("session.startup-reconciler.defect", { defect }),
+      ),
+    );
+
+  return {
+    reconcile,
+  } satisfies SessionStartupReconcilerShape;
+});
+
+export const SessionStartupReconcilerLive = Layer.effect(
+  SessionStartupReconciler,
+  makeSessionStartupReconciler,
+);

--- a/apps/server/src/provider/Layers/SessionStartupReconciler.ts
+++ b/apps/server/src/provider/Layers/SessionStartupReconciler.ts
@@ -1,4 +1,4 @@
-import * as Clock from "effect/Clock";
+import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { CommandId, type OrchestrationThreadShell } from "@t3tools/contracts";
@@ -80,8 +80,9 @@ const makeSessionStartupReconciler = Effect.gen(function* () {
       return;
     }
 
-    const nowMillis = yield* Clock.currentTimeMillis;
-    const now = new Date(nowMillis).toISOString();
+    const nowUtc = yield* DateTime.now;
+    const now = DateTime.formatIso(nowUtc);
+    const nowMillis = DateTime.toEpochMillis(nowUtc);
     let settledCount = 0;
     for (const thread of orphans) {
       if (yield* settleOrphan(thread, now, nowMillis)) {

--- a/apps/server/src/provider/Services/SessionStartupReconciler.ts
+++ b/apps/server/src/provider/Services/SessionStartupReconciler.ts
@@ -1,0 +1,16 @@
+import * as Context from "effect/Context";
+import type * as Effect from "effect/Effect";
+
+export interface SessionStartupReconcilerShape {
+  /**
+   * Settle sessions the read model considers live but whose provider process
+   * did not survive the last shutdown. Runs once during startup, after the
+   * projection pipeline is bootstrapped and before commands are accepted.
+   */
+  readonly reconcile: () => Effect.Effect<void>;
+}
+
+export class SessionStartupReconciler extends Context.Service<
+  SessionStartupReconciler,
+  SessionStartupReconcilerShape
+>()("t3/provider/Services/SessionStartupReconciler") {}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -34,6 +34,7 @@ import { ProviderAdapterRegistryLive } from "./provider/Layers/ProviderAdapterRe
 import * as ProviderEventLoggers from "./provider/Layers/ProviderEventLoggers.ts";
 import { ProviderServiceLive } from "./provider/Layers/ProviderService.ts";
 import { ProviderSessionReaperLive } from "./provider/Layers/ProviderSessionReaper.ts";
+import { SessionStartupReconcilerLive } from "./provider/Layers/SessionStartupReconciler.ts";
 import * as OpenCodeRuntime from "./provider/opencodeRuntime.ts";
 import * as CheckpointDiffQuery from "./checkpointing/CheckpointDiffQuery.ts";
 import * as CheckpointStore from "./checkpointing/CheckpointStore.ts";
@@ -363,10 +364,10 @@ const CloudManagedEndpointRuntimeLive = Layer.mergeAll(
   ),
 );
 
-const ProviderRuntimeLayerLive = ProviderSessionReaperLive.pipe(
-  Layer.provideMerge(ProviderLayerLive),
-  Layer.provideMerge(OrchestrationLayerLive),
-);
+const ProviderRuntimeLayerLive = Layer.mergeAll(
+  ProviderSessionReaperLive,
+  SessionStartupReconcilerLive,
+).pipe(Layer.provideMerge(ProviderLayerLive), Layer.provideMerge(OrchestrationLayerLive));
 
 const RuntimeCoreDependenciesLive = ReactorLayerLive.pipe(
   // Core Services

--- a/apps/server/src/serverRuntimeStartup.ts
+++ b/apps/server/src/serverRuntimeStartup.ts
@@ -34,6 +34,7 @@ import * as AnalyticsService from "./telemetry/AnalyticsService.ts";
 import * as ServerEnvironment from "./environment/ServerEnvironment.ts";
 import * as EnvironmentAuth from "./auth/EnvironmentAuth.ts";
 import * as ProviderSessionReaper from "./provider/Services/ProviderSessionReaper.ts";
+import * as SessionStartupReconciler from "./provider/Services/SessionStartupReconciler.ts";
 import { forkParked } from "./serverActivation.ts";
 import * as ServiceLauncherClient from "./cloud/serviceLauncherClient.ts";
 import {
@@ -302,6 +303,7 @@ export const make = (options?: StartupOptions) =>
     const keybindings = yield* Keybindings.Keybindings;
     const orchestrationReactor = yield* OrchestrationReactor.OrchestrationReactor;
     const providerSessionReaper = yield* ProviderSessionReaper.ProviderSessionReaper;
+    const sessionStartupReconciler = yield* SessionStartupReconciler.SessionStartupReconciler;
     const lifecycleEvents = yield* ServerLifecycleEvents.ServerLifecycleEvents;
     const serverSettings = yield* ServerSettings.ServerSettingsService;
     const serverEnvironment = yield* ServerEnvironment.ServerEnvironment;
@@ -351,6 +353,10 @@ export const make = (options?: StartupOptions) =>
         Effect.gen(function* () {
           yield* orchestrationReactor.start().pipe(Scope.provide(reactorScope));
           yield* providerSessionReaper.start().pipe(Scope.provide(reactorScope));
+          // Settle sessions orphaned by the previous shutdown before the
+          // command gate opens, so queued user messages never wait behind a
+          // turn whose provider process no longer exists.
+          yield* sessionStartupReconciler.reconcile();
         }),
       );
 


### PR DESCRIPTION
﻿## Problem

A server restart during an active turn leaves the thread stuck on Working forever. The session row keeps `status: running` and its `activeTurnId`, but no provider process exists after the restart, so no `session.exited` event can ever arrive and nothing reconciles the read model at boot. Every message the user sends afterwards queues behind the zombie turn and is never processed. This is #4584, and it compounds the flood conditions described in #5681 (evidence from my Windows setup is on both issues).

## Fix

Add a `SessionStartupReconciler` that runs once during startup, after `reactors.start` and before the command gate opens. It reads the shell snapshot (archived threads included), finds sessions the read model considers live (`running`, `starting`, or holding an `activeTurnId`) that have no live provider process in `ProviderService.listSessions()`, and settles each one by dispatching the same `thread.session.set` shape the ingestion path uses for `session.exited` - `status: "error"`, `activeTurnId: null`, and an actionable `lastError` ("Provider session did not survive a server restart. Send a new message to continue.").

Design points:

- Mirrors the `ProviderSessionReaper` service/layer shape; wired into `ProviderRuntimeLayerLive` and the `reactors.start` startup phase.
- Runs before `commandGate.signalCommandReady`, so queued user commands never race a zombie turn.
- Cannot fail startup: dispatch failures and defects degrade to log warnings.
- Settled threads are untouched - `thread.session.set` with `error` does not unsettle a settled thread (per `decider.settled.test.ts`).

## Verification

- 4 focused tests in `SessionStartupReconciler.test.ts` (orphan settled as error, starting + archived covered, settled/live/no-session threads skipped, dispatch failure does not break the sweep).
- `tsgo --noEmit` clean on apps/server.
- Live validation: booted this branch against a snapshot of my production database (Windows 11, heavy multi-project subagent use) - the reconciler settled 4 genuinely stuck threads at boot and new messages in those threads processed normally afterwards.

Fixes #4584.

---
Model: Claude Fable 5 · Harness: Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestration session state at a critical startup boundary; incorrect orphan detection could mark valid sessions as errors, though live sessions are explicitly excluded via listSessions.
> 
> **Overview**
> Adds **`SessionStartupReconciler`**, which runs once at boot (after reactors start, before the command gate opens) so threads no longer stay stuck “Working” when a restart left `running`/`starting` sessions and zombie `activeTurnId` values with no provider process.
> 
> It compares shell + archived snapshots against **`ProviderService.listSessions()`**, then dispatches **`thread.session.set`** for each orphan (`status: "error"`, cleared turn, restart **`lastError`**). Failures are logged only so startup still completes. Wired via **`ProviderRuntimeLayerLive`** and **`reactors.start`**; four unit tests cover settle, skip, and resilient dispatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dd74bea2d9b4c66c665baf9500cc4af1851724d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Settle orphaned provider sessions at server startup
> - Adds `SessionStartupReconciler`, a new service that runs once during startup to detect and settle provider sessions that did not survive the last shutdown.
> - On startup, it reads active and archived thread snapshots, compares them against live provider sessions, and dispatches a `thread.session.set` command to transition orphaned sessions (status `running`/`starting` or with a non-null `activeTurnId`) to `error` with the message: "Provider session did not survive a server restart. Send a new message to continue."
> - Reconciliation runs best-effort — individual dispatch failures are logged as warnings and do not abort startup or block subsequent candidates.
> - Wired into `serverRuntimeStartup.ts` after the orchestration reactor and `ProviderSessionReaper` start, before the command gate opens.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5dd74be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->