### PR TITLE
fix(server): read Azure DevOps pull requests from the app

### DIFF
--- a/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.test.ts
@@ -97,6 +97,49 @@ layer("AzureDevOpsPullRequestCli.layer", (it) => {
     }),
   );
 
+  it.effect("names the repository the way az does, not the way the remote does", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output(pullRequests(1, 1))));
+      const cli = yield* AzureDevOpsPullRequestCli.AzureDevOpsPullRequestCli;
+
+      yield* cli.listPullRequests({
+        cwd: "/w",
+        // What the service calls a repository below an Azure host: the whole remote path.
+        repository: "acme/platform/_git/web",
+        state: "open",
+        involvement: "all",
+        viewer: "bilal@acme.dev",
+        limit: 10,
+      });
+
+      // az puts `--repository` straight into the REST route it builds, so the path would address
+      // a route that does not exist and Azure would answer 404 rather than an empty listing.
+      const args = argsOfCall(0);
+      assert.strictEqual(args[args.indexOf("--repository") + 1], "web");
+      expect(args).not.toContain("acme/platform/_git/web");
+    }),
+  );
+
+  it.effect("unescapes the repository name, which the remote path carries escaped", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output(pullRequests(1, 1))));
+      const cli = yield* AzureDevOpsPullRequestCli.AzureDevOpsPullRequestCli;
+
+      yield* cli.listPullRequests({
+        cwd: "/w",
+        // A project and a repository both named with a space, as the remote spells them.
+        repository: "acme/shared%20platform/_git/web%20client",
+        state: "open",
+        involvement: "all",
+        viewer: "bilal@acme.dev",
+        limit: 10,
+      });
+
+      const args = argsOfCall(0);
+      assert.strictEqual(args[args.indexOf("--repository") + 1], "web client");
+    }),
+  );
+
   it.effect("reads the page unnarrowed when asked to search, having nothing to search with", () =>
     Effect.gen(function* () {
       mockedExecute.mockReturnValueOnce(Effect.succeed(output(pullRequests(3, 1))));
@@ -400,6 +443,13 @@ layer("AzureDevOpsPullRequestCli.layer", (it) => {
       expect(argsOfCall(0)).toContain("rest");
       expect(argsOfCall(0)).toContain(
         "https://dev.azure.com/acme/platform/_apis/git/r/web/pullRequests/42/threads?api-version=7.1",
+      );
+      // Azure DevOps is not the resource az asks for a token for by default, and it answers the
+      // sign-in page rather than refusing the wrong one, so the call has to name it.
+      const args = argsOfCall(0);
+      assert.strictEqual(
+        args[args.indexOf("--resource") + 1],
+        "499b84ac-1321-427f-aa17-267ca6975798",
       );
     }),
   );

--- a/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.ts
+++ b/apps/server/src/pullRequest/AzureDevOpsPullRequestCli.ts
@@ -112,6 +112,14 @@ export type AzureDevOpsPullRequestCliError =
 /** The version every REST call below is pinned to, so a new default cannot reshape a response. */
 const REST_API_VERSION = "7.1";
 
+/**
+ * The application `az rest` has to ask for a token for. Azure DevOps is not the resource az
+ * defaults to, and it does not refuse the wrong token: it answers the sign-in page, as HTML, with
+ * a status the CLI reports as success. So a call without this reads as a decode failure on a
+ * response nobody asked for rather than as the unauthenticated call it is.
+ */
+const AZURE_DEVOPS_RESOURCE_ID = "499b84ac-1321-427f-aa17-267ca6975798";
+
 export class AzureDevOpsPullRequestCli extends Context.Service<
   AzureDevOpsPullRequestCli,
   {
@@ -172,6 +180,28 @@ export class AzureDevOpsPullRequestCli extends Context.Service<
     }) => Effect.Effect<void, AzureDevOpsPullRequestCliError>;
   }
 >()("t3/pullRequest/AzureDevOpsPullRequestCli") {}
+
+/**
+ * The repository name `az` wants. The service names a repository the way its remote does — below
+ * an Azure host that is the whole path, `{organization}/{project}/_git/{repository}` — but
+ * `--repository` takes a name or an id, and az interpolates whatever it is given straight into the
+ * REST route it builds. A path there does not narrow the listing to the wrong repository; it
+ * addresses a route that does not exist, and Azure answers 404.
+ *
+ * The last segment is the name. It is unescaped because the path carries it as the remote spells
+ * it: a project or a repository named with a space reaches this as `%20`, which Azure would look
+ * up literally. A name recorded without a path is already a name and survives both steps.
+ */
+function repositoryNameOf(repository: string): string {
+  const name = repository.split("/").findLast((segment) => segment.length > 0);
+  if (name === undefined) return repository.trim();
+  try {
+    return decodeURIComponent(name);
+  } catch {
+    // A stray `%` is not an escape, so the name is whatever the remote spelled.
+    return name;
+  }
+}
 
 function statusArgs(state: PullRequestListState): ReadonlyArray<string> {
   switch (state) {
@@ -365,7 +395,8 @@ export const make = Effect.gen(function* () {
     listPullRequests: (input) =>
       listPullRequestPage({
         cwd: input.cwd,
-        repository: input.repository,
+        // Translated once, here, so every page of the walk asks for the same repository.
+        repository: repositoryNameOf(input.repository),
         state: input.state,
         involvement: input.involvement,
         viewer: input.viewer,
@@ -419,6 +450,8 @@ export const make = Effect.gen(function* () {
           "rest",
           "--method",
           "get",
+          "--resource",
+          AZURE_DEVOPS_RESOURCE_ID,
           "--url",
           `${input.threadsUrl}?api-version=${REST_API_VERSION}`,
         ],


### PR DESCRIPTION
## What Changed

Two independent reasons an Azure DevOps repository could not be read from the pull requests page.

**`az repos pr list --repository` was given a path, not a name.** The service names a repository the way its remote does, which below an Azure host is the whole path, `{organization}/{project}/_git/{repository}`. `az` takes a name or an id there and interpolates whatever it is given straight into the REST route it builds, so it addressed a route that does not exist and Azure answered 404. The page then reported the repository as unreadable and listed nothing. The name is now taken from the path and unescaped, because a project or repository named with a space reaches this as `%20`, which Azure would look up literally.

**The conversation read did not name the Azure DevOps resource.** `az rest` asked for a token for the resource it defaults to. Azure does not refuse the wrong one: it answers the sign-in page, as HTML, with a status the CLI reports as success, so the response failed to decode and no comment was ever shown. The call now passes `--resource 499b84ac-1321-427f-aa17-267ca6975798`.

Both are argument fixes to the `az` calls. No error semantics change: a thread read that fails still degrades to an empty conversation exactly as it does today.

## Why

The sidebar's pull request pill stopped opening the browser once the multi-provider page began claiming links it recognises, so for Azure DevOps hosts the click now lands on a surface that could not read the host.

Existing Azure tests passed throughout because every fixture used a bare repository name (`web`, `acme/web`), which the repository identity resolver never produces for an Azure remote. The added tests use the real `{organization}/{project}/_git/{repository}` shape, including an escaped space.

## Verification

Against a live Azure DevOps organization, in a checkout whose identity carries an escaped project name:

- the previous list command → `ERROR: The controller for path '/…/_apis/git/repositories/{organization}/{project}/_git/{repository}/pullRequests' was not found or does not implement IController. Operation returned a 404 status code.`
- the fixed list command → exit 0, `limit + 1` rows, so the truncation probe still works
- the previous threads command → exit 0 with an HTML sign-in page as the body
- the fixed threads command → exit 0, valid JSON, real thread records

Repo checks:

- `pnpm exec vp test run src/pullRequest` — 373 passed, 13 files (2 tests added)
- `pnpm exec tsgo --noEmit` in `apps/server` — exit 0, no new diagnostics
- `pnpm exec vp lint --report-unused-disable-directives` on the two changed files — clean

Note: `src/sourceControl/PrTemplateDetection.test.ts` (3) and `SourceControlRepositoryService.test.ts` (1) fail on this branch. I confirmed by stashing that they fail identically on unmodified `main` — pre-existing and unrelated.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changed, so there are no before/after screenshots
- [x] No animation or interaction changes require a video

Implemented with Claude Opus 5 (1M context) through the Claude Code harness in T3 Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Azure DevOps `az` commands are parameterized for all PR list and thread reads; wrong mapping would break listings or conversations for Azure remotes, but scope is limited to the Azure DevOps CLI adapter.
> 
> **Overview**
> Fixes Azure DevOps pull request listing and thread reads when the app passes **full remote repository paths** and when **`az rest`** needs an explicit DevOps resource.
> 
> **`listPullRequests`** now runs remote-style paths like `acme/platform/_git/web` through **`repositoryNameOf`** so `az repos pr list --repository` gets the bare repo name (`web`), avoiding REST routes that 404. Percent-encoded names (e.g. `web%20client`) are decoded before the CLI call.
> 
> **`listThreads`** adds **`--resource 499b84ac-1321-427f-aa17-267ca6975798`** on `az rest` so token acquisition targets Azure DevOps instead of returning an HTML sign-in page that was mistaken for JSON.
> 
> Tests cover path-to-name mapping, unescaping, and the new `--resource` argument on thread fetches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4785c82a667af46f22a1c70dc5cfe793f0a7591. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Azure DevOps pull request reading by decoding repository names and using correct resource ID
> - Adds `repositoryNameOf` helper in [`AzureDevOpsPullRequestCli.ts`](https://github.com/pingdotgg/t3code/pull/7316/files#diff-0b8f5ada7e21620936578efa3bd5442f2cad625b88400c60e0cb4752f24d95c7) to extract the last path segment from a remote-style repository URL and decode any percent-encoded characters before passing it to `az`, preventing 404s.
> - Passes `--resource <AZURE_DEVOPS_RESOURCE_ID>` to `az rest` calls in `listThreads` so tokens are acquired for the correct Azure DevOps resource, avoiding HTML sign-in responses that caused JSON decode failures.
> - Behavioral Change: `listPullRequests` and `listThreads` now always use the decoded repository name; callers passing full remote paths will see different `az` arguments than before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e4785c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->