### PR TITLE
fix(marketing): Safari gets the arm64 Mac download

### DIFF
--- a/apps/marketing/src/lib/macArch.test.ts
+++ b/apps/marketing/src/lib/macArch.test.ts
@@ -13,8 +13,11 @@ describe("macArchFromGpuRenderer", () => {
     );
   });
 
-  it("uses x64 for ambiguous Safari and unavailable renderer values", () => {
-    expect(macArchFromGpuRenderer("Apple GPU")).toBe("x64");
+  it("detects Safari's generic Apple Silicon renderer", () => {
+    expect(macArchFromGpuRenderer("Apple GPU")).toBe("arm64");
+  });
+
+  it("uses x64 when the renderer is unavailable", () => {
     expect(macArchFromGpuRenderer("")).toBe("x64");
   });
 });

--- a/apps/marketing/src/lib/macArch.ts
+++ b/apps/marketing/src/lib/macArch.ts
@@ -1,5 +1,5 @@
 const INTEL_GPU_PATTERN = /intel|amd|radeon|nvidia|geforce/i;
-const APPLE_SILICON_GPU_PATTERN = /\bapple\s+m\d/i;
+const APPLE_SILICON_GPU_PATTERN = /\bapple\s+(?:m\d|gpu)\b/i;
 
 export function macArchFromGpuRenderer(renderer: string): "arm64" | "x64" {
   if (INTEL_GPU_PATTERN.test(renderer)) {
@@ -9,8 +9,6 @@ export function macArchFromGpuRenderer(renderer: string): "arm64" | "x64" {
     return "arm64";
   }
 
-  // Generic "Apple GPU" renderers are ambiguous on Safari. x64 is the safe
-  // fallback because Apple Silicon can run it through Rosetta, while Intel
-  // Macs cannot run an arm64 build.
+  // Keep the fallback compatible with Intel Macs when WebGL is unavailable.
   return "x64";
 }


### PR DESCRIPTION
Safari on Apple Silicon reports its WebGL renderer as `Apple GPU`. The homepage treated that value as unknown and selected the x64 DMG, so M-series Macs downloaded the Intel build.

The detector now classifies Safari’s generic Apple GPU renderer as arm64 after it checks explicit Intel, AMD, Radeon, Nvidia, and GeForce markers. An unavailable renderer still falls back to x64. A focused test covers the Safari value.

Tested with:

- `vp test run apps/marketing/src/lib/macArch.test.ts`
- `vp run --filter @t3tools/marketing typecheck`

Created by GPT-5.6 using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to client-side download arch detection on the marketing site; no auth, data, or backend impact.
> 
> **Overview**
> Safari on Apple Silicon often reports WebGL as **`Apple GPU`**, which previously missed the Apple Silicon regex and fell through to the **x64** default—so the marketing homepage could offer the Intel DMG on M-series Macs.
> 
> **`macArchFromGpuRenderer`** now treats **`apple gpu`** (alongside **`apple m*`** chips) as **arm64**, still after Intel/AMD/Nvidia-style markers so hybrid strings like ANGLE + Intel stay **x64**. Empty or unavailable renderer values still default to **x64** for Intel compatibility. Tests split the Safari case from the empty-renderer fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 231cc010e5372d3c3cfcf25aafc6debcc2f5bd4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Safari browser to receive arm64 Mac download by matching 'Apple GPU' renderer
> Safari reports `Apple GPU` as the WebGL renderer string instead of a specific chip name like `Apple M1`. The `APPLE_SILICON_GPU_PATTERN` regex in [macArch.ts](https://github.com/pingdotgg/t3code/pull/7473/files#diff-67406ca413764da82bd619a6616fd2117bba3a4442c42d7d2849adb99f62635d) is expanded from `\bapple\s+m\d` to `\bapple\s+(?:m\d|gpu)\b` so `Apple GPU` now maps to `arm64` instead of falling back to `x64`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 231cc01.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->