### PR TITLE
feat(web): show project location in new thread picker

### DIFF
--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -150,6 +150,7 @@ export function buildProjectActionItems(input: {
   icon: (project: Project) => ReactNode;
   runProject: (project: Project) => Promise<void>;
   searchTerms?: (project: Project) => ReadonlyArray<string>;
+  renderDescription?: (project: Project) => ReactNode;
   shortcutCommand?: KeybindingCommand;
 }): CommandPaletteActionItem[] {
   return input.projects.map((project) => ({
@@ -157,7 +158,7 @@ export function buildProjectActionItems(input: {
     value: `${input.valuePrefix}:${project.environmentId}:${project.id}`,
     searchTerms: [project.title, project.workspaceRoot, ...(input.searchTerms?.(project) ?? [])],
     title: project.title,
-    description: project.workspaceRoot,
+    description: input.renderDescription?.(project) ?? project.workspaceRoot,
     icon: input.icon(project),
     ...(input.shortcutCommand !== undefined ? { shortcutCommand: input.shortcutCommand } : {}),
     run: async () => {

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -41,6 +41,7 @@ import {
   LinkIcon,
   MessageSquareIcon,
   PaletteIcon,
+  ServerIcon,
   SettingsIcon,
   SquarePenIcon,
   TextSearchIcon,
@@ -131,7 +132,11 @@ import { ProjectFavicon } from "./ProjectFavicon";
 import { ProjectFilePicker } from "./files/ProjectFilePicker";
 import { ProjectContentSearchDialog } from "./search/ProjectContentSearchDialog";
 import { toggleThemeEditorForTheme } from "./settings/themeEditorStore";
-import { ThreadCommandSubtitle } from "./ThreadCommandSubtitle";
+import {
+  COMMAND_PALETTE_META_ICON_CLASS,
+  CommandPaletteMetaDot,
+  ThreadCommandSubtitle,
+} from "./ThreadCommandSubtitle";
 import { ThreadRowLeadingStatus, ThreadRowTrailingStatus } from "./ThreadStatusIndicators";
 import { primaryServerKeybindingsAtom, primaryServerProvidersAtom } from "../state/server";
 import {
@@ -657,6 +662,27 @@ function OpenCommandPaletteDialog(props: {
       ),
     [environments],
   );
+  const projectEnvironmentLocationById = useMemo(
+    () =>
+      new Map(
+        environments.map((environment) => {
+          const isPrimary = environment.entry.target._tag === "PrimaryConnectionTarget";
+          const isLocal = isPrimary || isDesktopLocalConnectionTarget(environment.entry.target);
+          return [
+            environment.environmentId,
+            {
+              kind: isLocal ? "local" : "remote",
+              label: isPrimary
+                ? "Local"
+                : isLocal
+                  ? `${environment.label} (Local)`
+                  : environment.label,
+            },
+          ] as const;
+        }),
+      ),
+    [environments],
+  );
   const orderedProjects = useMemo(
     () =>
       orderItemsByPreferredIds({
@@ -1011,8 +1037,29 @@ function OpenCommandPaletteDialog(props: {
           valuePrefix: "new-thread-in",
           searchTerms: (project) => {
             const group = projectGroupByTargetKey.get(`${project.environmentId}:${project.id}`);
+            const location = projectEnvironmentLocationById.get(project.environmentId);
+            return [
+              ...(group?.memberProjects.flatMap((member) => [member.title, member.workspaceRoot]) ??
+                []),
+              ...(location ? [location.label] : []),
+            ];
+          },
+          renderDescription: (project) => {
+            const location = projectEnvironmentLocationById.get(project.environmentId) ?? {
+              kind: "remote",
+              label: "Remote",
+            };
             return (
-              group?.memberProjects.flatMap((member) => [member.title, member.workspaceRoot]) ?? []
+              <span className="flex min-w-0 items-center gap-1">
+                <span className="inline-flex min-w-0 items-center gap-1">
+                  {location.kind === "remote" ? (
+                    <ServerIcon aria-hidden className={COMMAND_PALETTE_META_ICON_CLASS} />
+                  ) : null}
+                  <span className="truncate">{location.label}</span>
+                </span>
+                <CommandPaletteMetaDot />
+                <span className="truncate">{project.workspaceRoot}</span>
+              </span>
             );
           },
           icon: projectFavicon,
@@ -1033,7 +1080,13 @@ function OpenCommandPaletteDialog(props: {
           },
         }),
       ),
-    [contextualProjectRef, handleNewThread, pickerProjects, projectGroupByTargetKey],
+    [
+      contextualProjectRef,
+      handleNewThread,
+      pickerProjects,
+      projectEnvironmentLocationById,
+      projectGroupByTargetKey,
+    ],
   );
 
   const allThreadItems = useMemo(

--- a/apps/web/src/components/ThreadCommandSubtitle.tsx
+++ b/apps/web/src/components/ThreadCommandSubtitle.tsx
@@ -18,20 +18,20 @@ export type ThreadCommandSubtitleVariant =
 export const THREAD_COMMAND_SUBTITLE_VARIANT: ThreadCommandSubtitleVariant =
   "favicon-workspace-harness";
 
-const META_ICON_CLASS = "size-3 shrink-0 text-muted-foreground/70";
+export const COMMAND_PALETTE_META_ICON_CLASS = "size-3 shrink-0 text-muted-foreground/70";
 
-function Dot() {
+export function CommandPaletteMetaDot() {
   return <span className="shrink-0 text-muted-foreground/50">·</span>;
 }
 
 function WorkspaceIcon(props: { variant: ThreadCommandSubtitleVariant; isWorktree: boolean }) {
   if (props.isWorktree) {
-    return <FolderGit2Icon className={META_ICON_CLASS} aria-hidden />;
+    return <FolderGit2Icon className={COMMAND_PALETTE_META_ICON_CLASS} aria-hidden />;
   }
   if (props.variant === "favicon-branch-harness") {
-    return <GitBranchIcon className={META_ICON_CLASS} aria-hidden />;
+    return <GitBranchIcon className={COMMAND_PALETTE_META_ICON_CLASS} aria-hidden />;
   }
-  return <FolderIcon className={META_ICON_CLASS} aria-hidden />;
+  return <FolderIcon className={COMMAND_PALETTE_META_ICON_CLASS} aria-hidden />;
 }
 
 export function ThreadCommandSubtitle(props: {
@@ -82,7 +82,7 @@ export function ThreadCommandSubtitle(props: {
 
       {branchLabel ? (
         <>
-          {projectLabel ? <Dot /> : null}
+          {projectLabel ? <CommandPaletteMetaDot /> : null}
           <span className="inline-flex min-w-0 items-center gap-1">
             <WorkspaceIcon variant={variant} isWorktree={isWorktree} />
             <span className="min-w-0 truncate">{branchLabel}</span>
@@ -92,7 +92,7 @@ export function ThreadCommandSubtitle(props: {
 
       {showHarness && props.driverKind ? (
         <>
-          {projectLabel || branchLabel ? <Dot /> : null}
+          {projectLabel || branchLabel ? <CommandPaletteMetaDot /> : null}
           <ProviderInstanceIcon
             driverKind={props.driverKind}
             displayName={props.providerDisplayName ?? props.driverKind}
@@ -103,7 +103,7 @@ export function ThreadCommandSubtitle(props: {
 
       {props.isCurrent ? (
         <>
-          {projectLabel || branchLabel || showHarness ? <Dot /> : null}
+          {projectLabel || branchLabel || showHarness ? <CommandPaletteMetaDot /> : null}
           <span className="shrink-0">Current thread</span>
         </>
       ) : null}


### PR DESCRIPTION
The new-thread project picker only showed workspace paths, so similarly named projects across multiple environments were hard to place.

Now each project row shows Local or its configured environment name before the workspace path. Desktop-local environments such as WSL retain their environment name and add (Local), and location labels are searchable.

## Screenshots

### Remote server

![Remote server project](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/5cb481dc-cf02-461e-8cf6-8042bf1b203a/t3code-new-thread-remote-server.png)

### Local

![Local project](https://pub-b182a4071edc4521829926b34990540b.r2.dev/files/5c6feb7d-1c80-4205-995c-35d9a0820f2b/t3code-new-thread-local.png)

## Verification

- Targeted web lint
- Web typecheck
- Command palette focused tests, 17 passing
- Browser-verified local and remote states in an isolated paired environment

Implemented by gpt-5.6-sol through the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and search-term changes in the command palette only; no auth, routing, or thread-creation behavior changes.
> 
> **Overview**
> **New thread in…** project rows no longer show only the workspace path. Each row’s description is now **location · workspace root**, where location is **Local** for the primary connection, **`{env} (Local)`** for desktop-local backends (e.g. WSL), or the environment label for remote servers, with a **server icon** on remote rows.
> 
> `buildProjectActionItems` gains an optional **`renderDescription`** callback (default remains `workspaceRoot`). The palette builds a per-environment **local vs remote** map using the same primary / `isDesktopLocalConnectionTarget` rules used elsewhere.
> 
> **Search** for those items also includes the location label so users can filter by “Local” or an environment name. **`CommandPaletteMetaDot`** and **`COMMAND_PALETTE_META_ICON_CLASS`** are exported from `ThreadCommandSubtitle` for shared subtitle styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a2836570fc2e54f5aee3d77f61e3824a9efb8dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show environment location icon and label in the new thread project picker
> - Adds a `projectEnvironmentLocationById` map in [`CommandPalette.tsx`](https://github.com/pingdotgg/t3code/pull/7392/files#diff-30c525d0ef54c6971e43ab0660a73ea227ef51e009f79e4083049d3349175a7a) that classifies each environment as `local` or `remote` with a human-readable label.
> - Updates the project items in the new-thread picker to display a `LaptopIcon` or `ServerIcon` alongside the location label and workspace root in the description field.
> - Extends search terms for project items to include the location label (e.g. `Local` or `<env label> (Local)`), so users can filter by environment location.
> - Adds an optional `renderDescription` callback to `buildProjectActionItems` in [`CommandPalette.logic.ts`](https://github.com/pingdotgg/t3code/pull/7392/files#diff-55f82e14ac05e7221288a697ea63ead189293a840ab2676cf127368f874e4d0e) to allow callers to customize item descriptions; defaults to `workspaceRoot`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a28365.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->