### PR TITLE
feat(swift-ios): surface recent projects in the project picker

### DIFF
--- a/apps/swift-ios/Features/Workspace/DailyUXModels.swift
+++ b/apps/swift-ios/Features/Workspace/DailyUXModels.swift
@@ -327,6 +327,39 @@ struct DailyUXRecentProject: Equatable {
     let project: FeatureProject
 }
 
+/// The project picker leads with the projects the account actually worked in
+/// most recently and keeps every remaining project below in the usual
+/// alphabetical order. A group appears in exactly one section so the list never
+/// repeats itself on the small project counts this picker normally shows.
+struct DailyUXProjectPickerSections: Equatable {
+    static let recentLimit = 3
+
+    let recents: [DailyUXProjectGroup]
+    let others: [DailyUXProjectGroup]
+
+    init(
+        groups: [DailyUXProjectGroup],
+        recentGroupIDs: [String],
+        limit: Int = DailyUXProjectPickerSections.recentLimit
+    ) {
+        let groupsByID = groups.reduce(into: [String: DailyUXProjectGroup]()) {
+            $0[$1.id] = $0[$1.id] ?? $1
+        }
+        var seenGroupIDs = Set<String>()
+        var ranked: [DailyUXProjectGroup] = []
+        for groupID in recentGroupIDs where ranked.count < max(0, limit) {
+            guard let group = groupsByID[groupID],
+                  seenGroupIDs.insert(group.id).inserted else {
+                continue
+            }
+            ranked.append(group)
+        }
+
+        recents = ranked
+        others = groups.filter { !seenGroupIDs.contains($0.id) }
+    }
+}
+
 struct DailyUXProjectGroup: Identifiable, Equatable {
     let id: String
     let name: String

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -147,6 +147,7 @@ public struct NewThreadView: View {
                 NewTaskProjectPicker(
                     groups: creationProjectGroups,
                     environments: model.snapshot.environments,
+                    recentGroupIDs: recentProjectGroupIDs,
                     selectionID: selectedProjectGroup?.id,
                     onSelect: { group in
                         if selectProjectGroup(group) {
@@ -296,6 +297,10 @@ public struct NewThreadView: View {
 
     private var creationProjectGroups: [DailyUXProjectGroup] {
         DailyUXCreationContext.projectGroups(in: model.snapshot)
+    }
+
+    private var recentProjectGroupIDs: [String] {
+        DailyUXCreationContext.recentProjects(in: model.snapshot).map(\.group.id)
     }
 
     private var selectedProjectGroup: DailyUXProjectGroup? {
@@ -961,6 +966,7 @@ private struct NewTaskProjectPicker: View {
     @SwiftUI.Environment(\.dismiss) private var dismiss
     let groups: [DailyUXProjectGroup]
     let environments: [FeatureEnvironment]
+    let recentGroupIDs: [String]
     let selectionID: String?
     let onSelect: (DailyUXProjectGroup) -> Void
 
@@ -974,46 +980,30 @@ private struct NewTaskProjectPicker: View {
                         description: Text("Reconnect an environment or add a project to continue.")
                     )
                 } else {
-                    List(groups) { group in
-                        Button {
-                            onSelect(group)
-                        } label: {
-                            HStack(alignment: .top, spacing: 12) {
-                                VStack(alignment: .leading, spacing: 3) {
-                                    Text(group.name)
-                                        .foregroundStyle(T3Colors.textPrimary)
-
-                                    ForEach(group.projects.prefix(2)) { project in
-                                        Text(projectLocation(project))
-                                            .font(T3Typography.supporting)
-                                            .foregroundStyle(T3Colors.textTertiary)
-                                            .lineLimit(1)
-                                            .truncationMode(.middle)
-                                    }
-
-                                    if group.projects.count > 2 {
-                                        Text("+\(group.projects.count - 2) more locations")
-                                            .font(T3Typography.supporting)
-                                            .foregroundStyle(T3Colors.textTertiary)
-                                    }
-                                }
-
-                                Spacer(minLength: 10)
-
-                                if group.id == selectionID {
-                                    Image(systemName: "checkmark")
-                                        .font(.system(size: 13, weight: .semibold))
-                                        .foregroundStyle(T3Colors.accent)
+                    let sections = DailyUXProjectPickerSections(
+                        groups: groups,
+                        recentGroupIDs: recentGroupIDs
+                    )
+                    List {
+                        if sections.recents.isEmpty {
+                            ForEach(sections.others) { group in
+                                projectRow(group)
+                            }
+                        } else {
+                            Section("Recent") {
+                                ForEach(sections.recents) { group in
+                                    projectRow(group)
                                 }
                             }
-                            .frame(minHeight: 46)
-                            .contentShape(Rectangle())
+
+                            if !sections.others.isEmpty {
+                                Section("Other projects") {
+                                    ForEach(sections.others) { group in
+                                        projectRow(group)
+                                    }
+                                }
+                            }
                         }
-                        .buttonStyle(.plain)
-                        .accessibilityAddTraits(
-                            group.id == selectionID ? .isSelected : []
-                        )
-                        .listRowBackground(T3Colors.background)
                     }
                     .listStyle(.plain)
                     .scrollContentBackground(.hidden)
@@ -1030,6 +1020,48 @@ private struct NewTaskProjectPicker: View {
         }
         .presentationDetents([.medium, .large])
         .presentationBackground(T3Colors.background)
+    }
+
+    private func projectRow(_ group: DailyUXProjectGroup) -> some View {
+        Button {
+            onSelect(group)
+        } label: {
+            HStack(alignment: .top, spacing: 12) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(group.name)
+                        .foregroundStyle(T3Colors.textPrimary)
+
+                    ForEach(group.projects.prefix(2)) { project in
+                        Text(projectLocation(project))
+                            .font(T3Typography.supporting)
+                            .foregroundStyle(T3Colors.textTertiary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+
+                    if group.projects.count > 2 {
+                        Text("+\(group.projects.count - 2) more locations")
+                            .font(T3Typography.supporting)
+                            .foregroundStyle(T3Colors.textTertiary)
+                    }
+                }
+
+                Spacer(minLength: 10)
+
+                if group.id == selectionID {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(T3Colors.accent)
+                }
+            }
+            .frame(minHeight: 46)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(
+            group.id == selectionID ? .isSelected : []
+        )
+        .listRowBackground(T3Colors.background)
     }
 
     private func projectLocation(_ project: FeatureProject) -> String {

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
@@ -839,6 +839,77 @@ struct DailyUXNewTaskTests {
         #expect(attachment.mimeType == "image/jpeg")
     }
 
+    @Test
+    func projectPickerLeadsWithRecentGroupsAndKeepsTheRestAlphabetical() {
+        let alpha = rankedProject("alpha", name: "Alpha")
+        let beta = rankedProject("beta", name: "Beta")
+        let gamma = rankedProject("gamma", name: "Gamma")
+        let delta = rankedProject("delta", name: "Delta")
+        let epsilon = rankedProject("epsilon", name: "Epsilon")
+        let value = rankedSnapshot(
+            projects: [gamma, alpha, epsilon, delta, beta],
+            threads: [
+                rankedThread("delta-thread", projectID: delta.id, activity: 40),
+                rankedThread("beta-thread", projectID: beta.id, activity: 30),
+                rankedThread("epsilon-thread", projectID: epsilon.id, activity: 20),
+                rankedThread("alpha-thread", projectID: alpha.id, activity: 10),
+            ]
+        )
+        let groups = DailyUXCreationContext.projectGroups(in: value)
+
+        let sections = DailyUXProjectPickerSections(
+            groups: groups,
+            recentGroupIDs: DailyUXCreationContext.recentProjects(in: value).map(\.group.id)
+        )
+
+        #expect(groups.map(\.name) == ["Alpha", "Beta", "Delta", "Epsilon", "Gamma"])
+        #expect(sections.recents.map(\.name) == ["Delta", "Beta", "Epsilon"])
+        #expect(sections.others.map(\.name) == ["Alpha", "Gamma"])
+        #expect(
+            Set(sections.recents.map(\.id))
+                .isDisjoint(with: Set(sections.others.map(\.id)))
+        )
+        #expect(sections.recents.count + sections.others.count == groups.count)
+    }
+
+    @Test
+    func projectPickerKeepsTheAlphabeticalListWhenNoProjectHasBeenUsed() {
+        let alpha = rankedProject("alpha", name: "Alpha")
+        let beta = rankedProject("beta", name: "Beta")
+        let value = rankedSnapshot(projects: [beta, alpha], threads: [])
+        let groups = DailyUXCreationContext.projectGroups(in: value)
+
+        let sections = DailyUXProjectPickerSections(
+            groups: groups,
+            recentGroupIDs: DailyUXCreationContext.recentProjects(in: value).map(\.group.id)
+        )
+
+        #expect(sections.recents.isEmpty)
+        #expect(sections.others.map(\.name) == ["Alpha", "Beta"])
+    }
+
+    @Test
+    func projectPickerRecentSectionIgnoresRepeatsAndProjectsThatAreGone() throws {
+        let alpha = rankedProject("alpha", name: "Alpha")
+        let beta = rankedProject("beta", name: "Beta")
+        let value = rankedSnapshot(projects: [alpha, beta], threads: [])
+        let groups = DailyUXCreationContext.projectGroups(in: value)
+        let alphaGroup = try #require(
+            DailyUXProjectGrouping.group(containing: alpha.id, in: groups)
+        )
+        let betaGroup = try #require(
+            DailyUXProjectGrouping.group(containing: beta.id, in: groups)
+        )
+
+        let sections = DailyUXProjectPickerSections(
+            groups: groups,
+            recentGroupIDs: [betaGroup.id, "removed-project-group", betaGroup.id, alphaGroup.id]
+        )
+
+        #expect(sections.recents.map(\.name) == ["Beta", "Alpha"])
+        #expect(sections.others.isEmpty)
+    }
+
     private func rankedProject(
         _ id: String,
         name: String,


### PR DESCRIPTION
## Behavior

The new-task project picker listed every project group alphabetically, so the project you were just working in could sit anywhere in the list — on a machine with a dozen projects, the common case was a scroll and a hunt.

The recency signal already existed: `DailyUXCreationContext.recentProjects(in:)` ranks project groups by each group's newest thread activity (`lastActivityAt ?? updatedAt`). Until now it was only consumed to *default* the initial project selection. This reuses it for the picker itself.

- New pure `DailyUXProjectPickerSections` partitions the groups into a capped (3) `Recent` list in most-recently-used order, plus the remaining alphabetical list under `Other projects`.
- A group appears in exactly one section, so the list never repeats itself at the small project counts this picker shows.
- With no recent activity the picker renders exactly as before: one plain alphabetical list, no section chrome.
- Selection semantics, row styling, accessibility traits and the empty-state `ContentUnavailableView` are unchanged — the row body was moved verbatim into a `projectRow(_:)` helper.

No new state, no persistence, no new wire field, no dependency change. Section shape follows the existing `ProviderModelPicker` convention in this codebase.

3 files, +156 / −20:

| File | Change |
| --- | --- |
| `apps/swift-ios/Features/Workspace/DailyUXModels.swift` | New `DailyUXProjectPickerSections` value type |
| `apps/swift-ios/Features/Workspace/NewThreadView.swift` | Picker renders `Recent` / `Other projects`; row extracted; `recentProjectGroupIDs` feeds it |
| `apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift` | Three focused Swift Testing cases |

## Focused test evidence

`xcodebuild test -only-testing:T3CodeTests/DailyUXNewTaskTests`, isolated temporary DerivedData, iPhone 17 Pro / iOS 26.5:

- **Real exit `0`**, `** TEST SUCCEEDED **`, **27 passed / 0 failed / 0 skipped / 0 expected failures** (nonzero run, confirmed via `xcresulttool` summary).
- New cases: `projectPickerLeadsWithRecentGroupsAndKeepsTheRestAlphabetical` (recency order that is neither alphabetical nor reverse-alphabetical, sections disjoint, no group lost), `projectPickerKeepsTheAlphabeticalListWhenNoProjectHasBeenUsed` (fallback identical to previous behavior), `projectPickerRecentSectionIgnoresRepeatsAndProjectsThatAreGone` (repeated ids de-duplicated, ids for removed projects skipped).

Simulator proof was captured on a disposable loopback backend with five seeded projects: with no thread activity the picker showed the plain alphabetical list; with three threads of differing recency it showed `Recent` = Delta Harbor → Echo Signal → Bravo Router (strict most-recently-used order) above `Other projects` starting at Alpha Ledger, with a single checkmark on the selection and no duplicate row.

## On-device acceptance

Accepted by the maintainer on a physical iPhone as **Test 88**. Acceptance is recorded on the owning issue.

## Review status — stated plainly

The independent cross-provider review (GPT-5.6 Sol, high reasoning) has **not** run against this head yet: the available quota resets at **2026-08-20T03:29Z**, and the review will be run against this exact head — `fbe96e043ac3390c54edaecdc9d0ec8af184039e` — once it does. Nothing in this PR should be read as having passed that review. The evidence above is a focused test run, a simulator proof, a self-review of the changed files, and maintainer acceptance on device.

One judgement call worth a reviewer's eye: this partitions groups so nothing is duplicated, whereas `ProviderModelPicker` duplicates its favourites/recents into the full list below. Partitioning suits the small project counts here; strict consistency with the model picker would be a small change to the section construction.

Coordination trace: T3 thread 09AA07C7-8B35-4797-9796-CFC0F854C544 · saphid/t3code-personal#111

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change that reuses existing recency ranking; no new persistence, APIs, or task-creation logic.
> 
> **Overview**
> The **new-task project picker** now surfaces recently used project groups at the top instead of burying them in a single alphabetical list.
> 
> A new **`DailyUXProjectPickerSections`** type splits groups into up to three **Recent** entries (order from existing `DailyUXCreationContext.recentProjects`) and **Other projects** (remaining groups, still alphabetical). Each group appears in only one section. With no thread activity, the picker stays a single undivided list.
> 
> **`NewTaskProjectPicker`** takes `recentGroupIDs`, builds those sections, and pulls row UI into **`projectRow(_:)`** without changing selection or styling behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2e20521d02670e3d28091e949993d76e0d03c9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface recent projects in the iOS project picker
> - Adds a `DailyUXProjectPickerSections` struct in [DailyUXModels.swift](https://github.com/pingdotgg/t3code/pull/7370/files#diff-2bae36acfcaa822eaaa43aea2e36dd5ded98f236fd6c38e524e50fbd0c85331e) that partitions project groups into a `recents` list (up to 3, deduped) and an `others` list.
> - Updates `NewTaskProjectPicker` in [NewThreadView.swift](https://github.com/pingdotgg/t3code/pull/7370/files#diff-b6ba9c0744007ccd1dd2c30b31fc66ec800d601a0a3153404e3ee2917cda96c5) to render a "Recent" section followed by an "Other projects" section; falls back to a flat alphabetical list when there are no recents.
> - Recent group IDs are derived from `DailyUXCreationContext.recentProjects(in: snapshot)` and passed into the picker at the call site.
> - Three new tests in [DailyUXNewTaskTests.swift](https://github.com/pingdotgg/t3code/pull/7370/files#diff-d51f0c7c4aaea5388173f149a61df6d24484136260388c8eba7aa05759d82e59) cover ordering, empty recents, and deduplication of unknown/repeated IDs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a2e2052.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->