### PR TITLE
fix(web): revalidate file previews on reopen

### DIFF
--- a/apps/web/src/components/files/projectFilesQueryState.test.ts
+++ b/apps/web/src/components/files/projectFilesQueryState.test.ts
@@ -1,13 +1,16 @@
 import type { ProjectReadFileResult } from "@t3tools/contracts";
 import { EnvironmentId } from "@t3tools/contracts";
+import { AsyncResult } from "effect/unstable/reactivity";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import {
   clearProjectFileQueryData,
   confirmProjectFileQueryData,
   getOptimisticProjectFileQueryData,
+  hasSettledProjectFileRevalidation,
   resolveProjectFileQueryData,
   setProjectFileQueryData,
+  shouldRevalidateProjectFileOnMount,
 } from "./projectFilesQueryState";
 
 const environmentId = EnvironmentId.make("environment-project-files-query-test");
@@ -47,5 +50,45 @@ describe("project files queries", () => {
     expect(
       confirmProjectFileQueryData(environmentId, "/repo", "convex.json", '{"nodeVersion":"22"}'),
     ).toBe(true);
+  });
+
+  it("keeps confirmed optimistic data until a later read settles successfully", () => {
+    const confirmedAgainst = AsyncResult.success({
+      relativePath: "convex.json",
+      contents: '{"nodeVersion":"20"}',
+      byteLength: 20,
+      truncated: false,
+    });
+    const refreshed = {
+      relativePath: "convex.json",
+      contents: '{"nodeVersion":"22"}',
+      byteLength: 20,
+      truncated: false,
+    } satisfies ProjectReadFileResult;
+
+    expect(
+      hasSettledProjectFileRevalidation(
+        confirmedAgainst,
+        AsyncResult.success(refreshed, { waiting: true }),
+      ),
+    ).toBe(false);
+    expect(
+      hasSettledProjectFileRevalidation(confirmedAgainst, AsyncResult.success(refreshed)),
+    ).toBe(true);
+  });
+
+  it("revalidates settled cached file data when the preview mounts", () => {
+    const cached = {
+      relativePath: "convex.json",
+      contents: '{"nodeVersion":"20"}',
+      byteLength: 20,
+      truncated: false,
+    } satisfies ProjectReadFileResult;
+
+    expect(shouldRevalidateProjectFileOnMount(AsyncResult.initial(false))).toBe(false);
+    expect(shouldRevalidateProjectFileOnMount(AsyncResult.success(cached, { waiting: true }))).toBe(
+      false,
+    );
+    expect(shouldRevalidateProjectFileOnMount(AsyncResult.success(cached))).toBe(true);
   });
 });

--- a/apps/web/src/components/files/projectFilesQueryState.ts
+++ b/apps/web/src/components/files/projectFilesQueryState.ts
@@ -7,7 +7,7 @@ import type {
 import * as Cause from "effect/Cause";
 import * as Option from "effect/Option";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 
 import { appAtomRegistry } from "~/rpc/atomRegistry";
 import { projectEnvironment } from "~/state/projects";
@@ -115,6 +115,24 @@ export function clearProjectFileQueryData(
   appAtomRegistry.set(optimisticFileAtom(environmentId, cwd, relativePath), null);
 }
 
+export function hasSettledProjectFileRevalidation(
+  confirmedAgainst: object | null | undefined,
+  result: AsyncResult.AsyncResult<ProjectReadFileResult, unknown>,
+): boolean {
+  return (
+    confirmedAgainst !== undefined &&
+    result !== confirmedAgainst &&
+    result._tag === "Success" &&
+    !result.waiting
+  );
+}
+
+export function shouldRevalidateProjectFileOnMount(
+  result: AsyncResult.AsyncResult<ProjectReadFileResult, unknown>,
+): boolean {
+  return result._tag !== "Initial" && !result.waiting;
+}
+
 function errorMessage<A>(result: AsyncResult.AsyncResult<A, unknown>): string | null {
   if (result._tag !== "Failure") return null;
   const cause = Cause.squash(result.cause);
@@ -185,13 +203,36 @@ export function useProjectFileQuery(
   const refreshAtom = useAtomRefresh(atom);
   const refresh = useCallback(() => refreshAtom(), [refreshAtom]);
   const data = Option.getOrNull(AsyncResult.value(result));
-  const optimisticResult = useAtomValue(
-    optimisticFileAtom(environmentId, cwd, relativePath ?? EMPTY_PROJECT_FILE_PATH),
+  const optimisticAtom = optimisticFileAtom(
+    environmentId,
+    cwd,
+    relativePath ?? EMPTY_PROJECT_FILE_PATH,
   );
+  const optimisticResult = useAtomValue(optimisticAtom);
   const optimisticFile = relativePath === null ? null : optimisticResult;
+  const revalidationSettled = hasSettledProjectFileRevalidation(
+    optimisticFile?.confirmedAgainst,
+    result,
+  );
+
+  useEffect(() => {
+    if (!enabled || relativePath === null) return;
+    const current = appAtomRegistry.get(atom);
+    // Mounting starts initial and stale queries. Force a read only when mount
+    // reused a still-fresh cache entry that would otherwise skip the disk.
+    if (!shouldRevalidateProjectFileOnMount(current)) return;
+    refreshAtom();
+  }, [atom, enabled, refreshAtom, relativePath]);
+
+  useEffect(() => {
+    // A new local draft can replace the confirmed entry before this effect
+    // runs. Clear only the entry whose revalidation just settled.
+    if (!revalidationSettled || appAtomRegistry.get(optimisticAtom) !== optimisticFile) return;
+    appAtomRegistry.set(optimisticAtom, null);
+  }, [optimisticAtom, optimisticFile, revalidationSettled]);
 
   return {
-    data: optimisticFile?.data ?? data,
+    data: revalidationSettled ? data : (optimisticFile?.data ?? data),
     error: errorMessage(result),
     isPending: result.waiting,
     refresh,


### PR DESCRIPTION
## What this does

File previews now re-read the workspace file when the preview mounts instead of trusting a fresh client cache entry. Confirmed editor content remains protected while a read is in flight or fails, but a later successful disk read can no longer be hidden by old optimistic state.

Fixes #5779.
Fixes #5866.

## Verification

- `pnpm exec vp test run apps/web/src/components/files/projectFilesQueryState.test.ts` (3 tests passed)
- `pnpm --filter @t3tools/web typecheck`
- Targeted Vite+ lint and formatting checks for both changed files

## Intentional decisions

This fix revalidates on preview mount and keeps the existing short-lived query cache for other consumers. Live filesystem watching and workspace-tree rescans remain separate concerns.

Generated with GPT-5.6 in the Codex harness through T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared file query/optimistic merge logic used by previews and t3.json reads; wrong timing could flash stale content or drop drafts, but changes are localized with new unit tests.
> 
> **Overview**
> **File previews** no longer show stale disk content when reopening a file that still has a fresh in-memory cache entry. `useProjectFileQuery` now triggers a refresh on mount when the query atom already holds settled success data, so the preview re-reads from the workspace instead of skipping I/O.
> 
> **Confirmed optimistic editor content** stays visible while a background revalidation is in flight or fails. New helpers (`hasSettledProjectFileRevalidation`, `shouldRevalidateProjectFileOnMount`) gate when server data replaces optimistic data and when mount-time refresh runs. Optimistic state is cleared only after a successful, non-waiting read that differs from what was confirmed—not immediately on confirm in all cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a59f1731e44f66cb56cec9d9682305f8aa419b4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix file preview revalidation on reopen in `useProjectFileQuery`
> - `useProjectFileQuery` now triggers a cache refresh on mount when a settled cached result exists, ensuring file previews reflect disk state when reopened rather than serving stale cached data.
> - Adds `hasSettledProjectFileRevalidation` to detect when a revalidation read has completed successfully relative to a prior confirmed result, and `shouldRevalidateProjectFileOnMount` to determine if a mount should trigger revalidation.
> - Once revalidation settles, the optimistic entry is cleared (only if it hasn't been replaced by a newer draft) and confirmed data is returned instead of the optimistic draft.
> - Behavioral Change: file previews that previously showed cached optimistic data on reopen will now show confirmed disk data after revalidation completes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a59f173.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->