### PR TITLE
fix(desktop): stop the passkey dialog from popping as soon as sign-in opens

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { ClerkProvider } from "@clerk/react";
-import { passkeys } from "@clerk/electron/passkeys";
+import { passkeys as electronPasskeys } from "@clerk/electron/passkeys";
 import { ClerkProvider as ElectronClerkProvider } from "@clerk/electron/react";
 import { createHashHistory, createBrowserHistory } from "@tanstack/react-router";
 
@@ -29,6 +29,16 @@ if (isElectron) {
 }
 
 const clerkPublishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY as string | undefined;
+
+// @clerk/electron reports passkey autofill as supported but executes the
+// "quiet" autofill request as a modal prompt, so Clerk's sign-in form pops an
+// OS passkey dialog the moment it mounts. Report autofill as unsupported; the
+// explicit "Use passkey" button keeps working.
+// Upstream: https://github.com/clerk/javascript/issues/9496
+const passkeys = {
+  ...electronPasskeys,
+  isAutoFillSupported: () => Promise.resolve(false),
+};
 
 const app = <AppRoot router={router} />;
 


### PR DESCRIPTION
Opening sign-in on the desktop app immediately pops an OS passkey dialog. Nobody asked for it; it fires the moment the Clerk sign-in form mounts.

Root cause is upstream in `@clerk/electron`: its passkey provider tells clerk-js that quiet passkey autofill is supported, but then executes the autofill request as a modal prompt (native OS sheet on macOS/Windows, modal Chromium dialog on the renderer path). clerk-js auto-starts the autofill flow when the sign-in form mounts, so the dialog opens with zero user intent. Filed upstream: clerk/javascript#9496.

Until that's fixed, this wraps the provider and reports autofill as unsupported on desktop. clerk-js then never auto-starts the flow. The explicit "Use passkey" button still works, and web keeps its silent browser autofill.

No screenshots: the change removes an unprompted OS dialog, which the desktop UI itself never renders.

🤖 Change by Claude Code (Fable 5).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Electron-only auth UX workaround with no change to web sign-in or passkey button behavior.
> 
> **Overview**
> **Desktop Electron** no longer auto-opens an OS passkey prompt when the Clerk sign-in form mounts.
> 
> The app wraps `@clerk/electron/passkeys` and overrides **`isAutoFillSupported`** to always resolve to `false`, so clerk-js skips the quiet autofill flow that upstream currently runs as a modal. Explicit **Use passkey** on desktop is unchanged; web still uses the default provider without this wrapper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 018ca8af21b5db34b8619bc49d19783718a57068. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent passkey autofill dialog from appearing on sign-in mount in desktop app
> Overrides `isAutoFillSupported` in [main.tsx](https://github.com/pingdotgg/t3code/pull/7437/files#diff-44decff659436a16ccdaaae62e456cd52d9f206c8628c8ca4447aa268c85e16b) to always resolve `false`, stopping the OS passkey prompt from triggering automatically when the sign-in view mounts. Explicit passkey usage remains functional. This works around an upstream issue in `@clerk/electron`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 018ca8a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->