### PR TITLE
feat(web): chat text contrast slider with live preview in Typography

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -563,7 +563,10 @@ function MarkdownDetails({
         <span>{summary}</span>
       </CollapsibleTrigger>
       <CollapsiblePanel>
-        <div className="pb-3 ps-6 text-foreground/80" data-markdown-details-content="">
+        <div
+          className="pb-3 ps-6 text-(--chat-markdown-foreground)"
+          data-markdown-details-content=""
+        >
           {content}
         </div>
       </CollapsiblePanel>
@@ -1789,7 +1792,7 @@ function ChatMarkdown({
   return (
     <div
       className={cn(
-        "chat-markdown w-full min-w-0 text-sm leading-relaxed text-foreground/80 [overflow-wrap:anywhere] [word-break:break-word]",
+        "chat-markdown w-full min-w-0 text-sm leading-relaxed text-(--chat-markdown-foreground) [overflow-wrap:anywhere] [word-break:break-word]",
         className,
       )}
       onCopy={handleCopy}

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -565,6 +565,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.fontSizePrompt,
       settings.fontSizeTerminal,
       settings.glassOpacity,
+      settings.chatTextContrast,
       settings.enableLegacyTokenStreaming,
       settings.enableProviderUpdateChecks,
       settings.sidebarAutoSettleAfterDays,

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -20,12 +20,14 @@ import {
   DEFAULT_ENVIRONMENT_IDENTIFICATION_MODE,
   DEFAULT_UNIFIED_SETTINGS,
   type EnvironmentIdentificationMode,
+  MAX_CHAT_TEXT_CONTRAST,
   MAX_CODE_FONT_SIZE,
   MAX_GLASS_OPACITY,
   MAX_INTERFACE_FONT_SIZE,
   MAX_PROMPT_FONT_SIZE,
   MAX_SIDEBAR_AUTO_SETTLE_AFTER_DAYS,
   MAX_TERMINAL_FONT_SIZE,
+  MIN_CHAT_TEXT_CONTRAST,
   MIN_CODE_FONT_SIZE,
   MIN_GLASS_OPACITY,
   MIN_INTERFACE_FONT_SIZE,
@@ -475,6 +477,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(!followSystem ? ["Follow system"] : []),
       ...(themeHalves !== null ? ["Theme mix"] : []),
       ...(settings.glassOpacity !== DEFAULT_UNIFIED_SETTINGS.glassOpacity ? ["Glass opacity"] : []),
+      ...(settings.chatTextContrast !== DEFAULT_UNIFIED_SETTINGS.chatTextContrast
+        ? ["Chat text contrast"]
+        : []),
       ...(settings.environmentIdentificationMode !==
       DEFAULT_UNIFIED_SETTINGS.environmentIdentificationMode
         ? ["Environment identification"]
@@ -642,6 +647,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       diffIgnoreWhitespace: DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
       environmentIdentificationMode: DEFAULT_UNIFIED_SETTINGS.environmentIdentificationMode,
       glassOpacity: DEFAULT_UNIFIED_SETTINGS.glassOpacity,
+      chatTextContrast: DEFAULT_UNIFIED_SETTINGS.chatTextContrast,
       sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
       sidebarProjectGroupingMode: DEFAULT_UNIFIED_SETTINGS.sidebarProjectGroupingMode,
       sidebarAutoSettleAfterDays: DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleAfterDays,
@@ -1414,8 +1420,77 @@ function TypographySection() {
       }
     >
       {advanced ? <FontSettingsGroup /> : <SimpleFontRows />}
+      <ChatTextContrastRow />
       <WordWrapRow />
     </SettingsSection>
+  );
+}
+
+function ChatTextContrastRow() {
+  const settings = usePrimarySettings();
+  const updateSettings = useUpdatePrimarySettings();
+  const ratio =
+    (settings.chatTextContrast - MIN_CHAT_TEXT_CONTRAST) /
+    (MAX_CHAT_TEXT_CONTRAST - MIN_CHAT_TEXT_CONTRAST);
+  const sliderStyle = {
+    "--settings-slider-progress": `${ratio * 100}%`,
+    "--settings-slider-fill-offset": `${0.5 - ratio}rem`,
+  } as CSSProperties;
+  return (
+    <SettingsRow
+      {...searchableSetting("setting-chat-text-contrast")}
+      description="Strength of agent reply text. 80% is the classic dimmed tone; 100% renders pure white in dark mode."
+      resetAction={
+        settings.chatTextContrast !== DEFAULT_UNIFIED_SETTINGS.chatTextContrast ? (
+          <SettingResetButton
+            label="chat text contrast"
+            onClick={() =>
+              updateSettings({ chatTextContrast: DEFAULT_UNIFIED_SETTINGS.chatTextContrast })
+            }
+          />
+        ) : null
+      }
+      control={
+        <div className="flex w-full items-center gap-3 sm:w-52">
+          <output
+            className="min-w-12 rounded-md bg-muted px-2 py-1 text-center font-mono text-xs font-medium tabular-nums text-foreground"
+            htmlFor="chat-text-contrast"
+          >
+            {settings.chatTextContrast}%
+          </output>
+          <input
+            aria-label="Chat text contrast"
+            className="settings-slider min-w-0 flex-1"
+            id="chat-text-contrast"
+            max={MAX_CHAT_TEXT_CONTRAST}
+            min={MIN_CHAT_TEXT_CONTRAST}
+            onChange={(event) => {
+              const chatTextContrast = Number(event.currentTarget.value);
+              if (
+                Number.isInteger(chatTextContrast) &&
+                chatTextContrast >= MIN_CHAT_TEXT_CONTRAST &&
+                chatTextContrast <= MAX_CHAT_TEXT_CONTRAST
+              ) {
+                updateSettings({ chatTextContrast });
+              }
+            }}
+            step={1}
+            style={sliderStyle}
+            type="range"
+            value={settings.chatTextContrast}
+          />
+        </div>
+      }
+    >
+      {/* Styled exactly like a chat reply and driven by the same CSS variable
+          the slider updates, so the sample tracks the drag live. */}
+      <div className="mt-1 mb-2 rounded-lg border border-border bg-background px-3 py-2">
+        <p className="text-sm leading-relaxed text-(--chat-markdown-foreground)">
+          Agent replies read in this tone. Adjust the slider until longer answers feel comfortable
+          to read — <strong>emphasis</strong> and body text brighten together.
+        </p>
+      </div>
+    </SettingsRow>
   );
 }
 

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -64,6 +64,12 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/appearance",
   },
   {
+    // Prefixed because the slider control already owns the `chat-text-contrast` id.
+    id: "setting-chat-text-contrast",
+    title: "Chat text contrast",
+    to: "/settings/appearance",
+  },
+  {
     id: "environment-identification",
     title: "Environment identification",
     to: "/settings/appearance",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -95,6 +95,16 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
   --glass-blur: 12px;
   --glass-opacity: 80%;
   --glass-saturation: 1.14;
+  /* Chat body text sits between the dimmed classic tone (foreground at 80%
+     alpha) and a full-contrast endpoint — plain foreground in light mode,
+     pure white in dark. The contrast var is driven by the appearance
+     setting; 0% reproduces the historical foreground/80 exactly. */
+  --chat-text-contrast: 0%;
+  --chat-markdown-foreground: color-mix(
+    in srgb,
+    color-mix(in srgb, var(--foreground) 80%, transparent),
+    var(--foreground) var(--chat-text-contrast)
+  );
   --desktop-window-right-resize-inset: 0px;
   --workspace-topbar-height: 52px;
   --workspace-controls-top: 0px;
@@ -109,6 +119,11 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
     --app-scrollbar-thumb-hover: rgb(255 255 255 / 12%);
     --glass-blur: 16px;
     --glass-saturation: 1.08;
+    --chat-markdown-foreground: color-mix(
+      in srgb,
+      color-mix(in srgb, var(--foreground) 80%, transparent),
+      #fff var(--chat-text-contrast)
+    );
   }
 }
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,4 +1,5 @@
 import { type ServerLifecycleWelcomePayload } from "@t3tools/contracts";
+import { MAX_CHAT_TEXT_CONTRAST, MIN_CHAT_TEXT_CONTRAST } from "@t3tools/contracts/settings";
 import { scopedProjectKey, scopeProjectRef } from "@t3tools/client-runtime/environment";
 import { squashAtomCommandFailure } from "@t3tools/client-runtime/state/runtime";
 import {
@@ -165,13 +166,15 @@ function ChatTextContrastSync() {
   const chatTextContrast = useClientSettings((settings) => settings.chatTextContrast);
 
   useEffect(() => {
-    // The setting reads as text strength (80 = classic foreground/80, 100 =
-    // full contrast); the CSS variable is the color-mix progress toward the
-    // full-contrast endpoint, so 80–100 maps onto 0–100%.
-    document.documentElement.style.setProperty(
-      "--chat-text-contrast",
-      `${(chatTextContrast - 80) * 5}%`,
-    );
+    // The setting reads as text strength (the minimum is the classic
+    // foreground/80, the maximum full contrast); the CSS variable is the
+    // color-mix progress toward the full-contrast endpoint, so the setting's
+    // range maps onto 0–100%.
+    const progress =
+      ((chatTextContrast - MIN_CHAT_TEXT_CONTRAST) /
+        (MAX_CHAT_TEXT_CONTRAST - MIN_CHAT_TEXT_CONTRAST)) *
+      100;
+    document.documentElement.style.setProperty("--chat-text-contrast", `${progress}%`);
   }, [chatTextContrast]);
 
   return null;

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -131,6 +131,7 @@ function RootRouteView() {
       <AnchoredToastProvider>
         <DocumentTitleSync />
         <GlassAppearanceSync />
+        <ChatTextContrastSync />
         <FontAppearanceSync />
         {primaryEnvironmentAuthenticated ? <AuthenticatedTracingBootstrap /> : null}
         <RelayClientInstallDialog />
@@ -156,6 +157,22 @@ function GlassAppearanceSync() {
   useEffect(() => {
     document.documentElement.style.setProperty("--glass-opacity", `${glassOpacity}%`);
   }, [glassOpacity]);
+
+  return null;
+}
+
+function ChatTextContrastSync() {
+  const chatTextContrast = useClientSettings((settings) => settings.chatTextContrast);
+
+  useEffect(() => {
+    // The setting reads as text strength (80 = classic foreground/80, 100 =
+    // full contrast); the CSS variable is the color-mix progress toward the
+    // full-contrast endpoint, so 80–100 maps onto 0–100%.
+    document.documentElement.style.setProperty(
+      "--chat-text-contrast",
+      `${(chatTextContrast - 80) * 5}%`,
+    );
+  }, [chatTextContrast]);
 
   return null;
 }

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -49,6 +49,22 @@ describe("ClientSettings glass opacity", () => {
   });
 });
 
+describe("ClientSettings chat text contrast", () => {
+  it("defaults to the classic dimmed chat text tone", () => {
+    expect(decodeClientSettings({}).chatTextContrast).toBe(80);
+  });
+
+  it.each([79, 101, 92.5])("rejects an invalid chat text contrast: %s", (value) => {
+    expect(() => decodeClientSettings({ chatTextContrast: value })).toThrow();
+    expect(() => decodeClientSettingsPatch({ chatTextContrast: value })).toThrow();
+  });
+
+  it.each([80, 90, 100])("accepts a chat text contrast within the supported range: %s", (value) => {
+    expect(decodeClientSettings({ chatTextContrast: value }).chatTextContrast).toBe(value);
+    expect(decodeClientSettingsPatch({ chatTextContrast: value }).chatTextContrast).toBe(value);
+  });
+});
+
 describe("ClientSettings environment identification", () => {
   it("defaults to artwork and accepts each presentation mode", () => {
     expect(decodeClientSettings({}).environmentIdentificationMode).toBe("artwork");

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -71,6 +71,21 @@ export const GlassOpacity = Schema.Int.check(
 );
 export type GlassOpacity = typeof GlassOpacity.Type;
 export const DEFAULT_GLASS_OPACITY: GlassOpacity = 80;
+export const MIN_CHAT_TEXT_CONTRAST = 80;
+export const MAX_CHAT_TEXT_CONTRAST = 100;
+/**
+ * Strength of chat body text, matching the historical tone at its minimum:
+ * 80 is the classic `foreground/80`, and 100 renders full foreground in
+ * light mode and pure white in dark mode.
+ */
+export const ChatTextContrast = Schema.Int.check(
+  Schema.isBetween({
+    minimum: MIN_CHAT_TEXT_CONTRAST,
+    maximum: MAX_CHAT_TEXT_CONTRAST,
+  }),
+);
+export type ChatTextContrast = typeof ChatTextContrast.Type;
+export const DEFAULT_CHAT_TEXT_CONTRAST: ChatTextContrast = 80;
 /**
  * Font size preferences, in CSS pixels. The ranges are deliberately narrow:
  * the interface size scales every rem-based dimension in the app, so the
@@ -161,6 +176,9 @@ export const ClientSettingsSchema = Schema.Struct({
   ),
   glassOpacity: GlassOpacity.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_GLASS_OPACITY)),
+  ),
+  chatTextContrast: ChatTextContrast.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_CHAT_TEXT_CONTRAST)),
   ),
   fontSizeInterface: InterfaceFontSize.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_INTERFACE_FONT_SIZE)),
@@ -817,6 +835,7 @@ export const ClientSettingsPatch = Schema.Struct({
   diffIgnoreWhitespace: Schema.optionalKey(Schema.Boolean),
   environmentIdentificationMode: Schema.optionalKey(EnvironmentIdentificationMode),
   glassOpacity: Schema.optionalKey(GlassOpacity),
+  chatTextContrast: Schema.optionalKey(ChatTextContrast),
   fontSizeInterface: Schema.optionalKey(InterfaceFontSize),
   fontSizePrompt: Schema.optionalKey(PromptFontSize),
   fontSizeCode: Schema.optionalKey(CodeFontSize),


### PR DESCRIPTION
## What Changed

A **Chat text contrast** slider in Settings → Appearance → Typography, controlling the tone of agent reply text in the web client.

- The scale reads as the text's strength: **80% (default)** reproduces the current `foreground/80` exactly — no visual change for any existing install.
- **100%** renders full foreground in light mode and pure white in dark mode; between is a `color-mix` interpolation.
- A sample line under the slider is styled by the same CSS variable the slider drives, so the tone previews live while dragging.

Mechanically: one `chatTextContrast` client setting in contracts (int 80–100, default 80), synced to a `--chat-text-contrast` CSS variable from the root route, consumed via a derived `--chat-markdown-foreground` color by the chat markdown root and collapsed details bodies. The slider row follows the existing glass-opacity pattern (reset, settings search, restore-defaults sweep). User message bubbles keep their own `message-foreground`. 7 files, +153/−2; no dependency changes. Mobile has its own native markdown theming and is deliberately untouched.

## Why

Chat body text renders at `foreground/80`, which composites to ~`#c6c6c6` over dark backgrounds. Over long reading sessions that tone gets genuinely tiring — but bumping it for everyone would repaint every install, and taste differs. A bounded slider whose default is pixel-identical to today's rendering lets people who feel this pick their tone without changing anything for anyone else.

I understand new features are usually unwelcome here — this one is deliberately tiny and default-preserving, but if it's not something you want, feel free to close, or I'm happy to convert it into a discussion instead.

## UI Changes

The setting with its live sample (dark mode). Dragging previews the tone immediately:

![Slider drag with live preview](https://raw.githubusercontent.com/dascapytal1559/t3code/assets/chat-text-contrast/chat-text-contrast-drag.gif)

Agent reply before/after, captured through the real slider → settings → CSS variable path. Computed colors verified: 80% → `srgb(.96 .96 .96 / 0.8)` (identical to current `foreground/80` rendering, so this is the "before"), 90% → `srgb(.98 .98 .98 / 0.9)`, 100% → `srgb(1 1 1)`.

**80% — before / default:**

![Reply at 80%](https://raw.githubusercontent.com/dascapytal1559/t3code/assets/chat-text-contrast/reply-crop-80.png)

**100% — pure white:**

![Reply at 100%](https://raw.githubusercontent.com/dascapytal1559/t3code/assets/chat-text-contrast/reply-crop-100.png)

The settings row in place:

![Chat text contrast setting](https://raw.githubusercontent.com/dascapytal1559/t3code/assets/chat-text-contrast/chat-text-contrast-setting.png)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Built by Claude Fable 5 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Appearance-only client setting with default 80 matching current rendering; no auth, data, or API changes.
> 
> **Overview**
> Adds a **Chat text contrast** control (80–100%, default 80) so users can brighten agent reply markdown without changing the look for existing installs at the default.
> 
> The setting is persisted in contracts as `chatTextContrast`, synced from the root route to `--chat-text-contrast` (mapped to a 0–100% mix progress), and applied via a new `--chat-markdown-foreground` `color-mix` in global CSS. **ChatMarkdown** and collapsible details bodies switch from fixed `text-foreground/80` to that variable.
> 
> Settings → Appearance → Typography gets a slider row (reset, restore-defaults, search) with a live preview sample. Contract tests cover validation and defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a50dc7e48e107cf8a4f838962b1d1f500f9abb07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add chat text contrast slider with live preview to Typography settings
> - Adds a `chatTextContrast` integer setting (range 80–100, default 80) to `ClientSettingsSchema` and `ClientSettingsPatch` in [settings.ts](https://github.com/pingdotgg/t3code/pull/7395/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c).
> - Introduces `--chat-text-contrast` and `--chat-markdown-foreground` CSS variables in [index.css](https://github.com/pingdotgg/t3code/pull/7395/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd); chat markdown text color now blends between 80% and 100% foreground opacity based on the setting.
> - Adds `ChatTextContrastSync` to the root tree in [__root.tsx](https://github.com/pingdotgg/t3code/pull/7395/files#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100) to keep the CSS variable in sync with the stored setting without a page reload.
> - Renders a slider with numeric output, reset button, and live preview paragraph in the Typography section of [SettingsPanels.tsx](https://github.com/pingdotgg/t3code/pull/7395/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18); restoring defaults also resets this value.
> - Makes the setting discoverable via settings search under "Chat text contrast" navigating to `/settings/appearance`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a50dc7e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->