### PR TITLE
fix(desktop): inherit Claude Bedrock environment

### DIFF
--- a/apps/desktop/src/backend/DesktopBackendConfiguration.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendConfiguration.test.ts
@@ -553,6 +553,40 @@ describe("DesktopBackendConfiguration", () => {
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
 
+  it.effect("resolveWsl forwards Claude Bedrock credentials across the WSL boundary", () =>
+    Effect.gen(function* () {
+      const previousBearerToken = process.env.AWS_BEARER_TOKEN_BEDROCK;
+      const previousRegion = process.env.AWS_REGION;
+      const previousUseBedrock = process.env.CLAUDE_CODE_USE_BEDROCK;
+      try {
+        process.env.AWS_BEARER_TOKEN_BEDROCK = "bedrock-token";
+        process.env.AWS_REGION = "us-west-2";
+        process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+
+        yield* withHarness(
+          Effect.gen(function* () {
+            const configuration = yield* DesktopBackendConfiguration.DesktopBackendConfiguration;
+            const config = yield* configuration.resolveWsl({
+              distro: "Ubuntu",
+              port: 4889,
+            });
+
+            assert.equal(config.env.AWS_BEARER_TOKEN_BEDROCK, "bedrock-token");
+            assert.equal(config.env.AWS_REGION, "us-west-2");
+            assert.equal(config.env.CLAUDE_CODE_USE_BEDROCK, "1");
+            assert.include(config.env.WSLENV ?? "", "AWS_BEARER_TOKEN_BEDROCK");
+            assert.include(config.env.WSLENV ?? "", "AWS_REGION");
+            assert.include(config.env.WSLENV ?? "", "CLAUDE_CODE_USE_BEDROCK");
+          }),
+        );
+      } finally {
+        restoreEnv("AWS_BEARER_TOKEN_BEDROCK", previousBearerToken);
+        restoreEnv("AWS_REGION", previousRegion);
+        restoreEnv("CLAUDE_CODE_USE_BEDROCK", previousUseBedrock);
+      }
+    }),
+  );
+
   it.effect(
     "resolvePrimary falls back to the Windows primary when wsl-only but WSL is unavailable",
     () =>

--- a/apps/desktop/src/backend/DesktopBackendConfiguration.ts
+++ b/apps/desktop/src/backend/DesktopBackendConfiguration.ts
@@ -91,7 +91,19 @@ const DESKTOP_BACKEND_ENV_NAMES = [
 // forward across the wsl.exe boundary without WSLENV. The dev-server URL is
 // handled separately via a `--dev-url` CLI flag because WSLENV translation of
 // URL-shaped values (colons / slashes) is unreliable.
-const WSL_FORWARDED_ENV_NAMES = ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"] as const;
+const WSL_FORWARDED_ENV_NAMES = [
+  "OPENAI_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "AWS_BEARER_TOKEN_BEDROCK",
+  "AWS_REGION",
+  "AWS_DEFAULT_REGION",
+  "AWS_PROFILE",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+  "CLAUDE_CODE_USE_BEDROCK",
+  "CLAUDE_CODE_SKIP_BEDROCK_AUTH",
+] as const;
 
 const WSL_SERVER_SYSTEM_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 

--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -129,6 +129,31 @@ describe("DesktopShellEnvironment", () => {
     }),
   );
 
+  it.effect("hydrates missing Claude Bedrock credentials from the login shell on macOS", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = {
+        SHELL: "/bin/zsh",
+        PATH: "/usr/bin",
+      };
+
+      yield* runShellEnvironment({
+        env,
+        platform: "darwin",
+        handler: () =>
+          envOutput({
+            PATH: "/opt/homebrew/bin:/usr/bin",
+            AWS_BEARER_TOKEN_BEDROCK: "bedrock-token",
+            AWS_REGION: "us-west-2",
+            CLAUDE_CODE_USE_BEDROCK: "1",
+          }),
+      });
+
+      assert.equal(env.AWS_BEARER_TOKEN_BEDROCK, "bedrock-token");
+      assert.equal(env.AWS_REGION, "us-west-2");
+      assert.equal(env.CLAUDE_CODE_USE_BEDROCK, "1");
+    }),
+  );
+
   it.effect("preserves inherited POSIX values when present", () =>
     Effect.gen(function* () {
       const env: NodeJS.ProcessEnv = {
@@ -344,6 +369,36 @@ describe("DesktopShellEnvironment", () => {
         env.FNM_MULTISHELL_PATH,
         "C:\\Users\\testuser\\AppData\\Local\\fnm_multishells\\123",
       );
+    }),
+  );
+
+  it.effect("hydrates missing Claude Bedrock credentials from the PowerShell profile", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = {
+        PATH: "C:\\Windows\\System32",
+        AWS_REGION: "eu-west-1",
+      };
+
+      yield* runShellEnvironment({
+        env,
+        platform: "win32",
+        handler: (command) => {
+          if (command._tag !== "StandardCommand") return "";
+          const loadProfile = !command.args.includes("-NoProfile");
+          return loadProfile
+            ? envOutput({
+                PATH: "C:\\Profile\\Node;C:\\Windows\\System32",
+                AWS_BEARER_TOKEN_BEDROCK: "bedrock-token",
+                AWS_REGION: "us-west-2",
+                CLAUDE_CODE_USE_BEDROCK: "1",
+              })
+            : envOutput({ PATH: "C:\\Windows\\System32" });
+        },
+      });
+
+      assert.equal(env.AWS_BEARER_TOKEN_BEDROCK, "bedrock-token");
+      assert.equal(env.AWS_REGION, "eu-west-1");
+      assert.equal(env.CLAUDE_CODE_USE_BEDROCK, "1");
     }),
   );
 

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -67,6 +67,17 @@ export class DesktopShellEnvironment extends Context.Service<
   }
 >()("@t3tools/desktop/shell/DesktopShellEnvironment") {}
 
+const CLAUDE_BEDROCK_ENV_NAMES = [
+  "AWS_BEARER_TOKEN_BEDROCK",
+  "AWS_REGION",
+  "AWS_DEFAULT_REGION",
+  "AWS_PROFILE",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+  "CLAUDE_CODE_USE_BEDROCK",
+  "CLAUDE_CODE_SKIP_BEDROCK_AUTH",
+] as const;
 const LOGIN_SHELL_ENV_NAMES = [
   "PATH",
   "DBUS_SESSION_BUS_ADDRESS",
@@ -85,8 +96,14 @@ const LOGIN_SHELL_ENV_NAMES = [
   "XDG_SESSION_DESKTOP",
   "XDG_SESSION_TYPE",
   "WAYLAND_DISPLAY",
+  ...CLAUDE_BEDROCK_ENV_NAMES,
 ] as const;
-const WINDOWS_PROFILE_ENV_NAMES = ["PATH", "FNM_DIR", "FNM_MULTISHELL_PATH"] as const;
+const WINDOWS_PROFILE_ENV_NAMES = [
+  "PATH",
+  "FNM_DIR",
+  "FNM_MULTISHELL_PATH",
+  ...CLAUDE_BEDROCK_ENV_NAMES,
+] as const;
 const LOCALE_ENV_NAMES = ["LANG", "LC_ALL", "LC_CTYPE"] as const;
 const FALLBACK_LC_CTYPE = "en_US.UTF-8";
 const WINDOWS_SHELL_CANDIDATES = ["pwsh.exe", "powershell.exe"] as const;
@@ -412,6 +429,11 @@ const installWindowsEnvironment = Effect.fn("desktop.shellEnvironment.installWin
     if (!config.env.FNM_MULTISHELL_PATH && profile.FNM_MULTISHELL_PATH) {
       config.env.FNM_MULTISHELL_PATH = profile.FNM_MULTISHELL_PATH;
     }
+    for (const name of CLAUDE_BEDROCK_ENV_NAMES) {
+      if (!config.env[name] && profile[name]) {
+        config.env[name] = profile[name];
+      }
+    }
   },
 );
 
@@ -448,6 +470,12 @@ const installPosixEnvironment = Effect.fn("desktop.shellEnvironment.installPosix
     }
     if (!config.env.SSH_AUTH_SOCK && shellEnvironment.SSH_AUTH_SOCK) {
       config.env.SSH_AUTH_SOCK = shellEnvironment.SSH_AUTH_SOCK;
+    }
+
+    for (const name of CLAUDE_BEDROCK_ENV_NAMES) {
+      if (!config.env[name] && shellEnvironment[name]) {
+        config.env[name] = shellEnvironment[name];
+      }
     }
 
     const shellPreferredEnvNames = [


### PR DESCRIPTION
## Background

Related to #4928.

When Claude Code uses Amazon Bedrock, both the provider status probe and actual sessions depend on AWS credential environment variables. When T3 Code is launched from a GUI entry point such as Finder, Electron does not naturally inherit `AWS_BEARER_TOKEN_BEDROCK`, the AWS region, or the Claude Code Bedrock flags from the user's login shell. The existing desktop environment hydration only restored variables such as PATH, locale, and SSH settings.

As a result, Claude Code configuration could still identify Bedrock as the active backend while the T3 server child process lacked the credentials needed to call it. The provider probe could appear unverified, and actual requests could fail.

Issue #4928 also describes managed Bedrock environments where SDK initialization returns no account information. This PR does not change the server-side authentication fallback strategy; it specifically fixes credential inheritance at the desktop process boundary.

## Changes

- Restore a controlled allowlist of AWS Bedrock credentials, region settings, and Claude Code Bedrock flags from the login shell on macOS and Linux.
- Restore the same variables from the PowerShell profile on Windows while preserving values already inherited by the desktop process.
- Forward these variables to the Windows WSL backend through the existing `WSLENV` mechanism.
- Add behavior coverage for macOS, Windows, and Windows-to-WSL propagation.

## Verification

- `git diff --check` passes.
- Targeted Vitest cases were added, but could not be executed because the current environment repeatedly failed while downloading the monorepo dependencies.

Model: GPT-5.6 Sol
Harness: T3 Code Codex