### PR TITLE
feat: refine thread action menus

### DIFF
--- a/apps/desktop/src/electron/ElectronMenu.test.ts
+++ b/apps/desktop/src/electron/ElectronMenu.test.ts
@@ -98,7 +98,10 @@ describe("ElectronMenu", () => {
       const electronMenu = yield* ElectronMenu.ElectronMenu;
       const selectedItemId = yield* electronMenu.showContextMenu({
         window: makeWindow(2),
-        items: [{ id: "copy", label: "Copy" }],
+        items: [
+          { id: "copy", label: "Copy" },
+          { id: "delete", label: "Delete", destructive: true, separatorBefore: true },
+        ],
         position: Option.some({ x: 10.8, y: 20.2 }),
       });
 
@@ -110,6 +113,38 @@ describe("ElectronMenu", () => {
         enabled: true,
         click: buildFromTemplateMock.mock.calls[0]?.[0][0].click,
       });
+      assert.deepEqual(
+        buildFromTemplateMock.mock.calls[0]?.[0].map(
+          (item: Electron.MenuItemConstructorOptions) => item.type ?? item.label,
+        ),
+        ["Copy", "separator", "Delete"],
+      );
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect("keeps a preceding non-destructive action in the destructive section", () =>
+    Effect.gen(function* () {
+      buildFromTemplateMock.mockImplementation(() => ({
+        popup: (options: Electron.PopupOptions) => options.callback?.(),
+      }));
+
+      const electronMenu = yield* ElectronMenu.ElectronMenu;
+      yield* electronMenu.showContextMenu({
+        window: makeWindow(),
+        items: [
+          { id: "copy", label: "Copy" },
+          { id: "archive", label: "Archive", separatorBefore: true },
+          { id: "delete", label: "Delete", destructive: true },
+        ],
+        position: Option.none(),
+      });
+
+      assert.deepEqual(
+        buildFromTemplateMock.mock.calls[0]?.[0].map(
+          (item: Electron.MenuItemConstructorOptions) => item.type ?? item.label,
+        ),
+        ["Copy", "separator", "Archive", "Delete"],
+      );
     }).pipe(Effect.provide(TestLayer)),
   );
 

--- a/apps/desktop/src/electron/ElectronMenu.ts
+++ b/apps/desktop/src/electron/ElectronMenu.ts
@@ -78,6 +78,7 @@ function normalizeContextMenuItems(source: readonly ContextMenuItem[]): ContextM
       label: sourceItem.label,
       destructive: sourceItem.destructive === true,
       disabled: sourceItem.disabled === true,
+      ...(sourceItem.separatorBefore === true ? { separatorBefore: true } : {}),
     };
 
     if (sourceItem.children) {
@@ -141,10 +142,24 @@ export const make = Effect.gen(function* () {
   ): Electron.MenuItemConstructorOptions[] => {
     const template: Electron.MenuItemConstructorOptions[] = [];
     let hasInsertedDestructiveSeparator = false;
+    let sectionStartedByExplicitSeparator = false;
+    const appendSeparator = () => {
+      if (template.length === 0 || template.at(-1)?.type === "separator") return;
+      template.push({ type: "separator" });
+    };
 
     for (const item of entries) {
-      if (item.destructive && !hasInsertedDestructiveSeparator && template.length > 0) {
-        template.push({ type: "separator" });
+      if (item.separatorBefore) {
+        appendSeparator();
+        sectionStartedByExplicitSeparator = true;
+      }
+      if (
+        item.destructive &&
+        !hasInsertedDestructiveSeparator &&
+        !sectionStartedByExplicitSeparator &&
+        template.length > 0
+      ) {
+        appendSeparator();
         hasInsertedDestructiveSeparator = true;
       }
 

--- a/apps/web/src/components/threadActionMenu.logic.test.ts
+++ b/apps/web/src/components/threadActionMenu.logic.test.ts
@@ -20,6 +20,12 @@ function ids(state: ThreadActionMenuState): string[] {
   return buildThreadActionMenuItems(state).map((item) => item.id);
 }
 
+function allIds(state: ThreadActionMenuState): string[] {
+  const flatten = (items: ReturnType<typeof buildThreadActionMenuItems>): string[] =>
+    items.flatMap((item) => [item.id, ...(item.children ? flatten(item.children) : [])]);
+  return flatten(buildThreadActionMenuItems(state));
+}
+
 describe("buildThreadActionMenuItems", () => {
   it("hides lifecycle items when the environment lacks the capabilities", () => {
     expect(
@@ -27,15 +33,15 @@ describe("buildThreadActionMenuItems", () => {
         ...baseState,
         supports: { settlement: false, snooze: false, pinning: false, titleRegeneration: false },
       }),
-    ).toEqual(["rename", "mark-unread", "copy-path", "copy-thread-id", "archive", "delete"]);
+    ).toEqual(["rename", "mark-unread", "copy", "archive", "delete"]);
   });
 
   it("includes branch items only for threads with a branch", () => {
-    const withBranch = ids({ ...baseState, branch: "feat/menu" });
+    const withBranch = allIds({ ...baseState, branch: "feat/menu" });
     expect(withBranch).toContain("new-thread-on-branch");
     expect(withBranch).toContain("copy-branch");
-    expect(ids(baseState)).not.toContain("new-thread-on-branch");
-    expect(ids(baseState)).not.toContain("copy-branch");
+    expect(allIds(baseState)).not.toContain("new-thread-on-branch");
+    expect(allIds(baseState)).not.toContain("copy-branch");
   });
 
   it("flips lifecycle labels with thread state", () => {
@@ -64,11 +70,12 @@ describe("buildThreadActionMenuItems", () => {
     const items = buildThreadActionMenuItems({ ...baseState, branch: "main" });
     expect(items.at(-1)).toMatchObject({ id: "delete", destructive: true });
   });
-
   it("offers archive as a non-destructive action right before delete", () => {
     const items = buildThreadActionMenuItems(baseState);
     const archiveItem = items.at(-2);
     expect(archiveItem?.id).toBe("archive");
+    expect(archiveItem?.icon).toBe("archive");
+    expect(archiveItem?.separatorBefore).toBe(true);
     expect(archiveItem?.destructive).toBeFalsy();
     expect(items.at(-1)?.id).toBe("delete");
   });

--- a/apps/web/src/components/threadActionMenu.logic.ts
+++ b/apps/web/src/components/threadActionMenu.logic.ts
@@ -18,6 +18,7 @@ export type ThreadActionMenuId =
   | "rename"
   | "regenerate-title"
   | "mark-unread"
+  | "copy"
   | "copy-path"
   | "copy-branch"
   | "copy-thread-id"
@@ -56,14 +57,15 @@ export function buildThreadActionMenuItems(
           {
             id: "new-thread-on-branch" as const,
             label: `New thread on ${state.branch}`,
+            icon: "message-square-plus",
           },
         ]
       : []),
     ...(state.supports.pinning
       ? [
           state.isPinned
-            ? { id: "unpin" as const, label: "Unpin thread" }
-            : { id: "pin" as const, label: "Pin thread" },
+            ? { id: "unpin" as const, label: "Unpin thread", icon: "pin-off" }
+            : { id: "pin" as const, label: "Pin thread", icon: "pin" },
         ]
       : []),
     // Both lifecycle actions stay available on pinned threads: settling
@@ -72,17 +74,18 @@ export function buildThreadActionMenuItems(
     ...(state.supports.settlement
       ? [
           state.isSettled
-            ? { id: "unsettle" as const, label: "Un-settle thread" }
-            : { id: "settle" as const, label: "Settle thread" },
+            ? { id: "unsettle" as const, label: "Un-settle thread", icon: "circle-check" }
+            : { id: "settle" as const, label: "Settle thread", icon: "circle-check" },
         ]
       : []),
     ...(state.supports.snooze
       ? [
           state.isSnoozed
-            ? { id: "unsnooze" as const, label: "Wake thread" }
+            ? { id: "unsnooze" as const, label: "Wake thread", icon: "clock" }
             : {
                 id: "snooze" as const,
                 label: "Snooze",
+                icon: "clock",
                 disabled: !state.canSnoozeNow,
                 children: state.snoozePresets.map((preset) => ({
                   id: `snooze:${preset.id}` as const,
@@ -91,26 +94,48 @@ export function buildThreadActionMenuItems(
               },
         ]
       : []),
-    { id: "rename", label: "Rename thread" },
+    { id: "rename", label: "Rename thread", icon: "pencil", separatorBefore: true },
     ...(state.supports.titleRegeneration
       ? [
           {
             id: "regenerate-title" as const,
             label: state.isRegeneratingTitle ? "Regenerating…" : "Regenerate title",
+            icon: "refresh-cw",
             disabled: state.isRegeneratingTitle,
           },
         ]
       : []),
-    { id: "mark-unread", label: "Mark unread" },
-    { id: "copy-path", label: "Copy path", icon: "copy" },
-    ...(state.branch ? [{ id: "copy-branch" as const, label: "Copy branch", icon: "copy" }] : []),
-    { id: "copy-thread-id", label: "Copy thread ID", icon: "copy" },
+    { id: "mark-unread", label: "Mark unread", icon: "mail-open" },
+    {
+      id: "copy",
+      label: "Copy",
+      icon: "copy",
+      separatorBefore: true,
+      children: [
+        { id: "copy-path", label: "Path", icon: "folder" },
+        ...(state.branch
+          ? [{ id: "copy-branch" as const, label: "Branch", icon: "git-branch" }]
+          : []),
+        { id: "copy-thread-id", label: "Thread ID", icon: "hash" },
+      ],
+    },
     // Archive removes the thread from the sidebar while keeping its
     // conversation under Settings > Archived threads — distinct from Settle
     // (stays visible in the Settled shelf) and Delete (clears history for
     // good), so it sits beside Delete without borrowing its destructive
     // styling.
-    { id: "archive", label: "Archive thread", disabled: state.isRunning },
-    { id: "delete", label: "Delete", destructive: true, icon: "trash" },
+    {
+      id: "archive",
+      label: "Archive thread",
+      icon: "archive",
+      disabled: state.isRunning,
+      separatorBefore: true,
+    },
+    {
+      id: "delete",
+      label: "Delete",
+      destructive: true,
+      icon: "trash",
+    },
   ];
 }

--- a/apps/web/src/contextMenuFallback.test.ts
+++ b/apps/web/src/contextMenuFallback.test.ts
@@ -69,11 +69,21 @@ class FakeElement {
   }
 
   focus() {
+    const fakeDocument = document as unknown as FakeDocument;
+    if (fakeDocument.activeElement === this) {
+      return;
+    }
+    fakeDocument.activeElement?.blur();
+    fakeDocument.activeElement = this;
     this.focused = true;
     this.dispatchEvent(new FakeDomEvent("focus"));
   }
 
   blur() {
+    const fakeDocument = document as unknown as FakeDocument;
+    if (fakeDocument.activeElement === this) {
+      fakeDocument.activeElement = null;
+    }
     this.focused = false;
     this.dispatchEvent(new FakeDomEvent("blur"));
   }
@@ -132,6 +142,7 @@ class FakeBody extends FakeElement {
 
 class FakeDocument {
   body = new FakeBody();
+  activeElement: FakeElement | null = null;
   private readonly listeners = new Map<string, FakeListener[]>();
 
   createElement(tagName: string) {
@@ -281,18 +292,26 @@ describe("showContextMenuFallback", () => {
 
     const parentButton = findButton("Copy");
     expect(parentButton).toBeTruthy();
+    expect(parentButton?.attributes.get("aria-haspopup")).toBe("menu");
+    expect(parentButton?.attributes.get("aria-expanded")).toBe("false");
     parentButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(parentButton?.attributes.get("aria-expanded")).toBe("true");
 
     const childButton = findButton("Path");
+    const siblingButton = findButton("Branch");
     expect(childButton).toBeTruthy();
+    expect(siblingButton).toBeTruthy();
     expect(childButton?.focused).toBe(true);
     expect(childButton?.style.background).toBe("var(--accent)");
     expect(childButton?.style.color).toBe("var(--accent-foreground)");
-    childButton?.blur();
+    siblingButton?.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+    expect(childButton?.focused).toBe(false);
     expect(childButton?.style.background).toBe("transparent");
-    childButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(siblingButton?.focused).toBe(true);
+    expect(siblingButton?.style.background).toBe("var(--accent)");
+    siblingButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
-    await expect(selectionPromise).resolves.toBe("copy:path");
+    await expect(selectionPromise).resolves.toBe("copy:branch");
   });
 });
 

--- a/apps/web/src/contextMenuFallback.test.ts
+++ b/apps/web/src/contextMenuFallback.test.ts
@@ -34,6 +34,14 @@ class FakeElement {
 
   constructor(readonly tagName: string) {}
 
+  get isConnected() {
+    let current: FakeElement | null = this;
+    while (current?.parent) {
+      current = current.parent;
+    }
+    return current?.tagName === "body";
+  }
+
   appendChild(child: FakeElement) {
     child.parent = this;
     this.children.push(child);
@@ -179,6 +187,7 @@ function findButton(label: string): FakeElement | undefined {
 
 beforeEach(() => {
   vi.stubGlobal("document", new FakeDocument());
+  vi.stubGlobal("HTMLElement", FakeElement);
   vi.stubGlobal("window", {
     innerWidth: 1280,
     innerHeight: 800,
@@ -279,6 +288,9 @@ describe("showContextMenuFallback", () => {
   });
 
   it("opens and focuses nested submenus when the parent is activated", async () => {
+    const invoker = (document as unknown as FakeDocument).createElement("button");
+    (document as unknown as FakeDocument).body.appendChild(invoker);
+    invoker.focus();
     const selectionPromise = showContextMenuFallback([
       {
         id: "copy:submenu",
@@ -312,6 +324,7 @@ describe("showContextMenuFallback", () => {
     siblingButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
     await expect(selectionPromise).resolves.toBe("copy:branch");
+    expect(invoker.focused).toBe(true);
   });
 });
 

--- a/apps/web/src/contextMenuFallback.test.ts
+++ b/apps/web/src/contextMenuFallback.test.ts
@@ -24,8 +24,10 @@ class FakeElement {
   parent: FakeElement | null = null;
   style: Record<string, string> & { cssText?: string } = {};
   dataset: Record<string, string> = {};
+  attributes = new Map<string, string>();
   className = "";
   disabled = false;
+  focused = false;
   type = "";
   private textValue = "";
   private readonly listeners = new Map<string, FakeListener[]>();
@@ -55,11 +57,19 @@ class FakeElement {
     this.listeners.set(type, existing);
   }
 
+  setAttribute(name: string, value: string) {
+    this.attributes.set(name, value);
+  }
+
   dispatchEvent(event: FakeDomEvent) {
     for (const listener of this.listeners.get(event.type) ?? []) {
       listener(event);
     }
     return true;
+  }
+
+  focus() {
+    this.focused = true;
   }
 
   set textContent(value: string) {
@@ -183,6 +193,21 @@ afterEach(() => {
 });
 
 describe("showContextMenuFallback", () => {
+  it("renders one separator between menu sections", async () => {
+    const selectionPromise = showContextMenuFallback([
+      { id: "rename", label: "Rename" },
+      { id: "archive", label: "Archive", separatorBefore: true },
+    ]);
+    const separators = (document as unknown as FakeDocument)
+      .querySelectorAll("div")
+      .filter((element) => element.dataset.contextMenuSeparator === "true");
+
+    expect(separators).toHaveLength(1);
+    expect(separators[0]?.attributes.get("role")).toBe("separator");
+    dismissContextMenu();
+    await expect(selectionPromise).resolves.toBeNull();
+  });
+
   it("resolves a clicked flat menu item", async () => {
     const selectionPromise = showContextMenuFallback([
       { id: "rename", label: "Rename" },
@@ -234,6 +259,30 @@ describe("showContextMenuFallback", () => {
     childButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
     await expect(selectionPromise).resolves.toBe("rename:project-b");
+  });
+
+  it("opens and focuses nested submenus when the parent is activated", async () => {
+    const selectionPromise = showContextMenuFallback([
+      {
+        id: "copy:submenu",
+        label: "Copy",
+        children: [
+          { id: "copy:path", label: "Path" },
+          { id: "copy:branch", label: "Branch" },
+        ],
+      },
+    ]);
+
+    const parentButton = findButton("Copy");
+    expect(parentButton).toBeTruthy();
+    parentButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    const childButton = findButton("Path");
+    expect(childButton).toBeTruthy();
+    expect(childButton?.focused).toBe(true);
+    childButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    await expect(selectionPromise).resolves.toBe("copy:path");
   });
 });
 

--- a/apps/web/src/contextMenuFallback.test.ts
+++ b/apps/web/src/contextMenuFallback.test.ts
@@ -70,6 +70,12 @@ class FakeElement {
 
   focus() {
     this.focused = true;
+    this.dispatchEvent(new FakeDomEvent("focus"));
+  }
+
+  blur() {
+    this.focused = false;
+    this.dispatchEvent(new FakeDomEvent("blur"));
   }
 
   set textContent(value: string) {
@@ -280,6 +286,10 @@ describe("showContextMenuFallback", () => {
     const childButton = findButton("Path");
     expect(childButton).toBeTruthy();
     expect(childButton?.focused).toBe(true);
+    expect(childButton?.style.background).toBe("var(--accent)");
+    expect(childButton?.style.color).toBe("var(--accent-foreground)");
+    childButton?.blur();
+    expect(childButton?.style.background).toBe("transparent");
     childButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
     await expect(selectionPromise).resolves.toBe("copy:path");

--- a/apps/web/src/contextMenuFallback.ts
+++ b/apps/web/src/contextMenuFallback.ts
@@ -206,6 +206,8 @@ export function showContextMenuFallback<T extends string>(
   position?: { x: number; y: number },
 ): Promise<T | null> {
   return new Promise<T | null>((resolve) => {
+    const previouslyFocusedElement =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
     const menuStack: HTMLDivElement[] = [];
     const submenuTriggerStack: Array<HTMLButtonElement | undefined> = [];
     let isDisposed = false;
@@ -224,8 +226,12 @@ export function showContextMenuFallback<T extends string>(
       document.removeEventListener("keydown", onKeyDown);
       document.removeEventListener("pointerdown", onPointerDown, true);
       document.removeEventListener("contextmenu", onContextMenu, true);
+      const shouldRestoreFocus = isNodeWithinMenuStack(document.activeElement, menuStack);
       for (const menu of menuStack) {
         menu.remove();
+      }
+      if (shouldRestoreFocus && previouslyFocusedElement?.isConnected) {
+        previouslyFocusedElement.focus({ preventScroll: true });
       }
       resolve(result);
     };

--- a/apps/web/src/contextMenuFallback.ts
+++ b/apps/web/src/contextMenuFallback.ts
@@ -4,6 +4,20 @@ const SVG_NS = "http://www.w3.org/2000/svg";
 
 // Inline Lucide-style icon paths (stroke-based, viewBox 0 0 24 24, strokeWidth 2).
 const ICON_PATHS: Record<string, ReadonlyArray<{ tag: string; attrs: Record<string, string> }>> = {
+  archive: [
+    { tag: "rect", attrs: { width: "20", height: "5", x: "2", y: "3", rx: "1" } },
+    { tag: "path", attrs: { d: "M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8" } },
+    { tag: "path", attrs: { d: "M10 12h4" } },
+  ],
+  "chevron-right": [{ tag: "path", attrs: { d: "m9 19 7-7-7-7" } }],
+  "circle-check": [
+    { tag: "circle", attrs: { cx: "12", cy: "12", r: "10" } },
+    { tag: "path", attrs: { d: "m9 12 2 2 4-4" } },
+  ],
+  clock: [
+    { tag: "path", attrs: { d: "M12 6v6l4 2" } },
+    { tag: "circle", attrs: { cx: "12", cy: "12", r: "10" } },
+  ],
   pencil: [
     {
       tag: "path",
@@ -16,6 +30,71 @@ const ICON_PATHS: Record<string, ReadonlyArray<{ tag: string; attrs: Record<stri
   copy: [
     { tag: "rect", attrs: { width: "14", height: "14", x: "8", y: "8", rx: "2", ry: "2" } },
     { tag: "path", attrs: { d: "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" } },
+  ],
+  folder: [
+    {
+      tag: "path",
+      attrs: {
+        d: "M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z",
+      },
+    },
+  ],
+  "git-branch": [
+    { tag: "line", attrs: { x1: "6", x2: "6", y1: "3", y2: "15" } },
+    { tag: "circle", attrs: { cx: "18", cy: "6", r: "3" } },
+    { tag: "circle", attrs: { cx: "6", cy: "18", r: "3" } },
+    { tag: "path", attrs: { d: "M18 9a9 9 0 0 1-9 9" } },
+  ],
+  hash: [
+    { tag: "line", attrs: { x1: "4", x2: "20", y1: "9", y2: "9" } },
+    { tag: "line", attrs: { x1: "4", x2: "20", y1: "15", y2: "15" } },
+    { tag: "line", attrs: { x1: "10", x2: "8", y1: "3", y2: "21" } },
+    { tag: "line", attrs: { x1: "16", x2: "14", y1: "3", y2: "21" } },
+  ],
+  "mail-open": [
+    {
+      tag: "path",
+      attrs: {
+        d: "M21.2 8.4c.5.38.8.97.8 1.6v10a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V10a2 2 0 0 1 .8-1.6l8-6a2 2 0 0 1 2.4 0l8 6Z",
+      },
+    },
+    { tag: "path", attrs: { d: "m22 10-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 10" } },
+  ],
+  "message-square-plus": [
+    {
+      tag: "path",
+      attrs: {
+        d: "M22 17a2 2 0 0 1-2 2H6.828a2 2 0 0 0-1.414.586l-2.202 2.202A.71.71 0 0 1 2 21.286V5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2z",
+      },
+    },
+    { tag: "path", attrs: { d: "M12 8v6" } },
+    { tag: "path", attrs: { d: "M9 11h6" } },
+  ],
+  pin: [
+    { tag: "path", attrs: { d: "M12 17v5" } },
+    {
+      tag: "path",
+      attrs: {
+        d: "M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z",
+      },
+    },
+  ],
+  "pin-off": [
+    { tag: "path", attrs: { d: "M12 17v5" } },
+    { tag: "path", attrs: { d: "M15 9.34V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H7.89" } },
+    { tag: "path", attrs: { d: "m2 2 20 20" } },
+    {
+      tag: "path",
+      attrs: {
+        d: "M9 9v1.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h11",
+      },
+    },
+  ],
+  "refresh-cw": [
+    { tag: "path", attrs: { d: "M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" } },
+    { tag: "path", attrs: { d: "M21 3v5h-5" } },
+    { tag: "path", attrs: { d: "M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" } },
+    { tag: "path", attrs: { d: "M8 16H3v5" } },
   ],
   "folder-tree": [
     {
@@ -44,7 +123,7 @@ const ICON_PATHS: Record<string, ReadonlyArray<{ tag: string; attrs: Record<stri
 
 function createIconElement(name: string, tone: "neutral" | "destructive"): SVGSVGElement | null {
   const paths = ICON_PATHS[name];
-  if (!paths) {
+  if (!paths || typeof document.createElementNS !== "function") {
     return null;
   }
   const svg = document.createElementNS(SVG_NS, "svg");
@@ -57,7 +136,9 @@ function createIconElement(name: string, tone: "neutral" | "destructive"): SVGSV
   svg.setAttribute("stroke-linejoin", "round");
   svg.setAttribute(
     "class",
-    tone === "destructive" ? "size-3.5 shrink-0" : "size-3.5 shrink-0 text-muted-foreground",
+    tone === "destructive"
+      ? "size-4.5 shrink-0 sm:size-4"
+      : "size-4.5 shrink-0 text-muted-foreground sm:size-4",
   );
   for (const node of paths) {
     const child = document.createElementNS(SVG_NS, node.tag);
@@ -200,6 +281,15 @@ export function showContextMenuFallback<T extends string>(
         "max-height:min(24rem,70vh);min-width:0;max-width:24rem;overflow-x:hidden;overflow-y:auto;padding:0.25rem;";
 
       for (const item of entries) {
+        if (item.separatorBefore === true && inner.children.length > 0) {
+          const separator = document.createElement("div");
+          separator.className = "mx-2 my-1 h-px bg-border";
+          separator.style.cssText = "height:1px;margin:0.25rem 0.5rem;background:var(--border);";
+          separator.dataset.contextMenuSeparator = "true";
+          separator.setAttribute("role", "separator");
+          inner.appendChild(separator);
+        }
+
         if (item.header === true) {
           const header = document.createElement("div");
           header.className = "px-2 py-1.5 font-medium text-muted-foreground text-xs";
@@ -247,10 +337,15 @@ export function showContextMenuFallback<T extends string>(
         button.appendChild(label);
 
         if (hasChildren) {
-          const chevron = document.createElement("span");
-          chevron.className = "ms-auto shrink-0 text-muted-foreground/80 text-sm leading-none";
-          chevron.textContent = ">";
-          button.appendChild(chevron);
+          const chevron = createIconElement("chevron-right", "neutral");
+          if (chevron) {
+            chevron.setAttribute(
+              "class",
+              "-me-0.5 ms-auto size-4.5 shrink-0 text-muted-foreground opacity-80 sm:size-4",
+            );
+            chevron.dataset.contextMenuChevron = "true";
+            button.appendChild(chevron);
+          }
         }
 
         if (!isDisabled) {
@@ -270,7 +365,7 @@ export function showContextMenuFallback<T extends string>(
           });
 
           if (hasChildren) {
-            button.addEventListener("mouseenter", () => {
+            const openSubmenu = (focusFirstItem = false) => {
               const rect = button.getBoundingClientRect();
               const nextLeft = rect.right + 4;
               const nextTop = rect.top;
@@ -284,9 +379,18 @@ export function showContextMenuFallback<T extends string>(
               if (childRect.right > window.innerWidth) {
                 clampMenuPosition(childMenu, rect.left - childRect.width - 4, rect.top);
               }
+              if (focusFirstItem) {
+                [...childMenu.querySelectorAll<HTMLButtonElement>("button")]
+                  .find((childButton) => !childButton.disabled)
+                  ?.focus();
+              }
+            };
+            button.addEventListener("mouseenter", () => {
+              openSubmenu();
             });
             button.addEventListener("click", (event) => {
               event.preventDefault();
+              openSubmenu(true);
             });
           } else {
             button.addEventListener("mouseenter", () => {

--- a/apps/web/src/contextMenuFallback.ts
+++ b/apps/web/src/contextMenuFallback.ts
@@ -349,19 +349,38 @@ export function showContextMenuFallback<T extends string>(
         }
 
         if (!isDisabled) {
+          let isHovered = false;
+          let isFocused = false;
+          const updateHighlight = () => {
+            const isHighlighted = isHovered || isFocused;
+            button.style.background = isHighlighted
+              ? isLeafDestructive
+                ? "color-mix(in srgb, var(--destructive) 10%, transparent)"
+                : "var(--accent)"
+              : "transparent";
+            button.style.color = isHighlighted
+              ? isLeafDestructive
+                ? "var(--destructive-foreground)"
+                : "var(--accent-foreground)"
+              : isLeafDestructive
+                ? "var(--destructive-foreground)"
+                : "var(--foreground)";
+          };
           button.addEventListener("mouseenter", () => {
-            button.style.background = isLeafDestructive
-              ? "color-mix(in srgb, var(--destructive) 10%, transparent)"
-              : "var(--accent)";
-            button.style.color = isLeafDestructive
-              ? "var(--destructive-foreground)"
-              : "var(--accent-foreground)";
+            isHovered = true;
+            updateHighlight();
           });
           button.addEventListener("mouseleave", () => {
-            button.style.background = "transparent";
-            button.style.color = isLeafDestructive
-              ? "var(--destructive-foreground)"
-              : "var(--foreground)";
+            isHovered = false;
+            updateHighlight();
+          });
+          button.addEventListener("focus", () => {
+            isFocused = true;
+            updateHighlight();
+          });
+          button.addEventListener("blur", () => {
+            isFocused = false;
+            updateHighlight();
           });
 
           if (hasChildren) {

--- a/apps/web/src/contextMenuFallback.ts
+++ b/apps/web/src/contextMenuFallback.ts
@@ -207,6 +207,7 @@ export function showContextMenuFallback<T extends string>(
 ): Promise<T | null> {
   return new Promise<T | null>((resolve) => {
     const menuStack: HTMLDivElement[] = [];
+    const submenuTriggerStack: Array<HTMLButtonElement | undefined> = [];
     let isDisposed = false;
     let canDismissFromPointer = false;
 
@@ -253,6 +254,7 @@ export function showContextMenuFallback<T extends string>(
 
     const closeMenusFromLevel = (level: number) => {
       while (menuStack.length > level) {
+        submenuTriggerStack.pop()?.setAttribute("aria-expanded", "false");
         menuStack.pop()?.remove();
       }
     };
@@ -262,6 +264,7 @@ export function showContextMenuFallback<T extends string>(
       preferredLeft: number,
       preferredTop: number,
       level: number,
+      parentTrigger?: HTMLButtonElement,
     ) => {
       closeMenusFromLevel(level);
 
@@ -337,12 +340,15 @@ export function showContextMenuFallback<T extends string>(
         button.appendChild(label);
 
         if (hasChildren) {
+          button.setAttribute("aria-haspopup", "menu");
+          button.setAttribute("aria-expanded", "false");
           const chevron = createIconElement("chevron-right", "neutral");
           if (chevron) {
             chevron.setAttribute(
               "class",
               "-me-0.5 ms-auto size-4.5 shrink-0 text-muted-foreground opacity-80 sm:size-4",
             );
+            chevron.setAttribute("aria-hidden", "true");
             chevron.dataset.contextMenuChevron = "true";
             button.appendChild(chevron);
           }
@@ -367,6 +373,7 @@ export function showContextMenuFallback<T extends string>(
                 : "var(--foreground)";
           };
           button.addEventListener("mouseenter", () => {
+            button.focus({ preventScroll: true });
             isHovered = true;
             updateHighlight();
           });
@@ -388,7 +395,8 @@ export function showContextMenuFallback<T extends string>(
               const rect = button.getBoundingClientRect();
               const nextLeft = rect.right + 4;
               const nextTop = rect.top;
-              openMenu(item.children!, nextLeft, nextTop, level + 1);
+              openMenu(item.children!, nextLeft, nextTop, level + 1, button);
+              button.setAttribute("aria-expanded", "true");
 
               const childMenu = menuStack[level + 1];
               if (!childMenu) {
@@ -432,6 +440,7 @@ export function showContextMenuFallback<T extends string>(
 
       document.body.appendChild(menu);
       menuStack[level] = menu;
+      submenuTriggerStack[level] = parentTrigger;
 
       requestAnimationFrame(() => {
         clampMenuPosition(menu, preferredLeft, preferredTop);

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -111,6 +111,8 @@ export interface ContextMenuItem<T extends string = string> {
   header?: boolean;
   /** Icon keyword resolved by the web fallback. Stripped on desktop native menus. */
   icon?: string;
+  /** Inserts a visual section divider immediately before this item. */
+  separatorBefore?: boolean;
   children?: readonly ContextMenuItem<T>[];
 }
 
@@ -121,6 +123,7 @@ export interface ContextMenuItemSchemaType {
   readonly disabled?: boolean;
   readonly header?: boolean;
   readonly icon?: string;
+  readonly separatorBefore?: boolean;
   readonly children?: readonly ContextMenuItemSchemaType[];
 }
 
@@ -131,6 +134,7 @@ export const ContextMenuItemSchema: Schema.Codec<ContextMenuItemSchemaType> = Sc
   disabled: Schema.optionalKey(Schema.Boolean),
   header: Schema.optionalKey(Schema.Boolean),
   icon: Schema.optionalKey(Schema.String),
+  separatorBefore: Schema.optionalKey(Schema.Boolean),
   children: Schema.optionalKey(
     Schema.Array(
       Schema.suspend((): Schema.Codec<ContextMenuItemSchemaType> => ContextMenuItemSchema),


### PR DESCRIPTION
## What changed

- Adds icons and section dividers to thread action menus.
- Groups path, branch, and thread ID copy actions under one Copy submenu.
- Keeps the menu structure consistent between Electron native menus and the web fallback.
- Opens fallback submenus from keyboard activation and focuses the first enabled action.

## Screenshots

_The original menu is on the left; this PR is on the right. Same viewport and copied application state._

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/fa3fdb54-86ea-4838-882c-b9201ba74ae2" alt="Thread menu before" width="440"></td>
<td><img src="https://github.com/user-attachments/assets/ca7795fd-168c-4349-9709-206bef484057" alt="Thread menu after" width="440"></td>
</tr>
</table>

## Why

Thread actions were visually flat and the copy actions occupied three top-level rows. This keeps one menu model across desktop and web while making the groups easier to scan.

This was separated from #7153 so workspace navigation and thread actions can be reviewed and merged independently.

## Validation

- 25 focused context-menu, Electron menu, and thread action tests
- Contracts, web, and desktop typechecks
- Browser verification of pointer rendering and keyboard submenu activation

Built with GPT-5.6-sol in the Codex harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refine thread action menus with grouped copy submenu, icons, and section separators
> - Groups copy-related actions (Path, Branch, Thread ID) under a new "Copy" parent submenu in `buildThreadActionMenuItems`.
> - Adds icon metadata to most thread action menu items and inserts visual separators before Rename, Copy, and Archive.
> - Extends the `ContextMenuItem` IPC contract with an optional `separatorBefore` flag, propagated through `normalizeContextMenuItems` and rendered by both the Electron and web fallback menu renderers.
> - The web fallback (`showContextMenuFallback`) gains click-to-open submenus with focus transfer, hover-driven highlighting, improved ARIA attributes on submenu triggers, and focus restoration after dismissal.
> - Adds several new SVG icon definitions to `ICON_PATHS` in [contextMenuFallback.ts](https://github.com/pingdotgg/t3code/pull/7476/files#diff-032cd4155f179490fdc876b54fb96f2609ab2552587ed8b42b9963c1d250a3be).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d30a05.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and menu-structure changes only; existing action IDs for copy/archive/delete are preserved under the new Copy parent.
> 
> **Overview**
> Refines thread action menus with **icons**, **section dividers**, and a **Copy** submenu so desktop and web share one menu shape.
> 
> Adds optional `separatorBefore` on `ContextMenuItem` (contracts + schema) and wires it through **Electron** menu templates (explicit separators; avoids double separators before destructive items) and the **web fallback** (visual dividers with `role="separator"`).
> 
> **Thread menu** (`buildThreadActionMenuItems`): path, branch, and thread ID copy actions move under a single **Copy** parent; rename, copy, and archive get `separatorBefore`; most rows get matching icon keywords.
> 
> **Web fallback** gains many Lucide-style icon paths, chevron submenus with `aria-haspopup` / `aria-expanded`, click-to-open submenus with focus on the first child, combined hover/focus highlighting, and focus restore to the invoker on dismiss.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d30a05ae99da81abe89f89c0c7badc2a28f3c90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->