### PR TITLE
fix(web): encode shifted characters correctly in the terminal

### DIFF
--- a/apps/web/src/terminal/ghostty/core.ts
+++ b/apps/web/src/terminal/ghostty/core.ts
@@ -1,5 +1,6 @@
 import {
   type GhosttyKeyboardLayoutMap,
+  ghosttyConsumedMods,
   ghosttyKeyForCode,
   ghosttyUnshiftedCodepoint,
   loadGhosttyKeyboardLayoutMap,
@@ -464,7 +465,11 @@ export class GhosttyTerminalCore {
       (event.getModifierState("CapsLock") ? 1 << 4 : 0) |
       (event.getModifierState("NumLock") ? 1 << 5 : 0);
     this.runtime.call("ghostty_key_event_set_mods", this.keyEvent, mods);
-    this.runtime.call("ghostty_key_event_set_consumed_mods", this.keyEvent, 0);
+    this.runtime.call(
+      "ghostty_key_event_set_consumed_mods",
+      this.keyEvent,
+      ghosttyConsumedMods(event),
+    );
     this.runtime.call("ghostty_key_event_set_composing", this.keyEvent, event.isComposing ? 1 : 0);
     this.runtime.call(
       "ghostty_key_event_set_unshifted_codepoint",

--- a/apps/web/src/terminal/ghostty/keyCodes.test.ts
+++ b/apps/web/src/terminal/ghostty/keyCodes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { ghosttyKeyForCode, ghosttyUnshiftedCodepoint } from "./keyCodes";
+import { ghosttyConsumedMods, ghosttyKeyForCode, ghosttyUnshiftedCodepoint } from "./keyCodes";
 
 describe("ghosttyKeyForCode", () => {
   it("keeps the tail of the pinned Ghostty key enum in order", () => {
@@ -8,6 +8,18 @@ describe("ghosttyKeyForCode", () => {
     expect(ghosttyKeyForCode("PrintScreen")).toBe(ghosttyKeyForCode("FnLock") + 1);
     expect(ghosttyKeyForCode("Pause")).toBe(ghosttyKeyForCode("ScrollLock") + 1);
     expect(ghosttyKeyForCode("Paste")).toBe(ghosttyKeyForCode("Cut") + 1);
+  });
+});
+
+describe("ghosttyConsumedMods", () => {
+  const shifted = { altKey: false, ctrlKey: false, key: "@", metaKey: false, shiftKey: true };
+
+  it("only consumes a lone Shift producing a character", () => {
+    expect(ghosttyConsumedMods(shifted)).toBe(1);
+    expect(ghosttyConsumedMods({ ...shifted, ctrlKey: true })).toBe(0);
+    expect(ghosttyConsumedMods({ ...shifted, key: "Tab" })).toBe(0);
+    // Deliberate: Shift+Space collapses to Space so it still types one.
+    expect(ghosttyConsumedMods({ ...shifted, key: " " })).toBe(1);
   });
 });
 

--- a/apps/web/src/terminal/ghostty/keyCodes.ts
+++ b/apps/web/src/terminal/ghostty/keyCodes.ts
@@ -233,6 +233,15 @@ export function loadGhosttyKeyboardLayoutMap(): Promise<GhosttyKeyboardLayoutMap
   return promise;
 }
 
+// Browsers do not expose consumed modifiers; treat Shift as consumed for
+// unchorded character input.
+export function ghosttyConsumedMods(
+  event: Pick<KeyboardEvent, "altKey" | "ctrlKey" | "key" | "metaKey" | "shiftKey">,
+): number {
+  if (!event.shiftKey || event.ctrlKey || event.altKey || event.metaKey) return 0;
+  return [...event.key].length === 1 ? 1 : 0;
+}
+
 export function ghosttyUnshiftedCodepoint(
   event: Pick<KeyboardEvent, "code" | "key" | "shiftKey">,
   layoutMap?: GhosttyKeyboardLayoutMap,


### PR DESCRIPTION
## What Changed

Fixes #5276

The web terminal's key encoder now marks Shift as consumed when it alone produced a printable character. Previously it always reported Shift as live, so `@` encoded as base key `2` plus Shift — which decodes back to `2`. On standard US layouts, shifted punctuation such as `!`, `@`, and `#` produced its unshifted character.

Chords are untouched — Shift only counts as consumed when it is the sole modifier, so keybindings resolve as before.

## Why

Bubble Tea v2 enables the Kitty keyboard protocol unconditionally, so every Charm-based TUI reads input through this path. Typing `@` into any prompt inserted `2` instead, making email addresses, handles, and paths unenterable.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Screenshots are not applicable
- [x] Video is not applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to keyboard event metadata in the web terminal with targeted unit tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **Kitty keyboard** encoding in the web Ghostty terminal so shifted punctuation (e.g. `@`, `!`, `#`) reaches TUIs as the typed character instead of the unshifted digit or symbol.
> 
> `encodeKey` no longer always passes `0` to `ghostty_key_event_set_consumed_mods`; it uses new **`ghosttyConsumedMods`**, which sets the Shift consumed bit when Shift is the only modifier and `event.key` is a single character. Chords with Ctrl/Alt/Meta still report no consumed mods, and non-character keys (e.g. Tab) are unchanged.
> 
> Unit tests cover the lone-Shift vs chord vs special-key cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf93f14d3f5588cf2c3d2df6c036f0d76484f7ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix shifted character encoding in the terminal by setting consumed mods correctly
> Adds a `ghosttyConsumedMods` function in [`keyCodes.ts`](https://github.com/pingdotgg/t3code/pull/7485/files#diff-93221f3e8e496f52536eb4798a536a527b2174d696e963f02a246d1601794687) that returns `1` when Shift is pressed alone and produces a single printable character, and `0` otherwise. Previously, `ghostty_key_event_set_consumed_mods` was always called with `0`, causing shifted characters to be encoded incorrectly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf93f14.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->