### PR TITLE
fix(server): fork Codex threads with active writers

### DIFF
--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -19,6 +19,7 @@ import {
   buildTurnStartParams,
   hasConfiguredMcpServer,
   isRecoverableThreadResumeError,
+  isThreadActiveWriterError,
   makeMemoryConsolidationNotificationFilter,
   openCodexThread,
 } from "./CodexSessionRuntime.ts";
@@ -570,13 +571,93 @@ describe("isRecoverableThreadResumeError", () => {
   });
 });
 
+describe("isThreadActiveWriterError", () => {
+  it("matches Codex thread writer conflicts", () => {
+    NodeAssert.equal(
+      isThreadActiveWriterError(
+        new CodexErrors.CodexAppServerRequestError({
+          code: -32603,
+          errorMessage: "thread provider-thread already has an active writer",
+        }),
+      ),
+      true,
+    );
+  });
+
+  it("ignores unrelated writer errors", () => {
+    NodeAssert.equal(
+      isThreadActiveWriterError(
+        new CodexErrors.CodexAppServerRequestError({
+          code: -32603,
+          errorMessage: "log file already has an active writer",
+        }),
+      ),
+      false,
+    );
+  });
+});
+
 describe("openCodexThread", () => {
+  it.effect("forks the thread when another Codex process owns its writer", () =>
+    Effect.gen(function* () {
+      const calls: Array<{
+        method: "thread/start" | "thread/resume" | "thread/fork";
+        payload: unknown;
+      }> = [];
+      const forked = makeThreadOpenResponse("forked-thread");
+      const client = {
+        request: <M extends "thread/start" | "thread/resume" | "thread/fork">(
+          method: M,
+          payload: CodexRpc.ClientRequestParamsByMethod[M],
+        ) => {
+          calls.push({ method, payload });
+          if (method === "thread/resume") {
+            return Effect.fail(
+              new CodexErrors.CodexAppServerRequestError({
+                code: -32603,
+                errorMessage: "thread provider-thread already has an active writer",
+              }),
+            );
+          }
+          return Effect.succeed(forked as CodexRpc.ClientRequestResponsesByMethod[M]);
+        },
+      };
+
+      const opened = yield* openCodexThread({
+        client,
+        threadId: ThreadId.make("thread-1"),
+        runtimeMode: "full-access",
+        cwd: "/tmp/project",
+        requestedModel: "gpt-5.3-codex",
+        serviceTier: undefined,
+        resumeThreadId: "provider-thread",
+      });
+
+      NodeAssert.equal(opened.thread.id, "forked-thread");
+      NodeAssert.deepStrictEqual(
+        calls.map((call) => call.method),
+        ["thread/resume", "thread/fork"],
+      );
+      NodeAssert.deepStrictEqual(calls[1]?.payload, {
+        threadId: "provider-thread",
+        cwd: "/tmp/project",
+        approvalPolicy: "never",
+        sandbox: "danger-full-access",
+        approvalsReviewer: "user",
+        model: "gpt-5.3-codex",
+      });
+    }),
+  );
+
   it.effect("falls back to thread/start when resume fails recoverably", () =>
     Effect.gen(function* () {
-      const calls: Array<{ method: "thread/start" | "thread/resume"; payload: unknown }> = [];
+      const calls: Array<{
+        method: "thread/start" | "thread/resume" | "thread/fork";
+        payload: unknown;
+      }> = [];
       const started = makeThreadOpenResponse("fresh-thread");
       const client = {
-        request: <M extends "thread/start" | "thread/resume">(
+        request: <M extends "thread/start" | "thread/resume" | "thread/fork">(
           method: M,
           payload: CodexRpc.ClientRequestParamsByMethod[M],
         ) => {
@@ -614,7 +695,7 @@ describe("openCodexThread", () => {
   it.effect("propagates non-recoverable resume failures", () =>
     Effect.gen(function* () {
       const client = {
-        request: <M extends "thread/start" | "thread/resume">(
+        request: <M extends "thread/start" | "thread/resume" | "thread/fork">(
           method: M,
           _payload: CodexRpc.ClientRequestParamsByMethod[M],
         ) => {

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -447,11 +447,17 @@ export function isRecoverableThreadResumeError(error: unknown): boolean {
   return RECOVERABLE_THREAD_RESUME_ERROR_SNIPPETS.some((snippet) => message.includes(snippet));
 }
 
+export function isThreadActiveWriterError(error: unknown): boolean {
+  const message = (error instanceof Error ? error.message : String(error)).toLowerCase();
+  return message.includes("thread") && message.includes("already has an active writer");
+}
+
 type CodexThreadOpenResponse =
   | CodexRpc.ClientRequestResponsesByMethod["thread/start"]
-  | CodexRpc.ClientRequestResponsesByMethod["thread/resume"];
+  | CodexRpc.ClientRequestResponsesByMethod["thread/resume"]
+  | CodexRpc.ClientRequestResponsesByMethod["thread/fork"];
 
-type CodexThreadOpenMethod = "thread/start" | "thread/resume";
+type CodexThreadOpenMethod = "thread/start" | "thread/resume" | "thread/fork";
 
 interface CodexThreadOpenClient {
   readonly request: <M extends CodexThreadOpenMethod>(
@@ -487,6 +493,29 @@ export const openCodexThread = (input: {
       ...startParams,
     })
     .pipe(
+      Effect.catchIf(isThreadActiveWriterError, (error) =>
+        Effect.logWarning("codex app-server thread resume forked from active writer", {
+          threadId: input.threadId,
+          requestedRuntimeMode: input.runtimeMode,
+          resumeThreadId,
+          cause: error,
+        }).pipe(
+          Effect.andThen(
+            Effect.suspend(() => {
+              const config = runtimeModeToThreadConfig(input.runtimeMode);
+              return input.client.request("thread/fork", {
+                threadId: resumeThreadId,
+                cwd: input.cwd,
+                approvalPolicy: config.approvalPolicy,
+                approvalsReviewer: config.approvalsReviewer,
+                sandbox: config.sandbox,
+                ...(input.requestedModel ? { model: input.requestedModel } : {}),
+                ...(input.serviceTier ? { serviceTier: input.serviceTier } : {}),
+              });
+            }),
+          ),
+        ),
+      ),
       Effect.catchIf(isRecoverableThreadResumeError, (error) =>
         Effect.logWarning("codex app-server thread resume fell back to fresh start", {
           threadId: input.threadId,


### PR DESCRIPTION
## Problem

Codex rejects `thread/resume` when another app-server process already owns the thread writer. T3 currently stops the session and surfaces the provider stack trace, even though Codex can branch the conversation safely.

## Fix

Detect the specific active-writer response and call `thread/fork` with the requested working directory, model, service tier, approval policy, and sandbox mode. T3 then stores the forked thread ID and continues from the persisted conversation history. Missing-thread fallback and unrelated resume failures keep their existing behavior.

## Tests

- `vp test run apps/server/src/provider/Layers/CodexSessionRuntime.test.ts`
- `vp run --filter ./apps/server typecheck`
- targeted lint and format checks for both changed files

Model: gpt-5.6-sol
Harness: T3 Code Codex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Codex session open/resume behavior on a specific provider error path; incorrect detection could fork when a fresh start was intended, but scope is narrow and covered by tests.
> 
> **Overview**
> When **`thread/resume`** fails because another Codex app-server process already holds the thread writer, the server no longer surfaces a fatal error. It detects that case via **`isThreadActiveWriterError`**, logs a warning, and calls **`thread/fork`** with the session’s cwd, runtime mode (approval policy and sandbox), model, and optional service tier so the conversation can continue from persisted history under a new provider thread id.
> 
> Missing-thread and other **recoverable** resume failures still fall back to **`thread/start`**; unrelated resume errors are unchanged. Tests cover the detector, the resume→fork path, and existing fallback/propagation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e884bb350ab16147c5adc294e4544c745f3dcd6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fork Codex threads when `thread/resume` fails with an active writer error
> - Adds `isThreadActiveWriterError` predicate in [`CodexSessionRuntime.ts`](https://github.com/pingdotgg/t3code/pull/7414/files#diff-e29bf409c8e737a2d4e655f7e9e7def9c78c008d98a0a23575baa5e714c4e12c) that detects errors containing both 'thread' and 'already has an active writer'.
> - When `thread/resume` fails with this error, `openCodexThread` now calls `thread/fork` instead of failing or starting a fresh thread, preserving thread continuity.
> - `CodexThreadOpenResponse` and `CodexThreadOpenMethod` types are extended to include `thread/fork`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e884bb3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

Closes #8259