### PR TITLE
fix(desktop): resolve text generation model from connected environments

### DIFF
--- a/apps/web/src/components/settings/SettingsPanels.logic.test.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.test.ts
@@ -23,7 +23,7 @@ import {
   projectGroupingModeFromToggle,
   resolveBackgroundActivityProfileOption,
   resolveGeneralSettingsEnvironmentId,
-  resolveTextGenerationModelDefaults,
+  resolveTextGenerationModelDefault,
 } from "./SettingsPanels.logic";
 
 describe("typography settings restore", () => {
@@ -158,9 +158,22 @@ describe("project grouping toggle", () => {
 });
 
 describe("text generation model defaults", () => {
-  it("uses the environment context for comparison without persisting its fallback", () => {
+  it("ignores an enabled but unusable Codex snapshot and preserves target model preferences", () => {
     const instanceId = ProviderInstanceId.make("opencode");
     const providers: ReadonlyArray<ServerProvider> = [
+      {
+        instanceId: ProviderInstanceId.make("codex"),
+        driver: ProviderDriverKind.make("codex"),
+        enabled: true,
+        installed: false,
+        version: null,
+        status: "error",
+        auth: { status: "unknown" },
+        checkedAt: "2026-01-01T00:00:00.000Z",
+        models: [],
+        slashCommands: [],
+        skills: [],
+      },
       {
         instanceId,
         driver: ProviderDriverKind.make("opencode"),
@@ -182,6 +195,10 @@ describe("text generation model defaults", () => {
     ];
     const settings = {
       ...DEFAULT_UNIFIED_SETTINGS,
+      providers: {
+        ...DEFAULT_UNIFIED_SETTINGS.providers,
+        opencode: { ...DEFAULT_UNIFIED_SETTINGS.providers.opencode, enabled: true },
+      },
       providerModelPreferences: {
         [instanceId]: {
           hiddenModels: [],
@@ -190,14 +207,48 @@ describe("text generation model defaults", () => {
       },
     };
 
-    const result = resolveTextGenerationModelDefaults(settings, providers);
+    const resolvedDefault = resolveTextGenerationModelDefault(settings, providers);
 
-    expect(result.effectiveSelection).toMatchObject({
+    expect(resolvedDefault).toMatchObject({
       instanceId,
       model: "anthropic/claude-sonnet-4-6",
     });
-    expect(result.resetSelection).toEqual(DEFAULT_SERVER_SETTINGS.textGenerationModelSelection);
-    expect(result.resetSelection).not.toEqual(result.effectiveSelection);
+    expect(resolvedDefault).not.toEqual(DEFAULT_SERVER_SETTINGS.textGenerationModelSelection);
+  });
+
+  it("returns no reset default when no provider is picker-ready", () => {
+    const instanceId = ProviderInstanceId.make("opencode");
+    const settings = {
+      ...DEFAULT_UNIFIED_SETTINGS,
+      providers: {
+        ...DEFAULT_UNIFIED_SETTINGS.providers,
+        opencode: { ...DEFAULT_UNIFIED_SETTINGS.providers.opencode, enabled: true },
+      },
+    };
+    const providers: ReadonlyArray<ServerProvider> = [
+      {
+        instanceId,
+        driver: ProviderDriverKind.make("opencode"),
+        enabled: true,
+        installed: true,
+        version: null,
+        status: "warning",
+        auth: { status: "authenticated" },
+        checkedAt: "2026-01-01T00:00:00.000Z",
+        models: [
+          {
+            slug: "openai/gpt-5",
+            name: "GPT-5",
+            isCustom: false,
+            capabilities: {},
+          },
+        ],
+        slashCommands: [],
+        skills: [],
+      },
+    ];
+
+    expect(resolveTextGenerationModelDefault(settings, providers)).toBeNull();
   });
 });
 
@@ -355,10 +406,36 @@ describe("resolveGeneralSettingsEnvironmentId", () => {
     isCustom: false,
     capabilities: null,
   };
-  const env = (id: EnvironmentId, hasModels = true, enabled?: boolean) => ({
+  const provider = (overrides: Partial<ServerProvider> = {}): ServerProvider => ({
+    instanceId: ProviderInstanceId.make("opencode"),
+    driver: ProviderDriverKind.make("opencode"),
+    enabled: true,
+    installed: true,
+    version: null,
+    status: "ready",
+    auth: { status: "authenticated" },
+    checkedAt: "2026-01-01T00:00:00.000Z",
+    models: [mockModel],
+    slashCommands: [],
+    skills: [],
+    ...overrides,
+  });
+  const enabledSettings = {
+    ...DEFAULT_SERVER_SETTINGS,
+    providers: {
+      ...DEFAULT_SERVER_SETTINGS.providers,
+      opencode: { ...DEFAULT_SERVER_SETTINGS.providers.opencode, enabled: true },
+    },
+  };
+  const env = (
+    id: EnvironmentId,
+    providers: ReadonlyArray<ServerProvider> = [provider()],
+    settings = enabledSettings,
+  ) => ({
     environmentId: id,
     serverConfig: {
-      providers: [{ installed: hasModels, enabled, models: hasModels ? [mockModel] : [] }],
+      providers,
+      settings,
     },
   });
 
@@ -370,35 +447,73 @@ describe("resolveGeneralSettingsEnvironmentId", () => {
 
   it("falls back to connected environment with models when primary environment has no models", () => {
     expect(
-      resolveGeneralSettingsEnvironmentId(
-        [env(primaryEnvId, false), env(wslEnvId, true)],
-        primaryEnvId,
-      ),
+      resolveGeneralSettingsEnvironmentId([env(primaryEnvId, []), env(wslEnvId)], primaryEnvId),
     ).toBe(wslEnvId);
   });
 
   it("falls back to connected environment with models when primary environment has installed models that are disabled", () => {
+    const disabledSettings = {
+      ...enabledSettings,
+      providers: {
+        ...enabledSettings.providers,
+        opencode: { ...enabledSettings.providers.opencode, enabled: false },
+      },
+    };
     expect(
       resolveGeneralSettingsEnvironmentId(
-        [env(primaryEnvId, true, false), env(wslEnvId, true, true)],
+        [env(primaryEnvId, [provider()], disabledSettings), env(wslEnvId)],
         primaryEnvId,
       ),
     ).toBe(wslEnvId);
   });
 
   it("returns remote environment with models in a remote-only setup", () => {
-    expect(resolveGeneralSettingsEnvironmentId([env(remoteEnvId, true)], null)).toBe(remoteEnvId);
+    expect(resolveGeneralSettingsEnvironmentId([env(remoteEnvId)], null)).toBe(remoteEnvId);
+  });
+
+  it("prefers a ready remote over an errored primary with cached models", () => {
+    expect(
+      resolveGeneralSettingsEnvironmentId(
+        [env(primaryEnvId, [provider({ status: "error" })]), env(remoteEnvId)],
+        primaryEnvId,
+      ),
+    ).toBe(remoteEnvId);
+  });
+
+  it("ignores a snapshot that the current settings overlay disables", () => {
+    const disabledSettings = {
+      ...enabledSettings,
+      providers: {
+        ...enabledSettings.providers,
+        opencode: { ...enabledSettings.providers.opencode, enabled: false },
+      },
+    };
+    expect(
+      resolveGeneralSettingsEnvironmentId(
+        [env(primaryEnvId, [provider()], disabledSettings), env(remoteEnvId)],
+        primaryEnvId,
+      ),
+    ).toBe(remoteEnvId);
+  });
+
+  it("keeps a connected remote fallback when the disconnected primary is absent", () => {
+    expect(
+      resolveGeneralSettingsEnvironmentId(
+        [env(remoteEnvId, [provider({ status: "warning" })])],
+        primaryEnvId,
+      ),
+    ).toBe(remoteEnvId);
   });
 
   it("falls back to primary or first environment when no models exist in any environment", () => {
     expect(
       resolveGeneralSettingsEnvironmentId(
-        [env(primaryEnvId, false), { environmentId: wslEnvId, serverConfig: null }],
+        [env(primaryEnvId, []), { environmentId: wslEnvId, serverConfig: null }],
         primaryEnvId,
       ),
     ).toBe(primaryEnvId);
 
-    expect(resolveGeneralSettingsEnvironmentId([env(wslEnvId, false)], null)).toBe(wslEnvId);
+    expect(resolveGeneralSettingsEnvironmentId([env(wslEnvId, [])], null)).toBe(wslEnvId);
 
     expect(resolveGeneralSettingsEnvironmentId([], null)).toBe(null);
   });

--- a/apps/web/src/components/settings/SettingsPanels.logic.test.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.test.ts
@@ -5,6 +5,7 @@ import {
   ProviderDriverKind,
   ProviderInstanceId,
   type ProviderInstanceConfig,
+  type ServerProvider,
   type ServerProviderModel,
 } from "@t3tools/contracts";
 import { getBackgroundActivityPresetSettings } from "@t3tools/shared/backgroundActivitySettings";
@@ -22,6 +23,7 @@ import {
   projectGroupingModeFromToggle,
   resolveBackgroundActivityProfileOption,
   resolveGeneralSettingsEnvironmentId,
+  resolveTextGenerationModelDefaults,
 } from "./SettingsPanels.logic";
 
 describe("typography settings restore", () => {
@@ -152,6 +154,50 @@ describe("project grouping toggle", () => {
   it("restores repository path grouping when the toggle is cycled", () => {
     expect(projectGroupingModeFromToggle(false, "repository_path")).toBe("separate");
     expect(projectGroupingModeFromToggle(true, "repository_path")).toBe("repository_path");
+  });
+});
+
+describe("text generation model defaults", () => {
+  it("uses the environment context for comparison without persisting its fallback", () => {
+    const instanceId = ProviderInstanceId.make("opencode");
+    const providers: ReadonlyArray<ServerProvider> = [
+      {
+        instanceId,
+        driver: ProviderDriverKind.make("opencode"),
+        enabled: true,
+        installed: true,
+        version: null,
+        status: "ready",
+        auth: { status: "authenticated" },
+        checkedAt: "2026-01-01T00:00:00.000Z",
+        models: ["openai/gpt-5", "anthropic/claude-sonnet-4-6"].map((slug) => ({
+          slug,
+          name: slug,
+          isCustom: false,
+          capabilities: {},
+        })),
+        slashCommands: [],
+        skills: [],
+      },
+    ];
+    const settings = {
+      ...DEFAULT_UNIFIED_SETTINGS,
+      providerModelPreferences: {
+        [instanceId]: {
+          hiddenModels: [],
+          modelOrder: ["anthropic/claude-sonnet-4-6", "openai/gpt-5"],
+        },
+      },
+    };
+
+    const result = resolveTextGenerationModelDefaults(settings, providers);
+
+    expect(result.effectiveSelection).toMatchObject({
+      instanceId,
+      model: "anthropic/claude-sonnet-4-6",
+    });
+    expect(result.resetSelection).toEqual(DEFAULT_SERVER_SETTINGS.textGenerationModelSelection);
+    expect(result.resetSelection).not.toEqual(result.effectiveSelection);
   });
 });
 

--- a/apps/web/src/components/settings/SettingsPanels.logic.test.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.test.ts
@@ -309,10 +309,10 @@ describe("resolveGeneralSettingsEnvironmentId", () => {
     isCustom: false,
     capabilities: null,
   };
-  const env = (id: EnvironmentId, hasModels = true) => ({
+  const env = (id: EnvironmentId, hasModels = true, enabled?: boolean) => ({
     environmentId: id,
     serverConfig: {
-      providers: [{ installed: hasModels, models: hasModels ? [mockModel] : [] }],
+      providers: [{ installed: hasModels, enabled, models: hasModels ? [mockModel] : [] }],
     },
   });
 
@@ -326,6 +326,15 @@ describe("resolveGeneralSettingsEnvironmentId", () => {
     expect(
       resolveGeneralSettingsEnvironmentId(
         [env(primaryEnvId, false), env(wslEnvId, true)],
+        primaryEnvId,
+      ),
+    ).toBe(wslEnvId);
+  });
+
+  it("falls back to connected environment with models when primary environment has installed models that are disabled", () => {
+    expect(
+      resolveGeneralSettingsEnvironmentId(
+        [env(primaryEnvId, true, false), env(wslEnvId, true, true)],
         primaryEnvId,
       ),
     ).toBe(wslEnvId);

--- a/apps/web/src/components/settings/SettingsPanels.logic.test.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.test.ts
@@ -1,9 +1,11 @@
 import {
   DEFAULT_SERVER_SETTINGS,
   DEFAULT_UNIFIED_SETTINGS,
+  EnvironmentId,
   ProviderDriverKind,
   ProviderInstanceId,
   type ProviderInstanceConfig,
+  type ServerProviderModel,
 } from "@t3tools/contracts";
 import { getBackgroundActivityPresetSettings } from "@t3tools/shared/backgroundActivitySettings";
 import * as Duration from "effect/Duration";
@@ -19,6 +21,7 @@ import {
   isProjectGroupingEnabled,
   projectGroupingModeFromToggle,
   resolveBackgroundActivityProfileOption,
+  resolveGeneralSettingsEnvironmentId,
 } from "./SettingsPanels.logic";
 
 describe("typography settings restore", () => {
@@ -293,5 +296,55 @@ describe("isSamePreviewViewport", () => {
         { _tag: "preset", width: 390, height: 844, presetId: "iphone-12-pro" },
       ),
     ).toBe(false);
+  });
+});
+
+describe("resolveGeneralSettingsEnvironmentId", () => {
+  const primaryEnvId = EnvironmentId.make("primary");
+  const wslEnvId = EnvironmentId.make("wsl");
+  const remoteEnvId = EnvironmentId.make("remote");
+  const mockModel: ServerProviderModel = {
+    slug: "model-1",
+    name: "Model 1",
+    isCustom: false,
+    capabilities: null,
+  };
+  const env = (id: EnvironmentId, hasModels = true) => ({
+    environmentId: id,
+    serverConfig: {
+      providers: [{ installed: hasModels, models: hasModels ? [mockModel] : [] }],
+    },
+  });
+
+  it("returns primary environment when primary has installed models", () => {
+    expect(
+      resolveGeneralSettingsEnvironmentId([env(primaryEnvId), env(wslEnvId)], primaryEnvId),
+    ).toBe(primaryEnvId);
+  });
+
+  it("falls back to connected environment with models when primary environment has no models", () => {
+    expect(
+      resolveGeneralSettingsEnvironmentId(
+        [env(primaryEnvId, false), env(wslEnvId, true)],
+        primaryEnvId,
+      ),
+    ).toBe(wslEnvId);
+  });
+
+  it("returns remote environment with models in a remote-only setup", () => {
+    expect(resolveGeneralSettingsEnvironmentId([env(remoteEnvId, true)], null)).toBe(remoteEnvId);
+  });
+
+  it("falls back to primary or first environment when no models exist in any environment", () => {
+    expect(
+      resolveGeneralSettingsEnvironmentId(
+        [env(primaryEnvId, false), { environmentId: wslEnvId, serverConfig: null }],
+        primaryEnvId,
+      ),
+    ).toBe(primaryEnvId);
+
+    expect(resolveGeneralSettingsEnvironmentId([env(wslEnvId, false)], null)).toBe(wslEnvId);
+
+    expect(resolveGeneralSettingsEnvironmentId([], null)).toBe(null);
   });
 });

--- a/apps/web/src/components/settings/SettingsPanels.logic.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.ts
@@ -1,10 +1,12 @@
 import type {
   BackgroundActivityProfile,
   BackgroundActivitySettings,
+  EnvironmentId,
   ProviderDriverKind,
   ProviderInstanceConfig,
   PreviewViewportSetting,
   ProviderInstanceId,
+  ServerProvider,
   ServerSettings,
   SidebarProjectGroupingMode,
   UnifiedSettings,
@@ -330,4 +332,29 @@ export function backgroundActivityOverrideSettings(
       overrides: nextOverrides as BackgroundActivitySettings["overrides"],
     },
   };
+}
+
+export function resolveGeneralSettingsEnvironmentId(
+  environments: ReadonlyArray<{
+    readonly environmentId: EnvironmentId;
+    readonly serverConfig?: {
+      readonly providers?: ReadonlyArray<Pick<ServerProvider, "installed" | "models">> | null;
+    } | null;
+  }>,
+  primaryEnvironmentId: EnvironmentId | null,
+): EnvironmentId | null {
+  const hasModels = (env?: (typeof environments)[number]) =>
+    env?.serverConfig?.providers?.some((p) => Boolean(p.installed && p.models?.length)) ?? false;
+
+  const primary = environments.find((env) => env.environmentId === primaryEnvironmentId);
+  if (hasModels(primary)) {
+    return primaryEnvironmentId;
+  }
+
+  return (
+    environments.find(hasModels)?.environmentId ??
+    primaryEnvironmentId ??
+    environments[0]?.environmentId ??
+    null
+  );
 }

--- a/apps/web/src/components/settings/SettingsPanels.logic.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.ts
@@ -11,7 +11,7 @@ import type {
   SidebarProjectGroupingMode,
   UnifiedSettings,
 } from "@t3tools/contracts";
-import { DEFAULT_SERVER_SETTINGS, DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
+import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
 import {
   getBackgroundActivityBaseProfile,
   normalizeBackgroundActivitySettings,
@@ -21,6 +21,11 @@ import {
 import * as Duration from "effect/Duration";
 import * as Equal from "effect/Equal";
 import { resolveAppModelSelectionState } from "../../modelSelection";
+import {
+  applyProviderInstanceSettings,
+  deriveProviderInstanceEntries,
+  isProviderInstancePickerReady,
+} from "../../providerInstances";
 
 export function isProjectGroupingEnabled(mode: SidebarProjectGroupingMode): boolean {
   return mode !== "separate";
@@ -197,21 +202,30 @@ export function backgroundActivitySharedPolicySettings(
   };
 }
 
-export function resolveTextGenerationModelDefaults(
+export function resolveTextGenerationModelDefault(
   settings: UnifiedSettings,
   providers: ReadonlyArray<ServerProvider>,
 ) {
-  const resetSelection = DEFAULT_SERVER_SETTINGS.textGenerationModelSelection;
-  return {
-    effectiveSelection: resolveAppModelSelectionState(
-      {
-        ...settings,
-        textGenerationModelSelection: resetSelection,
-      },
-      providers,
-    ),
-    resetSelection,
-  };
+  const usableProviders = resolvePickerUsableProviders(settings, providers);
+  if (usableProviders.length === 0) {
+    return null;
+  }
+  return resolveAppModelSelectionState(
+    {
+      ...settings,
+      textGenerationModelSelection: DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
+    },
+    usableProviders,
+  );
+}
+
+function resolvePickerUsableProviders(
+  settings: Pick<ServerSettings, "providerInstances" | "providers">,
+  providers: ReadonlyArray<ServerProvider>,
+): ReadonlyArray<ServerProvider> {
+  return applyProviderInstanceSettings(deriveProviderInstanceEntries(providers), settings)
+    .filter((entry) => isProviderInstancePickerReady(entry) && entry.models.length > 0)
+    .map((entry) => ({ ...entry.snapshot, enabled: entry.enabled }));
 }
 
 function collapseOtelSignalsUrl(input: {
@@ -356,19 +370,18 @@ export function resolveGeneralSettingsEnvironmentId(
   environments: ReadonlyArray<{
     readonly environmentId: EnvironmentId;
     readonly serverConfig?: {
-      readonly providers?: ReadonlyArray<
-        Pick<ServerProvider, "installed" | "models"> & {
-          readonly enabled?: boolean | undefined;
-        }
-      > | null;
+      readonly providers?: ReadonlyArray<ServerProvider> | null;
+      readonly settings: Pick<ServerSettings, "providerInstances" | "providers">;
     } | null;
   }>,
   primaryEnvironmentId: EnvironmentId | null,
 ): EnvironmentId | null {
   const hasModels = (env?: (typeof environments)[number]) =>
-    env?.serverConfig?.providers?.some((p) =>
-      Boolean(p.installed && p.enabled !== false && p.models?.length),
-    ) ?? false;
+    Boolean(
+      env?.serverConfig?.providers &&
+      resolvePickerUsableProviders(env.serverConfig.settings, env.serverConfig.providers).length >
+        0,
+    );
 
   const primary = environments.find((env) => env.environmentId === primaryEnvironmentId);
   if (hasModels(primary)) {
@@ -377,7 +390,7 @@ export function resolveGeneralSettingsEnvironmentId(
 
   return (
     environments.find(hasModels)?.environmentId ??
-    primaryEnvironmentId ??
+    primary?.environmentId ??
     environments[0]?.environmentId ??
     null
   );

--- a/apps/web/src/components/settings/SettingsPanels.logic.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.ts
@@ -338,13 +338,19 @@ export function resolveGeneralSettingsEnvironmentId(
   environments: ReadonlyArray<{
     readonly environmentId: EnvironmentId;
     readonly serverConfig?: {
-      readonly providers?: ReadonlyArray<Pick<ServerProvider, "installed" | "models">> | null;
+      readonly providers?: ReadonlyArray<
+        Pick<ServerProvider, "installed" | "models"> & {
+          readonly enabled?: boolean | undefined;
+        }
+      > | null;
     } | null;
   }>,
   primaryEnvironmentId: EnvironmentId | null,
 ): EnvironmentId | null {
   const hasModels = (env?: (typeof environments)[number]) =>
-    env?.serverConfig?.providers?.some((p) => Boolean(p.installed && p.models?.length)) ?? false;
+    env?.serverConfig?.providers?.some((p) =>
+      Boolean(p.installed && p.enabled !== false && p.models?.length),
+    ) ?? false;
 
   const primary = environments.find((env) => env.environmentId === primaryEnvironmentId);
   if (hasModels(primary)) {

--- a/apps/web/src/components/settings/SettingsPanels.logic.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.ts
@@ -11,7 +11,7 @@ import type {
   SidebarProjectGroupingMode,
   UnifiedSettings,
 } from "@t3tools/contracts";
-import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
+import { DEFAULT_SERVER_SETTINGS, DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
 import {
   getBackgroundActivityBaseProfile,
   normalizeBackgroundActivitySettings,
@@ -20,6 +20,7 @@ import {
 } from "@t3tools/shared/backgroundActivitySettings";
 import * as Duration from "effect/Duration";
 import * as Equal from "effect/Equal";
+import { resolveAppModelSelectionState } from "../../modelSelection";
 
 export function isProjectGroupingEnabled(mode: SidebarProjectGroupingMode): boolean {
   return mode !== "separate";
@@ -193,6 +194,23 @@ export function backgroundActivitySharedPolicySettings(
     profile: "custom",
     baseProfile: profile,
     overrides: normalized.profile === "custom" ? normalized.overrides : {},
+  };
+}
+
+export function resolveTextGenerationModelDefaults(
+  settings: UnifiedSettings,
+  providers: ReadonlyArray<ServerProvider>,
+) {
+  const resetSelection = DEFAULT_SERVER_SETTINGS.textGenerationModelSelection;
+  return {
+    effectiveSelection: resolveAppModelSelectionState(
+      {
+        ...settings,
+        textGenerationModelSelection: resetSelection,
+      },
+      providers,
+    ),
+    resetSelection,
   };
 }
 

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -148,7 +148,7 @@ import {
   rememberEnabledProjectGroupingMode,
   resolveBackgroundActivityProfileOption,
   resolveGeneralSettingsEnvironmentId,
-  resolveTextGenerationModelDefaults,
+  resolveTextGenerationModelDefault,
 } from "./SettingsPanels.logic";
 import {
   PolicyTooltip,
@@ -504,29 +504,30 @@ export function useSettingsRestore(onRestored?: () => void) {
     textGenSettings,
     serverProviders,
   );
-  const {
-    effectiveSelection: defaultTextGenerationModelSelection,
-    resetSelection: resetTextGenerationModelSelection,
-  } = resolveTextGenerationModelDefaults(textGenSettings, serverProviders);
+  const defaultTextGenerationModelSelection = resolveTextGenerationModelDefault(
+    textGenSettings,
+    serverProviders,
+  );
 
   const textGenerationResetStateRef = useRef({
     targetEnvironmentId,
     updateTextGenSettings,
-    resetTextGenerationModelSelection,
+    resetTextGenerationModelSelection: defaultTextGenerationModelSelection,
   });
   textGenerationResetStateRef.current = {
     targetEnvironmentId,
     updateTextGenSettings,
-    resetTextGenerationModelSelection,
+    resetTextGenerationModelSelection: defaultTextGenerationModelSelection,
   };
 
   const isTextGenerationModelDirty =
-    textGenerationModelSelection.instanceId !== defaultTextGenerationModelSelection.instanceId ||
-    textGenerationModelSelection.model !== defaultTextGenerationModelSelection.model ||
-    !Equal.equals(
-      textGenerationModelSelection.options ?? [],
-      defaultTextGenerationModelSelection.options ?? [],
-    );
+    defaultTextGenerationModelSelection !== null &&
+    (textGenerationModelSelection.instanceId !== defaultTextGenerationModelSelection.instanceId ||
+      textGenerationModelSelection.model !== defaultTextGenerationModelSelection.model ||
+      !Equal.equals(
+        textGenerationModelSelection.options ?? [],
+        defaultTextGenerationModelSelection.options ?? [],
+      ));
   const isBackgroundActivityDirty = hasChangedBackgroundActivitySettings(settings);
 
   const changedSettingLabels = useMemo(
@@ -739,13 +740,15 @@ export function useSettingsRestore(onRestored?: () => void) {
     // The target environment can change while the confirmation dialog is open.
     // Use its latest updater, but do not reset a different environment from the
     // one the user chose before confirming.
+    const currentTextGenerationResetState = textGenerationResetStateRef.current;
     if (
       isTextGenerationModelDirty &&
-      textGenerationResetStateRef.current.targetEnvironmentId === initialTargetEnvironmentId
+      currentTextGenerationResetState.targetEnvironmentId === initialTargetEnvironmentId &&
+      currentTextGenerationResetState.resetTextGenerationModelSelection !== null
     ) {
-      textGenerationResetStateRef.current.updateTextGenSettings({
+      currentTextGenerationResetState.updateTextGenSettings({
         textGenerationModelSelection:
-          textGenerationResetStateRef.current.resetTextGenerationModelSelection,
+          currentTextGenerationResetState.resetTextGenerationModelSelection,
       });
     }
     onRestored?.();
@@ -1931,17 +1934,18 @@ export function GeneralSettingsPanel() {
     textGenModel,
   );
 
-  const {
-    effectiveSelection: defaultTextGenerationModelSelection,
-    resetSelection: resetTextGenerationModelSelection,
-  } = resolveTextGenerationModelDefaults(textGenSettings, serverProviders);
+  const defaultTextGenerationModelSelection = resolveTextGenerationModelDefault(
+    textGenSettings,
+    serverProviders,
+  );
   const isTextGenerationModelDirty =
-    textGenerationModelSelection.instanceId !== defaultTextGenerationModelSelection.instanceId ||
-    textGenerationModelSelection.model !== defaultTextGenerationModelSelection.model ||
-    !Equal.equals(
-      textGenerationModelSelection.options ?? [],
-      defaultTextGenerationModelSelection.options ?? [],
-    );
+    defaultTextGenerationModelSelection !== null &&
+    (textGenerationModelSelection.instanceId !== defaultTextGenerationModelSelection.instanceId ||
+      textGenerationModelSelection.model !== defaultTextGenerationModelSelection.model ||
+      !Equal.equals(
+        textGenerationModelSelection.options ?? [],
+        defaultTextGenerationModelSelection.options ?? [],
+      ));
   const resolvedBackgroundActivity = resolveServerBackgroundActivitySettings(settings);
   const activeBackgroundActivityProfile = resolvedBackgroundActivity.profile;
   const backgroundActivityProfileOption = resolveBackgroundActivityProfileOption(settings);
@@ -2424,12 +2428,12 @@ export function GeneralSettingsPanel() {
           {...searchableSetting("text-generation-model")}
           description="Default model for generated text like thread titles and source control content. Source control settings can override it with a dedicated source control writer model."
           resetAction={
-            isTextGenerationModelDirty ? (
+            isTextGenerationModelDirty && defaultTextGenerationModelSelection !== null ? (
               <SettingResetButton
                 label="text generation model"
                 onClick={() =>
                   updateTextGenSettings({
-                    textGenerationModelSelection: resetTextGenerationModelSelection,
+                    textGenerationModelSelection: defaultTextGenerationModelSelection,
                   })
                 }
               />

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -482,7 +482,10 @@ export function useSettingsRestore(onRestored?: () => void) {
   const { environments } = useEnvironments();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
   const targetEnvironmentId =
-    resolveGeneralSettingsEnvironmentId(environments, primaryEnvironmentId) ?? primaryEnvironmentId;
+    resolveGeneralSettingsEnvironmentId(
+      environments.filter((environment) => environment.connection.phase === "connected"),
+      primaryEnvironmentId,
+    ) ?? primaryEnvironmentId;
   const textGenSettings = useEnvironmentSettings(
     targetEnvironmentId ?? (primaryEnvironmentId as EnvironmentId),
   );
@@ -504,6 +507,18 @@ export function useSettingsRestore(onRestored?: () => void) {
     DEFAULT_UNIFIED_SETTINGS,
     serverProviders,
   );
+
+  const liveStateRef = useRef({
+    targetEnvironmentId,
+    updateTextGenSettings,
+    defaultTextGenerationModelSelection,
+  });
+  liveStateRef.current = {
+    targetEnvironmentId,
+    updateTextGenSettings,
+    defaultTextGenerationModelSelection,
+  };
+
   const isTextGenerationModelDirty =
     textGenerationModelSelection.instanceId !== defaultTextGenerationModelSelection.instanceId ||
     textGenerationModelSelection.model !== defaultTextGenerationModelSelection.model ||
@@ -719,14 +734,13 @@ export function useSettingsRestore(onRestored?: () => void) {
       // rather than discovering it later.
       enableAgentBrowserAccess: DEFAULT_UNIFIED_SETTINGS.enableAgentBrowserAccess,
     });
-    updateTextGenSettings({
-      textGenerationModelSelection: defaultTextGenerationModelSelection,
+    liveStateRef.current.updateTextGenSettings({
+      textGenerationModelSelection: liveStateRef.current.defaultTextGenerationModelSelection,
     });
     onRestored?.();
   }, [
     changedSettingLabels,
     clearThemeHalves,
-    defaultTextGenerationModelSelection,
     onRestored,
     setFollowSystem,
     setTheme,
@@ -734,7 +748,6 @@ export function useSettingsRestore(onRestored?: () => void) {
     theme,
     themeHalves,
     updateSettings,
-    updateTextGenSettings,
   ]);
 
   return {
@@ -1840,7 +1853,10 @@ export function GeneralSettingsPanel() {
   const { environments } = useEnvironments();
   const primaryEnvironmentId = usePrimaryEnvironmentId();
   const targetEnvironmentId =
-    resolveGeneralSettingsEnvironmentId(environments, primaryEnvironmentId) ?? primaryEnvironmentId;
+    resolveGeneralSettingsEnvironmentId(
+      environments.filter((environment) => environment.connection.phase === "connected"),
+      primaryEnvironmentId,
+    ) ?? primaryEnvironmentId;
   const textGenSettings = useEnvironmentSettings(
     targetEnvironmentId ?? (primaryEnvironmentId as EnvironmentId),
   );

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -148,6 +148,7 @@ import {
   rememberEnabledProjectGroupingMode,
   resolveBackgroundActivityProfileOption,
   resolveGeneralSettingsEnvironmentId,
+  resolveTextGenerationModelDefaults,
 } from "./SettingsPanels.logic";
 import {
   PolicyTooltip,
@@ -503,20 +504,20 @@ export function useSettingsRestore(onRestored?: () => void) {
     textGenSettings,
     serverProviders,
   );
-  const defaultTextGenerationModelSelection = resolveAppModelSelectionState(
-    DEFAULT_UNIFIED_SETTINGS,
-    serverProviders,
-  );
+  const {
+    effectiveSelection: defaultTextGenerationModelSelection,
+    resetSelection: resetTextGenerationModelSelection,
+  } = resolveTextGenerationModelDefaults(textGenSettings, serverProviders);
 
   const textGenerationResetStateRef = useRef({
     targetEnvironmentId,
     updateTextGenSettings,
-    defaultTextGenerationModelSelection,
+    resetTextGenerationModelSelection,
   });
   textGenerationResetStateRef.current = {
     targetEnvironmentId,
     updateTextGenSettings,
-    defaultTextGenerationModelSelection,
+    resetTextGenerationModelSelection,
   };
 
   const isTextGenerationModelDirty =
@@ -735,16 +736,16 @@ export function useSettingsRestore(onRestored?: () => void) {
       // rather than discovering it later.
       enableAgentBrowserAccess: DEFAULT_UNIFIED_SETTINGS.enableAgentBrowserAccess,
     });
-    // Provider discovery can update the default while the confirmation dialog is
-    // open. Use the latest reset state, but do not reset a different environment
-    // from the one the user chose before confirming.
+    // The target environment can change while the confirmation dialog is open.
+    // Use its latest updater, but do not reset a different environment from the
+    // one the user chose before confirming.
     if (
       isTextGenerationModelDirty &&
       textGenerationResetStateRef.current.targetEnvironmentId === initialTargetEnvironmentId
     ) {
       textGenerationResetStateRef.current.updateTextGenSettings({
         textGenerationModelSelection:
-          textGenerationResetStateRef.current.defaultTextGenerationModelSelection,
+          textGenerationResetStateRef.current.resetTextGenerationModelSelection,
       });
     }
     onRestored?.();
@@ -1930,10 +1931,10 @@ export function GeneralSettingsPanel() {
     textGenModel,
   );
 
-  const defaultTextGenerationModelSelection = resolveAppModelSelectionState(
-    DEFAULT_UNIFIED_SETTINGS,
-    serverProviders,
-  );
+  const {
+    effectiveSelection: defaultTextGenerationModelSelection,
+    resetSelection: resetTextGenerationModelSelection,
+  } = resolveTextGenerationModelDefaults(textGenSettings, serverProviders);
   const isTextGenerationModelDirty =
     textGenerationModelSelection.instanceId !== defaultTextGenerationModelSelection.instanceId ||
     textGenerationModelSelection.model !== defaultTextGenerationModelSelection.model ||
@@ -2428,7 +2429,7 @@ export function GeneralSettingsPanel() {
                 label="text generation model"
                 onClick={() =>
                   updateTextGenSettings({
-                    textGenerationModelSelection: defaultTextGenerationModelSelection,
+                    textGenerationModelSelection: resetTextGenerationModelSelection,
                   })
                 }
               />

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -5,7 +5,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAtomValue } from "@effect/atom-react";
 import {
   type BackgroundActivityProfile,
+  DEFAULT_SERVER_SETTINGS,
   type DesktopUpdateChannel,
+  type EnvironmentId,
   ProviderDriverKind,
   type ScopedThreadRef,
   type SidebarProjectGroupingMode,
@@ -62,7 +64,12 @@ import {
   useTheme,
 } from "../../hooks/useTheme";
 import { useLocalStorage } from "../../hooks/useLocalStorage";
-import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSettings";
+import {
+  useEnvironmentSettings,
+  usePrimarySettings,
+  useUpdateEnvironmentSettings,
+  useUpdatePrimarySettings,
+} from "../../hooks/useSettings";
 import { useThreadActions } from "../../hooks/useThreadActions";
 import { useDesktopUpdateState } from "../../state/desktopUpdate";
 import {
@@ -77,7 +84,14 @@ import {
 } from "../../providerInstances";
 import { ensureLocalApi, readLocalApi } from "../../localApi";
 import { isMacPlatform } from "../../lib/utils";
-import { primaryServerObservabilityAtom, primaryServerProvidersAtom } from "../../state/server";
+import { useEnvironments, usePrimaryEnvironmentId } from "../../state/environments";
+import {
+  EMPTY_SERVER_PROVIDERS,
+  primaryServerObservabilityAtom,
+  primaryServerProvidersAtom,
+  primaryServerSettingsAtom,
+  serverEnvironment,
+} from "../../state/server";
 import { useProjects } from "../../state/entities";
 import { useArchivedThreadSnapshots } from "../../lib/archivedThreadsState";
 import { formatRelativeTimeLabel } from "../../timestampFormat";
@@ -133,6 +147,7 @@ import {
   readLastEnabledProjectGroupingMode,
   rememberEnabledProjectGroupingMode,
   resolveBackgroundActivityProfileOption,
+  resolveGeneralSettingsEnvironmentId,
 } from "./SettingsPanels.logic";
 import {
   PolicyTooltip,
@@ -464,10 +479,38 @@ export function useSettingsRestore(onRestored?: () => void) {
   const settings = usePrimarySettings();
   const updateSettings = useUpdatePrimarySettings();
 
-  const isTextGenerationModelDirty = !Equal.equals(
-    settings.textGenerationModelSelection ?? null,
-    DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection ?? null,
+  const { environments } = useEnvironments();
+  const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const targetEnvironmentId =
+    resolveGeneralSettingsEnvironmentId(environments, primaryEnvironmentId) ?? primaryEnvironmentId;
+  const textGenSettings = useEnvironmentSettings(
+    targetEnvironmentId ?? (primaryEnvironmentId as EnvironmentId),
   );
+  const updateTextGenSettings = useUpdateEnvironmentSettings(
+    targetEnvironmentId ?? (primaryEnvironmentId as EnvironmentId),
+  );
+  const serverProviders =
+    useAtomValue(
+      targetEnvironmentId
+        ? serverEnvironment.providersValueAtom(targetEnvironmentId)
+        : primaryServerProvidersAtom,
+    ) ?? EMPTY_SERVER_PROVIDERS;
+
+  const textGenerationModelSelection = resolveAppModelSelectionState(
+    textGenSettings,
+    serverProviders,
+  );
+  const defaultTextGenerationModelSelection = resolveAppModelSelectionState(
+    DEFAULT_UNIFIED_SETTINGS,
+    serverProviders,
+  );
+  const isTextGenerationModelDirty =
+    textGenerationModelSelection.instanceId !== defaultTextGenerationModelSelection.instanceId ||
+    textGenerationModelSelection.model !== defaultTextGenerationModelSelection.model ||
+    !Equal.equals(
+      textGenerationModelSelection.options ?? [],
+      defaultTextGenerationModelSelection.options ?? [],
+    );
   const isBackgroundActivityDirty = hasChangedBackgroundActivitySettings(settings);
 
   const changedSettingLabels = useMemo(
@@ -659,7 +702,6 @@ export function useSettingsRestore(onRestored?: () => void) {
       confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
       confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
       confirmQuit: DEFAULT_UNIFIED_SETTINGS.confirmQuit,
-      textGenerationModelSelection: DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
       fontFamilySans: DEFAULT_UNIFIED_SETTINGS.fontFamilySans,
       fontFamilyComposer: DEFAULT_UNIFIED_SETTINGS.fontFamilyComposer,
       fontFamilyCode: DEFAULT_UNIFIED_SETTINGS.fontFamilyCode,
@@ -677,10 +719,14 @@ export function useSettingsRestore(onRestored?: () => void) {
       // rather than discovering it later.
       enableAgentBrowserAccess: DEFAULT_UNIFIED_SETTINGS.enableAgentBrowserAccess,
     });
+    updateTextGenSettings({
+      textGenerationModelSelection: defaultTextGenerationModelSelection,
+    });
     onRestored?.();
   }, [
     changedSettingLabels,
     clearThemeHalves,
+    defaultTextGenerationModelSelection,
     onRestored,
     setFollowSystem,
     setTheme,
@@ -688,6 +734,7 @@ export function useSettingsRestore(onRestored?: () => void) {
     theme,
     themeHalves,
     updateSettings,
+    updateTextGenSettings,
   ]);
 
   return {
@@ -1789,12 +1836,35 @@ function LegacyFeaturesSection() {
 export function GeneralSettingsPanel() {
   const settings = usePrimarySettings();
   const updateSettings = useUpdatePrimarySettings();
+
+  const { environments } = useEnvironments();
+  const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const targetEnvironmentId =
+    resolveGeneralSettingsEnvironmentId(environments, primaryEnvironmentId) ?? primaryEnvironmentId;
+  const textGenSettings = useEnvironmentSettings(
+    targetEnvironmentId ?? (primaryEnvironmentId as EnvironmentId),
+  );
+  const updateTextGenSettings = useUpdateEnvironmentSettings(
+    targetEnvironmentId ?? (primaryEnvironmentId as EnvironmentId),
+  );
+
   const [backgroundActivityDialogOpen, setBackgroundActivityDialogOpen] = useState(false);
   const lastEnabledProjectGroupingMode = useRef<SidebarProjectGroupingMode>(
     readLastEnabledProjectGroupingMode(),
   );
   const observability = useAtomValue(primaryServerObservabilityAtom);
-  const serverProviders = useAtomValue(primaryServerProvidersAtom);
+  const serverProviders =
+    useAtomValue(
+      targetEnvironmentId
+        ? serverEnvironment.providersValueAtom(targetEnvironmentId)
+        : primaryServerProvidersAtom,
+    ) ?? EMPTY_SERVER_PROVIDERS;
+  const targetServerSettings =
+    useAtomValue(
+      targetEnvironmentId
+        ? serverEnvironment.settingsValueAtom(targetEnvironmentId)
+        : primaryServerSettingsAtom,
+    ) ?? DEFAULT_SERVER_SETTINGS;
   const diagnosticsDescription = formatDiagnosticsDescription({
     localTracingEnabled: observability?.localTracingEnabled ?? false,
     otlpTracesEnabled: observability?.otlpTracesEnabled ?? false,
@@ -1803,12 +1873,18 @@ export function GeneralSettingsPanel() {
     otlpMetricsUrl: observability?.otlpMetricsUrl,
   });
 
-  const textGenerationModelSelection = resolveAppModelSelectionState(settings, serverProviders);
+  const textGenerationModelSelection = resolveAppModelSelectionState(
+    textGenSettings,
+    serverProviders,
+  );
   const textGenInstanceId = textGenerationModelSelection.instanceId;
   const textGenModel = textGenerationModelSelection.model;
   const textGenModelOptions = textGenerationModelSelection.options;
   const textGenerationModelInstanceEntries = sortProviderInstanceEntries(
-    applyProviderInstanceSettings(deriveProviderInstanceEntries(serverProviders), settings),
+    applyProviderInstanceSettings(
+      deriveProviderInstanceEntries(serverProviders),
+      targetServerSettings,
+    ),
   );
   const textGenInstanceEntry = textGenerationModelInstanceEntries.find(
     (entry) => entry.instanceId === textGenInstanceId,
@@ -1816,15 +1892,27 @@ export function GeneralSettingsPanel() {
   const textGenProvider: ProviderDriverKind =
     textGenInstanceEntry?.driverKind ?? DEFAULT_DRIVER_KIND;
   const textGenerationModelOptionsByInstance = getCustomModelOptionsByInstance(
-    settings,
+    {
+      ...textGenSettings,
+      providerInstances: targetServerSettings.providerInstances,
+      providers: targetServerSettings.providers,
+    },
     serverProviders,
     textGenInstanceId,
     textGenModel,
   );
-  const isTextGenerationModelDirty = !Equal.equals(
-    settings.textGenerationModelSelection ?? null,
-    DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection ?? null,
+
+  const defaultTextGenerationModelSelection = resolveAppModelSelectionState(
+    DEFAULT_UNIFIED_SETTINGS,
+    serverProviders,
   );
+  const isTextGenerationModelDirty =
+    textGenerationModelSelection.instanceId !== defaultTextGenerationModelSelection.instanceId ||
+    textGenerationModelSelection.model !== defaultTextGenerationModelSelection.model ||
+    !Equal.equals(
+      textGenerationModelSelection.options ?? [],
+      defaultTextGenerationModelSelection.options ?? [],
+    );
   const resolvedBackgroundActivity = resolveServerBackgroundActivitySettings(settings);
   const activeBackgroundActivityProfile = resolvedBackgroundActivity.profile;
   const backgroundActivityProfileOption = resolveBackgroundActivityProfileOption(settings);
@@ -2311,9 +2399,8 @@ export function GeneralSettingsPanel() {
               <SettingResetButton
                 label="text generation model"
                 onClick={() =>
-                  updateSettings({
-                    textGenerationModelSelection:
-                      DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
+                  updateTextGenSettings({
+                    textGenerationModelSelection: defaultTextGenerationModelSelection,
                   })
                 }
               />
@@ -2330,10 +2417,10 @@ export function GeneralSettingsPanel() {
                 triggerVariant="outline"
                 triggerClassName="min-w-0 max-w-none shrink-0 text-foreground/90 hover:text-foreground"
                 onInstanceModelChange={(instanceId, model) => {
-                  updateSettings({
+                  updateTextGenSettings({
                     textGenerationModelSelection: resolveAppModelSelectionState(
                       {
-                        ...settings,
+                        ...textGenSettings,
                         textGenerationModelSelection: createModelSelection(instanceId, model),
                       },
                       serverProviders,
@@ -2359,10 +2446,10 @@ export function GeneralSettingsPanel() {
                 triggerVariant="outline"
                 triggerClassName="min-w-0 max-w-none shrink-0 text-foreground/90 hover:text-foreground"
                 onModelOptionsChange={(nextOptions) => {
-                  updateSettings({
+                  updateTextGenSettings({
                     textGenerationModelSelection: resolveAppModelSelectionState(
                       {
-                        ...settings,
+                        ...textGenSettings,
                         textGenerationModelSelection: createModelSelection(
                           textGenInstanceId,
                           textGenModel,

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -508,8 +508,16 @@ export function useSettingsRestore(onRestored?: () => void) {
     serverProviders,
   );
 
-  const targetEnvironmentIdRef = useRef(targetEnvironmentId);
-  targetEnvironmentIdRef.current = targetEnvironmentId;
+  const textGenerationResetStateRef = useRef({
+    targetEnvironmentId,
+    updateTextGenSettings,
+    defaultTextGenerationModelSelection,
+  });
+  textGenerationResetStateRef.current = {
+    targetEnvironmentId,
+    updateTextGenSettings,
+    defaultTextGenerationModelSelection,
+  };
 
   const isTextGenerationModelDirty =
     textGenerationModelSelection.instanceId !== defaultTextGenerationModelSelection.instanceId ||
@@ -637,10 +645,6 @@ export function useSettingsRestore(onRestored?: () => void) {
     );
     if (!confirmed) return;
 
-    if (targetEnvironmentIdRef.current !== initialTargetEnvironmentId) {
-      return;
-    }
-
     // Only touch the theme keys that are actually dirty, so a theme-storage
     // failure cannot block restoring unrelated settings. Preferences are
     // re-read after the confirmation dialog: they may have changed (another
@@ -731,16 +735,22 @@ export function useSettingsRestore(onRestored?: () => void) {
       // rather than discovering it later.
       enableAgentBrowserAccess: DEFAULT_UNIFIED_SETTINGS.enableAgentBrowserAccess,
     });
-    if (isTextGenerationModelDirty) {
-      updateTextGenSettings({
-        textGenerationModelSelection: defaultTextGenerationModelSelection,
+    // Provider discovery can update the default while the confirmation dialog is
+    // open. Use the latest reset state, but do not reset a different environment
+    // from the one the user chose before confirming.
+    if (
+      isTextGenerationModelDirty &&
+      textGenerationResetStateRef.current.targetEnvironmentId === initialTargetEnvironmentId
+    ) {
+      textGenerationResetStateRef.current.updateTextGenSettings({
+        textGenerationModelSelection:
+          textGenerationResetStateRef.current.defaultTextGenerationModelSelection,
       });
     }
     onRestored?.();
   }, [
     changedSettingLabels,
     clearThemeHalves,
-    defaultTextGenerationModelSelection,
     isTextGenerationModelDirty,
     onRestored,
     setFollowSystem,
@@ -750,7 +760,6 @@ export function useSettingsRestore(onRestored?: () => void) {
     theme,
     themeHalves,
     updateSettings,
-    updateTextGenSettings,
   ]);
 
   return {

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -508,16 +508,8 @@ export function useSettingsRestore(onRestored?: () => void) {
     serverProviders,
   );
 
-  const liveStateRef = useRef({
-    targetEnvironmentId,
-    updateTextGenSettings,
-    defaultTextGenerationModelSelection,
-  });
-  liveStateRef.current = {
-    targetEnvironmentId,
-    updateTextGenSettings,
-    defaultTextGenerationModelSelection,
-  };
+  const targetEnvironmentIdRef = useRef(targetEnvironmentId);
+  targetEnvironmentIdRef.current = targetEnvironmentId;
 
   const isTextGenerationModelDirty =
     textGenerationModelSelection.instanceId !== defaultTextGenerationModelSelection.instanceId ||
@@ -635,6 +627,7 @@ export function useSettingsRestore(onRestored?: () => void) {
 
   const restoreDefaults = useCallback(async () => {
     if (changedSettingLabels.length === 0) return;
+    const initialTargetEnvironmentId = targetEnvironmentId;
     const api = readLocalApi();
     const confirmed = await (api ?? ensureLocalApi()).dialogs.confirm(
       ["Restore default settings?", `This will reset: ${changedSettingLabels.join(", ")}.`].join(
@@ -643,6 +636,10 @@ export function useSettingsRestore(onRestored?: () => void) {
       { variant: "destructive" },
     );
     if (!confirmed) return;
+
+    if (targetEnvironmentIdRef.current !== initialTargetEnvironmentId) {
+      return;
+    }
 
     // Only touch the theme keys that are actually dirty, so a theme-storage
     // failure cannot block restoring unrelated settings. Preferences are
@@ -734,20 +731,26 @@ export function useSettingsRestore(onRestored?: () => void) {
       // rather than discovering it later.
       enableAgentBrowserAccess: DEFAULT_UNIFIED_SETTINGS.enableAgentBrowserAccess,
     });
-    liveStateRef.current.updateTextGenSettings({
-      textGenerationModelSelection: liveStateRef.current.defaultTextGenerationModelSelection,
-    });
+    if (isTextGenerationModelDirty) {
+      updateTextGenSettings({
+        textGenerationModelSelection: defaultTextGenerationModelSelection,
+      });
+    }
     onRestored?.();
   }, [
     changedSettingLabels,
     clearThemeHalves,
+    defaultTextGenerationModelSelection,
+    isTextGenerationModelDirty,
     onRestored,
     setFollowSystem,
     setTheme,
     setThemeHalf,
+    targetEnvironmentId,
     theme,
     themeHalves,
     updateSettings,
+    updateTextGenSettings,
   ]);
 
   return {


### PR DESCRIPTION
## What Changed

- Added `resolveGeneralSettingsEnvironmentId` to detect and fall back to connected environments that have installed models (e.g. OpenCode on WSL or remote connections).
- Bound text-generation model discovery, instance configuration overlay, and persistence updates in `GeneralSettingsPanel` to the resolved active environment.
- Scoped text-generation dirty-state detection and default restoration to evaluate and restore against the active environment's default text-generation model.
- Added unit tests covering primary, WSL fallback, remote-only, and zero-environment states in `SettingsPanels.logic.test.ts`.

## Why

When running T3 Code with providers installed on a connected environment (such as OpenCode running in WSL while using the Windows Desktop client), `Settings > General` hardcoded provider discovery and settings writes to the primary host. 

This caused the "Text generation model" picker to show "No models found", even if models were available to pick from one of the remotes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which environment’s settings are read and written for the text-generation model, including restore-defaults. Wrong targeting could persist the selection on the wrong host.
> 
> **Overview**
> Fixes the General **text generation model** picker showing “No models found” when providers live on a connected environment (WSL/remote) rather than the primary host.
> 
> Adds `resolveGeneralSettingsEnvironmentId` to prefer a connected environment with picker-ready, enabled models, then falls back to primary/first. `resolveTextGenerationModelDefault` computes the reset selection from those usable providers.
> 
> `GeneralSettingsPanel` and restore-defaults now read/write `textGenerationModelSelection` via environment-scoped settings. Restore is guarded so a target change while the confirm dialog is open cannot reset a different environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 434df663bda69a9740574dd8e5bb0b659a9dd359. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve text generation model defaults from connected environments in `GeneralSettingsPanel`
> - Adds `resolveGeneralSettingsEnvironmentId`, `resolveTextGenerationModelDefault`, and `resolvePickerUsableProviders` to [SettingsPanels.logic.ts](https://github.com/pingdotgg/t3code/pull/7457/files#diff-bad687287a18d0a58c30735640fef99f0f90283727a66f89de22cffd8cb302c4) so settings panels select an environment with usable providers before computing model defaults.
> - Refactors `useSettingsRestore` and `GeneralSettingsPanel` in [SettingsPanels.tsx](https://github.com/pingdotgg/t3code/pull/7457/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18) to read and update text-generation model settings per environment via environment-scoped hooks and atoms instead of global unified settings.
> - Reset action now compares against an environment-scoped computed default and only applies when a default exists and the target environment hasn't changed since the dialog opened.
> - Behavioral Change: `useSettingsRestore` no longer unconditionally resets `textGenerationModelSelection` globally; resets are conditional on dirtiness and applied to the selected environment only.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 434df66.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->