### PR TITLE
fix(packaging): install AUR launcher icons where icon themes look

### DIFF
--- a/packaging/aur/scripts/release.sh
+++ b/packaging/aur/scripts/release.sh
@@ -8,10 +8,8 @@ pkgrel="${PKGREL:-1}"
 
 if [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   pkgname='t3code-bin'
-  icon_path='assets/prod/black-universal-1024.png'
 elif [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-nightly\.[0-9]{8}\.[0-9]+$ ]]; then
   pkgname='t3code-nightly-bin'
-  icon_path='assets/nightly/nightly-universal-1024.png'
 else
   echo "Release $tag does not publish an AUR package."
   exit 0
@@ -33,10 +31,7 @@ fi
 work_dir="$(mktemp -d)"
 trap 'rm -rf -- "$work_dir"' EXIT
 gh api -H 'Accept: application/vnd.github.raw' \
-  "repos/$repo/contents/$icon_path?ref=$tag" > "$work_dir/icon.png"
-gh api -H 'Accept: application/vnd.github.raw' \
   "repos/$repo/contents/LICENSE?ref=$tag" > "$work_dir/LICENSE"
-icon_sha256="$(sha256sum "$work_dir/icon.png" | awk '{print $1}')"
 license_sha256="$(sha256sum "$work_dir/LICENSE" | awk '{print $1}')"
 
 package_dir="$repo_root/packaging/aur/$pkgname"
@@ -45,7 +40,6 @@ sed -Ei \
   -e "s/^pkgver=.*/pkgver=$pkgver/" \
   -e "s/^pkgrel=.*/pkgrel=$pkgrel/" \
   -e "/# AppImage$/s/'[0-9a-f]{64}'/'$appimage_sha256'/" \
-  -e "/# icon$/s/'[0-9a-f]{64}'/'$icon_sha256'/" \
   -e "/# upstream license$/s/'[0-9a-f]{64}'/'$license_sha256'/" \
   PKGBUILD
 

--- a/packaging/aur/t3code-bin/PKGBUILD
+++ b/packaging/aur/t3code-bin/PKGBUILD
@@ -46,12 +46,10 @@ options=('!debug' '!strip')
 _appimage="T3-Code-${pkgver}-x86_64.AppImage"
 source=(
   "$_appimage::https://github.com/pingdotgg/t3code/releases/download/v${pkgver}/$_appimage"
-  "${pkgname}-${pkgver}.png::https://raw.githubusercontent.com/pingdotgg/t3code/v${pkgver}/assets/prod/black-universal-1024.png"
   "${pkgname}-${pkgver}-LICENSE::https://raw.githubusercontent.com/pingdotgg/t3code/v${pkgver}/LICENSE"
 )
 sha256sums=(
   '415c8648f43c3d22d572f27f2c50fdc8c310ea7fcde9537b903e1e2f1c8775a1' # AppImage
-  '403e874556ffbecee8d1b2b5d612a874303fac791212a261bb3bd1b71d83e78d' # icon
   '935d8f2af0c703f9c39517ee57cc4930b19d02d533be930b63f0e82f93614b43' # upstream license
 )
 
@@ -79,8 +77,13 @@ exec /opt/t3code-bin/AppRun "$@"
 EOF
   ln -s t3code "$pkgdir/usr/bin/t3-code-desktop"
 
-  install -Dm644 "$srcdir/${pkgname}-${pkgver}.png" \
-    "$pkgdir/usr/share/icons/hicolor/1024x1024/apps/t3code.png"
+  # Icon lookup only sees sizes registered in hicolor's index.theme (max 512x512).
+  local icon size_dir
+  for icon in "$srcdir"/squashfs-root/usr/share/icons/hicolor/*/apps/t3code.png; do
+    size_dir="${icon%/apps/t3code.png}"
+    install -Dm644 "$icon" \
+      "$pkgdir/usr/share/icons/hicolor/${size_dir##*/}/apps/t3code.png"
+  done
 
   install -Dm644 /dev/stdin "$pkgdir/usr/share/applications/t3code.desktop" <<'EOF'
 [Desktop Entry]

--- a/packaging/aur/t3code-nightly-bin/PKGBUILD
+++ b/packaging/aur/t3code-nightly-bin/PKGBUILD
@@ -47,12 +47,10 @@ _upstream_version="${pkgver/_nightly./-nightly.}"
 _appimage="T3-Code-${_upstream_version}-x86_64.AppImage"
 source=(
   "$_appimage::https://github.com/pingdotgg/t3code/releases/download/v${_upstream_version}/$_appimage"
-  "${pkgname}-${pkgver}.png::https://raw.githubusercontent.com/pingdotgg/t3code/v${_upstream_version}/assets/nightly/nightly-universal-1024.png"
   "${pkgname}-${pkgver}-LICENSE::https://raw.githubusercontent.com/pingdotgg/t3code/v${_upstream_version}/LICENSE"
 )
 sha256sums=(
   'c4dea5bba9ed0b51b2f60f2d4a4867e61d62b57c50ea66f2792a73112e054566' # AppImage
-  '7e59b6394016ef83ed1e946847769e01bf36d4062c5c5af2577fd3e228285fd9' # icon
   '935d8f2af0c703f9c39517ee57cc4930b19d02d533be930b63f0e82f93614b43' # upstream license
 )
 
@@ -80,8 +78,13 @@ exec /opt/t3code-nightly-bin/AppRun "$@"
 EOF
   ln -s t3code-nightly "$pkgdir/usr/bin/t3-code-nightly-desktop"
 
-  install -Dm644 "$srcdir/${pkgname}-${pkgver}.png" \
-    "$pkgdir/usr/share/icons/hicolor/1024x1024/apps/t3code-nightly.png"
+  # Icon lookup only sees sizes registered in hicolor's index.theme (max 512x512).
+  local icon size_dir
+  for icon in "$srcdir"/squashfs-root/usr/share/icons/hicolor/*/apps/t3code.png; do
+    size_dir="${icon%/apps/t3code.png}"
+    install -Dm644 "$icon" \
+      "$pkgdir/usr/share/icons/hicolor/${size_dir##*/}/apps/t3code-nightly.png"
+  done
 
   install -Dm644 /dev/stdin "$pkgdir/usr/share/applications/t3code.desktop" <<'EOF'
 [Desktop Entry]


### PR DESCRIPTION
## What Changed

- `t3code-bin` and `t3code-nightly-bin` install the launcher icon from the AppImage's own hicolor icon set (16-512px, named per package) instead of a separately downloaded 1024px PNG
- `packaging/aur/scripts/release.sh` no longer fetches the icon asset or manages its checksum

## Why

Since the AUR recipes moved in-repo (#4128), the launcher icon has been installed only under `usr/share/icons/hicolor/1024x1024/apps/`. hicolor-icon-theme registers sizes only up to 512x512, and freedesktop icon lookup never scans unregistered directories, so GNOME and KDE show a generic icon for every nightly published since 2026-08-15. The previous out-of-repo recipe had the same 1024 path but was masked by a legacy `/usr/share/pixmaps` copy that the rewrite dropped.

The AppImage payload already ships the channel-correct icon pre-rendered at every registered hicolor size (the same set electron-builder's deb/rpm targets install), so the packages now reuse it and the extra download goes away.

Verified by building both packages and running GTK icon-theme lookups against the extracted contents (previously NOT FOUND at every size, now resolving 16 through 512), plus a live before/after on Arch + GNOME with a fully stock configuration.

## UI Changes

Before (published `t3code-nightly-bin` 0.0.34_nightly.20260818.1124-1) / after:

<img width="630" height="171" alt="Screenshot From 2026-08-18 12-55-27" src="https://github.com/user-attachments/assets/fd0627a5-8aea-4c4b-b505-6f69becb9394" />

<img width="630" height="171" alt="Screenshot From 2026-08-18 12-58-28" src="https://github.com/user-attachments/assets/e6fe6604-85bd-4962-b026-c823c00e4d71" />


Implemented with Claude Fable 5 in Claude Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Install AUR launcher icons from AppImage hicolor directories instead of a single downloaded PNG
> - Both [t3code-bin PKGBUILD](https://github.com/pingdotgg/t3code/pull/7421/files#diff-c0d3518bee615107213a70a683d65c4ed46e77aad42be0f61100f85b701ce953) and [t3code-nightly-bin PKGBUILD](https://github.com/pingdotgg/t3code/pull/7421/files#diff-128a22f5fa7fb9e65013fa3143a7a95668173845e38e789dd8cbcc53fac3e180) now extract icons from the AppImage's `squashfs-root/usr/share/icons/hicolor/*/apps/` and install them into matching hicolor size directories, so icon themes can find them.
> - Removes the separately downloaded 1024x1024 icon PNG from the source arrays and their sha256sum entries.
> - The [release.sh](https://github.com/pingdotgg/t3code/pull/7421/files#diff-95dd0840eed48d9bf92e26e60c9ef91b786639bcce7784b829c13ee36f66d4b3) script no longer fetches the icon asset or updates its checksum in PKGBUILD during release.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b72d9d8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only changes to icon install paths and release checksum updates; no runtime app or auth logic touched.
> 
> **Overview**
> Fixes missing launcher icons on GNOME/KDE by **stopping installation of a separately downloaded 1024×1024 PNG** (a size hicolor themes do not register) and **copying every `hicolor/*/apps/t3code.png` from the extracted AppImage** into the package at the matching theme sizes (`t3code.png` / `t3code-nightly.png`).
> 
> Both `t3code-bin` and `t3code-nightly-bin` PKGBUILDs drop the extra icon `source` entry and checksum; `release.sh` no longer fetches the repo icon asset or patches its SHA256 in `PKGBUILD`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b72d9d8585e0f05c256376c2e58ea138da80a957. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->