### PR TITLE
feat(web): mark remote projects in the sidebar project picker

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -379,9 +379,11 @@ function SidebarThreadTooltip({
 function RemoteProjectBadge({
   desktopLocal,
   labels,
+  className,
 }: {
   desktopLocal: boolean;
   labels: readonly string[];
+  className?: string;
 }) {
   const prefix = desktopLocal ? "Sandbox" : "Remote";
   const label = labels.length > 0 ? `${prefix}: ${labels.join(", ")}` : prefix;
@@ -390,7 +392,10 @@ function RemoteProjectBadge({
     <Tooltip>
       <TooltipTrigger
         render={
-          <span aria-label={label} className="inline-flex shrink-0 items-center text-icon-muted" />
+          <span
+            aria-label={label}
+            className={cn("inline-flex shrink-0 items-center text-icon-muted", className)}
+          />
         }
       >
         <Icon aria-hidden className="size-3" />
@@ -3526,6 +3531,9 @@ export default function Sidebar() {
                       <RemoteProjectBadge
                         desktopLocal={scopedProjectGroup.allRemoteMembersAreDesktopLocal}
                         labels={scopedProjectGroup.remoteEnvironmentLabels}
+                        // Follow SidebarMenuButton's icon contract, which only
+                        // reaches direct svg children (ui/sidebar.tsx).
+                        className="text-[var(--sidebar-icon-color)] hover:text-sidebar-foreground"
                       />
                     ) : null}
                     <ChevronDownIcon className="-mr-px size-4 shrink-0" />

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -41,6 +41,7 @@ import {
   CircleCheckIcon,
   CircleDashedIcon,
   ClockIcon,
+  ContainerIcon,
   FolderIcon,
   FolderPlusIcon,
   GitBranchIcon,
@@ -73,6 +74,7 @@ import {
   settlePromise,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
+import { isDesktopLocalConnectionTarget } from "../connection/desktopLocal";
 import { isElectron } from "../env";
 import {
   resolveShortcutCommand,
@@ -366,6 +368,35 @@ function SidebarThreadTooltip({
         </div>
       </div>
     </TooltipPopup>
+  );
+}
+
+/**
+ * Marks a remote-environment project in the project scope picker with the
+ * ServerIcon thread rows use for remote threads; the machine name surfaces
+ * in the tooltip.
+ */
+function RemoteProjectBadge({
+  desktopLocal,
+  labels,
+}: {
+  desktopLocal: boolean;
+  labels: readonly string[];
+}) {
+  const prefix = desktopLocal ? "Sandbox" : "Remote";
+  const label = labels.length > 0 ? `${prefix}: ${labels.join(", ")}` : prefix;
+  const Icon = desktopLocal ? ContainerIcon : ServerIcon;
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span aria-label={label} className="inline-flex shrink-0 items-center text-icon-muted" />
+        }
+      >
+        <Icon aria-hidden className="size-3" />
+      </TooltipTrigger>
+      <TooltipPopup side="top">{label}</TooltipPopup>
+    </Tooltip>
   );
 }
 
@@ -1824,6 +1855,15 @@ export default function Sidebar() {
       ),
     [environments],
   );
+  const desktopLocalEnvironmentIds = useMemo(
+    () =>
+      new Set(
+        environments
+          .filter((environment) => isDesktopLocalConnectionTarget(environment.entry.target))
+          .map((environment) => environment.environmentId),
+      ),
+    [environments],
+  );
   const orderedProjects = useMemo(
     () =>
       orderItemsByPreferredIds({
@@ -1844,8 +1884,10 @@ export default function Sidebar() {
         settings: projectGroupingSettings,
         primaryEnvironmentId,
         resolveEnvironmentLabel: (environmentId) => environmentLabelById.get(environmentId) ?? null,
+        isDesktopLocalEnvironment: (environmentId) => desktopLocalEnvironmentIds.has(environmentId),
       }),
     [
+      desktopLocalEnvironmentIds,
       environmentLabelById,
       orderedProjects,
       primaryEnvironmentId,
@@ -3480,6 +3522,12 @@ export default function Sidebar() {
                     <span className="min-w-0 flex-1 truncate">
                       {scopedProjectGroup?.displayName ?? "All projects"}
                     </span>
+                    {scopedProjectGroup?.environmentPresence === "remote-only" ? (
+                      <RemoteProjectBadge
+                        desktopLocal={scopedProjectGroup.allRemoteMembersAreDesktopLocal}
+                        labels={scopedProjectGroup.remoteEnvironmentLabels}
+                      />
+                    ) : null}
                     <ChevronDownIcon className="-mr-px size-4 shrink-0" />
                   </MenuTrigger>
                   <MenuPopup align="start" className="w-(--anchor-width)">
@@ -3513,19 +3561,27 @@ export default function Sidebar() {
                               className="size-4 shrink-0"
                             />
                             <span className="min-w-0 truncate text-sm">{project.displayName}</span>
-                            <Button
-                              size="icon-xs"
-                              variant="ghost-muted"
-                              aria-label={`Project settings for ${project.displayName}`}
-                              title={`Project settings for ${project.displayName}`}
-                              className="ml-auto size-6 [--control-icon-color:currentColor] text-icon-muted focus-visible:bg-accent focus-visible:text-foreground"
-                              onPointerDown={(event) => event.stopPropagation()}
-                              onClick={(event) => {
-                                void handleProjectSettings(event, project);
-                              }}
-                            >
-                              <SettingsIcon className="size-3.5" />
-                            </Button>
+                            <span className="ml-auto flex shrink-0 items-center">
+                              {project.environmentPresence === "remote-only" ? (
+                                <RemoteProjectBadge
+                                  desktopLocal={project.allRemoteMembersAreDesktopLocal}
+                                  labels={project.remoteEnvironmentLabels}
+                                />
+                              ) : null}
+                              <Button
+                                size="icon-xs"
+                                variant="ghost-muted"
+                                aria-label={`Project settings for ${project.displayName}`}
+                                title={`Project settings for ${project.displayName}`}
+                                className="size-6 [--control-icon-color:currentColor] text-icon-muted focus-visible:bg-accent focus-visible:text-foreground"
+                                onPointerDown={(event) => event.stopPropagation()}
+                                onClick={(event) => {
+                                  void handleProjectSettings(event, project);
+                                }}
+                              >
+                                <SettingsIcon className="size-3.5" />
+                              </Button>
+                            </span>
                           </MenuRadioItem>
                         );
                       })}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3510,7 +3510,7 @@ export default function Sidebar() {
                     render={
                       <SidebarMenuButton
                         aria-label="Filter threads by project"
-                        className="min-w-0 flex-1 ps-[calc(var(--sidebar-row-content-inset)-1px)] focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
+                        className="group/project-scope min-w-0 flex-1 ps-[calc(var(--sidebar-row-content-inset)-1px)] focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar"
                       />
                     }
                   >
@@ -3532,8 +3532,9 @@ export default function Sidebar() {
                         desktopLocal={scopedProjectGroup.allRemoteMembersAreDesktopLocal}
                         labels={scopedProjectGroup.remoteEnvironmentLabels}
                         // Follow SidebarMenuButton's icon contract, which only
-                        // reaches direct svg children (ui/sidebar.tsx).
-                        className="text-[var(--sidebar-icon-color)] hover:text-sidebar-foreground"
+                        // reaches direct svg children (ui/sidebar.tsx), keyed
+                        // off the button's own hover/active states.
+                        className="text-[var(--sidebar-icon-color)] group-hover/project-scope:text-sidebar-foreground group-active/project-scope:text-sidebar-foreground"
                       />
                     ) : null}
                     <ChevronDownIcon className="-mr-px size-4 shrink-0" />


### PR DESCRIPTION
The sidebar's project scope picker rendered same-named projects from different environments identically, so with a remote environment connected there was no way to tell the local `projects` from the remote one.

Now projects living on a remote environment carry the same ServerIcon thread rows use for remote threads, right-aligned beside the project settings button, with the environment name in a styled tooltip (`Remote: <name>`). Desktop-local environments such as WSL show a container icon and `Sandbox: <name>` instead, reusing the `allRemoteMembersAreDesktopLocal` distinction the legacy sidebar's project headers already draw. The scope trigger shows the same badge when filtered to a remote project. Follows #7392, which added the same disambiguation to the new-thread picker.

## Screenshots

### Before

![Before](https://raw.githubusercontent.com/kevin-tritz/t3code/pr-assets-sidebar-remote-badge/before.png)

### After

![After](https://raw.githubusercontent.com/kevin-tritz/t3code/pr-assets-sidebar-remote-badge/after.png)

### Tooltip

![Tooltip](https://raw.githubusercontent.com/kevin-tritz/t3code/pr-assets-sidebar-remote-badge/after-tooltip.png)

## Verification

- Web typecheck, 0 errors
- Repo lint including the `no-native-title-tooltip` rule, 0 errors
- Sidebar logic focused tests, 103 passing
- Browser-verified in an isolated paired environment with a genuine second remote environment connected

Implemented by Claude Fable 5 through the Claude Code harness in T3 Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sidebar-only UI and labeling; no auth, data, or API changes.
> 
> **Overview**
> **Remote-only projects** in the sidebar project scope filter are now visually distinct from local ones, matching the new-thread picker behavior from #7392.
> 
> Adds `RemoteProjectBadge` with a tooltip (`Remote: …` or `Sandbox: …` for desktop-local targets like WSL). **Server** vs **container** icons align with remote thread rows and the legacy sidebar. The badge appears on the scoped filter trigger when a remote project is selected, and on each remote-only row in the dropdown beside the settings control. `buildSidebarProjectSnapshots` now receives `isDesktopLocalEnvironment` (from `isDesktopLocalConnectionTarget`) so snapshots expose `environmentPresence`, labels, and the desktop-local distinction for rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a4bdc5119a2d4a143c9f0d7095427d4023a18c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mark remote and desktop-local projects with a badge in the sidebar project picker
> - Adds a `RemoteProjectBadge` component in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/7429/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) that renders an icon and tooltip for remote-only projects, using `ContainerIcon` for desktop-local sandboxes and `ServerIcon` for generic remotes.
> - The badge appears in both the project scope button and the project scope menu list when a project group's `environmentPresence` is `'remote-only'`.
> - Desktop-local environments are detected via `isDesktopLocalConnectionTarget` and a memoized Set of IDs, passed down to `buildSidebarProjectSnapshots`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6a4bdc5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->