### PR TITLE
feat(swift-ios): show build identity in settings

### DIFF
--- a/apps/swift-ios/Features/Settings/SettingsView.swift
+++ b/apps/swift-ios/Features/Settings/SettingsView.swift
@@ -169,6 +169,12 @@ public struct SettingsView: View {
                 settingsDivider
                 SettingsValueRow(title: "Platform", value: "Native SwiftUI")
                 settingsDivider
+                SettingsValueRow(title: "Version", value: appVersionLabel)
+                if let appCommit {
+                    settingsDivider
+                    SettingsValueRow(title: "Commit", value: appCommit)
+                }
+                settingsDivider
                 Link(destination: URL(string: "https://github.com/pingdotgg/t3code")!) {
                     SettingsNavigationRow(
                         title: "Open source",
@@ -191,6 +197,21 @@ public struct SettingsView: View {
     private var appDisplayName: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
             ?? "T3 Code SwiftUI"
+    }
+
+    private var appVersionLabel: String {
+        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+            ?? "?"
+        let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+            ?? "?"
+        return "\(version) (\(build))"
+    }
+
+    private var appCommit: String? {
+        guard let commit = Bundle.main.object(forInfoDictionaryKey: "T3GitCommit") as? String,
+              commit.isEmpty == false,
+              commit.hasPrefix("$(") == false else { return nil }
+        return String(commit.prefix(8))
     }
 
     private var canSave: Bool {

--- a/apps/swift-ios/Resources/Info.plist
+++ b/apps/swift-ios/Resources/Info.plist
@@ -34,6 +34,8 @@
             </dict>
         </dict>
     </dict>
+    <key>T3GitCommit</key>
+    <string>$(T3_GIT_COMMIT)</string>
     <key>T3ConnectClerkJWTTemplate</key>
     <string>$(T3CODE_CLERK_JWT_TEMPLATE)</string>
     <key>T3ConnectClerkPublishableKey</key>


### PR DESCRIPTION
Adds the running build's identity to the Settings → About section, so a screenshot or a
tester's description is enough to tell exactly which build is on a device.

## Behavior

- **Version** row, always shown: `CFBundleShortVersionString (CFBundleVersion)` — e.g. `0.1.0 (29)`.
- **Commit** row, shown only when a commit was injected at build time: the first 8 characters
  of a new `T3GitCommit` Info.plist key, which expands from a `T3_GIT_COMMIT` build setting.

The Commit row **fails closed**. `T3_GIT_COMMIT` is not declared in the project, so an ordinary
`xcodebuild` run leaves `T3GitCommit` as an empty string and the row is omitted entirely — no
empty value, no orphaned separator, and no literal `$(T3_GIT_COMMIT)` leaking into the UI. The
guard rejects a missing key, an empty string, and an unexpanded `$(`-prefixed value, so it also
stays correct if `INFOPLIST_EXPAND_BUILD_SETTINGS` is ever turned off. Injecting the value is
opt-in:

```
xcodebuild … T3_GIT_COMMIT=$(git rev-parse HEAD)
```

`Resources/Info.plist` is wired to the app target only — the widget and share extensions have
their own plists — so the new key does not reach the extensions.

## Evidence

Verified on an iOS 26.5 simulator in **both** configurations. Each check is a raw
`xcrun simctl io … screenshot`, and in each case the installed `T3Code.app/T3Code.debug.dylib`
was SHA-256-verified against the local build product immediately before capture. The two builds
produce different dylib hashes, confirming they are genuinely different products rather than one
build screenshotted twice.

**1. With a commit injected** — `T3_GIT_COMMIT=c334e57db4fb2e0b3b715a9cb5d849964b4608f8`
(the head of this branch). The About section reads:

```
App        T3 Swift Dev
Platform   Native SwiftUI
Version    0.1.0 (29)
Commit     c334e57d
Open source                    ↗
```

`c334e57d` is the first 8 characters of that SHA, and `0.1.0 (29)` matches
`CFBundleShortVersionString` / `CFBundleVersion` in the installed bundle.

**2. Plain build, no injection** — what CI and a default checkout produce. `plutil` confirms
`"T3GitCommit" => ""` in the built app, and the About section reads:

```
App        T3 Swift Dev
Platform   Native SwiftUI
Version    0.1.0 (29)
Open source                    ↗
```

The `Commit` row is absent and the separator between `Version` and `Open source` renders
normally — no double rule, no blank row.

Both builds: `xcodebuild … -scheme T3Code -configuration Debug` against
`platform=iOS Simulator`, real exit status **0** each. Screenshots are retained as build
artifacts on my side (SHA-256 `54b7352e…12bd` injected, `7ddd81c5…6e19f` plain); both cases
reproduce from the two commands above if you want to see them directly.

**On automated tests:** none added. The two computed properties are `private` members of
`SettingsView` reading `Bundle.main` directly, so they are unreachable from the test target even
under `@testable import` (which exposes `internal`, not `private`), and there is no injection
seam for the bundle. Adding coverage would mean changing production code — raising access levels
or extracting a bundle-injectable helper — which is a larger change than the behavior warrants
here. I verified the logic empirically instead, in both configurations above. Happy to extract a
testable helper if you'd prefer that shape.

## Notes for review

- This behavior is not new to me in practice: it has been running on my own device for some time
  through a personal Test-identity overlay, which is how I've been identifying builds day to day.
  That is long-standing real-world use rather than formal QA of this exact commit, so please read
  it as "this has been lived with", not as a substitute for your review.
- An independent **GPT-5.6 Sol** review is scheduled against this exact head
  (`c334e57db4fb2e0b3b715a9cb5d849964b4608f8`) after the 2026-08-20T03:29Z quota reset. I'll post
  its findings here; it has not run yet, so nothing in this PR has been cross-provider reviewed
  so far.
- One nit I noticed and deliberately left alone to keep the diff minimal: the surrounding `T3*`
  keys in `Resources/Info.plist` are alphabetized, and `T3GitCommit` is inserted before
  `T3ConnectClerkJWTTemplate` rather than after `T3ConnectRelayHTTPURL`. Say the word and I'll
  reorder it.

Coordination trace: T3 thread C2F820E6-CF27-4AD2-B4D7-9D7CB887E044 · saphid/t3code-personal#114

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Settings UI and Info.plist metadata only; no auth, networking, or data-path changes.
> 
> **Overview**
> **Settings → About** now surfaces which build is running: a **Version** row (`short version (build)`) and an optional **Commit** row (first 8 chars of the injected git SHA).
> 
> The commit comes from a new **`T3GitCommit`** Info.plist entry expanded from **`T3_GIT_COMMIT`** at build time (e.g. `xcodebuild … T3_GIT_COMMIT=$(git rev-parse HEAD)`). If the value is missing, empty, or still an unexpanded `$(…)` placeholder, the Commit row and its divider are omitted so default/CI builds stay clean.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b79847467cf6b05cfc574a70d23184b9b4cdbbcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show app version, build number, and git commit in iOS Settings
> - Adds Version and Commit rows to the About section in [SettingsView.swift](https://github.com/pingdotgg/t3code/pull/7355/files#diff-88d0cb55b5c03664b6d39d144cac600aca5e2e2208dc02fb7a932001b666d2c2), formatted as `version (build)` and an 8-character commit hash respectively.
> - The commit hash is read from a new `T3GitCommit` key in [Info.plist](https://github.com/pingdotgg/t3code/pull/7355/files#diff-4b717ba775c07089dcadbe8bb8cb6253b1ce8f7457f8398e9613d2e46ce55117), injected at build time via the `T3_GIT_COMMIT` build setting.
> - The Commit row is hidden when the value is missing, empty, or unresolved (starts with `$(`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b798474.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->