### PR TITLE
fix(server): keep normalized workspace paths unique

### DIFF
--- a/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
@@ -4,6 +4,7 @@ import {
   type GrepCursor,
   type GrepOptions,
   type GrepResult,
+  type MixedItem,
 } from "@ff-labs/fff-node";
 import { afterEach, expect, it } from "@effect/vitest";
 import * as Cause from "effect/Cause";
@@ -29,6 +30,39 @@ function fileItem(relativePath: string): FileItem {
     gitStatus: "clean",
   };
 }
+
+function mixedFileItem(relativePath: string): MixedItem {
+  return { type: "file", item: fileItem(relativePath) };
+}
+
+it.effect("deduplicates paths using their wire-normalized value", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const items = [mixedFileItem("pkg/notes.txt"), mixedFileItem("pkg/notes.txt\n")];
+      const finder = {
+        destroy: vi.fn(),
+        waitForIndexReady: vi.fn(async () => ({ ok: true as const, value: true })),
+        mixedSearch: vi.fn(() => ({
+          ok: true as const,
+          value: {
+            items,
+            scores: [],
+            totalMatched: items.length,
+            totalFiles: items.length,
+          },
+        })),
+      } as unknown as FileFinder;
+      vi.spyOn(FileFinder, "create").mockReturnValueOnce({ ok: true, value: finder });
+
+      const searchIndex = yield* WorkspaceSearchIndex.make("/workspace/project");
+      const result = yield* searchIndex.list();
+
+      expect(result.entries.filter((entry) => entry.path === "pkg/notes.txt")).toEqual([
+        { kind: "file", path: "pkg/notes.txt" },
+      ]);
+    }),
+  ),
+);
 
 it.effect("filters image searches before applying the result limit", () =>
   Effect.scoped(

--- a/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
@@ -79,7 +79,9 @@ it.effect("deduplicates paths using their wire-normalized value", () =>
 it.effect("trims wire whitespace before removing directory separators", () =>
   Effect.scoped(
     Effect.gen(function* () {
-      const items = [mixedDirectoryItem("pkg/"), mixedFileItem("pkg/ ")];
+      // The file ranks first to prove that a later directory upgrades the
+      // collision instead of leaving the file kind attached to a real folder.
+      const items = [mixedFileItem("pkg/ "), mixedDirectoryItem("pkg/")];
       const finder = {
         destroy: vi.fn(),
         waitForIndexReady: vi.fn(async () => ({ ok: true as const, value: true })),

--- a/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
@@ -1,5 +1,6 @@
 import {
   FileFinder,
+  type DirItem,
   type FileItem,
   type GrepCursor,
   type GrepOptions,
@@ -35,6 +36,15 @@ function mixedFileItem(relativePath: string): MixedItem {
   return { type: "file", item: fileItem(relativePath) };
 }
 
+function mixedDirectoryItem(relativePath: string): MixedItem {
+  const item: DirItem = {
+    relativePath,
+    dirName: relativePath.slice(relativePath.lastIndexOf("/") + 1),
+    maxAccessFrecency: 0,
+  };
+  return { type: "directory", item };
+}
+
 it.effect("deduplicates paths using their wire-normalized value", () =>
   Effect.scoped(
     Effect.gen(function* () {
@@ -55,11 +65,40 @@ it.effect("deduplicates paths using their wire-normalized value", () =>
       vi.spyOn(FileFinder, "create").mockReturnValueOnce({ ok: true, value: finder });
 
       const searchIndex = yield* WorkspaceSearchIndex.make("/workspace/project");
-      const result = yield* searchIndex.list();
+      const listResult = yield* searchIndex.list();
+      const searchResult = yield* searchIndex.search("", 10);
 
-      expect(result.entries.filter((entry) => entry.path === "pkg/notes.txt")).toEqual([
+      expect(listResult.entries.filter((entry) => entry.path === "pkg/notes.txt")).toEqual([
         { kind: "file", path: "pkg/notes.txt" },
       ]);
+      expect(searchResult.entries).toEqual([{ kind: "file", path: "pkg/notes.txt" }]);
+    }),
+  ),
+);
+
+it.effect("trims wire whitespace before removing directory separators", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const items = [mixedDirectoryItem("pkg/"), mixedFileItem("pkg/ ")];
+      const finder = {
+        destroy: vi.fn(),
+        waitForIndexReady: vi.fn(async () => ({ ok: true as const, value: true })),
+        mixedSearch: vi.fn(() => ({
+          ok: true as const,
+          value: {
+            items,
+            scores: [],
+            totalMatched: items.length,
+            totalFiles: 1,
+          },
+        })),
+      } as unknown as FileFinder;
+      vi.spyOn(FileFinder, "create").mockReturnValueOnce({ ok: true, value: finder });
+
+      const searchIndex = yield* WorkspaceSearchIndex.make("/workspace/project");
+      const result = yield* searchIndex.search("", 10);
+
+      expect(result.entries).toEqual([{ kind: "directory", path: "pkg" }]);
     }),
   ),
 );

--- a/apps/server/src/workspace/WorkspaceSearchIndex.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.ts
@@ -167,11 +167,18 @@ function toDirectoryEntry(item: DirItem): ProjectEntry | null {
 
 function uniqueProjectEntries(entries: Iterable<ProjectEntry | null>): ProjectEntry[] {
   const uniqueEntries: ProjectEntry[] = [];
-  const paths = new Set<string>();
+  const indexByPath = new Map<string, number>();
   for (const entry of entries) {
-    if (entry === null || paths.has(entry.path)) continue;
-    paths.add(entry.path);
-    uniqueEntries.push(entry);
+    if (entry === null) continue;
+    const existingIndex = indexByPath.get(entry.path);
+    if (existingIndex === undefined) {
+      indexByPath.set(entry.path, uniqueEntries.length);
+      uniqueEntries.push(entry);
+      continue;
+    }
+    if (entry.kind === "directory" && uniqueEntries[existingIndex]?.kind === "file") {
+      uniqueEntries[existingIndex] = entry;
+    }
   }
   return uniqueEntries;
 }

--- a/apps/server/src/workspace/WorkspaceSearchIndex.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.ts
@@ -132,16 +132,19 @@ function trimDirectorySeparator(input: string): string {
   return input.endsWith("/") ? input.slice(0, -1) : input;
 }
 
+function normalizeProjectEntryPath(input: string): string {
+  // ProjectEntry.path trims at the wire boundary. Trim first so a legal
+  // whitespace-only final segment cannot leave a separator-only collision.
+  return trimDirectorySeparator(toPosixPath(input).trim());
+}
+
 function parentPathOf(input: string): string | undefined {
   const separatorIndex = input.lastIndexOf("/");
   return separatorIndex === -1 ? undefined : input.slice(0, separatorIndex);
 }
 
 function toProjectEntry(item: MixedItem): ProjectEntry | null {
-  // ProjectEntry.path trims at the wire boundary. Normalize before the path
-  // map deduplicates entries so distinct raw names cannot collapse into a
-  // duplicate that crashes the client file tree.
-  const normalizedPath = trimDirectorySeparator(toPosixPath(item.item.relativePath)).trim();
+  const normalizedPath = normalizeProjectEntryPath(item.item.relativePath);
   if (!normalizedPath) {
     return null;
   }
@@ -153,13 +156,24 @@ function toProjectEntry(item: MixedItem): ProjectEntry | null {
 }
 
 function toFileEntry(item: FileItem): ProjectEntry | null {
-  const normalizedPath = trimDirectorySeparator(toPosixPath(item.relativePath));
+  const normalizedPath = normalizeProjectEntryPath(item.relativePath);
   return normalizedPath ? { path: normalizedPath, kind: "file" } : null;
 }
 
 function toDirectoryEntry(item: DirItem): ProjectEntry | null {
-  const normalizedPath = trimDirectorySeparator(toPosixPath(item.relativePath));
+  const normalizedPath = normalizeProjectEntryPath(item.relativePath);
   return normalizedPath ? { path: normalizedPath, kind: "directory" } : null;
+}
+
+function uniqueProjectEntries(entries: Iterable<ProjectEntry | null>): ProjectEntry[] {
+  const uniqueEntries: ProjectEntry[] = [];
+  const paths = new Set<string>();
+  for (const entry of entries) {
+    if (entry === null || paths.has(entry.path)) continue;
+    paths.add(entry.path);
+    uniqueEntries.push(entry);
+  }
+  return uniqueEntries;
 }
 
 function mapFileSearchResult(
@@ -167,10 +181,12 @@ function mapFileSearchResult(
   limit: number,
   imageOnly = false,
 ): ProjectSearchEntriesResult {
-  const entries = result.items.flatMap((item) => {
-    const entry = toFileEntry(item);
-    return entry && (!imageOnly || isWorkspaceImagePreviewPath(entry.path)) ? [entry] : [];
-  });
+  const entries = uniqueProjectEntries(
+    result.items.map((item) => {
+      const entry = toFileEntry(item);
+      return entry && (!imageOnly || isWorkspaceImagePreviewPath(entry.path)) ? entry : null;
+    }),
+  );
   return {
     entries: entries.slice(0, limit),
     truncated: entries.length > limit || result.totalMatched > result.items.length,
@@ -181,10 +197,7 @@ function mapDirectorySearchResult(
   result: DirSearchResult,
   limit: number,
 ): ProjectSearchEntriesResult {
-  const entries = result.items.flatMap((item) => {
-    const entry = toDirectoryEntry(item);
-    return entry ? [entry] : [];
-  });
+  const entries = uniqueProjectEntries(result.items.map(toDirectoryEntry));
   const rootDirectoryCount = result.items.some((item) => item.relativePath.length === 0) ? 1 : 0;
   return {
     entries: entries.slice(0, limit),
@@ -196,16 +209,7 @@ function mapMixedSearchResult(
   result: MixedSearchResult,
   limit: number,
 ): { readonly entries: ProjectEntry[]; readonly truncated: boolean } {
-  const entries: ProjectEntry[] = [];
-  for (const item of result.items) {
-    const entry = toProjectEntry(item);
-    if (entry) {
-      entries.push(entry);
-    }
-    if (entries.length >= limit) {
-      break;
-    }
-  }
+  const entries = uniqueProjectEntries(result.items.map(toProjectEntry));
 
   const rootDirectoryCount = result.items.some(
     (item) => item.type === "directory" && item.item.relativePath.length === 0,
@@ -213,8 +217,8 @@ function mapMixedSearchResult(
     ? 1
     : 0;
   return {
-    entries,
-    truncated: result.totalMatched - rootDirectoryCount > limit,
+    entries: entries.slice(0, limit),
+    truncated: entries.length > limit || result.totalMatched - rootDirectoryCount > limit,
   };
 }
 

--- a/apps/server/src/workspace/WorkspaceSearchIndex.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.ts
@@ -138,7 +138,10 @@ function parentPathOf(input: string): string | undefined {
 }
 
 function toProjectEntry(item: MixedItem): ProjectEntry | null {
-  const normalizedPath = trimDirectorySeparator(toPosixPath(item.item.relativePath));
+  // ProjectEntry.path trims at the wire boundary. Normalize before the path
+  // map deduplicates entries so distinct raw names cannot collapse into a
+  // duplicate that crashes the client file tree.
+  const normalizedPath = trimDirectorySeparator(toPosixPath(item.item.relativePath)).trim();
   if (!normalizedPath) {
     return null;
   }


### PR DESCRIPTION
## What this does

Workspace file listings no longer send duplicate paths after wire normalization. A legal Linux or macOS filename with trailing whitespace can no longer make the entire Files panel fail with a duplicate-path error.

Fixes #5501.

## Verification

- `pnpm exec vp test run apps/server/src/workspace/WorkspaceSearchIndex.test.ts` (10 tests passed)
- `pnpm --filter t3 typecheck`
- Targeted Vite+ lint and formatting checks for both changed files

## Intentional decisions

The existing project-entry contract trims surrounding whitespace. This change preserves that contract and drops normalized collisions before they reach the client instead of expanding this fix into a wire-format migration.

Generated with GPT-5.6 in the Codex harness through T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to workspace search index mapping and response shaping; no auth or persistence changes, with behavior limited to collapsing paths that only differed after normalization.
> 
> **Overview**
> Fixes workspace **list/search** responses that could emit **duplicate `ProjectEntry.path` values** after wire normalization (e.g. trailing whitespace or newline on an otherwise valid filename), which broke the Files UI with a duplicate-path error ([#5501](https://github.com/pingdotgg/t3code/issues/5501)).
> 
> **`WorkspaceSearchIndex`** now centralizes path shaping in `normalizeProjectEntryPath` (POSIX, **trim then** drop trailing `/`) and runs all file/directory/mixed mappers through **`uniqueProjectEntries`**, which keeps one row per normalized path and **prefers `directory` over `file`** when both collide. **`truncated`** for mixed/file results can reflect deduped counts, not only raw index hits.
> 
> New unit tests cover wire-normalized dedup and the file→directory upgrade when a trailing-space file path collides with a real folder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 378f54f5b66c0733fd782aec0a03c1e8a4eddf4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deduplicate normalized workspace paths in `WorkspaceSearchIndex`
> - Introduces `normalizeProjectEntryPath` in [`WorkspaceSearchIndex.ts`](https://github.com/pingdotgg/t3code/pull/7354/files#diff-c11793234fa6d81f052147cd8ae0b62e4e60366837e340f42279225a76704093) to trim wire-level whitespace before removing trailing directory separators, centralizing path normalization.
> - Adds `uniqueProjectEntries` to collapse duplicate paths across file, directory, and mixed search results, with directory entries taking precedence over file entries on collision.
> - Behavioral Change: mixed and file search results may now return fewer entries than before deduplication, and `truncated` can be true even when the raw item count is under the limit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 378f54f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->