### PR TITLE
refactor(mobile): drop the ignored busy input from outbox delivery

### DIFF
--- a/apps/mobile/src/state/thread-outbox-model.ts
+++ b/apps/mobile/src/state/thread-outbox-model.ts
@@ -148,12 +148,15 @@ export function threadOutboxRetryDelayMs(attempt: number): number {
 
 export type ThreadOutboxDeliveryAction = "wait" | "remove" | "send";
 
+/**
+ * Connectivity is the delivery boundary: a running turn does not hold a queued
+ * message back, because a message sent during one steers it.
+ */
 export function resolveThreadOutboxDeliveryAction(input: {
   readonly isCreation: boolean;
   readonly threadExists: boolean;
   readonly shellStatus: EnvironmentShellStatus;
   readonly environmentConnected: boolean;
-  readonly threadBusy: boolean;
 }): ThreadOutboxDeliveryAction {
   if (input.isCreation) {
     // A pending task creates its thread on delivery. If the thread already

--- a/apps/mobile/src/state/thread-outbox.test.ts
+++ b/apps/mobile/src/state/thread-outbox.test.ts
@@ -464,7 +464,6 @@ describe("thread outbox", () => {
         threadExists: false,
         shellStatus: "synchronizing",
         environmentConnected: true,
-        threadBusy: false,
       }),
     ).toBe("wait");
     expect(
@@ -473,7 +472,6 @@ describe("thread outbox", () => {
         threadExists: false,
         shellStatus: "live",
         environmentConnected: true,
-        threadBusy: false,
       }),
     ).toBe("remove");
     expect(
@@ -482,7 +480,6 @@ describe("thread outbox", () => {
         threadExists: true,
         shellStatus: "live",
         environmentConnected: true,
-        threadBusy: false,
       }),
     ).toBe("send");
   });
@@ -494,7 +491,6 @@ describe("thread outbox", () => {
         threadExists: true,
         shellStatus: "live",
         environmentConnected: true,
-        threadBusy: true,
       }),
     ).toBe("send");
     expect(
@@ -503,7 +499,6 @@ describe("thread outbox", () => {
         threadExists: true,
         shellStatus: "live",
         environmentConnected: false,
-        threadBusy: true,
       }),
     ).toBe("wait");
   });
@@ -515,7 +510,6 @@ describe("thread outbox", () => {
         threadExists: false,
         shellStatus: "cached",
         environmentConnected: false,
-        threadBusy: false,
       }),
     ).toBe("wait");
     // Connected but not yet synchronized: a previously delivered creation may
@@ -526,7 +520,6 @@ describe("thread outbox", () => {
         threadExists: false,
         shellStatus: "synchronizing",
         environmentConnected: true,
-        threadBusy: false,
       }),
     ).toBe("wait");
     expect(
@@ -535,7 +528,6 @@ describe("thread outbox", () => {
         threadExists: false,
         shellStatus: "live",
         environmentConnected: true,
-        threadBusy: false,
       }),
     ).toBe("send");
     expect(
@@ -544,7 +536,6 @@ describe("thread outbox", () => {
         threadExists: true,
         shellStatus: "live",
         environmentConnected: true,
-        threadBusy: true,
       }),
     ).toBe("remove");
   });

--- a/apps/mobile/src/state/use-thread-outbox-drain.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.ts
@@ -314,7 +314,6 @@ export function useThreadOutboxDrain(): void {
         threadExists: thread !== undefined,
         shellStatus,
         environmentConnected: environment?.connectionState === "connected",
-        threadBusy: thread?.session?.status === "running" || thread?.session?.status === "starting",
       });
       if (deliveryAction === "wait") {
         continue;


### PR DESCRIPTION
## What Changed

`resolveThreadOutboxDeliveryAction` no longer takes `threadBusy`. The drain no longer computes it at the call site, and the delivery-action tests no longer pass it.

No behavior change: every input the resolver accepted before returns the same action.

## Why

#6543 made connectivity the delivery boundary for the mobile outbox and dropped the `!input.threadBusy` term that was the only reader of that field. What stayed behind is a signature that still advertises a busy gate:

- `thread-outbox-model.ts` declares `readonly threadBusy: boolean`.
- `use-thread-outbox-drain.ts` recomputes `thread?.session?.status === "running" || thread?.session?.status === "starting"` on every drain pass and passes it in.
- `thread-outbox.test.ts` passes `threadBusy: true` in the steering cases, which reads as coverage for "a running turn does not hold a queued message back" but asserts nothing about it.

Read today, the resolver looks like a running turn can still gate a queued message. It cannot. Removing the input makes the contract say what the function does, and a short comment records why connectivity alone decides delivery so the gate is not reintroduced by inspection.

Called out as a leftover in #5436.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes
- [x] No animation or interaction changes

## Verification

- `vp test run apps/mobile/src/state/thread-outbox.test.ts` — 20 passed
- `vp run typecheck` from `apps/mobile` — clean
- `vp lint` on the three changed files — clean
- `vp fmt --check` on the three changed files — clean

Every `threadBusy` reference in the repo is in the three files changed here, and the removed field had no reader, so the resolver returns the same action for every input it accepted before.

Authored with Claude Opus 5 via Claude Code.
