### PR TITLE
fix(mobile): composer no longer wedges with a dead send button

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -815,6 +815,11 @@ export function NewTaskDraftScreen(props: {
       editable={!isIncomingShareTransferPending}
       multiline
       scrollEnabled
+      // The draft key identifies the controlled document: switching projects or
+      // starting another task replaces the prompt rather than editing it, so
+      // the editor must not classify it against the previous draft's revision
+      // history (see documentKey in T3ComposerEditor.types.ts).
+      documentKey={flow.draftKey ?? "new-task"}
       value={flow.prompt}
       skills={flow.selectedProviderSkills}
       onChangeText={flow.setPrompt}

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -289,6 +289,12 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
   const { onExpandedChange } = props;
 
   const [previewImageUri, setPreviewImageUri] = useState<string | null>(null);
+  // Identifies the controlled document handed to the editor: a thread switch
+  // or a send replaces the document rather than editing it, and the editor
+  // must not classify the replacement against the previous document's
+  // revision history (see documentKey in T3ComposerEditor.types.ts).
+  const [sendEpoch, setSendEpoch] = useState(0);
+  const composerDocumentKey = `${scopedThreadKey(props.environmentId, props.selectedThread.id)}:${sendEpoch}`;
   const hasContent = props.draftMessage.trim().length > 0 || props.draftAttachments.length > 0;
   // Opening and presentation count as active so the composer stays expanded
   // while focus moves between its native editor and the settings picker.
@@ -540,6 +546,11 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     const threadKey = scopedThreadKey(props.environmentId, props.selectedThread.id);
     if (inFlightThreadIdsRef.current.has(threadKey)) return;
     inFlightThreadIdsRef.current.add(threadKey);
+    // Sending replaces the controlled document (the draft clears). Bump the
+    // document identity before the cleared draft can render, so the editor
+    // applies the empty document instead of stamping it behind a stale
+    // revision and rejecting it.
+    setSendEpoch((epoch) => epoch + 1);
     try {
       await onSendMessage();
       // Sending a prompt starts agent work: arm the lock-screen card while the
@@ -782,6 +793,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
             <ComposerEditor
               ref={inputRef}
               multiline
+              documentKey={composerDocumentKey}
               value={props.draftMessage}
               skills={selectedProviderStatus?.skills ?? []}
               selection={composerSelection}

--- a/apps/mobile/src/native/T3ComposerEditor.ios.tsx
+++ b/apps/mobile/src/native/T3ComposerEditor.ios.tsx
@@ -29,6 +29,7 @@ import type { ComposerEditorProps, ComposerEditorSelection } from "./T3ComposerE
 
 const NATIVE_MODULE_NAME = "T3ComposerEditor";
 const EMPTY_SKILLS: NonNullable<ComposerEditorProps["skills"]> = [];
+const EMPTY_SNAPSHOTS: ComposerNativeEventSnapshot[] = [];
 
 type NativeEditorEvent = NativeSyntheticEvent<{
   readonly value: string;
@@ -108,20 +109,23 @@ export function ComposerEditor({
   // first controlled payload must be a non-echo so a restored draft (or a
   // recycled native view) is applied rather than skipped.
   const nativeEventSnapshotsRef = useRef<ComposerNativeEventSnapshot[]>([]);
-  const previousDocumentKeyRef = useRef(props.documentKey);
-  if (previousDocumentKeyRef.current !== props.documentKey) {
-    // A replaced document (thread switch, send clearing the draft) must not be
-    // matched against the previous document's snapshots: an empty draft
-    // matches an old empty snapshot and gets stamped behind the native
-    // revision, which the editor rejects — it keeps showing the previous
-    // document's text while the send button reads the new document's empty
-    // draft, and nothing recovers until the next keystroke. Snapshots only
-    // survive to this point when renders lag behind native events (an agent
-    // streaming into a heavy thread), which is why the wedge needs a busy app.
-    // Dropping the history stamps this render at the current native revision.
-    previousDocumentKeyRef.current = props.documentKey;
-    nativeEventSnapshotsRef.current = [];
-  }
+  const documentKeyRef = useRef(props.documentKey);
+  // A replaced document (thread switch, send clearing the draft) must not be
+  // matched against the previous document's snapshots: an empty draft matches
+  // an old empty snapshot and gets stamped behind the native revision, which
+  // the editor rejects — it keeps showing the previous document's text while
+  // the send button reads the new document's empty draft, and nothing recovers
+  // until the next keystroke. Snapshots only survive to this point when renders
+  // lag behind native events (an agent streaming into a heavy thread), which is
+  // why the wedge needs a busy app.
+  //
+  // Derived rather than mutated: React can discard a render, and a ref written
+  // during one is not rolled back. Advancing the key here would let a native
+  // event for the still-committed old document repopulate the history before
+  // the retry, which would then skip the reset and match the replacement
+  // against that stale snapshot — the very wedge this guards against.
+  const documentReplaced = documentKeyRef.current !== props.documentKey;
+  const nativeEventSnapshots = documentReplaced ? EMPTY_SNAPSHOTS : nativeEventSnapshotsRef.current;
   const confirmedTokensRef = useRef(collectComposerInlineTokens(props.value));
   const bodyText = useScaledTextRole("body");
   const textColor = useThemeColor("--color-foreground");
@@ -177,13 +181,13 @@ export function ComposerEditor({
     props.value,
     selection ?? null,
     mostRecentEventCount,
-    nativeEventSnapshotsRef.current,
+    nativeEventSnapshots,
   );
   const acknowledgesLatestNativeEvent = isComposerNativeEcho(
     props.value,
     selection ?? null,
     mostRecentEventCount,
-    nativeEventSnapshotsRef.current,
+    nativeEventSnapshots,
   );
   const isNativeEcho =
     controlledEventCount === mostRecentEventCount && acknowledgesLatestNativeEvent;
@@ -194,6 +198,13 @@ export function ComposerEditor({
     mostRecentEventCount: controlledEventCount,
     isNativeEcho,
   });
+  // Commits the transition the render derived. Declared before the prune and
+  // assume effects so the history is dropped before either rewrites it.
+  useEffect(() => {
+    if (documentKeyRef.current === props.documentKey) return;
+    documentKeyRef.current = props.documentKey;
+    nativeEventSnapshotsRef.current = [];
+  }, [props.documentKey]);
   useEffect(() => {
     if (!acknowledgesLatestNativeEvent) return;
     nativeEventSnapshotsRef.current = pruneAcknowledgedComposerNativeEvents(

--- a/apps/mobile/src/native/T3ComposerEditor.ios.tsx
+++ b/apps/mobile/src/native/T3ComposerEditor.ios.tsx
@@ -108,6 +108,20 @@ export function ComposerEditor({
   // first controlled payload must be a non-echo so a restored draft (or a
   // recycled native view) is applied rather than skipped.
   const nativeEventSnapshotsRef = useRef<ComposerNativeEventSnapshot[]>([]);
+  const previousDocumentKeyRef = useRef(props.documentKey);
+  if (previousDocumentKeyRef.current !== props.documentKey) {
+    // A replaced document (thread switch, send clearing the draft) must not be
+    // matched against the previous document's snapshots: an empty draft
+    // matches an old empty snapshot and gets stamped behind the native
+    // revision, which the editor rejects — it keeps showing the previous
+    // document's text while the send button reads the new document's empty
+    // draft, and nothing recovers until the next keystroke. Snapshots only
+    // survive to this point when renders lag behind native events (an agent
+    // streaming into a heavy thread), which is why the wedge needs a busy app.
+    // Dropping the history stamps this render at the current native revision.
+    previousDocumentKeyRef.current = props.documentKey;
+    nativeEventSnapshotsRef.current = [];
+  }
   const confirmedTokensRef = useRef(collectComposerInlineTokens(props.value));
   const bodyText = useScaledTextRole("body");
   const textColor = useThemeColor("--color-foreground");

--- a/apps/mobile/src/native/T3ComposerEditor.native.tsx
+++ b/apps/mobile/src/native/T3ComposerEditor.native.tsx
@@ -31,6 +31,7 @@ import type { ComposerEditorProps, ComposerEditorSelection } from "./T3ComposerE
 
 const NATIVE_MODULE_NAME = "T3ComposerEditor";
 const EMPTY_SKILLS: NonNullable<ComposerEditorProps["skills"]> = [];
+const EMPTY_SNAPSHOTS: ComposerNativeEventSnapshot[] = [];
 
 type NativeEditorEvent = NativeSyntheticEvent<{
   readonly value: string;
@@ -109,20 +110,23 @@ export function ComposerEditor({
   // first controlled payload must be a non-echo so a restored draft (or a
   // recycled native view) is applied rather than skipped.
   const nativeEventSnapshotsRef = useRef<ComposerNativeEventSnapshot[]>([]);
-  const previousDocumentKeyRef = useRef(props.documentKey);
-  if (previousDocumentKeyRef.current !== props.documentKey) {
-    // A replaced document (thread switch, send clearing the draft) must not be
-    // matched against the previous document's snapshots: an empty draft
-    // matches an old empty snapshot and gets stamped behind the native
-    // revision, which the editor rejects — it keeps showing the previous
-    // document's text while the send button reads the new document's empty
-    // draft, and nothing recovers until the next keystroke. Snapshots only
-    // survive to this point when renders lag behind native events (an agent
-    // streaming into a heavy thread), which is why the wedge needs a busy app.
-    // Dropping the history stamps this render at the current native revision.
-    previousDocumentKeyRef.current = props.documentKey;
-    nativeEventSnapshotsRef.current = [];
-  }
+  const documentKeyRef = useRef(props.documentKey);
+  // A replaced document (thread switch, send clearing the draft) must not be
+  // matched against the previous document's snapshots: an empty draft matches
+  // an old empty snapshot and gets stamped behind the native revision, which
+  // the editor rejects — it keeps showing the previous document's text while
+  // the send button reads the new document's empty draft, and nothing recovers
+  // until the next keystroke. Snapshots only survive to this point when renders
+  // lag behind native events (an agent streaming into a heavy thread), which is
+  // why the wedge needs a busy app.
+  //
+  // Derived rather than mutated: React can discard a render, and a ref written
+  // during one is not rolled back. Advancing the key here would let a native
+  // event for the still-committed old document repopulate the history before
+  // the retry, which would then skip the reset and match the replacement
+  // against that stale snapshot — the very wedge this guards against.
+  const documentReplaced = documentKeyRef.current !== props.documentKey;
+  const nativeEventSnapshots = documentReplaced ? EMPTY_SNAPSHOTS : nativeEventSnapshotsRef.current;
   const [initialConfirmedTokens] = useState(() => collectComposerInlineTokens(props.value));
   const confirmedTokensRef = useRef(initialConfirmedTokens);
   const textColor = useThemeColor("--color-foreground");
@@ -178,13 +182,13 @@ export function ComposerEditor({
     props.value,
     selection ?? null,
     mostRecentEventCount,
-    nativeEventSnapshotsRef.current,
+    nativeEventSnapshots,
   );
   const acknowledgesLatestNativeEvent = isComposerNativeEcho(
     props.value,
     selection ?? null,
     mostRecentEventCount,
-    nativeEventSnapshotsRef.current,
+    nativeEventSnapshots,
   );
   const isNativeEcho =
     controlledEventCount === mostRecentEventCount && acknowledgesLatestNativeEvent;
@@ -195,6 +199,13 @@ export function ComposerEditor({
     mostRecentEventCount: controlledEventCount,
     isNativeEcho,
   });
+  // Commits the transition the render derived. Declared before the prune and
+  // assume effects so the history is dropped before either rewrites it.
+  useEffect(() => {
+    if (documentKeyRef.current === props.documentKey) return;
+    documentKeyRef.current = props.documentKey;
+    nativeEventSnapshotsRef.current = [];
+  }, [props.documentKey]);
   useEffect(() => {
     if (!acknowledgesLatestNativeEvent) return;
     nativeEventSnapshotsRef.current = pruneAcknowledgedComposerNativeEvents(

--- a/apps/mobile/src/native/T3ComposerEditor.native.tsx
+++ b/apps/mobile/src/native/T3ComposerEditor.native.tsx
@@ -109,6 +109,20 @@ export function ComposerEditor({
   // first controlled payload must be a non-echo so a restored draft (or a
   // recycled native view) is applied rather than skipped.
   const nativeEventSnapshotsRef = useRef<ComposerNativeEventSnapshot[]>([]);
+  const previousDocumentKeyRef = useRef(props.documentKey);
+  if (previousDocumentKeyRef.current !== props.documentKey) {
+    // A replaced document (thread switch, send clearing the draft) must not be
+    // matched against the previous document's snapshots: an empty draft
+    // matches an old empty snapshot and gets stamped behind the native
+    // revision, which the editor rejects — it keeps showing the previous
+    // document's text while the send button reads the new document's empty
+    // draft, and nothing recovers until the next keystroke. Snapshots only
+    // survive to this point when renders lag behind native events (an agent
+    // streaming into a heavy thread), which is why the wedge needs a busy app.
+    // Dropping the history stamps this render at the current native revision.
+    previousDocumentKeyRef.current = props.documentKey;
+    nativeEventSnapshotsRef.current = [];
+  }
   const [initialConfirmedTokens] = useState(() => collectComposerInlineTokens(props.value));
   const confirmedTokensRef = useRef(initialConfirmedTokens);
   const textColor = useThemeColor("--color-foreground");

--- a/apps/mobile/src/native/T3ComposerEditor.types.ts
+++ b/apps/mobile/src/native/T3ComposerEditor.types.ts
@@ -16,6 +16,13 @@ export interface ComposerEditorHandle {
 export interface ComposerEditorProps {
   readonly ref?: Ref<ComposerEditorHandle>;
   readonly value: string;
+  /**
+   * Identity of the controlled document. Change it when `value` is replaced
+   * wholesale (a thread switch, a send clearing the draft) rather than edited,
+   * so the editor stamps the new document at the current native revision
+   * instead of matching it against snapshots of the previous document.
+   */
+  readonly documentKey?: string;
   readonly skills?: ReadonlyArray<
     Pick<ServerProviderSkill, "name" | "displayName" | "shortDescription" | "description">
   >;

--- a/apps/mobile/src/native/composerEditorRevision.test.ts
+++ b/apps/mobile/src/native/composerEditorRevision.test.ts
@@ -192,3 +192,33 @@ describe("assumeComposerControlledState", () => {
     );
   });
 });
+
+describe("controlled document replacement", () => {
+  // The composer wedge: while renders lag behind native events (an agent
+  // streaming into a heavy thread saturates the JS thread), the snapshot
+  // history still holds the previous document's states when the parent
+  // replaces the document (a thread switch to an empty draft, or a send
+  // clearing it). The empty value matches an old empty snapshot, so it gets
+  // stamped behind the native revision — and the editor rejects everything
+  // stamped behind, so the old text stays on screen while the send button
+  // reads the new empty draft. Only the next native event recovers it.
+  const laggedSnapshots = [
+    { eventCount: 0, value: "", selection: { start: 0, end: 0 } },
+    { eventCount: 4, value: "hell", selection: { start: 4, end: 4 } },
+    { eventCount: 5, value: "hello", selection: { start: 5, end: 5 } },
+  ];
+
+  it("stamps a replacement that matches a stale snapshot behind the native revision", () => {
+    expect(resolveComposerControlledEventCount("", { start: 0, end: 0 }, 5, laggedSnapshots)).toBe(
+      0,
+    );
+  });
+
+  it("stamps the same replacement at the current revision once the history is dropped", () => {
+    // This is what a documentKey change does: with no snapshots to match, the
+    // replacement classifies as a parent-driven edit at the latest revision,
+    // which the editor's revision guard accepts.
+    expect(resolveComposerControlledEventCount("", { start: 0, end: 0 }, 5, [])).toBe(5);
+    expect(isComposerNativeEcho("", { start: 0, end: 0 }, 5, [])).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #7390.

On iOS the composer can reach a state where the send button stays disabled with text visibly in the box, and that text carries into every other thread you open. Typing one more character clears it; so does restarting the app.

The send button has a single input — `canSend = hasContent`, read from the per-thread draft store — so text surviving a thread switch means the native editor is *rejecting* the controlled document rather than lagging behind it.

## The cause

The editor is revision-gated: the native view drops any controlled document stamped behind its own counter, and the JS side deliberately stamps behind when a rendered value matches an older snapshot with a different selection. That is correct as a mid-typing race guard.

It breaks when the parent **replaces** the document instead of editing it — a thread switch, or a send clearing the draft. Normally a settled render classifies as a native echo and prunes the snapshot history, so the replacement is not found in it and is stamped at the current revision. But when renders lag behind native events, that settle render never runs, the history still holds the previous document's states including an early empty one, and the replacement (an empty draft) matches it — stamped behind, rejected, and re-rejected identically on every later render. Only a fresh native event breaks the loop.

Renders lag because `useThreadComposerState` rebuilds the whole feed on every thread-detail change (`buildThreadFeed` maps every message and activity and sorts the history, unthrottled on the render path). Measured at ~10ms per rebuild on a 6,081-activity thread on an M-series Mac, up to 8×/second while streaming. That is a separate performance problem worth its own issue; this PR fixes the composer's inability to recover.

## The fix

Give the editor a `documentKey` identifying the controlled document and drop the snapshot history when it changes. A replacement then classifies as a parent-driven edit at the current native revision, which the guard accepts. Editing keeps its history, so the race guard that prevents a stale caret or stale text from landing mid-typing is untouched.

Wired at all three call sites: the thread composer (keyed by scoped thread key plus a send epoch), and the new-task screen (keyed by its draft key).

## Verification

Driving the real functions in `composerEditorRevision.ts` through the failing sequence:

```
                       before                     after
switch to B (draft ""): REJECTED (stale revision)  applied
  native shows          "hello"                    ""
  send enabled          false                      false (correct: draft is empty)
after 50 renders        STILL WEDGED               recovered
after typing "!"        heals                      heals
```

- 26 tests in `composerEditorRevision.test.ts`, including two covering the replacement classification
- Mobile typecheck, lint, format clean
- Live pass on an iPad simulator against a real-data snapshot (66 threads): drafts swap correctly per thread, no carry-over, typing unaffected

**Limitation:** the wedge itself was not reproduced live — it needs a saturated JS thread (an agent actively streaming), which scripted interaction on an idle simulator cannot create. The mechanism is proven at the protocol level against the shipped code, and the live pass confirms no regression in normal use.

This is JS-only, so it ships over the bundle with no native rebuild.

Model: Claude Opus 5 (1M context), via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches revision-gated controlled-state sync for the native composer on send and thread switches; behavior is localized to JS with tests, but incorrect keying could affect mid-typing race guards.
> 
> **Overview**
> Fixes a mobile composer wedge where **stale native revision snapshots** could reject a wholesale document replacement (thread switch or send clearing the draft), leaving old text on screen while the draft store and send button reflected the new empty document.
> 
> Adds an optional **`documentKey`** on `ComposerEditor` so iOS and Android wrappers **ignore prior snapshot history** when the key changes, then **clear** that history in an effect. Revision resolution uses an empty snapshot list on the transition render so replacements stamp at the current native revision instead of matching an old empty snapshot.
> 
> **`ThreadComposer`** bumps a **`sendEpoch`** at the start of send and keys the editor with scoped thread id plus epoch; **`NewTaskDraftScreen`** passes **`flow.draftKey`**. Tests document the lagged-snapshot failure mode and the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50e386d4cd9c8551374309bc45234988f2e1d9e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix mobile composer send button wedging by resetting editor snapshot history on document key change
> - Introduces a `documentKey` prop to `ComposerEditor` (iOS and Android) that identifies the active draft document. When the key changes, the editor discards its native snapshot history and stamps the replacement at the current revision.
> - `ThreadComposer` increments a `sendEpoch` counter at the start of each send, bumping the `documentKey` so the editor immediately applies the empty post-send document without matching against stale snapshots.
> - `NewTaskDraftScreen` passes `flow.draftKey` (or `'new-task'` fallback) as `documentKey`, resetting history when switching projects or starting a new task.
> - New tests in [`composerEditorRevision.test.ts`](https://github.com/pingdotgg/t3code/pull/7391/files#diff-9025f97a0ca149ec43fd3733af5d5b9a27db814b8df86878f6fb522edc9d298b) cover the stale-snapshot and document-replacement stamping cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 50e386d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->