### PR TITLE
fix(server): status-free task updates no longer revive an idle task

### DIFF
--- a/apps/server/src/orchestration/ThreadBackgroundLiveness.test.ts
+++ b/apps/server/src/orchestration/ThreadBackgroundLiveness.test.ts
@@ -28,6 +28,58 @@ describe("ThreadBackgroundLiveness", () => {
     expect(liveness.getThreadBackgroundLiveness("thread")).toBeNull();
   });
 
+  it("does not let status-free updated restart an idle task", () => {
+    const liveness = ThreadBackgroundLiveness.make();
+    liveness.recordTaskLiveness({
+      threadId: "thread",
+      taskId: "task",
+      taskType: undefined,
+      status: undefined,
+      kind: "started",
+    });
+    liveness.recordTaskLiveness({
+      threadId: "thread",
+      taskId: "task",
+      taskType: undefined,
+      status: "idle",
+      kind: "updated",
+    });
+    liveness.recordTaskLiveness({
+      threadId: "thread",
+      taskId: "task",
+      taskType: undefined,
+      status: undefined,
+      kind: "updated",
+    });
+    expect(liveness.getThreadBackgroundLiveness("thread")).toBeNull();
+  });
+
+  it("a genuine restart (kind: started) still revives an idle task", () => {
+    const liveness = ThreadBackgroundLiveness.make();
+    liveness.recordTaskLiveness({
+      threadId: "thread",
+      taskId: "task",
+      taskType: undefined,
+      status: undefined,
+      kind: "started",
+    });
+    liveness.recordTaskLiveness({
+      threadId: "thread",
+      taskId: "task",
+      taskType: undefined,
+      status: "idle",
+      kind: "updated",
+    });
+    liveness.recordTaskLiveness({
+      threadId: "thread",
+      taskId: "task",
+      taskType: undefined,
+      status: undefined,
+      kind: "started",
+    });
+    expect(liveness.getThreadBackgroundLiveness("thread")).toBe("working");
+  });
+
   it("agents present as working; monitors as monitoring; agents win", () => {
     const liveness = ThreadBackgroundLiveness.make();
     const threadId = "t-live-1";

--- a/apps/server/src/orchestration/ThreadBackgroundLiveness.ts
+++ b/apps/server/src/orchestration/ThreadBackgroundLiveness.ts
@@ -130,10 +130,11 @@ export function make(): ThreadBackgroundLivenessService["Service"] {
         return;
       }
 
-      // Status-free progress is a description tick, not a restart. A delayed
-      // progress event after idle must not put the task back in the live set
-      // (#7128).
-      if (input.kind === "progress" && input.status === undefined) {
+      // Status-free progress/updated is a description tick, not a restart. A
+      // delayed progress or updated event after idle must not put the task
+      // back in the live set (#7128, #7172). "started" is excluded on
+      // purpose: a genuine restart must still revive the task.
+      if ((input.kind === "progress" || input.kind === "updated") && input.status === undefined) {
         const existing = stateByThreadId.get(input.threadId);
         const stillLive =
           existing !== undefined &&


### PR DESCRIPTION
#7128 / #7172 stopped a delayed status-free `progress` event from putting an already-dropped task back in the live set. The same hole is still open for `updated`: the guard only tests `input.kind === "progress"`, so a status-free `updated` falls through to `drop()` + `bucket.add()` and revives a task that had gone idle. The sidebar status pill then stays pinned on "working" until the session exits.

That input is real, not hypothetical. `ClaudeAdapter`'s `task_updated` case emits `task.updated` with `...(status ? { status } : {})`, so no `status` field is sent whenever the patch carries only `description`, `error`, `end_time` or `is_backgrounded` — and `ProviderRuntimeIngestion` forwards it straight through as `kind: "updated"` with `status: undefined`.

The fix extends the existing guard to cover `updated` as well. `started` is deliberately left out so a genuine restart still revives the task.

Two tests: one for the bug, one pinning that `kind: "started"` after idle still returns `"working"` so the guard cannot over-correct.

Verified by mutation, not just by a green run — dropping the `updated` clause back out fails the new test with `expected 'working' to be null`, and restoring it returns 9/9 green. Full `apps/server` suite: 2614 passed, 7 skipped, exit 0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to in-memory sidebar liveness with regression tests and no auth or persistence impact.
> 
> **Overview**
> Extends the **status-free lifecycle guard** in `ThreadBackgroundLiveness` so delayed **`updated`** events (no `status`, e.g. description-only patches from `ClaudeAdapter`) cannot re-add a task that already went **idle**, matching the existing behavior for **`progress`** (#7128, #7172).
> 
> **`kind: "started"`** is unchanged so a real restart still shows the thread as **working**. Adds tests for the `updated` bug and for restart-after-idle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beb1fa64c2b775b27525f1665a1586351dbe15a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix status-free `updated` events to no longer revive an idle task
> In [`ThreadBackgroundLiveness`](https://github.com/pingdotgg/t3code/pull/7468/files#diff-b0c25dad649cb92e4b2e2045f18da810e4c2ecce6520501428293b115d9940cd), the no-restart guard previously only applied to `progress` events with no status. It now also applies to `updated` events with no status, treating them as description ticks rather than task revivals. Only `started` events can revive an idle task.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized beb1fa6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->