### PR TITLE
fix(clients): project icons no longer vanish or differ across machines

### DIFF
--- a/apps/mobile/src/components/ProjectFavicon.tsx
+++ b/apps/mobile/src/components/ProjectFavicon.tsx
@@ -1,14 +1,25 @@
 import { SymbolView } from "./AppSymbol";
+import { useAtomValue } from "@effect/atom-react";
 import { Image } from "expo-image";
-import { useLayoutEffect, useMemo, useState } from "react";
+import { useLayoutEffect, useMemo, useState, useSyncExternalStore } from "react";
 import { View } from "react-native";
 import type { EnvironmentId } from "@t3tools/contracts";
+import { derivePhysicalProjectKeyFromPath } from "@t3tools/client-runtime/state/project-grouping";
+import {
+  forgetProjectFavicon,
+  getRememberedProjectFavicon,
+  planProjectFaviconRender,
+  projectFaviconMemoryVersion,
+  rememberProjectFavicon,
+  subscribeProjectFaviconMemory,
+} from "@t3tools/client-runtime/state/project-favicon";
 import {
   getProjectFaviconCacheKey,
   isProjectFaviconFallbackUrl,
 } from "@t3tools/shared/projectFavicon";
 import { useThemeColor } from "../lib/useThemeColor";
 import { useAssetUrl } from "../state/assets";
+import { projectFaviconSourcesAtom } from "../state/projects";
 import {
   beginProjectFaviconRequest,
   createProjectFaviconRequest,
@@ -18,6 +29,12 @@ import {
 } from "./projectFaviconCache";
 
 /* ─── Component ──────────────────────────────────────────────────────── */
+/**
+ * Renders a project's icon by repository identity: every row of a repo group
+ * asks the same source environment for the same file, the last loaded icon is
+ * remembered for the session so a dropped connection never blanks it, and the
+ * row's own environment is the last resort before the folder glyph.
+ */
 export function ProjectFavicon(props: {
   readonly environmentId: EnvironmentId;
   readonly open?: boolean;
@@ -27,27 +44,57 @@ export function ProjectFavicon(props: {
   readonly faviconPath?: string | null;
 }) {
   const size = props.size ?? 42;
-  const faviconUrl = useAssetUrl(
-    props.environmentId,
-    props.workspaceRoot === null || props.workspaceRoot === undefined
+  const workspaceRoot = props.workspaceRoot ?? null;
+  const physicalKey =
+    workspaceRoot === null
       ? null
-      : {
-          _tag: "project-favicon",
-          cwd: props.workspaceRoot,
-          ...(props.faviconPath ? { path: props.faviconPath } : {}),
-        },
+      : derivePhysicalProjectKeyFromPath(props.environmentId, workspaceRoot);
+  const faviconSources = useAtomValue(projectFaviconSourcesAtom);
+  const source = (physicalKey === null ? null : faviconSources.get(physicalKey)) ?? null;
+  const iconKey = source?.iconKey ?? physicalKey;
+
+  const faviconResource = (cwd: string, faviconPath: string | null) =>
+    ({
+      _tag: "project-favicon",
+      cwd,
+      ...(faviconPath ? { path: faviconPath } : {}),
+    }) as const;
+  const sourceUrl = useAssetUrl(
+    source?.environmentId ?? props.environmentId,
+    workspaceRoot === null
+      ? null
+      : faviconResource(
+          source?.cwd ?? workspaceRoot,
+          source ? source.faviconPath : (props.faviconPath ?? null),
+        ),
   );
-  const renderableFaviconUrl = isProjectFaviconFallbackUrl(faviconUrl) ? null : faviconUrl;
-  const cacheKey =
-    renderableFaviconUrl && props.workspaceRoot
-      ? getProjectFaviconCacheKey(props.environmentId, props.workspaceRoot, renderableFaviconUrl)
+  const ownUrl = useAssetUrl(
+    props.environmentId,
+    workspaceRoot === null ? null : faviconResource(workspaceRoot, props.faviconPath ?? null),
+  );
+  useSyncExternalStore(subscribeProjectFaviconMemory, projectFaviconMemoryVersion);
+
+  const liveOf = (url: string | null, environmentId: EnvironmentId, cwd: string | null) =>
+    url !== null && cwd !== null && !isProjectFaviconFallbackUrl(url)
+      ? { url, cacheKey: getProjectFaviconCacheKey(environmentId, cwd, url) }
       : null;
+  const plan = planProjectFaviconRender({
+    sourceLive: liveOf(
+      sourceUrl,
+      source?.environmentId ?? props.environmentId,
+      source?.cwd ?? workspaceRoot,
+    ),
+    ownLive: liveOf(ownUrl, props.environmentId, workspaceRoot),
+    remembered: iconKey === null ? null : getRememberedProjectFavicon(iconKey),
+  });
 
   return (
     <ProjectFaviconImage
-      key={cacheKey}
-      cacheKey={cacheKey}
-      faviconUrl={renderableFaviconUrl}
+      key={plan?.cacheKey ?? null}
+      cacheKey={plan?.cacheKey ?? null}
+      iconKey={iconKey}
+      faviconUrl={plan?.url ?? null}
+      remember={plan?.remember ?? false}
       open={props.open}
       projectTitle={props.projectTitle}
       size={size}
@@ -57,7 +104,9 @@ export function ProjectFavicon(props: {
 
 function ProjectFaviconImage(props: {
   readonly cacheKey: string | null;
+  readonly iconKey: string | null;
   readonly faviconUrl: string | null;
+  readonly remember: boolean;
   readonly open?: boolean;
   readonly projectTitle: string;
   readonly size: number;
@@ -122,10 +171,19 @@ function ProjectFaviconImage(props: {
           contentFit="contain"
           onLoad={() => {
             if (!markProjectFaviconLoaded(faviconRequest)) return;
+            if (props.remember && props.iconKey !== null) {
+              rememberProjectFavicon(props.iconKey, {
+                url: faviconRequest.faviconUrl,
+                cacheKey: faviconRequest.cacheKey,
+              });
+            }
             setStatus("loaded");
           }}
           onError={() => {
             if (!markProjectFaviconFailed(faviconRequest)) return;
+            if (props.iconKey !== null) {
+              forgetProjectFavicon(props.iconKey, faviconRequest.faviconUrl);
+            }
             setStatus("error");
           }}
         />

--- a/apps/mobile/src/state/projects.ts
+++ b/apps/mobile/src/state/projects.ts
@@ -1,5 +1,7 @@
 import { createEnvironmentProjectAtoms } from "@t3tools/client-runtime/state/projects";
 import { createProjectEnvironmentAtoms } from "@t3tools/client-runtime/state/projects";
+import { selectProjectFaviconSources } from "@t3tools/client-runtime/state/project-favicon";
+import { Atom } from "effect/unstable/reactivity";
 
 import { environmentCatalog } from "../connection/catalog";
 import { connectionAtomRuntime } from "../connection/runtime";
@@ -10,3 +12,8 @@ export const environmentProjects = createEnvironmentProjectAtoms({
   catalogValueAtom: environmentCatalog.catalogValueAtom,
   snapshotAtom: environmentSnapshotAtom,
 });
+
+/** One favicon source per repository group, keyed by physical project key. */
+export const projectFaviconSourcesAtom = Atom.make((get) =>
+  selectProjectFaviconSources(get(environmentProjects.projectsAtom), null),
+).pipe(Atom.withLabel("mobile-project-favicon-sources"));

--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -61,10 +61,12 @@ describe("AssetAccess", () => {
       expect(yield* resolveAsset(token, "report.html")).toEqual({
         kind: "file",
         path: canonicalHtmlPath,
+        cache: "default",
       });
       expect(yield* resolveAsset(token, "report.css")).toEqual({
         kind: "file",
         path: canonicalCssPath,
+        cache: "default",
       });
       expect(yield* resolveAsset(token, "../secret.txt")).toBeNull();
       expect(yield* resolveAsset(token, ".env")).toBeNull();
@@ -178,6 +180,7 @@ describe("AssetAccess", () => {
       expect(yield* resolveAsset(token, "icon.png")).toEqual({
         kind: "file",
         path: canonicalImagePath,
+        cache: "default",
       });
       expect(yield* resolveAsset(token, "other.png")).toBeNull();
       expect(yield* resolveAsset(token, "../icon.png")).toBeNull();
@@ -204,6 +207,7 @@ describe("AssetAccess", () => {
       expect(yield* resolveAsset(token, "ignored.png")).toEqual({
         kind: "file",
         path: attachmentPath,
+        cache: "default",
       });
     }).pipe(Effect.provide(testLayer)),
   );
@@ -239,7 +243,7 @@ describe("AssetAccess", () => {
           faviconSuffix.slice(0, faviconSeparatorIndex),
           faviconSuffix.slice(faviconSeparatorIndex + 1),
         ),
-      ).toEqual({ kind: "file", path: canonicalFaviconPath });
+      ).toEqual({ kind: "file", path: canonicalFaviconPath, cache: "immutable" });
 
       yield* fileSystem.writeFileString(faviconPath, updatedFavicon);
       const updatedFaviconResult = yield* issueAssetUrl({

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -95,7 +95,12 @@ const AssetClaimsJson = Schema.fromJsonString(AssetClaimsSchema);
 const decodeAssetClaims = Schema.decodeUnknownOption(AssetClaimsJson);
 const encodeAssetClaims = Schema.encodeSync(AssetClaimsJson);
 
-export type ResolvedAsset = { readonly kind: "file"; readonly path: string };
+export type ResolvedAsset = {
+  readonly kind: "file";
+  readonly path: string;
+  /** Immutable assets embed a content hash in their URL and cache long-term. */
+  readonly cache: "default" | "immutable";
+};
 
 function decodeClaims(encodedPayload: string): AssetClaims | null {
   try {
@@ -428,7 +433,7 @@ export const resolveAsset = Effect.fn("AssetAccess.resolveAsset")(function* (
       Effect.orElseSucceed(() => Option.none()),
     );
     return Option.isSome(info) && info.value.type === "File"
-      ? ({ kind: "file", path: attachmentPath } satisfies ResolvedAsset)
+      ? ({ kind: "file", path: attachmentPath, cache: "default" } satisfies ResolvedAsset)
       : null;
   }
 
@@ -438,7 +443,9 @@ export const resolveAsset = Effect.fn("AssetAccess.resolveAsset")(function* (
       workspaceRoot: claims.workspaceRoot,
       relativePath: claims.relativePath,
     });
-    return faviconPath ? ({ kind: "file", path: faviconPath } satisfies ResolvedAsset) : null;
+    return faviconPath
+      ? ({ kind: "file", path: faviconPath, cache: "immutable" } satisfies ResolvedAsset)
+      : null;
   }
 
   const decodedPath = decodeRelativePath(relativePath);
@@ -451,7 +458,7 @@ export const resolveAsset = Effect.fn("AssetAccess.resolveAsset")(function* (
       relativePath: claims.relativePath,
     });
     return exactWorkspaceFile
-      ? ({ kind: "file", path: exactWorkspaceFile } satisfies ResolvedAsset)
+      ? ({ kind: "file", path: exactWorkspaceFile, cache: "default" } satisfies ResolvedAsset)
       : null;
   }
   const segments = decodedPath.split(/[\\/]/);
@@ -469,5 +476,7 @@ export const resolveAsset = Effect.fn("AssetAccess.resolveAsset")(function* (
     workspaceRoot: claims.workspaceRoot,
     relativePath: joinedRelativePath,
   });
-  return workspaceFile ? ({ kind: "file", path: workspaceFile } satisfies ResolvedAsset) : null;
+  return workspaceFile
+    ? ({ kind: "file", path: workspaceFile, cache: "default" } satisfies ResolvedAsset)
+    : null;
 });

--- a/apps/server/src/http.test.ts
+++ b/apps/server/src/http.test.ts
@@ -44,4 +44,11 @@ describe("assetResponseHeaders", () => {
       "X-Content-Type-Options": "nosniff",
     });
   });
+
+  it("caches immutable assets long-term", () => {
+    expect(assetResponseHeaders("/repo/favicon.png", "immutable")).toEqual({
+      "Cache-Control": "private, max-age=31536000, immutable",
+      "X-Content-Type-Options": "nosniff",
+    });
+  });
 });

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -45,9 +45,15 @@ const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "::1", "localhost"]);
 const DESKTOP_RENDERER_ORIGINS = ["t3code://app", "t3code-dev://app"];
 const SVG_CONTENT_SECURITY_POLICY = "default-src 'none'; style-src 'unsafe-inline'; sandbox";
 
-export function assetResponseHeaders(filePath: string): Record<string, string> {
+export function assetResponseHeaders(
+  filePath: string,
+  cache: "default" | "immutable" = "default",
+): Record<string, string> {
   return {
-    "Cache-Control": "private, max-age=3600",
+    // Immutable assets embed a content hash in their URL (project favicons),
+    // so browsers may keep serving them while the environment is unreachable.
+    "Cache-Control":
+      cache === "immutable" ? "private, max-age=31536000, immutable" : "private, max-age=3600",
     "X-Content-Type-Options": "nosniff",
     ...(filePath.toLowerCase().endsWith(".svg")
       ? { "Content-Security-Policy": SVG_CONTENT_SECURITY_POLICY }
@@ -219,7 +225,7 @@ export const assetRouteLayer = HttpRouter.add(
     }
     return yield* HttpServerResponse.file(asset.path, {
       status: 200,
-      headers: assetResponseHeaders(asset.path),
+      headers: assetResponseHeaders(asset.path, asset.cache),
     }).pipe(
       Effect.orElseSucceed(() => HttpServerResponse.text("Internal Server Error", { status: 500 })),
     );

--- a/apps/web/src/components/ProjectFavicon.test.tsx
+++ b/apps/web/src/components/ProjectFavicon.test.tsx
@@ -1,10 +1,16 @@
+import { derivePhysicalProjectKeyFromPath } from "@t3tools/client-runtime/state/project-grouping";
+import {
+  forgetProjectFavicon,
+  rememberProjectFavicon,
+} from "@t3tools/client-runtime/state/project-favicon";
 import type { ComponentType, Dispatch, ReactElement, SetStateAction } from "react";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { EnvironmentId } from "@t3tools/contracts";
 
 const testState = vi.hoisted(() => ({
-  faviconUrl: "https://environment.test/api/assets/token-a/v1-20-favicon.svg",
-  lastResource: null as unknown,
+  faviconUrl: "https://environment.test/api/assets/token-a/v1-20-favicon.svg" as string | null,
+  faviconSources: new Map<string, unknown>(),
+  lastRequests: [] as Array<{ environmentId: unknown; resource: unknown }>,
 }));
 
 const hooks = vi.hoisted(() => {
@@ -48,22 +54,35 @@ vi.mock("react", async (importOriginal) => {
   return {
     ...actual,
     useState: hooks.useState,
+    useSyncExternalStore: (_subscribe: unknown, getSnapshot: () => unknown) => getSnapshot(),
   };
 });
 
 vi.mock("react/compiler-runtime", () => ({ c: hooks.useMemoCache }));
 vi.mock("../assets/assetUrls", () => ({
-  useAssetUrlState: (_environmentId: unknown, resource: unknown) => {
-    testState.lastResource = resource;
-    return { _tag: "Success", url: testState.faviconUrl };
+  useAssetUrlState: (environmentId: unknown, resource: unknown) => {
+    testState.lastRequests.push({ environmentId, resource });
+    return testState.faviconUrl === null
+      ? { _tag: "Loading" }
+      : { _tag: "Success", url: testState.faviconUrl };
   },
 }));
+vi.mock("@effect/atom-react", () => ({
+  useAtomValue: () => testState.faviconSources,
+}));
+vi.mock("~/state/projects", () => ({ projectFaviconSourcesAtom: Symbol("sources") }));
 
 import { ProjectFavicon } from "./ProjectFavicon";
 
+const environmentId = "environment-test" as EnvironmentId;
+const cwd = "/workspace-test";
+const iconKey = derivePhysicalProjectKeyFromPath(environmentId, cwd);
+
 type ProjectFaviconImageProps = {
   readonly cacheKey: string;
+  readonly iconKey: string;
   readonly src: string;
+  readonly remember: boolean;
   readonly className?: string | undefined;
   readonly fallbackIcon: ComponentType<{ className?: string }>;
 };
@@ -78,17 +97,22 @@ type ProjectFaviconImageElement = ReactElement<{
   readonly children: [ReactElement | null, ImageElement | null, ImageElement | null];
 }>;
 
+function renderFavicon(faviconPath?: string): ReactElement<ProjectFaviconImageProps> {
+  hooks.beginRender();
+  const element = ProjectFavicon({
+    environmentId,
+    cwd,
+    ...(faviconPath === undefined ? {} : { faviconPath }),
+  }) as ReactElement<ProjectFaviconImageProps>;
+  hooks.reset();
+  return element;
+}
+
 function resolveImageComponent(): {
   readonly Component: (props: ProjectFaviconImageProps) => ProjectFaviconImageElement;
   readonly props: ProjectFaviconImageProps;
 } {
-  hooks.beginRender();
-  const element = ProjectFavicon({
-    environmentId: "environment-test" as EnvironmentId,
-    cwd: "/workspace-test",
-  }) as ReactElement<ProjectFaviconImageProps>;
-  hooks.reset();
-
+  const element = renderFavicon();
   return {
     Component: element.type as (props: ProjectFaviconImageProps) => ProjectFaviconImageElement,
     props: element.props,
@@ -106,6 +130,11 @@ function renderImage(
 describe("ProjectFavicon", () => {
   beforeEach(() => {
     hooks.reset();
+    testState.faviconUrl = "https://environment.test/api/assets/token-a/v1-20-favicon.svg";
+    testState.faviconSources = new Map();
+    testState.lastRequests = [];
+    forgetProjectFavicon(iconKey, "https://environment.test/api/assets/token-a/v1-20-favicon.svg");
+    forgetProjectFavicon("repo-key", "https://source.test/api/assets/token-s/v1-source.png");
   });
 
   it("falls back when the displayed favicon fails without discarding a valid older image early", () => {
@@ -131,16 +160,49 @@ describe("ProjectFavicon", () => {
   });
 
   it("requests a saved favicon path when one is set", () => {
-    ProjectFavicon({
-      environmentId: "environment-test" as EnvironmentId,
-      cwd: "/workspace-test",
-      faviconPath: "brand/icon.svg",
-    });
+    renderFavicon("brand/icon.svg");
 
-    expect(testState.lastResource).toEqual({
+    expect(testState.lastRequests.at(-1)?.resource).toEqual({
       _tag: "project-favicon",
       cwd: "/workspace-test",
       path: "brand/icon.svg",
     });
+  });
+
+  it("requests the repository group's favicon source instead of the row's project", () => {
+    testState.faviconSources = new Map([
+      [
+        iconKey,
+        {
+          environmentId: "environment-source",
+          cwd: "/source-checkout",
+          faviconPath: "assets/icon.png",
+          iconKey: "repo-key",
+        },
+      ],
+    ]);
+
+    const element = renderFavicon("brand/icon.svg");
+
+    expect(testState.lastRequests[0]).toEqual({
+      environmentId: "environment-source",
+      resource: { _tag: "project-favicon", cwd: "/source-checkout", path: "assets/icon.png" },
+    });
+    expect(element.props.iconKey).toBe("repo-key");
+  });
+
+  it("keeps showing the remembered icon while the connection is gone", () => {
+    testState.faviconUrl = null;
+
+    expect(renderFavicon().props.src).toBeUndefined();
+
+    rememberProjectFavicon(iconKey, {
+      url: "https://environment.test/api/assets/token-a/v1-20-favicon.svg",
+      cacheKey: "remembered-cache-key",
+    });
+    const element = renderFavicon();
+    expect(element.props.src).toBe("https://environment.test/api/assets/token-a/v1-20-favicon.svg");
+    expect(element.props.cacheKey).toBe("remembered-cache-key");
+    expect(element.props.remember).toBe(false);
   });
 });

--- a/apps/web/src/components/ProjectFavicon.tsx
+++ b/apps/web/src/components/ProjectFavicon.tsx
@@ -1,3 +1,13 @@
+import { useAtomValue } from "@effect/atom-react";
+import { derivePhysicalProjectKeyFromPath } from "@t3tools/client-runtime/state/project-grouping";
+import {
+  forgetProjectFavicon,
+  getRememberedProjectFavicon,
+  planProjectFaviconRender,
+  projectFaviconMemoryVersion,
+  rememberProjectFavicon,
+  subscribeProjectFaviconMemory,
+} from "@t3tools/client-runtime/state/project-favicon";
 import type { EnvironmentId } from "@t3tools/contracts";
 import {
   getProjectFaviconCacheKey,
@@ -5,12 +15,19 @@ import {
 } from "@t3tools/shared/projectFavicon";
 import { FolderIcon } from "lucide-react";
 import type { ComponentType } from "react";
-import { useState } from "react";
+import { useState, useSyncExternalStore } from "react";
 import { useAssetUrlState } from "../assets/assetUrls";
+import { projectFaviconSourcesAtom } from "~/state/projects";
 import { cn } from "~/lib/utils";
 
 const loadedProjectFaviconSrcs = new Map<string, string>();
 
+/**
+ * Renders a project's icon by repository identity: every row of a repo group
+ * asks the same source environment for the same file, the last loaded icon is
+ * remembered for the session so a dropped connection never blanks it, and the
+ * row's own environment is the last resort before the folder glyph.
+ */
 export function ProjectFavicon(input: {
   environmentId: EnvironmentId;
   cwd: string;
@@ -18,21 +35,47 @@ export function ProjectFavicon(input: {
   className?: string | undefined;
   fallbackIcon?: ComponentType<{ className?: string }>;
 }) {
-  const state = useProjectFaviconAsset(input);
-  const src = state._tag === "Success" ? state.url : null;
+  const physicalKey = derivePhysicalProjectKeyFromPath(input.environmentId, input.cwd);
+  const source = useAtomValue(projectFaviconSourcesAtom).get(physicalKey) ?? null;
+  const iconKey = source?.iconKey ?? physicalKey;
+  const sourceState = useProjectFaviconAsset({
+    environmentId: source?.environmentId ?? input.environmentId,
+    cwd: source?.cwd ?? input.cwd,
+    faviconPath: source ? source.faviconPath : input.faviconPath,
+  });
+  const ownState = useProjectFaviconAsset(input);
+  useSyncExternalStore(subscribeProjectFaviconMemory, projectFaviconMemoryVersion);
+
+  const liveOf = (
+    state: ReturnType<typeof useProjectFaviconAsset>,
+    environmentId: EnvironmentId,
+    cwd: string,
+  ) =>
+    state._tag === "Success" && !isProjectFaviconFallbackUrl(state.url)
+      ? { url: state.url, cacheKey: getProjectFaviconCacheKey(environmentId, cwd, state.url) }
+      : null;
+  const plan = planProjectFaviconRender({
+    sourceLive: liveOf(
+      sourceState,
+      source?.environmentId ?? input.environmentId,
+      source?.cwd ?? input.cwd,
+    ),
+    ownLive: liveOf(ownState, input.environmentId, input.cwd),
+    remembered: getRememberedProjectFavicon(iconKey),
+  });
   const FallbackIcon = input.fallbackIcon ?? FolderIcon;
 
-  if (!src || isProjectFaviconFallbackUrl(src)) {
+  if (plan === null) {
     return <ProjectFaviconFallback className={input.className} icon={FallbackIcon} />;
   }
 
-  const cacheKey = getProjectFaviconCacheKey(input.environmentId, input.cwd, src);
-
   return (
     <ProjectFaviconImage
-      key={cacheKey}
-      cacheKey={cacheKey}
-      src={src}
+      key={plan.cacheKey}
+      cacheKey={plan.cacheKey}
+      iconKey={iconKey}
+      src={plan.url}
+      remember={plan.remember}
       className={input.className}
       fallbackIcon={FallbackIcon}
     />
@@ -63,12 +106,16 @@ function ProjectFaviconFallback({
 
 function ProjectFaviconImage({
   cacheKey,
+  iconKey,
   src,
+  remember,
   className,
   fallbackIcon: FallbackIcon,
 }: {
   readonly cacheKey: string;
+  readonly iconKey: string;
   readonly src: string;
+  readonly remember: boolean;
   readonly className?: string | undefined;
   readonly fallbackIcon: ComponentType<{ className?: string }>;
 }) {
@@ -80,7 +127,15 @@ function ProjectFaviconImage({
     if (loadedProjectFaviconSrcs.get(cacheKey) === failedSrc) {
       loadedProjectFaviconSrcs.delete(cacheKey);
     }
+    forgetProjectFavicon(iconKey, failedSrc);
     setDisplayedSrc((currentSrc) => (currentSrc === failedSrc ? null : currentSrc));
+  };
+  const handleLoad = () => {
+    loadedProjectFaviconSrcs.set(cacheKey, src);
+    if (remember) {
+      rememberProjectFavicon(iconKey, { url: src, cacheKey });
+    }
+    setDisplayedSrc(src);
   };
 
   return (
@@ -101,10 +156,7 @@ function ProjectFaviconImage({
           src={src}
           alt=""
           className="hidden"
-          onLoad={() => {
-            loadedProjectFaviconSrcs.set(cacheKey, src);
-            setDisplayedSrc(src);
-          }}
+          onLoad={handleLoad}
           onError={() => handleLoadError(src)}
         />
       ) : null}

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -1,10 +1,13 @@
 import { createEnvironmentProjectAtoms } from "@t3tools/client-runtime/state/projects";
 import { createProjectEnvironmentAtoms } from "@t3tools/client-runtime/state/projects";
+import { selectProjectFaviconSources } from "@t3tools/client-runtime/state/project-favicon";
 import { createEnvironmentRpcQueryAtomFamily } from "@t3tools/client-runtime/state/runtime";
 import { WS_METHODS } from "@t3tools/contracts";
+import { Atom } from "effect/unstable/reactivity";
 
 import { environmentCatalog } from "../connection/catalog";
 import { connectionAtomRuntime } from "../connection/runtime";
+import { primaryEnvironmentIdAtom } from "./primaryEnvironment";
 import { environmentSnapshotAtom } from "./shell";
 
 export const projectEnvironment = createProjectEnvironmentAtoms(connectionAtomRuntime);
@@ -23,3 +26,8 @@ export const environmentProjects = createEnvironmentProjectAtoms({
   catalogValueAtom: environmentCatalog.catalogValueAtom,
   snapshotAtom: environmentSnapshotAtom,
 });
+
+/** One favicon source per repository group, keyed by physical project key. */
+export const projectFaviconSourcesAtom = Atom.make((get) =>
+  selectProjectFaviconSources(get(environmentProjects.projectsAtom), get(primaryEnvironmentIdAtom)),
+).pipe(Atom.withLabel("web-project-favicon-sources"));

--- a/docs/user/project-settings.md
+++ b/docs/user/project-settings.md
@@ -13,4 +13,8 @@ To choose a different icon:
 T3 Code supports SVG, PNG, ICO, JPEG, GIF, AVIF, and WebP files. The selected path applies to
 each checkout in the project group and appears on your connected clients.
 
+Projects that share a repository share one icon, even when the repository is checked out on
+several environments. If the environment that provides the icon disconnects, T3 Code keeps
+showing the last icon it loaded.
+
 To use automatic detection again, select **Automatic**.

--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -91,6 +91,10 @@
       "types": "./src/state/projectGrouping.ts",
       "default": "./src/state/projectGrouping.ts"
     },
+    "./state/project-favicon": {
+      "types": "./src/state/projectFavicon.ts",
+      "default": "./src/state/projectFavicon.ts"
+    },
     "./state/relay": {
       "types": "./src/state/relayDiscovery.ts",
       "default": "./src/state/relayDiscovery.ts"

--- a/packages/client-runtime/src/state/projectFavicon.test.ts
+++ b/packages/client-runtime/src/state/projectFavicon.test.ts
@@ -1,0 +1,194 @@
+import { EnvironmentId, ProjectId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import type { EnvironmentProject } from "./models.ts";
+import { derivePhysicalProjectKeyFromPath } from "./projectGrouping.ts";
+import {
+  forgetProjectFavicon,
+  getRememberedProjectFavicon,
+  planProjectFaviconRender,
+  rememberProjectFavicon,
+  selectProjectFaviconSources,
+  subscribeProjectFaviconMemory,
+} from "./projectFavicon.ts";
+
+const repositoryIdentity = {
+  canonicalKey: "github.com/t3tools/t3code",
+  locator: {
+    source: "git-remote" as const,
+    remoteName: "upstream",
+    remoteUrl: "https://github.com/t3tools/t3code.git",
+  },
+  provider: "github",
+  owner: "t3tools",
+  name: "t3code",
+  displayName: "T3 Code",
+};
+
+function makeProject(
+  environmentId: string,
+  id: string,
+  workspaceRoot: string,
+  overrides: Partial<EnvironmentProject> = {},
+): EnvironmentProject {
+  return {
+    environmentId: EnvironmentId.make(environmentId),
+    id: ProjectId.make(id),
+    title: id,
+    workspaceRoot,
+    repositoryIdentity,
+    defaultModelSelection: null,
+    scripts: [],
+    createdAt: "2026-07-01T00:00:00.000Z",
+    updatedAt: "2026-07-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("selectProjectFaviconSources", () => {
+  it("maps every repository member to one shared source", () => {
+    const sources = selectProjectFaviconSources(
+      [
+        makeProject("env-a", "a", "/work/t3code"),
+        makeProject("env-b", "b", "/machines/t3code", { faviconPath: "assets/icon.png" }),
+        makeProject("env-c", "c", "/home/t3code"),
+      ],
+      null,
+    );
+
+    const expected = {
+      environmentId: "env-a",
+      cwd: "/work/t3code",
+      faviconPath: null,
+      iconKey: repositoryIdentity.canonicalKey,
+    };
+    expect(sources.get(derivePhysicalProjectKeyFromPath("env-a", "/work/t3code"))).toEqual(
+      expected,
+    );
+    expect(sources.get(derivePhysicalProjectKeyFromPath("env-b", "/machines/t3code"))).toEqual(
+      expected,
+    );
+    expect(sources.get(derivePhysicalProjectKeyFromPath("env-c", "/home/t3code"))).toEqual(
+      expected,
+    );
+  });
+
+  it("prefers the primary environment's member as the source", () => {
+    const sources = selectProjectFaviconSources(
+      [
+        makeProject("env-a", "a", "/work/t3code", { updatedAt: "2026-08-01T00:00:00.000Z" }),
+        makeProject("env-b", "b", "/machines/t3code", { faviconPath: "assets/icon.png" }),
+      ],
+      EnvironmentId.make("env-b"),
+    );
+
+    expect(sources.get(derivePhysicalProjectKeyFromPath("env-a", "/work/t3code"))).toMatchObject({
+      environmentId: "env-b",
+      cwd: "/machines/t3code",
+      faviconPath: "assets/icon.png",
+    });
+  });
+
+  it("falls back to the freshest member when the primary environment has none", () => {
+    const sources = selectProjectFaviconSources(
+      [
+        makeProject("env-a", "a", "/work/t3code"),
+        makeProject("env-b", "b", "/machines/t3code", { updatedAt: "2026-08-01T00:00:00.000Z" }),
+      ],
+      EnvironmentId.make("env-x"),
+    );
+
+    expect(
+      sources.get(derivePhysicalProjectKeyFromPath("env-a", "/work/t3code"))?.environmentId,
+    ).toBe("env-b");
+  });
+
+  it("keeps projects without a repository identity as their own source", () => {
+    const key = derivePhysicalProjectKeyFromPath("env-a", "/work/scratch");
+    const sources = selectProjectFaviconSources(
+      [
+        makeProject("env-a", "a", "/work/scratch", { repositoryIdentity: null }),
+        makeProject("env-b", "b", "/machines/t3code"),
+      ],
+      null,
+    );
+
+    expect(sources.get(key)).toEqual({
+      environmentId: "env-a",
+      cwd: "/work/scratch",
+      faviconPath: null,
+      iconKey: key,
+    });
+  });
+});
+
+describe("project favicon memory", () => {
+  it("remembers, updates, and forgets icons per key", () => {
+    const key = "memory-test-basic";
+    expect(getRememberedProjectFavicon(key)).toBeNull();
+
+    rememberProjectFavicon(key, { url: "https://a/1.png", cacheKey: "cache-1" });
+    expect(getRememberedProjectFavicon(key)).toEqual({
+      url: "https://a/1.png",
+      cacheKey: "cache-1",
+    });
+
+    rememberProjectFavicon(key, { url: "https://a/2.png", cacheKey: "cache-2" });
+    expect(getRememberedProjectFavicon(key)?.url).toBe("https://a/2.png");
+
+    forgetProjectFavicon(key, "https://a/1.png");
+    expect(getRememberedProjectFavicon(key)?.url).toBe("https://a/2.png");
+
+    forgetProjectFavicon(key, "https://a/2.png");
+    expect(getRememberedProjectFavicon(key)).toBeNull();
+  });
+
+  it("notifies subscribers only on real changes", () => {
+    const key = "memory-test-notify";
+    let notified = 0;
+    const unsubscribe = subscribeProjectFaviconMemory(() => {
+      notified += 1;
+    });
+
+    rememberProjectFavicon(key, { url: "https://a/1.png", cacheKey: "cache-1" });
+    rememberProjectFavicon(key, { url: "https://a/1.png", cacheKey: "cache-1" });
+    expect(notified).toBe(1);
+
+    forgetProjectFavicon(key, "https://a/other.png");
+    expect(notified).toBe(1);
+
+    forgetProjectFavicon(key, "https://a/1.png");
+    expect(notified).toBe(2);
+
+    unsubscribe();
+    rememberProjectFavicon(key, { url: "https://a/1.png", cacheKey: "cache-1" });
+    expect(notified).toBe(2);
+  });
+});
+
+describe("planProjectFaviconRender", () => {
+  const live = { url: "https://source/icon.png", cacheKey: "source-key" };
+  const own = { url: "https://own/icon.png", cacheKey: "own-key" };
+  const remembered = { url: "https://memory/icon.png", cacheKey: "memory-key" };
+
+  it("prefers the live source and marks it for remembering", () => {
+    expect(planProjectFaviconRender({ sourceLive: live, ownLive: own, remembered })).toEqual({
+      ...live,
+      remember: true,
+    });
+  });
+
+  it("falls back to memory before the row's own environment", () => {
+    expect(planProjectFaviconRender({ sourceLive: null, ownLive: own, remembered })).toEqual({
+      ...remembered,
+      remember: false,
+    });
+    expect(planProjectFaviconRender({ sourceLive: null, ownLive: own, remembered: null })).toEqual({
+      ...own,
+      remember: true,
+    });
+    expect(
+      planProjectFaviconRender({ sourceLive: null, ownLive: null, remembered: null }),
+    ).toBeNull();
+  });
+});

--- a/packages/client-runtime/src/state/projectFavicon.ts
+++ b/packages/client-runtime/src/state/projectFavicon.ts
@@ -1,0 +1,167 @@
+import type { EnvironmentId } from "@t3tools/contracts";
+
+import type { EnvironmentProject } from "./models.ts";
+import { derivePhysicalProjectKey, projectFreshnessTime } from "./projectGrouping.ts";
+
+/**
+ * A project icon is a property of the repository, not of the machine that
+ * happens to render a row. Every project that shares a repository identity is
+ * mapped to one favicon source so all clients ask the same environment for
+ * the same file, and a session-scoped memory keeps the last icon that loaded
+ * so a dropped connection never blanks rows back to the folder glyph.
+ */
+
+export interface ProjectFaviconSource {
+  readonly environmentId: EnvironmentId;
+  readonly cwd: string;
+  readonly faviconPath: string | null;
+  /** Stable identity icons are remembered under: the repo key when known. */
+  readonly iconKey: string;
+}
+
+function isBetterFaviconSource(
+  candidate: EnvironmentProject,
+  current: EnvironmentProject,
+  primaryEnvironmentId: EnvironmentId | null,
+): boolean {
+  if (primaryEnvironmentId !== null) {
+    const candidatePrimary = candidate.environmentId === primaryEnvironmentId;
+    const currentPrimary = current.environmentId === primaryEnvironmentId;
+    if (candidatePrimary !== currentPrimary) {
+      return candidatePrimary;
+    }
+  }
+  const freshnessDelta = projectFreshnessTime(candidate) - projectFreshnessTime(current);
+  if (freshnessDelta !== 0) {
+    return freshnessDelta > 0;
+  }
+  if (candidate.environmentId !== current.environmentId) {
+    return candidate.environmentId < current.environmentId;
+  }
+  return candidate.workspaceRoot < current.workspaceRoot;
+}
+
+/**
+ * Picks one favicon source project per repository group and maps every
+ * member's physical project key to it. The primary environment wins when it
+ * is a member, then the freshest project, with a stable tiebreak so the
+ * choice does not flap between renders. Projects without a repository
+ * identity stay their own source.
+ */
+export function selectProjectFaviconSources(
+  projects: ReadonlyArray<EnvironmentProject>,
+  primaryEnvironmentId: EnvironmentId | null,
+): ReadonlyMap<string, ProjectFaviconSource> {
+  const sourceByRepositoryKey = new Map<string, EnvironmentProject>();
+  for (const project of projects) {
+    const repositoryKey = project.repositoryIdentity?.canonicalKey;
+    if (!repositoryKey) {
+      continue;
+    }
+    const current = sourceByRepositoryKey.get(repositoryKey);
+    if (current === undefined || isBetterFaviconSource(project, current, primaryEnvironmentId)) {
+      sourceByRepositoryKey.set(repositoryKey, project);
+    }
+  }
+
+  const sources = new Map<string, ProjectFaviconSource>();
+  for (const project of projects) {
+    const physicalKey = derivePhysicalProjectKey(project);
+    if (sources.has(physicalKey)) {
+      continue;
+    }
+    const repositoryKey = project.repositoryIdentity?.canonicalKey;
+    const source = repositoryKey ? (sourceByRepositoryKey.get(repositoryKey) ?? project) : project;
+    sources.set(physicalKey, {
+      environmentId: source.environmentId,
+      cwd: source.workspaceRoot,
+      faviconPath: source.faviconPath ?? null,
+      iconKey: repositoryKey ?? physicalKey,
+    });
+  }
+  return sources;
+}
+
+export interface RememberedProjectFavicon {
+  readonly url: string;
+  readonly cacheKey: string;
+}
+
+const MAX_REMEMBERED_FAVICONS = 256;
+const rememberedFavicons = new Map<string, RememberedProjectFavicon>();
+const memoryListeners = new Set<() => void>();
+let memoryVersion = 0;
+
+function notifyMemoryListeners() {
+  memoryVersion += 1;
+  for (const listener of memoryListeners) {
+    listener();
+  }
+}
+
+export function rememberProjectFavicon(iconKey: string, entry: RememberedProjectFavicon): void {
+  const current = rememberedFavicons.get(iconKey);
+  if (current !== undefined && current.url === entry.url && current.cacheKey === entry.cacheKey) {
+    return;
+  }
+  rememberedFavicons.delete(iconKey);
+  rememberedFavicons.set(iconKey, entry);
+  if (rememberedFavicons.size > MAX_REMEMBERED_FAVICONS) {
+    rememberedFavicons.delete(rememberedFavicons.keys().next().value!);
+  }
+  notifyMemoryListeners();
+}
+
+/** Drops a remembered icon, but only while it still points at the failed URL. */
+export function forgetProjectFavicon(iconKey: string, url: string): void {
+  if (rememberedFavicons.get(iconKey)?.url !== url) {
+    return;
+  }
+  rememberedFavicons.delete(iconKey);
+  notifyMemoryListeners();
+}
+
+export function getRememberedProjectFavicon(iconKey: string): RememberedProjectFavicon | null {
+  return rememberedFavicons.get(iconKey) ?? null;
+}
+
+/** Subscription pair for useSyncExternalStore in the web and mobile clients. */
+export function subscribeProjectFaviconMemory(listener: () => void): () => void {
+  memoryListeners.add(listener);
+  return () => {
+    memoryListeners.delete(listener);
+  };
+}
+
+export function projectFaviconMemoryVersion(): number {
+  return memoryVersion;
+}
+
+export interface ProjectFaviconRenderPlan {
+  readonly url: string;
+  readonly cacheKey: string;
+  /** Write the icon to memory once it loads (only live URLs qualify). */
+  readonly remember: boolean;
+}
+
+/**
+ * Render precedence: the group source's live icon, then the remembered icon
+ * (survives disconnects), then the row's own environment as a last resort,
+ * then the fallback glyph.
+ */
+export function planProjectFaviconRender(input: {
+  readonly sourceLive: { readonly url: string; readonly cacheKey: string } | null;
+  readonly ownLive: { readonly url: string; readonly cacheKey: string } | null;
+  readonly remembered: RememberedProjectFavicon | null;
+}): ProjectFaviconRenderPlan | null {
+  if (input.sourceLive !== null) {
+    return { ...input.sourceLive, remember: true };
+  }
+  if (input.remembered !== null) {
+    return { url: input.remembered.url, cacheKey: input.remembered.cacheKey, remember: false };
+  }
+  if (input.ownLive !== null) {
+    return { ...input.ownLive, remember: true };
+  }
+  return null;
+}

--- a/packages/client-runtime/src/state/projectGrouping.ts
+++ b/packages/client-runtime/src/state/projectGrouping.ts
@@ -209,7 +209,7 @@ export interface ProjectGroup<TProject extends EnvironmentProject = EnvironmentP
   readonly memberProjectRefs: ReadonlyArray<ScopedProjectRef>;
 }
 
-function projectFreshnessTime(project: EnvironmentProject): number {
+export function projectFreshnessTime(project: EnvironmentProject): number {
   const updatedAtTime = Date.parse(project.updatedAt);
   if (Number.isFinite(updatedAtTime)) {
     return updatedAtTime;


### PR DESCRIPTION
When a remote environment disconnects, every project favicon it served blanks to the folder glyph immediately. And the same repo can show a different icon on every machine: each row resolves the icon against its own environment's checkout, so a stale checkout, a missing t3.json, or a disconnected member each produce a different answer.

Two changes make icons follow the repository instead of the connection:

- **One icon per repo group.** A shared selector in client-runtime picks a single favicon source project per repository identity (primary environment first, then freshest, stable tiebreak). Web and mobile rows all request that source's icon, so grouped projects match across environments. Rows fall back to their own environment only when the source is unreachable and nothing is remembered.
- **Icons survive disconnects.** The last icon that actually loaded is remembered per repo for the session and keeps rendering while the source is unreachable. Favicon asset URLs embed a content hash, so the server now serves them with `Cache-Control: immutable` and the browser can render them from cache while offline.

No wire changes. Verified with unit tests for source selection, memory, and both favicon components, plus targeted typecheck and lint for the touched packages.

Change made by Claude Fable 5 running in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and asset caching behavior only; no auth or wire protocol changes, with broad unit test coverage for selection, memory, and components.
> 
> **Overview**
> Project icons now follow **repository identity** instead of each sidebar row’s environment. A new `client-runtime` module picks one favicon source per repo (primary environment, then freshest member, stable tiebreak), exposes `projectFaviconSourcesAtom` on web and mobile, and uses **`planProjectFaviconRender`** so rows prefer the group source, then **session-remembered** icons when live fetch fails, then the row’s own checkout.
> 
> Web and mobile **`ProjectFavicon`** components subscribe to that memory via `useSyncExternalStore`, remember icons on successful load, and forget them on load errors.
> 
> On the server, **`ResolvedAsset`** adds a **`cache`** hint; project favicon responses use **`Cache-Control: private, max-age=31536000, immutable`** so hash-versioned URLs can be served from the browser cache while an environment is unreachable. User docs note shared-repo icons and last-loaded behavior when a provider disconnects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d48756027b9b54c689acdc7217986a04b0c2d9c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix project favicons to persist across disconnects and stay consistent across machines
> - Favicon sourcing now uses a shared repository-group identity (`derivePhysicalProjectKeyFromPath`, `projectFaviconSourcesAtom`) so all projects sharing a repo show the same icon regardless of machine or environment.
> - A session-scoped memory store (`rememberProjectFavicon`/`forgetProjectFavicon`) retains the last successfully loaded favicon per repo key, so icons remain visible when the source environment disconnects.
> - A new `planProjectFaviconRender` planner selects between live source URL, remembered URL, or the row's own live URL as a last resort before falling back to a glyph.
> - Asset responses now carry an explicit cache policy: project favicons are served with `Cache-Control: private, max-age=31536000, immutable`; all other assets use `max-age=3600`.
> - Behavioral Change: favicon URLs for projects in a repo group may now resolve from a different environment than the project row itself.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d487560. 9 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->