### PR TITLE
fix(web): use the styled tooltip for the sidebar project settings button

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3513,19 +3513,27 @@ export default function Sidebar() {
                               className="size-4 shrink-0"
                             />
                             <span className="min-w-0 truncate text-sm">{project.displayName}</span>
-                            <Button
-                              size="icon-xs"
-                              variant="ghost-muted"
-                              aria-label={`Project settings for ${project.displayName}`}
-                              title={`Project settings for ${project.displayName}`}
-                              className="ml-auto size-6 [--control-icon-color:currentColor] text-icon-muted focus-visible:bg-accent focus-visible:text-foreground"
-                              onPointerDown={(event) => event.stopPropagation()}
-                              onClick={(event) => {
-                                void handleProjectSettings(event, project);
-                              }}
-                            >
-                              <SettingsIcon className="size-3.5" />
-                            </Button>
+                            <Tooltip>
+                              <TooltipTrigger
+                                render={
+                                  <Button
+                                    size="icon-xs"
+                                    variant="ghost-muted"
+                                    aria-label={`Project settings for ${project.displayName}`}
+                                    className="ml-auto size-6 [--control-icon-color:currentColor] text-icon-muted focus-visible:bg-accent focus-visible:text-foreground"
+                                    onPointerDown={(event) => event.stopPropagation()}
+                                    onClick={(event) => {
+                                      void handleProjectSettings(event, project);
+                                    }}
+                                  >
+                                    <SettingsIcon className="size-3.5" />
+                                  </Button>
+                                }
+                              />
+                              <TooltipPopup side="top">
+                                {`Project settings for ${project.displayName}`}
+                              </TooltipPopup>
+                            </Tooltip>
                           </MenuRadioItem>
                         );
                       })}


### PR DESCRIPTION
#7209 migrated native title tooltips to the styled Tooltip and added the `t3code/no-native-title-tooltip` lint rule, but the rule can't see `title` passed through component props, so the project settings button in the sidebar's project picker kept the browser-native tooltip and clashes with the styled tooltips around it.

Now the button renders through `Tooltip`/`TooltipTrigger`/`TooltipPopup` like the rest of the app; the `aria-label` stays for screen readers. No behavior change beyond tooltip presentation.

## Screenshot

![Styled tooltip on the project settings button](https://raw.githubusercontent.com/kevin-tritz/t3code/pr-assets-sidebar-remote-badge/gear-tooltip.png)

(The before state is the OS-native tooltip, which doesn't render in-page and so can't be captured in a screenshot.)

## Verification

- Web typecheck, 0 errors
- Repo lint, 0 errors
- Browser-verified in an isolated paired environment

Implemented by Claude Fable 5 through the Claude Code harness in T3 Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only tooltip presentation in the sidebar; no auth, data, or navigation logic changes.
> 
> **Overview**
> Replaces the **browser-native `title` tooltip** on the project settings gear in the sidebar project picker with the app’s **`Tooltip` / `TooltipTrigger` / `TooltipPopup`** pattern, so it matches nearby controls after the styled-tooltip migration.
> 
> The **`title` prop is removed** from the settings `Button`; **`aria-label`** is unchanged for screen readers. Click behavior (`handleProjectSettings`, `stopPropagation` on pointer down) is the same—only hover hint presentation changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec99f82ab4ab9045ba6cb61aa09c04876f74cfe6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace browser title tooltip with styled tooltip on sidebar project settings button
> Wraps the project settings button in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/7430/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) with a `Tooltip` component, replacing the native browser `title` attribute with a `TooltipPopup` displaying "Project settings for ${project.displayName}". The `aria-label` is retained; only the tooltip presentation changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec99f82.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->