### PR TITLE
fix(desktop): prevent quit shortcut spillover

### DIFF
--- a/apps/desktop/src/window/QuitHold.test.ts
+++ b/apps/desktop/src/window/QuitHold.test.ts
@@ -77,15 +77,30 @@ describe("makeQuitHoldHandler", () => {
     expect(harness.notifications).toEqual(["down", "up"]);
   });
 
-  it("quits once the shortcut auto-repeats past the hold duration", async () => {
+  it("quits after a completed hold is released", async () => {
     const harness = makeHarness();
     await harness.send(makeInput({}));
-    await harness.holdFor(QUIT_HOLD_DURATION_MS - 200);
+    await harness.holdFor(QUIT_HOLD_DURATION_MS + 200);
     expect(harness.quit).not.toHaveBeenCalled();
-    await harness.holdFor(400);
+    await harness.send(makeInput({ type: "keyUp", key: "Meta", meta: false }));
+    expect(harness.quit).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(QUIT_HOLD_RELEASE_GRACE_MS);
     expect(harness.quit).toHaveBeenCalledTimes(1);
-    // Exactly one hint cycle for the whole hold.
     expect(harness.notifications).toEqual(["down", "up"]);
+  });
+
+  it("waits for Q release when Cmd is released first", async () => {
+    const harness = makeHarness();
+    await harness.send(makeInput({}));
+    await harness.holdFor(QUIT_HOLD_DURATION_MS + 200);
+    await harness.send(makeInput({ type: "keyUp", key: "Meta", meta: false }));
+    harness.preventDefault.mockClear();
+    await harness.send(makeInput({ meta: false, isAutoRepeat: true }));
+    expect(harness.preventDefault).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(QUIT_HOLD_RELEASE_GRACE_MS * 2);
+    expect(harness.quit).not.toHaveBeenCalled();
+    await harness.send(makeInput({ type: "keyUp", meta: false }));
+    expect(harness.quit).toHaveBeenCalledTimes(1);
   });
 
   it("does not quit when the hold stops before the duration", async () => {
@@ -107,12 +122,11 @@ describe("makeQuitHoldHandler", () => {
     expect(harness.quit).not.toHaveBeenCalled();
   });
 
-  it("quits immediately on a single press when disabled", async () => {
+  it("quits without showing a hint when hold-to-quit is disabled", async () => {
     const harness = makeHarness({ enabled: false });
     await harness.send(makeInput({}));
     expect(harness.quit).toHaveBeenCalledTimes(1);
-    // The hint is dismissed in case the quit gets cancelled downstream.
-    expect(harness.notifications).toEqual(["down", "up"]);
+    expect(harness.notifications).toEqual([]);
   });
 
   it("discards a stale isEnabled resolution from a superseded press", async () => {
@@ -138,6 +152,7 @@ describe("makeQuitHoldHandler", () => {
     // Press #2 resolves enabled and completes a full hold.
     resolvers[1]?.(true);
     await harness.holdFor(QUIT_HOLD_DURATION_MS + 200);
+    await harness.send(makeInput({ type: "keyUp" }));
     expect(harness.quit).toHaveBeenCalledTimes(1);
   });
 
@@ -196,6 +211,7 @@ describe("makeQuitHoldHandler", () => {
     await harness.send(makeInput({ meta: false, control: true }));
     expect(harness.preventDefault).toHaveBeenCalledTimes(1);
     await harness.holdFor(QUIT_HOLD_DURATION_MS + 200, { meta: false, control: true });
+    await harness.send(makeInput({ type: "keyUp", meta: false, control: true }));
     expect(harness.quit).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/window/QuitHold.ts
+++ b/apps/desktop/src/window/QuitHold.ts
@@ -2,7 +2,8 @@
 
 // Chrome-style hold-to-quit. The quit accelerator is intercepted in
 // before-input-event (which runs before the native menu accelerator), and the
-// app only quits once the shortcut has been held for QUIT_HOLD_DURATION_MS.
+// app only quits after the shortcut has been held for QUIT_HOLD_DURATION_MS
+// and released.
 // A quick tap just shows the renderer's "Hold to Quit" hint, and a second tap
 // within QUIT_DOUBLE_TAP_MS quits immediately. Quitting from the application
 // menu itself is untouched and quits immediately.
@@ -10,11 +11,11 @@ export const QUIT_HOLD_DURATION_MS = 1200;
 // A second quick tap of the shortcut is the user insisting: quit immediately.
 export const QUIT_DOUBLE_TAP_MS = 500;
 // "Still held" is proven by auto-repeat keydowns, not by the absence of a
-// release: macOS suppresses a letter's keyUp while the command key is down, so
-// a tap's release can go completely unseen and a release-based timer would
-// quit anyway. The press is treated as released once no key event has arrived
-// for QUIT_HOLD_RELEASE_GRACE_MS past the hold duration. Keyboards with
-// auto-repeat disabled cannot hold-to-quit and fall back to the menu's Quit.
+// release: macOS suppresses a letter keyUp while the command key is down, so a
+// tap release can go completely unseen and a release-based timer would quit
+// anyway. Once held, quitting waits for Q keyUp or a quiet grace period after
+// modifier keyUp so repeats cannot reach the next app. Keyboards with
+// auto-repeat disabled fall back to the application menu Quit action.
 export const QUIT_HOLD_RELEASE_GRACE_MS = 600;
 
 export type QuitHoldState = "down" | "up";
@@ -42,8 +43,9 @@ export function makeQuitHoldHandler(
   const modifierKey = options.platform === "darwin" ? "meta" : "control";
   let watchdog: NodeJS.Timeout | undefined;
   let holding = false;
-  // Set once isEnabled resolves true; auto-repeats may only quit when armed.
+  // Set once isEnabled resolves true; auto-repeats may only complete the hold when armed.
   let armed = false;
+  let quitOnRelease = false;
   let heldSince = 0;
   let lastPressAt = 0;
   // Incremented on every new press and every release/quit so a pending
@@ -60,14 +62,16 @@ export function makeQuitHoldHandler(
 
   const release = () => {
     if (!holding) return;
+    const shouldNotify = armed || quitOnRelease;
     generation += 1;
     holding = false;
     armed = false;
+    quitOnRelease = false;
     clearWatchdog();
-    options.notify("up");
+    if (shouldNotify) options.notify("up");
   };
 
-  // Dismisses the overlay first: if the quit is cancelled downstream the
+  // Dismisses any overlay first: if the quit is cancelled downstream the
   // renderer must not be left with a stuck "Hold to Quit" hint.
   const quitNow = () => {
     release();
@@ -77,10 +81,26 @@ export function makeQuitHoldHandler(
   return (event, input) => {
     const key = input.key.toLowerCase();
     if (input.type === "keyUp") {
-      if (key === "q" || key === modifierKey) release();
+      if (key === "q") {
+        const shouldQuit = quitOnRelease;
+        release();
+        if (shouldQuit) options.quit();
+      } else if (key === modifierKey) {
+        if (!quitOnRelease) {
+          release();
+        } else {
+          watchdog = setTimeout(quitNow, QUIT_HOLD_RELEASE_GRACE_MS);
+        }
+      }
       return;
     }
     if (input.type !== "keyDown") return;
+
+    if (quitOnRelease && input.isAutoRepeat && key === "q") {
+      event.preventDefault();
+      clearWatchdog();
+      return;
+    }
 
     const modifierDown = options.platform === "darwin" ? input.meta : input.control;
     if (!modifierDown || input.alt || input.shift || key !== "q") {
@@ -101,7 +121,9 @@ export function makeQuitHoldHandler(
 
     if (input.isAutoRepeat) {
       if (armed && Date.now() - heldSince >= QUIT_HOLD_DURATION_MS) {
-        quitNow();
+        armed = false;
+        quitOnRelease = true;
+        clearWatchdog();
       }
       return;
     }
@@ -121,7 +143,6 @@ export function makeQuitHoldHandler(
     const pressGeneration = generation;
     holding = true;
     heldSince = now;
-    options.notify("down");
     void options.isEnabled().then(
       (enabled) => {
         if (generation !== pressGeneration) return;
@@ -131,6 +152,7 @@ export function makeQuitHoldHandler(
           return;
         }
         armed = true;
+        options.notify("down");
         // No auto-repeat by then means the key was released (possibly with a
         // suppressed keyUp) or repeat is disabled; either way, don't quit.
         watchdog = setTimeout(() => {


### PR DESCRIPTION
## Problem

Holding Cmd+Q could close T3 while the shortcut was still repeating, so the next macOS app could receive the same quit shortcut. Turning Hold to quit off also still emitted the hold overlay state before the setting check finished.

## Fix

- Complete the hold first, then wait for a safe key release before exiting.
- If Cmd is released before Q, keep T3 alive, consume Q repeats, and quit after Q is released or a quiet release grace period.
- Send hold overlay state only after Hold to quit is confirmed enabled.

## Tests

- 37 focused desktop tests passed.
- Desktop typecheck passed.
- Targeted lint and format checks passed.

Fixes #7369