### PR TITLE
fix(server): stop probing Grok, Cursor, and OpenCode unless turned on

### DIFF
--- a/apps/server/src/provider/Layers/GrokProvider.test.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.test.ts
@@ -23,9 +23,19 @@ describe("buildInitialGrokProviderSnapshot", () => {
     }),
   );
 
-  it.effect("returns a pending snapshot by default", () =>
+  it.effect("returns a disabled snapshot by default — Grok is opt-in", () =>
     Effect.gen(function* () {
       const snapshot = yield* buildInitialGrokProviderSnapshot(decodeGrokSettings({}));
+      expect(snapshot.enabled).toBe(false);
+      expect(snapshot.status).toBe("disabled");
+    }),
+  );
+
+  it.effect("returns a pending snapshot when enabled", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* buildInitialGrokProviderSnapshot(
+        decodeGrokSettings({ enabled: true }),
+      );
       expect(snapshot.enabled).toBe(true);
       expect(snapshot.installed).toBe(true);
       expect(snapshot.status).toBe("warning");

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
@@ -223,6 +223,32 @@ describe("ProviderInstanceRegistryLive — multi-instance codex slice", () => {
     }).pipe(Effect.provide(testLayer)),
   );
 
+  it.live("treats an explicit in-config enabled:false as disabling despite the envelope", () =>
+    Effect.gen(function* () {
+      // Old settings files can carry both flags with conflicting values.
+      // The explicit false must win so a user's disable is never undone.
+      const staleId = ProviderInstanceId.make("codex_stale");
+      const configMap: ProviderInstanceConfigMap = {
+        [staleId]: {
+          driver: ProviderDriverKind.make("codex"),
+          enabled: true,
+          config: makeCodexConfig({ enabled: false }),
+        },
+      };
+
+      const { registry } = yield* makeProviderInstanceRegistry({
+        drivers: [CodexDriver],
+        configMap,
+      });
+
+      const instance = yield* registry.getInstance(staleId);
+      expect(instance).toBeDefined();
+      expect(instance!.enabled).toBe(false);
+      const snapshot = yield* instance!.snapshot.getSnapshot;
+      expect(snapshot.enabled).toBe(false);
+    }).pipe(Effect.provide(testLayer)),
+  );
+
   it.live(
     "shadows instances whose driver is not registered in this build without failing boot",
     () =>

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.ts
@@ -34,6 +34,7 @@
  */
 import {
   defaultInstanceIdForDriver,
+  providerInstanceConfigEnabledFlag,
   ProviderInstanceId,
   type ProviderInstanceConfig,
   type ProviderInstanceConfigMap,
@@ -93,12 +94,20 @@ interface RegistryState {
 const entryEqual = (a: ProviderInstanceConfig, b: ProviderInstanceConfig): boolean =>
   Equal.equals(a, b);
 
-const decodedConfigEnabled = (config: unknown): boolean | undefined => {
-  if (!config || typeof config !== "object" || globalThis.Array.isArray(config)) {
-    return undefined;
+/**
+ * Resolve an entry's enabled state. An explicit false on either the
+ * envelope or the raw config blob wins (most restrictive) — old settings
+ * files can carry both flags with conflicting values, and a user's disable
+ * must never be silently undone. Otherwise the envelope flag wins, then the
+ * decoded config's flag (which carries the driver schema's default for
+ * built-ins and forks alike), then enabled by default.
+ */
+const resolveEntryEnabled = (entry: ProviderInstanceConfig, typedConfig: unknown): boolean => {
+  const rawConfigEnabled = providerInstanceConfigEnabledFlag(entry.config);
+  if (entry.enabled === false || rawConfigEnabled === false) {
+    return false;
   }
-  const enabled = (config as { readonly enabled?: unknown }).enabled;
-  return typeof enabled === "boolean" ? enabled : undefined;
+  return entry.enabled ?? providerInstanceConfigEnabledFlag(typedConfig) ?? true;
 };
 
 /**
@@ -171,7 +180,7 @@ const buildEntry = <R>(input: {
         displayName: entry.displayName,
         accentColor: entry.accentColor,
         environment: entry.environment ?? [],
-        enabled: entry.enabled ?? decodedConfigEnabled(typedConfig) ?? true,
+        enabled: resolveEntryEnabled(entry, typedConfig),
         config: typedConfig,
       })
       .pipe(Effect.provideService(Scope.Scope, childScope), Effect.result);

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -487,6 +487,59 @@ it.layer(NodeServices.layer)("server settings", (it) => {
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
+  it.effect("folds a legacy in-config enabled flag into the envelope on load", () =>
+    Effect.gen(function* () {
+      const serverConfig = yield* ServerConfig.ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+      // Old settings files can carry both flags with conflicting values.
+      // The explicit false must win so a user's disable sticks.
+      yield* fileSystem.writeFileString(
+        serverConfig.settingsPath,
+        '{"providerInstances":{"grok":{"driver":"grok","enabled":true,"config":{"enabled":false}},"codex_work":{"driver":"codex","config":{"enabled":true,"homePath":"~/.codex"}}}}',
+      );
+
+      const settings = yield* serverSettings.getSettings;
+
+      const grokId = ProviderInstanceId.make("grok");
+      const codexWorkId = ProviderInstanceId.make("codex_work");
+      assert.deepEqual(settings.providerInstances[grokId], {
+        driver: ProviderDriverKind.make("grok"),
+        enabled: false,
+        config: {},
+      });
+      // A lone in-config flag is lifted to the envelope and stripped.
+      assert.deepEqual(settings.providerInstances[codexWorkId], {
+        driver: ProviderDriverKind.make("codex"),
+        enabled: true,
+        config: { homePath: "~/.codex" },
+      });
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
+  it.effect("folds in-config enabled flags arriving through updates", () =>
+    Effect.gen(function* () {
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+      const grokId = ProviderInstanceId.make("grok");
+
+      const next = yield* serverSettings.updateSettings({
+        providerInstances: {
+          [grokId]: {
+            driver: ProviderDriverKind.make("grok"),
+            enabled: true,
+            config: { enabled: false, binaryPath: "/opt/grok" },
+          },
+        },
+      });
+
+      assert.deepEqual(next.providerInstances[grokId], {
+        driver: ProviderDriverKind.make("grok"),
+        enabled: false,
+        config: { binaryPath: "/opt/grok" },
+      });
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
   it.effect("trims provider path settings when updates are applied", () =>
     Effect.gen(function* () {
       const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
@@ -524,7 +577,8 @@ it.layer(NodeServices.layer)("server settings", (it) => {
         launchArgs: "",
       });
       assert.deepEqual(next.providers.opencode, {
-        enabled: true,
+        // OpenCode is disabled by default; this update only touches paths.
+        enabled: false,
         binaryPath: "/opt/homebrew/bin/opencode",
         serverUrl: "http://127.0.0.1:4096",
         serverPassword: "secret-password",

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -496,7 +496,7 @@ it.layer(NodeServices.layer)("server settings", (it) => {
       // The explicit false must win so a user's disable sticks.
       yield* fileSystem.writeFileString(
         serverConfig.settingsPath,
-        '{"providerInstances":{"grok":{"driver":"grok","enabled":true,"config":{"enabled":false}},"codex_work":{"driver":"codex","config":{"enabled":true,"homePath":"~/.codex"}}}}',
+        '{"providerInstances":{"grok":{"driver":"grok","enabled":true,"config":{"enabled":false}},"codex_work":{"driver":"codex","config":{"enabled":true,"homePath":"~/.codex"}},"cursor":{"driver":"cursor","config":{"enabled":"nope"}}}}',
       );
 
       const settings = yield* serverSettings.getSettings;
@@ -513,6 +513,12 @@ it.layer(NodeServices.layer)("server settings", (it) => {
         driver: ProviderDriverKind.make("codex"),
         enabled: true,
         config: { homePath: "~/.codex" },
+      });
+      // A malformed flag is left alone so driver schema validation can
+      // surface it instead of the fold silently repairing the config.
+      assert.deepEqual(settings.providerInstances[ProviderInstanceId.make("cursor")], {
+        driver: ProviderDriverKind.make("cursor"),
+        config: { enabled: "nope" },
       });
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -61,11 +61,57 @@ const decodeServerSettings = Schema.decodeUnknownEffect(ServerSettings);
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 
+/**
+ * Fold the legacy in-config `enabled` flag into the envelope-level
+ * `ProviderInstanceConfig.enabled` and strip it from the config blob, so
+ * explicit provider instances carry exactly one enabled flag. Old settings
+ * files can hold both flags with conflicting values; an explicit false on
+ * either side wins so a user's disable is never silently undone. Runs on
+ * every load and update — the file converges on the next write.
+ */
+const foldProviderInstanceEnabledFlags = (settings: ServerSettings): ServerSettings => {
+  let changed = false;
+  const providerInstances: Record<string, ProviderInstanceConfig> = {};
+  for (const [instanceId, instance] of Object.entries(settings.providerInstances)) {
+    const config = instance.config;
+    if (
+      config === null ||
+      typeof config !== "object" ||
+      Array.isArray(config) ||
+      !("enabled" in config)
+    ) {
+      providerInstances[instanceId] = instance;
+      continue;
+    }
+    const { enabled: configEnabled, ...restConfig } = config as Record<string, unknown>;
+    const resolved =
+      typeof configEnabled === "boolean"
+        ? instance.enabled === false || configEnabled === false
+          ? false
+          : (instance.enabled ?? configEnabled)
+        : instance.enabled;
+    changed = true;
+    providerInstances[instanceId] = {
+      ...instance,
+      ...(resolved === undefined ? {} : { enabled: resolved }),
+      config: restConfig,
+    } satisfies ProviderInstanceConfig;
+  }
+  if (!changed) {
+    return settings;
+  }
+  return {
+    ...settings,
+    providerInstances: providerInstances as ServerSettings["providerInstances"],
+  };
+};
+
 const normalizeServerSettings = (
   settings: ServerSettings,
 ): Effect.Effect<ServerSettings, ServerSettingsError> =>
   encodeServerSettings(settings).pipe(
     Effect.flatMap(decodeServerSettings),
+    Effect.map(foldProviderInstanceEnabledFlags),
     Effect.mapError(
       (cause) =>
         new ServerSettingsError({
@@ -303,7 +349,7 @@ const make = Effect.gen(function* () {
       });
       return DEFAULT_SERVER_SETTINGS;
     }
-    return decoded.value;
+    return foldProviderInstanceEnabledFlags(decoded.value);
   });
 
   const settingsCache = yield* Cache.make<typeof cacheKey, ServerSettings, ServerSettingsError>({

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -74,26 +74,29 @@ const foldProviderInstanceEnabledFlags = (settings: ServerSettings): ServerSetti
   const providerInstances: Record<string, ProviderInstanceConfig> = {};
   for (const [instanceId, instance] of Object.entries(settings.providerInstances)) {
     const config = instance.config;
+    // Only fold boolean flags: a malformed `enabled` (e.g. `"false"`) must
+    // stay in the blob so driver schema validation flags it instead of the
+    // fold silently repairing the config.
     if (
       config === null ||
       typeof config !== "object" ||
       Array.isArray(config) ||
-      !("enabled" in config)
+      typeof (config as { readonly enabled?: unknown }).enabled !== "boolean"
     ) {
       providerInstances[instanceId] = instance;
       continue;
     }
-    const { enabled: configEnabled, ...restConfig } = config as Record<string, unknown>;
+    const { enabled: configEnabled, ...restConfig } = config as Record<string, unknown> & {
+      readonly enabled: boolean;
+    };
     const resolved =
-      typeof configEnabled === "boolean"
-        ? instance.enabled === false || configEnabled === false
-          ? false
-          : (instance.enabled ?? configEnabled)
-        : instance.enabled;
+      instance.enabled === false || configEnabled === false
+        ? false
+        : (instance.enabled ?? configEnabled);
     changed = true;
     providerInstances[instanceId] = {
       ...instance,
-      ...(resolved === undefined ? {} : { enabled: resolved }),
+      enabled: resolved,
       config: restConfig,
     } satisfies ProviderInstanceConfig;
   }

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -15,6 +15,7 @@ import * as Result from "effect/Result";
 import { useState, type ReactNode } from "react";
 import {
   isProviderDriverKind,
+  resolveProviderInstanceEnabled,
   type ProviderInstanceConfig,
   type ProviderInstanceEnvironmentVariable,
   type ProviderInstanceId,
@@ -368,12 +369,10 @@ interface ProviderInstanceCardProps {
  *     notice instead of editable fields, so fork instances round-trip
  *     without accidentally destroying their config.
  *   - The enabled Switch writes to the envelope's `instance.enabled`
- *     field; the server's registry consults this at `entry.enabled ?? true`
- *     before materializing the instance, and the probe also checks its
- *     driver-specific `config.enabled`. We treat the envelope flag as the
- *     single source of truth from the UI — built-in cards used to write
- *     the inner flag, but on the promotion-to-instance path every edit
- *     flows through the envelope.
+ *     field, which is the single enabled flag: the server folds any legacy
+ *     driver-specific `config.enabled` into the envelope on load and both
+ *     sides resolve through `resolveProviderInstanceEnabled` (an explicit
+ *     false wins, then envelope, then config, then the driver default).
  */
 export function ProviderInstanceCard({
   instanceId,
@@ -394,7 +393,7 @@ export function ProviderInstanceCard({
   onRunUpdate,
   isUpdating = false,
 }: ProviderInstanceCardProps) {
-  const enabled = instance.enabled ?? true;
+  const enabled = resolveProviderInstanceEnabled(instance);
   // The server-reported status wins when present; otherwise fall back to
   // "disabled"/"warning" based on the local `enabled` flag so the dot
   // reflects the persisted intent even before the first probe completes.

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -12,6 +12,7 @@ import {
   ProviderDriverKind,
   type ProviderInstanceConfig,
   type ProviderInstanceId,
+  resolveProviderInstanceEnabled,
 } from "@t3tools/contracts";
 import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
 import {
@@ -838,7 +839,7 @@ export function EnvironmentProviderSettings({
                   }))
                 }
                 onUpdate={(next) => {
-                  const wasEnabled = row.instance.enabled ?? true;
+                  const wasEnabled = resolveProviderInstanceEnabled(row.instance);
                   const isDisabling = next.enabled === false && wasEnabled;
                   const shouldClearTextGen = isDisabling && textGenInstanceId === row.instanceId;
                   if (shouldClearTextGen) {

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -530,15 +530,23 @@ export function EnvironmentProviderSettings({
     // instance or a legacy blob there is nothing to render for the slot.
     const legacyConfig = legacyProviders[providerSettings.provider];
     const defaultLegacyConfig = defaultLegacyProviders[providerSettings.provider];
+    // The envelope is the single enabled flag: keep the legacy in-config
+    // flag out of the synthesized blob, or an explicit `enabled: false`
+    // would keep winning over the envelope and the Switch could never
+    // turn a default-off provider on.
+    const synthesizedInstance = (): ProviderInstanceConfig | undefined => {
+      if (legacyConfig === undefined) {
+        return undefined;
+      }
+      const { enabled: legacyEnabled, ...legacyConfigRest } = legacyConfig;
+      return {
+        driver,
+        enabled: legacyEnabled,
+        config: legacyConfigRest,
+      } satisfies ProviderInstanceConfig;
+    };
     const effectiveInstance: ProviderInstanceConfig | undefined =
-      explicitInstance ??
-      (legacyConfig !== undefined
-        ? ({
-            driver,
-            enabled: legacyConfig.enabled,
-            config: legacyConfig,
-          } satisfies ProviderInstanceConfig)
-        : undefined);
+      explicitInstance ?? synthesizedInstance();
     // Only the default slot depends on the legacy blob; custom instances for
     // the driver must still render even when the slot has nothing to show.
     if (effectiveInstance !== undefined) {

--- a/apps/web/src/providerInstances.ts
+++ b/apps/web/src/providerInstances.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_MODEL_BY_PROVIDER,
   defaultInstanceIdForDriver,
   PROVIDER_DISPLAY_NAMES,
+  resolveProviderInstanceEnabled,
   type ModelSelection,
   type ProviderDriverKind,
   ProviderInstanceId,
@@ -220,7 +221,7 @@ export function applyProviderInstanceSettings(
   return entries.map((entry) => {
     const explicitInstance = settings.providerInstances?.[entry.instanceId];
     const enabled = explicitInstance
-      ? (explicitInstance.enabled ?? true)
+      ? resolveProviderInstanceEnabled(explicitInstance)
       : entry.isDefault
         ? (legacyProviders[entry.driverKind]?.enabled ?? entry.enabled)
         : false;

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -62,6 +62,9 @@ to use, then authenticate it.
 | Grok Build | [Grok Build CLI](https://x.ai/cli)                    | `grok`         | `grok login`          |
 | OpenCode   | [OpenCode](https://opencode.ai)                       | `opencode`     | `opencode auth login` |
 
+Codex and Claude are on by default. Cursor, Grok Build, and OpenCode are off by default; turn
+them on in **Settings** → the provider's card when you want to use them.
+
 Cursor is the one to watch: install Cursor CLI, which provides the `cursor-agent` binary that
 T3 Code looks for, but authenticate with `agent login`, not `cursor-agent login`.
 

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vite-plus/test";
 import * as Schema from "effect/Schema";
 
-import { ProviderInstanceId } from "./providerInstance.ts";
+import { ProviderDriverKind, ProviderInstanceId } from "./providerInstance.ts";
 import {
   ClientSettingsSchema,
   ClientSettingsPatch,
   DEFAULT_SERVER_SETTINGS,
+  defaultEnabledForDriver,
+  resolveProviderInstanceEnabled,
   ServerSettings,
   ServerSettingsPatch,
 } from "./settings.ts";
@@ -174,6 +176,46 @@ describe("ServerSettings.providerInstances (slice-2 invariant)", () => {
         providerInstances: { "1bad": { driver: "codex" } },
       }),
     ).toThrow();
+  });
+});
+
+describe("provider enabled defaults", () => {
+  it("enables only the stable bindings by default", () => {
+    const decoded = decodeServerSettings({});
+    expect(decoded.providers.codex.enabled).toBe(true);
+    expect(decoded.providers.claudeAgent.enabled).toBe(true);
+    expect(decoded.providers.cursor.enabled).toBe(false);
+    expect(decoded.providers.grok.enabled).toBe(false);
+    expect(decoded.providers.opencode.enabled).toBe(false);
+  });
+
+  it("derives per-driver defaults from the settings schemas", () => {
+    expect(defaultEnabledForDriver(ProviderDriverKind.make("codex"))).toBe(true);
+    expect(defaultEnabledForDriver(ProviderDriverKind.make("grok"))).toBe(false);
+    // Unknown fork drivers stay enabled; their own build decides otherwise.
+    expect(defaultEnabledForDriver(ProviderDriverKind.make("ollama"))).toBe(true);
+  });
+
+  it("resolves instance enabled state with explicit false winning", () => {
+    const grok = ProviderDriverKind.make("grok");
+    const codex = ProviderDriverKind.make("codex");
+    // No flags anywhere: driver default applies.
+    expect(resolveProviderInstanceEnabled({ driver: grok, config: {} })).toBe(false);
+    expect(resolveProviderInstanceEnabled({ driver: codex, config: {} })).toBe(true);
+    // Envelope flag wins over the driver default.
+    expect(resolveProviderInstanceEnabled({ driver: grok, enabled: true, config: {} })).toBe(true);
+    expect(resolveProviderInstanceEnabled({ driver: codex, enabled: false, config: {} })).toBe(
+      false,
+    );
+    // Legacy in-config flag fills in when the envelope is silent.
+    expect(resolveProviderInstanceEnabled({ driver: grok, config: { enabled: true } })).toBe(true);
+    // Conflicting flags: the explicit false wins, whichever side it is on.
+    expect(
+      resolveProviderInstanceEnabled({ driver: grok, enabled: true, config: { enabled: false } }),
+    ).toBe(false);
+    expect(
+      resolveProviderInstanceEnabled({ driver: codex, enabled: false, config: { enabled: true } }),
+    ).toBe(false);
   });
 });
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -18,7 +18,11 @@ import {
   PreviewViewportSetting,
   PreviewZoomFactor,
 } from "./preview.ts";
-import { ProviderInstanceConfig, ProviderInstanceId } from "./providerInstance.ts";
+import {
+  ProviderInstanceConfig,
+  ProviderInstanceId,
+  type ProviderDriverKind,
+} from "./providerInstance.ts";
 
 // ── Client Settings (local-only) ───────────────────────────────
 
@@ -403,6 +407,8 @@ export type ClaudeSettings = typeof ClaudeSettings.Type;
 
 export const CursorSettings = makeProviderSettingsSchema(
   {
+    // Off by default (like Grok and OpenCode): the binding is not yet
+    // stable enough to probe on every install. Users opt in from Settings.
     enabled: Schema.Boolean.pipe(
       Schema.withDecodingDefault(Effect.succeed(false)),
       Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
@@ -438,8 +444,10 @@ export type CursorSettings = typeof CursorSettings.Type;
 
 export const GrokSettings = makeProviderSettingsSchema(
   {
+    // Off by default (like Cursor and OpenCode): the binding is not yet
+    // stable enough to probe on every install. Users opt in from Settings.
     enabled: Schema.Boolean.pipe(
-      Schema.withDecodingDefault(Effect.succeed(true)),
+      Schema.withDecodingDefault(Effect.succeed(false)),
       Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
     ),
     binaryPath: makeBinaryPathSetting("grok").pipe(
@@ -462,8 +470,10 @@ export type GrokSettings = typeof GrokSettings.Type;
 
 export const OpenCodeSettings = makeProviderSettingsSchema(
   {
+    // Off by default (like Cursor and Grok): the binding is not yet stable
+    // enough to probe on every install. Users opt in from Settings.
     enabled: Schema.Boolean.pipe(
-      Schema.withDecodingDefault(Effect.succeed(true)),
+      Schema.withDecodingDefault(Effect.succeed(false)),
       Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
     ),
     binaryPath: makeBinaryPathSetting("opencode").pipe(
@@ -666,6 +676,50 @@ export const ServerSettings = Schema.Struct({
 export type ServerSettings = typeof ServerSettings.Type;
 
 export const DEFAULT_SERVER_SETTINGS: ServerSettings = Schema.decodeSync(ServerSettings)({});
+
+/**
+ * Read the legacy `enabled` flag embedded in a provider instance config
+ * blob. The envelope-level `ProviderInstanceConfig.enabled` is the single
+ * flag going forward; this reader exists for legacy `providers.<kind>`
+ * blobs and old settings files that still carry the flag in-config.
+ */
+export const providerInstanceConfigEnabledFlag = (config: unknown): boolean | undefined => {
+  if (config === null || typeof config !== "object" || Array.isArray(config)) {
+    return undefined;
+  }
+  const enabled = (config as { readonly enabled?: unknown }).enabled;
+  return typeof enabled === "boolean" ? enabled : undefined;
+};
+
+/**
+ * Default enabled state for a built-in driver when neither the envelope nor
+ * the config blob carries a flag. Derived from the driver's settings schema
+ * through `DEFAULT_SERVER_SETTINGS`, so the schema's decoding default stays
+ * the single source of truth. Unknown (fork) drivers default to enabled.
+ */
+export const defaultEnabledForDriver = (driver: ProviderDriverKind): boolean => {
+  const legacyDefaults = DEFAULT_SERVER_SETTINGS.providers as Record<
+    string,
+    { readonly enabled?: boolean } | undefined
+  >;
+  return legacyDefaults[driver]?.enabled ?? true;
+};
+
+/**
+ * Resolve whether a configured provider instance is enabled. An explicit
+ * false on either the envelope or the in-config flag wins (most
+ * restrictive), so a user's disable is never silently undone by the other
+ * flag. Otherwise: envelope, then config, then the driver's default.
+ */
+export const resolveProviderInstanceEnabled = (
+  instance: Pick<ProviderInstanceConfig, "driver" | "enabled" | "config">,
+): boolean => {
+  const configEnabled = providerInstanceConfigEnabledFlag(instance.config);
+  if (instance.enabled === false || configEnabled === false) {
+    return false;
+  }
+  return instance.enabled ?? configEnabled ?? defaultEnabledForDriver(instance.driver);
+};
 
 export const ServerSettingsOperation = Schema.Literals([
   "normalize",

--- a/packages/shared/src/serverSettings.ts
+++ b/packages/shared/src/serverSettings.ts
@@ -1,6 +1,7 @@
 import {
   isProviderDriverKind,
   isProviderAvailable,
+  resolveProviderInstanceEnabled,
   type ModelSelection,
   type ProviderDriverKind,
   type ServerProvider,
@@ -36,7 +37,7 @@ export function isModelSelectionProviderEnabled(
 ): boolean {
   const instanceConfig = settings.providerInstances[selection.instanceId];
   if (instanceConfig !== undefined) {
-    return instanceConfig.enabled ?? true;
+    return resolveProviderInstanceEnabled(instanceConfig);
   }
 
   return (


### PR DESCRIPTION
The Grok, Cursor, and OpenCode bindings have known issues, but every install probed them anyway: all five providers were enabled by default, so the server ran `grok --version` (and friends) on every health refresh even when the CLI was not installed.

On top of that, there were two `enabled` flags: the envelope-level `providerInstances.<id>.enabled` and the driver-config `config.enabled`. The envelope silently won, so disabling through one path did not stick.

Now:

- Grok and OpenCode default to `enabled: false` in their settings schemas, matching Cursor. Codex and Claude stay on. Disabled providers skip all probing and stay visible in Settings with the toggle to opt in.
- The envelope flag is the single enabled flag. The server folds a legacy `config.enabled` into the envelope on load/update and strips it; an explicit false on either side wins, so an existing disable is never undone.
- Clients resolve enablement through one shared helper (`resolveProviderInstanceEnabled`) instead of scattered `enabled ?? true` fallbacks.

Behavior note: users of Grok/Cursor/OpenCode who never touched provider settings will find the provider disabled after updating and need to flip it on once in Settings.

Change made by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default provider behavior and settings migration paths across server, contracts, and UI; incorrect enablement resolution could skip probes or ignore user disables, but behavior is heavily tested.
> 
> **Overview**
> **Grok, Cursor, and OpenCode** no longer probe on every install: their settings schemas default `enabled` to `false` (Grok was previously on by default). **Codex and Claude** stay enabled by default. Install docs note the opt-in behavior.
> 
> Provider enablement is consolidated on the **envelope** `providerInstances.<id>.enabled`. The server **folds** legacy `config.enabled` into the envelope on load/normalize/update and strips it from the blob; **explicit `false` on either side wins** so disables stick. Shared helpers (`resolveProviderInstanceEnabled`, `defaultEnabledForDriver`) replace scattered `enabled ?? true` in the registry, web settings UI, and model-selection checks. Legacy-to-instance synthesis in settings **omits** in-config `enabled` so toggles can turn default-off providers on.
> 
> **Upgrade note:** users who relied on Grok/OpenCode probing without changing settings must enable them once in Settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00ad4bea50d73cd5e1a3e7d118670bf22dd42200. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable Grok, Cursor, and OpenCode provider probing by default
> - Changes the default `enabled` state for Grok and OpenCode settings schemas from `true` to `false`; Cursor was already `false`. These providers are now opt-in via Settings.
> - Adds `resolveProviderInstanceEnabled` in [settings.ts](https://github.com/pingdotgg/t3code/pull/7459/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c) to unify enabled-state resolution: explicit `false` on either the envelope or in-config wins; otherwise falls back to per-driver defaults.
> - Introduces `foldProviderInstanceEnabledFlags` in [serverSettings.ts](https://github.com/pingdotgg/t3code/pull/7459/files#diff-ec910be99e19e00c0e09b15484059b34164d71de8d0026f4ba98471bbbb3680e) to normalize legacy in-config `enabled` flags into the envelope on load and update, stripping the flag from the config blob.
> - Updates UI components and shared utilities to use `resolveProviderInstanceEnabled` instead of `instance.enabled ?? true`.
> - Behavioral Change: Grok, Cursor, and OpenCode instances are now disabled on fresh or existing configs where `enabled` was not explicitly set to `true`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 00ad4be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent provider enablement handling across settings and provider selection.
  * Cursor, Grok, and OpenCode are now disabled by default and can be enabled in Settings.
  * Legacy provider enablement settings are automatically migrated.

* **Bug Fixes**
  * Explicitly disabling a provider now takes precedence over conflicting enablement settings.
  * Provider cards and settings accurately reflect each provider’s effective status.

* **Documentation**
  * Clarified default provider availability and opt-in integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->