### PR TITLE
fix(web): align sidebar statuses with project names

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1422,7 +1422,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                     isWokeStatus
                       ? "pointer-events-auto"
                       : "pointer-events-none group-has-[:focus-visible]/sidebar-status-slot:absolute group-has-[:focus-visible]/sidebar-status-slot:right-0 group-has-[:focus-visible]/sidebar-status-slot:opacity-0 group-hover/sidebar-row:absolute group-hover/sidebar-row:right-0 group-hover/sidebar-row:opacity-0",
-                    "self-center justify-self-end tabular-nums text-secondary-label transition-opacity",
+                    "flex items-center self-center justify-self-end tabular-nums text-secondary-label transition-opacity",
                     snoozeMenuOpen && "pointer-events-none absolute right-0 opacity-0",
                   )}
                 >


### PR DESCRIPTION
The Woke, Working, and Done badges in sidebar card rows sat about 2px above the project name. The leading SVG established the inline-flex baseline and lifted the status wrapper inside its 20px slot.

The status wrapper is now a flex container with centered children. This keeps the resting badges aligned without changing the existing hover, keyboard-focus, snooze, or settle behavior. The compact settled-row layout already used flex alignment and is unchanged.

## Verification

- `vp test run apps/web/src/components/Sidebar.logic.test.ts apps/web/src/components/Sidebar.snooze.test.ts apps/web/src/components/threadSidebarWidth.test.ts`, 116 passed
- `vp run --filter @t3tools/web typecheck`
- `vp lint apps/web/src/components/Sidebar.tsx`
- `vp fmt --check apps/web/src/components/Sidebar.tsx`
- Tested the status alignment in the local web app.

## Screenshots

Woke, before and after:

<img width="800" alt="Woke badge alignment before and after" src="https://github.com/user-attachments/assets/2d2241e0-b2ea-4f73-8176-ee068a2c8b72" />

Done and Working, before and after:

<img width="800" alt="Done and Working badge alignment before and after" src="https://github.com/user-attachments/assets/74159f31-dbb8-4c27-b973-55a565a9c4e4" />

---
Built by GPT-5.6 Sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class on a presentational wrapper in Sidebar.tsx; no logic or interaction changes.
> 
> **Overview**
> Sidebar **card** rows showed Woke, Working, and Done badges sitting slightly above the project name because the status label wrapper did not vertically center its contents inside the fixed `h-5` slot.
> 
> The change adds **`flex items-center`** to that wrapper’s classes so badges and icons align with the project row without altering hover, keyboard-focus, snooze, or settle behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5ee633ae2177535f58fe1e6d251634ff845e990. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->