### PR TITLE
fix(swift-ios): open thread links inside the app

### DIFF
--- a/apps/swift-ios/App/Platform/PlatformRootView.swift
+++ b/apps/swift-ios/App/Platform/PlatformRootView.swift
@@ -26,6 +26,16 @@ struct PlatformRootView: View {
                 navigationRequest = nil
             }
         )
+        .environment(\.openURL, OpenURLAction { url in
+            // Links tapped inside the app (message Markdown above all) would
+            // otherwise leave for Safari or be rejected by an unregistered
+            // scheme, so keep the ones this device can already show.
+            guard let route = PlatformInAppLinkRouter.route(for: url, in: model.snapshot) else {
+                return .systemAction
+            }
+            handle(route)
+            return .handled
+        })
         .onOpenURL { url in
             handle(url: url, letOnboardingConfirmConnection: true)
         }

--- a/apps/swift-ios/App/Platform/PlatformRouteResolver.swift
+++ b/apps/swift-ios/App/Platform/PlatformRouteResolver.swift
@@ -27,3 +27,62 @@ enum PlatformRouteResolver {
         return matches.first
     }
 }
+
+/// Decides which links tapped inside the app navigate in place instead of
+/// being handed to the system.
+///
+/// A T3 link only stays in the app when it names a destination this device can
+/// already show, so unknown web links keep opening on the web instead of
+/// failing with an in-app error. Pairing links are always left to the system so
+/// onboarding keeps owning connection confirmation.
+enum PlatformInAppLinkRouter {
+    static func route(for url: URL, in snapshot: FeatureSnapshot) -> PlatformRoute? {
+        guard let route = try? PlatformDeepLinkParser.parse(url) else { return nil }
+
+        switch route {
+        case .connection:
+            return nil
+        case let .thread(environmentID, threadID):
+            guard isSavedEnvironment(environmentID, in: snapshot),
+                  PlatformRouteResolver.thread(
+                      in: snapshot,
+                      environmentID: environmentID,
+                      id: threadID
+                  ) != nil
+            else {
+                return nil
+            }
+            return route
+        case let .project(environmentID, projectID):
+            guard isSavedEnvironment(environmentID, in: snapshot),
+                  PlatformRouteResolver.project(
+                      in: snapshot,
+                      environmentID: environmentID,
+                      id: projectID
+                  ) != nil
+            else {
+                return nil
+            }
+            return route
+        case let .environment(id):
+            guard isSavedEnvironment(id, in: snapshot) else { return nil }
+            return route
+        case let .newTask(environmentID, projectID):
+            guard isSavedEnvironment(environmentID, in: snapshot) else { return nil }
+            guard let projectID else { return route }
+            guard PlatformRouteResolver.project(
+                in: snapshot,
+                environmentID: environmentID,
+                id: projectID
+            ) != nil else {
+                return nil
+            }
+            return route
+        }
+    }
+
+    private static func isSavedEnvironment(_ id: String?, in snapshot: FeatureSnapshot) -> Bool {
+        guard let id else { return true }
+        return snapshot.environments.contains { $0.id == id }
+    }
+}

--- a/apps/swift-ios/Tests/PlatformTests/PlatformDeepLinkTests.swift
+++ b/apps/swift-ios/Tests/PlatformTests/PlatformDeepLinkTests.swift
@@ -126,6 +126,126 @@ struct PlatformDeepLinkTests {
     }
 
     @Test
+    func opensNativeThreadLinksInsideTheApp() throws {
+        let snapshot = Self.linkedSnapshot()
+        let expected = PlatformRoute.thread(environmentID: "environment-1", threadID: "thread-7")
+
+        for link in [
+            "\(PlatformRoute.nativeScheme)://threads/environment-1/thread-7",
+            "t3code://threads/environment-1/thread-7",
+            "t3://threads/environment-1/thread-7",
+            "https://app.t3.codes/environment-1/thread-7",
+            "https://app.t3.codes/threads/thread-7?environment=environment-1",
+        ] {
+            let url = try #require(URL(string: link))
+            #expect(
+                PlatformInAppLinkRouter.route(for: url, in: snapshot) == expected,
+                "Expected \(link) to open in the app"
+            )
+        }
+    }
+
+    @Test
+    func opensThreadLinksByWireIdentifierWithoutAnEnvironment() throws {
+        let snapshot = Self.linkedSnapshot()
+        let url = try #require(URL(string: "t3code://threads/wire-thread-7"))
+
+        #expect(
+            PlatformInAppLinkRouter.route(for: url, in: snapshot)
+                == .thread(environmentID: nil, threadID: "wire-thread-7")
+        )
+    }
+
+    @Test
+    func leavesLinksThisDeviceCannotShowToTheSystem() throws {
+        let snapshot = Self.linkedSnapshot()
+
+        for link in [
+            // Nothing on this device matches the destination.
+            "t3code://threads/environment-1/thread-missing",
+            "t3code://threads/environment-missing/thread-7",
+            "t3code://projects/environment-1/project-missing",
+            "t3code://environments/environment-missing",
+            "t3code://new-task?environment=environment-1&project=project-missing",
+            // Trusted web pages that are not thread destinations.
+            "https://app.t3.codes/docs/getting-started",
+            "https://app.t3.codes/settings",
+            // Ordinary links inside message content.
+            "https://example.com/environment-1/thread-7",
+            "mailto:someone@example.com",
+        ] {
+            let url = try #require(URL(string: link))
+            #expect(
+                PlatformInAppLinkRouter.route(for: url, in: snapshot) == nil,
+                "Expected \(link) to keep its system behavior"
+            )
+        }
+    }
+
+    @Test
+    func leavesPairingLinksToOnboarding() throws {
+        let snapshot = Self.linkedSnapshot()
+        let url = try #require(
+            URL(string: "t3code://pair?pairingUrl=https%3A%2F%2Fremote.example.com%2Fpair%23token%3DPAIR")
+        )
+
+        #expect(PlatformInAppLinkRouter.route(for: url, in: snapshot) == nil)
+    }
+
+    @Test
+    func opensProjectEnvironmentAndNewTaskLinksInsideTheApp() throws {
+        let snapshot = Self.linkedSnapshot()
+
+        let project = try #require(URL(string: "t3code://projects/environment-1/project-3"))
+        #expect(
+            PlatformInAppLinkRouter.route(for: project, in: snapshot)
+                == .project(environmentID: "environment-1", projectID: "project-3")
+        )
+
+        let environment = try #require(URL(string: "t3code://environments/environment-1"))
+        #expect(
+            PlatformInAppLinkRouter.route(for: environment, in: snapshot)
+                == .environment(id: "environment-1")
+        )
+
+        let newTask = try #require(
+            URL(string: "t3code://new-task?environment=environment-1&project=project-3")
+        )
+        #expect(
+            PlatformInAppLinkRouter.route(for: newTask, in: snapshot)
+                == .newTask(environmentID: "environment-1", projectID: "project-3")
+        )
+    }
+
+    private static func linkedSnapshot() -> FeatureSnapshot {
+        let environment = FeatureEnvironment(
+            id: "environment-1",
+            name: "Environment 1",
+            endpoint: "https://environment-1.example",
+            isActive: true
+        )
+        let project = FeatureProject(
+            id: "project-3",
+            wireID: "wire-project-3",
+            environmentID: environment.id,
+            name: "Project 3",
+            path: "/project-3"
+        )
+        let thread = FeatureThread(
+            id: "thread-7",
+            wireID: "wire-thread-7",
+            projectID: project.id,
+            environmentID: environment.id,
+            title: "Thread 7"
+        )
+        return FeatureSnapshot(
+            environments: [environment],
+            projects: [project],
+            threads: [thread]
+        )
+    }
+
+    @Test
     func resolverRequiresEnvironmentForDuplicateWireIDs() throws {
         let active = FeatureEnvironment(
             id: "active",


### PR DESCRIPTION
## Behavior

A T3 link tapped **inside** the SwiftUI app was handed straight to the system. That meant a trusted web thread link (`https://app.t3.codes/<environmentId>/<threadId>`) left the app for Safari, and a `t3code://` or `t3://` thread link was rejected outright because `Resources/Info.plist` registers only `$(T3CODE_URL_SCHEME)` (`t3code-swiftui` / `-dev`). Deep links delivered *by* the system already navigated correctly through `PlatformRootView.onOpenURL`; only in-app taps were affected.

This installs a root `OpenURLAction` so an in-app tap consults `PlatformInAppLinkRouter.route(for:in:)` first:

- The link stays in the app when it parses as a T3 navigation route **and** its destination already exists in the current snapshot. Navigation reuses the existing `handle(_:)` / `consume(_:)` path, so a thread link pushes the native thread view.
- Everything else returns `.systemAction`. Unknown destinations and ordinary links keep opening on the web exactly as before, so a tap can no longer dead-end in an in-app "not available on this device" error.
- Connection/pairing links are deliberately excluded, so message content can never trigger pairing; `ConnectionOnboardingView` keeps owning that confirmation.

Three files, +189/-0:

| File | Change |
| --- | --- |
| `apps/swift-ios/App/Platform/PlatformRouteResolver.swift` | +59 — new `PlatformInAppLinkRouter.route(for:in:)` |
| `apps/swift-ios/App/Platform/PlatformRootView.swift` | +10 — root `.environment(\.openURL, OpenURLAction { … })` |
| `apps/swift-ios/Tests/PlatformTests/PlatformDeepLinkTests.swift` | +120 — 5 new deep-link tests |

## Focused test evidence

```
xcodebuild -project apps/swift-ios/T3Code.xcodeproj -scheme T3Code \
  -destination 'platform=iOS Simulator,id=<iPhone 17 Pro>' \
  test -only-testing:T3CodeTests/PlatformDeepLinkTests
```

Run with an isolated temporary DerivedData path. Real result: `** TEST SUCCEEDED **`, result bundle summary `"result": "Passed"` — **16 passed / 0 failed / 0 skipped** (11 pre-existing plus 5 new), iPhone 17 Pro, iOS 26.5.

New tests:

- `opensNativeThreadLinksInsideTheApp` — native scheme, legacy `t3code://` / `t3://`, and trusted web thread links all resolve to the in-app thread route.
- `opensThreadLinksByWireIdentifierWithoutAnEnvironment`
- `leavesLinksThisDeviceCannotShowToTheSystem` — unknown threads/projects/environments, non-thread `app.t3.codes` pages, ordinary external links, and `mailto:` all keep system behavior.
- `leavesPairingLinksToOnboarding`
- `opensProjectEnvironmentAndNewTaskLinksInsideTheApp`

Simulator interaction proof: with a disposable local backend and a seeded message containing `https://app.t3.codes/<environmentId>/handoff-haptics`, tapping the rendered link kept the app in the foreground and pushed the native thread view for that thread. That run also confirmed on live data that the web route's `$environmentId` equals the device-saved environment id from the pairing descriptor, which is what lets a real `app.t3.codes` thread link resolve locally.

## On-device acceptance

Accepted by Alex on the phone in the combined Test build (builds 86/87); per-feature acceptance is recorded on `saphid/t3code-personal#108`.

## Review status

The GPT-5.6 Sol cross-provider review has not run yet — Codex capacity was exhausted (`You've hit your usage limit … try again at Aug 20th, 2026 1:29 PM`) and the launch attempt exited non-zero with no report. It is queued for the 2026-08-20T03:29Z quota reset and will run against this exact head. Per Alex it no longer blocks opening this PR.

Coordination trace: T3 thread AA323DE1-96DD-416C-9582-347A84D2272F · saphid/t3code-personal#108

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation-only change with snapshot-gated routing and tests; no auth, data, or API surface changes.
> 
> **Overview**
> **In-app link taps** (e.g. Markdown in messages) now go through a root `OpenURLAction` on `PlatformRootView` instead of always delegating to the system, so trusted T3 URLs can navigate inside the app.
> 
> A new **`PlatformInAppLinkRouter`** parses the URL and returns a `PlatformRoute` only when the destination exists in the current `FeatureSnapshot` (via `PlatformRouteResolver`). Matching routes call the existing `handle(_:)` path; everything else uses `.systemAction`. **Pairing/connection links are never intercepted**, so onboarding still owns pairing confirmation.
> 
> Supported in-app routes include threads (native, legacy schemes, and `app.t3.codes`), projects, environments, and new-task links when the environment/project is on device. Unknown or external URLs keep Safari/system behavior instead of surfacing in-app “not available” errors.
> 
> Five new **`PlatformDeepLinkTests`** cover in-app routing, wire IDs without environment, fall-through cases, pairing exclusion, and project/environment/new-task links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 857ccb8b5da1bb2dc45576f8d535dde71920fc5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Open thread, project, and environment links inside the iOS app instead of in Safari
> - Injects a custom `OpenURLAction` in [`PlatformRootView`](https://github.com/pingdotgg/t3code/pull/7343/files#diff-8437ab1c6019f4d29da7e054f828ff3b35a5b9a757cfd457de6fa3d34efa0040) that intercepts tapped URLs and routes them in-app when possible, falling back to system behavior otherwise.
> - Adds [`PlatformInAppLinkRouter`](https://github.com/pingdotgg/t3code/pull/7343/files#diff-4e7928022364bf2a27e1e6be8a02a80ec578a101c6e55c3bc846a2943532657b) with a `route(for:in:)` method that parses a URL into a `PlatformRoute` and returns it only when the destination exists in the local snapshot; connection/pairing links always fall through to the system.
> - Behavioral Change: links to threads, projects, and environments that exist on-device now open natively; links to non-existent resources or external pages continue to open in Safari.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 857ccb8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->