### PR TITLE
feat(mobile): keep Android thread lists current in background

### DIFF
--- a/apps/mobile/index.ts
+++ b/apps/mobile/index.ts
@@ -4,6 +4,7 @@ import { LogBox } from "react-native";
 import { featureFlags } from "react-native-screens";
 
 import App from "./src/App";
+import { registerBackgroundConnectionHeadlessTask } from "./src/features/background-connection/headless-task-registration";
 
 // Required for react-native-screens' iOS FormSheet sizing fix when a nested
 // native stack is rendered inside a non-fitToContents formSheet.
@@ -13,4 +14,5 @@ if (process.env.EXPO_PUBLIC_SHOWCASE === "1") {
   LogBox.ignoreAllLogs();
 }
 
+registerBackgroundConnectionHeadlessTask();
 registerRootComponent(App);

--- a/apps/mobile/modules/t3-background-connection/android/build.gradle
+++ b/apps/mobile/modules/t3-background-connection/android/build.gradle
@@ -1,0 +1,21 @@
+apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
+
+group = 'com.t3tools.backgroundconnection'
+version = '0.0.0'
+
+android {
+  namespace 'expo.modules.t3backgroundconnection'
+  compileSdk rootProject.ext.compileSdkVersion
+
+  defaultConfig {
+    minSdkVersion rootProject.ext.minSdkVersion
+    targetSdkVersion rootProject.ext.targetSdkVersion
+  }
+}
+
+dependencies {
+  implementation project(':expo-modules-core')
+  implementation 'com.facebook.react:react-android'
+  testImplementation 'junit:junit:4.13.2'
+}

--- a/apps/mobile/modules/t3-background-connection/android/src/main/AndroidManifest.xml
+++ b/apps/mobile/modules/t3-background-connection/android/src/main/AndroidManifest.xml
@@ -1,0 +1,27 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_REMOTE_MESSAGING" />
+  <uses-permission android:name="android.permission.WAKE_LOCK" />
+  <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+  <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+  <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+  <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+
+  <application>
+    <service
+      android:name="expo.modules.t3backgroundconnection.T3BackgroundConnectionService"
+      android:exported="false"
+      android:foregroundServiceType="remoteMessaging"
+      android:stopWithTask="false" />
+
+    <receiver
+      android:name="expo.modules.t3backgroundconnection.T3BackgroundConnectionReceiver"
+      android:enabled="true"
+      android:exported="false">
+      <intent-filter>
+        <action android:name="android.intent.action.BOOT_COMPLETED" />
+        <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+      </intent-filter>
+    </receiver>
+  </application>
+</manifest>

--- a/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionModule.kt
+++ b/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionModule.kt
@@ -1,0 +1,107 @@
+package expo.modules.t3backgroundconnection
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+import expo.modules.kotlin.functions.Queues
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+class T3BackgroundConnectionModule : Module() {
+  private val statusListener: (Map<String, Any>) -> Unit = { status ->
+    sendEvent(T3BackgroundConnectionState.STATUS_EVENT, status)
+  }
+  private val stopRequestListener: () -> Unit = {
+    sendEvent(T3BackgroundConnectionState.STOP_REQUEST_EVENT)
+  }
+
+  override fun definition() = ModuleDefinition {
+    Name("T3BackgroundConnection")
+
+    Events(
+      T3BackgroundConnectionState.STATUS_EVENT,
+      T3BackgroundConnectionState.STOP_REQUEST_EVENT,
+    )
+
+    OnCreate {
+      val context = applicationContext()
+      T3BackgroundConnectionState.initialize(context)
+      T3BackgroundConnectionState.addStatusListener(statusListener)
+      T3BackgroundConnectionState.addStopRequestListener(stopRequestListener)
+    }
+
+    OnDestroy {
+      T3BackgroundConnectionState.removeStatusListener(statusListener)
+      T3BackgroundConnectionState.removeStopRequestListener(stopRequestListener)
+    }
+
+    OnActivityEntersForeground {
+      // The battery-optimization request has no result callback. Refreshing on
+      // resume makes the settings status reflect the user's choice immediately.
+      val context = applicationContext()
+      if (T3BackgroundConnectionState.shouldEnsureStartedOnActivityForeground(context)) {
+        // A visible Activity is an allowed foreground-service start context.
+        // A successful start also cancels any pending recovery alarm.
+        T3BackgroundConnectionController.ensureStarted(context)
+      }
+      T3BackgroundConnectionState.refreshStatus()
+    }
+
+    Function("getStatus") {
+      T3BackgroundConnectionState.status(applicationContext())
+    }
+
+    AsyncFunction("setEnabled") { enabled: Boolean ->
+      val context = applicationContext()
+      T3BackgroundConnectionState.setEnabled(context, enabled)
+      if (enabled) {
+        T3BackgroundConnectionController.ensureStarted(context)
+      } else {
+        T3BackgroundConnectionState.requestOrderlyStop(context)
+      }
+      T3BackgroundConnectionState.status(context)
+    }.runOnQueue(Queues.MAIN)
+
+    Function("ensureStarted") {
+      val context = applicationContext()
+      T3BackgroundConnectionController.ensureStarted(context)
+      T3BackgroundConnectionState.status(context)
+    }
+
+    AsyncFunction("requestBatteryOptimizationExemption") {
+      val context = applicationContext()
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        val intent = Intent(
+          Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
+          Uri.parse("package:${context.packageName}"),
+        )
+        val activity = appContext.currentActivity
+        if (activity != null) {
+          activity.startActivity(intent)
+        } else {
+          context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+        }
+      }
+      T3BackgroundConnectionState.status(context)
+    }.runOnQueue(Queues.MAIN)
+
+    Function("setRuntimeReady") { ready: Boolean ->
+      val context = applicationContext()
+      T3BackgroundConnectionState.markRuntimeReady(ready)
+      T3BackgroundConnectionState.status(context)
+    }
+
+    Function("acknowledgeStop") {
+      val context = applicationContext()
+      T3BackgroundConnectionState.acknowledgeStop(context)
+      T3BackgroundConnectionState.status(context)
+    }
+  }
+
+  private fun applicationContext(): Context =
+    requireNotNull(appContext.reactContext?.applicationContext) {
+      "T3BackgroundConnection requires an Android React context"
+    }
+}

--- a/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionReceiver.kt
+++ b/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionReceiver.kt
@@ -1,0 +1,26 @@
+package expo.modules.t3backgroundconnection
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.facebook.react.HeadlessJsTaskService
+
+class T3BackgroundConnectionReceiver : BroadcastReceiver() {
+  override fun onReceive(context: Context, intent: Intent?) {
+    if (
+      intent?.action != Intent.ACTION_BOOT_COMPLETED &&
+      intent?.action != Intent.ACTION_MY_PACKAGE_REPLACED &&
+      intent?.action != T3BackgroundConnectionState.RESTART_ACTION
+    ) {
+      return
+    }
+    if (!T3BackgroundConnectionState.isEnabled(context)) return
+
+    if (T3BackgroundConnectionController.ensureStarted(context)) {
+      // Acquire before returning from the receiver, but only after Android
+      // accepted the service launch so a rejected FGS cannot leak the static
+      // React Native wake lock.
+      HeadlessJsTaskService.acquireWakeLockNow(context)
+    }
+  }
+}

--- a/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionRecoveryPolicy.kt
+++ b/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionRecoveryPolicy.kt
@@ -1,0 +1,13 @@
+package expo.modules.t3backgroundconnection
+
+internal object T3BackgroundConnectionRecoveryPolicy {
+  fun shouldScheduleRestartAfterStartFailure(
+    batteryOptimizationIgnored: Boolean
+  ): Boolean = batteryOptimizationIgnored
+
+  fun shouldEnsureStartedOnActivityForeground(
+    enabled: Boolean,
+    serviceRunning: Boolean,
+    runtimeReady: Boolean
+  ): Boolean = enabled && (!serviceRunning || !runtimeReady)
+}

--- a/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionRestartBackoff.kt
+++ b/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionRestartBackoff.kt
@@ -1,0 +1,12 @@
+package expo.modules.t3backgroundconnection
+
+internal object T3BackgroundConnectionRestartBackoff {
+  private const val INITIAL_DELAY_MS = 1_000L
+  private const val MAX_DELAY_MS = 5 * 60_000L
+
+  fun delayMs(consecutiveFailures: Int): Long {
+    val exponent = consecutiveFailures.coerceIn(0, 20)
+    val exponentialDelay = INITIAL_DELAY_MS * (1L shl exponent)
+    return exponentialDelay.coerceAtMost(MAX_DELAY_MS)
+  }
+}

--- a/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionService.kt
+++ b/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionService.kt
@@ -1,0 +1,169 @@
+package expo.modules.t3backgroundconnection
+
+import android.annotation.SuppressLint
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.net.wifi.WifiManager
+import android.os.Build
+import com.facebook.react.HeadlessJsTaskService
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.jstasks.HeadlessJsTaskConfig
+
+class T3BackgroundConnectionService : HeadlessJsTaskService() {
+  private var wifiLock: WifiManager.WifiLock? = null
+
+  override fun onCreate() {
+    super.onCreate()
+    T3BackgroundConnectionState.initialize(this)
+    startInForeground()
+    T3BackgroundConnectionState.markServiceRunning(true)
+    acquireWifiLock()
+  }
+
+  override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+    if (!T3BackgroundConnectionState.isEnabled(this)) {
+      stopSelf(startId)
+      return Service.START_NOT_STICKY
+    }
+
+    if (T3BackgroundConnectionState.claimTask()) {
+      super.onStartCommand(intent, flags, startId)
+    }
+    return Service.START_STICKY
+  }
+
+  override fun getTaskConfig(intent: Intent?): HeadlessJsTaskConfig =
+    HeadlessJsTaskConfig(
+      T3BackgroundConnectionState.TASK_NAME,
+      Arguments.createMap(),
+      0,
+      true,
+    )
+
+  override fun onHeadlessJsTaskFinish(taskId: Int) {
+    val shouldRestart = T3BackgroundConnectionState.isEnabled(this)
+    T3BackgroundConnectionState.releaseTask()
+    super.onHeadlessJsTaskFinish(taskId)
+    if (shouldRestart) {
+      T3BackgroundConnectionState.scheduleRestartAfterUnexpectedTaskFinish(this)
+    }
+  }
+
+  override fun onDestroy() {
+    releaseWifiLock()
+    T3BackgroundConnectionState.markServiceRunning(false)
+    super.onDestroy()
+  }
+
+  private fun startInForeground() {
+    createNotificationChannel()
+    val notification = createNotification()
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+      startForeground(
+        NOTIFICATION_ID,
+        notification,
+        ServiceInfo.FOREGROUND_SERVICE_TYPE_REMOTE_MESSAGING,
+      )
+    } else {
+      startForeground(NOTIFICATION_ID, notification)
+    }
+  }
+
+  private fun createNotificationChannel() {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+    val channel = NotificationChannel(
+      NOTIFICATION_CHANNEL_ID,
+      "Background connection",
+      NotificationManager.IMPORTANCE_LOW,
+    ).apply {
+      description = "Keeps T3 Code connected while the app is in the background"
+      setSound(null, null)
+      enableLights(false)
+      enableVibration(false)
+      setShowBadge(false)
+      lockscreenVisibility = Notification.VISIBILITY_PRIVATE
+    }
+    getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+  }
+
+  private fun createNotification(): Notification {
+    val launchIntent = packageManager.getLaunchIntentForPackage(packageName)
+    val contentIntent = launchIntent?.let {
+      PendingIntent.getActivity(
+        this,
+        0,
+        it,
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+      )
+    }
+    val smallIcon = resources.getIdentifier("notification_icon", "drawable", packageName)
+      .takeIf { it != 0 }
+      ?: android.R.drawable.stat_notify_sync_noanim
+
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      Notification.Builder(this, NOTIFICATION_CHANNEL_ID)
+    } else {
+      @Suppress("DEPRECATION")
+      Notification.Builder(this)
+    }.apply {
+      setContentTitle("T3 Code")
+      setContentText("Background connection enabled")
+      setSmallIcon(smallIcon)
+      setOngoing(true)
+      setOnlyAlertOnce(true)
+      setShowWhen(false)
+      setCategory(Notification.CATEGORY_SERVICE)
+      setVisibility(Notification.VISIBILITY_PRIVATE)
+      contentIntent?.let(::setContentIntent)
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        setForegroundServiceBehavior(Notification.FOREGROUND_SERVICE_IMMEDIATE)
+      }
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+        @Suppress("DEPRECATION")
+        setPriority(Notification.PRIORITY_LOW)
+        @Suppress("DEPRECATION")
+        setSound(null)
+      }
+    }.build()
+  }
+
+  @SuppressLint("WakelockTimeout")
+  @Suppress("DEPRECATION")
+  private fun acquireWifiLock() {
+    try {
+      val wifiManager = applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+      wifiLock = wifiManager.createWifiLock(
+        WifiManager.WIFI_MODE_FULL_HIGH_PERF,
+        "$packageName:t3-background-connection",
+      ).apply {
+        setReferenceCounted(false)
+        acquire()
+      }
+    } catch (_: RuntimeException) {
+      // The lock is best-effort. The foreground task and connection supervisor
+      // remain authoritative on devices that reject or do not expose it.
+      wifiLock = null
+    }
+  }
+
+  private fun releaseWifiLock() {
+    try {
+      wifiLock?.takeIf { it.isHeld }?.release()
+    } catch (_: RuntimeException) {
+      // The system may already have released the lock during process teardown.
+    } finally {
+      wifiLock = null
+    }
+  }
+
+  private companion object {
+    const val NOTIFICATION_CHANNEL_ID = "t3code_background_connection"
+    const val NOTIFICATION_ID = 0x7433
+  }
+}

--- a/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionState.kt
+++ b/apps/mobile/modules/t3-background-connection/android/src/main/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionState.kt
@@ -1,0 +1,332 @@
+package expo.modules.t3backgroundconnection
+
+import android.annotation.SuppressLint
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.os.PowerManager
+import android.os.SystemClock
+import android.util.Log
+import java.util.concurrent.CopyOnWriteArraySet
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal object T3BackgroundConnectionState {
+  const val TASK_NAME = "T3BackgroundConnection"
+  const val STATUS_EVENT = "onStatusChange"
+  const val STOP_REQUEST_EVENT = "onStopRequested"
+  const val RESTART_ACTION =
+    "expo.modules.t3backgroundconnection.action.RESTART_BACKGROUND_CONNECTION"
+
+  private const val PREFERENCES_NAME = "t3_background_connection"
+  private const val ENABLED_KEY = "enabled"
+  private const val STOP_FALLBACK_DELAY_MS = 5_000L
+  private const val STABLE_RUNTIME_RESET_DELAY_MS = 60_000L
+
+  private val mainHandler = Handler(Looper.getMainLooper())
+  private val serviceRunning = AtomicBoolean(false)
+  private val runtimeReady = AtomicBoolean(false)
+  private val taskStarted = AtomicBoolean(false)
+  private val statusListeners = CopyOnWriteArraySet<(Map<String, Any>) -> Unit>()
+  private val stopRequestListeners = CopyOnWriteArraySet<() -> Unit>()
+
+  @Volatile
+  private var applicationContext: Context? = null
+
+  @Volatile
+  private var stopFallback: Runnable? = null
+
+  @Volatile
+  private var restartFallback: Runnable? = null
+
+  @Volatile
+  private var stableRuntimeReset: Runnable? = null
+
+  private var consecutiveUnexpectedFailures = 0
+
+  fun initialize(context: Context) {
+    applicationContext = context.applicationContext
+  }
+
+  fun isEnabled(context: Context): Boolean =
+    preferences(context).getBoolean(ENABLED_KEY, false)
+
+  @SuppressLint("ApplySharedPref")
+  fun setEnabled(context: Context, enabled: Boolean) {
+    initialize(context)
+    val wasEnabled = isEnabled(context)
+    // Commit before starting the service so a process death cannot start a
+    // sticky service whose boot-time preference still says it is disabled.
+    preferences(context).edit().putBoolean(ENABLED_KEY, enabled).commit()
+    if (enabled) {
+      cancelStopFallback()
+      if (!wasEnabled) {
+        resetUnexpectedRestartBackoff()
+      }
+    } else {
+      resetUnexpectedRestartBackoff()
+    }
+    emitStatus()
+  }
+
+  fun status(context: Context): Map<String, Any> {
+    initialize(context)
+
+    return mapOf(
+      "supported" to true,
+      "enabled" to isEnabled(context),
+      "serviceRunning" to serviceRunning.get(),
+      "runtimeReady" to runtimeReady.get(),
+      "batteryOptimizationIgnored" to isBatteryOptimizationIgnored(context),
+    )
+  }
+
+  fun shouldEnsureStartedOnActivityForeground(context: Context): Boolean =
+    T3BackgroundConnectionRecoveryPolicy.shouldEnsureStartedOnActivityForeground(
+      enabled = isEnabled(context),
+      serviceRunning = serviceRunning.get(),
+      runtimeReady = runtimeReady.get(),
+    )
+
+  fun isBatteryOptimizationIgnored(context: Context): Boolean {
+    val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+    return powerManager.isIgnoringBatteryOptimizations(context.packageName)
+  }
+
+  fun addStatusListener(listener: (Map<String, Any>) -> Unit) {
+    statusListeners.add(listener)
+  }
+
+  fun removeStatusListener(listener: (Map<String, Any>) -> Unit) {
+    statusListeners.remove(listener)
+  }
+
+  fun addStopRequestListener(listener: () -> Unit) {
+    stopRequestListeners.add(listener)
+  }
+
+  fun removeStopRequestListener(listener: () -> Unit) {
+    stopRequestListeners.remove(listener)
+  }
+
+  fun refreshStatus() {
+    emitStatus()
+  }
+
+  fun markServiceRunning(running: Boolean) {
+    serviceRunning.set(running)
+    if (!running) {
+      runtimeReady.set(false)
+      taskStarted.set(false)
+      cancelStopFallback()
+      cancelStableRuntimeReset()
+    }
+    emitStatus()
+  }
+
+  fun markRuntimeReady(ready: Boolean) {
+    val appliedReady = ready && serviceRunning.get()
+    runtimeReady.set(appliedReady)
+    if (appliedReady) {
+      scheduleStableRuntimeReset()
+    } else {
+      cancelStableRuntimeReset()
+    }
+    emitStatus()
+  }
+
+  fun claimTask(): Boolean = taskStarted.compareAndSet(false, true)
+
+  fun releaseTask() {
+    taskStarted.set(false)
+    runtimeReady.set(false)
+    cancelStableRuntimeReset()
+    emitStatus()
+  }
+
+  fun requestOrderlyStop(context: Context) {
+    initialize(context)
+    cancelStopFallback()
+    if (!serviceRunning.get()) {
+      stopService(context)
+      return
+    }
+
+    // A claimed task can be creating the React context, or can already own
+    // subscriptions while it bootstraps Clerk and persistence. Keep the
+    // service alive long enough for that task to observe the disabled
+    // preference and unwind; only an idle service is safe to stop immediately.
+    // The bounded fallback below still handles a runtime that never responds.
+    if (!taskStarted.get()) {
+      stopService(context)
+      return
+    }
+
+    mainHandler.post {
+      if (!isEnabled(context)) {
+        stopRequestListeners.forEach { listener -> listener() }
+      }
+    }
+
+    val fallback = Runnable {
+      stopFallback = null
+      if (isEnabled(context)) return@Runnable
+      runtimeReady.set(false)
+      emitStatus()
+      stopService(context)
+    }
+    stopFallback = fallback
+    mainHandler.postDelayed(fallback, STOP_FALLBACK_DELAY_MS)
+  }
+
+  fun acknowledgeStop(context: Context) {
+    initialize(context)
+    cancelStopFallback()
+    runtimeReady.set(false)
+    emitStatus()
+    if (!isEnabled(context)) {
+      stopService(context)
+    }
+  }
+
+  @Suppress("TooGenericExceptionCaught")
+  fun scheduleRestartAfterUnexpectedTaskFinish(context: Context) {
+    initialize(context)
+    cancelScheduledRestart(context)
+    val delayMs = T3BackgroundConnectionRestartBackoff.delayMs(consecutiveUnexpectedFailures)
+    consecutiveUnexpectedFailures = (consecutiveUnexpectedFailures + 1).coerceAtMost(20)
+    try {
+      val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+      alarmManager.setAndAllowWhileIdle(
+        AlarmManager.ELAPSED_REALTIME_WAKEUP,
+        SystemClock.elapsedRealtime() + delayMs,
+        checkNotNull(restartPendingIntent(context, PendingIntent.FLAG_UPDATE_CURRENT)),
+      )
+    } catch (error: RuntimeException) {
+      // AlarmManager is the durable path. Keep an in-process fallback for an
+      // unusual vendor failure so recovery still has a best-effort attempt.
+      Log.w("T3BackgroundConnection", "Could not schedule durable restart alarm", error)
+      val restart = Runnable {
+        restartFallback = null
+        if (isEnabled(context)) {
+          T3BackgroundConnectionController.ensureStarted(context)
+        }
+      }
+      restartFallback = restart
+      mainHandler.postDelayed(restart, delayMs)
+    }
+  }
+
+  fun scheduleRestartAfterStartFailure(context: Context) {
+    if (
+      T3BackgroundConnectionRecoveryPolicy.shouldScheduleRestartAfterStartFailure(
+        batteryOptimizationIgnored = isBatteryOptimizationIgnored(context),
+      )
+    ) {
+      scheduleRestartAfterUnexpectedTaskFinish(context)
+      return
+    }
+
+    // An alarm is not a valid exemption from Android's background foreground-
+    // service launch restrictions. Re-arming it here would create an endless
+    // failure ladder on a non-exempt app. Leave the feature enabled and recover
+    // on the next Activity foreground, boot/package update, or sticky restart.
+    cancelScheduledRestart(context)
+  }
+
+  private fun preferences(context: Context) =
+    context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+
+  private fun emitStatus() {
+    val context = applicationContext ?: return
+    val snapshot = status(context)
+    mainHandler.post {
+      statusListeners.forEach { listener -> listener(snapshot) }
+    }
+  }
+
+  private fun cancelStopFallback() {
+    stopFallback?.let(mainHandler::removeCallbacks)
+    stopFallback = null
+  }
+
+  fun cancelScheduledRestart(context: Context) {
+    restartFallback?.let(mainHandler::removeCallbacks)
+    restartFallback = null
+    val pendingIntent = restartPendingIntent(context, PendingIntent.FLAG_NO_CREATE) ?: return
+    val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+    alarmManager.cancel(pendingIntent)
+    pendingIntent.cancel()
+  }
+
+  private fun scheduleStableRuntimeReset() {
+    cancelStableRuntimeReset()
+    val reset = Runnable {
+      stableRuntimeReset = null
+      if (runtimeReady.get() && serviceRunning.get()) {
+        consecutiveUnexpectedFailures = 0
+      }
+    }
+    stableRuntimeReset = reset
+    mainHandler.postDelayed(reset, STABLE_RUNTIME_RESET_DELAY_MS)
+  }
+
+  private fun cancelStableRuntimeReset() {
+    stableRuntimeReset?.let(mainHandler::removeCallbacks)
+    stableRuntimeReset = null
+  }
+
+  private fun resetUnexpectedRestartBackoff() {
+    consecutiveUnexpectedFailures = 0
+    applicationContext?.let(::cancelScheduledRestart)
+    cancelStableRuntimeReset()
+  }
+
+  private fun restartPendingIntent(context: Context, creationFlag: Int): PendingIntent? =
+    PendingIntent.getBroadcast(
+      context.applicationContext,
+      RESTART_REQUEST_CODE,
+      Intent(context.applicationContext, T3BackgroundConnectionReceiver::class.java).apply {
+        action = RESTART_ACTION
+      },
+      creationFlag or PendingIntent.FLAG_IMMUTABLE,
+    )
+
+  private fun stopService(context: Context) {
+    context.applicationContext.stopService(
+      Intent(context.applicationContext, T3BackgroundConnectionService::class.java),
+    )
+  }
+
+  private const val RESTART_REQUEST_CODE = 0x7434
+}
+
+internal object T3BackgroundConnectionController {
+  @Suppress("TooGenericExceptionCaught")
+  fun ensureStarted(context: Context): Boolean {
+    val applicationContext = context.applicationContext
+    T3BackgroundConnectionState.initialize(applicationContext)
+    if (!T3BackgroundConnectionState.isEnabled(applicationContext)) return false
+
+    val intent = Intent(applicationContext, T3BackgroundConnectionService::class.java)
+    return try {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        applicationContext.startForegroundService(intent)
+      } else {
+        applicationContext.startService(intent)
+      }
+      T3BackgroundConnectionState.cancelScheduledRestart(applicationContext)
+      true
+    } catch (error: RuntimeException) {
+      // Android can reject a background FGS launch. Keep the preference
+      // enabled and let the recovery policy either retry an exempt app or
+      // park until a foreground/OS trigger can legally start the service.
+      Log.w("T3BackgroundConnection", "Could not start foreground service", error)
+      T3BackgroundConnectionState.scheduleRestartAfterStartFailure(applicationContext)
+      false
+    }
+  }
+}

--- a/apps/mobile/modules/t3-background-connection/android/src/test/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionRecoveryPolicyTest.kt
+++ b/apps/mobile/modules/t3-background-connection/android/src/test/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionRecoveryPolicyTest.kt
@@ -1,0 +1,57 @@
+package expo.modules.t3backgroundconnection
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class T3BackgroundConnectionRecoveryPolicyTest {
+  @Test
+  fun `start failure retries only while battery optimization is ignored`() {
+    assertTrue(
+      T3BackgroundConnectionRecoveryPolicy.shouldScheduleRestartAfterStartFailure(
+        batteryOptimizationIgnored = true,
+      ),
+    )
+    assertFalse(
+      T3BackgroundConnectionRecoveryPolicy.shouldScheduleRestartAfterStartFailure(
+        batteryOptimizationIgnored = false,
+      ),
+    )
+  }
+
+  @Test
+  fun `foreground recovers an enabled service that is stopped or not ready`() {
+    assertTrue(
+      T3BackgroundConnectionRecoveryPolicy.shouldEnsureStartedOnActivityForeground(
+        enabled = true,
+        serviceRunning = false,
+        runtimeReady = false,
+      ),
+    )
+    assertTrue(
+      T3BackgroundConnectionRecoveryPolicy.shouldEnsureStartedOnActivityForeground(
+        enabled = true,
+        serviceRunning = true,
+        runtimeReady = false,
+      ),
+    )
+  }
+
+  @Test
+  fun `foreground leaves a healthy or disabled service alone`() {
+    assertFalse(
+      T3BackgroundConnectionRecoveryPolicy.shouldEnsureStartedOnActivityForeground(
+        enabled = true,
+        serviceRunning = true,
+        runtimeReady = true,
+      ),
+    )
+    assertFalse(
+      T3BackgroundConnectionRecoveryPolicy.shouldEnsureStartedOnActivityForeground(
+        enabled = false,
+        serviceRunning = false,
+        runtimeReady = false,
+      ),
+    )
+  }
+}

--- a/apps/mobile/modules/t3-background-connection/android/src/test/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionRestartBackoffTest.kt
+++ b/apps/mobile/modules/t3-background-connection/android/src/test/java/expo/modules/t3backgroundconnection/T3BackgroundConnectionRestartBackoffTest.kt
@@ -1,0 +1,16 @@
+package expo.modules.t3backgroundconnection
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class T3BackgroundConnectionRestartBackoffTest {
+  @Test
+  fun `repeated failures back off and remain bounded`() {
+    assertEquals(1_000L, T3BackgroundConnectionRestartBackoff.delayMs(0))
+    assertEquals(2_000L, T3BackgroundConnectionRestartBackoff.delayMs(1))
+    assertEquals(4_000L, T3BackgroundConnectionRestartBackoff.delayMs(2))
+    assertEquals(256_000L, T3BackgroundConnectionRestartBackoff.delayMs(8))
+    assertEquals(300_000L, T3BackgroundConnectionRestartBackoff.delayMs(9))
+    assertEquals(300_000L, T3BackgroundConnectionRestartBackoff.delayMs(Int.MAX_VALUE))
+  }
+}

--- a/apps/mobile/modules/t3-background-connection/expo-module.config.json
+++ b/apps/mobile/modules/t3-background-connection/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["android"],
+  "android": {
+    "modules": ["expo.modules.t3backgroundconnection.T3BackgroundConnectionModule"]
+  }
+}

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -2,7 +2,7 @@ import { BlurTargetView } from "expo-blur";
 import * as Linking from "expo-linking";
 import * as SplashScreen from "expo-splash-screen";
 import { useEffect } from "react";
-import { StatusBar } from "react-native";
+import { Platform, StatusBar } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardProvider } from "react-native-keyboard-controller";
 import { SafeAreaProvider } from "react-native-safe-area-context";
@@ -23,6 +23,7 @@ import { OverlayPortalHost } from "./components/OverlayPortal";
 import { appBlurTargetRef } from "./lib/appBlurTarget";
 import { useThemeColor } from "./lib/useThemeColor";
 import { useMobileNavigationTheme } from "./lib/useMobileNavigationTheme";
+import { ensureBackgroundConnectionStarted } from "./native/backgroundConnection";
 
 import "../global.css";
 
@@ -58,9 +59,19 @@ function SplashScreenCoordinator() {
   return null;
 }
 
+function BackgroundConnectionServiceCoordinator() {
+  useEffect(() => {
+    if (Platform.OS === "android") {
+      ensureBackgroundConnectionStarted();
+    }
+  }, []);
+  return null;
+}
+
 export default function App() {
   return (
     <RegistryContext.Provider value={appAtomRegistry}>
+      <BackgroundConnectionServiceCoordinator />
       <CloudAuthProvider>
         <AppearancePreferencesProvider>
           <AppContent />

--- a/apps/mobile/src/connection/app-state-wakeups.test.ts
+++ b/apps/mobile/src/connection/app-state-wakeups.test.ts
@@ -18,4 +18,19 @@ describe("mobileApplicationActiveWakeup", () => {
       mobileApplicationActiveWakeup(20_000, 20_000 + MOBILE_BACKGROUND_RECONNECT_AFTER_MS),
     ).toBe("application-active-reconnect");
   });
+
+  it("preserves a protected background connection", () => {
+    expect(
+      mobileApplicationActiveWakeup(20_000, 20_000 + MOBILE_BACKGROUND_RECONNECT_AFTER_MS, {
+        serviceRunning: true,
+        runtimeReady: true,
+      }),
+    ).toBe("application-active-preserved");
+    expect(
+      mobileApplicationActiveWakeup(20_000, 20_000 + MOBILE_BACKGROUND_RECONNECT_AFTER_MS, {
+        serviceRunning: true,
+        runtimeReady: false,
+      }),
+    ).toBe("application-active-reconnect");
+  });
 });

--- a/apps/mobile/src/connection/app-state-wakeups.ts
+++ b/apps/mobile/src/connection/app-state-wakeups.ts
@@ -4,13 +4,22 @@ export const MOBILE_BACKGROUND_RECONNECT_AFTER_MS = 10_000;
 
 export type MobileApplicationActiveWakeup = Extract<
   Wakeups.ConnectionWakeup,
-  "application-active-probe" | "application-active-reconnect"
+  "application-active-preserved" | "application-active-probe" | "application-active-reconnect"
 >;
+
+export interface MobileBackgroundConnectionProtection {
+  readonly serviceRunning: boolean;
+  readonly runtimeReady: boolean;
+}
 
 export function mobileApplicationActiveWakeup(
   backgroundedAtMs: number | null,
   activeAtMs: number,
+  protection?: MobileBackgroundConnectionProtection,
 ): MobileApplicationActiveWakeup {
+  if (protection?.serviceRunning === true && protection.runtimeReady === true) {
+    return "application-active-preserved";
+  }
   return backgroundedAtMs !== null &&
     activeAtMs - backgroundedAtMs >= MOBILE_BACKGROUND_RECONNECT_AFTER_MS
     ? "application-active-reconnect"

--- a/apps/mobile/src/connection/platform.ts
+++ b/apps/mobile/src/connection/platform.ts
@@ -26,11 +26,15 @@ import { AppState } from "react-native";
 
 import { authClientMetadata } from "../lib/authClientMetadata";
 import * as Runtime from "../lib/runtime";
+import { getBackgroundConnectionStatus } from "../native/backgroundConnection";
 import * as MobileStorage from "../persistence/mobile-storage";
 import { appAtomRegistry } from "../state/atom-registry";
 import { clearThreadOutboxEnvironment } from "../state/thread-outbox";
 import { clearComposerDraftsEnvironment } from "../state/use-composer-drafts";
-import { mobileApplicationActiveWakeup } from "./app-state-wakeups";
+import {
+  type MobileApplicationActiveWakeup,
+  mobileApplicationActiveWakeup,
+} from "./app-state-wakeups";
 import { connectionStorageLayer } from "./storage";
 
 function networkStatus(state: Network.NetworkState): "unknown" | "offline" | "online" {
@@ -87,7 +91,7 @@ const connectivityLayer = Connectivity.layer({
 
 const wakeupsLayer = Wakeups.layer({
   changes: Stream.merge(
-    Stream.callback<"application-active-probe" | "application-active-reconnect">((queue) =>
+    Stream.callback<MobileApplicationActiveWakeup>((queue) =>
       Effect.acquireRelease(
         Effect.sync(() => {
           let backgroundedAtMs = AppState.currentState === "background" ? Date.now() : null;
@@ -97,7 +101,14 @@ const wakeupsLayer = Wakeups.layer({
               return;
             }
             if (state === "active") {
-              Queue.offerUnsafe(queue, mobileApplicationActiveWakeup(backgroundedAtMs, Date.now()));
+              Queue.offerUnsafe(
+                queue,
+                mobileApplicationActiveWakeup(
+                  backgroundedAtMs,
+                  Date.now(),
+                  getBackgroundConnectionStatus(),
+                ),
+              );
               backgroundedAtMs = null;
             }
           });

--- a/apps/mobile/src/features/background-connection/BackgroundConnectionSettingsSection.test.tsx
+++ b/apps/mobile/src/features/background-connection/BackgroundConnectionSettingsSection.test.tsx
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import type { BackgroundConnectionStatus } from "../../native/backgroundConnection";
+
+const native = vi.hoisted(() => ({
+  status: null as BackgroundConnectionStatus | null,
+  setEnabled: vi.fn(),
+  requestExemption: vi.fn(),
+  removeStatusListener: vi.fn(),
+}));
+
+const reactNative = vi.hoisted(() => ({
+  alert: vi.fn(),
+  removeAppStateListener: vi.fn(),
+}));
+
+vi.mock("react", () => ({
+  useCallback: (callback: unknown) => callback,
+  useEffect: (setup: () => void | (() => void)) => {
+    setup();
+  },
+  useState: (initial: unknown) => [
+    typeof initial === "function" ? (initial as () => unknown)() : initial,
+    vi.fn(),
+  ],
+}));
+
+vi.mock("react-native", () => ({
+  Alert: { alert: reactNative.alert },
+  AppState: {
+    addEventListener: vi.fn(() => ({ remove: reactNative.removeAppStateListener })),
+  },
+  Platform: { OS: "android" },
+  Pressable: "Pressable",
+  View: "View",
+}));
+
+vi.mock("../../components/AppText", () => ({ AppText: "Text" }));
+vi.mock("../settings/components/SettingsSection", () => ({
+  SettingsSection: "SettingsSection",
+}));
+vi.mock("../settings/components/SettingsSwitchRow", () => ({
+  SettingsSwitchRow: "SettingsSwitchRow",
+}));
+vi.mock("../../native/backgroundConnection", () => ({
+  addBackgroundConnectionStatusListener: vi.fn(() => ({
+    remove: native.removeStatusListener,
+  })),
+  getBackgroundConnectionStatus: () => native.status,
+  requestBackgroundConnectionBatteryOptimizationExemption: native.requestExemption,
+  setBackgroundConnectionEnabled: native.setEnabled,
+}));
+
+import { BackgroundConnectionSettingsSection } from "./BackgroundConnectionSettingsSection";
+
+interface ElementNode {
+  readonly props?: {
+    readonly children?: unknown;
+    readonly onValueChange?: (enabled: boolean) => void;
+  };
+}
+
+function children(node: unknown): ReadonlyArray<unknown> {
+  const value = (node as ElementNode | null)?.props?.children;
+  if (value === undefined) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function renderSwitch(): ElementNode {
+  const root = BackgroundConnectionSettingsSection();
+  const section = children(root)[0];
+  return children(section)[0] as ElementNode;
+}
+
+function status(overrides: Partial<BackgroundConnectionStatus> = {}): BackgroundConnectionStatus {
+  return {
+    supported: true,
+    enabled: false,
+    serviceRunning: false,
+    runtimeReady: false,
+    batteryOptimizationIgnored: true,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  native.status = status();
+  native.setEnabled.mockImplementation(async (enabled: boolean) =>
+    status({
+      enabled,
+      serviceRunning: enabled,
+      runtimeReady: enabled,
+    }),
+  );
+  native.requestExemption.mockResolvedValue(status({ enabled: true }));
+});
+
+describe("BackgroundConnectionSettingsSection", () => {
+  it("enables the native runtime and keeps it enabled when battery exemption is declined", async () => {
+    native.setEnabled.mockResolvedValue(
+      status({
+        enabled: true,
+        serviceRunning: true,
+        runtimeReady: true,
+        batteryOptimizationIgnored: false,
+      }),
+    );
+    native.requestExemption.mockResolvedValue(
+      status({ enabled: true, batteryOptimizationIgnored: false }),
+    );
+
+    renderSwitch().props?.onValueChange?.(true);
+
+    await vi.waitFor(() => {
+      expect(native.setEnabled).toHaveBeenCalledWith(true);
+      expect(reactNative.alert).toHaveBeenCalledOnce();
+    });
+    const buttons = reactNative.alert.mock.calls[0]?.[2] as
+      | ReadonlyArray<{ readonly text: string; readonly onPress?: () => void }>
+      | undefined;
+    buttons?.find((button) => button.text === "Allow")?.onPress?.();
+    await vi.waitFor(() => expect(native.requestExemption).toHaveBeenCalledOnce());
+
+    expect(native.setEnabled).not.toHaveBeenCalledWith(false);
+  });
+
+  it("disables the native runtime without requesting a battery exemption", async () => {
+    native.status = status({
+      enabled: true,
+      serviceRunning: true,
+      runtimeReady: true,
+    });
+    native.setEnabled.mockResolvedValue(status());
+
+    renderSwitch().props?.onValueChange?.(false);
+
+    await vi.waitFor(() => expect(native.setEnabled).toHaveBeenCalledWith(false));
+    expect(reactNative.alert).not.toHaveBeenCalled();
+    expect(native.requestExemption).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/features/background-connection/BackgroundConnectionSettingsSection.tsx
+++ b/apps/mobile/src/features/background-connection/BackgroundConnectionSettingsSection.tsx
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useState } from "react";
+import { Alert, AppState, Platform, Pressable, View } from "react-native";
+
+import { AppText as Text } from "../../components/AppText";
+import {
+  addBackgroundConnectionStatusListener,
+  getBackgroundConnectionStatus,
+  requestBackgroundConnectionBatteryOptimizationExemption,
+  setBackgroundConnectionEnabled,
+  type BackgroundConnectionStatus,
+} from "../../native/backgroundConnection";
+import { SettingsSection } from "../settings/components/SettingsSection";
+import { SettingsSwitchRow } from "../settings/components/SettingsSwitchRow";
+import {
+  backgroundConnectionStatusLabel,
+  shouldRequestBackgroundConnectionBatteryExemption,
+} from "./settings-model";
+
+function promptForBatteryExemption(
+  requestExemption: () => Promise<BackgroundConnectionStatus>,
+): void {
+  Alert.alert(
+    "Allow unrestricted battery use?",
+    "Android can otherwise pause the background connection while T3 Code is locked or another app is open.",
+    [
+      { text: "Not Now", style: "cancel" },
+      { text: "Allow", onPress: () => void requestExemption() },
+    ],
+  );
+}
+
+export function BackgroundConnectionSettingsSection() {
+  const [status, setStatus] = useState(getBackgroundConnectionStatus);
+  const [changing, setChanging] = useState(false);
+
+  useEffect(() => {
+    if (Platform.OS !== "android") {
+      return;
+    }
+    setStatus(getBackgroundConnectionStatus());
+    const nativeSubscription = addBackgroundConnectionStatusListener(setStatus);
+    const appStateSubscription = AppState.addEventListener("change", (nextState) => {
+      if (nextState === "active") {
+        setStatus(getBackgroundConnectionStatus());
+      }
+    });
+    return () => {
+      nativeSubscription.remove();
+      appStateSubscription.remove();
+    };
+  }, []);
+
+  const requestExemption = useCallback(async () => {
+    const next = await requestBackgroundConnectionBatteryOptimizationExemption();
+    setStatus(next);
+    return next;
+  }, []);
+
+  const handleEnabledChange = useCallback(
+    async (enabled: boolean) => {
+      if (changing) {
+        return;
+      }
+      setChanging(true);
+      setStatus((current) => ({ ...current, enabled }));
+      const next = await setBackgroundConnectionEnabled(enabled);
+      setStatus(next);
+      setChanging(false);
+      if (shouldRequestBackgroundConnectionBatteryExemption(next)) {
+        promptForBatteryExemption(requestExemption);
+      }
+    },
+    [changing, requestExemption],
+  );
+
+  if (Platform.OS !== "android") {
+    return null;
+  }
+
+  const statusLabel = backgroundConnectionStatusLabel(status);
+  const canRetryBatteryExemption = shouldRequestBackgroundConnectionBatteryExemption(status);
+
+  return (
+    <View className="gap-3">
+      <SettingsSection title="Background connection">
+        <SettingsSwitchRow
+          disabled={!status.supported || changing}
+          icon="bolt.horizontal.circle"
+          label="Keep connected in background"
+          value={status.enabled}
+          onValueChange={(enabled) => void handleEnabledChange(enabled)}
+        />
+        <View className="border-t border-border px-4 py-3">
+          {canRetryBatteryExemption ? (
+            <Pressable
+              accessibilityRole="button"
+              onPress={() => void requestExemption()}
+              className="py-1"
+            >
+              <Text className="text-sm font-t3-medium text-foreground">{statusLabel}</Text>
+              <Text className="mt-1 text-sm text-foreground-muted">
+                Tap to allow unrestricted battery use.
+              </Text>
+            </Pressable>
+          ) : (
+            <Text className="text-sm font-t3-medium text-foreground-muted">{statusLabel}</Text>
+          )}
+        </View>
+      </SettingsSection>
+      <Text className="px-2 text-sm leading-normal text-foreground-muted">
+        Keeps environment thread lists synchronized while your phone is locked or another app is
+        open. This can noticeably increase battery use, and Android will show a silent ongoing
+        service status.
+      </Text>
+    </View>
+  );
+}

--- a/apps/mobile/src/features/background-connection/background-root.test.ts
+++ b/apps/mobile/src/features/background-connection/background-root.test.ts
@@ -1,0 +1,46 @@
+import type { AtomRegistry } from "effect/unstable/reactivity";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { acquireBackgroundConnectionRoot } from "./background-root";
+
+const mocks = vi.hoisted(() => ({ threadShellsAtom: {} }));
+
+vi.mock("../../state/threads", () => ({
+  environmentThreadShells: { threadShellsAtom: mocks.threadShellsAtom },
+}));
+
+function makeRegistry() {
+  const release = vi.fn();
+  const mount = vi.fn(() => release);
+  return {
+    registry: { mount } as unknown as AtomRegistry.AtomRegistry,
+    mount,
+    release,
+  };
+}
+
+describe("background connection root", () => {
+  it("shares one shell lease across owners", () => {
+    const { registry, mount, release } = makeRegistry();
+    const releaseFirst = acquireBackgroundConnectionRoot(registry);
+    const releaseSecond = acquireBackgroundConnectionRoot(registry);
+
+    expect(mount).toHaveBeenCalledOnce();
+    expect(mount).toHaveBeenCalledWith(mocks.threadShellsAtom);
+
+    releaseFirst();
+    expect(release).not.toHaveBeenCalled();
+    releaseSecond();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("ignores duplicate releases", () => {
+    const { registry, release } = makeRegistry();
+    const releaseRoot = acquireBackgroundConnectionRoot(registry);
+
+    releaseRoot();
+    releaseRoot();
+
+    expect(release).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/mobile/src/features/background-connection/background-root.ts
+++ b/apps/mobile/src/features/background-connection/background-root.ts
@@ -1,0 +1,33 @@
+import type { AtomRegistry } from "effect/unstable/reactivity";
+
+import { environmentThreadShells } from "../../state/threads";
+
+const roots = new WeakMap<
+  AtomRegistry.AtomRegistry,
+  { owners: number; readonly release: () => void }
+>();
+
+export function acquireBackgroundConnectionRoot(registry: AtomRegistry.AtomRegistry): () => void {
+  let shared = roots.get(registry);
+  if (shared === undefined) {
+    shared = {
+      owners: 1,
+      release: registry.mount(environmentThreadShells.threadShellsAtom),
+    };
+    roots.set(registry, shared);
+  } else {
+    shared.owners += 1;
+  }
+
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    const current = roots.get(registry);
+    if (current === undefined) return;
+    current.owners -= 1;
+    if (current.owners > 0) return;
+    roots.delete(registry);
+    current.release();
+  };
+}

--- a/apps/mobile/src/features/background-connection/background-task.test.ts
+++ b/apps/mobile/src/features/background-connection/background-task.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, expect, it, vi } from "vite-plus/test";
+
+const mocks = vi.hoisted(() => ({
+  acquireRoot: vi.fn(() => vi.fn()),
+  relayStop: vi.fn(),
+  setRuntimeReady: vi.fn(),
+  acknowledgeStop: vi.fn(),
+  enabled: true,
+  firstAttempt: Promise.resolve(),
+  stopListener: null as (() => void) | null,
+  removeStopListener: vi.fn(),
+}));
+
+vi.mock("../cloud/backgroundManagedRelayAuth", () => ({
+  startBackgroundManagedRelayAuth: () => ({
+    firstAttempt: mocks.firstAttempt,
+    retryNow: vi.fn(),
+    stop: mocks.relayStop,
+  }),
+}));
+vi.mock("../../native/backgroundConnection", () => ({
+  addBackgroundConnectionStopRequestListener: (listener: () => void) => {
+    mocks.stopListener = listener;
+    return { remove: mocks.removeStopListener };
+  },
+  getBackgroundConnectionStatus: () => ({ enabled: mocks.enabled }),
+  setBackgroundConnectionRuntimeReady: mocks.setRuntimeReady,
+  acknowledgeBackgroundConnectionStop: mocks.acknowledgeStop,
+}));
+vi.mock("../../state/atom-registry", () => ({ appAtomRegistry: {} }));
+vi.mock("./background-root", () => ({
+  acquireBackgroundConnectionRoot: mocks.acquireRoot,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  mocks.enabled = true;
+  mocks.firstAttempt = Promise.resolve();
+  mocks.stopListener = null;
+});
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+it("shares one runtime across duplicate native task starts and cleans it up once", async () => {
+  const { runBackgroundConnectionHeadlessTask } = await import("./background-task");
+
+  const first = runBackgroundConnectionHeadlessTask();
+  const second = runBackgroundConnectionHeadlessTask();
+  expect(first).toBe(second);
+  await vi.waitFor(() => {
+    expect(mocks.acquireRoot).toHaveBeenCalledOnce();
+    expect(mocks.setRuntimeReady).toHaveBeenCalledWith(true);
+  });
+
+  mocks.stopListener?.();
+  await Promise.all([first, second]);
+
+  expect(mocks.acquireRoot.mock.results[0]?.value).toHaveBeenCalledOnce();
+  expect(mocks.relayStop).toHaveBeenCalledOnce();
+  expect(mocks.removeStopListener).toHaveBeenCalledOnce();
+  expect(mocks.setRuntimeReady).toHaveBeenLastCalledWith(false);
+  expect(mocks.acknowledgeStop).toHaveBeenCalledOnce();
+});
+
+it("cleans up a task that finishes loading after the feature was disabled", async () => {
+  mocks.enabled = false;
+  const { runBackgroundConnectionHeadlessTask } = await import("./background-task");
+
+  await runBackgroundConnectionHeadlessTask();
+
+  expect(mocks.acquireRoot).not.toHaveBeenCalled();
+  expect(mocks.setRuntimeReady).not.toHaveBeenCalledWith(true);
+  expect(mocks.relayStop).not.toHaveBeenCalled();
+  expect(mocks.removeStopListener).toHaveBeenCalledOnce();
+  expect(mocks.setRuntimeReady).toHaveBeenLastCalledWith(false);
+  expect(mocks.acknowledgeStop).toHaveBeenCalledOnce();
+});
+
+it("marks shell subscriptions ready and stops promptly while relay auth is loading", async () => {
+  const authBootstrap = deferred();
+  mocks.firstAttempt = authBootstrap.promise;
+  const { runBackgroundConnectionHeadlessTask } = await import("./background-task");
+
+  const task = runBackgroundConnectionHeadlessTask();
+  await vi.waitFor(() => {
+    expect(mocks.acquireRoot).toHaveBeenCalledOnce();
+    expect(mocks.setRuntimeReady).toHaveBeenCalledWith(true);
+  });
+
+  mocks.stopListener?.();
+  await task;
+
+  expect(mocks.setRuntimeReady).toHaveBeenCalledWith(true);
+  expect(mocks.acquireRoot.mock.results[0]?.value).toHaveBeenCalledOnce();
+  expect(mocks.relayStop).toHaveBeenCalledOnce();
+  expect(mocks.acknowledgeStop).toHaveBeenCalledOnce();
+
+  authBootstrap.resolve();
+});

--- a/apps/mobile/src/features/background-connection/background-task.ts
+++ b/apps/mobile/src/features/background-connection/background-task.ts
@@ -1,0 +1,78 @@
+import { startBackgroundManagedRelayAuth } from "../cloud/backgroundManagedRelayAuth";
+import {
+  acknowledgeBackgroundConnectionStop,
+  addBackgroundConnectionStopRequestListener,
+  getBackgroundConnectionStatus,
+  setBackgroundConnectionRuntimeReady,
+} from "../../native/backgroundConnection";
+import { appAtomRegistry } from "../../state/atom-registry";
+import { acquireBackgroundConnectionRoot } from "./background-root";
+
+let activeTask: Promise<void> | null = null;
+
+function bestEffortCleanup(label: string, cleanup: (() => void) | null): void {
+  if (cleanup === null) {
+    return;
+  }
+  try {
+    cleanup();
+  } catch (error) {
+    console.error(`[background-connection] ${label} cleanup failed`, error);
+  }
+}
+
+async function runTask(): Promise<void> {
+  let hasStopBeenRequested = false;
+  let requestStop!: () => void;
+  const stopRequested = new Promise<void>((resolve) => {
+    requestStop = () => {
+      hasStopBeenRequested = true;
+      resolve();
+    };
+  });
+  // Subscribe before acquiring anything so a disable request cannot race the
+  // cold React runtime bootstrap and leave the service waiting indefinitely.
+  const stopSubscription = addBackgroundConnectionStopRequestListener(requestStop);
+  // Native may have stopped the service before this cold JS runtime finished
+  // loading and installed its listener. Treat the persisted disabled state as
+  // the same stop request so that a late task cannot leak its leases.
+  if (!getBackgroundConnectionStatus().enabled) {
+    requestStop();
+  }
+  let relayAuth: ReturnType<typeof startBackgroundManagedRelayAuth> | null = null;
+  let releaseRoot: (() => void) | null = null;
+
+  try {
+    if (hasStopBeenRequested) {
+      return;
+    }
+    relayAuth = startBackgroundManagedRelayAuth();
+    releaseRoot = acquireBackgroundConnectionRoot(appAtomRegistry);
+    setBackgroundConnectionRuntimeReady(true);
+    await stopRequested;
+  } catch (error) {
+    console.error("[background-connection] headless runtime failed", error);
+    // Normal completion lets native release React Native's wake lock and use
+    // its bounded exponential restart ladder for bootstrap defects.
+  } finally {
+    bestEffortCleanup("root", releaseRoot);
+    bestEffortCleanup("relay authentication", () => relayAuth?.stop());
+    bestEffortCleanup("stop listener", () => stopSubscription.remove());
+    setBackgroundConnectionRuntimeReady(false);
+    acknowledgeBackgroundConnectionStop();
+  }
+}
+
+/** Native guards task creation too; this JS guard protects hot reloads and races. */
+export function runBackgroundConnectionHeadlessTask(): Promise<void> {
+  if (activeTask !== null) {
+    return activeTask;
+  }
+  const task = runTask().finally(() => {
+    if (activeTask === task) {
+      activeTask = null;
+    }
+  });
+  activeTask = task;
+  return task;
+}

--- a/apps/mobile/src/features/background-connection/headless-task-registration.test.ts
+++ b/apps/mobile/src/features/background-connection/headless-task-registration.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, expect, it, vi } from "vite-plus/test";
+
+const registerHeadlessTask = vi.hoisted(() => vi.fn());
+
+vi.mock("react-native", () => ({
+  AppRegistry: { registerHeadlessTask },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+});
+
+it("registers exactly one Android Headless JS task", async () => {
+  const registration = await import("./headless-task-registration");
+
+  registration.registerBackgroundConnectionHeadlessTask();
+  registration.registerBackgroundConnectionHeadlessTask();
+
+  expect(registerHeadlessTask).toHaveBeenCalledOnce();
+  expect(registerHeadlessTask).toHaveBeenCalledWith(
+    registration.BACKGROUND_CONNECTION_HEADLESS_TASK,
+    expect.any(Function),
+  );
+});
+
+it("finishes the native task when its dynamic import fails", async () => {
+  const registration = await import("./headless-task-registration");
+  const error = new Error("bundle chunk unavailable");
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+  await expect(
+    registration.runRegisteredBackgroundConnectionTask(() => Promise.reject(error)),
+  ).resolves.toBeUndefined();
+
+  expect(consoleError).toHaveBeenCalledWith(
+    "[background-connection] registered headless task failed",
+    error,
+  );
+  consoleError.mockRestore();
+});

--- a/apps/mobile/src/features/background-connection/headless-task-registration.ts
+++ b/apps/mobile/src/features/background-connection/headless-task-registration.ts
@@ -1,0 +1,42 @@
+import { AppRegistry } from "react-native";
+
+export const BACKGROUND_CONNECTION_HEADLESS_TASK = "T3BackgroundConnection";
+
+let registered = false;
+
+interface BackgroundConnectionTaskModule {
+  readonly runBackgroundConnectionHeadlessTask: () => Promise<void>;
+}
+
+type BackgroundConnectionTaskLoader = () => Promise<BackgroundConnectionTaskModule>;
+
+const loadBackgroundConnectionTask: BackgroundConnectionTaskLoader = () =>
+  import("./background-task");
+
+/**
+ * React Native does not finish an unlimited Headless JS task when its provider
+ * rejects with a generic error. Convert import/bootstrap defects into normal
+ * completion so native can release its wake lock and apply bounded recovery.
+ */
+export async function runRegisteredBackgroundConnectionTask(
+  loadTask: BackgroundConnectionTaskLoader = loadBackgroundConnectionTask,
+): Promise<void> {
+  try {
+    const { runBackgroundConnectionHeadlessTask } = await loadTask();
+    await runBackgroundConnectionHeadlessTask();
+  } catch (error) {
+    console.error("[background-connection] registered headless task failed", error);
+  }
+}
+
+/** Must run before Expo registers the Activity's root component. */
+export function registerBackgroundConnectionHeadlessTask(): void {
+  if (registered) {
+    return;
+  }
+  registered = true;
+  AppRegistry.registerHeadlessTask(
+    BACKGROUND_CONNECTION_HEADLESS_TASK,
+    () => () => runRegisteredBackgroundConnectionTask(),
+  );
+}

--- a/apps/mobile/src/features/background-connection/settings-model.test.ts
+++ b/apps/mobile/src/features/background-connection/settings-model.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import type { BackgroundConnectionStatus } from "../../native/backgroundConnection";
+import {
+  backgroundConnectionStatusLabel,
+  shouldRequestBackgroundConnectionBatteryExemption,
+} from "./settings-model";
+
+const status = (overrides: Partial<BackgroundConnectionStatus>): BackgroundConnectionStatus => ({
+  supported: true,
+  enabled: true,
+  serviceRunning: true,
+  runtimeReady: true,
+  batteryOptimizationIgnored: true,
+  ...overrides,
+});
+
+describe("backgroundConnectionStatusLabel", () => {
+  it("reports the fully ready runtime", () => {
+    expect(backgroundConnectionStatusLabel(status({}))).toBe("Running");
+  });
+
+  it("reports startup until both native service and JavaScript are ready", () => {
+    expect(backgroundConnectionStatusLabel(status({ runtimeReady: false }))).toBe("Starting");
+    expect(backgroundConnectionStatusLabel(status({ serviceRunning: false }))).toBe("Starting");
+  });
+
+  it("makes degraded battery protection explicit", () => {
+    expect(backgroundConnectionStatusLabel(status({ batteryOptimizationIgnored: false }))).toBe(
+      "Battery optimization enabled",
+    );
+  });
+
+  it("reports disabled and unsupported installations as stopped", () => {
+    expect(backgroundConnectionStatusLabel(status({ enabled: false }))).toBe("Stopped");
+    expect(backgroundConnectionStatusLabel(status({ supported: false }))).toBe("Stopped");
+  });
+
+  it("keeps the feature enabled when the battery exemption is still declined", () => {
+    const declined = status({ batteryOptimizationIgnored: false });
+    expect(shouldRequestBackgroundConnectionBatteryExemption(declined)).toBe(true);
+    expect(declined.enabled).toBe(true);
+  });
+
+  it("does not request an exemption while disabling", () => {
+    expect(
+      shouldRequestBackgroundConnectionBatteryExemption(
+        status({ enabled: false, batteryOptimizationIgnored: false }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/mobile/src/features/background-connection/settings-model.ts
+++ b/apps/mobile/src/features/background-connection/settings-model.ts
@@ -1,0 +1,25 @@
+import type { BackgroundConnectionStatus } from "../../native/backgroundConnection";
+
+export type BackgroundConnectionStatusLabel =
+  | "Running"
+  | "Starting"
+  | "Stopped"
+  | "Battery optimization enabled";
+
+export function backgroundConnectionStatusLabel(
+  status: BackgroundConnectionStatus,
+): BackgroundConnectionStatusLabel {
+  if (!status.supported || !status.enabled) {
+    return "Stopped";
+  }
+  if (!status.batteryOptimizationIgnored) {
+    return "Battery optimization enabled";
+  }
+  return status.serviceRunning && status.runtimeReady ? "Running" : "Starting";
+}
+
+export function shouldRequestBackgroundConnectionBatteryExemption(
+  status: BackgroundConnectionStatus,
+): boolean {
+  return status.supported && status.enabled && !status.batteryOptimizationIgnored;
+}

--- a/apps/mobile/src/features/cloud/CloudAuthProvider.test.ts
+++ b/apps/mobile/src/features/cloud/CloudAuthProvider.test.ts
@@ -2,8 +2,13 @@ import { managedRelaySessionAtom } from "@t3tools/client-runtime/relay";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { appAtomRegistry } from "../../state/atom-registry";
-import { activateCloudRelayAccount, deactivateCloudRelayAccount } from "./CloudAuthProvider";
+import {
+  activateCloudRelayAccount,
+  deactivateCloudRelayAccount,
+  releaseCloudRelayUiAccount,
+} from "./CloudAuthProvider";
 import { setAgentAwarenessRelayTokenProvider } from "../agent-awareness/remoteRegistration";
+import { acquireBackgroundManagedRelaySession } from "./managedRelaySessionOwnership";
 
 vi.mock("@clerk/expo", () => ({
   ClerkProvider: vi.fn(),
@@ -35,6 +40,7 @@ vi.mock("./publicConfig", () => ({
 }));
 
 vi.mock("../agent-awareness/remoteRegistration", () => ({
+  releaseAgentAwarenessRelayTokenProvider: vi.fn(),
   setAgentAwarenessRelayTokenProvider: vi.fn(),
   unregisterAgentAwarenessDeviceForCurrentUser: vi.fn(),
 }));
@@ -56,5 +62,19 @@ describe("CloudAuthProvider relay account isolation", () => {
     expect(appAtomRegistry.get(managedRelaySessionAtom)).toBeNull();
     expect(vi.mocked(setAgentAwarenessRelayTokenProvider)).toHaveBeenLastCalledWith(null);
     await cleanup;
+  });
+
+  it("preserves the background session when the UI bridge unmounts", () => {
+    const releaseBackground = acquireBackgroundManagedRelaySession({
+      accountId: "account-1",
+      readClerkToken: async () => "background-token",
+    });
+    activateCloudRelayAccount("account-1", async () => "ui-token");
+
+    releaseCloudRelayUiAccount();
+
+    expect(appAtomRegistry.get(managedRelaySessionAtom)?.accountId).toBe("account-1");
+    releaseBackground?.();
+    expect(appAtomRegistry.get(managedRelaySessionAtom)).toBeNull();
   });
 });

--- a/apps/mobile/src/features/cloud/CloudAuthProvider.tsx
+++ b/apps/mobile/src/features/cloud/CloudAuthProvider.tsx
@@ -1,6 +1,6 @@
 import { ClerkProvider, useAuth } from "@clerk/expo";
 import { tokenCache } from "@clerk/expo/token-cache";
-import { ManagedRelay, setManagedRelaySession } from "@t3tools/client-runtime/relay";
+import { ManagedRelay } from "@t3tools/client-runtime/relay";
 import {
   reportAtomCommandResult,
   settleAsyncResult,
@@ -11,7 +11,6 @@ import { type ReactNode, useEffect, useRef } from "react";
 
 import { environmentCatalog } from "../../connection/catalog";
 import { runtime } from "../../lib/runtime";
-import { appAtomRegistry } from "../../state/atom-registry";
 import { useAtomCommand } from "../../state/use-atom-command";
 import {
   releaseAgentAwarenessRelayTokenProvider,
@@ -19,6 +18,11 @@ import {
   unregisterAgentAwarenessDeviceForCurrentUser,
 } from "../agent-awareness/remoteRegistration";
 import { clearConnectOnboardingRequest, requestConnectOnboarding } from "./connectOnboarding";
+import {
+  invalidateBackgroundManagedRelayAuth,
+  refreshBackgroundManagedRelayAuth,
+} from "./backgroundManagedRelayAuth";
+import { managedRelaySessionOwnership } from "./managedRelaySessionOwnership";
 import { resolveCloudPublicConfig, resolveRelayClerkTokenOptions } from "./publicConfig";
 
 function resetManagedRelayTokenCache() {
@@ -29,9 +33,15 @@ function resetManagedRelayTokenCache() {
   );
 }
 
-export function deactivateCloudRelayAccount(): void {
+export function deactivateCloudRelayAccount(
+  options: { readonly refreshBackground?: boolean } = {},
+): void {
   setAgentAwarenessRelayTokenProvider(null);
-  setManagedRelaySession(appAtomRegistry, null);
+  invalidateBackgroundManagedRelayAuth();
+  managedRelaySessionOwnership.clear();
+  if (options.refreshBackground !== false) {
+    void refreshBackgroundManagedRelayAuth();
+  }
 }
 
 export function activateCloudRelayAccount(
@@ -39,10 +49,27 @@ export function activateCloudRelayAccount(
   tokenProvider: () => Promise<string | null>,
 ): void {
   setAgentAwarenessRelayTokenProvider(tokenProvider, accountId);
-  setManagedRelaySession(appAtomRegistry, {
+  managedRelaySessionOwnership.setOwner("ui", {
     accountId,
     readClerkToken: tokenProvider,
   });
+  void refreshBackgroundManagedRelayAuth();
+}
+
+export function releaseCloudRelayUiAccount(
+  options: { readonly refreshAfter?: Promise<void> | null } = {},
+): void {
+  releaseAgentAwarenessRelayTokenProvider();
+  managedRelaySessionOwnership.releaseOwner("ui");
+  const refresh = () => {
+    void refreshBackgroundManagedRelayAuth();
+  };
+  const refreshAfter = options.refreshAfter ?? null;
+  if (refreshAfter === null) {
+    refresh();
+  } else {
+    void refreshAfter.then(refresh, refresh);
+  }
 }
 
 function CloudAuthBridge(props: { readonly children: ReactNode }) {
@@ -147,7 +174,7 @@ function CloudAuthBridge(props: { readonly children: ReactNode }) {
       previousObservedAccount !== userId
     ) {
       previousTokenProviderRef.current = null;
-      deactivateCloudRelayAccount();
+      deactivateCloudRelayAccount({ refreshBackground: false });
       activateAfterTransition(queueAccountCleanup(previous));
     } else {
       activateAfterTransition(accountTransitionRef.current ?? Promise.resolve());
@@ -164,8 +191,7 @@ function CloudAuthBridge(props: { readonly children: ReactNode }) {
       // Unmounting is not a sign-out: the user is usually still signed in, so
       // detach the provider without ending lock-screen activities or wiping the
       // persisted registration (a remount reuses both).
-      releaseAgentAwarenessRelayTokenProvider();
-      setManagedRelaySession(appAtomRegistry, null);
+      releaseCloudRelayUiAccount({ refreshAfter: accountTransitionRef.current });
     },
     [],
   );

--- a/apps/mobile/src/features/cloud/backgroundManagedRelayAuth.test.ts
+++ b/apps/mobile/src/features/cloud/backgroundManagedRelayAuth.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  bootstrapBackgroundManagedRelayAuth,
+  invalidateBackgroundManagedRelayAuth,
+  refreshBackgroundManagedRelayAuth,
+  startBackgroundManagedRelayAuth,
+} from "./backgroundManagedRelayAuth";
+
+vi.mock("@clerk/expo", () => ({ getClerkInstance: vi.fn() }));
+vi.mock("@clerk/expo/token-cache", () => ({ tokenCache: {} }));
+vi.mock("expo-constants", () => ({
+  default: { expoConfig: { extra: {} } },
+}));
+
+const configuredPublicConfig = {
+  clerk: {
+    publishableKey: "pk_test_example",
+    jwtTemplate: "relay-template",
+  },
+  relay: { url: "https://relay.example.com/" },
+  observability: {
+    tracesUrl: null,
+    tracesDataset: null,
+    tracesToken: null,
+  },
+} as const;
+
+function deferred<A>() {
+  let resolve!: (value: A) => void;
+  const promise = new Promise<A>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe("background managed relay authentication", () => {
+  it("loads Clerk and acquires a renewable session for the active account", async () => {
+    const load = vi.fn(async () => undefined);
+    const getToken = vi.fn(async () => "relay-token");
+    const release = vi.fn();
+    const acquireSession = vi.fn(
+      (_session: {
+        readonly accountId: string;
+        readonly readClerkToken: () => Promise<string | null>;
+      }) => release,
+    );
+    const resolveTokenOptions = vi.fn(() => ({
+      template: "relay-template",
+      skipCache: true as const,
+    }));
+
+    const result = await bootstrapBackgroundManagedRelayAuth({
+      resolveConfig: () => configuredPublicConfig,
+      createClerk: () => ({
+        loaded: false,
+        load,
+        session: { user: { id: "account-1" }, getToken },
+      }),
+      resolveTokenOptions,
+      acquireSession,
+    });
+
+    expect(result.state).toEqual({ status: "active", accountId: "account-1" });
+    expect(load).toHaveBeenCalledOnce();
+    const session = acquireSession.mock.calls[0]?.[0];
+    expect(session?.accountId).toBe("account-1");
+    await expect(session?.readClerkToken()).resolves.toBe("relay-token");
+    expect(getToken).toHaveBeenCalledWith({
+      template: "relay-template",
+      skipCache: true,
+    });
+  });
+
+  it("treats a loaded Clerk instance without a session as signed out", async () => {
+    const acquireSession = vi.fn(
+      (_session: {
+        readonly accountId: string;
+        readonly readClerkToken: () => Promise<string | null>;
+      }) => vi.fn(),
+    );
+
+    const result = await bootstrapBackgroundManagedRelayAuth({
+      resolveConfig: () => configuredPublicConfig,
+      createClerk: () => ({ loaded: true, load: vi.fn(), session: null }),
+      resolveTokenOptions: vi.fn(() => ({
+        template: "relay-template",
+        skipCache: true as const,
+      })),
+      acquireSession,
+    });
+
+    expect(result.state).toEqual({ status: "signed-out" });
+    expect(acquireSession).not.toHaveBeenCalled();
+  });
+
+  it("does not report active when a stale background owner is rejected", async () => {
+    const result = await bootstrapBackgroundManagedRelayAuth({
+      resolveConfig: () => configuredPublicConfig,
+      createClerk: () => ({
+        loaded: true,
+        load: vi.fn(),
+        session: {
+          user: { id: "stale-account" },
+          getToken: vi.fn(async () => "stale-token"),
+        },
+      }),
+      resolveTokenOptions: vi.fn(() => ({
+        template: "relay-template",
+        skipCache: true as const,
+      })),
+      acquireSession: vi.fn(() => null),
+    });
+
+    expect(result).toEqual({ state: { status: "superseded" } });
+  });
+
+  it("returns immediately for missing public configuration", async () => {
+    const createClerk = vi.fn();
+    const result = await bootstrapBackgroundManagedRelayAuth({
+      resolveConfig: () => ({
+        ...configuredPublicConfig,
+        clerk: { publishableKey: null, jwtTemplate: null },
+      }),
+      createClerk,
+      resolveTokenOptions: vi.fn(() => ({
+        template: "relay-template",
+        skipCache: true as const,
+      })),
+      acquireSession: vi.fn(
+        (_session: {
+          readonly accountId: string;
+          readonly readClerkToken: () => Promise<string | null>;
+        }) => vi.fn(),
+      ),
+    });
+
+    expect(result.state).toEqual({ status: "unconfigured" });
+    expect(createClerk).not.toHaveBeenCalled();
+  });
+
+  it("reports transient Clerk initialization failures without throwing", async () => {
+    const error = new Error("Network unavailable");
+    const result = await bootstrapBackgroundManagedRelayAuth({
+      resolveConfig: () => configuredPublicConfig,
+      createClerk: () => {
+        throw error;
+      },
+      resolveTokenOptions: vi.fn(() => ({
+        template: "relay-template",
+        skipCache: true as const,
+      })),
+      acquireSession: vi.fn(
+        (_session: {
+          readonly accountId: string;
+          readonly readClerkToken: () => Promise<string | null>;
+        }) => vi.fn(),
+      ),
+    });
+
+    expect(result.state).toEqual({ status: "retrying", error });
+  });
+
+  it("cannot restore a stale account after sign-out invalidates an in-flight load", async () => {
+    const load = deferred<void>();
+    const acquireSession = vi.fn(() => vi.fn());
+    const attempt = bootstrapBackgroundManagedRelayAuth({
+      resolveConfig: () => configuredPublicConfig,
+      createClerk: () => ({
+        loaded: false,
+        load: () => load.promise,
+        session: {
+          user: { id: "old-account" },
+          getToken: vi.fn(async () => "old-token"),
+        },
+      }),
+      resolveTokenOptions: vi.fn(() => ({
+        template: "relay-template",
+        skipCache: true as const,
+      })),
+      acquireSession,
+    });
+
+    invalidateBackgroundManagedRelayAuth();
+    load.resolve();
+
+    await expect(attempt).resolves.toEqual({ state: { status: "superseded" } });
+    expect(acquireSession).not.toHaveBeenCalled();
+  });
+
+  it("keeps the controller alive and retries transient Clerk failures", async () => {
+    const error = new Error("Clerk is temporarily unavailable");
+    const release = vi.fn();
+    const bootstrap = vi
+      .fn()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce({
+        state: { status: "active", accountId: "account-1" },
+        release,
+      });
+    const scheduledRetries: Array<{ retry: () => void; delayMs: number }> = [];
+    const controller = startBackgroundManagedRelayAuth({
+      bootstrap,
+      scheduleRetry: (retry, delayMs) => {
+        scheduledRetries.push({ retry, delayMs });
+        return vi.fn();
+      },
+    });
+
+    await expect(controller.firstAttempt).resolves.toEqual({ status: "retrying", error });
+    expect(scheduledRetries).toHaveLength(1);
+    expect(scheduledRetries[0]?.delayMs).toBe(1_000);
+    await expect(controller.retryNow()).resolves.toEqual({
+      status: "active",
+      accountId: "account-1",
+    });
+
+    controller.stop();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("retries a signed-out bootstrap when UI ownership changes", async () => {
+    const release = vi.fn();
+    const bootstrap = vi
+      .fn()
+      .mockResolvedValueOnce({ state: { status: "signed-out" } })
+      .mockResolvedValueOnce({
+        state: { status: "active", accountId: "account-1" },
+        release,
+      });
+    const controller = startBackgroundManagedRelayAuth({ bootstrap });
+    await expect(controller.firstAttempt).resolves.toEqual({ status: "signed-out" });
+
+    await refreshBackgroundManagedRelayAuth();
+
+    expect(bootstrap).toHaveBeenCalledTimes(2);
+    controller.stop();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("queues a fresh bootstrap when refresh is requested during an in-flight attempt", async () => {
+    const first = deferred<{ state: { status: "superseded" } }>();
+    const bootstrap = vi
+      .fn()
+      .mockImplementationOnce(() => first.promise)
+      .mockResolvedValueOnce({ state: { status: "signed-out" } });
+    const controller = startBackgroundManagedRelayAuth({ bootstrap });
+
+    const refreshed = controller.retryNow();
+    expect(bootstrap).toHaveBeenCalledOnce();
+    first.resolve({ state: { status: "superseded" } });
+
+    await expect(refreshed).resolves.toEqual({ status: "signed-out" });
+    expect(bootstrap).toHaveBeenCalledTimes(2);
+    controller.stop();
+  });
+
+  it("stops retrying and releases ownership idempotently", async () => {
+    const release = vi.fn();
+    const controller = startBackgroundManagedRelayAuth({
+      bootstrap: async () => ({
+        state: { status: "active", accountId: "account-1" },
+        release,
+      }),
+    });
+    await controller.firstAttempt;
+
+    controller.stop();
+    controller.stop();
+    expect(release).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/mobile/src/features/cloud/backgroundManagedRelayAuth.ts
+++ b/apps/mobile/src/features/cloud/backgroundManagedRelayAuth.ts
@@ -1,0 +1,219 @@
+import { getClerkInstance } from "@clerk/expo";
+import { tokenCache } from "@clerk/expo/token-cache";
+
+import { acquireBackgroundManagedRelaySession } from "./managedRelaySessionOwnership";
+import { resolveCloudPublicConfig, resolveRelayClerkTokenOptions } from "./publicConfig";
+
+const INITIAL_RETRY_DELAY_MS = 1_000;
+const MAX_RETRY_DELAY_MS = 30_000;
+
+export type BackgroundManagedRelayAuthState =
+  | { readonly status: "active"; readonly accountId: string }
+  | { readonly status: "signed-out" }
+  | { readonly status: "unconfigured" }
+  | { readonly status: "superseded" }
+  | { readonly status: "retrying"; readonly error: unknown };
+
+interface BackgroundClerkSession {
+  readonly user: { readonly id: string };
+  readonly getToken: (
+    options: ReturnType<typeof resolveRelayClerkTokenOptions>,
+  ) => Promise<string | null>;
+}
+
+interface BackgroundClerk {
+  readonly loaded: boolean;
+  readonly session: BackgroundClerkSession | null | undefined;
+  readonly load: () => Promise<void>;
+}
+
+interface BackgroundManagedRelayAuthDependencies {
+  readonly resolveConfig: typeof resolveCloudPublicConfig;
+  readonly createClerk: (publishableKey: string) => BackgroundClerk;
+  readonly resolveTokenOptions: typeof resolveRelayClerkTokenOptions;
+  readonly acquireSession: typeof acquireBackgroundManagedRelaySession;
+}
+
+interface BackgroundManagedRelayAuthAttempt {
+  readonly state: BackgroundManagedRelayAuthState;
+  readonly release?: () => void;
+}
+
+const defaultDependencies: BackgroundManagedRelayAuthDependencies = {
+  resolveConfig: resolveCloudPublicConfig,
+  createClerk: (publishableKey) => getClerkInstance({ publishableKey, tokenCache }),
+  resolveTokenOptions: resolveRelayClerkTokenOptions,
+  acquireSession: acquireBackgroundManagedRelaySession,
+};
+
+let authenticationEpoch = 0;
+
+/** Prevent an in-flight Clerk load from restoring ownership after sign-out. */
+export function invalidateBackgroundManagedRelayAuth(): void {
+  authenticationEpoch += 1;
+}
+
+export async function bootstrapBackgroundManagedRelayAuth(
+  dependencies: BackgroundManagedRelayAuthDependencies = defaultDependencies,
+): Promise<BackgroundManagedRelayAuthAttempt> {
+  const attemptEpoch = authenticationEpoch;
+  try {
+    const config = dependencies.resolveConfig();
+    if (!config.clerk.publishableKey || !config.clerk.jwtTemplate || !config.relay.url) {
+      return { state: { status: "unconfigured" } };
+    }
+
+    const clerk = dependencies.createClerk(config.clerk.publishableKey);
+    if (!clerk.loaded) {
+      await clerk.load();
+    }
+    const session = clerk.session;
+    if (!session?.user.id) {
+      return { state: { status: "signed-out" } };
+    }
+
+    // Clerk loading crosses an async boundary. Sign-out or account switching
+    // can invalidate this result while it is in flight; never let that stale
+    // account reacquire the background owner after ownership was cleared.
+    if (attemptEpoch !== authenticationEpoch) {
+      return { state: { status: "superseded" } };
+    }
+
+    const release = dependencies.acquireSession({
+      accountId: session.user.id,
+      readClerkToken: () => session.getToken(dependencies.resolveTokenOptions()),
+    });
+    if (release === null) {
+      return { state: { status: "superseded" } };
+    }
+    return {
+      state: { status: "active", accountId: session.user.id },
+      release,
+    };
+  } catch (error) {
+    return { state: { status: "retrying", error } };
+  }
+}
+
+interface BackgroundManagedRelayAuthControllerOptions {
+  readonly bootstrap?: () => Promise<BackgroundManagedRelayAuthAttempt>;
+  readonly scheduleRetry?: (retry: () => void, delayMs: number) => () => void;
+  readonly onStateChange?: (state: BackgroundManagedRelayAuthState) => void;
+}
+
+export interface BackgroundManagedRelayAuthController {
+  readonly firstAttempt: Promise<BackgroundManagedRelayAuthState>;
+  readonly retryNow: () => Promise<BackgroundManagedRelayAuthState>;
+  readonly stop: () => void;
+}
+
+const backgroundManagedRelayAuthRefreshers = new Set<
+  () => Promise<BackgroundManagedRelayAuthState>
+>();
+
+export async function refreshBackgroundManagedRelayAuth(): Promise<void> {
+  await Promise.all([...backgroundManagedRelayAuthRefreshers].map((refresh) => refresh()));
+}
+
+function defaultScheduleRetry(retry: () => void, delayMs: number): () => void {
+  const timeout = setTimeout(retry, delayMs);
+  return () => clearTimeout(timeout);
+}
+
+export function startBackgroundManagedRelayAuth(
+  options: BackgroundManagedRelayAuthControllerOptions = {},
+): BackgroundManagedRelayAuthController {
+  const bootstrap = options.bootstrap ?? (() => bootstrapBackgroundManagedRelayAuth());
+  const scheduleRetry = options.scheduleRetry ?? defaultScheduleRetry;
+  let stopped = false;
+  let failureCount = 0;
+  let releaseSession: (() => void) | null = null;
+  let cancelRetry: (() => void) | null = null;
+  let inFlight: Promise<BackgroundManagedRelayAuthState> | null = null;
+  let refreshRequested = false;
+
+  const cancelScheduledRetry = () => {
+    cancelRetry?.();
+    cancelRetry = null;
+  };
+
+  const runAttempt = (): Promise<BackgroundManagedRelayAuthState> => {
+    if (inFlight) {
+      return inFlight;
+    }
+    cancelScheduledRetry();
+    const operation = (async () => {
+      const attempt = await bootstrap().catch(
+        (error): BackgroundManagedRelayAuthAttempt => ({
+          state: { status: "retrying", error },
+        }),
+      );
+      if (stopped) {
+        attempt.release?.();
+        return attempt.state;
+      }
+
+      if (attempt.state.status === "active") {
+        failureCount = 0;
+        const previousRelease = releaseSession;
+        releaseSession = attempt.release ?? null;
+        previousRelease?.();
+      } else if (attempt.state.status === "retrying") {
+        const retryDelay = Math.min(INITIAL_RETRY_DELAY_MS * 2 ** failureCount, MAX_RETRY_DELAY_MS);
+        failureCount += 1;
+        cancelRetry = scheduleRetry(() => {
+          cancelRetry = null;
+          void runAttempt();
+        }, retryDelay);
+      } else {
+        releaseSession?.();
+        releaseSession = null;
+      }
+
+      options.onStateChange?.(attempt.state);
+      return attempt.state;
+    })();
+    const trackedOperation = operation.finally(() => {
+      if (inFlight === trackedOperation) {
+        inFlight = null;
+      }
+    });
+    inFlight = trackedOperation;
+    return trackedOperation;
+  };
+
+  const requestAttempt = (): Promise<BackgroundManagedRelayAuthState> => {
+    const currentAttempt = inFlight;
+    if (currentAttempt === null) {
+      return runAttempt();
+    }
+    // Coalesce refreshes, but guarantee one fresh bootstrap after the current
+    // attempt. Returning the in-flight promise alone would let a sign-out
+    // invalidation be consumed by the stale attempt without rereading Clerk.
+    refreshRequested = true;
+    return currentAttempt.then((state) => {
+      if (stopped || !refreshRequested) {
+        return state;
+      }
+      refreshRequested = false;
+      return runAttempt();
+    });
+  };
+
+  backgroundManagedRelayAuthRefreshers.add(requestAttempt);
+  const firstAttempt = runAttempt();
+  return {
+    firstAttempt,
+    retryNow: requestAttempt,
+    stop() {
+      if (stopped) {
+        return;
+      }
+      stopped = true;
+      backgroundManagedRelayAuthRefreshers.delete(requestAttempt);
+      cancelScheduledRetry();
+      releaseSession?.();
+      releaseSession = null;
+    },
+  };
+}

--- a/apps/mobile/src/features/cloud/managedRelaySessionOwnership.test.ts
+++ b/apps/mobile/src/features/cloud/managedRelaySessionOwnership.test.ts
@@ -1,0 +1,111 @@
+import { managedRelaySessionAtom } from "@t3tools/client-runtime/relay";
+import { AtomRegistry } from "effect/unstable/reactivity";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { createManagedRelaySessionOwnership } from "./managedRelaySessionOwnership";
+
+function createHarness() {
+  const registry = AtomRegistry.make();
+  const ownership = createManagedRelaySessionOwnership(registry);
+  const provider = (token: string) => vi.fn(async () => token);
+  return { ownership, provider, registry };
+}
+
+describe("managed relay session ownership", () => {
+  it("keeps the UI owner effective while a background owner is present", () => {
+    const { ownership, provider, registry } = createHarness();
+    const backgroundProvider = provider("background");
+    const uiProvider = provider("ui");
+
+    ownership.setOwner("background", {
+      accountId: "account-1",
+      readClerkToken: backgroundProvider,
+    });
+    ownership.setOwner("ui", { accountId: "account-1", readClerkToken: uiProvider });
+
+    const session = registry.get(managedRelaySessionAtom);
+    expect(session?.accountId).toBe("account-1");
+    ownership.releaseOwner("ui");
+    expect(registry.get(managedRelaySessionAtom)?.accountId).toBe("account-1");
+  });
+
+  it("releasing one owner preserves the other owner", () => {
+    const { ownership, provider, registry } = createHarness();
+    const releaseBackground = ownership.setOwner("background", {
+      accountId: "account-1",
+      readClerkToken: provider("background"),
+    });
+    ownership.setOwner("ui", {
+      accountId: "account-1",
+      readClerkToken: provider("ui"),
+    });
+
+    expect(releaseBackground).not.toBeNull();
+    releaseBackground?.();
+    expect(registry.get(managedRelaySessionAtom)?.accountId).toBe("account-1");
+    ownership.releaseOwner("ui");
+    expect(registry.get(managedRelaySessionAtom)).toBeNull();
+  });
+
+  it("does not let an obsolete release remove a newer lease", () => {
+    const { ownership, provider, registry } = createHarness();
+    const releaseFirst = ownership.setOwner("background", {
+      accountId: "account-1",
+      readClerkToken: provider("first"),
+    });
+    ownership.setOwner("background", {
+      accountId: "account-1",
+      readClerkToken: provider("second"),
+    });
+
+    expect(releaseFirst).not.toBeNull();
+    releaseFirst?.();
+    expect(registry.get(managedRelaySessionAtom)?.accountId).toBe("account-1");
+  });
+
+  it("invalidates a stale background owner on a UI account switch", () => {
+    const { ownership, provider, registry } = createHarness();
+    ownership.setOwner("background", {
+      accountId: "account-1",
+      readClerkToken: provider("background"),
+    });
+    ownership.setOwner("ui", {
+      accountId: "account-2",
+      readClerkToken: provider("ui"),
+    });
+
+    ownership.releaseOwner("ui");
+    expect(registry.get(managedRelaySessionAtom)).toBeNull();
+  });
+
+  it("rejects a stale background bootstrap that completes after a UI switch", () => {
+    const { ownership, provider, registry } = createHarness();
+    ownership.setOwner("ui", {
+      accountId: "account-2",
+      readClerkToken: provider("ui"),
+    });
+    const rejected = ownership.setOwner("background", {
+      accountId: "account-1",
+      readClerkToken: provider("background"),
+    });
+
+    expect(rejected).toBeNull();
+    ownership.releaseOwner("ui");
+    expect(registry.get(managedRelaySessionAtom)).toBeNull();
+  });
+
+  it("clears both owners for sign-out", () => {
+    const { ownership, provider, registry } = createHarness();
+    ownership.setOwner("background", {
+      accountId: "account-1",
+      readClerkToken: provider("background"),
+    });
+    ownership.setOwner("ui", {
+      accountId: "account-1",
+      readClerkToken: provider("ui"),
+    });
+
+    ownership.clear();
+    expect(registry.get(managedRelaySessionAtom)).toBeNull();
+  });
+});

--- a/apps/mobile/src/features/cloud/managedRelaySessionOwnership.ts
+++ b/apps/mobile/src/features/cloud/managedRelaySessionOwnership.ts
@@ -1,0 +1,98 @@
+import {
+  type ManagedRelaySessionInput,
+  setManagedRelaySession,
+} from "@t3tools/client-runtime/relay";
+import type { AtomRegistry } from "effect/unstable/reactivity";
+
+import { appAtomRegistry } from "../../state/atom-registry";
+
+export type ManagedRelaySessionOwner = "ui" | "background";
+
+interface OwnerLease extends ManagedRelaySessionInput {
+  readonly id: number;
+}
+
+export interface ManagedRelaySessionOwnership {
+  readonly setOwner: (
+    owner: ManagedRelaySessionOwner,
+    session: ManagedRelaySessionInput,
+  ) => (() => void) | null;
+  readonly releaseOwner: (owner: ManagedRelaySessionOwner) => void;
+  readonly clear: () => void;
+}
+
+export function createManagedRelaySessionOwnership(
+  registry: AtomRegistry.AtomRegistry,
+): ManagedRelaySessionOwnership {
+  let nextLeaseId = 0;
+  let ui: OwnerLease | null = null;
+  let background: OwnerLease | null = null;
+  let appliedLeaseId: number | null = null;
+
+  const applyEffectiveOwner = () => {
+    const effective = ui ?? background;
+    const effectiveLeaseId = effective?.id ?? null;
+    if (effectiveLeaseId === appliedLeaseId) {
+      return;
+    }
+    appliedLeaseId = effectiveLeaseId;
+    setManagedRelaySession(registry, effective);
+  };
+
+  const releaseLease = (owner: ManagedRelaySessionOwner, leaseId: number) => {
+    if (owner === "ui") {
+      if (ui?.id !== leaseId) {
+        return;
+      }
+      ui = null;
+    } else {
+      if (background?.id !== leaseId) {
+        return;
+      }
+      background = null;
+    }
+    applyEffectiveOwner();
+  };
+
+  return {
+    setOwner(owner, session) {
+      const lease: OwnerLease = { ...session, id: ++nextLeaseId };
+      if (owner === "ui") {
+        ui = lease;
+        if (background?.accountId !== session.accountId) {
+          background = null;
+        }
+      } else {
+        // A headless bootstrap may finish after the user switches accounts in
+        // the UI. Never retain that stale result for a later UI unmount.
+        if (ui && ui.accountId !== session.accountId) {
+          return null;
+        }
+        background = lease;
+      }
+      applyEffectiveOwner();
+      return () => releaseLease(owner, lease.id);
+    },
+    releaseOwner(owner) {
+      if (owner === "ui") {
+        ui = null;
+      } else {
+        background = null;
+      }
+      applyEffectiveOwner();
+    },
+    clear() {
+      ui = null;
+      background = null;
+      applyEffectiveOwner();
+    },
+  };
+}
+
+export const managedRelaySessionOwnership = createManagedRelaySessionOwnership(appAtomRegistry);
+
+export function acquireBackgroundManagedRelaySession(
+  session: ManagedRelaySessionInput,
+): (() => void) | null {
+  return managedRelaySessionOwnership.setOwner("background", session);
+}

--- a/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
@@ -43,6 +43,7 @@ import {
   runAppUpdateCheck,
 } from "../updates/app-updates";
 import { useSavedRemoteConnections } from "../../state/use-remote-environment-registry";
+import { BackgroundConnectionSettingsSection } from "../background-connection/BackgroundConnectionSettingsSection";
 import { SettingsRow } from "./components/SettingsRow";
 import { SettingsSection } from "./components/SettingsSection";
 import { SettingsSwitchRow } from "./components/SettingsSwitchRow";
@@ -126,6 +127,8 @@ function LocalSettingsRouteScreen() {
         </SettingsSection>
 
         <GeneralSettingsSection />
+
+        <BackgroundConnectionSettingsSection />
 
         <SettingsSection title="Appearance">
           <SettingsRow icon="paintbrush" label="Appearance" target="SettingsAppearance" />
@@ -512,6 +515,8 @@ function ConfiguredSettingsRouteScreen() {
         </SettingsSection>
 
         <GeneralSettingsSection />
+
+        <BackgroundConnectionSettingsSection />
 
         <SettingsSection title="Appearance">
           <SettingsRow icon="paintbrush" label="Appearance" target="SettingsAppearance" />

--- a/apps/mobile/src/native/backgroundConnection.test.ts
+++ b/apps/mobile/src/native/backgroundConnection.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const expoMocks = vi.hoisted(() => ({
+  requireOptionalNativeModule: vi.fn((_name: string): unknown => null),
+}));
+
+vi.mock("expo", () => ({
+  NativeModule: class {
+    readonly __nativeModule = true;
+  },
+  requireOptionalNativeModule: expoMocks.requireOptionalNativeModule,
+}));
+
+const runningStatus = {
+  supported: true,
+  enabled: true,
+  serviceRunning: true,
+  runtimeReady: true,
+  batteryOptimizationIgnored: true,
+} as const;
+
+describe("backgroundConnection native bridge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    expoMocks.requireOptionalNativeModule.mockReturnValue(null);
+  });
+
+  it("is safe when the Android native module is unavailable", async () => {
+    const bridge = await import("./backgroundConnection");
+
+    expect(bridge.getBackgroundConnectionStatus()).toEqual({
+      supported: false,
+      enabled: false,
+      serviceRunning: false,
+      runtimeReady: false,
+      batteryOptimizationIgnored: false,
+    });
+    await expect(bridge.setBackgroundConnectionEnabled(true)).resolves.toMatchObject({
+      supported: false,
+    });
+    await expect(
+      bridge.requestBackgroundConnectionBatteryOptimizationExemption(),
+    ).resolves.toMatchObject({ supported: false });
+    expect(bridge.ensureBackgroundConnectionStarted()).toMatchObject({ supported: false });
+    expect(bridge.addBackgroundConnectionStatusListener(vi.fn()).remove).not.toThrow();
+    expect(bridge.addBackgroundConnectionStopRequestListener(vi.fn()).remove).not.toThrow();
+  });
+
+  it("forwards status and lifecycle calls to the installed native module", async () => {
+    const setEnabled = vi.fn(async () => runningStatus);
+    const ensureStarted = vi.fn(() => runningStatus);
+    const requestBatteryOptimizationExemption = vi.fn(async () => runningStatus);
+    const setRuntimeReady = vi.fn(() => runningStatus);
+    const acknowledgeStop = vi.fn(() => runningStatus);
+    expoMocks.requireOptionalNativeModule.mockReturnValue({
+      getStatus: () => runningStatus,
+      setEnabled,
+      ensureStarted,
+      requestBatteryOptimizationExemption,
+      setRuntimeReady,
+      acknowledgeStop,
+    });
+    const bridge = await import("./backgroundConnection");
+
+    expect(bridge.getBackgroundConnectionStatus()).toEqual(runningStatus);
+    await expect(bridge.setBackgroundConnectionEnabled(true)).resolves.toEqual(runningStatus);
+    await expect(bridge.requestBackgroundConnectionBatteryOptimizationExemption()).resolves.toEqual(
+      runningStatus,
+    );
+    expect(bridge.ensureBackgroundConnectionStarted()).toEqual(runningStatus);
+    expect(bridge.setBackgroundConnectionRuntimeReady(true)).toEqual(runningStatus);
+    expect(bridge.acknowledgeBackgroundConnectionStop()).toEqual(runningStatus);
+    expect(setEnabled).toHaveBeenCalledWith(true);
+    expect(requestBatteryOptimizationExemption).toHaveBeenCalledOnce();
+    expect(ensureStarted).toHaveBeenCalledOnce();
+    expect(setRuntimeReady).toHaveBeenCalledWith(true);
+    expect(acknowledgeStop).toHaveBeenCalledOnce();
+  });
+
+  it("normalizes native status events and exposes the stop request", async () => {
+    const listeners = new Map<string, (event?: unknown) => void>();
+    const remove = vi.fn();
+    expoMocks.requireOptionalNativeModule.mockReturnValue({
+      getStatus: () => runningStatus,
+      addListener: (eventName: string, listener: (event?: unknown) => void) => {
+        listeners.set(eventName, listener);
+        return { remove };
+      },
+    });
+    const bridge = await import("./backgroundConnection");
+    const onStatus = vi.fn();
+    const onStop = vi.fn();
+
+    const statusSubscription = bridge.addBackgroundConnectionStatusListener(onStatus);
+    bridge.addBackgroundConnectionStopRequestListener(onStop);
+    listeners.get("onStatusChange")?.({
+      ...runningStatus,
+      runtimeReady: 1,
+    });
+    listeners.get("onStopRequested")?.();
+    statusSubscription.remove();
+
+    expect(onStatus).toHaveBeenCalledWith({ ...runningStatus, runtimeReady: false });
+    expect(onStop).toHaveBeenCalledOnce();
+    expect(remove).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/mobile/src/native/backgroundConnection.ts
+++ b/apps/mobile/src/native/backgroundConnection.ts
@@ -1,0 +1,141 @@
+import { NativeModule, requireOptionalNativeModule } from "expo";
+
+export interface BackgroundConnectionStatus {
+  readonly supported: boolean;
+  readonly enabled: boolean;
+  readonly serviceRunning: boolean;
+  readonly runtimeReady: boolean;
+  readonly batteryOptimizationIgnored: boolean;
+}
+
+type BackgroundConnectionNativeEvents = {
+  readonly onStatusChange: (status: BackgroundConnectionStatus) => void;
+  readonly onStopRequested: () => void;
+};
+
+declare class BackgroundConnectionNativeModule extends NativeModule<BackgroundConnectionNativeEvents> {
+  readonly getStatus?: () => BackgroundConnectionStatus;
+  readonly setEnabled?: (enabled: boolean) => Promise<BackgroundConnectionStatus>;
+  readonly ensureStarted?: () => BackgroundConnectionStatus;
+  readonly requestBatteryOptimizationExemption?: () => Promise<BackgroundConnectionStatus>;
+  readonly setRuntimeReady?: (ready: boolean) => BackgroundConnectionStatus;
+  readonly acknowledgeStop?: () => BackgroundConnectionStatus;
+}
+
+export interface BackgroundConnectionSubscription {
+  readonly remove: () => void;
+}
+
+const UNSUPPORTED_STATUS: BackgroundConnectionStatus = {
+  supported: false,
+  enabled: false,
+  serviceRunning: false,
+  runtimeReady: false,
+  batteryOptimizationIgnored: false,
+};
+
+let cachedNativeModule: BackgroundConnectionNativeModule | null | undefined;
+
+function getNativeModule(): BackgroundConnectionNativeModule | null {
+  if (cachedNativeModule !== undefined) return cachedNativeModule;
+  try {
+    cachedNativeModule =
+      requireOptionalNativeModule<BackgroundConnectionNativeModule>("T3BackgroundConnection");
+  } catch {
+    cachedNativeModule = null;
+  }
+  return cachedNativeModule;
+}
+
+function normalizeStatus(status: BackgroundConnectionStatus | null | undefined) {
+  if (status?.supported !== true) return UNSUPPORTED_STATUS;
+  return {
+    supported: true,
+    enabled: status.enabled === true,
+    serviceRunning: status.serviceRunning === true,
+    runtimeReady: status.runtimeReady === true,
+    batteryOptimizationIgnored: status.batteryOptimizationIgnored === true,
+  } satisfies BackgroundConnectionStatus;
+}
+
+export function getBackgroundConnectionStatus(): BackgroundConnectionStatus {
+  try {
+    return normalizeStatus(getNativeModule()?.getStatus?.());
+  } catch {
+    return UNSUPPORTED_STATUS;
+  }
+}
+
+export async function setBackgroundConnectionEnabled(
+  enabled: boolean,
+): Promise<BackgroundConnectionStatus> {
+  try {
+    const nativeModule = getNativeModule();
+    if (!nativeModule?.setEnabled) return UNSUPPORTED_STATUS;
+    return normalizeStatus(await nativeModule.setEnabled(enabled));
+  } catch {
+    return getBackgroundConnectionStatus();
+  }
+}
+
+export function ensureBackgroundConnectionStarted(): BackgroundConnectionStatus {
+  try {
+    return normalizeStatus(getNativeModule()?.ensureStarted?.());
+  } catch {
+    return getBackgroundConnectionStatus();
+  }
+}
+
+export async function requestBackgroundConnectionBatteryOptimizationExemption(): Promise<BackgroundConnectionStatus> {
+  try {
+    const nativeModule = getNativeModule();
+    if (!nativeModule?.requestBatteryOptimizationExemption) return UNSUPPORTED_STATUS;
+    return normalizeStatus(await nativeModule.requestBatteryOptimizationExemption());
+  } catch {
+    return getBackgroundConnectionStatus();
+  }
+}
+
+export function setBackgroundConnectionRuntimeReady(ready: boolean): BackgroundConnectionStatus {
+  try {
+    return normalizeStatus(getNativeModule()?.setRuntimeReady?.(ready));
+  } catch {
+    return getBackgroundConnectionStatus();
+  }
+}
+
+export function acknowledgeBackgroundConnectionStop(): BackgroundConnectionStatus {
+  try {
+    return normalizeStatus(getNativeModule()?.acknowledgeStop?.());
+  } catch {
+    return getBackgroundConnectionStatus();
+  }
+}
+
+export function addBackgroundConnectionStatusListener(
+  listener: (status: BackgroundConnectionStatus) => void,
+): BackgroundConnectionSubscription {
+  try {
+    const nativeModule = getNativeModule();
+    if (!nativeModule) return NOOP_SUBSCRIPTION;
+    return nativeModule.addListener("onStatusChange", (status) => {
+      listener(normalizeStatus(status));
+    });
+  } catch {
+    return NOOP_SUBSCRIPTION;
+  }
+}
+
+export function addBackgroundConnectionStopRequestListener(
+  listener: () => void,
+): BackgroundConnectionSubscription {
+  try {
+    return getNativeModule()?.addListener("onStopRequested", listener) ?? NOOP_SUBSCRIPTION;
+  } catch {
+    return NOOP_SUBSCRIPTION;
+  }
+}
+
+const NOOP_SUBSCRIPTION: BackgroundConnectionSubscription = {
+  remove() {},
+};

--- a/docs/internals/connection-runtime.md
+++ b/docs/internals/connection-runtime.md
@@ -157,6 +157,23 @@ Application code must not construct RPC clients, retry loops, or raw
 orchestration commands. Persistence paths belong to the platform registration
 and cache stores, with explicit migration or invalidation policy.
 
+### Android background owner
+
+The opt-in Android foreground service starts the existing mobile runtime through
+React Native Headless JS. Its only data lease mounts the aggregate thread-shell
+atom, which keeps shell subscriptions and caches current for every saved
+environment. The UI and service share the process-wide Atom registry, so they
+still produce one supervisor and one transport per environment.
+
+T3 Connect has matching UI and background credential owners. UI ownership wins
+while mounted; a cold headless start restores Clerk's persisted session for the
+same relay runtime. Direct and Tailscale connections do not wait for Clerk.
+
+The service uses a silent ongoing notification, a Headless JS CPU wake lock,
+and a best-effort Wi-Fi lock. It restores an enabled preference after normal
+process reclamation, package replacement, or reboot. Android force-stop remains
+absolute until the user launches the app again.
+
 ## Verification
 
 Core state-machine tests use `@effect/vitest` and deterministic service layers.

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -32,6 +32,21 @@ That gives you:
 - transport security at the network layer
 - less exposure than opening the server to the public internet
 
+## Keeping the Android App Connected
+
+On Android, **Keep connected in background** keeps saved environments and their thread lists
+synchronized while the phone is locked or another app is open. Enable it under **Settings** →
+**Background connection**.
+
+The setting works with direct LAN, Tailscale, and T3 Connect environments. Android shows a silent
+ongoing notification while it is enabled, and the extra network activity can increase battery and
+mobile-data use. Allow unrestricted battery use when prompted for more reliable operation while the
+screen is off.
+
+Force-stopping T3 Code prevents Android from restarting the connection until you launch the app
+again. If a Tailscale environment depends on the Tailscale Android app, that VPN must also remain
+connected.
+
 ## Enabling Network Access
 
 There are three ways to reach your server from another device: expose the desktop app's backend,

--- a/packages/client-runtime/src/connection/supervisor.test.ts
+++ b/packages/client-runtime/src/connection/supervisor.test.ts
@@ -873,6 +873,32 @@ describe("EnvironmentSupervisor", () => {
     }),
   );
 
+  it.effect("probes a preserved mobile session without changing its generation", () =>
+    Effect.gen(function* () {
+      const probeCalled = yield* Deferred.make<void>();
+      const harness = yield* makeHarness({
+        probe: () => Deferred.succeed(probeCalled, undefined),
+      });
+      const supervisor = yield* EnvironmentSupervisor.make(TARGET_ENTRY, {
+        initiallyDesired: true,
+      }).pipe(Effect.provide(harness.dependencies));
+
+      yield* awaitState(
+        supervisor.state,
+        (state) => state.phase === "connected" && state.generation === 1,
+      );
+      yield* harness.wake("application-active-preserved");
+      yield* Deferred.await(probeCalled);
+
+      expect(yield* Ref.get(harness.sessionCount)).toBe(1);
+      expect(yield* Ref.get(harness.releaseCount)).toBe(0);
+      expect(yield* SubscriptionRef.get(supervisor.state)).toMatchObject({
+        phase: "connected",
+        generation: 1,
+      });
+    }),
+  );
+
   it.effect("immediately replaces a mobile session after a long background resume", () =>
     Effect.gen(function* () {
       const probeCount = yield* Ref.make(0);

--- a/packages/client-runtime/src/connection/supervisor.ts
+++ b/packages/client-runtime/src/connection/supervisor.ts
@@ -418,10 +418,15 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
             // replaces that lease and starts a fresh attempt without backoff.
             return true;
           }
-          if (next.reason === "application-active" || next.reason === "application-active-probe") {
+          if (
+            next.reason === "application-active" ||
+            next.reason === "application-active-preserved" ||
+            next.reason === "application-active-probe"
+          ) {
             const probe = yield* lease.session.probe.pipe(
               Effect.timeoutOrElse({
                 duration:
+                  next.reason === "application-active-preserved" ||
                   next.reason === "application-active-probe"
                     ? MOBILE_CONNECTION_PROBE_TIMEOUT
                     : CONNECTION_PROBE_TIMEOUT,

--- a/packages/client-runtime/src/connection/wakeups.test.ts
+++ b/packages/client-runtime/src/connection/wakeups.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { isApplicationActiveWakeup, shouldResubscribeAfterWakeup } from "./wakeups.ts";
+
+describe("connection wakeups", () => {
+  it("probes preserved resumes without restarting subscriptions", () => {
+    expect(isApplicationActiveWakeup("application-active-preserved")).toBe(true);
+    expect(shouldResubscribeAfterWakeup("application-active-preserved")).toBe(false);
+  });
+});

--- a/packages/client-runtime/src/connection/wakeups.ts
+++ b/packages/client-runtime/src/connection/wakeups.ts
@@ -4,6 +4,7 @@ import type * as Stream from "effect/Stream";
 
 export type ConnectionWakeup =
   | "application-active"
+  | "application-active-preserved"
   | "application-active-probe"
   | "application-active-reconnect"
   | "credentials-changed";
@@ -11,6 +12,7 @@ export type ConnectionWakeup =
 export function isApplicationActiveWakeup(reason: ConnectionWakeup): boolean {
   return (
     reason === "application-active" ||
+    reason === "application-active-preserved" ||
     reason === "application-active-probe" ||
     reason === "application-active-reconnect"
   );


### PR DESCRIPTION
Android currently suspends the mobile connection when the app is backgrounded, so returning can show stale thread lists while every environment reconnects.

This adds an opt-in Android foreground service backed by React Native Headless JS. The background task mounts the existing aggregate thread-shell atom, preserving one supervisor and transport per environment and keeping saved environment thread lists current across direct, Tailscale, and T3 Connect connections. Resume probes the preserved transport and falls back to the existing reconnect path when it is stale.

This is a current-main successor to #5179. It keeps the work Android-specific, reuses the existing connection machinery, and exposes the feature as an off-by-default mobile setting with clear battery and foreground-service status. Thanks @snipemanmike for the original implementation and lifecycle fixes.

Validation:
- 76 focused background-connection tests across 12 files
- mobile and client-runtime typechecks
- targeted lint and formatting
- Expo Android prebuild, local-module autolinking, and Android Metro bundle
- background connection exercised in a physical Android dev client
- Android native Gradle tests and lint pending CI because this machine has no Android SDK

Built with GPT-5.6 via Codex in T3 Code.
