### PR TITLE
feat(swift-ios): settle thread rows with a full swipe

### DIFF
--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -196,11 +196,14 @@ struct HomeThreadCollectionView: UIViewRepresentable {
 
             let actions = HomeThreadSwipeAction
                 .trailingActions(for: thread, isArchived: isArchived, at: .now)
-                .map { contextualAction($0, for: thread) }
-            let configuration = UISwipeActionsConfiguration(actions: actions)
-            // A full swipe never fires the first action: the leading slot is
-            // destructive, and pinned rows now carry a settlement action too.
-            configuration.performsFirstActionWithFullSwipe = false
+            let configuration = UISwipeActionsConfiguration(
+                actions: actions.map { contextualAction($0, for: thread) }
+            )
+            // A full swipe runs the edge action, which is only ever settlement.
+            // Delete can never reach that slot, so the gesture cannot destroy a
+            // thread; rows with nothing to settle keep the full swipe disabled.
+            configuration.performsFirstActionWithFullSwipe =
+                HomeThreadSwipeAction.performsFullSwipe(with: actions)
             return configuration
         }
 
@@ -600,7 +603,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
 /// gesture semantics stay deterministic and testable without hosting a
 /// collection view. Order is outermost-first, matching
 /// `UISwipeActionsConfiguration`, which lays trailing actions out from the
-/// trailing edge inward.
+/// trailing edge inward and runs the first action on a full swipe.
 enum HomeThreadSwipeAction: Equatable {
     case delete
     case restore
@@ -619,33 +622,48 @@ enum HomeThreadSwipeAction: Equatable {
         case setSettled(Bool)
     }
 
-    /// Archived rows stay restore-only. A pinned row keeps Delete and Unpin
-    /// where they already were and gains its settlement action beside them, in
-    /// the same Unpin-before-Settle order the row's context menu uses: the
-    /// pinned shelf also holds settled threads, so before this a pinned task
-    /// could only be settled or reopened by unpinning it first or by opening
-    /// the context menu.
+    /// Settlement owns the edge slot on every row that can settle, so a full
+    /// swipe clears the task in one motion and a partial swipe still reveals
+    /// every button. Delete is always last and therefore can never be the
+    /// full-swipe action. A pinned row keeps Unpin between the two: settling
+    /// already clears the pin, so the full swipe unpins and settles together.
+    /// Archived rows stay restore-only, and a row with nothing to settle keeps
+    /// its reversible action at the edge with the full swipe turned off.
     static func trailingActions(
         for thread: FeatureThread,
         isArchived: Bool,
         at now: Date
     ) -> [HomeThreadSwipeAction] {
-        guard !isArchived else { return [.delete, .restore] }
+        guard !isArchived else { return [.restore, .delete] }
 
         let settlement: HomeThreadSwipeAction? = thread.canToggleSettlement
             ? (thread.isEffectivelySettled(at: now) ? .reopen : .settle)
             : nil
+        let isPinned = thread.pinnedAt != nil && thread.canTogglePin
 
-        var actions: [HomeThreadSwipeAction] = [.delete]
-        if thread.pinnedAt != nil, thread.canTogglePin {
-            actions.append(.unpin)
-            if let settlement {
-                actions.append(settlement)
+        var actions: [HomeThreadSwipeAction] = []
+        if let settlement {
+            actions.append(settlement)
+            if isPinned {
+                actions.append(.unpin)
             }
+        } else if isPinned {
+            actions.append(.unpin)
         } else {
-            actions.append(settlement ?? .archive)
+            actions.append(.archive)
         }
+        actions.append(.delete)
         return actions
+    }
+
+    /// The full swipe is armed only when the edge action settles or reopens.
+    /// Nothing else may run from the gesture alone.
+    static func performsFullSwipe(with actions: [HomeThreadSwipeAction]) -> Bool {
+        actions.first?.isSettlement ?? false
+    }
+
+    var isSettlement: Bool {
+        self == .settle || self == .reopen
     }
 
     var intent: Intent {

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -194,55 +194,47 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 return nil
             }
 
-            let delete = UIContextualAction(style: .destructive, title: "Delete") { [weak self] _, _, finish in
-                self?.parent.onDelete(thread)
-                finish(true)
-            }
-            delete.image = UIImage(systemName: "trash")
-
-            let primaryAction: UIContextualAction
-            if isArchived {
-                primaryAction = UIContextualAction(style: .normal, title: "Restore") {
-                    [weak self] _, _, finish in
-                    self?.parent.onArchive(thread, false)
-                    finish(true)
-                }
-                primaryAction.image = UIImage(systemName: "arrow.uturn.backward")
-                primaryAction.backgroundColor = .systemBlue
-            } else if thread.pinnedAt != nil, thread.canTogglePin {
-                primaryAction = UIContextualAction(style: .normal, title: "Unpin") {
-                    [weak self] _, _, finish in
-                    self?.parent.onPin(thread, false)
-                    finish(true)
-                }
-                primaryAction.image = UIImage(systemName: "pin.slash")
-                primaryAction.backgroundColor = .systemBlue
-            } else if thread.canToggleSettlement {
-                let isSettled = thread.isEffectivelySettled(at: .now)
-                primaryAction = UIContextualAction(
-                    style: .normal,
-                    title: isSettled ? "Reopen" : "Settle"
-                ) { [weak self] _, _, finish in
-                    self?.parent.onSettle(thread, !isSettled)
-                    finish(true)
-                }
-                primaryAction.image = UIImage(
-                    systemName: isSettled ? "arrow.counterclockwise" : "checkmark"
-                )
-                primaryAction.backgroundColor = isSettled ? .systemBlue : .systemGreen
-            } else {
-                primaryAction = UIContextualAction(style: .normal, title: "Archive") {
-                    [weak self] _, _, finish in
-                    self?.parent.onArchive(thread, true)
-                    finish(true)
-                }
-                primaryAction.image = UIImage(systemName: "archivebox")
-                primaryAction.backgroundColor = .systemGray
-            }
-
-            let configuration = UISwipeActionsConfiguration(actions: [delete, primaryAction])
+            let actions = HomeThreadSwipeAction
+                .trailingActions(for: thread, isArchived: isArchived, at: .now)
+                .map { contextualAction($0, for: thread) }
+            let configuration = UISwipeActionsConfiguration(actions: actions)
+            // A full swipe never fires the first action: the leading slot is
+            // destructive, and pinned rows now carry a settlement action too.
             configuration.performsFirstActionWithFullSwipe = false
             return configuration
+        }
+
+        private func contextualAction(
+            _ action: HomeThreadSwipeAction,
+            for thread: FeatureThread
+        ) -> UIContextualAction {
+            let contextualAction = UIContextualAction(
+                style: action.style,
+                title: action.title
+            ) { [weak self] _, _, finish in
+                self?.perform(action.intent, for: thread)
+                finish(true)
+            }
+            contextualAction.image = UIImage(systemName: action.systemImage)
+            if let backgroundColor = action.backgroundColor {
+                contextualAction.backgroundColor = backgroundColor
+            }
+            return contextualAction
+        }
+
+        /// Swipe actions reuse the same closures the context menu does, so a
+        /// settle from either surface takes the one real settlement path.
+        private func perform(_ intent: HomeThreadSwipeAction.Intent, for thread: FeatureThread) {
+            switch intent {
+            case .delete:
+                parent.onDelete(thread)
+            case let .setArchived(archived):
+                parent.onArchive(thread, archived)
+            case let .setPinned(pinned):
+                parent.onPin(thread, pinned)
+            case let .setSettled(settled):
+                parent.onSettle(thread, settled)
+            }
         }
 
         private func configure(
@@ -601,6 +593,106 @@ struct HomeThreadCollectionView: UIViewRepresentable {
             }
         }
         return items
+    }
+}
+
+/// The trailing swipe actions a Home row offers, resolved as data so the row's
+/// gesture semantics stay deterministic and testable without hosting a
+/// collection view. Order is outermost-first, matching
+/// `UISwipeActionsConfiguration`, which lays trailing actions out from the
+/// trailing edge inward.
+enum HomeThreadSwipeAction: Equatable {
+    case delete
+    case restore
+    case unpin
+    case settle
+    case reopen
+    case archive
+
+    /// The lifecycle mutation an action requests. Keeping it separate from the
+    /// action keeps the swipe wiring verifiable and forces every case through
+    /// the row's existing callbacks instead of a second settlement path.
+    enum Intent: Equatable {
+        case delete
+        case setArchived(Bool)
+        case setPinned(Bool)
+        case setSettled(Bool)
+    }
+
+    /// Archived rows stay restore-only. A pinned row keeps Delete and Unpin
+    /// where they already were and gains its settlement action beside them, in
+    /// the same Unpin-before-Settle order the row's context menu uses: the
+    /// pinned shelf also holds settled threads, so before this a pinned task
+    /// could only be settled or reopened by unpinning it first or by opening
+    /// the context menu.
+    static func trailingActions(
+        for thread: FeatureThread,
+        isArchived: Bool,
+        at now: Date
+    ) -> [HomeThreadSwipeAction] {
+        guard !isArchived else { return [.delete, .restore] }
+
+        let settlement: HomeThreadSwipeAction? = thread.canToggleSettlement
+            ? (thread.isEffectivelySettled(at: now) ? .reopen : .settle)
+            : nil
+
+        var actions: [HomeThreadSwipeAction] = [.delete]
+        if thread.pinnedAt != nil, thread.canTogglePin {
+            actions.append(.unpin)
+            if let settlement {
+                actions.append(settlement)
+            }
+        } else {
+            actions.append(settlement ?? .archive)
+        }
+        return actions
+    }
+
+    var intent: Intent {
+        switch self {
+        case .delete: .delete
+        case .restore: .setArchived(false)
+        case .archive: .setArchived(true)
+        case .unpin: .setPinned(false)
+        case .settle: .setSettled(true)
+        case .reopen: .setSettled(false)
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .delete: "Delete"
+        case .restore: "Restore"
+        case .unpin: "Unpin"
+        case .settle: "Settle"
+        case .reopen: "Reopen"
+        case .archive: "Archive"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .delete: "trash"
+        case .restore: "arrow.uturn.backward"
+        case .unpin: "pin.slash"
+        case .settle: "checkmark"
+        case .reopen: "arrow.counterclockwise"
+        case .archive: "archivebox"
+        }
+    }
+
+    var style: UIContextualAction.Style {
+        self == .delete ? .destructive : .normal
+    }
+
+    /// Destructive actions keep UIKit's own tint.
+    var backgroundColor: UIColor? {
+        switch self {
+        case .delete: nil
+        case .restore, .unpin, .reopen: .systemBlue
+        case .settle: .systemGreen
+        case .archive: .systemGray
+        }
     }
 }
 

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadSwipeActionTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadSwipeActionTests.swift
@@ -1,0 +1,304 @@
+import Foundation
+import Testing
+import UIKit
+@testable import T3Code
+
+@MainActor
+@Suite("Home row trailing swipe actions")
+struct HomeThreadSwipeActionTests {
+    private let now = Date(timeIntervalSince1970: 20_000)
+
+    @Test
+    func pinnedRowsRevealSettleBesideUnpin() {
+        let pinned = thread(id: "pinned", pinnedAt: now.addingTimeInterval(-30))
+
+        let actions = HomeThreadSwipeAction.trailingActions(
+            for: pinned,
+            isArchived: false,
+            at: now
+        )
+
+        #expect(actions == [.delete, .unpin, .settle])
+        #expect(actions.map(\.title) == ["Delete", "Unpin", "Settle"])
+        #expect(actions.map(\.systemImage) == ["trash", "pin.slash", "checkmark"])
+    }
+
+    /// The pinned shelf also holds settled threads, so a pinned row has to be
+    /// able to offer the reverse action instead of a second settle.
+    @Test
+    func pinnedSettledRowsRevealReopenInsteadOfSettle() {
+        var pinnedSettled = thread(id: "pinned-settled", pinnedAt: now.addingTimeInterval(-30))
+        pinnedSettled.isSettled = true
+
+        let actions = HomeThreadSwipeAction.trailingActions(
+            for: pinnedSettled,
+            isArchived: false,
+            at: now
+        )
+
+        #expect(actions == [.delete, .unpin, .reopen])
+        #expect(actions.map(\.title) == ["Delete", "Unpin", "Reopen"])
+
+        // A pinned row that has aged into automatic settlement reads the same way.
+        var restingPinned = thread(id: "resting-pinned", pinnedAt: now.addingTimeInterval(-30))
+        restingPinned.lastActivityAt = now.addingTimeInterval(-4 * 24 * 60 * 60)
+        #expect(
+            HomeThreadSwipeAction.trailingActions(
+                for: restingPinned,
+                isArchived: false,
+                at: now
+            ) == [.delete, .unpin, .reopen]
+        )
+    }
+
+    @Test
+    func pinnedRowsWithoutSettlementSupportKeepOnlyUnpin() {
+        var unsupported = thread(id: "unsupported", pinnedAt: now.addingTimeInterval(-30))
+        unsupported.supportsSettlement = false
+
+        #expect(
+            HomeThreadSwipeAction.trailingActions(
+                for: unsupported,
+                isArchived: false,
+                at: now
+            ) == [.delete, .unpin]
+        )
+
+        // An already settled thread keeps its reverse action even when the
+        // environment reports no settlement capability.
+        unsupported.isSettled = true
+        #expect(
+            HomeThreadSwipeAction.trailingActions(
+                for: unsupported,
+                isArchived: false,
+                at: now
+            ) == [.delete, .unpin, .reopen]
+        )
+    }
+
+    @Test
+    func unpinnedAndArchivedRowsKeepTheirExistingActions() {
+        let active = thread(id: "active")
+        #expect(
+            HomeThreadSwipeAction.trailingActions(for: active, isArchived: false, at: now)
+                == [.delete, .settle]
+        )
+
+        var settled = thread(id: "settled")
+        settled.isSettled = true
+        #expect(
+            HomeThreadSwipeAction.trailingActions(for: settled, isArchived: false, at: now)
+                == [.delete, .reopen]
+        )
+
+        var unsupported = thread(id: "no-settlement")
+        unsupported.supportsSettlement = false
+        #expect(
+            HomeThreadSwipeAction.trailingActions(for: unsupported, isArchived: false, at: now)
+                == [.delete, .archive]
+        )
+
+        // Archived rows stay restore-only, including a pinned or settled one.
+        var archived = thread(id: "archived", pinnedAt: now.addingTimeInterval(-30))
+        archived.isArchived = true
+        archived.isSettled = true
+        #expect(
+            HomeThreadSwipeAction.trailingActions(for: archived, isArchived: true, at: now)
+                == [.delete, .restore]
+        )
+    }
+
+    /// Delete stays in the outermost slot on every row and the configuration
+    /// disables the first-action full swipe, so widening a pinned row's actions
+    /// cannot turn a long swipe into a destructive one.
+    @Test
+    func everyRowKeepsOneDestructiveOutermostActionAndNoDuplicates() {
+        var candidates: [(FeatureThread, Bool)] = []
+        for isSettled in [false, true] {
+            for isPinned in [false, true] {
+                for supportsSettlement in [nil, true, false] as [Bool?] {
+                    for isArchived in [false, true] {
+                        var candidate = thread(
+                            id: "row-\(isSettled)-\(isPinned)-\(String(describing: supportsSettlement))",
+                            pinnedAt: isPinned ? now.addingTimeInterval(-30) : nil
+                        )
+                        candidate.isSettled = isSettled
+                        candidate.supportsSettlement = supportsSettlement
+                        candidate.isArchived = isArchived
+                        candidates.append((candidate, isArchived))
+                    }
+                }
+            }
+        }
+
+        for (candidate, isArchived) in candidates {
+            let actions = HomeThreadSwipeAction.trailingActions(
+                for: candidate,
+                isArchived: isArchived,
+                at: now
+            )
+            #expect(actions.first == .delete)
+            #expect(actions.count == Set(actions).count)
+            #expect(actions.filter { $0.style == .destructive } == [.delete])
+            #expect(actions.filter { [.settle, .reopen].contains($0) }.count <= 1)
+            #expect(!actions.isEmpty)
+        }
+    }
+
+    @Test
+    func actionsRequestExactlyOneLifecycleMutationEach() {
+        #expect(HomeThreadSwipeAction.settle.intent == .setSettled(true))
+        #expect(HomeThreadSwipeAction.reopen.intent == .setSettled(false))
+        #expect(HomeThreadSwipeAction.unpin.intent == .setPinned(false))
+        #expect(HomeThreadSwipeAction.archive.intent == .setArchived(true))
+        #expect(HomeThreadSwipeAction.restore.intent == .setArchived(false))
+        #expect(HomeThreadSwipeAction.delete.intent == .delete)
+
+        // The settlement actions keep the row's existing accent vocabulary and
+        // never inherit the destructive style.
+        #expect(HomeThreadSwipeAction.settle.style == .normal)
+        #expect(HomeThreadSwipeAction.settle.backgroundColor == .systemGreen)
+        #expect(HomeThreadSwipeAction.reopen.backgroundColor == .systemBlue)
+        #expect(HomeThreadSwipeAction.reopen.systemImage == "arrow.counterclockwise")
+        #expect(HomeThreadSwipeAction.delete.style == .destructive)
+        #expect(HomeThreadSwipeAction.delete.backgroundColor == nil)
+    }
+
+    /// The swipe action carries no settlement logic of its own: its intent is
+    /// applied through the same `FeatureRootModel.setSettled` call the row's
+    /// context menu uses, which reaches the client's real settlement request.
+    @Test
+    func settlingAPinnedRowTakesTheRealSettlementPathAndClearsThePin() async throws {
+        let client = SwipeSettlementClientStub()
+        var pinned = thread(id: "pinned", pinnedAt: now.addingTimeInterval(-30))
+        pinned.lastActivityAt = now
+        client.snapshot = FeatureSnapshot(
+            projects: [
+                FeatureProject(
+                    id: "project",
+                    environmentID: "environment",
+                    name: "Studio",
+                    path: "/studio"
+                ),
+            ],
+            threads: [pinned]
+        )
+        let model = testRootModel(client: client)
+        await model.reload()
+
+        #expect(presentation(for: model).pinned.map(\.id) == ["pinned"])
+
+        let settle = try #require(
+            HomeThreadSwipeAction.trailingActions(
+                for: pinned,
+                isArchived: false,
+                at: now
+            ).last
+        )
+        #expect(settle == .settle)
+        #expect(settle.intent == .setSettled(true))
+
+        // Applying that intent the way the row's `onSettle` closure does.
+        guard case let .setSettled(settled) = settle.intent else { return }
+        await model.setSettled(pinned.id, settled: settled)
+
+        #expect(client.settlementRequests == [SettlementRequest(id: "pinned", settled: true)])
+        let updated = try #require(model.snapshot.threads.first { $0.id == "pinned" })
+        #expect(updated.isSettled)
+        #expect(!updated.keepsActive)
+        #expect(updated.settledAt != nil)
+        #expect(updated.pinnedAt == nil)
+
+        // The row leaves the pinned shelf for Settled, where its swipe now
+        // offers the reverse action instead.
+        let shelves = presentation(for: model)
+        #expect(shelves.pinned.isEmpty)
+        #expect(shelves.settled.map(\.id) == ["pinned"])
+        #expect(
+            HomeThreadSwipeAction.trailingActions(for: updated, isArchived: false, at: now)
+                == [.delete, .reopen]
+        )
+    }
+
+    private func presentation(for model: FeatureRootModel) -> HomePresentation {
+        HomePresentation(
+            snapshot: model.snapshot,
+            query: "",
+            projectID: nil,
+            now: now
+        )
+    }
+
+    private func thread(
+        id: String,
+        pinnedAt: Date? = nil
+    ) -> FeatureThread {
+        FeatureThread(
+            id: id,
+            projectID: "project",
+            title: "Task \(id)",
+            createdAt: now.addingTimeInterval(-100),
+            updatedAt: now.addingTimeInterval(-50),
+            state: .idle,
+            lastActivityAt: now.addingTimeInterval(-50),
+            pinnedAt: pinnedAt
+        )
+    }
+}
+
+@MainActor
+private func testRootModel(client: SwipeSettlementClientStub) -> FeatureRootModel {
+    FeatureRootModel(
+        client: client,
+        outboxStore: FeatureOutboxStore(
+            fileURL: FileManager.default.temporaryDirectory
+                .appendingPathComponent("t3-swipe-settlement-outbox-\(UUID().uuidString).json")
+        )
+    )
+}
+
+private struct SettlementRequest: Equatable {
+    let id: String
+    let settled: Bool
+}
+
+/// Records the settlement requests the feature client actually receives, so the
+/// swipe action's wiring is proved against the real client call rather than a
+/// view-local shortcut.
+@MainActor
+private final class SwipeSettlementClientStub: FeatureClient {
+    var snapshot = FeatureSnapshot()
+    var settlementRequests: [SettlementRequest] = []
+
+    func initialSnapshot() async throws -> FeatureSnapshot { snapshot }
+
+    func setThreadSettled(id: String, settled: Bool) async throws {
+        settlementRequests.append(SettlementRequest(id: id, settled: settled))
+    }
+
+    func pair(endpoint: String, token: String?) async throws {}
+
+    func createThread(
+        projectID: String,
+        title: String?,
+        selection: FeatureSelection?
+    ) async throws -> FeatureThread {
+        FeatureThread(id: "created", projectID: projectID, title: title ?? "Created")
+    }
+
+    func renameThread(id: String, title: String) async throws {}
+    func setThreadArchived(id: String, archived: Bool) async throws {}
+    func deleteThread(id: String) async throws {}
+
+    func loadThread(id: String) async throws -> FeatureThreadDetail {
+        FeatureThreadDetail(
+            thread: snapshot.threads.first { $0.id == id }
+                ?? FeatureThread(id: id, projectID: "project", title: "Task")
+        )
+    }
+
+    func sendMessage(threadID: String, text: String, selection: FeatureSelection?) async throws {}
+    func cancelTurn(threadID: String) async throws {}
+    func resolveApproval(id: String, decision: FeatureApprovalDecision) async throws {}
+    func saveSettings(_ settings: FeatureSettings) async throws {}
+}

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadSwipeActionTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadSwipeActionTests.swift
@@ -9,139 +9,156 @@ struct HomeThreadSwipeActionTests {
     private let now = Date(timeIntervalSince1970: 20_000)
 
     @Test
-    func pinnedRowsRevealSettleBesideUnpin() {
-        let pinned = thread(id: "pinned", pinnedAt: now.addingTimeInterval(-30))
+    func settlementOwnsTheEdgeSlotSoAFullSwipeSettles() {
+        let active = thread(id: "active")
+        let actions = HomeThreadSwipeAction.trailingActions(
+            for: active,
+            isArchived: false,
+            at: now
+        )
 
+        #expect(actions == [.settle, .delete])
+        #expect(actions.first == .settle)
+        #expect(actions.first?.intent == .setSettled(true))
+        #expect(HomeThreadSwipeAction.performsFullSwipe(with: actions))
+        #expect(actions.map(\.title) == ["Settle", "Delete"])
+    }
+
+    @Test
+    func pinnedRowsSettleFromTheEdgeAndKeepUnpinBesideIt() {
+        let pinned = thread(id: "pinned", pinnedAt: now.addingTimeInterval(-30))
         let actions = HomeThreadSwipeAction.trailingActions(
             for: pinned,
             isArchived: false,
             at: now
         )
 
-        #expect(actions == [.delete, .unpin, .settle])
-        #expect(actions.map(\.title) == ["Delete", "Unpin", "Settle"])
-        #expect(actions.map(\.systemImage) == ["trash", "pin.slash", "checkmark"])
+        #expect(actions == [.settle, .unpin, .delete])
+        #expect(HomeThreadSwipeAction.performsFullSwipe(with: actions))
+        #expect(actions.map(\.title) == ["Settle", "Unpin", "Delete"])
+        #expect(actions.map(\.systemImage) == ["checkmark", "pin.slash", "trash"])
     }
 
-    /// The pinned shelf also holds settled threads, so a pinned row has to be
-    /// able to offer the reverse action instead of a second settle.
+    /// The pinned shelf also holds settled threads, so the edge action has to be
+    /// able to reverse instead of settling a second time.
     @Test
-    func pinnedSettledRowsRevealReopenInsteadOfSettle() {
-        var pinnedSettled = thread(id: "pinned-settled", pinnedAt: now.addingTimeInterval(-30))
-        pinnedSettled.isSettled = true
-
-        let actions = HomeThreadSwipeAction.trailingActions(
-            for: pinnedSettled,
+    func settledRowsPutReopenAtTheEdge() {
+        var settled = thread(id: "settled")
+        settled.isSettled = true
+        let settledActions = HomeThreadSwipeAction.trailingActions(
+            for: settled,
             isArchived: false,
             at: now
         )
+        #expect(settledActions == [.reopen, .delete])
+        #expect(settledActions.first?.intent == .setSettled(false))
+        #expect(HomeThreadSwipeAction.performsFullSwipe(with: settledActions))
 
-        #expect(actions == [.delete, .unpin, .reopen])
-        #expect(actions.map(\.title) == ["Delete", "Unpin", "Reopen"])
-
-        // A pinned row that has aged into automatic settlement reads the same way.
-        var restingPinned = thread(id: "resting-pinned", pinnedAt: now.addingTimeInterval(-30))
-        restingPinned.lastActivityAt = now.addingTimeInterval(-4 * 24 * 60 * 60)
+        var pinnedSettled = thread(id: "pinned-settled", pinnedAt: now.addingTimeInterval(-30))
+        pinnedSettled.isSettled = true
         #expect(
             HomeThreadSwipeAction.trailingActions(
-                for: restingPinned,
+                for: pinnedSettled,
                 isArchived: false,
                 at: now
-            ) == [.delete, .unpin, .reopen]
+            ) == [.reopen, .unpin, .delete]
+        )
+
+        // A row that aged into automatic settlement reads the same way.
+        var resting = thread(id: "resting")
+        resting.lastActivityAt = now.addingTimeInterval(-4 * 24 * 60 * 60)
+        #expect(
+            HomeThreadSwipeAction.trailingActions(
+                for: resting,
+                isArchived: false,
+                at: now
+            ) == [.reopen, .delete]
         )
     }
 
     @Test
-    func pinnedRowsWithoutSettlementSupportKeepOnlyUnpin() {
-        var unsupported = thread(id: "unsupported", pinnedAt: now.addingTimeInterval(-30))
-        unsupported.supportsSettlement = false
-
-        #expect(
-            HomeThreadSwipeAction.trailingActions(
-                for: unsupported,
-                isArchived: false,
-                at: now
-            ) == [.delete, .unpin]
-        )
-
-        // An already settled thread keeps its reverse action even when the
-        // environment reports no settlement capability.
-        unsupported.isSettled = true
-        #expect(
-            HomeThreadSwipeAction.trailingActions(
-                for: unsupported,
-                isArchived: false,
-                at: now
-            ) == [.delete, .unpin, .reopen]
-        )
-    }
-
-    @Test
-    func unpinnedAndArchivedRowsKeepTheirExistingActions() {
-        let active = thread(id: "active")
-        #expect(
-            HomeThreadSwipeAction.trailingActions(for: active, isArchived: false, at: now)
-                == [.delete, .settle]
-        )
-
-        var settled = thread(id: "settled")
-        settled.isSettled = true
-        #expect(
-            HomeThreadSwipeAction.trailingActions(for: settled, isArchived: false, at: now)
-                == [.delete, .reopen]
-        )
-
+    func rowsWithNothingToSettleKeepAReversibleEdgeActionAndNoFullSwipe() {
         var unsupported = thread(id: "no-settlement")
         unsupported.supportsSettlement = false
-        #expect(
-            HomeThreadSwipeAction.trailingActions(for: unsupported, isArchived: false, at: now)
-                == [.delete, .archive]
+        let unsupportedActions = HomeThreadSwipeAction.trailingActions(
+            for: unsupported,
+            isArchived: false,
+            at: now
         )
+        #expect(unsupportedActions == [.archive, .delete])
+        #expect(!HomeThreadSwipeAction.performsFullSwipe(with: unsupportedActions))
 
-        // Archived rows stay restore-only, including a pinned or settled one.
+        var pinnedUnsupported = thread(
+            id: "pinned-no-settlement",
+            pinnedAt: now.addingTimeInterval(-30)
+        )
+        pinnedUnsupported.supportsSettlement = false
+        let pinnedActions = HomeThreadSwipeAction.trailingActions(
+            for: pinnedUnsupported,
+            isArchived: false,
+            at: now
+        )
+        #expect(pinnedActions == [.unpin, .delete])
+        #expect(!HomeThreadSwipeAction.performsFullSwipe(with: pinnedActions))
+
+        // Archived rows stay restore-only, and restoring is not a full swipe.
         var archived = thread(id: "archived", pinnedAt: now.addingTimeInterval(-30))
         archived.isArchived = true
         archived.isSettled = true
-        #expect(
-            HomeThreadSwipeAction.trailingActions(for: archived, isArchived: true, at: now)
-                == [.delete, .restore]
+        let archivedActions = HomeThreadSwipeAction.trailingActions(
+            for: archived,
+            isArchived: true,
+            at: now
         )
+        #expect(archivedActions == [.restore, .delete])
+        #expect(!HomeThreadSwipeAction.performsFullSwipe(with: archivedActions))
     }
 
-    /// Delete stays in the outermost slot on every row and the configuration
-    /// disables the first-action full swipe, so widening a pinned row's actions
-    /// cannot turn a long swipe into a destructive one.
+    /// Delete must never reach the edge slot, because the edge slot is what a
+    /// full swipe runs. This sweeps every pinned/settled/capability/archived
+    /// combination rather than trusting the branch order.
     @Test
-    func everyRowKeepsOneDestructiveOutermostActionAndNoDuplicates() {
-        var candidates: [(FeatureThread, Bool)] = []
+    func deleteIsNeverTheEdgeActionAndOnlySettlementArmsTheFullSwipe() {
         for isSettled in [false, true] {
             for isPinned in [false, true] {
                 for supportsSettlement in [nil, true, false] as [Bool?] {
-                    for isArchived in [false, true] {
-                        var candidate = thread(
-                            id: "row-\(isSettled)-\(isPinned)-\(String(describing: supportsSettlement))",
-                            pinnedAt: isPinned ? now.addingTimeInterval(-30) : nil
-                        )
-                        candidate.isSettled = isSettled
-                        candidate.supportsSettlement = supportsSettlement
-                        candidate.isArchived = isArchived
-                        candidates.append((candidate, isArchived))
+                    for supportsPinning in [nil, true, false] as [Bool?] {
+                        for isArchived in [false, true] {
+                            var candidate = thread(
+                                id: "row",
+                                pinnedAt: isPinned ? now.addingTimeInterval(-30) : nil
+                            )
+                            candidate.isSettled = isSettled
+                            candidate.supportsSettlement = supportsSettlement
+                            candidate.supportsPinning = supportsPinning
+                            candidate.isArchived = isArchived
+
+                            let actions = HomeThreadSwipeAction.trailingActions(
+                                for: candidate,
+                                isArchived: isArchived,
+                                at: now
+                            )
+
+                            #expect(actions.last == .delete)
+                            #expect(actions.first != .delete)
+                            #expect(actions.count == Set(actions).count)
+                            #expect(actions.filter { $0.style == .destructive } == [.delete])
+                            #expect(actions.filter(\.isSettlement).count <= 1)
+
+                            let armsFullSwipe = HomeThreadSwipeAction.performsFullSwipe(with: actions)
+                            #expect(armsFullSwipe == (actions.first?.isSettlement ?? false))
+                            if armsFullSwipe {
+                                switch actions.first?.intent {
+                                case .setSettled:
+                                    break
+                                default:
+                                    Issue.record("A full swipe may only request settlement")
+                                }
+                            }
+                        }
                     }
                 }
             }
-        }
-
-        for (candidate, isArchived) in candidates {
-            let actions = HomeThreadSwipeAction.trailingActions(
-                for: candidate,
-                isArchived: isArchived,
-                at: now
-            )
-            #expect(actions.first == .delete)
-            #expect(actions.count == Set(actions).count)
-            #expect(actions.filter { $0.style == .destructive } == [.delete])
-            #expect(actions.filter { [.settle, .reopen].contains($0) }.count <= 1)
-            #expect(!actions.isEmpty)
         }
     }
 
@@ -154,8 +171,13 @@ struct HomeThreadSwipeActionTests {
         #expect(HomeThreadSwipeAction.restore.intent == .setArchived(false))
         #expect(HomeThreadSwipeAction.delete.intent == .delete)
 
+        #expect(HomeThreadSwipeAction.settle.isSettlement)
+        #expect(HomeThreadSwipeAction.reopen.isSettlement)
+        #expect(!HomeThreadSwipeAction.unpin.isSettlement)
+        #expect(!HomeThreadSwipeAction.delete.isSettlement)
+
         // The settlement actions keep the row's existing accent vocabulary and
-        // never inherit the destructive style.
+        // never inherit the destructive style that arms a destructive swipe.
         #expect(HomeThreadSwipeAction.settle.style == .normal)
         #expect(HomeThreadSwipeAction.settle.backgroundColor == .systemGreen)
         #expect(HomeThreadSwipeAction.reopen.backgroundColor == .systemBlue)
@@ -164,11 +186,12 @@ struct HomeThreadSwipeActionTests {
         #expect(HomeThreadSwipeAction.delete.backgroundColor == nil)
     }
 
-    /// The swipe action carries no settlement logic of its own: its intent is
-    /// applied through the same `FeatureRootModel.setSettled` call the row's
-    /// context menu uses, which reaches the client's real settlement request.
+    /// The full swipe carries no settlement logic of its own: its edge action is
+    /// applied through the same `FeatureRootModel.setSettled` call the context
+    /// menu uses, which reaches the client's real settlement request and clears
+    /// the pin, so one motion unpins and settles.
     @Test
-    func settlingAPinnedRowTakesTheRealSettlementPathAndClearsThePin() async throws {
+    func aFullSwipeOnAPinnedRowSettlesThroughTheRealPathAndClearsThePin() async throws {
         let client = SwipeSettlementClientStub()
         var pinned = thread(id: "pinned", pinnedAt: now.addingTimeInterval(-30))
         pinned.lastActivityAt = now
@@ -188,35 +211,35 @@ struct HomeThreadSwipeActionTests {
 
         #expect(presentation(for: model).pinned.map(\.id) == ["pinned"])
 
-        let settle = try #require(
-            HomeThreadSwipeAction.trailingActions(
-                for: pinned,
-                isArchived: false,
-                at: now
-            ).last
+        let actions = HomeThreadSwipeAction.trailingActions(
+            for: pinned,
+            isArchived: false,
+            at: now
         )
-        #expect(settle == .settle)
-        #expect(settle.intent == .setSettled(true))
+        let edge = try #require(actions.first)
+        #expect(edge == .settle)
+        #expect(HomeThreadSwipeAction.performsFullSwipe(with: actions))
 
-        // Applying that intent the way the row's `onSettle` closure does.
-        guard case let .setSettled(settled) = settle.intent else { return }
+        // Applying the edge action the way the row's `onSettle` closure does.
+        guard case let .setSettled(settled) = edge.intent else { return }
         await model.setSettled(pinned.id, settled: settled)
 
         #expect(client.settlementRequests == [SettlementRequest(id: "pinned", settled: true)])
+        #expect(client.pinRequests.isEmpty)
         let updated = try #require(model.snapshot.threads.first { $0.id == "pinned" })
         #expect(updated.isSettled)
         #expect(!updated.keepsActive)
         #expect(updated.settledAt != nil)
         #expect(updated.pinnedAt == nil)
 
-        // The row leaves the pinned shelf for Settled, where its swipe now
-        // offers the reverse action instead.
+        // One motion: the row leaves the pinned shelf for Settled, where its
+        // edge action is now the reverse.
         let shelves = presentation(for: model)
         #expect(shelves.pinned.isEmpty)
         #expect(shelves.settled.map(\.id) == ["pinned"])
         #expect(
             HomeThreadSwipeAction.trailingActions(for: updated, isArchived: false, at: now)
-                == [.delete, .reopen]
+                == [.reopen, .delete]
         )
     }
 
@@ -269,11 +292,16 @@ private struct SettlementRequest: Equatable {
 private final class SwipeSettlementClientStub: FeatureClient {
     var snapshot = FeatureSnapshot()
     var settlementRequests: [SettlementRequest] = []
+    var pinRequests: [String] = []
 
     func initialSnapshot() async throws -> FeatureSnapshot { snapshot }
 
     func setThreadSettled(id: String, settled: Bool) async throws {
         settlementRequests.append(SettlementRequest(id: id, settled: settled))
+    }
+
+    func setThreadPinned(id: String, pinned: Bool) async throws {
+        pinRequests.append(id)
     }
 
     func pair(endpoint: String, token: String?) async throws {}


### PR DESCRIPTION
Home rows could not be cleared with the swipe gesture alone. A pinned row's trailing swipe offered only Delete and Unpin — the action chain reached the pin branch first, so the settlement branch was unreachable while a thread was pinned, even though the row's context menu already offered Settle. Every other row revealed buttons but still required a second tap.

## Behavior

Trailing swipe actions are now resolved as data (`HomeThreadSwipeAction` plus a static resolver), following the existing `ThreadBackSwipeGesture` precedent of a deterministic, unit-testable gesture decision. Settlement owns the edge slot on every row that can settle, and `performsFirstActionWithFullSwipe` is armed only when that edge action settles or reopens, so:

- A full left swipe **performs** the settlement directly — no button tap.
- Delete is appended last on every path, so it can never occupy the slot a full swipe runs. A full swipe cannot delete a thread.
- A partial swipe still reveals every button, unchanged.

Resolved order, outermost first (outermost is what a full swipe runs):

| Row | Actions | Full swipe |
| --- | --- | --- |
| Unpinned, settleable | `Settle`, `Delete` | armed |
| Pinned | `Settle`, `Unpin`, `Delete` | armed |
| Already settled (pinned or not) | `Reopen`, …, `Delete` | armed (reopens) |
| No settlement capability | `Unpin`/`Archive`, `Delete` | disabled |
| Archived | `Restore`, `Delete` | disabled |

A pinned row needs no separate unpin request: `FeatureRootModel.setSettled` clears `pinnedAt` and the server clears the pin as part of settling, so one motion unpins and settles, and the row moves from the pinned shelf to Settled. Each action carries the single lifecycle mutation it requests and applies it through the row's existing callbacks, so a swipe settle takes the same `setThreadSettled` path as the context menu — no new client or model surface.

Rows that cannot settle keep a reversible action at the edge with the gesture disarmed, so no non-settlement action can fire from a bare swipe.

## Tests

`Tests/FeatureTests/HomeThreadSwipeActionTests.swift` covers edge-action identity for pinned, unpinned, settled, capability-limited, and archived rows; the full-swipe-performs-settlement semantics; and the invariant that Delete is never the edge action. One test sweeps every pinned × settled × settlement-capability × pinning-capability × archived combination and asserts Delete is last, never first, and that the full swipe is armed if and only if the edge action's intent is `setSettled`. Another drives `FeatureRootModel.setSettled` against a recording client and asserts the client received the real settlement request, that no separate pin request was made, that the pin cleared, and that the row moved from the pinned shelf to Settled.

Focused run on this exact head, isolated DerivedData, iOS Simulator:

```
xcodebuild -project apps/swift-ios/T3Code.xcodeproj -scheme T3Code \
  -destination 'platform=iOS Simulator,...' \
  test -only-testing:T3CodeTests/HomeThreadSwipeActionTests \
       -only-testing:T3CodeTests/DailyUXSidebarTests
```

Real exit status 0 — 23 tests, 23 passed, 0 failed, 0 skipped (`DailyUXSidebarTests` included as shelf-semantics regression cover).

## Verification beyond unit tests

Simulator interaction proof against a disposable local backend: a full swipe on a pinned row settled it with the pin cleared in the same motion; a full swipe on an unpinned row settled it; a partial swipe still revealed Settle, Unpin, Delete with Settle at the trailing edge. Each UI result was corroborated against the backend's thread projection (`settled_override`, `settled_at`, cleared pin), not screenshots alone.

Accepted on device in a combined TestFlight build (build 86/87).

An independent GPT-5.6 Sol cross-provider review has not run yet: the provider quota is exhausted until 2026-08-20T03:29Z. It is queued to run against this exact head after the reset. Per the repository owner this review no longer blocks opening the PR.

Coordination trace: T3 thread FD81DC09-F7BE-4C90-8B4D-57AED9F8DA03 · saphid/t3code-personal#109

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized iOS home list gesture UX with deterministic rules and strong test coverage; lifecycle mutations still use existing row callbacks and model APIs.
> 
> **Overview**
> Home thread rows now resolve trailing swipe actions through **`HomeThreadSwipeAction`** instead of inline UIKit branching, so ordering and full-swipe behavior are explicit and unit-testable.
> 
> **Settle/reopen** sits at the trailing edge whenever the row can toggle settlement (including pinned rows, where **Unpin** sits between settle and delete). **`performsFirstActionWithFullSwipe`** is enabled only when that edge action is settle or reopen, so a full swipe can complete or reopen a task in one motion but **cannot** delete. Rows without settlement keep archive or unpin at the edge with full swipe off; archived rows stay restore + delete. Swipes dispatch through the same **`onSettle` / `onArchive` / `onPin` / `onDelete`** callbacks as the context menu.
> 
> Adds **`HomeThreadSwipeActionTests`** covering action matrices, delete-never-edge invariants, and an integration-style check that the edge settle path hits **`FeatureRootModel.setSettled`** (clearing pin without a separate unpin request).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fcdc729d8e22d2ccd73eab98ca177f8370225b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add full-swipe settle gesture to thread rows in the iOS home view
> - Replaces hardcoded trailing swipe actions with a data-driven `HomeThreadSwipeAction` enum that computes ordered actions per row state (e.g. `[.settle, .unpin, .delete]` for pinned threads).
> - Settlement/reopen always occupies the edge slot and is the only action that arms a full-swipe gesture; delete is never the edge action.
> - Archived rows show `[.restore, .delete]`; rows without a settlement action get a reversible edge action (archive or unpin) with full-swipe disabled.
> - Adds `HomeThreadSwipeActionTests` covering action ordering, intent mapping, iconography, colors, and full-swipe logic via a stubbed `FeatureClient`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3fcdc72.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->