### PR TITLE
docs(server): record why the Codex collaborationMode patch stays

### DIFF
--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -74,8 +74,13 @@ const CodexUserInputAnswerObject = Schema.Struct({
 const isCodexResumeCursorSchema = Schema.is(CodexResumeCursorSchema);
 const isCodexUserInputAnswerObject = Schema.is(CodexUserInputAnswerObject);
 
-// TODO: Verify `packages/effect-codex-app-server/scripts/generate.ts` so the generated
-// `V2TurnStartParams` schema includes `collaborationMode` directly.
+// Upstream's TurnStartParams JSON schema genuinely omits `collaborationMode`, so this
+// patch has to stay. Confirmed in the generated output itself (schema.gen.ts, produced
+// straight from the UPSTREAM_REF pin in generate.ts): `V2TurnStartParams__CollaborationMode`
+// is emitted as an orphaned definition that nothing in `V2TurnStartParams`'s properties
+// references — unlike every other nested type there (e.g. `V2TurnStartParams__ReasoningEffort`,
+// which the `effort` field does reference), and `ClientRequest__CollaborationMode` shows the
+// same orphaning elsewhere in the file. Regenerating would reproduce this gap, not close it.
 const CodexTurnStartParamsWithCollaborationMode = EffectCodexSchema.V2TurnStartParams.pipe(
   Schema.fieldsAssign({
     collaborationMode: Schema.optionalKey(EffectCodexSchema.V2TurnStartParams__CollaborationMode),


### PR DESCRIPTION
`CodexSessionRuntime.ts` carries a local `Schema.fieldsAssign` patch that adds `collaborationMode` to `V2TurnStartParams`, above a `TODO` asking whether `packages/effect-codex-app-server/scripts/generate.ts` could be fixed so the generated schema includes the field directly.

It can't, so I replaced the open question with the finding. Upstream's `TurnStartParams` schema genuinely omits `collaborationMode`: in the generated output, `V2TurnStartParams__CollaborationMode` is emitted as an orphaned definition that nothing in `V2TurnStartParams`' properties references — unlike sibling nested types such as `V2TurnStartParams__ReasoningEffort`, which the `effort` field does reference. `ClientRequest__CollaborationMode` shows the same orphaning elsewhere in the file. Regenerating reproduces the gap rather than closing it, so the local patch is load-bearing and should stay.

Comment-only; no behavior change.

Verified against this branch's base: `vp test run src/provider/Layers/CodexSessionRuntime.test.ts` → 25/25 passing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only; no code or behavior change.
> 
> **Overview**
> **Documentation-only** change above the existing `Schema.fieldsAssign` that adds optional `collaborationMode` to `V2TurnStartParams` in `CodexSessionRuntime.ts`.
> 
> Replaces a **TODO** about fixing `generate.ts` with a settled explanation: upstream’s `TurnStartParams` JSON schema omits `collaborationMode`, so regeneration leaves `V2TurnStartParams__CollaborationMode` as an **orphaned** type (unlike `effort` / `V2TurnStartParams__ReasoningEffort`). The local patch is intentional and should not be removed by chasing codegen.
> 
> No runtime or schema behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc9ba9b9e140649ac5ea7c6e0bc264574ee538db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document why `collaborationMode` patch is retained in `CodexSessionRuntime`
> Replaces a TODO comment in [`CodexSessionRuntime.ts`](https://github.com/pingdotgg/t3code/pull/7436/files#diff-e29bf409c8e737a2d4e655f7e9e7def9c78c008d98a0a23575baa5e714c4e12c) with an explanatory note clarifying that the upstream `TurnStartParams` JSON schema omits `collaborationMode`, referencing the generated `schema.gen.ts` artifacts and the orphaned `V2TurnStartParams__CollaborationMode` and `ClientRequest__CollaborationMode` definitions. No functional changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cc9ba9b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->