### PR TITLE
fix(web): label pull request merge actions

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -1337,7 +1337,7 @@ export function PullRequestDetailPanel({
                                     icon and the label need their own row to share a line. */}
                                 <span className="flex min-w-0 items-center gap-2">
                                   <GitMergeIcon className="size-3.5" />
-                                  <span className="capitalize">{method}</span>
+                                  <span>{MERGE_METHOD_LABELS[method]}</span>
                                 </span>
                               </MenuRadioItem>
                             ))}

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -147,6 +147,12 @@ const ACTION_SUCCESS_LABELS: Record<PullRequestAction, string> = {
   "disable-auto-merge": "Auto-merge turned off",
 };
 
+const MERGE_METHOD_LABELS: Record<PullRequestMergeMethod, string> = {
+  merge: "Merge",
+  squash: "Squash",
+  rebase: "Rebase",
+};
+
 /** Said as the thing that did not happen, rather than as the operation that returned an error. */
 const ACTION_FAILURE_LABELS: Record<PullRequestAction, string> = {
   merge: "Could not merge this pull request",
@@ -460,9 +466,11 @@ export function PullRequestDetailPanel({
     if (scroller) scroller.scrollTop = Math.max(0, scroller.scrollTop + delta);
   }, [condensed]);
   const [mergeMethod, setMergeMethod] = useState<PullRequestMergeMethod>("merge");
-  const [confirmAction, setConfirmAction] = useState<
-    "merge" | "close" | "enable-auto-merge" | null
-  >(null);
+  const [confirmation, setConfirmation] = useState<{
+    readonly open: boolean;
+    readonly action: "merge" | "close" | "enable-auto-merge";
+  }>({ open: false, action: "merge" });
+  const confirmAction = confirmation.action;
   // Which handoff is preparing, keyed so a per-finding button can say "Preparing..." on itself
   // alone. One at a time whatever the key: they all check the same pull request out.
   const [handoff, setHandoff] = useState<string | null>(null);
@@ -1013,6 +1021,7 @@ export function PullRequestDetailPanel({
   const selectedMergeMethod = allowedMergeMethods.includes(mergeMethod)
     ? mergeMethod
     : (allowedMergeMethods[0] ?? "merge");
+  const selectedMergeMethodLabel = MERGE_METHOD_LABELS[selectedMergeMethod];
   const conflicting = detail?.state === "open" && detail.mergeability === "conflicting";
   // Only an outright yes arms it. A host that reports nothing has not said the merge is already
   // spoken for, and an off switch for something that may not be on says the wrong thing twice.
@@ -1297,7 +1306,9 @@ export function PullRequestDetailPanel({
                         allowedMergeMethods.length > 0 ? (
                         <MenuItem
                           disabled={actionPending}
-                          onClick={() => setConfirmAction("enable-auto-merge")}
+                          onClick={() =>
+                            setConfirmation({ open: true, action: "enable-auto-merge" })
+                          }
                         >
                           <GitMergeIcon className="size-3.5" />
                           Enable auto-merge
@@ -1363,7 +1374,7 @@ export function PullRequestDetailPanel({
                       <MenuItem
                         variant="destructive"
                         disabled={actionPending}
-                        onClick={() => setConfirmAction("close")}
+                        onClick={() => setConfirmation({ open: true, action: "close" })}
                       >
                         <GitPullRequestClosedIcon className="size-3.5" />
                         Close pull request
@@ -1461,9 +1472,9 @@ export function PullRequestDetailPanel({
                 <Button
                   size="xs"
                   disabled={actionPending}
-                  onClick={() => setConfirmAction("merge")}
+                  onClick={() => setConfirmation({ open: true, action: "merge" })}
                 >
-                  {pendingAction === "merge" ? "Merging..." : "Merge"}
+                  {pendingAction === "merge" ? "Merging..." : selectedMergeMethodLabel}
                 </Button>
               ) : null}
             </>
@@ -1980,8 +1991,11 @@ export function PullRequestDetailPanel({
       </div>
 
       <AlertDialog
-        open={confirmAction !== null}
-        onOpenChange={(open) => !open && setConfirmAction(null)}
+        open={confirmation.open}
+        onOpenChange={(open) => setConfirmation((current) => ({ ...current, open }))}
+        onOpenChangeComplete={(open) => {
+          if (!open) setConfirmation({ open: false, action: "merge" });
+        }}
       >
         <AlertDialogPopup>
           <AlertDialogHeader>
@@ -2013,7 +2027,7 @@ export function PullRequestDetailPanel({
               disabled={actionPending}
               onClick={() => {
                 const action = confirmAction;
-                setConfirmAction(null);
+                setConfirmation((current) => ({ ...current, open: false }));
                 if (action === "merge") void perform("merge", selectedMergeMethod);
                 if (action === "enable-auto-merge")
                   void perform("enable-auto-merge", selectedMergeMethod);
@@ -2021,7 +2035,7 @@ export function PullRequestDetailPanel({
               }}
             >
               {confirmAction === "merge"
-                ? "Merge"
+                ? selectedMergeMethodLabel
                 : confirmAction === "enable-auto-merge"
                   ? "Enable auto-merge"
                   : "Close"}


### PR DESCRIPTION
## What Changed

- Label the primary and confirmation merge buttons from the selected merge method: `Merge`, `Squash`, or `Rebase`.
- Keep the confirmation action intact until the dialog's closing transition completes, then reset it.

## Why

Selecting `Squash` or `Rebase` still left the primary and confirmation buttons labeled `Merge`, even though the selected method would be used.

Dismissing the confirmation dialog also reset its content as the closing transition began, causing parts of the dialog to disappear mid-animation.

## UI Changes

### Before

https://github.com/user-attachments/assets/30fcd5de-e9ec-48e8-812f-dc99ad933c65

### After

https://github.com/user-attachments/assets/d5174a23-9b9a-4e7b-9edc-3e8da7794616

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Built with GPT-5.6-Sol using Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI and dialog state in the pull request detail panel; merge behavior still uses the existing `perform` path with `selectedMergeMethod`.
> 
> **Overview**
> Merge controls in **`PullRequestDetailPanel`** now reflect the **selected merge strategy** (`Merge`, `Squash`, or `Rebase`) on the primary action button, the merge-method menu radios, and the confirmation dialog’s confirm label—instead of always saying **Merge** while `selectedMergeMethod` is passed to `perform`.
> 
> Confirmation flow is refactored from a nullable `confirmAction` to **`confirmation: { open, action }`**. **`onOpenChangeComplete`** clears the stored action only after the dialog close animation finishes, so title/copy/button text no longer flicker or vanish mid-dismiss.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d27d496538c3045119b83e2ddf187b0fa35e8a4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Label pull request merge actions with human-readable method names
> Adds a `MERGE_METHOD_LABELS` mapping in [`PullRequestDetailPanel.tsx`](https://github.com/pingdotgg/t3code/pull/7381/files#diff-3c76d43f3539848054e21911e658895287b4fe9c387c3267c21684290baebd3a) to display "Merge", "Squash", or "Rebase" instead of raw method identifiers. The primary merge button, merge method radio options, and confirmation dialog button all now reflect the selected label. The confirmation state is refactored from a nullable string to an object with an explicit `open` flag, so the action type is preserved during the dialog close animation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d27d496.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->