### PR TITLE
fix(server,web): render Claude thinking blocks as live reasoning items

### DIFF
--- a/apps/mobile/src/features/threads/thread-work-log.tsx
+++ b/apps/mobile/src/features/threads/thread-work-log.tsx
@@ -49,6 +49,8 @@ function workRowSymbolName(icon: ThreadFeedActivity["icon"]): AppSymbolName {
       return { ios: "sparkles", android: "auto_awesome" };
     case "alert":
       return { ios: "exclamationmark.triangle", android: "error" };
+    case "brain":
+      return { ios: "brain", android: "psychology" };
     case "check":
       return { ios: "checkmark", android: "check" };
     case "command":
@@ -250,20 +252,32 @@ export function ThreadWorkLog(props: {
 
               {fullDetail ? (
                 <View className="ml-7 border-l border-neutral-300/60 pb-1 pl-3 pt-0.5 dark:border-white/[0.12]">
-                  <ScrollView
-                    nestedScrollEnabled
-                    directionalLockEnabled
-                    showsVerticalScrollIndicator
-                    className="max-h-60"
-                    contentContainerStyle={{ paddingRight: 8 }}
-                  >
+                  {row.icon === "brain" ? (
+                    // Reasoning is streamed prose the user follows live: the
+                    // block grows with the text instead of scrolling inside a
+                    // fixed-height box (tool outputs keep the max-h-60 clamp).
                     <Text
                       selectable
-                      className="font-mono text-2xs leading-normal text-foreground-muted"
+                      className="pr-2 font-mono text-2xs leading-normal text-foreground-muted"
                     >
                       {fullDetail}
                     </Text>
-                  </ScrollView>
+                  ) : (
+                    <ScrollView
+                      nestedScrollEnabled
+                      directionalLockEnabled
+                      showsVerticalScrollIndicator
+                      className="max-h-60"
+                      contentContainerStyle={{ paddingRight: 8 }}
+                    >
+                      <Text
+                        selectable
+                        className="font-mono text-2xs leading-normal text-foreground-muted"
+                      >
+                        {fullDetail}
+                      </Text>
+                    </ScrollView>
+                  )}
                 </View>
               ) : null}
             </Animated.View>

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -203,6 +203,132 @@ describe("buildThreadFeed", () => {
     ]);
   });
 
+  it("collapses tool lifecycle rows keyed by payload-level toolCallId", () => {
+    const thread = makeThread({
+      id: ThreadId.make("thread-tcid"),
+      projectId: ProjectId.make("project-1"),
+      title: "Payload identity",
+      latestTurn: {
+        turnId: TurnId.make("turn-1"),
+        state: "completed",
+        requestedAt: "2026-04-01T00:00:00.000Z",
+        startedAt: "2026-04-01T00:00:01.000Z",
+        completedAt: null,
+        assistantMessageId: null,
+      },
+      activities: [
+        makeActivity({
+          id: EventId.make("t-updated"),
+          kind: "tool.updated",
+          tone: "tool",
+          summary: "Run tests",
+          createdAt: "2026-04-01T00:00:01.000Z",
+          turnId: TurnId.make("turn-1"),
+          payload: {
+            title: "Run tests",
+            itemType: "command_execution",
+            toolCallId: "call-1",
+            detail: "bun test",
+          },
+        }),
+        makeActivity({
+          id: EventId.make("other-tool"),
+          kind: "tool.completed",
+          tone: "tool",
+          summary: "Read file",
+          createdAt: "2026-04-01T00:00:02.000Z",
+          turnId: TurnId.make("turn-1"),
+          payload: {
+            title: "Read file",
+            itemType: "file_read",
+            toolCallId: "call-2",
+            detail: "index.ts",
+          },
+        }),
+        makeActivity({
+          id: EventId.make("t-completed"),
+          kind: "tool.completed",
+          tone: "tool",
+          summary: "Run tests",
+          createdAt: "2026-04-01T00:00:03.000Z",
+          turnId: TurnId.make("turn-1"),
+          payload: {
+            title: "Run tests",
+            itemType: "command_execution",
+            toolCallId: "call-1",
+            detail: "bun test — 3 passed",
+          },
+        }),
+      ],
+    });
+
+    const feed = buildThreadFeed(thread);
+    const activities = feed.flatMap((entry) =>
+      entry.type === "activity-group" ? entry.activities : [],
+    );
+    // The interleaved completion folds into its first row even though the
+    // identity arrived at payload level, not inside data.
+    expect(activities).toHaveLength(2);
+    expect(activities[0]?.summary).toContain("Run tests");
+    expect(activities[0]?.getFullDetail()).toContain("3 passed");
+  });
+
+  it("does not collapse a reused toolCallId across turns", () => {
+    const turn1 = TurnId.make("turn-1");
+    const turn2 = TurnId.make("turn-2");
+    const thread = makeThread({
+      id: ThreadId.make("thread-cross-turn"),
+      projectId: ProjectId.make("project-1"),
+      title: "Cross turn",
+      latestTurn: {
+        turnId: turn2,
+        state: "completed",
+        requestedAt: "2026-04-01T00:00:05.000Z",
+        startedAt: "2026-04-01T00:00:06.000Z",
+        completedAt: null,
+        assistantMessageId: null,
+      },
+      activities: [
+        makeActivity({
+          id: EventId.make("turn1-updated"),
+          kind: "tool.updated",
+          tone: "tool",
+          summary: "Run tests",
+          createdAt: "2026-04-01T00:00:01.000Z",
+          turnId: turn1,
+          payload: {
+            title: "Run tests",
+            itemType: "command_execution",
+            toolCallId: "call-1",
+            detail: "first run",
+          },
+        }),
+        makeActivity({
+          id: EventId.make("turn2-updated"),
+          kind: "tool.updated",
+          tone: "tool",
+          summary: "Run tests",
+          createdAt: "2026-04-01T00:00:06.000Z",
+          turnId: turn2,
+          payload: {
+            title: "Run tests",
+            itemType: "command_execution",
+            toolCallId: "call-1",
+            detail: "second run",
+          },
+        }),
+      ],
+    });
+
+    const feed = buildThreadFeed(thread);
+    const activities = feed.flatMap((entry) =>
+      entry.type === "activity-group" ? entry.activities : [],
+    );
+    expect(activities).toHaveLength(2);
+    expect(activities[0]?.getFullDetail()).toContain("first run");
+    expect(activities[1]?.getFullDetail()).toContain("second run");
+  });
+
   it("collapses matching tool lifecycle rows like desktop", () => {
     const thread = makeThread({
       id: ThreadId.make("thread-2"),

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -329,6 +329,62 @@ describe("buildThreadFeed", () => {
     expect(activities[1]?.getFullDetail()).toContain("second run");
   });
 
+  it("does not identity-collapse reused toolCallIds without turn boundaries", () => {
+    const thread = makeThread({
+      id: ThreadId.make("thread-turnless-identity"),
+      projectId: ProjectId.make("project-1"),
+      title: "Turnless identities",
+      activities: [
+        makeActivity({
+          id: EventId.make("turnless-tool-first"),
+          kind: "tool.updated",
+          tone: "tool",
+          summary: "Tool",
+          createdAt: "2026-04-01T00:00:01.000Z",
+          payload: {
+            title: "Tool",
+            itemType: "command_execution",
+            toolCallId: "reused-call",
+            detail: "first turnless chain",
+          },
+        }),
+        makeActivity({
+          id: EventId.make("turnless-tool-interleaved"),
+          kind: "tool.updated",
+          tone: "tool",
+          summary: "Other tool",
+          createdAt: "2026-04-01T00:00:02.000Z",
+          payload: {
+            title: "Other tool",
+            itemType: "command_execution",
+            toolCallId: "other-call",
+            detail: "interleaved chain",
+          },
+        }),
+        makeActivity({
+          id: EventId.make("turnless-tool-second"),
+          kind: "tool.updated",
+          tone: "tool",
+          summary: "Tool",
+          createdAt: "2026-04-01T00:00:03.000Z",
+          payload: {
+            title: "Tool",
+            itemType: "command_execution",
+            toolCallId: "reused-call",
+            detail: "second turnless chain",
+          },
+        }),
+      ],
+    });
+
+    const activities = buildThreadFeed(thread).flatMap((entry) =>
+      entry.type === "activity-group" ? entry.activities : [],
+    );
+    expect(activities).toHaveLength(3);
+    expect(activities[0]?.getFullDetail()).toContain("first turnless chain");
+    expect(activities[2]?.getFullDetail()).toContain("second turnless chain");
+  });
+
   it("collapses matching tool lifecycle rows like desktop", () => {
     const thread = makeThread({
       id: ThreadId.make("thread-2"),

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -558,6 +558,219 @@ describe("buildThreadFeed", () => {
     });
   });
 
+  it("never marks reasoning rows as failures when thinking quotes errors", () => {
+    const turnId = TurnId.make("turn-reasoning");
+    const thread = makeThread({
+      id: ThreadId.make("thread-reasoning"),
+      projectId: ProjectId.make("project-1"),
+      title: "Thinking",
+      latestTurn: {
+        turnId,
+        state: "running",
+        requestedAt: "2026-04-01T00:00:00.000Z",
+        startedAt: "2026-04-01T00:00:01.000Z",
+        completedAt: null,
+        assistantMessageId: null,
+      },
+      activities: [
+        makeActivity({
+          id: EventId.make("reasoning-1"),
+          kind: "tool.completed",
+          tone: "tool",
+          summary: "Reasoning",
+          createdAt: "2026-04-01T00:00:05.000Z",
+          turnId,
+          payload: {
+            title: "Reasoning",
+            itemType: "reasoning",
+            detail: "The previous attempt failed with exit code 1: command not found",
+            status: "completed",
+          },
+        }),
+      ],
+    });
+
+    const feed = buildThreadFeed(thread);
+    expect(feed[0]).toMatchObject({
+      type: "activity-group",
+      activities: [{ status: null, icon: "brain" }],
+    });
+  });
+
+  it("collapses reasoning updates interleaved with streaming tool calls into one row", () => {
+    // Claude streams thinking deltas interleaved with tool_call input deltas;
+    // adjacent-only folding used to split one block into a row per update.
+    const turnId = TurnId.make("turn-reasoning-interleaved");
+    const thread = makeThread({
+      id: ThreadId.make("thread-reasoning-interleaved"),
+      projectId: ProjectId.make("project-1"),
+      title: "Thinking",
+      latestTurn: {
+        turnId,
+        state: "running",
+        requestedAt: "2026-04-01T00:00:00.000Z",
+        startedAt: "2026-04-01T00:00:01.000Z",
+        completedAt: null,
+        assistantMessageId: null,
+      },
+      activities: [
+        makeActivity({
+          id: EventId.make("reasoning-update-1"),
+          kind: "tool.updated",
+          tone: "tool",
+          summary: "Reasoning",
+          createdAt: "2026-04-01T00:00:02.000Z",
+          turnId,
+          payload: {
+            itemType: "reasoning",
+            status: "inProgress",
+            detail: "Let",
+            data: { toolCallId: "reasoning-item-1" },
+          },
+        }),
+        makeActivity({
+          id: EventId.make("grep-update"),
+          kind: "tool.updated",
+          tone: "tool",
+          summary: "Grep",
+          createdAt: "2026-04-01T00:00:03.000Z",
+          turnId,
+          payload: {
+            itemType: "dynamic_tool_call",
+            status: "inProgress",
+            detail: 'Grep: {"pattern":"rea',
+            data: { toolCallId: "call-grep-1" },
+          },
+        }),
+        makeActivity({
+          id: EventId.make("reasoning-complete"),
+          kind: "tool.completed",
+          tone: "tool",
+          summary: "Reasoning",
+          createdAt: "2026-04-01T00:00:04.000Z",
+          turnId,
+          payload: {
+            itemType: "reasoning",
+            status: "completed",
+            detail: "Let me look at the code",
+            data: { toolCallId: "reasoning-item-1" },
+          },
+        }),
+        makeActivity({
+          id: EventId.make("grep-complete"),
+          kind: "tool.completed",
+          tone: "tool",
+          summary: "Grep",
+          createdAt: "2026-04-01T00:00:05.000Z",
+          turnId,
+          payload: {
+            itemType: "dynamic_tool_call",
+            status: "completed",
+            detail: 'Grep: {"pattern":"reasoning"}',
+            data: { toolCallId: "call-grep-1" },
+          },
+        }),
+      ],
+    });
+
+    const feed = buildThreadFeed(thread);
+    const activities = feed.flatMap((entry) =>
+      entry.type === "activity-group" ? entry.activities : [],
+    );
+    const reasoning = activities.filter((activity) => activity.icon === "brain");
+    expect(reasoning).toHaveLength(1);
+    // The row anchors where thinking started and carries the final full text.
+    expect(reasoning[0]?.id).toBe(EventId.make("reasoning-update-1"));
+    expect(reasoning[0]?.getFullDetail()).toContain("Let me look at the code");
+    const grep = activities.filter((activity) => activity.summary.includes("Grep"));
+    expect(grep).toHaveLength(1);
+    expect(grep[0]?.id).toBe(EventId.make("grep-update"));
+  });
+
+  it("hides reasoning rows that never accumulated thinking text", () => {
+    const turnId = TurnId.make("turn-reasoning-empty");
+    const thread = makeThread({
+      id: ThreadId.make("thread-reasoning-empty"),
+      projectId: ProjectId.make("project-1"),
+      title: "Redacted thinking",
+      latestTurn: {
+        turnId,
+        state: "running",
+        requestedAt: "2026-04-01T00:00:00.000Z",
+        startedAt: "2026-04-01T00:00:01.000Z",
+        completedAt: null,
+        assistantMessageId: null,
+      },
+      activities: [
+        makeActivity({
+          id: EventId.make("reasoning-empty"),
+          kind: "tool.completed",
+          tone: "tool",
+          summary: "Reasoning",
+          createdAt: "2026-04-01T00:00:05.000Z",
+          turnId,
+          payload: {
+            title: "Reasoning",
+            itemType: "reasoning",
+            status: "completed",
+          },
+        }),
+      ],
+    });
+
+    // No thinking text (e.g. redacted_thinking): the row stays neutral and
+    // the presentation filter keeps it out of the feed.
+    const feed = buildThreadFeed(thread);
+    const presented = deriveThreadFeedPresentation(feed, thread.latestTurn, new Set());
+    expect(presented.filter((entry) => entry.type === "activity-group")).toHaveLength(0);
+  });
+
+  it("collapses a streamed reasoning update chain into one live row", () => {
+    const turnId = TurnId.make("turn-reasoning-stream");
+    const reasoningUpdate = (id: string, createdAt: string, detail: string) =>
+      makeActivity({
+        id: EventId.make(id),
+        kind: "tool.updated",
+        tone: "tool",
+        summary: "Reasoning",
+        createdAt,
+        turnId,
+        payload: {
+          title: "Reasoning",
+          itemType: "reasoning",
+          status: "inProgress",
+          detail,
+          data: { toolCallId: "reasoning-item-1" },
+        },
+      });
+    const thread = makeThread({
+      id: ThreadId.make("thread-reasoning-stream"),
+      projectId: ProjectId.make("project-1"),
+      title: "Thinking",
+      latestTurn: {
+        turnId,
+        state: "running",
+        requestedAt: "2026-04-01T00:00:00.000Z",
+        startedAt: "2026-04-01T00:00:01.000Z",
+        completedAt: null,
+        assistantMessageId: null,
+      },
+      activities: [
+        reasoningUpdate("rs-1", "2026-04-01T00:00:02.000Z", "Let me"),
+        reasoningUpdate("rs-2", "2026-04-01T00:00:03.000Z", "Let me think"),
+        reasoningUpdate("rs-3", "2026-04-01T00:00:04.000Z", "Let me think about this"),
+      ],
+    });
+
+    const feed = buildThreadFeed(thread);
+    expect(feed).toHaveLength(1);
+    // The whole chain folds into a single row carrying the latest text.
+    expect(feed[0]).toMatchObject({
+      type: "activity-group",
+      activities: [{ detail: "Let me think about this", icon: "brain" }],
+    });
+  });
+
   it("appends active work as a normal timeline row", () => {
     const startedAt = "2026-04-01T00:00:01.000Z";
     const presented = deriveThreadFeedPresentation([], null, new Set(), new Set(), startedAt);
@@ -588,6 +801,7 @@ describe("buildThreadFeed", () => {
       getCopyText: () => id,
       icon: "command",
       toolLike: true,
+      toolCall: true,
       status,
     });
     const feed: ThreadFeedEntry[] = [

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -458,13 +458,13 @@ function collapseDerivedWorkLogEntries(
   // Subagent rows collapse by identity, not adjacency (quiet-timeline
   // guarantee; mirrors web's session-logic).
   const taskRowIndex = new Map<string, number>();
-  // Rows carrying a toolCallId identity also collapse by identity (mirrors
-  // web): Claude streams thinking deltas interleaved with tool_call input
-  // deltas, and adjacent-only folding split one reasoning block into a row
-  // per update whenever a tool call streamed in between. The anchor keeps
+  // Turn-stamped rows carrying a toolCallId also collapse by identity
+  // (mirrors web): Claude streams thinking deltas interleaved with tool_call
+  // input deltas, and adjacent-only folding split one reasoning block into a
+  // row per update whenever a tool call streamed in between. The anchor keeps
   // the FIRST row's id/createdAt/turnId so the row grows in place with a
-  // stable key. The fuzzy collapseKey fallback (no toolCallId) stays
-  // adjacency-only.
+  // stable key. Turnless rows keep the adjacency-only fuzzy fallback; their
+  // ids are not safe identities across the lifetime of the thread.
   const toolRowIndex = new Map<string, number>();
   for (const entry of entries) {
     const isTaskRow =
@@ -484,6 +484,7 @@ function collapseDerivedWorkLogEntries(
     }
     const toolIdentityKey =
       entry.toolCallId !== undefined &&
+      entry.turnId !== null &&
       (entry.activityKind === "tool.updated" || entry.activityKind === "tool.completed")
         ? entry.collapseKey
         : undefined;
@@ -586,11 +587,11 @@ function deriveToolLifecycleCollapseKey(entry: DerivedWorkLogEntry): string | un
   if (entry.activityKind !== "tool.updated" && entry.activityKind !== "tool.completed") {
     return undefined;
   }
-  // An explicit toolCallId (adapters emit one for streaming items like
-  // reasoning) is a stable identity across the whole update chain; keying on
-  // the growing detail instead would render every update as its own row.
-  if (entry.toolCallId) {
-    return `tool:${entry.turnId ?? "no-turn"}:${entry.toolCallId}`;
+  // An explicit toolCallId is a stable identity for streaming items like
+  // reasoning only inside a known turn. Without that boundary, a provider may
+  // reuse the id for a later chain, so retain the local fuzzy fallback.
+  if (entry.toolCallId && entry.turnId) {
+    return `tool:${entry.turnId}:${entry.toolCallId}`;
   }
   const normalizedLabel = normalizeCompactToolLabel(entry.toolTitle ?? entry.label);
   const detail = entry.detail?.trim() ?? "";

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -395,7 +395,10 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   };
   const itemType = extractWorkLogItemType(payload);
   const requestKind = extractWorkLogRequestKind(payload);
-  const toolCallId = asTrimmedString(asRecord(payload?.data)?.toolCallId);
+  // Ingestion stamps the stable id at payload level; adapters (Claude
+  // reasoning) carry it in data.toolCallId. Read both, like the web client.
+  const toolCallId =
+    asTrimmedString(payload?.toolCallId) ?? asTrimmedString(asRecord(payload?.data)?.toolCallId);
   if (
     !taskDetailAsLabel &&
     payload &&
@@ -525,6 +528,11 @@ function shouldCollapseToolLifecycleEntries(
   if (next.activityKind !== "tool.updated" && next.activityKind !== "tool.completed") {
     return false;
   }
+  // Tool identities are only unique within a turn: a later turn reusing an
+  // in-progress id must stay a separate row (mirrors the web client).
+  if (previous.turnId !== next.turnId) {
+    return false;
+  }
   if (previous.activityKind === "tool.completed") {
     return false;
   }
@@ -582,7 +590,7 @@ function deriveToolLifecycleCollapseKey(entry: DerivedWorkLogEntry): string | un
   // reasoning) is a stable identity across the whole update chain; keying on
   // the growing detail instead would render every update as its own row.
   if (entry.toolCallId) {
-    return `tool:${entry.toolCallId}`;
+    return `tool:${entry.turnId ?? "no-turn"}:${entry.toolCallId}`;
   }
   const normalizedLabel = normalizeCompactToolLabel(entry.toolTitle ?? entry.label);
   const detail = entry.detail?.trim() ?? "";

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -42,6 +42,7 @@ export interface ThreadFeedActivity {
   readonly icon:
     | "agent"
     | "alert"
+    | "brain"
     | "check"
     | "command"
     | "edit"
@@ -53,6 +54,8 @@ export interface ThreadFeedActivity {
     | "wrench"
     | "zap";
   readonly toolLike: boolean;
+  /** toolLike minus reasoning: gates the "N tool calls" group label. */
+  readonly toolCall: boolean;
   readonly status: "success" | "failure" | "neutral" | null;
 }
 
@@ -71,7 +74,7 @@ interface WorkLogEntry {
   changedFiles?: ReadonlyArray<string>;
   tone: "thinking" | "tool" | "info" | "error";
   toolTitle?: string;
-  itemType?: ToolLifecycleItemType;
+  itemType?: ToolLifecycleItemType | "reasoning";
   requestKind?: PendingApproval["requestKind"];
   toolLifecycleStatus?: WorkLogToolLifecycleStatus;
   toolData?: unknown;
@@ -80,6 +83,7 @@ interface WorkLogEntry {
 interface DerivedWorkLogEntry extends WorkLogEntry {
   activityKind: OrchestrationThreadActivity["kind"];
   collapseKey?: string;
+  toolCallId?: string;
   /** Grouping key for subagent lifecycle rows (one row per agent). */
   taskId?: string;
 }
@@ -391,6 +395,7 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   };
   const itemType = extractWorkLogItemType(payload);
   const requestKind = extractWorkLogRequestKind(payload);
+  const toolCallId = asTrimmedString(asRecord(payload?.data)?.toolCallId);
   if (
     !taskDetailAsLabel &&
     payload &&
@@ -423,6 +428,9 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   if (itemType) {
     entry.itemType = itemType;
   }
+  if (toolCallId) {
+    entry.toolCallId = toolCallId;
+  }
   if (requestKind) {
     entry.requestKind = requestKind;
   }
@@ -447,6 +455,14 @@ function collapseDerivedWorkLogEntries(
   // Subagent rows collapse by identity, not adjacency (quiet-timeline
   // guarantee; mirrors web's session-logic).
   const taskRowIndex = new Map<string, number>();
+  // Rows carrying a toolCallId identity also collapse by identity (mirrors
+  // web): Claude streams thinking deltas interleaved with tool_call input
+  // deltas, and adjacent-only folding split one reasoning block into a row
+  // per update whenever a tool call streamed in between. The anchor keeps
+  // the FIRST row's id/createdAt/turnId so the row grows in place with a
+  // stable key. The fuzzy collapseKey fallback (no toolCallId) stays
+  // adjacency-only.
+  const toolRowIndex = new Map<string, number>();
   for (const entry of entries) {
     const isTaskRow =
       entry.taskId !== undefined &&
@@ -460,6 +476,32 @@ function collapseDerivedWorkLogEntries(
         continue;
       }
       taskRowIndex.set(entry.taskId, collapsed.length);
+      collapsed.push(entry);
+      continue;
+    }
+    const toolIdentityKey =
+      entry.toolCallId !== undefined &&
+      (entry.activityKind === "tool.updated" || entry.activityKind === "tool.completed")
+        ? entry.collapseKey
+        : undefined;
+    if (toolIdentityKey !== undefined) {
+      const existingIndex = toolRowIndex.get(toolIdentityKey);
+      const existing =
+        existingIndex !== undefined && existingIndex < collapsed.length
+          ? collapsed[existingIndex]
+          : undefined;
+      if (existingIndex !== undefined && existing && existing.activityKind !== "tool.completed") {
+        collapsed[existingIndex] = {
+          ...mergeDerivedWorkLogEntries(existing, entry),
+          id: existing.id,
+          createdAt: existing.createdAt,
+          turnId: existing.turnId ?? null,
+        };
+        continue;
+      }
+      // A completed anchor never absorbs later activity for the same
+      // identity, so a stale late update cannot regress the final detail.
+      toolRowIndex.set(toolIdentityKey, collapsed.length);
       collapsed.push(entry);
       continue;
     }
@@ -501,6 +543,7 @@ function mergeDerivedWorkLogEntries(
   const itemType = next.itemType ?? previous.itemType;
   const requestKind = next.requestKind ?? previous.requestKind;
   const collapseKey = next.collapseKey ?? previous.collapseKey;
+  const toolCallId = next.toolCallId ?? previous.toolCallId;
   const toolLifecycleStatus = next.toolLifecycleStatus ?? previous.toolLifecycleStatus;
   const toolData = next.toolData ?? previous.toolData;
   return {
@@ -514,6 +557,7 @@ function mergeDerivedWorkLogEntries(
     ...(itemType ? { itemType } : {}),
     ...(requestKind ? { requestKind } : {}),
     ...(collapseKey ? { collapseKey } : {}),
+    ...(toolCallId ? { toolCallId } : {}),
     ...(toolLifecycleStatus ? { toolLifecycleStatus } : {}),
     ...(toolData !== undefined ? { toolData } : {}),
   };
@@ -533,6 +577,12 @@ function mergeChangedFiles(
 function deriveToolLifecycleCollapseKey(entry: DerivedWorkLogEntry): string | undefined {
   if (entry.activityKind !== "tool.updated" && entry.activityKind !== "tool.completed") {
     return undefined;
+  }
+  // An explicit toolCallId (adapters emit one for streaming items like
+  // reasoning) is a stable identity across the whole update chain; keying on
+  // the growing detail instead would render every update as its own row.
+  if (entry.toolCallId) {
+    return `tool:${entry.toolCallId}`;
   }
   const normalizedLabel = normalizeCompactToolLabel(entry.toolTitle ?? entry.label);
   const detail = entry.detail?.trim() ?? "";
@@ -581,6 +631,12 @@ function toolDetailTextLooksLikeFailure(text: string): boolean {
 }
 
 function workEntryIndicatesToolFailure(entry: WorkLogEntry): boolean {
+  // Reasoning rows carry the model's prose as detail; running the tool-output
+  // failure heuristic over it would flag any quoted error ("exit code 1") as
+  // a tool failure even though nothing failed.
+  if (entry.itemType === "reasoning") {
+    return false;
+  }
   if (entry.tone === "error") {
     return true;
   }
@@ -609,6 +665,14 @@ function workEntryIndicatesToolSuccess(entry: WorkLogEntry): boolean {
 }
 
 function workEntryStatus(entry: WorkLogEntry): ThreadFeedActivity["status"] {
+  // Reasoning rows have no tool outcome: no failure heuristic (above), no
+  // success affordance, and never "neutral" — the neutral filter would hide
+  // the live thinking row for the whole turn. Exception: a reasoning item
+  // with no thinking text (e.g. redacted_thinking) stays neutral so the
+  // empty-row filter still hides it instead of rendering a bare row.
+  if (entry.itemType === "reasoning") {
+    return (entry.detail?.trim().length ?? 0) === 0 ? "neutral" : null;
+  }
   if (!workLogEntryIsToolLike(entry)) {
     return null;
   }
@@ -640,6 +704,7 @@ function workEntryIcon(entry: DerivedWorkLogEntry): ThreadFeedActivity["icon"] {
   if (entry.itemType === "dynamic_tool_call" || entry.itemType === "collab_agent_tool_call") {
     return "hammer";
   }
+  if (entry.itemType === "reasoning") return "brain";
   if (entry.tone === "error") return "alert";
   if (entry.tone === "thinking") return "agent";
   if (entry.tone === "info") return "check";
@@ -955,7 +1020,10 @@ function stripTrailingExitCode(value: string): {
 function extractWorkLogItemType(
   payload: Record<string, unknown> | null,
 ): WorkLogEntry["itemType"] | undefined {
-  if (typeof payload?.itemType === "string" && isToolLifecycleItemType(payload.itemType)) {
+  if (
+    typeof payload?.itemType === "string" &&
+    (isToolLifecycleItemType(payload.itemType) || payload.itemType === "reasoning")
+  ) {
     return payload.itemType;
   }
   return undefined;
@@ -1337,7 +1405,7 @@ function appendPresentedFeedEntry(
     groupId,
     hiddenCount,
     expanded,
-    onlyToolActivities: activities.every((activity) => activity.toolLike),
+    onlyToolActivities: activities.every((activity) => activity.toolCall),
   });
 }
 
@@ -1565,6 +1633,7 @@ export function buildThreadFeed(
               getCopyText,
               icon: workEntryIcon(entry),
               toolLike: workLogEntryIsToolLike(entry),
+              toolCall: workLogEntryIsToolLike(entry) && entry.itemType !== "reasoning",
               status: workEntryStatus(entry),
             },
           };

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -1117,6 +1117,165 @@ describe("ProviderRuntimeIngestion", () => {
     expect(rawOutput?.content).toBe('import * as Effect from "effect/Effect"\n');
   });
 
+  it("keeps reasoning item lifecycle activities with the full thinking detail", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+    const thinking = "g".repeat(400);
+
+    harness.emit({
+      type: "item.started",
+      eventId: asEventId("evt-reasoning-started"),
+      provider: ProviderDriverKind.make("claudeAgent"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-reasoning"),
+      itemId: asItemId("item-reasoning-1"),
+      payload: {
+        itemType: "reasoning",
+        status: "inProgress",
+        title: "Reasoning",
+      },
+    });
+
+    harness.emit({
+      type: "item.updated",
+      eventId: asEventId("evt-reasoning-updated"),
+      provider: ProviderDriverKind.make("claudeAgent"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-reasoning"),
+      itemId: asItemId("item-reasoning-1"),
+      payload: {
+        itemType: "reasoning",
+        status: "inProgress",
+        title: "Reasoning",
+        detail: thinking,
+        data: { toolCallId: "item-reasoning-1" },
+      },
+    });
+
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-reasoning-completed"),
+      provider: ProviderDriverKind.make("claudeAgent"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-reasoning"),
+      itemId: asItemId("item-reasoning-1"),
+      payload: {
+        itemType: "reasoning",
+        status: "completed",
+        title: "Reasoning",
+        detail: thinking,
+        data: { toolCallId: "item-reasoning-1" },
+      },
+    });
+
+    const thread = await waitForThread(harness.readModel, (entry) =>
+      entry.activities.some(
+        (activity: ProviderRuntimeTestActivity) => activity.id === "evt-reasoning-completed",
+      ),
+    );
+
+    const started = thread.activities.find(
+      (entry: ProviderRuntimeTestActivity) => entry.id === "evt-reasoning-started",
+    );
+    expect(started?.kind).toBe("tool.started");
+    const startedPayload = started?.payload as Record<string, unknown> | undefined;
+    expect(startedPayload?.itemType).toBe("reasoning");
+
+    const updated = thread.activities.find(
+      (entry: ProviderRuntimeTestActivity) => entry.id === "evt-reasoning-updated",
+    );
+    expect(updated?.kind).toBe("tool.updated");
+    const updatedPayload = updated?.payload as Record<string, unknown> | undefined;
+    expect(updatedPayload?.itemType).toBe("reasoning");
+    // The thinking text is the payload, not a preview: no 180-char truncation.
+    expect(updatedPayload?.detail).toBe(thinking);
+
+    const completed = thread.activities.find(
+      (entry: ProviderRuntimeTestActivity) => entry.id === "evt-reasoning-completed",
+    );
+    expect(completed?.kind).toBe("tool.completed");
+    const completedPayload = completed?.payload as Record<string, unknown> | undefined;
+    expect(completedPayload?.itemType).toBe("reasoning");
+    expect(completedPayload?.detail).toBe(thinking);
+    const completedData = completedPayload?.data as { toolCallId?: string } | undefined;
+    expect(completedData?.toolCallId).toBe("item-reasoning-1");
+  });
+
+  it("drops reasoning events without a renderable title (Codex summaryPartAdded shape)", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+
+    // Codex emits reasoning updates with no title and no data.toolCallId;
+    // persisting them would create unlabeled "Tool updated" rows clients
+    // cannot fold, so they stay dropped until the adapter emits Claude's shape.
+    harness.emit({
+      type: "item.updated",
+      eventId: asEventId("evt-codex-reasoning-updated"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-codex-reasoning"),
+      itemId: asItemId("item-codex-reasoning-1"),
+      payload: {
+        itemType: "reasoning",
+        data: { itemId: "item-codex-reasoning-1", summaryIndex: 0, text: "partial summary" },
+      },
+    });
+
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-codex-reasoning-completed"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-codex-reasoning"),
+      itemId: asItemId("item-codex-reasoning-1"),
+      payload: {
+        itemType: "reasoning",
+        status: "completed",
+      },
+    });
+
+    // A renderable reasoning event in the same turn proves only the
+    // unrenderable ones were dropped.
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-claude-reasoning-completed"),
+      provider: ProviderDriverKind.make("claudeAgent"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-codex-reasoning"),
+      itemId: asItemId("item-claude-reasoning-1"),
+      payload: {
+        itemType: "reasoning",
+        status: "completed",
+        title: "Reasoning",
+        detail: "done thinking",
+        data: { toolCallId: "item-claude-reasoning-1" },
+      },
+    });
+
+    const thread = await waitForThread(harness.readModel, (entry) =>
+      entry.activities.some(
+        (activity: ProviderRuntimeTestActivity) => activity.id === "evt-claude-reasoning-completed",
+      ),
+    );
+
+    expect(
+      thread.activities.some(
+        (activity: ProviderRuntimeTestActivity) => activity.id === "evt-codex-reasoning-updated",
+      ),
+    ).toBe(false);
+    expect(
+      thread.activities.some(
+        (activity: ProviderRuntimeTestActivity) => activity.id === "evt-codex-reasoning-completed",
+      ),
+    ).toBe(false);
+  });
+
   it("normalizes command execution activities to ran-command summaries", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -211,6 +211,43 @@ function truncateDetail(value: string, limit = 180): string {
   return value.length > limit ? `${value.slice(0, limit - 3)}...` : value;
 }
 
+// Reasoning items carry the model's full thinking text as their detail —
+// truncating that to the tool-card default would make them useless.
+const REASONING_DETAIL_LIMIT = 20_000;
+
+function isActivityItemType(value: string): boolean {
+  return isToolLifecycleItemType(value) || value === "reasoning";
+}
+
+/**
+ * Reasoning items are only renderable when the adapter emits the shape
+ * clients can fold: a stable title (Claude always sends "Reasoning"; updates
+ * and completions also carry data.toolCallId). Other providers' reasoning
+ * events — e.g. Codex `item/reasoning/summaryPartAdded` — have neither, and
+ * letting them through would persist unlabeled "Tool updated" rows that no
+ * client can collapse. Until those adapters emit the renderable shape, their
+ * reasoning events stay dropped (the behavior before reasoning passed the
+ * item-lifecycle guard).
+ */
+function isSupportedItemActivity(
+  itemType: string,
+  payload: { readonly title?: string | undefined },
+): boolean {
+  if (!isActivityItemType(itemType)) {
+    return false;
+  }
+  if (itemType === "reasoning" && typeof payload.title !== "string") {
+    return false;
+  }
+  return true;
+}
+
+function truncateActivityDetail(itemType: string, detail: string): string {
+  return itemType === "reasoning"
+    ? truncateDetail(detail, REASONING_DETAIL_LIMIT)
+    : truncateDetail(detail);
+}
+
 function normalizeProposedPlanMarkdown(planMarkdown: string | undefined): string | undefined {
   const trimmed = planMarkdown?.trim();
   if (!trimmed) {
@@ -784,7 +821,7 @@ export function runtimeEventToActivities(
     }
 
     case "item.updated": {
-      if (!isToolLifecycleItemType(event.payload.itemType)) {
+      if (!isSupportedItemActivity(event.payload.itemType, event.payload)) {
         return [];
       }
       // A streaming update's `data` carries the full tool output accumulated
@@ -805,7 +842,9 @@ export function runtimeEventToActivities(
             itemType: event.payload.itemType,
             ...(event.itemId !== undefined ? { toolCallId: event.itemId } : {}),
             ...(event.payload.status ? { status: event.payload.status } : {}),
-            ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
+            ...(event.payload.detail
+              ? { detail: truncateActivityDetail(event.payload.itemType, event.payload.detail) }
+              : {}),
             ...(event.payload.data !== undefined ? { data: event.payload.data } : {}),
             ...(event.payload.agentId ? { agentId: event.payload.agentId } : {}),
             ...(event.payload.parentToolUseId
@@ -819,7 +858,7 @@ export function runtimeEventToActivities(
     }
 
     case "item.completed": {
-      if (!isToolLifecycleItemType(event.payload.itemType)) {
+      if (!isSupportedItemActivity(event.payload.itemType, event.payload)) {
         return [];
       }
       return [
@@ -833,7 +872,9 @@ export function runtimeEventToActivities(
             itemType: event.payload.itemType,
             ...(event.itemId !== undefined ? { toolCallId: event.itemId } : {}),
             ...(event.payload.status ? { status: event.payload.status } : {}),
-            ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
+            ...(event.payload.detail
+              ? { detail: truncateActivityDetail(event.payload.itemType, event.payload.detail) }
+              : {}),
             ...(event.payload.data !== undefined ? { data: event.payload.data } : {}),
             ...(event.payload.agentId ? { agentId: event.payload.agentId } : {}),
             ...(event.payload.parentToolUseId
@@ -847,7 +888,7 @@ export function runtimeEventToActivities(
     }
 
     case "item.started": {
-      if (!isToolLifecycleItemType(event.payload.itemType)) {
+      if (!isSupportedItemActivity(event.payload.itemType, event.payload)) {
         return [];
       }
       return [
@@ -861,7 +902,9 @@ export function runtimeEventToActivities(
             itemType: event.payload.itemType,
             ...(event.itemId !== undefined ? { toolCallId: event.itemId } : {}),
             ...(event.payload.status ? { status: event.payload.status } : {}),
-            ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
+            ...(event.payload.detail
+              ? { detail: truncateActivityDetail(event.payload.itemType, event.payload.detail) }
+              : {}),
             ...(event.payload.data !== undefined ? { data: event.payload.data } : {}),
             ...(event.payload.agentId ? { agentId: event.payload.agentId } : {}),
             ...(event.payload.parentToolUseId

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1209,6 +1209,137 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect(
+    "does not duplicate reasoning that streamed live into a synthetic turn when its snapshot arrives",
+    () => {
+      const harness = makeHarness();
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+
+        const eventsFiber = yield* adapter.streamEvents.pipe(
+          Stream.takeUntil((event) => event.type === "turn.completed"),
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+
+        yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          runtimeMode: "full-access",
+        });
+
+        // No sendTurn: a background assistant snapshot opens a synthetic turn
+        // and backfills its thinking.
+        harness.query.emit({
+          type: "assistant",
+          session_id: "sdk-session-1",
+          uuid: "assistant-bg-1",
+          parent_tool_use_id: null,
+          message: {
+            id: "assistant-bg-message-1",
+            content: [
+              { type: "thinking", thinking: "Background thought" },
+              { type: "text", text: "Background answer." },
+            ],
+          },
+        } as unknown as SDKMessage);
+
+        // The background agent keeps working: its next message streams live
+        // into the still-open synthetic turn.
+        harness.query.emit({
+          type: "stream_event",
+          session_id: "sdk-session-1",
+          uuid: "stream-bg-0",
+          parent_tool_use_id: null,
+          event: {
+            type: "message_start",
+            message: { id: "assistant-bg-message-2" },
+          },
+        } as unknown as SDKMessage);
+
+        harness.query.emit({
+          type: "stream_event",
+          session_id: "sdk-session-1",
+          uuid: "stream-bg-1",
+          parent_tool_use_id: null,
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: {
+              type: "thinking",
+              thinking: "",
+            },
+          },
+        } as unknown as SDKMessage);
+
+        harness.query.emit({
+          type: "stream_event",
+          session_id: "sdk-session-1",
+          uuid: "stream-bg-2",
+          parent_tool_use_id: null,
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: {
+              type: "thinking_delta",
+              thinking: "Streamed thought",
+            },
+          },
+        } as unknown as SDKMessage);
+
+        harness.query.emit({
+          type: "stream_event",
+          session_id: "sdk-session-1",
+          uuid: "stream-bg-3",
+          parent_tool_use_id: null,
+          event: {
+            type: "content_block_stop",
+            index: 0,
+          },
+        } as unknown as SDKMessage);
+
+        // The full snapshot of that same message must not re-emit the block.
+        harness.query.emit({
+          type: "assistant",
+          session_id: "sdk-session-1",
+          uuid: "assistant-bg-2",
+          parent_tool_use_id: null,
+          message: {
+            id: "assistant-bg-message-2",
+            content: [
+              { type: "thinking", thinking: "Streamed thought" },
+              { type: "text", text: "Done." },
+            ],
+          },
+        } as unknown as SDKMessage);
+
+        harness.query.emit({
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          errors: [],
+          session_id: "sdk-session-1",
+          uuid: "result-bg-1",
+        } as unknown as SDKMessage);
+
+        const events = Array.from(yield* Fiber.join(eventsFiber));
+        const reasoningCompleted = events.filter(
+          (event) => event.type === "item.completed" && event.payload.itemType === "reasoning",
+        );
+        assert.equal(reasoningCompleted.length, 2);
+        assert.deepEqual(
+          reasoningCompleted.map((event) =>
+            event.type === "item.completed" ? event.payload.detail : undefined,
+          ),
+          ["Background thought", "Streamed thought"],
+        );
+      }).pipe(
+        Effect.provideService(Random.Random, makeDeterministicRandomService()),
+        Effect.provide(harness.layer),
+      );
+    },
+  );
+
   it.effect("ignores a subagent's content_block_stop for the parent's reasoning block", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1159,6 +1159,104 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("ignores a subagent's content_block_stop for the parent's reasoning block", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const runtimeEventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "think while a subagent runs",
+        attachments: [],
+      });
+
+      // Parent thinking block opens at index 0.
+      harness.query.emit({
+        type: "stream_event",
+        session_id: "sdk-session-1",
+        uuid: "stream-0",
+        parent_tool_use_id: null,
+        event: {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "thinking", thinking: "" },
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "stream_event",
+        session_id: "sdk-session-1",
+        uuid: "stream-1",
+        parent_tool_use_id: null,
+        event: {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "thinking_delta", thinking: "Parent thought" },
+        },
+      } as unknown as SDKMessage);
+
+      // A subagent's stop at the same index must NOT seal the parent's block.
+      harness.query.emit({
+        type: "stream_event",
+        session_id: "sdk-session-1",
+        uuid: "stream-2",
+        parent_tool_use_id: "toolu_subagent_1",
+        event: {
+          type: "content_block_stop",
+          index: 0,
+        },
+      } as unknown as SDKMessage);
+
+      // The parent's own stop completes it.
+      harness.query.emit({
+        type: "stream_event",
+        session_id: "sdk-session-1",
+        uuid: "stream-3",
+        parent_tool_use_id: null,
+        event: {
+          type: "content_block_stop",
+          index: 0,
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "sdk-session-1",
+        uuid: "result-1",
+      } as unknown as SDKMessage);
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      const reasoningCompletions = runtimeEvents.filter(
+        (event) => event.type === "item.completed" && event.payload.itemType === "reasoning",
+      );
+      // Exactly one completion, after the PARENT's stop — the subagent's stop
+      // would have completed it early with the partial text.
+      assert.equal(reasoningCompletions.length, 1);
+      const completion = reasoningCompletions[0];
+      if (completion?.type === "item.completed") {
+        assert.equal(completion.payload.detail, "Parent thought");
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("does not emit turn.completed for a result with no active turn", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1159,6 +1159,56 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("backfills reasoning items from snapshots that arrive with no active turn", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil(
+          (event) => event.type === "item.completed" && event.payload.itemType === "reasoning",
+        ),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      // No sendTurn: a background/resumed assistant snapshot arrives with
+      // thinking content — the synthetic turn must surface its reasoning.
+      harness.query.emit({
+        type: "assistant",
+        session_id: "sdk-session-1",
+        uuid: "assistant-bg-1",
+        parent_tool_use_id: null,
+        message: {
+          id: "assistant-bg-message-1",
+          content: [
+            { type: "thinking", thinking: "Background thought" },
+            { type: "text", text: "Background answer." },
+          ],
+        },
+      } as unknown as SDKMessage);
+
+      const events = Array.from(yield* Fiber.join(eventsFiber));
+      const reasoningCompleted = events.find(
+        (event) => event.type === "item.completed" && event.payload.itemType === "reasoning",
+      );
+      assert.equal(reasoningCompleted?.type, "item.completed");
+      if (reasoningCompleted?.type === "item.completed") {
+        assert.equal(reasoningCompleted.payload.detail, "Background thought");
+        assert.equal(reasoningCompleted.payload.title, "Reasoning");
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("ignores a subagent's content_block_stop for the parent's reasoning block", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -978,6 +978,187 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("attaches thinking blocks to a reasoning item with a stable itemId", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const runtimeEventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      const turn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "think, then answer",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "stream_event",
+        session_id: "sdk-session-1",
+        uuid: "stream-0",
+        parent_tool_use_id: null,
+        event: {
+          type: "content_block_start",
+          index: 0,
+          content_block: {
+            type: "thinking",
+            thinking: "",
+          },
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "stream_event",
+        session_id: "sdk-session-1",
+        uuid: "stream-1",
+        parent_tool_use_id: null,
+        event: {
+          type: "content_block_delta",
+          index: 0,
+          delta: {
+            type: "thinking_delta",
+            thinking: "Let me ",
+          },
+        },
+      } as unknown as SDKMessage);
+
+      // Long enough to cross the live-update throttle (512 chars) exactly once.
+      const longThought = "x".repeat(600);
+      harness.query.emit({
+        type: "stream_event",
+        session_id: "sdk-session-1",
+        uuid: "stream-2",
+        parent_tool_use_id: null,
+        event: {
+          type: "content_block_delta",
+          index: 0,
+          delta: {
+            type: "thinking_delta",
+            thinking: longThought,
+          },
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "stream_event",
+        session_id: "sdk-session-1",
+        uuid: "stream-3",
+        parent_tool_use_id: null,
+        event: {
+          type: "content_block_stop",
+          index: 0,
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "assistant",
+        session_id: "sdk-session-1",
+        uuid: "assistant-1",
+        parent_tool_use_id: null,
+        message: {
+          id: "assistant-message-1",
+          content: [
+            { type: "thinking", thinking: `Let me ${longThought}` },
+            { type: "text", text: "Done." },
+          ],
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "sdk-session-1",
+        uuid: "result-1",
+      } as unknown as SDKMessage);
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+
+      const reasoningStarted = runtimeEvents.find(
+        (event) => event.type === "item.started" && event.payload.itemType === "reasoning",
+      );
+      assert.equal(reasoningStarted?.type, "item.started");
+      if (reasoningStarted?.type !== "item.started") {
+        return;
+      }
+      assert.equal(reasoningStarted.payload.status, "inProgress");
+      assert.equal(reasoningStarted.payload.title, "Reasoning");
+      const reasoningItemId = reasoningStarted.itemId;
+      assert.equal(typeof reasoningItemId, "string");
+
+      const reasoningDeltas = runtimeEvents.filter(
+        (event) => event.type === "content.delta" && event.payload.streamKind === "reasoning_text",
+      );
+      assert.equal(reasoningDeltas.length, 2);
+      for (const delta of reasoningDeltas) {
+        assert.equal(String(delta.itemId), String(reasoningItemId));
+      }
+      assert.deepEqual(
+        reasoningDeltas.map((delta) => (delta.type === "content.delta" ? delta.payload.delta : "")),
+        ["Let me ", longThought],
+      );
+
+      const reasoningUpdates = runtimeEvents.filter(
+        (event) => event.type === "item.updated" && event.payload.itemType === "reasoning",
+      );
+      // First text goes out immediately; the 600-char delta crosses the
+      // live-update throttle once more.
+      assert.equal(reasoningUpdates.length, 2);
+      const firstUpdate = reasoningUpdates[0];
+      if (firstUpdate?.type === "item.updated") {
+        assert.equal(String(firstUpdate.itemId), String(reasoningItemId));
+        assert.equal(firstUpdate.payload.detail, "Let me ");
+      }
+      const reasoningUpdate = reasoningUpdates[1];
+      if (reasoningUpdate?.type === "item.updated") {
+        assert.equal(String(reasoningUpdate.itemId), String(reasoningItemId));
+        assert.equal(reasoningUpdate.payload.detail, `Let me ${longThought}`);
+        const updateData = reasoningUpdate.payload.data as { toolCallId?: string } | undefined;
+        assert.equal(String(updateData?.toolCallId), String(reasoningItemId));
+      }
+
+      const reasoningCompleted = runtimeEvents.find(
+        (event) => event.type === "item.completed" && event.payload.itemType === "reasoning",
+      );
+      assert.equal(reasoningCompleted?.type, "item.completed");
+      if (reasoningCompleted?.type === "item.completed") {
+        assert.equal(String(reasoningCompleted.itemId), String(reasoningItemId));
+        assert.equal(reasoningCompleted.payload.status, "completed");
+        assert.equal(reasoningCompleted.payload.detail, `Let me ${longThought}`);
+        const completedData = reasoningCompleted.payload.data as
+          | { toolCallId?: string }
+          | undefined;
+        assert.equal(String(completedData?.toolCallId), String(reasoningItemId));
+      }
+
+      const startedIndex = runtimeEvents.indexOf(reasoningStarted);
+      const completedIndex = runtimeEvents.indexOf(reasoningCompleted!);
+      assert.equal(startedIndex >= 0 && completedIndex > startedIndex, true);
+
+      // Thinking text must not leak into the assistant message backfill.
+      const assistantCompleted = runtimeEvents.find(
+        (event) =>
+          event.type === "item.completed" && event.payload.itemType === "assistant_message",
+      );
+      if (assistantCompleted?.type === "item.completed") {
+        assert.equal(assistantCompleted.payload.detail, "Done.");
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("does not emit turn.completed for a result with no active turn", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {
@@ -1119,7 +1300,7 @@ describe("ClaudeAdapterLive", () => {
     return Effect.gen(function* () {
       const adapter = yield* ClaudeAdapter;
 
-      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 11).pipe(
+      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 14).pipe(
         Stream.runCollect,
         Effect.forkChild,
       );
@@ -1229,14 +1410,22 @@ describe("ClaudeAdapterLive", () => {
           "session.state.changed",
           "turn.started",
           "thread.started",
+          "item.started",
           "content.delta",
+          "item.updated",
           "item.started",
           "item.updated",
           "item.updated",
           "item.completed",
+          "item.completed",
           "turn.completed",
         ],
       );
+
+      const reasoningStarted = runtimeEvents.find(
+        (event) => event.type === "item.started" && event.payload.itemType === "reasoning",
+      );
+      assert.equal(reasoningStarted?.type, "item.started");
 
       const reasoningDelta = runtimeEvents.find(
         (event) => event.type === "content.delta" && event.payload.streamKind === "reasoning_text",
@@ -1245,9 +1434,21 @@ describe("ClaudeAdapterLive", () => {
       if (reasoningDelta?.type === "content.delta") {
         assert.equal(reasoningDelta.payload.delta, "Let");
         assert.equal(String(reasoningDelta.turnId), String(turn.turnId));
+        // Thinking deltas carry the reasoning itemId (upstream issue #5542).
+        assert.equal(String(reasoningDelta.itemId), String(reasoningStarted?.itemId));
       }
 
-      const toolStarted = runtimeEvents.find((event) => event.type === "item.started");
+      const reasoningCompleted = runtimeEvents.find(
+        (event) => event.type === "item.completed" && event.payload.itemType === "reasoning",
+      );
+      assert.equal(reasoningCompleted?.type, "item.completed");
+      if (reasoningCompleted?.type === "item.completed") {
+        assert.equal(reasoningCompleted.payload.detail, "Let");
+      }
+
+      const toolStarted = runtimeEvents.find(
+        (event) => event.type === "item.started" && event.payload.itemType !== "reasoning",
+      );
       assert.equal(toolStarted?.type, "item.started");
       if (toolStarted?.type === "item.started") {
         assert.equal(toolStarted.payload.itemType, "dynamic_tool_call");

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -2106,6 +2106,67 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     }
   });
 
+  /**
+   * Reasoning counterpart of `backfillAssistantTextBlocksFromSnapshot`,
+   * scoped to synthetic turns: when a snapshot arrives with no active turn
+   * (background/resumed output), its thinking deltas never had a turnState to
+   * accumulate into, so the snapshot is the only place the text survives.
+   * Live turns are excluded deliberately — their blocks already streamed and
+   * completed, and a second completed item would duplicate the row.
+   */
+  const backfillReasoningBlocksFromSnapshot = Effect.fn("backfillReasoningBlocksFromSnapshot")(
+    function* (context: ClaudeSessionContext, message: SDKMessage) {
+      const turnState = context.turnState;
+      if (!turnState || turnState.synthetic !== true) {
+        return;
+      }
+      if (message.type !== "assistant") {
+        return;
+      }
+      const content = message.message?.content;
+      if (!Array.isArray(content)) {
+        return;
+      }
+      for (const block of content) {
+        if (!block || typeof block !== "object") {
+          continue;
+        }
+        const thinking = block as { type?: unknown; thinking?: unknown };
+        if (thinking.type !== "thinking" || typeof thinking.thinking !== "string") {
+          continue;
+        }
+        const text = thinking.thinking.trim();
+        if (text.length === 0) {
+          continue;
+        }
+        const itemId = yield* randomUUIDv4;
+        const stamp = yield* makeEventStamp();
+        yield* offerRuntimeEvent({
+          type: "item.completed",
+          eventId: stamp.eventId,
+          provider: PROVIDER,
+          createdAt: stamp.createdAt,
+          threadId: context.session.threadId,
+          turnId: turnState.turnId,
+          itemId: asRuntimeItemId(itemId),
+          payload: {
+            itemType: "reasoning",
+            status: "completed",
+            title: "Reasoning",
+            detail: text,
+            data: { toolCallId: itemId },
+          },
+          providerRefs: nativeProviderRefs(context),
+          raw: {
+            source: "claude.sdk.message" as const,
+            method: "claude/assistant-reasoning-backfill",
+            payload: message,
+          },
+        });
+      }
+    },
+  );
+
   const ensureThreadId = Effect.fn("ensureThreadId")(function* (
     context: ClaudeSessionContext,
     message: SDKMessage,
@@ -3172,6 +3233,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     if (context.turnState) {
       context.turnState.items.push(message.message);
       yield* backfillAssistantTextBlocksFromSnapshot(context, message);
+      yield* backfillReasoningBlocksFromSnapshot(context, message);
     }
 
     context.lastAssistantUuid = message.uuid;

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -2874,6 +2874,16 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     if (event.type === "content_block_stop") {
       const { index } = event;
       const reasoningBlock = context.turnState?.reasoningBlocks.get(index);
+      const assistantBlock =
+        reasoningBlock === undefined
+          ? context.turnState?.assistantTextBlocks.get(index)
+          : undefined;
+      // A subagent's stop at the same block index (commonly 0) must not seal
+      // the PARENT's text/thinking block — subagent starts/deltas are dropped
+      // above, so any mapped block at this index belongs to the parent.
+      if ((reasoningBlock ?? assistantBlock) !== undefined && streamParentToolUseId != null) {
+        return;
+      }
       if (reasoningBlock) {
         yield* completeReasoningBlock(context, reasoningBlock, {
           rawMethod: "claude/stream_event/content_block_stop",
@@ -2881,7 +2891,6 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         });
         return;
       }
-      const assistantBlock = context.turnState?.assistantTextBlocks.get(index);
       if (assistantBlock) {
         assistantBlock.streamClosed = true;
         yield* completeAssistantTextBlock(context, assistantBlock, {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -141,6 +141,14 @@ interface ClaudeTurnState {
   readonly assistantTextBlocks: Map<number, AssistantTextBlockState>;
   readonly assistantTextBlockOrder: Array<AssistantTextBlockState>;
   readonly reasoningBlocks: Map<number, ReasoningBlockState>;
+  /**
+   * `${apiMessageId}:${blockIndex}` of every reasoning item already emitted
+   * this turn — the dedup key that keeps snapshot backfills from re-emitting
+   * blocks that streamed live (or were already backfilled).
+   */
+  readonly emittedReasoningBlockKeys: Set<string>;
+  /** API message id from the latest `message_start` stream event. */
+  activeStreamMessageId: string | undefined;
   readonly capturedProposedPlanKeys: Set<string>;
   nextSyntheticAssistantBlockIndex: number;
 }
@@ -164,6 +172,8 @@ interface AssistantTextBlockState {
 interface ReasoningBlockState {
   readonly itemId: string;
   readonly blockIndex: number;
+  /** API message id (`message_start`) this block streamed under. */
+  readonly messageId: string | undefined;
   text: string;
   completionEmitted: boolean;
   /** Length of `text` at the last emitted `item.updated` (throttles live updates). */
@@ -183,6 +193,15 @@ interface ReasoningBlockState {
  * than a per-delta threshold would.
  */
 const REASONING_UPDATE_CHUNK = 512;
+
+/**
+ * Dedup key shared by live-streamed and snapshot-backfilled reasoning items:
+ * the API message id scopes the content-block index, which repeats across
+ * messages within a turn.
+ */
+function reasoningBlockKey(messageId: string | undefined, blockIndex: number): string {
+  return `${messageId ?? ""}:${blockIndex}`;
+}
 
 interface PendingApproval {
   readonly requestType: CanonicalRequestType;
@@ -1883,6 +1902,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     const block: ReasoningBlockState = {
       itemId: yield* randomUUIDv4,
       blockIndex,
+      messageId: turnState.activeStreamMessageId,
       text: "",
       completionEmitted: false,
       lastEmittedLength: 0,
@@ -1931,6 +1951,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     }
 
     block.completionEmitted = true;
+    turnState.emittedReasoningBlockKeys.add(reasoningBlockKey(block.messageId, block.blockIndex));
     if (turnState.reasoningBlocks.get(block.blockIndex) === block) {
       turnState.reasoningBlocks.delete(block.blockIndex);
     }
@@ -2113,6 +2134,10 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
    * accumulate into, so the snapshot is the only place the text survives.
    * Live turns are excluded deliberately — their blocks already streamed and
    * completed, and a second completed item would duplicate the row.
+   *
+   * Synthetic turns stay open across messages, so later thinking deltas DO
+   * stream live into them; `emittedReasoningBlockKeys` (message id + block
+   * index) keeps the backfill from re-emitting those as duplicate rows.
    */
   const backfillReasoningBlocksFromSnapshot = Effect.fn("backfillReasoningBlocksFromSnapshot")(
     function* (context: ClaudeSessionContext, message: SDKMessage) {
@@ -2127,7 +2152,10 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       if (!Array.isArray(content)) {
         return;
       }
-      for (const block of content) {
+      const snapshotMessageId = trimmedString(
+        (message.message as { id?: unknown } | undefined)?.id,
+      );
+      for (const [blockIndex, block] of content.entries()) {
         if (!block || typeof block !== "object") {
           continue;
         }
@@ -2139,6 +2167,11 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         if (text.length === 0) {
           continue;
         }
+        const blockKey = reasoningBlockKey(snapshotMessageId, blockIndex);
+        if (turnState.emittedReasoningBlockKeys.has(blockKey)) {
+          continue;
+        }
+        turnState.emittedReasoningBlockKeys.add(blockKey);
         const itemId = yield* randomUUIDv4;
         const stamp = yield* makeEventStamp();
         yield* offerRuntimeEvent({
@@ -2631,6 +2664,18 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       if (dropStart || dropDelta) {
         return;
       }
+    }
+
+    if (event.type === "message_start") {
+      // Track the API message id so streamed reasoning blocks can be told
+      // apart from same-index blocks of other messages (snapshot dedup).
+      if (streamParentToolUseId === null || streamParentToolUseId === undefined) {
+        const apiMessageId = trimmedString((event.message as { id?: unknown } | undefined)?.id);
+        if (apiMessageId && context.turnState) {
+          context.turnState.activeStreamMessageId = apiMessageId;
+        }
+      }
+      return;
     }
 
     if (event.type === "message_delta") {
@@ -3171,6 +3216,8 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         assistantTextBlocks: new Map(),
         assistantTextBlockOrder: [],
         reasoningBlocks: new Map(),
+        emittedReasoningBlockKeys: new Set(),
+        activeStreamMessageId: undefined,
         capturedProposedPlanKeys: new Set(),
         nextSyntheticAssistantBlockIndex: -1,
       };
@@ -4692,6 +4739,8 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         assistantTextBlocks: new Map(),
         assistantTextBlockOrder: [],
         reasoningBlocks: new Map(),
+        emittedReasoningBlockKeys: new Set(),
+        activeStreamMessageId: undefined,
         capturedProposedPlanKeys: new Set(),
         nextSyntheticAssistantBlockIndex: -1,
       };

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -140,6 +140,7 @@ interface ClaudeTurnState {
   readonly items: Array<unknown>;
   readonly assistantTextBlocks: Map<number, AssistantTextBlockState>;
   readonly assistantTextBlockOrder: Array<AssistantTextBlockState>;
+  readonly reasoningBlocks: Map<number, ReasoningBlockState>;
   readonly capturedProposedPlanKeys: Set<string>;
   nextSyntheticAssistantBlockIndex: number;
 }
@@ -152,6 +153,36 @@ interface AssistantTextBlockState {
   streamClosed: boolean;
   completionEmitted: boolean;
 }
+
+/**
+ * Live state for a streamed `thinking` content block. Unlike assistant text
+ * blocks (which only need a stable itemId for delta grouping), reasoning
+ * blocks accumulate their full text so `item.completed` can carry it as the
+ * activity detail — the same shape the Codex adapter emits for its native
+ * reasoning items.
+ */
+interface ReasoningBlockState {
+  readonly itemId: string;
+  readonly blockIndex: number;
+  text: string;
+  completionEmitted: boolean;
+  /** Length of `text` at the last emitted `item.updated` (throttles live updates). */
+  lastEmittedLength: number;
+}
+
+/**
+ * Live reasoning updates are throttled, but the FIRST one goes out as soon as
+ * any thinking text exists: upstream (or a proxying shim) may deliver thinking
+ * in multi-hundred-char bursts seconds apart, and a pure size threshold would
+ * hold the first visible text hostage until 256 chars accumulate.
+ *
+ * Each emitted `item.updated` persists the full accumulated thinking (capped at
+ * the ingestion limit), so the per-block storage cost grows quadratically with
+ * 1/CHUNK. 512 chars keeps the live row visibly streaming (a handful of updates
+ * per second at typical thinking speeds) while bounding that cost ~10x tighter
+ * than a per-delta threshold would.
+ */
+const REASONING_UPDATE_CHUNK = 512;
 
 interface PendingApproval {
   readonly requestType: CanonicalRequestType;
@@ -1823,6 +1854,116 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     return { blockIndex, block };
   });
 
+  /**
+   * Reasoning counterpart of `ensureAssistantTextBlock`. The SDK emits
+   * `thinking` blocks without any provider-side item id, so the adapter
+   * mints one at `content_block_start` (or lazily at the first delta) and
+   * emits `item.started` — without this, thinking deltas go out with no
+   * `itemId` and the client can never attach them to a rendered item
+   * (upstream issue #5542).
+   */
+  const ensureReasoningBlock = Effect.fn("ensureReasoningBlock")(function* (
+    context: ClaudeSessionContext,
+    blockIndex: number,
+    options?: {
+      readonly rawMethod?: string;
+      readonly rawPayload?: unknown;
+    },
+  ) {
+    const turnState = context.turnState;
+    if (!turnState) {
+      return undefined;
+    }
+
+    const existing = turnState.reasoningBlocks.get(blockIndex);
+    if (existing && !existing.completionEmitted) {
+      return { blockIndex, block: existing };
+    }
+
+    const block: ReasoningBlockState = {
+      itemId: yield* randomUUIDv4,
+      blockIndex,
+      text: "",
+      completionEmitted: false,
+      lastEmittedLength: 0,
+    };
+    turnState.reasoningBlocks.set(blockIndex, block);
+
+    const stamp = yield* makeEventStamp();
+    yield* offerRuntimeEvent({
+      type: "item.started",
+      eventId: stamp.eventId,
+      provider: PROVIDER,
+      createdAt: stamp.createdAt,
+      threadId: context.session.threadId,
+      turnId: turnState.turnId,
+      itemId: asRuntimeItemId(block.itemId),
+      payload: {
+        itemType: "reasoning",
+        status: "inProgress",
+        title: "Reasoning",
+      },
+      providerRefs: nativeProviderRefs(context),
+      ...(options?.rawMethod || options?.rawPayload
+        ? {
+            raw: {
+              source: "claude.sdk.message" as const,
+              ...(options.rawMethod ? { method: options.rawMethod } : {}),
+              payload: options.rawPayload,
+            },
+          }
+        : {}),
+    });
+    return { blockIndex, block };
+  });
+
+  const completeReasoningBlock = Effect.fn("completeReasoningBlock")(function* (
+    context: ClaudeSessionContext,
+    block: ReasoningBlockState,
+    options?: {
+      readonly rawMethod?: string;
+      readonly rawPayload?: unknown;
+    },
+  ) {
+    const turnState = context.turnState;
+    if (!turnState || block.completionEmitted) {
+      return;
+    }
+
+    block.completionEmitted = true;
+    if (turnState.reasoningBlocks.get(block.blockIndex) === block) {
+      turnState.reasoningBlocks.delete(block.blockIndex);
+    }
+
+    const stamp = yield* makeEventStamp();
+    yield* offerRuntimeEvent({
+      type: "item.completed",
+      eventId: stamp.eventId,
+      provider: PROVIDER,
+      createdAt: stamp.createdAt,
+      itemId: asRuntimeItemId(block.itemId),
+      threadId: context.session.threadId,
+      turnId: turnState.turnId,
+      payload: {
+        itemType: "reasoning",
+        status: "completed",
+        title: "Reasoning",
+        ...(block.text.length > 0 ? { detail: block.text } : {}),
+        data: { toolCallId: block.itemId },
+      },
+      providerRefs: nativeProviderRefs(context),
+      ...(options?.rawMethod || options?.rawPayload
+        ? {
+            raw: {
+              source: "claude.sdk.message" as const,
+              ...(options.rawMethod ? { method: options.rawMethod } : {}),
+              payload: options.rawPayload,
+            },
+          }
+        : {}),
+    });
+  });
+
   const createSyntheticAssistantTextBlock = Effect.fn("createSyntheticAssistantTextBlock")(
     function* (context: ClaudeSessionContext, fallbackText: string) {
       const turnState = context.turnState;
@@ -2345,6 +2486,13 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       });
     }
 
+    for (const block of turnState.reasoningBlocks.values()) {
+      yield* completeReasoningBlock(context, block, {
+        rawMethod: "claude/result",
+        rawPayload: result ?? { status },
+      });
+    }
+
     context.turns.push({
       id: turnState.turnId,
       items: [...turnState.items],
@@ -2459,17 +2607,21 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         const assistantBlockEntry =
           event.delta.type === "text_delta"
             ? yield* ensureAssistantTextBlock(context, event.index)
-            : context.turnState.assistantTextBlocks.get(event.index)
-              ? {
-                  blockIndex: event.index,
-                  block: context.turnState.assistantTextBlocks.get(
-                    event.index,
-                  ) as AssistantTextBlockState,
-                }
-              : undefined;
-        if (assistantBlockEntry?.block && event.delta.type === "text_delta") {
+            : undefined;
+        const reasoningBlockEntry =
+          event.delta.type === "thinking_delta"
+            ? yield* ensureReasoningBlock(context, event.index, {
+                rawMethod: "claude/stream_event/content_block_delta",
+                rawPayload: message,
+              })
+            : undefined;
+        if (assistantBlockEntry?.block) {
           assistantBlockEntry.block.emittedTextDelta = true;
         }
+        if (reasoningBlockEntry?.block) {
+          reasoningBlockEntry.block.text += deltaText;
+        }
+        const itemEntry = assistantBlockEntry ?? reasoningBlockEntry;
         const stamp = yield* makeEventStamp();
         yield* offerRuntimeEvent({
           type: "content.delta",
@@ -2478,9 +2630,9 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           createdAt: stamp.createdAt,
           threadId: context.session.threadId,
           turnId: context.turnState.turnId,
-          ...(assistantBlockEntry?.block
+          ...(itemEntry?.block
             ? {
-                itemId: asRuntimeItemId(assistantBlockEntry.block.itemId),
+                itemId: asRuntimeItemId(itemEntry.block.itemId),
               }
             : {}),
           payload: {
@@ -2494,6 +2646,41 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
             payload: message,
           },
         });
+
+        // Live reasoning text: throttled `item.updated` carrying the accumulated
+        // thinking and a stable `data.toolCallId`, so the client collapses the
+        // update chain into a single row (same mechanism as tool output).
+        const reasoningBlock = reasoningBlockEntry?.block;
+        if (
+          reasoningBlock &&
+          (reasoningBlock.lastEmittedLength === 0 ||
+            reasoningBlock.text.length - reasoningBlock.lastEmittedLength >= REASONING_UPDATE_CHUNK)
+        ) {
+          reasoningBlock.lastEmittedLength = reasoningBlock.text.length;
+          const updateStamp = yield* makeEventStamp();
+          yield* offerRuntimeEvent({
+            type: "item.updated",
+            eventId: updateStamp.eventId,
+            provider: PROVIDER,
+            createdAt: updateStamp.createdAt,
+            threadId: context.session.threadId,
+            turnId: context.turnState.turnId,
+            itemId: asRuntimeItemId(reasoningBlock.itemId),
+            payload: {
+              itemType: "reasoning",
+              status: "inProgress",
+              title: "Reasoning",
+              detail: reasoningBlock.text,
+              data: { toolCallId: reasoningBlock.itemId },
+            },
+            providerRefs: nativeProviderRefs(context),
+            raw: {
+              source: "claude.sdk.message",
+              method: "claude/stream_event/content_block_delta",
+              payload: message,
+            },
+          });
+        }
         return;
       }
 
@@ -2603,6 +2790,13 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         });
         return;
       }
+      if (block.type === "thinking" || block.type === "redacted_thinking") {
+        yield* ensureReasoningBlock(context, index, {
+          rawMethod: "claude/stream_event/content_block_start",
+          rawPayload: message,
+        });
+        return;
+      }
       if (
         block.type !== "tool_use" &&
         block.type !== "server_tool_use" &&
@@ -2679,6 +2873,14 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
     if (event.type === "content_block_stop") {
       const { index } = event;
+      const reasoningBlock = context.turnState?.reasoningBlocks.get(index);
+      if (reasoningBlock) {
+        yield* completeReasoningBlock(context, reasoningBlock, {
+          rawMethod: "claude/stream_event/content_block_stop",
+          rawPayload: message,
+        });
+        return;
+      }
       const assistantBlock = context.turnState?.assistantTextBlocks.get(index);
       if (assistantBlock) {
         assistantBlock.streamClosed = true;
@@ -2898,6 +3100,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         items: [],
         assistantTextBlocks: new Map(),
         assistantTextBlockOrder: [],
+        reasoningBlocks: new Map(),
         capturedProposedPlanKeys: new Set(),
         nextSyntheticAssistantBlockIndex: -1,
       };
@@ -4417,6 +4620,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         items: [],
         assistantTextBlocks: new Map(),
         assistantTextBlockOrder: [],
+        reasoningBlocks: new Map(),
         capturedProposedPlanKeys: new Set(),
         nextSyntheticAssistantBlockIndex: -1,
       };

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -512,6 +512,68 @@ function startLifecycleRuntime() {
   });
 }
 
+function assertOpenReasoningSealedAtTurnEnd(input: {
+  readonly terminalEvent: ProviderEvent;
+  readonly terminalType: "turn.completed" | "turn.aborted";
+}) {
+  return Effect.gen(function* () {
+    const { adapter, runtime } = yield* startLifecycleRuntime();
+    const lifecycleEventsFiber = yield* adapter.streamEvents.pipe(
+      Stream.filter(
+        (event) =>
+          event.type === "item.updated" ||
+          event.type === "item.completed" ||
+          event.type === input.terminalType,
+      ),
+      Stream.takeUntil((event) => event.type === input.terminalType),
+      Stream.runCollect,
+      Effect.forkChild,
+    );
+
+    const emitDelta = (id: string, delta: string) =>
+      runtime.emit({
+        id: asEventId(id),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: "2026-01-01T00:00:00.000Z",
+        method: "item/reasoning/summaryTextDelta",
+        threadId: asThreadId("thread-1"),
+        turnId: asTurnId("turn-1"),
+        itemId: asItemId("rs-open"),
+        payload: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "rs-open",
+          summaryIndex: 0,
+          delta,
+        },
+      } satisfies ProviderEvent);
+
+    yield* emitDelta("evt-open-reasoning-1", "partial");
+    // This remains below the live-update threshold. The terminal completion
+    // still has to flush the full accumulated text, not the last emitted text.
+    yield* emitDelta("evt-open-reasoning-2", " tail");
+    yield* runtime.emit(input.terminalEvent);
+
+    const events = Array.from(yield* Fiber.join(lifecycleEventsFiber));
+    NodeAssert.deepStrictEqual(
+      events.map((event) => event.type),
+      ["item.updated", "item.completed", input.terminalType],
+    );
+    const completion = events[1];
+    if (completion?.type !== "item.completed") {
+      return;
+    }
+    NodeAssert.notEqual(completion.eventId, input.terminalEvent.id);
+    NodeAssert.equal(completion.itemId, "rs-open");
+    NodeAssert.equal(completion.payload.itemType, "reasoning");
+    NodeAssert.equal(completion.payload.status, "completed");
+    NodeAssert.equal(completion.payload.detail, "partial tail");
+    NodeAssert.deepStrictEqual(completion.payload.data, { toolCallId: "rs-open" });
+    NodeAssert.equal(events[2]?.eventId, input.terminalEvent.id);
+  });
+}
+
 lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
   it.effect("maps completed agent message items to canonical item.completed events", () =>
     Effect.gen(function* () {
@@ -659,6 +721,45 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
         `Analizez prioritatea operatorilor${"x".repeat(600)}`,
       );
       NodeAssert.equal(second.itemId, first.itemId);
+    }),
+  );
+
+  it.effect("seals open reasoning rows before a turn completes", () =>
+    assertOpenReasoningSealedAtTurnEnd({
+      terminalType: "turn.completed",
+      terminalEvent: {
+        id: asEventId("evt-turn-completed-with-open-reasoning"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: "2026-01-01T00:00:01.000Z",
+        method: "turn/completed",
+        threadId: asThreadId("thread-1"),
+        turnId: asTurnId("turn-1"),
+        payload: {
+          threadId: "thread-1",
+          turn: {
+            id: "turn-1",
+            items: [],
+            status: "completed",
+          },
+        },
+      } satisfies ProviderEvent,
+    }),
+  );
+
+  it.effect("seals open reasoning rows before a turn aborts", () =>
+    assertOpenReasoningSealedAtTurnEnd({
+      terminalType: "turn.aborted",
+      terminalEvent: {
+        id: asEventId("evt-turn-aborted-with-open-reasoning"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: "2026-01-01T00:00:01.000Z",
+        method: "turn/aborted",
+        threadId: asThreadId("thread-1"),
+        turnId: asTurnId("turn-1"),
+        message: "Stopped by user",
+      } satisfies ProviderEvent,
     }),
   );
 

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -571,6 +571,49 @@ function assertOpenReasoningSealedAtTurnEnd(input: {
     NodeAssert.equal(completion.payload.detail, "partial tail");
     NodeAssert.deepStrictEqual(completion.payload.data, { toolCallId: "rs-open" });
     NodeAssert.equal(events[2]?.eventId, input.terminalEvent.id);
+
+    const lateEventsFiber = yield* adapter.streamEvents.pipe(
+      Stream.filter((event) => event.type === "item.completed" || event.type === "turn.started"),
+      Stream.takeUntil((event) => event.type === "turn.started"),
+      Stream.runCollect,
+      Effect.forkChild,
+    );
+    yield* runtime.emit({
+      id: asEventId("evt-late-native-reasoning-completion"),
+      kind: "notification",
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:02.000Z",
+      method: "item/completed",
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-1"),
+      itemId: asItemId("rs-open"),
+      payload: {
+        completedAtMs: 1_778_000_000_002,
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          type: "reasoning",
+          id: "rs-open",
+          summary: ["partial tail"],
+          content: [],
+        },
+      },
+    } satisfies ProviderEvent);
+    yield* runtime.emit({
+      id: asEventId("evt-next-turn-started"),
+      kind: "notification",
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:03.000Z",
+      method: "turn/started",
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-2"),
+    } satisfies ProviderEvent);
+
+    const lateEvents = Array.from(yield* Fiber.join(lateEventsFiber));
+    NodeAssert.deepStrictEqual(
+      lateEvents.map((event) => event.type),
+      ["turn.started"],
+    );
   });
 }
 

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -556,6 +556,304 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
     }),
   );
 
+  it.effect(
+    "surfaces completed reasoning items with their summary text and a collapsible identity",
+    () =>
+      Effect.gen(function* () {
+        const { adapter, runtime } = yield* startLifecycleRuntime();
+        const firstEventFiber = yield* Stream.runHead(adapter.streamEvents).pipe(Effect.forkChild);
+
+        yield* runtime.emit({
+          id: asEventId("evt-reasoning-complete"),
+          kind: "notification",
+          provider: ProviderDriverKind.make("codex"),
+          createdAt: "2026-01-01T00:00:00.000Z",
+          method: "item/completed",
+          threadId: asThreadId("thread-1"),
+          turnId: asTurnId("turn-1"),
+          itemId: asItemId("rs_1"),
+          payload: {
+            completedAtMs: 1_778_000_000_000,
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              type: "reasoning",
+              id: "rs_1",
+              summary: ["**Clarifying precedence**", "Unary minus binds looser"],
+              content: [],
+            },
+          },
+        } satisfies ProviderEvent);
+
+        const firstEvent = yield* Fiber.join(firstEventFiber);
+        NodeAssert.equal(firstEvent._tag, "Some");
+        if (firstEvent._tag !== "Some") {
+          return;
+        }
+        NodeAssert.equal(firstEvent.value.type, "item.completed");
+        if (firstEvent.value.type !== "item.completed") {
+          return;
+        }
+        NodeAssert.equal(firstEvent.value.payload.itemType, "reasoning");
+        NodeAssert.equal(firstEvent.value.payload.title, "Reasoning");
+        NodeAssert.equal(
+          firstEvent.value.payload.detail,
+          "**Clarifying precedence**\n\nUnary minus binds looser",
+        );
+        NodeAssert.deepStrictEqual(
+          (firstEvent.value.payload.data as { readonly toolCallId?: unknown } | undefined)
+            ?.toolCallId,
+          "rs_1",
+        );
+      }),
+  );
+
+  it.effect("streams reasoning text deltas as throttled reasoning item updates", () =>
+    Effect.gen(function* () {
+      const { adapter, runtime } = yield* startLifecycleRuntime();
+      const updatesFiber = yield* Stream.take(
+        Stream.filter(adapter.streamEvents, (event) => event.type === "item.updated"),
+        2,
+      ).pipe(Stream.runCollect, Effect.forkChild);
+
+      const emitDelta = (id: string, delta: string) =>
+        runtime.emit({
+          id: asEventId(id),
+          kind: "notification",
+          provider: ProviderDriverKind.make("codex"),
+          createdAt: "2026-01-01T00:00:00.000Z",
+          method: "item/reasoning/summaryTextDelta",
+          threadId: asThreadId("thread-1"),
+          turnId: asTurnId("turn-1"),
+          itemId: asItemId("rs_1"),
+          payload: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "rs_1",
+            summaryIndex: 0,
+            delta,
+          },
+        } satisfies ProviderEvent);
+
+      yield* emitDelta("evt-delta-1", "Analizez ");
+      // Under the 512-char chunk threshold: accumulated, but no new update.
+      yield* emitDelta("evt-delta-2", "prioritatea operatorilor");
+      yield* emitDelta("evt-delta-3", "x".repeat(600));
+
+      const updates = Array.from(yield* Fiber.join(updatesFiber));
+      NodeAssert.equal(updates.length, 2);
+      const [first, second] = updates;
+      if (first?.type !== "item.updated" || second?.type !== "item.updated") {
+        return;
+      }
+      NodeAssert.equal(first.payload.itemType, "reasoning");
+      NodeAssert.equal(first.payload.title, "Reasoning");
+      NodeAssert.equal(first.payload.status, "inProgress");
+      NodeAssert.equal(first.payload.detail, "Analizez ");
+      NodeAssert.deepStrictEqual(
+        (first.payload.data as { readonly toolCallId?: unknown } | undefined)?.toolCallId,
+        "rs_1",
+      );
+      NodeAssert.equal(
+        second.payload.detail,
+        `Analizez prioritatea operatorilor${"x".repeat(600)}`,
+      );
+      NodeAssert.equal(second.itemId, first.itemId);
+    }),
+  );
+
+  it.effect("drops the reasoning accumulator when the reasoning item completes", () =>
+    Effect.gen(function* () {
+      const { adapter, runtime } = yield* startLifecycleRuntime();
+      const updatesFiber = yield* Stream.take(
+        Stream.filter(adapter.streamEvents, (event) => event.type === "item.updated"),
+        2,
+      ).pipe(Stream.runCollect, Effect.forkChild);
+
+      const emitDelta = (id: string, delta: string) =>
+        runtime.emit({
+          id: asEventId(id),
+          kind: "notification",
+          provider: ProviderDriverKind.make("codex"),
+          createdAt: "2026-01-01T00:00:00.000Z",
+          method: "item/reasoning/summaryTextDelta",
+          threadId: asThreadId("thread-1"),
+          turnId: asTurnId("turn-1"),
+          itemId: asItemId("rs_1"),
+          payload: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "rs_1",
+            summaryIndex: 0,
+            delta,
+          },
+        } satisfies ProviderEvent);
+
+      yield* emitDelta("evt-delta-complete-1", "part one");
+      yield* runtime.emit({
+        id: asEventId("evt-reasoning-complete-cleanup"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: "2026-01-01T00:00:01.000Z",
+        method: "item/completed",
+        threadId: asThreadId("thread-1"),
+        turnId: asTurnId("turn-1"),
+        itemId: asItemId("rs_1"),
+        payload: {
+          completedAtMs: 1_778_000_000_001,
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: { type: "reasoning", id: "rs_1", summary: ["part one"], content: [] },
+        },
+      } satisfies ProviderEvent);
+      // A delta for the same itemId after completion starts a fresh
+      // accumulator instead of appending to the sealed item's text.
+      yield* emitDelta("evt-delta-complete-2", "fresh start");
+
+      const updates = Array.from(yield* Fiber.join(updatesFiber));
+      NodeAssert.equal(updates.length, 2);
+      const second = updates[1];
+      if (second?.type !== "item.updated") {
+        return;
+      }
+      NodeAssert.equal(second.payload.detail, "fresh start");
+    }),
+  );
+
+  it.effect("reads reasoning text from string-array content when summary is empty", () =>
+    Effect.gen(function* () {
+      const { adapter, runtime } = yield* startLifecycleRuntime();
+      const firstEventFiber = yield* Stream.runHead(adapter.streamEvents).pipe(Effect.forkChild);
+
+      yield* runtime.emit({
+        id: asEventId("evt-reasoning-content-complete"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: "2026-01-01T00:00:00.000Z",
+        method: "item/completed",
+        threadId: asThreadId("thread-1"),
+        turnId: asTurnId("turn-1"),
+        itemId: asItemId("rs_2"),
+        payload: {
+          completedAtMs: 1_778_000_000_000,
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            type: "reasoning",
+            id: "rs_2",
+            summary: [],
+            content: ["chain", "of thought"],
+          },
+        },
+      } satisfies ProviderEvent);
+
+      const firstEvent = yield* Fiber.join(firstEventFiber);
+      NodeAssert.equal(firstEvent._tag, "Some");
+      if (firstEvent._tag !== "Some" || firstEvent.value.type !== "item.completed") {
+        return;
+      }
+      NodeAssert.equal(firstEvent.value.payload.detail, "chain\n\nof thought");
+    }),
+  );
+
+  it.effect("keeps interleaved reasoning summary parts separated by part index", () =>
+    Effect.gen(function* () {
+      const { adapter, runtime } = yield* startLifecycleRuntime();
+      const updatesFiber = yield* Stream.take(
+        Stream.filter(adapter.streamEvents, (event) => event.type === "item.updated"),
+        2,
+      ).pipe(Stream.runCollect, Effect.forkChild);
+
+      const emitDelta = (id: string, summaryIndex: number, delta: string) =>
+        runtime.emit({
+          id: asEventId(id),
+          kind: "notification",
+          provider: ProviderDriverKind.make("codex"),
+          createdAt: "2026-01-01T00:00:00.000Z",
+          method: "item/reasoning/summaryTextDelta",
+          threadId: asThreadId("thread-1"),
+          turnId: asTurnId("turn-1"),
+          itemId: asItemId("rs_1"),
+          payload: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "rs_1",
+            summaryIndex,
+            delta,
+          },
+        } satisfies ProviderEvent);
+
+      yield* emitDelta("evt-part-0", 0, "First part.");
+      // A second indexed part must compose with a paragraph boundary, not
+      // merge into the first part's tail.
+      yield* emitDelta("evt-part-1", 1, "x".repeat(600));
+
+      const updates = Array.from(yield* Fiber.join(updatesFiber));
+      NodeAssert.equal(updates.length, 2);
+      const second = updates[1];
+      if (second?.type !== "item.updated") {
+        return;
+      }
+      NodeAssert.equal(second.payload.detail, `First part.\n\n${"x".repeat(600)}`);
+    }),
+  );
+
+  it.effect("composes live reasoning in completion order: summary parts, then content parts", () =>
+    Effect.gen(function* () {
+      const { adapter, runtime } = yield* startLifecycleRuntime();
+      const updatesFiber = yield* Stream.take(
+        Stream.filter(adapter.streamEvents, (event) => event.type === "item.updated"),
+        2,
+      ).pipe(Stream.runCollect, Effect.forkChild);
+
+      const emitDelta = (
+        id: string,
+        method: "item/reasoning/summaryTextDelta" | "item/reasoning/textDelta",
+        delta: string,
+        index: number,
+      ) =>
+        runtime.emit({
+          id: asEventId(id),
+          kind: "notification",
+          provider: ProviderDriverKind.make("codex"),
+          createdAt: "2026-01-01T00:00:00.000Z",
+          method,
+          threadId: asThreadId("thread-1"),
+          turnId: asTurnId("turn-1"),
+          itemId: asItemId("rs_1"),
+          payload:
+            method === "item/reasoning/summaryTextDelta"
+              ? {
+                  threadId: "thread-1",
+                  turnId: "turn-1",
+                  itemId: "rs_1",
+                  summaryIndex: index,
+                  delta,
+                }
+              : {
+                  threadId: "thread-1",
+                  turnId: "turn-1",
+                  itemId: "rs_1",
+                  contentIndex: index,
+                  delta,
+                },
+        } satisfies ProviderEvent);
+
+      // A content part arriving FIRST must not jump ahead of the summary in
+      // the live row — completion orders summary parts before content parts.
+      yield* emitDelta("evt-content-first", "item/reasoning/textDelta", "chain of thought", 0);
+      yield* emitDelta("evt-summary-second", "item/reasoning/summaryTextDelta", "x".repeat(600), 0);
+
+      const updates = Array.from(yield* Fiber.join(updatesFiber));
+      NodeAssert.equal(updates.length, 2);
+      const second = updates[1];
+      if (second?.type !== "item.updated") {
+        return;
+      }
+      NodeAssert.equal(second.payload.detail, `${"x".repeat(600)}\n\nchain of thought`);
+    }),
+  );
+
   it.effect("labels MCP lifecycle entries with server and tool names", () =>
     Effect.gen(function* () {
       const { adapter, runtime } = yield* startLifecycleRuntime();

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -11,7 +11,9 @@ import {
   type CanonicalItemType,
   type CanonicalRequestType,
   type CodexSettings,
+  EventId,
   ProviderDriverKind,
+  ProviderItemId,
   type ProviderEvent,
   ProviderInstanceId,
   type ProviderRuntimeEvent,
@@ -820,17 +822,65 @@ function mapCollabAgentEvent(
  * blocks: first update goes out as soon as any text exists, later ones every
  * CODEX_REASONING_UPDATE_CHUNK chars.
  */
+interface CodexReasoningParts {
+  readonly summary: Map<number, string>;
+  readonly content: Map<number, string>;
+}
+
 interface CodexReasoningStreamState {
   /** itemId → indexed parts, summary and content apart (see compose note). */
-  readonly partsByItemId: Map<
-    string,
-    { readonly summary: Map<number, string>; readonly content: Map<number, string> }
-  >;
+  readonly partsByItemId: Map<string, CodexReasoningParts>;
   /** itemId → composed text length at the last emitted item.updated (throttles live updates). */
   readonly lastEmittedLengthByItemId: Map<string, number>;
 }
 
 const CODEX_REASONING_UPDATE_CHUNK = 512;
+
+function composeReasoningStreamParts(parts: CodexReasoningParts): string {
+  const byIndex = (a: [number, string], b: [number, string]) => a[0] - b[0];
+  return [
+    ...Array.from(parts.summary.entries()).sort(byIndex),
+    ...Array.from(parts.content.entries()).sort(byIndex),
+  ]
+    .map(([, value]) => value)
+    .join("\n\n");
+}
+
+/**
+ * Turn terminals can arrive without item/completed after an interruption.
+ * Seal every live reasoning row before the terminal event so persisted work
+ * never remains inProgress, then clear the accumulator for the next turn.
+ */
+function completeOpenReasoningStreams(
+  state: CodexReasoningStreamState,
+  event: ProviderEvent,
+  canonicalThreadId: ThreadId,
+): ReadonlyArray<ProviderRuntimeEvent> {
+  const base = runtimeEventBase(event, canonicalThreadId);
+  const completed = Array.from(state.partsByItemId, ([itemId, parts]) => {
+    const detail = composeReasoningStreamParts(parts);
+    return {
+      ...base,
+      eventId: EventId.make(`${event.id}:reasoning:${itemId}:completed`),
+      itemId: RuntimeItemId.make(itemId),
+      providerRefs: {
+        ...base.providerRefs,
+        providerItemId: ProviderItemId.make(itemId),
+      },
+      type: "item.completed",
+      payload: {
+        itemType: "reasoning",
+        status: "completed",
+        title: "Reasoning",
+        ...(detail.trim().length > 0 ? { detail } : {}),
+        data: { toolCallId: itemId },
+      },
+    } satisfies ProviderRuntimeEvent;
+  });
+  state.partsByItemId.clear();
+  state.lastEmittedLengthByItemId.clear();
+  return completed;
+}
 
 function accumulateReasoningDeltaEvent(
   state: CodexReasoningStreamState,
@@ -855,13 +905,7 @@ function accumulateReasoningDeltaEvent(
   const bucket = part.kind === "summary" ? parts.summary : parts.content;
   const index = part.index ?? 0;
   bucket.set(index, (bucket.get(index) ?? "") + delta);
-  const byIndex = (a: [number, string], b: [number, string]) => a[0] - b[0];
-  const text = [
-    ...Array.from(parts.summary.entries()).sort(byIndex),
-    ...Array.from(parts.content.entries()).sort(byIndex),
-  ]
-    .map(([, value]) => value)
-    .join("\n\n");
+  const text = composeReasoningStreamParts(parts);
   const lastEmittedLength = state.lastEmittedLengthByItemId.get(itemId) ?? 0;
   if (lastEmittedLength > 0 && text.length - lastEmittedLength < CODEX_REASONING_UPDATE_CHUNK) {
     return undefined;
@@ -1162,13 +1206,12 @@ function mapToRuntimeEvents(
     if (!payload) {
       return [];
     }
-    // A finished turn seals every reasoning item it streamed; anything left in
-    // the accumulator belongs to items that never completed and would
-    // otherwise leak for the session's lifetime.
-    reasoningStreams?.partsByItemId.clear();
-    reasoningStreams?.lastEmittedLengthByItemId.clear();
+    const reasoningCompletions = reasoningStreams
+      ? completeOpenReasoningStreams(reasoningStreams, event, canonicalThreadId)
+      : [];
     const errorMessage = trimText(payload.turn.error?.message);
     return [
+      ...reasoningCompletions,
       {
         ...runtimeEventBase(event, canonicalThreadId),
         type: "turn.completed",
@@ -1181,11 +1224,11 @@ function mapToRuntimeEvents(
   }
 
   if (event.method === "turn/aborted") {
-    // Aborted turns never complete their reasoning items — drop the live
-    // accumulator with them (same leak guard as turn/completed).
-    reasoningStreams?.partsByItemId.clear();
-    reasoningStreams?.lastEmittedLengthByItemId.clear();
+    const reasoningCompletions = reasoningStreams
+      ? completeOpenReasoningStreams(reasoningStreams, event, canonicalThreadId)
+      : [];
     return [
+      ...reasoningCompletions,
       {
         ...runtimeEventBase(event, canonicalThreadId),
         type: "turn.aborted",

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -832,6 +832,8 @@ interface CodexReasoningStreamState {
   readonly partsByItemId: Map<string, CodexReasoningParts>;
   /** itemId → composed text length at the last emitted item.updated (throttles live updates). */
   readonly lastEmittedLengthByItemId: Map<string, number>;
+  /** Native completions matching the latest synthetic turn-end seal are dropped. */
+  readonly syntheticallyCompletedItemKeys: Set<string>;
 }
 
 const CODEX_REASONING_UPDATE_CHUNK = 512;
@@ -846,6 +848,10 @@ function composeReasoningStreamParts(parts: CodexReasoningParts): string {
     .join("\n\n");
 }
 
+function reasoningStreamIdentityKey(turnId: ProviderEvent["turnId"], itemId: string): string {
+  return `${turnId ?? "no-turn"}\u001f${itemId}`;
+}
+
 /**
  * Turn terminals can arrive without item/completed after an interruption.
  * Seal every live reasoning row before the terminal event so persisted work
@@ -857,8 +863,13 @@ function completeOpenReasoningStreams(
   canonicalThreadId: ThreadId,
 ): ReadonlyArray<ProviderRuntimeEvent> {
   const base = runtimeEventBase(event, canonicalThreadId);
+  // Provider notifications are ordered. Retaining only the latest terminal's
+  // identities bounds this defensive dedup state while covering native
+  // completions delivered immediately after their turn terminal.
+  state.syntheticallyCompletedItemKeys.clear();
   const completed = Array.from(state.partsByItemId, ([itemId, parts]) => {
     const detail = composeReasoningStreamParts(parts);
+    state.syntheticallyCompletedItemKeys.add(reasoningStreamIdentityKey(event.turnId, itemId));
     return {
       ...base,
       eventId: EventId.make(`${event.id}:reasoning:${itemId}:completed`),
@@ -1288,6 +1299,20 @@ function mapToRuntimeEvents(
       return [];
     }
     const itemType = toCanonicalItemType(item.type);
+    const completedItemId =
+      event.itemId ?? ("id" in item && typeof item.id === "string" ? item.id : undefined);
+    if (
+      itemType === "reasoning" &&
+      completedItemId !== undefined &&
+      reasoningStreams?.syntheticallyCompletedItemKeys.has(
+        reasoningStreamIdentityKey(event.turnId, completedItemId),
+      )
+    ) {
+      // A terminal already sealed this row. Persisting the provider's late
+      // native completion would create a second completed row that clients
+      // deliberately refuse to fold into the first terminal row.
+      return [];
+    }
     if (itemType === "plan") {
       const detail = itemDetail(itemType, item);
       if (!detail) {
@@ -1308,12 +1333,12 @@ function mapToRuntimeEvents(
     // itemId can never inherit a previous item's text.
     if (
       reasoningStreams &&
-      event.itemId !== undefined &&
+      completedItemId !== undefined &&
       completed?.type === "item.completed" &&
       completed.payload.itemType === "reasoning"
     ) {
-      reasoningStreams.partsByItemId.delete(event.itemId);
-      reasoningStreams.lastEmittedLengthByItemId.delete(event.itemId);
+      reasoningStreams.partsByItemId.delete(completedItemId);
+      reasoningStreams.lastEmittedLengthByItemId.delete(completedItemId);
     }
     return completed ? [completed] : [];
   }
@@ -1917,6 +1942,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
         const reasoningStreams: CodexReasoningStreamState = {
           partsByItemId: new Map(),
           lastEmittedLengthByItemId: new Map(),
+          syntheticallyCompletedItemKeys: new Set(),
         };
         const eventFiber = yield* Stream.runForEach(runtime.events, (event) =>
           Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -270,8 +270,44 @@ function itemTitle(itemType: CanonicalItemType, item?: CodexLifecycleItem): stri
   }
 }
 
+/**
+ * Codex reasoning items carry their thinking in `summary` (string[]) and
+ * `content` ({text}[]) rather than a plain string field, so the generic
+ * candidate scan below never finds it. Lifting it is what makes the completed
+ * reasoning row render its text instead of hiding as an empty row.
+ */
+function reasoningItemText(item: Record<string, unknown>): string | undefined {
+  const summary = item.summary;
+  const content = item.content;
+  const parts: string[] = [];
+  if (typeof summary === "string") {
+    parts.push(summary);
+  } else if (Array.isArray(summary)) {
+    parts.push(...summary.filter((part): part is string => typeof part === "string"));
+  }
+  if (Array.isArray(content)) {
+    for (const block of content) {
+      // `content` is typed string[] on the wire; the object-with-text shape
+      // shows up in older app-server builds, so accept both.
+      if (typeof block === "string") {
+        parts.push(block);
+      } else if (block && typeof block === "object") {
+        const text = (block as { readonly text?: unknown }).text;
+        if (typeof text === "string") {
+          parts.push(text);
+        }
+      }
+    }
+  }
+  const text = parts.join("\n\n").trim();
+  return text.length > 0 ? text : undefined;
+}
+
 function itemDetail(itemType: CanonicalItemType, item: CodexLifecycleItem): string | undefined {
   const itemRecord = item as Record<string, unknown>;
+  if (itemType === "reasoning") {
+    return reasoningItemText(itemRecord);
+  }
   const action = itemRecord.action as Record<string, unknown> | undefined;
   const actionQueries = Array.isArray(action?.queries) ? action.queries : [];
   const candidates = [
@@ -484,6 +520,19 @@ function mapItemLifecycle(
           ? item.status
           : "completed"
         : undefined;
+  // Reasoning items get the renderable identity the ingestion guard and the
+  // client collapse need: data.toolCallId ties started/updated/completed to
+  // one row (same contract the Claude adapter emits for thinking blocks).
+  const itemId = "id" in item && typeof item.id === "string" ? item.id : undefined;
+  const data =
+    event.payload !== undefined
+      ? itemType === "reasoning" &&
+        itemId !== undefined &&
+        typeof event.payload === "object" &&
+        event.payload !== null
+        ? { ...(event.payload as Record<string, unknown>), toolCallId: itemId }
+        : event.payload
+      : undefined;
 
   return {
     ...runtimeEventBase(event, canonicalThreadId),
@@ -493,7 +542,7 @@ function mapItemLifecycle(
       ...(status ? { status } : {}),
       ...(itemTitle(itemType, item) ? { title: itemTitle(itemType, item) } : {}),
       ...(detail ? { detail } : {}),
-      ...(event.payload !== undefined ? { data: event.payload } : {}),
+      ...(data !== undefined ? { data } : {}),
     },
   };
 }
@@ -761,9 +810,80 @@ function mapCollabAgentEvent(
   }
 }
 
+/**
+ * Live reasoning accumulator. Codex streams thinking as bare content deltas
+ * (`item/reasoning/summaryTextDelta`, `item/reasoning/textDelta`) with no item
+ * lifecycle shape of their own, so without this the user only ever saw the
+ * final summary at `item.completed`. We accumulate per itemId and emit
+ * throttled `item.updated` events in the renderable reasoning shape (title +
+ * data.toolCallId) — the same contract the Claude adapter emits for thinking
+ * blocks: first update goes out as soon as any text exists, later ones every
+ * CODEX_REASONING_UPDATE_CHUNK chars.
+ */
+interface CodexReasoningStreamState {
+  /** itemId → indexed parts, summary and content apart (see compose note). */
+  readonly partsByItemId: Map<
+    string,
+    { readonly summary: Map<number, string>; readonly content: Map<number, string> }
+  >;
+  /** itemId → composed text length at the last emitted item.updated (throttles live updates). */
+  readonly lastEmittedLengthByItemId: Map<string, number>;
+}
+
+const CODEX_REASONING_UPDATE_CHUNK = 512;
+
+function accumulateReasoningDeltaEvent(
+  state: CodexReasoningStreamState,
+  event: ProviderEvent,
+  canonicalThreadId: ThreadId,
+  delta: string,
+  part: { readonly kind: "summary" | "content"; readonly index: number | undefined },
+): ProviderRuntimeEvent | undefined {
+  const itemId = event.itemId;
+  if (itemId === undefined) {
+    return undefined;
+  }
+  // Parts stream interleaved (summary sections, content blocks), each with
+  // its own index — track them separately and compose summary-then-content
+  // in index order, the same order reasoningItemText emits at completion,
+  // or the live text reshuffles when the block seals.
+  let parts = state.partsByItemId.get(itemId);
+  if (!parts) {
+    parts = { summary: new Map(), content: new Map() };
+    state.partsByItemId.set(itemId, parts);
+  }
+  const bucket = part.kind === "summary" ? parts.summary : parts.content;
+  const index = part.index ?? 0;
+  bucket.set(index, (bucket.get(index) ?? "") + delta);
+  const byIndex = (a: [number, string], b: [number, string]) => a[0] - b[0];
+  const text = [
+    ...Array.from(parts.summary.entries()).sort(byIndex),
+    ...Array.from(parts.content.entries()).sort(byIndex),
+  ]
+    .map(([, value]) => value)
+    .join("\n\n");
+  const lastEmittedLength = state.lastEmittedLengthByItemId.get(itemId) ?? 0;
+  if (lastEmittedLength > 0 && text.length - lastEmittedLength < CODEX_REASONING_UPDATE_CHUNK) {
+    return undefined;
+  }
+  state.lastEmittedLengthByItemId.set(itemId, text.length);
+  return {
+    ...runtimeEventBase(event, canonicalThreadId),
+    type: "item.updated",
+    payload: {
+      itemType: "reasoning",
+      status: "inProgress",
+      title: "Reasoning",
+      detail: text,
+      data: { toolCallId: itemId },
+    },
+  };
+}
+
 function mapToRuntimeEvents(
   event: ProviderEvent,
   canonicalThreadId: ThreadId,
+  reasoningStreams?: CodexReasoningStreamState,
 ): ReadonlyArray<ProviderRuntimeEvent> {
   if (event.kind === "notification" && event.method.startsWith("collabAgent/")) {
     return mapCollabAgentEvent(event, canonicalThreadId);
@@ -1132,6 +1252,17 @@ function mapToRuntimeEvents(
       ];
     }
     const completed = mapItemLifecycle(event, canonicalThreadId, "item.completed");
+    // The reasoning item is sealed; drop its live accumulator so a recycled
+    // itemId can never inherit a previous item's text.
+    if (
+      reasoningStreams &&
+      event.itemId !== undefined &&
+      completed?.type === "item.completed" &&
+      completed.payload.itemType === "reasoning"
+    ) {
+      reasoningStreams.partsByItemId.delete(event.itemId);
+      reasoningStreams.lastEmittedLengthByItemId.delete(event.itemId);
+    }
     return completed ? [completed] : [];
   }
 
@@ -1238,17 +1369,22 @@ function mapToRuntimeEvents(
     if (!delta || delta.length === 0) {
       return [];
     }
-    return [
-      {
-        ...runtimeEventBase(event, canonicalThreadId),
-        type: "content.delta",
-        payload: {
-          streamKind: "reasoning_summary_text",
-          delta,
-          ...(payload ? { summaryIndex: payload.summaryIndex } : {}),
-        },
+    const contentDelta: ProviderRuntimeEvent = {
+      ...runtimeEventBase(event, canonicalThreadId),
+      type: "content.delta",
+      payload: {
+        streamKind: "reasoning_summary_text",
+        delta,
+        ...(payload ? { summaryIndex: payload.summaryIndex } : {}),
       },
-    ];
+    };
+    const reasoningUpdate = reasoningStreams
+      ? accumulateReasoningDeltaEvent(reasoningStreams, event, canonicalThreadId, delta, {
+          kind: "summary",
+          index: payload?.summaryIndex,
+        })
+      : undefined;
+    return reasoningUpdate ? [contentDelta, reasoningUpdate] : [contentDelta];
   }
 
   if (event.method === "item/reasoning/textDelta") {
@@ -1257,17 +1393,22 @@ function mapToRuntimeEvents(
     if (!delta || delta.length === 0) {
       return [];
     }
-    return [
-      {
-        ...runtimeEventBase(event, canonicalThreadId),
-        type: "content.delta",
-        payload: {
-          streamKind: "reasoning_text",
-          delta,
-          ...(payload ? { contentIndex: payload.contentIndex } : {}),
-        },
+    const contentDelta: ProviderRuntimeEvent = {
+      ...runtimeEventBase(event, canonicalThreadId),
+      type: "content.delta",
+      payload: {
+        streamKind: "reasoning_text",
+        delta,
+        ...(payload ? { contentIndex: payload.contentIndex } : {}),
       },
-    ];
+    };
+    const reasoningUpdate = reasoningStreams
+      ? accumulateReasoningDeltaEvent(reasoningStreams, event, canonicalThreadId, delta, {
+          kind: "content",
+          index: payload?.contentIndex,
+        })
+      : undefined;
+    return reasoningUpdate ? [contentDelta, reasoningUpdate] : [contentDelta];
   }
 
   if (event.method === "item/mcpToolCall/progress") {
@@ -1721,10 +1862,14 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
         // this a child of `startSession`, and Effect interrupts a fiber's
         // children when it completes, so the consumer died on return and every
         // runtime event the session emitted afterwards was dropped.
+        const reasoningStreams: CodexReasoningStreamState = {
+          partsByItemId: new Map(),
+          lastEmittedLengthByItemId: new Map(),
+        };
         const eventFiber = yield* Stream.runForEach(runtime.events, (event) =>
           Effect.gen(function* () {
             yield* writeNativeEvent(event);
-            const runtimeEvents = mapToRuntimeEvents(event, event.threadId);
+            const runtimeEvents = mapToRuntimeEvents(event, event.threadId, reasoningStreams);
             if (runtimeEvents.length === 0) {
               yield* Effect.logDebug("ignoring unhandled Codex provider event", {
                 method: event.method,

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1162,6 +1162,11 @@ function mapToRuntimeEvents(
     if (!payload) {
       return [];
     }
+    // A finished turn seals every reasoning item it streamed; anything left in
+    // the accumulator belongs to items that never completed and would
+    // otherwise leak for the session's lifetime.
+    reasoningStreams?.partsByItemId.clear();
+    reasoningStreams?.lastEmittedLengthByItemId.clear();
     const errorMessage = trimText(payload.turn.error?.message);
     return [
       {
@@ -1176,6 +1181,10 @@ function mapToRuntimeEvents(
   }
 
   if (event.method === "turn/aborted") {
+    // Aborted turns never complete their reasoning items — drop the live
+    // accumulator with them (same leak guard as turn/completed).
+    reasoningStreams?.partsByItemId.clear();
+    reasoningStreams?.lastEmittedLengthByItemId.clear();
     return [
       {
         ...runtimeEventBase(event, canonicalThreadId),

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1393,7 +1393,6 @@ describe("deriveMessagesTimelineRows", () => {
         toolLifecycleStatus: status,
       },
     }));
-
     const rows = deriveMessagesTimelineRows({
       timelineEntries,
       isWorking: false,
@@ -1457,6 +1456,62 @@ describe("deriveMessagesTimelineRows", () => {
       hiddenCount: 2,
       summary: null,
       hasFailure: true,
+    });
+  });
+
+  it("does not count reasoning rows as tool calls in the overflow toggle", () => {
+    const timelineEntries = [
+      {
+        id: "work-entry-1",
+        kind: "work" as const,
+        createdAt: "2026-01-01T00:00:01Z",
+        entry: {
+          id: "work-reasoning",
+          createdAt: "2026-01-01T00:00:01Z",
+          label: "Reasoning",
+          detail: "thinking about the approach",
+          tone: "tool" as const,
+          itemType: "reasoning" as const,
+        },
+      },
+      {
+        id: "work-entry-2",
+        kind: "work" as const,
+        createdAt: "2026-01-01T00:00:02Z",
+        entry: {
+          id: "work-2",
+          createdAt: "2026-01-01T00:00:02Z",
+          label: "edit",
+          detail: "Editing MessagesTimeline.tsx",
+          tone: "tool" as const,
+        },
+      },
+      {
+        id: "work-entry-3",
+        kind: "work" as const,
+        createdAt: "2026-01-01T00:00:03Z",
+        entry: {
+          id: "work-3",
+          createdAt: "2026-01-01T00:00:03Z",
+          label: "test",
+          detail: "Running tests",
+          tone: "tool" as const,
+        },
+      },
+    ];
+
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries,
+      isWorking: false,
+      activeTurnStartedAt: null,
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    // Reasoning is not a tool call: the group falls back to "log entries"
+    // wording instead of claiming "3 tool calls".
+    expect(rows.find((row) => row.kind === "work-toggle")).toMatchObject({
+      onlyToolEntries: false,
     });
   });
 });

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -3,6 +3,7 @@ import {
   formatDuration,
   workEntryDisplayIndicatesToolFailure,
   workEntryIndicatesToolNeutralStatus,
+  workLogEntryIsToolCall,
   workLogEntryIsToolLike,
   type TimelineEntry,
   type TurnPlanEntry,
@@ -848,9 +849,13 @@ export function deriveMessagesTimelineRows(input: {
         (entry) => entry,
       );
       if (visibleGroupedEntries.length > 0) {
+        // Reasoning is not a tool call: a group containing it takes the
+        // mixed-group path below, never the one-line tool collapse (whose
+        // summary would claim a tool-call count over thinking rows).
         const onlyToolEntries = visibleGroupedEntries.every(
           (entry) =>
             workLogEntryIsToolLike(entry) &&
+            entry.itemType !== "reasoning" &&
             entry.agentSpawn === undefined &&
             entry.tone !== "error",
         );
@@ -955,7 +960,7 @@ export function deriveMessagesTimelineRows(input: {
               groupId,
               hiddenCount: hiddenEntries.length,
               expanded,
-              onlyToolEntries: hiddenEntries.every(workLogEntryIsToolLike),
+              onlyToolEntries: hiddenEntries.every(workLogEntryIsToolCall),
               summary: null,
               summaryKind: null,
               hasFailure: hiddenEntries.some((entry) =>

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -2423,7 +2423,11 @@ function liveWorkEntryLabel(
     return "Running command";
   }
 
-  return workEntryPreview(workEntry, workspaceRoot) ?? toolWorkEntryHeading(workEntry);
+  const preview = workEntryPreview(workEntry, workspaceRoot) ?? toolWorkEntryHeading(workEntry);
+  // A streaming reasoning preview is the full thinking text (up to 20k): the
+  // visible row truncates to one line, but this string also becomes the live
+  // button's accessible name — keep it a label, not a transcript.
+  return preview.length > 200 ? `${preview.slice(0, 200)}…` : preview;
 }
 
 function buildToolCallExpandedBody(

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -46,6 +46,7 @@ import {
 import ChatMarkdown from "../ChatMarkdown";
 import {
   BotIcon,
+  BrainIcon,
   CheckIcon,
   ChevronDownIcon,
   ChevronRightIcon,
@@ -2143,6 +2144,7 @@ function formatWorkingTimerNow(startIso: string): string {
 
 type WorkEntryIconName =
   | "bot"
+  | "brain"
   | "check"
   | "circle-alert"
   | "eye"
@@ -2160,6 +2162,8 @@ function WorkEntryIconSvg({ name, className }: { name: WorkEntryIconName; classN
   switch (name) {
     case "bot":
       return <BotIcon className={className} aria-hidden />;
+    case "brain":
+      return <BrainIcon className={className} aria-hidden />;
     case "check":
       return <CheckIcon className={className} aria-hidden />;
     case "circle-alert":

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -2667,19 +2667,20 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
         ? "text-secondary-label"
         : "text-foreground/80";
   const showEntryIcon = !isExpandedToolGroupEntry || showWarningIndicator || showFailedIndicator;
+  // Reasoning previews carry the full thinking text (up to 20k) and command
+  // rows put the verbatim command here: clamp BEFORE composing the failure
+  // suffix, so the announcement is never sliced off, and the accessible name
+  // stays a label, not a transcript.
+  const clampedDisplayText =
+    displayText.length > 200 ? `${displayText.slice(0, 200)}…` : displayText;
   const accessibleDisplayText = showFailedIndicator
-    ? `${displayText}, tool call failed`
-    : displayText;
+    ? `${clampedDisplayText}, tool call failed`
+    : clampedDisplayText;
   const rowToggleProps = canExpand
     ? {
         role: "button" as const,
         tabIndex: 0 as const,
-        // Reasoning previews carry the full thinking text (up to 20k); the
-        // accessible name must stay a label, not a transcript.
-        "aria-label":
-          accessibleDisplayText.length > 200
-            ? `${accessibleDisplayText.slice(0, 200)}…`
-            : accessibleDisplayText,
+        "aria-label": accessibleDisplayText,
         "aria-expanded": expanded,
         onClick: () => setExpanded((v) => !v),
         onKeyDown: (e: KeyboardEvent<HTMLDivElement>) => {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -2457,6 +2457,13 @@ function buildToolCallExpandedBody(
 const toolCallExpandedBodyClassName =
   "max-h-64 cursor-text overflow-auto whitespace-pre-wrap break-words font-mono text-secondary-label text-[length:var(--font-size-code,0.6875rem)] leading-relaxed select-text";
 
+// Reasoning is streamed prose the user follows live: clamping it to max-h-64
+// forced scrolling a 16rem box while the thinking kept growing past it. The
+// block grows with the text instead (Claude Code behavior); tool outputs keep
+// the clamp.
+const reasoningExpandedBodyClassName =
+  "cursor-text whitespace-pre-wrap break-words font-mono text-secondary-label text-[length:var(--font-size-code,0.6875rem)] leading-relaxed select-text";
+
 function workEntryIconName(workEntry: TimelineWorkEntry): WorkEntryIconName {
   if (
     workEntry.sourceActivityKind === "user-input.requested" ||
@@ -2474,6 +2481,8 @@ function workEntryIconName(workEntry: TimelineWorkEntry): WorkEntryIconName {
       return "hammer";
     case "collab_agent_tool_call":
       return "bot";
+    case "reasoning":
+      return "brain";
   }
 
   // Subagent lifecycle rows (grouped by taskId) get agent identity chrome.
@@ -2657,7 +2666,12 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
     ? {
         role: "button" as const,
         tabIndex: 0 as const,
-        "aria-label": accessibleDisplayText,
+        // Reasoning previews carry the full thinking text (up to 20k); the
+        // accessible name must stay a label, not a transcript.
+        "aria-label":
+          accessibleDisplayText.length > 200
+            ? `${accessibleDisplayText.slice(0, 200)}…`
+            : accessibleDisplayText,
         "aria-expanded": expanded,
         onClick: () => setExpanded((v) => !v),
         onKeyDown: (e: KeyboardEvent<HTMLDivElement>) => {
@@ -2719,7 +2733,15 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
           onClick={stopRowToggle}
           onPointerDown={stopRowToggle}
         >
-          <pre className={toolCallExpandedBodyClassName}>{expandedBody}</pre>
+          <pre
+            className={
+              workEntry.itemType === "reasoning"
+                ? reasoningExpandedBodyClassName
+                : toolCallExpandedBodyClassName
+            }
+          >
+            {expandedBody}
+          </pre>
         </div>
       ) : null}
     </div>

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -1071,12 +1071,13 @@ describe("deriveWorkLogEntries", () => {
 
     const entries = deriveWorkLogEntries(activities);
     expect(entries.map((entry) => entry.itemType)).toEqual(["reasoning", "dynamic_tool_call"]);
-    // The reasoning row anchors where thinking started; the merged row keeps
-    // the latest activity's identity (upstream collapse semantics).
-    expect(entries[0]?.id).toBe(EventId.make("reasoning-completed"));
+    // The reasoning row anchors where thinking started and keeps the FIRST
+    // activity's id/createdAt, so it neither jumps past interleaved tool rows
+    // nor remounts mid-stream.
+    expect(entries[0]?.id).toBe(EventId.make("reasoning-updated-1"));
     expect(entries[0]?.detail).toBe("Let me look at the code");
     expect(entries[0]?.toolLifecycleStatus).toBe("completed");
-    expect(entries[1]?.id).toBe(EventId.make("grep-completed"));
+    expect(entries[1]?.id).toBe(EventId.make("grep-updated"));
     expect(entries[1]?.detail).toBe('Grep: {"pattern":"reasoning"}');
   });
 
@@ -1134,8 +1135,8 @@ describe("deriveWorkLogEntries", () => {
     const entries = deriveWorkLogEntries(activities);
     expect(entries.map((entry) => entry.detail)).toEqual(["First block done", "Second block done"]);
     expect(entries.map((entry) => entry.id)).toEqual([
-      EventId.make("block-a-end"),
-      EventId.make("block-b-end"),
+      EventId.make("block-a-start"),
+      EventId.make("block-b-start"),
     ]);
   });
 
@@ -1515,13 +1516,15 @@ describe("deriveWorkLogEntries", () => {
 
     expect(deriveWorkLogEntries(activities)).toMatchObject([
       {
-        id: "tool-a-complete",
+        // The anchor keeps the FIRST activity's id/createdAt: the row neither
+        // jumps past interleaved rows nor remounts when the completion lands.
+        id: "tool-a-progress",
         command: "vp test run",
         toolCallId: "call-a",
         toolLifecycleStatus: "completed",
       },
       {
-        id: "tool-b-complete",
+        id: "tool-b-progress",
         command: "vp lint",
         toolCallId: "call-b",
         toolLifecycleStatus: "completed",
@@ -1772,7 +1775,7 @@ describe("deriveWorkLogEntries", () => {
     const entries = deriveWorkLogEntries(activities);
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({
-      id: "grep-complete",
+      id: "grep-update",
       toolTitle: "grep",
       detail: "19 files",
       itemType: "web_search",
@@ -1821,7 +1824,7 @@ describe("deriveWorkLogEntries", () => {
     const entries = deriveWorkLogEntries(activities);
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({
-      id: "read-complete",
+      id: "read-update",
       toolTitle: "Read File",
       detail: 'import * as Effect from "effect/Effect"',
       itemType: "dynamic_tool_call",

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -955,10 +955,12 @@ describe("deriveWorkLogEntries", () => {
   });
 
   it("collapses the reasoning update chain into one row with the final thinking text", () => {
+    const turnId = "turn-reasoning-chain";
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({
         id: "reasoning-started",
         createdAt: "2026-02-23T00:00:01.000Z",
+        turnId,
         kind: "tool.started",
         summary: "Reasoning started",
         tone: "tool",
@@ -970,6 +972,7 @@ describe("deriveWorkLogEntries", () => {
       makeActivity({
         id: "reasoning-updated-1",
         createdAt: "2026-02-23T00:00:02.000Z",
+        turnId,
         kind: "tool.updated",
         summary: "Reasoning",
         tone: "tool",
@@ -983,6 +986,7 @@ describe("deriveWorkLogEntries", () => {
       makeActivity({
         id: "reasoning-updated-2",
         createdAt: "2026-02-23T00:00:03.000Z",
+        turnId,
         kind: "tool.updated",
         summary: "Reasoning",
         tone: "tool",
@@ -996,6 +1000,7 @@ describe("deriveWorkLogEntries", () => {
       makeActivity({
         id: "reasoning-completed",
         createdAt: "2026-02-23T00:00:04.000Z",
+        turnId,
         kind: "tool.completed",
         summary: "Reasoning",
         tone: "tool",
@@ -1018,10 +1023,12 @@ describe("deriveWorkLogEntries", () => {
   it("collapses reasoning updates interleaved with streaming tool calls into one anchored row", () => {
     // Claude streams thinking deltas interleaved with tool_call input deltas;
     // adjacent-only folding used to split one block into a row per update.
+    const turnId = "turn-reasoning-interleaved";
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({
         id: "reasoning-updated-1",
         createdAt: "2026-02-23T00:00:01.000Z",
+        turnId,
         kind: "tool.updated",
         summary: "Reasoning",
         payload: {
@@ -1034,6 +1041,7 @@ describe("deriveWorkLogEntries", () => {
       makeActivity({
         id: "grep-updated",
         createdAt: "2026-02-23T00:00:02.000Z",
+        turnId,
         kind: "tool.updated",
         summary: "Tool call",
         payload: {
@@ -1046,6 +1054,7 @@ describe("deriveWorkLogEntries", () => {
       makeActivity({
         id: "reasoning-completed",
         createdAt: "2026-02-23T00:00:03.000Z",
+        turnId,
         kind: "tool.completed",
         summary: "Reasoning",
         payload: {
@@ -1058,6 +1067,7 @@ describe("deriveWorkLogEntries", () => {
       makeActivity({
         id: "grep-completed",
         createdAt: "2026-02-23T00:00:04.000Z",
+        turnId,
         kind: "tool.completed",
         summary: "Tool call",
         payload: {
@@ -1092,6 +1102,7 @@ describe("deriveWorkLogEntries", () => {
       makeActivity({
         id,
         createdAt,
+        turnId: "turn-reasoning-blocks",
         kind,
         summary: "Reasoning",
         payload: {
@@ -1563,6 +1574,54 @@ describe("deriveWorkLogEntries", () => {
     expect(deriveWorkLogEntries(activities)).toHaveLength(2);
   });
 
+  it("does not identity-collapse reused tool call ids without turn boundaries", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "turnless-tool-first",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.updated",
+        summary: "Tool",
+        payload: {
+          itemType: "command_execution",
+          toolCallId: "reused-call",
+          status: "inProgress",
+          detail: "first turnless chain",
+        },
+      }),
+      makeActivity({
+        id: "turnless-tool-interleaved",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "tool.updated",
+        summary: "Other tool",
+        payload: {
+          itemType: "command_execution",
+          toolCallId: "other-call",
+          status: "inProgress",
+          detail: "interleaved chain",
+        },
+      }),
+      makeActivity({
+        id: "turnless-tool-second",
+        createdAt: "2026-02-23T00:00:03.000Z",
+        kind: "tool.updated",
+        summary: "Tool",
+        payload: {
+          itemType: "command_execution",
+          toolCallId: "reused-call",
+          status: "inProgress",
+          detail: "second turnless chain",
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities);
+    expect(entries.map((entry) => entry.id)).toEqual([
+      EventId.make("turnless-tool-first"),
+      EventId.make("turnless-tool-interleaved"),
+      EventId.make("turnless-tool-second"),
+    ]);
+  });
+
   it("unwraps PowerShell command wrappers for displayed command text", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({
@@ -1734,10 +1793,12 @@ describe("deriveWorkLogEntries", () => {
   });
 
   it("uses grep raw output summaries instead of repeating the generic tool label", () => {
+    const turnId = "turn-grep-preview";
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({
         id: "grep-update",
         createdAt: "2026-02-23T00:00:01.000Z",
+        turnId,
         kind: "tool.updated",
         summary: "grep",
         payload: {
@@ -1754,6 +1815,7 @@ describe("deriveWorkLogEntries", () => {
       makeActivity({
         id: "grep-complete",
         createdAt: "2026-02-23T00:00:02.000Z",
+        turnId,
         kind: "tool.completed",
         summary: "grep",
         payload: {
@@ -1783,10 +1845,12 @@ describe("deriveWorkLogEntries", () => {
   });
 
   it("uses completed read-file output previews and still collapses the same tool call", () => {
+    const turnId = "turn-read-preview";
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({
         id: "read-update",
         createdAt: "2026-02-23T00:00:01.000Z",
+        turnId,
         kind: "tool.updated",
         summary: "Read File",
         payload: {
@@ -1803,6 +1867,7 @@ describe("deriveWorkLogEntries", () => {
       makeActivity({
         id: "read-complete",
         createdAt: "2026-02-23T00:00:02.000Z",
+        turnId,
         kind: "tool.completed",
         summary: "Read File",
         payload: {

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -879,6 +879,58 @@ describe("workEntryIndicatesToolFailure", () => {
       }),
     ).toBe(false);
   });
+
+  it("never treats reasoning rows as failures, even when thinking quotes errors", () => {
+    expect(
+      workEntryIndicatesToolFailure({
+        ...base,
+        label: "Reasoning",
+        tone: "tool",
+        itemType: "reasoning",
+        detail: "The previous attempt failed with exit code 1: command not found",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps reasoning rows out of the tool success and neutral affordances", () => {
+    const reasoningBase = {
+      ...base,
+      label: "Reasoning",
+      tone: "tool" as const,
+      itemType: "reasoning" as const,
+      detail: "thinking…",
+    };
+    // A completed reasoning row must not claim the tool "Completed" check.
+    expect(
+      workEntryIndicatesToolSuccess({ ...reasoningBase, toolLifecycleStatus: "completed" }),
+    ).toBe(false);
+    // An in-progress reasoning row must not classify as neutral — the neutral
+    // filter would hide the live thinking row for the whole turn.
+    expect(
+      workEntryIndicatesToolNeutralStatus({ ...reasoningBase, toolLifecycleStatus: "inProgress" }),
+    ).toBe(false);
+    expect(
+      workEntryIndicatesToolNeutralStatus({ ...reasoningBase, toolLifecycleStatus: "completed" }),
+    ).toBe(false);
+    // A reasoning row with no thinking text (e.g. redacted_thinking) stays
+    // neutral so the empty-row filter still hides it.
+    expect(
+      workEntryIndicatesToolNeutralStatus({
+        ...base,
+        label: "Reasoning",
+        tone: "tool" as const,
+        itemType: "reasoning" as const,
+        toolLifecycleStatus: "completed",
+      }),
+    ).toBe(true);
+    expect(
+      workEntryIndicatesToolNeutralStatus({
+        ...reasoningBase,
+        detail: "   ",
+        toolLifecycleStatus: "completed",
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("deriveWorkLogEntries", () => {
@@ -900,6 +952,226 @@ describe("deriveWorkLogEntries", () => {
 
     const entries = deriveWorkLogEntries(activities);
     expect(entries.map((entry) => entry.id)).toEqual(["tool-complete"]);
+  });
+
+  it("collapses the reasoning update chain into one row with the final thinking text", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "reasoning-started",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.started",
+        summary: "Reasoning started",
+        tone: "tool",
+        payload: {
+          itemType: "reasoning",
+          status: "inProgress",
+        },
+      }),
+      makeActivity({
+        id: "reasoning-updated-1",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "tool.updated",
+        summary: "Reasoning",
+        tone: "tool",
+        payload: {
+          itemType: "reasoning",
+          status: "inProgress",
+          detail: "Let me think",
+          data: { toolCallId: "reasoning-item-1" },
+        },
+      }),
+      makeActivity({
+        id: "reasoning-updated-2",
+        createdAt: "2026-02-23T00:00:03.000Z",
+        kind: "tool.updated",
+        summary: "Reasoning",
+        tone: "tool",
+        payload: {
+          itemType: "reasoning",
+          status: "inProgress",
+          detail: "Let me think step by step",
+          data: { toolCallId: "reasoning-item-1" },
+        },
+      }),
+      makeActivity({
+        id: "reasoning-completed",
+        createdAt: "2026-02-23T00:00:04.000Z",
+        kind: "tool.completed",
+        summary: "Reasoning",
+        tone: "tool",
+        payload: {
+          itemType: "reasoning",
+          status: "completed",
+          detail: "Let me think step by step about the answer",
+          data: { toolCallId: "reasoning-item-1" },
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities);
+    expect(entries.length).toBe(1);
+    expect(entries[0]?.itemType).toBe("reasoning");
+    expect(entries[0]?.detail).toBe("Let me think step by step about the answer");
+    expect(entries[0]?.toolLifecycleStatus).toBe("completed");
+  });
+
+  it("collapses reasoning updates interleaved with streaming tool calls into one anchored row", () => {
+    // Claude streams thinking deltas interleaved with tool_call input deltas;
+    // adjacent-only folding used to split one block into a row per update.
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "reasoning-updated-1",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.updated",
+        summary: "Reasoning",
+        payload: {
+          itemType: "reasoning",
+          status: "inProgress",
+          detail: "Let",
+          data: { toolCallId: "reasoning-item-1" },
+        },
+      }),
+      makeActivity({
+        id: "grep-updated",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "tool.updated",
+        summary: "Tool call",
+        payload: {
+          itemType: "dynamic_tool_call",
+          status: "inProgress",
+          detail: 'Grep: {"pattern":"rea',
+          data: { toolCallId: "call-grep-1" },
+        },
+      }),
+      makeActivity({
+        id: "reasoning-completed",
+        createdAt: "2026-02-23T00:00:03.000Z",
+        kind: "tool.completed",
+        summary: "Reasoning",
+        payload: {
+          itemType: "reasoning",
+          status: "completed",
+          detail: "Let me look at the code",
+          data: { toolCallId: "reasoning-item-1" },
+        },
+      }),
+      makeActivity({
+        id: "grep-completed",
+        createdAt: "2026-02-23T00:00:04.000Z",
+        kind: "tool.completed",
+        summary: "Tool call",
+        payload: {
+          itemType: "dynamic_tool_call",
+          status: "completed",
+          detail: 'Grep: {"pattern":"reasoning"}',
+          data: { toolCallId: "call-grep-1" },
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities);
+    expect(entries.map((entry) => entry.itemType)).toEqual(["reasoning", "dynamic_tool_call"]);
+    // The reasoning row anchors where thinking started; the merged row keeps
+    // the latest activity's identity (upstream collapse semantics).
+    expect(entries[0]?.id).toBe(EventId.make("reasoning-completed"));
+    expect(entries[0]?.detail).toBe("Let me look at the code");
+    expect(entries[0]?.toolLifecycleStatus).toBe("completed");
+    expect(entries[1]?.id).toBe(EventId.make("grep-completed"));
+    expect(entries[1]?.detail).toBe('Grep: {"pattern":"reasoning"}');
+  });
+
+  it("keeps two interleaved reasoning blocks as separate anchored rows", () => {
+    const reasoningActivity = (
+      id: string,
+      createdAt: string,
+      kind: "tool.updated" | "tool.completed",
+      detail: string,
+      toolCallId: string,
+    ) =>
+      makeActivity({
+        id,
+        createdAt,
+        kind,
+        summary: "Reasoning",
+        payload: {
+          itemType: "reasoning",
+          status: kind === "tool.completed" ? "completed" : "inProgress",
+          detail,
+          data: { toolCallId },
+        },
+      });
+    const activities: OrchestrationThreadActivity[] = [
+      reasoningActivity(
+        "block-a-start",
+        "2026-02-23T00:00:01.000Z",
+        "tool.updated",
+        "First",
+        "reasoning-a",
+      ),
+      reasoningActivity(
+        "block-b-start",
+        "2026-02-23T00:00:02.000Z",
+        "tool.updated",
+        "Second",
+        "reasoning-b",
+      ),
+      reasoningActivity(
+        "block-a-end",
+        "2026-02-23T00:00:03.000Z",
+        "tool.completed",
+        "First block done",
+        "reasoning-a",
+      ),
+      reasoningActivity(
+        "block-b-end",
+        "2026-02-23T00:00:04.000Z",
+        "tool.completed",
+        "Second block done",
+        "reasoning-b",
+      ),
+    ];
+
+    const entries = deriveWorkLogEntries(activities);
+    expect(entries.map((entry) => entry.detail)).toEqual(["First block done", "Second block done"]);
+    expect(entries.map((entry) => entry.id)).toEqual([
+      EventId.make("block-a-end"),
+      EventId.make("block-b-end"),
+    ]);
+  });
+
+  it("does not let a late update regress a completed row for the same identity", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "reasoning-completed",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.completed",
+        summary: "Reasoning",
+        payload: {
+          itemType: "reasoning",
+          status: "completed",
+          detail: "Full final thinking text",
+          data: { toolCallId: "reasoning-item-1" },
+        },
+      }),
+      makeActivity({
+        id: "reasoning-late-update",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "tool.updated",
+        summary: "Reasoning",
+        payload: {
+          itemType: "reasoning",
+          status: "inProgress",
+          detail: "Full",
+          data: { toolCallId: "reasoning-item-1" },
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities);
+    expect(entries.length).toBe(2);
+    expect(entries[0]?.detail).toBe("Full final thinking text");
+    expect(entries[0]?.toolLifecycleStatus).toBe("completed");
+    expect(entries[1]?.id).toBe(EventId.make("reasoning-late-update"));
   });
 
   it("omits task.started but shows task.progress and task.completed", () => {

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -1057,7 +1057,7 @@ function toolLifecycleCollapseMapKey(entry: DerivedWorkLogEntry): string | undef
   if (entry.activityKind !== "tool.updated" && entry.activityKind !== "tool.completed") {
     return undefined;
   }
-  return entry.toolCallId ? `tool:${entry.turnId ?? "no-turn"}:${entry.toolCallId}` : undefined;
+  return entry.toolCallId && entry.turnId ? `tool:${entry.turnId}:${entry.toolCallId}` : undefined;
 }
 
 function collapseDerivedWorkLogEntries(
@@ -1076,6 +1076,9 @@ function collapseDerivedWorkLogEntries(
   // own turn splintered one batch into a stream of "Kicked off N subagents"
   // rows (live-test finding, thread 7ac7ef05).
   const groupKeyByTaskId = new Map<string, string>();
+  // Tool-call ids are only globally safe inside a known turn. Turnless rows
+  // retain the adjacent fuzzy fallback below instead of sharing one identity
+  // map for the lifetime of the thread.
   const toolLifecycleRowIndex = new Map<string, number>();
   for (const entry of entries) {
     const isTaskRow =
@@ -1246,8 +1249,11 @@ function deriveToolLifecycleCollapseKey(entry: DerivedWorkLogEntry): string | un
   if (entry.activityKind !== "tool.updated" && entry.activityKind !== "tool.completed") {
     return undefined;
   }
-  if (entry.toolCallId) {
-    return `tool:${entry.turnId ?? "no-turn"}:${entry.toolCallId}`;
+  // A provider may reuse an id in a later chain. The turn boundary makes the
+  // identity safe for non-adjacent streaming updates; without one, fall back
+  // to the local fuzzy key below.
+  if (entry.toolCallId && entry.turnId) {
+    return `tool:${entry.turnId}:${entry.toolCallId}`;
   }
   const normalizedLabel = normalizeCompactToolLabel(entry.toolTitle ?? entry.label);
   const detail = entry.detail?.trim() ?? "";

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -1131,7 +1131,15 @@ function collapseDerivedWorkLogEntries(
         matchingEntry &&
         shouldCollapseToolLifecycleEntries(matchingEntry, entry)
       ) {
-        collapsed[matchingLifecycleIndex] = mergeDerivedWorkLogEntries(matchingEntry, entry);
+        // Pin the anchor's identity: merged rows keep the FIRST activity's
+        // id/createdAt, so the live row neither jumps past interleaved tool
+        // rows (the timeline sorts by createdAt) nor remounts mid-stream.
+        collapsed[matchingLifecycleIndex] = {
+          ...mergeDerivedWorkLogEntries(matchingEntry, entry),
+          id: matchingEntry.id,
+          createdAt: matchingEntry.createdAt,
+          turnId: matchingEntry.turnId ?? null,
+        };
         continue;
       }
       toolLifecycleRowIndex.delete(lifecycleKey);

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -75,7 +75,7 @@ export interface WorkLogEntry {
   tone: "thinking" | "tool" | "info" | "error";
   toolTitle?: string;
   toolData?: unknown;
-  itemType?: ToolLifecycleItemType;
+  itemType?: ToolLifecycleItemType | "reasoning";
   requestKind?: PendingApproval["requestKind"];
   /** From runtime item / task payload `status` when present (e.g. tool.updated). */
   toolLifecycleStatus?: WorkLogToolLifecycleStatus;
@@ -180,6 +180,15 @@ export function workLogEntryIsToolLike(entry: WorkLogEntry): boolean {
   return entry.itemType !== undefined && isToolLifecycleItemType(entry.itemType);
 }
 
+/**
+ * Stricter than tool-like for the "N tool calls" group labels: reasoning rows
+ * are tool-like for styling, but they are not tool calls and must not inflate
+ * the count.
+ */
+export function workLogEntryIsToolCall(entry: WorkLogEntry): boolean {
+  return entry.itemType !== "reasoning" && workLogEntryIsToolLike(entry);
+}
+
 /** Heuristic: providers often emit successful lifecycle status while error text lives in `detail` / `command`. */
 function toolDetailTextLooksLikeFailure(text: string): boolean {
   const t = text.toLowerCase();
@@ -230,6 +239,12 @@ function workEntryIndicatesToolFailureFromOutput(
   entry: WorkLogEntry,
   includeCommand: boolean,
 ): boolean {
+  // Reasoning rows carry the model's prose as detail; running the tool-output
+  // failure heuristic over it would flag any quoted error ("exit code 1") as
+  // a tool failure even though nothing failed.
+  if (entry.itemType === "reasoning") {
+    return false;
+  }
   if (entry.tone === "error") {
     return true;
   }
@@ -266,6 +281,11 @@ export function workEntryDisplayIndicatesToolFailure(entry: WorkLogEntry): boole
 
 /** Tool/command row completed without failure (blue check affordance). */
 export function workEntryIndicatesToolSuccess(entry: WorkLogEntry): boolean {
+  // Reasoning is not a tool call; it must never claim the tool success
+  // affordance ("Completed" check).
+  if (entry.itemType === "reasoning") {
+    return false;
+  }
   if (!workLogEntryIsToolLike(entry)) {
     return false;
   }
@@ -290,6 +310,14 @@ export function workEntryIndicatesToolSuccess(entry: WorkLogEntry): boolean {
 
 /** Tool-like row with neither clear success nor failure (empty, incomplete, in progress, etc.). */
 export function workEntryIndicatesToolNeutralStatus(entry: WorkLogEntry): boolean {
+  // Reasoning rows have no tool outcome; the neutral filter would hide the
+  // live thinking row for the entire turn (in-progress rows classify as
+  // neutral and both timeline builders drop them). Reasoning items with no
+  // thinking text (e.g. redacted_thinking blocks) stay neutral so they are
+  // still hidden instead of rendering a bare "Reasoning" row.
+  if (entry.itemType === "reasoning") {
+    return (entry.detail?.trim().length ?? 0) === 0;
+  }
   // Spawn CTA rows are never neutral-hidden: mid-run they derive from
   // task.progress (tone "thinking") and the neutral filter was swallowing
   // them exactly while the fleet ran — the one moment they matter most.
@@ -1662,7 +1690,10 @@ function stripTrailingExitCode(value: string): {
 function extractWorkLogItemType(
   payload: Record<string, unknown> | null,
 ): WorkLogEntry["itemType"] | undefined {
-  if (typeof payload?.itemType === "string" && isToolLifecycleItemType(payload.itemType)) {
+  if (
+    typeof payload?.itemType === "string" &&
+    (isToolLifecycleItemType(payload.itemType) || payload.itemType === "reasoning")
+  ) {
     return payload.itemType;
   }
   return undefined;


### PR DESCRIPTION
## Problem

When using the Claude provider, thinking blocks never reach the UI (reported in #5542). The adapter ignores `content_block_start` for `thinking` blocks, so no item state is ever created for them; `thinking_delta` events go out as `reasoning_text` deltas **without an `itemId`**, leaving the client nothing to attach them to.

Two more layers compound it, for every provider:

- **Ingestion drops reasoning lifecycle events**: `item.started`/`item.updated`/`item.completed` with `itemType: "reasoning"` are discarded because only tool-lifecycle item types pass the guard.
- **The client has no reasoning work-entry type**, so nothing renders even if events arrive.

## Fix

**`ClaudeAdapter.ts`** — track thinking blocks like assistant text blocks:
- `content_block_start` (`thinking`/`redacted_thinking`) creates a reasoning block with a fresh `itemId` and emits `item.started` (`itemType: "reasoning"`, mirroring the Codex adapter's shape).
- `thinking_delta` attaches that stable `itemId` to each `reasoning_text` delta, accumulates the text, and emits throttled `item.updated` events carrying the accumulated thinking plus `data.toolCallId`, so clients collapse the update chain into one live row (same mechanism as tool output). The first update goes out as soon as any text exists — a size-only threshold would hold the first visible text hostage when upstream delivers thinking in sparse bursts.
- `content_block_stop` and turn end complete the block (`item.completed` with the full text as `detail`), so interrupted turns never strand an `inProgress` item.

**`ProviderRuntimeIngestion.ts`** — keep `itemType: "reasoning"` in the item lifecycle cases, with a 20k-char detail limit instead of the 180-char tool default (the thinking text is the payload, not a preview).

**Web** — accept `reasoning` work-log entries (collapse of the live update chain covered by a test) and give them a timeline icon.

## Tests

- `ClaudeAdapter.test.ts`: thinking blocks get a stable `itemId` across start/deltas/updates/completion, live updates are throttled, thinking never leaks into the assistant-message backfill. The pre-existing reasoning-delta test was updated (it encoded the old no-`itemId` behavior).
- `ProviderRuntimeIngestion.test.ts`: reasoning lifecycle events survive with full (untruncated) detail.
- `session-logic.test.ts`: the `tool.updated → tool.completed` reasoning chain collapses into one row with the final text.
- `MessagesTimeline.logic.test.ts`: unaffected; suite green.

`vp test run` for all touched files: 191 tests green; `tsgo --noEmit` clean on server + web.

Validated live against a real Claude Code CLI (Kimi K3 via an Anthropic-compatible endpoint): the Reasoning row appears mid-turn within seconds and grows as thinking streams.

## Update (2026-08-20): live-streaming UX fixes

Two follow-ups found by watching a real turn with slow, interleaved thinking:

- **Collapse by identity, not adjacency** (web `session-logic.ts`, mobile `threadActivity.ts`): Claude streams thinking deltas interleaved with `tool_call` input deltas, so adjacent-only folding split one reasoning block into a row per update whenever a tool call streamed in between — a tiny first-chunk row, then a separate full-text row. Rows carrying a `toolCallId` now merge into their first occurrence regardless of interleaving, and the anchor keeps its id/createdAt so the row grows in place under a stable key. The fuzzy collapseKey fallback stays adjacency-only (two identical commands an hour apart remain two rows), and a completed anchor never absorbs a late update (a stale one can't regress the final detail).
- **Unclamped reasoning body** (web `MessagesTimeline.tsx`, mobile `thread-work-log.tsx`): the expanded reasoning body shared the tool-output clamp (`max-h-64` with internal scroll on web, `max-h-60` ScrollView on mobile), so following live thinking meant scrolling a fixed 16rem box while the text grew past it. Reasoning rows now grow with the streamed text; tool outputs keep the clamp.

New tests: interleaved-collapse regression on web + mobile, two interleaved blocks stay separate rows, a late update after completion starts a fresh row instead of regressing the completed one. Verified against the full activity stream of a real turn: 32 reasoning rows collapse to 24 (one per block), each carrying its final text.

- **Codex reasoning surfaces too** (`CodexAdapter.ts`): Codex reasoning items arrived with their thinking in `item.summary` (a string array) that `itemDetail` never read, so the completed row persisted empty and the client hid it; the streaming `summaryTextDelta`/`textDelta` events went out as bare content deltas with no item identity. The adapter now lifts the summary/content text into the completed row's `detail`, stamps `data.toolCallId` on reasoning lifecycle events, and accumulates reasoning deltas per itemId into throttled `item.updated` events in the same renderable shape (title + `data.toolCallId`) the ingestion guard and the identity collapse expect. Verified live against codex-cli 0.148.0 (GPT-5.6, Responses API): the Reasoning row streams mid-turn and completes with the full summary text.

## Update (2026-08-22): rebuilt on current `main`

Rebuilt the eight PR-scoped commits on `2c4158f87` after upstream changed Codex tool outcomes and timeline grouping. The rebuilt series keeps upstream's native `failed` / `declined` statuses and final-call group failure semantics while preserving reasoning identity, streaming, deduplication, and web/mobile rendering. Local-only work-log settings remain outside this PR.

Validation on the rebuilt head:
- 347 focused adapter / ingestion / web / mobile tests pass
- server, web, and mobile typechecks pass
- thread HTTP/WebSocket transfer budget passes
- diff remains limited to the same 14 PR-scoped files

## Note

The pre-existing test at `ClaudeAdapter.test.ts` ("maps Claude reasoning deltas…") asserted the old drop-on-the-floor event sequence; updated to the corrected sequence. Happy to split the ingestion/client pieces into a follow-up PR if you'd rather land the adapter fix alone.

Done with Kimi K3 (Moonshot AI) via Claude Code, running inside T3 Code itself.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider event mapping, activity persistence, and work-log collapse identity across server, web, and mobile. Bugs here can duplicate, hide, or mis-merge timeline rows, but it does not change auth or data access.
> 
> **Overview**
> Claude thinking and Codex reasoning now stream as live **Reasoning** work-log rows (brain icon) instead of being dropped or split across interleaved tool updates.
> 
> **Adapters** mint a stable `itemId`/`data.toolCallId`, emit throttled `item.updated` every 512 chars (first chunk immediately), and complete open streams at block stop or turn end. Claude backfills thinking on synthetic turns without duplicating live blocks; Codex lifts `summary`/`content` into `detail` and seals open streams before turn complete/abort.
> 
> **Ingestion** persists `itemType: "reasoning"` with a 20k-char detail cap when a title is present; title-less Codex-shaped events stay dropped.
> 
> **Web and mobile** collapse by `tool:<turnId>:<toolCallId>` (not adjacency), keep the first row’s id so the block grows in place, skip failure/success heuristics on thinking text, exclude reasoning from “N tool calls” labels, and let expanded reasoning grow unclamped. Empty/redacted thinking stays hidden.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4315cadac0bfccd0cb4a72a7f47c184c5c977812. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render Claude and Codex thinking blocks as live reasoning items across server, web, and mobile
> - Server adapters now emit `item.started`, `item.updated`, and `item.completed` lifecycle events for reasoning blocks with stable `data.toolCallId`, throttled updates (~512 chars), and synthetic completion at turn end. See [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/7423/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc) and [CodexAdapter.ts](https://github.com/pingdotgg/t3code/pull/7423/files#diff-f37bcac225467446dcf6198df38d357c15304b19eebacbdcdea70047f507707d).
> - Runtime ingestion accepts `itemType === "reasoning"`, requires a title, and persists detail up to 20 000 chars. See [ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/7423/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7).
> - Web and mobile render reasoning rows with a `brain` icon, unclamped expanded body, and exclude them from the "N tool calls" group label. See [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/7423/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) and [thread-work-log.tsx](https://github.com/pingdotgg/t3code/pull/7423/files#diff-06f278f3ca8d6524ea378cdd0d5fea4e0a691986d150c0b93b43724ed8d40909).
> - Work-log collapsing now keys on `toolCallId` + `turnId`; reasoning rows are never flagged as failures or successes, and empty reasoning rows are filtered as neutral. See [session-logic.ts](https://github.com/pingdotgg/t3code/pull/7423/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) and [threadActivity.ts](https://github.com/pingdotgg/t3code/pull/7423/files#diff-a18e8ed6aa4a9d6b3d9e32ea2fa3034dfd7621b6af3d640ec1b95a8564c97eb5).
> - Risk: `toolLifecycleCollapseMapKey` in [session-logic.ts](https://github.com/pingdotgg/t3code/pull/7423/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) now requires both `toolCallId` and `turnId`; turnless lifecycle rows fall back to adjacency-based collapsing and may no longer merge across gaps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4315cad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
