### PR TITLE
feat(web): add in-thread find

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,6 +39,7 @@
     "jszip": "3.10.1",
     "lexical": "^0.41.0",
     "lucide-react": "^0.564.0",
+    "mdast-util-to-string": "^4.0.0",
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "react-markdown": "^10.1.0",
@@ -46,7 +47,9 @@
     "rehype-sanitize": "^6.0.0",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
     "tailwind-merge": "^3.4.0",
+    "unified": "^11.0.5",
     "zustand": "^5.0.11"
   },
   "devDependencies": {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -3,8 +3,10 @@ import {
   computeStableMessagesTimelineRows,
   computeMessageDurationStart,
   deriveMessagesTimelineRows,
+  findCaseInsensitiveTextRanges,
   findTextMatches,
   normalizeCompactToolLabel,
+  renderMarkdownSearchText,
   resolveAssistantMessageCopyState,
   shouldPreserveAssistantLineBreaks,
 } from "./MessagesTimeline.logic";
@@ -17,6 +19,16 @@ describe("findTextMatches", () => {
       { textIndex: 2, occurrenceIndex: 0 },
     ]);
     expect(findTextMatches(["anything"], "")).toEqual([]);
+  });
+
+  it("uses original string offsets when case folding expands a Unicode character", () => {
+    expect(findCaseInsensitiveTextRanges("İstanbul", "İ")).toEqual([{ start: 0, end: 1 }]);
+  });
+
+  it("searches rendered Markdown text rather than hidden link destinations", () => {
+    const text = renderMarkdownSearchText("Read [the docs](https://example.com/hidden) now");
+    expect(findTextMatches([text], "docs")).toHaveLength(1);
+    expect(findTextMatches([text], "hidden")).toHaveLength(0);
   });
 });
 

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -3,10 +3,18 @@ import {
   computeStableMessagesTimelineRows,
   computeMessageDurationStart,
   deriveMessagesTimelineRows,
+  findTextMatches,
   normalizeCompactToolLabel,
   resolveAssistantMessageCopyState,
   shouldPreserveAssistantLineBreaks,
 } from "./MessagesTimeline.logic";
+
+describe("findTextMatches", () => {
+  it("finds every case-insensitive occurrence and returns its text index", () => {
+    expect(findTextMatches(["One one", null, "another ONE"], "one")).toEqual([0, 0, 2]);
+    expect(findTextMatches(["anything"], "")).toEqual([]);
+  });
+});
 
 describe("shouldPreserveAssistantLineBreaks", () => {
   it("preserves Claude insight formatting without changing regular markdown", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -10,8 +10,12 @@ import {
 } from "./MessagesTimeline.logic";
 
 describe("findTextMatches", () => {
-  it("finds every case-insensitive occurrence and returns its text index", () => {
-    expect(findTextMatches(["One one", null, "another ONE"], "one")).toEqual([0, 0, 2]);
+  it("finds every case-insensitive occurrence and identifies it within its text", () => {
+    expect(findTextMatches(["One one", null, "another ONE"], "one")).toEqual([
+      { textIndex: 0, occurrenceIndex: 0 },
+      { textIndex: 0, occurrenceIndex: 1 },
+      { textIndex: 2, occurrenceIndex: 0 },
+    ]);
     expect(findTextMatches(["anything"], "")).toEqual([]);
   });
 });

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -3,7 +3,7 @@ import {
   computeStableMessagesTimelineRows,
   computeMessageDurationStart,
   deriveMessagesTimelineRows,
-  findCaseInsensitiveTextRanges,
+  findTextRanges,
   findTextMatches,
   normalizeCompactToolLabel,
   renderMarkdownSearchText,
@@ -22,7 +22,16 @@ describe("findTextMatches", () => {
   });
 
   it("uses original string offsets when case folding expands a Unicode character", () => {
-    expect(findCaseInsensitiveTextRanges("İstanbul", "İ")).toEqual([{ start: 0, end: 1 }]);
+    expect(findTextRanges("İstanbul", "İ")).toEqual([{ start: 0, end: 1 }]);
+  });
+
+  it("optionally matches exact casing", () => {
+    expect(findTextMatches(["One one ONE"], "One", true)).toEqual([
+      { textIndex: 0, occurrenceIndex: 0 },
+    ]);
+    expect(findTextMatches(["One one ONE"], "one", true)).toEqual([
+      { textIndex: 0, occurrenceIndex: 0 },
+    ]);
   });
 
   it("searches rendered Markdown text rather than hidden link destinations", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -36,6 +36,12 @@ describe("findTextMatches", () => {
     expect(text).toBe("foobar");
     expect(findTextMatches([text], "oob")).toHaveLength(1);
   });
+
+  it("searches inline and fenced code in prompts and responses", () => {
+    const text = renderMarkdownSearchText("Run `pnpm test`:\n\n```ts\nconst answer = 42;\n```");
+    expect(findTextMatches([text], "pnpm test")).toHaveLength(1);
+    expect(findTextMatches([text], "answer = 42")).toHaveLength(1);
+  });
 });
 
 describe("shouldPreserveAssistantLineBreaks", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -30,6 +30,12 @@ describe("findTextMatches", () => {
     expect(findTextMatches([text], "docs")).toHaveLength(1);
     expect(findTextMatches([text], "hidden")).toHaveLength(0);
   });
+
+  it("preserves matches that span adjacent inline Markdown nodes", () => {
+    const text = renderMarkdownSearchText("**foo**bar");
+    expect(text).toBe("foobar");
+    expect(findTextMatches([text], "oob")).toHaveLength(1);
+  });
 });
 
 describe("shouldPreserveAssistantLineBreaks", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -262,7 +262,16 @@ export function renderMarkdownSearchText(markdown: string): string {
   return toString(markdownSearchTextProcessor.parse(markdown), { includeImageAlt: false });
 }
 
-export function findCaseInsensitiveTextRanges(text: string, query: string): TextRange[] {
+export function findTextRanges(text: string, query: string, caseSensitive = false): TextRange[] {
+  if (caseSensitive) {
+    if (!query) return [];
+    const ranges: TextRange[] = [];
+    for (let offset = 0; (offset = text.indexOf(query, offset)) !== -1; offset += query.length) {
+      ranges.push({ start: offset, end: offset + query.length });
+    }
+    return ranges;
+  }
+
   const normalizedOffsets: TextRange[] = [];
   let normalizedText = "";
   for (let start = 0; start < text.length; ) {
@@ -295,12 +304,13 @@ export function findCaseInsensitiveTextRanges(text: string, query: string): Text
 export function findTextMatches(
   texts: ReadonlyArray<string | null | undefined>,
   query: string,
+  caseSensitive = false,
 ): TextMatch[] {
   if (!query) return [];
 
   const matches: TextMatch[] = [];
   texts.forEach((text, textIndex) => {
-    findCaseInsensitiveTextRanges(text ?? "", query).forEach((_, occurrenceIndex) => {
+    findTextRanges(text ?? "", query, caseSensitive).forEach((_, occurrenceIndex) => {
       matches.push({ textIndex, occurrenceIndex });
     });
   });

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -1,4 +1,8 @@
 import * as Equal from "effect/Equal";
+import { toString } from "mdast-util-to-string";
+import remarkGfm from "remark-gfm";
+import remarkParse from "remark-parse";
+import { unified } from "unified";
 import {
   formatDuration,
   workEntryIndicatesToolNeutralStatus,
@@ -247,25 +251,58 @@ export interface TextMatch {
   readonly occurrenceIndex: number;
 }
 
+export interface TextRange {
+  readonly start: number;
+  readonly end: number;
+}
+
+const markdownSearchTextProcessor = unified().use(remarkParse).use(remarkGfm);
+
+export function renderMarkdownSearchText(markdown: string): string {
+  return toString(markdownSearchTextProcessor.parse(markdown), { includeImageAlt: false });
+}
+
+export function findCaseInsensitiveTextRanges(text: string, query: string): TextRange[] {
+  const normalizedOffsets: TextRange[] = [];
+  let normalizedText = "";
+  for (let start = 0; start < text.length; ) {
+    const codePoint = text.codePointAt(start)!;
+    const end = start + (codePoint > 0xffff ? 2 : 1);
+    const normalized = text.slice(start, end).toLowerCase();
+    normalizedText += normalized;
+    for (let index = 0; index < normalized.length; index += 1) {
+      normalizedOffsets.push({ start, end });
+    }
+    start = end;
+  }
+
+  const needle = query.toLowerCase();
+  if (!needle) return [];
+
+  const ranges: TextRange[] = [];
+  for (
+    let offset = 0;
+    (offset = normalizedText.indexOf(needle, offset)) !== -1;
+    offset += needle.length
+  ) {
+    const first = normalizedOffsets[offset];
+    const last = normalizedOffsets[offset + needle.length - 1];
+    if (first && last) ranges.push({ start: first.start, end: last.end });
+  }
+  return ranges;
+}
+
 export function findTextMatches(
   texts: ReadonlyArray<string | null | undefined>,
   query: string,
 ): TextMatch[] {
-  const needle = query.toLowerCase();
-  if (!needle) return [];
+  if (!query) return [];
 
   const matches: TextMatch[] = [];
   texts.forEach((text, textIndex) => {
-    const haystack = text?.toLowerCase() ?? "";
-    let occurrenceIndex = 0;
-    for (
-      let offset = 0;
-      (offset = haystack.indexOf(needle, offset)) !== -1;
-      offset += needle.length
-    ) {
+    findCaseInsensitiveTextRanges(text ?? "", query).forEach((_, occurrenceIndex) => {
       matches.push({ textIndex, occurrenceIndex });
-      occurrenceIndex += 1;
-    }
+    });
   });
   return matches;
 }

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -242,22 +242,29 @@ export function normalizeCompactToolLabel(value: string): string {
   return value.replace(/\s+(?:complete|completed)\s*$/i, "").trim();
 }
 
+export interface TextMatch {
+  readonly textIndex: number;
+  readonly occurrenceIndex: number;
+}
+
 export function findTextMatches(
   texts: ReadonlyArray<string | null | undefined>,
   query: string,
-): number[] {
+): TextMatch[] {
   const needle = query.toLowerCase();
   if (!needle) return [];
 
-  const matches: number[] = [];
-  texts.forEach((text, index) => {
+  const matches: TextMatch[] = [];
+  texts.forEach((text, textIndex) => {
     const haystack = text?.toLowerCase() ?? "";
+    let occurrenceIndex = 0;
     for (
       let offset = 0;
       (offset = haystack.indexOf(needle, offset)) !== -1;
       offset += needle.length
     ) {
-      matches.push(index);
+      matches.push({ textIndex, occurrenceIndex });
+      occurrenceIndex += 1;
     }
   });
   return matches;

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -242,6 +242,27 @@ export function normalizeCompactToolLabel(value: string): string {
   return value.replace(/\s+(?:complete|completed)\s*$/i, "").trim();
 }
 
+export function findTextMatches(
+  texts: ReadonlyArray<string | null | undefined>,
+  query: string,
+): number[] {
+  const needle = query.toLowerCase();
+  if (!needle) return [];
+
+  const matches: number[] = [];
+  texts.forEach((text, index) => {
+    const haystack = text?.toLowerCase() ?? "";
+    for (
+      let offset = 0;
+      (offset = haystack.indexOf(needle, offset)) !== -1;
+      offset += needle.length
+    ) {
+      matches.push(index);
+    }
+  });
+  return matches;
+}
+
 export function resolveAssistantMessageCopyState({
   text,
   showCopyButton,

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -68,6 +68,7 @@ import {
   ZapIcon,
 } from "lucide-react";
 import { Button } from "../ui/button";
+import { InputGroup, InputGroupAddon, InputGroupInput } from "../ui/input-group";
 import { buildExpandedImagePreview, ExpandedImagePreview } from "./ExpandedImagePreview";
 import { ProposedPlanCard } from "./ProposedPlanCard";
 import { ChangedFilesCard } from "./ChangedFilesTree";
@@ -428,21 +429,25 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   const [findQuery, setFindQuery] = useState("");
   const [findMatchIndex, setFindMatchIndex] = useState(0);
   const findInputRef = useRef<HTMLInputElement>(null);
+  const [timelineViewportElement, setTimelineViewportElement] = useState<HTMLDivElement | null>(
+    null,
+  );
+  const findMessageEntries = useMemo(
+    () => timelineEntries.filter((entry) => entry.kind === "message"),
+    [timelineEntries],
+  );
   const findTexts = useMemo(
-    () => rows.map((row) => (row.kind === "message" ? row.message.text : null)),
-    [rows],
+    () => findMessageEntries.map((entry) => entry.message.text),
+    [findMessageEntries],
   );
   const findMatches = useMemo(() => findTextMatches(findTexts, findQuery), [findQuery, findTexts]);
   const updateFindQuery = useCallback(
     (query: string) => {
       setFindQuery(query);
       setFindMatchIndex(0);
-      const firstMatch = findTextMatches(findTexts, query)[0];
-      if (firstMatch === undefined) return;
-      onManualNavigation();
-      void listRef.current?.scrollToIndex({ index: firstMatch, animated: false, viewOffset: 80 });
+      if (findTextMatches(findTexts, query).length > 0) onManualNavigation();
     },
-    [findTexts, listRef, onManualNavigation],
+    [findTexts, onManualNavigation],
   );
   const goToFindMatch = useCallback(
     (delta: number) => {
@@ -450,13 +455,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       const next = (findMatchIndex + delta + findMatches.length) % findMatches.length;
       setFindMatchIndex(next);
       onManualNavigation();
-      void listRef.current?.scrollToIndex({
-        index: findMatches[next]!,
-        animated: false,
-        viewOffset: 80,
-      });
     },
-    [findMatchIndex, findMatches, listRef, onManualNavigation],
+    [findMatchIndex, findMatches, onManualNavigation],
   );
 
   useEffect(() => {
@@ -466,7 +466,15 @@ export const MessagesTimeline = memo(function MessagesTimeline({
         (!event.metaKey && !event.ctrlKey) ||
         event.altKey ||
         event.shiftKey ||
-        (event.target instanceof Element && event.target.closest("[data-terminal-owner]"))
+        !timelineViewportElement ||
+        timelineViewportElement.getBoundingClientRect().width === 0 ||
+        timelineViewportElement.closest('[data-chat-column-maximized-away="true"]') ||
+        (event.target instanceof Element &&
+          event.target !== document.body &&
+          (event.target.closest("[data-terminal-owner]") ||
+            !timelineViewportElement
+              .closest("[data-chat-column-maximized-away]")
+              ?.contains(event.target)))
       ) {
         return;
       }
@@ -476,7 +484,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     };
     window.addEventListener("keydown", handleFindShortcut, true);
     return () => window.removeEventListener("keydown", handleFindShortcut, true);
-  }, []);
+  }, [timelineViewportElement]);
 
   useEffect(() => {
     if (!findOpen) return;
@@ -486,14 +494,26 @@ export const MessagesTimeline = memo(function MessagesTimeline({
 
   useEffect(() => {
     CSS.highlights.delete(THREAD_FIND_HIGHLIGHT);
-    const rowIndex = findMatches[findMatchIndex];
-    const rowId = rowIndex === undefined ? undefined : rows[rowIndex]?.id;
-    if (!findOpen || !findQuery || !rowId) return;
+    const match = findMatches[findMatchIndex];
+    const entry = match === undefined ? undefined : findMessageEntries[match.textIndex];
+    if (!findOpen || !findQuery || !match || !entry) return;
+
+    const rowIndex = rows.findIndex((row) => row.id === entry.id);
+    if (rowIndex === -1) {
+      const turnId = entry.message.turnId;
+      if (turnId && !expandedTurnIds.has(turnId)) {
+        suspendEndScrollMaintenanceForDisclosure(`turn-fold:${turnId}`);
+        setExpandedTurnIds((existing) => new Set(existing).add(turnId));
+      }
+      return;
+    }
+
+    void listRef.current?.scrollToIndex({ index: rowIndex, animated: false, viewOffset: 80 });
 
     let paintFrame = 0;
     const mountFrame = requestAnimationFrame(() => {
       paintFrame = requestAnimationFrame(() => {
-        const root = document.querySelector(`[data-timeline-row-id="${CSS.escape(rowId)}"]`);
+        const root = document.querySelector(`[data-timeline-row-id="${CSS.escape(entry.id)}"]`);
         if (!root) return;
 
         const ranges: Range[] = [];
@@ -512,7 +532,22 @@ export const MessagesTimeline = memo(function MessagesTimeline({
             ranges.push(range);
           }
         }
-        CSS.highlights.set(THREAD_FIND_HIGHLIGHT, new Highlight(...ranges));
+        const activeRange = ranges[match.occurrenceIndex];
+        if (!activeRange) return;
+        CSS.highlights.set(THREAD_FIND_HIGHLIGHT, new Highlight(activeRange));
+
+        let scrollParent = root.parentElement;
+        while (scrollParent && !/(auto|scroll)/u.test(getComputedStyle(scrollParent).overflowY)) {
+          scrollParent = scrollParent.parentElement;
+        }
+        if (scrollParent) {
+          const matchRect = activeRange.getBoundingClientRect();
+          const viewportRect = scrollParent.getBoundingClientRect();
+          if (matchRect.top < viewportRect.top || matchRect.bottom > viewportRect.bottom) {
+            scrollParent.scrollTop +=
+              matchRect.top - viewportRect.top - scrollParent.clientHeight / 2;
+          }
+        }
       });
     });
     return () => {
@@ -520,11 +555,18 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       cancelAnimationFrame(paintFrame);
       CSS.highlights.delete(THREAD_FIND_HIGHLIGHT);
     };
-  }, [findMatchIndex, findMatches, findOpen, findQuery, rows]);
+  }, [
+    expandedTurnIds,
+    findMatchIndex,
+    findMatches,
+    findMessageEntries,
+    findOpen,
+    findQuery,
+    listRef,
+    rows,
+    suspendEndScrollMaintenanceForDisclosure,
+  ]);
   const minimapItems = useMemo(() => deriveTimelineMinimapItems(rows), [rows]);
-  const [timelineViewportElement, setTimelineViewportElement] = useState<HTMLDivElement | null>(
-    null,
-  );
   const [minimapHasPersistentGutter, setMinimapHasPersistentGutter] = useState(false);
   const [minimapHitStripWidth, setMinimapHitStripWidth] = useState(0);
   const handleAnchorReady = useCallback(
@@ -675,9 +717,11 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       <TimelineRowActivityCtx value={activityState}>
         <div ref={setTimelineViewportElement} className="relative h-full min-h-0">
           {findOpen ? (
-            <div className="absolute right-4 top-3 z-30 flex h-9 items-center gap-1 rounded-lg border bg-background/95 px-2 shadow-lg backdrop-blur">
-              <SearchIcon className="size-3.5 text-muted-foreground" aria-hidden="true" />
-              <input
+            <InputGroup className="surface-glass absolute right-4 top-3 z-30 h-9 w-auto shadow-lg">
+              <InputGroupAddon>
+                <SearchIcon aria-hidden="true" />
+              </InputGroupAddon>
+              <InputGroupInput
                 ref={findInputRef}
                 value={findQuery}
                 onChange={(event) => updateFindQuery(event.target.value)}
@@ -687,43 +731,45 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                 }}
                 aria-label="Find in thread"
                 placeholder="Find in thread"
-                className="w-48 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+                className="w-48"
               />
-              <span className="min-w-12 text-center text-xs text-muted-foreground">
-                {findQuery
-                  ? `${findMatches.length ? findMatchIndex + 1 : 0}/${findMatches.length}`
-                  : ""}
-              </span>
-              <Button
-                type="button"
-                size="icon-xs"
-                variant="ghost"
-                disabled={findMatches.length === 0}
-                aria-label="Previous match"
-                onClick={() => goToFindMatch(-1)}
-              >
-                <ChevronUpIcon />
-              </Button>
-              <Button
-                type="button"
-                size="icon-xs"
-                variant="ghost"
-                disabled={findMatches.length === 0}
-                aria-label="Next match"
-                onClick={() => goToFindMatch(1)}
-              >
-                <ChevronDownIcon />
-              </Button>
-              <Button
-                type="button"
-                size="icon-xs"
-                variant="ghost"
-                aria-label="Close find"
-                onClick={() => setFindOpen(false)}
-              >
-                <XIcon />
-              </Button>
-            </div>
+              <InputGroupAddon align="inline-end" className="gap-1">
+                <span className="min-w-12 text-center text-xs text-muted-foreground">
+                  {findQuery
+                    ? `${findMatches.length ? findMatchIndex + 1 : 0}/${findMatches.length}`
+                    : ""}
+                </span>
+                <Button
+                  type="button"
+                  size="icon-xs"
+                  variant="ghost"
+                  disabled={findMatches.length === 0}
+                  aria-label="Previous match"
+                  onClick={() => goToFindMatch(-1)}
+                >
+                  <ChevronUpIcon />
+                </Button>
+                <Button
+                  type="button"
+                  size="icon-xs"
+                  variant="ghost"
+                  disabled={findMatches.length === 0}
+                  aria-label="Next match"
+                  onClick={() => goToFindMatch(1)}
+                >
+                  <ChevronDownIcon />
+                </Button>
+                <Button
+                  type="button"
+                  size="icon-xs"
+                  variant="ghost"
+                  aria-label="Close find"
+                  onClick={() => setFindOpen(false)}
+                >
+                  <XIcon />
+                </Button>
+              </InputGroupAddon>
+            </InputGroup>
           ) : null}
           <LegendList<MessagesTimelineRow>
             ref={listRef}

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -726,7 +726,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       <TimelineRowActivityCtx value={activityState}>
         <div ref={setTimelineViewportElement} className="relative h-full min-h-0">
           {findOpen ? (
-            <InputGroup className="absolute right-4 top-3 z-30 w-auto shadow-lg **:[input]:w-48">
+            <InputGroup className="absolute right-4 top-3 z-30 w-auto shadow-lg dark:bg-background **:[input]:w-48">
               <InputGroupAddon>
                 <SearchIcon aria-hidden="true" />
               </InputGroupAddon>

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -804,8 +804,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       <TimelineRowActivityCtx value={activityState}>
         <div ref={setTimelineViewportElement} className="relative h-full min-h-0">
           {findOpen ? (
-            <div className="absolute inset-x-4 top-3 z-30 rounded-[var(--control-radius)] shadow-lg">
-              <InputGroup className="ml-auto w-full max-w-sm dark:bg-background">
+            <div className="absolute right-4 top-3 z-30 w-[calc(100%-2rem)] max-w-sm rounded-[var(--control-radius)] shadow-lg">
+              <InputGroup className="w-full dark:bg-background">
                 <InputGroupAddon>
                   <SearchIcon aria-hidden="true" />
                 </InputGroupAddon>

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -804,8 +804,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       <TimelineRowActivityCtx value={activityState}>
         <div ref={setTimelineViewportElement} className="relative h-full min-h-0">
           {findOpen ? (
-            <div className="absolute right-4 top-3 z-30 rounded-[var(--control-radius)] shadow-lg">
-              <InputGroup className="w-auto dark:bg-background **:[input]:w-48">
+            <div className="absolute inset-x-4 top-3 z-30 rounded-[var(--control-radius)] shadow-lg">
+              <InputGroup className="ml-auto w-full max-w-sm dark:bg-background">
                 <InputGroupAddon>
                   <SearchIcon aria-hidden="true" />
                 </InputGroupAddon>

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -151,6 +151,7 @@ interface TimelineRowSharedState {
   onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
   onToggleTurnFold: (turnId: TurnId) => void;
   onToggleWorkGroup: (groupId: string, anchorKey: string) => void;
+  activeFindMessageId: MessageId | null;
   agentPanelModel: AgentPanelModel;
   onOpenAgents: () => void;
 }
@@ -451,6 +452,10 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     [findCaseSensitive, findQuery, findTexts],
   );
   const findMatchIndex = Math.min(findMatchCursor, Math.max(0, findMatches.length - 1));
+  const activeFindMessageId =
+    findOpen && findQuery
+      ? (findMessageEntries[findMatches[findMatchIndex]?.textIndex ?? -1]?.message.id ?? null)
+      : null;
   const updateFindQuery = useCallback(
     (query: string) => {
       setFindQuery(query);
@@ -746,6 +751,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       onOpenTurnDiff,
       onToggleTurnFold,
       onToggleWorkGroup,
+      activeFindMessageId,
       agentPanelModel,
       onOpenAgents,
     }),
@@ -762,6 +768,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       onOpenTurnDiff,
       onToggleTurnFold,
       onToggleWorkGroup,
+      activeFindMessageId,
       agentPanelModel,
       onOpenAgents,
     ],
@@ -824,7 +831,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                     pressed={findCaseSensitive}
                     size="xs"
                     variant="primary"
-                    className="font-mono text-[11px]"
+                    className="font-mono text-[11px] sm:text-[11px]"
                     aria-label="Match case"
                     title="Match case"
                     onPressedChange={(pressed) => {
@@ -1333,6 +1340,7 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
           terminalContexts={terminalContexts}
           skills={ctx.skills}
           markdownCwd={ctx.markdownCwd}
+          forceExpanded={ctx.activeFindMessageId === row.message.id}
         />
       </div>
       <div className="flex w-full max-w-[80%] items-center justify-end pe-1 text-xs tabular-nums opacity-0 transition-opacity duration-200 focus-within:opacity-100 group-hover:opacity-100">
@@ -1902,9 +1910,13 @@ const CollapsibleUserMessageBody = memo(function CollapsibleUserMessageBody(prop
   terminalContexts: ParsedTerminalContextEntry[];
   skills: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">>;
   markdownCwd: string | undefined;
+  forceExpanded?: boolean;
   footer?: ReactNode;
 }) {
   const [expanded, setExpanded] = useState(false);
+  useEffect(() => {
+    if (props.forceExpanded) setExpanded(true);
+  }, [props.forceExpanded]);
   const hasVisibleBody = props.text.trim().length > 0 || props.terminalContexts.length > 0;
   const canCollapse = hasVisibleBody && shouldCollapseUserMessage(props.text);
   const isCollapsed = canCollapse && !expanded;

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -69,7 +69,6 @@ import {
   ZapIcon,
 } from "lucide-react";
 import { Button } from "../ui/button";
-import { Checkbox } from "../ui/checkbox";
 import { InputGroup, InputGroupAddon, InputGroupInput } from "../ui/input-group";
 import { buildExpandedImagePreview, ExpandedImagePreview } from "./ExpandedImagePreview";
 import { ProposedPlanCard } from "./ProposedPlanCard";
@@ -473,19 +472,37 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     const handleFindShortcut = (event: globalThis.KeyboardEvent) => {
       const key = event.key.toLowerCase();
       if (
-        (key !== "f" && key !== "g") ||
-        (!event.metaKey && !event.ctrlKey) ||
-        event.altKey ||
         !timelineViewportElement ||
         timelineViewportElement.getBoundingClientRect().width === 0 ||
-        timelineViewportElement.closest('[data-chat-column-maximized-away="true"]') ||
-        (event.target instanceof Element &&
-          event.target !== document.body &&
-          (event.target.closest("[data-terminal-owner]") ||
-            !timelineViewportElement
-              .closest("[data-chat-column-maximized-away]")
-              ?.contains(event.target)))
+        timelineViewportElement.closest('[data-chat-column-maximized-away="true"]')
       ) {
+        return;
+      }
+
+      if (key === "escape") {
+        if (
+          !findOpen ||
+          (event.target instanceof Element &&
+            event.target.closest('[role="dialog"], [data-terminal-owner]'))
+        ) {
+          return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        setFindOpen(false);
+        return;
+      }
+      if (
+        event.target instanceof Element &&
+        event.target !== document.body &&
+        (event.target.closest("[data-terminal-owner]") ||
+          !timelineViewportElement
+            .closest("[data-chat-column-maximized-away]")
+            ?.contains(event.target))
+      ) {
+        return;
+      }
+      if ((key !== "f" && key !== "g") || (!event.metaKey && !event.ctrlKey) || event.altKey) {
         return;
       }
 
@@ -797,24 +814,27 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                   onChange={(event) => updateFindQuery(event.target.value)}
                   onKeyDown={(event) => {
                     if (event.key === "Enter") goToFindMatch(event.shiftKey ? -1 : 1);
-                    if (event.key === "Escape") setFindOpen(false);
                   }}
                   aria-label="Find in thread"
                   placeholder="Find in thread"
                 />
                 <InputGroupAddon align="inline-end" className="gap-1">
-                  <label className="flex cursor-pointer items-center gap-1 text-xs text-muted-foreground">
-                    <Checkbox
-                      checked={findCaseSensitive}
-                      onCheckedChange={(checked) => {
-                        setFindCaseSensitive(checked === true);
-                        setFindMatchIndex(0);
-                        onManualNavigation();
-                      }}
-                      aria-label="Match case"
-                    />
-                    Match case
-                  </label>
+                  <Button
+                    type="button"
+                    size="icon-xs"
+                    variant="ghost"
+                    data-pressed={findCaseSensitive || undefined}
+                    aria-label="Match case"
+                    aria-pressed={findCaseSensitive}
+                    title="Match case"
+                    onClick={() => {
+                      setFindCaseSensitive(!findCaseSensitive);
+                      setFindMatchIndex(0);
+                      onManualNavigation();
+                    }}
+                  >
+                    <span className="text-[11px] font-semibold leading-none">Aa</span>
+                  </Button>
                   <span className="min-w-12 text-center text-xs text-muted-foreground">
                     {findQuery
                       ? `${findMatches.length ? findMatchIndex + 1 : 0}/${findMatches.length}`

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -518,20 +518,31 @@ export const MessagesTimeline = memo(function MessagesTimeline({
         const root = document.querySelector(`[data-timeline-row-id="${CSS.escape(entry.id)}"]`);
         if (!root) return;
 
-        const ranges: Range[] = [];
         const needle = findQuery.toLowerCase();
         const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+        const textNodes: Array<{ node: Text; start: number; end: number }> = [];
+        let text = "";
         for (let node = walker.nextNode(); node; node = walker.nextNode()) {
-          const text = node.textContent ?? "";
-          for (const { start, end } of findCaseInsensitiveTextRanges(text, needle)) {
-            const range = new Range();
-            range.setStart(node, start);
-            range.setEnd(node, end);
-            ranges.push(range);
-          }
+          const value = node.textContent ?? "";
+          textNodes.push({
+            node: node as Text,
+            start: text.length,
+            end: text.length + value.length,
+          });
+          text += value;
         }
-        const activeRange = ranges[match.occurrenceIndex];
-        if (!activeRange) return;
+        const activeMatch = findCaseInsensitiveTextRanges(text, needle)[match.occurrenceIndex];
+        if (!activeMatch) return;
+        const startNode = textNodes.find(
+          ({ start, end }) => start <= activeMatch.start && activeMatch.start < end,
+        );
+        const endNode = textNodes.find(
+          ({ start, end }) => start < activeMatch.end && activeMatch.end <= end,
+        );
+        if (!startNode || !endNode) return;
+        const activeRange = new Range();
+        activeRange.setStart(startNode.node, activeMatch.start - startNode.start);
+        activeRange.setEnd(endNode.node, activeMatch.end - endNode.start);
         CSS.highlights.set(THREAD_FIND_HIGHLIGHT, new Highlight(activeRange));
 
         let scrollParent = root.parentElement;

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -69,6 +69,7 @@ import {
   ZapIcon,
 } from "lucide-react";
 import { Button } from "../ui/button";
+import { Checkbox } from "../ui/checkbox";
 import { InputGroup, InputGroupAddon, InputGroupInput } from "../ui/input-group";
 import { buildExpandedImagePreview, ExpandedImagePreview } from "./ExpandedImagePreview";
 import { ProposedPlanCard } from "./ProposedPlanCard";
@@ -78,7 +79,7 @@ import { MessageCopyButton } from "./MessageCopyButton";
 import {
   computeStableMessagesTimelineRows,
   deriveMessagesTimelineRows,
-  findCaseInsensitiveTextRanges,
+  findTextRanges,
   findTextMatches,
   normalizeCompactToolLabel,
   renderMarkdownSearchText,
@@ -431,6 +432,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   const rows = useStableRows(rawRows);
   const [findOpen, setFindOpen] = useState(false);
   const [findQuery, setFindQuery] = useState("");
+  const [findCaseSensitive, setFindCaseSensitive] = useState(false);
   const [findMatchCursor, setFindMatchIndex] = useState(0);
   const findInputRef = useRef<HTMLInputElement>(null);
   const [timelineViewportElement, setTimelineViewportElement] = useState<HTMLDivElement | null>(
@@ -444,15 +446,18 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     () => findMessageEntries.map((entry) => renderMarkdownSearchText(entry.message.text)),
     [findMessageEntries],
   );
-  const findMatches = useMemo(() => findTextMatches(findTexts, findQuery), [findQuery, findTexts]);
+  const findMatches = useMemo(
+    () => findTextMatches(findTexts, findQuery, findCaseSensitive),
+    [findCaseSensitive, findQuery, findTexts],
+  );
   const findMatchIndex = Math.min(findMatchCursor, Math.max(0, findMatches.length - 1));
   const updateFindQuery = useCallback(
     (query: string) => {
       setFindQuery(query);
       setFindMatchIndex(0);
-      if (findTextMatches(findTexts, query).length > 0) onManualNavigation();
+      if (findTextMatches(findTexts, query, findCaseSensitive).length > 0) onManualNavigation();
     },
-    [findTexts, onManualNavigation],
+    [findCaseSensitive, findTexts, onManualNavigation],
   );
   const goToFindMatch = useCallback(
     (delta: number) => {
@@ -554,9 +559,10 @@ export const MessagesTimeline = memo(function MessagesTimeline({
           });
           text += value;
         }
-        for (const [occurrenceIndex, textRange] of findCaseInsensitiveTextRanges(
+        for (const [occurrenceIndex, textRange] of findTextRanges(
           text,
           findQuery,
+          findCaseSensitive,
         ).entries()) {
           const startNode = textNodes.find(
             ({ start, end }) => start <= textRange.start && textRange.start < end,
@@ -618,6 +624,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     };
   }, [
     expandedTurnIds,
+    findCaseSensitive,
     findMatchIndex,
     findMatches,
     findMessageEntries,
@@ -796,6 +803,18 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                   placeholder="Find in thread"
                 />
                 <InputGroupAddon align="inline-end" className="gap-1">
+                  <label className="flex cursor-pointer items-center gap-1 text-xs text-muted-foreground">
+                    <Checkbox
+                      checked={findCaseSensitive}
+                      onCheckedChange={(checked) => {
+                        setFindCaseSensitive(checked === true);
+                        setFindMatchIndex(0);
+                        onManualNavigation();
+                      }}
+                      aria-label="Match case"
+                    />
+                    Match case
+                  </label>
                   <span className="min-w-12 text-center text-xs text-muted-foreground">
                     {findQuery
                       ? `${findMatches.length ? findMatchIndex + 1 : 0}/${findMatches.length}`

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -39,6 +39,7 @@ import {
   workLogEntryIsToolLike,
 } from "../../session-logic";
 import { type TurnDiffSummary } from "../../types";
+import { isElectron } from "../../env";
 import {
   getRenderablePatch,
   resolveDiffThemeName,
@@ -195,6 +196,7 @@ function TimelineLoadEarlierHeader({
 }
 const TIMELINE_LIST_FOOTER = <div className="h-3 sm:h-4" />;
 const THREAD_FIND_HIGHLIGHT = "thread-find";
+const THREAD_FIND_ACTIVE_HIGHLIGHT = "thread-find-active";
 const EMPTY_TIMELINE_SKILLS: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">> = [];
 const TIMELINE_MAINTAIN_SCROLL_AT_END = {
   animated: false,
@@ -464,11 +466,11 @@ export const MessagesTimeline = memo(function MessagesTimeline({
 
   useEffect(() => {
     const handleFindShortcut = (event: globalThis.KeyboardEvent) => {
+      const key = event.key.toLowerCase();
       if (
-        event.key.toLowerCase() !== "f" ||
+        (key !== "f" && key !== "g") ||
         (!event.metaKey && !event.ctrlKey) ||
         event.altKey ||
-        event.shiftKey ||
         !timelineViewportElement ||
         timelineViewportElement.getBoundingClientRect().width === 0 ||
         timelineViewportElement.closest('[data-chat-column-maximized-away="true"]') ||
@@ -481,13 +483,28 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       ) {
         return;
       }
+
+      const inputFocused = document.activeElement === findInputRef.current;
+      if (key === "g") {
+        if (!findOpen || inputFocused) return;
+        event.preventDefault();
+        event.stopPropagation();
+        goToFindMatch(event.shiftKey ? -1 : 1);
+        return;
+      }
+      if (event.shiftKey || (!isElectron && findOpen && inputFocused)) return;
+
       event.preventDefault();
       event.stopPropagation();
-      setFindOpen(true);
+      if (findOpen) {
+        findInputRef.current?.focus();
+      } else {
+        setFindOpen(true);
+      }
     };
     window.addEventListener("keydown", handleFindShortcut, true);
     return () => window.removeEventListener("keydown", handleFindShortcut, true);
-  }, [timelineViewportElement]);
+  }, [findOpen, goToFindMatch, timelineViewportElement]);
 
   useEffect(() => {
     if (!findOpen) return;
@@ -497,9 +514,10 @@ export const MessagesTimeline = memo(function MessagesTimeline({
 
   useEffect(() => {
     CSS.highlights.delete(THREAD_FIND_HIGHLIGHT);
+    CSS.highlights.delete(THREAD_FIND_ACTIVE_HIGHLIGHT);
     const match = findMatches[findMatchIndex];
     const entry = match === undefined ? undefined : findMessageEntries[match.textIndex];
-    if (!findOpen || !findQuery || !match || !entry) return;
+    if (!findOpen || !findQuery || !match || !entry || !timelineViewportElement) return;
 
     const rowIndex = rows.findIndex((row) => row.id === entry.id);
     if (rowIndex === -1) {
@@ -514,12 +532,16 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     void listRef.current?.scrollToIndex({ index: rowIndex, animated: false, viewOffset: 80 });
 
     let paintFrame = 0;
-    const mountFrame = requestAnimationFrame(() => {
-      paintFrame = requestAnimationFrame(() => {
-        const root = document.querySelector(`[data-timeline-row-id="${CSS.escape(entry.id)}"]`);
-        if (!root) return;
+    let repaintFrame = 0;
+    const paintHighlights = () => {
+      const allRanges: Range[] = [];
+      let activeRange: Range | undefined;
+      for (const [textIndex, messageEntry] of findMessageEntries.entries()) {
+        const root = timelineViewportElement?.querySelector(
+          `[data-timeline-row-id="${CSS.escape(messageEntry.id)}"]`,
+        );
+        if (!root) continue;
 
-        const needle = findQuery.toLowerCase();
         const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
         const textNodes: Array<{ node: Text; start: number; end: number }> = [];
         let text = "";
@@ -532,19 +554,45 @@ export const MessagesTimeline = memo(function MessagesTimeline({
           });
           text += value;
         }
-        const activeMatch = findCaseInsensitiveTextRanges(text, needle)[match.occurrenceIndex];
-        if (!activeMatch) return;
-        const startNode = textNodes.find(
-          ({ start, end }) => start <= activeMatch.start && activeMatch.start < end,
+        for (const [occurrenceIndex, textRange] of findCaseInsensitiveTextRanges(
+          text,
+          findQuery,
+        ).entries()) {
+          const startNode = textNodes.find(
+            ({ start, end }) => start <= textRange.start && textRange.start < end,
+          );
+          const endNode = textNodes.find(
+            ({ start, end }) => start < textRange.end && textRange.end <= end,
+          );
+          if (!startNode || !endNode) continue;
+          const range = new Range();
+          range.setStart(startNode.node, textRange.start - startNode.start);
+          range.setEnd(endNode.node, textRange.end - endNode.start);
+          allRanges.push(range);
+          if (textIndex === match.textIndex && occurrenceIndex === match.occurrenceIndex) {
+            activeRange = range;
+          }
+        }
+      }
+      CSS.highlights.set(THREAD_FIND_HIGHLIGHT, new Highlight(...allRanges));
+      if (activeRange) {
+        CSS.highlights.set(THREAD_FIND_ACTIVE_HIGHLIGHT, new Highlight(activeRange));
+      }
+      return activeRange;
+    };
+    const scheduleRepaint = () => {
+      cancelAnimationFrame(repaintFrame);
+      repaintFrame = requestAnimationFrame(() => paintHighlights());
+    };
+    const observer = new MutationObserver(scheduleRepaint);
+    observer.observe(timelineViewportElement, { childList: true, subtree: true });
+    const mountFrame = requestAnimationFrame(() => {
+      paintFrame = requestAnimationFrame(() => {
+        const activeRange = paintHighlights();
+        const root = timelineViewportElement.querySelector(
+          `[data-timeline-row-id="${CSS.escape(entry.id)}"]`,
         );
-        const endNode = textNodes.find(
-          ({ start, end }) => start < activeMatch.end && activeMatch.end <= end,
-        );
-        if (!startNode || !endNode) return;
-        const activeRange = new Range();
-        activeRange.setStart(startNode.node, activeMatch.start - startNode.start);
-        activeRange.setEnd(endNode.node, activeMatch.end - endNode.start);
-        CSS.highlights.set(THREAD_FIND_HIGHLIGHT, new Highlight(activeRange));
+        if (!root || !activeRange) return;
 
         let scrollParent = root.parentElement;
         while (scrollParent && !/(auto|scroll)/u.test(getComputedStyle(scrollParent).overflowY)) {
@@ -563,7 +611,10 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     return () => {
       cancelAnimationFrame(mountFrame);
       cancelAnimationFrame(paintFrame);
+      cancelAnimationFrame(repaintFrame);
+      observer.disconnect();
       CSS.highlights.delete(THREAD_FIND_HIGHLIGHT);
+      CSS.highlights.delete(THREAD_FIND_ACTIVE_HIGHLIGHT);
     };
   }, [
     expandedTurnIds,
@@ -575,6 +626,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     listRef,
     rows,
     suspendEndScrollMaintenanceForDisclosure,
+    timelineViewportElement,
   ]);
   const minimapItems = useMemo(() => deriveTimelineMinimapItems(rows), [rows]);
   const [minimapHasPersistentGutter, setMinimapHasPersistentGutter] = useState(false);

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -77,8 +77,10 @@ import { MessageCopyButton } from "./MessageCopyButton";
 import {
   computeStableMessagesTimelineRows,
   deriveMessagesTimelineRows,
+  findCaseInsensitiveTextRanges,
   findTextMatches,
   normalizeCompactToolLabel,
+  renderMarkdownSearchText,
   resolveAssistantMessageCopyState,
   resolveTimelineIsAtEnd,
   resolveTimelineMinimapHasPersistentGutter,
@@ -437,7 +439,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     [timelineEntries],
   );
   const findTexts = useMemo(
-    () => findMessageEntries.map((entry) => entry.message.text),
+    () => findMessageEntries.map((entry) => renderMarkdownSearchText(entry.message.text)),
     [findMessageEntries],
   );
   const findMatches = useMemo(() => findTextMatches(findTexts, findQuery), [findQuery, findTexts]);
@@ -520,15 +522,11 @@ export const MessagesTimeline = memo(function MessagesTimeline({
         const needle = findQuery.toLowerCase();
         const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
         for (let node = walker.nextNode(); node; node = walker.nextNode()) {
-          const text = node.textContent?.toLowerCase() ?? "";
-          for (
-            let offset = 0;
-            (offset = text.indexOf(needle, offset)) !== -1;
-            offset += needle.length
-          ) {
+          const text = node.textContent ?? "";
+          for (const { start, end } of findCaseInsensitiveTextRanges(text, needle)) {
             const range = new Range();
-            range.setStart(node, offset);
-            range.setEnd(node, offset + needle.length);
+            range.setStart(node, start);
+            range.setEnd(node, end);
             ranges.push(range);
           }
         }
@@ -717,7 +715,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       <TimelineRowActivityCtx value={activityState}>
         <div ref={setTimelineViewportElement} className="relative h-full min-h-0">
           {findOpen ? (
-            <InputGroup className="surface-glass absolute right-4 top-3 z-30 h-9 w-auto shadow-lg">
+            <InputGroup className="surface-glass absolute right-4 top-3 z-30 w-auto shadow-lg **:[input]:w-48">
               <InputGroupAddon>
                 <SearchIcon aria-hidden="true" />
               </InputGroupAddon>
@@ -731,7 +729,6 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                 }}
                 aria-label="Find in thread"
                 placeholder="Find in thread"
-                className="w-48"
               />
               <InputGroupAddon align="inline-end" className="gap-1">
                 <span className="min-w-12 text-center text-xs text-muted-foreground">

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -726,7 +726,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       <TimelineRowActivityCtx value={activityState}>
         <div ref={setTimelineViewportElement} className="relative h-full min-h-0">
           {findOpen ? (
-            <InputGroup className="surface-glass absolute right-4 top-3 z-30 w-auto shadow-lg **:[input]:w-48">
+            <InputGroup className="absolute right-4 top-3 z-30 w-auto shadow-lg **:[input]:w-48">
               <InputGroupAddon>
                 <SearchIcon aria-hidden="true" />
               </InputGroupAddon>

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -429,7 +429,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   const rows = useStableRows(rawRows);
   const [findOpen, setFindOpen] = useState(false);
   const [findQuery, setFindQuery] = useState("");
-  const [findMatchIndex, setFindMatchIndex] = useState(0);
+  const [findMatchCursor, setFindMatchIndex] = useState(0);
   const findInputRef = useRef<HTMLInputElement>(null);
   const [timelineViewportElement, setTimelineViewportElement] = useState<HTMLDivElement | null>(
     null,
@@ -443,6 +443,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     [findMessageEntries],
   );
   const findMatches = useMemo(() => findTextMatches(findTexts, findQuery), [findQuery, findTexts]);
+  const findMatchIndex = Math.min(findMatchCursor, Math.max(0, findMatches.length - 1));
   const updateFindQuery = useCallback(
     (query: string) => {
       setFindQuery(query);

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -59,10 +59,12 @@ import {
   PaintbrushIcon,
   MinusIcon,
   SquarePenIcon,
+  SearchIcon,
   TerminalIcon,
   Undo2Icon,
   WrenchIcon,
   XIcon,
+  ChevronUpIcon,
   ZapIcon,
 } from "lucide-react";
 import { Button } from "../ui/button";
@@ -74,6 +76,7 @@ import { MessageCopyButton } from "./MessageCopyButton";
 import {
   computeStableMessagesTimelineRows,
   deriveMessagesTimelineRows,
+  findTextMatches,
   normalizeCompactToolLabel,
   resolveAssistantMessageCopyState,
   resolveTimelineIsAtEnd,
@@ -188,6 +191,7 @@ function TimelineLoadEarlierHeader({
   );
 }
 const TIMELINE_LIST_FOOTER = <div className="h-3 sm:h-4" />;
+const THREAD_FIND_HIGHLIGHT = "thread-find";
 const EMPTY_TIMELINE_SKILLS: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">> = [];
 const TIMELINE_MAINTAIN_SCROLL_AT_END = {
   animated: false,
@@ -420,6 +424,103 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     ],
   );
   const rows = useStableRows(rawRows);
+  const [findOpen, setFindOpen] = useState(false);
+  const [findQuery, setFindQuery] = useState("");
+  const [findMatchIndex, setFindMatchIndex] = useState(0);
+  const findInputRef = useRef<HTMLInputElement>(null);
+  const findTexts = useMemo(
+    () => rows.map((row) => (row.kind === "message" ? row.message.text : null)),
+    [rows],
+  );
+  const findMatches = useMemo(() => findTextMatches(findTexts, findQuery), [findQuery, findTexts]);
+  const updateFindQuery = useCallback(
+    (query: string) => {
+      setFindQuery(query);
+      setFindMatchIndex(0);
+      const firstMatch = findTextMatches(findTexts, query)[0];
+      if (firstMatch === undefined) return;
+      onManualNavigation();
+      void listRef.current?.scrollToIndex({ index: firstMatch, animated: false, viewOffset: 80 });
+    },
+    [findTexts, listRef, onManualNavigation],
+  );
+  const goToFindMatch = useCallback(
+    (delta: number) => {
+      if (findMatches.length === 0) return;
+      const next = (findMatchIndex + delta + findMatches.length) % findMatches.length;
+      setFindMatchIndex(next);
+      onManualNavigation();
+      void listRef.current?.scrollToIndex({
+        index: findMatches[next]!,
+        animated: false,
+        viewOffset: 80,
+      });
+    },
+    [findMatchIndex, findMatches, listRef, onManualNavigation],
+  );
+
+  useEffect(() => {
+    const handleFindShortcut = (event: globalThis.KeyboardEvent) => {
+      if (
+        event.key.toLowerCase() !== "f" ||
+        (!event.metaKey && !event.ctrlKey) ||
+        event.altKey ||
+        event.shiftKey ||
+        (event.target instanceof Element && event.target.closest("[data-terminal-owner]"))
+      ) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      setFindOpen(true);
+    };
+    window.addEventListener("keydown", handleFindShortcut, true);
+    return () => window.removeEventListener("keydown", handleFindShortcut, true);
+  }, []);
+
+  useEffect(() => {
+    if (!findOpen) return;
+    const frame = requestAnimationFrame(() => findInputRef.current?.focus());
+    return () => cancelAnimationFrame(frame);
+  }, [findOpen]);
+
+  useEffect(() => {
+    CSS.highlights.delete(THREAD_FIND_HIGHLIGHT);
+    const rowIndex = findMatches[findMatchIndex];
+    const rowId = rowIndex === undefined ? undefined : rows[rowIndex]?.id;
+    if (!findOpen || !findQuery || !rowId) return;
+
+    let paintFrame = 0;
+    const mountFrame = requestAnimationFrame(() => {
+      paintFrame = requestAnimationFrame(() => {
+        const root = document.querySelector(`[data-timeline-row-id="${CSS.escape(rowId)}"]`);
+        if (!root) return;
+
+        const ranges: Range[] = [];
+        const needle = findQuery.toLowerCase();
+        const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+        for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+          const text = node.textContent?.toLowerCase() ?? "";
+          for (
+            let offset = 0;
+            (offset = text.indexOf(needle, offset)) !== -1;
+            offset += needle.length
+          ) {
+            const range = new Range();
+            range.setStart(node, offset);
+            range.setEnd(node, offset + needle.length);
+            ranges.push(range);
+          }
+        }
+        CSS.highlights.set(THREAD_FIND_HIGHLIGHT, new Highlight(...ranges));
+      });
+    });
+    return () => {
+      cancelAnimationFrame(mountFrame);
+      cancelAnimationFrame(paintFrame);
+      CSS.highlights.delete(THREAD_FIND_HIGHLIGHT);
+    };
+  }, [findMatchIndex, findMatches, findOpen, findQuery, rows]);
   const minimapItems = useMemo(() => deriveTimelineMinimapItems(rows), [rows]);
   const [timelineViewportElement, setTimelineViewportElement] = useState<HTMLDivElement | null>(
     null,
@@ -573,6 +674,57 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     <TimelineRowCtx value={sharedState}>
       <TimelineRowActivityCtx value={activityState}>
         <div ref={setTimelineViewportElement} className="relative h-full min-h-0">
+          {findOpen ? (
+            <div className="absolute right-4 top-3 z-30 flex h-9 items-center gap-1 rounded-lg border bg-background/95 px-2 shadow-lg backdrop-blur">
+              <SearchIcon className="size-3.5 text-muted-foreground" aria-hidden="true" />
+              <input
+                ref={findInputRef}
+                value={findQuery}
+                onChange={(event) => updateFindQuery(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") goToFindMatch(event.shiftKey ? -1 : 1);
+                  if (event.key === "Escape") setFindOpen(false);
+                }}
+                aria-label="Find in thread"
+                placeholder="Find in thread"
+                className="w-48 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+              />
+              <span className="min-w-12 text-center text-xs text-muted-foreground">
+                {findQuery
+                  ? `${findMatches.length ? findMatchIndex + 1 : 0}/${findMatches.length}`
+                  : ""}
+              </span>
+              <Button
+                type="button"
+                size="icon-xs"
+                variant="ghost"
+                disabled={findMatches.length === 0}
+                aria-label="Previous match"
+                onClick={() => goToFindMatch(-1)}
+              >
+                <ChevronUpIcon />
+              </Button>
+              <Button
+                type="button"
+                size="icon-xs"
+                variant="ghost"
+                disabled={findMatches.length === 0}
+                aria-label="Next match"
+                onClick={() => goToFindMatch(1)}
+              >
+                <ChevronDownIcon />
+              </Button>
+              <Button
+                type="button"
+                size="icon-xs"
+                variant="ghost"
+                aria-label="Close find"
+                onClick={() => setFindOpen(false)}
+              >
+                <XIcon />
+              </Button>
+            </div>
+          ) : null}
           <LegendList<MessagesTimelineRow>
             ref={listRef}
             data={rows}

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -70,6 +70,7 @@ import {
 } from "lucide-react";
 import { Button } from "../ui/button";
 import { InputGroup, InputGroupAddon, InputGroupInput } from "../ui/input-group";
+import { Toggle } from "../ui/toggle";
 import { buildExpandedImagePreview, ExpandedImagePreview } from "./ExpandedImagePreview";
 import { ProposedPlanCard } from "./ProposedPlanCard";
 import { ChangedFilesCard } from "./ChangedFilesTree";
@@ -819,23 +820,21 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                   placeholder="Find in thread"
                 />
                 <InputGroupAddon align="inline-end" className="gap-1">
-                  <Button
-                    type="button"
-                    size="icon-xs"
-                    variant="ghost"
-                    className="data-pressed:border-primary! data-pressed:bg-primary! data-pressed:text-primary-foreground!"
-                    data-pressed={findCaseSensitive || undefined}
+                  <Toggle
+                    pressed={findCaseSensitive}
+                    size="xs"
+                    variant="primary"
+                    className="font-mono text-[11px]"
                     aria-label="Match case"
-                    aria-pressed={findCaseSensitive}
                     title="Match case"
-                    onClick={() => {
-                      setFindCaseSensitive(!findCaseSensitive);
+                    onPressedChange={(pressed) => {
+                      setFindCaseSensitive(pressed);
                       setFindMatchIndex(0);
                       onManualNavigation();
                     }}
                   >
-                    <span className="text-[11px] font-semibold leading-none">Aa</span>
-                  </Button>
+                    Aa
+                  </Toggle>
                   <span className="min-w-12 text-center text-xs text-muted-foreground">
                     {findQuery
                       ? `${findMatches.length ? findMatchIndex + 1 : 0}/${findMatches.length}`

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -823,6 +823,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                     type="button"
                     size="icon-xs"
                     variant="ghost"
+                    className="data-pressed:border-primary! data-pressed:bg-primary! data-pressed:text-primary-foreground!"
                     data-pressed={findCaseSensitive || undefined}
                     aria-label="Match case"
                     aria-pressed={findCaseSensitive}

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -726,58 +726,60 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       <TimelineRowActivityCtx value={activityState}>
         <div ref={setTimelineViewportElement} className="relative h-full min-h-0">
           {findOpen ? (
-            <InputGroup className="absolute right-4 top-3 z-30 w-auto shadow-lg dark:bg-background **:[input]:w-48">
-              <InputGroupAddon>
-                <SearchIcon aria-hidden="true" />
-              </InputGroupAddon>
-              <InputGroupInput
-                ref={findInputRef}
-                value={findQuery}
-                onChange={(event) => updateFindQuery(event.target.value)}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter") goToFindMatch(event.shiftKey ? -1 : 1);
-                  if (event.key === "Escape") setFindOpen(false);
-                }}
-                aria-label="Find in thread"
-                placeholder="Find in thread"
-              />
-              <InputGroupAddon align="inline-end" className="gap-1">
-                <span className="min-w-12 text-center text-xs text-muted-foreground">
-                  {findQuery
-                    ? `${findMatches.length ? findMatchIndex + 1 : 0}/${findMatches.length}`
-                    : ""}
-                </span>
-                <Button
-                  type="button"
-                  size="icon-xs"
-                  variant="ghost"
-                  disabled={findMatches.length === 0}
-                  aria-label="Previous match"
-                  onClick={() => goToFindMatch(-1)}
-                >
-                  <ChevronUpIcon />
-                </Button>
-                <Button
-                  type="button"
-                  size="icon-xs"
-                  variant="ghost"
-                  disabled={findMatches.length === 0}
-                  aria-label="Next match"
-                  onClick={() => goToFindMatch(1)}
-                >
-                  <ChevronDownIcon />
-                </Button>
-                <Button
-                  type="button"
-                  size="icon-xs"
-                  variant="ghost"
-                  aria-label="Close find"
-                  onClick={() => setFindOpen(false)}
-                >
-                  <XIcon />
-                </Button>
-              </InputGroupAddon>
-            </InputGroup>
+            <div className="absolute right-4 top-3 z-30 rounded-[var(--control-radius)] shadow-lg">
+              <InputGroup className="w-auto dark:bg-background **:[input]:w-48">
+                <InputGroupAddon>
+                  <SearchIcon aria-hidden="true" />
+                </InputGroupAddon>
+                <InputGroupInput
+                  ref={findInputRef}
+                  value={findQuery}
+                  onChange={(event) => updateFindQuery(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") goToFindMatch(event.shiftKey ? -1 : 1);
+                    if (event.key === "Escape") setFindOpen(false);
+                  }}
+                  aria-label="Find in thread"
+                  placeholder="Find in thread"
+                />
+                <InputGroupAddon align="inline-end" className="gap-1">
+                  <span className="min-w-12 text-center text-xs text-muted-foreground">
+                    {findQuery
+                      ? `${findMatches.length ? findMatchIndex + 1 : 0}/${findMatches.length}`
+                      : ""}
+                  </span>
+                  <Button
+                    type="button"
+                    size="icon-xs"
+                    variant="ghost"
+                    disabled={findMatches.length === 0}
+                    aria-label="Previous match"
+                    onClick={() => goToFindMatch(-1)}
+                  >
+                    <ChevronUpIcon />
+                  </Button>
+                  <Button
+                    type="button"
+                    size="icon-xs"
+                    variant="ghost"
+                    disabled={findMatches.length === 0}
+                    aria-label="Next match"
+                    onClick={() => goToFindMatch(1)}
+                  >
+                    <ChevronDownIcon />
+                  </Button>
+                  <Button
+                    type="button"
+                    size="icon-xs"
+                    variant="ghost"
+                    aria-label="Close find"
+                    onClick={() => setFindOpen(false)}
+                  >
+                    <XIcon />
+                  </Button>
+                </InputGroupAddon>
+              </InputGroup>
+            </div>
           ) : null}
           <LegendList<MessagesTimelineRow>
             ref={listRef}

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -514,9 +514,10 @@ export const MessagesTimeline = memo(function MessagesTimeline({
 
       const inputFocused = document.activeElement === findInputRef.current;
       if (key === "g") {
-        if (!findOpen || inputFocused) return;
+        if (inputFocused) return;
         event.preventDefault();
         event.stopPropagation();
+        if (!findOpen) setFindOpen(true);
         goToFindMatch(event.shiftKey ? -1 : 1);
         return;
       }

--- a/apps/web/src/components/search/ProjectContentSearchDialog.tsx
+++ b/apps/web/src/components/search/ProjectContentSearchDialog.tsx
@@ -66,9 +66,9 @@ function SearchOptionButton(props: {
           <Toggle
             aria-label={props.label}
             pressed={props.active}
-            className="size-8 rounded-[5px] font-mono text-muted-foreground data-pressed:text-foreground sm:size-7"
+            className="size-8 rounded-[5px] font-mono text-muted-foreground sm:size-7"
             size="compact"
-            variant="ghost"
+            variant="primary"
             onClick={props.onClick}
           />
         }

--- a/apps/web/src/components/ui/toggle.tsx
+++ b/apps/web/src/components/ui/toggle.tsx
@@ -26,7 +26,7 @@ const toggleVariants = cva(
         ghost:
           "border-transparent text-foreground shadow-none [:disabled,:active,[data-pressed]]:shadow-none before:shadow-none data-pressed:bg-accent data-pressed:text-accent-foreground disabled:opacity-100 disabled:text-muted-foreground disabled:[&_svg]:opacity-100",
         primary:
-          "border-transparent text-foreground shadow-none [:disabled,:active,[data-pressed]]:shadow-none before:shadow-none data-pressed:bg-primary data-pressed:text-primary-foreground disabled:opacity-100 disabled:text-muted-foreground disabled:[&_svg]:opacity-100",
+          "border-transparent text-foreground shadow-none [:disabled,:active,[data-pressed]]:shadow-none before:shadow-none data-pressed:bg-primary data-pressed:text-primary-foreground data-pressed:hover:bg-primary/90 disabled:opacity-100 disabled:text-muted-foreground disabled:[&_svg]:opacity-100",
         outline:
           "border-input bg-background not-dark:bg-clip-padding shadow-xs/5 not-disabled:not-active:not-data-pressed:before:shadow-[0_1px_--theme(--color-black/4%)] dark:bg-input/32 dark:data-pressed:bg-input dark:hover:bg-input/64 dark:not-disabled:not-active:not-data-pressed:before:shadow-[0_-1px_--theme(--color-white/6%)] dark:not-disabled:not-data-pressed:before:shadow-[0_-1px_--theme(--color-white/2%)] [:disabled,:active,[data-pressed]]:shadow-none",
       },

--- a/apps/web/src/components/ui/toggle.tsx
+++ b/apps/web/src/components/ui/toggle.tsx
@@ -25,6 +25,8 @@ const toggleVariants = cva(
         default: "border-transparent",
         ghost:
           "border-transparent text-foreground shadow-none [:disabled,:active,[data-pressed]]:shadow-none before:shadow-none data-pressed:bg-accent data-pressed:text-accent-foreground disabled:opacity-100 disabled:text-muted-foreground disabled:[&_svg]:opacity-100",
+        primary:
+          "border-transparent text-foreground shadow-none [:disabled,:active,[data-pressed]]:shadow-none before:shadow-none data-pressed:bg-primary data-pressed:text-primary-foreground disabled:opacity-100 disabled:text-muted-foreground disabled:[&_svg]:opacity-100",
         outline:
           "border-input bg-background not-dark:bg-clip-padding shadow-xs/5 not-disabled:not-active:not-data-pressed:before:shadow-[0_1px_--theme(--color-black/4%)] dark:bg-input/32 dark:data-pressed:bg-input dark:hover:bg-input/64 dark:not-disabled:not-active:not-data-pressed:before:shadow-[0_-1px_--theme(--color-white/6%)] dark:not-disabled:not-data-pressed:before:shadow-[0_-1px_--theme(--color-white/2%)] [:disabled,:active,[data-pressed]]:shadow-none",
       },

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5,6 +5,10 @@
 /* Window Controls Overlay: active when Electron exposes native titlebar control geometry. */
 @custom-variant wco (&:is(.wco, .wco *));
 
+::highlight(thread-find) {
+  background-color: color-mix(in srgb, var(--primary) 35%, transparent);
+}
+
 /* On mobile, morph the expanded hero composer into the compact docked
    composer while it moves; the rest of the app remains visually stationary. */
 html[data-mobile-composer-route-transition="true"]::view-transition-old(root),

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6,7 +6,14 @@
 @custom-variant wco (&:is(.wco, .wco *));
 
 ::highlight(thread-find) {
-  background-color: color-mix(in srgb, var(--primary) 35%, transparent);
+  background-color: color-mix(in srgb, var(--primary) 25%, transparent);
+}
+
+::highlight(thread-find-active) {
+  background-color: color-mix(in srgb, var(--primary) 55%, transparent);
+  text-decoration: underline;
+  text-decoration-color: var(--primary);
+  text-decoration-thickness: 2px;
 }
 
 /* On mobile, morph the expanded hero composer into the compact docked

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -597,6 +597,9 @@ importers:
       lucide-react:
         specifier: ^0.564.0
         version: 0.564.0(react@19.2.6)
+      mdast-util-to-string:
+        specifier: ^4.0.0
+        version: 4.0.0
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -618,9 +621,15 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.6.0
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
       zustand:
         specifier: ^5.0.11
         version: 5.0.14(@types/react@19.2.16)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))


### PR DESCRIPTION
Users currently cannot find text in the open thread from the desktop app because Cmd/Ctrl+F has no in-app target.

This was sloppified by GPT-5.6 Sol Medium. I (a real human) also built and used the desktop and web apps, then tested the UI to make sure it worked well.

This adds a compact, responsive find bar directly to the existing virtualized message timeline. It stays anchored to the top right within narrow chat columns by shrinking the text field while preserving every control. It searches every user prompt and assistant response, including inline and fenced code snippets, and expands a collapsed long prompt when navigating to a match inside it. Search is case-insensitive by default, with a compact **Aa** toggle and a clear primary-color active state for exact-case matching. It counts each occurrence, scrolls to matching virtualized rows, highlights every rendered match, and gives the active match a stronger highlight and underline.

The bar supports Cmd/Ctrl+F, Enter, Shift+Enter, Escape, previous/next controls, and Cmd/Ctrl+G or Shift+Cmd/Ctrl+G while focus is outside the search field. Cmd/Ctrl+G reopens a closed bar with its retained query and immediately navigates to the next match; adding Shift navigates to the previous match. Escape closes the bar even after focus has moved elsewhere in the chat. Pressing Cmd/Ctrl+F again refocuses an open bar; in a regular browser, pressing it again while that input is already focused falls through to the browser's native find. Terminal focus keeps ownership of its shortcuts.

The implementation remains client-only, with no contract or server changes and no state outside the timeline.

### Web dependencies

These three additions are kept because search counts need to be derived from visible Markdown text rather than raw Markdown syntax:

- `unified`: creates and reuses the Markdown processing pipeline.
- `remark-parse`: parses message Markdown into an mdast tree, so syntax and hidden link destinations are not counted as visible matches.
- `mdast-util-to-string`: extracts the visible text from that tree, including inline/fenced code while excluding image alt text, so occurrence counts line up with rendered highlights.

`remark-gfm` was already a web dependency; the search parser reuses it so GitHub-flavored Markdown is interpreted consistently with `ChatMarkdown`.

Validation:

- `vp test run apps/web/src/components/chat/MessagesTimeline.logic.test.ts` (35 tests, including exact-case matching)
- `pnpm --filter @t3tools/web typecheck`
- targeted `vp lint` on the changed web files
- real browser pass: all matches remain highlighted; Enter changes 1/2 → 2/2 with a stronger active result; Cmd+G and Shift+Cmd+G navigate; Cmd+F refocuses the open custom input; a second Cmd+F while it is focused opens Chrome's native find

Screenshots:

Before:

![Current chat without in-thread search](https://github.com/user-attachments/assets/61f93e4d-c99f-417a-a24e-47f1ef521a81)

After — the active `browser` result is highlighted:

![Cmd+F find bar with browser highlighted](https://github.com/user-attachments/assets/2d3d6817-f3f2-4ee4-af98-86a5d65be7bf)

Context: #1486, #4599

Built with Codex (GPT-5).
