### PR TITLE
feat(web): continue branches across environments

### DIFF
--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -7494,6 +7494,123 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
+  it.effect("continues a fetched branch with the same name in a destination worktree", () =>
+    Effect.gen(function* () {
+      const dispatchedCommands: Array<OrchestrationCommand> = [];
+      const remoteExists = vi.fn(
+        (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["remoteExists"]>[0]) =>
+          Effect.succeed(true),
+      );
+      const fetchRemote = vi.fn(
+        (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["fetchRemote"]>[0]) => Effect.void,
+      );
+      const resolveRemoteTrackingCommit = vi.fn(
+        (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["resolveRemoteTrackingCommit"]>[0]) =>
+          Effect.succeed({
+            commitSha: "0123456789abcdef0123456789abcdef01234567",
+            remoteRefName: "origin/feat/handoff",
+          }),
+      );
+      const listRefs = vi.fn((_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["listRefs"]>[0]) =>
+        Effect.succeed({
+          refs: [],
+          isRepo: true,
+          hasPrimaryRemote: true,
+          nextCursor: null,
+          totalCount: 0,
+        }),
+      );
+      const createWorktree = vi.fn(
+        (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["createWorktree"]>[0]) =>
+          Effect.succeed({
+            worktree: {
+              refName: "feat/handoff",
+              path: "/tmp/handoff-worktree",
+            },
+          }),
+      );
+
+      yield* buildAppUnderTest({
+        layers: {
+          gitVcsDriver: {
+            remoteExists,
+            fetchRemote,
+            resolveRemoteTrackingCommit,
+            listRefs,
+            createWorktree,
+          },
+          orchestrationEngine: {
+            dispatch: (command) =>
+              Effect.sync(() => {
+                dispatchedCommands.push(command);
+                return { sequence: dispatchedCommands.length };
+              }),
+            readEvents: () => Stream.empty,
+          },
+        },
+      });
+
+      const createdAt = "2026-01-01T00:00:00.000Z";
+      const wsUrl = yield* getWsServerUrl("/ws");
+      yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[ORCHESTRATION_WS_METHODS.dispatchCommand]({
+            type: "thread.turn.start",
+            commandId: CommandId.make("cmd-continue-branch"),
+            threadId: ThreadId.make("thread-continue-branch"),
+            message: {
+              messageId: MessageId.make("msg-continue-branch"),
+              role: "user",
+              text: "continue here",
+              attachments: [],
+            },
+            modelSelection: defaultModelSelection,
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            bootstrap: {
+              createThread: {
+                projectId: defaultProjectId,
+                title: "Continue branch",
+                modelSelection: defaultModelSelection,
+                runtimeMode: "full-access",
+                interactionMode: "default",
+                branch: "feat/handoff",
+                worktreePath: null,
+                createdAt,
+              },
+              prepareWorktree: {
+                projectCwd: "/tmp/project",
+                baseBranch: "feat/handoff",
+                branch: "feat/handoff",
+                startFromOrigin: true,
+                continueBranch: true,
+              },
+            },
+            createdAt,
+          }),
+        ),
+      );
+
+      assert.deepEqual(listRefs.mock.calls[0]?.[0], {
+        cwd: "/tmp/project",
+        query: "feat/handoff",
+        refKind: "local",
+        refresh: true,
+        limit: 100,
+      });
+      assert.deepEqual(createWorktree.mock.calls[0]?.[0], {
+        cwd: "/tmp/project",
+        refName: "origin/feat/handoff",
+        newRefName: "feat/handoff",
+        path: null,
+      });
+      assert.deepEqual(
+        dispatchedCommands.map((command) => command.type),
+        ["thread.create", "thread.meta.update", "thread.turn.start"],
+      );
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
   it.effect(
     "falls back to the local base branch when startFromOrigin is set but no origin remote exists",
     () =>

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -58,6 +58,7 @@ import {
   WS_METHODS,
   WsRpcGroup,
 } from "@t3tools/contracts";
+import { normalizeProjectPathForComparison } from "@t3tools/shared/path";
 import { resolveServerBackgroundActivitySettings } from "@t3tools/shared/backgroundActivitySettings";
 import { HttpRouter, HttpServerRequest, HttpServerRespondable } from "effect/unstable/http";
 import { RpcSerialization, RpcServer } from "effect/unstable/rpc";
@@ -913,36 +914,68 @@ const makeWsRpcLayer = (
             }
 
             if (bootstrap?.prepareWorktree) {
-              let worktreeBaseRef = bootstrap.prepareWorktree.baseBranch;
+              const prepareWorktree = bootstrap.prepareWorktree;
+              let worktreeBaseRef = prepareWorktree.baseBranch;
               // "Start from origin" is a stored default; repos without an
               // origin remote fall back to the local base branch instead of
               // failing the whole bootstrap on `git fetch origin`.
               const startFromOrigin =
-                bootstrap.prepareWorktree.startFromOrigin === true &&
+                prepareWorktree.startFromOrigin === true &&
                 (yield* gitWorkflow.remoteExists({
-                  cwd: bootstrap.prepareWorktree.projectCwd,
+                  cwd: prepareWorktree.projectCwd,
                   remoteName: "origin",
                 }));
               if (startFromOrigin) {
                 yield* gitWorkflow.fetchRemote({
-                  cwd: bootstrap.prepareWorktree.projectCwd,
+                  cwd: prepareWorktree.projectCwd,
                   remoteName: "origin",
                 });
                 const resolvedRemoteBase = yield* gitWorkflow.resolveRemoteTrackingCommit({
-                  cwd: bootstrap.prepareWorktree.projectCwd,
-                  refName: bootstrap.prepareWorktree.baseBranch,
+                  cwd: prepareWorktree.projectCwd,
+                  refName: prepareWorktree.baseBranch,
                   fallbackRemoteName: "origin",
                 });
-                worktreeBaseRef = resolvedRemoteBase.commitSha;
+                worktreeBaseRef = prepareWorktree.continueBranch
+                  ? resolvedRemoteBase.remoteRefName
+                  : resolvedRemoteBase.commitSha;
               }
-              const worktree = yield* gitWorkflow.createWorktree({
-                cwd: bootstrap.prepareWorktree.projectCwd,
-                refName: worktreeBaseRef,
-                newRefName: bootstrap.prepareWorktree.branch,
-                baseRefName: bootstrap.prepareWorktree.baseBranch,
-                path: null,
-              });
-              targetWorktreePath = worktree.worktree.path;
+              const localBranch = prepareWorktree.continueBranch
+                ? (yield* gitWorkflow.listRefs({
+                    cwd: prepareWorktree.projectCwd,
+                    query: prepareWorktree.baseBranch,
+                    refKind: "local",
+                    refresh: true,
+                    limit: 100,
+                  })).refs.find((ref) => ref.name === prepareWorktree.baseBranch && !ref.isRemote)
+                : null;
+              const worktree = localBranch?.worktreePath
+                ? {
+                    worktree: {
+                      path: localBranch.worktreePath,
+                      refName: prepareWorktree.baseBranch,
+                    },
+                  }
+                : yield* gitWorkflow.createWorktree({
+                    cwd: prepareWorktree.projectCwd,
+                    refName: localBranch ? prepareWorktree.baseBranch : worktreeBaseRef,
+                    ...(!localBranch
+                      ? {
+                          newRefName: prepareWorktree.continueBranch
+                            ? prepareWorktree.baseBranch
+                            : prepareWorktree.branch,
+                        }
+                      : {}),
+                    ...(!prepareWorktree.continueBranch
+                      ? { baseRefName: prepareWorktree.baseBranch }
+                      : {}),
+                    path: null,
+                  });
+              const usesProjectCheckout =
+                localBranch?.worktreePath !== null &&
+                localBranch?.worktreePath !== undefined &&
+                normalizeProjectPathForComparison(localBranch.worktreePath) ===
+                  normalizeProjectPathForComparison(prepareWorktree.projectCwd);
+              targetWorktreePath = usesProjectCheckout ? null : worktree.worktree.path;
               yield* orchestrationEngine.dispatch({
                 type: "thread.meta.update",
                 commandId: yield* serverCommandId("bootstrap-thread-meta-update"),
@@ -950,7 +983,7 @@ const makeWsRpcLayer = (
                 branch: worktree.worktree.refName,
                 worktreePath: targetWorktreePath,
               });
-              yield* refreshGitStatus(targetWorktreePath);
+              yield* refreshGitStatus(targetWorktreePath ?? prepareWorktree.projectCwd);
             }
 
             yield* runSetupProgram();

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4106,6 +4106,7 @@ function ChatViewContent(props: ChatViewProps) {
       ? (pendingServerThreadStartFromOriginByThreadId[activeThread?.id ?? ""] ??
         primaryServerSettings.newWorktreesStartFromOrigin)
       : false;
+  const continueBranch = isLocalDraftThread && draftThread?.continueBranch === true;
   const sendEnvMode = resolveSendEnvMode({
     requestedEnvMode: envMode,
     isGitRepo,
@@ -5285,8 +5286,11 @@ function ChatViewContent(props: ChatViewProps) {
                     prepareWorktree: {
                       projectCwd: activeProject.workspaceRoot,
                       baseBranch: baseBranchForWorktree,
-                      branch: buildTemporaryWorktreeBranchName(randomHex),
+                      branch: continueBranch
+                        ? baseBranchForWorktree
+                        : buildTemporaryWorktreeBranchName(randomHex),
                       ...(startFromOrigin ? { startFromOrigin: true } : {}),
+                      ...(continueBranch ? { continueBranch: true } : {}),
                     },
                     runSetupScript: true,
                   }

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -74,6 +74,7 @@ import { isDesktopLocalConnectionTarget } from "../connection/desktopLocal";
 import { useDesktopLocalBootstraps } from "../connection/useDesktopLocalBootstraps";
 import { isElectron } from "../env";
 import { useOpenPrLink } from "../lib/openPullRequestLink";
+import { continueBranchTargetIndex, resolveContinueBranchTargets } from "../continueBranch";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { isMacPlatform } from "../lib/utils";
 import {
@@ -1123,6 +1124,8 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     (settings) => settings.confirmThreadArchive,
   );
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
+  const allProjects = useProjects();
+  const { environments } = useEnvironments();
   const deleteProject = useAtomCommand(projectEnvironment.delete, {
     reportFailure: false,
   });
@@ -2137,10 +2140,29 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       );
       const threadWorkspacePath =
         thread.worktreePath ?? threadProject?.workspaceRoot ?? project.workspaceRoot ?? null;
+      const continueBranchTargets = resolveContinueBranchTargets({
+        sourceProjectRef: scopeProjectRef(thread.environmentId, thread.projectId),
+        projects: allProjects,
+        environments,
+      });
       const clicked = await api.contextMenu.show(
         [
           ...(thread.branch
-            ? [{ id: "new-thread-on-branch", label: `New thread on ${thread.branch}` }]
+            ? [
+                { id: "new-thread-on-branch", label: `New thread on ${thread.branch}` },
+                ...(continueBranchTargets.length > 0
+                  ? [
+                      {
+                        id: "continue-branch-on",
+                        label: "Continue branch on…",
+                        children: continueBranchTargets.map((target, index) => ({
+                          id: `continue-branch-on:${index}`,
+                          label: target.label,
+                        })),
+                      },
+                    ]
+                  : []),
+              ]
             : []),
           { id: "rename", label: "Rename thread" },
           { id: "mark-unread", label: "Mark unread" },
@@ -2150,6 +2172,32 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         ],
         position,
       );
+
+      const continueTargetIndex = clicked ? continueBranchTargetIndex(clicked) : null;
+      if (continueTargetIndex !== null && thread.branch) {
+        const target = continueBranchTargets[continueTargetIndex];
+        if (!target) return;
+        const result = await settlePromise(() =>
+          handleNewThread(target.projectRef, {
+            branch: thread.branch,
+            worktreePath: null,
+            envMode: "worktree",
+            startFromOrigin: true,
+            continueBranch: true,
+          }),
+        );
+        if (result._tag === "Failure") {
+          const error = squashAtomCommandFailure(result);
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Could not continue branch",
+              description: error instanceof Error ? error.message : "An error occurred.",
+            }),
+          );
+        }
+        return;
+      }
 
       if (clicked === "new-thread-on-branch") {
         // Explicit branch carry-over: reuse the thread's worktree when it
@@ -2229,9 +2277,11 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     },
     [
       appSettingsConfirmThreadDelete,
+      allProjects,
       copyPathToClipboard,
       copyThreadIdToClipboard,
       deleteThread,
+      environments,
       handleNewThread,
       markThreadUnread,
       memberProjectByScopedKey,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -120,6 +120,7 @@ import { formatRelativeTimeLabel, parseTimestampDate } from "../timestampFormat"
 import type { SidebarThreadSummary } from "../types";
 import { cn } from "~/lib/utils";
 import { buildThreadActionMenuItems } from "./threadActionMenu.logic";
+import { continueBranchTargetIndex, resolveContinueBranchTargets } from "../continueBranch";
 import {
   buildBulkTitleRegenerationContextMenuItem,
   formatWorkingDurationLabel,
@@ -3050,10 +3051,16 @@ export default function Sidebar() {
         const isPinned = thread.pinnedAt != null;
         // Presets resolve at menu-open time (same as the popover).
         const snoozePresets = resolveSnoozePresets(new Date(), timestampFormat);
+        const continueBranchTargets = resolveContinueBranchTargets({
+          sourceProjectRef: scopeProjectRef(thread.environmentId, thread.projectId),
+          projects,
+          environments,
+        });
         const clicked = await settlePromise(() =>
           api.contextMenu.show(
             buildThreadActionMenuItems({
               branch: thread.branch ?? null,
+              continueBranchTargetLabels: continueBranchTargets.map((target) => target.label),
               isPinned,
               isSettled,
               isSnoozed,
@@ -3073,6 +3080,31 @@ export default function Sidebar() {
           ),
         );
         if (clicked._tag === "Failure") return;
+        const continueTargetIndex = clicked.value ? continueBranchTargetIndex(clicked.value) : null;
+        if (continueTargetIndex !== null && thread.branch) {
+          const target = continueBranchTargets[continueTargetIndex];
+          if (!target) return;
+          const result = await settlePromise(() =>
+            handleNewThreadRef.current(target.projectRef, {
+              branch: thread.branch,
+              worktreePath: null,
+              envMode: "worktree",
+              startFromOrigin: true,
+              continueBranch: true,
+            }),
+          );
+          if (result._tag === "Failure") {
+            const error = squashAtomCommandFailure(result);
+            toastManager.add(
+              stackedThreadToast({
+                type: "error",
+                title: "Could not continue branch",
+                description: error instanceof Error ? error.message : "An error occurred.",
+              }),
+            );
+          }
+          return;
+        }
         if (clicked.value?.startsWith("snooze:")) {
           const preset = snoozePresets.find(
             (candidate) => `snooze:${candidate.id}` === clicked.value,
@@ -3238,9 +3270,11 @@ export default function Sidebar() {
       copyPathToClipboard,
       copyThreadIdToClipboard,
       deleteThread,
+      environments,
       handleMultiSelectContextMenu,
       markThreadUnread,
       projectCwdByKey,
+      projects,
       serverConfigs,
       startThreadRename,
       updateThreadMetadata,

--- a/apps/web/src/components/threadActionMenu.logic.test.ts
+++ b/apps/web/src/components/threadActionMenu.logic.test.ts
@@ -4,6 +4,7 @@ import { buildThreadActionMenuItems, type ThreadActionMenuState } from "./thread
 
 const baseState: ThreadActionMenuState = {
   branch: null,
+  continueBranchTargetLabels: [],
   isPinned: false,
   isSettled: false,
   isSnoozed: false,
@@ -36,6 +37,19 @@ describe("buildThreadActionMenuItems", () => {
     expect(withBranch).toContain("copy-branch");
     expect(ids(baseState)).not.toContain("new-thread-on-branch");
     expect(ids(baseState)).not.toContain("copy-branch");
+  });
+
+  it("offers connected handoff targets as a branch submenu", () => {
+    const item = buildThreadActionMenuItems({
+      ...baseState,
+      branch: "feat/handoff",
+      continueBranchTargetLabels: ["My Mac", "VPS 2"],
+    }).find((candidate) => candidate.id === "continue-branch-on");
+
+    expect(item?.children).toEqual([
+      { id: "continue-branch-on:0", label: "My Mac" },
+      { id: "continue-branch-on:1", label: "VPS 2" },
+    ]);
   });
 
   it("flips lifecycle labels with thread state", () => {

--- a/apps/web/src/components/threadActionMenu.logic.ts
+++ b/apps/web/src/components/threadActionMenu.logic.ts
@@ -8,6 +8,8 @@ import type { SnoozePreset } from "@t3tools/client-runtime/state/thread-settled"
  */
 export type ThreadActionMenuId =
   | "new-thread-on-branch"
+  | "continue-branch-on"
+  | `continue-branch-on:${number}`
   | "pin"
   | "unpin"
   | "settle"
@@ -26,6 +28,7 @@ export type ThreadActionMenuId =
 
 export interface ThreadActionMenuState {
   readonly branch: string | null;
+  readonly continueBranchTargetLabels: ReadonlyArray<string>;
   readonly isPinned: boolean;
   readonly isSettled: boolean;
   readonly isSnoozed: boolean;
@@ -57,6 +60,18 @@ export function buildThreadActionMenuItems(
             id: "new-thread-on-branch" as const,
             label: `New thread on ${state.branch}`,
           },
+          ...(state.continueBranchTargetLabels.length > 0
+            ? [
+                {
+                  id: "continue-branch-on" as const,
+                  label: "Continue branch on…",
+                  children: state.continueBranchTargetLabels.map((label, index) => ({
+                    id: `continue-branch-on:${index}` as const,
+                    label,
+                  })),
+                },
+              ]
+            : []),
         ]
       : []),
     ...(state.supports.pinning

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -1123,19 +1123,22 @@ describe("composerDraftStore project draft thread mapping", () => {
     });
   });
 
-  it("stores the start-from-origin choice with the draft thread", () => {
+  it("stores worktree bootstrap choices with the draft thread", () => {
     const store = useComposerDraftStore.getState();
     store.setProjectDraftThreadId(projectRef, draftId, {
       threadId,
       envMode: "worktree",
       startFromOrigin: true,
+      continueBranch: true,
     });
 
     expect(useComposerDraftStore.getState().getDraftThread(draftId)?.startFromOrigin).toBe(true);
+    expect(useComposerDraftStore.getState().getDraftThread(draftId)?.continueBranch).toBe(true);
 
-    store.setDraftThreadContext(draftId, { startFromOrigin: false });
+    store.setDraftThreadContext(draftId, { startFromOrigin: false, continueBranch: false });
 
     expect(useComposerDraftStore.getState().getDraftThread(draftId)?.startFromOrigin).toBe(false);
+    expect(useComposerDraftStore.getState().getDraftThread(draftId)?.continueBranch).toBe(false);
   });
 
   it("preserves existing branch and worktree when setProjectDraftThreadId receives undefined", () => {

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -217,6 +217,7 @@ const PersistedDraftThreadState = Schema.Struct({
   worktreePath: Schema.NullOr(Schema.String),
   envMode: DraftThreadEnvModeSchema,
   startFromOrigin: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  continueBranch: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   promotedTo: Schema.optionalKey(
     Schema.NullOr(
       Schema.Struct({
@@ -321,6 +322,8 @@ export interface DraftSessionState {
   worktreePath: string | null;
   envMode: DraftThreadEnvMode;
   startFromOrigin: boolean;
+  /** Check out `branch` itself instead of creating a temporary branch from it. */
+  continueBranch: boolean;
   promotedTo?: ScopedThreadRef | null;
 }
 
@@ -383,6 +386,7 @@ interface ComposerDraftStoreState {
       createdAt?: string;
       envMode?: DraftThreadEnvMode;
       startFromOrigin?: boolean;
+      continueBranch?: boolean;
       runtimeMode?: RuntimeMode;
       interactionMode?: ProviderInteractionMode;
     },
@@ -398,6 +402,7 @@ interface ComposerDraftStoreState {
       createdAt?: string;
       envMode?: DraftThreadEnvMode;
       startFromOrigin?: boolean;
+      continueBranch?: boolean;
       runtimeMode?: RuntimeMode;
       interactionMode?: ProviderInteractionMode;
     },
@@ -412,6 +417,7 @@ interface ComposerDraftStoreState {
       createdAt?: string;
       envMode?: DraftThreadEnvMode;
       startFromOrigin?: boolean;
+      continueBranch?: boolean;
       runtimeMode?: RuntimeMode;
       interactionMode?: ProviderInteractionMode;
     },
@@ -1371,6 +1377,7 @@ function createDraftThreadState(
     createdAt?: string;
     envMode?: DraftThreadEnvMode;
     startFromOrigin?: boolean;
+    continueBranch?: boolean;
     runtimeMode?: RuntimeMode;
     interactionMode?: ProviderInteractionMode;
   },
@@ -1399,6 +1406,12 @@ function createDraftThreadState(
     options?.startFromOrigin === undefined
       ? (existingThread?.startFromOrigin ?? false)
       : options.startFromOrigin;
+  const nextContinueBranch =
+    options?.continueBranch === undefined
+      ? projectChanged
+        ? false
+        : (existingThread?.continueBranch ?? false)
+      : options.continueBranch;
   return {
     threadId,
     environmentId: projectRef.environmentId,
@@ -1413,6 +1426,7 @@ function createDraftThreadState(
     envMode:
       options?.envMode ?? (nextWorktreePath ? "worktree" : (existingThread?.envMode ?? "local")),
     startFromOrigin: nextStartFromOrigin,
+    continueBranch: nextContinueBranch,
     promotedTo: null,
   };
 }
@@ -1445,6 +1459,7 @@ function draftThreadsEqual(left: DraftThreadState | undefined, right: DraftThrea
     left.worktreePath === right.worktreePath &&
     left.envMode === right.envMode &&
     left.startFromOrigin === right.startFromOrigin &&
+    left.continueBranch === right.continueBranch &&
     scopedThreadRefsEqual(left.promotedTo, right.promotedTo)
   );
 }
@@ -1540,6 +1555,7 @@ function normalizePersistedDraftThreads(
       const branch = candidateDraftThread.branch;
       const worktreePath = candidateDraftThread.worktreePath;
       const startFromOrigin = candidateDraftThread.startFromOrigin === true;
+      const continueBranch = candidateDraftThread.continueBranch === true;
       const normalizedWorktreePath = typeof worktreePath === "string" ? worktreePath : null;
       const promotedToCandidate = candidateDraftThread.promotedTo;
       const promotedToRecord =
@@ -1588,6 +1604,7 @@ function normalizePersistedDraftThreads(
         worktreePath: normalizedWorktreePath,
         envMode: normalizeDraftThreadEnvMode(candidateDraftThread.envMode, normalizedWorktreePath),
         startFromOrigin,
+        continueBranch,
         promotedTo,
       };
     }
@@ -1634,6 +1651,7 @@ function normalizePersistedDraftThreads(
           worktreePath: null,
           envMode: "local",
           startFromOrigin: false,
+          continueBranch: false,
           promotedTo: null,
         };
       } else if (
@@ -2237,6 +2255,7 @@ function toHydratedDraftThreadState(
     worktreePath: persistedDraftThread.worktreePath,
     envMode: persistedDraftThread.envMode,
     startFromOrigin: persistedDraftThread.startFromOrigin,
+    continueBranch: persistedDraftThread.continueBranch,
     promotedTo: persistedDraftThread.promotedTo
       ? scopeThreadRef(
           persistedDraftThread.promotedTo.environmentId as EnvironmentId,
@@ -2455,6 +2474,12 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
               options.startFromOrigin === undefined
                 ? existing.startFromOrigin
                 : options.startFromOrigin;
+            const nextContinueBranch =
+              options.continueBranch === undefined
+                ? projectChanged
+                  ? false
+                  : existing.continueBranch
+                : options.continueBranch;
             const nextDraftThread: DraftThreadState = {
               threadId: existing.threadId,
               environmentId: nextProjectRef.environmentId,
@@ -2471,6 +2496,7 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
               envMode:
                 options.envMode ?? (nextWorktreePath ? "worktree" : (existing.envMode ?? "local")),
               startFromOrigin: nextStartFromOrigin,
+              continueBranch: nextContinueBranch,
               promotedTo: existing.promotedTo ?? null,
             };
             const isUnchanged =
@@ -2484,6 +2510,7 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
               nextDraftThread.worktreePath === existing.worktreePath &&
               nextDraftThread.envMode === existing.envMode &&
               nextDraftThread.startFromOrigin === existing.startFromOrigin &&
+              nextDraftThread.continueBranch === existing.continueBranch &&
               scopedThreadRefsEqual(nextDraftThread.promotedTo, existing.promotedTo);
             if (isUnchanged) {
               return state;

--- a/apps/web/src/continueBranch.test.ts
+++ b/apps/web/src/continueBranch.test.ts
@@ -1,0 +1,112 @@
+import { EnvironmentId, ProjectId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { continueBranchTargetIndex, resolveContinueBranchTargets } from "./continueBranch";
+
+function project(environmentId: string, id: string, root: string, canonicalKey: string) {
+  return {
+    environmentId: EnvironmentId.make(environmentId),
+    id: ProjectId.make(id),
+    title: "T3 Code",
+    workspaceRoot: root,
+    repositoryIdentity: {
+      canonicalKey,
+      locator: {
+        source: "git-remote" as const,
+        remoteName: "origin",
+        remoteUrl: `https://${canonicalKey}`,
+      },
+      rootPath: root,
+      name: "t3code",
+      displayName: "T3 Code",
+    },
+    defaultModelSelection: null,
+    scripts: [],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+describe("resolveContinueBranchTargets", () => {
+  it("offers connected copies of the same project on other environments", () => {
+    const projects = [
+      project("vps", "vps-project", "/srv/t3code", "github.com:t3tools/t3code"),
+      project("local", "local-project", "/Users/me/t3code", "github.com:t3tools/t3code"),
+      project("other", "other-project", "/tmp/other", "github.com:t3tools/other"),
+    ];
+
+    expect(
+      resolveContinueBranchTargets({
+        sourceProjectRef: {
+          environmentId: EnvironmentId.make("vps"),
+          projectId: ProjectId.make("vps-project"),
+        },
+        projects,
+        environments: [
+          {
+            environmentId: EnvironmentId.make("vps"),
+            label: "VPS",
+            connection: { phase: "connected" },
+          },
+          {
+            environmentId: EnvironmentId.make("local"),
+            label: "My Mac",
+            connection: { phase: "connected" },
+          },
+          {
+            environmentId: EnvironmentId.make("other"),
+            label: "Other",
+            connection: { phase: "connected" },
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        label: "My Mac",
+        projectRef: {
+          environmentId: EnvironmentId.make("local"),
+          projectId: ProjectId.make("local-project"),
+        },
+      },
+    ]);
+  });
+
+  it("does not offer disconnected or identity-less projects", () => {
+    const source = project("vps", "vps-project", "/srv/t3code", "repo");
+    expect(
+      resolveContinueBranchTargets({
+        sourceProjectRef: {
+          environmentId: EnvironmentId.make("vps"),
+          projectId: ProjectId.make("vps-project"),
+        },
+        projects: [source, project("local", "local-project", "/code/t3", "repo")],
+        environments: [
+          {
+            environmentId: EnvironmentId.make("local"),
+            label: "Local",
+            connection: { phase: "offline" },
+          },
+        ],
+      }),
+    ).toEqual([]);
+
+    expect(
+      resolveContinueBranchTargets({
+        sourceProjectRef: {
+          environmentId: EnvironmentId.make("vps"),
+          projectId: ProjectId.make("vps-project"),
+        },
+        projects: [{ ...source, repositoryIdentity: null }],
+        environments: [],
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("continueBranchTargetIndex", () => {
+  it("only parses destination action ids", () => {
+    expect(continueBranchTargetIndex("continue-branch-on:2")).toBe(2);
+    expect(continueBranchTargetIndex("continue-branch-on:nope")).toBeNull();
+    expect(continueBranchTargetIndex("snooze:2")).toBeNull();
+  });
+});

--- a/apps/web/src/continueBranch.ts
+++ b/apps/web/src/continueBranch.ts
@@ -1,0 +1,79 @@
+import { scopeProjectRef } from "@t3tools/client-runtime/environment";
+import type { EnvironmentProject } from "@t3tools/client-runtime/state/models";
+import type { EnvironmentId, ScopedProjectRef } from "@t3tools/contracts";
+
+import { deriveLogicalProjectKey } from "./logicalProject";
+
+interface ContinueBranchEnvironment {
+  readonly environmentId: EnvironmentId;
+  readonly label: string;
+  readonly connection: {
+    readonly phase: string;
+  };
+}
+
+export interface ContinueBranchTarget {
+  readonly label: string;
+  readonly projectRef: ScopedProjectRef;
+}
+
+/**
+ * Finds connected copies of the same repository project on other environments.
+ * Project grouping is intentional here even when the sidebar is configured to
+ * show environments separately: that display preference must not hide a valid
+ * handoff destination.
+ */
+export function resolveContinueBranchTargets(input: {
+  readonly sourceProjectRef: ScopedProjectRef;
+  readonly projects: ReadonlyArray<EnvironmentProject>;
+  readonly environments: ReadonlyArray<ContinueBranchEnvironment>;
+}): ReadonlyArray<ContinueBranchTarget> {
+  const sourceProject = input.projects.find(
+    (project) =>
+      project.environmentId === input.sourceProjectRef.environmentId &&
+      project.id === input.sourceProjectRef.projectId,
+  );
+  if (!sourceProject?.repositoryIdentity?.canonicalKey) return [];
+
+  const sourceLogicalKey = deriveLogicalProjectKey(sourceProject, {
+    groupingMode: "repository_path",
+  });
+  const connectedEnvironmentLabels = new Map(
+    input.environments
+      .filter((environment) => environment.connection.phase === "connected")
+      .map((environment) => [environment.environmentId, environment.label] as const),
+  );
+  const candidates = input.projects.filter(
+    (project) =>
+      project.environmentId !== sourceProject.environmentId &&
+      connectedEnvironmentLabels.has(project.environmentId) &&
+      deriveLogicalProjectKey(project, { groupingMode: "repository_path" }) === sourceLogicalKey,
+  );
+  const countByEnvironment = new Map<EnvironmentId, number>();
+  for (const candidate of candidates) {
+    countByEnvironment.set(
+      candidate.environmentId,
+      (countByEnvironment.get(candidate.environmentId) ?? 0) + 1,
+    );
+  }
+
+  return candidates
+    .map((project) => {
+      const environmentLabel = connectedEnvironmentLabels.get(project.environmentId)!;
+      return {
+        label:
+          countByEnvironment.get(project.environmentId) === 1
+            ? environmentLabel
+            : `${environmentLabel} — ${project.workspaceRoot}`,
+        projectRef: scopeProjectRef(project.environmentId, project.id),
+      };
+    })
+    .toSorted((left, right) => left.label.localeCompare(right.label));
+}
+
+export function continueBranchTargetIndex(action: string): number | null {
+  const match = /^continue-branch-on:(\d+)$/.exec(action);
+  if (!match) return null;
+  const index = Number(match[1]);
+  return Number.isSafeInteger(index) ? index : null;
+}

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -36,6 +36,7 @@ interface NewThreadWorkspaceOptions {
   worktreePath?: string | null;
   envMode?: DraftThreadEnvMode;
   startFromOrigin?: boolean;
+  continueBranch?: boolean;
 }
 
 // The workspace options the caller passed explicitly, shaped for the draft
@@ -47,6 +48,7 @@ function pickExplicitWorkspaceOptions(options: NewThreadWorkspaceOptions | undef
     ...(options?.worktreePath !== undefined ? { worktreePath: options.worktreePath } : {}),
     ...(options?.envMode !== undefined ? { envMode: options.envMode } : {}),
     ...(options?.startFromOrigin !== undefined ? { startFromOrigin: options.startFromOrigin } : {}),
+    ...(options?.continueBranch !== undefined ? { continueBranch: options.continueBranch } : {}),
   };
 }
 
@@ -73,6 +75,7 @@ export function useNewThreadHandler() {
         worktreePath?: string | null;
         envMode?: DraftThreadEnvMode;
         startFromOrigin?: boolean;
+        continueBranch?: boolean;
         replace?: boolean;
         /**
          * Move the viewed draft's typed content (prompt + images) into the
@@ -184,6 +187,7 @@ export function useNewThreadHandler() {
       const hasWorktreePathOption = options?.worktreePath !== undefined;
       const hasEnvModeOption = options?.envMode !== undefined;
       const hasStartFromOriginOption = options?.startFromOrigin !== undefined;
+      const hasContinueBranchOption = options?.continueBranch !== undefined;
       const storedDraftThread = getDraftSessionByLogicalProjectKey(logicalProjectKey);
       const storedDraftThreadRef = storedDraftThread
         ? scopeThreadRef(storedDraftThread.environmentId, storedDraftThread.threadId)
@@ -220,7 +224,8 @@ export function useNewThreadHandler() {
             hasBranchOption ||
             hasWorktreePathOption ||
             hasEnvModeOption ||
-            hasStartFromOriginOption;
+            hasStartFromOriginOption ||
+            hasContinueBranchOption;
           // Resurrecting an empty stored draft must not resurrect its stale
           // context: explicit workspace options win outright; otherwise the
           // env context resets to the configured defaults so drafts seeded
@@ -265,6 +270,7 @@ export function useNewThreadHandler() {
                 envMode: defaultEnvMode,
                 newWorktreesStartFromOrigin: primaryServerSettings.newWorktreesStartFromOrigin,
               }),
+              continueBranch: false,
             };
           }
           if (workspaceContext) {
@@ -334,7 +340,8 @@ export function useNewThreadHandler() {
           hasBranchOption ||
           hasWorktreePathOption ||
           hasEnvModeOption ||
-          hasStartFromOriginOption
+          hasStartFromOriginOption ||
+          hasContinueBranchOption
         ) {
           setDraftThreadContext(currentRouteTarget.draftId, pickExplicitWorkspaceOptions(options));
         }
@@ -405,6 +412,7 @@ export function useNewThreadHandler() {
               envMode: initialEnvMode,
               newWorktreesStartFromOrigin: primaryServerSettings.newWorktreesStartFromOrigin,
             }),
+          continueBranch: options?.continueBranch ?? false,
           runtimeMode: carryRuntimeMode ?? DEFAULT_RUNTIME_MODE,
           ...(carryInteractionMode ? { interactionMode: carryInteractionMode } : {}),
         });

--- a/apps/web/src/hooks/useThreadActionMenu.ts
+++ b/apps/web/src/hooks/useThreadActionMenu.ts
@@ -19,6 +19,7 @@ import {
   buildThreadActionMenuItems,
   type ThreadActionMenuId,
 } from "../components/threadActionMenu.logic";
+import { continueBranchTargetIndex, resolveContinueBranchTargets } from "../continueBranch";
 import { stackedThreadToast, toastManager } from "../components/ui/toast";
 import { threadEnvironment } from "../state/threads";
 import { useAtomCommand } from "../state/use-atom-command";
@@ -28,7 +29,9 @@ import {
   readEnvironmentSupportsSnooze,
   readEnvironmentSupportsTitleRegeneration,
   readThreadShell,
+  useProjects,
 } from "../state/entities";
+import { useEnvironments } from "../state/environments";
 import { readLocalApi } from "../localApi";
 import { useUiStateStore } from "../uiStateStore";
 import { useCopyToClipboard } from "./useCopyToClipboard";
@@ -79,6 +82,8 @@ export function useThreadActionMenu(input: {
     reportFailure: false,
   });
   const handleNewThread = useNewThreadHandler();
+  const projects = useProjects();
+  const { environments } = useEnvironments();
   const markThreadUnread = useUiStateStore((s) => s.markThreadUnread);
   const autoSettleAfterDays = useClientSettings((s) => s.sidebarAutoSettleAfterDays);
   const autoSettleOnMerge = useClientSettings((s) => s.sidebarAutoSettleOnMerge);
@@ -124,8 +129,14 @@ export function useThreadActionMenu(input: {
         };
         const isRegeneratingTitle = thread.titleRegeneration != null;
         const snoozePresets = resolveSnoozePresets(now, timestampFormat);
+        const continueBranchTargets = resolveContinueBranchTargets({
+          sourceProjectRef: scopeProjectRef(threadRef.environmentId, thread.projectId),
+          projects,
+          environments,
+        });
         const items = buildThreadActionMenuItems({
           branch: thread.branch ?? null,
+          continueBranchTargetLabels: continueBranchTargets.map((target) => target.label),
           isPinned: thread.pinnedAt != null,
           isSettled:
             supports.settlement &&
@@ -148,6 +159,24 @@ export function useThreadActionMenu(input: {
         const clicked = await settlePromise(() => api.contextMenu.show(items, position));
         if (clicked._tag === "Failure" || clicked.value === null) return;
         const action: ThreadActionMenuId = clicked.value;
+        const continueTargetIndex = continueBranchTargetIndex(action);
+        if (continueTargetIndex !== null && thread.branch) {
+          const target = continueBranchTargets[continueTargetIndex];
+          if (!target) return;
+          const result = await settlePromise(() =>
+            handleNewThread(target.projectRef, {
+              branch: thread.branch,
+              worktreePath: null,
+              envMode: "worktree",
+              startFromOrigin: true,
+              continueBranch: true,
+            }),
+          );
+          if (result._tag === "Failure") {
+            failureToast("Could not continue branch", squashAtomCommandFailure(result));
+          }
+          return;
+        }
         if (action.startsWith("snooze:")) {
           const preset = snoozePresets.find((candidate) => `snooze:${candidate.id}` === action);
           if (!preset) return;
@@ -313,6 +342,7 @@ export function useThreadActionMenu(input: {
       autoSettleAfterDays,
       autoSettleOnMerge,
       changeRequestState,
+      environments,
       confirmThreadArchive,
       confirmThreadDelete,
       copyBranchToClipboard,
@@ -322,6 +352,7 @@ export function useThreadActionMenu(input: {
       handleNewThread,
       markThreadUnread,
       onStartRename,
+      projects,
       pinThread,
       projectCwd,
       settleThread,

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -12,6 +12,16 @@ If reordering is unavailable for one environment, update the T3 Code server runn
 environment. Older servers can still pin and unpin threads, but do not understand synced ordering;
 their pinned threads keep the default newest-first order below the ones you have arranged.
 
+## Continue a branch on another environment
+
+When the same repository project is available on two connected environments, open a thread's
+menu and choose **Continue branch on…**, then choose the destination environment. T3 Code opens a
+new thread draft there. On the first send, it fetches `origin` and checks out the same branch in a
+worktree. The source thread and its conversation stay where they are.
+
+Push the branch before continuing it so the destination can fetch it. If the branch already has a
+checkout on the destination, T3 Code reuses that checkout instead of creating a duplicate.
+
 ## Environment artwork
 
 Dev and Nightly environments can identify themselves with artwork at the top of the sidebar and in

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -283,6 +283,7 @@ it.effect("accepts bootstrap metadata in thread.turn.start", () =>
           baseBranch: "main",
           branch: "t3code/example",
           startFromOrigin: true,
+          continueBranch: true,
         },
         runSetupScript: true,
       },
@@ -291,6 +292,7 @@ it.effect("accepts bootstrap metadata in thread.turn.start", () =>
     assert.strictEqual(parsed.bootstrap?.createThread?.projectId, "project-1");
     assert.strictEqual(parsed.bootstrap?.prepareWorktree?.baseBranch, "main");
     assert.strictEqual(parsed.bootstrap?.prepareWorktree?.startFromOrigin, true);
+    assert.strictEqual(parsed.bootstrap?.prepareWorktree?.continueBranch, true);
     assert.strictEqual(parsed.bootstrap?.runSetupScript, true);
   }),
 );

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -812,6 +812,7 @@ const ThreadTurnStartBootstrapPrepareWorktree = Schema.Struct({
   baseBranch: TrimmedNonEmptyString,
   branch: Schema.optional(TrimmedNonEmptyString),
   startFromOrigin: Schema.optional(Schema.Boolean),
+  continueBranch: Schema.optional(Schema.Boolean),
 });
 
 const ThreadTurnStartBootstrap = Schema.Struct({


### PR DESCRIPTION
## Problem

A thread and its work can live on a remote environment even when the user wants to continue the pushed branch on another connected machine. Moving the full conversation is covered by the broader direction in #2829, but branch-only handoff can be useful independently.

## Solution

- add a Continue branch on… submenu for matching repository projects on connected environments
- open a fresh destination draft without copying conversation history
- fetch origin on first send and check out the same branch name in a destination worktree
- reuse an existing destination checkout, while treating the primary checkout as local so it cannot be mistaken for a removable worktree
- expose the action in the chat header and both web/desktop sidebar implementations

## Testing

- 92 focused web tests passed
- 44 contract tests passed
- contracts, server, and web typechecks passed
- targeted lint and formatting passed
- added a focused server integration test; its local execution was blocked before assertions by an environment-level EDQUOT error while the test secret store was being created

## Screenshots

Omitted at maintainer request.

Built with GPT-5.6 Sol in T3 Code via the Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'Continue branch on…' action to continue a branch across connected environments
> - Adds a 'Continue branch on…' submenu to thread action menus in both [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/7329/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) and [LegacySidebar.tsx](https://github.com/pingdotgg/t3code/pull/7329/files#diff-ef6c49faf62e0e2403f09772084537ac313e826ae0f90db230a898204f3bdd86), listing connected environments that share the same repository.
> - When selected, opens a new draft on the target environment with `continueBranch: true`, causing the server to fetch `origin/<branch>` and check it out directly instead of creating a temporary worktree branch.
> - If a matching local branch already exists in a worktree, the server reuses that checkout rather than creating a new one.
> - Adds `continueBranch` to [composerDraftStore.ts](https://github.com/pingdotgg/t3code/pull/7329/files#diff-fe25f0ac6b3f15bcb25522be5eddf9c2db913c035393f9a4dc019a9afda80f8a) persisted state and the `ThreadTurnStartBootstrapPrepareWorktree` contract schema.
> - Risk: branches must be pushed to origin before continuing; the feature silently falls back to the local base branch if no origin remote exists.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f34ef5a. 11 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->