### PR TITLE
feat(web): show newest direct agents first

### DIFF
--- a/packages/client-runtime/src/state/subagentRuntime.test.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.test.ts
@@ -426,7 +426,7 @@ describe("deriveAgentPanelModel", () => {
     expect(model.liveCount).toBe(0);
   });
 
-  it("keeps direct spawns in first-seen order as their activity changes", () => {
+  it("shows newest direct spawns first without reordering them on activity", () => {
     const directRoster = fold([
       activity("task.started", { taskId: "direct-a", title: "First" }, "2026-08-01T11:00:00.000Z"),
       activity("task.started", { taskId: "direct-b", title: "Second" }, "2026-08-01T11:00:01.000Z"),
@@ -439,10 +439,10 @@ describe("deriveAgentPanelModel", () => {
 
     expect(
       deriveAgentPanelModel({ agents: directRoster }).directAgents.map((agent) => agent.id),
-    ).toEqual(["direct-a", "direct-b"]);
+    ).toEqual(["direct-b", "direct-a"]);
   });
 
-  it("keeps first-seen order after the roster retention ranking runs", () => {
+  it("keeps newest-first order after the roster retention ranking runs", () => {
     const starts = Array.from({ length: 101 }, (_, index) =>
       activity(
         "task.started",
@@ -465,8 +465,8 @@ describe("deriveAgentPanelModel", () => {
       (agent) => agent.id,
     );
     expect(ids).toHaveLength(100);
-    expect(ids.slice(0, 3)).toEqual(["capped-0", "capped-2", "capped-3"]);
-    expect(ids.at(-1)).toBe("capped-100");
+    expect(ids.slice(0, 3)).toEqual(["capped-100", "capped-99", "capped-98"]);
+    expect(ids.at(-1)).toBe("capped-0");
   });
 
   it("a phase with only pending members never reads as running", () => {

--- a/packages/client-runtime/src/state/subagentRuntime.ts
+++ b/packages/client-runtime/src/state/subagentRuntime.ts
@@ -844,7 +844,7 @@ export function deriveAgentPanelModel({
     // that remain visible.
     directAgents: direct
       .slice()
-      .sort((a, b) => a.firstSeenAt.localeCompare(b.firstSeenAt) || a.id.localeCompare(b.id)),
+      .sort((a, b) => b.firstSeenAt.localeCompare(a.firstSeenAt) || a.id.localeCompare(b.id)),
     runningCount,
     waitingCount,
     idleCount,


### PR DESCRIPTION
## What Changed

Direct spawns in the right-side Agents panel now appear newest first. Their order is based on when they were first seen, so later activity does not move older rows above newer ones.

Workflow ordering is unchanged.

## Why

New direct agents were appended to the bottom of the list, so the most recent work could land below the visible area in long-running threads. Reversing the existing first-seen sort keeps new work visible without introducing a new ordering model.

Closes #7324

## UI Changes

The Direct spawns list changes from oldest-first to newest-first. There are no styling, animation, or timing changes.

Screenshots are not included yet; this PR is awaiting an integrated browser pass.

## Verification

- `vp test run packages/client-runtime/src/state/subagentRuntime.test.ts` (48 passed)
- `vp run --filter @t3tools/client-runtime typecheck`
- `vp lint packages/client-runtime/src/state/subagentRuntime.ts packages/client-runtime/src/state/subagentRuntime.test.ts`
- `vp fmt --check packages/client-runtime/src/state/subagentRuntime.ts packages/client-runtime/src/state/subagentRuntime.test.ts`
- `git diff --check`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for the UI change
- [x] No animation or timing changes require a video

Implemented with GPT-5.6 Sol through the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only ordering change for direct agents in the panel model; workflow logic and counts are untouched.
> 
> **Overview**
> **Direct spawns** in the Agents panel are now listed **newest first**, using each row’s `firstSeenAt` timestamp. Later progress or activity does not reshuffle visible rows—only the initial sighting order matters, now reversed.
> 
> `deriveAgentPanelModel` flips the `directAgents` sort from ascending to descending `firstSeenAt` (with `id` as tiebreaker). **Workflow** grouping and ordering are unchanged.
> 
> Tests were updated to expect newest-first ordering, including after the >100-agent retention cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70dba18d12b2d0dde7ee39332c1deba0241fed7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->