### PR TITLE
refactor(server): simplify error transformation with Effect.mapError in GitHubPullRequestCli

### DIFF
--- a/apps/server/src/pullRequest/GitHubPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.ts
@@ -1451,8 +1451,7 @@ export const make = Effect.gen(function* () {
           // the page. Narrowed to a command that ran and was refused: a missing `gh` or a
           // signed-out one fails the same way for every request.
           Effect.catchTags({
-            GitHubCliCommandError: (error) =>
-              filesPage(1).pipe(Effect.catch(() => Effect.fail(error))),
+            GitHubCliCommandError: (error) => filesPage(1).pipe(Effect.mapError(() => error)),
           }),
         );
     },


### PR DESCRIPTION
### Summary
- In `apps/server/src/pullRequest/GitHubPullRequestCli.ts`, replace `filesPage(1).pipe(Effect.catch(() => Effect.fail(error)))` with `filesPage(1).pipe(Effect.mapError(() => error))`.
- Expresses the error transformation directly in idiomatic Effect syntax.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line Effect refactor in error handling for an existing fallback path; behavior should be unchanged.
> 
> **Overview**
> In **`getPullRequestDiff`**, when `gh pr diff` fails with **`GitHubCliCommandError`** and the code retries via the files API (`filesPage(1)`), a failed fallback still surfaces the **original** CLI refusal—not the files-page error.
> 
> The implementation switches from **`Effect.catch(() => Effect.fail(error))`** to **`Effect.mapError(() => error)`**, which expresses the same “replace fallback failure with the caught error” behavior in more idiomatic Effect style. **No intended runtime behavior change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7e4b6cd7d17109cfa8def3a1b7553c74441b009. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Simplify error handling in `GitHubPullRequestCli` fallback path using `Effect.mapError`
> Replaces `Effect.catch(() => Effect.fail(error))` with `Effect.mapError(() => error)` on the `filesPage(1)` call in [GitHubPullRequestCli.ts](https://github.com/pingdotgg/t3code/pull/7385/files#diff-5f996ba58ab5dee2c62090f97591f9434b30c9db0025bf3f8212b5732391e966). Both approaches map any error from `filesPage(1)` to the original `GitHubCliCommandError`, but `mapError` is more idiomatic and concise.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d7e4b6c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->