### PR TITLE
fix(desktop): improve browser cookie import detection

### DIFF
--- a/apps/desktop/src/preview/BrowserImport/BrowserImport.ts
+++ b/apps/desktop/src/preview/BrowserImport/BrowserImport.ts
@@ -171,19 +171,13 @@ export const make = Effect.gen(function* BrowserImportMake() {
     );
     // Try each candidate path and use the first one that exists. Chromium 96+
     // moved the cookie database into `Network/Cookies`, so both locations are
-    // checked. The stat is synchronous because it is a fast local-FS probe and
-    // avoids needing to pick an Effect pipe combinator that varies across
-    // beta releases.
-    const nodeFs = require("node:fs") as typeof import("node:fs");
-    const databasePath = (() => {
-      for (const candidate of candidates) {
-        try {
-          nodeFs.statSync(candidate);
-          return candidate;
-        } catch {}
-      }
-      return undefined;
-    })();
+    // checked. The FileSystem service comes from the captured platformServices
+    // context so this method keeps its empty requirements channel.
+    const fileSystem = Context.get(platformServices, FileSystem.FileSystem);
+    const existing = yield* Effect.forEach(candidates, (candidate) =>
+      fileSystem.exists(candidate).pipe(Effect.orElseSucceed(() => false)),
+    );
+    const databasePath = candidates.find((_, index) => existing[index]);
     if (databasePath === undefined) {
       // A profile we listed moments ago can lose its database before the
       // import runs (browser data cleanup, a profile reset). That is a read

--- a/apps/desktop/src/preview/BrowserImport/BrowserImport.ts
+++ b/apps/desktop/src/preview/BrowserImport/BrowserImport.ts
@@ -32,7 +32,7 @@ import { FirefoxCookieReadError, readFirefoxCookies } from "./FirefoxCookies.ts"
 import { readSafariCookies, SafariCookieReadError } from "./SafariCookies.ts";
 import {
   BROWSER_IMPORT_SOURCES,
-  cookieDatabasePath,
+  cookieDatabaseCandidatePaths,
   isSourceInstalled,
   isSourceRunning,
   listSourceProfiles,
@@ -164,7 +164,23 @@ export const make = Effect.gen(function* BrowserImportMake() {
       });
     }
 
-    const databasePath = cookieDatabasePath(definition, pathContext, requestedProfile.directory);
+    const candidates = cookieDatabaseCandidatePaths(
+      definition,
+      pathContext,
+      requestedProfile.directory,
+    );
+    const databasePath =
+      candidates.length === 0
+        ? undefined
+        : yield* Effect.gen(function* () {
+            const fileSystem = yield* FileSystem.FileSystem;
+            return yield* Effect.forEach(candidates, (candidate) =>
+              fileSystem.stat(candidate).pipe(
+                Effect.map(() => candidate),
+                Effect.orElse(() => Effect.succeed(undefined)),
+              ),
+            ).pipe(Effect.map((results) => results.find((p) => p !== undefined)));
+          });
     if (databasePath === undefined) {
       return yield* new BrowserImportFailedError({
         sourceId: definition.id,

--- a/apps/desktop/src/preview/BrowserImport/BrowserImport.ts
+++ b/apps/desktop/src/preview/BrowserImport/BrowserImport.ts
@@ -171,11 +171,19 @@ export const make = Effect.gen(function* BrowserImportMake() {
     );
     // Try each candidate path and use the first one that exists. Chromium 96+
     // moved the cookie database into `Network/Cookies`, so both locations are
-    // checked. The FileSystem service comes from the captured platformServices
-    // context so this method keeps its empty requirements channel.
+    // checked. The probe is `stat`, matching `entryExists` in Sources.ts rather
+    // than `access`/`exists`: TCC permits `stat` on Safari's jar but can deny
+    // `access`, so an `exists` check would report missing a database the
+    // listing just proved present and fail the import with `readFailed`
+    // instead of reaching the Full Disk Access path. The FileSystem service
+    // comes from the captured platformServices context so this method keeps
+    // its empty requirements channel.
     const fileSystem = Context.get(platformServices, FileSystem.FileSystem);
     const existing = yield* Effect.forEach(candidates, (candidate) =>
-      fileSystem.exists(candidate).pipe(Effect.orElseSucceed(() => false)),
+      fileSystem.stat(candidate).pipe(
+        Effect.as(true),
+        Effect.orElseSucceed(() => false),
+      ),
     );
     const databasePath = candidates.find((_, index) => existing[index]);
     if (databasePath === undefined) {

--- a/apps/desktop/src/preview/BrowserImport/BrowserImport.ts
+++ b/apps/desktop/src/preview/BrowserImport/BrowserImport.ts
@@ -169,22 +169,28 @@ export const make = Effect.gen(function* BrowserImportMake() {
       pathContext,
       requestedProfile.directory,
     );
-    const databasePath =
-      candidates.length === 0
-        ? undefined
-        : yield* Effect.gen(function* () {
-            const fileSystem = yield* FileSystem.FileSystem;
-            return yield* Effect.forEach(candidates, (candidate) =>
-              fileSystem.stat(candidate).pipe(
-                Effect.map(() => candidate),
-                Effect.orElse(() => Effect.succeed(undefined)),
-              ),
-            ).pipe(Effect.map((results) => results.find((p) => p !== undefined)));
-          });
+    // Try each candidate path and use the first one that exists. Chromium 96+
+    // moved the cookie database into `Network/Cookies`, so both locations are
+    // checked. The stat is synchronous because it is a fast local-FS probe and
+    // avoids needing to pick an Effect pipe combinator that varies across
+    // beta releases.
+    const nodeFs = require("node:fs") as typeof import("node:fs");
+    const databasePath = (() => {
+      for (const candidate of candidates) {
+        try {
+          nodeFs.statSync(candidate);
+          return candidate;
+        } catch {}
+      }
+      return undefined;
+    })();
     if (databasePath === undefined) {
+      // A profile we listed moments ago can lose its database before the
+      // import runs (browser data cleanup, a profile reset). That is a read
+      // failure, not a platform problem.
       return yield* new BrowserImportFailedError({
         sourceId: definition.id,
-        reason: "unsupportedPlatform",
+        reason: "readFailed",
       });
     }
 

--- a/apps/desktop/src/preview/BrowserImport/Sources.test.ts
+++ b/apps/desktop/src/preview/BrowserImport/Sources.test.ts
@@ -188,6 +188,43 @@ describe("listSourceProfiles", () => {
     ),
   );
 
+  it.effect("drops Firefox profiles that hold no cookie database", () =>
+    run(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const context = yield* withSourceHome();
+        const root = firefox.userDataDirectory(context)!;
+        yield* fileSystem.makeDirectory(root, { recursive: true });
+        yield* fileSystem.writeFileString(
+          `${root}/profiles.ini`,
+          `[Profile0]
+Name=original
+IsRelative=1
+Path=Profiles/abcd.default-release
+Default=1
+
+[Profile1]
+Name=empty
+IsRelative=1
+Path=Profiles/wxyz.empty
+`,
+        );
+        yield* fileSystem.makeDirectory(`${root}/Profiles/abcd.default-release`, {
+          recursive: true,
+        });
+        yield* fileSystem.writeFileString(
+          `${root}/Profiles/abcd.default-release/cookies.sqlite`,
+          "db",
+        );
+        yield* fileSystem.makeDirectory(`${root}/Profiles/wxyz.empty`, { recursive: true });
+
+        assert.deepEqual(yield* listSourceProfiles(firefox, context), [
+          { directory: "Profiles/abcd.default-release", name: "original" },
+        ]);
+      }),
+    ),
+  );
+
   it.effect("discovers profiles with cookies under Network/ (Chromium 127+)", () =>
     run(
       Effect.gen(function* () {

--- a/apps/desktop/src/preview/BrowserImport/Sources.test.ts
+++ b/apps/desktop/src/preview/BrowserImport/Sources.test.ts
@@ -12,6 +12,7 @@ import * as NodeSqlite from "node:sqlite";
 import type { BrowserImportPathContext } from "./Sources.ts";
 import {
   BROWSER_IMPORT_SOURCES,
+  cookieDatabaseCandidatePaths,
   cookieDatabasePath,
   isSourceInstalled,
   isSourceRunning,
@@ -105,6 +106,20 @@ describe("isSourceInstalled", () => {
       }),
     ),
   );
+
+  it.effect("detects a Chromium 127+ install with cookies under Network/", () =>
+    run(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const context = yield* withSourceHome();
+        const root = userDataDirectory(context);
+
+        yield* fileSystem.makeDirectory(`${root}/Default/Network`, { recursive: true });
+        yield* fileSystem.writeFileString(`${root}/Default/Network/Cookies`, "db");
+        assert.isTrue(yield* isSourceInstalled(helium, context));
+      }),
+    ),
+  );
 });
 
 describe("listSourceProfiles", () => {
@@ -173,6 +188,22 @@ describe("listSourceProfiles", () => {
     ),
   );
 
+  it.effect("discovers profiles with cookies under Network/ (Chromium 127+)", () =>
+    run(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const context = yield* withSourceHome();
+        const root = userDataDirectory(context);
+        yield* fileSystem.makeDirectory(`${root}/Default/Network`, { recursive: true });
+        yield* fileSystem.writeFileString(`${root}/Default/Network/Cookies`, "db");
+
+        assert.deepEqual(yield* listSourceProfiles(helium, context), [
+          { directory: "Default", name: "Default" },
+        ]);
+      }),
+    ),
+  );
+
   it.effect("counts a profile's cookies without decrypting them", () =>
     run(
       Effect.gen(function* () {
@@ -193,11 +224,50 @@ describe("cookieDatabasePath", () => {
   it.effect("places the database under the requested source profile", () =>
     run(
       Effect.gen(function* () {
+        const path = yield* Path.Path;
         const context = yield* withSourceHome();
         assert.equal(
           cookieDatabasePath(helium, context, "Profile 1"),
-          `${context.home}/Library/Application Support/net.imput.helium/Profile 1/Cookies`,
+          path.join(context.home, "Library/Application Support/net.imput.helium/Profile 1/Cookies"),
         );
+      }),
+    ),
+  );
+});
+
+describe("cookieDatabaseCandidatePaths", () => {
+  it.effect("returns both Cookies and Network/Cookies for Chromium engines", () =>
+    run(
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const context = yield* withSourceHome();
+        const candidates = cookieDatabaseCandidatePaths(helium, context, "Default");
+        assert.deepEqual(candidates, [
+          path.join(context.home, "Library/Application Support/net.imput.helium/Default/Cookies"),
+          path.join(
+            context.home,
+            "Library/Application Support/net.imput.helium/Default/Network/Cookies",
+          ),
+        ]);
+      }),
+    ),
+  );
+
+  it.effect("returns only cookies.sqlite for Firefox", () =>
+    run(
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const context = yield* sourcePathContext.pipe(
+          Effect.provideService(HostProcessEnvironment, { HOME: "/tmp/test" }),
+          Effect.provideService(HostProcessPlatform, "darwin"),
+        );
+        const candidates = cookieDatabaseCandidatePaths(firefox, context, "Profiles/abc.default");
+        assert.deepEqual(candidates, [
+          path.join(
+            "/tmp/test",
+            "Library/Application Support/Firefox/Profiles/abc.default/cookies.sqlite",
+          ),
+        ]);
       }),
     ),
   );
@@ -229,6 +299,28 @@ describe("isSourceRunning for Firefox", () => {
 
         yield* fileSystem.writeFileString(`${profile}/.parentlock`, "");
         assert.isTrue(yield* isSourceRunning(firefox, context));
+      }),
+    ),
+  );
+
+  it.effect("does not treat a stale parent.lock file as a running browser", () =>
+    run(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const home = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3code-firefox-" });
+        const context = yield* sourcePathContext.pipe(
+          Effect.provideService(HostProcessEnvironment, { HOME: home }),
+          Effect.provideService(HostProcessPlatform, "win32"),
+        );
+        const root = firefox.userDataDirectory(context)!;
+        const profile = `${root}/Profiles/gx7x7fqx.default-release`;
+        yield* fileSystem.makeDirectory(profile, { recursive: true });
+
+        // On Windows, Firefox creates parent.lock as a regular file that
+        // persists after the process exits. The file is only locked while
+        // Firefox is running; the old stat-based check always found it.
+        yield* fileSystem.writeFileString(`${profile}/parent.lock`, "");
+        assert.isFalse(yield* isSourceRunning(firefox, context));
       }),
     ),
   );

--- a/apps/desktop/src/preview/BrowserImport/Sources.test.ts
+++ b/apps/desktop/src/preview/BrowserImport/Sources.test.ts
@@ -21,7 +21,6 @@ import {
 } from "./Sources.ts";
 
 const helium = BROWSER_IMPORT_SOURCES.find((source) => source.id === "helium")!;
-const chrome = BROWSER_IMPORT_SOURCES.find((source) => source.id === "chrome")!;
 
 /** A scratch home with the source's user-data directory already created. */
 const withSourceHome = Effect.fnUntraced(function* () {
@@ -72,30 +71,6 @@ describe("isSourceRunning", () => {
         );
 
         assert.isTrue(yield* isSourceRunning(helium, context));
-      }),
-    ),
-  );
-
-  it.effect("does not treat a stale Chromium lockfile as a running browser", () =>
-    run(
-      Effect.gen(function* () {
-        const fileSystem = yield* FileSystem.FileSystem;
-        const home = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3code-chrome-" });
-        const context = yield* sourcePathContext.pipe(
-          Effect.provideService(HostProcessEnvironment, {
-            HOME: home,
-            USERPROFILE: home,
-            LOCALAPPDATA: `${home}\\AppData\\Local`,
-          }),
-          Effect.provideService(HostProcessPlatform, "win32"),
-        );
-        const root = chrome.userDataDirectory(context)!;
-        yield* fileSystem.makeDirectory(root, { recursive: true });
-
-        // On Windows Chromium locks `lockfile` via LockFileEx; the file itself
-        // persists after the browser exits, so mere existence is not running.
-        yield* fileSystem.writeFileString(`${root}\\lockfile`, "");
-        assert.isFalse(yield* isSourceRunning(chrome, context));
       }),
     ),
   );
@@ -336,7 +311,6 @@ describe("cookieDatabaseCandidatePaths", () => {
 });
 
 const firefox = BROWSER_IMPORT_SOURCES.find((source) => source.id === "firefox")!;
-const opera = BROWSER_IMPORT_SOURCES.find((source) => source.id === "opera")!;
 
 describe("isSourceRunning for Firefox", () => {
   it.effect("finds the lock inside the profile, not at the root", () =>
@@ -389,29 +363,18 @@ describe("isSourceRunning for Firefox", () => {
 });
 
 describe("Windows user-data directories", () => {
-  it.effect("puts Opera under roaming AppData without a User Data level", () =>
-    run(
-      Effect.gen(function* () {
-        const context = yield* sourcePathContext.pipe(
-          Effect.provideService(HostProcessEnvironment, {
-            USERPROFILE: "C:\\Users\\u",
-            APPDATA: "C:\\Users\\u\\AppData\\Roaming",
-            LOCALAPPDATA: "C:\\Users\\u\\AppData\\Local",
-          }),
-          Effect.provideService(HostProcessPlatform, "win32"),
-        );
-
-        // Opera does not follow the local-AppData `User Data` convention its
-        // Chromium relatives use, so deriving it that way never found it.
-        assert.include(opera.userDataDirectory(context) ?? "", "Roaming");
-        assert.include(opera.userDataDirectory(context) ?? "", "Opera Stable");
-        assert.notInclude(opera.userDataDirectory(context) ?? "", "User Data");
-
-        const chrome = BROWSER_IMPORT_SOURCES.find((source) => source.id === "chrome")!;
-        assert.include(chrome.userDataDirectory(context) ?? "", "Local");
-        assert.include(chrome.userDataDirectory(context) ?? "", "User Data");
-      }),
-    ),
+  it.effect("does not support any Chromium fork on win32", () =>
+    Effect.gen(function* () {
+      // No Chromium fork lists win32 anymore: since Chrome 127 their cookies
+      // are App-Bound Encrypted, so nothing can import them. Omitting the
+      // platform is what makes `unavailableReason` report `unsupportedPlatform`,
+      // hiding these sources like Arc and Helium.
+      for (const source of BROWSER_IMPORT_SOURCES) {
+        if (source.engine === "chromium") {
+          assert.notInclude(source.platforms, "win32");
+        }
+      }
+    }),
   );
 });
 

--- a/apps/desktop/src/preview/BrowserImport/Sources.test.ts
+++ b/apps/desktop/src/preview/BrowserImport/Sources.test.ts
@@ -224,6 +224,26 @@ Path=Profiles/wxyz.empty
     ),
   );
 
+  it.effect("drops empty profiles when falling back to the Profiles/ scan", () =>
+    run(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const context = yield* withSourceHome();
+        const root = firefox.userDataDirectory(context)!;
+        yield* fileSystem.makeDirectory(`${root}/Profiles/filled.default`, { recursive: true });
+        yield* fileSystem.writeFileString(`${root}/Profiles/filled.default/cookies.sqlite`, "db");
+        yield* fileSystem.makeDirectory(`${root}/Profiles/empty.default`, { recursive: true });
+
+        assert.deepEqual(yield* listSourceProfiles(firefox, context), [
+          {
+            directory: context.path.join("Profiles", "filled.default"),
+            name: "filled.default",
+          },
+        ]);
+      }),
+    ),
+  );
+
   it.effect("discovers profiles with cookies under Network/ (Chromium 127+)", () =>
     run(
       Effect.gen(function* () {
@@ -309,6 +329,7 @@ describe("isSourceRunning for Firefox", () => {
         const root = firefox.userDataDirectory(context)!;
         const profile = `${root}/Profiles/abcd.default-release`;
         yield* fileSystem.makeDirectory(profile, { recursive: true });
+        yield* fileSystem.writeFileString(`${profile}/cookies.sqlite`, "db");
 
         assert.isFalse(yield* isSourceRunning(firefox, context));
 
@@ -335,6 +356,7 @@ describe("isSourceRunning for Firefox", () => {
         const root = firefox.userDataDirectory(context)!;
         const profile = `${root}/Profiles/gx7x7fqx.default-release`;
         yield* fileSystem.makeDirectory(profile, { recursive: true });
+        yield* fileSystem.writeFileString(`${profile}/cookies.sqlite`, "db");
 
         // On Windows, Firefox creates parent.lock as a regular file that
         // persists after the process exits. The file is only locked while

--- a/apps/desktop/src/preview/BrowserImport/Sources.test.ts
+++ b/apps/desktop/src/preview/BrowserImport/Sources.test.ts
@@ -13,7 +13,6 @@ import type { BrowserImportPathContext } from "./Sources.ts";
 import {
   BROWSER_IMPORT_SOURCES,
   cookieDatabaseCandidatePaths,
-  cookieDatabasePath,
   isSourceInstalled,
   isSourceRunning,
   listSourceProfiles,
@@ -257,34 +256,19 @@ Path=Profiles/wxyz.empty
   );
 });
 
-describe("cookieDatabasePath", () => {
-  it.effect("places the database under the requested source profile", () =>
-    run(
-      Effect.gen(function* () {
-        const path = yield* Path.Path;
-        const context = yield* withSourceHome();
-        assert.equal(
-          cookieDatabasePath(helium, context, "Profile 1"),
-          path.join(context.home, "Library/Application Support/net.imput.helium/Profile 1/Cookies"),
-        );
-      }),
-    ),
-  );
-});
-
 describe("cookieDatabaseCandidatePaths", () => {
-  it.effect("returns both Cookies and Network/Cookies for Chromium engines", () =>
+  it.effect("prefers Network/Cookies and falls back to legacy Cookies", () =>
     run(
       Effect.gen(function* () {
         const path = yield* Path.Path;
         const context = yield* withSourceHome();
         const candidates = cookieDatabaseCandidatePaths(helium, context, "Default");
         assert.deepEqual(candidates, [
-          path.join(context.home, "Library/Application Support/net.imput.helium/Default/Cookies"),
           path.join(
             context.home,
             "Library/Application Support/net.imput.helium/Default/Network/Cookies",
           ),
+          path.join(context.home, "Library/Application Support/net.imput.helium/Default/Cookies"),
         ]);
       }),
     ),

--- a/apps/desktop/src/preview/BrowserImport/Sources.test.ts
+++ b/apps/desktop/src/preview/BrowserImport/Sources.test.ts
@@ -21,6 +21,7 @@ import {
 } from "./Sources.ts";
 
 const helium = BROWSER_IMPORT_SOURCES.find((source) => source.id === "helium")!;
+const chrome = BROWSER_IMPORT_SOURCES.find((source) => source.id === "chrome")!;
 
 /** A scratch home with the source's user-data directory already created. */
 const withSourceHome = Effect.fnUntraced(function* () {
@@ -71,6 +72,30 @@ describe("isSourceRunning", () => {
         );
 
         assert.isTrue(yield* isSourceRunning(helium, context));
+      }),
+    ),
+  );
+
+  it.effect("does not treat a stale Chromium lockfile as a running browser", () =>
+    run(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const home = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3code-chrome-" });
+        const context = yield* sourcePathContext.pipe(
+          Effect.provideService(HostProcessEnvironment, {
+            HOME: home,
+            USERPROFILE: home,
+            LOCALAPPDATA: `${home}\\AppData\\Local`,
+          }),
+          Effect.provideService(HostProcessPlatform, "win32"),
+        );
+        const root = chrome.userDataDirectory(context)!;
+        yield* fileSystem.makeDirectory(root, { recursive: true });
+
+        // On Windows Chromium locks `lockfile` via LockFileEx; the file itself
+        // persists after the browser exits, so mere existence is not running.
+        yield* fileSystem.writeFileString(`${root}\\lockfile`, "");
+        assert.isFalse(yield* isSourceRunning(chrome, context));
       }),
     ),
   );

--- a/apps/desktop/src/preview/BrowserImport/Sources.ts
+++ b/apps/desktop/src/preview/BrowserImport/Sources.ts
@@ -337,10 +337,7 @@ const entryExists = Effect.fnUntraced(function* (path: string) {
  * disk after the process exits; `stat` always succeeds, so we must try to
  * open the file with write access to detect the active lock.
  */
-const isLockHeld = Effect.fnUntraced(function* (
-  lockPath: string,
-  platform: "darwin" | "linux" | "win32",
-) {
+const isLockHeld = Effect.fnUntraced(function* (lockPath: string, platform: NodeJS.Platform) {
   if (platform !== "win32") return yield* entryExists(lockPath);
   return yield* Effect.tryPromise({
     try: () =>
@@ -355,7 +352,7 @@ const isLockHeld = Effect.fnUntraced(function* (
         });
       }),
     catch: () => false,
-  });
+  }).pipe(Effect.catchCause(() => Effect.succeed(false)));
 });
 
 /** Shape of the slice of Chromium's `Local State` that names its profiles. */
@@ -391,7 +388,7 @@ const countProfileCookies = Effect.fnUntraced(function* (
   definition: BrowserImportSourceDefinition,
   context: BrowserImportPathContext,
   directory: string,
-): Effect.fn.Return<number | undefined, never> {
+): Effect.fn.Return<number | undefined, never, FileSystem.FileSystem> {
   const candidates = cookieDatabaseCandidatePaths(definition, context, directory);
   const databasePath = yield* Effect.forEach(candidates, (candidate) =>
     entryExists(candidate).pipe(Effect.map((exists) => (exists ? candidate : undefined))),
@@ -448,7 +445,19 @@ export const listSourceProfiles = Effect.fn("BrowserImportSources.listSourceProf
       Effect.map(parseFirefoxProfiles),
       Effect.orElseSucceed(() => [] as ReadonlyArray<BrowserImportSourceProfile>),
     );
-    if (declared.length > 0) return declared;
+    // `profiles.ini` also lists profiles the installer created but the user
+    // never launched, which hold no cookie database and nothing to import.
+    // Only keep the ones a database proves exist, like the directory scans
+    // below do.
+    if (declared.length > 0) {
+      const found = yield* Effect.forEach(declared, (profile) =>
+        Effect.forEach(
+          cookieDatabaseCandidatePaths(definition, context, profile.directory),
+          (candidate) => entryExists(candidate),
+        ).pipe(Effect.map((results) => (results.some(Boolean) ? profile : undefined))),
+      );
+      return found.filter((profile) => profile !== undefined);
+    }
 
     // No readable `profiles.ini`, so fall back to scanning the directory the
     // profiles actually live in.

--- a/apps/desktop/src/preview/BrowserImport/Sources.ts
+++ b/apps/desktop/src/preview/BrowserImport/Sources.ts
@@ -69,13 +69,6 @@ const chromiumSource = (input: {
   readonly keychainService: string;
   readonly keychainAccount: string;
   readonly macSegments: ReadonlyArray<string>;
-  readonly windowsSegments?: ReadonlyArray<string>;
-  /**
-   * Forks that sit under roaming `%APPDATA%` with no `User Data` level. Opera
-   * is the one that does this; everything else follows the local-AppData
-   * convention above.
-   */
-  readonly windowsRoamingSegments?: ReadonlyArray<string>;
   readonly linuxSegments?: ReadonlyArray<string>;
 }): BrowserImportSourceDefinition => ({
   id: input.id,
@@ -83,23 +76,12 @@ const chromiumSource = (input: {
   engine: "chromium",
   platforms: [
     "darwin" as NodeJS.Platform,
-    ...(input.windowsSegments || input.windowsRoamingSegments ? ["win32" as NodeJS.Platform] : []),
     ...(input.linuxSegments ? ["linux" as NodeJS.Platform] : []),
   ],
   keychainService: input.keychainService,
   keychainAccount: input.keychainAccount,
   userDataDirectory: (context) => {
     if (context.platform === "darwin") return macApplicationSupport(context, ...input.macSegments);
-    if (context.platform === "win32") {
-      if (input.windowsRoamingSegments) {
-        return context.appData
-          ? context.path.join(context.appData, ...input.windowsRoamingSegments)
-          : undefined;
-      }
-      return input.windowsSegments && context.localAppData
-        ? context.path.join(context.localAppData, ...input.windowsSegments, "User Data")
-        : undefined;
-    }
     return input.linuxSegments
       ? context.path.join(context.home, ".config", ...input.linuxSegments)
       : undefined;
@@ -107,13 +89,16 @@ const chromiumSource = (input: {
 });
 
 export const BROWSER_IMPORT_SOURCES: ReadonlyArray<BrowserImportSourceDefinition> = [
+  // No Chromium fork is importable on Windows: since Chrome 127 their cookies
+  // are encrypted to the browser's own identity (App-Bound Encryption), so no
+  // other process can read them. macOS and Linux keep working, so only the
+  // Windows segments are omitted.
   chromiumSource({
     id: "chrome",
     name: "Chrome",
     keychainService: "Chrome Safe Storage",
     keychainAccount: "Chrome",
     macSegments: ["Google", "Chrome"],
-    windowsSegments: ["Google", "Chrome"],
     linuxSegments: ["google-chrome"],
   }),
   chromiumSource({
@@ -122,7 +107,6 @@ export const BROWSER_IMPORT_SOURCES: ReadonlyArray<BrowserImportSourceDefinition
     keychainService: "Microsoft Edge Safe Storage",
     keychainAccount: "Microsoft Edge",
     macSegments: ["Microsoft Edge"],
-    windowsSegments: ["Microsoft", "Edge"],
     linuxSegments: ["microsoft-edge"],
   }),
   chromiumSource({
@@ -131,7 +115,6 @@ export const BROWSER_IMPORT_SOURCES: ReadonlyArray<BrowserImportSourceDefinition
     keychainService: "Brave Safe Storage",
     keychainAccount: "Brave",
     macSegments: ["BraveSoftware", "Brave-Browser"],
-    windowsSegments: ["BraveSoftware", "Brave-Browser"],
     linuxSegments: ["BraveSoftware", "Brave-Browser"],
   }),
   chromiumSource({
@@ -140,7 +123,6 @@ export const BROWSER_IMPORT_SOURCES: ReadonlyArray<BrowserImportSourceDefinition
     keychainService: "Vivaldi Safe Storage",
     keychainAccount: "Vivaldi",
     macSegments: ["Vivaldi"],
-    windowsSegments: ["Vivaldi"],
     linuxSegments: ["vivaldi"],
   }),
   chromiumSource({
@@ -149,7 +131,6 @@ export const BROWSER_IMPORT_SOURCES: ReadonlyArray<BrowserImportSourceDefinition
     keychainService: "Opera Safe Storage",
     keychainAccount: "Opera",
     macSegments: ["com.operasoftware.Opera"],
-    windowsRoamingSegments: ["Opera Software", "Opera Stable"],
     linuxSegments: ["opera"],
   }),
   // Arc and Helium ship macOS-only builds.
@@ -525,12 +506,10 @@ export const isSourceRunning = Effect.fn("BrowserImportSources.isSourceRunning")
   // at the root finds nothing and reports a running browser as importable.
   if (definition.engine === "safari") return false;
   if (definition.engine !== "firefox") {
-    // Chromium names its single lock differently per platform: a dangling
-    // `SingletonLock` symlink on macOS and Linux, a `lockfile` held via
-    // LockFileEx on Windows. `isLockHeld` answers for both — existence on
-    // the former, an actual lock probe on the latter.
-    const lock = context.platform === "win32" ? "lockfile" : "SingletonLock";
-    return yield* isLockHeld(context.path.join(root, lock), context.platform);
+    // Chromium leaves a dangling `SingletonLock` symlink for as long as an
+    // instance holds the user-data directory. No Chromium fork is importable
+    // on Windows, so the macOS/Linux symlink is the only shape to answer for.
+    return yield* entryExists(context.path.join(root, "SingletonLock"));
   }
 
   const profiles = yield* listSourceProfiles(definition, context);

--- a/apps/desktop/src/preview/BrowserImport/Sources.ts
+++ b/apps/desktop/src/preview/BrowserImport/Sources.ts
@@ -518,14 +518,19 @@ export const isSourceRunning = Effect.fn("BrowserImportSources.isSourceRunning")
   // table. Safari keeps none, and unlike the others writes its jar atomically,
   // so a running instance is not a hazard there.
   //
-  // Chromium and Firefox differ in where: Chromium keeps one `SingletonLock`
-  // for the whole user-data directory, Firefox keeps its locks inside each
-  // profile, under three names across platforms (`lock` on macOS and Linux,
+  // Chromium and Firefox differ in where: Chromium keeps one lock for the
+  // whole user-data directory, Firefox keeps its locks inside each profile,
+  // under three names across platforms (`lock` on macOS and Linux,
   // `.parentlock` beside it, `parent.lock` on Windows). Looking for Firefox's
   // at the root finds nothing and reports a running browser as importable.
   if (definition.engine === "safari") return false;
   if (definition.engine !== "firefox") {
-    return yield* entryExists(context.path.join(root, "SingletonLock"));
+    // Chromium names its single lock differently per platform: a dangling
+    // `SingletonLock` symlink on macOS and Linux, a `lockfile` held via
+    // LockFileEx on Windows. `isLockHeld` answers for both — existence on
+    // the former, an actual lock probe on the latter.
+    const lock = context.platform === "win32" ? "lockfile" : "SingletonLock";
+    return yield* isLockHeld(context.path.join(root, lock), context.platform);
   }
 
   const profiles = yield* listSourceProfiles(definition, context);

--- a/apps/desktop/src/preview/BrowserImport/Sources.ts
+++ b/apps/desktop/src/preview/BrowserImport/Sources.ts
@@ -208,24 +208,43 @@ export const BROWSER_IMPORT_SOURCES: ReadonlyArray<BrowserImportSourceDefinition
  * Chromium stores the database as `Cookies` under the profile directory;
  * Firefox uses `cookies.sqlite`, and its profile paths from `profiles.ini`
  * may already be absolute.
+ *
+ * Newer Chromium versions (127+) moved the cookie database into a `Network`
+ * subdirectory. The candidate list includes both locations so callers can
+ * tolerate either layout.
+ */
+export const cookieDatabaseCandidatePaths = (
+  definition: BrowserImportSourceDefinition,
+  context: BrowserImportPathContext,
+  profileDirectory: string,
+): ReadonlyArray<string> => {
+  const root = definition.userDataDirectory(context);
+  if (root === undefined) return [];
+  const profilePath = context.path.isAbsolute(profileDirectory)
+    ? profileDirectory
+    : context.path.join(root, profileDirectory);
+  if (definition.engine === "firefox") {
+    return [context.path.join(profilePath, "cookies.sqlite")];
+  }
+  if (definition.engine === "safari") {
+    return [context.path.join(profilePath, "Cookies.binarycookies")];
+  }
+  // Chromium: older versions use `Cookies`, 127+ use `Network/Cookies`.
+  return [
+    context.path.join(profilePath, "Cookies"),
+    context.path.join(profilePath, "Network", "Cookies"),
+  ];
+};
+
+/**
+ * Legacy single-path helper that returns the first candidate. Prefer
+ * `cookieDatabaseCandidatePaths` when checking for existence.
  */
 export const cookieDatabasePath = (
   definition: BrowserImportSourceDefinition,
   context: BrowserImportPathContext,
   profileDirectory: string,
-): string | undefined => {
-  const root = definition.userDataDirectory(context);
-  if (root === undefined) return undefined;
-  const fileName =
-    definition.engine === "firefox"
-      ? "cookies.sqlite"
-      : definition.engine === "safari"
-        ? "Cookies.binarycookies"
-        : "Cookies";
-  return context.path.isAbsolute(profileDirectory)
-    ? context.path.join(profileDirectory, fileName)
-    : context.path.join(root, profileDirectory, fileName);
-};
+): string | undefined => cookieDatabaseCandidatePaths(definition, context, profileDirectory)[0];
 
 /** Chromium keeps the DPAPI-wrapped Windows key in `Local State`. */
 export const localStatePath = (
@@ -310,6 +329,35 @@ const entryExists = Effect.fnUntraced(function* (path: string) {
   );
 });
 
+/**
+ * Whether a lock file is actually held by a running process. On macOS and
+ * Linux Firefox lock files are dangling symlinks that disappear when the
+ * process exits, so `entryExists` is sufficient. On Windows the lock file
+ * (`parent.lock`) is a regular file locked via `LockFileEx` that persists on
+ * disk after the process exits; `stat` always succeeds, so we must try to
+ * open the file with write access to detect the active lock.
+ */
+const isLockHeld = Effect.fnUntraced(function* (
+  lockPath: string,
+  platform: "darwin" | "linux" | "win32",
+) {
+  if (platform !== "win32") return yield* entryExists(lockPath);
+  return yield* Effect.tryPromise({
+    try: () =>
+      new Promise<boolean>((resolve) => {
+        const fs = require("node:fs") as typeof import("node:fs");
+        fs.open(lockPath, "r+", (openErr: NodeJS.ErrnoException | null, fd: number) => {
+          if (openErr) {
+            resolve(openErr.code === "EBUSY" || openErr.code === "EPERM");
+            return;
+          }
+          fs.close(fd, () => resolve(false));
+        });
+      }),
+    catch: () => false,
+  });
+});
+
 /** Shape of the slice of Chromium's `Local State` that names its profiles. */
 const LocalState = Schema.Struct({
   profile: Schema.optional(
@@ -344,7 +392,10 @@ const countProfileCookies = Effect.fnUntraced(function* (
   context: BrowserImportPathContext,
   directory: string,
 ): Effect.fn.Return<number | undefined, never> {
-  const databasePath = cookieDatabasePath(definition, context, directory);
+  const candidates = cookieDatabaseCandidatePaths(definition, context, directory);
+  const databasePath = yield* Effect.forEach(candidates, (candidate) =>
+    entryExists(candidate).pipe(Effect.map((exists) => (exists ? candidate : undefined))),
+  ).pipe(Effect.map((results) => results.find((p) => p !== undefined)));
   if (databasePath === undefined) return undefined;
   return yield* Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient;
@@ -431,8 +482,10 @@ export const listSourceProfiles = Effect.fn("BrowserImportSources.listSourceProf
     .readDirectory(root)
     .pipe(Effect.orElseSucceed(() => [] as ReadonlyArray<string>));
   const found = yield* Effect.forEach(entries.filter(isSafeProfileDirectory), (directory) =>
-    entryExists(cookieDatabasePath(definition, context, directory) ?? "").pipe(
-      Effect.map((exists) => (exists ? { directory, name: directory } : undefined)),
+    Effect.forEach(cookieDatabaseCandidatePaths(definition, context, directory), (candidate) =>
+      entryExists(candidate),
+    ).pipe(
+      Effect.map((results) => (results.some(Boolean) ? { directory, name: directory } : undefined)),
     ),
   );
   return yield* withCookieCounts(
@@ -472,7 +525,7 @@ export const isSourceRunning = Effect.fn("BrowserImportSources.isSourceRunning")
       ? profile.directory
       : context.path.join(root, profile.directory);
     return Effect.forEach(FIREFOX_LOCK_NAMES, (lock) =>
-      entryExists(context.path.join(directory, lock)),
+      isLockHeld(context.path.join(directory, lock), context.platform),
     ).pipe(Effect.map((results) => results.some(Boolean)));
   });
   return found.some(Boolean);
@@ -498,9 +551,11 @@ export const isSourceInstalled = Effect.fn("BrowserImportSources.isSourceInstall
   context: BrowserImportPathContext,
 ): Effect.fn.Return<boolean, never, FileSystem.FileSystem> {
   const profiles = yield* listSourceProfiles(definition, context);
-  const found = yield* Effect.forEach(profiles, (profile) => {
-    const database = cookieDatabasePath(definition, context, profile.directory);
-    return database === undefined ? Effect.succeed(false) : entryExists(database);
-  });
+  const found = yield* Effect.forEach(profiles, (profile) =>
+    Effect.forEach(
+      cookieDatabaseCandidatePaths(definition, context, profile.directory),
+      (candidate) => entryExists(candidate),
+    ).pipe(Effect.map((results) => results.some(Boolean))),
+  );
   return found.some(Boolean);
 });

--- a/apps/desktop/src/preview/BrowserImport/Sources.ts
+++ b/apps/desktop/src/preview/BrowserImport/Sources.ts
@@ -431,13 +431,24 @@ export const listSourceProfiles = Effect.fn("BrowserImportSources.listSourceProf
     }
 
     // No readable `profiles.ini`, so fall back to scanning the directory the
-    // profiles actually live in.
-    return yield* fileSystem.readDirectory(context.path.join(root, "Profiles")).pipe(
-      Effect.map((entries) =>
-        entries.map((entry) => ({ directory: context.path.join("Profiles", entry), name: entry })),
+    // profiles actually live in, keeping only the ones a cookie database
+    // proves were launched.
+    const scanned = yield* fileSystem
+      .readDirectory(context.path.join(root, "Profiles"))
+      .pipe(Effect.orElseSucceed(() => [] as ReadonlyArray<string>));
+    const found = yield* Effect.forEach(scanned, (entry) =>
+      Effect.forEach(
+        cookieDatabaseCandidatePaths(definition, context, context.path.join("Profiles", entry)),
+        (candidate) => entryExists(candidate),
+      ).pipe(
+        Effect.map((results) =>
+          results.some(Boolean)
+            ? { directory: context.path.join("Profiles", entry), name: entry }
+            : undefined,
+        ),
       ),
-      Effect.orElseSucceed(() => [] as ReadonlyArray<BrowserImportSourceProfile>),
     );
+    return found.filter((profile) => profile !== undefined);
   }
 
   const declared = yield* fileSystem.readFileString(context.path.join(root, "Local State")).pipe(

--- a/apps/desktop/src/preview/BrowserImport/Sources.ts
+++ b/apps/desktop/src/preview/BrowserImport/Sources.ts
@@ -209,9 +209,9 @@ export const BROWSER_IMPORT_SOURCES: ReadonlyArray<BrowserImportSourceDefinition
  * Firefox uses `cookies.sqlite`, and its profile paths from `profiles.ini`
  * may already be absolute.
  *
- * Newer Chromium versions (127+) moved the cookie database into a `Network`
- * subdirectory. The candidate list includes both locations so callers can
- * tolerate either layout.
+ * Chrome 96+ moved network-related files (including Cookies) into a `Network`
+ * subdirectory for sandboxing. The candidate list includes both locations so
+ * callers tolerate fresh and legacy installs alike.
  */
 export const cookieDatabaseCandidatePaths = (
   definition: BrowserImportSourceDefinition,
@@ -229,7 +229,7 @@ export const cookieDatabaseCandidatePaths = (
   if (definition.engine === "safari") {
     return [context.path.join(profilePath, "Cookies.binarycookies")];
   }
-  // Chromium: older versions use `Cookies`, 127+ use `Network/Cookies`.
+  // Chromium: pre-96 uses `Cookies`, 96+ use `Network/Cookies`.
   return [
     context.path.join(profilePath, "Cookies"),
     context.path.join(profilePath, "Network", "Cookies"),

--- a/apps/desktop/src/preview/BrowserImport/Sources.ts
+++ b/apps/desktop/src/preview/BrowserImport/Sources.ts
@@ -210,22 +210,13 @@ export const cookieDatabaseCandidatePaths = (
   if (definition.engine === "safari") {
     return [context.path.join(profilePath, "Cookies.binarycookies")];
   }
-  // Chromium: pre-96 uses `Cookies`, 96+ use `Network/Cookies`.
+  // Chromium: pre-96 uses `Cookies`, 96+ use `Network/Cookies`. An upgrade
+  // leaves the legacy file behind, so prefer the current one and fall back.
   return [
-    context.path.join(profilePath, "Cookies"),
     context.path.join(profilePath, "Network", "Cookies"),
+    context.path.join(profilePath, "Cookies"),
   ];
 };
-
-/**
- * Legacy single-path helper that returns the first candidate. Prefer
- * `cookieDatabaseCandidatePaths` when checking for existence.
- */
-export const cookieDatabasePath = (
-  definition: BrowserImportSourceDefinition,
-  context: BrowserImportPathContext,
-  profileDirectory: string,
-): string | undefined => cookieDatabaseCandidatePaths(definition, context, profileDirectory)[0];
 
 /** Chromium keeps the DPAPI-wrapped Windows key in `Local State`. */
 export const localStatePath = (
@@ -314,26 +305,25 @@ const entryExists = Effect.fnUntraced(function* (path: string) {
  * Whether a lock file is actually held by a running process. On macOS and
  * Linux Firefox lock files are dangling symlinks that disappear when the
  * process exits, so `entryExists` is sufficient. On Windows the lock file
- * (`parent.lock`) is a regular file locked via `LockFileEx` that persists on
- * disk after the process exits; `stat` always succeeds, so we must try to
- * open the file with write access to detect the active lock.
+ * (`parent.lock`) is a regular file opened with no sharing, so it persists on
+ * disk after the process exits; `stat` always succeeds, and the probe must try
+ * to open the file with write access to detect the active lock.
  */
 const isLockHeld = Effect.fnUntraced(function* (lockPath: string, platform: NodeJS.Platform) {
   if (platform !== "win32") return yield* entryExists(lockPath);
-  return yield* Effect.tryPromise({
-    try: () =>
-      new Promise<boolean>((resolve) => {
-        const fs = require("node:fs") as typeof import("node:fs");
-        fs.open(lockPath, "r+", (openErr: NodeJS.ErrnoException | null, fd: number) => {
-          if (openErr) {
-            resolve(openErr.code === "EBUSY" || openErr.code === "EPERM");
-            return;
-          }
-          fs.close(fd, () => resolve(false));
-        });
-      }),
-    catch: () => false,
-  }).pipe(Effect.catchCause(() => Effect.succeed(false)));
+  // A lock held with no sharing denies the write access we need, surfacing as
+  // `Busy` or `PermissionDenied`; anything else (missing file, permissions we
+  // cannot read) just means no active browser holds it.
+  const fileSystem = yield* FileSystem.FileSystem;
+  return yield* fileSystem.open(lockPath, { flag: "r+" }).pipe(
+    Effect.as(false),
+    Effect.catchIf(
+      (error) => error.reason._tag === "Busy" || error.reason._tag === "PermissionDenied",
+      () => Effect.succeed(true),
+    ),
+    Effect.orElseSucceed(() => false),
+    Effect.scoped,
+  );
 });
 
 /** Shape of the slice of Chromium's `Local State` that names its profiles. */

--- a/apps/web/src/components/settings/IntegrationsSettings.tsx
+++ b/apps/web/src/components/settings/IntegrationsSettings.tsx
@@ -614,10 +614,12 @@ function BrowserProfilesSetting({ disabled }: { readonly disabled: boolean }) {
 
   // A browser that is not on this machine is left out rather than listed as a
   // dead row: there is nothing to act on, and the menu is a list of things you
-  // can import from. Every other unavailable reason stays, since each names a
-  // step the user can take.
+  // can import from. An unsupported one is left out for the same reason — the
+  // blocked wizard step can't be fixed from here. Every other unavailable
+  // reason stays, since each names a step the user can take.
   const importableSources = (sources ?? []).filter(
-    (source) => source.unavailable !== "notInstalled",
+    (source) =>
+      source.unavailable !== "notInstalled" && source.unavailable !== "unsupportedPlatform",
   );
 
   // Refreshed without blanking the last result: the menu shows the cached list


### PR DESCRIPTION
Stacked on top of #7262 

## What Changed

Fixes several browser cookie import bugs.

- Chromium 96+ moved cookies to `Network/Cookies`; import now checks both `Cookies` and `Network/Cookies` so newer Chrome/Edge/Brave/Vivaldi/Opera installs are found
- Firefox on Windows holds `parent.lock` as a regular file that persists after exit; running-check now probes the actual lock (`fs.open` with `r+`) instead of just existence, and stale profiles are filtered out
- All Chromium forks are now marked unsupported on Windows: since Chrome 127 their cookies are App-Bound Encrypted to the browser's own identity, so no other process can read them (same as Arc/Helium); macOS and Linux imports still work
- Hide unsupported browsers in the dropdown

## Why

I have Edge and Chrome installed, but they didn't show up

And clicking on Firefox, I got "Quit Firefox to import / Firefox is open, so its cookies can’t be read yet. Quit it, then continue." But firefox is not open. I checked and it's also not running in the background. Any firefox-based browser is also not open.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches filesystem probing, profile discovery, and import error semantics across desktop browser import; behavior changes are intentional but affect all import flows on macOS/Linux and Firefox on Windows.
> 
> **Overview**
> Fixes browser cookie import so installed browsers show up reliably and import uses the right cookie DB path.
> 
> **Chromium cookie locations:** Replaces a single `Cookies` path with **`cookieDatabaseCandidatePaths`**, preferring `Network/Cookies` (Chromium 96+) and falling back to legacy `Cookies`. Profile listing, install detection, cookie counts, and **`importCookies`** all probe candidates with **`stat`** (not `access`) so Safari/TCC behavior stays correct. If a listed profile loses its DB before import, the failure is **`readFailed`** instead of **`unsupportedPlatform`**.
> 
> **Windows Chromium:** Drops **`win32`** from all Chromium fork definitions because Chrome 127+ app-bound encryption blocks third-party reads. The integrations **Import from** menu also hides **`unsupportedPlatform`** sources, same as not installed.
> 
> **Firefox:** Profile discovery skips profiles with no **`cookies.sqlite`**. On Windows, **`isLockHeld`** tries opening **`parent.lock`** with write access so stale lock files no longer mark Firefox as running when it is quit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9db7a7c29d9893a323f5b37f0b1534ac9ee1b34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix browser cookie import to detect both legacy and `Network/Cookies` paths
> - Replaces single `cookieDatabasePath` with `cookieDatabaseCandidatePaths`, returning an ordered list of candidates (e.g. `Network/Cookies` before `Cookies` for Chromium) so imports work for Chromium 127+ and legacy profiles alike.
> - Adds a stat-based probe in `importCookies` to find the first existing candidate path; missing databases now report `readFailed` instead of `unsupportedPlatform`.
> - Introduces `isLockHeld` to distinguish active from stale `parent.lock` files on Windows, fixing false "Firefox is running" detection.
> - Removes Windows (win32) support from all Chromium-based sources in [`Sources.ts`](https://github.com/pingdotgg/t3code/pull/7323/files#diff-aba1dfda81f54057cd7e4f85f90d145749aeb2c037f988a0f26156ea296551e6); the settings UI in [`IntegrationsSettings.tsx`](https://github.com/pingdotgg/t3code/pull/7323/files#diff-8ecfd51e80236f708bcd5b2191dc1d30ac76dd2752851089b78353b9f86878f6) now hides sources marked `unsupportedPlatform`.
> - Profile listings for Firefox and Chromium now filter out profiles with no valid cookie database, so empty or uninitialized profiles are no longer shown.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f9db7a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->