### PR TITLE
fix(server): stop routine events from rescanning thread history

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -174,6 +174,78 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
         assert.equal(row.lastAppliedSequence, 3);
       }
 
+      // Assistant messages and routine activities only update the shell timestamp.
+      // A summary refresh would produce a second projection_threads update.
+      yield* sql`CREATE TABLE thread_shell_update_count (count INTEGER NOT NULL)`;
+      yield* sql`INSERT INTO thread_shell_update_count (count) VALUES (0)`;
+      yield* sql`
+        CREATE TRIGGER count_thread_shell_updates
+        AFTER UPDATE ON projection_threads
+        WHEN NEW.thread_id = 'thread-1'
+        BEGIN
+          UPDATE thread_shell_update_count SET count = count + 1;
+        END;
+      `;
+
+      yield* eventStore.append({
+        type: "thread.message-sent",
+        eventId: EventId.make("evt-assistant-update"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-1"),
+        occurredAt: "2026-01-01T00:00:00.100Z",
+        commandId: CommandId.make("cmd-assistant-update"),
+        causationEventId: null,
+        correlationId: CommandId.make("cmd-assistant-update"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-1"),
+          messageId: MessageId.make("message-2"),
+          role: "assistant",
+          text: "more work",
+          turnId: null,
+          streaming: false,
+          createdAt: "2026-01-01T00:00:00.100Z",
+          updatedAt: "2026-01-01T00:00:00.100Z",
+        },
+      });
+      yield* projectionPipeline.bootstrap;
+      let threadUpdateRows = yield* sql<{ readonly count: number }>`
+        SELECT count FROM thread_shell_update_count
+      `;
+      assert.deepEqual(threadUpdateRows, [{ count: 1 }]);
+
+      yield* sql`UPDATE thread_shell_update_count SET count = 0`;
+      yield* eventStore.append({
+        type: "thread.activity-appended",
+        eventId: EventId.make("evt-routine-activity"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-1"),
+        occurredAt: "2026-01-01T00:00:00.200Z",
+        commandId: CommandId.make("cmd-routine-activity"),
+        causationEventId: null,
+        correlationId: CommandId.make("cmd-routine-activity"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-1"),
+          activity: {
+            id: EventId.make("activity-routine"),
+            tone: "tool",
+            kind: "tool.updated",
+            summary: "Tool made progress",
+            payload: {},
+            turnId: null,
+            createdAt: "2026-01-01T00:00:00.200Z",
+          },
+        },
+      });
+      yield* projectionPipeline.bootstrap;
+      threadUpdateRows = yield* sql<{ readonly count: number }>`
+        SELECT count FROM thread_shell_update_count
+      `;
+      assert.deepEqual(threadUpdateRows, [{ count: 1 }]);
+      yield* sql`DROP TRIGGER count_thread_shell_updates`;
+      yield* sql`DROP TABLE thread_shell_update_count`;
+
       // Settled lifecycle through the DB pipeline: thread.settled writes the
       // override + timestamp, thread.unsettled(user) flips to the active pin.
       yield* eventStore.append({

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -130,6 +130,28 @@ function isStalePendingApprovalFailureDetail(detail: string | null): boolean {
   );
 }
 
+function eventCanChangeThreadShellSummary(event: OrchestrationEvent): boolean {
+  // These are the only message and activity events that affect the fields
+  // derived by refreshThreadShellSummary.
+  if (event.type === "thread.message-sent") {
+    return event.payload.role === "user";
+  }
+  if (event.type !== "thread.activity-appended") {
+    return true;
+  }
+  switch (event.payload.activity.kind) {
+    case "approval.requested":
+    case "approval.resolved":
+    case "provider.approval.respond.failed":
+    case "user-input.requested":
+    case "user-input.resolved":
+    case "provider.user-input.respond.failed":
+      return true;
+    default:
+      return false;
+  }
+}
+
 function derivePendingUserInputCountFromActivities(
   activities: ReadonlyArray<ProjectionThreadActivity>,
 ): number {
@@ -865,7 +887,9 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             ...existingRow.value,
             updatedAt: event.occurredAt,
           });
-          yield* refreshThreadShellSummary(event.payload.threadId);
+          if (eventCanChangeThreadShellSummary(event)) {
+            yield* refreshThreadShellSummary(event.payload.threadId);
+          }
           return;
         }
 


### PR DESCRIPTION
Fixes #5719.

## What Changed

The threads projector no longer calls `refreshThreadShellSummary` for assistant messages or routine activities. Those events still update their normal projections and advance the thread's `updatedAt`, but they skip the second operation that reloads the thread's complete message, proposed-plan, activity, and approval histories.

The existing full refresh remains in place for events that can change the current shell summary:

- user messages
- approval and user-input lifecycle activities
- proposed plans and explicit approval/user-input responses
- session and latest-turn changes
- thread reverts

A focused projection-pipeline regression test verifies that an assistant message and a routine `tool.updated` activity each produce only the expected thread timestamp update, rather than that update followed by a summary rewrite.

## Why

`refreshThreadShellSummary` derives four fields: the latest user-message time, pending approval count, pending user-input count, and actionable-plan state. Assistant messages and ordinary tool/context activities cannot change any of them, but every such event currently reloads all four backing collections.

On a high-activity thread with 27,303 activities and 23,778 messages, activity projection averaged 734 ms per event. A burst of 526 routine activity and assistant-message events therefore accounted for approximately 386 seconds of serialized projection work, delaying unrelated threads behind the same global ingestion worker.

This change removes that measured hot path without changing summary derivation or introducing incremental counters.

Related: #5855 and #6608 address the same projection cost with broader changes. This PR intentionally keeps the existing summary implementation and only avoids invoking it for events that cannot affect its result.

## Verification

- `vp test run apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts` — 22 passed
- server typecheck passed
- targeted lint and formatting passed
- server bundle build passed
- `git diff --check` passed

No schema, projector cursor, transaction, replay, queue, client, or UI changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes; screenshots are not applicable
- [x] No animation or interaction changes; video is not applicable

Model and harness: GPT-5.6 Sol using the Codex harness in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop assistant messages and routine activities from rescanning thread history
> - Adds `eventCanChangeThreadShellSummary` in [ProjectionPipeline.ts](https://github.com/pingdotgg/t3code/pull/7356/files#diff-fd69e677e48d4705b0235085da8402910510d529ec5a507d804037a88fca07f4) to gate calls to `refreshThreadShellSummary`. Only user messages and specific activity kinds (`approval.requested`, `approval.resolved`, `user-input.requested`, etc.) qualify.
> - Assistant messages and routine activities (e.g. `tool.updated`) now only update the thread shell `updatedAt` timestamp instead of triggering a full summary refresh.
> - Behavioral Change: previously every `thread.message-sent` and `thread.activity-appended` event caused a summary rescan; now only a subset does.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 77b586e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which events recompute thread list/shell summary fields; incorrect gating could leave stale pending counts or user-message timestamps, though existing tests cover approval/user-input paths and the new assistant/tool cases.
> 
> **Overview**
> **Skips expensive thread shell summary rescans** for assistant messages and routine activities (e.g. `tool.updated`) during orchestration projection, while still bumping the thread shell `updatedAt`.
> 
> Adds `eventCanChangeThreadShellSummary` in `ProjectionPipeline.ts` so `refreshThreadShellSummary` runs only when an event can change derived fields (latest user message time, pending approvals/user input, actionable plans). User messages and approval/user-input lifecycle activities still trigger a full refresh; proposed plans and explicit response events behave as before.
> 
> A regression test uses a SQLite trigger on `projection_threads` to assert assistant messages and routine activities cause a single row update (timestamp only), not a second update from summary refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77b586e3eaa35db26fccbe68a60e4a936a964e77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->