### PR TITLE
fix(server): unwrap JSON envelope leaking into generated titles

### DIFF
--- a/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
+++ b/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
@@ -158,6 +158,15 @@ describe("sanitizeThreadTitle", () => {
     );
   });
 
+  it("extracts the sole string field even when other non-string fields exist", () => {
+    expect(
+      sanitizeThreadTitle('{"name": "Add dark mode toggle", "priority": 2, "done": false}'),
+    ).toBe("Add dark mode toggle");
+    expect(sanitizeThreadTitle('{"confidence": 0.9, "title": "Fix the flaky login test"}')).toBe(
+      "Fix the flaky login test",
+    );
+  });
+
   it("prefers the title key when several string values are ambiguous", () => {
     expect(
       sanitizeThreadTitle('{"summary": "restate the request", "title": "Real thread name"}'),

--- a/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
+++ b/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
@@ -209,6 +209,11 @@ describe("sanitizeThreadTitle", () => {
     );
   });
 
+  it("keeps the first word of a single-line fenced prose title", () => {
+    // The leading token is only dropped when the remainder is parseable JSON.
+    expect(sanitizeThreadTitle("```Deploy {config} now```")).toBe("Deploy {config} now");
+  });
+
   it("unwraps an envelope that is both quoted and fenced", () => {
     // A JSON string whose contents are a fenced JSON block — Macroscope's case.
     expect(sanitizeThreadTitle('"```json\\n{\\"title\\": \\"Fix test\\"}\\n```"')).toBe("Fix test");

--- a/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
+++ b/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
@@ -178,19 +178,15 @@ describe("sanitizeThreadTitle", () => {
     expect(sanitizeThreadTitle(raw)).toBe(raw);
   });
 
-  it("unwraps a JSON envelope that models decorated with surrounding quotes", () => {
-    expect(sanitizeThreadTitle('"{"title": "Fix the flaky login test"}"')).toBe(
-      "Fix the flaky login test",
-    );
-    expect(sanitizeThreadTitle('`{"name": "Add dark mode toggle"}`')).toBe("Add dark mode toggle");
+  it("unwraps a JSON-encoded string wrapping the title", () => {
+    // The whole title arrives JSON-string-encoded, e.g. `"Fix the flaky login test"`.
+    expect(sanitizeThreadTitle('"Fix the flaky login test"')).toBe("Fix the flaky login test");
   });
 
-  it("unwraps a JSON envelope wrapped in a code fence", () => {
-    expect(sanitizeThreadTitle('```json\n{"title": "Add dark mode toggle"}\n```')).toBe(
-      "Add dark mode toggle",
-    );
-    expect(sanitizeThreadTitle('```\n{"name": "Add dark mode toggle"}\n```')).toBe(
-      "Add dark mode toggle",
+  it("unwraps a JSON-string-encoded envelope (object serialised as a JSON string)", () => {
+    // Decodes to the string `{"title": "Fix the flaky login test"}`, then to the title.
+    expect(sanitizeThreadTitle('"{\\"title\\": \\"Fix the flaky login test\\"}"')).toBe(
+      "Fix the flaky login test",
     );
   });
 
@@ -223,8 +219,8 @@ describe("sanitizePrTitle", () => {
     );
   });
 
-  it("unwraps a quote-decorated JSON envelope (PR titles are not quote-stripped)", () => {
-    expect(sanitizePrTitle('"{"title": "fix(auth): reject expired tokens"}"')).toBe(
+  it("unwraps a JSON-string-encoded envelope (PR titles are not quote-stripped)", () => {
+    expect(sanitizePrTitle('"{\\"title\\": \\"fix(auth): reject expired tokens\\"}"')).toBe(
       "fix(auth): reject expired tokens",
     );
   });

--- a/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
+++ b/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
@@ -151,6 +151,24 @@ describe("sanitizeThreadTitle", () => {
     );
   });
 
+  it("unwraps a single string value regardless of the key name", () => {
+    expect(sanitizeThreadTitle('{"name": "Add dark mode toggle"}')).toBe("Add dark mode toggle");
+    expect(sanitizeThreadTitle('{"summary": "Investigate reconnect regressions"}')).toBe(
+      "Investigate reconnect regressions",
+    );
+  });
+
+  it("prefers the title key when several string values are ambiguous", () => {
+    expect(
+      sanitizeThreadTitle('{"summary": "restate the request", "title": "Real thread name"}'),
+    ).toBe("Real thread name");
+  });
+
+  it("leaves an ambiguous object without a title key untouched", () => {
+    const raw = '{"name": "one", "label": "two"}';
+    expect(sanitizeThreadTitle(raw)).toBe(raw);
+  });
+
   it("unwraps a JSON envelope surrounded by prose or code fences", () => {
     expect(sanitizeThreadTitle('```json\n{"title": "Add dark mode toggle"}\n```')).toBe(
       "Add dark mode toggle",

--- a/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
+++ b/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
@@ -178,9 +178,21 @@ describe("sanitizeThreadTitle", () => {
     expect(sanitizeThreadTitle(raw)).toBe(raw);
   });
 
-  it("unwraps a JSON envelope surrounded by prose or code fences", () => {
+  it("unwraps a JSON envelope wrapped in a code fence", () => {
     expect(sanitizeThreadTitle('```json\n{"title": "Add dark mode toggle"}\n```')).toBe(
       "Add dark mode toggle",
+    );
+    expect(sanitizeThreadTitle('```\n{"name": "Add dark mode toggle"}\n```')).toBe(
+      "Add dark mode toggle",
+    );
+  });
+
+  it("does not unwrap a JSON object embedded in surrounding prose", () => {
+    expect(sanitizeThreadTitle('Document {"foo":"bar"} syntax')).toBe(
+      'Document {"foo":"bar"} syntax',
+    );
+    expect(sanitizeThreadTitle('Explain the {"name": "widget"} config')).toBe(
+      'Explain the {"name": "widget"} config',
     );
   });
 

--- a/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
+++ b/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
@@ -190,6 +190,21 @@ describe("sanitizeThreadTitle", () => {
     );
   });
 
+  it("unwraps a JSON envelope inside a Markdown code block", () => {
+    expect(sanitizeThreadTitle('```json\n{"title": "Add dark mode toggle"}\n```')).toBe(
+      "Add dark mode toggle",
+    );
+    expect(sanitizeThreadTitle('```\n{"name": "Add dark mode toggle"}\n```')).toBe(
+      "Add dark mode toggle",
+    );
+    expect(sanitizeThreadTitle('`{"title": "Add dark mode toggle"}`')).toBe("Add dark mode toggle");
+  });
+
+  it("unwraps an envelope that is both quoted and fenced", () => {
+    // A JSON string whose contents are a fenced JSON block — Macroscope's case.
+    expect(sanitizeThreadTitle('"```json\\n{\\"title\\": \\"Fix test\\"}\\n```"')).toBe("Fix test");
+  });
+
   it("does not unwrap a JSON object embedded in surrounding prose", () => {
     expect(sanitizeThreadTitle('Document {"foo":"bar"} syntax')).toBe(
       'Document {"foo":"bar"} syntax',

--- a/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
+++ b/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
@@ -200,6 +200,15 @@ describe("sanitizeThreadTitle", () => {
     expect(sanitizeThreadTitle('`{"title": "Add dark mode toggle"}`')).toBe("Add dark mode toggle");
   });
 
+  it("unwraps an envelope on the same line as the fence opener", () => {
+    expect(sanitizeThreadTitle('```json {"title": "Add dark mode toggle"}```')).toBe(
+      "Add dark mode toggle",
+    );
+    expect(sanitizeThreadTitle('```{"name": "Add dark mode toggle"}```')).toBe(
+      "Add dark mode toggle",
+    );
+  });
+
   it("unwraps an envelope that is both quoted and fenced", () => {
     // A JSON string whose contents are a fenced JSON block — Macroscope's case.
     expect(sanitizeThreadTitle('"```json\\n{\\"title\\": \\"Fix test\\"}\\n```"')).toBe("Fix test");

--- a/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
+++ b/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
@@ -6,7 +6,7 @@ import {
   buildPrContentPrompt,
   buildThreadTitlePrompt,
 } from "./TextGenerationPrompts.ts";
-import { normalizeCliError, sanitizeThreadTitle } from "./TextGenerationUtils.ts";
+import { normalizeCliError, sanitizePrTitle, sanitizeThreadTitle } from "./TextGenerationUtils.ts";
 import { TextGenerationError } from "@t3tools/contracts";
 
 describe("buildCommitMessagePrompt", () => {
@@ -143,6 +143,42 @@ describe("sanitizeThreadTitle", () => {
         '  "Reconnect failures after restart because the session state does not recover"  ',
       ),
     ).toBe("Reconnect failures after restart because the se...");
+  });
+
+  it("unwraps a self-wrapped JSON envelope emitted as the title value", () => {
+    expect(sanitizeThreadTitle('{"title": "Fix the flaky login test"}')).toBe(
+      "Fix the flaky login test",
+    );
+  });
+
+  it("unwraps a JSON envelope surrounded by prose or code fences", () => {
+    expect(sanitizeThreadTitle('```json\n{"title": "Add dark mode toggle"}\n```')).toBe(
+      "Add dark mode toggle",
+    );
+  });
+
+  it("unwraps a doubly-wrapped JSON envelope", () => {
+    expect(sanitizeThreadTitle('{"title": "{\\"title\\": \\"Refactor auth flow\\"}"}')).toBe(
+      "Refactor auth flow",
+    );
+  });
+
+  it("leaves a plain title containing braces untouched", () => {
+    expect(sanitizeThreadTitle("Handle { and } in the parser")).toBe(
+      "Handle { and } in the parser",
+    );
+  });
+});
+
+describe("sanitizePrTitle", () => {
+  it("unwraps a self-wrapped JSON envelope emitted as the title value", () => {
+    expect(sanitizePrTitle('{"title": "fix(auth): reject expired tokens"}')).toBe(
+      "fix(auth): reject expired tokens",
+    );
+  });
+
+  it("keeps a normal single-line title", () => {
+    expect(sanitizePrTitle("feat: add retry to uploader")).toBe("feat: add retry to uploader");
   });
 });
 

--- a/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
+++ b/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
@@ -178,6 +178,13 @@ describe("sanitizeThreadTitle", () => {
     expect(sanitizeThreadTitle(raw)).toBe(raw);
   });
 
+  it("unwraps a JSON envelope that models decorated with surrounding quotes", () => {
+    expect(sanitizeThreadTitle('"{"title": "Fix the flaky login test"}"')).toBe(
+      "Fix the flaky login test",
+    );
+    expect(sanitizeThreadTitle('`{"name": "Add dark mode toggle"}`')).toBe("Add dark mode toggle");
+  });
+
   it("unwraps a JSON envelope wrapped in a code fence", () => {
     expect(sanitizeThreadTitle('```json\n{"title": "Add dark mode toggle"}\n```')).toBe(
       "Add dark mode toggle",
@@ -212,6 +219,12 @@ describe("sanitizeThreadTitle", () => {
 describe("sanitizePrTitle", () => {
   it("unwraps a self-wrapped JSON envelope emitted as the title value", () => {
     expect(sanitizePrTitle('{"title": "fix(auth): reject expired tokens"}')).toBe(
+      "fix(auth): reject expired tokens",
+    );
+  });
+
+  it("unwraps a quote-decorated JSON envelope (PR titles are not quote-stripped)", () => {
+    expect(sanitizePrTitle('"{"title": "fix(auth): reject expired tokens"}"')).toBe(
       "fix(auth): reject expired tokens",
     );
   });

--- a/apps/server/src/textGeneration/TextGenerationUtils.ts
+++ b/apps/server/src/textGeneration/TextGenerationUtils.ts
@@ -11,14 +11,28 @@ const MAX_TITLE_UNWRAP_DEPTH = 8;
  */
 function stripCodeMarkdown(value: string): string {
   const trimmed = value.trim();
-  const fenced = trimmed.match(/^```[^\n]*\n([\s\S]*?)\n?```$/);
-  if (fenced?.[1] !== undefined) {
-    return fenced[1].trim();
+
+  if (trimmed.startsWith("```") && trimmed.endsWith("```") && trimmed.length >= 6) {
+    const inner = trimmed.slice(3, -3);
+    const newlineIndex = inner.indexOf("\n");
+    if (newlineIndex >= 0) {
+      // Standard fence: the opener line holds an optional language tag and the
+      // content follows on the next line. Drop the tag only when it is one.
+      const infoString = inner.slice(0, newlineIndex).trim();
+      return /^[A-Za-z0-9_-]*$/.test(infoString)
+        ? inner.slice(newlineIndex + 1).trim()
+        : inner.trim();
+    }
+    // Single-line fence, e.g. ```json {"title":"x"}```: drop a leading language
+    // tag when JSON-ish content follows it on the same line.
+    return inner.replace(/^[A-Za-z0-9_-]+\s+(?=[[{"])/, "").trim();
   }
+
   const inline = trimmed.match(/^`+([^`]*)`+$/);
   if (inline?.[1] !== undefined) {
     return inline[1].trim();
   }
+
   return trimmed;
 }
 

--- a/apps/server/src/textGeneration/TextGenerationUtils.ts
+++ b/apps/server/src/textGeneration/TextGenerationUtils.ts
@@ -9,6 +9,15 @@ const MAX_TITLE_UNWRAP_DEPTH = 8;
  * block or inline `` `…` `` backticks. Returns the trimmed inner content, or the
  * trimmed input when there is no such wrapper.
  */
+function isParseableJson(value: string): boolean {
+  try {
+    JSON.parse(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function stripCodeMarkdown(value: string): string {
   const trimmed = value.trim();
 
@@ -24,8 +33,10 @@ function stripCodeMarkdown(value: string): string {
         : inner.trim();
     }
     // Single-line fence, e.g. ```json {"title":"x"}```: drop a leading language
-    // tag when JSON-ish content follows it on the same line.
-    return inner.replace(/^[A-Za-z0-9_-]+\s+(?=[[{"])/, "").trim();
+    // tag before an object/array, but only when doing so yields parseable JSON,
+    // so a real first word in a fenced prose title is never eaten.
+    const withoutTag = inner.replace(/^[A-Za-z0-9_-]+\s+(?=[[{])/, "");
+    return (withoutTag !== inner && isParseableJson(withoutTag) ? withoutTag : inner).trim();
   }
 
   const inline = trimmed.match(/^`+([^`]*)`+$/);

--- a/apps/server/src/textGeneration/TextGenerationUtils.ts
+++ b/apps/server/src/textGeneration/TextGenerationUtils.ts
@@ -5,10 +5,30 @@ import * as Schema from "effect/Schema";
 const MAX_TITLE_UNWRAP_DEPTH = 8;
 
 /**
+ * Peel one layer of Markdown code decoration: a fenced ```` ```lang … ``` ````
+ * block or inline `` `…` `` backticks. Returns the trimmed inner content, or the
+ * trimmed input when there is no such wrapper.
+ */
+function stripCodeMarkdown(value: string): string {
+  const trimmed = value.trim();
+  const fenced = trimmed.match(/^```[^\n]*\n([\s\S]*?)\n?```$/);
+  if (fenced?.[1] !== undefined) {
+    return fenced[1].trim();
+  }
+  const inline = trimmed.match(/^`+([^`]*)`+$/);
+  if (inline?.[1] !== undefined) {
+    return inline[1].trim();
+  }
+  return trimmed;
+}
+
+/**
  * Some models ignore the structured-output contract and emit the whole JSON
  * envelope as the field's value, so a title comes back as the literal string
- * `{"title": "Fix the flaky test"}` (or a JSON-encoded string, possibly nested)
- * instead of `Fix the flaky test`. Peel that back by decoding as JSON:
+ * `{"title": "Fix the flaky test"}` (or a JSON-encoded string, possibly nested,
+ * possibly inside a Markdown code block) instead of `Fix the flaky test`. Peel
+ * that back at each level by first stripping a Markdown code block, then
+ * decoding as JSON:
  *
  * - decodes to a JSON string → recursively unwrap the decoded string;
  * - decodes to a JSON object with exactly one string value → recursively unwrap
@@ -17,30 +37,32 @@ const MAX_TITLE_UNWRAP_DEPTH = 8;
  * - decodes to a JSON object with several string values → recursively unwrap a
  *   string `title` when present, otherwise give up;
  * - anything else (not JSON, a number, an array, an ambiguous object) → return
- *   the value unchanged.
+ *   the value unchanged (after code-block stripping).
  *
  * Because plain prose is not valid JSON, a legitimate title that merely
- * mentions an object, like `Document {"foo":"bar"} syntax`, decodes as nothing
- * and is left intact.
+ * mentions an object, like `Document {"foo":"bar"} syntax`, is left intact.
  */
 export function unwrapJsonEnvelopeTitle(raw: string): string {
-  return unwrapJsonValue(raw.trim(), 0);
+  return unwrapJsonValue(raw, 0);
 }
 
 function unwrapJsonValue(value: string, depth: number): string {
   if (depth >= MAX_TITLE_UNWRAP_DEPTH) {
-    return value;
+    return value.trim();
   }
+
+  // Strip a Markdown code block first, then attempt to decode as JSON.
+  const unwrapped = stripCodeMarkdown(value);
 
   let parsed: unknown;
   try {
-    parsed = JSON.parse(value);
+    parsed = JSON.parse(unwrapped);
   } catch {
-    return value;
+    return unwrapped;
   }
 
   if (typeof parsed === "string") {
-    return unwrapJsonValue(parsed.trim(), depth + 1);
+    return unwrapJsonValue(parsed, depth + 1);
   }
 
   if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
@@ -50,18 +72,18 @@ function unwrapJsonValue(value: string, depth: number): string {
     const [firstStringValue] = stringValues;
     if (stringValues.length === 1 && firstStringValue !== undefined) {
       // Single string value: use it whatever the key is called.
-      return unwrapJsonValue(firstStringValue.trim(), depth + 1);
+      return unwrapJsonValue(firstStringValue, depth + 1);
     }
     if (stringValues.length > 1) {
       // Ambiguous: disambiguate with a `title` key when present.
       const title = (parsed as { title?: unknown }).title;
       if (typeof title === "string") {
-        return unwrapJsonValue(title.trim(), depth + 1);
+        return unwrapJsonValue(title, depth + 1);
       }
     }
   }
 
-  return value;
+  return unwrapped;
 }
 
 const isTextGenerationError = Schema.is(TextGenerationError);

--- a/apps/server/src/textGeneration/TextGenerationUtils.ts
+++ b/apps/server/src/textGeneration/TextGenerationUtils.ts
@@ -11,15 +11,27 @@ function stripCodeFence(value: string): string {
 }
 
 /**
+ * Remove decorations models wrap around a JSON envelope before we test it: a
+ * code fence and/or surrounding quotes/backticks. Titles regularly arrive
+ * quoted, so `"{"title":"X"}"` must still be recognised as an envelope.
+ */
+function stripEnvelopeDecorations(value: string): string {
+  return stripCodeFence(value.trim())
+    .replace(/^['"`]+/, "")
+    .replace(/['"`]+$/, "")
+    .trim();
+}
+
+/**
  * Some models ignore the structured-output contract and emit the whole JSON
  * envelope as the field's value, so a title comes back as the literal string
  * `{"title": "Fix the flaky test"}` instead of `Fix the flaky test`. Detect
  * that shape and unwrap the inner value, recursing to handle double-wrapping.
  *
  * We only unwrap when the *entire* title (after stripping an optional code
- * fence) is a single JSON object — never an object embedded in surrounding
- * prose, so a legitimate title like `Document {"foo":"bar"} syntax` is left
- * intact. When that object has exactly one string value we take it regardless
+ * fence and surrounding quotes) is a single JSON object — never an object
+ * embedded in surrounding prose, so a legitimate title like
+ * `Document {"foo":"bar"} syntax` is left intact. When that object has exactly one string value we take it regardless
  * of the key name (models label it `title`, `name`, `summary`, ...) and
  * regardless of how many non-string fields sit alongside it (`confidence`,
  * `reasoning`, ...). Only when several string values make the choice ambiguous
@@ -28,7 +40,7 @@ function stripCodeFence(value: string): string {
 export function unwrapJsonEnvelopeTitle(raw: string): string {
   let current = raw.trim();
   for (let depth = 0; depth < MAX_TITLE_UNWRAP_DEPTH; depth += 1) {
-    const candidate = stripCodeFence(current);
+    const candidate = stripEnvelopeDecorations(current);
     // Require the whole value to be the object; do not pull one out of prose.
     if (!candidate.startsWith("{") || !candidate.endsWith("}")) {
       return current;

--- a/apps/server/src/textGeneration/TextGenerationUtils.ts
+++ b/apps/server/src/textGeneration/TextGenerationUtils.ts
@@ -11,10 +11,12 @@ const MAX_TITLE_UNWRAP_DEPTH = 5;
  * `{"title": "Fix the flaky test"}` instead of `Fix the flaky test`. Detect
  * that shape and unwrap the inner value, recursing to handle double-wrapping.
  *
- * When the object has a single string value we take it regardless of the key
- * name (models label it `title`, `name`, `summary`, ...). Only when several
- * keys make that ambiguous do we prefer a string `title`. Anything that is not
- * a JSON object with such a value is returned as-is.
+ * When the object has exactly one string value we take it regardless of the
+ * key name (models label it `title`, `name`, `summary`, ...) and regardless of
+ * how many non-string fields sit alongside it (`confidence`, `reasoning`, ...).
+ * Only when several string values make the choice ambiguous do we prefer a
+ * string `title`. Anything that is not a JSON object with such a value is
+ * returned as-is.
  */
 export function unwrapJsonEnvelopeTitle(raw: string): string {
   let current = raw.trim();

--- a/apps/server/src/textGeneration/TextGenerationUtils.ts
+++ b/apps/server/src/textGeneration/TextGenerationUtils.ts
@@ -9,8 +9,12 @@ const MAX_TITLE_UNWRAP_DEPTH = 5;
  * Some models ignore the structured-output contract and emit the whole JSON
  * envelope as the field's value, so a title comes back as the literal string
  * `{"title": "Fix the flaky test"}` instead of `Fix the flaky test`. Detect
- * that shape and unwrap the inner `title`, recursing to handle double-wrapping.
- * Anything that is not a JSON object with a string `title` is returned as-is.
+ * that shape and unwrap the inner value, recursing to handle double-wrapping.
+ *
+ * When the object has a single string value we take it regardless of the key
+ * name (models label it `title`, `name`, `summary`, ...). Only when several
+ * keys make that ambiguous do we prefer a string `title`. Anything that is not
+ * a JSON object with such a value is returned as-is.
  */
 export function unwrapJsonEnvelopeTitle(raw: string): string {
   let current = raw.trim();
@@ -25,11 +29,23 @@ export function unwrapJsonEnvelopeTitle(raw: string): string {
     if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
       return current;
     }
-    const title = (parsed as { title?: unknown }).title;
-    if (typeof title !== "string") {
+    const entries = Object.entries(parsed as Record<string, unknown>);
+    const stringEntries = entries.filter(([, value]) => typeof value === "string");
+    let unwrapped: string | undefined;
+    if (stringEntries.length === 1) {
+      // Single string value: use it whatever the key is called.
+      unwrapped = stringEntries[0]?.[1] as string;
+    } else if (stringEntries.length > 1) {
+      // Ambiguous: disambiguate with a `title` key when present.
+      const title = (parsed as { title?: unknown }).title;
+      if (typeof title === "string") {
+        unwrapped = title;
+      }
+    }
+    if (unwrapped === undefined) {
       return current;
     }
-    current = title.trim();
+    current = unwrapped.trim();
   }
   return current;
 }

--- a/apps/server/src/textGeneration/TextGenerationUtils.ts
+++ b/apps/server/src/textGeneration/TextGenerationUtils.ts
@@ -1,9 +1,14 @@
 import { TextGenerationError } from "@t3tools/contracts";
-import { extractJsonObject } from "@t3tools/shared/schemaJson";
 import * as Schema from "effect/Schema";
 
 /** Guard against pathological nesting when unwrapping a self-wrapped title. */
 const MAX_TITLE_UNWRAP_DEPTH = 5;
+
+/** Strip a single ```` ```json ... ``` ```` (or bare ```` ``` ... ``` ````) fence, if the value is one. */
+function stripCodeFence(value: string): string {
+  const match = value.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?\s*```$/i);
+  return match?.[1]?.trim() ?? value;
+}
 
 /**
  * Some models ignore the structured-output contract and emit the whole JSON
@@ -11,17 +16,23 @@ const MAX_TITLE_UNWRAP_DEPTH = 5;
  * `{"title": "Fix the flaky test"}` instead of `Fix the flaky test`. Detect
  * that shape and unwrap the inner value, recursing to handle double-wrapping.
  *
- * When the object has exactly one string value we take it regardless of the
- * key name (models label it `title`, `name`, `summary`, ...) and regardless of
- * how many non-string fields sit alongside it (`confidence`, `reasoning`, ...).
- * Only when several string values make the choice ambiguous do we prefer a
- * string `title`. Anything that is not a JSON object with such a value is
- * returned as-is.
+ * We only unwrap when the *entire* title (after stripping an optional code
+ * fence) is a single JSON object — never an object embedded in surrounding
+ * prose, so a legitimate title like `Document {"foo":"bar"} syntax` is left
+ * intact. When that object has exactly one string value we take it regardless
+ * of the key name (models label it `title`, `name`, `summary`, ...) and
+ * regardless of how many non-string fields sit alongside it (`confidence`,
+ * `reasoning`, ...). Only when several string values make the choice ambiguous
+ * do we prefer a string `title`. Anything else is returned as-is.
  */
 export function unwrapJsonEnvelopeTitle(raw: string): string {
   let current = raw.trim();
-  for (let depth = 0; depth < MAX_TITLE_UNWRAP_DEPTH && current.includes("{"); depth += 1) {
-    const candidate = extractJsonObject(current);
+  for (let depth = 0; depth < MAX_TITLE_UNWRAP_DEPTH; depth += 1) {
+    const candidate = stripCodeFence(current);
+    // Require the whole value to be the object; do not pull one out of prose.
+    if (!candidate.startsWith("{") || !candidate.endsWith("}")) {
+      return current;
+    }
     let parsed: unknown;
     try {
       parsed = JSON.parse(candidate);

--- a/apps/server/src/textGeneration/TextGenerationUtils.ts
+++ b/apps/server/src/textGeneration/TextGenerationUtils.ts
@@ -2,77 +2,66 @@ import { TextGenerationError } from "@t3tools/contracts";
 import * as Schema from "effect/Schema";
 
 /** Guard against pathological nesting when unwrapping a self-wrapped title. */
-const MAX_TITLE_UNWRAP_DEPTH = 5;
-
-/** Strip a single ```` ```json ... ``` ```` (or bare ```` ``` ... ``` ````) fence, if the value is one. */
-function stripCodeFence(value: string): string {
-  const match = value.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?\s*```$/i);
-  return match?.[1]?.trim() ?? value;
-}
-
-/**
- * Remove decorations models wrap around a JSON envelope before we test it: a
- * code fence and/or surrounding quotes/backticks. Titles regularly arrive
- * quoted, so `"{"title":"X"}"` must still be recognised as an envelope.
- */
-function stripEnvelopeDecorations(value: string): string {
-  return stripCodeFence(value.trim())
-    .replace(/^['"`]+/, "")
-    .replace(/['"`]+$/, "")
-    .trim();
-}
+const MAX_TITLE_UNWRAP_DEPTH = 8;
 
 /**
  * Some models ignore the structured-output contract and emit the whole JSON
  * envelope as the field's value, so a title comes back as the literal string
- * `{"title": "Fix the flaky test"}` instead of `Fix the flaky test`. Detect
- * that shape and unwrap the inner value, recursing to handle double-wrapping.
+ * `{"title": "Fix the flaky test"}` (or a JSON-encoded string, possibly nested)
+ * instead of `Fix the flaky test`. Peel that back by decoding as JSON:
  *
- * We only unwrap when the *entire* title (after stripping an optional code
- * fence and surrounding quotes) is a single JSON object — never an object
- * embedded in surrounding prose, so a legitimate title like
- * `Document {"foo":"bar"} syntax` is left intact. When that object has exactly one string value we take it regardless
- * of the key name (models label it `title`, `name`, `summary`, ...) and
- * regardless of how many non-string fields sit alongside it (`confidence`,
- * `reasoning`, ...). Only when several string values make the choice ambiguous
- * do we prefer a string `title`. Anything else is returned as-is.
+ * - decodes to a JSON string → recursively unwrap the decoded string;
+ * - decodes to a JSON object with exactly one string value → recursively unwrap
+ *   that value, whatever its key (`title`, `name`, `summary`, ...) and however
+ *   many non-string fields sit alongside it (`confidence`, `reasoning`, ...);
+ * - decodes to a JSON object with several string values → recursively unwrap a
+ *   string `title` when present, otherwise give up;
+ * - anything else (not JSON, a number, an array, an ambiguous object) → return
+ *   the value unchanged.
+ *
+ * Because plain prose is not valid JSON, a legitimate title that merely
+ * mentions an object, like `Document {"foo":"bar"} syntax`, decodes as nothing
+ * and is left intact.
  */
 export function unwrapJsonEnvelopeTitle(raw: string): string {
-  let current = raw.trim();
-  for (let depth = 0; depth < MAX_TITLE_UNWRAP_DEPTH; depth += 1) {
-    const candidate = stripEnvelopeDecorations(current);
-    // Require the whole value to be the object; do not pull one out of prose.
-    if (!candidate.startsWith("{") || !candidate.endsWith("}")) {
-      return current;
-    }
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(candidate);
-    } catch {
-      return current;
-    }
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-      return current;
-    }
-    const entries = Object.entries(parsed as Record<string, unknown>);
-    const stringEntries = entries.filter(([, value]) => typeof value === "string");
-    let unwrapped: string | undefined;
-    if (stringEntries.length === 1) {
+  return unwrapJsonValue(raw.trim(), 0);
+}
+
+function unwrapJsonValue(value: string, depth: number): string {
+  if (depth >= MAX_TITLE_UNWRAP_DEPTH) {
+    return value;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return value;
+  }
+
+  if (typeof parsed === "string") {
+    return unwrapJsonValue(parsed.trim(), depth + 1);
+  }
+
+  if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+    const stringValues = Object.values(parsed as Record<string, unknown>).filter(
+      (entry): entry is string => typeof entry === "string",
+    );
+    const [firstStringValue] = stringValues;
+    if (stringValues.length === 1 && firstStringValue !== undefined) {
       // Single string value: use it whatever the key is called.
-      unwrapped = stringEntries[0]?.[1] as string;
-    } else if (stringEntries.length > 1) {
+      return unwrapJsonValue(firstStringValue.trim(), depth + 1);
+    }
+    if (stringValues.length > 1) {
       // Ambiguous: disambiguate with a `title` key when present.
       const title = (parsed as { title?: unknown }).title;
       if (typeof title === "string") {
-        unwrapped = title;
+        return unwrapJsonValue(title.trim(), depth + 1);
       }
     }
-    if (unwrapped === undefined) {
-      return current;
-    }
-    current = unwrapped.trim();
   }
-  return current;
+
+  return value;
 }
 
 const isTextGenerationError = Schema.is(TextGenerationError);

--- a/apps/server/src/textGeneration/TextGenerationUtils.ts
+++ b/apps/server/src/textGeneration/TextGenerationUtils.ts
@@ -1,5 +1,38 @@
 import { TextGenerationError } from "@t3tools/contracts";
+import { extractJsonObject } from "@t3tools/shared/schemaJson";
 import * as Schema from "effect/Schema";
+
+/** Guard against pathological nesting when unwrapping a self-wrapped title. */
+const MAX_TITLE_UNWRAP_DEPTH = 5;
+
+/**
+ * Some models ignore the structured-output contract and emit the whole JSON
+ * envelope as the field's value, so a title comes back as the literal string
+ * `{"title": "Fix the flaky test"}` instead of `Fix the flaky test`. Detect
+ * that shape and unwrap the inner `title`, recursing to handle double-wrapping.
+ * Anything that is not a JSON object with a string `title` is returned as-is.
+ */
+export function unwrapJsonEnvelopeTitle(raw: string): string {
+  let current = raw.trim();
+  for (let depth = 0; depth < MAX_TITLE_UNWRAP_DEPTH && current.includes("{"); depth += 1) {
+    const candidate = extractJsonObject(current);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(candidate);
+    } catch {
+      return current;
+    }
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return current;
+    }
+    const title = (parsed as { title?: unknown }).title;
+    if (typeof title !== "string") {
+      return current;
+    }
+    current = title.trim();
+  }
+  return current;
+}
 
 const isTextGenerationError = Schema.is(TextGenerationError);
 
@@ -35,7 +68,7 @@ export function sanitizeCommitSubject(raw: string): string {
 
 /** Normalise a raw PR title to a single line with a sensible fallback. */
 export function sanitizePrTitle(raw: string): string {
-  const singleLine = raw.trim().split(/\r?\n/g)[0]?.trim() ?? "";
+  const singleLine = unwrapJsonEnvelopeTitle(raw).split(/\r?\n/g)[0]?.trim() ?? "";
   if (singleLine.length > 0) {
     return singleLine;
   }
@@ -44,8 +77,7 @@ export function sanitizePrTitle(raw: string): string {
 
 /** Normalise a raw thread title to a compact single-line sidebar-safe label. */
 export function sanitizeThreadTitle(raw: string): string {
-  const normalized = raw
-    .trim()
+  const normalized = unwrapJsonEnvelopeTitle(raw)
     .split(/\r?\n/g)[0]
     ?.trim()
     .replace(/^['"`]+|['"`]+$/g, "")


### PR DESCRIPTION
## Problem

Sometimes T3 Code names a thread with the raw JSON envelope — e.g. the sidebar shows `{"title": "the actual name"}` instead of just `the actual name`. Some provider models ignore the structured-output contract and emit the whole JSON object *as the value* of the `title` field. The shared title sanitizers only stripped surrounding quotes, so that JSON string leaked straight through into the label.

## Fix

Add `unwrapJsonEnvelopeTitle` in `TextGenerationUtils`, which detects a JSON object whose `title` is a string and unwraps the inner value:

- recurses to handle double-wrapping (`{"title": "{\"title\": \"…\"}"}`),
- tolerates surrounding prose / code fences via the existing `extractJsonObject` helper,
- leaves plain titles that merely contain `{`/`}` untouched.

It's applied in both `sanitizeThreadTitle` and `sanitizePrTitle`, so every provider (Claude, Codex, Cursor, Grok, OpenCode) benefits from the single shared sink. Added focused unit tests covering the wrapped, double-wrapped, code-fenced, and plain-braces cases.

## Testing

- `vp test run apps/server/src/textGeneration/TextGenerationPrompts.test.ts` — 25 passed
- targeted `tsgo --noEmit` and `vp lint` on the changed files — clean

---
Done with Claude Opus 4.8 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized display sanitization for generated titles with conservative parsing rules and broad test coverage; no auth, persistence, or API contract changes.
> 
> **Overview**
> Fixes thread and PR labels sometimes showing raw model output like `{"title": "…"}` when providers ignore structured-output and return the whole JSON envelope as the title string.
> 
> Adds **`unwrapJsonEnvelopeTitle`** in `TextGenerationUtils`, which strips Markdown fences/backticks, recursively parses JSON (strings, single-string objects, multi-string objects with a `title` key), and stops at ambiguous or non-JSON prose—with a depth cap. **`sanitizeThreadTitle`** and **`sanitizePrTitle`** now run through this helper before their existing quote-stripping, truncation, and fallbacks.
> 
> Extensive unit tests cover fenced/quoted/double-wrapped envelopes, alternate keys (`name`, `summary`), and cases that must **not** unwrap (embedded JSON in prose, ambiguous multi-string objects).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83b7dd002a466267497879709d3f9acca487b9c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix JSON envelope leaking into generated titles in `sanitizeThreadTitle` and `sanitizePrTitle`
> - Adds `unwrapJsonEnvelopeTitle` in [TextGenerationUtils.ts](https://github.com/pingdotgg/t3code/pull/7413/files#diff-d7cc46884f2a9f396346252876b2861a6ac0a0467c6695cc7f1321756d51d63c) that recursively strips Markdown code fences and JSON wrappers (up to depth 8) before title normalization.
> - `sanitizeThreadTitle` and `sanitizePrTitle` now call `unwrapJsonEnvelopeTitle` first, so titles returned as raw JSON objects or Markdown-fenced strings are decoded to plain text.
> - When unwrapping an object, the sole string field is used; if multiple string fields exist, the `title` key is preferred; ambiguous objects without a `title` key are left unchanged.
> - Behavioral Change: titles that were previously exposed as raw JSON (e.g. `{"title":"My PR"}`) now appear as plain strings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 83b7dd0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->