### PR TITLE
fix(shared): read the Machine and User registry PATH scopes on Windows

### DIFF
--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -275,6 +275,45 @@ describe("readEnvironmentFromWindowsShell", () => {
     expect(execFile.mock.calls[0]?.[1]).not.toContain("-NoProfile");
   });
 
+  it("reads the Machine and User registry scopes for PATH", () => {
+    const execFile = vi.fn<
+      (
+        file: string,
+        args: ReadonlyArray<string>,
+        options: { encoding: "utf8"; timeout: number },
+      ) => string
+    >(
+      () =>
+        "__T3CODE_ENV_PATH_START__\nC:\\Tools\n__T3CODE_ENV_PATH_END__\n" +
+        "__T3CODE_ENV_FNM_DIR_START__\nC:\\fnm\n__T3CODE_ENV_FNM_DIR_END__\n",
+    );
+
+    expect(readEnvironmentFromWindowsShell(["PATH", "FNM_DIR"], execFile)).toEqual({
+      PATH: "C:\\Tools",
+      FNM_DIR: "C:\\fnm",
+    });
+
+    // Pin the full ordered statement sequence, not isolated substrings. This
+    // command cannot execute on the machines that run this suite, so the text
+    // is the only guard. A substring assertion still passes with the scoped
+    // reads discarded, with the join dropped, or with the order reversed.
+    const command = execFile.mock.calls[0]?.[1].at(-1) ?? "";
+    expect(command).toContain(
+      [
+        "$value = [Environment]::GetEnvironmentVariable('PATH')",
+        "$machine = [Environment]::GetEnvironmentVariable('PATH', 'Machine')",
+        "$user = [Environment]::GetEnvironmentVariable('PATH', 'User')",
+        "$value = (@($value, $machine, $user) | Where-Object { $_ }) -join ';'",
+        "if ($null -ne $value -and $value.Length -gt 0) { Write-Output $value }",
+      ].join("; "),
+    );
+    expect(command).toContain(
+      "$value = [Environment]::GetEnvironmentVariable('FNM_DIR'); if ($null -ne $value",
+    );
+    expect(command).not.toContain("[Environment]::GetEnvironmentVariable('FNM_DIR', 'Machine')");
+    expect(command).not.toContain("[Environment]::GetEnvironmentVariable('FNM_DIR', 'User')");
+  });
+
   it("falls back to Windows PowerShell when pwsh.exe is unavailable", () => {
     const execFile = vi.fn<
       (

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -269,9 +269,25 @@ function buildWindowsEnvironmentCaptureCommand(names: ReadonlyArray<string>): st
         throw new Error(`Unsupported environment variable name: ${name}`);
       }
 
+      // The unscoped read returns the PATH this process inherited, which is
+      // stale when the user registered a directory after the parent process
+      // started. The Machine and User registry scopes hold what a fresh
+      // sign-in would see, so capture those too. The process value stays
+      // first to keep the existing resolution order, and mergePathValues
+      // drops the duplicates later.
+      const readValue =
+        name === "PATH"
+          ? [
+              `$value = [Environment]::GetEnvironmentVariable('${name}')`,
+              `$machine = [Environment]::GetEnvironmentVariable('${name}', 'Machine')`,
+              `$user = [Environment]::GetEnvironmentVariable('${name}', 'User')`,
+              "$value = (@($value, $machine, $user) | Where-Object { $_ }) -join ';'",
+            ]
+          : [`$value = [Environment]::GetEnvironmentVariable('${name}')`];
+
       return [
         `Write-Output '${envCaptureStart(name)}'`,
-        `$value = [Environment]::GetEnvironmentVariable('${name}')`,
+        ...readValue,
         "if ($null -ne $value -and $value.Length -gt 0) { Write-Output $value }",
         `Write-Output '${envCaptureEnd(name)}'`,
       ];


### PR DESCRIPTION
TITLE: fix(shared): read the Machine and User registry PATH scopes on Windows

Fixes #7406.

When the app launches with a stale Windows environment, for example after Node was installed later in the same desktop session, the Windows PATH repair never finds the registered Node directory and the one-click provider update dies with `NotFound: ChildProcess.spawn`. The repair probes PowerShell with an unscoped `[Environment]::GetEnvironmentVariable('PATH')`, which returns the PATH the probe inherited from the app itself, while the directory it needs sits in the Machine or User registry scope that the probe never reads.

## What changed

`buildWindowsEnvironmentCaptureCommand` now reads the Machine and User registry scopes for PATH alongside the existing unscoped read and joins the non-empty values, process value first. Every other captured name keeps the single unscoped read. The new test pins the exact generated statement sequence for the PATH capture and pins that FNM_DIR keeps its unscoped read.

## Why this shape

The registry scopes hold what a fresh sign-in would see, which is what the repair is trying to reconstruct. Ordering is preserved on purpose. The process value stays first in the join, so every directory that resolved before still wins, and the registry values only add what was missing. `mergePathValues` already drops the duplicates case-insensitively downstream.

## Testing

- `npx vitest run --root packages/shared shell.test.ts` passes, 30 tests.
- `tsgo --noEmit` is clean for `packages/shared`.
- The new assertion pins the full ordered statement sequence as text, because the generated command cannot execute on the machines that run this suite. The pin fails if the scoped reads are discarded, reordered, joined with the wrong separator, or left unfiltered.
- On Windows 11 with process PATH limited to `C:\Windows\System32` and Node registered only in the User registry PATH, the repaired environment contains the Node directory, `resolveSpawnCommand("npm", ["--version"])` resolves the full `npm.CMD` path with `shell: true`, and the command exits 0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Windows spawn/PATH repair used for Node and CLI resolution; behavior change is narrow (PATH capture only) but affects command discovery when the inherited PATH is stale.
> 
> **Overview**
> Fixes Windows PATH repair when the app inherits a **stale process PATH** (e.g. Node added to User/Machine registry after launch). `buildWindowsEnvironmentCaptureCommand` now, for **`PATH` only**, reads the unscoped value plus **`Machine`** and **`User`** registry scopes, joins non-empty segments with `;` (process value first); other captured names still use a single unscoped read. Downstream **`mergePathValues`** continues to dedupe.
> 
> A new unit test locks the generated PowerShell statement order for PATH and confirms vars like **`FNM_DIR`** do not get scoped reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ff87e5ce90aea076ba9e85fa440b021cb72a6a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `readEnvironmentFromWindowsShell` to read Machine and User registry PATH scopes on Windows
> Previously, `buildWindowsEnvironmentCaptureCommand` in [shell.ts](https://github.com/pingdotgg/t3code/pull/7407/files#diff-89a91f85db41a9a0912bc86c336bf9429751f3797ee50a089248c68cde8489ce) read `PATH` using a single unscoped `[Environment]::GetEnvironmentVariable` call, which only returned the process-level value. Now, when the variable name is `PATH`, the generated PowerShell reads from the process, Machine, and User registry scopes separately and joins the non-null results with `;`. Non-PATH variables continue to use the single unscoped read.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ff87e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->