### PR TITLE
feat(source-control): add cursor origin as a git host

### DIFF
--- a/apps/mobile/src/components/SourceControlIcon.tsx
+++ b/apps/mobile/src/components/SourceControlIcon.tsx
@@ -1,6 +1,11 @@
 import Svg, { Defs, LinearGradient, Path, Stop } from "react-native-svg";
 
-export type SourceControlIconKind = "github" | "gitlab" | "bitbucket" | "azure-devops";
+export type SourceControlIconKind =
+  | "github"
+  | "gitlab"
+  | "bitbucket"
+  | "azure-devops"
+  | "cursor-origin";
 
 export function SourceControlIcon(props: {
   readonly kind: SourceControlIconKind;
@@ -92,6 +97,15 @@ export function SourceControlIcon(props: {
           <Path
             fill="url(#bitbucket-a)"
             d="M2379.27,763.06h-745.5l-125.12,730.42H992.31l-609.67,723.67c19.32,16.71,43.96,26,69.5,26.21h1618.13 c39.35,0.51,73.14-27.88,79.44-66.72L2379.27,763.06z"
+          />
+        </Svg>
+      );
+    case "cursor-origin":
+      return (
+        <Svg width={size} height={size} viewBox="0 0 466.73 532.09" fill="none">
+          <Path
+            fill={props.color ?? "#EDECEC"}
+            d="M457.43,125.94L244.42,2.96c-6.84-3.95-15.28-3.95-22.12,0L9.3,125.94c-5.75,3.32-9.3,9.46-9.3,16.11v247.99c0,6.65,3.55,12.79,9.3,16.11l213.01,122.98c6.84,3.95,15.28,3.95,22.12,0l213.01-122.98c5.75-3.32,9.3-9.46,9.3-16.11v-247.99c0-6.65-3.55-12.79-9.3-16.11h-.01ZM444.05,151.99l-205.63,356.16c-1.39,2.4-5.06,1.42-5.06-1.36v-233.21c0-4.66-2.49-8.97-6.53-11.31L24.87,145.67c-2.4-1.39-1.42-5.06,1.36-5.06h411.26c5.84,0,9.49,6.33,6.57,11.39h-.01Z"
           />
         </Svg>
       );

--- a/apps/mobile/src/features/projects/AddProjectRepositoryRoute.tsx
+++ b/apps/mobile/src/features/projects/AddProjectRepositoryRoute.tsx
@@ -18,7 +18,8 @@ export function AddProjectRepositoryRoute({
     source === "github" ||
     source === "gitlab" ||
     source === "bitbucket" ||
-    source === "azure-devops"
+    source === "azure-devops" ||
+    source === "cursor-origin"
       ? addProjectRemoteSourceLabel(source)
       : "Git URL";
 

--- a/apps/mobile/src/features/projects/AddProjectScreen.tsx
+++ b/apps/mobile/src/features/projects/AddProjectScreen.tsx
@@ -102,7 +102,8 @@ function sourceFromParam(value: string | string[] | undefined): AddProjectRemote
     source === "github" ||
     source === "gitlab" ||
     source === "bitbucket" ||
-    source === "azure-devops"
+    source === "azure-devops" ||
+    source === "cursor-origin"
   ) {
     return source;
   }

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -60,6 +60,7 @@ import * as ServerSettings from "../serverSettings.ts";
 import type { GitManagerServiceError } from "@t3tools/contracts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
 import * as SourceControlProviderRegistry from "../sourceControl/SourceControlProviderRegistry.ts";
+import { originGitHttpsUrl } from "../sourceControl/originPullRequests.ts";
 import { detectPrTemplate } from "../sourceControl/PrTemplateDetection.ts";
 import type { ChangeRequest } from "@t3tools/contracts";
 
@@ -578,6 +579,13 @@ function shouldPreferSshRemote(url: string | null): boolean {
   return isSshRemoteUrl(url);
 }
 
+function httpsRemoteUrl(
+  kind: string,
+  urls: { readonly url: string; readonly nameWithOwner: string },
+): string {
+  return kind === "cursor-origin" ? originGitHttpsUrl(urls.nameWithOwner) : urls.url;
+}
+
 function toPullRequestHeadRemoteInfo(pr: {
   isCrossRepository?: boolean | undefined;
   headRepositoryNameWithOwner?: string | null | undefined;
@@ -717,12 +725,15 @@ export const make = Effect.gen(function* () {
         return;
       }
 
-      const cloneUrls = yield* (yield* sourceControlProvider(cwd)).getRepositoryCloneUrls({
+      const provider = yield* sourceControlProvider(cwd);
+      const cloneUrls = yield* provider.getRepositoryCloneUrls({
         cwd,
         repository: repositoryNameWithOwner,
       });
       const originRemoteUrl = yield* gitCore.readConfigValue(cwd, "remote.origin.url");
-      const remoteUrl = shouldPreferSshRemote(originRemoteUrl) ? cloneUrls.sshUrl : cloneUrls.url;
+      const remoteUrl = shouldPreferSshRemote(originRemoteUrl)
+        ? cloneUrls.sshUrl
+        : httpsRemoteUrl(provider.kind, cloneUrls);
       const preferredRemoteName =
         pullRequest.headRepositoryOwnerLogin?.trim() ||
         repositoryNameWithOwner.split("/")[0]?.trim() ||
@@ -780,12 +791,15 @@ export const make = Effect.gen(function* () {
         return;
       }
 
-      const cloneUrls = yield* (yield* sourceControlProvider(cwd)).getRepositoryCloneUrls({
+      const provider = yield* sourceControlProvider(cwd);
+      const cloneUrls = yield* provider.getRepositoryCloneUrls({
         cwd,
         repository: repositoryNameWithOwner,
       });
       const originRemoteUrl = yield* gitCore.readConfigValue(cwd, "remote.origin.url");
-      const remoteUrl = shouldPreferSshRemote(originRemoteUrl) ? cloneUrls.sshUrl : cloneUrls.url;
+      const remoteUrl = shouldPreferSshRemote(originRemoteUrl)
+        ? cloneUrls.sshUrl
+        : httpsRemoteUrl(provider.kind, cloneUrls);
       const preferredRemoteName =
         pullRequest.headRepositoryOwnerLogin?.trim() ||
         repositoryNameWithOwner.split("/")[0]?.trim() ||

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -41,6 +41,7 @@ import * as AzureDevOpsCli from "./sourceControl/AzureDevOpsCli.ts";
 import * as BitbucketApi from "./sourceControl/BitbucketApi.ts";
 import * as GitHubCli from "./sourceControl/GitHubCli.ts";
 import * as GitLabCli from "./sourceControl/GitLabCli.ts";
+import * as OriginCli from "./sourceControl/OriginCli.ts";
 import * as TextGeneration from "./textGeneration/TextGeneration.ts";
 import { ProviderInstanceRegistryHydrationLive } from "./provider/Layers/ProviderInstanceRegistryHydration.ts";
 import * as TerminalManager from "./terminal/Manager.ts";
@@ -272,7 +273,13 @@ const VcsDriverRegistryLayerLive = VcsDriverRegistry.layer.pipe(
 
 const SourceControlProviderRegistryLayerLive = SourceControlProviderRegistry.layer.pipe(
   Layer.provide(
-    Layer.mergeAll(AzureDevOpsCli.layer, BitbucketApi.layer, GitHubCli.layer, GitLabCli.layer),
+    Layer.mergeAll(
+      AzureDevOpsCli.layer,
+      BitbucketApi.layer,
+      GitHubCli.layer,
+      GitLabCli.layer,
+      OriginCli.layer,
+    ),
   ),
   Layer.provideMerge(GitVcsDriver.layer),
   Layer.provideMerge(VcsDriverRegistryLayerLive),

--- a/apps/server/src/sourceControl/OriginCli.test.ts
+++ b/apps/server/src/sourceControl/OriginCli.test.ts
@@ -1,0 +1,188 @@
+import { assert, it, afterEach, describe, expect, vi } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as PlatformError from "effect/PlatformError";
+import { ChildProcessSpawner } from "effect/unstable/process";
+import { VcsProcessExitError, VcsProcessSpawnError } from "@t3tools/contracts";
+
+import * as VcsProcess from "../vcs/VcsProcess.ts";
+import * as OriginCli from "./OriginCli.ts";
+import { ORIGIN_PULL_REQUEST_JSON_FIELDS } from "./originPullRequests.ts";
+
+const processOutput = (stdout: string): VcsProcess.VcsProcessOutput => ({
+  exitCode: ChildProcessSpawner.ExitCode(0),
+  stdout,
+  stderr: "",
+  stdoutTruncated: false,
+  stderrTruncated: false,
+});
+
+const mockRun = vi.fn<VcsProcess.VcsProcess["Service"]["run"]>();
+
+const layer = OriginCli.layer.pipe(
+  Layer.provide(
+    Layer.mock(VcsProcess.VcsProcess)({
+      run: mockRun,
+    }),
+  ),
+);
+
+afterEach(() => {
+  mockRun.mockReset();
+});
+
+describe("OriginCli.layer", () => {
+  it("does not classify a missing cwd as an unavailable origin executable", () => {
+    const context = { command: "origin", cwd: "/repo" } as const;
+    const missingCwd = new VcsProcessSpawnError({
+      operation: "OriginCli.execute",
+      command: "origin",
+      cwd: context.cwd,
+      cause: PlatformError.systemError({
+        _tag: "NotFound",
+        module: "FileSystem",
+        method: "access",
+        pathOrDescriptor: context.cwd,
+      }),
+    });
+
+    const commandFailure = OriginCli.fromVcsError(context, missingCwd);
+
+    assert.equal(commandFailure._tag, "OriginCliCommandError");
+    assert.strictEqual(commandFailure.cause, missingCwd);
+  });
+
+  it.effect("parses pull request view output", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(
+        Effect.succeed(
+          processOutput(
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify({
+              number: 13,
+              title: "Add Origin provider",
+              url: "https://cursor.com/codebase/acme/checkout/pull/13",
+              status: "open",
+              head: { ref: "feature/origin" },
+              base: { ref: "main" },
+            }),
+          ),
+        ),
+      );
+
+      const origin = yield* OriginCli.OriginCli;
+      const result = yield* origin.getPullRequest({
+        cwd: "/repo",
+        reference: "13",
+      });
+
+      assert.deepStrictEqual(result, {
+        number: 13,
+        title: "Add Origin provider",
+        url: "https://cursor.com/codebase/acme/checkout/pull/13",
+        baseRefName: "main",
+        headRefName: "feature/origin",
+        state: "open",
+        updatedAt: Option.none(),
+      });
+      expect(mockRun).toHaveBeenCalledWith({
+        operation: "OriginCli.execute",
+        command: "origin",
+        args: ["pr", "view", "13", "--json", ORIGIN_PULL_REQUEST_JSON_FIELDS],
+        cwd: "/repo",
+        timeoutMs: 30_000,
+      });
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("creates repositories without a visibility flag", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(
+        Effect.succeed(
+          processOutput(
+            "Created repository acme/checkout\nhttps://origin.cursor.com/acme/checkout.git\n",
+          ),
+        ),
+      );
+
+      const origin = yield* OriginCli.OriginCli;
+      const result = yield* origin.createRepository({
+        cwd: "/repo",
+        repository: "acme/checkout",
+        visibility: "public",
+      });
+
+      assert.deepStrictEqual(result, {
+        nameWithOwner: "acme/checkout",
+        url: "https://origin.cursor.com/acme/checkout",
+        sshUrl: "git@origin.cursor.com:acme/checkout.git",
+      });
+      expect(mockRun).toHaveBeenNthCalledWith(1, {
+        operation: "OriginCli.execute",
+        command: "origin",
+        args: ["repo", "create", "acme/checkout"],
+        cwd: "/repo",
+        timeoutMs: 30_000,
+      });
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("opens pull requests as open rather than Origin's draft default", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(Effect.succeed(processOutput("")));
+
+      const origin = yield* OriginCli.OriginCli;
+      yield* origin.createPullRequest({
+        cwd: "/repo",
+        baseBranch: "main",
+        headSelector: "feature/origin",
+        title: "Add Origin provider",
+        bodyFile: "/tmp/body.md",
+      });
+
+      expect(mockRun).toHaveBeenCalledWith({
+        operation: "OriginCli.execute",
+        command: "origin",
+        args: [
+          "pr",
+          "create",
+          "--base",
+          "main",
+          "--head",
+          "feature/origin",
+          "--title",
+          "Add Origin provider",
+          "--body-file",
+          "/tmp/body.md",
+          "--status",
+          "open",
+        ],
+        cwd: "/repo",
+        timeoutMs: 30_000,
+      });
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("surfaces a friendly error when the pull request is not found", () =>
+    Effect.gen(function* () {
+      const cause = new VcsProcessExitError({
+        operation: "OriginCli.execute",
+        command: "origin pr view",
+        cwd: "/repo",
+        exitCode: 1,
+        failureKind: "not-found",
+        detail: "pull request 13 was not found",
+      });
+      mockRun.mockReturnValueOnce(Effect.fail(cause));
+
+      const origin = yield* OriginCli.OriginCli;
+      const error = yield* origin
+        .getPullRequest({ cwd: "/repo", reference: "13" })
+        .pipe(Effect.flip);
+
+      assert.equal(error._tag, "OriginPullRequestNotFoundError");
+      assert.strictEqual(error.cause, cause);
+    }).pipe(Effect.provide(layer)),
+  );
+});

--- a/apps/server/src/sourceControl/OriginCli.test.ts
+++ b/apps/server/src/sourceControl/OriginCli.test.ts
@@ -143,7 +143,7 @@ describe("OriginCli.layer", () => {
 
       assert.deepStrictEqual(result, {
         nameWithOwner: "acme/checkout",
-        url: "https://origin.cursor.com/acme/checkout",
+        url: "https://cursor.com/codebase/acme/checkout",
         sshUrl: "git@origin.cursor.com:acme/checkout.git",
       });
       expect(mockRun).toHaveBeenNthCalledWith(1, {

--- a/apps/server/src/sourceControl/OriginCli.test.ts
+++ b/apps/server/src/sourceControl/OriginCli.test.ts
@@ -96,6 +96,34 @@ describe("OriginCli.layer", () => {
     }).pipe(Effect.provide(layer)),
   );
 
+  it.effect("rebuilds Origin pull request URLs from the repository identity", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(
+        Effect.succeed(
+          processOutput(
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify({
+              number: 13,
+              title: "Add Origin provider",
+              status: "open",
+              head: { ref: "feature/origin" },
+              base: { ref: "main" },
+            }),
+          ),
+        ),
+      );
+
+      const origin = yield* OriginCli.OriginCli;
+      const result = yield* origin.getPullRequest({
+        cwd: "/repo",
+        reference: "13",
+        nameWithOwner: "acme/checkout",
+      });
+
+      assert.strictEqual(result.url, "https://cursor.com/codebase/acme/checkout/pull/13");
+    }).pipe(Effect.provide(layer)),
+  );
+
   it.effect("creates repositories without a visibility flag", () =>
     Effect.gen(function* () {
       mockRun.mockReturnValueOnce(

--- a/apps/server/src/sourceControl/OriginCli.ts
+++ b/apps/server/src/sourceControl/OriginCli.ts
@@ -219,11 +219,13 @@ export class OriginCli extends Context.Service<
       readonly headSelector: string;
       readonly state: "open" | "closed" | "merged" | "all";
       readonly limit?: number;
+      readonly nameWithOwner?: string;
     }) => Effect.Effect<ReadonlyArray<OriginPullRequestSummary>, OriginCliError>;
 
     readonly getPullRequest: (input: {
       readonly cwd: string;
       readonly reference: string;
+      readonly nameWithOwner?: string;
     }) => Effect.Effect<OriginPullRequestSummary, OriginCliError>;
 
     readonly getRepositoryCloneUrls: (input: {
@@ -370,7 +372,14 @@ export const make = Effect.gen(function* () {
         Effect.flatMap((raw) =>
           raw.length === 0
             ? Effect.succeed([])
-            : Effect.sync(() => decodeOriginPullRequestListJson(raw)).pipe(
+            : Effect.sync(() =>
+                decodeOriginPullRequestListJson(
+                  raw,
+                  input.nameWithOwner === undefined
+                    ? undefined
+                    : { nameWithOwner: input.nameWithOwner },
+                ),
+              ).pipe(
                 Effect.flatMap((decoded) => {
                   if (!Result.isSuccess(decoded)) {
                     return Effect.fail(
@@ -394,7 +403,14 @@ export const make = Effect.gen(function* () {
       }).pipe(
         Effect.map((result) => result.stdout.trim()),
         Effect.flatMap((raw) =>
-          Effect.sync(() => decodeOriginPullRequestJson(raw)).pipe(
+          Effect.sync(() =>
+            decodeOriginPullRequestJson(
+              raw,
+              input.nameWithOwner === undefined
+                ? undefined
+                : { nameWithOwner: input.nameWithOwner },
+            ),
+          ).pipe(
             Effect.flatMap((decoded) => {
               if (!Result.isSuccess(decoded)) {
                 return Effect.fail(

--- a/apps/server/src/sourceControl/OriginCli.ts
+++ b/apps/server/src/sourceControl/OriginCli.ts
@@ -1,0 +1,490 @@
+import * as Context from "effect/Context";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as PlatformError from "effect/PlatformError";
+import * as Result from "effect/Result";
+import * as Schema from "effect/Schema";
+
+import {
+  TrimmedNonEmptyString,
+  type SourceControlRepositoryVisibility,
+  type VcsError,
+} from "@t3tools/contracts";
+
+import * as VcsProcess from "../vcs/VcsProcess.ts";
+import {
+  ORIGIN_GIT_HOST,
+  ORIGIN_PULL_REQUEST_JSON_FIELDS,
+  decodeOriginPullRequestJson,
+  decodeOriginPullRequestListJson,
+  originHttpsCloneUrl,
+  originSshCloneUrl,
+} from "./originPullRequests.ts";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+const originCliFailureFields = {
+  command: Schema.Literal("origin"),
+  cwd: Schema.String,
+  cause: Schema.Defect(),
+} as const;
+
+export class OriginCliUnavailableError extends Schema.TaggedErrorClass<OriginCliUnavailableError>()(
+  "OriginCliUnavailableError",
+  originCliFailureFields,
+) {
+  get detail(): string {
+    return "Origin CLI (`origin`) is required but not available on PATH.";
+  }
+
+  override get message(): string {
+    return `Origin CLI failed in execute: ${this.detail}`;
+  }
+}
+
+export class OriginCliAuthenticationError extends Schema.TaggedErrorClass<OriginCliAuthenticationError>()(
+  "OriginCliAuthenticationError",
+  originCliFailureFields,
+) {
+  get detail(): string {
+    return "Origin CLI is not authenticated. Run `origin auth login` and retry.";
+  }
+
+  override get message(): string {
+    return `Origin CLI failed in execute: ${this.detail}`;
+  }
+}
+
+export class OriginCliRateLimitError extends Schema.TaggedErrorClass<OriginCliRateLimitError>()(
+  "OriginCliRateLimitError",
+  originCliFailureFields,
+) {
+  get detail(): string {
+    return "Origin API rate limit exceeded.";
+  }
+
+  override get message(): string {
+    return `Origin CLI failed in execute: ${this.detail}`;
+  }
+}
+
+export class OriginPullRequestNotFoundError extends Schema.TaggedErrorClass<OriginPullRequestNotFoundError>()(
+  "OriginPullRequestNotFoundError",
+  originCliFailureFields,
+) {
+  get detail(): string {
+    return "Pull request not found. Check the PR number or URL and try again.";
+  }
+
+  override get message(): string {
+    return `Origin CLI failed in execute: ${this.detail}`;
+  }
+}
+
+export class OriginCliCommandError extends Schema.TaggedErrorClass<OriginCliCommandError>()(
+  "OriginCliCommandError",
+  originCliFailureFields,
+) {
+  get detail(): string {
+    return "Origin CLI command failed.";
+  }
+
+  override get message(): string {
+    return `Origin CLI failed in execute: ${this.detail}`;
+  }
+}
+
+const originCliDecodeFields = {
+  command: Schema.Literal("origin"),
+  cwd: Schema.String,
+  cause: Schema.Defect(),
+} as const;
+
+export class OriginPullRequestListDecodeError extends Schema.TaggedErrorClass<OriginPullRequestListDecodeError>()(
+  "OriginPullRequestListDecodeError",
+  originCliDecodeFields,
+) {
+  get detail(): string {
+    return "Origin CLI returned invalid PR list JSON.";
+  }
+
+  override get message(): string {
+    return `Origin CLI failed in listPullRequests: ${this.detail}`;
+  }
+}
+
+export class OriginPullRequestDecodeError extends Schema.TaggedErrorClass<OriginPullRequestDecodeError>()(
+  "OriginPullRequestDecodeError",
+  originCliDecodeFields,
+) {
+  get detail(): string {
+    return "Origin CLI returned invalid pull request JSON.";
+  }
+
+  override get message(): string {
+    return `Origin CLI failed in getPullRequest: ${this.detail}`;
+  }
+}
+
+export class OriginRepositoryDecodeError extends Schema.TaggedErrorClass<OriginRepositoryDecodeError>()(
+  "OriginRepositoryDecodeError",
+  originCliDecodeFields,
+) {
+  get detail(): string {
+    return "Origin CLI returned invalid repository JSON.";
+  }
+
+  override get message(): string {
+    return `Origin CLI failed in getRepositoryCloneUrls: ${this.detail}`;
+  }
+}
+
+export const OriginCliError = Schema.Union([
+  OriginCliUnavailableError,
+  OriginCliAuthenticationError,
+  OriginCliRateLimitError,
+  OriginPullRequestNotFoundError,
+  OriginCliCommandError,
+  OriginPullRequestListDecodeError,
+  OriginPullRequestDecodeError,
+  OriginRepositoryDecodeError,
+]);
+export type OriginCliError = typeof OriginCliError.Type;
+
+export const isOriginCliError = Schema.is(OriginCliError);
+
+export function fromVcsError(
+  context: {
+    readonly command: "origin";
+    readonly cwd: string;
+  },
+  error: VcsError,
+): OriginCliError {
+  if (
+    error._tag === "VcsProcessSpawnError" &&
+    error.cause instanceof PlatformError.PlatformError &&
+    error.cause.reason._tag === "NotFound" &&
+    error.cause.reason.module === "ChildProcess" &&
+    error.cause.reason.method === "spawn"
+  ) {
+    return new OriginCliUnavailableError({ ...context, cause: error });
+  }
+
+  if (error._tag === "VcsProcessExitError") {
+    if (error.failureKind === "authentication") {
+      return new OriginCliAuthenticationError({ ...context, cause: error });
+    }
+    if (error.failureKind === "rate-limited") {
+      return new OriginCliRateLimitError({ ...context, cause: error });
+    }
+    if (error.failureKind === "not-found") {
+      return new OriginPullRequestNotFoundError({ ...context, cause: error });
+    }
+  }
+
+  return new OriginCliCommandError({ ...context, cause: error });
+}
+
+export interface OriginPullRequestSummary {
+  readonly number: number;
+  readonly title: string;
+  readonly url: string;
+  readonly baseRefName: string;
+  readonly headRefName: string;
+  readonly state?: "open" | "closed" | "merged";
+  readonly updatedAt?: Option.Option<DateTime.Utc>;
+}
+
+export interface OriginRepositoryCloneUrls {
+  readonly nameWithOwner: string;
+  readonly url: string;
+  readonly sshUrl: string;
+}
+
+export class OriginCli extends Context.Service<
+  OriginCli,
+  {
+    readonly execute: (input: {
+      readonly cwd: string;
+      readonly args: ReadonlyArray<string>;
+      readonly timeoutMs?: number;
+      readonly stdin?: string;
+      readonly maxOutputBytes?: number;
+    }) => Effect.Effect<VcsProcess.VcsProcessOutput, OriginCliError>;
+
+    readonly listPullRequests: (input: {
+      readonly cwd: string;
+      readonly headSelector: string;
+      readonly state: "open" | "closed" | "merged" | "all";
+      readonly limit?: number;
+    }) => Effect.Effect<ReadonlyArray<OriginPullRequestSummary>, OriginCliError>;
+
+    readonly getPullRequest: (input: {
+      readonly cwd: string;
+      readonly reference: string;
+    }) => Effect.Effect<OriginPullRequestSummary, OriginCliError>;
+
+    readonly getRepositoryCloneUrls: (input: {
+      readonly cwd: string;
+      readonly repository: string;
+    }) => Effect.Effect<OriginRepositoryCloneUrls, OriginCliError>;
+
+    readonly createRepository: (input: {
+      readonly cwd: string;
+      readonly repository: string;
+      readonly visibility: SourceControlRepositoryVisibility;
+    }) => Effect.Effect<OriginRepositoryCloneUrls, OriginCliError>;
+
+    readonly createPullRequest: (input: {
+      readonly cwd: string;
+      readonly baseBranch: string;
+      readonly headSelector: string;
+      readonly title: string;
+      readonly bodyFile: string;
+    }) => Effect.Effect<void, OriginCliError>;
+
+    readonly getDefaultBranch: (input: {
+      readonly cwd: string;
+    }) => Effect.Effect<string | null, OriginCliError>;
+
+    readonly checkoutPullRequest: (input: {
+      readonly cwd: string;
+      readonly reference: string;
+      readonly force?: boolean;
+    }) => Effect.Effect<void, OriginCliError>;
+  }
+>()("t3/sourceControl/OriginCli") {}
+
+const RawOriginRepositoryViewSchema = Schema.Struct({
+  org: Schema.optional(TrimmedNonEmptyString),
+  name: Schema.optional(TrimmedNonEmptyString),
+  fullName: Schema.optional(TrimmedNonEmptyString),
+  cloneUrl: Schema.optional(TrimmedNonEmptyString),
+  sshUrl: Schema.optional(TrimmedNonEmptyString),
+  defaultBranch: Schema.optional(TrimmedNonEmptyString),
+});
+const decodeRawOriginRepositoryView = Schema.decodeEffect(
+  Schema.fromJsonString(RawOriginRepositoryViewSchema),
+);
+
+function nameWithOwnerFromView(
+  raw: Schema.Schema.Type<typeof RawOriginRepositoryViewSchema>,
+  fallback: string,
+): string {
+  const fullName = raw.fullName?.trim();
+  if (fullName && fullName.includes("/")) {
+    return fullName;
+  }
+  const org = raw.org?.trim();
+  const name = raw.name?.trim();
+  if (org && name) {
+    return `${org}/${name}`;
+  }
+  return fallback;
+}
+
+function normalizeRepositoryCloneUrls(
+  raw: Schema.Schema.Type<typeof RawOriginRepositoryViewSchema>,
+  repository: string,
+): OriginRepositoryCloneUrls {
+  const nameWithOwner = nameWithOwnerFromView(raw, repository);
+  return {
+    nameWithOwner,
+    url: raw.cloneUrl ?? originHttpsCloneUrl(nameWithOwner).replace(/\.git$/u, ""),
+    sshUrl: raw.sshUrl ?? originSshCloneUrl(nameWithOwner),
+  };
+}
+
+/**
+ * `origin repo create` prints clone instructions on stdout. Prefer a parsed
+ * HTTPS URL when the CLI emits one; otherwise derive GitHub-shaped Origin
+ * clone URLs from the requested `owner/repo`.
+ */
+function deriveRepositoryCloneUrlsFromCreateOutput(
+  stdout: string,
+  repository: string,
+): OriginRepositoryCloneUrls {
+  const match = stdout.match(/https?:\/\/[^\s]+/);
+  if (match) {
+    const cleaned = match[0].replace(/\.git$/u, "");
+    try {
+      const parsed = new URL(cleaned);
+      const pathname = parsed.pathname.replace(/^\/+|\/+$/g, "");
+      const segments = pathname.split("/").filter(Boolean);
+      if (segments.length >= 2) {
+        const nameWithOwner = `${segments.at(-2)}/${segments.at(-1)}`;
+        return {
+          nameWithOwner,
+          url: `https://${ORIGIN_GIT_HOST}/${nameWithOwner}`,
+          sshUrl: originSshCloneUrl(nameWithOwner),
+        };
+      }
+    } catch {
+      // Fall through to the input-derived defaults below.
+    }
+  }
+  return {
+    nameWithOwner: repository,
+    url: `https://${ORIGIN_GIT_HOST}/${repository}`,
+    sshUrl: originSshCloneUrl(repository),
+  };
+}
+
+export const make = Effect.gen(function* () {
+  const process = yield* VcsProcess.VcsProcess;
+
+  const execute: OriginCli["Service"]["execute"] = (input) =>
+    process
+      .run({
+        operation: "OriginCli.execute",
+        command: "origin",
+        args: input.args,
+        cwd: input.cwd,
+        timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+        ...(input.stdin !== undefined ? { stdin: input.stdin } : {}),
+        ...(input.maxOutputBytes !== undefined ? { maxOutputBytes: input.maxOutputBytes } : {}),
+      })
+      .pipe(Effect.mapError((error) => fromVcsError({ command: "origin", cwd: input.cwd }, error)));
+
+  return OriginCli.of({
+    execute,
+    listPullRequests: (input) =>
+      execute({
+        cwd: input.cwd,
+        args: [
+          "pr",
+          "list",
+          "--head",
+          input.headSelector,
+          "--state",
+          input.state,
+          "--limit",
+          String(input.limit ?? 20),
+          "--json",
+          ORIGIN_PULL_REQUEST_JSON_FIELDS,
+        ],
+      }).pipe(
+        Effect.map((result) => result.stdout.trim()),
+        Effect.flatMap((raw) =>
+          raw.length === 0
+            ? Effect.succeed([])
+            : Effect.sync(() => decodeOriginPullRequestListJson(raw)).pipe(
+                Effect.flatMap((decoded) => {
+                  if (!Result.isSuccess(decoded)) {
+                    return Effect.fail(
+                      new OriginPullRequestListDecodeError({
+                        command: "origin",
+                        cwd: input.cwd,
+                        cause: decoded.failure,
+                      }),
+                    );
+                  }
+
+                  return Effect.succeed(decoded.success);
+                }),
+              ),
+        ),
+      ),
+    getPullRequest: (input) =>
+      execute({
+        cwd: input.cwd,
+        args: ["pr", "view", input.reference, "--json", ORIGIN_PULL_REQUEST_JSON_FIELDS],
+      }).pipe(
+        Effect.map((result) => result.stdout.trim()),
+        Effect.flatMap((raw) =>
+          Effect.sync(() => decodeOriginPullRequestJson(raw)).pipe(
+            Effect.flatMap((decoded) => {
+              if (!Result.isSuccess(decoded)) {
+                return Effect.fail(
+                  new OriginPullRequestDecodeError({
+                    command: "origin",
+                    cwd: input.cwd,
+                    cause: decoded.failure,
+                  }),
+                );
+              }
+
+              return Effect.succeed(decoded.success);
+            }),
+          ),
+        ),
+      ),
+    getRepositoryCloneUrls: (input) =>
+      execute({
+        cwd: input.cwd,
+        args: ["repo", "view", input.repository, "--json", "org,name,fullName,cloneUrl,sshUrl"],
+      }).pipe(
+        Effect.map((result) => result.stdout.trim()),
+        Effect.flatMap((raw) =>
+          decodeRawOriginRepositoryView(raw).pipe(
+            Effect.mapError(
+              (cause) =>
+                new OriginRepositoryDecodeError({
+                  command: "origin",
+                  cwd: input.cwd,
+                  cause,
+                }),
+            ),
+          ),
+        ),
+        Effect.map((raw) => normalizeRepositoryCloneUrls(raw, input.repository)),
+      ),
+    createRepository: (input) =>
+      execute({
+        cwd: input.cwd,
+        // Origin repositories are private to the codebase; the CLI has no
+        // --public/--private flag, so requested visibility is ignored.
+        args: ["repo", "create", input.repository],
+      }).pipe(
+        Effect.map((result) =>
+          deriveRepositoryCloneUrlsFromCreateOutput(result.stdout, input.repository),
+        ),
+      ),
+    createPullRequest: (input) =>
+      execute({
+        cwd: input.cwd,
+        args: [
+          "pr",
+          "create",
+          "--base",
+          input.baseBranch,
+          "--head",
+          input.headSelector,
+          "--title",
+          input.title,
+          "--body-file",
+          input.bodyFile,
+          "--status",
+          "open",
+        ],
+      }).pipe(Effect.asVoid),
+    getDefaultBranch: (input) =>
+      execute({
+        cwd: input.cwd,
+        args: ["repo", "view", "--json", "defaultBranch"],
+      }).pipe(
+        Effect.map((value) => value.stdout.trim()),
+        Effect.flatMap((trimmed) => {
+          if (trimmed.length === 0) {
+            return Effect.succeed(null);
+          }
+          return decodeRawOriginRepositoryView(trimmed).pipe(
+            Effect.map((raw) => {
+              const branch = raw.defaultBranch?.trim() ?? "";
+              return branch.length > 0 ? branch : null;
+            }),
+            Effect.orElseSucceed(() => (trimmed.startsWith("{") ? null : trimmed)),
+          );
+        }),
+      ),
+    checkoutPullRequest: (input) =>
+      execute({
+        cwd: input.cwd,
+        args: ["pr", "checkout", input.reference, ...(input.force ? ["--force"] : [])],
+      }).pipe(Effect.asVoid),
+  });
+});
+
+export const layer = Layer.effect(OriginCli, make);

--- a/apps/server/src/sourceControl/OriginCli.ts
+++ b/apps/server/src/sourceControl/OriginCli.ts
@@ -15,12 +15,11 @@ import {
 
 import * as VcsProcess from "../vcs/VcsProcess.ts";
 import {
-  ORIGIN_GIT_HOST,
   ORIGIN_PULL_REQUEST_JSON_FIELDS,
   decodeOriginPullRequestJson,
   decodeOriginPullRequestListJson,
-  originHttpsCloneUrl,
   originSshCloneUrl,
+  originWebRepositoryUrl,
 } from "./originPullRequests.ts";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -294,15 +293,15 @@ function normalizeRepositoryCloneUrls(
   const nameWithOwner = nameWithOwnerFromView(raw, repository);
   return {
     nameWithOwner,
-    url: raw.cloneUrl ?? originHttpsCloneUrl(nameWithOwner).replace(/\.git$/u, ""),
+    url: originWebRepositoryUrl(nameWithOwner),
     sshUrl: raw.sshUrl ?? originSshCloneUrl(nameWithOwner),
   };
 }
 
 /**
  * `origin repo create` prints clone instructions on stdout. Prefer a parsed
- * HTTPS URL when the CLI emits one; otherwise derive GitHub-shaped Origin
- * clone URLs from the requested `owner/repo`.
+ * owner/repo from an HTTPS URL when the CLI emits one; the returned `url` is
+ * the Origin codebase page so "Open" lands on the product, not the git host.
  */
 function deriveRepositoryCloneUrlsFromCreateOutput(
   stdout: string,
@@ -319,7 +318,7 @@ function deriveRepositoryCloneUrlsFromCreateOutput(
         const nameWithOwner = `${segments.at(-2)}/${segments.at(-1)}`;
         return {
           nameWithOwner,
-          url: `https://${ORIGIN_GIT_HOST}/${nameWithOwner}`,
+          url: originWebRepositoryUrl(nameWithOwner),
           sshUrl: originSshCloneUrl(nameWithOwner),
         };
       }
@@ -329,7 +328,7 @@ function deriveRepositoryCloneUrlsFromCreateOutput(
   }
   return {
     nameWithOwner: repository,
-    url: `https://${ORIGIN_GIT_HOST}/${repository}`,
+    url: originWebRepositoryUrl(repository),
     sshUrl: originSshCloneUrl(repository),
   };
 }

--- a/apps/server/src/sourceControl/OriginSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/OriginSourceControlProvider.test.ts
@@ -95,6 +95,36 @@ it.effect("lists Origin pull requests with updatedAt from CLI JSON", () =>
   }),
 );
 
+it.effect("passes the remote repository identity into Origin PR lookups", () =>
+  Effect.gen(function* () {
+    type ListPullRequestsInput = Parameters<OriginCli.OriginCli["Service"]["listPullRequests"]>[0];
+    let listInput: ListPullRequestsInput | undefined;
+    const provider = yield* makeProvider({
+      listPullRequests: (input: ListPullRequestsInput) => {
+        listInput = input;
+        return Effect.succeed([]);
+      },
+    });
+
+    yield* provider.listChangeRequests({
+      cwd: "/repo",
+      headSelector: "feature/origin",
+      state: "open",
+      context: {
+        provider: {
+          kind: "cursor-origin",
+          name: "Cursor Origin",
+          baseUrl: "https://origin.cursor.com",
+        },
+        remoteName: "origin",
+        remoteUrl: "git@origin.cursor.com:acme/checkout.git",
+      },
+    });
+
+    assert.strictEqual(listInput?.nameWithOwner, "acme/checkout");
+  }),
+);
+
 it.effect("adds safe request context while retaining Origin CLI causes", () =>
   Effect.gen(function* () {
     const cause = new OriginCli.OriginPullRequestNotFoundError({
@@ -155,10 +185,32 @@ it("treats a failed Origin auth probe as unauthenticated", () => {
   assert.equal(Option.getOrNull(auth.detail)?.includes("not logged in"), true);
 });
 
+it("does not treat negated Origin login copy as authenticated", () => {
+  const auth = OriginSourceControlProvider.discovery.parseAuth(
+    processResult("Not logged in as theo\n", { exitCode: ChildProcessSpawner.ExitCode(1) }),
+  );
+
+  assert.strictEqual(auth.status, "unauthenticated");
+  assert.equal(Option.getOrNull(auth.account), null);
+});
+
 it("extracts the account from Origin auth status text", () => {
   assert.deepStrictEqual(parseOriginAuthStatus("Logged in as theo\n"), {
     parsed: true,
     host: "origin.cursor.com",
     account: "theo",
+  });
+});
+
+it("does not treat negated Origin auth output as an account", () => {
+  assert.deepStrictEqual(parseOriginAuthStatus("Not logged in as theo\n"), {
+    parsed: false,
+    host: null,
+    account: null,
+  });
+  assert.deepStrictEqual(parseOriginAuthStatus("No account: run origin auth login\n"), {
+    parsed: false,
+    host: null,
+    account: null,
   });
 });

--- a/apps/server/src/sourceControl/OriginSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/OriginSourceControlProvider.test.ts
@@ -1,0 +1,164 @@
+import { assert, it } from "@effect/vitest";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import * as VcsProcess from "../vcs/VcsProcess.ts";
+import * as OriginCli from "./OriginCli.ts";
+import { parseOriginAuthStatus } from "./originAuthStatus.ts";
+import * as OriginSourceControlProvider from "./OriginSourceControlProvider.ts";
+
+const processResult = (
+  stdout: string,
+  options?: {
+    readonly stderr?: string;
+    readonly exitCode?: ChildProcessSpawner.ExitCode;
+  },
+): VcsProcess.VcsProcessOutput => ({
+  exitCode: options?.exitCode ?? ChildProcessSpawner.ExitCode(0),
+  stdout,
+  stderr: options?.stderr ?? "",
+  stdoutTruncated: false,
+  stderrTruncated: false,
+});
+
+function makeProvider(origin: Partial<OriginCli.OriginCli["Service"]>) {
+  return OriginSourceControlProvider.make.pipe(
+    Effect.provide(Layer.mock(OriginCli.OriginCli)(origin)),
+  );
+}
+
+it.effect("maps Origin PR summaries into provider-neutral change requests", () =>
+  Effect.gen(function* () {
+    const provider = yield* makeProvider({
+      getPullRequest: () =>
+        Effect.succeed({
+          number: 13,
+          title: "Add Origin provider",
+          url: "https://cursor.com/codebase/acme/checkout/pull/13",
+          baseRefName: "main",
+          headRefName: "feature/origin",
+          state: "open",
+        }),
+    });
+
+    const changeRequest = yield* provider.getChangeRequest({
+      cwd: "/repo",
+      reference: "13",
+    });
+
+    assert.deepStrictEqual(changeRequest, {
+      provider: "cursor-origin",
+      number: 13,
+      title: "Add Origin provider",
+      url: "https://cursor.com/codebase/acme/checkout/pull/13",
+      baseRefName: "main",
+      headRefName: "feature/origin",
+      state: "open",
+      updatedAt: Option.none(),
+    });
+  }),
+);
+
+it.effect("lists Origin pull requests with updatedAt from CLI JSON", () =>
+  Effect.gen(function* () {
+    const provider = yield* makeProvider({
+      listPullRequests: () =>
+        Effect.succeed([
+          {
+            number: 7,
+            title: "Merged work",
+            url: "https://cursor.com/codebase/acme/checkout/pull/7",
+            baseRefName: "main",
+            headRefName: "feature/merged",
+            state: "merged",
+            updatedAt: Option.some(DateTime.makeUnsafe("2026-01-02T00:00:00.000Z")),
+          },
+        ]),
+    });
+
+    const changeRequests = yield* provider.listChangeRequests({
+      cwd: "/repo",
+      headSelector: "feature/merged",
+      state: "merged",
+      limit: 10,
+    });
+
+    assert.strictEqual(changeRequests[0]?.provider, "cursor-origin");
+    assert.strictEqual(changeRequests[0]?.state, "merged");
+    assert.deepStrictEqual(
+      changeRequests[0]?.updatedAt,
+      Option.some(DateTime.makeUnsafe("2026-01-02T00:00:00.000Z")),
+    );
+  }),
+);
+
+it.effect("adds safe request context while retaining Origin CLI causes", () =>
+  Effect.gen(function* () {
+    const cause = new OriginCli.OriginPullRequestNotFoundError({
+      command: "origin",
+      cwd: "/repo",
+      cause: new Error("raw upstream detail that should remain in the cause"),
+    });
+    const provider = yield* makeProvider({
+      getPullRequest: () => Effect.fail(cause),
+    });
+
+    const error = yield* provider
+      .getChangeRequest({
+        cwd: "/repo",
+        reference: "https://user:secret@origin.cursor.com/acme/checkout/pull/13?token=secret",
+      })
+      .pipe(Effect.flip);
+
+    assert.deepStrictEqual(
+      {
+        provider: error.provider,
+        operation: error.operation,
+        command: error.command,
+        cwd: error.cwd,
+        reference: error.reference,
+        detail: error.detail,
+      },
+      {
+        provider: "cursor-origin",
+        operation: "getChangeRequest",
+        command: "origin",
+        cwd: "/repo",
+        reference: "https://origin.cursor.com/acme/checkout/pull/13",
+        detail: "Pull request not found. Check the PR number or URL and try again.",
+      },
+    );
+    assert.strictEqual(error.cause, cause);
+    assert.equal(error.message.includes("raw upstream detail"), false);
+  }),
+);
+
+it("parses Origin CLI auth status without exposing tokens", () => {
+  const auth = OriginSourceControlProvider.discovery.parseAuth(
+    processResult("Logged in to origin.cursor.com as origin-user\n"),
+  );
+
+  assert.strictEqual(auth.status, "authenticated");
+  assert.deepStrictEqual(auth.account, Option.some("origin-user"));
+  assert.deepStrictEqual(auth.host, Option.some("origin.cursor.com"));
+});
+
+it("treats a failed Origin auth probe as unauthenticated", () => {
+  const auth = OriginSourceControlProvider.discovery.parseAuth(
+    processResult("not logged in\n", { exitCode: ChildProcessSpawner.ExitCode(1) }),
+  );
+
+  assert.strictEqual(auth.status, "unauthenticated");
+  assert.equal(Option.getOrNull(auth.detail)?.includes("not logged in"), true);
+});
+
+it("extracts the account from Origin auth status text", () => {
+  assert.deepStrictEqual(parseOriginAuthStatus("Logged in as theo\n"), {
+    parsed: true,
+    host: "origin.cursor.com",
+    account: "theo",
+  });
+});

--- a/apps/server/src/sourceControl/OriginSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/OriginSourceControlProvider.ts
@@ -1,0 +1,211 @@
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import { SourceControlProviderError, type ChangeRequest } from "@t3tools/contracts";
+
+import * as OriginCli from "./OriginCli.ts";
+import { parseOriginAuthStatus } from "./originAuthStatus.ts";
+import * as SourceControlProvider from "./SourceControlProvider.ts";
+import {
+  combinedAuthOutput,
+  firstSafeAuthLine,
+  providerAuth,
+  type SourceControlAuthProbeInput,
+  type SourceControlCliDiscoverySpec,
+} from "./SourceControlProviderDiscovery.ts";
+
+function toChangeRequest(summary: OriginCli.OriginPullRequestSummary): ChangeRequest {
+  return {
+    provider: "cursor-origin",
+    number: summary.number,
+    title: summary.title,
+    url: summary.url,
+    baseRefName: summary.baseRefName,
+    headRefName: summary.headRefName,
+    state: summary.state ?? "open",
+    updatedAt: summary.updatedAt ?? Option.none(),
+  };
+}
+
+function parseOriginAuth(input: SourceControlAuthProbeInput) {
+  const output = combinedAuthOutput(input);
+  const authStatus = parseOriginAuthStatus(output);
+  const host = authStatus.host ?? "origin.cursor.com";
+
+  if (authStatus.account) {
+    return providerAuth({
+      status: "authenticated",
+      account: authStatus.account,
+      host,
+    });
+  }
+
+  if (input.exitCode !== 0) {
+    return providerAuth({
+      status: "unauthenticated",
+      host,
+      detail: firstSafeAuthLine(output) ?? "Run `origin auth login` to authenticate Origin CLI.",
+    });
+  }
+
+  return providerAuth({
+    status: "unknown",
+    host,
+    detail: firstSafeAuthLine(output) ?? "Origin CLI auth status could not be parsed.",
+  });
+}
+
+export const discovery = {
+  type: "cli",
+  kind: "cursor-origin",
+  label: "Cursor Origin",
+  executable: "origin",
+  versionArgs: ["--version"],
+  authArgs: ["auth", "status"],
+  parseAuth: parseOriginAuth,
+  installHint:
+    "Install the Origin CLI (`origin`) with `curl -fsSL https://downloads.cursor.com/origin/install.sh | sh`, add `~/.local/bin` to PATH, then run `origin auth login`.",
+} satisfies SourceControlCliDiscoverySpec;
+
+export const make = Effect.gen(function* () {
+  const origin = yield* OriginCli.OriginCli;
+
+  return SourceControlProvider.SourceControlProvider.of({
+    kind: "cursor-origin",
+    listChangeRequests: (input) =>
+      origin
+        .listPullRequests({
+          cwd: input.cwd,
+          headSelector: input.headSelector,
+          state: input.state,
+          ...(input.limit !== undefined ? { limit: input.limit } : {}),
+        })
+        .pipe(
+          Effect.map((items) => items.map(toChangeRequest)),
+          Effect.mapError(
+            (error) =>
+              new SourceControlProviderError({
+                provider: "cursor-origin",
+                operation: "listChangeRequests",
+                command: error.command,
+                cwd: input.cwd,
+                reference: SourceControlProvider.transportSafeSourceControlErrorValue(
+                  input.headSelector,
+                ),
+                detail: error.detail,
+                cause: error,
+              }),
+          ),
+        ),
+    getChangeRequest: (input) =>
+      origin.getPullRequest(input).pipe(
+        Effect.map(toChangeRequest),
+        Effect.mapError(
+          (error) =>
+            new SourceControlProviderError({
+              provider: "cursor-origin",
+              operation: "getChangeRequest",
+              command: error.command,
+              cwd: input.cwd,
+              reference: SourceControlProvider.transportSafeSourceControlErrorValue(
+                input.reference,
+              ),
+              detail: error.detail,
+              cause: error,
+            }),
+        ),
+      ),
+    createChangeRequest: (input) =>
+      origin
+        .createPullRequest({
+          cwd: input.cwd,
+          baseBranch: input.baseRefName,
+          headSelector: input.headSelector,
+          title: input.title,
+          bodyFile: input.bodyFile,
+        })
+        .pipe(
+          Effect.mapError(
+            (error) =>
+              new SourceControlProviderError({
+                provider: "cursor-origin",
+                operation: "createChangeRequest",
+                command: error.command,
+                cwd: input.cwd,
+                reference: SourceControlProvider.transportSafeSourceControlErrorValue(
+                  input.headSelector,
+                ),
+                detail: error.detail,
+                cause: error,
+              }),
+          ),
+        ),
+    getRepositoryCloneUrls: (input) =>
+      origin.getRepositoryCloneUrls(input).pipe(
+        Effect.mapError(
+          (error) =>
+            new SourceControlProviderError({
+              provider: "cursor-origin",
+              operation: "getRepositoryCloneUrls",
+              command: error.command,
+              cwd: input.cwd,
+              repository: SourceControlProvider.transportSafeSourceControlErrorValue(
+                input.repository,
+              ),
+              detail: error.detail,
+              cause: error,
+            }),
+        ),
+      ),
+    createRepository: (input) =>
+      origin.createRepository(input).pipe(
+        Effect.mapError(
+          (error) =>
+            new SourceControlProviderError({
+              provider: "cursor-origin",
+              operation: "createRepository",
+              command: error.command,
+              cwd: input.cwd,
+              repository: SourceControlProvider.transportSafeSourceControlErrorValue(
+                input.repository,
+              ),
+              detail: error.detail,
+              cause: error,
+            }),
+        ),
+      ),
+    getDefaultBranch: (input) =>
+      origin.getDefaultBranch(input).pipe(
+        Effect.mapError(
+          (error) =>
+            new SourceControlProviderError({
+              provider: "cursor-origin",
+              operation: "getDefaultBranch",
+              command: error.command,
+              cwd: input.cwd,
+              detail: error.detail,
+              cause: error,
+            }),
+        ),
+      ),
+    checkoutChangeRequest: (input) =>
+      origin.checkoutPullRequest(input).pipe(
+        Effect.mapError(
+          (error) =>
+            new SourceControlProviderError({
+              provider: "cursor-origin",
+              operation: "checkoutChangeRequest",
+              command: error.command,
+              cwd: input.cwd,
+              reference: SourceControlProvider.transportSafeSourceControlErrorValue(
+                input.reference,
+              ),
+              detail: error.detail,
+              cause: error,
+            }),
+        ),
+      ),
+  });
+});
+
+export const layer = Layer.effect(SourceControlProvider.SourceControlProvider, make);

--- a/apps/server/src/sourceControl/OriginSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/OriginSourceControlProvider.ts
@@ -5,6 +5,7 @@ import { SourceControlProviderError, type ChangeRequest } from "@t3tools/contrac
 
 import * as OriginCli from "./OriginCli.ts";
 import { parseOriginAuthStatus } from "./originAuthStatus.ts";
+import { originNameWithOwnerFromGitUrl } from "./originPullRequests.ts";
 import * as SourceControlProvider from "./SourceControlProvider.ts";
 import {
   combinedAuthOutput,
@@ -25,6 +26,16 @@ function toChangeRequest(summary: OriginCli.OriginPullRequestSummary): ChangeReq
     state: summary.state ?? "open",
     updatedAt: summary.updatedAt ?? Option.none(),
   };
+}
+
+function nameWithOwnerFromContext(
+  context: SourceControlProvider.SourceControlProviderContext | undefined,
+): { readonly nameWithOwner: string } | Record<string, never> {
+  if (!context?.remoteUrl) {
+    return {};
+  }
+  const nameWithOwner = originNameWithOwnerFromGitUrl(context.remoteUrl);
+  return nameWithOwner ? { nameWithOwner } : {};
 }
 
 function parseOriginAuth(input: SourceControlAuthProbeInput) {
@@ -79,6 +90,7 @@ export const make = Effect.gen(function* () {
           headSelector: input.headSelector,
           state: input.state,
           ...(input.limit !== undefined ? { limit: input.limit } : {}),
+          ...nameWithOwnerFromContext(input.context),
         })
         .pipe(
           Effect.map((items) => items.map(toChangeRequest)),
@@ -98,23 +110,29 @@ export const make = Effect.gen(function* () {
           ),
         ),
     getChangeRequest: (input) =>
-      origin.getPullRequest(input).pipe(
-        Effect.map(toChangeRequest),
-        Effect.mapError(
-          (error) =>
-            new SourceControlProviderError({
-              provider: "cursor-origin",
-              operation: "getChangeRequest",
-              command: error.command,
-              cwd: input.cwd,
-              reference: SourceControlProvider.transportSafeSourceControlErrorValue(
-                input.reference,
-              ),
-              detail: error.detail,
-              cause: error,
-            }),
+      origin
+        .getPullRequest({
+          cwd: input.cwd,
+          reference: input.reference,
+          ...nameWithOwnerFromContext(input.context),
+        })
+        .pipe(
+          Effect.map(toChangeRequest),
+          Effect.mapError(
+            (error) =>
+              new SourceControlProviderError({
+                provider: "cursor-origin",
+                operation: "getChangeRequest",
+                command: error.command,
+                cwd: input.cwd,
+                reference: SourceControlProvider.transportSafeSourceControlErrorValue(
+                  input.reference,
+                ),
+                detail: error.detail,
+                cause: error,
+              }),
+          ),
         ),
-      ),
     createChangeRequest: (input) =>
       origin
         .createPullRequest({

--- a/apps/server/src/sourceControl/SourceControlDiscovery.test.ts
+++ b/apps/server/src/sourceControl/SourceControlDiscovery.test.ts
@@ -13,6 +13,7 @@ import * as AzureDevOpsCli from "./AzureDevOpsCli.ts";
 import * as BitbucketApi from "./BitbucketApi.ts";
 import * as GitHubCli from "./GitHubCli.ts";
 import * as GitLabCli from "./GitLabCli.ts";
+import * as OriginCli from "./OriginCli.ts";
 import * as SourceControlDiscovery from "./SourceControlDiscovery.ts";
 import * as SourceControlProviderRegistry from "./SourceControlProviderRegistry.ts";
 
@@ -30,6 +31,7 @@ const sourceControlProviderRegistryTestLayer = (input: {
         Layer.mock(BitbucketApi.BitbucketApi)(input.bitbucket),
         Layer.mock(GitHubCli.GitHubCli)({}),
         Layer.mock(GitLabCli.GitLabCli)({}),
+        Layer.mock(OriginCli.OriginCli)({}),
         Layer.mock(VcsDriverRegistry.VcsDriverRegistry)({}),
         Layer.mock(VcsProcess.VcsProcess)(input.process),
       ),
@@ -161,6 +163,12 @@ it.effect("reports implemented tools separately from locally available executabl
           auth: "unauthenticated",
           account: Option.none(),
         },
+        {
+          kind: "cursor-origin",
+          status: "missing",
+          auth: "unknown",
+          account: Option.none(),
+        },
       ],
     );
     const bitbucket = result.sourceControlProviders.find((item) => item.kind === "bitbucket");
@@ -201,6 +209,9 @@ it.effect("probes provider authentication without exposing token details", () =>
 Logged in to gitlab.com as gitlab-user
 `),
         );
+      }
+      if (input.command === "origin" && input.args.join(" ") === "auth status") {
+        return Effect.succeed(processOutput("Logged in to origin.cursor.com as origin-user\n"));
       }
       if (
         input.command === "az" &&
@@ -275,6 +286,12 @@ Logged in to gitlab.com as gitlab-user
           kind: "bitbucket",
           auth: "authenticated",
           account: Option.some("bitbucket-user"),
+          detail: Option.none(),
+        },
+        {
+          kind: "cursor-origin",
+          auth: "authenticated",
+          account: Option.some("origin-user"),
           detail: Option.none(),
         },
       ],

--- a/apps/server/src/sourceControl/SourceControlProviderRegistry.test.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderRegistry.test.ts
@@ -15,6 +15,7 @@ import * as AzureDevOpsCli from "./AzureDevOpsCli.ts";
 import * as BitbucketApi from "./BitbucketApi.ts";
 import * as GitHubCli from "./GitHubCli.ts";
 import * as GitLabCli from "./GitLabCli.ts";
+import * as OriginCli from "./OriginCli.ts";
 import * as SourceControlProviderRegistry from "./SourceControlProviderRegistry.ts";
 
 const TEST_EPOCH = DateTime.makeUnsafe("1970-01-01T00:00:00.000Z");
@@ -92,6 +93,7 @@ function makeRegistry(input: {
         Layer.mock(BitbucketApi.BitbucketApi)({}),
         Layer.mock(GitHubCli.GitHubCli)({}),
         Layer.mock(GitLabCli.GitLabCli)({}),
+        Layer.mock(OriginCli.OriginCli)({}),
         ServerConfig.layerTest(process.cwd(), {
           prefix: "t3-source-control-registry-test-",
         }).pipe(Layer.provide(NodeServices.layer)),
@@ -279,6 +281,18 @@ it.effect("routes Azure DevOps remotes to the Azure DevOps provider", () =>
     const provider = yield* registry.resolve({ cwd: "/repo" });
 
     assert.strictEqual(provider.kind, "azure-devops");
+  }),
+);
+
+it.effect("routes Cursor Origin remotes to the Origin provider", () =>
+  Effect.gen(function* () {
+    const registry = yield* makeRegistry({
+      remotes: [{ name: "origin", url: "https://origin.cursor.com/acme/checkout.git" }],
+    });
+
+    const provider = yield* registry.resolve({ cwd: "/repo" });
+
+    assert.strictEqual(provider.kind, "cursor-origin");
   }),
 );
 

--- a/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
@@ -15,6 +15,7 @@ import * as AzureDevOpsSourceControlProvider from "./AzureDevOpsSourceControlPro
 import * as BitbucketSourceControlProvider from "./BitbucketSourceControlProvider.ts";
 import * as GitHubSourceControlProvider from "./GitHubSourceControlProvider.ts";
 import * as GitLabSourceControlProvider from "./GitLabSourceControlProvider.ts";
+import * as OriginSourceControlProvider from "./OriginSourceControlProvider.ts";
 import * as SourceControlProvider from "./SourceControlProvider.ts";
 import {
   probeSourceControlProvider,
@@ -298,6 +299,7 @@ export const make = Effect.gen(function* () {
   const bitbucket = yield* BitbucketSourceControlProvider.make;
   const bitbucketDiscovery = yield* BitbucketSourceControlProvider.makeDiscovery;
   const azureDevOps = yield* AzureDevOpsSourceControlProvider.make;
+  const cursorOrigin = yield* OriginSourceControlProvider.make;
   return yield* makeWithProviders([
     {
       kind: "github",
@@ -318,6 +320,11 @@ export const make = Effect.gen(function* () {
       kind: "bitbucket",
       provider: bitbucket,
       discovery: bitbucketDiscovery,
+    },
+    {
+      kind: "cursor-origin",
+      provider: cursorOrigin,
+      discovery: OriginSourceControlProvider.discovery,
     },
   ]);
 });

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.ts
@@ -21,6 +21,7 @@ import {
 
 import { ServerConfig } from "../config.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
+import { originGitHttpsUrl } from "./originPullRequests.ts";
 import * as SourceControlProviderRegistry from "./SourceControlProviderRegistry.ts";
 const isSourceControlRepositoryError = Schema.is(SourceControlRepositoryError);
 
@@ -65,12 +66,13 @@ function toRepositoryInfo(
 }
 
 function selectRemoteUrl(
+  provider: SourceControlProviderKind,
   urls: SourceControlRepositoryCloneUrls,
   protocol: SourceControlCloneProtocol | undefined,
 ): string {
   switch (protocol ?? "auto") {
     case "https":
-      return urls.url;
+      return provider === "cursor-origin" ? originGitHttpsUrl(urls.nameWithOwner) : urls.url;
     case "ssh":
     case "auto":
       return urls.sshUrl;
@@ -191,7 +193,7 @@ export const make = Effect.gen(function* () {
         repository: input.repository,
         cwd: preparedDestination.parentPath,
       });
-      remoteUrl = selectRemoteUrl(repository, input.protocol);
+      remoteUrl = selectRemoteUrl(provider, repository, input.protocol);
       provider = input.provider;
     }
 
@@ -230,7 +232,7 @@ export const make = Effect.gen(function* () {
         repository: input.repository.trim(),
         visibility: input.visibility,
       });
-      const remoteUrl = selectRemoteUrl(urls, input.protocol);
+      const remoteUrl = selectRemoteUrl(providerKind, urls, input.protocol);
       const remoteName = yield* git.ensureRemote({
         cwd: input.cwd,
         preferredName: input.remoteName?.trim() || "origin",

--- a/apps/server/src/sourceControl/originAuthStatus.ts
+++ b/apps/server/src/sourceControl/originAuthStatus.ts
@@ -1,0 +1,47 @@
+export interface OriginAuthStatus {
+  readonly parsed: boolean;
+  readonly account: string | null;
+  readonly host: string | null;
+}
+
+function nonEmptyString(value: string | undefined): string | null {
+  const trimmed = value?.trim() ?? "";
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function firstMatch(text: string, patterns: ReadonlyArray<RegExp>): RegExpExecArray | null {
+  for (const pattern of patterns) {
+    const match = pattern.exec(text);
+    if (match) {
+      return match;
+    }
+  }
+  return null;
+}
+
+export function parseOriginAuthStatus(text: string): OriginAuthStatus {
+  const loggedIn = firstMatch(text, [
+    /Logged in to ([^\s]+) as\s+([^\s(]+)/iu,
+    /Logged in as\s+([^\s(]+)/iu,
+    /Authenticated as\s+([^\s(]+)/iu,
+    /account:\s*([^\s(]+)/iu,
+  ]);
+
+  if (!loggedIn) {
+    return { parsed: false, account: null, host: null };
+  }
+
+  if (loggedIn.length >= 3 && loggedIn[1] && loggedIn[2]) {
+    return {
+      parsed: true,
+      host: nonEmptyString(loggedIn[1])?.toLowerCase() ?? "origin.cursor.com",
+      account: nonEmptyString(loggedIn[2]),
+    };
+  }
+
+  return {
+    parsed: true,
+    host: "origin.cursor.com",
+    account: nonEmptyString(loggedIn[1]),
+  };
+}

--- a/apps/server/src/sourceControl/originAuthStatus.ts
+++ b/apps/server/src/sourceControl/originAuthStatus.ts
@@ -21,10 +21,10 @@ function firstMatch(text: string, patterns: ReadonlyArray<RegExp>): RegExpExecAr
 
 export function parseOriginAuthStatus(text: string): OriginAuthStatus {
   const loggedIn = firstMatch(text, [
-    /Logged in to ([^\s]+) as\s+([^\s(]+)/iu,
-    /Logged in as\s+([^\s(]+)/iu,
-    /Authenticated as\s+([^\s(]+)/iu,
-    /account:\s*([^\s(]+)/iu,
+    /^[ \t]*Logged in to ([^\s]+) as\s+([^\s(]+)[ \t]*$/imu,
+    /^[ \t]*Logged in as\s+([^\s(]+)[ \t]*$/imu,
+    /^[ \t]*Authenticated as\s+([^\s(]+)[ \t]*$/imu,
+    /^[ \t]*account:\s*([^\s(]+)[ \t]*$/imu,
   ]);
 
   if (!loggedIn) {

--- a/apps/server/src/sourceControl/originPullRequests.test.ts
+++ b/apps/server/src/sourceControl/originPullRequests.test.ts
@@ -6,6 +6,7 @@ import {
   decodeOriginPullRequestJson,
   decodeOriginPullRequestListJson,
   originNameWithOwnerFromGitUrl,
+  originWebRepositoryUrl,
 } from "./originPullRequests.ts";
 
 describe("decodeOriginPullRequestJson", () => {
@@ -136,6 +137,14 @@ describe("originNameWithOwnerFromGitUrl", () => {
     );
     expect(originNameWithOwnerFromGitUrl("https://origin.cursor.com/acme/checkout.git")).toBe(
       "acme/checkout",
+    );
+  });
+});
+
+describe("originWebRepositoryUrl", () => {
+  it("builds the Origin codebase page, not the git host", () => {
+    expect(originWebRepositoryUrl("acme/checkout")).toBe(
+      "https://cursor.com/codebase/acme/checkout",
     );
   });
 });

--- a/apps/server/src/sourceControl/originPullRequests.test.ts
+++ b/apps/server/src/sourceControl/originPullRequests.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vite-plus/test";
+import * as Option from "effect/Option";
+import * as Result from "effect/Result";
+
+import {
+  decodeOriginPullRequestJson,
+  decodeOriginPullRequestListJson,
+} from "./originPullRequests.ts";
+
+describe("decodeOriginPullRequestJson", () => {
+  it("accepts Origin CLI field names and numeric strings", () => {
+    const decoded = decodeOriginPullRequestJson(
+      JSON.stringify({
+        number: "13",
+        title: "Add Origin provider",
+        url: "https://cursor.com/codebase/acme/checkout/pull/13",
+        status: "open",
+        head: { ref: "refs/heads/feature/origin" },
+        base: { ref: "main" },
+        updatedAt: "2026-08-17T00:00:00.000Z",
+      }),
+    );
+
+    expect(Result.isSuccess(decoded)).toBe(true);
+    if (!Result.isSuccess(decoded)) return;
+    expect(decoded.success.number).toBe(13);
+    expect(decoded.success.headRefName).toBe("feature/origin");
+    expect(decoded.success.baseRefName).toBe("main");
+    expect(decoded.success.state).toBe("open");
+    expect(Option.isSome(decoded.success.updatedAt)).toBe(true);
+  });
+
+  it("treats merged closed pull requests as merged", () => {
+    const decoded = decodeOriginPullRequestJson(
+      JSON.stringify({
+        number: 4,
+        title: "Landed",
+        url: "https://cursor.com/codebase/acme/checkout/pull/4",
+        state: "closed",
+        merged: true,
+        head: "feature/landed",
+        base: "main",
+      }),
+    );
+
+    expect(Result.isSuccess(decoded)).toBe(true);
+    if (!Result.isSuccess(decoded)) return;
+    expect(decoded.success.state).toBe("merged");
+    expect(decoded.success.headRefName).toBe("feature/landed");
+  });
+});
+
+describe("decodeOriginPullRequestListJson", () => {
+  it("skips malformed rows instead of failing the list", () => {
+    const decoded = decodeOriginPullRequestListJson(
+      JSON.stringify([
+        {
+          number: 1,
+          title: "Ready",
+          url: "https://cursor.com/codebase/acme/checkout/pull/1",
+          status: "open",
+          head: "feature/ready",
+          base: "main",
+        },
+        { title: "Missing number" },
+      ]),
+    );
+
+    expect(Result.isSuccess(decoded)).toBe(true);
+    if (!Result.isSuccess(decoded)) return;
+    expect(decoded.success).toHaveLength(1);
+    expect(decoded.success[0]?.number).toBe(1);
+  });
+});

--- a/apps/server/src/sourceControl/originPullRequests.test.ts
+++ b/apps/server/src/sourceControl/originPullRequests.test.ts
@@ -5,6 +5,7 @@ import * as Result from "effect/Result";
 import {
   decodeOriginPullRequestJson,
   decodeOriginPullRequestListJson,
+  originNameWithOwnerFromGitUrl,
 } from "./originPullRequests.ts";
 
 describe("decodeOriginPullRequestJson", () => {
@@ -70,5 +71,71 @@ describe("decodeOriginPullRequestListJson", () => {
     if (!Result.isSuccess(decoded)) return;
     expect(decoded.success).toHaveLength(1);
     expect(decoded.success[0]?.number).toBe(1);
+  });
+
+  it("rebuilds Origin web URLs from the repository identity when url is omitted", () => {
+    const decoded = decodeOriginPullRequestListJson(
+      JSON.stringify([
+        {
+          number: 13,
+          title: "Missing url",
+          status: "open",
+          head: "feature/origin",
+          base: "main",
+        },
+      ]),
+      { nameWithOwner: "acme/checkout" },
+    );
+
+    expect(Result.isSuccess(decoded)).toBe(true);
+    if (!Result.isSuccess(decoded)) return;
+    expect(decoded.success[0]?.url).toBe("https://cursor.com/codebase/acme/checkout/pull/13");
+  });
+
+  it("rebuilds Origin web URLs from JSON org and name", () => {
+    const decoded = decodeOriginPullRequestJson(
+      JSON.stringify({
+        number: 4,
+        title: "From org fields",
+        status: "open",
+        head: "feature/org",
+        base: "main",
+        org: "acme",
+        name: "checkout",
+      }),
+    );
+
+    expect(Result.isSuccess(decoded)).toBe(true);
+    if (!Result.isSuccess(decoded)) return;
+    expect(decoded.success.url).toBe("https://cursor.com/codebase/acme/checkout/pull/4");
+  });
+
+  it("drops rows that cannot form a valid Origin pull request URL", () => {
+    const decoded = decodeOriginPullRequestListJson(
+      JSON.stringify([
+        {
+          number: 13,
+          title: "Missing url and repo",
+          status: "open",
+          head: "feature/origin",
+          base: "main",
+        },
+      ]),
+    );
+
+    expect(Result.isSuccess(decoded)).toBe(true);
+    if (!Result.isSuccess(decoded)) return;
+    expect(decoded.success).toHaveLength(0);
+  });
+});
+
+describe("originNameWithOwnerFromGitUrl", () => {
+  it("reads owner and repo from Origin clone URLs", () => {
+    expect(originNameWithOwnerFromGitUrl("git@origin.cursor.com:acme/checkout.git")).toBe(
+      "acme/checkout",
+    );
+    expect(originNameWithOwnerFromGitUrl("https://origin.cursor.com/acme/checkout.git")).toBe(
+      "acme/checkout",
+    );
   });
 });

--- a/apps/server/src/sourceControl/originPullRequests.ts
+++ b/apps/server/src/sourceControl/originPullRequests.ts
@@ -258,3 +258,11 @@ export function originHttpsCloneUrl(nameWithOwner: string): string {
 export function originSshCloneUrl(nameWithOwner: string): string {
   return `git@${ORIGIN_GIT_HOST}:${nameWithOwner}.git`;
 }
+
+export function originGitHttpsUrl(nameWithOwner: string): string {
+  return originHttpsCloneUrl(nameWithOwner).replace(/\.git$/u, "");
+}
+
+export function originWebRepositoryUrl(nameWithOwner: string): string {
+  return `${ORIGIN_WEB_BASE}/${nameWithOwner}`;
+}

--- a/apps/server/src/sourceControl/originPullRequests.ts
+++ b/apps/server/src/sourceControl/originPullRequests.ts
@@ -1,0 +1,186 @@
+import * as Cause from "effect/Cause";
+import * as DateTime from "effect/DateTime";
+import * as Exit from "effect/Exit";
+import * as Option from "effect/Option";
+import * as Result from "effect/Result";
+import * as Schema from "effect/Schema";
+import { PositiveInt, TrimmedNonEmptyString } from "@t3tools/contracts";
+import { decodeJsonResult, formatSchemaError } from "@t3tools/shared/schemaJson";
+
+export const ORIGIN_GIT_HOST = "origin.cursor.com";
+export const ORIGIN_WEB_BASE = "https://cursor.com/codebase";
+export const ORIGIN_PULL_REQUEST_JSON_FIELDS = "number,title,url,status,head,base,updatedAt";
+
+export interface NormalizedOriginPullRequestRecord {
+  readonly number: number;
+  readonly title: string;
+  readonly url: string;
+  readonly baseRefName: string;
+  readonly headRefName: string;
+  readonly state: "open" | "closed" | "merged";
+  readonly updatedAt: Option.Option<DateTime.Utc>;
+}
+
+const OriginPullRequestNumber = Schema.Union([PositiveInt, TrimmedNonEmptyString]);
+const OriginRef = Schema.Union([
+  TrimmedNonEmptyString,
+  Schema.Struct({
+    ref: Schema.optional(Schema.NullOr(Schema.String)),
+  }),
+]);
+
+const OriginPullRequestSchema = Schema.Struct({
+  number: OriginPullRequestNumber,
+  title: TrimmedNonEmptyString,
+  url: Schema.optional(Schema.NullOr(Schema.String)),
+  status: Schema.optional(Schema.NullOr(Schema.String)),
+  state: Schema.optional(Schema.NullOr(Schema.String)),
+  merged: Schema.optional(Schema.Boolean),
+  mergedAt: Schema.optional(Schema.NullOr(Schema.String)),
+  updatedAt: Schema.optional(Schema.OptionFromNullOr(Schema.DateTimeUtcFromString)),
+  head: Schema.optional(Schema.NullOr(OriginRef)),
+  base: Schema.optional(Schema.NullOr(OriginRef)),
+  headRefName: Schema.optional(Schema.NullOr(Schema.String)),
+  baseRefName: Schema.optional(Schema.NullOr(Schema.String)),
+});
+
+function trimOptionalString(value: string | null | undefined): string | null {
+  const trimmed = value?.trim() ?? "";
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function parsePullRequestNumber(value: number | string): number | null {
+  if (typeof value === "number") {
+    return Number.isInteger(value) && value >= 1 ? value : null;
+  }
+  const trimmed = value.trim();
+  if (!/^[1-9]\d*$/u.test(trimmed)) {
+    return null;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isInteger(parsed) && parsed >= 1 ? parsed : null;
+}
+
+function originRefName(value: string | null | undefined): string | null {
+  const trimmed = trimOptionalString(value)?.replace(/^refs\/heads\//u, "") ?? null;
+  return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+function refFromField(
+  value: Schema.Schema.Type<typeof OriginRef> | null | undefined,
+): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === "string") {
+    return originRefName(value);
+  }
+  return originRefName(value.ref);
+}
+
+function normalizeOriginPullRequestState(input: {
+  status?: string | null | undefined;
+  state?: string | null | undefined;
+  merged?: boolean | undefined;
+  mergedAt?: string | null | undefined;
+}): "open" | "closed" | "merged" {
+  if (
+    input.merged === true ||
+    (typeof input.mergedAt === "string" && input.mergedAt.trim().length > 0)
+  ) {
+    return "merged";
+  }
+  const normalized = (input.status ?? input.state)?.trim().toLowerCase();
+  if (normalized === "merged") {
+    return "merged";
+  }
+  if (normalized === "closed") {
+    return "closed";
+  }
+  return "open";
+}
+
+function originPullRequestUrl(input: {
+  readonly url: string | null;
+  readonly number: number;
+}): string {
+  if (input.url) {
+    return input.url;
+  }
+  return `${ORIGIN_WEB_BASE}/pull/${input.number}`;
+}
+
+function normalizeOriginPullRequestRecord(
+  raw: Schema.Schema.Type<typeof OriginPullRequestSchema>,
+): NormalizedOriginPullRequestRecord | null {
+  const number = parsePullRequestNumber(raw.number);
+  const headRefName = originRefName(raw.headRefName) ?? refFromField(raw.head);
+  const baseRefName = originRefName(raw.baseRefName) ?? refFromField(raw.base);
+  if (number === null || headRefName === null || baseRefName === null) {
+    return null;
+  }
+
+  return {
+    number,
+    title: raw.title,
+    url: originPullRequestUrl({ url: trimOptionalString(raw.url), number }),
+    baseRefName,
+    headRefName,
+    state: normalizeOriginPullRequestState(raw),
+    updatedAt: raw.updatedAt ?? Option.none(),
+  };
+}
+
+const decodeOriginPullRequestList = decodeJsonResult(Schema.Array(Schema.Unknown));
+const decodeOriginPullRequest = decodeJsonResult(OriginPullRequestSchema);
+const decodeOriginPullRequestEntry = Schema.decodeUnknownExit(OriginPullRequestSchema);
+
+export const formatOriginJsonDecodeError = formatSchemaError;
+
+export function decodeOriginPullRequestListJson(
+  raw: string,
+): Result.Result<
+  ReadonlyArray<NormalizedOriginPullRequestRecord>,
+  Cause.Cause<Schema.SchemaError>
+> {
+  const result = decodeOriginPullRequestList(raw);
+  if (Result.isSuccess(result)) {
+    const pullRequests: NormalizedOriginPullRequestRecord[] = [];
+    for (const entry of result.success) {
+      const decodedEntry = decodeOriginPullRequestEntry(entry);
+      if (Exit.isFailure(decodedEntry)) {
+        continue;
+      }
+      const normalized = normalizeOriginPullRequestRecord(decodedEntry.value);
+      if (normalized) {
+        pullRequests.push(normalized);
+      }
+    }
+    return Result.succeed(pullRequests);
+  }
+  return Result.fail(result.failure);
+}
+
+export function decodeOriginPullRequestJson(
+  raw: string,
+): Result.Result<NormalizedOriginPullRequestRecord, Cause.Cause<Schema.SchemaError>> {
+  const result = decodeOriginPullRequest(raw);
+  if (Result.isFailure(result)) {
+    return Result.fail(result.failure);
+  }
+  const normalized = normalizeOriginPullRequestRecord(result.success);
+  if (normalized === null) {
+    return Result.fail(
+      Cause.die(new Error("Origin pull request JSON is missing number, head, or base.")),
+    );
+  }
+  return Result.succeed(normalized);
+}
+
+export function originHttpsCloneUrl(nameWithOwner: string): string {
+  return `https://${ORIGIN_GIT_HOST}/${nameWithOwner}.git`;
+}
+
+export function originSshCloneUrl(nameWithOwner: string): string {
+  return `git@${ORIGIN_GIT_HOST}:${nameWithOwner}.git`;
+}

--- a/apps/server/src/sourceControl/originPullRequests.ts
+++ b/apps/server/src/sourceControl/originPullRequests.ts
@@ -42,7 +42,15 @@ const OriginPullRequestSchema = Schema.Struct({
   base: Schema.optional(Schema.NullOr(OriginRef)),
   headRefName: Schema.optional(Schema.NullOr(Schema.String)),
   baseRefName: Schema.optional(Schema.NullOr(Schema.String)),
+  fullName: Schema.optional(Schema.NullOr(Schema.String)),
+  org: Schema.optional(Schema.NullOr(Schema.String)),
+  name: Schema.optional(Schema.NullOr(Schema.String)),
+  repository: Schema.optional(Schema.NullOr(Schema.String)),
 });
+
+export interface OriginPullRequestDecodeOptions {
+  readonly nameWithOwner?: string;
+}
 
 function trimOptionalString(value: string | null | undefined): string | null {
   const trimmed = value?.trim() ?? "";
@@ -100,18 +108,71 @@ function normalizeOriginPullRequestState(input: {
   return "open";
 }
 
+function nameWithOwnerFromPath(path: string): string | null {
+  const segments = path
+    .replace(/\.git$/u, "")
+    .replace(/^\/+|\/+$/gu, "")
+    .split("/")
+    .filter(Boolean);
+  if (segments.length < 2) {
+    return null;
+  }
+  const owner = segments.at(-2);
+  const repo = segments.at(-1);
+  return owner && repo ? `${owner}/${repo}` : null;
+}
+
+export function originNameWithOwnerFromGitUrl(remoteUrl: string): string | null {
+  const trimmed = remoteUrl.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  const scpMatch = /^[a-zA-Z0-9._-]+@[^:]+:(.+)$/u.exec(trimmed);
+  if (scpMatch?.[1]) {
+    return nameWithOwnerFromPath(scpMatch[1]);
+  }
+
+  try {
+    return nameWithOwnerFromPath(new URL(trimmed).pathname);
+  } catch {
+    return nameWithOwnerFromPath(trimmed);
+  }
+}
+
+function originNameWithOwnerFromRecord(
+  raw: Schema.Schema.Type<typeof OriginPullRequestSchema>,
+): string | null {
+  const fullName = trimOptionalString(raw.fullName);
+  if (fullName?.includes("/")) {
+    return nameWithOwnerFromPath(fullName);
+  }
+  const repository = trimOptionalString(raw.repository);
+  if (repository?.includes("/")) {
+    return nameWithOwnerFromPath(repository);
+  }
+  const org = trimOptionalString(raw.org);
+  const name = trimOptionalString(raw.name);
+  return org && name ? `${org}/${name}` : null;
+}
+
 function originPullRequestUrl(input: {
   readonly url: string | null;
   readonly number: number;
-}): string {
+  readonly nameWithOwner: string | null;
+}): string | null {
   if (input.url) {
     return input.url;
   }
-  return `${ORIGIN_WEB_BASE}/pull/${input.number}`;
+  if (input.nameWithOwner) {
+    return `${ORIGIN_WEB_BASE}/${input.nameWithOwner}/pull/${input.number}`;
+  }
+  return null;
 }
 
 function normalizeOriginPullRequestRecord(
   raw: Schema.Schema.Type<typeof OriginPullRequestSchema>,
+  options?: OriginPullRequestDecodeOptions,
 ): NormalizedOriginPullRequestRecord | null {
   const number = parsePullRequestNumber(raw.number);
   const headRefName = originRefName(raw.headRefName) ?? refFromField(raw.head);
@@ -120,10 +181,19 @@ function normalizeOriginPullRequestRecord(
     return null;
   }
 
+  const url = originPullRequestUrl({
+    url: trimOptionalString(raw.url),
+    number,
+    nameWithOwner: originNameWithOwnerFromRecord(raw) ?? trimOptionalString(options?.nameWithOwner),
+  });
+  if (url === null) {
+    return null;
+  }
+
   return {
     number,
     title: raw.title,
-    url: originPullRequestUrl({ url: trimOptionalString(raw.url), number }),
+    url,
     baseRefName,
     headRefName,
     state: normalizeOriginPullRequestState(raw),
@@ -139,6 +209,7 @@ export const formatOriginJsonDecodeError = formatSchemaError;
 
 export function decodeOriginPullRequestListJson(
   raw: string,
+  options?: OriginPullRequestDecodeOptions,
 ): Result.Result<
   ReadonlyArray<NormalizedOriginPullRequestRecord>,
   Cause.Cause<Schema.SchemaError>
@@ -151,7 +222,7 @@ export function decodeOriginPullRequestListJson(
       if (Exit.isFailure(decodedEntry)) {
         continue;
       }
-      const normalized = normalizeOriginPullRequestRecord(decodedEntry.value);
+      const normalized = normalizeOriginPullRequestRecord(decodedEntry.value, options);
       if (normalized) {
         pullRequests.push(normalized);
       }
@@ -163,15 +234,18 @@ export function decodeOriginPullRequestListJson(
 
 export function decodeOriginPullRequestJson(
   raw: string,
+  options?: OriginPullRequestDecodeOptions,
 ): Result.Result<NormalizedOriginPullRequestRecord, Cause.Cause<Schema.SchemaError>> {
   const result = decodeOriginPullRequest(raw);
   if (Result.isFailure(result)) {
     return Result.fail(result.failure);
   }
-  const normalized = normalizeOriginPullRequestRecord(result.success);
+  const normalized = normalizeOriginPullRequestRecord(result.success, options);
   if (normalized === null) {
     return Result.fail(
-      Cause.die(new Error("Origin pull request JSON is missing number, head, or base.")),
+      Cause.die(
+        new Error("Origin pull request JSON is missing number, head, base, or repository."),
+      ),
     );
   }
   return Result.succeed(normalized);

--- a/apps/server/src/vcs/VcsProcess.test.ts
+++ b/apps/server/src/vcs/VcsProcess.test.ts
@@ -5,6 +5,7 @@ import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import { TestClock } from "effect/testing";
+import { ChildProcessSpawner } from "effect/unstable/process";
 
 import {
   VcsProcessExitError,
@@ -41,6 +42,35 @@ const captureProcessResult = (
       ProcessRunner.ProcessRunner.of({ run: () => result }),
     ),
     Effect.flatMap((service) => service.run(baseInput)),
+    Effect.flip,
+  );
+
+const captureClassifiedExit = (command: string, stderr: string) =>
+  VcsProcess.make.pipe(
+    Effect.provideService(
+      ProcessRunner.ProcessRunner,
+      ProcessRunner.ProcessRunner.of({
+        run: () =>
+          Effect.succeed({
+            stdout: "",
+            stderr,
+            code: ChildProcessSpawner.ExitCode(1),
+            timedOut: false,
+            stdoutTruncated: false,
+            stderrTruncated: false,
+            stdoutInvalidUtf8: false,
+            stderrInvalidUtf8: false,
+          }),
+      }),
+    ),
+    Effect.flatMap((service) =>
+      service.run({
+        operation: "test.classify",
+        command,
+        args: ["pr", "view", "13"],
+        cwd: "/repo",
+      }),
+    ),
     Effect.flip,
   );
 
@@ -138,6 +168,30 @@ describe("VcsProcess.run", () => {
       expect(error.message).not.toContain(secretStderr);
       expect(error.message).not.toContain("super-secret-token");
     }).pipe(provideLive),
+  );
+
+  it.effect("classifies Origin auth login hints as authentication failures", () =>
+    Effect.gen(function* () {
+      const error = yield* captureClassifiedExit("origin", "No account: run origin auth login");
+
+      expect(error).toMatchObject({
+        command: "origin",
+        failureKind: "authentication",
+        detail: "Authentication failed.",
+      });
+    }),
+  );
+
+  it.effect("classifies Origin missing pull requests as not-found", () =>
+    Effect.gen(function* () {
+      const error = yield* captureClassifiedExit("origin", "pull request 13 was not found");
+
+      expect(error).toMatchObject({
+        command: "origin",
+        failureKind: "not-found",
+        detail: "Pull request not found.",
+      });
+    }),
   );
 
   it.effect("classifies API rate limits without retaining provider stderr", () =>

--- a/apps/server/src/vcs/VcsProcess.ts
+++ b/apps/server/src/vcs/VcsProcess.ts
@@ -61,6 +61,7 @@ const classifyNonZeroExit = (command: string, stderr: string): VcsProcessExitFai
     normalized.includes("not logged in") ||
     normalized.includes("gh auth login") ||
     normalized.includes("glab auth login") ||
+    normalized.includes("origin auth login") ||
     normalized.includes("az devops login") ||
     normalized.includes("please run az login") ||
     normalized.includes("no oauth token") ||
@@ -85,6 +86,12 @@ const classifyNonZeroExit = (command: string, stderr: string): VcsProcessExitFai
         normalized.includes("repository.pullrequest") ||
         normalized.includes("no pull requests found for branch") ||
         normalized.includes("pull request not found"))) ||
+    (command === "origin" &&
+      (normalized.includes("could not resolve to a pullrequest") ||
+        normalized.includes("no pull requests found for branch") ||
+        normalized.includes("pull request not found") ||
+        normalized.includes("pr not found") ||
+        (normalized.includes("pull request") && normalized.includes("not found")))) ||
     (command === "glab" &&
       (normalized.includes("merge request not found") ||
         normalized.includes("not found") ||

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -115,6 +115,7 @@ import * as AzureDevOpsCli from "./sourceControl/AzureDevOpsCli.ts";
 import * as BitbucketApi from "./sourceControl/BitbucketApi.ts";
 import * as GitHubCli from "./sourceControl/GitHubCli.ts";
 import * as GitLabCli from "./sourceControl/GitLabCli.ts";
+import * as OriginCli from "./sourceControl/OriginCli.ts";
 import * as SourceControlProviderRegistry from "./sourceControl/SourceControlProviderRegistry.ts";
 import * as GitVcsDriver from "./vcs/GitVcsDriver.ts";
 import * as VcsDriverRegistry from "./vcs/VcsDriverRegistry.ts";
@@ -2339,6 +2340,7 @@ export const websocketRpcRouteLayer = Layer.unwrap(
                           BitbucketApi.layer,
                           GitHubCli.layer,
                           GitLabCli.layer,
+                          OriginCli.layer,
                         ),
                       ),
                       Layer.provideMerge(GitVcsDriver.layer),

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -126,7 +126,7 @@ import { orderItemsByPreferredIds, sortLogicalProjectsForSidebar } from "./Sideb
 import { resolveEnvironmentOptionLabel } from "./BranchToolbar.logic";
 import { CommandPaletteContent } from "./CommandPaletteContent";
 import { CommandPaletteResults } from "./CommandPaletteResults";
-import { AzureDevOpsIcon, BitbucketIcon, GitHubIcon, GitLabIcon } from "./Icons";
+import { AzureDevOpsIcon, BitbucketIcon, CursorIcon, GitHubIcon, GitLabIcon } from "./Icons";
 import { ProjectFavicon } from "./ProjectFavicon";
 import { ProjectFilePicker } from "./files/ProjectFilePicker";
 import { ProjectContentSearchDialog } from "./search/ProjectContentSearchDialog";
@@ -201,7 +201,7 @@ interface AddProjectEnvironmentOption {
 
 type AddProjectRemoteProviderKind = Extract<
   SourceControlProviderKind,
-  "github" | "gitlab" | "bitbucket" | "azure-devops"
+  "github" | "gitlab" | "bitbucket" | "azure-devops" | "cursor-origin"
 >;
 type AddProjectRemoteSource = AddProjectRemoteProviderKind | "url";
 
@@ -226,12 +226,14 @@ const REMOTE_PROJECT_SOURCES: ReadonlyArray<AddProjectRemoteSource> = [
   "gitlab",
   "bitbucket",
   "azure-devops",
+  "cursor-origin",
 ];
 const REMOTE_PROJECT_PROVIDER_SOURCES: ReadonlyArray<AddProjectRemoteProviderKind> = [
   "github",
   "gitlab",
   "bitbucket",
   "azure-devops",
+  "cursor-origin",
 ];
 
 function remoteProjectSourceLabel(source: AddProjectRemoteSource): string {
@@ -244,6 +246,8 @@ function remoteProjectSourceLabel(source: AddProjectRemoteSource): string {
       return "Bitbucket";
     case "azure-devops":
       return "Azure DevOps";
+    case "cursor-origin":
+      return "Cursor Origin";
     case "url":
       return "Git URL";
   }
@@ -259,6 +263,8 @@ function remoteProjectSourcePathHint(source: AddProjectRemoteSource): string {
       return "workspace/repository";
     case "azure-devops":
       return "project/repository";
+    case "cursor-origin":
+      return "owner/repo";
     case "url":
       return "URL";
   }
@@ -280,6 +286,8 @@ function remoteProjectSourceIcon(source: AddProjectRemoteSource, className: stri
       return <BitbucketIcon className={className} />;
     case "azure-devops":
       return <AzureDevOpsIcon className={className} />;
+    case "cursor-origin":
+      return <CursorIcon className={className} />;
     case "url":
       return <LinkIcon className={className} />;
   }
@@ -329,6 +337,7 @@ function buildAddProjectRemoteSourceReadiness(
     gitlab: unavailable,
     bitbucket: unavailable,
     "azure-devops": unavailable,
+    "cursor-origin": unavailable,
   };
 
   if (!discovery) {

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -474,6 +474,8 @@ function PublishRepositoryDialog(props: PublishRepositoryDialogProps) {
     selectedPublishProvider !== null && publishProviderReadiness[selectedPublishProvider].ready
       ? selectedPublishProvider
       : (firstReadyPublishProvider ?? selectedPublishProvider ?? "github");
+  const effectivePublishVisibility: SourceControlRepositoryVisibility =
+    publishProvider === "cursor-origin" ? "private" : publishVisibility;
   const selectedPublishProviderReadiness = publishProviderReadiness[publishProvider];
   const publishRepositoryPrefill = publishAccountByProvider[publishProvider]
     ? `${publishAccountByProvider[publishProvider]}/`
@@ -511,7 +513,7 @@ function PublishRepositoryDialog(props: PublishRepositoryDialogProps) {
       const result = await publishRepositoryAction.run({
         provider: publishProvider,
         repository: publishRepository.trim(),
-        visibility: publishProvider === "cursor-origin" ? "private" : publishVisibility,
+        visibility: effectivePublishVisibility,
         remoteName: publishRemoteName.trim() || "origin",
         protocol: publishProtocol,
       });
@@ -538,7 +540,7 @@ function PublishRepositoryDialog(props: PublishRepositoryDialogProps) {
     publishRemoteName,
     publishRepository,
     publishRepositoryAction,
-    publishVisibility,
+    effectivePublishVisibility,
   ]);
 
   const resetState = useCallback(() => {
@@ -640,9 +642,6 @@ function PublishRepositoryDialog(props: PublishRepositoryDialogProps) {
                     const next = value as PublishProviderKind;
                     setSelectedPublishProvider(next);
                     setPublishRepositoryOverride(null);
-                    if (next === "cursor-origin") {
-                      setPublishVisibility("private");
-                    }
                   }}
                   aria-labelledby="publish-provider-cards-label"
                   className="grid grid-cols-2 gap-2.5"
@@ -752,7 +751,7 @@ function PublishRepositoryDialog(props: PublishRepositoryDialogProps) {
                     Visibility
                   </span>
                   <RadioGroup
-                    value={publishVisibility}
+                    value={effectivePublishVisibility}
                     onValueChange={(value) =>
                       setPublishVisibility(value as SourceControlRepositoryVisibility)
                     }
@@ -785,7 +784,7 @@ function PublishRepositoryDialog(props: PublishRepositoryDialogProps) {
                             },
                           ]),
                     ].map((option) => {
-                      const isSelected = publishVisibility === option.value;
+                      const isSelected = effectivePublishVisibility === option.value;
                       return (
                         <RadioPrimitive.Root
                           key={option.value}

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -32,7 +32,13 @@ import {
   GlobeIcon,
 } from "lucide-react";
 import { Radio as RadioPrimitive } from "@base-ui/react/radio";
-import { AzureDevOpsIcon, BitbucketIcon, GitHubIcon, GitLabIcon } from "~/components/Icons";
+import {
+  AzureDevOpsIcon,
+  BitbucketIcon,
+  CursorIcon,
+  GitHubIcon,
+  GitLabIcon,
+} from "~/components/Icons";
 import { RadioGroup } from "~/components/ui/radio-group";
 import { Spinner } from "~/components/ui/spinner";
 import { cn } from "~/lib/utils";
@@ -115,7 +121,7 @@ interface PendingDefaultBranchAction {
 
 type PublishProviderKind = Extract<
   SourceControlProviderKind,
-  "github" | "gitlab" | "bitbucket" | "azure-devops"
+  "github" | "gitlab" | "bitbucket" | "azure-devops" | "cursor-origin"
 >;
 
 type GitActionToastId = ReturnType<typeof toastManager.add>;
@@ -194,6 +200,14 @@ const PUBLISH_PROVIDER_OPTIONS = [
     host: "dev.azure.com",
     pathPlaceholder: "project/repository",
     Icon: AzureDevOpsIcon,
+  },
+  {
+    value: "cursor-origin",
+    label: "Cursor Origin",
+    description: "origin.cursor.com",
+    host: "origin.cursor.com",
+    pathPlaceholder: "owner/repo",
+    Icon: CursorIcon,
   },
 ] as const satisfies ReadonlyArray<{
   readonly value: PublishProviderKind;
@@ -416,6 +430,7 @@ function PublishRepositoryDialog(props: PublishRepositoryDialogProps) {
       gitlab: null,
       bitbucket: null,
       "azure-devops": null,
+      "cursor-origin": null,
     };
     for (const provider of sourceControlDiscovery.data?.sourceControlProviders ?? []) {
       if (isPublishProviderKind(provider.kind)) {
@@ -496,7 +511,7 @@ function PublishRepositoryDialog(props: PublishRepositoryDialogProps) {
       const result = await publishRepositoryAction.run({
         provider: publishProvider,
         repository: publishRepository.trim(),
-        visibility: publishVisibility,
+        visibility: publishProvider === "cursor-origin" ? "private" : publishVisibility,
         remoteName: publishRemoteName.trim() || "origin",
         protocol: publishProtocol,
       });
@@ -622,8 +637,12 @@ function PublishRepositoryDialog(props: PublishRepositoryDialogProps) {
                 <RadioGroup
                   value={publishProvider}
                   onValueChange={(value) => {
-                    setSelectedPublishProvider(value as PublishProviderKind);
+                    const next = value as PublishProviderKind;
+                    setSelectedPublishProvider(next);
                     setPublishRepositoryOverride(null);
+                    if (next === "cursor-origin") {
+                      setPublishVisibility("private");
+                    }
                   }}
                   aria-labelledby="publish-provider-cards-label"
                   className="grid grid-cols-2 gap-2.5"
@@ -739,21 +758,32 @@ function PublishRepositoryDialog(props: PublishRepositoryDialogProps) {
                     }
                     aria-labelledby="publish-visibility-cards-label"
                     disabled={publishRepositoryAction.isPending}
-                    className="grid grid-cols-2 gap-2.5"
+                    className={
+                      publishProvider === "cursor-origin"
+                        ? "grid grid-cols-1 gap-2.5"
+                        : "grid grid-cols-2 gap-2.5"
+                    }
                   >
                     {[
                       {
                         value: "private" as const,
                         label: "Private",
-                        description: "Only invited people",
+                        description:
+                          publishProvider === "cursor-origin"
+                            ? "Shared with your Origin codebase"
+                            : "Only invited people",
                         Icon: LockIcon,
                       },
-                      {
-                        value: "public" as const,
-                        label: "Public",
-                        description: "Anyone on the web",
-                        Icon: GlobeIcon,
-                      },
+                      ...(publishProvider === "cursor-origin"
+                        ? []
+                        : [
+                            {
+                              value: "public" as const,
+                              label: "Public",
+                              description: "Anyone on the web",
+                              Icon: GlobeIcon,
+                            },
+                          ]),
                     ].map((option) => {
                       const isSelected = publishVisibility === option.value;
                       return (

--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -47,6 +47,7 @@ import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import {
   AzureDevOpsIcon,
   BitbucketIcon,
+  CursorIcon,
   GitHubIcon,
   GitIcon,
   GitLabIcon,
@@ -73,6 +74,7 @@ const SOURCE_CONTROL_PROVIDER_ICONS: Partial<Record<SourceControlProviderKind, I
   gitlab: GitLabIcon,
   "azure-devops": AzureDevOpsIcon,
   bitbucket: BitbucketIcon,
+  "cursor-origin": CursorIcon,
 };
 
 const VCS_ICONS: Partial<Record<VcsDriverKind, Icon>> = {

--- a/apps/web/src/sourceControlPresentation.ts
+++ b/apps/web/src/sourceControlPresentation.ts
@@ -15,7 +15,13 @@ import {
   resolveChangeRequestPresentation,
   type ChangeRequestTerminology,
 } from "@t3tools/shared/sourceControl";
-import { AzureDevOpsIcon, BitbucketIcon, GitHubIcon, GitLabIcon } from "./components/Icons";
+import {
+  AzureDevOpsIcon,
+  BitbucketIcon,
+  CursorIcon,
+  GitHubIcon,
+  GitLabIcon,
+} from "./components/Icons";
 
 export interface SourceControlPresentation {
   readonly providerName: string;
@@ -51,6 +57,12 @@ export function getSourceControlPresentation(
         providerName: provider?.name || presentation.providerName,
         terminology: getChangeRequestTerminology(provider),
         Icon: BitbucketIcon,
+      };
+    case "cursor-origin":
+      return {
+        providerName: provider?.name || presentation.providerName,
+        terminology: getChangeRequestTerminology(provider),
+        Icon: CursorIcon,
       };
     case "change-request":
       return {

--- a/apps/web/src/state/sourceControlActions.ts
+++ b/apps/web/src/state/sourceControlActions.ts
@@ -267,7 +267,7 @@ export function useSourceControlPublishRepositoryAction(scope: SourceControlActi
   );
   const action = useCallback(
     async (input: {
-      provider: "github" | "gitlab" | "bitbucket" | "azure-devops";
+      provider: "github" | "gitlab" | "bitbucket" | "azure-devops" | "cursor-origin";
       repository: string;
       visibility: SourceControlRepositoryVisibility;
       remoteName: string;

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -10,6 +10,7 @@ T3 Code works with the platforms your team already uses:
 - **GitLab** – Merge requests, repository publishing, and hosted clones
 - **Bitbucket** – Pull request workflows (via API token authentication)
 - **Azure DevOps** – Pull request support for Microsoft-hosted repositories
+- **Cursor Origin** – Pull requests, repository publishing, and clones via the Origin CLI
 
 ## What You Can Do
 
@@ -18,13 +19,13 @@ T3 Code works with the platforms your team already uses:
 **Clone repositories directly**
 
 - Open the Command Palette (`Cmd/Ctrl + K`) → **Add Project**
-- Choose **GitHub repository**, **GitLab repository**, **Bitbucket repository**, **Azure DevOps repository**, or paste any **Git URL**
+- Choose **GitHub repository**, **GitLab repository**, **Bitbucket repository**, **Azure DevOps repository**, **Cursor Origin repository**, or paste any **Git URL**
 - Enter the repository path (`owner/repo`, `group/project`, `workspace/repository`, or `project/repository`) or a full Git URL, pick a destination, and start coding
 
 **Publish local projects to the cloud**
 
 - Have a local Git repository without a remote?
-- Use the **Publish Repository** action to create a new hosted repository (GitHub, GitLab, Bitbucket, or Azure DevOps), add it as your origin remote, and push, in one flow
+- Use the **Publish Repository** action to create a new hosted repository (GitHub, GitLab, Bitbucket, Azure DevOps, or Cursor Origin), add it as your origin remote, and push, in one flow
 - If the local repository has no commits yet, publishing creates the remote and wires it up but does not push. Make a commit, then push normally.
 
 ### Manage Code Reviews Without Context Switching
@@ -33,7 +34,7 @@ T3 Code works with the platforms your team already uses:
 
 - Push a branch and create a pull request from the Git actions controls in the toolbar
 - T3 Code can suggest titles and descriptions based on your commits
-- Supports GitHub Pull Requests, GitLab Merge Requests, Bitbucket Pull Requests, and Azure DevOps Pull Requests
+- Supports GitHub Pull Requests, GitLab Merge Requests, Bitbucket Pull Requests, Azure DevOps Pull Requests, and Cursor Origin Pull Requests
 
 **Stay on top of open reviews**
 
@@ -129,6 +130,21 @@ Control settings**.
    az login
    ```
 
+### For Cursor Origin
+
+1. Install the Origin CLI on the machine running T3 Code:
+   ```bash
+   curl -fsSL https://downloads.cursor.com/origin/install.sh | sh
+   ```
+   Add `~/.local/bin` to `PATH` if your shell cannot find `origin`.
+2. Sign in:
+   ```bash
+   origin auth login
+   ```
+3. Check **Settings → Source Control** to confirm the connection
+
+Origin repositories are private to your Cursor codebase. The in-app Pull requests inbox still uses GitHub, GitLab, Bitbucket, and Azure DevOps; Origin change requests are created, listed, and checked out from Git actions.
+
 ---
 
 ## Requirements & Troubleshooting
@@ -148,3 +164,4 @@ Control settings**.
 - [GitHub CLI](https://cli.github.com/)
 - [GitLab CLI](https://gitlab.com/gitlab-org/cli)
 - [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/)
+- [Origin CLI](https://cursor.com/docs/origin/cli)

--- a/packages/client-runtime/src/operations/projects.ts
+++ b/packages/client-runtime/src/operations/projects.ts
@@ -25,7 +25,7 @@ import type { EnvironmentProject } from "../state/models.ts";
 
 export type AddProjectRemoteProviderKind = Extract<
   SourceControlProviderKind,
-  "github" | "gitlab" | "bitbucket" | "azure-devops"
+  "github" | "gitlab" | "bitbucket" | "azure-devops" | "cursor-origin"
 >;
 export type AddProjectRemoteSource = AddProjectRemoteProviderKind | "url";
 
@@ -61,6 +61,7 @@ const ADD_PROJECT_REMOTE_SOURCES: ReadonlyArray<AddProjectRemoteSource> = [
   "gitlab",
   "bitbucket",
   "azure-devops",
+  "cursor-origin",
 ];
 
 const ADD_PROJECT_REMOTE_PROVIDER_SOURCES: ReadonlyArray<AddProjectRemoteProviderKind> = [
@@ -68,6 +69,7 @@ const ADD_PROJECT_REMOTE_PROVIDER_SOURCES: ReadonlyArray<AddProjectRemoteProvide
   "gitlab",
   "bitbucket",
   "azure-devops",
+  "cursor-origin",
 ];
 
 export function addProjectRemoteSourceLabel(source: AddProjectRemoteSource): string {
@@ -80,6 +82,8 @@ export function addProjectRemoteSourceLabel(source: AddProjectRemoteSource): str
       return "Bitbucket";
     case "azure-devops":
       return "Azure DevOps";
+    case "cursor-origin":
+      return "Cursor Origin";
     case "url":
       return "Git URL";
   }
@@ -95,6 +99,8 @@ export function addProjectRemoteSourcePathHint(source: AddProjectRemoteSource): 
       return "workspace/repository";
     case "azure-devops":
       return "project/repository";
+    case "cursor-origin":
+      return "owner/repo";
     case "url":
       return "URL";
   }
@@ -137,6 +143,7 @@ export function buildAddProjectRemoteSourceReadiness(
     gitlab: unavailable,
     bitbucket: unavailable,
     "azure-devops": unavailable,
+    "cursor-origin": unavailable,
   };
 
   if (!discovery) {

--- a/packages/contracts/src/pullRequest.ts
+++ b/packages/contracts/src/pullRequest.ts
@@ -1006,6 +1006,11 @@ const PROVIDER_REQUIREMENT: Partial<
     unauthenticated:
       "Bitbucket rejected the configured credentials. Check T3CODE_BITBUCKET_EMAIL and T3CODE_BITBUCKET_API_TOKEN.",
   },
+  "cursor-origin": {
+    missing:
+      "Origin CLI (`origin`) is required to browse change requests on this host. Install it from https://cursor.com/docs/origin/cli and reload.",
+    unauthenticated: "Origin CLI is not authenticated. Run `origin auth login` and retry.",
+  },
 };
 
 /**

--- a/packages/contracts/src/sourceControl.ts
+++ b/packages/contracts/src/sourceControl.ts
@@ -7,6 +7,7 @@ export const SourceControlProviderKind = Schema.Literals([
   "gitlab",
   "azure-devops",
   "bitbucket",
+  "cursor-origin",
   "unknown",
 ]);
 export type SourceControlProviderKind = typeof SourceControlProviderKind.Type;

--- a/packages/contracts/src/vcs.ts
+++ b/packages/contracts/src/vcs.ts
@@ -140,7 +140,7 @@ export class VcsProcessExitError extends Schema.TaggedErrorClass<VcsProcessExitE
           : failureKind === "not-found"
             ? context.command === "glab"
               ? "Merge request not found."
-              : context.command === "gh" || context.command === "az"
+              : context.command === "gh" || context.command === "az" || context.command === "origin"
                 ? "Pull request not found."
                 : "VCS resource not found."
             : "Process exited with a non-zero status.";

--- a/packages/shared/src/sourceControl.test.ts
+++ b/packages/shared/src/sourceControl.test.ts
@@ -28,6 +28,10 @@ describe("source control presentation", () => {
       shortLabel: "PR",
       singular: "pull request",
     });
+    expect(getChangeRequestTerminologyForKind("cursor-origin")).toEqual({
+      shortLabel: "PR",
+      singular: "pull request",
+    });
   });
 
   it("falls back to generic change request copy for unknown providers", () => {
@@ -56,6 +60,12 @@ describe("detectSourceControlProviderFromRemoteUrl", () => {
     expect(
       detectSourceControlProviderFromRemoteUrl("git@bitbucket.org:workspace/repo.git")?.kind,
     ).toBe("bitbucket");
+    expect(
+      detectSourceControlProviderFromRemoteUrl("https://origin.cursor.com/acme/checkout.git")?.kind,
+    ).toBe("cursor-origin");
+    expect(
+      detectSourceControlProviderFromRemoteUrl("git@origin.cursor.com:acme/checkout.git")?.kind,
+    ).toBe("cursor-origin");
   });
 
   it("detects Azure DevOps SSH remotes", () => {
@@ -119,6 +129,9 @@ describe("detectSourceControlProviderFromRemoteUrl", () => {
       detectSourceControlProviderFromRemoteUrl(
         "https://notbitbucket.example.com/workspace/repo.git",
       )?.kind,
+    ).toBe("unknown");
+    expect(
+      detectSourceControlProviderFromRemoteUrl("https://cursor.com/codebase/acme/checkout")?.kind,
     ).toBe("unknown");
   });
 

--- a/packages/shared/src/sourceControl.ts
+++ b/packages/shared/src/sourceControl.ts
@@ -1,7 +1,13 @@
 import type { SourceControlProviderInfo, SourceControlProviderKind } from "@t3tools/contracts";
 
 export interface ChangeRequestPresentation {
-  readonly icon: "github" | "gitlab" | "azure-devops" | "bitbucket" | "change-request";
+  readonly icon:
+    | "github"
+    | "gitlab"
+    | "azure-devops"
+    | "bitbucket"
+    | "cursor-origin"
+    | "change-request";
   readonly providerName: string;
   readonly shortName: string;
   readonly longName: string;
@@ -64,6 +70,17 @@ const BITBUCKET_CHANGE_REQUEST_PRESENTATION: ChangeRequestPresentation = {
   urlExample: "https://bitbucket.org/workspace/repo/pull-requests/42",
 };
 
+const CURSOR_ORIGIN_CHANGE_REQUEST_PRESENTATION: ChangeRequestPresentation = {
+  icon: "cursor-origin",
+  providerName: "Cursor Origin",
+  shortName: "PR",
+  longName: "pull request",
+  pluralLongName: "pull requests",
+  providerLongName: "Cursor Origin pull request",
+  checkoutCommandExample: "origin pr checkout 123",
+  urlExample: "https://cursor.com/codebase/owner/repo/pull/42",
+};
+
 const GENERIC_CHANGE_REQUEST_PRESENTATION: ChangeRequestPresentation = {
   icon: "change-request",
   providerName: "source control",
@@ -87,6 +104,8 @@ export function resolveChangeRequestPresentation(
       return AZURE_DEVOPS_CHANGE_REQUEST_PRESENTATION;
     case "bitbucket":
       return BITBUCKET_CHANGE_REQUEST_PRESENTATION;
+    case "cursor-origin":
+      return CURSOR_ORIGIN_CHANGE_REQUEST_PRESENTATION;
     case "unknown":
       return GENERIC_CHANGE_REQUEST_PRESENTATION;
   }
@@ -198,6 +217,10 @@ function isBitbucketHost(host: string): boolean {
   return host === "bitbucket.org" || hasDnsLabel(host, "bitbucket");
 }
 
+function isCursorOriginHost(host: string): boolean {
+  return host === "origin.cursor.com";
+}
+
 export function detectSourceControlProviderFromRemoteUrl(
   remoteUrl: string,
 ): SourceControlProviderInfo | null {
@@ -235,6 +258,14 @@ export function detectSourceControlProviderFromRemoteUrl(
     return {
       kind: "bitbucket",
       name: hostname === "bitbucket.org" ? "Bitbucket" : "Bitbucket Self-Hosted",
+      baseUrl: toBaseUrl(host),
+    };
+  }
+
+  if (isCursorOriginHost(hostname)) {
+    return {
+      kind: "cursor-origin",
+      name: "Cursor Origin",
       baseUrl: toBaseUrl(host),
     };
   }


### PR DESCRIPTION
## What Changed

T3 Code now treats Cursor Origin as a first-class git host. Remotes at `origin.cursor.com` are recognized instead of falling through as unknown, so Settings, Add Project, Publish Repository, and Git actions can clone, publish, and open pull requests with the Origin CLI (`origin`) the same way they already do with `gh` and `glab`.

The new `cursor-origin` provider probes `origin --version` and `origin auth login` status, lists and views PRs through `origin pr`, creates repos with `origin repo create`, and derives HTTPS/SSH clone URLs for `origin.cursor.com`. Origin has no public repos, so publish stays private. The in-app Pull requests inbox is still GitHub, GitLab, Bitbucket, and Azure DevOps only; Origin change requests are created, listed, and checked out from Git actions.

## Why

Cursor Origin is a git forge with a documented CLI and HTTPS remotes, but T3 Code could not classify those remotes or drive the `origin` binary. Users who host on Origin had to paste raw git URLs and could not publish or open PRs from the app.

Deliberately scoped so Origin plugs into the existing source-control path without taking on a full inbox:

- Detection matches only `origin.cursor.com`, so `cursor.com` web URLs stay unclassified.
- The adapter is CLI-backed like GitHub, not a new REST client. `origin pr create` passes `--status open` because Origin defaults to draft.
- `origin repo create` has no visibility flag; public is omitted in the publish UI rather than sending a flag the CLI would reject.
- Pull request JSON decode accepts both CLI field names (`status`, `head.ref`) and numeric strings, and skips malformed list rows instead of dropping the whole listing.
- A missing or unauthenticated `origin` binary degrades to the existing Settings install/auth hint rather than breaking other hosts.

## UI Changes

**Before:** Add Project, Publish Repository, and Settings → Source Control listed GitHub, GitLab, Bitbucket, and Azure DevOps. An `origin.cursor.com` remote showed as an unknown host.

**After:** Cursor Origin appears in those same surfaces with the Cursor mark. Origin remotes classify as Cursor Origin. Publish offers only private visibility, matching Origin codebase-private repos.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core git/source-control paths (remote resolution, fork PR fetch, clone/publish URLs) and shells out to a new CLI; mistakes could mis-route remotes or break PR workflows for Origin repos, but changes are additive and covered by tests.
> 
> **Overview**
> Adds **Cursor Origin** (`cursor-origin`) as a first-class source-control provider so `origin.cursor.com` remotes are recognized and driven through the existing clone, publish, and Git-actions flows.
> 
> The server introduces an **`origin` CLI adapter** (`OriginCli` + `OriginSourceControlProvider`) for PR list/view/create, repo create/view, checkout, and auth discovery, with JSON normalization and safe error handling. **GitManager** and **SourceControlRepositoryService** use Origin-specific HTTPS clone URLs when the provider kind is `cursor-origin`. **VcsProcess** classifies Origin auth and PR-not-found stderr like other CLIs.
> 
> **Web and mobile** surface Cursor Origin in Add Project, Publish Repository, and Settings (icon, labels, path hints). Publish **forces private visibility** and hides public for Origin because the CLI has no visibility flag. Contracts and shared detection add the new kind; user docs describe install/auth via `origin auth login`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a101169e162b89a7203f791d2477e3e354a9aa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Cursor Origin as a git host and source control provider
> - Introduces `cursor-origin` as a recognized `SourceControlProviderKind` across contracts, client runtime, server, web, and mobile.
> - Adds `OriginCli` service in [`OriginCli.ts`](https://github.com/pingdotgg/t3code/pull/7351/files#diff-d8e4a6bfb82a8897ab3cc73cef02ca7c09eb908e97e91088b2dbec13a27965b0) wrapping the `origin` executable to support listing/creating PRs, cloning, publishing, and branch operations.
> - Adds `OriginSourceControlProvider` that maps `OriginCli` operations to the provider-neutral `SourceControlProvider` interface and plugs into the registry.
> - The Publish dialog forces private visibility when Cursor Origin is selected; the Public option is hidden.
> - Discovery parses `origin auth status` output to detect installation and authentication state, surfacing actionable errors referencing `origin auth login`.
> - Remote URLs at `origin.cursor.com` are detected as `cursor-origin` and use Origin-specific HTTPS URL formatting (no `.git` suffix) for remote configuration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a10116.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->