### PR TITLE
fix(web): make terminal links appear clickable only when clickable

### DIFF
--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -42,7 +42,7 @@ import {
 } from "~/terminal/ghostty/surface";
 import { type GhosttyColor, type GhosttyTheme } from "~/terminal/ghostty/core";
 import { useOpenInPreferredEditor } from "../editorPreferences";
-import { isTerminalLinkActivation, resolvePathLinkTarget } from "../terminal-links";
+import { isTerminalLinkActivation, isTerminalUrl, resolvePathLinkTarget } from "../terminal-links";
 import {
   isDiffToggleShortcut,
   isTerminalClearShortcut,
@@ -749,7 +749,7 @@ export function TerminalViewport({
         if (!isTerminalLinkActivation(event)) return;
         const latestTerminal = terminalRef.current;
         if (!latestTerminal) return;
-        if (/^https?:\/\//u.test(text)) {
+        if (isTerminalUrl(text)) {
           if (!localApi) {
             writeSystemMessage(latestTerminal, "Opening links is unavailable in this browser.");
             return;

--- a/apps/web/src/terminal-links.test.ts
+++ b/apps/web/src/terminal-links.test.ts
@@ -4,6 +4,7 @@ import {
   collectWrappedTerminalLinkLine,
   extractTerminalLinks,
   isTerminalLinkActivation,
+  isTerminalUrl,
   resolvePathLinkTarget,
   resolveWrappedTerminalLinkRange,
   wrappedTerminalLinkRangeIntersectsBufferLine,
@@ -35,6 +36,13 @@ describe("extractTerminalLinks", () => {
         end: 81,
       },
     ]);
+  });
+
+  it("classifies uppercase schemes as URLs at activation time too", () => {
+    expect(isTerminalUrl("HTTPS://example.com/docs")).toBe(true);
+    expect(isTerminalUrl("Http://example.com")).toBe(true);
+    expect(isTerminalUrl("src/components/main.ts")).toBe(false);
+    expect(isTerminalUrl("httpsdocs/readme.md")).toBe(false);
   });
 
   it("finds URLs regardless of scheme casing", () => {

--- a/apps/web/src/terminal-links.test.ts
+++ b/apps/web/src/terminal-links.test.ts
@@ -37,6 +37,17 @@ describe("extractTerminalLinks", () => {
     ]);
   });
 
+  it("finds URLs regardless of scheme casing", () => {
+    expect(extractTerminalLinks("open HTTPS://example.com/docs")).toEqual([
+      {
+        kind: "url",
+        text: "HTTPS://example.com/docs",
+        start: 5,
+        end: 29,
+      },
+    ]);
+  });
+
   it("trims trailing punctuation from links", () => {
     const line = "(https://example.com/docs), ./src/main.ts:12.";
     expect(extractTerminalLinks(line)).toEqual([

--- a/apps/web/src/terminal-links.ts
+++ b/apps/web/src/terminal-links.ts
@@ -36,7 +36,7 @@ export interface WrappedTerminalLinkLine {
   segments: ReadonlyArray<WrappedTerminalLinkLineSegment>;
 }
 
-const URL_PATTERN = /https?:\/\/[^\s"'`<>]+/g;
+const URL_PATTERN = /https?:\/\/[^\s"'`<>]+/giu;
 const FILE_PATH_PATTERN =
   /(?:~\/|\.{1,2}\/|\/|[A-Za-z]:[\\/]|\\\\)[^\s"'`<>]+|[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)+(?::\d+){0,2}/g;
 const TRAILING_PUNCTUATION_PATTERN = /[.,;!?]+$/;
@@ -80,7 +80,7 @@ function collectMatches(
 
     const trimmed = trimClosingDelimiters(raw);
     if (trimmed.length === 0) continue;
-    if (kind === "path" && /^https?:\/\//i.test(trimmed)) continue;
+    if (kind === "path" && isTerminalUrl(trimmed)) continue;
 
     const candidate: TerminalLinkMatch = {
       kind,
@@ -170,6 +170,10 @@ export function extractTerminalLinks(line: string): TerminalLinkMatch[] {
   const urlMatches = collectMatches(line, "url", URL_PATTERN, []);
   const pathMatches = collectMatches(line, "path", FILE_PATH_PATTERN, urlMatches);
   return [...urlMatches, ...pathMatches].toSorted((a, b) => a.start - b.start);
+}
+
+export function isTerminalUrl(value: string): boolean {
+  return /^https?:\/\//iu.test(value);
 }
 
 export function collectWrappedTerminalLinkLine(

--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -20,7 +20,6 @@ import {
   resolveTerminalMouseTrackingState,
   shouldBlinkTerminalCursor,
   shouldReportTerminalMouse,
-  shouldShowTerminalLinkHover,
   terminalGridCellAt,
   terminalScrollbarGeometry,
   terminalScrollbarOffsetAtPointer,
@@ -437,13 +436,6 @@ describe("application mouse reporting", () => {
       tracking: false,
       motionData: "\u001b[<35;8;4M",
     });
-  });
-
-  it("only shows link hover during mouse tracking when the link modifier is held", () => {
-    expect(shouldShowTerminalLinkHover(false, false)).toBe(true);
-    expect(shouldShowTerminalLinkHover(false, true)).toBe(true);
-    expect(shouldShowTerminalLinkHover(true, false)).toBe(false);
-    expect(shouldShowTerminalLinkHover(true, true)).toBe(true);
   });
 });
 

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -483,13 +483,6 @@ export function isTerminalLinkPointerGesture(
     : event.ctrlKey && !event.metaKey;
 }
 
-export function shouldShowTerminalLinkHover(
-  mouseTracking: boolean,
-  linkModifierActive: boolean,
-): boolean {
-  return !mouseTracking || linkModifierActive;
-}
-
 export function ghosttyMouseButton(button: number): number | null {
   switch (button) {
     case 0:
@@ -1407,12 +1400,11 @@ export class GhosttyTerminalSurface {
     this.canvas.style.cursor = cursor;
   }
 
+  // Hover feedback only while the link modifier is held: an unmodified click
+  // never activates a link, so an unmodified hover must not promise one.
   private refreshHoveredLink(): void {
     const pointer = this.hoverPointer;
-    const link =
-      pointer && shouldShowTerminalLinkHover(this.core.isMouseTracking(), this.linkModifierActive)
-        ? this.linkAt(pointer.x, pointer.y)
-        : null;
+    const link = pointer && this.linkModifierActive ? this.linkAt(pointer.x, pointer.y) : null;
     this.setHoveredLink(link);
   }
 

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -1400,8 +1400,6 @@ export class GhosttyTerminalSurface {
     this.canvas.style.cursor = cursor;
   }
 
-  // Hover feedback only while the link modifier is held: an unmodified click
-  // never activates a link, so an unmodified hover must not promise one.
   private refreshHoveredLink(): void {
     const pointer = this.hoverPointer;
     const link = pointer && this.linkModifierActive ? this.linkAt(pointer.x, pointer.y) : null;


### PR DESCRIPTION
## What Changed

- Terminal paths and URLs now only show the clickable hover treatment while you hold the link modifier: Cmd on macOS, Ctrl elsewhere. 
- URL detection is case-insensitive now, so `HTTPS://...` links match.

## Why

Link detection styled paths and URLs as clickable on any hover, but clicking one without the modifier does nothing. As reference for precedence: Ghostty-based terminals appear the same way: no hover treatment until you hold the modifier, modifier-click to open.

## UI Changes

### Before

Plain hover underlines the path even though clicking it does nothing:

<img width="800" height="140" alt="image" src="https://github.com/user-attachments/assets/8bc54123-36f4-4d44-b792-8c0dd04f21e8" />


### After

<!-- after screenshots: unmodified hover shows nothing; Cmd-hover shows the underline -->
https://github.com/user-attachments/assets/5c419e46-5104-4b3d-998b-75bf41fc5a6b
## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes

---

Implemented by GPT-5.6 Sol and Fable 5 via Codex and T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix terminal link hover and activation to respect link modifier and URL casing
> - Adds `isTerminalUrl` helper in [terminal-links.ts](https://github.com/pingdotgg/t3code/pull/7488/files#diff-5f57eb38e8e99e705308a736729815ef1ec005cf2f20cca912a9f7abcf28c110) with case-insensitive scheme matching (`/^https?:\/\//iu`) and applies `iu` flags to `URL_PATTERN` so links like `HTTPS://` are detected
> - `ThreadTerminalDrawer` now uses `isTerminalUrl` instead of a direct regex test when activating links
> - `collectMatches` uses `isTerminalUrl` to avoid misclassifying URLs as paths
> - Removes `shouldShowTerminalLinkHover` from [surface.ts](https://github.com/pingdotgg/t3code/pull/7488/files#diff-036d64ffe3b3b3d167137e8ea29edae7af74a9e0323fc798c4f291992235d267); `refreshHoveredLink` now shows link hover only when the link modifier is held, ignoring mouse tracking state
> - Behavioral Change: link hover no longer depends on mouse tracking state; URLs with uppercase schemes now activate and extract correctly
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 867be7b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->