### PR TITLE
fix(swift-ios): show cached source control status

### DIFF
--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -5172,7 +5172,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                 backgroundWorkIsActive: backgroundWorkIsActive,
                 fallbackUpdatedAt: thread.updatedAt
             ),
-            latestTurnCompletedAt: thread.latestTurn?.completedAt.map(parseDate),
+            latestTurnCompletedAt: thread.latestTurn?.completedAt.flatMap(parseValidDate),
             settlementFacts: settlementFacts(
                 override: thread.settledOverride,
                 session: thread.session,
@@ -5253,7 +5253,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                 backgroundWorkIsActive: backgroundWorkIsActive,
                 fallbackUpdatedAt: thread.updatedAt
             ),
-            latestTurnCompletedAt: thread.latestTurn?.completedAt.map(parseDate),
+            latestTurnCompletedAt: thread.latestTurn?.completedAt.flatMap(parseValidDate),
             settlementFacts: settlementFacts(
                 override: thread.settledOverride,
                 session: thread.session,

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -36,6 +36,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     private static let olderThreadPageUserTurnLimit = 20
     private static let projectFaviconRefreshInterval: TimeInterval = 15 * 60
     private static let projectFaviconFallbackMarker = "project-favicon-missing"
+    private static let sourceControlStatusStreamTimeoutSeconds: TimeInterval = 30
 
     private let runtime: EnvironmentRuntime
     let t3ConnectController: T3ConnectController
@@ -2559,6 +2560,85 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         )
     }
 
+    func sourceControlStatuses(
+        threadID: String
+    ) async throws -> AsyncThrowingStream<FeatureSourceControlStatus, Error> {
+        let route = try threadRoute(for: threadID)
+        let context = try workspaceContext(route: route)
+        let client = route.client
+        let environmentID = route.environmentID
+        let generation = environmentGeneration
+        let events = await client.vcsStatusEvents(cwd: context.cwd)
+        // Each element is a whole status, so only the newest one is ever useful.
+        let (statuses, continuation) = AsyncThrowingStream.makeStream(
+            of: FeatureSourceControlStatus.self,
+            bufferingPolicy: .bufferingNewest(1)
+        )
+        let task = Task { [weak self] in
+            // The server publishes `remoteUpdated` only when the remote
+            // fingerprint changes, and backs off silently when a remote refresh
+            // fails, so the remote half may never arrive. Bound the wait rather
+            // than leaving the screen loading forever, and say so instead of
+            // leaving the status quietly half-known.
+            let deadline = Task {
+                try? await Task.sleep(
+                    for: .seconds(Self.sourceControlStatusStreamTimeoutSeconds)
+                )
+                guard !Task.isCancelled else { return }
+                continuation.finish(throwing: NativeFeatureClientError.remoteStatusUnavailable)
+            }
+            defer { deadline.cancel() }
+
+            var accumulator = NativeSourceControlStatusAccumulator()
+            do {
+                for try await event in events {
+                    // Superseded by cancellation or an environment switch: the
+                    // stream is over, but nothing about it was malformed, so it
+                    // must not run the end-of-stream validation below.
+                    guard !Task.isCancelled else {
+                        continuation.finish()
+                        return
+                    }
+                    guard let self else {
+                        continuation.finish()
+                        return
+                    }
+                    guard self.isKnownClient(
+                        client,
+                        environmentID: environmentID,
+                        generation: generation
+                    ) else {
+                        continuation.finish()
+                        return
+                    }
+                    if let status = accumulator.consume(event) {
+                        continuation.yield(status)
+                    }
+                    if accumulator.isComplete {
+                        continuation.finish()
+                        return
+                    }
+                }
+                if Task.isCancelled {
+                    continuation.finish()
+                } else {
+                    try accumulator.validateEnd()
+                    continuation.finish()
+                }
+            } catch is CancellationError {
+                continuation.finish()
+            } catch {
+                if Task.isCancelled {
+                    continuation.finish()
+                } else {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+        continuation.onTermination = { @Sendable _ in task.cancel() }
+        return statuses
+    }
+
     func sourceControlStatusEvents(threadID: String) -> AsyncStream<FeatureSourceControlStatus> {
         let stream = AsyncStream<FeatureSourceControlStatus>.makeStream(
             bufferingPolicy: .bufferingNewest(1)
@@ -2614,8 +2694,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         monitorID: UUID
     ) async {
         let events = await client.vcsStatusEvents(cwd: key.workingDirectory)
-        var local: VCSLocalStatus?
-        var remote: VCSRemoteStatus?
+        var accumulator = NativeSourceControlStatusAccumulator()
 
         do {
             for try await event in events {
@@ -2624,24 +2703,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                     break
                 }
 
-                switch event {
-                case let .snapshot(nextLocal, nextRemote):
-                    local = nextLocal
-                    remote = nextRemote
-                case let .localUpdated(nextLocal):
-                    if local?.refName != nextLocal.refName {
-                        remote = nil
-                    }
-                    local = nextLocal
-                case let .remoteUpdated(nextRemote):
-                    remote = nextRemote
-                }
-
-                guard let local else { continue }
-                let status = NativeWorkspaceMapper.sourceControl(
-                    local: local,
-                    remote: remote
-                )
+                guard let status = accumulator.consume(event) else { continue }
                 guard let monitor = sourceControlMonitors[key],
                       monitor.id == monitorID,
                       monitor.latestStatus != status else {
@@ -5110,7 +5172,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                 backgroundWorkIsActive: backgroundWorkIsActive,
                 fallbackUpdatedAt: thread.updatedAt
             ),
-            latestTurnCompletedAt: thread.latestTurn?.completedAt.flatMap(parseValidDate),
+            latestTurnCompletedAt: thread.latestTurn?.completedAt.map(parseDate),
             settlementFacts: settlementFacts(
                 override: thread.settledOverride,
                 session: thread.session,
@@ -5191,7 +5253,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                 backgroundWorkIsActive: backgroundWorkIsActive,
                 fallbackUpdatedAt: thread.updatedAt
             ),
-            latestTurnCompletedAt: thread.latestTurn?.completedAt.flatMap(parseValidDate),
+            latestTurnCompletedAt: thread.latestTurn?.completedAt.map(parseDate),
             settlementFacts: settlementFacts(
                 override: thread.settledOverride,
                 session: thread.session,
@@ -7534,6 +7596,7 @@ private enum NativeFeatureClientError: LocalizedError {
     case missingScope(String)
     case tooManyAttachments
     case invalidAutomaticSettlementDays
+    case remoteStatusUnavailable
 
     var errorDescription: String? {
         switch self {
@@ -7552,6 +7615,8 @@ private enum NativeFeatureClientError: LocalizedError {
         case .missingScope: "This connection does not have permission to manage devices."
         case .tooManyAttachments: "You can attach up to 8 files per message."
         case .invalidAutomaticSettlementDays: "Choose a value from 1 to 90 days."
+        case .remoteStatusUnavailable:
+            "Couldn't check the remote status. Try reloading."
         }
     }
 }

--- a/apps/swift-ios/App/NativeWorkspaceMapper.swift
+++ b/apps/swift-ios/App/NativeWorkspaceMapper.swift
@@ -123,6 +123,33 @@ enum NativeWorkspaceMapper {
         )
     }
 
+    static func sourceControl(
+        local: VCSLocalStatus,
+        remote: VCSRemoteStatus?
+    ) -> FeatureSourceControlStatus {
+        FeatureSourceControlStatus(
+            isRepository: local.isRepo,
+            branch: local.refName,
+            aheadCount: remote?.aheadCount ?? 0,
+            behindCount: remote?.behindCount ?? 0,
+            files: local.workingTree.files.map {
+                FeatureSourceControlFile(
+                    path: $0.path,
+                    state: .modified,
+                    isStaged: false
+                )
+            },
+            pullRequest: remote?.pr.map {
+                FeaturePullRequest(
+                    number: $0.number,
+                    title: $0.title,
+                    state: $0.state,
+                    url: URL(string: $0.url)
+                )
+            }
+        )
+    }
+
     static func gitAction(_ action: FeatureSourceControlAction) -> GitStackedAction {
         switch action {
         case .commit: .commit
@@ -373,5 +400,37 @@ enum NativeWorkspaceMapper {
                 .first
                 ?? ""
         )
+    }
+}
+
+struct NativeSourceControlStatusAccumulator {
+    private var local: VCSLocalStatus?
+    private(set) var isComplete = false
+
+    mutating func consume(_ event: VCSStatusEvent) -> FeatureSourceControlStatus? {
+        switch event {
+        case let .snapshot(nextLocal, remote):
+            local = nextLocal
+            isComplete = remote != nil || !nextLocal.isRepo || !nextLocal.hasPrimaryRemote
+            return NativeWorkspaceMapper.sourceControl(local: nextLocal, remote: remote)
+        case let .localUpdated(nextLocal):
+            local = nextLocal
+            isComplete = !nextLocal.isRepo || !nextLocal.hasPrimaryRemote
+            return NativeWorkspaceMapper.sourceControl(local: nextLocal, remote: nil)
+        case let .remoteUpdated(remote):
+            guard let local else { return nil }
+            isComplete = true
+            return NativeWorkspaceMapper.sourceControl(local: local, remote: remote)
+        }
+    }
+
+    var prematureEndError: RPCError {
+        RPCError.protocolViolation(
+            "The source-control status stream ended before completion."
+        )
+    }
+
+    func validateEnd() throws {
+        guard isComplete else { throw prematureEndError }
     }
 }

--- a/apps/swift-ios/App/NativeWorkspaceMapper.swift
+++ b/apps/swift-ios/App/NativeWorkspaceMapper.swift
@@ -97,13 +97,15 @@ enum NativeWorkspaceMapper {
         files: [VCSWorkingTreeFile],
         aheadCount: Int,
         behindCount: Int,
-        pullRequest: VCSChangeRequest?
+        pullRequest: VCSChangeRequest?,
+        isRemoteKnown: Bool = true
     ) -> FeatureSourceControlStatus {
         FeatureSourceControlStatus(
             isRepository: isRepository,
             branch: branch,
             aheadCount: aheadCount,
             behindCount: behindCount,
+            isRemoteKnown: isRemoteKnown,
             files: files.map {
                 FeatureSourceControlFile(
                     path: $0.path,
@@ -123,33 +125,21 @@ enum NativeWorkspaceMapper {
         )
     }
 
+    /// The streamed counterpart, where the remote half arrives separately and
+    /// may still be pending.
     static func sourceControl(
         local: VCSLocalStatus,
-        remote: VCSRemoteStatus?
+        remote: VCSRemoteStatus?,
+        isRemoteKnown: Bool
     ) -> FeatureSourceControlStatus {
-        FeatureSourceControlStatus(
+        sourceControl(
             isRepository: local.isRepo,
             branch: local.refName,
+            files: local.workingTree.files,
             aheadCount: remote?.aheadCount ?? 0,
             behindCount: remote?.behindCount ?? 0,
-            // A workspace with no repository or no primary remote will never
-            // receive a remote half, so nothing is pending in those cases.
-            isRemoteKnown: remote != nil || !local.isRepo || !local.hasPrimaryRemote,
-            files: local.workingTree.files.map {
-                FeatureSourceControlFile(
-                    path: $0.path,
-                    state: .modified,
-                    isStaged: false
-                )
-            },
-            pullRequest: remote?.pr.map {
-                FeaturePullRequest(
-                    number: $0.number,
-                    title: $0.title,
-                    state: $0.state,
-                    url: URL(string: $0.url)
-                )
-            }
+            pullRequest: remote?.pr,
+            isRemoteKnown: isRemoteKnown
         )
     }
 
@@ -406,32 +396,46 @@ enum NativeWorkspaceMapper {
     }
 }
 
-/// Folds `vcs.subscribeStatus` events into successive UI statuses, mirroring
-/// `applyGitStatusStreamEvent` in packages/shared: the last known remote half is
-/// carried across local-only updates instead of being dropped.
+/// Folds `vcs.subscribeStatus` events into successive UI statuses. Modelled on
+/// `applyGitStatusStreamEvent` in packages/shared — a snapshot replaces both
+/// halves, while the last known remote half is carried across same-branch local
+/// updates and discarded when the branch changes. The explicit pending state is
+/// needed because this client presents partial status.
 struct NativeSourceControlStatusAccumulator {
     private var local: VCSLocalStatus?
     private var remote: VCSRemoteStatus?
+    /// Tracked separately from `remote` because the remote half can legitimately
+    /// resolve to nil — "known to be absent" is not the same as "still pending".
+    private var isRemoteResolved = false
     private(set) var isComplete = false
 
     mutating func consume(_ event: VCSStatusEvent) -> FeatureSourceControlStatus? {
         switch event {
         case let .snapshot(nextLocal, nextRemote):
             local = nextLocal
-            if let nextRemote { remote = nextRemote }
+            remote = nextRemote
+            isRemoteResolved = nextRemote != nil
         case let .localUpdated(nextLocal):
+            if let previousLocal = local, previousLocal.refName != nextLocal.refName {
+                remote = nil
+                isRemoteResolved = false
+            }
             local = nextLocal
         case let .remoteUpdated(nextRemote):
             remote = nextRemote
+            isRemoteResolved = true
         }
 
         guard let local else { return nil }
-        // Latches: a later local-only update must not reopen a stream whose
-        // remote half already arrived.
-        if remote != nil || !local.isRepo || !local.hasPrimaryRemote {
-            isComplete = true
-        }
-        return NativeWorkspaceMapper.sourceControl(local: local, remote: remote)
+        // A workspace with no repository or no primary remote never receives a
+        // remote half, so nothing is pending in those cases.
+        let isRemoteKnown = isRemoteResolved || !local.isRepo || !local.hasPrimaryRemote
+        isComplete = isRemoteKnown
+        return NativeWorkspaceMapper.sourceControl(
+            local: local,
+            remote: remote,
+            isRemoteKnown: isRemoteKnown
+        )
     }
 
     func validateEnd() throws {

--- a/apps/swift-ios/App/NativeWorkspaceMapper.swift
+++ b/apps/swift-ios/App/NativeWorkspaceMapper.swift
@@ -132,6 +132,9 @@ enum NativeWorkspaceMapper {
             branch: local.refName,
             aheadCount: remote?.aheadCount ?? 0,
             behindCount: remote?.behindCount ?? 0,
+            // A workspace with no repository or no primary remote will never
+            // receive a remote half, so nothing is pending in those cases.
+            isRemoteKnown: remote != nil || !local.isRepo || !local.hasPrimaryRemote,
             files: local.workingTree.files.map {
                 FeatureSourceControlFile(
                     path: $0.path,
@@ -403,34 +406,39 @@ enum NativeWorkspaceMapper {
     }
 }
 
+/// Folds `vcs.subscribeStatus` events into successive UI statuses, mirroring
+/// `applyGitStatusStreamEvent` in packages/shared: the last known remote half is
+/// carried across local-only updates instead of being dropped.
 struct NativeSourceControlStatusAccumulator {
     private var local: VCSLocalStatus?
+    private var remote: VCSRemoteStatus?
     private(set) var isComplete = false
 
     mutating func consume(_ event: VCSStatusEvent) -> FeatureSourceControlStatus? {
         switch event {
-        case let .snapshot(nextLocal, remote):
+        case let .snapshot(nextLocal, nextRemote):
             local = nextLocal
-            isComplete = remote != nil || !nextLocal.isRepo || !nextLocal.hasPrimaryRemote
-            return NativeWorkspaceMapper.sourceControl(local: nextLocal, remote: remote)
+            if let nextRemote { remote = nextRemote }
         case let .localUpdated(nextLocal):
             local = nextLocal
-            isComplete = !nextLocal.isRepo || !nextLocal.hasPrimaryRemote
-            return NativeWorkspaceMapper.sourceControl(local: nextLocal, remote: nil)
-        case let .remoteUpdated(remote):
-            guard let local else { return nil }
-            isComplete = true
-            return NativeWorkspaceMapper.sourceControl(local: local, remote: remote)
+        case let .remoteUpdated(nextRemote):
+            remote = nextRemote
         }
-    }
 
-    var prematureEndError: RPCError {
-        RPCError.protocolViolation(
-            "The source-control status stream ended before completion."
-        )
+        guard let local else { return nil }
+        // Latches: a later local-only update must not reopen a stream whose
+        // remote half already arrived.
+        if remote != nil || !local.isRepo || !local.hasPrimaryRemote {
+            isComplete = true
+        }
+        return NativeWorkspaceMapper.sourceControl(local: local, remote: remote)
     }
 
     func validateEnd() throws {
-        guard isComplete else { throw prematureEndError }
+        guard isComplete else {
+            throw RPCError.protocolViolation(
+                "The source-control status stream ended before completion."
+            )
+        }
     }
 }

--- a/apps/swift-ios/Features/Shared/FeatureClient.swift
+++ b/apps/swift-ios/Features/Shared/FeatureClient.swift
@@ -208,6 +208,9 @@ public protocol FeatureClient: AnyObject {
     ) async throws -> FeatureReviewFileContents?
 
     func sourceControlStatus(threadID: String) async throws -> FeatureSourceControlStatus
+    func sourceControlStatuses(
+        threadID: String
+    ) async throws -> AsyncThrowingStream<FeatureSourceControlStatus, Error>
     func sourceControlStatusEvents(threadID: String) -> AsyncStream<FeatureSourceControlStatus>
     /// Completes at the mutation boundary. Callers refresh status separately so a refresh
     /// failure cannot make an already-completed non-idempotent action retryable.
@@ -605,6 +608,18 @@ public extension FeatureClient {
 
     func sourceControlStatus(threadID: String) async throws -> FeatureSourceControlStatus {
         throw FeatureCapabilityUnavailable("Source control")
+    }
+
+    func sourceControlStatuses(
+        threadID: String
+    ) async throws -> AsyncThrowingStream<FeatureSourceControlStatus, Error> {
+        let status = try await sourceControlStatus(threadID: threadID)
+        let (stream, continuation) = AsyncThrowingStream.makeStream(
+            of: FeatureSourceControlStatus.self
+        )
+        continuation.yield(status)
+        continuation.finish()
+        return stream
     }
 
     func sourceControlStatusEvents(threadID: String) -> AsyncStream<FeatureSourceControlStatus> {

--- a/apps/swift-ios/Features/Shared/FeatureToolModels.swift
+++ b/apps/swift-ios/Features/Shared/FeatureToolModels.swift
@@ -889,6 +889,9 @@ public struct FeatureSourceControlStatus: Sendable, Equatable, Codable {
     public var upstream: String?
     public var aheadCount: Int
     public var behindCount: Int
+    /// `false` while the remote half of a streamed status is still pending, so
+    /// ahead/behind/pull-request fields are "not yet known" rather than zero.
+    public var isRemoteKnown: Bool
     public var files: [FeatureSourceControlFile]
     public var pullRequest: FeaturePullRequest?
     public var isBusy: Bool
@@ -899,6 +902,7 @@ public struct FeatureSourceControlStatus: Sendable, Equatable, Codable {
         upstream: String? = nil,
         aheadCount: Int = 0,
         behindCount: Int = 0,
+        isRemoteKnown: Bool = true,
         files: [FeatureSourceControlFile] = [],
         pullRequest: FeaturePullRequest? = nil,
         isBusy: Bool = false
@@ -908,6 +912,7 @@ public struct FeatureSourceControlStatus: Sendable, Equatable, Codable {
         self.upstream = upstream
         self.aheadCount = aheadCount
         self.behindCount = behindCount
+        self.isRemoteKnown = isRemoteKnown
         self.files = files
         self.pullRequest = pullRequest
         self.isBusy = isBusy
@@ -919,13 +924,15 @@ public struct FeatureSourceControlStatus: Sendable, Equatable, Codable {
         if !files.isEmpty {
             actions.append(.commit)
             actions.append(.commitAndPush)
-            if pullRequest == nil {
+            if isRemoteKnown, pullRequest == nil {
                 actions.append(.commitPushAndCreatePullRequest)
             }
         }
         if aheadCount > 0 { actions.append(.push) }
         if behindCount > 0 { actions.append(.pull) }
-        if pullRequest == nil { actions.append(.createPullRequest) }
+        // Withheld until the remote half lands: offering it against an unknown
+        // remote can propose a second PR for a branch that already has one.
+        if isRemoteKnown, pullRequest == nil { actions.append(.createPullRequest) }
         return actions
     }
 }

--- a/apps/swift-ios/Features/SourceControl/FeatureSourceControlView.swift
+++ b/apps/swift-ios/Features/SourceControl/FeatureSourceControlView.swift
@@ -1,5 +1,20 @@
 import SwiftUI
 
+@MainActor
+func runFeatureSourceControlAction<Value>(
+    setRunning: (Bool) -> Void,
+    operation: () async throws -> Value
+) async -> Result<Value, Error> {
+    setRunning(true)
+    defer { setRunning(false) }
+
+    do {
+        return .success(try await operation())
+    } catch {
+        return .failure(error)
+    }
+}
+
 public struct FeatureSourceControlView: View {
     let client: any FeatureClient
     let threadID: String
@@ -9,6 +24,9 @@ public struct FeatureSourceControlView: View {
     @State private var isRunningAction = false
     @State private var runState = FeatureToolRunState<FeatureSourceControlOperation>()
     @State private var recovery = FeatureToolFailureState<FeatureSourceControlOperation>()
+    @State private var errorMessage: String?
+    @State private var loadGeneration = 0
+    @State private var statusGeneration = 0
     @State private var commitMessage = ""
     @State private var pendingCommitAction: FeatureSourceControlAction?
     @AccessibilityFocusState private var recoveryFocus: FeatureToolRecoveryFocus?
@@ -48,9 +66,15 @@ public struct FeatureSourceControlView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
-                Button { Task { await load() } } label: { Image(systemName: "arrow.clockwise") }
-                    .disabled(isLoading || runState.isBusy)
-                    .accessibilityLabel("Reload source control")
+                Button { Task { await reload() } } label: {
+                    if isLoading {
+                        ProgressView()
+                    } else {
+                        Image(systemName: "arrow.clockwise")
+                    }
+                }
+                .disabled(runState.isBusy)
+                .accessibilityLabel("Reload source control")
             }
         }
         .alert("Commit changes", isPresented: Binding(
@@ -140,19 +164,41 @@ public struct FeatureSourceControlView: View {
 
     private func statusList(_ status: FeatureSourceControlStatus) -> some View {
         List {
+            // Once a status is on screen the unavailable-state view is
+            // unreachable, so a later failure needs its own inline surface.
+            if let errorMessage {
+                Section {
+                    Label(errorMessage, systemImage: "exclamationmark.triangle")
+                        .font(T3Typography.supporting)
+                        .foregroundStyle(.orange)
+                }
+            }
+
             Section("Repository") {
                 LabeledContent("Branch", value: status.branch ?? "Detached HEAD")
                     .accessibilityFocused($recoveryFocus, equals: .recoveredContent)
                 if let upstream = status.upstream {
                     LabeledContent("Upstream", value: upstream)
                 }
-                HStack {
-                    Label("\(status.aheadCount) ahead", systemImage: "arrow.up")
-                    Spacer()
-                    Label("\(status.behindCount) behind", systemImage: "arrow.down")
+                if status.isRemoteKnown {
+                    HStack {
+                        Label("\(status.aheadCount) ahead", systemImage: "arrow.up")
+                        Spacer()
+                        Label("\(status.behindCount) behind", systemImage: "arrow.down")
+                    }
+                    .font(T3Typography.supporting)
+                    .foregroundStyle(T3Colors.textSecondary)
+                } else {
+                    // Only claim to be checking while something actually is.
+                    Label(
+                        isLoading ? "Checking remote…" : "Remote status unavailable",
+                        systemImage: isLoading
+                            ? "arrow.triangle.2.circlepath"
+                            : "exclamationmark.triangle"
+                    )
+                    .font(T3Typography.supporting)
+                    .foregroundStyle(T3Colors.textSecondary)
                 }
-                .font(T3Typography.supporting)
-                .foregroundStyle(T3Colors.textSecondary)
                 if let pullRequest = status.pullRequest {
                     if let url = pullRequest.url {
                         Link(destination: url) {
@@ -207,7 +253,7 @@ public struct FeatureSourceControlView: View {
         }
         .listStyle(.insetGrouped)
         .scrollContentBackground(.hidden)
-        .refreshable { await load() }
+        .refreshable { await reload() }
         .overlay {
             if isRunningAction {
                 ProgressView()
@@ -226,8 +272,69 @@ public struct FeatureSourceControlView: View {
         }
     }
 
+    /// Cached loading can be replaced by an action or an explicit refresh.
     private func load() async {
-        await run(.load)
+        await load(force: false)
+    }
+
+    private func reload() async {
+        await load(force: true)
+    }
+
+    private func load(force: Bool) async {
+        guard !runState.isBusy else { return }
+        if force, !runState.begin(.load) { return }
+        loadGeneration += 1
+        statusGeneration += 1
+        let loadID = loadGeneration
+        let statusID = statusGeneration
+        isLoading = true
+        recovery.begin(.load)
+        defer {
+            if loadID == loadGeneration { isLoading = false }
+            if force { runState.finish(.load) }
+        }
+        do {
+            try Task.checkCancellation()
+            if force {
+                let refreshed = try await client.sourceControlStatus(threadID: threadID)
+                guard statusID == statusGeneration else { return }
+                status = refreshed
+                errorMessage = nil
+                recovery.recordSuccess(.load)
+            } else {
+                let statuses = try await client.sourceControlStatuses(threadID: threadID)
+                for try await nextStatus in statuses {
+                    guard statusID == statusGeneration else { return }
+                    status = nextStatus
+                    errorMessage = nil
+                    if nextStatus.isRemoteKnown { recovery.recordSuccess(.load) }
+                }
+            }
+        } catch {
+            guard statusID == statusGeneration else { return }
+            if FeatureToolFailureState<FeatureSourceControlOperation>.isCancellation(error) {
+                recovery.recordFailure(.load, error: error)
+                return
+            }
+            // An unrelated status failure must not discard a failed action's retry.
+            if let retained = recovery.retryOperation, !retained.isLoad {
+                errorMessage = error.localizedDescription
+            } else {
+                recovery.recordFailure(.load, error: error)
+            }
+            guard !force, status?.isRemoteKnown == false else { return }
+            if loadID == loadGeneration { isLoading = false }
+            for await recoveredStatus in client.sourceControlStatusEvents(threadID: threadID) {
+                guard statusID == statusGeneration else { return }
+                status = recoveredStatus
+                if recoveredStatus.isRemoteKnown {
+                    errorMessage = nil
+                    recovery.recordSuccess(.load)
+                    return
+                }
+            }
+        }
     }
 
     private func perform(_ action: FeatureSourceControlAction, message: String?) async {
@@ -236,48 +343,48 @@ public struct FeatureSourceControlView: View {
         )
     }
 
-    /// Single entry point for every source control request, so a retry replays the exact failed
-    /// operation — commit message included — instead of falling back to a plain reload.
+    /// Mutations finish before refresh so Retry cannot repeat completed work.
     private func run(_ operation: FeatureSourceControlOperation) async {
+        guard case let .action(action, message) = operation else {
+            await reload()
+            return
+        }
         guard runState.begin(operation) else { return }
+        loadGeneration += 1
+        statusGeneration += 1
+        isLoading = false
         recovery.begin(operation)
-        if operation.isLoad {
-            isLoading = true
-        } else {
-            isRunningAction = true
+        let result = await runFeatureSourceControlAction(
+            setRunning: { isRunningAction = $0 }
+        ) {
+            try await client.performSourceControlAction(
+                threadID: threadID,
+                action: action,
+                message: message
+            )
         }
-        defer {
-            runState.finish(operation)
-            if operation.isLoad {
-                isLoading = false
-            } else {
-                isRunningAction = false
-            }
-        }
-        do {
-            switch operation {
-            case .load:
+        var shouldRecoverStatus = false
+        switch result {
+        case .success:
+            do {
                 status = try await client.sourceControlStatus(threadID: threadID)
-                recovery.recordSuccess(operation)
-            case .action(let action, let message):
-                try await client.performSourceControlAction(
-                    threadID: threadID,
-                    action: action,
-                    message: message
+                errorMessage = nil
+                recovery.recordSuccess(operation, .load)
+            } catch {
+                recovery.recordFollowUpFailure(
+                    .load,
+                    afterCompletionOf: operation,
+                    error: error
                 )
-                do {
-                    status = try await client.sourceControlStatus(threadID: threadID)
-                    recovery.recordSuccess(operation, .load)
-                } catch {
-                    recovery.recordFollowUpFailure(
-                        .load,
-                        afterCompletionOf: operation,
-                        error: error
-                    )
-                }
             }
-        } catch {
+        case let .failure(error):
             recovery.recordFailure(operation, error: error)
+            shouldRecoverStatus = !FeatureToolFailureState<FeatureSourceControlOperation>
+                .isCancellation(error)
+        }
+        runState.finish(operation)
+        if shouldRecoverStatus {
+            await load(force: false)
         }
     }
 }

--- a/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
@@ -4,6 +4,24 @@ import Testing
 
 @Suite("Thread tool state")
 struct FeatureToolStateTests {
+    @MainActor
+    @Test("A failed source-control action stops progress before recovery")
+    func failedSourceControlActionStopsProgressBeforeRecovery() async {
+        var phases: [String] = []
+
+        let result: Result<Void, Error> = await runFeatureSourceControlAction(
+            setRunning: { phases.append($0 ? "running" : "stopped") }
+        ) {
+            throw FeatureCapabilityUnavailable("Source control")
+        }
+
+        if case .failure = result {
+            phases.append("recovery")
+        }
+
+        #expect(phases == ["running", "stopped", "recovery"])
+    }
+
     private static func vcsLocal(
         isRepo: Bool = true,
         hasPrimaryRemote: Bool = true,

--- a/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
@@ -224,6 +224,9 @@ struct FeatureToolStateTests {
 
         #expect(replaced.aheadCount == 0)
         #expect(replaced.isRemoteKnown == false)
+        // The latch holds even though this event alone would not set it:
+        // without it the stream would report a spurious protocol violation.
+        #expect(accumulator.isComplete)
     }
 
     @Test("Completion never regresses across a long mixed sequence")
@@ -235,6 +238,9 @@ struct FeatureToolStateTests {
             .remoteUpdated(Self.vcsRemote(aheadCount: 1)),
             .localUpdated(Self.vcsLocal(refName: "feature/seq", files: ["a.swift", "b.swift"])),
             .remoteUpdated(nil),
+            // Drives the latch: on its own this snapshot leaves the remote half
+            // unresolved again, so completion would regress without it.
+            .snapshot(local: Self.vcsLocal(refName: "feature/seq"), remote: nil),
             .localUpdated(Self.vcsLocal(refName: "feature/seq")),
         ]
 

--- a/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
@@ -242,13 +242,11 @@ struct FeatureToolStateTests {
 
         #expect(replaced.aheadCount == 0)
         #expect(replaced.isRemoteKnown == false)
-        // The latch holds even though this event alone would not set it:
-        // without it the stream would report a spurious protocol violation.
-        #expect(accumulator.isComplete)
+        #expect(accumulator.isComplete == false)
     }
 
-    @Test("Completion never regresses across a long mixed sequence")
-    func completionLatchesAcrossMixedSequence() {
+    @Test("A fresh snapshot can return a reused monitor to pending")
+    func completionTracksTheCurrentSequence() {
         var accumulator = NativeSourceControlStatusAccumulator()
         let events: [VCSStatusEvent] = [
             .snapshot(local: Self.vcsLocal(refName: "feature/seq"), remote: nil),
@@ -256,24 +254,40 @@ struct FeatureToolStateTests {
             .remoteUpdated(Self.vcsRemote(aheadCount: 1)),
             .localUpdated(Self.vcsLocal(refName: "feature/seq", files: ["a.swift", "b.swift"])),
             .remoteUpdated(nil),
-            // Drives the latch: on its own this snapshot leaves the remote half
-            // unresolved again, so completion would regress without it.
+            // A reused monitor can begin a fresh cached-local-first sequence.
             .snapshot(local: Self.vcsLocal(refName: "feature/seq"), remote: nil),
             .localUpdated(Self.vcsLocal(refName: "feature/seq")),
         ]
 
-        var completedAt: Int?
-        for (index, event) in events.enumerated() {
+        var completionStates: [Bool] = []
+        for event in events {
             _ = accumulator.consume(event)
-            if accumulator.isComplete, completedAt == nil {
-                completedAt = index
-            }
-            if completedAt != nil {
-                #expect(accumulator.isComplete)
-            }
+            completionStates.append(accumulator.isComplete)
         }
 
-        #expect(completedAt == 2)
+        #expect(completionStates == [false, false, true, true, true, false, false])
+    }
+
+    @Test("Changing branches discards the prior branch remote status")
+    func branchChangeReturnsRemoteStatusToPending() throws {
+        var accumulator = NativeSourceControlStatusAccumulator()
+        _ = accumulator.consume(
+            .snapshot(
+                local: Self.vcsLocal(refName: "feature/one"),
+                remote: Self.vcsRemote(aheadCount: 4)
+            )
+        )
+
+        let consumed = accumulator.consume(
+            .localUpdated(Self.vcsLocal(refName: "feature/two"))
+        )
+        let changedBranch = try #require(consumed)
+
+        #expect(changedBranch.branch == "feature/two")
+        #expect(changedBranch.aheadCount == 0)
+        #expect(changedBranch.pullRequest == nil)
+        #expect(changedBranch.isRemoteKnown == false)
+        #expect(accumulator.isComplete == false)
     }
 
     @Test("A completed stream ends without error")

--- a/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
@@ -186,6 +186,72 @@ struct FeatureToolStateTests {
         #expect(throws: RPCError.self) { try accumulator.validateEnd() }
     }
 
+    @Test("An absent remote half resolves the status instead of leaving it pending")
+    func nilRemotePayloadResolvesTheRemoteHalf() throws {
+        var accumulator = NativeSourceControlStatusAccumulator()
+        _ = accumulator.consume(.snapshot(local: Self.vcsLocal(), remote: nil))
+        #expect(accumulator.isComplete == false)
+
+        let consumed = accumulator.consume(.remoteUpdated(nil))
+        let resolved = try #require(consumed)
+
+        // "Known to be absent" is not "still pending": the stream is finished
+        // and the screen must stop claiming it is checking.
+        #expect(resolved.isRemoteKnown)
+        #expect(resolved.aheadCount == 0)
+        #expect(resolved.behindCount == 0)
+        #expect(resolved.pullRequest == nil)
+        #expect(accumulator.isComplete)
+    }
+
+    @Test("A later snapshot replaces the remote half rather than merging into it")
+    func snapshotReplacesKnownRemoteStatus() throws {
+        var accumulator = NativeSourceControlStatusAccumulator()
+        _ = accumulator.consume(
+            .snapshot(
+                local: Self.vcsLocal(refName: "feature/one"),
+                remote: Self.vcsRemote(aheadCount: 7)
+            )
+        )
+
+        // Resubscribe after a reconnect: the server prepends a fresh snapshot
+        // carrying whatever its cache holds, so a stale ahead count must not
+        // survive and must not be reported as known.
+        let consumed = accumulator.consume(
+            .snapshot(local: Self.vcsLocal(refName: "feature/one"), remote: nil)
+        )
+        let replaced = try #require(consumed)
+
+        #expect(replaced.aheadCount == 0)
+        #expect(replaced.isRemoteKnown == false)
+    }
+
+    @Test("Completion never regresses across a long mixed sequence")
+    func completionLatchesAcrossMixedSequence() {
+        var accumulator = NativeSourceControlStatusAccumulator()
+        let events: [VCSStatusEvent] = [
+            .snapshot(local: Self.vcsLocal(refName: "feature/seq"), remote: nil),
+            .localUpdated(Self.vcsLocal(refName: "feature/seq", files: ["a.swift"])),
+            .remoteUpdated(Self.vcsRemote(aheadCount: 1)),
+            .localUpdated(Self.vcsLocal(refName: "feature/seq", files: ["a.swift", "b.swift"])),
+            .remoteUpdated(nil),
+            .localUpdated(Self.vcsLocal(refName: "feature/seq")),
+        ]
+
+        var completedAt: Int?
+        for (index, event) in events.enumerated() {
+            _ = accumulator.consume(event)
+            if accumulator.isComplete, completedAt == nil {
+                completedAt = index
+            }
+            if completedAt != nil {
+                #expect(accumulator.isComplete)
+            }
+        }
+
+        #expect(completedAt == 2)
+    }
+
     @Test("A completed stream ends without error")
     func completedStreamEndIsAccepted() throws {
         var accumulator = NativeSourceControlStatusAccumulator()

--- a/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
@@ -4,6 +4,171 @@ import Testing
 
 @Suite("Thread tool state")
 struct FeatureToolStateTests {
+    private static func vcsLocal(
+        isRepo: Bool = true,
+        hasPrimaryRemote: Bool = true,
+        refName: String? = "feature/cached",
+        files: [String] = []
+    ) -> VCSLocalStatus {
+        VCSLocalStatus(
+            isRepo: isRepo,
+            sourceControlProvider: nil,
+            hasPrimaryRemote: hasPrimaryRemote,
+            isDefaultRef: false,
+            refName: refName,
+            hasWorkingTreeChanges: files.isEmpty == false,
+            workingTree: VCSWorkingTree(
+                files: files.map {
+                    VCSWorkingTreeFile(path: $0, insertions: 1, deletions: 0)
+                },
+                insertions: files.count,
+                deletions: 0
+            )
+        )
+    }
+
+    private static func vcsRemote(
+        aheadCount: Int,
+        behindCount: Int = 0,
+        pullRequest: VCSChangeRequest? = nil
+    ) -> VCSRemoteStatus {
+        VCSRemoteStatus(
+            hasUpstream: true,
+            aheadCount: aheadCount,
+            behindCount: behindCount,
+            aheadOfDefaultCount: nil,
+            pr: pullRequest
+        )
+    }
+
+    @Test(
+        "Cached local status is available before remote status",
+        .bug("https://github.com/saphid/t3code-personal/issues/107")
+    )
+    func cachedLocalStatusArrivesFirst() throws {
+        var accumulator = NativeSourceControlStatusAccumulator()
+
+        let consumedLocal = accumulator.consume(
+            .snapshot(
+                local: Self.vcsLocal(files: ["App/NativeFeatureClient.swift"]),
+                remote: nil
+            )
+        )
+        let localOnly = try #require(consumedLocal)
+
+        #expect(localOnly.branch == "feature/cached")
+        #expect(localOnly.files.map(\.path) == ["App/NativeFeatureClient.swift"])
+        #expect(localOnly.aheadCount == 0)
+        #expect(localOnly.pullRequest == nil)
+        #expect(accumulator.isComplete == false)
+    }
+
+    @Test(
+        "Remote status combines with the latest local status",
+        .bug("https://github.com/saphid/t3code-personal/issues/107")
+    )
+    func remoteStatusUsesLatestLocalState() throws {
+        var accumulator = NativeSourceControlStatusAccumulator()
+        _ = accumulator.consume(
+            .snapshot(local: Self.vcsLocal(refName: "feature/old"), remote: nil)
+        )
+        _ = accumulator.consume(
+            .localUpdated(Self.vcsLocal(refName: "feature/new", files: ["new.swift"]))
+        )
+        let pullRequest = VCSChangeRequest(
+            number: 107,
+            title: "Cached status",
+            url: "https://github.com/saphid/t3code-personal/pull/107",
+            baseRef: "main",
+            headRef: "feature/new",
+            state: "OPEN"
+        )
+
+        let consumedRemote = accumulator.consume(
+            .remoteUpdated(
+                Self.vcsRemote(
+                    aheadCount: 2,
+                    behindCount: 1,
+                    pullRequest: pullRequest
+                )
+            )
+        )
+        let combined = try #require(consumedRemote)
+
+        #expect(combined.branch == "feature/new")
+        #expect(combined.files.map(\.path) == ["new.swift"])
+        #expect(combined.aheadCount == 2)
+        #expect(combined.behindCount == 1)
+        #expect(combined.pullRequest?.number == 107)
+        #expect(accumulator.isComplete)
+    }
+
+    @Test(
+        "Remote-before-local ordering is ignored safely",
+        .bug("https://github.com/saphid/t3code-personal/issues/107")
+    )
+    func remoteBeforeLocalIsSafe() throws {
+        var accumulator = NativeSourceControlStatusAccumulator()
+
+        let remoteBeforeLocal = accumulator.consume(
+            .remoteUpdated(Self.vcsRemote(aheadCount: 9))
+        )
+        #expect(remoteBeforeLocal == nil)
+        let consumedLocal = accumulator.consume(
+            .localUpdated(Self.vcsLocal(refName: "feature/local"))
+        )
+        let localOnly = try #require(consumedLocal)
+        let consumedRemote = accumulator.consume(
+            .remoteUpdated(Self.vcsRemote(aheadCount: 3))
+        )
+        let combined = try #require(consumedRemote)
+
+        #expect(localOnly.aheadCount == 0)
+        #expect(combined.branch == "feature/local")
+        #expect(combined.aheadCount == 3)
+        #expect(accumulator.isComplete)
+    }
+
+    @Test(
+        "Terminal local states do not wait for remote status",
+        .bug("https://github.com/saphid/t3code-personal/issues/107"),
+        arguments: [
+            Self.vcsLocal(isRepo: false, hasPrimaryRemote: false, refName: nil),
+            Self.vcsLocal(hasPrimaryRemote: false, refName: "local-only"),
+        ]
+    )
+    func terminalLocalStatesAreExplicit(local: VCSLocalStatus) throws {
+        var accumulator = NativeSourceControlStatusAccumulator()
+
+        let consumed = accumulator.consume(.snapshot(local: local, remote: nil))
+        let status = try #require(consumed)
+
+        #expect(status.isRepository == local.isRepo)
+        #expect(status.branch == local.refName)
+        #expect(status.pullRequest == nil)
+        #expect(accumulator.isComplete)
+    }
+
+    @Test(
+        "Premature stream end has an explicit protocol error",
+        .bug("https://github.com/saphid/t3code-personal/issues/107")
+    )
+    func prematureStreamEndIsExplicit() {
+        let accumulator = NativeSourceControlStatusAccumulator()
+
+        do {
+            try accumulator.validateEnd()
+            Issue.record("Expected the incomplete stream to report a protocol error.")
+        } catch let error as RPCError {
+            #expect(
+                error.errorDescription
+                    == "The source-control status stream ended before completion."
+            )
+        } catch {
+            Issue.record("Unexpected stream error: \(error)")
+        }
+    }
+
     @Test
     func fileFilteringKeepsDirectoriesFirstAndHonorsHiddenFiles() {
         let entries = [

--- a/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureToolStateTests.swift
@@ -41,10 +41,7 @@ struct FeatureToolStateTests {
         )
     }
 
-    @Test(
-        "Cached local status is available before remote status",
-        .bug("https://github.com/saphid/t3code-personal/issues/107")
-    )
+    @Test("Cached local status is available before remote status")
     func cachedLocalStatusArrivesFirst() throws {
         var accumulator = NativeSourceControlStatusAccumulator()
 
@@ -61,12 +58,15 @@ struct FeatureToolStateTests {
         #expect(localOnly.aheadCount == 0)
         #expect(localOnly.pullRequest == nil)
         #expect(accumulator.isComplete == false)
+        // Ahead/behind are unknown rather than zero, so remote-dependent
+        // actions stay withheld until the remote half lands.
+        #expect(localOnly.isRemoteKnown == false)
+        #expect(localOnly.availableActions.contains(.createPullRequest) == false)
+        #expect(localOnly.availableActions.contains(.commitPushAndCreatePullRequest) == false)
+        #expect(localOnly.availableActions.contains(.commit))
     }
 
-    @Test(
-        "Remote status combines with the latest local status",
-        .bug("https://github.com/saphid/t3code-personal/issues/107")
-    )
+    @Test("Remote status combines with the latest local status")
     func remoteStatusUsesLatestLocalState() throws {
         var accumulator = NativeSourceControlStatusAccumulator()
         _ = accumulator.consume(
@@ -76,9 +76,9 @@ struct FeatureToolStateTests {
             .localUpdated(Self.vcsLocal(refName: "feature/new", files: ["new.swift"]))
         )
         let pullRequest = VCSChangeRequest(
-            number: 107,
+            number: 42,
             title: "Cached status",
-            url: "https://github.com/saphid/t3code-personal/pull/107",
+            url: "https://example.com/pull/42",
             baseRef: "main",
             headRef: "feature/new",
             state: "OPEN"
@@ -99,31 +99,56 @@ struct FeatureToolStateTests {
         #expect(combined.files.map(\.path) == ["new.swift"])
         #expect(combined.aheadCount == 2)
         #expect(combined.behindCount == 1)
-        #expect(combined.pullRequest?.number == 107)
+        #expect(combined.pullRequest?.number == 42)
+        #expect(combined.isRemoteKnown)
         #expect(accumulator.isComplete)
     }
 
-    @Test(
-        "Remote-before-local ordering is ignored safely",
-        .bug("https://github.com/saphid/t3code-personal/issues/107")
-    )
-    func remoteBeforeLocalIsSafe() throws {
+    @Test("Remote status is retained across a later local-only update")
+    func localUpdateKeepsKnownRemoteStatus() throws {
+        var accumulator = NativeSourceControlStatusAccumulator()
+        _ = accumulator.consume(
+            .snapshot(
+                local: Self.vcsLocal(refName: "feature/one"),
+                remote: Self.vcsRemote(aheadCount: 4, behindCount: 2)
+            )
+        )
+        #expect(accumulator.isComplete)
+
+        let consumed = accumulator.consume(
+            .localUpdated(Self.vcsLocal(refName: "feature/one", files: ["later.swift"]))
+        )
+        let updated = try #require(consumed)
+
+        #expect(updated.files.map(\.path) == ["later.swift"])
+        #expect(updated.aheadCount == 4)
+        #expect(updated.behindCount == 2)
+        #expect(updated.isRemoteKnown)
+        // Completion latches: a local-only update must not reopen the stream.
+        #expect(accumulator.isComplete)
+    }
+
+    @Test("Remote-before-local ordering retains the remote status")
+    func remoteBeforeLocalIsRetained() throws {
         var accumulator = NativeSourceControlStatusAccumulator()
 
         let remoteBeforeLocal = accumulator.consume(
             .remoteUpdated(Self.vcsRemote(aheadCount: 9))
         )
         #expect(remoteBeforeLocal == nil)
+        #expect(accumulator.isComplete == false)
+
         let consumedLocal = accumulator.consume(
             .localUpdated(Self.vcsLocal(refName: "feature/local"))
         )
-        let localOnly = try #require(consumedLocal)
+        let withRetainedRemote = try #require(consumedLocal)
         let consumedRemote = accumulator.consume(
             .remoteUpdated(Self.vcsRemote(aheadCount: 3))
         )
         let combined = try #require(consumedRemote)
 
-        #expect(localOnly.aheadCount == 0)
+        #expect(withRetainedRemote.aheadCount == 9)
+        #expect(withRetainedRemote.isRemoteKnown)
         #expect(combined.branch == "feature/local")
         #expect(combined.aheadCount == 3)
         #expect(accumulator.isComplete)
@@ -131,7 +156,6 @@ struct FeatureToolStateTests {
 
     @Test(
         "Terminal local states do not wait for remote status",
-        .bug("https://github.com/saphid/t3code-personal/issues/107"),
         arguments: [
             Self.vcsLocal(isRepo: false, hasPrimaryRemote: false, refName: nil),
             Self.vcsLocal(hasPrimaryRemote: false, refName: "local-only"),
@@ -146,27 +170,33 @@ struct FeatureToolStateTests {
         #expect(status.isRepository == local.isRepo)
         #expect(status.branch == local.refName)
         #expect(status.pullRequest == nil)
+        // No remote will ever arrive, so nothing is left pending.
+        #expect(status.isRemoteKnown)
         #expect(accumulator.isComplete)
     }
 
-    @Test(
-        "Premature stream end has an explicit protocol error",
-        .bug("https://github.com/saphid/t3code-personal/issues/107")
-    )
-    func prematureStreamEndIsExplicit() {
-        let accumulator = NativeSourceControlStatusAccumulator()
+    @Test("A stream ending after only a cached local status is a protocol error")
+    func prematureStreamEndIsExplicit() throws {
+        var accumulator = NativeSourceControlStatusAccumulator()
+        _ = accumulator.consume(
+            .snapshot(local: Self.vcsLocal(files: ["pending.swift"]), remote: nil)
+        )
+        #expect(accumulator.isComplete == false)
 
-        do {
-            try accumulator.validateEnd()
-            Issue.record("Expected the incomplete stream to report a protocol error.")
-        } catch let error as RPCError {
-            #expect(
-                error.errorDescription
-                    == "The source-control status stream ended before completion."
+        #expect(throws: RPCError.self) { try accumulator.validateEnd() }
+    }
+
+    @Test("A completed stream ends without error")
+    func completedStreamEndIsAccepted() throws {
+        var accumulator = NativeSourceControlStatusAccumulator()
+        _ = accumulator.consume(
+            .snapshot(
+                local: Self.vcsLocal(),
+                remote: Self.vcsRemote(aheadCount: 1)
             )
-        } catch {
-            Issue.record("Unexpected stream error: \(error)")
-        }
+        )
+
+        try accumulator.validateEnd()
     }
 
     @Test


### PR DESCRIPTION
Source Control shows cached branch and changed-file data as soon as it opens, then fills in remote and pull-request data. Manual reload still asks the server for fresh status. Remote data stays marked as unknown until it arrives.

This version is rebased onto the current SwiftUI branch. It preserves failed Git output and the exact Retry operation. If a Git action succeeds but its status refresh fails, Retry repeats only the refresh.

Validation: 53 focused native tests passed in `FeatureToolRecoveryTests` and `FeatureToolStateTests` at `4992d1dac5ac24d0a0aff5deb81dd6b876443f4c`, based on `614a7b672a86ee638f284298fe26e8b0194e0eaa`. A second source review found no defects.

Modernized and fixed with GPT-6 in Codex.
