### PR TITLE
fix(files): rescan workspace from refresh actions

### DIFF
--- a/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
+++ b/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
@@ -42,6 +42,7 @@ import { FileTreeBrowser } from "./FileTreeBrowser";
 import { preloadWorkspaceFileContents } from "./preload-workspace-file";
 import { SourceFileSurface } from "./SourceFileSurface";
 import { ThreadFileNavigatorPane } from "./thread-file-navigator-pane";
+import { useProjectEntriesRefresh } from "./use-project-entries-refresh";
 import { WorkspaceFileImagePreview } from "./WorkspaceFileImagePreview";
 import { WorkspaceFileWebPreview } from "./WorkspaceFileWebPreview";
 import {
@@ -259,6 +260,7 @@ export function ThreadFilesTreeScreen(props: ThreadFilesRouteScreenProps) {
         })
       : null,
   );
+  const entriesRefresh = useProjectEntriesRefresh(environmentId, cwd);
   const entriesData = entriesQuery.data as ProjectListEntriesResult | null;
   const handleReturnToThread = useCallback(() => {
     if (navigation.canGoBack()) {
@@ -408,7 +410,7 @@ export function ThreadFilesTreeScreen(props: ThreadFilesRouteScreenProps) {
               {
                 accessibilityLabel: "Refresh files",
                 icon: "arrow.clockwise",
-                onPress: entriesQuery.refresh,
+                onPress: entriesRefresh.refresh,
               },
             ]}
           />
@@ -451,11 +453,11 @@ export function ThreadFilesTreeScreen(props: ThreadFilesRouteScreenProps) {
       <FileTreeBrowser
         entries={entriesData?.entries ?? []}
         error={entriesQuery.error}
-        isPending={entriesQuery.isPending}
+        isPending={entriesQuery.isPending || entriesRefresh.isRefreshing}
         searchQuery={searchQuery}
         selectedPath={null}
         onPreviewFile={handlePreviewFile}
-        onRefresh={entriesQuery.refresh}
+        onRefresh={entriesRefresh.refresh}
         onSelectFile={handleSelectFile}
       />
       <FilesToolbarBottomFade />

--- a/apps/mobile/src/features/files/thread-file-navigator-pane.tsx
+++ b/apps/mobile/src/features/files/thread-file-navigator-pane.tsx
@@ -18,6 +18,7 @@ import { useEnvironmentQuery } from "../../state/query";
 import { useAppearancePreferences } from "../settings/appearance/AppearancePreferencesProvider";
 import { FileTreeBrowser } from "./FileTreeBrowser";
 import { preloadWorkspaceFileContents } from "./preload-workspace-file";
+import { useProjectEntriesRefresh } from "./use-project-entries-refresh";
 
 export function ThreadFileNavigatorPane(props: {
   readonly cwd: string;
@@ -39,6 +40,7 @@ export function ThreadFileNavigatorPane(props: {
       input: { cwd: props.cwd },
     }),
   );
+  const entriesRefresh = useProjectEntriesRefresh(props.environmentId, props.cwd);
   const entriesData = entriesQuery.data as ProjectListEntriesResult | null;
   const handlePreviewFile = useCallback(
     (relativePath: string) => {
@@ -58,25 +60,25 @@ export function ThreadFileNavigatorPane(props: {
           accessibilityLabel: "Refresh files",
           icon: { name: "arrow.clockwise", type: "sfSymbol" as const },
           identifier: "thread-file-navigator-refresh",
-          onPress: entriesQuery.refresh,
+          onPress: entriesRefresh.refresh,
           sharesBackground: false,
           tintColor: foregroundColor,
           type: "button" as const,
           width: 44,
         },
       ] as ComponentProps<typeof ScreenStackHeaderConfig>["headerRightBarButtonItems"],
-    [entriesQuery.refresh, foregroundColor],
+    [entriesRefresh.refresh, foregroundColor],
   );
 
   const fileTree = (
     <FileTreeBrowser
       entries={entriesData?.entries ?? []}
       error={entriesQuery.error}
-      isPending={entriesQuery.isPending}
+      isPending={entriesQuery.isPending || entriesRefresh.isRefreshing}
       searchQuery={searchQuery}
       selectedPath={props.selectedPath}
       onPreviewFile={handlePreviewFile}
-      onRefresh={entriesQuery.refresh}
+      onRefresh={entriesRefresh.refresh}
       onSelectFile={props.onSelectFile}
     />
   );
@@ -150,7 +152,7 @@ export function ThreadFileNavigatorPane(props: {
             accessibilityLabel="Refresh files"
             hitSlop={8}
             className="h-8 w-8 items-center justify-center rounded-full active:bg-subtle"
-            onPress={entriesQuery.refresh}
+            onPress={entriesRefresh.refresh}
           >
             <SymbolView name="arrow.clockwise" size={14} tintColor={iconColor} type="monochrome" />
           </Pressable>

--- a/apps/mobile/src/features/files/use-project-entries-refresh.ts
+++ b/apps/mobile/src/features/files/use-project-entries-refresh.ts
@@ -12,12 +12,12 @@ export function useProjectEntriesRefresh(
   const requestIdRef = useRef(0);
   const [isRefreshing, setIsRefreshing] = useState(false);
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    setIsRefreshing(false);
+    return () => {
       requestIdRef.current += 1;
-    },
-    [],
-  );
+    };
+  }, [cwd, environmentId]);
 
   const refresh = useCallback(() => {
     if (environmentId === null || cwd === null) return;

--- a/apps/mobile/src/features/files/use-project-entries-refresh.ts
+++ b/apps/mobile/src/features/files/use-project-entries-refresh.ts
@@ -1,0 +1,34 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { projectEnvironment } from "../../state/projects";
+import { useAtomCommand } from "../../state/use-atom-command";
+
+export function useProjectEntriesRefresh(
+  environmentId: EnvironmentId | null,
+  cwd: string | null,
+): { readonly isRefreshing: boolean; readonly refresh: () => void } {
+  const runRefresh = useAtomCommand(projectEnvironment.refreshEntries);
+  const requestIdRef = useRef(0);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  useEffect(
+    () => () => {
+      requestIdRef.current += 1;
+    },
+    [],
+  );
+
+  const refresh = useCallback(() => {
+    if (environmentId === null || cwd === null) return;
+    const requestId = ++requestIdRef.current;
+    setIsRefreshing(true);
+    void runRefresh({ environmentId, input: { cwd } }).finally(() => {
+      if (requestIdRef.current === requestId) {
+        setIsRefreshing(false);
+      }
+    });
+  }, [cwd, environmentId, runRefresh]);
+
+  return { isRefreshing, refresh };
+}

--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -77,6 +77,7 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.sourceControlCloneRepository]: AuthOrchestrationOperateScope,
   [WS_METHODS.sourceControlPublishRepository]: AuthOrchestrationOperateScope,
   [WS_METHODS.projectsListEntries]: AuthOrchestrationReadScope,
+  [WS_METHODS.projectsRefreshEntries]: AuthOrchestrationReadScope,
   [WS_METHODS.projectsReadFile]: AuthOrchestrationReadScope,
   [WS_METHODS.projectsSearchContents]: AuthOrchestrationReadScope,
   [WS_METHODS.projectsSearchEntries]: AuthOrchestrationReadScope,

--- a/apps/server/src/workspace/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.test.ts
@@ -121,6 +121,27 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
         expect(result.truncated).toBe(false);
       }),
     );
+
+    it.effect("rescans files created after the workspace index was cached", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-list-refresh-" });
+        yield* writeTextFile(cwd, "existing.txt");
+
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        yield* workspaceEntries.list({ cwd });
+        yield* writeTextFile(cwd, "created-after-list.txt");
+
+        const cached = yield* workspaceEntries.list({ cwd });
+        expect(cached.entries.some((entry) => entry.path === "created-after-list.txt")).toBe(false);
+
+        yield* workspaceEntries.refresh(cwd);
+        const refreshed = yield* workspaceEntries.list({ cwd });
+        expect(refreshed.entries).toContainEqual({
+          path: "created-after-list.txt",
+          kind: "file",
+        });
+      }),
+    );
   });
 
   describe("search", () => {

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1804,6 +1804,10 @@ const makeWsRpcLayer = (
             ),
             { "rpc.aggregate": "workspace" },
           ),
+        [WS_METHODS.projectsRefreshEntries]: (input) =>
+          observeRpcEffect(WS_METHODS.projectsRefreshEntries, workspaceEntries.refresh(input.cwd), {
+            "rpc.aggregate": "workspace",
+          }),
         [WS_METHODS.projectsReadFile]: (input) =>
           observeRpcEffect(
             WS_METHODS.projectsReadFile,

--- a/apps/web/src/components/files/projectFilesQueryState.ts
+++ b/apps/web/src/components/files/projectFilesQueryState.ts
@@ -7,12 +7,13 @@ import type {
 import * as Cause from "effect/Cause";
 import * as Option from "effect/Option";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { appAtomRegistry } from "~/rpc/atomRegistry";
 import { projectEnvironment } from "~/state/projects";
 import { useProjectPathSearch } from "~/state/queries";
 import { executeAtomQuery } from "@t3tools/client-runtime/state/runtime";
+import { useAtomCommand } from "~/state/use-atom-command";
 
 const EMPTY_PROJECT_FILE_PATH = "";
 const EMPTY_PROJECT_FILE_QUERY_ATOM = Atom.make(
@@ -127,12 +128,28 @@ export function useProjectEntriesQuery(
 ): ProjectQueryState<ProjectListEntriesResult> {
   const atom = getProjectEntriesQueryAtom(environmentId, cwd);
   const result = useAtomValue(atom);
-  const refreshAtom = useAtomRefresh(atom);
-  const refresh = useCallback(() => refreshAtom(), [refreshAtom]);
+  const runRefresh = useAtomCommand(projectEnvironment.refreshEntries);
+  const refreshRequestId = useRef(0);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  useEffect(
+    () => () => {
+      refreshRequestId.current += 1;
+    },
+    [],
+  );
+  const refresh = useCallback(() => {
+    const requestId = ++refreshRequestId.current;
+    setIsRefreshing(true);
+    void runRefresh({ environmentId, input: { cwd } }).finally(() => {
+      if (refreshRequestId.current === requestId) {
+        setIsRefreshing(false);
+      }
+    });
+  }, [cwd, environmentId, runRefresh]);
   return {
     data: Option.getOrNull(AsyncResult.value(result)),
     error: errorMessage(result),
-    isPending: result.waiting,
+    isPending: result.waiting || isRefreshing,
     refresh,
   };
 }

--- a/apps/web/src/components/files/projectFilesQueryState.ts
+++ b/apps/web/src/components/files/projectFilesQueryState.ts
@@ -131,12 +131,12 @@ export function useProjectEntriesQuery(
   const runRefresh = useAtomCommand(projectEnvironment.refreshEntries);
   const refreshRequestId = useRef(0);
   const [isRefreshing, setIsRefreshing] = useState(false);
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    setIsRefreshing(false);
+    return () => {
       refreshRequestId.current += 1;
-    },
-    [],
-  );
+    };
+  }, [cwd, environmentId]);
   const refresh = useCallback(() => {
     const requestId = ++refreshRequestId.current;
     setIsRefreshing(true);

--- a/packages/client-runtime/src/state/projectCommands.ts
+++ b/packages/client-runtime/src/state/projectCommands.ts
@@ -1,5 +1,6 @@
 import { type EnvironmentId, type ProjectReadFileResult, WS_METHODS } from "@t3tools/contracts";
 import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
 import { Atom } from "effect/unstable/reactivity";
 
 import {
@@ -43,6 +44,7 @@ export function createProjectEnvironmentAtoms<R, E>(
   runtime: Atom.AtomRuntime<EnvironmentRegistry | Crypto.Crypto | R, E>,
 ) {
   const projectScheduler = createAtomCommandScheduler();
+  const entriesScheduler = createAtomCommandScheduler();
   const fileScheduler = createAtomCommandScheduler();
   const optimisticFileFamily = Atom.family((key: string) =>
     Atom.make<OptimisticProjectFile | null>(null).pipe(
@@ -54,18 +56,33 @@ export function createProjectEnvironmentAtoms<R, E>(
     key: ({ environmentId, input }: { environmentId: string; input: { projectId: string } }) =>
       JSON.stringify([environmentId, input.projectId]),
   };
+  const listEntries = createEnvironmentRpcQueryAtomFamily(runtime, {
+    label: "environment-data:projects:list-entries",
+    tag: WS_METHODS.projectsListEntries,
+    staleTimeMs: 30_000,
+    idleTtlMs: 5 * 60_000,
+  });
+  const refreshEntries = createEnvironmentRpcCommand(runtime, {
+    label: "environment-data:projects:refresh-entries",
+    tag: WS_METHODS.projectsRefreshEntries,
+    scheduler: entriesScheduler,
+    concurrency: {
+      mode: "singleFlight",
+      key: ({ environmentId, input }) => JSON.stringify([environmentId, input.cwd]),
+    },
+    onSuccess: ({ environmentId, input }, registry) =>
+      Effect.sync(() => {
+        registry.refresh(listEntries({ environmentId, input }));
+      }),
+  });
   return {
     searchEntries: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:projects:search-entries",
       tag: WS_METHODS.projectsSearchEntries,
       staleTimeMs: 15_000,
     }),
-    listEntries: createEnvironmentRpcQueryAtomFamily(runtime, {
-      label: "environment-data:projects:list-entries",
-      tag: WS_METHODS.projectsListEntries,
-      staleTimeMs: 30_000,
-      idleTtlMs: 5 * 60_000,
-    }),
+    listEntries,
+    refreshEntries,
     readFile: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:projects:read-file",
       tag: WS_METHODS.projectsReadFile,

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -199,6 +199,7 @@ export const WS_METHODS = {
   projectsAdd: "projects.add",
   projectsRemove: "projects.remove",
   projectsListEntries: "projects.listEntries",
+  projectsRefreshEntries: "projects.refreshEntries",
   projectsReadFile: "projects.readFile",
   projectsSearchContents: "projects.searchContents",
   projectsSearchEntries: "projects.searchEntries",
@@ -636,6 +637,12 @@ export const WsProjectsListEntriesRpc = Rpc.make(WS_METHODS.projectsListEntries,
   error: Schema.Union([ProjectListEntriesError, EnvironmentAuthorizationError]),
 });
 
+export const WsProjectsRefreshEntriesRpc = Rpc.make(WS_METHODS.projectsRefreshEntries, {
+  payload: ProjectListEntriesInput,
+  success: Schema.Void,
+  error: EnvironmentAuthorizationError,
+});
+
 export const WsProjectsReadFileRpc = Rpc.make(WS_METHODS.projectsReadFile, {
   payload: ProjectReadFileInput,
   success: ProjectReadFileResult,
@@ -1027,6 +1034,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsSourceControlCloneRepositoryRpc,
   WsSourceControlPublishRepositoryRpc,
   WsProjectsListEntriesRpc,
+  WsProjectsRefreshEntriesRpc,
   WsProjectsReadFileRpc,
   WsProjectsSearchContentsRpc,
   WsProjectsSearchEntriesRpc,


### PR DESCRIPTION
## What this does

Refresh files now triggers a real server-side workspace index rescan before the clients reload the listing. Files created, renamed, moved, or deleted outside T3 become visible from the existing refresh controls on web, desktop, iOS, and Android, including remote environments.

Fixes #6452.

## Verification

- Focused WorkspaceEntries test: 31 passed
- Typechecks: contracts, client runtime, server, web, and mobile
- Targeted lint and format checks
- Diff and secret scans

## Intentional decisions

Normal list reads keep the cached index for performance. Only explicit refresh performs a scan. Repeated refreshes for the same environment and workspace share one in-flight scan. If a scan fails, the existing server service invalidates the cache so the follow-up read rebuilds it.

Generated with GPT-5.6 in the Codex harness through T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to explicit refresh UX and read-path RPC; list caching behavior for normal reads is unchanged, with a focused server test for rescan-after-cache.
> 
> **Overview**
> **File refresh** no longer only re-fetches the cached listing—it triggers a **server-side workspace index rescan** first, so files changed outside T3 show up when users hit existing refresh controls on web and mobile.
> 
> A new **`projects.refreshEntries`** RPC wires through **`WorkspaceEntries.refresh`**, with read-scope auth. The client adds a **`refreshEntries`** command (single-flight per environment + `cwd`) that **invalidates `listEntries`** after a successful scan; normal list reads stay cached for performance.
> 
> **Web** `useProjectEntriesQuery` and **mobile** `useProjectEntriesRefresh` call that command and keep the file tree in a pending state until the scan finishes, replacing prior local query-atom refresh behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6f120fec7270ae74dd4ac5ac76428ba30add506. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `projects.refreshEntries` RPC to rescan workspace from refresh actions
> - Introduces a new `projects.refreshEntries` WebSocket RPC (defined in [rpc.ts](https://github.com/pingdotgg/t3code/pull/7358/files#diff-64c16995299d1af309c72e94a298ffcb5c2ee5c65774cf0c73bf997358e9c266)) that triggers a server-side rescan of workspace directory entries.
> - Adds a `refreshEntries` command in [projectCommands.ts](https://github.com/pingdotgg/t3code/pull/7358/files#diff-bc687aa4d1b8d5f2fa74076e08007ba644d990eaac8550473b0ac9df2a0dd41c) with single-flight concurrency keyed by `[environmentId, cwd]`; on success, it invalidates the `listEntries` query cache.
> - Replaces direct query refresh calls in the mobile Files screen and navigator pane with a dedicated `useProjectEntriesRefresh` hook that tracks `isRefreshing` state and ignores stale completions when `environmentId` or `cwd` change.
> - Updates `useProjectEntriesQuery` on web to use the same command-based refresh instead of `useAtomRefresh`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b6f120f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->