### PR TITLE
fix(desktop): boot the main window unthrottled so cold start paints at full speed

### DIFF
--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -80,6 +80,7 @@ function makeFakeBrowserWindow() {
     reload: vi.fn(),
     replaceMisspelling: vi.fn(),
     send: vi.fn(),
+    setBackgroundThrottling: vi.fn(),
     setWindowOpenHandler: vi.fn(),
   };
 
@@ -124,6 +125,7 @@ function makeFakeBrowserWindow() {
     reload: webContents.reload,
     send: webContents.send,
     setZoomLevel: webContents.setZoomLevel,
+    setBackgroundThrottling: webContents.setBackgroundThrottling,
     setAutoHideCursor: window.setAutoHideCursor,
     webContentsListeners,
     windowListeners,
@@ -455,7 +457,7 @@ describe("DesktopWindow", () => {
         assert.isUndefined(createdWindowOptions[0]?.x);
         assert.isUndefined(createdWindowOptions[0]?.y);
         assert.isTrue(createdWindowOptions[0]?.disableAutoHideCursor);
-        assert.isUndefined(createdWindowOptions[0]?.webPreferences?.backgroundThrottling);
+        assert.isFalse(createdWindowOptions[0]?.webPreferences?.backgroundThrottling);
         assert.deepEqual(fakeWindow.setAutoHideCursor.mock.calls, [[false]]);
         assert.deepEqual(fakeWindow.loadURL.mock.calls[0], ["t3code-dev://app/"]);
         assert.equal(fakeWindow.openDevTools.mock.calls.length, 1);
@@ -600,6 +602,35 @@ describe("DesktopWindow", () => {
         }
         readyToShow();
         assert.equal(fakeWindow.maximize.mock.calls.length, 1);
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
+  // The window boots hidden with throttling disabled so first paint runs at
+  // full speed; the first reveal must hand it back to normal hidden-window
+  // throttling or a minimized window stays expensive forever.
+  it.effect("re-enables background throttling on first reveal", () =>
+    Effect.gen(function* () {
+      const fakeWindow = makeFakeBrowserWindow();
+      const createCount = yield* Ref.make(0);
+      const mainWindow = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(Option.none());
+      const layer = makeTestLayer({
+        window: fakeWindow.window,
+        createCount,
+        mainWindow,
+      });
+
+      yield* Effect.gen(function* () {
+        const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        yield* desktopWindow.handleBackendReady(new URL("http://127.0.0.1:3773"));
+
+        assert.equal(fakeWindow.setBackgroundThrottling.mock.calls.length, 0);
+        const readyToShow = fakeWindow.windowListeners.get("ready-to-show");
+        if (!readyToShow) {
+          return yield* Effect.die("window ready-to-show listener was not registered");
+        }
+        readyToShow();
+        assert.deepEqual(fakeWindow.setBackgroundThrottling.mock.calls, [[true]]);
       }).pipe(Effect.provide(layer));
     }),
   );

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -359,6 +359,12 @@ export const make = Effect.gen(function* () {
       ...getWindowTitleBarOptions(shouldUseDarkColors, environment.platform),
       webPreferences: {
         preload: environment.preloadPath,
+        // The window boots hidden (show: false until ready-to-show), and
+        // Chromium throttles hidden renderers: timers coalesce and rAF stops,
+        // which stalls first paint. Boot unthrottled; the first-reveal trigger
+        // re-enables throttling so a hidden or minimized window goes back to
+        // being cheap after it has been shown once.
+        backgroundThrottling: false,
         contextIsolation: true,
         nodeIntegration: false,
         sandbox: true,
@@ -725,6 +731,11 @@ export const make = Effect.gen(function* () {
       revealSubscribers.push((fire) => window.webContents.once("did-finish-load", fire));
     }
     bindFirstRevealTrigger(revealSubscribers, () => {
+      // Boot is done; hand the window back to normal hidden-window throttling
+      // (see the backgroundThrottling comment on the create options above).
+      if (!window.isDestroyed()) {
+        window.webContents.setBackgroundThrottling(true);
+      }
       // Reveal the real window, then close the connecting splash (if any) so the
       // two don't overlap and there's no blank gap between them.
       if (persistedSettings.mainWindowMaximized) {


### PR DESCRIPTION
The desktop app boots its main window hidden (`show: false` until `ready-to-show`), and Chromium throttles hidden renderers: timers coalesce to 1s and `requestAnimationFrame` stops entirely. #7445 removed `backgroundThrottling: false` from the main window while fixing hidden preview rendering, which put every cold boot into that throttled state. Claude Desktop shipped the same class of fix last week and measured ~2x faster background starts.

The fix keeps both behaviors: the window is created with `backgroundThrottling: false` so boot runs at full speed while hidden, and the first-reveal trigger flips throttling back on. After the window has been shown once, hiding or minimizing it throttles normally, so the #7445 win stays intact.

---
Change made by Claude Fable 5 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop startup performance tweak with a targeted re-enable on first show; limited to main window webPreferences and covered by new unit tests.
> 
> **Overview**
> Fixes slow cold starts caused by Chromium throttling the main renderer while the window stays hidden until `ready-to-show`.
> 
> The main window is created with **`backgroundThrottling: false`** so timers and `requestAnimationFrame` run at full speed during hidden boot. On the **first reveal** (same path that maximizes and shows the window), the code calls **`setBackgroundThrottling(true)`** so afterward hidden or minimized windows throttle normally again—preserving the behavior from the earlier preview fix.
> 
> Tests expect `webPreferences.backgroundThrottling` to be `false` at creation and assert `setBackgroundThrottling(true)` runs once when `ready-to-show` fires.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f64bbd57fa3762f558948daae5255d077bc47aa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Boot the main window with `backgroundThrottling` disabled to improve cold start paint speed
> Sets `webPreferences.backgroundThrottling: false` when creating the hidden main `BrowserWindow` in [`DesktopWindow.ts`](https://github.com/pingdotgg/t3code/pull/7460/files#diff-d92229c509071d1e9d3595d187fe2f1f13c394b22e1d9d2070ed6fb99678f429) so the renderer runs unthrottled during startup. On the first `ready-to-show`/`did-finish-load` event, `setBackgroundThrottling(true)` is called to restore normal hidden-window throttling. Behavioral Change: the main window now boots with throttling disabled by default rather than using Electron's default (enabled).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f64bbd5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->