### PR TITLE
fix(server): settle turns when provider interrupts fail

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -2486,6 +2486,79 @@ describe("ProviderCommandReactor", () => {
     });
   });
 
+  it("settles the thread when provider interrupt and session cleanup fail", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+    harness.interruptTurn.mockImplementationOnce(
+      () =>
+        Effect.fail(
+          new ProviderAdapterRequestError({
+            provider: "opencode",
+            method: "session.abort",
+            detail: "OpenCode server is unavailable.",
+          }),
+        ) as never,
+    );
+    harness.stopSession.mockImplementationOnce(
+      () =>
+        Effect.fail(
+          new ProviderAdapterRequestError({
+            provider: "opencode",
+            method: "session.stop",
+            detail: "OpenCode server is unavailable.",
+          }),
+        ) as never,
+    );
+
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("cmd-session-set-before-failed-interrupt"),
+        threadId: ThreadId.make("thread-1"),
+        session: {
+          threadId: ThreadId.make("thread-1"),
+          status: "running",
+          providerName: "opencode",
+          runtimeMode: "approval-required",
+          activeTurnId: asTurnId("turn-1"),
+          lastError: null,
+          updatedAt: now,
+        },
+        createdAt: now,
+      }),
+    );
+
+    await harness.runEffect(
+      harness.engine.dispatch({
+        type: "thread.turn.interrupt",
+        commandId: CommandId.make("cmd-turn-interrupt-provider-failure"),
+        threadId: ThreadId.make("thread-1"),
+        turnId: asTurnId("turn-1"),
+        createdAt: now,
+      }),
+    );
+
+    await harness.drain();
+
+    expect(harness.interruptTurn).toHaveBeenCalledWith({ threadId: "thread-1" });
+    expect(harness.stopSession).toHaveBeenCalledWith({ threadId: "thread-1" });
+    const readModel = await harness.readModel();
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    expect(thread?.session).toMatchObject({
+      status: "error",
+      activeTurnId: null,
+      lastError: "OpenCode server is unavailable.",
+    });
+    expect(
+      thread?.activities.find((activity) => activity.kind === "provider.turn.interrupt.failed"),
+    ).toMatchObject({
+      turnId: "turn-1",
+      payload: {
+        detail: "OpenCode server is unavailable.",
+      },
+    });
+  });
+
   it("starts a fresh session when only projected session state exists", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -394,7 +394,7 @@ const make = Effect.gen(function* () {
       ),
     );
 
-  const setThreadSessionErrorOnTurnStartFailure = Effect.fnUntraced(function* (input: {
+  const setThreadSessionError = Effect.fnUntraced(function* (input: {
     readonly threadId: ThreadId;
     readonly detail: string;
     readonly createdAt: string;
@@ -1119,7 +1119,7 @@ const make = Effect.gen(function* () {
         return Effect.void;
       }
       const detail = formatFailureDetail(cause);
-      return setThreadSessionErrorOnTurnStartFailure({
+      return setThreadSessionError({
         threadId: event.payload.threadId,
         detail,
         createdAt: event.payload.createdAt,
@@ -1193,7 +1193,57 @@ const make = Effect.gen(function* () {
     }
 
     // Orchestration turn ids are not provider turn ids, so interrupt by session.
-    yield* providerService.interruptTurn({ threadId: event.payload.threadId });
+    yield* providerService.interruptTurn({ threadId: event.payload.threadId }).pipe(
+      Effect.catchCause((cause) => {
+        if (Cause.hasInterruptsOnly(cause)) {
+          return Effect.interrupt;
+        }
+        const detail = formatFailureDetail(cause);
+        return providerService.stopSession({ threadId: event.payload.threadId }).pipe(
+          Effect.catchCause((stopCause) =>
+            Cause.hasInterruptsOnly(stopCause)
+              ? Effect.interrupt
+              : Effect.logWarning(
+                  "provider command reactor failed to stop session after turn interrupt failure",
+                  {
+                    threadId: event.payload.threadId,
+                    cause: Cause.pretty(stopCause),
+                    originalCause: Cause.pretty(cause),
+                  },
+                ),
+          ),
+          Effect.flatMap(() =>
+            setThreadSessionError({
+              threadId: event.payload.threadId,
+              detail,
+              createdAt: event.payload.createdAt,
+            }),
+          ),
+          Effect.flatMap(() =>
+            appendProviderFailureActivity({
+              threadId: event.payload.threadId,
+              kind: "provider.turn.interrupt.failed",
+              summary: "Provider turn interrupt failed",
+              detail,
+              turnId: event.payload.turnId ?? null,
+              createdAt: event.payload.createdAt,
+            }),
+          ),
+          Effect.catchCause((recoveryCause) =>
+            Cause.hasInterruptsOnly(recoveryCause)
+              ? Effect.interrupt
+              : Effect.logWarning(
+                  "provider command reactor failed to recover turn interrupt failure",
+                  {
+                    threadId: event.payload.threadId,
+                    cause: Cause.pretty(recoveryCause),
+                    originalCause: Cause.pretty(cause),
+                  },
+                ),
+          ),
+        );
+      }),
+    );
   });
 
   const processApprovalResponseRequested = Effect.fn("processApprovalResponseRequested")(function* (


### PR DESCRIPTION
The stop button could leave a thread showing Working forever when the provider abort failed. The asynchronous reactor left the active turn set, while the provider failure never became visible to the user.

Interrupt failure is now fail-safe: T3 records a provider failure activity, attempts to stop the provider session, and clears the projected active turn even if session cleanup also fails.

## Verification

- pnpm exec vp test run apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
- pnpm exec vp fmt --check apps/server/src/orchestration/Layers/ProviderCommandReactor.ts apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
- pnpm exec vp lint --report-unused-disable-directives apps/server/src/orchestration/Layers/ProviderCommandReactor.ts apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
- pnpm exec vp run --filter t3 typecheck
- git diff --check

Fixes #7368

Implemented with GPT-5.6 Sol through Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration session state on interrupt failure paths; behavior is localized to ProviderCommandReactor with test coverage, but affects stop-button UX and projected thread state.
> 
> **Overview**
> Fixes threads that could stay in **Working** forever when **Stop** failed because the provider abort errored and the reactor never cleared `activeTurnId` or surfaced the failure.
> 
> **Turn interrupt** handling in `ProviderCommandReactor` is now fail-safe: if `interruptTurn` fails, the reactor tries `stopSession`, then uses the shared `setThreadSessionError` helper (renamed from the turn-start-only variant) to set session **error**, clear **activeTurnId**, and set **lastError**, and it records a `provider.turn.interrupt.failed` activity. Recovery still runs when session stop also fails.
> 
> A regression test covers the case where both interrupt and stop fail against an unavailable OpenCode server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eb952e4e73bcc2180a8a218cb3238a3012a4648. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Handle provider turn interrupt failures by settling thread session with error state
> - When `providerService.interruptTurn` fails, the handler now attempts `providerService.stopSession`, marks the thread session as error with the failure detail, and appends a `provider.turn.interrupt.failed` activity.
> - If `stopSession` also fails, a warning is logged with both the stop cause and the original interrupt cause; the thread is still settled.
> - Renames the internal `setThreadSessionErrorOnTurnStartFailure` utility to `setThreadSessionError` and reuses it across both turn start and interrupt failure paths in [ProviderCommandReactor.ts](https://github.com/pingdotgg/t3code/pull/7376/files#diff-0630e9ad70d5dcd1c8586d29297f9b7d5f5436cc8e10fc88dc22acc511f1450d).
> - Interrupt-only causes (e.g. fiber cancellation) still short-circuit as interrupts without triggering recovery.
> - Behavioral Change: provider turn interrupts that previously propagated errors now produce a settled error session state instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4eb952e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->