### PR TITLE
feat(swift-ios): show message timestamps

### DIFF
--- a/apps/swift-ios/Features/Chat/FeatureMessageTimestamps.swift
+++ b/apps/swift-ios/Features/Chat/FeatureMessageTimestamps.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Decides which transcript messages show their time, and how that time reads.
+///
+/// Stamping every message would bury the conversation, so a message only earns a
+/// separator when the reader has actually lost their place: it opens the
+/// transcript, it starts a new day, or it follows a quiet gap.
+enum FeatureMessageTimestamps {
+    /// A pause long enough that "when did this happen" stops being obvious from
+    /// the message above.
+    static let quietGap: TimeInterval = 15 * 60
+
+    /// Message ID to separator label, for the messages that earn one. Messages
+    /// without a separator are absent from the result.
+    static func separatorLabels(
+        for messages: [FeatureMessage],
+        now: Date = .now,
+        calendar: Calendar = .current,
+        locale: Locale = .current
+    ) -> [String: String] {
+        var labels: [String: String] = [:]
+        var previous: Date?
+        for message in messages {
+            let createdAt = message.createdAt
+            defer { previous = createdAt }
+            if let previous, !opensSeparator(createdAt, after: previous, calendar: calendar) {
+                continue
+            }
+            labels[message.id] = label(
+                for: createdAt,
+                now: now,
+                calendar: calendar,
+                locale: locale
+            )
+        }
+        return labels
+    }
+
+    /// Same day and close behind its predecessor means the reader still has the
+    /// time in view; anything else reopens the question.
+    private static func opensSeparator(
+        _ createdAt: Date,
+        after previous: Date,
+        calendar: Calendar
+    ) -> Bool {
+        !calendar.isDate(createdAt, inSameDayAs: previous)
+            || createdAt.timeIntervalSince(previous) >= quietGap
+    }
+
+    /// Today needs only a clock time; older days carry just enough date to place
+    /// them without turning into a header.
+    static func label(
+        for createdAt: Date,
+        now: Date = .now,
+        calendar: Calendar = .current,
+        locale: Locale = .current
+    ) -> String {
+        let style = Date.FormatStyle(
+            locale: locale,
+            calendar: calendar,
+            timeZone: calendar.timeZone
+        )
+        let time = createdAt.formatted(style.hour().minute())
+        guard !calendar.isDate(createdAt, inSameDayAs: now) else { return time }
+
+        let daysBack = calendar.dateComponents(
+            [.day],
+            from: calendar.startOfDay(for: createdAt),
+            to: calendar.startOfDay(for: now)
+        ).day ?? 0
+
+        switch daysBack {
+        case 1:
+            return "Yesterday \(time)"
+        case 2...6:
+            return "\(createdAt.formatted(style.weekday(.abbreviated))) \(time)"
+        default:
+            let sameYear = calendar.component(.year, from: createdAt)
+                == calendar.component(.year, from: now)
+            let day = sameYear
+                ? createdAt.formatted(style.month(.abbreviated).day())
+                : createdAt.formatted(style.month(.abbreviated).day().year())
+            return "\(day) \(time)"
+        }
+    }
+}

--- a/apps/swift-ios/Features/Chat/FeatureMessageTimestamps.swift
+++ b/apps/swift-ios/Features/Chat/FeatureMessageTimestamps.swift
@@ -6,6 +6,24 @@ import Foundation
 /// separator when the reader has actually lost their place: it opens the
 /// transcript, it starts a new day, or it follows a quiet gap.
 enum FeatureMessageTimestamps {
+    struct PresentationContext: Equatable {
+        let day: Date
+        let calendarIdentifier: Calendar.Identifier
+        let timeZone: TimeZone
+        let localeIdentifier: String
+
+        init(
+            now: Date = .now,
+            calendar: Calendar = .current,
+            locale: Locale = .current
+        ) {
+            day = calendar.startOfDay(for: now)
+            calendarIdentifier = calendar.identifier
+            timeZone = calendar.timeZone
+            localeIdentifier = locale.identifier
+        }
+    }
+
     /// A pause long enough that "when did this happen" stops being obvious from
     /// the message above.
     static let quietGap: TimeInterval = 15 * 60

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -716,6 +716,8 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
         private var messagesByID: [String: FeatureMessage] = [:]
         private var orderedIDs: [String] = []
         private var timestampLabelsByID: [String: String] = [:]
+        private var timestampCreatedAtByID: [String: Date] = [:]
+        private var timestampPresentationContext: FeatureMessageTimestamps.PresentationContext?
         private var currentThreadID: String?
         private var currentDetailRevision: UInt64?
         private var currentDynamicTypeSize: DynamicTypeSize?
@@ -871,15 +873,43 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
                 messagesByID = replacementMessagesByID
             }
             orderedIDs = newIDs
-            // A separator depends on the message above it, so prepends and
-            // reorders can retire one the reader is already looking at.
-            let previousTimestampLabels = timestampLabelsByID
-            timestampLabelsByID = FeatureMessageTimestamps.separatorLabels(
-                for: newIDs.compactMap { messagesByID[$0] }
+            let now = Date.now
+            let calendar = Calendar.current
+            let locale = Locale.current
+            let presentationContext = FeatureMessageTimestamps.PresentationContext(
+                now: now,
+                calendar: calendar,
+                locale: locale
             )
-            let timestampChangedIDs = threadChanged
-                ? []
-                : newIDs.filter { previousTimestampLabels[$0] != timestampLabelsByID[$0] }
+            let timestampDateChanged = changedIDs.contains {
+                timestampCreatedAtByID[$0] != messagesByID[$0]?.createdAt
+            }
+            let shouldRefreshTimestamps = threadChanged || idsChanged || timestampDateChanged
+                || timestampPresentationContext != presentationContext
+            let timestampChangedIDs: [String]
+            if shouldRefreshTimestamps {
+                // A separator depends on the message above it, so prepends and
+                // reorders can retire one the reader is already looking at.
+                let previousTimestampLabels = timestampLabelsByID
+                let orderedMessages = newIDs.compactMap { messagesByID[$0] }
+                timestampLabelsByID = FeatureMessageTimestamps.separatorLabels(
+                    for: orderedMessages,
+                    now: now,
+                    calendar: calendar,
+                    locale: locale
+                )
+                timestampCreatedAtByID = orderedMessages.reduce(into: [:]) {
+                    $0[$1.id] = $1.createdAt
+                }
+                timestampPresentationContext = presentationContext
+                timestampChangedIDs = threadChanged
+                    ? []
+                    : newIDs.filter {
+                        previousTimestampLabels[$0] != timestampLabelsByID[$0]
+                    }
+            } else {
+                timestampChangedIDs = []
+            }
             (collectionView as? BottomAnchoredTranscriptCollectionView)?.maintainsBottomAnchor =
                 isInitialLoad || wasNearBottom
 
@@ -961,6 +991,7 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
         private struct VisibleAnchor {
             let id: String
             let offsetFromViewportTop: CGFloat
+            let itemHeight: CGFloat
         }
 
         private func visibleAnchor(
@@ -976,7 +1007,8 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
                 }
                 return VisibleAnchor(
                     id: id,
-                    offsetFromViewportTop: attributes.frame.minY - collectionView.contentOffset.y
+                    offsetFromViewportTop: attributes.frame.minY - collectionView.contentOffset.y,
+                    itemHeight: attributes.frame.height
                 )
             }
             return nil
@@ -1001,7 +1033,15 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
             )
             let targetY = min(
                 maximumY,
-                max(minimumY, attributes.frame.minY - anchor.offsetFromViewportTop)
+                max(
+                    minimumY,
+                    TranscriptViewportGeometry.restoredPrependOffset(
+                        itemMinY: attributes.frame.minY,
+                        itemHeight: attributes.frame.height,
+                        previousItemHeight: anchor.itemHeight,
+                        previousOffsetFromViewportTop: anchor.offsetFromViewportTop
+                    )
+                )
             )
             (collectionView as? BottomAnchoredTranscriptCollectionView)?.maintainsBottomAnchor = false
             collectionView.setContentOffset(
@@ -1270,6 +1310,15 @@ struct TranscriptViewportGeometry: Equatable {
 
     var bottomOffset: CGFloat {
         max(-topInset, contentHeight - viewportHeight + bottomInset)
+    }
+
+    static func restoredPrependOffset(
+        itemMinY: CGFloat,
+        itemHeight: CGFloat,
+        previousItemHeight: CGFloat,
+        previousOffsetFromViewportTop: CGFloat
+    ) -> CGFloat {
+        itemMinY - previousOffsetFromViewportTop + (itemHeight - previousItemHeight)
     }
 
     func restoredBottomOffset(

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -722,6 +722,7 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
         private var dataSource: UICollectionViewDiffableDataSource<Section, String>?
         private var messagesByID: [String: FeatureMessage] = [:]
         private var orderedIDs: [String] = []
+        private var timestampLabelsByID: [String: String] = [:]
         private var currentThreadID: String?
         private var currentDetailRevision: UInt64?
         private var currentDynamicTypeSize: DynamicTypeSize?
@@ -773,7 +774,10 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
                 }
 
                 cell.contentConfiguration = UIHostingConfiguration {
-                    FeatureMessageView(message: message)
+                    FeatureMessageView(
+                        message: message,
+                        timestamp: self?.timestampLabelsByID[messageID]
+                    )
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 .margins(.all, 0)
@@ -874,6 +878,15 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
                 messagesByID = replacementMessagesByID
             }
             orderedIDs = newIDs
+            // A separator depends on the message above it, so prepends and
+            // reorders can retire one the reader is already looking at.
+            let previousTimestampLabels = timestampLabelsByID
+            timestampLabelsByID = FeatureMessageTimestamps.separatorLabels(
+                for: newIDs.compactMap { messagesByID[$0] }
+            )
+            let timestampChangedIDs = threadChanged
+                ? []
+                : newIDs.filter { previousTimestampLabels[$0] != timestampLabelsByID[$0] }
             (collectionView as? BottomAnchoredTranscriptCollectionView)?.maintainsBottomAnchor =
                 isInitialLoad || wasNearBottom
 
@@ -918,6 +931,12 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
             }
             let appendedIDSet = Set(state.appendedIDs)
             var reconfiguredIDs = changedIDs.filter { !appendedIDSet.contains($0) }
+            let contentReconfiguredIDs = Set(reconfiguredIDs)
+            reconfiguredIDs.append(
+                contentsOf: timestampChangedIDs.filter {
+                    !appendedIDSet.contains($0) && !contentReconfiguredIDs.contains($0)
+                }
+            )
             if loadEarlierChanged,
                snapshot.indexOfItem(FeatureTranscriptCollectionView.loadEarlierID) != nil {
                 reconfiguredIDs.append(FeatureTranscriptCollectionView.loadEarlierID)
@@ -1741,8 +1760,23 @@ private enum FeatureAttachmentThumbnailError: Error {
 
 struct FeatureMessageView: View {
     let message: FeatureMessage
+    var timestamp: String?
 
     var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if let timestamp {
+                Text(timestamp)
+                    .font(T3Typography.supporting)
+                    .foregroundStyle(T3Colors.textSecondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .accessibilityIdentifier("message-timestamp-\(message.id)")
+            }
+            content
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
         switch message.role {
         case .user:
             HStack {

--- a/apps/swift-ios/Tests/FeatureTests/FeatureMessageTimestampTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureMessageTimestampTests.swift
@@ -1,0 +1,256 @@
+import Foundation
+import Testing
+@testable import T3Code
+
+@Suite("Transcript message timestamps")
+struct FeatureMessageTimestampTests {
+    private let locale = Locale(identifier: "en_US_POSIX")
+    private let calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        calendar.locale = Locale(identifier: "en_US_POSIX")
+        return calendar
+    }()
+
+    private func date(
+        year: Int = 2026,
+        month: Int = 8,
+        day: Int = 18,
+        hour: Int = 0,
+        minute: Int = 0
+    ) -> Date {
+        calendar.date(
+            from: DateComponents(
+                timeZone: calendar.timeZone,
+                year: year,
+                month: month,
+                day: day,
+                hour: hour,
+                minute: minute
+            )
+        )!
+    }
+
+    private func message(_ id: String, at createdAt: Date) -> FeatureMessage {
+        FeatureMessage(id: id, role: .user, text: id, createdAt: createdAt)
+    }
+
+    private func labels(_ messages: [FeatureMessage], now: Date) -> [String: String] {
+        FeatureMessageTimestamps.separatorLabels(
+            for: messages,
+            now: now,
+            calendar: calendar,
+            locale: locale
+        )
+    }
+
+    /// The time as the app itself renders it, so structural assertions below
+    /// stay honest without pinning ICU's exact clock formatting.
+    private func time(_ instant: Date) -> String {
+        instant.formatted(
+            Date.FormatStyle(locale: locale, calendar: calendar, timeZone: calendar.timeZone)
+                .hour()
+                .minute()
+        )
+    }
+
+    @Test
+    func emptyTranscriptProducesNoSeparators() {
+        #expect(labels([], now: date(hour: 12)).isEmpty)
+    }
+
+    @Test
+    func firstMessageAlwaysOpensWithItsTime() {
+        let sent = date(hour: 9, minute: 5)
+        let result = labels([message("m1", at: sent)], now: date(hour: 12))
+
+        #expect(result == ["m1": time(sent)])
+    }
+
+    @Test
+    func messagesInsideTheQuietGapStayBare() {
+        let first = date(hour: 9, minute: 0)
+        let result = labels(
+            [
+                message("m1", at: first),
+                message("m2", at: first.addingTimeInterval(60)),
+                message("m3", at: first.addingTimeInterval(14 * 60 + 59)),
+            ],
+            now: date(hour: 12)
+        )
+
+        #expect(Set(result.keys) == ["m1"])
+    }
+
+    @Test
+    func aQuietGapEarnsAFreshTime() {
+        let first = date(hour: 9, minute: 0)
+        let resumed = first.addingTimeInterval(40 * 60)
+        let result = labels(
+            [
+                message("m1", at: first),
+                message("m2", at: first.addingTimeInterval(30)),
+                message("m3", at: resumed),
+                message("m4", at: resumed.addingTimeInterval(30)),
+            ],
+            now: date(hour: 12)
+        )
+
+        #expect(Set(result.keys) == ["m1", "m3"])
+        #expect(result["m3"] == time(resumed))
+    }
+
+    @Test
+    func theGapBoundaryItselfCounts() {
+        let first = date(hour: 9, minute: 0)
+        let atBoundary = first.addingTimeInterval(FeatureMessageTimestamps.quietGap)
+        let result = labels(
+            [message("m1", at: first), message("m2", at: atBoundary)],
+            now: date(hour: 12)
+        )
+
+        #expect(Set(result.keys) == ["m1", "m2"])
+    }
+
+    @Test
+    func aNewDayEarnsATimeEvenSecondsApart() {
+        let lateLastNight = date(day: 17, hour: 23, minute: 59)
+        let justAfterMidnight = date(day: 18, hour: 0, minute: 0)
+        let result = labels(
+            [message("m1", at: lateLastNight), message("m2", at: justAfterMidnight)],
+            now: date(hour: 12)
+        )
+
+        #expect(Set(result.keys) == ["m1", "m2"])
+    }
+
+    @Test
+    func anOutOfOrderMessageDoesNotInventASeparator() {
+        let first = date(hour: 9, minute: 30)
+        let result = labels(
+            [message("m1", at: first), message("m2", at: first.addingTimeInterval(-60))],
+            now: date(hour: 12)
+        )
+
+        #expect(Set(result.keys) == ["m1"])
+    }
+
+    @Test
+    func todayReadsAsAClockTimeAlone() {
+        let sent = date(hour: 20, minute: 21)
+        let label = FeatureMessageTimestamps.label(
+            for: sent,
+            now: date(hour: 22),
+            calendar: calendar,
+            locale: locale
+        )
+
+        #expect(label == time(sent))
+    }
+
+    @Test
+    func yesterdayIsNamed() {
+        let sent = date(day: 17, hour: 20, minute: 21)
+        let label = FeatureMessageTimestamps.label(
+            for: sent,
+            now: date(day: 18, hour: 9),
+            calendar: calendar,
+            locale: locale
+        )
+
+        #expect(label == "Yesterday \(time(sent))")
+    }
+
+    @Test
+    func earlierThisWeekCarriesTheWeekday() {
+        // 2026-08-15 is a Saturday; three days before the 18th.
+        let sent = date(day: 15, hour: 20, minute: 21)
+        let label = FeatureMessageTimestamps.label(
+            for: sent,
+            now: date(day: 18, hour: 9),
+            calendar: calendar,
+            locale: locale
+        )
+
+        let weekday = sent.formatted(
+            Date.FormatStyle(locale: locale, calendar: calendar, timeZone: calendar.timeZone)
+                .weekday(.abbreviated)
+        )
+        #expect(label == "\(weekday) \(time(sent))")
+        #expect(label.hasPrefix("Sat"))
+    }
+
+    @Test
+    func olderThisYearCarriesTheDateWithoutTheYear() {
+        let sent = date(month: 6, day: 2, hour: 20, minute: 21)
+        let label = FeatureMessageTimestamps.label(
+            for: sent,
+            now: date(day: 18, hour: 9),
+            calendar: calendar,
+            locale: locale
+        )
+
+        #expect(label.hasPrefix("Jun 2"))
+        #expect(label.hasSuffix(time(sent)))
+        #expect(!label.contains("2026"))
+    }
+
+    @Test
+    func anotherYearSaysSo() {
+        let sent = date(year: 2025, month: 12, day: 30, hour: 20, minute: 21)
+        let label = FeatureMessageTimestamps.label(
+            for: sent,
+            now: date(day: 18, hour: 9),
+            calendar: calendar,
+            locale: locale
+        )
+
+        #expect(label.hasPrefix("Dec 30"))
+        #expect(label.contains("2025"))
+        #expect(label.hasSuffix(time(sent)))
+    }
+
+    @Test
+    func separatorsFollowTheSuppliedLocale() {
+        let sent = date(hour: 20, minute: 21)
+        let british = FeatureMessageTimestamps.label(
+            for: sent,
+            now: date(hour: 22),
+            calendar: calendar,
+            locale: Locale(identifier: "en_GB")
+        )
+
+        #expect(british.hasPrefix("20:21"))
+    }
+
+    @Test
+    func separatorsFollowTheSuppliedTimeZone() {
+        var pacific = calendar
+        pacific.timeZone = TimeZone(identifier: "America/Los_Angeles")!
+        let sent = date(hour: 20, minute: 21)
+
+        let label = FeatureMessageTimestamps.label(
+            for: sent,
+            now: date(hour: 22),
+            calendar: pacific,
+            locale: locale
+        )
+
+        // 20:21 UTC is 13:21 the same day in Los Angeles, so it stays time-only.
+        #expect(label.hasPrefix("1:21"))
+    }
+
+    @Test
+    func eachSeparatorBelongsToAMessageInTheTranscript() {
+        let first = date(hour: 8)
+        let messages = [
+            message("m1", at: first),
+            message("m2", at: first.addingTimeInterval(60)),
+            message("m3", at: first.addingTimeInterval(3 * 3600)),
+        ]
+        let result = labels(messages, now: date(hour: 12))
+
+        #expect(Set(result.keys).isSubset(of: Set(messages.map(\.id))))
+        #expect(result.values.allSatisfy { !$0.isEmpty })
+    }
+}

--- a/apps/swift-ios/Tests/FeatureTests/FeatureMessageTimestampTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureMessageTimestampTests.swift
@@ -241,6 +241,38 @@ struct FeatureMessageTimestampTests {
     }
 
     @Test
+    func presentationContextChangesWithTheDay() {
+        let beforeMidnight = FeatureMessageTimestamps.PresentationContext(
+            now: date(day: 17, hour: 23, minute: 59),
+            calendar: calendar,
+            locale: locale
+        )
+        let afterMidnight = FeatureMessageTimestamps.PresentationContext(
+            now: date(day: 18),
+            calendar: calendar,
+            locale: locale
+        )
+
+        #expect(beforeMidnight != afterMidnight)
+    }
+
+    @Test
+    func presentationContextIsStableWithinTheDay() {
+        let morning = FeatureMessageTimestamps.PresentationContext(
+            now: date(hour: 8),
+            calendar: calendar,
+            locale: locale
+        )
+        let evening = FeatureMessageTimestamps.PresentationContext(
+            now: date(hour: 20),
+            calendar: calendar,
+            locale: locale
+        )
+
+        #expect(morning == evening)
+    }
+
+    @Test
     func eachSeparatorBelongsToAMessageInTheTranscript() {
         let first = date(hour: 8)
         let messages = [

--- a/apps/swift-ios/Tests/FeatureTests/TranscriptViewportGeometryTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/TranscriptViewportGeometryTests.swift
@@ -6,6 +6,30 @@ import UIKit
 @Suite("Transcript viewport anchoring")
 struct TranscriptViewportGeometryTests {
     @Test
+    func prependAnchorCompensatesWhenTimestampRetirementShrinksTheCell() {
+        let offset = TranscriptViewportGeometry.restoredPrependOffset(
+            itemMinY: 620,
+            itemHeight: 132,
+            previousItemHeight: 160,
+            previousOffsetFromViewportTop: 80
+        )
+
+        #expect(offset == 512)
+    }
+
+    @Test
+    func prependAnchorKeepsItsOriginalOffsetWhenCellHeightIsStable() {
+        let offset = TranscriptViewportGeometry.restoredPrependOffset(
+            itemMinY: 620,
+            itemHeight: 160,
+            previousItemHeight: 160,
+            previousOffsetFromViewportTop: 80
+        )
+
+        #expect(offset == 540)
+    }
+
+    @Test
     func firstLoadedTranscriptAnchorsToLatestMessage() {
         let empty = TranscriptViewportGeometry(
             contentHeight: 0,


### PR DESCRIPTION
## What

Messages in the SwiftUI transcript now show a time only when the reader has likely lost context:

- the first message in the transcript,
- the first message on a new calendar day, or
- the first message after a gap of 15 minutes or more.

Rapid back-and-forth stays bare. Labels are locale and time-zone aware: today uses a clock time, yesterday uses `Yesterday …`, recent days use a weekday, and older messages use a date (plus the year when needed).

## How

- `FeatureMessageTimestamps` is a deterministic policy over the ordered message array with injected calendar, locale, and current time.
- `FeatureMessageView` renders the separator in the transcript's existing supporting/secondary style.
- The collection-view coordinator caches timestamp inputs and labels, so streaming assistant chunks do not reformat the entire loaded transcript on the main actor.
- Prepend restoration tracks the anchored cell height as well as its top offset, preserving the visible message body when loading earlier messages retires a separator.

`FeatureMessage.createdAt` already existed, so there is no model, wire, server, or dependency change.

## Current head

- PR head: `23a60e0739e459f2f3ad260624408c60f8840ec3`
- Base: `t3code/rebuild-mobile-app-swift` at `c2276320f06a0d007aea611feec41965b6b485ce`
- Mergeable and 0 commits behind the fetched base; updated with a normal merge, never rebased or force-pushed.
- Diff: 4 files, +502 / -3, all under `apps/swift-ios`.

## Testing

Focused `xcodebuild test` on iPhone 17 Pro with isolated DerivedData: **62 passed, 0 failed, 0 skipped, exit 0**.

```text
FeatureMessageTimestampTests       17 passed
FeatureRootModelTests              32 passed
TranscriptViewportGeometryTests    13 passed
```

This includes regression coverage for timestamp presentation-context invalidation and for preserving the message-body anchor when a prepended page retires a timestamp. The exact-head proof build also completed with `** BUILD SUCCEEDED **` and exit 0.

## Exact-head screenshots

Captured on canonical simulator `B0B16E05-D2DE-4243-B27B-6837D50FDFE6` after the built and installed debug dylibs matched byte-for-byte. The transcript shows three time separators across six messages; the rapid replies remain bare.

| Light | Dark |
|---|---|
| ![Light mode exact-head message timestamp proof](https://raw.githubusercontent.com/saphid/t3code/2e6838498a2f3dac0e1cae73bfff4df8c39f3503/pr-proof/7372/light.png) | ![Dark mode exact-head message timestamp proof](https://raw.githubusercontent.com/saphid/t3code/2e6838498a2f3dac0e1cae73bfff4df8c39f3503/pr-proof/7372/dark.png) |

- Light SHA-256: `ff415189110537a7e58ecb02593ba01aa8e4e14893acf962e893d9dc452c553f`
- Dark SHA-256: `40e5826d12179cf72fd985eb5faa5eb54455d78504c3f2bb2497026b43e1f203`
- [Proof manifest](https://github.com/saphid/t3code/blob/2e6838498a2f3dac0e1cae73bfff4df8c39f3503/pr-proof/7372/manifest.txt)

No video is needed because this feature has no interaction or motion behavior.

## Review status

- Theo's screenshots request is addressed by the exact-head light and dark evidence above.
- The only inline thread was Cursor's prepend-anchor finding. It is already resolved and outdated; the current head also carries focused regression coverage for that case.
- Current-head CI and review checks pass, apart from the known-external `Vercel - t3code-marketing` fork-authorization failure.
- Cross-provider review was skipped because the user explicitly prohibited Claude/Anthropic models, processes, and reviewers. No Claude or Anthropic process was launched for this current-head wave.

## Known limitation

A transcript left idle across midnight refreshes relative wording on its next transcript/view update rather than from a clock tick. Same-day time-only labels are unaffected.

Current-head update, fixes, tests, and proof: GPT-5.6 Sol via T3 Code.

Coordination trace: T3 thread 1B46827F-FDA6-4112-B2CE-7EDB6E2A29E2 · saphid/t3code-personal#112

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transcript snapshot updates and scroll anchoring, so label or height mistakes can jump the reader’s place when loading earlier messages. No auth, model, or API changes.
> 
> **Overview**
> Shows time separators in the iOS thread transcript only when they help: first message, a new calendar day, or a gap of 15+ minutes. Rapid back-and-forth stays unstamped.
> 
> Labels are locale- and timezone-aware: clock time for today, `Yesterday` + time, weekday + time for the last week, then month/day (and year if needed). `FeatureMessageView` draws the label as centered secondary text above the message.
> 
> The collection-view coordinator recomputes labels with the snapshot, reconfigures only cells whose separator changed, and adjusts prepend scroll restore when a retired timestamp shrinks a visible cell. Coverage includes gap/day/locale cases and the new prepend-offset math.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23a60e0739e459f2f3ad260624408c60f8840ec3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Coordination trace: T3 thread 79C159CA-B6F7-4418-B5AA-5C90160A6D38 · saphid/t3code-personal#112


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-message timestamp separators to iOS chat transcript
> - Introduces `FeatureMessageTimestamps` in [FeatureMessageTimestamps.swift](https://github.com/pingdotgg/t3code/pull/7372/files#diff-348e59da3c7d5f56095cf71c6d569f9dc505653ca2102b298b5cf21af81078a5), which computes timestamp labels for messages that start a new day, follow a 15-minute quiet gap, or open the transcript. Labels use `Date.FormatStyle` bound to the user's locale/calendar/timezone with relative-day semantics (time today, 'Yesterday', weekday, or month/day with optional year).
> - Integrates the logic into the transcript coordinator in [ThreadDetailView.swift](https://github.com/pingdotgg/t3code/pull/7372/files#diff-c987f84bf3746c99e23dc49057c113592bca2c0bce299b9dd80fe73c9495af30): caches labels per message ID, recomputes on thread/content/context changes, and reconfigures only affected cells in the diffable snapshot.
> - Extends `FeatureMessageView` to render a centered secondary-text timestamp line above the message when a label is present.
> - Fixes scroll-position restoration after prepends to account for cell height changes caused by timestamps appearing or disappearing, via `TranscriptViewportGeometry.restoredPrependOffset` and an extended `VisibleAnchor` that records item height.
> - Adds test suites in [FeatureMessageTimestampTests.swift](https://github.com/pingdotgg/t3code/pull/7372/files#diff-dea4d11f735f574c571dada1f55bbb59a259cd8ff08ede8816a7fc0fd11a26f1) and [TranscriptViewportGeometryTests.swift](https://github.com/pingdotgg/t3code/pull/7372/files#diff-177ccdc39e6a056ecd668ebe5e714fe8cff83788612b00fd1d0cbbcf3d9c2829) covering gap boundaries, day transitions, locale/timezone adherence, and offset math.
> - Behavioral Change: message cells may now grow in height when a timestamp separator appears; the restored-offset helper compensates, but custom cell sizing logic outside the coordinator that does not account for the timestamp line may mis-measure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 23a60e0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
