### PR TITLE
perf(desktop): cache Windows shell environment

### DIFF
--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -1,6 +1,7 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, describe, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Logger from "effect/Logger";
 import * as PlatformError from "effect/PlatformError";
@@ -69,11 +70,18 @@ function runShellEnvironment(input: {
   readonly platform: NodeJS.Platform;
   readonly handler: (command: ChildProcess.Command) => string;
   readonly failure?: PlatformError.PlatformError;
+  readonly stateDir?: string;
 }) {
   const environmentLayer = Layer.succeed(
     DesktopEnvironment.DesktopEnvironment,
     DesktopEnvironment.DesktopEnvironment.of({
       platform: input.platform,
+      ...(input.stateDir === undefined
+        ? {}
+        : {
+            stateDir: input.stateDir,
+            path: { join: (directory: string, fileName: string) => `${directory}\\${fileName}` },
+          }),
     } as DesktopEnvironment.DesktopEnvironment["Service"]),
   );
   const spawnerLayer = Layer.succeed(
@@ -345,6 +353,103 @@ describe("DesktopShellEnvironment", () => {
         "C:\\Users\\testuser\\AppData\\Local\\fnm_multishells\\123",
       );
     }),
+  );
+
+  it.effect("reuses a fresh Windows shell environment cache on the next launch", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const stateDir = yield* fileSystem.makeTempDirectoryScoped({
+          prefix: "t3-windows-shell-environment-test-",
+        });
+        const makeEnv = (): NodeJS.ProcessEnv => ({
+          PATH: "C:\\Windows\\System32",
+          APPDATA: "C:\\Users\\testuser\\AppData\\Roaming",
+          LOCALAPPDATA: "C:\\Users\\testuser\\AppData\\Local",
+          USERPROFILE: "C:\\Users\\testuser",
+        });
+        let commandCount = 0;
+        const handler = (command: ChildProcess.Command) => {
+          commandCount += 1;
+          if (command._tag !== "StandardCommand") return "";
+          return command.args.includes("-NoProfile")
+            ? envOutput({ PATH: "C:\\Custom\\Bin;C:\\Windows\\System32" })
+            : envOutput({ PATH: "C:\\Profile\\Node;C:\\Windows\\System32" });
+        };
+
+        const firstEnv = makeEnv();
+        yield* runShellEnvironment({
+          env: firstEnv,
+          platform: "win32",
+          stateDir,
+          handler,
+        });
+        assert.equal(commandCount, 2);
+
+        const secondEnv = makeEnv();
+        yield* runShellEnvironment({
+          env: secondEnv,
+          platform: "win32",
+          stateDir,
+          handler,
+        });
+        assert.equal(commandCount, 2);
+        assert.equal(secondEnv.PATH, firstEnv.PATH);
+      }),
+    ).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("retries incomplete Windows shell environment probes on the next launch", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const stateDir = yield* fileSystem.makeTempDirectoryScoped({
+          prefix: "t3-windows-shell-environment-test-",
+        });
+        const makeEnv = (): NodeJS.ProcessEnv => ({
+          PATH: "C:\\Windows\\System32",
+          APPDATA: "C:\\Users\\testuser\\AppData\\Roaming",
+          LOCALAPPDATA: "C:\\Users\\testuser\\AppData\\Local",
+          USERPROFILE: "C:\\Users\\testuser",
+        });
+        let commandCount = 0;
+        let profileProbeSucceeds = false;
+        const handler = (command: ChildProcess.Command) => {
+          commandCount += 1;
+          if (command._tag !== "StandardCommand") return "";
+          if (command.args.includes("-NoProfile")) {
+            return envOutput({ PATH: "C:\\Custom\\Bin;C:\\Windows\\System32" });
+          }
+          return profileProbeSucceeds
+            ? envOutput({
+                PATH: "C:\\Profile\\Node;C:\\Windows\\System32",
+                FNM_DIR: "C:\\Users\\testuser\\AppData\\Roaming\\fnm",
+              })
+            : envOutput({ FNM_DIR: "C:\\Incomplete\\fnm" });
+        };
+
+        yield* runShellEnvironment({
+          env: makeEnv(),
+          platform: "win32",
+          stateDir,
+          handler,
+        });
+        assert.equal(commandCount, 2);
+
+        profileProbeSucceeds = true;
+        const secondEnv = makeEnv();
+        yield* runShellEnvironment({
+          env: secondEnv,
+          platform: "win32",
+          stateDir,
+          handler,
+        });
+
+        assert.equal(commandCount, 4);
+        assert.match(secondEnv.PATH ?? "", /^C:\\Profile\\Node;/u);
+        assert.equal(secondEnv.FNM_DIR, "C:\\Users\\testuser\\AppData\\Roaming\\fnm");
+      }),
+    ).pipe(Effect.provide(NodeServices.layer)),
   );
 
   it.effect("prefers login-shell desktop session hints over inherited values on linux", () =>

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -1,4 +1,5 @@
 import * as Context from "effect/Context";
+import * as Clock from "effect/Clock";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -16,6 +17,10 @@ interface ShellEnvironmentConfig {
   readonly env: NodeJS.ProcessEnv;
   readonly platform: NodeJS.Platform;
   readonly userShell: Option.Option<string>;
+  readonly windowsEnvironmentCache?: {
+    readonly path: string;
+    readonly directory: string;
+  };
 }
 
 interface WindowsProbeOptions {
@@ -93,6 +98,20 @@ const WINDOWS_SHELL_CANDIDATES = ["pwsh.exe", "powershell.exe"] as const;
 const LOGIN_SHELL_TIMEOUT = Duration.seconds(5);
 const LAUNCHCTL_TIMEOUT = Duration.seconds(2);
 const PROCESS_TERMINATE_GRACE = Duration.seconds(1);
+const WINDOWS_ENVIRONMENT_CACHE_MAX_AGE_MS = Duration.toMillis(Duration.hours(24));
+const WINDOWS_ENVIRONMENT_CACHE_FILE_NAME = "windows-shell-environment.json";
+
+const WindowsEnvironmentCache = Schema.Struct({
+  version: Schema.Literal(1),
+  capturedAt: Schema.Number,
+  inheritedPath: Schema.String,
+  noProfile: Schema.Record(Schema.String, Schema.String),
+  profile: Schema.Record(Schema.String, Schema.String),
+});
+type WindowsEnvironmentCache = typeof WindowsEnvironmentCache.Type;
+const WindowsEnvironmentCacheJson = Schema.fromJsonString(WindowsEnvironmentCache);
+const decodeWindowsEnvironmentCache = Schema.decodeUnknownOption(WindowsEnvironmentCacheJson);
+const encodeWindowsEnvironmentCache = Schema.encodeEffect(WindowsEnvironmentCacheJson);
 
 const trimNonEmpty = (value: string | null | undefined): Option.Option<string> =>
   Option.fromNullishOr(value).pipe(
@@ -383,19 +402,65 @@ const readWindowsEnvironment = Effect.fn("desktop.shellEnvironment.readWindowsEn
 const installWindowsEnvironment = Effect.fn("desktop.shellEnvironment.installWindowsEnvironment")(
   function* (
     config: ShellEnvironmentConfig,
-  ): Effect.fn.Return<void, never, ChildProcessSpawner.ChildProcessSpawner> {
-    // Concurrent, not sequential: these two probes are independent (only their
-    // results are combined below) and each spawns its own PowerShell. Run in
-    // series they sit at offset 0 of desktop.startup, before anything else, and
-    // launch traces measured them at 2718ms then 2066ms — the entire 4.8s
-    // startup span, of which desktop.bootstrap is ~30ms.
-    const [noProfile, profile] = yield* Effect.all(
-      [
-        readWindowsEnvironment(["PATH"], { loadProfile: false }),
-        readWindowsEnvironment(WINDOWS_PROFILE_ENV_NAMES, { loadProfile: true }),
-      ],
-      { concurrency: 2 },
-    );
+  ): Effect.fn.Return<
+    void,
+    never,
+    ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem
+  > {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const inheritedPath = Option.getOrElse(readEnvPath(config.env), () => "");
+    const cache = config.windowsEnvironmentCache ?? null;
+    const cachePath = cache?.path ?? null;
+    const now = yield* Clock.currentTimeMillis;
+    // Loading a PowerShell profile dominates warm Windows launches. Reuse its
+    // small environment snapshot while the inherited PATH is unchanged, but
+    // bound its lifetime so profile-only changes are eventually discovered.
+    // A missing, corrupt, or stale cache simply falls through to the probes.
+    const cached: Option.Option<WindowsEnvironmentCache> =
+      cachePath === null
+        ? Option.none<WindowsEnvironmentCache>()
+        : yield* fileSystem.readFileString(cachePath).pipe(
+            Effect.map(decodeWindowsEnvironmentCache),
+            Effect.orElseSucceed(() => Option.none()),
+            Effect.map((entry) =>
+              Option.filter(
+                entry,
+                (value) =>
+                  value.inheritedPath === inheritedPath &&
+                  now >= value.capturedAt &&
+                  now - value.capturedAt <= WINDOWS_ENVIRONMENT_CACHE_MAX_AGE_MS,
+              ),
+            ),
+          );
+
+    const [noProfile, profile] = Option.isSome(cached)
+      ? [cached.value.noProfile, cached.value.profile]
+      : yield* Effect.all(
+          [
+            readWindowsEnvironment(["PATH"], { loadProfile: false }),
+            readWindowsEnvironment(WINDOWS_PROFILE_ENV_NAMES, { loadProfile: true }),
+          ],
+          { concurrency: 2 },
+        );
+
+    const probesCompleted =
+      Option.isSome(trimNonEmpty(noProfile.PATH)) && Option.isSome(trimNonEmpty(profile.PATH));
+
+    if (Option.isNone(cached) && cache !== null && probesCompleted) {
+      const encoded = yield* encodeWindowsEnvironmentCache({
+        version: 1,
+        capturedAt: now,
+        inheritedPath,
+        noProfile,
+        profile,
+      }).pipe(Effect.option);
+      if (Option.isSome(encoded)) {
+        yield* fileSystem.makeDirectory(cache.directory, { recursive: true }).pipe(
+          Effect.andThen(fileSystem.writeFileString(cache.path, `${encoded.value}\n`)),
+          Effect.catchCause(() => Effect.void),
+        );
+      }
+    }
     const mergedPath = mergePaths("win32", [
       trimNonEmpty(profile.PATH),
       trimNonEmpty(knownWindowsCliDirs(config.env).join(";")),
@@ -539,6 +604,17 @@ export const make = Effect.gen(function* () {
       env: process.env,
       platform: environment.platform,
       userShell: Option.none(),
+      ...(typeof environment.stateDir === "string" && environment.stateDir.length > 0
+        ? {
+            windowsEnvironmentCache: {
+              path: environment.path.join(
+                environment.stateDir,
+                WINDOWS_ENVIRONMENT_CACHE_FILE_NAME,
+              ),
+              directory: environment.stateDir,
+            },
+          }
+        : {}),
     }).pipe(
       Effect.provideService(FileSystem.FileSystem, fileSystem),
       Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),


### PR DESCRIPTION
## What Changed

- Cache successful PowerShell-derived Windows shell environment snapshots between desktop launches.
- Reuse the snapshot for up to 24 hours while the inherited `PATH` remains unchanged.
- Retry discovery after failed, timed-out, or incomplete probes instead of caching partial results.
- Add focused coverage for cache reuse and incomplete-probe recovery.

The independent Windows tray/background feature is tracked in #7493.

## Why

Loading the PowerShell profile dominates repeated Windows desktop startup. Reusing a verified snapshot removes that repeated work while the inherited environment is stable, without allowing a transient probe failure to suppress profile-derived `PATH` and FNM variables for 24 hours.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (not applicable; no UI changes)
- [x] I included a video for animation/interaction changes (not applicable; no interaction changes)

Implemented with GPT-5.6-sol through the Codex harness in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache Windows shell environment to disk to avoid redundant PowerShell probes on launch
> - On Windows, `installWindowsEnvironment` now reads a cache file (stored in `stateDir`) before running PowerShell probes. The cache is reused when the inherited PATH matches and the cache is ≤24 hours old.
> - If no valid cache exists, the two PowerShell probes (`-NoProfile` and profile) run concurrently as before. A new cache is written only when both probes return PATH.
> - Incomplete probe results (missing PATH) are not cached, forcing a fresh probe on the next launch.
> - Two new tests in [DesktopShellEnvironment.test.ts](https://github.com/pingdotgg/t3code/pull/7492/files#diff-f471118e4cc833dc2f437b6809611dd111ffc1bcfd2663f2241b0e2fd767bdce) cover cache reuse and incomplete-probe retry behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 75c39fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Windows shell environment results are now cached between launches, reducing repeated PowerShell checks and improving startup speed.

* **Reliability**
  * Incomplete Windows environment checks are retried on the next launch instead of being reused as valid results.
  * Cached results are validated before reuse and refreshed when outdated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->