### PR TITLE
fix(server): discover $-picker skills per project instead of at the server cwd

### DIFF
--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -32,6 +32,7 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.serverProbe]: AuthOrchestrationReadScope,
   [WS_METHODS.serverGetConfig]: AuthOrchestrationReadScope,
   [WS_METHODS.serverRefreshProviders]: AuthOrchestrationOperateScope,
+  [WS_METHODS.serverListProviderSkills]: AuthOrchestrationReadScope,
   [WS_METHODS.serverUpdateProvider]: AuthOrchestrationOperateScope,
   [WS_METHODS.serverUpdateServer]: AuthOrchestrationOperateScope,
   [WS_METHODS.serverUpdateServerWithProgress]: AuthOrchestrationOperateScope,

--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -34,6 +34,7 @@ import {
   makePendingClaudeProvider,
   probeClaudeCapabilities,
 } from "../Layers/ClaudeProvider.ts";
+import { discoverClaudeSkills } from "./ClaudeSkills.ts";
 import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
 import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
 import {
@@ -216,6 +217,11 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         snapshot,
         adapter,
         textGeneration,
+        discoverSkills: (workspaceCwd) =>
+          discoverClaudeSkills(effectiveConfig, workspaceCwd, processEnv).pipe(
+            Effect.provideService(FileSystem.FileSystem, fileSystem),
+            Effect.provideService(Path.Path, path),
+          ),
       } satisfies ProviderInstance;
     }),
 };

--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -36,7 +36,12 @@ import { ServerConfig } from "../../config.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import { ProviderDriverError } from "../Errors.ts";
 import { makeCodexAdapter } from "../Layers/CodexAdapter.ts";
-import { checkCodexProviderStatus, makePendingCodexProvider } from "../Layers/CodexProvider.ts";
+import {
+  checkCodexProviderStatus,
+  discoverCodexSkills,
+  makePendingCodexProvider,
+} from "../Layers/CodexProvider.ts";
+import { resolveCodexLaunchArgs } from "../Layers/codexLaunchArgs.ts";
 import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
 import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
 import type { ProviderDriver, ProviderInstance } from "../ProviderDriver.ts";
@@ -208,6 +213,14 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
         snapshot,
         adapter,
         textGeneration,
+        discoverSkills: (workspaceCwd) =>
+          discoverCodexSkills({
+            binaryPath: effectiveConfig.binaryPath,
+            homePath: effectiveConfig.homePath,
+            launchArgs: resolveCodexLaunchArgs(effectiveConfig.launchArgs, processEnv),
+            cwd: workspaceCwd,
+            environment: processEnv,
+          }).pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner)),
       } satisfies ProviderInstance;
     }),
 };

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -319,14 +319,22 @@ export function buildCodexInitializeParams(): CodexSchema.V1InitializeParams {
   };
 }
 
-const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(function* (input: {
+interface CodexAppServerConnectInput {
   readonly binaryPath: string;
   readonly homePath?: string;
   readonly launchArgs?: string;
   readonly cwd: string;
-  readonly customModels?: ReadonlyArray<string>;
   readonly environment?: NodeJS.ProcessEnv;
-}) {
+}
+
+/**
+ * Spawn `codex app-server` in `cwd`, run the initialize handshake, and
+ * hand back the connected client. Requires a `Scope` — the subprocess and
+ * client live until the caller's scope closes.
+ */
+const connectCodexAppServerClient = Effect.fn("connectCodexAppServerClient")(function* (
+  input: CodexAppServerConnectInput,
+) {
   // `~` is not shell-expanded when env vars are set via `child_process.spawn`,
   // so `CODEX_HOME=~/.codex_work` would reach codex verbatim and trip
   // "CODEX_HOME points to '~/.codex_work', but that path does not exist".
@@ -380,6 +388,45 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
     },
   });
   yield* client.notify("initialized", undefined);
+
+  return { client, initialize };
+});
+
+/**
+ * Contextual skill inventory for the `$` picker: what a Codex session
+ * launched in `cwd` would load, straight from the app-server's
+ * `skills/list`. Best-effort — any failure or timeout yields `[]`.
+ */
+// Same budget as the auth probe: both pay one app-server spawn + handshake.
+const CODEX_SKILLS_PROBE_TIMEOUT_MS = AUTH_PROBE_TIMEOUT_MS;
+
+export const discoverCodexSkills = Effect.fn("discoverCodexSkills")(function* (
+  input: CodexAppServerConnectInput,
+): Effect.fn.Return<
+  ReadonlyArray<ServerProviderSkill>,
+  never,
+  ChildProcessSpawner.ChildProcessSpawner
+> {
+  return yield* Effect.gen(function* () {
+    const { client } = yield* connectCodexAppServerClient(input);
+    const skillsResponse = yield* client.request("skills/list", {
+      cwds: [input.cwd],
+    });
+    return parseCodexSkillsListResponse(skillsResponse, input.cwd);
+  }).pipe(
+    Effect.scoped,
+    Effect.timeoutOption(Duration.millis(CODEX_SKILLS_PROBE_TIMEOUT_MS)),
+    Effect.map(Option.getOrElse((): ReadonlyArray<ServerProviderSkill> => [])),
+    Effect.orElseSucceed((): ReadonlyArray<ServerProviderSkill> => []),
+  );
+});
+
+const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(function* (
+  input: CodexAppServerConnectInput & {
+    readonly customModels?: ReadonlyArray<string>;
+  },
+) {
+  const { client, initialize } = yield* connectCodexAppServerClient(input);
 
   // Extract the version string after the first '/' in userAgent, up to the next space or the end
   const versionMatch = initialize.userAgent.match(/\/([^\s]+)/);

--- a/apps/server/src/provider/ProviderDriver.ts
+++ b/apps/server/src/provider/ProviderDriver.ts
@@ -25,6 +25,7 @@ import type {
   ProviderDriverKind,
   ProviderInstanceEnvironment,
   ProviderInstanceId,
+  ServerProviderSkill,
 } from "@t3tools/contracts";
 import type * as Effect from "effect/Effect";
 import type * as Schema from "effect/Schema";
@@ -71,6 +72,14 @@ export interface ProviderInstance {
   readonly snapshot: ServerProviderShape;
   readonly adapter: ProviderAdapterShape<ProviderAdapterError>;
   readonly textGeneration: TextGeneration.TextGeneration["Service"];
+  /**
+   * Contextual skill discovery for the composer's `$` picker: the skills
+   * this instance would load for a workspace directory. Never fails —
+   * implementations degrade to an empty list. Omitted by drivers whose
+   * CLI has no per-directory skill inventory (Cursor, OpenCode); callers
+   * fall back to the snapshot's baseline `skills`.
+   */
+  readonly discoverSkills?: (cwd: string) => Effect.Effect<ReadonlyArray<ServerProviderSkill>>;
 }
 
 export interface ProviderContinuationIdentity {

--- a/apps/server/src/provider/Services/ProviderSkillDiscovery.test.ts
+++ b/apps/server/src/provider/Services/ProviderSkillDiscovery.test.ts
@@ -1,0 +1,252 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { describe, expect, it } from "@effect/vitest";
+import {
+  ProviderDriverKind,
+  ProviderInstanceId,
+  type ServerProvider,
+  type ServerProviderSkill,
+} from "@t3tools/contracts";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Layer from "effect/Layer";
+import * as PubSub from "effect/PubSub";
+import * as Stream from "effect/Stream";
+
+import { makeManualOnlyProviderMaintenanceCapabilities } from "../providerMaintenance.ts";
+import type { ProviderInstance } from "../ProviderDriver.ts";
+import type * as TextGeneration from "../../textGeneration/TextGeneration.ts";
+import * as ProviderInstanceRegistry from "./ProviderInstanceRegistry.ts";
+import { ProviderSkillDiscovery, ProviderSkillDiscoveryLive } from "./ProviderSkillDiscovery.ts";
+
+const DRIVER_KIND = ProviderDriverKind.make("grok");
+
+const BASELINE_SKILL: ServerProviderSkill = {
+  name: "baseline",
+  path: "/home/user/.grok/skills/baseline/SKILL.md",
+  enabled: true,
+  scope: "user",
+};
+
+const PROJECT_SKILL: ServerProviderSkill = {
+  name: "project-skill",
+  path: "/repo/.grok/skills/project-skill/SKILL.md",
+  enabled: true,
+  scope: "project",
+};
+
+const makeInstance = (input: {
+  readonly instanceId: string;
+  readonly discoverSkills?: ProviderInstance["discoverSkills"];
+}): ProviderInstance => ({
+  instanceId: ProviderInstanceId.make(input.instanceId),
+  driverKind: DRIVER_KIND,
+  continuationIdentity: {
+    driverKind: DRIVER_KIND,
+    continuationKey: `${DRIVER_KIND}:instance:${input.instanceId}`,
+  },
+  displayName: undefined,
+  enabled: true,
+  snapshot: {
+    maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
+      provider: DRIVER_KIND,
+      packageName: null,
+    }),
+    getSnapshot: Effect.succeed({ skills: [BASELINE_SKILL] } as unknown as ServerProvider),
+    refresh: Effect.succeed({} as unknown as ServerProvider),
+    streamChanges: Stream.empty,
+  },
+  adapter: {} as ProviderInstance["adapter"],
+  textGeneration: {} as unknown as TextGeneration.TextGeneration["Service"],
+  ...(input.discoverSkills ? { discoverSkills: input.discoverSkills } : {}),
+});
+
+const makeLayer = (instances: ReadonlyArray<ProviderInstance>) =>
+  Layer.mergeAll(
+    Layer.provide(
+      ProviderSkillDiscoveryLive,
+      Layer.mergeAll(
+        Layer.succeed(ProviderInstanceRegistry.ProviderInstanceRegistry, {
+          getInstance: (instanceId) =>
+            Effect.succeed(instances.find((instance) => instance.instanceId === instanceId)),
+          listInstances: Effect.succeed(instances),
+          listUnavailable: Effect.succeed([]),
+          streamChanges: Stream.empty,
+          subscribeChanges: Effect.flatMap(PubSub.unbounded<void>(), (pubsub) =>
+            PubSub.subscribe(pubsub),
+          ),
+        }),
+        NodeServices.layer,
+      ),
+    ),
+    NodeServices.layer,
+  );
+
+describe("ProviderSkillDiscovery", () => {
+  it.effect("returns an empty inventory for an unknown instance", () =>
+    Effect.gen(function* () {
+      const discovery = yield* ProviderSkillDiscovery;
+      const result = yield* discovery.listSkills({
+        instanceId: ProviderInstanceId.make("missing"),
+        cwd: "/repo",
+      });
+      expect(result.skills).toEqual([]);
+    }).pipe(Effect.provide(makeLayer([]))),
+  );
+
+  it.effect("serves the snapshot baseline for a null cwd", () =>
+    Effect.gen(function* () {
+      const discovery = yield* ProviderSkillDiscovery;
+      const result = yield* discovery.listSkills({
+        instanceId: ProviderInstanceId.make("grok"),
+        cwd: null,
+      });
+      expect(result.skills).toEqual([BASELINE_SKILL]);
+    }).pipe(
+      Effect.provide(
+        makeLayer([
+          makeInstance({
+            instanceId: "grok",
+            discoverSkills: () => Effect.succeed([PROJECT_SKILL]),
+          }),
+        ]),
+      ),
+    ),
+  );
+
+  it.effect("serves the snapshot baseline when the driver has no discovery", () =>
+    Effect.gen(function* () {
+      const discovery = yield* ProviderSkillDiscovery;
+      const result = yield* discovery.listSkills({
+        instanceId: ProviderInstanceId.make("cursor-like"),
+        cwd: "/repo",
+      });
+      expect(result.skills).toEqual([BASELINE_SKILL]);
+    }).pipe(Effect.provide(makeLayer([makeInstance({ instanceId: "cursor-like" })]))),
+  );
+
+  it.effect("waits for the first probe, then serves cached while revalidating", () => {
+    const state = { probes: 0, secondProbeDone: undefined as Deferred.Deferred<void> | undefined };
+    const instance = makeInstance({
+      instanceId: "grok",
+      discoverSkills: () =>
+        Effect.suspend(() => {
+          state.probes += 1;
+          return state.probes >= 2 && state.secondProbeDone
+            ? Deferred.succeed(state.secondProbeDone, undefined).pipe(Effect.as([PROJECT_SKILL]))
+            : Effect.succeed([PROJECT_SKILL]);
+        }),
+    });
+    return Effect.gen(function* () {
+      state.secondProbeDone = yield* Deferred.make<void>();
+      const discovery = yield* ProviderSkillDiscovery;
+      const instanceId = ProviderInstanceId.make("grok");
+
+      const cold = yield* discovery.listSkills({ instanceId, cwd: "/repo" });
+      expect(cold.skills).toEqual([PROJECT_SKILL]);
+      expect(state.probes).toBe(1);
+
+      // The warm hit answers from cache and forks one background probe.
+      const warm = yield* discovery.listSkills({ instanceId, cwd: "/repo" });
+      expect(warm.skills).toEqual([PROJECT_SKILL]);
+      yield* Deferred.await(state.secondProbeDone);
+      expect(state.probes).toBe(2);
+    }).pipe(Effect.provide(makeLayer([instance])));
+  });
+
+  it.effect("keeps the last good inventory when a revalidation dies", () => {
+    const state = { probes: 0, secondProbeDone: undefined as Deferred.Deferred<void> | undefined };
+    const instance = makeInstance({
+      instanceId: "grok",
+      discoverSkills: () =>
+        Effect.suspend(() => {
+          state.probes += 1;
+          if (state.probes === 1 || !state.secondProbeDone) {
+            return Effect.succeed([PROJECT_SKILL]);
+          }
+          return Deferred.succeed(state.secondProbeDone, undefined).pipe(
+            Effect.flatMap(() => Effect.die("probe crashed")),
+          );
+        }),
+    });
+    return Effect.gen(function* () {
+      state.secondProbeDone = yield* Deferred.make<void>();
+      const discovery = yield* ProviderSkillDiscovery;
+      const instanceId = ProviderInstanceId.make("grok");
+
+      const cold = yield* discovery.listSkills({ instanceId, cwd: "/repo" });
+      expect(cold.skills).toEqual([PROJECT_SKILL]);
+
+      const warm = yield* discovery.listSkills({ instanceId, cwd: "/repo" });
+      expect(warm.skills).toEqual([PROJECT_SKILL]);
+      yield* Deferred.await(state.secondProbeDone);
+
+      // The dead probe must not have evicted the last good inventory.
+      const afterFailure = yield* discovery.listSkills({ instanceId, cwd: "/repo" });
+      expect(afterFailure.skills).toEqual([PROJECT_SKILL]);
+    }).pipe(Effect.provide(makeLayer([instance])));
+  });
+
+  it.effect("evicts the oldest key once the cache bound is exceeded", () => {
+    const probedCwds: string[] = [];
+    const instance = makeInstance({
+      instanceId: "grok",
+      discoverSkills: (cwd) =>
+        Effect.sync(() => {
+          probedCwds.push(cwd);
+          return [PROJECT_SKILL];
+        }),
+    });
+    return Effect.gen(function* () {
+      const discovery = yield* ProviderSkillDiscovery;
+      const instanceId = ProviderInstanceId.make("grok");
+
+      // Fill one entry past the 64-entry bound, evicting the first key.
+      for (let index = 0; index <= 64; index += 1) {
+        yield* discovery.listSkills({ instanceId, cwd: `/repo-${index}` });
+      }
+      const probesBefore = probedCwds.length;
+
+      // The evicted key is cold again: this request waits on a fresh probe
+      // rather than answering from cache.
+      const refetched = yield* discovery.listSkills({ instanceId, cwd: "/repo-0" });
+      expect(refetched.skills).toEqual([PROJECT_SKILL]);
+      expect(probedCwds.length).toBeGreaterThan(probesBefore);
+      expect(probedCwds.at(-1)).toBe("/repo-0");
+    }).pipe(Effect.provide(makeLayer([instance])));
+  });
+
+  it.effect("coalesces concurrent cold requests onto one probe", () => {
+    const state = { probes: 0, release: undefined as Deferred.Deferred<void> | undefined };
+    const instance = makeInstance({
+      instanceId: "grok",
+      discoverSkills: () =>
+        Effect.suspend(() => {
+          state.probes += 1;
+          return state.release
+            ? Deferred.await(state.release).pipe(Effect.as([PROJECT_SKILL]))
+            : Effect.succeed([PROJECT_SKILL]);
+        }),
+    });
+    return Effect.gen(function* () {
+      state.release = yield* Deferred.make<void>();
+      const discovery = yield* ProviderSkillDiscovery;
+      const instanceId = ProviderInstanceId.make("grok");
+
+      const fiberA = yield* discovery
+        .listSkills({ instanceId, cwd: "/repo" })
+        .pipe(Effect.forkChild);
+      const fiberB = yield* discovery
+        .listSkills({ instanceId, cwd: "/repo" })
+        .pipe(Effect.forkChild);
+      yield* Effect.yieldNow;
+      yield* Deferred.succeed(state.release, undefined);
+
+      const first = yield* Fiber.join(fiberA);
+      const second = yield* Fiber.join(fiberB);
+      expect(first.skills).toEqual([PROJECT_SKILL]);
+      expect(second.skills).toEqual([PROJECT_SKILL]);
+      expect(state.probes).toBe(1);
+    }).pipe(Effect.provide(makeLayer([instance])));
+  });
+});

--- a/apps/server/src/provider/Services/ProviderSkillDiscovery.ts
+++ b/apps/server/src/provider/Services/ProviderSkillDiscovery.ts
@@ -1,0 +1,150 @@
+/**
+ * ProviderSkillDiscovery — contextual skill inventories for the composer's
+ * `$` picker, keyed by `(providerInstanceId, realpath(cwd))`.
+ *
+ * Served stale-while-revalidate: a cached inventory returns immediately
+ * while a fresh probe runs in the background for the next request; a cold
+ * key waits for its first probe, with concurrent requests coalesced onto
+ * one probe. A `null` cwd (directoryless threads) and providers without
+ * contextual discovery answer from the instance's snapshot baseline. A
+ * failed probe keeps the last good inventory.
+ *
+ * @module provider/Services/ProviderSkillDiscovery
+ */
+import type {
+  ServerProviderSkill,
+  ServerProviderSkillsInput,
+  ServerProviderSkillsResult,
+} from "@t3tools/contracts";
+import * as Context from "effect/Context";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Scope from "effect/Scope";
+
+import { ProviderInstanceRegistry } from "./ProviderInstanceRegistry.ts";
+
+/** Bounds the cache across instances x workspaces; oldest entry evicted. */
+const SKILL_CACHE_CAPACITY = 64;
+
+const KEY_SEPARATOR = String.fromCharCode(0);
+
+export interface ProviderSkillDiscoveryShape {
+  readonly listSkills: (
+    input: ServerProviderSkillsInput,
+  ) => Effect.Effect<ServerProviderSkillsResult>;
+}
+
+export class ProviderSkillDiscovery extends Context.Service<
+  ProviderSkillDiscovery,
+  ProviderSkillDiscoveryShape
+>()("t3/provider/Services/ProviderSkillDiscovery") {}
+
+export const ProviderSkillDiscoveryLive = Layer.effect(
+  ProviderSkillDiscovery,
+  Effect.gen(function* () {
+    const registry = yield* ProviderInstanceRegistry;
+    const fileSystem = yield* FileSystem.FileSystem;
+    const revalidateScope = yield* Scope.make("sequential");
+    yield* Effect.addFinalizer(() => Scope.close(revalidateScope, Exit.void));
+
+    const cache = new Map<string, ReadonlyArray<ServerProviderSkill>>();
+    const inflight = new Map<string, Deferred.Deferred<ReadonlyArray<ServerProviderSkill>>>();
+
+    const rememberSkills = (key: string, skills: ReadonlyArray<ServerProviderSkill>) => {
+      cache.delete(key);
+      cache.set(key, skills);
+      while (cache.size > SKILL_CACHE_CAPACITY) {
+        const oldestKey = cache.keys().next().value;
+        if (oldestKey === undefined) break;
+        cache.delete(oldestKey);
+      }
+    };
+
+    const runProbe = (
+      key: string,
+      deferred: Deferred.Deferred<ReadonlyArray<ServerProviderSkill>>,
+      discover: (cwd: string) => Effect.Effect<ReadonlyArray<ServerProviderSkill>>,
+      cwd: string,
+    ) =>
+      Effect.gen(function* () {
+        const exit = yield* Effect.exit(discover(cwd));
+        if (Exit.isSuccess(exit)) {
+          rememberSkills(key, exit.value);
+        } else {
+          yield* Effect.logWarning("Provider skill probe failed; keeping last inventory.", {
+            key,
+          });
+        }
+        yield* Deferred.succeed(
+          deferred,
+          Exit.isSuccess(exit) ? exit.value : (cache.get(key) ?? []),
+        );
+      }).pipe(
+        // Cleanup on ANY exit, interruption included: drop the inflight
+        // entry and unblock waiters with the last good inventory. A
+        // completed deferred ignores the second succeed.
+        Effect.onExit(() =>
+          Effect.gen(function* () {
+            inflight.delete(key);
+            yield* Deferred.succeed(deferred, cache.get(key) ?? []);
+          }),
+        ),
+      );
+
+    /**
+     * Ensure one probe is in flight for `key` and return its deferred.
+     * The probe runs detached in the service scope so an interrupted
+     * request (picker closed, client gone) can never orphan the inflight
+     * entry and wedge the key.
+     */
+    const ensureProbe = (
+      key: string,
+      discover: (cwd: string) => Effect.Effect<ReadonlyArray<ServerProviderSkill>>,
+      cwd: string,
+    ): Effect.Effect<Deferred.Deferred<ReadonlyArray<ServerProviderSkill>>> =>
+      Effect.gen(function* () {
+        const deferred = yield* Deferred.make<ReadonlyArray<ServerProviderSkill>>();
+        // No yield points between the check and the set: the first fiber
+        // to reach here wins the key, later ones join its deferred.
+        const existing = inflight.get(key);
+        if (existing) {
+          return existing;
+        }
+        inflight.set(key, deferred);
+        yield* runProbe(key, deferred, discover, cwd).pipe(Effect.forkIn(revalidateScope));
+        return deferred;
+      });
+
+    const listSkills = (
+      input: ServerProviderSkillsInput,
+    ): Effect.Effect<ServerProviderSkillsResult> =>
+      Effect.gen(function* () {
+        const instance = yield* registry.getInstance(input.instanceId);
+        if (instance === undefined) {
+          return { skills: [] };
+        }
+        const discover = instance.discoverSkills;
+        const workspaceCwd = input.cwd;
+        if (workspaceCwd === null || discover === undefined) {
+          const snapshot = yield* instance.snapshot.getSnapshot;
+          return { skills: snapshot.skills };
+        }
+
+        const cwd = yield* fileSystem
+          .realPath(workspaceCwd)
+          .pipe(Effect.orElseSucceed(() => workspaceCwd));
+        const key = `${input.instanceId}${KEY_SEPARATOR}${cwd}`;
+        const cached = cache.get(key);
+        const deferred = yield* ensureProbe(key, discover, cwd);
+        if (cached !== undefined) {
+          return { skills: cached };
+        }
+        return { skills: yield* Deferred.await(deferred) };
+      });
+
+    return { listSkills } satisfies ProviderSkillDiscoveryShape;
+  }),
+);

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -114,6 +114,7 @@ import * as ProjectionSnapshotQuery from "./orchestration/Services/ProjectionSna
 import { SqlitePersistenceMemory } from "./persistence/Layers/Sqlite.ts";
 import { PersistenceSqlError } from "./persistence/Errors.ts";
 import * as ProviderRegistry from "./provider/Services/ProviderRegistry.ts";
+import * as ProviderSkillDiscovery from "./provider/Services/ProviderSkillDiscovery.ts";
 import { makeManualOnlyProviderMaintenanceCapabilities } from "./provider/providerMaintenance.ts";
 import * as ServerLifecycleEvents from "./serverLifecycleEvents.ts";
 import * as ServerRuntimeStartup from "./serverRuntimeStartup.ts";
@@ -627,18 +628,23 @@ const buildAppUnderTest = (options?: {
         }),
       ),
       Layer.provide(
-        Layer.mock(ProviderRegistry.ProviderRegistry)({
-          getProviders: Effect.succeed([]),
-          refresh: () => Effect.succeed([]),
-          refreshInstance: () => Effect.succeed([]),
-          getProviderMaintenanceCapabilitiesForInstance: (_instanceId, provider) =>
-            Effect.succeed(
-              makeManualOnlyProviderMaintenanceCapabilities({ provider, packageName: null }),
-            ),
-          setProviderMaintenanceActionState: () => Effect.succeed([]),
-          streamChanges: Stream.empty,
-          ...options?.layers?.providerRegistry,
-        }),
+        Layer.mergeAll(
+          Layer.mock(ProviderRegistry.ProviderRegistry)({
+            getProviders: Effect.succeed([]),
+            refresh: () => Effect.succeed([]),
+            refreshInstance: () => Effect.succeed([]),
+            getProviderMaintenanceCapabilitiesForInstance: (_instanceId, provider) =>
+              Effect.succeed(
+                makeManualOnlyProviderMaintenanceCapabilities({ provider, packageName: null }),
+              ),
+            setProviderMaintenanceActionState: () => Effect.succeed([]),
+            streamChanges: Stream.empty,
+            ...options?.layers?.providerRegistry,
+          }),
+          Layer.mock(ProviderSkillDiscovery.ProviderSkillDiscovery)({
+            listSkills: () => Effect.succeed({ skills: [] }),
+          }),
+        ),
       ),
       Layer.provide(
         Layer.mock(ServerSettings.ServerSettingsService)({

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -43,6 +43,7 @@ import * as GitHubCli from "./sourceControl/GitHubCli.ts";
 import * as GitLabCli from "./sourceControl/GitLabCli.ts";
 import * as TextGeneration from "./textGeneration/TextGeneration.ts";
 import { ProviderInstanceRegistryHydrationLive } from "./provider/Layers/ProviderInstanceRegistryHydration.ts";
+import { ProviderSkillDiscoveryLive } from "./provider/Services/ProviderSkillDiscovery.ts";
 import * as TerminalManager from "./terminal/Manager.ts";
 import * as McpHttpServer from "./mcp/McpHttpServer.ts";
 import * as McpSessionRegistry from "./mcp/McpSessionRegistry.ts";
@@ -384,8 +385,12 @@ const RuntimeCoreDependenciesLive = ReactorLayerLive.pipe(
   // adapter lookup, and runtime ingestion all resolve `ProviderInstanceId`
   // through this layer. Built-in drivers come from `BUILT_IN_DRIVERS`;
   // `providerInstances` hydration merges `settings.providers.<kind>`
-  // with explicit `providerInstances` entries on boot.
-  Layer.provideMerge(ProviderInstanceRegistryHydrationLive),
+  // with explicit `providerInstances` entries on boot. Skill discovery
+  // (contextual `$`-picker inventories per (instance, cwd)) rides the
+  // same entry, fed by the registry it resolves instances from.
+  Layer.provideMerge(
+    ProviderSkillDiscoveryLive.pipe(Layer.provideMerge(ProviderInstanceRegistryHydrationLive)),
+  ),
   // Shared native/canonical NDJSON writers used by both the per-instance
   // drivers (native stream, written from inside each `<X>Adapter`) and
   // `ProviderService` (canonical stream, written after event normalization).

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -79,6 +79,7 @@ import {
   observeRpcStreamEffect as instrumentRpcStreamEffect,
 } from "./observability/RpcInstrumentation.ts";
 import * as ProviderRegistry from "./provider/Services/ProviderRegistry.ts";
+import * as ProviderSkillDiscovery from "./provider/Services/ProviderSkillDiscovery.ts";
 import * as ProviderMaintenanceRunner from "./provider/providerMaintenanceRunner.ts";
 import * as ServerSelfUpdate from "./cloud/selfUpdate.ts";
 import * as ServerLifecycleEvents from "./serverLifecycleEvents.ts";
@@ -371,6 +372,7 @@ const makeWsRpcLayer = (
       const previewManager = yield* PreviewManager.PreviewManager;
       const portDiscovery = yield* PortScanner.PortDiscovery;
       const providerRegistry = yield* ProviderRegistry.ProviderRegistry;
+      const providerSkillDiscovery = yield* ProviderSkillDiscovery.ProviderSkillDiscovery;
       const providerMaintenanceRunner = yield* ProviderMaintenanceRunner.ProviderMaintenanceRunner;
       const serverSelfUpdate = yield* ServerSelfUpdate.ServerSelfUpdate;
       const config = yield* ServerConfig.ServerConfig;
@@ -1445,6 +1447,12 @@ const makeWsRpcLayer = (
           observeRpcEffect(WS_METHODS.serverGetConfig, loadServerConfig, {
             "rpc.aggregate": "server",
           }),
+        [WS_METHODS.serverListProviderSkills]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.serverListProviderSkills,
+            providerSkillDiscovery.listSkills(input),
+            { "rpc.aggregate": "server" },
+          ),
         [WS_METHODS.serverRefreshProviders]: (input) =>
           observeRpcEffect(
             WS_METHODS.serverRefreshProviders,

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -9,6 +9,7 @@ import type {
   RuntimeMode,
   ScopedThreadRef,
   ServerProvider,
+  ServerProviderSkill,
   ThreadId,
 } from "@t3tools/contracts";
 import {
@@ -76,6 +77,7 @@ import {
   removeInlineTerminalContextPlaceholder,
 } from "../../lib/terminalContext";
 import { useComposerPathSearch } from "../../lib/composerPathSearchState";
+import { useProviderContextSkills } from "../../state/queries";
 import { type ElementContextDraft } from "../../lib/elementContext";
 import { ComposerPendingElementContexts } from "./ComposerPendingElementContexts";
 import { ComposerPendingReviewComments } from "./ComposerPendingReviewComments";
@@ -1031,6 +1033,37 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     cwd: isPathTrigger ? gitCwd : null,
     query: isPathTrigger ? pathTriggerQuery : null,
   });
+  // Contextual skills for the `$` picker: what this instance would load
+  // in the thread's workspace, not the snapshot's server-global list.
+  // Fetched only while the `$` trigger is active; the last inventory is
+  // retained afterwards so inserted `$name` chips keep their labels and
+  // descriptions once the trigger closes and the query goes idle. Until
+  // the first response lands the snapshot baseline fills in.
+  const isSkillTrigger = composerTriggerKind === "skill";
+  const providerContextSkills = useProviderContextSkills({
+    environmentId,
+    instanceId: isSkillTrigger && !noProviderAvailable ? selectedInstanceId : null,
+    cwd: gitCwd,
+  });
+  const retainedContextSkillsRef = useRef<{
+    key: string;
+    skills: ReadonlyArray<ServerProviderSkill>;
+  } | null>(null);
+  const contextSkillsKey = `${selectedInstanceId} ${gitCwd ?? ""}`;
+  if (providerContextSkills.skills !== null) {
+    retainedContextSkillsRef.current = {
+      key: contextSkillsKey,
+      skills: providerContextSkills.skills,
+    };
+  }
+  const retainedContextSkills =
+    retainedContextSkillsRef.current?.key === contextSkillsKey
+      ? retainedContextSkillsRef.current.skills
+      : null;
+  const composerSkills = useMemo(
+    () => retainedContextSkills ?? selectedProviderStatus?.skills ?? [],
+    [retainedContextSkills, selectedProviderStatus],
+  );
 
   const composerMenuItems = useMemo<ComposerCommandItem[]>(() => {
     if (!composerTrigger) return [];
@@ -1090,22 +1123,21 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       return searchSlashCommandItems(slashCommandItems, query);
     }
     if (composerTrigger.kind === "skill") {
-      return searchProviderSkills(selectedProviderStatus?.skills ?? [], composerTrigger.query).map(
-        (skill) => ({
-          id: `skill:${selectedProvider}:${skill.name}`,
-          type: "skill" as const,
-          provider: selectedProvider,
-          skill,
-          label: formatProviderSkillDisplayName(skill),
-          description:
-            skill.shortDescription ??
-            skill.description ??
-            (skill.scope ? `${skill.scope} skill` : "Run provider skill"),
-        }),
-      );
+      return searchProviderSkills(composerSkills, composerTrigger.query).map((skill) => ({
+        id: `skill:${selectedProvider}:${skill.name}`,
+        type: "skill" as const,
+        provider: selectedProvider,
+        skill,
+        label: formatProviderSkillDisplayName(skill),
+        description:
+          skill.shortDescription ??
+          skill.description ??
+          (skill.scope ? `${skill.scope} skill` : "Run provider skill"),
+      }));
     }
     return [];
   }, [
+    composerSkills,
     composerTrigger,
     planModeUiEnabled,
     selectedProvider,
@@ -1175,7 +1207,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   ]);
 
   const isComposerMenuLoading =
-    composerTriggerKind === "path" && pathTriggerQuery.length > 0 && workspaceEntries.isPending;
+    (composerTriggerKind === "path" && pathTriggerQuery.length > 0 && workspaceEntries.isPending) ||
+    (composerTriggerKind === "skill" &&
+      composerSkills.length === 0 &&
+      providerContextSkills.isPending);
   const composerMenuEmptyState = useMemo(() => {
     if (composerTriggerKind === "skill") {
       return "No skills found. Try / to browse provider commands.";
@@ -3057,7 +3092,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                     ? composerTerminalContexts
                     : []
                 }
-                skills={selectedProviderStatus?.skills ?? []}
+                skills={composerSkills}
                 {...(showMobilePendingAnswerActions ? { className: "max-sm:pb-11" } : {})}
                 onRemoveTerminalContext={removeComposerTerminalContextFromDraft}
                 onChange={onPromptChange}

--- a/apps/web/src/state/queries.ts
+++ b/apps/web/src/state/queries.ts
@@ -14,6 +14,7 @@ import type {
   OrchestrationThread,
   ProjectContentMatch,
   ProjectEntryKind,
+  ProviderInstanceId,
   ThreadId,
   VcsListRefsResult,
   VcsRef,
@@ -28,6 +29,7 @@ import { orchestrationEnvironment } from "./orchestration";
 import { isPaginatedBranchesNextPagePending } from "./paginatedBranches";
 import { projectContentSearch, projectEnvironment } from "./projects";
 import { useEnvironmentQuery } from "./query";
+import { serverEnvironment } from "./server";
 import { useEnvironmentThread } from "./threads";
 import { vcsEnvironment } from "./vcs";
 
@@ -300,6 +302,34 @@ export function useProjectPathSearch(
 
 export function useComposerPathSearch(target: ComposerPathSearchTarget) {
   return useProjectPathSearch(target, COMPOSER_PATH_SEARCH_LIMIT);
+}
+
+interface ProviderContextSkillsTarget {
+  readonly environmentId: EnvironmentId | null;
+  readonly instanceId: ProviderInstanceId | null;
+  readonly cwd: string | null;
+}
+
+/**
+ * The skills the selected provider instance would load for the thread's
+ * workspace, from `server.listProviderSkills`. `skills` is `null` until
+ * the first response lands — callers fall back to the provider snapshot's
+ * baseline list. Fetched per (environment, instance, cwd); the server
+ * serves cached inventories stale-while-revalidate.
+ */
+export function useProviderContextSkills(target: ProviderContextSkillsTarget) {
+  const result = useEnvironmentQuery(
+    target.environmentId !== null && target.instanceId !== null
+      ? serverEnvironment.providerSkills({
+          environmentId: target.environmentId,
+          input: { instanceId: target.instanceId, cwd: target.cwd },
+        })
+      : null,
+  );
+  return {
+    skills: result.data?.skills ?? null,
+    isPending: result.isPending,
+  };
 }
 
 interface ProjectContentSearchTarget {

--- a/docs/internals/glossary.md
+++ b/docs/internals/glossary.md
@@ -116,6 +116,18 @@ Controls how assistant text reaches the thread timeline. In [the contracts][1], 
 
 A point-in-time view of state. The word is used in multiple layers, including orchestration, provider, and checkpointing. See [ProjectionSnapshotQuery.ts][10], [ProviderAdapter.ts][15], and [CheckpointStore.ts][19].
 
+#### Skill discovery
+
+The contextual skill inventory behind the composer's `$` picker. Each driver may expose
+`discoverSkills(cwd)` on its `ProviderInstance` (Claude and Codex do today; Cursor and
+OpenCode do not), and `ProviderSkillDiscovery` serves `server.listProviderSkills` requests
+keyed by `(instanceId, realpath(cwd))` stale-while-revalidate: cached inventories answer
+immediately while one detached probe refreshes the key, cold requests coalesce onto that
+probe, and failed probes keep the last good inventory. The provider snapshot's flat `skills`
+field remains the user-scope baseline, used for directoryless threads, providers without
+discovery, and clients that have not adopted the request — the mobile composer deliberately
+stays on it until it adopts the additive contract.
+
 ### Checkpointing
 
 Checkpointing captures workspace state over time so the app can diff turns and restore earlier points. The main pieces are [CheckpointStore.ts][19], [CheckpointDiffQuery.ts][20], and [CheckpointReactor.ts][6].

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -3,3 +3,10 @@
 Messages can contain up to 120,000 characters. If a draft is longer, T3 Code keeps it in the
 composer and shows how many characters need to be removed. Shorten the draft or split it into
 multiple messages, then send again in the same thread.
+
+## Skills
+
+Type `$` to browse the skills the selected agent can use. The list shows what that agent would
+load in the thread's own workspace — personal skills plus the project's skills — so different
+projects show different lists, and a skill you add to a project appears within moments of the
+next time you open the picker. Threads without a workspace directory show personal skills only.

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -723,6 +723,15 @@ export function createServerEnvironmentAtoms<R, E>(
           Stream.mapAccum(Option.none<ServerLifecycleWelcomePayload>, projectServerWelcome),
         ),
     }),
+    // Contextual `$`-picker skills for (instance, cwd). The server serves
+    // these stale-while-revalidate, so a short client stale window only
+    // dedupes rapid picker re-opens.
+    providerSkills: createEnvironmentRpcQueryAtomFamily(runtime, {
+      label: "environment-data:server:provider-skills",
+      tag: WS_METHODS.serverListProviderSkills,
+      staleTimeMs: 5_000,
+      idleTtlMs: 5 * 60_000,
+    }),
     refreshProviders: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:server:refresh-providers",
       tag: WS_METHODS.serverRefreshProviders,

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -154,6 +154,8 @@ import {
 import {
   ServerConfigStreamEvent,
   ServerConfig,
+  ServerProviderSkillsInput,
+  ServerProviderSkillsResult,
   ServerProviderUpdateError,
   ServerProviderUpdateInput,
   ServerLifecycleStreamEvent,
@@ -255,6 +257,7 @@ export const WS_METHODS = {
   serverProbe: "server.probe",
   serverGetConfig: "server.getConfig",
   serverRefreshProviders: "server.refreshProviders",
+  serverListProviderSkills: "server.listProviderSkills",
   serverUpdateProvider: "server.updateProvider",
   serverUpdateServer: "server.updateServer",
   serverUpdateServerWithProgress: "server.updateServerWithProgress",
@@ -350,6 +353,12 @@ export const WsServerRefreshProvidersRpc = Rpc.make(WS_METHODS.serverRefreshProv
     instanceId: Schema.optional(ProviderInstanceId),
   }),
   success: ServerProviderUpdatedPayload,
+  error: EnvironmentAuthorizationError,
+});
+
+export const WsServerListProviderSkillsRpc = Rpc.make(WS_METHODS.serverListProviderSkills, {
+  payload: ServerProviderSkillsInput,
+  success: ServerProviderSkillsResult,
   error: EnvironmentAuthorizationError,
 });
 
@@ -986,6 +995,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsServerProbeRpc,
   WsServerGetConfigRpc,
   WsServerRefreshProvidersRpc,
+  WsServerListProviderSkillsRpc,
   WsServerUpdateProviderRpc,
   WsServerUpdateServerRpc,
   WsServerUpdateServerWithProgressRpc,

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -97,6 +97,30 @@ export const ServerProviderSkill = Schema.Struct({
 export type ServerProviderSkill = typeof ServerProviderSkill.Type;
 
 /**
+ * Request the skills a provider instance would load for a workspace
+ * directory — the picker's data source. `cwd: null` asks for the
+ * user-scope inventory (directoryless threads). The `cwd` is
+ * client-supplied, matching the workspace file APIs.
+ */
+export const ServerProviderSkillsInput = Schema.Struct({
+  instanceId: ProviderInstanceId,
+  cwd: Schema.NullOr(TrimmedNonEmptyString),
+});
+export type ServerProviderSkillsInput = typeof ServerProviderSkillsInput.Type;
+
+/**
+ * The provider's authoritative merged skill list for the requested
+ * directory. Served stale-while-revalidate: a cached inventory returns
+ * immediately while a fresh probe runs for the next request. An unknown
+ * instance or a provider without contextual discovery yields the
+ * instance's snapshot baseline instead of an error.
+ */
+export const ServerProviderSkillsResult = Schema.Struct({
+  skills: Schema.Array(ServerProviderSkill),
+});
+export type ServerProviderSkillsResult = typeof ServerProviderSkillsResult.Type;
+
+/**
  * Availability of a configured provider instance from the runtime's POV.
  *
  *  - `available` — the build ships this driver and an instance is wired


### PR DESCRIPTION
## What Changed

Skill discovery for the composer's `$` picker is now contextual instead of server-global. A new `server.listProviderSkills` request (read scope) returns the skills a provider instance would load for a workspace directory; drivers expose an optional `discoverSkills(cwd)` at the adapter boundary — Claude reuses its filesystem scan, Codex gets a skills-only app-server probe via a connect helper extracted from the existing auth probe (probe path unchanged). A `ProviderSkillDiscovery` service serves inventories stale-while-revalidate keyed by `(instanceId, realpath(cwd))`: cached answers return instantly while one detached probe refreshes the key, cold requests coalesce onto that probe, failed probes keep the last good inventory, and probes run detached from the requesting fiber so an interrupted request can never wedge a key. The web picker fetches while the `$` trigger is active and retains the last inventory so inserted `$name` chips keep their labels.

The provider snapshot's flat `skills` field is unchanged and remains the user-scope baseline — used for directoryless threads, providers without contextual discovery (Cursor, OpenCode; Grok gains it when #7293's `grok inspect` discovery lands), and clients that haven't adopted the additive request (mobile keeps working on the baseline).

## Why

Discovery ran once per provider at the server process's cwd. The packaged desktop app spawns the backend at the user's home directory (`DesktopEnvironment.backendCwd = homeDirectory` when packaged), so project-scope skills — the `.agents/skills` / `.claude/skills` entries checked into repos — never appeared in the picker for any provider. It only ever looked right under `npx t3` dev usage because the server happened to start inside a repo. One server-global list also cannot express per-project skills at all on a multi-client server. This fixes the wrong shape at the source rather than patching the cwd: skills are per `(provider instance, workspace cwd)`, so the request is too.

Verified against a real desktop-shaped setup (server cwd = home): Claude and Codex threads now list repo-scope skills for the open project; directoryless behavior unchanged. Focused tests cover the service (cold-wait, warm+revalidate, coalescing, keep-last-good on a dying probe, cache-bound eviction, null-cwd and unknown-instance fallbacks) plus the RPC scope gate.

Happy to convert this to a discussion first if you'd prefer per CONTRIBUTING — the diagnosis half (desktop cwd) may be useful either way.

## UI Changes

No rendering changes — the existing picker receives per-project data; a cold Codex fetch shows the picker's existing loading state. Can add before/after screenshots on request.

Work done by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New RPC and Codex app-server spawns on picker open add process/timeout surface area, but probes are best-effort, cached, and scoped read-only; snapshot baseline behavior is unchanged for null cwd and unsupported drivers.
> 
> **Overview**
> The composer's **`$` skill picker** no longer relies on the provider snapshot's server-global skill list when a thread has a workspace. It calls **`server.listProviderSkills`** (read scope) with `(instanceId, cwd)` so inventories reflect what that agent would load **in that project**.
> 
> **Server:** **`ProviderSkillDiscovery`** resolves instances from the registry, caches by `(instanceId, realpath(cwd))` with stale-while-revalidate (64-entry LRU, coalesced probes, last-good on failure). **`ProviderInstance.discoverSkills(cwd)`** is implemented for **Claude** (filesystem scan) and **Codex** (app-server `skills/list` via shared **`connectCodexAppServerClient`**); drivers without it still use snapshot baseline skills.
> 
> **Web:** **`useProviderContextSkills`** fetches while the `$` trigger is active; **`ChatComposer`** uses that list (with retention for chip labels) instead of **`selectedProviderStatus?.skills`**.
> 
> Contracts, client-runtime query atoms, WS handler, runtime layer wiring, tests, and user/docs glossary updates ship with the RPC.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a065ab2f1b167c47f9618fd2ccfbd3249e202a1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Discover `$`-picker skills per project workspace instead of server cwd
> - Adds a `ProviderSkillDiscovery` service with stale-while-revalidate (SWR) semantics, bounded LRU cache (64 entries), per-key single-flight probes, and background revalidation so skill lists stay fresh without blocking the UI.
> - Claude and Codex `ProviderInstance` objects now expose `discoverSkills(cwd)` to return context-specific skills for a given workspace directory.
> - The `$`-picker in `ChatComposer` fetches skills per `(instanceId, cwd)` and shows a loading indicator while discovery is pending; the last known inventory is retained when the trigger closes.
> - Adds `server.listProviderSkills` RPC (requiring `AuthOrchestrationReadScope`) wired through contracts, WebSocket handler, and client-runtime query atom with a 5-second client stale window.
> - Behavioral Change: skills shown in the `$`-picker now reflect the thread's workspace directory and may differ between projects; directoryless threads fall back to the snapshot baseline.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a065ab2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->