### PR TITLE
fix(web): refresh open file with the file tree

### DIFF
--- a/apps/web/src/components/files/FileBrowserPanel.tsx
+++ b/apps/web/src/components/files/FileBrowserPanel.tsx
@@ -31,6 +31,7 @@ interface FileBrowserPanelProps {
   /** Bumped when the same path should be revealed again (e.g. re-opened from search). */
   selectedPathRevealId: number;
   onOpenFile: (relativePath: string) => void;
+  onRefreshSelectedFile?: () => void;
 }
 
 const TREE_UNSAFE_CSS = `
@@ -105,6 +106,7 @@ export default function FileBrowserPanel({
   selectedPath,
   selectedPathRevealId,
   onOpenFile,
+  onRefreshSelectedFile,
 }: FileBrowserPanelProps) {
   const { resolvedTheme } = useTheme();
   const composerRef = useComposerHandleContext();
@@ -254,6 +256,10 @@ export default function FileBrowserPanel({
     }
     search.setValue(value);
   };
+  const handleRefresh = () => {
+    entriesQuery.refresh();
+    onRefreshSelectedFile?.();
+  };
 
   useEffect(() => {
     if (previousTreePathsRef.current === treePaths) return;
@@ -354,7 +360,7 @@ export default function FileBrowserPanel({
         className="flex h-10 min-h-10 shrink-0 items-center gap-1 border-b border-border/60 bg-background px-2 in-data-[preview-panel-mode=inline]:mb-3 in-data-[preview-panel-mode=inline]:h-7 in-data-[preview-panel-mode=inline]:min-h-7 in-data-[preview-panel-mode=inline]:border-b-transparent"
         data-surface-subheader
       >
-        <RefreshFilesButton isPending={entriesQuery.isPending} onRefresh={entriesQuery.refresh} />
+        <RefreshFilesButton isPending={entriesQuery.isPending} onRefresh={handleRefresh} />
         <FileSearchField
           name="project-files-search"
           ariaLabel={`Search ${projectName} files`}

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -1080,6 +1080,7 @@ export default function FilePreviewPanel({
               selectedPath={relativePath}
               selectedPathRevealId={revealRequestId}
               onOpenFile={onOpenFile}
+              {...(relativePath && !isImage ? { onRefreshSelectedFile: file.refresh } : {})}
             />
           </aside>
         ) : null}


### PR DESCRIPTION
The workspace refresh button updated the file tree but left the open file's contents stale after an external edit.

The refresh action now reloads the selected text file alongside the tree. It stays user-initiated, so there is no polling, subscription, broadcast, or background traffic.

Fixes #7377

## Verification

- `pnpm --filter @t3tools/web typecheck`
- `pnpm exec vp test run apps/web/src/components/files/projectFilesQueryState.test.ts apps/web/src/components/files/FilePreviewPanel.test.ts`
- targeted lint and formatting
- integrated web pass over the Tailscale-shared development environment

Made with GPT-5.6 SOL in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 456fa6eaa3513c759eb2222412700d65f5c6da2d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refresh the open file preview when refreshing the file tree
> When the refresh button in `FileBrowserPanel` is clicked, it now also refreshes the currently open non-image file's query. This is wired via a new optional `onRefreshSelectedFile` callback prop on `FileBrowserPanel`, which `FilePreviewPanel` passes as `file.refresh` when a non-image file is selected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 456fa6e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->