### PR TITLE
feat(swift-ios): mark Dev and Test builds in the home title

### DIFF
--- a/apps/swift-ios/Features/Workspace/PersonalBuildChannel.swift
+++ b/apps/swift-ios/Features/Workspace/PersonalBuildChannel.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+/// Publication channel of the running build, so a personal Dev or Test install is
+/// recognisable on sight instead of being mistaken for an ordinary upstream build.
+enum PersonalBuildChannel: String, Equatable {
+    case upstream
+    case dev
+    case test
+
+    /// Reads the generic `T3BuildChannel` Info.plist value. Forks and feature branches
+    /// can opt into a label without embedding contributor-specific identifiers here.
+    init(info: [String: Any]?) {
+        self = Self.declared(in: info) ?? .upstream
+    }
+
+    static let current = PersonalBuildChannel(info: Bundle.main.infoDictionary)
+
+    /// The channel word appended to the Home title. `nil` leaves an upstream build unmarked.
+    var titleSuffix: String? {
+        switch self {
+        case .upstream: nil
+        case .dev: "Dev"
+        case .test: "Test"
+        }
+    }
+
+    var homeAccessibilityLabel: String {
+        titleSuffix
+            .map { "T3 Code \($0). Manage environments" }
+            ?? "T3 Code. Manage environments"
+    }
+
+    var color: Color {
+        switch self {
+        case .upstream: T3Colors.textSecondary
+        case .dev: T3Colors.syntaxNumber
+        case .test: T3Colors.syntaxKeyword
+        }
+    }
+
+    /// `T3BuildChannel` expands from the `T3_BUILD_CHANNEL` build setting. An empty value
+    /// and a literal unexpanded `$(…)` both mean "not declared".
+    private static func declared(in info: [String: Any]?) -> PersonalBuildChannel? {
+        let raw = (info?["T3BuildChannel"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() ?? ""
+        guard !raw.isEmpty, !raw.hasPrefix("$(") else { return nil }
+        return PersonalBuildChannel(rawValue: raw) ?? .upstream
+    }
+}

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -418,6 +418,11 @@ public struct WorkspaceView: View {
                     Text("Code")
                         .fontWeight(.medium)
                         .foregroundStyle(T3Colors.textSecondary)
+                    if let suffix = PersonalBuildChannel.current.titleSuffix {
+                        Text(suffix)
+                            .fontWeight(.bold)
+                            .foregroundStyle(PersonalBuildChannel.current.color)
+                    }
                     Image(systemName: "chevron.down")
                         .font(.system(size: 10, weight: .semibold))
                         .foregroundStyle(T3Colors.textTertiary)
@@ -428,7 +433,7 @@ public struct WorkspaceView: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("T3 Code. Manage environments")
+            .accessibilityLabel(PersonalBuildChannel.current.homeAccessibilityLabel)
             .accessibilityIdentifier("sidebar-environments-button")
         }
     }

--- a/apps/swift-ios/README.md
+++ b/apps/swift-ios/README.md
@@ -71,6 +71,7 @@ Info.plist:
 | `T3CODE_CLERK_PUBLISHABLE_KEY` | T3 Connect only | Clerk publishable key.                          |
 | `T3CODE_CLERK_JWT_TEMPLATE`    | No              | Relay JWT template; defaults to `t3-relay`.     |
 | `T3CODE_RELAY_URL`             | T3 Connect only | Relay base URL using HTTPS.                     |
+| `T3_BUILD_CHANNEL`             | No              | Home title marker: `dev` or `test`.             |
 | `DEVELOPMENT_TEAM`             | Device/archive  | Apple Developer team used by automatic signing. |
 | `MARKETING_VERSION`            | Release         | User-facing version.                            |
 | `CURRENT_PROJECT_VERSION`      | Release         | Monotonically increasing build number.          |

--- a/apps/swift-ios/Resources/Info.plist
+++ b/apps/swift-ios/Resources/Info.plist
@@ -34,6 +34,8 @@
             </dict>
         </dict>
     </dict>
+    <key>T3BuildChannel</key>
+    <string>$(T3_BUILD_CHANNEL)</string>
     <key>T3GitCommit</key>
     <string>$(T3_GIT_COMMIT)</string>
     <key>T3ConnectClerkJWTTemplate</key>

--- a/apps/swift-ios/Tests/FeatureTests/PersonalBuildChannelTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/PersonalBuildChannelTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Testing
+@testable import T3Code
+
+@Suite("Personal build channel")
+struct PersonalBuildChannelTests {
+    private func info(channel: String? = nil) -> [String: Any] {
+        var info: [String: Any] = [:]
+        if let channel { info["T3BuildChannel"] = channel }
+        return info
+    }
+
+    @Test
+    func declaredChannelWins() {
+        #expect(PersonalBuildChannel(info: info(channel: "dev")) == .dev)
+        #expect(PersonalBuildChannel(info: info(channel: "test")) == .test)
+        #expect(PersonalBuildChannel(info: info(channel: "upstream")) == .upstream)
+        #expect(PersonalBuildChannel(info: info(channel: " TEST ")) == .test)
+    }
+
+    @Test
+    func anUnrecognisedDeclaredChannelIsUnmarked() {
+        let staging = info(channel: "staging")
+        #expect(PersonalBuildChannel(info: staging) == .upstream)
+    }
+
+    @Test
+    func anUndeclaredChannelIsUnmarked() {
+        let undeclared = ["", "   ", "$(T3_BUILD_CHANNEL)"]
+        for value in undeclared {
+            #expect(PersonalBuildChannel(info: info(channel: value)) == .upstream)
+        }
+    }
+
+    @Test
+    func onlyThePersonalChannelsCarryATitleSuffix() {
+        #expect(PersonalBuildChannel.dev.titleSuffix == "Dev")
+        #expect(PersonalBuildChannel.test.titleSuffix == "Test")
+        #expect(PersonalBuildChannel.upstream.titleSuffix == nil)
+    }
+
+    @Test
+    func homeAccessibilityLabelMatchesTheVisibleChannel() {
+        #expect(
+            PersonalBuildChannel.dev.homeAccessibilityLabel
+                == "T3 Code Dev. Manage environments"
+        )
+        #expect(
+            PersonalBuildChannel.test.homeAccessibilityLabel
+                == "T3 Code Test. Manage environments"
+        )
+        #expect(
+            PersonalBuildChannel.upstream.homeAccessibilityLabel
+                == "T3 Code. Manage environments"
+        )
+    }
+
+    @Test
+    func theTwoPersonalChannelsAreVisuallyDistinct() {
+        #expect(PersonalBuildChannel.dev.color == T3Colors.syntaxNumber)
+        #expect(PersonalBuildChannel.test.color == T3Colors.syntaxKeyword)
+        #expect(PersonalBuildChannel.dev.color != PersonalBuildChannel.test.color)
+    }
+
+    @Test
+    func anEmptyInfoDictionaryIsTreatedAsUpstream() {
+        #expect(PersonalBuildChannel(info: nil) == .upstream)
+        #expect(PersonalBuildChannel(info: [:]) == .upstream)
+    }
+}


### PR DESCRIPTION
## What Changed

Label the SwiftUI Home title “T3 Code Dev” or “T3 Code Test” when a build explicitly declares its channel. Ordinary and unknown channels keep the normal title.

## Why

People with multiple native builds installed need to distinguish them. The label uses a declared build setting instead of guessing from a personal bundle identifier.

## Verification and remaining proof

Candidate: `0bb6321643348ddba4efa68bd385c03961544398`. This PR targets `t3code/rebuild-mobile-app-swift`; its historical integration base is `22b22f1463b83963d851bd0574a36a20f224a28d`. The current native parent inspected in the readiness review is `b99405468a6b2be1e0f67d551ece824b1627e35c`. Merging this child does not by itself deliver the native app to upstream main.

The [hosted native build/test job](https://github.com/pingdotgg/t3code/actions/runs/33042151143/job/98417939090) passed on the candidate. The earlier report records seven PersonalBuildChannelTests, three channel-specific Simulator builds and a successful direct Claude Opus 5 review for this head against 22b22f1463b83963d851bd0574a36a20f224a28d. It also records an ENOSPC attempt before the successful test retry; that failure remains part of the evidence. No local build, test or client session was run for this description update; full historical local invocations were not recovered here.

Upstream acceptance of Dev/Test branding remains a scope decision; the readiness review recommends keeping private-distribution branding in its overlay. Current-parent integration and proof remain required if the public contribution is retained. This PR is not evidence-complete for human merge review against the current native parent.

## Earlier visual evidence

These retained captures/reports belong to the revisions and conditions stated below. They were not recaptured, visually inspected or revalidated for current-parent integration in this pass. Historical access/playback statements describe the original check, not a new one.

<details>
<summary>Earlier captures and their original conditions</summary>

The original capture report identifies builds of head `0bb632164`. The fixture contains one sanitized project and no threads. Dark mode is first, tight title crops are primary, and full-window context is collapsed.

### Dark mode

#### Before, unmarked ordinary build

![Ordinary T3 Code title, dark mode](https://github.com/saphid/t3code/releases/download/pr-7453-evidence-0bb632164-20260830/ordinary-dark-tight.png)

#### After, Dev build

![T3 Code Dev title, dark mode](https://github.com/saphid/t3code/releases/download/pr-7453-evidence-0bb632164-20260830/dev-dark-tight.png)

#### After, Test build

![T3 Code Test title, dark mode](https://github.com/saphid/t3code/releases/download/pr-7453-evidence-0bb632164-20260830/test-dark-tight.png)

#### Ordinary, Dev, and Test comparison

![Dark-mode build-channel comparison](https://github.com/saphid/t3code/releases/download/pr-7453-evidence-0bb632164-20260830/channel-identity-dark-comparison.gif)

#### Live action sequence

![Dark-mode historical build-channel identity sequence](https://github.com/saphid/t3code/releases/download/pr-7453-evidence-0bb632164-20260830/channel-identity-dark-action.gif)

[Clean dark-mode MP4](https://github.com/saphid/t3code/releases/download/pr-7453-evidence-0bb632164-20260830/channel-identity-dark-clean.mp4) | [Annotated dark-mode MP4](https://github.com/saphid/t3code/releases/download/pr-7453-evidence-0bb632164-20260830/channel-identity-dark-annotated.mp4)

<details>
<summary>Full-window context, dark mode</summary>

#### Ordinary

![Ordinary T3 Code full window, dark mode](https://github.com/saphid/t3code/releases/download/pr-7453-evidence-0bb632164-20260830/ordinary-dark-full.png)

#### Dev

![T3 Code Dev full window, dark mode](https://github.com/saphid/t3code/releases/download/pr-7453-evidence-0bb632164-20260830/dev-dark-full.png)

#### Test

![T3 Code Test full window, dark mode](https://github.com/saphid/t3code/releases/download/pr-7453-evidence-0bb632164-20260830/test-dark-full.png)

</details>

<details>
<summary>Light mode evidence</summary>

#### Before, unmarked ordinary build

![Ordinary T3 Code title, light mode](https://github.com/saphid/t3code/releases/download/pr-7453-evidence-0bb632164-20260830/ordinary-light-tight.png)

#### After, Dev build

![T3 Code Dev title, light mode](https://github.com/saphid/t3code/releases/download/pr-7453-evidence-0bb632164-20260830/dev-light-tight.png)

#### After, Test build

![T3 Code Test title, light mode](https://github.com/saphid/t3code/releases/download/pr-7453-evidence-0bb632164-20260830/test-light-tight.png)

#### Ordinary, Dev, and Test comparison

![Light-mode build-channel comparison](https://github.com/saphid/t3code/releases/download/pr-7453-evidence-0bb632164-20260830/channel-identity-light-comparison.gif)

#### Live action sequence

![Light-mode historical build-channel identity sequence](https://github.com/saphid/t3code/releases/download/pr-7453-evidence-0bb632164-20260830/channel-identity-light-action.gif)

[Clean light-mode MP4](https://github.com/saphid/t3code/releases/download/pr-7453-evidence-0bb632164-20260830/channel-identity-light-clean.mp4) | [Annotated light-mode MP4](https://github.com/saphid/t3code/releases/download/pr-7453-evidence-0bb632164-20260830/channel-identity-light-annotated.mp4)

<details>
<summary>Full-window context, light mode</summary>

#### Ordinary

![Ordinary T3 Code full window, light mode](https://github.com/saphid/t3code/releases/download/pr-7453-evidence-0bb632164-20260830/ordinary-light-full.png)

#### Dev

![T3 Code Dev full window, light mode](https://github.com/saphid/t3code/releases/download/pr-7453-evidence-0bb632164-20260830/dev-light-full.png)

#### Test

![T3 Code Test full window, light mode](https://github.com/saphid/t3code/releases/download/pr-7453-evidence-0bb632164-20260830/test-light-full.png)

</details>

</details>

This section supersedes the earlier screenshot-only proof in the PR conversation.

</details>

Tracking: [native work item #121](https://github.com/saphid/t3code-personal/issues/121).

Implementation: GPT-5.6 Sol high in the Codex harness. Independent review: Claude Opus 5 high, read-only, exit 0, no actionable findings.

Description and evidence audit: GPT-6 in Codex, using prepare-proof-media from #9926.
