### PR TITLE
fix(server): fix opencode sessions getting stuck running after subagents

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -1441,4 +1441,115 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       NodeAssert.deepEqual(closeCallsDuringRun, []);
     }),
   );
+
+  it.effect("completes the running turn on the OpenCode session.idle event", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-session-idle");
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+
+      const turn = yield* adapter.sendTurn({
+        threadId,
+        input: "do a thing",
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("opencode"),
+          model: "openai/gpt-5",
+        },
+      });
+
+      const completionsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "turn.completed"),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      runtimeMock.state.subscribedEvents.push(
+        {
+          type: "session.status",
+          properties: {
+            sessionID: "http://127.0.0.1:9999/session",
+            status: { type: "busy" },
+          },
+        },
+        {
+          type: "session.idle",
+          properties: { sessionID: "http://127.0.0.1:9999/session" },
+        },
+      );
+
+      const completions = Array.from(
+        yield* Fiber.join(completionsFiber).pipe(Effect.timeout("1 second")),
+      );
+      NodeAssert.equal(completions.length, 1);
+      NodeAssert.equal(completions[0]?.type, "turn.completed");
+      if (completions[0]?.type === "turn.completed") {
+        NodeAssert.equal(String(completions[0].turnId), String(turn.turnId));
+      }
+
+      const session = (yield* adapter.listSessions()).find((entry) => entry.threadId === threadId);
+      NodeAssert.equal(session?.status, "ready");
+      NodeAssert.equal(session?.activeTurnId, undefined);
+    }),
+  );
+
+  it.effect("does not leave the session stuck running across a subagent busy->idle cycle", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-subagent-idle");
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({
+        threadId,
+        input: "delegate to a subagent",
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("opencode"),
+          model: "openai/gpt-5",
+        },
+      });
+
+      const completionsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "turn.completed"),
+        Stream.take(2),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      // Main turn, then a background subagent continuation: each runs through
+      // its own busy->idle cycle. The first idle closes the turn; the second
+      // idle must still return the session to ready instead of leaving it
+      // "running" forever (the pre-fix behaviour).
+      runtimeMock.state.subscribedEvents.push(
+        {
+          type: "session.status",
+          properties: { sessionID: "http://127.0.0.1:9999/session", status: { type: "busy" } },
+        },
+        { type: "session.idle", properties: { sessionID: "http://127.0.0.1:9999/session" } },
+        {
+          type: "session.status",
+          properties: { sessionID: "http://127.0.0.1:9999/session", status: { type: "busy" } },
+        },
+        { type: "session.idle", properties: { sessionID: "http://127.0.0.1:9999/session" } },
+      );
+
+      const completions = Array.from(
+        yield* Fiber.join(completionsFiber).pipe(Effect.timeout("1 second")),
+      );
+      NodeAssert.equal(completions.length, 2);
+
+      const session = (yield* adapter.listSessions()).find((entry) => entry.threadId === threadId);
+      NodeAssert.equal(session?.status, "ready");
+      NodeAssert.equal(session?.activeTurnId, undefined);
+    }),
+  );
 });

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -204,13 +204,31 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
         },
       },
       event: {
-        subscribe: async () => ({
-          stream: (async function* () {
-            for (const event of runtimeMock.state.subscribedEvents) {
-              yield event;
-            }
-          })(),
-        }),
+        subscribe: async (_arg: unknown, options?: { signal?: AbortSignal }) => {
+          const signal = options?.signal;
+          return {
+            stream: (async function* () {
+              // Keep the subscription open so tests can push events in
+              // batches (the adapter's event pump must not see the stream end
+              // just because the array ran dry mid-test), and stop promptly
+              // when the session scope's AbortController fires so teardown can
+              // interrupt the pump. A microtask yield (not setTimeout) is used
+              // because the Effect test harness virtualizes timer-based
+              // scheduling.
+              let index = 0;
+              while (true) {
+                if (index < runtimeMock.state.subscribedEvents.length) {
+                  yield runtimeMock.state.subscribedEvents[index];
+                  index += 1;
+                } else if (signal?.aborted) {
+                  return;
+                } else {
+                  await new Promise<void>((resolve) => queueMicrotask(resolve));
+                }
+              }
+            })(),
+          };
+        },
       },
     }) as unknown as ReturnType<OpenCodeRuntimeShape["createOpenCodeSdkClient"]>,
   loadOpenCodeInventory: () =>
@@ -1478,8 +1496,8 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
           },
         },
         {
-          type: "session.idle",
-          properties: { sessionID: "http://127.0.0.1:9999/session" },
+          type: "session.status",
+          properties: { sessionID: "http://127.0.0.1:9999/session", status: { type: "idle" } },
         },
       );
 
@@ -1550,6 +1568,107 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       const session = (yield* adapter.listSessions()).find((entry) => entry.threadId === threadId);
       NodeAssert.equal(session?.status, "ready");
       NodeAssert.equal(session?.activeTurnId, undefined);
+    }),
+  );
+
+  it.effect("ignores a stale paired idle that lags a sendTurn", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-stale-idle");
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+
+      const turnOne = yield* adapter.sendTurn({
+        threadId,
+        input: "first turn",
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("opencode"),
+          model: "openai/gpt-5",
+        },
+      });
+
+      const firstCompletionFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "turn.completed"),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      // Turn one finishes; OpenCode pairs a `session.idle` with it.
+      runtimeMock.state.subscribedEvents.push(
+        {
+          type: "session.status",
+          properties: { sessionID: "http://127.0.0.1:9999/session", status: { type: "busy" } },
+        },
+        {
+          type: "session.status",
+          properties: { sessionID: "http://127.0.0.1:9999/session", status: { type: "idle" } },
+        },
+      );
+
+      const firstCompletions = Array.from(
+        yield* Fiber.join(firstCompletionFiber).pipe(Effect.timeout("1 second")),
+      );
+      NodeAssert.equal(firstCompletions.length, 1);
+      NodeAssert.equal(String(firstCompletions[0]?.turnId), String(turnOne.turnId));
+      // A follow-up is sent between the paired idle notifications.
+      const turnTwo = yield* adapter.sendTurn({
+        threadId,
+        input: "second turn",
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("opencode"),
+          model: "openai/gpt-5",
+        },
+      });
+      NodeAssert.ok(String(turnTwo.turnId) !== String(turnOne.turnId));
+
+      const secondCompletionFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "turn.completed"),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      // The stale `session.idle` for turn one lands after the new turn opened.
+      runtimeMock.state.subscribedEvents.push({
+        type: "session.idle",
+        properties: { sessionID: "http://127.0.0.1:9999/session" },
+      });
+      yield* advanceTestClock(10);
+
+      // The stale idle must not tear down the fresh turn.
+      const afterStaleIdle = (yield* adapter.listSessions()).find(
+        (entry) => entry.threadId === threadId,
+      );
+      NodeAssert.equal(afterStaleIdle?.status, "running");
+      NodeAssert.equal(String(afterStaleIdle?.activeTurnId), String(turnTwo.turnId));
+
+      // The new turn runs its own busy->idle cycle and completes normally.
+      runtimeMock.state.subscribedEvents.push(
+        {
+          type: "session.status",
+          properties: { sessionID: "http://127.0.0.1:9999/session", status: { type: "busy" } },
+        },
+        {
+          type: "session.status",
+          properties: { sessionID: "http://127.0.0.1:9999/session", status: { type: "idle" } },
+        },
+      );
+
+      const secondCompletions = Array.from(
+        yield* Fiber.join(secondCompletionFiber).pipe(Effect.timeout("1 second")),
+      );
+      NodeAssert.equal(secondCompletions.length, 1);
+      NodeAssert.equal(String(secondCompletions[0]?.turnId), String(turnTwo.turnId));
+
+      const finalSession = (yield* adapter.listSessions()).find(
+        (entry) => entry.threadId === threadId,
+      );
+      NodeAssert.equal(finalSession?.status, "ready");
     }),
   );
 });

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -245,9 +245,10 @@ interface OpenCodeSessionContext {
   openTurnId: TurnId | undefined;
   /**
    * True once `turn.completed` has been emitted for the current busy->idle
-   * cycle of `openTurnId`. Reset on busy so paired idle signals (the legacy
-   * `session.status: idle` and the newer `session.idle` event) and repeated
-   * subagent cycles each complete at most once.
+   * cycle of `openTurnId`. Re-armed only by a real busy event, so paired idle
+   * signals (the legacy `session.status: idle` and the newer `session.idle`
+   * event) and repeated subagent cycles each complete at most once, and a
+   * stale idle that lags a sendTurn cannot complete the fresh turn.
    */
   turnCompletionSent: boolean;
   activeAgent: string | undefined;
@@ -849,22 +850,28 @@ export function makeOpenCodeAdapter(
         if (completedTurnId === undefined) {
           return;
         }
-        context.activeTurnId = undefined;
-        yield* updateProviderSession(context, { status: "ready" }, { clearActiveTurnId: true });
-        if (!context.turnCompletionSent) {
-          context.turnCompletionSent = true;
-          yield* emit({
-            ...(yield* buildEventBase({
-              threadId: context.session.threadId,
-              turnId: completedTurnId,
-              raw: event,
-            })),
-            type: "turn.completed",
-            payload: {
-              state: "completed",
-            },
-          });
+        // A completion for this open turn was already emitted this busy cycle.
+        // That covers both the paired `session.status: idle` + `session.idle`
+        // notifications and a stale idle that lags behind a sendTurn opened
+        // between them — ignore it entirely (including the state clear) so it
+        // cannot tear down the new turn.
+        if (context.turnCompletionSent) {
+          return;
         }
+        context.activeTurnId = undefined;
+        context.turnCompletionSent = true;
+        yield* updateProviderSession(context, { status: "ready" }, { clearActiveTurnId: true });
+        yield* emit({
+          ...(yield* buildEventBase({
+            threadId: context.session.threadId,
+            turnId: completedTurnId,
+            raw: event,
+          })),
+          type: "turn.completed",
+          payload: {
+            state: "completed",
+          },
+        });
       });
 
       switch (event.type) {
@@ -1525,7 +1532,10 @@ export function makeOpenCodeAdapter(
 
       context.activeTurnId = turnId;
       context.openTurnId = turnId;
-      context.turnCompletionSent = false;
+      // Deliberately does not re-arm `turnCompletionSent`: a sendTurn between
+      // the paired `session.status: idle` / `session.idle` notifications must
+      // not let the stale second idle complete the fresh turn. Only a real
+      // busy event re-arms it.
       context.activeAgent = agent ?? (input.interactionMode === "plan" ? "plan" : undefined);
       context.activeVariant = variant;
       yield* updateProviderSession(

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -235,6 +235,21 @@ interface OpenCodeSessionContext {
   readonly completedAssistantPartIds: Set<string>;
   readonly turns: Array<OpenCodeTurnSnapshot>;
   activeTurnId: TurnId | undefined;
+  /**
+   * The turn id currently in flight for this OpenCode session. Unlike
+   * `activeTurnId` (cleared on every idle so the projector closes the turn),
+   * this survives the extra busy/idle cycles OpenCode emits around background
+   * subagent continuations, so a later busy can re-attach to the same turn and
+   * a later idle can close it instead of leaving the session stuck "running".
+   */
+  openTurnId: TurnId | undefined;
+  /**
+   * True once `turn.completed` has been emitted for the current busy->idle
+   * cycle of `openTurnId`. Reset on busy so paired idle signals (the legacy
+   * `session.status: idle` and the newer `session.idle` event) and repeated
+   * subagent cycles each complete at most once.
+   */
+  turnCompletionSent: boolean;
   activeAgent: string | undefined;
   activeVariant: string | undefined;
   /**
@@ -821,6 +836,37 @@ export function makeOpenCodeAdapter(
         },
       });
 
+      // Close the in-flight turn when OpenCode reports idle. Uses `openTurnId`
+      // (not just `activeTurnId`) so an idle that follows a subagent's busy
+      // cycle still completes the turn instead of being dropped, which is what
+      // left sessions stuck "running" while OpenCode was idle. Both the legacy
+      // `session.status: idle` and the newer `session.idle` event land here.
+      const completeTurnForIdle = Effect.fn("completeTurnForIdle")(function* (
+        context: OpenCodeSessionContext,
+        event: OpenCodeSubscribedEvent,
+      ) {
+        const completedTurnId = context.openTurnId ?? context.activeTurnId;
+        if (completedTurnId === undefined) {
+          return;
+        }
+        context.activeTurnId = undefined;
+        yield* updateProviderSession(context, { status: "ready" }, { clearActiveTurnId: true });
+        if (!context.turnCompletionSent) {
+          context.turnCompletionSent = true;
+          yield* emit({
+            ...(yield* buildEventBase({
+              threadId: context.session.threadId,
+              turnId: completedTurnId,
+              raw: event,
+            })),
+            type: "turn.completed",
+            payload: {
+              state: "completed",
+            },
+          });
+        }
+      });
+
       switch (event.type) {
         case "session.updated": {
           const title = openCodeEventSessionTitle(event);
@@ -1051,10 +1097,15 @@ export function makeOpenCodeAdapter(
 
         case "session.status": {
           if (event.properties.status.type === "busy") {
-            yield* updateProviderSession(context, {
-              status: "running",
-              activeTurnId: turnId,
-            });
+            const runningTurnId = context.openTurnId ?? context.activeTurnId;
+            if (runningTurnId !== undefined) {
+              context.activeTurnId = runningTurnId;
+              context.turnCompletionSent = false;
+              yield* updateProviderSession(context, {
+                status: "running",
+                activeTurnId: runningTurnId,
+              });
+            }
           }
 
           if (event.properties.status.type === "retry") {
@@ -1073,21 +1124,14 @@ export function makeOpenCodeAdapter(
             break;
           }
 
-          if (event.properties.status.type === "idle" && turnId) {
-            context.activeTurnId = undefined;
-            yield* updateProviderSession(context, { status: "ready" }, { clearActiveTurnId: true });
-            yield* emit({
-              ...(yield* buildEventBase({
-                threadId: context.session.threadId,
-                turnId,
-                raw: event,
-              })),
-              type: "turn.completed",
-              payload: {
-                state: "completed",
-              },
-            });
+          if (event.properties.status.type === "idle") {
+            yield* completeTurnForIdle(context, event);
           }
+          break;
+        }
+
+        case "session.idle": {
+          yield* completeTurnForIdle(context, event);
           break;
         }
 
@@ -1095,6 +1139,8 @@ export function makeOpenCodeAdapter(
           const message = sessionErrorMessage(event.properties.error);
           const activeTurnId = context.activeTurnId;
           context.activeTurnId = undefined;
+          context.openTurnId = undefined;
+          context.turnCompletionSent = false;
           yield* updateProviderSession(
             context,
             {
@@ -1400,6 +1446,8 @@ export function makeOpenCodeAdapter(
           completedAssistantPartIds: new Set(),
           turns: [],
           activeTurnId: undefined,
+          openTurnId: undefined,
+          turnCompletionSent: false,
           activeAgent: undefined,
           activeVariant: undefined,
           stopped: yield* Ref.make(false),
@@ -1476,6 +1524,8 @@ export function makeOpenCodeAdapter(
       const variant = getModelSelectionStringOptionValue(modelSelection, "variant");
 
       context.activeTurnId = turnId;
+      context.openTurnId = turnId;
+      context.turnCompletionSent = false;
       context.activeAgent = agent ?? (input.interactionMode === "plan" ? "plan" : undefined);
       context.activeVariant = variant;
       yield* updateProviderSession(
@@ -1519,6 +1569,8 @@ export function makeOpenCodeAdapter(
             ? Effect.void
             : Effect.gen(function* () {
                 context.activeTurnId = undefined;
+                context.openTurnId = undefined;
+                context.turnCompletionSent = false;
                 context.activeAgent = undefined;
                 context.activeVariant = undefined;
                 yield* updateProviderSession(


### PR DESCRIPTION
## What Changed

OpenCode threads could get stuck showing `running` long after the OpenCode session went idle.

- The adapter only closed a turn when it saw `session.status: idle` while an active turn id was set. Background subagent continuations emit extra busy->idle cycles, and the idle following one was dropped once the first idle had cleared `activeTurnId`, so the thread stayed `running` forever.
- The adapter also never handled OpenCode's dedicated `session.idle` event at all.

The fix tracks the in-flight turn (`openTurnId`) separately from `activeTurnId`, so a later busy can re-attach to the same turn and a later idle can close it. Both the legacy `session.status: idle` and the newer `session.idle` event now route through a shared completion path that returns the session to `ready` at most once per busy cycle.

## Why

Subagents are the primary trigger: spawning one emits additional busy->idle cycles on the parent session. After the main response's idle completed the turn, the subagent's busy marked the session running again and its idle was ignored, leaving the thread stuck "running" while OpenCode sat idle. Threads looked busy for hours, and stopping appeared to do nothing.

## Validation

- `vp test run apps/server/src/provider/Layers/OpenCodeAdapter.test.ts` — 34 passed, including two new regression tests: idle completion on the `session.idle` event, and a subagent busy->idle cycle that no longer leaves the session stuck running.
- Server typecheck passed.
- Focused lint passed.
- Manually verified against a live OpenCode server: spawning a subagent that exits quickly now returns the thread to a stopped/ready state.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes; screenshots are not applicable
- [x] No animation or interaction changes; video is not applicable

Model: DeepSeek V4 Flash
Harness: OpenCode in T3 Code


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provider turn/session state machine and event handling for OpenCode; behavior is localized and covered by new adapter tests, but incorrect idle handling could still affect thread status and turn completion.
> 
> **Overview**
> Fixes OpenCode threads that stayed **`running`** after the upstream session was idle, especially when background subagents added extra busy→idle cycles.
> 
> The adapter now tracks an in-flight turn with **`openTurnId`** and a per-cycle **`turnCompletionSent`** guard (separate from **`activeTurnId`**, which was cleared on the first idle). **`session.status: busy`** re-attaches the same turn and re-arms completion; **`completeTurnForIdle`** handles both **`session.status: idle`** and **`session.idle`**, emitting **`turn.completed`** and returning the session to **`ready`** at most once per cycle so duplicate idle signals and lagging idles after a new **`sendTurn`** cannot close the wrong turn.
> 
> Tests update the event-subscribe mock to keep the pump open for batched events and add regressions for **`session.idle`**, subagent busy→idle, and stale paired idle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57852129f8eefe66110e485139482eb3d91ce888. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix OpenCode sessions getting stuck in running state after subagent busy/idle cycles
> - Introduces `openTurnId` and `turnCompletionSent` fields to `OpenCodeSessionContext` to track the in-flight turn across multiple busy/idle cycles emitted by subagent continuations.
> - Adds a `completeTurnForIdle` helper in [`OpenCodeAdapter.ts`](https://github.com/pingdotgg/t3code/pull/7471/files#diff-a4267388b15e5043ae1899beded972cbee9e52533ca3d9d65d438a91a9f7fbe7) that guards against duplicate `turn.completed` emissions and handles both `session.status: idle` and `session.idle` events.
> - On `session.status: busy`, the adapter re-attaches to the existing open turn and re-arms completion; stale idle events arriving after a new `sendTurn` are ignored by not resetting `turnCompletionSent` on turn start.
> - Adds three new tests in [`OpenCodeAdapter.test.ts`](https://github.com/pingdotgg/t3code/pull/7471/files#diff-2d1ef28752ab2f1ec0f021e6723508dc18e6a9294ebd20255ec3767afe34cf5f) covering: idle completing a turn, two consecutive busy/idle cycles producing two `turn.completed` events, and stale idle not prematurely closing a new turn.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5785212.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->