### PR TITLE
fix(desktop): improve Windows host lifecycle

### DIFF
--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -15,6 +15,7 @@ import * as DesktopAppIdentity from "./DesktopAppIdentity.ts";
 import * as DesktopClerk from "./DesktopClerk.ts";
 import * as DesktopApplicationMenu from "../window/DesktopApplicationMenu.ts";
 import * as DesktopWindow from "../window/DesktopWindow.ts";
+import * as DesktopTray from "../window/DesktopTray.ts";
 import * as DesktopBackendPool from "../backend/DesktopBackendPool.ts";
 import * as DesktopEnvironment from "./DesktopEnvironment.ts";
 import * as DesktopLifecycle from "./DesktopLifecycle.ts";
@@ -230,6 +231,7 @@ const startup = Effect.gen(function* () {
   const preReadyElectronOptions = yield* DesktopPreReadyPlatform.DesktopPreReadyElectronOptions;
   const safeStorage = yield* ElectronSafeStorage.ElectronSafeStorage;
   const updates = yield* DesktopUpdates.DesktopUpdates;
+  const tray = yield* DesktopTray.DesktopTray;
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
 
   yield* shellEnvironment.installIntoProcess;
@@ -285,6 +287,7 @@ const startup = Effect.gen(function* () {
   }
   yield* appIdentity.configure;
   yield* applicationMenu.configure;
+  yield* tray.configure;
   yield* updates.configure;
   yield* linuxUrlHandler.register;
   yield* bootstrap.pipe(Effect.catchCause((cause) => fatalStartupCause("bootstrap", cause)));

--- a/apps/desktop/src/app/DesktopLifecycle.test.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.test.ts
@@ -17,6 +17,7 @@ describe("DesktopLifecycle", () => {
   for (const platform of ["darwin", "win32", "linux"] satisfies ReadonlyArray<NodeJS.Platform>) {
     it.effect(`lets the updater's quit event proceed on ${platform}`, () => {
       const appListeners = new Map<string, (...args: readonly unknown[]) => void>();
+      let quitPrepared = false;
 
       const electronAppLayer = Layer.succeed(ElectronApp.ElectronApp, {
         metadata: Effect.die("unexpected metadata read"),
@@ -78,6 +79,10 @@ describe("DesktopLifecycle", () => {
         handleBackendReady: () => Effect.void,
         handleBackendNotReady: Effect.void,
         flushMainWindowBounds: Effect.void,
+        setBackgroundModeEnabled: () => undefined,
+        prepareForQuit: () => {
+          quitPrepared = true;
+        },
         dispatchMenuAction: () => Effect.void,
         zoomMain: () => Effect.void,
         syncAppearance: Effect.void,
@@ -116,6 +121,7 @@ describe("DesktopLifecycle", () => {
             prevented,
             "cancelling this event prevents the updater from completing its relaunch",
           );
+          assert.isTrue(quitPrepared);
 
           const state = yield* DesktopState.DesktopState;
           assert.isTrue(yield* Ref.get(state.quitting));

--- a/apps/desktop/src/app/DesktopLifecycle.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.ts
@@ -91,7 +91,9 @@ function handleBeforeQuit(
   runEffect: <A, E>(effect: Effect.Effect<A, E, DesktopLifecycleRuntimeServices>) => Promise<A>,
   allowQuit: () => boolean,
   markQuitAllowed: () => void,
+  prepareForQuit: () => void,
 ): void {
+  prepareForQuit();
   if (allowQuit()) {
     void runEffect(
       Effect.gen(function* () {
@@ -201,6 +203,7 @@ export const make = DesktopLifecycle.of({
         () => {
           quitAllowed = true;
         },
+        desktopWindow.prepareForQuit,
       );
     });
     yield* electronApp.on("activate", () => {

--- a/apps/desktop/src/backend/DesktopBackendPool.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendPool.test.ts
@@ -90,6 +90,8 @@ function makePoolLayer(
           handleBackendReady: () => Effect.void,
           handleBackendNotReady: Effect.void,
           flushMainWindowBounds: Effect.void,
+          setBackgroundModeEnabled: () => undefined,
+          prepareForQuit: () => undefined,
           dispatchMenuAction: () => Effect.die("unexpected menu action"),
           zoomMain: () => Effect.die("unexpected zoom"),
           syncAppearance: Effect.void,

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -60,6 +60,7 @@ import * as DesktopUpdates from "./updates/DesktopUpdates.ts";
 import * as BrowserSession from "./preview/BrowserSession.ts";
 import * as PreviewManager from "./preview/Manager.ts";
 import * as DesktopWindow from "./window/DesktopWindow.ts";
+import * as DesktopTray from "./window/DesktopTray.ts";
 import * as DesktopWslBackend from "./wsl/DesktopWslBackend.ts";
 import * as DesktopWslEnvironment from "./wsl/DesktopWslEnvironment.ts";
 import * as DesktopWslServerTree from "./wsl/DesktopWslServerTree.ts";
@@ -185,6 +186,7 @@ const desktopLocalEnvironmentAuthLayer = DesktopLocalEnvironmentAuth.layer.pipe(
 const desktopApplicationLayer = Layer.mergeAll(
   DesktopLifecycle.layer,
   DesktopApplicationMenu.layer,
+  DesktopTray.layer,
   DesktopLinuxUrlHandler.layer,
   DesktopShellEnvironment.layer,
   desktopSshLayer,

--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -1,6 +1,7 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, describe, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Logger from "effect/Logger";
 import * as PlatformError from "effect/PlatformError";
@@ -69,11 +70,18 @@ function runShellEnvironment(input: {
   readonly platform: NodeJS.Platform;
   readonly handler: (command: ChildProcess.Command) => string;
   readonly failure?: PlatformError.PlatformError;
+  readonly stateDir?: string;
 }) {
   const environmentLayer = Layer.succeed(
     DesktopEnvironment.DesktopEnvironment,
     DesktopEnvironment.DesktopEnvironment.of({
       platform: input.platform,
+      ...(input.stateDir === undefined
+        ? {}
+        : {
+            stateDir: input.stateDir,
+            path: { join: (directory: string, fileName: string) => `${directory}\\${fileName}` },
+          }),
     } as DesktopEnvironment.DesktopEnvironment["Service"]),
   );
   const spawnerLayer = Layer.succeed(
@@ -345,6 +353,50 @@ describe("DesktopShellEnvironment", () => {
         "C:\\Users\\testuser\\AppData\\Local\\fnm_multishells\\123",
       );
     }),
+  );
+
+  it.effect("reuses a fresh Windows shell environment cache on the next launch", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const stateDir = yield* fileSystem.makeTempDirectoryScoped({
+          prefix: "t3-windows-shell-environment-test-",
+        });
+        const makeEnv = (): NodeJS.ProcessEnv => ({
+          PATH: "C:\\Windows\\System32",
+          APPDATA: "C:\\Users\\testuser\\AppData\\Roaming",
+          LOCALAPPDATA: "C:\\Users\\testuser\\AppData\\Local",
+          USERPROFILE: "C:\\Users\\testuser",
+        });
+        let commandCount = 0;
+        const handler = (command: ChildProcess.Command) => {
+          commandCount += 1;
+          if (command._tag !== "StandardCommand") return "";
+          return command.args.includes("-NoProfile")
+            ? envOutput({ PATH: "C:\\Custom\\Bin;C:\\Windows\\System32" })
+            : envOutput({ PATH: "C:\\Profile\\Node;C:\\Windows\\System32" });
+        };
+
+        const firstEnv = makeEnv();
+        yield* runShellEnvironment({
+          env: firstEnv,
+          platform: "win32",
+          stateDir,
+          handler,
+        });
+        assert.equal(commandCount, 2);
+
+        const secondEnv = makeEnv();
+        yield* runShellEnvironment({
+          env: secondEnv,
+          platform: "win32",
+          stateDir,
+          handler,
+        });
+        assert.equal(commandCount, 2);
+        assert.equal(secondEnv.PATH, firstEnv.PATH);
+      }),
+    ).pipe(Effect.provide(NodeServices.layer)),
   );
 
   it.effect("prefers login-shell desktop session hints over inherited values on linux", () =>

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -1,4 +1,5 @@
 import * as Context from "effect/Context";
+import * as Clock from "effect/Clock";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -16,6 +17,10 @@ interface ShellEnvironmentConfig {
   readonly env: NodeJS.ProcessEnv;
   readonly platform: NodeJS.Platform;
   readonly userShell: Option.Option<string>;
+  readonly windowsEnvironmentCache?: {
+    readonly path: string;
+    readonly directory: string;
+  };
 }
 
 interface WindowsProbeOptions {
@@ -93,6 +98,20 @@ const WINDOWS_SHELL_CANDIDATES = ["pwsh.exe", "powershell.exe"] as const;
 const LOGIN_SHELL_TIMEOUT = Duration.seconds(5);
 const LAUNCHCTL_TIMEOUT = Duration.seconds(2);
 const PROCESS_TERMINATE_GRACE = Duration.seconds(1);
+const WINDOWS_ENVIRONMENT_CACHE_MAX_AGE_MS = Duration.toMillis(Duration.hours(24));
+const WINDOWS_ENVIRONMENT_CACHE_FILE_NAME = "windows-shell-environment.json";
+
+const WindowsEnvironmentCache = Schema.Struct({
+  version: Schema.Literal(1),
+  capturedAt: Schema.Number,
+  inheritedPath: Schema.String,
+  noProfile: Schema.Record(Schema.String, Schema.String),
+  profile: Schema.Record(Schema.String, Schema.String),
+});
+type WindowsEnvironmentCache = typeof WindowsEnvironmentCache.Type;
+const WindowsEnvironmentCacheJson = Schema.fromJsonString(WindowsEnvironmentCache);
+const decodeWindowsEnvironmentCache = Schema.decodeUnknownOption(WindowsEnvironmentCacheJson);
+const encodeWindowsEnvironmentCache = Schema.encodeEffect(WindowsEnvironmentCacheJson);
 
 const trimNonEmpty = (value: string | null | undefined): Option.Option<string> =>
   Option.fromNullishOr(value).pipe(
@@ -383,19 +402,62 @@ const readWindowsEnvironment = Effect.fn("desktop.shellEnvironment.readWindowsEn
 const installWindowsEnvironment = Effect.fn("desktop.shellEnvironment.installWindowsEnvironment")(
   function* (
     config: ShellEnvironmentConfig,
-  ): Effect.fn.Return<void, never, ChildProcessSpawner.ChildProcessSpawner> {
-    // Concurrent, not sequential: these two probes are independent (only their
-    // results are combined below) and each spawns its own PowerShell. Run in
-    // series they sit at offset 0 of desktop.startup, before anything else, and
-    // launch traces measured them at 2718ms then 2066ms — the entire 4.8s
-    // startup span, of which desktop.bootstrap is ~30ms.
-    const [noProfile, profile] = yield* Effect.all(
-      [
-        readWindowsEnvironment(["PATH"], { loadProfile: false }),
-        readWindowsEnvironment(WINDOWS_PROFILE_ENV_NAMES, { loadProfile: true }),
-      ],
-      { concurrency: 2 },
-    );
+  ): Effect.fn.Return<
+    void,
+    never,
+    ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem
+  > {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const inheritedPath = Option.getOrElse(readEnvPath(config.env), () => "");
+    const cache = config.windowsEnvironmentCache ?? null;
+    const cachePath = cache?.path ?? null;
+    const now = yield* Clock.currentTimeMillis;
+    // Loading a PowerShell profile dominates warm Windows launches. Reuse its
+    // small environment snapshot while the inherited PATH is unchanged, but
+    // bound its lifetime so profile-only changes are eventually discovered.
+    // A missing, corrupt, or stale cache simply falls through to the probes.
+    const cached: Option.Option<WindowsEnvironmentCache> =
+      cachePath === null
+        ? Option.none<WindowsEnvironmentCache>()
+        : yield* fileSystem.readFileString(cachePath).pipe(
+            Effect.map(decodeWindowsEnvironmentCache),
+            Effect.orElseSucceed(() => Option.none()),
+            Effect.map((entry) =>
+              Option.filter(
+                entry,
+                (value) =>
+                  value.inheritedPath === inheritedPath &&
+                  now >= value.capturedAt &&
+                  now - value.capturedAt <= WINDOWS_ENVIRONMENT_CACHE_MAX_AGE_MS,
+              ),
+            ),
+          );
+
+    const [noProfile, profile] = Option.isSome(cached)
+      ? [cached.value.noProfile, cached.value.profile]
+      : yield* Effect.all(
+          [
+            readWindowsEnvironment(["PATH"], { loadProfile: false }),
+            readWindowsEnvironment(WINDOWS_PROFILE_ENV_NAMES, { loadProfile: true }),
+          ],
+          { concurrency: 2 },
+        );
+
+    if (Option.isNone(cached) && cache !== null) {
+      const encoded = yield* encodeWindowsEnvironmentCache({
+        version: 1,
+        capturedAt: now,
+        inheritedPath,
+        noProfile,
+        profile,
+      }).pipe(Effect.option);
+      if (Option.isSome(encoded)) {
+        yield* fileSystem.makeDirectory(cache.directory, { recursive: true }).pipe(
+          Effect.andThen(fileSystem.writeFileString(cache.path, `${encoded.value}\n`)),
+          Effect.catchCause(() => Effect.void),
+        );
+      }
+    }
     const mergedPath = mergePaths("win32", [
       trimNonEmpty(profile.PATH),
       trimNonEmpty(knownWindowsCliDirs(config.env).join(";")),
@@ -539,6 +601,17 @@ export const make = Effect.gen(function* () {
       env: process.env,
       platform: environment.platform,
       userShell: Option.none(),
+      ...(typeof environment.stateDir === "string" && environment.stateDir.length > 0
+        ? {
+            windowsEnvironmentCache: {
+              path: environment.path.join(
+                environment.stateDir,
+                WINDOWS_ENVIRONMENT_CACHE_FILE_NAME,
+              ),
+              directory: environment.stateDir,
+            },
+          }
+        : {}),
     }).pipe(
       Effect.provideService(FileSystem.FileSystem, fileSystem),
       Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),

--- a/apps/desktop/src/window/DesktopApplicationMenu.test.ts
+++ b/apps/desktop/src/window/DesktopApplicationMenu.test.ts
@@ -80,6 +80,8 @@ const makeDesktopWindowLayer = (selectedAction: Deferred.Deferred<string>) =>
     handleBackendReady: () => Effect.void,
     handleBackendNotReady: Effect.void,
     flushMainWindowBounds: Effect.void,
+    setBackgroundModeEnabled: () => undefined,
+    prepareForQuit: () => undefined,
     dispatchMenuAction: (action) => Deferred.succeed(selectedAction, action).pipe(Effect.asVoid),
     zoomMain: (direction) =>
       Deferred.succeed(selectedAction, `zoom-${direction}`).pipe(Effect.asVoid),

--- a/apps/desktop/src/window/DesktopTray.test.ts
+++ b/apps/desktop/src/window/DesktopTray.test.ts
@@ -1,0 +1,146 @@
+import { assert, describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+
+import type * as Electron from "electron";
+import { vi } from "vite-plus/test";
+
+const electronMocks = vi.hoisted(() => {
+  interface FakeTray {
+    iconPath: string;
+    listeners: Map<string, () => void>;
+    setContextMenu: ReturnType<typeof vi.fn>;
+    setToolTip: ReturnType<typeof vi.fn>;
+    destroy: ReturnType<typeof vi.fn>;
+    on: (eventName: string, listener: () => void) => void;
+  }
+
+  const trays: FakeTray[] = [];
+  const Tray = vi.fn(function TrayMock(this: FakeTray, iconPath: string) {
+    this.iconPath = iconPath;
+    this.listeners = new Map();
+    this.setContextMenu = vi.fn();
+    this.setToolTip = vi.fn();
+    this.destroy = vi.fn();
+    this.on = (eventName, listener) => {
+      this.listeners.set(eventName, listener);
+    };
+    trays.push(this);
+  });
+  const buildFromTemplate = vi.fn(
+    (template: readonly Electron.MenuItemConstructorOptions[]) => template,
+  );
+  return { buildFromTemplate, Tray, trays };
+});
+
+vi.mock("electron", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("electron")>()),
+  Menu: { buildFromTemplate: electronMocks.buildFromTemplate },
+  Tray: electronMocks.Tray,
+}));
+
+import * as DesktopAssets from "../app/DesktopAssets.ts";
+import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
+import * as ElectronApp from "../electron/ElectronApp.ts";
+import * as DesktopTray from "./DesktopTray.ts";
+import * as DesktopWindow from "./DesktopWindow.ts";
+
+function makeLayer(input: {
+  readonly iconPath: Option.Option<string>;
+  readonly backgroundModeChanges: boolean[];
+  readonly opens: string[];
+  readonly quits: string[];
+}) {
+  const window = {
+    createMain: Effect.die("unexpected createMain"),
+    ensureMain: Effect.die("unexpected ensureMain"),
+    revealOrCreateMain: Effect.sync(() => {
+      input.opens.push("open");
+      return {} as Electron.BrowserWindow;
+    }),
+    activate: Effect.void,
+    createMainIfBackendReady: Effect.void,
+    showConnectingSplash: Effect.void,
+    handleBackendReady: () => Effect.void,
+    handleBackendNotReady: Effect.void,
+    flushMainWindowBounds: Effect.void,
+    setBackgroundModeEnabled: (enabled: boolean) => {
+      input.backgroundModeChanges.push(enabled);
+    },
+    prepareForQuit: () => undefined,
+    dispatchMenuAction: () => Effect.void,
+    zoomMain: () => Effect.void,
+    syncAppearance: Effect.void,
+  } satisfies DesktopWindow.DesktopWindow["Service"];
+
+  return DesktopTray.layer.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        Layer.succeed(DesktopEnvironment.DesktopEnvironment, {
+          platform: "win32",
+          displayName: "T3 Code",
+        } as DesktopEnvironment.DesktopEnvironment["Service"]),
+        Layer.succeed(DesktopAssets.DesktopAssets, {
+          iconPaths: Effect.succeed({
+            ico: input.iconPath,
+            icns: Option.none(),
+            png: Option.none(),
+          }),
+          resolveResourcePath: () => Effect.succeed(Option.none()),
+        }),
+        Layer.succeed(ElectronApp.ElectronApp, {
+          quit: Effect.sync(() => {
+            input.quits.push("quit");
+          }),
+        } as ElectronApp.ElectronApp["Service"]),
+        Layer.succeed(DesktopWindow.DesktopWindow, window),
+      ),
+    ),
+  );
+}
+
+describe("DesktopTray", () => {
+  it.effect("keeps Windows background mode active for the tray lifetime", () => {
+    const backgroundModeChanges: boolean[] = [];
+    const opens: string[] = [];
+    const quits: string[] = [];
+    const layer = makeLayer({
+      iconPath: Option.some("C:\\T3 Code\\icon.ico"),
+      backgroundModeChanges,
+      opens,
+      quits,
+    });
+
+    return Effect.scoped(
+      Effect.gen(function* () {
+        const trayService = yield* DesktopTray.DesktopTray;
+        yield* trayService.configure;
+
+        const tray = electronMocks.trays.at(-1);
+        assert.isDefined(tray);
+        assert.equal(tray.iconPath, "C:\\T3 Code\\icon.ico");
+        assert.deepEqual(backgroundModeChanges, [true]);
+
+        tray.listeners.get("click")?.();
+        const template = electronMocks.buildFromTemplate.mock.calls.at(-1)?.[0];
+        const quitItem = template?.find((item) => item.label === "Quit T3 Code");
+        quitItem?.click?.(
+          {} as Electron.MenuItem,
+          undefined as unknown as Electron.BaseWindow,
+          {} as Electron.KeyboardEvent,
+        );
+        yield* Effect.yieldNow;
+        assert.deepEqual(opens, ["open"]);
+        assert.deepEqual(quits, ["quit"]);
+      }).pipe(Effect.provide(layer)),
+    ).pipe(
+      Effect.andThen(
+        Effect.sync(() => {
+          assert.deepEqual(backgroundModeChanges, [true, false]);
+          assert.equal(electronMocks.trays.at(-1)?.destroy.mock.calls.length, 1);
+        }),
+      ),
+    );
+  });
+});

--- a/apps/desktop/src/window/DesktopTray.ts
+++ b/apps/desktop/src/window/DesktopTray.ts
@@ -1,0 +1,88 @@
+import * as Context from "effect/Context";
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Scope from "effect/Scope";
+
+import * as Electron from "electron";
+
+import * as DesktopAssets from "../app/DesktopAssets.ts";
+import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
+import { makeComponentLogger } from "../app/DesktopObservability.ts";
+import * as ElectronApp from "../electron/ElectronApp.ts";
+import * as DesktopWindow from "./DesktopWindow.ts";
+
+export class DesktopTray extends Context.Service<
+  DesktopTray,
+  {
+    readonly configure: Effect.Effect<void, never, Scope.Scope>;
+  }
+>()("@t3tools/desktop/window/DesktopTray") {}
+
+const { logInfo: logTrayInfo, logWarning: logTrayWarning } = makeComponentLogger("desktop-tray");
+
+export const make = Effect.gen(function* () {
+  const assets = yield* DesktopAssets.DesktopAssets;
+  const environment = yield* DesktopEnvironment.DesktopEnvironment;
+  const electronApp = yield* ElectronApp.ElectronApp;
+  const desktopWindow = yield* DesktopWindow.DesktopWindow;
+  const context = yield* Effect.context<ElectronApp.ElectronApp | DesktopWindow.DesktopWindow>();
+  const runPromise = Effect.runPromiseWith(context);
+
+  const configure = Effect.gen(function* () {
+    if (environment.platform !== "win32") return;
+
+    const iconPaths = yield* assets.iconPaths;
+    if (Option.isNone(iconPaths.ico)) {
+      yield* logTrayWarning("Windows tray icon is unavailable; close-to-background disabled");
+      return;
+    }
+    const iconPath = iconPaths.ico.value;
+
+    yield* Effect.acquireRelease(
+      Effect.sync(() => {
+        const open = () => {
+          void runPromise(desktopWindow.revealOrCreateMain);
+        };
+        const quit = () => {
+          void runPromise(electronApp.quit);
+        };
+        const tray = new Electron.Tray(iconPath);
+        try {
+          tray.setToolTip(environment.displayName);
+          tray.setContextMenu(
+            Electron.Menu.buildFromTemplate([
+              { label: `Open ${environment.displayName}`, click: open },
+              { type: "separator" },
+              { label: `Quit ${environment.displayName}`, click: quit },
+            ]),
+          );
+          tray.on("click", open);
+          desktopWindow.setBackgroundModeEnabled(true);
+          return tray;
+        } catch (cause) {
+          tray.destroy();
+          throw cause;
+        }
+      }),
+      (tray) =>
+        Effect.sync(() => {
+          desktopWindow.setBackgroundModeEnabled(false);
+          tray.destroy();
+        }),
+    );
+    yield* logTrayInfo("Windows tray configured");
+  }).pipe(
+    Effect.catchCause((cause) =>
+      logTrayWarning("Windows tray setup failed; close-to-background disabled", {
+        cause: Cause.pretty(cause),
+      }),
+    ),
+    Effect.withSpan("desktop.tray.configure"),
+  );
+
+  return DesktopTray.of({ configure });
+});
+
+export const layer = Layer.effect(DesktopTray, make);

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -103,6 +103,7 @@ function makeFakeBrowserWindow() {
       windowListeners.set(eventName, listener);
     }),
     restore: vi.fn(),
+    hide: vi.fn(),
     setBackgroundColor: vi.fn(),
     setAutoHideCursor: vi.fn(),
     setTitle: vi.fn(),
@@ -115,6 +116,7 @@ function makeFakeBrowserWindow() {
     window: window as unknown as Electron.BrowserWindow,
     getBounds: window.getBounds,
     getNormalBounds: window.getNormalBounds,
+    hide: window.hide,
     isDestroyed: window.isDestroyed,
     isFullScreen: window.isFullScreen,
     isMaximized: window.isMaximized,
@@ -205,6 +207,7 @@ function makeTestLayer(input: {
   ) => Effect.Effect<void>;
   readonly openedExternalUrls?: unknown[];
   readonly previewZoomReapplies?: number[];
+  readonly platform?: NodeJS.Platform;
 }) {
   let desktopSettings = input.desktopSettings ?? DesktopAppSettings.DEFAULT_DESKTOP_SETTINGS;
   const desktopAppSettingsLayer = Layer.succeed(DesktopAppSettings.DesktopAppSettings, {
@@ -259,11 +262,26 @@ function makeTestLayer(input: {
     syncAllAppearance: (sync) => sync(input.window),
   } satisfies ElectronWindow.ElectronWindow["Service"]);
 
+  const environmentLayer =
+    input.platform === undefined
+      ? desktopEnvironmentLayer
+      : DesktopEnvironment.layer({ ...environmentInput, platform: input.platform }).pipe(
+          Layer.provide(
+            Layer.mergeAll(
+              NodeServices.layer,
+              DesktopConfig.layerTest({
+                T3CODE_PORT: "3773",
+                VITE_DEV_SERVER_URL: "http://127.0.0.1:5733",
+              }),
+            ),
+          ),
+        );
+
   return DesktopWindow.layer.pipe(
     Layer.provide(
       Layer.mergeAll(
         desktopAssetsLayer,
-        desktopEnvironmentLayer,
+        environmentLayer,
         desktopAppSettingsLayer,
         desktopClientSettingsLayer,
         desktopServerExposureLayer,
@@ -506,6 +524,42 @@ describe("DesktopWindow", () => {
         prevented = false;
         beforeInput(event, { ...input, meta: false });
         assert.isFalse(prevented);
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
+  it.effect("hides a Windows window while background mode is active and closes it for Quit", () =>
+    Effect.gen(function* () {
+      const fakeWindow = makeFakeBrowserWindow();
+      const createCount = yield* Ref.make(0);
+      const mainWindow = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(Option.none());
+      const layer = makeTestLayer({
+        window: fakeWindow.window,
+        createCount,
+        mainWindow,
+        platform: "win32",
+      });
+
+      yield* Effect.gen(function* () {
+        const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        yield* desktopWindow.handleBackendReady(new URL("http://127.0.0.1:3773"));
+        desktopWindow.setBackgroundModeEnabled(true);
+
+        const close = fakeWindow.windowListeners.get("close");
+        if (!close) {
+          return yield* Effect.die("window close listener was not registered");
+        }
+
+        const backgroundClose = { preventDefault: vi.fn() };
+        close(backgroundClose);
+        assert.equal(backgroundClose.preventDefault.mock.calls.length, 1);
+        assert.equal(fakeWindow.hide.mock.calls.length, 1);
+
+        desktopWindow.prepareForQuit();
+        const quitClose = { preventDefault: vi.fn() };
+        close(quitClose);
+        assert.equal(quitClose.preventDefault.mock.calls.length, 0);
+        assert.equal(fakeWindow.hide.mock.calls.length, 1);
       }).pipe(Effect.provide(layer));
     }),
   );

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -99,6 +99,10 @@ export class DesktopWindow extends Context.Service<
     // produce a stranded window pointing at nothing.
     readonly handleBackendNotReady: Effect.Effect<void>;
     readonly flushMainWindowBounds: Effect.Effect<void>;
+    // These switches are synchronous because Electron's native close event must
+    // be accepted or cancelled before its listener returns.
+    readonly setBackgroundModeEnabled: (enabled: boolean) => void;
+    readonly prepareForQuit: () => void;
     readonly dispatchMenuAction: (action: string) => Effect.Effect<void, DesktopWindowError>;
     // Zooms the main window's own webContents. The Electron `zoomIn`/`zoomOut`
     // menu roles act on whichever webContents has keyboard focus, so with an
@@ -287,6 +291,8 @@ export const make = Effect.gen(function* () {
   const runFork = Effect.runForkWith(context);
   const runPromise = Effect.runPromiseWith(context);
   let flushMainWindowBounds: Effect.Effect<void> = Effect.void;
+  let backgroundModeEnabled = false;
+  let quitPrepared = false;
 
   const dismissConnectingSplash = Effect.gen(function* () {
     const splash = yield* Ref.getAndSet(splashWindowRef, Option.none());
@@ -592,8 +598,12 @@ export const make = Effect.gen(function* () {
     window.on("move", scheduleBoundsPersist);
     window.on("maximize", scheduleBoundsPersist);
     window.on("unmaximize", scheduleBoundsPersist);
-    window.on("close", () => {
+    window.on("close", (event) => {
       runFork(flushBoundsPersist);
+      if (environment.platform === "win32" && backgroundModeEnabled && !quitPrepared) {
+        event.preventDefault();
+        window.hide();
+      }
     });
 
     if (environment.platform === "darwin") {
@@ -871,6 +881,12 @@ export const make = Effect.gen(function* () {
     flushMainWindowBounds: Effect.suspend(() => flushMainWindowBounds).pipe(
       Effect.withSpan("desktop.window.flushMainWindowBounds"),
     ),
+    setBackgroundModeEnabled: (enabled) => {
+      backgroundModeEnabled = enabled;
+    },
+    prepareForQuit: () => {
+      quitPrepared = true;
+    },
     dispatchMenuAction: Effect.fn("desktop.window.dispatchMenuAction")(function* (action) {
       yield* Effect.annotateCurrentSpan({ action });
       const existingWindow = yield* focusedMainWindow;

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -46,6 +46,10 @@ If you are already running the desktop app and want to make it reachable from ot
 3. The settings panel will show the default reachable endpoint, with a `+N` control when more endpoints are available. Expand it to inspect alternatives such as loopback, LAN, private-network, or HTTPS endpoints.
 4. Use **Create Link** to generate a pairing link you can share with another device.
 
+On Windows, closing the desktop window keeps T3 Code and its backend running in the system tray so
+paired devices can remain connected. Select the tray icon to reopen the window, or use **Quit T3
+Code** from its menu to stop the app and backend completely.
+
 The default endpoint controls the QR code and primary copy action for pairing links. You can change it from the expanded endpoint list. The preference is stored by endpoint type, so choosing the local LAN endpoint survives normal IP address changes when you move between networks.
 
 When no user default is saved, the app uses the built-in LAN endpoint for pairing links when


### PR DESCRIPTION
## What Changed

- Add a Windows system tray with Open and Quit actions.
- Hide the desktop window on close while keeping the backend and remote connections running.
- Preserve the existing graceful shutdown path when the user explicitly quits.
- Enable close-to-background only after tray creation succeeds, preventing an inaccessible hidden app.
- Cache the PowerShell-derived Windows shell environment for repeated launches.
- Invalidate the cache after 24 hours or whenever the inherited PATH changes.
- Add focused lifecycle, tray, window-close, and shell-environment tests.
- Document the Windows background behavior in the remote-access guide.

## Why

Closing the final T3 Code window on Windows previously exited the entire desktop host. That stopped the backend and disconnected devices using T3 Code remotely.

Windows startup also synchronously repeated expensive PowerShell environment discovery even when the inherited environment had not changed. Local traces showed this adding roughly 3–4 seconds to repeated launches.

This keeps the Windows host available for remote use, provides an explicit way to quit it completely, and avoids repeated environment-discovery work without changing lifecycle behavior on macOS or Linux.

## UI Changes

<img width="1533" height="1066" alt="image" src="https://github.com/user-attachments/assets/101ee891-a3ed-4b44-9623-5f9bcaf76214" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Implemented with GPT-5.6-sol through the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Windows quit/close semantics and process lifetime (backend stays up when the window is hidden), which affects remote connections and shutdown; macOS/Linux behavior is largely unchanged aside from test stubs.
> 
> **Overview**
> **Windows** no longer exits when the main window is closed if the system tray is active: closing **hides** the window and keeps the backend running for remote pairing, while **Quit** from the tray (or the normal shutdown path) still tears down the app.
> 
> A new **Windows-only system tray** (Open / Quit) is registered at startup; **close-to-background** is enabled only after the tray is created successfully so users are not left with a hidden app and no way to reopen it. `before-quit` calls **`prepareForQuit`** so updater-driven and explicit quits bypass the hide behavior.
> 
> **Startup on Windows** caches the PowerShell-derived shell environment snapshot under the app state directory (`windows-shell-environment.json`), reusing it for up to **24 hours** or until the inherited **PATH** changes, avoiding repeated profile probes on warm launches.
> 
> Tests cover tray lifecycle, window close vs quit, lifecycle `prepareForQuit`, and cache reuse; **remote-access** docs describe the tray behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5325cb9cd16383aac894a0f99337c42ee93b9fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Windows system tray support with background mode and shell environment caching
> - On Windows, the app now creates a system tray icon (via `DesktopTray`) with Open and Quit menu actions. Closing the main window hides it rather than quitting while the tray is active.
> - `DesktopWindow` gains `setBackgroundModeEnabled` and `prepareForQuit` methods; `prepareForQuit` is called during `before-quit` so subsequent closes proceed normally instead of hiding.
> - On Windows, shell environment variables from PowerShell are cached to disk (under `stateDir`) and reused for up to 24 hours when the inherited PATH is unchanged, reducing repeated PowerShell profile loads on each launch.
> - User-facing docs in [remote-access.md](https://github.com/pingdotgg/t3code/pull/7489/files#diff-e6cd63b1b8b5df551539c3cbb1790b40f70baa2a5ed146d56f1c7044d7adcb8a) explain the tray behavior and how to fully quit the app.
> - Behavioral Change: on Windows, closing the main window no longer quits the app when the tray is active; users must use the tray Quit action to stop the process.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c5325cb. 7 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->