### PR TITLE
fix(server): stop no longer hangs on an unresponsive Claude runtime

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -95,8 +95,14 @@ class FakeClaudeQuery implements AsyncIterable<SDKMessage> {
     }
   }
 
+  /** Simulates a wedged CLI: the control request is taken and never answered. */
+  public hangInterrupt = false;
+
   readonly interrupt = async (): Promise<void> => {
     this.interruptCalls.push(undefined);
+    if (this.hangInterrupt) {
+      await new Promise<never>(() => {});
+    }
   };
 
   readonly stopTask = async (taskId: string): Promise<void> => {
@@ -1658,6 +1664,53 @@ describe("ClaudeAdapterLive", () => {
         assert.equal(stoppedTaskEvent.payload.status, "stopped");
         assert.equal(stoppedTaskEvent.payload.taskType, "local_agent");
         assert.equal(stoppedTaskEvent.payload.title, "Agent A");
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("interruptTurn stops a session whose runtime never acknowledges", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const turnCompletedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.type === "turn.completed"),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      const turn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        attachments: [],
+      });
+
+      harness.query.hangInterrupt = true;
+      const interruptFiber = yield* adapter.interruptTurn(session.threadId).pipe(Effect.forkChild);
+      yield* TestClock.adjust("10 seconds");
+
+      // Stop returns instead of hanging on the unanswered control request.
+      yield* Fiber.join(interruptFiber);
+      assert.equal(harness.query.interruptCalls.length, 1);
+      // ...and the unresponsive runtime is torn down, so the thread is not
+      // left pinned to a session that can never report a terminal state.
+      assert.equal(harness.query.closeCalls, 1);
+
+      const turnCompletedEvents = Array.from(yield* Fiber.join(turnCompletedFiber));
+      const turnCompleted = turnCompletedEvents[0];
+      assert.equal(turnCompleted?.type, "turn.completed");
+      if (turnCompleted?.type === "turn.completed") {
+        assert.equal(String(turnCompleted.turnId), String(turn.turnId));
+        assert.equal(turnCompleted.payload.state, "interrupted");
       }
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -8,6 +8,7 @@ import type {
   Options as ClaudeQueryOptions,
   PermissionMode,
   PermissionResult,
+  SDKControlGetContextUsageResponse,
   SDKMessage,
   SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";
@@ -97,6 +98,13 @@ class FakeClaudeQuery implements AsyncIterable<SDKMessage> {
 
   /** Simulates a wedged CLI: the control request is taken and never answered. */
   public hangInterrupt = false;
+
+  /**
+   * Left undefined by default so `queryCurrentContextUsage` short-circuits,
+   * matching the tests that predate context usage. Assigned per-test to cover
+   * the probe, including the wedged case where it never settles.
+   */
+  public getContextUsage?: () => Promise<SDKControlGetContextUsageResponse>;
 
   readonly interrupt = async (): Promise<void> => {
     this.interruptCalls.push(undefined);
@@ -1671,7 +1679,7 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
-  it.effect("interruptTurn stops a session whose runtime never acknowledges", () => {
+  it.effect("interruptTurn stops a session whose runtime never answers its control channel", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {
       const adapter = yield* ClaudeAdapter;
@@ -1694,9 +1702,15 @@ describe("ClaudeAdapterLive", () => {
         attachments: [],
       });
 
+      // A wedged CLI stops answering its control channel altogether, so the
+      // context-usage probe that completeTurn runs during teardown hangs on
+      // the same dead channel. Both bounds have to fire, or the escalation
+      // stalls in the same place the interrupt did.
       harness.query.hangInterrupt = true;
+      harness.query.getContextUsage = () => new Promise<never>(() => {});
       const interruptFiber = yield* adapter.interruptTurn(session.threadId).pipe(Effect.forkChild);
       yield* TestClock.adjust("10 seconds");
+      yield* TestClock.adjust("1 second");
 
       // Stop returns instead of hanging on the unanswered control request.
       yield* Fiber.join(interruptFiber);

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -4518,10 +4518,25 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           { concurrency: 8, discard: true },
         ).pipe(Effect.timeoutOption("10 seconds"), Effect.ignore);
       }
-      yield* Effect.tryPromise({
+      // Bounded for the same reason as the tasks above, and this is the one
+      // that actually strands a thread: a wedged CLI never answers the
+      // interrupt control request, so an unbounded await left the session
+      // pinned at "running" forever. Every later Stop press then queued
+      // behind a promise that would never settle, the client's outbox stayed
+      // blocked on the busy session, and the thread could not even be
+      // archived. Stop has to mean something, so a runtime that will not
+      // acknowledge gets torn down instead — the same path its own process
+      // exit would have taken, which completes the turn and frees the thread.
+      const acknowledged = yield* Effect.tryPromise({
         try: () => context.query.interrupt(),
         catch: (cause) => toRequestError(threadId, "turn/interrupt", cause),
-      });
+      }).pipe(Effect.timeoutOption("10 seconds"));
+      if (Option.isNone(acknowledged)) {
+        yield* Effect.logWarning("claude.turn.interrupt.timeout", {
+          threadId,
+        });
+        yield* stopSessionInternal(context, { emitExitEvent: true });
+      }
     },
   );
 

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -2100,13 +2100,17 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       return undefined;
     }
 
+    // Bounded because this rides the same control channel as interrupt, and
+    // completeTurn runs on the teardown path: an unbounded probe against a
+    // wedged CLI would hang the very escalation meant to free the thread.
+    // A skipped context-meter refresh is invisible next to a stranded turn.
     const usage = yield* Effect.promise(async () => {
       try {
         return await context.query.getContextUsage?.();
       } catch {
         return undefined;
       }
-    });
+    }).pipe(Effect.timeoutOption("1 second"), Effect.map(Option.getOrUndefined));
     if (!usage) {
       return undefined;
     }


### PR DESCRIPTION
## The problem

`ClaudeAdapter.interruptTurn` awaited `query.interrupt()` with no bound. That call writes a control request to the CLI's stdin and waits for an acknowledgement, so a wedged CLI — alive, but no longer answering — makes the promise never settle.

The thread is then unrecoverable from any client. The session projection stays `running` with `active_turn_id` pinned to a turn that is already terminal, every further Stop press appends another `thread.turn-interrupt-requested` that cannot settle, and the only way out is finding the child PID and killing it by hand.

Two knock-on effects are worth calling out, because they make this worse than a dead Stop button:

- The mobile outbox gates delivery on `session.status === "running"` (`use-thread-outbox-drain.ts:317`), so queued messages sit undelivered for as long as the session is stuck.
- Archiving is refused while a session is `running` with an `activeTurnId` (`useThreadActions.ts:214`), so the user cannot even clear the thread away.

I hit this on a real thread: 30 interrupt events over 44 minutes, all no-ops, against a `claude` child that had been sleeping at 0.4% CPU with no output for over an hour. `SIGTERM` on that one PID let the adapter finalize the session immediately, and three queued mobile messages delivered themselves a second later.

This looks like the mechanism behind #4713 and #5587.

## The fix

Bound the interrupt at 10 seconds. If the runtime does not acknowledge, tear the session down instead — the same `stopSessionInternal` path the process exit would have taken, which completes the turn as `interrupted` and frees the thread.

That teardown had a second unbounded await on the same control channel, caught by Bugbot: `stopSessionInternal` runs `completeTurn`, which probes `getContextUsage` with no bound, so a wedged runtime could stall the escalation in the same place the interrupt did. That probe is now bounded at one second, which covers the normal `completeTurn` path too. #5891 bounds the same call for the same reason.

The bounded `stopTask` loop directly above already guards this exact hazard for child tasks, and its comment names it: *"Effect.ignore handles rejection, not non-resolution"*. The parent call was simply missed.

A rejected `interrupt()` deliberately keeps its existing behavior. Rejections can be benign, and tearing down a healthy session on one would be worse than the bug.

## Relationship to #5891

**#5891 supersedes this if it merges** — it removes `interrupt()` and `stopTask()` from `interruptTurn` entirely in favor of closing the query, so there would be no unbounded await left to bound. I opened this because #5891 has been idle since Aug 9 and this bug is still live on `main`, but maintainers should take whichever they prefer rather than both.

The two differ in more than size: this keeps the graceful interrupt and only escalates when the runtime proves unresponsive, whereas #5891 always hard-closes. #6531 applies the same "don't block on a provider call that may hang" shape to OpenCode.

## Validation

- `vp test run apps/server/src/provider/Layers/ClaudeAdapter.test.ts` — 71 passed, including the new case
- The regression test hangs both `interrupt` and `getContextUsage`, since a wedged CLI stops answering its control channel altogether rather than just one request
- Each bound was reverted independently to confirm the test bites: either one alone leaves the test hanging until the 60s vitest timeout
- `vp lint` on both files — clean apart from one pre-existing warning outside the diff
- `vp run --filter t3 typecheck` — exit 0

Not audited: whether Codex, Cursor, Grok, or OpenCode share the hazard. They are structurally different (runtime-delegated, ACP, and HTTP abort respectively), and #5587 raises the same question. Worth a separate pass.

Made with Claude Opus 5 (1M context) in T3 Code through the Claude Code harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session stop and teardown paths for Claude threads; mis-tuned timeouts could tear down healthy sessions, but the change replaces indefinite hangs on a known production failure mode.
> 
> **Overview**
> **Stop** no longer blocks forever when the Claude CLI accepts control requests but never answers. `interruptTurn` still tries `query.interrupt()` first, but after **10 seconds** without acknowledgement it logs `claude.turn.interrupt.timeout` and tears the session down via `stopSessionInternal` (turn completes as **interrupted**, thread unpinned). Rejected interrupts are unchanged.
> 
> Teardown was also stalling on the same channel: **`queryCurrentContextUsage`** now caps `getContextUsage` at **1 second** so `completeTurn` cannot hang while escalating after a wedged interrupt.
> 
> Tests add a fake runtime that never resolves interrupt/context usage and assert Stop returns, the query closes, and `turn.completed` is **interrupted**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69b9d6efa7b486974f65944dead23f2b925c1bc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `interruptTurn` hang when Claude runtime is unresponsive
> - `interruptTurn` in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/7349/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc) now bounds the `query.interrupt` call with a 10-second timeout; on timeout it logs a warning and force-stops the session via `stopSessionInternal`, emitting exit events.
> - `queryCurrentContextUsage` now wraps `getContextUsage` in a 1-second timeout, returning `undefined` instead of hanging indefinitely.
> - Behavioral Change: sessions that previously hung forever on an unresponsive runtime will now be torn down after 10 seconds with an interrupted `turn.completed` event.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 69b9d6e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
