### PR TITLE
fix(shared): repair stale Windows PATH capture

### DIFF
--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -238,6 +238,28 @@ describe("readEnvironmentFromWindowsShell", () => {
     );
   });
 
+  it("captures the persisted Windows PATH scopes after the process PATH", () => {
+    const execFile = vi.fn<
+      (
+        file: string,
+        args: ReadonlyArray<string>,
+        options: { encoding: "utf8"; timeout: number },
+      ) => string
+    >(
+      () =>
+        "__T3CODE_ENV_PATH_START__\nC:\\Windows\\System32;C:\\Program Files\\nodejs;C:\\Users\\testuser\\AppData\\Local\\Microsoft\\WinGet\\Links\n__T3CODE_ENV_PATH_END__\n",
+    );
+
+    expect(readEnvironmentFromWindowsShell(["PATH"], execFile)).toEqual({
+      PATH: "C:\\Windows\\System32;C:\\Program Files\\nodejs;C:\\Users\\testuser\\AppData\\Local\\Microsoft\\WinGet\\Links",
+    });
+
+    const command = execFile.mock.calls[0]?.[1]?.at(-1);
+    expect(command).toContain("GetEnvironmentVariable('PATH', 'Process')");
+    expect(command).toContain("GetEnvironmentVariable('PATH', 'Machine')");
+    expect(command).toContain("GetEnvironmentVariable('PATH', 'User')");
+  });
+
   it("strips CRLF delimiters from captured PowerShell values", () => {
     const execFile = vi.fn<
       (

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -269,10 +269,20 @@ function buildWindowsEnvironmentCaptureCommand(names: ReadonlyArray<string>): st
         throw new Error(`Unsupported environment variable name: ${name}`);
       }
 
+      const readValue =
+        name === "PATH"
+          ? [
+              `$value = @([Environment]::GetEnvironmentVariable('${name}', 'Process'), [Environment]::GetEnvironmentVariable('${name}', 'Machine'), [Environment]::GetEnvironmentVariable('${name}', 'User')) | Where-Object { $null -ne $_ -and $_.Length -gt 0 }`,
+              "if (@($value).Count -gt 0) { Write-Output ($value -join ';') }",
+            ]
+          : [
+              `$value = [Environment]::GetEnvironmentVariable('${name}')`,
+              "if ($null -ne $value -and $value.Length -gt 0) { Write-Output $value }",
+            ];
+
       return [
         `Write-Output '${envCaptureStart(name)}'`,
-        `$value = [Environment]::GetEnvironmentVariable('${name}')`,
-        "if ($null -ne $value -and $value.Length -gt 0) { Write-Output $value }",
+        ...readValue,
         `Write-Output '${envCaptureEnd(name)}'`,
       ];
     }),


### PR DESCRIPTION
Fixes #7406

## Problem

On Windows, the desktop app can inherit a stale process PATH after a Node upgrade. The one-click provider update then cannot find Node even though it is installed.

## Fix

Capture PATH from the process, machine, and user scopes in precedence order, while preserving the existing process-only handling for the other captured variables.

## Verification

- `vp test run packages/shared/src/shell.test.ts`
- `vp run --filter @t3tools/shared typecheck`
- `vp fmt --check packages/shared/src/shell.ts packages/shared/src/shell.test.ts`

Created with GPT-5.6-terra in T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale Windows PATH capture by reading Process, Machine, and User scopes
> The `buildWindowsEnvironmentCaptureCommand` function in [shell.ts](https://github.com/pingdotgg/t3code/pull/7411/files#diff-89a91f85db41a9a0912bc86c336bf9429751f3797ee50a089248c68cde8489ce) previously read PATH from a single environment scope, which could miss persisted Machine or User PATH entries. It now collects PATH from all three Windows scopes (Process, Machine, User), filters out null/empty values, and joins them with `;`. Other environment variables retain the original single-value behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b6490c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Windows PATH is built for spawn and command resolution; impact is limited to shared shell env logic and is covered by new tests.
> 
> **Overview**
> Fixes Windows desktop PATH hydration when the app process still has an outdated **PATH** after a Node install or upgrade.
> 
> **PATH** capture in `buildWindowsEnvironmentCaptureCommand` no longer relies on a single `GetEnvironmentVariable` call. It now reads **Process**, **Machine**, and **User** scopes in that order, drops empty values, and joins them with `;`. Other captured variables keep the previous single-value behavior.
> 
> A unit test asserts the generated PowerShell command queries all three scopes and that the merged PATH is returned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b6490c5447c902bf80555c2baadb5de8e8e0b6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->