### PR TITLE
feat(usage): add OpenCode usage

### DIFF
--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -463,9 +463,11 @@ function UsageCoverageNotice(props: {
     props.merged.staleEnvironments.includes(environment.environmentId),
   );
   const duplicateSources = props.merged.duplicateSources;
+  const sourceIssues = props.merged.sourceIssues;
   if (
     failed.length === 0 &&
     stale.length === 0 &&
+    sourceIssues.length === 0 &&
     duplicateSources.length === 0 &&
     !props.isPartial
   ) {
@@ -489,9 +491,14 @@ function UsageCoverageNotice(props: {
           {environment.label} runs an older server version and is excluded from totals.
         </Text>
       ))}
+      {sourceIssues.map((issue) => (
+        <Text key={issue} className="text-sm text-foreground-muted">
+          {issue}
+        </Text>
+      ))}
       {duplicateSources.length > 0 ? (
         <Text className="text-sm text-foreground-muted">
-          Counted once across environments sharing a transcript directory:{" "}
+          Counted once across environments sharing a provider usage store:{" "}
           {duplicateSources.join(", ")}
         </Text>
       ) : null}

--- a/apps/mobile/src/features/usage/usageProviders.ts
+++ b/apps/mobile/src/features/usage/usageProviders.ts
@@ -5,11 +5,12 @@ import { useAppearancePreferences } from "../settings/appearance/AppearancePrefe
  * Series and table order. The chart stacks providers from the bottom in this
  * order, so it also fixes which band sits on top of the bars.
  */
-export const PROVIDER_ORDER: readonly UsageProviderKind[] = ["codex", "claude"];
+export const PROVIDER_ORDER: readonly UsageProviderKind[] = ["codex", "claude", "opencode"];
 
 export const PROVIDER_LABEL: Record<UsageProviderKind, string> = {
   claude: "Claude Code",
   codex: "Codex",
+  opencode: "OpenCode",
 };
 
 /**
@@ -21,5 +22,6 @@ export function useProviderColors(): Record<UsageProviderKind, string> {
   return {
     claude: "#d97757",
     codex: scheme === "dark" ? "#e6e6e6" : "#3c3c43",
+    opencode: "#4f8cff",
   };
 }

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -1,5 +1,5 @@
 /**
- * UsageService - scans provider transcripts and returns priced usage buckets.
+ * UsageService - scans provider usage stores and returns priced usage buckets.
  *
  * The scan reads the provider CLIs' own session files rather than T3 Code's
  * orchestration projections, so usage covers turns driven outside T3 Code too.
@@ -38,6 +38,7 @@ import * as ServerSettings from "../serverSettings.ts";
 import { resolveClaudeHomePath } from "../provider/Drivers/ClaudeHome.ts";
 import { resolveCodexHomeLayout } from "../provider/Drivers/CodexHomeLayout.ts";
 import { UsageAggregator } from "./usageAggregation.ts";
+import { readOpenCodeUsageRecords, resolveOpenCodeDataDir } from "./usageOpenCodeReader.ts";
 import { parseRateTable, type RateTable } from "./usagePricing.ts";
 import {
   listTranscriptFiles,
@@ -197,8 +198,8 @@ export const make = Effect.gen(function* () {
       return nestedExists ? nested : path.join(homePath, "projects");
     });
 
-  /** Resolves the transcript directory for each provider. */
-  const resolveTranscriptDirs = Effect.fn("UsageService.resolveTranscriptDirs")(function* () {
+  /** Resolves every provider-owned local usage source. */
+  const resolveUsageSources = Effect.fn("UsageService.resolveUsageSources")(function* () {
     // A settings failure must surface as an error: swallowing it here would
     // present "zero usage from every provider" as a valid answer.
     const settings = yield* settingsService.getSettings.pipe(
@@ -218,11 +219,19 @@ export const make = Effect.gen(function* () {
     const claudeHome = yield* resolveClaudeHomePath(settings.providers.claudeAgent);
     const claudeDir = yield* resolveClaudeTranscriptDir(claudeHome);
     const codexLayout = yield* resolveCodexHomeLayout(settings.providers.codex);
+    const openCodeDataDir = resolveOpenCodeDataDir();
 
-    return [
-      { provider: "claude" as const, dir: claudeDir },
-      { provider: "codex" as const, dir: path.join(codexLayout.sharedHomePath, "sessions") },
-    ];
+    return {
+      transcriptDirs: [
+        { provider: "claude" as const, dir: claudeDir },
+        { provider: "codex" as const, dir: path.join(codexLayout.sharedHomePath, "sessions") },
+      ],
+      openCode: {
+        dataDir: openCodeDataDir,
+        databasePath: path.join(openCodeDataDir, "opencode.db"),
+        remote: settings.providers.opencode.serverUrl.length > 0,
+      },
+    };
   });
 
   /**
@@ -329,7 +338,9 @@ export const make = Effect.gen(function* () {
     const hostId = NodeOS.hostname();
     // The home resolvers ask for `Path` themselves; satisfy them from the
     // instance we already hold so `readSummary` stays context-free.
-    const dirs = yield* resolveTranscriptDirs().pipe(Effect.provideService(Path.Path, path));
+    const resolvedSources = yield* resolveUsageSources().pipe(
+      Effect.provideService(Path.Path, path),
+    );
     const windowStart = DateTime.make(`${input.sinceDay}T00:00:00Z`);
     if (Option.isNone(windowStart)) {
       return yield* new UsageReadError({
@@ -353,7 +364,7 @@ export const make = Effect.gen(function* () {
     const livePaths = new Set<string>();
     const walkedRoots: string[] = [];
 
-    for (const { provider, dir } of dirs) {
+    for (const { provider, dir } of resolvedSources.transcriptDirs) {
       const volumeId = yield* Effect.promise(() => readDirectoryVolumeId(dir));
       const exists = yield* fileSystem
         .exists(dir)
@@ -406,6 +417,77 @@ export const make = Effect.gen(function* () {
         distinctSessions: sessionIds.size,
         message: null,
       });
+    }
+
+    const openCodeVolumeId = yield* Effect.promise(() =>
+      readDirectoryVolumeId(resolvedSources.openCode.dataDir),
+    );
+    const openCodeFingerprint = {
+      hostId,
+      provider: "opencode" as const,
+      resolvedHomePath: resolvedSources.openCode.dataDir,
+      volumeId: openCodeVolumeId,
+    };
+
+    if (resolvedSources.openCode.remote) {
+      sources.push({
+        fingerprint: openCodeFingerprint,
+        status: "partial",
+        scannedFiles: 0,
+        skippedFiles: 0,
+        malformedRecords: 0,
+        distinctSessions: 0,
+        message: "Usage from a remote OpenCode server is not available on this environment.",
+      });
+    } else {
+      const openCodeDatabaseExists = yield* fileSystem
+        .exists(resolvedSources.openCode.databasePath)
+        .pipe(Effect.catchCause(() => Effect.succeed(false)));
+      if (!openCodeDatabaseExists) {
+        sources.push({
+          fingerprint: openCodeFingerprint,
+          status: "missing",
+          scannedFiles: 0,
+          skippedFiles: 0,
+          malformedRecords: 0,
+          distinctSessions: 0,
+          message: "No OpenCode usage database on this environment.",
+        });
+      } else {
+        const openCode = yield* Effect.sync(() =>
+          readOpenCodeUsageRecords(resolvedSources.openCode.databasePath, windowStartMs),
+        );
+        if (openCode.status === "failed") {
+          sources.push({
+            fingerprint: openCodeFingerprint,
+            status: "failed",
+            scannedFiles: 0,
+            skippedFiles: 1,
+            malformedRecords: 0,
+            distinctSessions: 0,
+            message: openCode.message,
+          });
+        } else {
+          const sessionIds = new Set<string>();
+          for (const record of openCode.records) {
+            if (aggregator.add(record) && record.sessionId.length > 0) {
+              sessionIds.add(record.sessionId);
+            }
+          }
+          sources.push({
+            fingerprint: openCodeFingerprint,
+            status: openCode.malformedRecords > 0 ? "partial" : "ok",
+            scannedFiles: 1,
+            skippedFiles: 0,
+            malformedRecords: openCode.malformedRecords,
+            distinctSessions: sessionIds.size,
+            message:
+              openCode.malformedRecords > 0
+                ? `${openCode.malformedRecords} OpenCode usage records could not be read.`
+                : null,
+          });
+        }
+      }
     }
 
     const pruned = pruneScanCache(fileCache, {

--- a/apps/server/src/usage/usageAggregation.test.ts
+++ b/apps/server/src/usage/usageAggregation.test.ts
@@ -196,9 +196,10 @@ describe("UsageAggregator", () => {
     const result = aggregate([
       record(),
       record({ provider: "codex", model: "gpt-5.6-sol" }),
+      record({ provider: "opencode", model: "openai/gpt-5.6" }),
       record({ model: "claude-opus-5" }),
     ]);
 
-    expect(result.buckets).toHaveLength(3);
+    expect(result.buckets).toHaveLength(4);
   });
 });

--- a/apps/server/src/usage/usageOpenCodeReader.test.ts
+++ b/apps/server/src/usage/usageOpenCodeReader.test.ts
@@ -30,6 +30,7 @@ function createCurrentTable(database: NodeSqlite.DatabaseSync): void {
       time_created INTEGER NOT NULL,
       data TEXT NOT NULL
     );
+    CREATE INDEX session_message_time_created_idx ON session_message (time_created);
   `);
 }
 
@@ -41,6 +42,8 @@ function createLegacyTable(database: NodeSqlite.DatabaseSync): void {
       time_created INTEGER NOT NULL,
       data TEXT NOT NULL
     );
+    CREATE INDEX message_session_time_created_id_idx
+      ON message (session_id, time_created, id);
   `);
 }
 
@@ -110,7 +113,7 @@ describe("readOpenCodeUsageRecords", () => {
     });
   });
 
-  it("unions migrated databases by message ID and prefers current duplicates", () => {
+  it("uses per-session migration boundaries for nonmatching dual-write IDs", () => {
     const { database, path } = makeDatabase();
     createCurrentTable(database);
     createLegacyTable(database);
@@ -119,10 +122,11 @@ describe("readOpenCodeUsageRecords", () => {
         "INSERT INTO session_message (id, session_id, type, time_created, data) VALUES (?, ?, 'assistant', ?, ?)",
       )
       .run(
-        "shared-message",
+        "step-start-event",
         "session-1",
-        1000,
+        1100,
         JSON.stringify({
+          time: { completed: 1200 },
           model: { providerID: "openai", id: "gpt-5" },
           tokens: { input: 10, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
         }),
@@ -130,11 +134,26 @@ describe("readOpenCodeUsageRecords", () => {
     database
       .prepare("INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)")
       .run(
-        "shared-message",
+        "legacy-before-migration",
         "session-1",
-        1000,
+        900,
         JSON.stringify({
           role: "assistant",
+          time: { completed: 1000 },
+          providerID: "openai",
+          modelID: "gpt-4.1",
+          tokens: { input: 4, output: 2, reasoning: 0, cache: { read: 0, write: 0 } },
+        }),
+      );
+    database
+      .prepare("INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)")
+      .run(
+        "legacy-dual-write-message",
+        "session-1",
+        1050,
+        JSON.stringify({
+          role: "assistant",
+          time: { completed: 1201 },
           providerID: "openai",
           modelID: "gpt-5",
           tokens: { input: 10, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
@@ -145,7 +164,7 @@ describe("readOpenCodeUsageRecords", () => {
       .run(
         "legacy-only",
         "session-old",
-        1100,
+        1300,
         JSON.stringify({
           role: "assistant",
           providerID: "anthropic",
@@ -161,9 +180,94 @@ describe("readOpenCodeUsageRecords", () => {
     if (result.status !== "ok") return;
     expect(result.schema).toBe("mixed");
     expect(result.records.map((record) => record.dedupeKey).sort()).toEqual([
+      "opencode:legacy-before-migration",
       "opencode:legacy-only",
-      "opencode:shared-message",
+      "opencode:step-start-event",
     ]);
+  });
+
+  it("counts inherited legacy history once across repeated forks", () => {
+    const { database, path } = makeDatabase();
+    createLegacyTable(database);
+    const insert = database.prepare(
+      "INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)",
+    );
+    const inherited = JSON.stringify({
+      role: "assistant",
+      time: { completed: 1100 },
+      providerID: "anthropic",
+      modelID: "claude-sonnet-4",
+      cost: 0.25,
+      tokens: { input: 20, output: 8, reasoning: 2, cache: { read: 100, write: 0 } },
+    });
+    insert.run("original-message", "original-session", 1000, inherited);
+    insert.run("first-fork-clone", "first-fork", 1000, inherited);
+    insert.run("second-fork-clone", "second-fork", 1000, inherited);
+    insert.run(
+      "post-fork-call",
+      "second-fork",
+      2000,
+      JSON.stringify({
+        role: "assistant",
+        time: { completed: 2100 },
+        providerID: "anthropic",
+        modelID: "claude-sonnet-4",
+        cost: 0.1,
+        tokens: { input: 7, output: 3, reasoning: 0, cache: { read: 0, write: 0 } },
+      }),
+    );
+    database.close();
+
+    const result = readOpenCodeUsageRecords(path, 0);
+
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+    expect(result.records.map((record) => record.dedupeKey)).toEqual([
+      "opencode:original-message",
+      "opencode:post-fork-call",
+    ]);
+  });
+
+  it("does not resurrect a current-owned call through legacy fork clones", () => {
+    const { database, path } = makeDatabase();
+    createCurrentTable(database);
+    createLegacyTable(database);
+    database
+      .prepare(
+        "INSERT INTO session_message (id, session_id, type, time_created, data) VALUES (?, ?, 'assistant', ?, ?)",
+      )
+      .run(
+        "step-start-event",
+        "original-session",
+        1010,
+        JSON.stringify({
+          time: { completed: 1090 },
+          model: { providerID: "openai", id: "gpt-5" },
+          cost: 0.4,
+          tokens: { input: 30, output: 10, reasoning: 0, cache: { read: 0, write: 0 } },
+        }),
+      );
+    const insert = database.prepare(
+      "INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)",
+    );
+    const inherited = JSON.stringify({
+      role: "assistant",
+      time: { completed: 1100 },
+      providerID: "openai",
+      modelID: "gpt-5",
+      cost: 0.4,
+      tokens: { input: 30, output: 10, reasoning: 0, cache: { read: 0, write: 0 } },
+    });
+    insert.run("legacy-original", "original-session", 1000, inherited);
+    insert.run("legacy-fork-one", "fork-one", 1000, inherited);
+    insert.run("legacy-fork-two", "fork-two", 1000, inherited);
+    database.close();
+
+    const result = readOpenCodeUsageRecords(path, 0);
+
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+    expect(result.records.map((record) => record.dedupeKey)).toEqual(["opencode:step-start-event"]);
   });
 
   it("falls back to legacy message rows", () => {
@@ -235,6 +339,40 @@ describe("readOpenCodeUsageRecords", () => {
     const result = readOpenCodeUsageRecords(path, 1000);
 
     expect(result).toMatchObject({ status: "ok", records: [], malformedRecords: 1 });
+  });
+
+  it("reuses unchanged database results and invalidates them after a write", () => {
+    const { database, path } = makeDatabase();
+    createLegacyTable(database);
+    const insert = database.prepare(
+      "INSERT INTO message (id, session_id, time_created, data) VALUES (?, 'session-1', ?, ?)",
+    );
+    const usage = (input: number) =>
+      JSON.stringify({
+        role: "assistant",
+        providerID: "openai",
+        modelID: "gpt-5",
+        tokens: { input, output: 1, reasoning: 0, cache: { read: 0, write: 0 } },
+      });
+    insert.run("first", 1000, usage(1));
+    database.close();
+
+    const first = readOpenCodeUsageRecords(path, 0);
+    expect(readOpenCodeUsageRecords(path, 0)).toBe(first);
+
+    const writer = new NodeSqlite.DatabaseSync(path);
+    writer
+      .prepare(
+        "INSERT INTO message (id, session_id, time_created, data) VALUES (?, 'session-1', ?, ?)",
+      )
+      .run("second", 2000, usage(2));
+    writer.close();
+
+    const afterWrite = readOpenCodeUsageRecords(path, 0);
+    expect(afterWrite).not.toBe(first);
+    expect(afterWrite.status).toBe("ok");
+    if (afterWrite.status !== "ok") return;
+    expect(afterWrite.records).toHaveLength(2);
   });
 
   it("reports unsupported databases without presenting zero usage as valid", () => {

--- a/apps/server/src/usage/usageOpenCodeReader.test.ts
+++ b/apps/server/src/usage/usageOpenCodeReader.test.ts
@@ -218,8 +218,13 @@ describe("readOpenCodeUsageRecords", () => {
     );
     insert.run("malformed", 1000, JSON.stringify({ model: { providerID: "openai" } }));
     insert.run(
-      "cancelled",
+      "interrupted",
       1001,
+      JSON.stringify({ model: { providerID: "openai", id: "gpt-5" } }),
+    );
+    insert.run(
+      "cancelled",
+      1002,
       JSON.stringify({
         model: { providerID: "openai", id: "gpt-5" },
         tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },

--- a/apps/server/src/usage/usageOpenCodeReader.test.ts
+++ b/apps/server/src/usage/usageOpenCodeReader.test.ts
@@ -1,0 +1,245 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import * as NodeSqlite from "node:sqlite";
+
+import { afterEach, describe, expect, it } from "@effect/vitest";
+
+import { readOpenCodeUsageRecords, resolveOpenCodeDataDir } from "./usageOpenCodeReader.ts";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) NodeFS.rmSync(dir, { recursive: true, force: true });
+});
+
+function makeDatabase(): { readonly database: NodeSqlite.DatabaseSync; readonly path: string } {
+  const dir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-opencode-usage-"));
+  tempDirs.push(dir);
+  const path = NodePath.join(dir, "opencode.db");
+  return { database: new NodeSqlite.DatabaseSync(path), path };
+}
+
+function createCurrentTable(database: NodeSqlite.DatabaseSync): void {
+  database.exec(`
+    CREATE TABLE session_message (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      type TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      data TEXT NOT NULL
+    );
+  `);
+}
+
+function createLegacyTable(database: NodeSqlite.DatabaseSync): void {
+  database.exec(`
+    CREATE TABLE message (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      data TEXT NOT NULL
+    );
+  `);
+}
+
+describe("resolveOpenCodeDataDir", () => {
+  it("uses the XDG data home when configured", () => {
+    expect(resolveOpenCodeDataDir({ XDG_DATA_HOME: "/var/data" }, "/home/test")).toBe(
+      "/var/data/opencode",
+    );
+  });
+
+  it("uses OpenCode's default data home", () => {
+    expect(resolveOpenCodeDataDir({}, "/home/test")).toBe("/home/test/.local/share/opencode");
+  });
+});
+
+describe("readOpenCodeUsageRecords", () => {
+  it("reads exact current-schema message usage", () => {
+    const { database, path } = makeDatabase();
+    createCurrentTable(database);
+    database
+      .prepare(
+        "INSERT INTO session_message (id, session_id, type, time_created, data) VALUES (?, ?, ?, ?, ?)",
+      )
+      .run(
+        "message-1",
+        "session-1",
+        "assistant",
+        Date.parse("2026-08-15T10:00:00.000Z"),
+        JSON.stringify({
+          time: { completed: Date.parse("2026-08-15T10:00:05.000Z") },
+          model: { providerID: "anthropic", id: "claude-opus-4-1" },
+          cost: 1.25,
+          tokens: {
+            input: 100,
+            output: 50,
+            reasoning: 20,
+            cache: { read: 1000, write: 10 },
+          },
+          content: [{ type: "text", text: "This large field is never selected." }],
+        }),
+      );
+    database.close();
+
+    const result = readOpenCodeUsageRecords(path, Date.parse("2026-08-01T00:00:00.000Z"));
+
+    expect(result).toEqual({
+      status: "ok",
+      schema: "current",
+      malformedRecords: 0,
+      records: [
+        {
+          provider: "opencode",
+          timestampMs: Date.parse("2026-08-15T10:00:05.000Z"),
+          model: "anthropic/claude-opus-4-1",
+          sessionId: "session-1",
+          totals: {
+            uncachedInputTokens: 100,
+            cachedInputTokens: 1000,
+            cacheCreationTokens: 10,
+            outputTokens: 70,
+            reasoningTokens: 20,
+          },
+          reportedCostUsd: 1.25,
+          dedupeKey: "opencode:message-1",
+        },
+      ],
+    });
+  });
+
+  it("unions migrated databases by message ID and prefers current duplicates", () => {
+    const { database, path } = makeDatabase();
+    createCurrentTable(database);
+    createLegacyTable(database);
+    database
+      .prepare(
+        "INSERT INTO session_message (id, session_id, type, time_created, data) VALUES (?, ?, 'assistant', ?, ?)",
+      )
+      .run(
+        "shared-message",
+        "session-1",
+        1000,
+        JSON.stringify({
+          model: { providerID: "openai", id: "gpt-5" },
+          tokens: { input: 10, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
+        }),
+      );
+    database
+      .prepare("INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)")
+      .run(
+        "shared-message",
+        "session-1",
+        1000,
+        JSON.stringify({
+          role: "assistant",
+          providerID: "openai",
+          modelID: "gpt-5",
+          tokens: { input: 10, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
+        }),
+      );
+    database
+      .prepare("INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)")
+      .run(
+        "legacy-only",
+        "session-old",
+        1100,
+        JSON.stringify({
+          role: "assistant",
+          providerID: "anthropic",
+          modelID: "claude-sonnet-4",
+          tokens: { input: 20, output: 8, reasoning: 0, cache: { read: 0, write: 0 } },
+        }),
+      );
+    database.close();
+
+    const result = readOpenCodeUsageRecords(path, 0);
+
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+    expect(result.schema).toBe("mixed");
+    expect(result.records.map((record) => record.dedupeKey).sort()).toEqual([
+      "opencode:legacy-only",
+      "opencode:shared-message",
+    ]);
+  });
+
+  it("falls back to legacy message rows", () => {
+    const { database, path } = makeDatabase();
+    createLegacyTable(database);
+    database
+      .prepare("INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)")
+      .run(
+        "legacy-message",
+        "session-legacy",
+        2000,
+        JSON.stringify({
+          role: "assistant",
+          providerID: "google",
+          modelID: "gemini-2.5-pro",
+          cost: 0,
+          tokens: {
+            input: 15,
+            output: 7,
+            reasoning: 3,
+            cache: { read: 4, write: 2 },
+          },
+        }),
+      );
+    database.close();
+
+    const result = readOpenCodeUsageRecords(path, 0);
+
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+    expect(result.schema).toBe("legacy");
+    expect(result.records[0]).toMatchObject({
+      model: "google/gemini-2.5-pro",
+      reportedCostUsd: 0,
+      totals: { outputTokens: 10, reasoningTokens: 3 },
+    });
+  });
+
+  it("uses the indexed creation time as a prefilter and counts unusable rows", () => {
+    const { database, path } = makeDatabase();
+    createCurrentTable(database);
+    const insert = database.prepare(
+      "INSERT INTO session_message (id, session_id, type, time_created, data) VALUES (?, 'session-1', 'assistant', ?, ?)",
+    );
+    insert.run(
+      "before-window",
+      999,
+      JSON.stringify({
+        model: { providerID: "openai", id: "gpt-5" },
+        tokens: { input: 1, output: 1, reasoning: 0, cache: { read: 0, write: 0 } },
+      }),
+    );
+    insert.run("malformed", 1000, JSON.stringify({ model: { providerID: "openai" } }));
+    insert.run(
+      "cancelled",
+      1001,
+      JSON.stringify({
+        model: { providerID: "openai", id: "gpt-5" },
+        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      }),
+    );
+    database.close();
+
+    const result = readOpenCodeUsageRecords(path, 1000);
+
+    expect(result).toMatchObject({ status: "ok", records: [], malformedRecords: 1 });
+  });
+
+  it("reports unsupported databases without presenting zero usage as valid", () => {
+    const { database, path } = makeDatabase();
+    database.exec("CREATE TABLE unrelated (id TEXT PRIMARY KEY)");
+    database.close();
+
+    expect(readOpenCodeUsageRecords(path, 0)).toEqual({
+      status: "failed",
+      message: "The OpenCode database uses an unsupported session schema.",
+    });
+  });
+});

--- a/apps/server/src/usage/usageOpenCodeReader.ts
+++ b/apps/server/src/usage/usageOpenCodeReader.ts
@@ -1,0 +1,251 @@
+// @effect-diagnostics nodeBuiltinImport:off
+/**
+ * Read-only access to OpenCode's local usage database.
+ *
+ * OpenCode keeps exact usage on assistant messages. Current releases use the
+ * `session_message` table while older releases use `message`. Installations
+ * migrating between them may contain both, so rows are unioned by message ID
+ * with the current representation winning duplicates.
+ *
+ * @module usageOpenCodeReader
+ */
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import * as NodeSqlite from "node:sqlite";
+
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+
+import { totalTokens, type UsageRecord } from "./usageTranscripts.ts";
+
+const OpenCodeUsageRow = Schema.Struct({
+  id: Schema.String,
+  sessionId: Schema.String,
+  timestampMs: Schema.NullOr(Schema.Number),
+  providerId: Schema.NullOr(Schema.String),
+  modelId: Schema.NullOr(Schema.String),
+  costUsd: Schema.NullOr(Schema.Number),
+  inputTokens: Schema.NullOr(Schema.Number),
+  outputTokens: Schema.NullOr(Schema.Number),
+  reasoningTokens: Schema.NullOr(Schema.Number),
+  cacheReadTokens: Schema.NullOr(Schema.Number),
+  cacheWriteTokens: Schema.NullOr(Schema.Number),
+});
+const decodeOpenCodeUsageRow = Schema.decodeUnknownOption(OpenCodeUsageRow);
+const decodeOpenCodeUsageRows = Schema.decodeUnknownOption(Schema.Array(OpenCodeUsageRow));
+
+export type OpenCodeUsageSchema = "current" | "legacy" | "mixed";
+
+export interface OpenCodeUsageReadSuccess {
+  readonly status: "ok";
+  readonly schema: OpenCodeUsageSchema;
+  readonly records: readonly UsageRecord[];
+  readonly malformedRecords: number;
+}
+
+export interface OpenCodeUsageReadFailure {
+  readonly status: "failed";
+  readonly message: string;
+}
+
+export type OpenCodeUsageReadResult = OpenCodeUsageReadSuccess | OpenCodeUsageReadFailure;
+
+/** Mirrors OpenCode's `xdg-basedir` data path without starting the CLI. */
+export function resolveOpenCodeDataDir(
+  environment: NodeJS.ProcessEnv = process.env,
+  homePath: string = NodeOS.homedir(),
+): string {
+  const configured = environment.XDG_DATA_HOME?.trim();
+  const dataHome =
+    configured && configured.length > 0 ? configured : NodePath.join(homePath, ".local", "share");
+  return NodePath.join(dataHome, "opencode");
+}
+
+function nonNegativeInt(value: number | null): number {
+  return value !== null && Number.isFinite(value) && value > 0 ? Math.trunc(value) : 0;
+}
+
+function tableExists(database: NodeSqlite.DatabaseSync, table: string): boolean {
+  return (
+    database
+      .prepare("SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1")
+      .get(table) !== undefined
+  );
+}
+
+function tableHasRows(database: NodeSqlite.DatabaseSync, table: string): boolean {
+  return database.prepare(`SELECT 1 AS present FROM ${table} LIMIT 1`).get() !== undefined;
+}
+
+const CURRENT_USAGE_QUERY = `
+  SELECT
+    id,
+    session_id AS sessionId,
+    COALESCE(json_extract(data, '$.time.completed'), time_created) AS timestampMs,
+    json_extract(data, '$.model.providerID') AS providerId,
+    json_extract(data, '$.model.id') AS modelId,
+    json_extract(data, '$.cost') AS costUsd,
+    json_extract(data, '$.tokens.input') AS inputTokens,
+    json_extract(data, '$.tokens.output') AS outputTokens,
+    json_extract(data, '$.tokens.reasoning') AS reasoningTokens,
+    json_extract(data, '$.tokens.cache.read') AS cacheReadTokens,
+    json_extract(data, '$.tokens.cache.write') AS cacheWriteTokens
+  FROM session_message
+  WHERE type = 'assistant' AND time_created >= ?
+  ORDER BY time_created, id
+`;
+
+const LEGACY_USAGE_QUERY = `
+  SELECT
+    id,
+    session_id AS sessionId,
+    COALESCE(json_extract(data, '$.time.completed'), time_created) AS timestampMs,
+    json_extract(data, '$.providerID') AS providerId,
+    json_extract(data, '$.modelID') AS modelId,
+    json_extract(data, '$.cost') AS costUsd,
+    json_extract(data, '$.tokens.input') AS inputTokens,
+    json_extract(data, '$.tokens.output') AS outputTokens,
+    json_extract(data, '$.tokens.reasoning') AS reasoningTokens,
+    json_extract(data, '$.tokens.cache.read') AS cacheReadTokens,
+    json_extract(data, '$.tokens.cache.write') AS cacheWriteTokens
+  FROM message
+  WHERE json_extract(data, '$.role') = 'assistant' AND time_created >= ?
+  ORDER BY time_created, id
+`;
+
+const MIXED_LEGACY_USAGE_QUERY = `
+  SELECT
+    message.id AS id,
+    message.session_id AS sessionId,
+    COALESCE(json_extract(message.data, '$.time.completed'), message.time_created) AS timestampMs,
+    json_extract(message.data, '$.providerID') AS providerId,
+    json_extract(message.data, '$.modelID') AS modelId,
+    json_extract(message.data, '$.cost') AS costUsd,
+    json_extract(message.data, '$.tokens.input') AS inputTokens,
+    json_extract(message.data, '$.tokens.output') AS outputTokens,
+    json_extract(message.data, '$.tokens.reasoning') AS reasoningTokens,
+    json_extract(message.data, '$.tokens.cache.read') AS cacheReadTokens,
+    json_extract(message.data, '$.tokens.cache.write') AS cacheWriteTokens
+  FROM message
+  WHERE
+    json_extract(message.data, '$.role') = 'assistant'
+    AND message.time_created >= ?
+    AND NOT EXISTS (SELECT 1 FROM session_message WHERE session_message.id = message.id)
+  ORDER BY message.time_created, message.id
+`;
+
+/**
+ * Reads message-level OpenCode usage without materialising message content.
+ *
+ * `sinceMs` is only a query prefilter. Exact daily/hourly bounds are still
+ * applied by {@link UsageAggregator}, just as they are for transcript files.
+ */
+export function readOpenCodeUsageRecords(
+  databasePath: string,
+  sinceMs: number,
+): OpenCodeUsageReadResult {
+  let database: NodeSqlite.DatabaseSync | null = null;
+  try {
+    database = new NodeSqlite.DatabaseSync(databasePath, { readOnly: true });
+
+    const hasCurrent = tableExists(database, "session_message");
+    const hasLegacy = tableExists(database, "message");
+    const hasCurrentRows = hasCurrent && tableHasRows(database, "session_message");
+    const schema: OpenCodeUsageSchema | null =
+      hasCurrentRows && hasLegacy
+        ? "mixed"
+        : hasCurrentRows
+          ? "current"
+          : hasLegacy
+            ? "legacy"
+            : hasCurrent
+              ? "current"
+              : null;
+    if (schema === null) {
+      return {
+        status: "failed",
+        message: "The OpenCode database uses an unsupported session schema.",
+      };
+    }
+
+    const rows =
+      schema === "current"
+        ? database.prepare(CURRENT_USAGE_QUERY).all(sinceMs)
+        : schema === "legacy"
+          ? database.prepare(LEGACY_USAGE_QUERY).all(sinceMs)
+          : [
+              ...database.prepare(CURRENT_USAGE_QUERY).all(sinceMs),
+              ...database.prepare(MIXED_LEGACY_USAGE_QUERY).all(sinceMs),
+            ];
+    const decodedRows = decodeOpenCodeUsageRows(rows);
+    const candidates = Option.isSome(decodedRows)
+      ? decodedRows.value.map((value) => Option.some(value))
+      : rows.map((row) => decodeOpenCodeUsageRow(row));
+    const records: UsageRecord[] = [];
+    let malformedRecords = 0;
+
+    for (const decoded of candidates) {
+      if (Option.isNone(decoded)) {
+        malformedRecords += 1;
+        continue;
+      }
+
+      const value = decoded.value;
+      const providerId = value.providerId?.trim() ?? "";
+      const modelId = value.modelId?.trim() ?? "";
+      if (
+        value.timestampMs === null ||
+        !Number.isFinite(value.timestampMs) ||
+        providerId.length === 0 ||
+        modelId.length === 0
+      ) {
+        malformedRecords += 1;
+        continue;
+      }
+
+      const reasoningTokens = nonNegativeInt(value.reasoningTokens);
+      const totals = {
+        uncachedInputTokens: nonNegativeInt(value.inputTokens),
+        cachedInputTokens: nonNegativeInt(value.cacheReadTokens),
+        cacheCreationTokens: nonNegativeInt(value.cacheWriteTokens),
+        // OpenCode records reasoning separately from visible output. T3's
+        // contract models reasoning as a subset of output, so combine them.
+        outputTokens: nonNegativeInt(value.outputTokens) + reasoningTokens,
+        reasoningTokens,
+      };
+      if (totalTokens(totals) === 0) {
+        const hasTokenPayload = [
+          value.inputTokens,
+          value.outputTokens,
+          value.reasoningTokens,
+          value.cacheReadTokens,
+          value.cacheWriteTokens,
+        ].some((tokenCount) => tokenCount !== null);
+        if (!hasTokenPayload) malformedRecords += 1;
+        continue;
+      }
+
+      records.push({
+        provider: "opencode",
+        timestampMs: value.timestampMs,
+        model: `${providerId}/${modelId}`,
+        sessionId: value.sessionId,
+        totals,
+        reportedCostUsd:
+          value.costUsd !== null && Number.isFinite(value.costUsd) && value.costUsd >= 0
+            ? value.costUsd
+            : null,
+        dedupeKey: `opencode:${value.id}`,
+      });
+    }
+
+    return { status: "ok", schema, records, malformedRecords };
+  } catch {
+    return {
+      status: "failed",
+      message: "The OpenCode usage database could not be read.",
+    };
+  } finally {
+    database?.close();
+  }
+}

--- a/apps/server/src/usage/usageOpenCodeReader.ts
+++ b/apps/server/src/usage/usageOpenCodeReader.ts
@@ -214,14 +214,10 @@ export function readOpenCodeUsageRecords(
         reasoningTokens,
       };
       if (totalTokens(totals) === 0) {
-        const hasTokenPayload = [
-          value.inputTokens,
-          value.outputTokens,
-          value.reasoningTokens,
-          value.cacheReadTokens,
-          value.cacheWriteTokens,
-        ].some((tokenCount) => tokenCount !== null);
-        if (!hasTokenPayload) malformedRecords += 1;
+        // OpenCode creates the assistant row before a provider responds. An
+        // interrupted turn can leave that otherwise valid row without a token
+        // payload, while cancelled turns persist an all-zero payload. Neither
+        // represents usage or a damaged usage record.
         continue;
       }
 

--- a/apps/server/src/usage/usageOpenCodeReader.ts
+++ b/apps/server/src/usage/usageOpenCodeReader.ts
@@ -4,11 +4,13 @@
  *
  * OpenCode keeps exact usage on assistant messages. Current releases use the
  * `session_message` table while older releases use `message`. Installations
- * migrating between them may contain both, so rows are unioned by message ID
- * with the current representation winning duplicates.
+ * migrating between them may contain both. The current representation owns a
+ * session from its first projected assistant onward; older legacy rows remain
+ * useful before that boundary.
  *
  * @module usageOpenCodeReader
  */
+import * as NodeFS from "node:fs";
 import * as NodeOS from "node:os";
 import * as NodePath from "node:path";
 import * as NodeSqlite from "node:sqlite";
@@ -19,8 +21,10 @@ import * as Schema from "effect/Schema";
 import { totalTokens, type UsageRecord } from "./usageTranscripts.ts";
 
 const OpenCodeUsageRow = Schema.Struct({
+  source: Schema.Union([Schema.Literal("current"), Schema.Literal("legacy")]),
   id: Schema.String,
   sessionId: Schema.String,
+  createdAtMs: Schema.Number,
   timestampMs: Schema.NullOr(Schema.Number),
   providerId: Schema.NullOr(Schema.String),
   modelId: Schema.NullOr(Schema.String),
@@ -33,6 +37,14 @@ const OpenCodeUsageRow = Schema.Struct({
 });
 const decodeOpenCodeUsageRow = Schema.decodeUnknownOption(OpenCodeUsageRow);
 const decodeOpenCodeUsageRows = Schema.decodeUnknownOption(Schema.Array(OpenCodeUsageRow));
+
+const OpenCodeMigrationBoundary = Schema.Struct({
+  sessionId: Schema.String,
+  timestampMs: Schema.Number,
+});
+const decodeOpenCodeMigrationBoundaries = Schema.decodeUnknownSync(
+  Schema.Array(OpenCodeMigrationBoundary),
+);
 
 export type OpenCodeUsageSchema = "current" | "legacy" | "mixed";
 
@@ -79,8 +91,10 @@ function tableHasRows(database: NodeSqlite.DatabaseSync, table: string): boolean
 
 const CURRENT_USAGE_QUERY = `
   SELECT
+    'current' AS source,
     id,
     session_id AS sessionId,
+    time_created AS createdAtMs,
     COALESCE(json_extract(data, '$.time.completed'), time_created) AS timestampMs,
     json_extract(data, '$.model.providerID') AS providerId,
     json_extract(data, '$.model.id') AS modelId,
@@ -92,13 +106,14 @@ const CURRENT_USAGE_QUERY = `
     json_extract(data, '$.tokens.cache.write') AS cacheWriteTokens
   FROM session_message
   WHERE type = 'assistant' AND time_created >= ?
-  ORDER BY time_created, id
 `;
 
 const LEGACY_USAGE_QUERY = `
   SELECT
+    'legacy' AS source,
     id,
     session_id AS sessionId,
+    time_created AS createdAtMs,
     COALESCE(json_extract(data, '$.time.completed'), time_created) AS timestampMs,
     json_extract(data, '$.providerID') AS providerId,
     json_extract(data, '$.modelID') AS modelId,
@@ -110,29 +125,62 @@ const LEGACY_USAGE_QUERY = `
     json_extract(data, '$.tokens.cache.write') AS cacheWriteTokens
   FROM message
   WHERE json_extract(data, '$.role') = 'assistant' AND time_created >= ?
-  ORDER BY time_created, id
 `;
 
-const MIXED_LEGACY_USAGE_QUERY = `
+const CURRENT_MIGRATION_BOUNDARIES_QUERY = `
   SELECT
-    message.id AS id,
-    message.session_id AS sessionId,
-    COALESCE(json_extract(message.data, '$.time.completed'), message.time_created) AS timestampMs,
-    json_extract(message.data, '$.providerID') AS providerId,
-    json_extract(message.data, '$.modelID') AS modelId,
-    json_extract(message.data, '$.cost') AS costUsd,
-    json_extract(message.data, '$.tokens.input') AS inputTokens,
-    json_extract(message.data, '$.tokens.output') AS outputTokens,
-    json_extract(message.data, '$.tokens.reasoning') AS reasoningTokens,
-    json_extract(message.data, '$.tokens.cache.read') AS cacheReadTokens,
-    json_extract(message.data, '$.tokens.cache.write') AS cacheWriteTokens
-  FROM message
-  WHERE
-    json_extract(message.data, '$.role') = 'assistant'
-    AND message.time_created >= ?
-    AND NOT EXISTS (SELECT 1 FROM session_message WHERE session_message.id = message.id)
-  ORDER BY message.time_created, message.id
+    session_id AS sessionId,
+    MIN(time_created) AS timestampMs
+  FROM session_message
+  WHERE type = 'assistant'
+  GROUP BY session_id
 `;
+
+interface OpenCodeUsageCacheEntry {
+  readonly databaseState: string;
+  readonly resultsBySinceMs: Map<number, OpenCodeUsageReadSuccess>;
+}
+
+const MAX_CACHED_WINDOWS = 8;
+const usageCache = new Map<string, OpenCodeUsageCacheEntry>();
+
+function fileState(path: string, required: boolean): string | null {
+  try {
+    const stat = NodeFS.statSync(path, { bigint: true });
+    return [stat.dev, stat.ino, stat.size, stat.mtimeNs, stat.ctimeNs].map(String).join(":");
+  } catch {
+    return required ? null : "missing";
+  }
+}
+
+/** Includes SQLite sidecars so uncheckpointed WAL writes invalidate the cache. */
+function databaseState(databasePath: string): string | null {
+  const main = fileState(databasePath, true);
+  if (main === null) return null;
+  return [
+    main,
+    fileState(`${databasePath}-wal`, false),
+    fileState(`${databasePath}-journal`, false),
+  ].join("|");
+}
+
+function usageIdentity(value: typeof OpenCodeUsageRow.Type): string {
+  // Forks copy these provider-call fields and timestamps verbatim while
+  // replacing the message and session IDs. A genuine post-fork call receives
+  // fresh timestamps and therefore remains distinct.
+  return JSON.stringify([
+    value.createdAtMs,
+    value.timestampMs,
+    value.providerId,
+    value.modelId,
+    value.costUsd,
+    value.inputTokens,
+    value.outputTokens,
+    value.reasoningTokens,
+    value.cacheReadTokens,
+    value.cacheWriteTokens,
+  ]);
+}
 
 /**
  * Reads message-level OpenCode usage without materialising message content.
@@ -140,7 +188,7 @@ const MIXED_LEGACY_USAGE_QUERY = `
  * `sinceMs` is only a query prefilter. Exact daily/hourly bounds are still
  * applied by {@link UsageAggregator}, just as they are for transcript files.
  */
-export function readOpenCodeUsageRecords(
+function readOpenCodeUsageRecordsUncached(
   databasePath: string,
   sinceMs: number,
 ): OpenCodeUsageReadResult {
@@ -175,13 +223,26 @@ export function readOpenCodeUsageRecords(
           ? database.prepare(LEGACY_USAGE_QUERY).all(sinceMs)
           : [
               ...database.prepare(CURRENT_USAGE_QUERY).all(sinceMs),
-              ...database.prepare(MIXED_LEGACY_USAGE_QUERY).all(sinceMs),
+              ...database.prepare(LEGACY_USAGE_QUERY).all(sinceMs),
             ];
+    const migrationBoundaries =
+      schema === "mixed"
+        ? new Map(
+            decodeOpenCodeMigrationBoundaries(
+              database.prepare(CURRENT_MIGRATION_BOUNDARIES_QUERY).all(),
+            ).map((value) => [value.sessionId, value.timestampMs] as const),
+          )
+        : new Map<string, number>();
     const decodedRows = decodeOpenCodeUsageRows(rows);
     const candidates = Option.isSome(decodedRows)
       ? decodedRows.value.map((value) => Option.some(value))
       : rows.map((row) => decodeOpenCodeUsageRow(row));
-    const records: UsageRecord[] = [];
+    const validCandidates: Array<{
+      readonly source: "current" | "legacy";
+      readonly identity: string;
+      readonly record: UsageRecord;
+      readonly coveredByCurrentMigration: boolean;
+    }> = [];
     let malformedRecords = 0;
 
     for (const decoded of candidates) {
@@ -221,18 +282,49 @@ export function readOpenCodeUsageRecords(
         continue;
       }
 
-      records.push({
-        provider: "opencode",
-        timestampMs: value.timestampMs,
-        model: `${providerId}/${modelId}`,
-        sessionId: value.sessionId,
-        totals,
-        reportedCostUsd:
-          value.costUsd !== null && Number.isFinite(value.costUsd) && value.costUsd >= 0
-            ? value.costUsd
-            : null,
-        dedupeKey: `opencode:${value.id}`,
+      const identity = usageIdentity(value);
+      const boundary = migrationBoundaries.get(value.sessionId);
+      validCandidates.push({
+        source: value.source,
+        identity,
+        coveredByCurrentMigration:
+          value.source === "legacy" && boundary !== undefined && value.timestampMs >= boundary,
+        record: {
+          provider: "opencode",
+          timestampMs: value.timestampMs,
+          model: `${providerId}/${modelId}`,
+          sessionId: value.sessionId,
+          totals,
+          reportedCostUsd:
+            value.costUsd !== null && Number.isFinite(value.costUsd) && value.costUsd >= 0
+              ? value.costUsd
+              : null,
+          dedupeKey: `opencode:${value.id}`,
+        },
       });
+    }
+
+    // A mixed-schema legacy row at or after its session's first projected
+    // assistant is a dual-write, even though the projection is keyed by the
+    // generated step event rather than the legacy message ID. Propagate that
+    // provenance across identical legacy rows so forked copies are excluded
+    // along with the original dual-write.
+    const currentOwnedLegacy = new Set(
+      validCandidates
+        .filter((candidate) => candidate.coveredByCurrentMigration)
+        .map((candidate) => candidate.identity),
+    );
+    const seenBySource = {
+      current: new Set<string>(),
+      legacy: new Set<string>(),
+    };
+    const records: UsageRecord[] = [];
+    for (const candidate of validCandidates) {
+      if (candidate.source === "legacy" && currentOwnedLegacy.has(candidate.identity)) continue;
+      const seen = seenBySource[candidate.source];
+      if (seen.has(candidate.identity)) continue;
+      seen.add(candidate.identity);
+      records.push(candidate.record);
     }
 
     return { status: "ok", schema, records, malformedRecords };
@@ -244,4 +336,40 @@ export function readOpenCodeUsageRecords(
   } finally {
     database?.close();
   }
+}
+
+/**
+ * Reads message-level OpenCode usage without materialising message content.
+ * Results are cached until the database or one of its write sidecars changes,
+ * keeping the legacy JSON predicate off the server event loop on warm reads.
+ *
+ * `sinceMs` is only a query prefilter. Exact daily/hourly bounds are still
+ * applied by {@link UsageAggregator}, just as they are for transcript files.
+ */
+export function readOpenCodeUsageRecords(
+  databasePath: string,
+  sinceMs: number,
+): OpenCodeUsageReadResult {
+  const before = databaseState(databasePath);
+  const cached = usageCache.get(databasePath);
+  if (before !== null && cached?.databaseState === before) {
+    const result = cached.resultsBySinceMs.get(sinceMs);
+    if (result !== undefined) return result;
+  }
+
+  const result = readOpenCodeUsageRecordsUncached(databasePath, sinceMs);
+  const after = databaseState(databasePath);
+  if (result.status === "ok" && before !== null && before === after) {
+    const resultsBySinceMs =
+      cached?.databaseState === before
+        ? cached.resultsBySinceMs
+        : new Map<number, OpenCodeUsageReadSuccess>();
+    if (!resultsBySinceMs.has(sinceMs) && resultsBySinceMs.size >= MAX_CACHED_WINDOWS) {
+      const oldestSinceMs = resultsBySinceMs.keys().next().value;
+      if (oldestSinceMs !== undefined) resultsBySinceMs.delete(oldestSinceMs);
+    }
+    resultsBySinceMs.set(sinceMs, result);
+    usageCache.set(databasePath, { databaseState: before, resultsBySinceMs });
+  }
+  return result;
 }

--- a/apps/server/src/usage/usageScanCache.ts
+++ b/apps/server/src/usage/usageScanCache.ts
@@ -134,7 +134,7 @@ export function decodeScanCache(document: unknown): ScanCache {
     if (typeof raw !== "object" || raw === null) continue;
     const entry = raw as Partial<SerializedFile>;
     if (typeof entry.s !== "number" || typeof entry.m !== "number") continue;
-    if (entry.p !== "claude" && entry.p !== "codex") continue;
+    if (entry.p !== "claude" && entry.p !== "codex" && entry.p !== "opencode") continue;
     if (!isRecordArray(entry.r)) continue;
 
     const provider: UsageProviderKind = entry.p;

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -180,6 +180,7 @@ export function UsagePage() {
                 <UsageCoverageNotice
                   environments={environments}
                   duplicateSources={merged.duplicateSources}
+                  sourceIssues={merged.sourceIssues}
                   staleEnvironments={merged.staleEnvironments}
                 />
 
@@ -397,7 +398,10 @@ export function UsagePage() {
                       <tbody>
                         {breakdownPeriods.length === 0 ? (
                           <tr>
-                            <td colSpan={5} className="py-6 text-center text-muted-foreground">
+                            <td
+                              colSpan={PROVIDER_ORDER.length + 3}
+                              className="py-6 text-center text-muted-foreground"
+                            >
                               No activity in this window.
                             </td>
                           </tr>
@@ -481,17 +485,24 @@ function Metric({
 function UsageCoverageNotice({
   environments,
   duplicateSources,
+  sourceIssues,
   staleEnvironments,
 }: {
   readonly environments: readonly EnvironmentUsageStatus[];
   readonly duplicateSources: readonly string[];
+  readonly sourceIssues: readonly string[];
   readonly staleEnvironments: readonly string[];
 }) {
   const failed = environments.filter((environment) => environment.error !== null);
   const stale = environments.filter((environment) =>
     staleEnvironments.includes(environment.environmentId),
   );
-  if (failed.length === 0 && stale.length === 0 && duplicateSources.length === 0) {
+  if (
+    failed.length === 0 &&
+    stale.length === 0 &&
+    sourceIssues.length === 0 &&
+    duplicateSources.length === 0
+  ) {
     return null;
   }
 
@@ -505,9 +516,12 @@ function UsageCoverageNotice({
           {environment.label} runs an older server version and is excluded from totals.
         </span>
       ))}
+      {sourceIssues.map((issue) => (
+        <span key={issue}>{issue}</span>
+      ))}
       {duplicateSources.length > 0 ? (
         <span>
-          Counted once across environments sharing a transcript directory:{" "}
+          Counted once across environments sharing a provider usage store:{" "}
           {duplicateSources.join(", ")}
         </span>
       ) : null}

--- a/apps/web/src/components/usage/UsageProviderChart.test.ts
+++ b/apps/web/src/components/usage/UsageProviderChart.test.ts
@@ -85,6 +85,7 @@ describe("buildDayColumns", () => {
     expect(first?.bands).toEqual([
       { provider: "codex", value: 10 },
       { provider: "claude", value: 20 },
+      { provider: "opencode", value: 0 },
     ]);
   });
 

--- a/apps/web/src/components/usage/usageProviders.ts
+++ b/apps/web/src/components/usage/usageProviders.ts
@@ -1,6 +1,6 @@
 import type { UsageProviderKind } from "@t3tools/contracts";
 
-import { ClaudeAI, type Icon, OpenAI } from "../Icons";
+import { ClaudeAI, type Icon, OpenAI, OpenCodeIcon } from "../Icons";
 
 type UsageProviderPresentation = {
   readonly label: string;
@@ -23,6 +23,11 @@ export const PROVIDER_PRESENTATION = {
     label: "Claude Code",
     color: "#d97757",
     mark: ClaudeAI,
+  },
+  opencode: {
+    label: "OpenCode",
+    color: "#4f8cff",
+    mark: OpenCodeIcon,
   },
 } satisfies Record<UsageProviderKind, UsageProviderPresentation>;
 

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -1,9 +1,13 @@
 # Review usage
 
-The Usage page combines Codex and Claude Code activity from your connected environments. It reads
-the providers' local session history and shows API-equivalent token cost, processed tokens, cache
-savings, provider shares, and model breakdowns. Subscription billing is separate from the raw token
-cost shown here.
+The Usage page combines Codex, Claude Code, and OpenCode activity from your connected environments.
+It reads the providers' local session history and shows API-equivalent token cost, processed tokens,
+cache savings, provider shares, and model breakdowns. Subscription billing is separate from the raw
+token cost shown here.
+
+OpenCode usage comes from its local usage database. Environments configured to use an OpenCode
+server on another machine report that source as unavailable instead of substituting unrelated local
+history.
 
 Use **Past 24h** for an hourly chart covering the exact rolling 24-hour period. The **7 days**,
 **30 days**, and **90 days** ranges use daily resolution. Cost and token toggles update both the

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -1,14 +1,14 @@
 /**
  * Usage reporting contract.
  *
- * Each environment scans the provider CLIs' own on-disk session transcripts
- * (`~/.claude/projects/**\/*.jsonl`, `~/.codex/sessions/**\/*.jsonl`) rather than
- * relying on T3 Code's own orchestration projections, so usage stays complete
- * even for turns that were never driven through T3 Code. This mirrors the
- * approach `ccusage` takes.
+ * Each environment scans the provider CLIs' own on-disk session histories
+ * (`~/.claude/projects/**\/*.jsonl`, `~/.codex/sessions/**\/*.jsonl`, and
+ * OpenCode's local usage database) rather than relying on T3 Code's own
+ * orchestration projections, so usage stays complete even for turns that were
+ * never driven through T3 Code. This mirrors the approach `ccusage` takes.
  *
  * Environments return pre-aggregated `(day, hourStart?, provider, model)`
- * buckets. Raw transcript records never cross the wire.
+ * buckets. Raw provider records never cross the wire.
  *
  * @module usage
  */
@@ -21,9 +21,9 @@ import { NonNegativeInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
  * client renders partial coverage when an environment reports an older version
  * rather than failing the whole page.
  */
-export const USAGE_CONTRACT_VERSION = 4 as const;
+export const USAGE_CONTRACT_VERSION = 5 as const;
 
-export const UsageProviderKind = Schema.Literals(["claude", "codex"]);
+export const UsageProviderKind = Schema.Literals(["claude", "codex", "opencode"]);
 export type UsageProviderKind = typeof UsageProviderKind.Type;
 
 /**

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -40,6 +40,8 @@ function summary(
     homePath: string;
     volumeId?: string;
     distinctSessions?: number;
+    status?: "ok" | "missing" | "partial" | "failed";
+    message?: string | null;
   }[],
   contractVersion: number = USAGE_CONTRACT_VERSION,
 ): UsageSummary {
@@ -57,12 +59,12 @@ function summary(
         resolvedHomePath: source.homePath,
         volumeId: source.volumeId ?? `vol-${source.hostId}`,
       },
-      status: "ok" as const,
+      status: source.status ?? ("ok" as const),
       scannedFiles: 1,
       skippedFiles: 0,
       malformedRecords: 0,
       distinctSessions: source.distinctSessions ?? 1,
-      message: null,
+      message: source.message ?? null,
     })),
     pricing: { status: "fresh", source: "litellm", fetchedAt: null, knownModels: 10 },
     scanDurationMs: 1,
@@ -187,6 +189,58 @@ describe("mergeUsage", () => {
     expect(merged.providers[0]?.costShare).toBeCloseTo(0.75, 5);
     expect(merged.costQuality.unpricedShare).toBeCloseTo(0.5, 5);
     expect(merged.costQuality.cacheSavingsUsd).toBe(4);
+  });
+
+  it("includes OpenCode in provider and model totals", () => {
+    const merged = mergeUsage(
+      [
+        environment(
+          "env-a",
+          summary(
+            [
+              bucket({
+                provider: "opencode",
+                model: "anthropic/claude-opus-4-1",
+                costUsd: 3,
+              }),
+            ],
+            [{ provider: "opencode", hostId: "linux", homePath: "/home/test/opencode" }],
+          ),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(merged.providers[0]?.provider).toBe("opencode");
+    expect(merged.models[0]).toMatchObject({
+      provider: "opencode",
+      model: "anthropic/claude-opus-4-1",
+    });
+  });
+
+  it("surfaces owned provider sources with incomplete coverage", () => {
+    const merged = mergeUsage(
+      [
+        environment(
+          "env-a",
+          summary(
+            [],
+            [
+              {
+                provider: "opencode",
+                hostId: "linux",
+                homePath: "/home/test/opencode",
+                status: "partial",
+                message: "Remote OpenCode usage is unavailable.",
+              },
+            ],
+          ),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(merged.sourceIssues).toEqual(["env-a: Remote OpenCode usage is unavailable."]);
   });
 
   it("keeps two machines apart when hostname and home path collide", () => {

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -75,6 +75,8 @@ export interface MergedUsage {
   readonly daily: readonly DailyTotals[];
   readonly hourly: readonly HourlyTotals[];
   readonly costQuality: CostQuality;
+  /** Provider sources that were readable only partially or not at all. */
+  readonly sourceIssues: readonly string[];
   /** Environments whose data was dropped as a duplicate of another's. */
   readonly duplicateSources: readonly string[];
   readonly contributingEnvironments: readonly EnvironmentId[];
@@ -82,7 +84,7 @@ export interface MergedUsage {
 }
 
 /**
- * Two sources are the same physical transcript directory only when host,
+ * Two sources are the same physical provider usage store only when host,
  * provider, path and filesystem identity all agree.
  *
  * `volumeId` is what stops two machines that happen to share a hostname and a
@@ -99,10 +101,10 @@ function fingerprintKey(fingerprint: UsageSourceFingerprint): string {
 }
 
 /**
- * Decides which environment owns each physical transcript directory.
+ * Decides which environment owns each physical provider usage store.
  *
  * Several environments on one machine (worktree servers, for instance) resolve
- * the same provider home and would otherwise double count every token. The
+ * the same provider store and would otherwise double count every token. The
  * first environment in a stable order claims a fingerprint; the rest have that
  * provider's buckets dropped. Environments are sorted by id so the winner does
  * not change between renders.
@@ -184,6 +186,7 @@ const EMPTY_MERGED: MergedUsage = {
     unpricedShare: 0,
     cacheSavingsUsd: 0,
   },
+  sourceIssues: [],
   duplicateSources: [],
   contributingEnvironments: [],
   staleEnvironments: [],
@@ -253,6 +256,7 @@ export function mergeUsage(
     }
   >();
   const contributingEnvironments: EnvironmentId[] = [];
+  const sourceIssues: string[] = [];
 
   for (const environment of current) {
     const { buckets, sessions: environmentSessions } = ownedContribution(
@@ -261,6 +265,15 @@ export function mergeUsage(
     );
     if (buckets.length > 0) contributingEnvironments.push(environment.environmentId);
     sessions += environmentSessions;
+
+    for (const source of environment.summary.sources) {
+      if (source.status !== "partial" && source.status !== "failed") continue;
+      const key = fingerprintKey(source.fingerprint);
+      if (ownerByFingerprint.get(key) !== environment.environmentId) continue;
+      sourceIssues.push(
+        `${environment.label}: ${source.message ?? `${source.fingerprint.provider} usage is incomplete.`}`,
+      );
+    }
 
     for (const bucket of buckets) {
       const tokens = bucketTokens(bucket);
@@ -391,6 +404,7 @@ export function mergeUsage(
         records === 0 ? 0 : (records - providerReportedRecords - unpricedRecords) / records,
       cacheSavingsUsd,
     },
+    sourceIssues,
     duplicateSources: duplicates,
     contributingEnvironments,
     staleEnvironments,


### PR DESCRIPTION
The Usage page currently leaves out OpenCode activity, even though OpenCode is otherwise a supported provider. That makes its totals and model usage invisible next to Codex and Claude Code.

This adds OpenCode as a first-class usage source by reading its local SQLite usage store directly instead of parsing the human-oriented `opencode stats` output. The reader supports current, legacy, and partially migrated schemas, deduplicates overlapping messages, preserves provider/model identity, and reports remote OpenCode servers as unavailable rather than substituting unrelated local history. The shared contract, aggregation, web/desktop presentation, mobile presentation, coverage notices, and user documentation now include OpenCode.

## Screenshots

| Before | After |
| --- | --- |
| ![Usage page before OpenCode support](https://raw.githubusercontent.com/RyanLatimer/t3code/1d420cfbafda468a0144456fe896737e85a5b848/opencode-usage-before.png) | ![Usage page with OpenCode support](https://raw.githubusercontent.com/RyanLatimer/t3code/1d420cfbafda468a0144456fe896737e85a5b848/opencode-usage-after.png) |

## Verification

- `vp test run apps/server/src/usage packages/shared/src/usageMerge.test.ts apps/web/src/components/usage --passWithNoTests` (67 tests)
- Affected package typechecks: server, web, mobile, contracts, and shared
- Targeted lint and formatting checks
- Contributor-tested locally against an existing OpenCode usage database, including the Usage page's provider/model breakdowns and time windows

Authored with GPT-5.6-sol via the Codex harness in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OpenCode as a supported usage provider across server, web, and mobile
> - Adds a new `usageOpenCodeReader` module that reads OpenCode's local SQLite usage database using XDG-based path resolution, supporting current, legacy, and mixed schemas.
> - Extends `UsageService.readSummary` to discover and aggregate OpenCode usage records alongside existing Claude and Codex transcript sources.
> - Updates `UsageProviderKind` in [usage.ts](https://github.com/pingdotgg/t3code/pull/7350/files#diff-9abc3595e224ffc63bc8ed068d884a2dad83ccb207f0b183e94259fb7f486a13) to include `'opencode'` and bumps the contract version from 4 to 5.
> - Adds OpenCode presentation (label, color `#4f8cff`, icon) to provider charts and tables on both web and mobile.
> - Surfaces `sourceIssues` from partial/failed sources in `mergeUsage` and displays them in the coverage notice on web and mobile.
> - Behavioral Change: clients connecting to the updated server will see contract version 5; older clients may not handle the new provider kind.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized da6ca9b. 10 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
