### PR TITLE
fix(mobile): support Android image attachments

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -86,6 +86,7 @@
     "expo-glass-effect": "~56.0.4",
     "expo-haptics": "~56.0.3",
     "expo-image": "~56.0.11",
+    "expo-image-manipulator": "~56.0.24",
     "expo-image-picker": "~56.0.18",
     "expo-linking": "~56.0.14",
     "expo-network": "~56.0.5",

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -836,7 +836,16 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
             </View>
           ) : null}
           {!isExpanded ? (
-            <Animated.View entering={FadeIn.duration(180)} exiting={FadeOut.duration(100)}>
+            <Animated.View
+              className="flex-row items-center gap-1.5"
+              entering={FadeIn.duration(180)}
+              exiting={FadeOut.duration(100)}
+            >
+              <ControlPill
+                accessibilityLabel="Add attachment"
+                icon="plus"
+                onPress={() => void props.onPickDraftImages()}
+              />
               {showStopAction ? (
                 <ControlPill icon="stop.fill" variant="danger" onPress={props.onStopThread} />
               ) : (

--- a/apps/mobile/src/lib/composerImages.test.ts
+++ b/apps/mobile/src/lib/composerImages.test.ts
@@ -2,6 +2,21 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { PROVIDER_SEND_TURN_MAX_ATTACHMENTS } from "@t3tools/contracts";
 
 const files = new Map<string, { base64: string; deleted: boolean }>();
+const launchImageLibraryAsync = vi.fn();
+const saveAsync = vi.fn();
+const renderedRelease = vi.fn();
+const contextRelease = vi.fn();
+const renderAsync = vi.fn(async () => ({ release: renderedRelease, saveAsync }));
+const manipulate = vi.fn(() => ({ release: contextRelease, renderAsync }));
+
+vi.mock("expo-image-picker", () => ({
+  launchImageLibraryAsync,
+}));
+
+vi.mock("expo-image-manipulator", () => ({
+  ImageManipulator: { manipulate },
+  SaveFormat: { JPEG: "jpeg" },
+}));
 
 vi.mock("expo-file-system", () => ({
   File: class {
@@ -39,6 +54,7 @@ vi.mock("./uuid", () => ({
 import {
   convertPastedImagesToAttachments,
   isOwnedPastedImageUri,
+  pickComposerImages,
   toUploadChatImageAttachments,
 } from "./composerImages";
 
@@ -71,6 +87,12 @@ describe("toUploadChatImageAttachments", () => {
 describe("native pasted image cleanup", () => {
   beforeEach(() => {
     files.clear();
+    launchImageLibraryAsync.mockReset();
+    saveAsync.mockReset();
+    renderedRelease.mockClear();
+    contextRelease.mockClear();
+    renderAsync.mockClear();
+    manipulate.mockClear();
   });
 
   it("recognizes only files created in the native composer paste directory", () => {
@@ -81,6 +103,67 @@ describe("native pasted image cleanup", () => {
     ).toBe(true);
     expect(isOwnedPastedImageUri("file:///private/var/mobile/photos/id.png")).toBe(false);
     expect(isOwnedPastedImageUri("https://example.com/t3-composer-paste/id.png")).toBe(false);
+  });
+
+  it("reads a selected image URI when Android omits picker base64", async () => {
+    const uri = "file:///data/user/0/app/cache/selected.png";
+    files.set(uri, { base64: "aGVsbG8=", deleted: false });
+    launchImageLibraryAsync.mockResolvedValue({
+      canceled: false,
+      assets: [{ fileName: "selected.png", fileSize: 5, mimeType: "image/png", uri }],
+    });
+
+    await expect(pickComposerImages({ existingCount: 0 })).resolves.toEqual({
+      error: null,
+      images: [
+        expect.objectContaining({
+          dataUrl: "data:image/png;base64,aGVsbG8=",
+          previewUri: uri,
+        }),
+      ],
+    });
+  });
+
+  it("converts selected HEIF images to provider-supported JPEG data", async () => {
+    const uri = "file:///data/user/0/app/cache/selected.heif";
+    launchImageLibraryAsync.mockResolvedValue({
+      canceled: false,
+      assets: [{ fileName: "selected.heif", fileSize: 2, mimeType: "image/heif", uri }],
+    });
+    saveAsync.mockResolvedValue({ base64: "aGVsbG8=", uri: `${uri}.jpg` });
+
+    await expect(pickComposerImages({ existingCount: 0 })).resolves.toEqual({
+      error: null,
+      images: [
+        expect.objectContaining({
+          dataUrl: "data:image/jpeg;base64,aGVsbG8=",
+          mimeType: "image/jpeg",
+          name: "selected.jpg",
+          previewUri: `${uri}.jpg`,
+          sizeBytes: 5,
+        }),
+      ],
+    });
+    expect(manipulate).toHaveBeenCalledWith(uri);
+    expect(saveAsync).toHaveBeenCalledWith({ base64: true, compress: 0.9, format: "jpeg" });
+    expect(renderedRelease).toHaveBeenCalledOnce();
+    expect(contextRelease).toHaveBeenCalledOnce();
+  });
+
+  it("reports failed HEIF conversion and releases native image resources", async () => {
+    const uri = "file:///data/user/0/app/cache/selected.heic";
+    launchImageLibraryAsync.mockResolvedValue({
+      canceled: false,
+      assets: [{ fileName: "selected.heic", mimeType: "image/heic", uri }],
+    });
+    saveAsync.mockRejectedValue(new Error("conversion failed"));
+
+    await expect(pickComposerImages({ existingCount: 0 })).resolves.toEqual({
+      error: "Failed to convert 'selected.heic' to JPEG.",
+      images: [],
+    });
+    expect(renderedRelease).toHaveBeenCalledOnce();
+    expect(contextRelease).toHaveBeenCalledOnce();
   });
 
   it("converts owned files to data-backed previews and deletes the source", async () => {

--- a/apps/mobile/src/lib/composerImages.ts
+++ b/apps/mobile/src/lib/composerImages.ts
@@ -27,6 +27,15 @@ export function toUploadChatImageAttachments(
 }
 
 const OWNED_PASTED_IMAGE_DIRECTORY = "t3-composer-paste";
+const HEIF_IMAGE_MIME_TYPES = new Set([
+  "image/heic",
+  "image/heic-sequence",
+  "image/heif",
+  "image/heif-sequence",
+  "image/vnd.android.heic",
+  "image/x-heic",
+  "image/x-heif",
+]);
 
 async function loadImagePicker() {
   try {
@@ -41,6 +50,42 @@ async function loadClipboard() {
     return await import("expo-clipboard");
   } catch (error) {
     throw new Error("Clipboard paste is unavailable right now.", { cause: error });
+  }
+}
+
+function isHeifImage(mimeType: string | undefined, fileName: string | null | undefined): boolean {
+  return (
+    (mimeType !== undefined && HEIF_IMAGE_MIME_TYPES.has(mimeType)) ||
+    /\.(?:heic|heif)$/i.test(fileName ?? "")
+  );
+}
+
+function jpegFileName(fileName: string | null | undefined): string {
+  const stem = (fileName ?? "image").replace(/\.(?:heic|heif)$/i, "");
+  return `${stem.slice(0, 251)}.jpg`;
+}
+
+async function convertHeifImage(
+  uri: string,
+): Promise<{ readonly base64: string; readonly uri: string }> {
+  const { ImageManipulator, SaveFormat } = await import("expo-image-manipulator");
+  const context = ImageManipulator.manipulate(uri);
+  let rendered: Awaited<ReturnType<typeof context.renderAsync>> | null = null;
+
+  try {
+    rendered = await context.renderAsync();
+    const result = await rendered.saveAsync({
+      base64: true,
+      compress: 0.9,
+      format: SaveFormat.JPEG,
+    });
+    if (!result.base64) {
+      throw new Error("HEIF conversion did not return image data.");
+    }
+    return { base64: result.base64, uri: result.uri };
+  } finally {
+    rendered?.release();
+    context.release();
   }
 }
 
@@ -94,36 +139,68 @@ export async function pickComposerImages(input: { readonly existingCount: number
   let error: string | null = null;
 
   for (const asset of result.assets) {
-    const mimeType = asset.mimeType?.toLowerCase();
+    const originalMimeType = asset.mimeType?.toLowerCase();
+    let mimeType = originalMimeType;
+    let fileName = asset.fileName ?? "image";
+    let base64 = asset.base64;
+    let previewUri = asset.uri;
+    let sizeBytes = asset.fileSize;
+    let convertedFromHeif = false;
+
+    if (isHeifImage(originalMimeType, asset.fileName)) {
+      try {
+        const converted = await convertHeifImage(asset.uri);
+        mimeType = "image/jpeg";
+        fileName = jpegFileName(asset.fileName);
+        base64 = converted.base64;
+        previewUri = converted.uri;
+        sizeBytes = undefined;
+        convertedFromHeif = true;
+      } catch {
+        error = `Failed to convert '${asset.fileName ?? "image"}' to JPEG.`;
+        continue;
+      }
+    }
+
     if (!mimeType?.startsWith("image/")) {
-      error = `Unsupported file type for '${asset.fileName ?? "image"}'.`;
+      error = `Unsupported file type for '${fileName}'.`;
       continue;
     }
     if (!isProviderSendTurnSupportedImageMimeType(mimeType)) {
-      error = `'${asset.fileName ?? "image"}' is not a supported image type. Attach GIF, JPEG, PNG, or WebP images.`;
+      error = `'${fileName}' is not a supported image type. Attach GIF, JPEG, PNG, or WebP images.`;
       continue;
     }
 
-    const base64 = asset.base64;
     if (!base64) {
-      error = `Failed to read '${asset.fileName ?? "image"}'.`;
+      try {
+        const { File } = await import("expo-file-system");
+        base64 = await new File(asset.uri).base64();
+      } catch {
+        // Keep the existing user-facing error below when the picker URI cannot
+        // be read on a particular Android media provider.
+      }
+    }
+    if (!base64) {
+      error = `Failed to read '${fileName}'.`;
       continue;
     }
 
-    const sizeBytes = asset.fileSize ?? estimateBase64ByteSize(base64);
+    sizeBytes ??= estimateBase64ByteSize(base64);
     if (sizeBytes <= 0 || sizeBytes > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES) {
-      error = `'${asset.fileName ?? "image"}' exceeds the 10 MB attachment limit.`;
+      error = convertedFromHeif
+        ? `'${asset.fileName ?? "image"}' exceeds the 10 MB attachment limit after JPEG conversion.`
+        : `'${fileName}' exceeds the 10 MB attachment limit.`;
       continue;
     }
 
     nextImages.push({
       id: uuidv4(),
       type: "image",
-      name: asset.fileName ?? "image",
+      name: fileName,
       mimeType,
       sizeBytes,
       dataUrl: `data:${mimeType};base64,${base64}`,
-      previewUri: asset.uri,
+      previewUri,
     });
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,6 +325,9 @@ importers:
       expo-image:
         specifier: ~56.0.11
         version: 56.0.11(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      expo-image-manipulator:
+        specifier: ~56.0.24
+        version: 56.0.24(expo@56.0.12)
       expo-image-picker:
         specifier: ~56.0.18
         version: 56.0.18(expo@56.0.12)
@@ -6639,6 +6642,11 @@ packages:
 
   expo-image-loader@56.0.3:
     resolution: {integrity: sha512-JgUo4fUeU1ZC+z8iBFj8v7yoGQnZrLbOVPyNE+DWVrld55F2F6R1ck+rmdm/8TNWLz1LhNQfD7c3XYP1ZikxXA==}
+    peerDependencies:
+      expo: '*'
+
+  expo-image-manipulator@56.0.24:
+    resolution: {integrity: sha512-GDEE0I3ZKgOxWBrE0IT/Lheb5M1wXydprHOt/mPABjq+1gEaKOjm0hUHxjKbL3g6WmRyzfJx/Szv51vJ81FAcg==}
     peerDependencies:
       expo: '*'
 
@@ -16959,6 +16967,11 @@ snapshots:
   expo-image-loader@56.0.3(expo@56.0.12):
     dependencies:
       expo: 56.0.12(8895228379997a2a064f9644cda56ed0)
+
+  expo-image-manipulator@56.0.24(expo@56.0.12):
+    dependencies:
+      expo: 56.0.12(8895228379997a2a064f9644cda56ed0)
+      expo-image-loader: 56.0.3(expo@56.0.12)
 
   expo-image-picker@56.0.18(expo@56.0.12):
     dependencies:


### PR DESCRIPTION
## What Changed

- Expose the existing image picker in the collapsed Android composer.
- Read picker URIs when Android does not return base64 data.
- Convert HEIF and HEIC images to JPEG before attachment validation.
- Validate the converted size and use the converted cache file for previews.
- Add focused tests for URI fallback, conversion, and resource cleanup.

The provider attachment contract remains GIF, JPEG, PNG, and WebP.

## Why

The native Android composer hides image picking until the editor expands. Android media providers can also return picker assets without base64 data, and HEIF or HEIC images do not match the provider upload contract.

Issue #2803 reports the same visible symptom on mobile web. This PR changes only the native Android client.

Checks completed:

- `vp test apps/mobile/src/lib/composerImages.test.ts` (7 passed)
- targeted `vp lint`
- targeted `vp format --check`
- `vp run --filter @t3tools/mobile typecheck`
- Android release APK build
- Samsung SM-F966U1 on Android 16: selected an 800 x 600 HEIF fixture through Android Photo Picker and confirmed the attachment thumbnail appeared without sending a message
- Claude Fable 5 high-effort review: no blocking or important findings

## UI Changes

A clean before-and-after screenshot is still needed before this draft is marked ready. Device UI-tree verification confirmed the collapsed attachment control and selected-image thumbnail.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] No animation or interaction timing changes

Model: GPT-5.6-Sol
Harness: Codex in T3 Code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Android image attachment support with HEIF-to-JPEG conversion in mobile composer
> - Adds an 'Add attachment' `ControlPill` button to the collapsed composer view in [ThreadComposer.tsx](https://github.com/pingdotgg/t3code/pull/7375/files#diff-502492556086911b96852cf16aab1ae84244ebd70447d8b950e267a9037d0462) that triggers image picking.
> - Extends `pickComposerImages` in [composerImages.ts](https://github.com/pingdotgg/t3code/pull/7375/files#diff-8723c2d87dbdbb196075db6f79088889d3a7f72c0b472d71bc669adc4b533e51) to detect HEIF/HEIC images and convert them to JPEG using `expo-image-manipulator`, updating filename, MIME type, and preview URI accordingly.
> - Falls back to reading base64 directly from the file URI via `expo-file-system` when the Android image picker omits base64 data.
> - Error messages are tailored to reflect the filename and whether a HEIF conversion was attempted.
> - Risk: `sizeBytes` is set to `undefined` after HEIF conversion and recomputed from base64, which may cause size limit checks to behave differently for converted images.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca961fc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->