### PR TITLE
feat(web): add mermaid rendering to chat UI + zoom and pan

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,6 +39,7 @@
     "jszip": "3.10.1",
     "lexical": "^0.41.0",
     "lucide-react": "^0.564.0",
+    "mermaid": "^11.16.1",
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "react-markdown": "^10.1.0",

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1538,6 +1538,19 @@ function ChatMarkdown({
     ];
     return buildFileLinkParentSuffixByPath(filePaths);
   }, [inlineCodeFileLinkMetaByText, markdownFileLinkMetaByHref]);
+  // ReactMarkdown remounts every custom tag whose component identity changes.
+  // Streaming updates `text` (and the file-link maps derived from it) on every
+  // token; keep those on refs so mermaid state survives until the fence settles.
+  const textRef = useRef(text);
+  textRef.current = text;
+  const isStreamingRef = useRef(isStreaming);
+  isStreamingRef.current = isStreaming;
+  const markdownFileLinkMetaByHrefRef = useRef(markdownFileLinkMetaByHref);
+  markdownFileLinkMetaByHrefRef.current = markdownFileLinkMetaByHref;
+  const inlineCodeFileLinkMetaByTextRef = useRef(inlineCodeFileLinkMetaByText);
+  inlineCodeFileLinkMetaByTextRef.current = inlineCodeFileLinkMetaByText;
+  const fileLinkParentSuffixByPathRef = useRef(fileLinkParentSuffixByPath);
+  fileLinkParentSuffixByPathRef.current = fileLinkParentSuffixByPath;
   const markdownUrlTransform = useCallback((href: string) => {
     return rewriteMarkdownFileUriHref(href) ?? defaultUrlTransform(href);
   }, []);
@@ -1632,14 +1645,14 @@ function ChatMarkdown({
   );
   /* eslint-disable react/no-unstable-nested-components -- ReactMarkdown requires component
    * renderers that close over this message's metadata. useMemo keeps them stable until that
-   * metadata changes. */
+   * metadata changes. Streaming text is read from refs so mermaid diagrams do not remount. */
   const markdownComponents = useMemo<Components>(() => {
     const fileLinkChip = (
       fileLinkMeta: MarkdownFileLinkMeta,
       copyMarkdown: string,
       className?: string,
     ) => {
-      const parentSuffix = fileLinkParentSuffixByPath.get(fileLinkMeta.filePath);
+      const parentSuffix = fileLinkParentSuffixByPathRef.current.get(fileLinkMeta.filePath);
       const labelParts = [fileLinkMeta.basename];
       if (typeof parentSuffix === "string" && parentSuffix.length > 0) {
         labelParts.push(parentSuffix);
@@ -1712,7 +1725,9 @@ function ChatMarkdown({
       li({ node, children, ...props }) {
         const listItemStart = node?.position?.start.offset;
         const markerOffset =
-          typeof listItemStart === "number" ? findTaskListMarkerOffset(text, listItemStart) : null;
+          typeof listItemStart === "number"
+            ? findTaskListMarkerOffset(textRef.current, listItemStart)
+            : null;
         return (
           <li {...props} data-task-marker-offset={markerOffset ?? undefined}>
             {renderSkillInlineMarkdownChildren(children, skills)}
@@ -1750,7 +1765,9 @@ function ChatMarkdown({
       },
       a({ node, href, children, title: _title, ...props }) {
         const normalizedHref = href ? normalizeMarkdownLinkHrefKey(href) : "";
-        const fileLinkMeta = normalizedHref ? markdownFileLinkMetaByHref.get(normalizedHref) : null;
+        const fileLinkMeta = normalizedHref
+          ? markdownFileLinkMetaByHrefRef.current.get(normalizedHref)
+          : null;
         if (!fileLinkMeta) {
           const faviconHost = resolveExternalWebLinkHost(href);
           const isSameDocumentLink = href?.startsWith("#") ?? false;
@@ -1840,7 +1857,7 @@ function ChatMarkdown({
         if (node?.properties?.dataInlineCode != null) {
           const codeText = nodeToPlainText(children);
           const fileLinkMeta =
-            inlineCodeFileLinkMetaByText.get(codeText.trim()) ??
+            inlineCodeFileLinkMetaByTextRef.current.get(codeText.trim()) ??
             resolveInlineCodeFileLinkMeta(codeText, cwd);
           if (fileLinkMeta) {
             return fileLinkChip(fileLinkMeta, `\`${codeText}\``);
@@ -1873,7 +1890,7 @@ function ChatMarkdown({
                 className={codeBlock.className}
                 code={codeBlock.code}
                 themeName={diffThemeName}
-                isStreaming={isStreaming}
+                isStreaming={isStreamingRef.current}
               />
             </Suspense>
           </RenderErrorBoundary>
@@ -1885,7 +1902,7 @@ function ChatMarkdown({
               language={language}
               fenceTitle={fenceTitle}
               theme={resolvedTheme}
-              isStreaming={isStreaming}
+              isStreaming={isStreamingRef.current}
             >
               {highlighted}
             </MermaidMarkdownCodeBlock>
@@ -1906,10 +1923,6 @@ function ChatMarkdown({
   }, [
     cwd,
     diffThemeName,
-    fileLinkParentSuffixByPath,
-    inlineCodeFileLinkMetaByText,
-    isStreaming,
-    markdownFileLinkMetaByHref,
     onTaskListChange,
     openFileInPanel,
     openInPreferredEditor,
@@ -1917,7 +1930,6 @@ function ChatMarkdown({
     openMarkdownFileInPreview,
     resolvedTheme,
     skills,
-    text,
     threadRef,
   ]);
   /* eslint-enable react/no-unstable-nested-components */

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -2,6 +2,7 @@ import { useAtomValue } from "@effect/atom-react";
 import {
   CheckIcon,
   ChevronRightIcon,
+  CodeIcon,
   CopyIcon,
   GlobeIcon,
   InfoIcon,
@@ -11,6 +12,7 @@ import {
   Minimize2Icon,
   OctagonAlertIcon,
   TriangleAlertIcon,
+  WorkflowIcon,
   WrapTextIcon,
 } from "lucide-react";
 import type { ScopedThreadRef, ServerProviderSkill } from "@t3tools/contracts";
@@ -63,7 +65,9 @@ import { useOpenInPreferredEditor } from "../editorPreferences";
 import { resolveDiffThemeName, type DiffThemeName } from "../lib/diffRendering";
 import { fnv1a32 } from "../lib/diffRendering";
 import { LRUCache } from "../lib/lruCache";
+import { isMermaidFenceLanguage } from "../lib/mermaidRendering";
 import { getSyntaxHighlighterPromise } from "../lib/syntaxHighlighting";
+import { MermaidDiagram } from "./chat/MermaidDiagram";
 import { RenderErrorBoundary } from "./RenderErrorBoundary";
 import { useTheme } from "../hooks/useTheme";
 import { getClientSettings } from "../hooks/useSettings";
@@ -617,19 +621,24 @@ function MarkdownCodeBlock({
   language,
   fenceTitle,
   theme,
+  diagram,
   children,
 }: {
   code: string;
   language: string;
   fenceTitle: string | null;
   theme: "light" | "dark";
+  diagram?: ReactNode;
   children: ReactNode;
 }) {
   const [copied, setCopied] = useState(false);
   const [wrapped, setWrapped] = useState(readInitialWordWrapSetting);
+  const [view, setView] = useState<"code" | "diagram">(diagram ? "diagram" : "code");
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const showingDiagram = diagram != null && view === "diagram";
   const wrapLabel = wrapped ? "Disable line wrap" : "Wrap lines";
   const copyLabel = copied ? "Copied" : "Copy code";
+  const diagramToggleLabel = showingDiagram ? "Show code" : "Show diagram";
 
   const handleCopy = useCallback(() => {
     if (typeof navigator === "undefined" || navigator.clipboard == null) {
@@ -674,6 +683,7 @@ function MarkdownCodeBlock({
       className="chat-markdown-codeblock my-[0.65rem] overflow-hidden rounded-[var(--radius)] border border-border/70 bg-secondary leading-snug dark:border-transparent dark:bg-input/32"
       data-language={language}
       data-wrap={wrapped ? "true" : "false"}
+      data-mermaid-view={diagram != null ? view : undefined}
     >
       <div className="chat-markdown-codeblock-header flex items-center justify-between gap-2 pt-1.5 pr-1.5 pb-0 pl-3 select-none">
         <span className="inline-flex min-w-0 items-center gap-[0.4rem] [font-family:var(--font-mono,ui-monospace,SFMono-Regular,monospace)] [font-size:0.6875rem]">
@@ -684,24 +694,52 @@ function MarkdownCodeBlock({
           />
         </span>
         <span className="flex items-center gap-0.5" role="toolbar" aria-label="Code block actions">
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-xs"
-                  className="chat-markdown-chrome-action"
-                  aria-pressed={wrapped}
-                  onClick={() => setWrapped((value) => !value)}
-                  aria-label={wrapLabel}
-                />
-              }
-            >
-              <WrapTextIcon className="size-3" />
-            </TooltipTrigger>
-            <TooltipPopup side="top">{wrapLabel}</TooltipPopup>
-          </Tooltip>
+          {diagram != null ? (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    className="chat-markdown-chrome-action"
+                    aria-pressed={showingDiagram}
+                    onClick={() =>
+                      setView((current) => (current === "diagram" ? "code" : "diagram"))
+                    }
+                    aria-label={diagramToggleLabel}
+                  />
+                }
+              >
+                {showingDiagram ? (
+                  <CodeIcon className="size-3" />
+                ) : (
+                  <WorkflowIcon className="size-3" />
+                )}
+              </TooltipTrigger>
+              <TooltipPopup side="top">{diagramToggleLabel}</TooltipPopup>
+            </Tooltip>
+          ) : null}
+          {showingDiagram ? null : (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    className="chat-markdown-chrome-action"
+                    aria-pressed={wrapped}
+                    onClick={() => setWrapped((value) => !value)}
+                    aria-label={wrapLabel}
+                  />
+                }
+              >
+                <WrapTextIcon className="size-3" />
+              </TooltipTrigger>
+              <TooltipPopup side="top">{wrapLabel}</TooltipPopup>
+            </Tooltip>
+          )}
           <Tooltip>
             <TooltipTrigger
               render={
@@ -721,7 +759,7 @@ function MarkdownCodeBlock({
           </Tooltip>
         </span>
       </div>
-      {children}
+      {showingDiagram ? diagram : children}
     </div>
   );
 }
@@ -1751,6 +1789,23 @@ function ChatMarkdown({
             language={language}
             fenceTitle={fenceTitle}
             theme={resolvedTheme}
+            diagram={
+              isMermaidFenceLanguage(language) ? (
+                <RenderErrorBoundary
+                  fallback={
+                    <div className="chat-markdown-mermaid-error" role="alert">
+                      <p>Couldn't render this diagram.</p>
+                    </div>
+                  }
+                >
+                  <MermaidDiagram
+                    code={codeBlock.code}
+                    theme={resolvedTheme}
+                    isStreaming={isStreaming}
+                  />
+                </RenderErrorBoundary>
+              ) : undefined
+            }
           >
             <RenderErrorBoundary fallback={<pre {...props}>{children}</pre>}>
               <Suspense fallback={<pre {...props}>{children}</pre>}>

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -65,7 +65,7 @@ import { useOpenInPreferredEditor } from "../editorPreferences";
 import { resolveDiffThemeName, type DiffThemeName } from "../lib/diffRendering";
 import { fnv1a32 } from "../lib/diffRendering";
 import { LRUCache } from "../lib/lruCache";
-import { isMermaidFenceLanguage } from "../lib/mermaidRendering";
+import { isMermaidFenceLanguage, mermaidSourceAsMarkdownFence } from "../lib/mermaidRendering";
 import { getSyntaxHighlighterPromise } from "../lib/syntaxHighlighting";
 import { MermaidDiagram } from "./chat/MermaidDiagram";
 import { MermaidOverlay } from "./chat/MermaidOverlay";
@@ -819,7 +819,11 @@ function MermaidMarkdownCodeBlock({
         diagram={
           <RenderErrorBoundary
             fallback={
-              <div className="chat-markdown-mermaid-error" role="alert">
+              <div
+                className="chat-markdown-mermaid-error"
+                data-markdown-copy={mermaidSourceAsMarkdownFence(code)}
+                role="alert"
+              >
                 <p>Couldn't render this diagram.</p>
               </div>
             }

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -68,6 +68,7 @@ import { LRUCache } from "../lib/lruCache";
 import { isMermaidFenceLanguage } from "../lib/mermaidRendering";
 import { getSyntaxHighlighterPromise } from "../lib/syntaxHighlighting";
 import { MermaidDiagram } from "./chat/MermaidDiagram";
+import { MermaidOverlay } from "./chat/MermaidOverlay";
 import { RenderErrorBoundary } from "./RenderErrorBoundary";
 import { useTheme } from "../hooks/useTheme";
 import { getClientSettings } from "../hooks/useSettings";
@@ -622,6 +623,8 @@ function MarkdownCodeBlock({
   fenceTitle,
   theme,
   diagram,
+  canExpandDiagram = false,
+  onExpandDiagram,
   children,
 }: {
   code: string;
@@ -629,6 +632,8 @@ function MarkdownCodeBlock({
   fenceTitle: string | null;
   theme: "light" | "dark";
   diagram?: ReactNode;
+  canExpandDiagram?: boolean;
+  onExpandDiagram?: () => void;
   children: ReactNode;
 }) {
   const [copied, setCopied] = useState(false);
@@ -720,6 +725,26 @@ function MarkdownCodeBlock({
               <TooltipPopup side="top">{diagramToggleLabel}</TooltipPopup>
             </Tooltip>
           ) : null}
+          {showingDiagram && canExpandDiagram && onExpandDiagram != null ? (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    className="chat-markdown-chrome-action"
+                    onClick={onExpandDiagram}
+                    aria-label="Expand diagram"
+                    data-mermaid-expand=""
+                  />
+                }
+              >
+                <Maximize2Icon className="size-3" />
+              </TooltipTrigger>
+              <TooltipPopup side="top">Expand diagram</TooltipPopup>
+            </Tooltip>
+          ) : null}
           {showingDiagram ? null : (
             <Tooltip>
               <TooltipTrigger
@@ -761,6 +786,64 @@ function MarkdownCodeBlock({
       </div>
       {showingDiagram ? diagram : children}
     </div>
+  );
+}
+
+function MermaidMarkdownCodeBlock({
+  code,
+  language,
+  fenceTitle,
+  theme,
+  isStreaming,
+  children,
+}: {
+  code: string;
+  language: string;
+  fenceTitle: string | null;
+  theme: "light" | "dark";
+  isStreaming: boolean;
+  children: ReactNode;
+}) {
+  const [overlayOpen, setOverlayOpen] = useState(false);
+  const [svg, setSvg] = useState<string | null>(null);
+
+  return (
+    <>
+      <MarkdownCodeBlock
+        code={code}
+        language={language}
+        fenceTitle={fenceTitle}
+        theme={theme}
+        canExpandDiagram={svg != null}
+        onExpandDiagram={() => setOverlayOpen(true)}
+        diagram={
+          <RenderErrorBoundary
+            fallback={
+              <div className="chat-markdown-mermaid-error" role="alert">
+                <p>Couldn't render this diagram.</p>
+              </div>
+            }
+          >
+            <MermaidDiagram
+              code={code}
+              theme={theme}
+              isStreaming={isStreaming}
+              onSvgChange={setSvg}
+            />
+          </RenderErrorBoundary>
+        }
+      >
+        {children}
+      </MarkdownCodeBlock>
+      {svg != null ? (
+        <MermaidOverlay
+          open={overlayOpen}
+          svg={svg}
+          title={fenceTitle ?? "Diagram"}
+          onOpenChange={setOverlayOpen}
+        />
+      ) : null}
+    </>
   );
 }
 
@@ -1783,40 +1866,39 @@ function ChatMarkdown({
 
         const language = extractFenceLanguage(codeBlock.className);
         const fenceTitle = extractFenceTitle(extractPreCodeMeta(node));
+        const highlighted = (
+          <RenderErrorBoundary fallback={<pre {...props}>{children}</pre>}>
+            <Suspense fallback={<pre {...props}>{children}</pre>}>
+              <SuspenseShikiCodeBlock
+                className={codeBlock.className}
+                code={codeBlock.code}
+                themeName={diffThemeName}
+                isStreaming={isStreaming}
+              />
+            </Suspense>
+          </RenderErrorBoundary>
+        );
+        if (isMermaidFenceLanguage(language)) {
+          return (
+            <MermaidMarkdownCodeBlock
+              code={codeBlock.code}
+              language={language}
+              fenceTitle={fenceTitle}
+              theme={resolvedTheme}
+              isStreaming={isStreaming}
+            >
+              {highlighted}
+            </MermaidMarkdownCodeBlock>
+          );
+        }
         return (
           <MarkdownCodeBlock
             code={codeBlock.code}
             language={language}
             fenceTitle={fenceTitle}
             theme={resolvedTheme}
-            diagram={
-              isMermaidFenceLanguage(language) ? (
-                <RenderErrorBoundary
-                  fallback={
-                    <div className="chat-markdown-mermaid-error" role="alert">
-                      <p>Couldn't render this diagram.</p>
-                    </div>
-                  }
-                >
-                  <MermaidDiagram
-                    code={codeBlock.code}
-                    theme={resolvedTheme}
-                    isStreaming={isStreaming}
-                  />
-                </RenderErrorBoundary>
-              ) : undefined
-            }
           >
-            <RenderErrorBoundary fallback={<pre {...props}>{children}</pre>}>
-              <Suspense fallback={<pre {...props}>{children}</pre>}>
-                <SuspenseShikiCodeBlock
-                  className={codeBlock.className}
-                  code={codeBlock.code}
-                  themeName={diffThemeName}
-                  isStreaming={isStreaming}
-                />
-              </Suspense>
-            </RenderErrorBoundary>
+            {highlighted}
           </MarkdownCodeBlock>
         );
       },

--- a/apps/web/src/components/chat/MermaidDiagram.tsx
+++ b/apps/web/src/components/chat/MermaidDiagram.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "react";
+
+import {
+  mermaidSourceAsMarkdownFence,
+  renderMermaidSvg,
+  type MermaidColorScheme,
+} from "~/lib/mermaidRendering";
+
+const STREAMING_RENDER_DEBOUNCE_MS = 120;
+
+interface MermaidDiagramProps {
+  readonly code: string;
+  readonly theme: MermaidColorScheme;
+  readonly isStreaming: boolean;
+}
+
+type MermaidDiagramState =
+  | { readonly status: "idle" }
+  | { readonly status: "ready"; readonly svg: string }
+  | { readonly status: "error"; readonly message: string };
+
+export function MermaidDiagram({ code, theme, isStreaming }: MermaidDiagramProps) {
+  const [state, setState] = useState<MermaidDiagramState>({ status: "idle" });
+
+  useEffect(() => {
+    const trimmed = code.trim();
+    if (trimmed.length === 0) {
+      setState({ status: "idle" });
+      return;
+    }
+
+    let cancelled = false;
+    const run = () => {
+      void renderMermaidSvg(trimmed, theme).then(
+        (svg) => {
+          if (!cancelled) setState({ status: "ready", svg });
+        },
+        (cause) => {
+          if (cancelled) return;
+          if (isStreaming) {
+            // Incomplete fences fail parse on nearly every token. Keep the last
+            // good diagram (or the idle placeholder) until the source settles.
+            return;
+          }
+          const message = cause instanceof Error ? cause.message : "Couldn't render this diagram.";
+          setState({ status: "error", message });
+        },
+      );
+    };
+
+    const timeout = isStreaming ? setTimeout(run, STREAMING_RENDER_DEBOUNCE_MS) : undefined;
+    if (!isStreaming) run();
+
+    return () => {
+      cancelled = true;
+      if (timeout != null) clearTimeout(timeout);
+    };
+  }, [code, isStreaming, theme]);
+
+  const copyMarkdown = mermaidSourceAsMarkdownFence(code);
+
+  if (state.status === "ready") {
+    return (
+      <div
+        className="chat-markdown-mermaid"
+        data-markdown-copy={copyMarkdown}
+        dangerouslySetInnerHTML={{ __html: state.svg }}
+      />
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <div className="chat-markdown-mermaid-error" data-markdown-copy={copyMarkdown} role="alert">
+        <p>Couldn't render this diagram.</p>
+        <p>{state.message}</p>
+      </div>
+    );
+  }
+
+  return (
+    <pre className="chat-markdown-mermaid-pending" data-markdown-copy={copyMarkdown}>
+      {code.replace(/\n$/, "")}
+    </pre>
+  );
+}

--- a/apps/web/src/components/chat/MermaidDiagram.tsx
+++ b/apps/web/src/components/chat/MermaidDiagram.tsx
@@ -12,6 +12,7 @@ interface MermaidDiagramProps {
   readonly code: string;
   readonly theme: MermaidColorScheme;
   readonly isStreaming: boolean;
+  readonly onSvgChange?: (svg: string | null) => void;
 }
 
 type MermaidDiagramState =
@@ -19,7 +20,7 @@ type MermaidDiagramState =
   | { readonly status: "ready"; readonly svg: string }
   | { readonly status: "error"; readonly message: string };
 
-export function MermaidDiagram({ code, theme, isStreaming }: MermaidDiagramProps) {
+export function MermaidDiagram({ code, theme, isStreaming, onSvgChange }: MermaidDiagramProps) {
   const [state, setState] = useState<MermaidDiagramState>({ status: "idle" });
 
   useEffect(() => {
@@ -56,6 +57,16 @@ export function MermaidDiagram({ code, theme, isStreaming }: MermaidDiagramProps
       if (timeout != null) clearTimeout(timeout);
     };
   }, [code, isStreaming, theme]);
+
+  useEffect(() => {
+    if (state.status === "ready") {
+      onSvgChange?.(state.svg);
+      return;
+    }
+    if (state.status === "error" || code.trim().length === 0) {
+      onSvgChange?.(null);
+    }
+  }, [code, onSvgChange, state]);
 
   const copyMarkdown = mermaidSourceAsMarkdownFence(code);
 

--- a/apps/web/src/components/chat/MermaidDiagram.tsx
+++ b/apps/web/src/components/chat/MermaidDiagram.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 
 import {
   mermaidSourceAsMarkdownFence,
+  peekCachedMermaidSvg,
   renderMermaidSvg,
   type MermaidColorScheme,
 } from "~/lib/mermaidRendering";
@@ -21,7 +22,10 @@ type MermaidDiagramState =
   | { readonly status: "error"; readonly message: string };
 
 export function MermaidDiagram({ code, theme, isStreaming, onSvgChange }: MermaidDiagramProps) {
-  const [state, setState] = useState<MermaidDiagramState>({ status: "idle" });
+  const [state, setState] = useState<MermaidDiagramState>(() => {
+    const cached = peekCachedMermaidSvg(code, theme);
+    return cached == null ? { status: "idle" } : { status: "ready", svg: cached };
+  });
 
   useEffect(() => {
     const trimmed = code.trim();

--- a/apps/web/src/components/chat/MermaidOverlay.tsx
+++ b/apps/web/src/components/chat/MermaidOverlay.tsx
@@ -1,4 +1,5 @@
 import {
+  useCallback,
   useEffect,
   useId,
   useLayoutEffect,
@@ -10,17 +11,21 @@ import {
 } from "react";
 import { RotateCcwIcon, XIcon, ZoomInIcon, ZoomOutIcon } from "lucide-react";
 
-import { remapMermaidSvgIds } from "~/lib/mermaidRendering";
+import { prepareMermaidOverlaySvg } from "~/lib/mermaidRendering";
 import {
   fitMermaidViewport,
+  keepMermaidViewportInScene,
   MAX_MERMAID_OVERLAY_ZOOM,
+  mermaidOverlayZoomPercent,
   mermaidSvgContentSize,
+  mermaidViewportContentCenter,
   MERMAID_OVERLAY_ZOOM_STEP,
   MIN_MERMAID_OVERLAY_ZOOM,
   panMermaidViewport,
   resetMermaidViewport,
   zoomMermaidViewportAtPoint,
   type MermaidViewport,
+  type Size,
 } from "~/lib/mermaidViewport";
 import { Button } from "~/components/ui/button";
 import {
@@ -50,75 +55,83 @@ function scenePoint(
   return { x: clientX - rect.left, y: clientY - rect.top };
 }
 
-function measuredSvgSize(
-  scene: HTMLElement,
-  zoom: number,
-): { width: number; height: number } | null {
-  const svg = scene.querySelector("svg");
-  if (!(svg instanceof SVGElement) || zoom === 0) return null;
-  const rect = svg.getBoundingClientRect();
-  const width = rect.width / zoom;
-  const height = rect.height / zoom;
-  if (width <= 0 || height <= 0) return null;
-  return { width, height };
+function sceneSize(scene: HTMLElement): Size {
+  return { width: scene.clientWidth, height: scene.clientHeight };
 }
 
 export function MermaidOverlay({ open, svg, title, onOpenChange }: MermaidOverlayProps) {
   const overlayDomId = useId().replace(/[^a-zA-Z0-9_-]/g, "");
   const sceneRef = useRef<HTMLDivElement | null>(null);
   const viewportRef = useRef<MermaidViewport>(resetMermaidViewport());
+  const fitZoomRef = useRef(1);
   const pointerRef = useRef<{ x: number; y: number } | null>(null);
   const userAdjustedRef = useRef(false);
   const [sceneEl, setSceneEl] = useState<HTMLDivElement | null>(null);
   const [viewport, setViewport] = useState<MermaidViewport>(resetMermaidViewport);
+  const [fitZoom, setFitZoom] = useState(1);
   const [panning, setPanning] = useState(false);
 
   const overlaySvg = useMemo(
-    () => remapMermaidSvgIds(svg, `-${overlayDomId}`),
+    () => prepareMermaidOverlaySvg(svg, `-${overlayDomId}`),
     [overlayDomId, svg],
   );
-  const contentSize = useMemo(() => mermaidSvgContentSize(svg), [svg]);
+  const contentSize = useMemo(() => mermaidSvgContentSize(overlaySvg), [overlaySvg]);
 
-  const setSceneNode = (node: HTMLDivElement | null) => {
+  const lastSceneSizeRef = useRef<Size | null>(null);
+
+  const setSceneNode = useCallback((node: HTMLDivElement | null) => {
     sceneRef.current = node;
     setSceneEl((current) => (current === node ? current : node));
-  };
+  }, []);
 
   const commitViewport = (next: MermaidViewport, userAdjusted: boolean) => {
+    const scene = sceneRef.current;
+    const clamped =
+      scene != null && contentSize != null
+        ? keepMermaidViewportInScene(next, sceneSize(scene), contentSize)
+        : next;
     if (userAdjusted) userAdjustedRef.current = true;
-    viewportRef.current = next;
-    setViewport(next);
+    viewportRef.current = clamped;
+    setViewport(clamped);
   };
 
   const fitToScene = (scene: HTMLElement) => {
-    if (scene.clientWidth <= 0 || scene.clientHeight <= 0) return;
-    const size = contentSize ?? measuredSvgSize(scene, viewportRef.current.zoom);
-    if (!size) return;
+    if (scene.clientWidth <= 0 || scene.clientHeight <= 0 || contentSize == null) return;
+    const next = fitMermaidViewport(sceneSize(scene), contentSize);
+    lastSceneSizeRef.current = sceneSize(scene);
     userAdjustedRef.current = false;
-    commitViewport(
-      fitMermaidViewport({ width: scene.clientWidth, height: scene.clientHeight }, size),
-      false,
-    );
+    fitZoomRef.current = next.zoom;
+    setFitZoom(next.zoom);
+    viewportRef.current = next;
+    setViewport(next);
   };
 
   useLayoutEffect(() => {
     if (!open) {
       userAdjustedRef.current = false;
       pointerRef.current = null;
-      commitViewport(resetMermaidViewport(), false);
+      fitZoomRef.current = 1;
+      viewportRef.current = resetMermaidViewport();
+      setFitZoom(1);
+      setViewport(resetMermaidViewport());
       return;
     }
-    if (sceneEl) fitToScene(sceneEl);
-  }, [open, svg, sceneEl, contentSize]);
+    if (sceneEl && !userAdjustedRef.current) fitToScene(sceneEl);
+  }, [open, overlaySvg, sceneEl, contentSize]);
 
   useEffect(() => {
     if (!open || sceneEl == null || typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver(() => {
-      if (!userAdjustedRef.current) fitToScene(sceneEl);
+    const observer = new ResizeObserver((entries) => {
+      if (userAdjustedRef.current) return;
+      const size = entries[0]?.contentRect;
+      if (size == null) return;
+      const last = lastSceneSizeRef.current;
+      if (last != null && last.width === size.width && last.height === size.height) return;
+      fitToScene(sceneEl);
     });
     observer.observe(sceneEl);
     return () => observer.disconnect();
-  }, [open, svg, sceneEl, contentSize]);
+  }, [open, overlaySvg, sceneEl, contentSize]);
 
   useEffect(() => {
     if (!open || sceneEl == null) return;
@@ -132,6 +145,7 @@ export function MermaidOverlay({ open, svg, title, onOpenChange }: MermaidOverla
           viewportRef.current,
           viewportRef.current.zoom * factor,
           scenePoint(sceneEl, event.clientX, event.clientY),
+          fitZoomRef.current,
         ),
         true,
       );
@@ -139,18 +153,18 @@ export function MermaidOverlay({ open, svg, title, onOpenChange }: MermaidOverla
 
     sceneEl.addEventListener("wheel", onWheel, { passive: false });
     return () => sceneEl.removeEventListener("wheel", onWheel);
-  }, [open, sceneEl]);
+  }, [open, sceneEl, contentSize]);
 
   const zoomByStep = (direction: 1 | -1) => {
-    const scene = sceneRef.current;
-    if (!scene) return;
-    const rect = scene.getBoundingClientRect();
+    if (contentSize == null) return;
     const step = direction === 1 ? MERMAID_OVERLAY_ZOOM_STEP : 1 / MERMAID_OVERLAY_ZOOM_STEP;
     commitViewport(
-      zoomMermaidViewportAtPoint(viewportRef.current, viewportRef.current.zoom * step, {
-        x: rect.width / 2,
-        y: rect.height / 2,
-      }),
+      zoomMermaidViewportAtPoint(
+        viewportRef.current,
+        viewportRef.current.zoom * step,
+        mermaidViewportContentCenter(viewportRef.current, contentSize),
+        fitZoomRef.current,
+      ),
       true,
     );
   };
@@ -198,9 +212,9 @@ export function MermaidOverlay({ open, svg, title, onOpenChange }: MermaidOverla
     }
   };
 
-  const zoomPercent = Math.round(viewport.zoom * 100);
-  const zoomInDisabled = viewport.zoom >= MAX_MERMAID_OVERLAY_ZOOM;
-  const zoomOutDisabled = viewport.zoom <= MIN_MERMAID_OVERLAY_ZOOM;
+  const zoomPercent = mermaidOverlayZoomPercent(viewport.zoom, fitZoom);
+  const zoomInDisabled = viewport.zoom >= fitZoom * MAX_MERMAID_OVERLAY_ZOOM - 1e-6;
+  const zoomOutDisabled = viewport.zoom <= fitZoom * MIN_MERMAID_OVERLAY_ZOOM + 1e-6;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/apps/web/src/components/chat/MermaidOverlay.tsx
+++ b/apps/web/src/components/chat/MermaidOverlay.tsx
@@ -1,0 +1,330 @@
+import {
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type PointerEvent,
+} from "react";
+import { RotateCcwIcon, XIcon, ZoomInIcon, ZoomOutIcon } from "lucide-react";
+
+import { remapMermaidSvgIds } from "~/lib/mermaidRendering";
+import {
+  fitMermaidViewport,
+  MAX_MERMAID_OVERLAY_ZOOM,
+  mermaidSvgContentSize,
+  MERMAID_OVERLAY_ZOOM_STEP,
+  MIN_MERMAID_OVERLAY_ZOOM,
+  panMermaidViewport,
+  resetMermaidViewport,
+  zoomMermaidViewportAtPoint,
+  type MermaidViewport,
+} from "~/lib/mermaidViewport";
+import { Button } from "~/components/ui/button";
+import {
+  Dialog,
+  DialogDescription,
+  DialogHeader,
+  DialogPopup,
+  DialogTitle,
+} from "~/components/ui/dialog";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
+
+const WHEEL_ZOOM_SENSITIVITY = 0.0015;
+
+interface MermaidOverlayProps {
+  readonly open: boolean;
+  readonly svg: string;
+  readonly title: string;
+  readonly onOpenChange: (open: boolean) => void;
+}
+
+function scenePoint(
+  scene: HTMLElement,
+  clientX: number,
+  clientY: number,
+): { x: number; y: number } {
+  const rect = scene.getBoundingClientRect();
+  return { x: clientX - rect.left, y: clientY - rect.top };
+}
+
+function measuredSvgSize(
+  scene: HTMLElement,
+  zoom: number,
+): { width: number; height: number } | null {
+  const svg = scene.querySelector("svg");
+  if (!(svg instanceof SVGElement) || zoom === 0) return null;
+  const rect = svg.getBoundingClientRect();
+  const width = rect.width / zoom;
+  const height = rect.height / zoom;
+  if (width <= 0 || height <= 0) return null;
+  return { width, height };
+}
+
+export function MermaidOverlay({ open, svg, title, onOpenChange }: MermaidOverlayProps) {
+  const overlayDomId = useId().replace(/[^a-zA-Z0-9_-]/g, "");
+  const sceneRef = useRef<HTMLDivElement>(null);
+  const viewportRef = useRef<MermaidViewport>(resetMermaidViewport());
+  const pointerRef = useRef<{ x: number; y: number } | null>(null);
+  const userAdjustedRef = useRef(false);
+  const [viewport, setViewport] = useState<MermaidViewport>(resetMermaidViewport);
+  const [panning, setPanning] = useState(false);
+
+  const overlaySvg = useMemo(
+    () => remapMermaidSvgIds(svg, `-${overlayDomId}`),
+    [overlayDomId, svg],
+  );
+  const contentSize = useMemo(() => mermaidSvgContentSize(svg), [svg]);
+
+  const commitViewport = (next: MermaidViewport, userAdjusted: boolean) => {
+    if (userAdjusted) userAdjustedRef.current = true;
+    viewportRef.current = next;
+    setViewport(next);
+  };
+
+  const fitToScene = () => {
+    const scene = sceneRef.current;
+    if (!scene) return;
+    const size = contentSize ?? measuredSvgSize(scene, viewportRef.current.zoom);
+    if (!size) return;
+    userAdjustedRef.current = false;
+    commitViewport(
+      fitMermaidViewport({ width: scene.clientWidth, height: scene.clientHeight }, size),
+      false,
+    );
+  };
+
+  useLayoutEffect(() => {
+    if (!open) {
+      userAdjustedRef.current = false;
+      pointerRef.current = null;
+      commitViewport(resetMermaidViewport(), false);
+      return;
+    }
+    fitToScene();
+    // Fit once the dialog geometry is available; user pan/zoom must win after that.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- opening or a new svg is the only reason to refit
+  }, [open, svg]);
+
+  useEffect(() => {
+    if (!open) return;
+    const scene = sceneRef.current;
+    if (!scene || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => {
+      if (!userAdjustedRef.current) fitToScene();
+    });
+    observer.observe(scene);
+    return () => observer.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- observer is bound to the open scene
+  }, [open, svg]);
+
+  useEffect(() => {
+    if (!open) return;
+    const scene = sceneRef.current;
+    if (!scene) return;
+
+    const onWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      const factor = Math.exp(-event.deltaY * WHEEL_ZOOM_SENSITIVITY);
+      commitViewport(
+        zoomMermaidViewportAtPoint(
+          viewportRef.current,
+          viewportRef.current.zoom * factor,
+          scenePoint(scene, event.clientX, event.clientY),
+        ),
+        true,
+      );
+    };
+
+    scene.addEventListener("wheel", onWheel, { passive: false });
+    return () => scene.removeEventListener("wheel", onWheel);
+  }, [open]);
+
+  const zoomByStep = (direction: 1 | -1) => {
+    const scene = sceneRef.current;
+    if (!scene) return;
+    const rect = scene.getBoundingClientRect();
+    const step = direction === 1 ? MERMAID_OVERLAY_ZOOM_STEP : 1 / MERMAID_OVERLAY_ZOOM_STEP;
+    commitViewport(
+      zoomMermaidViewportAtPoint(viewportRef.current, viewportRef.current.zoom * step, {
+        x: rect.width / 2,
+        y: rect.height / 2,
+      }),
+      true,
+    );
+  };
+
+  const onPointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    pointerRef.current = { x: event.clientX, y: event.clientY };
+    setPanning(true);
+  };
+
+  const onPointerMove = (event: PointerEvent<HTMLDivElement>) => {
+    const last = pointerRef.current;
+    if (last == null) return;
+    const dx = event.clientX - last.x;
+    const dy = event.clientY - last.y;
+    pointerRef.current = { x: event.clientX, y: event.clientY };
+    commitViewport(panMermaidViewport(viewportRef.current, dx, dy), true);
+  };
+
+  const endPan = (event: PointerEvent<HTMLDivElement>) => {
+    if (pointerRef.current == null) return;
+    pointerRef.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    setPanning(false);
+  };
+
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "+" || event.key === "=") {
+      event.preventDefault();
+      zoomByStep(1);
+      return;
+    }
+    if (event.key === "-" || event.key === "_") {
+      event.preventDefault();
+      zoomByStep(-1);
+      return;
+    }
+    if (event.key === "0") {
+      event.preventDefault();
+      fitToScene();
+    }
+  };
+
+  const zoomPercent = Math.round(viewport.zoom * 100);
+  const zoomInDisabled = viewport.zoom >= MAX_MERMAID_OVERLAY_ZOOM;
+  const zoomOutDisabled = viewport.zoom <= MIN_MERMAID_OVERLAY_ZOOM;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogPopup
+        showCloseButton={false}
+        bottomStickOnMobile={false}
+        className="h-[min(92vh,64rem)] max-w-[min(96vw,90rem)] gap-0 overflow-hidden p-0"
+        onKeyDown={onKeyDown}
+        data-mermaid-overlay=""
+      >
+        <DialogHeader className="flex-row items-center gap-3 space-y-0 border-b px-4 py-2.5">
+          <div className="min-w-0 flex-1">
+            <DialogTitle className="truncate text-base">{title}</DialogTitle>
+            <DialogDescription className="sr-only">
+              Scroll to zoom, drag to pan. Press Escape to close.
+            </DialogDescription>
+          </div>
+          <div className="flex shrink-0 items-center gap-0.5">
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    className="chat-markdown-chrome-action"
+                    aria-label="Zoom out"
+                    data-mermaid-overlay-zoom-out=""
+                    disabled={zoomOutDisabled}
+                    onClick={() => zoomByStep(-1)}
+                  />
+                }
+              >
+                <ZoomOutIcon className="size-3.5" />
+              </TooltipTrigger>
+              <TooltipPopup side="bottom">Zoom out</TooltipPopup>
+            </Tooltip>
+            <span
+              className="min-w-12 px-1 text-center text-xs text-muted-foreground tabular-nums"
+              data-mermaid-overlay-zoom=""
+            >
+              {zoomPercent}%
+            </span>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    className="chat-markdown-chrome-action"
+                    aria-label="Zoom in"
+                    data-mermaid-overlay-zoom-in=""
+                    disabled={zoomInDisabled}
+                    onClick={() => zoomByStep(1)}
+                  />
+                }
+              >
+                <ZoomInIcon className="size-3.5" />
+              </TooltipTrigger>
+              <TooltipPopup side="bottom">Zoom in</TooltipPopup>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    className="chat-markdown-chrome-action"
+                    aria-label="Reset view"
+                    data-mermaid-overlay-reset=""
+                    onClick={() => fitToScene()}
+                  />
+                }
+              >
+                <RotateCcwIcon className="size-3.5" />
+              </TooltipTrigger>
+              <TooltipPopup side="bottom">Reset view</TooltipPopup>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    className="chat-markdown-chrome-action"
+                    aria-label="Close"
+                    onClick={() => onOpenChange(false)}
+                  />
+                }
+              >
+                <XIcon className="size-3.5" />
+              </TooltipTrigger>
+              <TooltipPopup side="bottom">Close</TooltipPopup>
+            </Tooltip>
+          </div>
+        </DialogHeader>
+        <div
+          ref={sceneRef}
+          className="chat-markdown-mermaid-overlay-scene"
+          data-mermaid-overlay-scene=""
+          data-panning={panning ? "true" : undefined}
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={endPan}
+          onPointerCancel={endPan}
+          onLostPointerCapture={endPan}
+        >
+          <div
+            className="chat-markdown-mermaid-overlay-canvas"
+            style={{
+              width: contentSize?.width,
+              height: contentSize?.height,
+              transform: `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`,
+              willChange: panning ? "transform" : undefined,
+            }}
+            dangerouslySetInnerHTML={{ __html: overlaySvg }}
+          />
+        </div>
+      </DialogPopup>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/chat/MermaidOverlay.tsx
+++ b/apps/web/src/components/chat/MermaidOverlay.tsx
@@ -65,10 +65,11 @@ function measuredSvgSize(
 
 export function MermaidOverlay({ open, svg, title, onOpenChange }: MermaidOverlayProps) {
   const overlayDomId = useId().replace(/[^a-zA-Z0-9_-]/g, "");
-  const sceneRef = useRef<HTMLDivElement>(null);
+  const sceneRef = useRef<HTMLDivElement | null>(null);
   const viewportRef = useRef<MermaidViewport>(resetMermaidViewport());
   const pointerRef = useRef<{ x: number; y: number } | null>(null);
   const userAdjustedRef = useRef(false);
+  const [sceneEl, setSceneEl] = useState<HTMLDivElement | null>(null);
   const [viewport, setViewport] = useState<MermaidViewport>(resetMermaidViewport);
   const [panning, setPanning] = useState(false);
 
@@ -78,15 +79,19 @@ export function MermaidOverlay({ open, svg, title, onOpenChange }: MermaidOverla
   );
   const contentSize = useMemo(() => mermaidSvgContentSize(svg), [svg]);
 
+  const setSceneNode = (node: HTMLDivElement | null) => {
+    sceneRef.current = node;
+    setSceneEl((current) => (current === node ? current : node));
+  };
+
   const commitViewport = (next: MermaidViewport, userAdjusted: boolean) => {
     if (userAdjusted) userAdjustedRef.current = true;
     viewportRef.current = next;
     setViewport(next);
   };
 
-  const fitToScene = () => {
-    const scene = sceneRef.current;
-    if (!scene) return;
+  const fitToScene = (scene: HTMLElement) => {
+    if (scene.clientWidth <= 0 || scene.clientHeight <= 0) return;
     const size = contentSize ?? measuredSvgSize(scene, viewportRef.current.zoom);
     if (!size) return;
     userAdjustedRef.current = false;
@@ -103,27 +108,20 @@ export function MermaidOverlay({ open, svg, title, onOpenChange }: MermaidOverla
       commitViewport(resetMermaidViewport(), false);
       return;
     }
-    fitToScene();
-    // Fit once the dialog geometry is available; user pan/zoom must win after that.
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- opening or a new svg is the only reason to refit
-  }, [open, svg]);
+    if (sceneEl) fitToScene(sceneEl);
+  }, [open, svg, sceneEl, contentSize]);
 
   useEffect(() => {
-    if (!open) return;
-    const scene = sceneRef.current;
-    if (!scene || typeof ResizeObserver === "undefined") return;
+    if (!open || sceneEl == null || typeof ResizeObserver === "undefined") return;
     const observer = new ResizeObserver(() => {
-      if (!userAdjustedRef.current) fitToScene();
+      if (!userAdjustedRef.current) fitToScene(sceneEl);
     });
-    observer.observe(scene);
+    observer.observe(sceneEl);
     return () => observer.disconnect();
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- observer is bound to the open scene
-  }, [open, svg]);
+  }, [open, svg, sceneEl, contentSize]);
 
   useEffect(() => {
-    if (!open) return;
-    const scene = sceneRef.current;
-    if (!scene) return;
+    if (!open || sceneEl == null) return;
 
     const onWheel = (event: WheelEvent) => {
       event.preventDefault();
@@ -133,15 +131,15 @@ export function MermaidOverlay({ open, svg, title, onOpenChange }: MermaidOverla
         zoomMermaidViewportAtPoint(
           viewportRef.current,
           viewportRef.current.zoom * factor,
-          scenePoint(scene, event.clientX, event.clientY),
+          scenePoint(sceneEl, event.clientX, event.clientY),
         ),
         true,
       );
     };
 
-    scene.addEventListener("wheel", onWheel, { passive: false });
-    return () => scene.removeEventListener("wheel", onWheel);
-  }, [open]);
+    sceneEl.addEventListener("wheel", onWheel, { passive: false });
+    return () => sceneEl.removeEventListener("wheel", onWheel);
+  }, [open, sceneEl]);
 
   const zoomByStep = (direction: 1 | -1) => {
     const scene = sceneRef.current;
@@ -196,7 +194,7 @@ export function MermaidOverlay({ open, svg, title, onOpenChange }: MermaidOverla
     }
     if (event.key === "0") {
       event.preventDefault();
-      fitToScene();
+      if (sceneRef.current) fitToScene(sceneRef.current);
     }
   };
 
@@ -275,7 +273,9 @@ export function MermaidOverlay({ open, svg, title, onOpenChange }: MermaidOverla
                     className="chat-markdown-chrome-action"
                     aria-label="Reset view"
                     data-mermaid-overlay-reset=""
-                    onClick={() => fitToScene()}
+                    onClick={() => {
+                      if (sceneRef.current) fitToScene(sceneRef.current);
+                    }}
                   />
                 }
               >
@@ -303,7 +303,7 @@ export function MermaidOverlay({ open, svg, title, onOpenChange }: MermaidOverla
           </div>
         </DialogHeader>
         <div
-          ref={sceneRef}
+          ref={setSceneNode}
           className="chat-markdown-mermaid-overlay-scene"
           data-mermaid-overlay-scene=""
           data-panning={panning ? "true" : undefined}

--- a/apps/web/src/components/chat/MermaidOverlay.tsx
+++ b/apps/web/src/components/chat/MermaidOverlay.tsx
@@ -122,11 +122,15 @@ export function MermaidOverlay({ open, svg, title, onOpenChange }: MermaidOverla
   useEffect(() => {
     if (!open || sceneEl == null || typeof ResizeObserver === "undefined") return;
     const observer = new ResizeObserver((entries) => {
-      if (userAdjustedRef.current) return;
       const size = entries[0]?.contentRect;
       if (size == null) return;
       const last = lastSceneSizeRef.current;
       if (last != null && last.width === size.width && last.height === size.height) return;
+      lastSceneSizeRef.current = { width: size.width, height: size.height };
+      if (userAdjustedRef.current) {
+        commitViewport(viewportRef.current, true);
+        return;
+      }
       fitToScene(sceneEl);
     });
     observer.observe(sceneEl);
@@ -139,7 +143,8 @@ export function MermaidOverlay({ open, svg, title, onOpenChange }: MermaidOverla
     const onWheel = (event: WheelEvent) => {
       event.preventDefault();
       event.stopPropagation();
-      const factor = Math.exp(-event.deltaY * WHEEL_ZOOM_SENSITIVITY);
+      const deltaY = event.deltaMode === 1 ? event.deltaY * 16 : event.deltaY;
+      const factor = Math.exp(-deltaY * WHEEL_ZOOM_SENSITIVITY);
       commitViewport(
         zoomMermaidViewportAtPoint(
           viewportRef.current,

--- a/apps/web/src/components/chat/MermaidOverlay.tsx
+++ b/apps/web/src/components/chat/MermaidOverlay.tsx
@@ -238,9 +238,8 @@ export function MermaidOverlay({ open, svg, title, onOpenChange }: MermaidOverla
                 render={
                   <Button
                     type="button"
-                    variant="ghost"
+                    variant="ghost-muted"
                     size="icon-xs"
-                    className="chat-markdown-chrome-action"
                     aria-label="Zoom out"
                     data-mermaid-overlay-zoom-out=""
                     disabled={zoomOutDisabled}
@@ -263,9 +262,8 @@ export function MermaidOverlay({ open, svg, title, onOpenChange }: MermaidOverla
                 render={
                   <Button
                     type="button"
-                    variant="ghost"
+                    variant="ghost-muted"
                     size="icon-xs"
-                    className="chat-markdown-chrome-action"
                     aria-label="Zoom in"
                     data-mermaid-overlay-zoom-in=""
                     disabled={zoomInDisabled}
@@ -282,9 +280,8 @@ export function MermaidOverlay({ open, svg, title, onOpenChange }: MermaidOverla
                 render={
                   <Button
                     type="button"
-                    variant="ghost"
+                    variant="ghost-muted"
                     size="icon-xs"
-                    className="chat-markdown-chrome-action"
                     aria-label="Reset view"
                     data-mermaid-overlay-reset=""
                     onClick={() => {
@@ -302,9 +299,8 @@ export function MermaidOverlay({ open, svg, title, onOpenChange }: MermaidOverla
                 render={
                   <Button
                     type="button"
-                    variant="ghost"
+                    variant="ghost-muted"
                     size="icon-xs"
-                    className="chat-markdown-chrome-action"
                     aria-label="Close"
                     onClick={() => onOpenChange(false)}
                   />

--- a/apps/web/src/components/chat/MermaidOverlay.tsx
+++ b/apps/web/src/components/chat/MermaidOverlay.tsx
@@ -78,6 +78,7 @@ export function MermaidOverlay({ open, svg, title, onOpenChange }: MermaidOverla
   const contentSize = useMemo(() => mermaidSvgContentSize(overlaySvg), [overlaySvg]);
 
   const lastSceneSizeRef = useRef<Size | null>(null);
+  const fittedSvgRef = useRef<string | null>(null);
 
   const setSceneNode = useCallback((node: HTMLDivElement | null) => {
     sceneRef.current = node;
@@ -109,6 +110,7 @@ export function MermaidOverlay({ open, svg, title, onOpenChange }: MermaidOverla
   useLayoutEffect(() => {
     if (!open) {
       userAdjustedRef.current = false;
+      fittedSvgRef.current = null;
       pointerRef.current = null;
       fitZoomRef.current = 1;
       viewportRef.current = resetMermaidViewport();
@@ -116,7 +118,14 @@ export function MermaidOverlay({ open, svg, title, onOpenChange }: MermaidOverla
       setViewport(resetMermaidViewport());
       return;
     }
-    if (sceneEl && !userAdjustedRef.current) fitToScene(sceneEl);
+    if (!sceneEl) return;
+    const diagramChanged = fittedSvgRef.current !== overlaySvg;
+    // Pan/zoom survives a scene resize of the same diagram. A new SVG (streaming
+    // redraw) has a different canvas, so refit or the previous viewport is stale.
+    if (diagramChanged || !userAdjustedRef.current) {
+      fittedSvgRef.current = overlaySvg;
+      fitToScene(sceneEl);
+    }
   }, [open, overlaySvg, sceneEl, contentSize]);
 
   useEffect(() => {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2264,10 +2264,10 @@ code {
   user-select: none;
   /* Same surface as the inline mermaid code block, so theme fills stay readable. */
   background: var(--secondary);
-}
 
-.dark .chat-markdown-mermaid-overlay-scene {
-  background: color-mix(in srgb, var(--input) 32%, transparent);
+  @variant dark {
+    background: color-mix(in srgb, var(--input) 32%, transparent);
+  }
 }
 
 .chat-markdown-mermaid-overlay-scene[data-panning="true"] {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2209,6 +2209,49 @@ code {
   background: transparent !important;
 }
 
+.chat-markdown .chat-markdown-mermaid {
+  overflow-x: auto;
+  max-width: 100%;
+  padding: 0.75rem 0.85rem 0.9rem;
+}
+
+.chat-markdown .chat-markdown-mermaid svg {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin-inline: auto;
+  background: transparent !important;
+}
+
+.chat-markdown .chat-markdown-mermaid-pending {
+  margin: 0;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  padding: 0.75rem 0.85rem 0.9rem;
+  overflow-x: auto;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 0.75rem;
+  line-height: 1.45;
+  color: color-mix(in srgb, var(--foreground) 78%, transparent);
+}
+
+.chat-markdown .chat-markdown-mermaid-error {
+  padding: 0.75rem 0.85rem 0.9rem;
+  font-size: 0.75rem;
+  line-height: 1.45;
+  color: color-mix(in srgb, var(--foreground) 72%, transparent);
+}
+
+.chat-markdown .chat-markdown-mermaid-error p {
+  margin: 0;
+}
+
+.chat-markdown .chat-markdown-mermaid-error p + p {
+  margin-top: 0.25rem;
+  color: color-mix(in srgb, var(--foreground) 58%, transparent);
+}
+
 /* Diagnostics-style tables: row separators only, uppercase headers, and a
    scroll-fade container for horizontal overflow. The root chat-markdown
    wrapping rules (overflow-wrap: anywhere) would let columns shrink to single

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2229,7 +2229,8 @@ code {
   background: transparent !important;
 }
 
-.chat-markdown .chat-markdown-mermaid-pending {
+/* Three classes so color wins over `html[data-theme-id] .chat-markdown pre`. */
+.chat-markdown .chat-markdown-codeblock .chat-markdown-mermaid-pending {
   margin: 0;
   border: none;
   border-radius: 0;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1783,6 +1783,12 @@ html[data-theme-id] .chat-markdown .chat-markdown-codeblock {
   color: var(--code-foreground);
 }
 
+/* Overlay is portaled onto document.body, so it cannot use the .chat-markdown
+   ancestor the inline mermaid code block uses. */
+html[data-theme-id] .chat-markdown-mermaid-overlay-scene {
+  background: var(--code-background);
+}
+
 html[data-theme-id] .chat-markdown pre {
   background-color: var(--code-background);
   color: var(--code-foreground);
@@ -2262,7 +2268,9 @@ code {
   touch-action: none;
   cursor: grab;
   user-select: none;
-  /* Same surface as the inline mermaid code block, so theme fills stay readable. */
+  /* Default palette matches the inline mermaid code block. Custom themes tint
+     --secondary/--input with the accent, so the overlay uses --code-background
+     via html[data-theme-id] .chat-markdown-mermaid-overlay-scene. */
   background: var(--secondary);
 
   @variant dark {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2237,7 +2237,7 @@ code {
   padding: 0.75rem 0.85rem 0.9rem;
   overflow-x: auto;
   font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
-  font-size: 0.75rem;
+  font-size: var(--font-size-code, 0.75rem);
   line-height: 1.45;
   color: color-mix(in srgb, var(--foreground) 78%, transparent);
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2262,7 +2262,12 @@ code {
   touch-action: none;
   cursor: grab;
   user-select: none;
-  background: color-mix(in srgb, var(--background) 88%, var(--muted));
+  /* Same surface as the inline mermaid code block, so theme fills stay readable. */
+  background: var(--secondary);
+}
+
+.dark .chat-markdown-mermaid-overlay-scene {
+  background: color-mix(in srgb, var(--input) 32%, transparent);
 }
 
 .chat-markdown-mermaid-overlay-scene[data-panning="true"] {
@@ -2274,13 +2279,15 @@ code {
   top: 0;
   left: 0;
   transform-origin: 0 0;
+  color: unset;
 }
 
 .chat-markdown-mermaid-overlay-canvas svg {
   display: block;
   width: 100%;
-  height: 100%;
+  height: auto;
   max-width: none;
+  overflow: visible;
   background: transparent !important;
 }
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2252,6 +2252,38 @@ code {
   color: color-mix(in srgb, var(--foreground) 58%, transparent);
 }
 
+.chat-markdown-mermaid-overlay-scene {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  overscroll-behavior: none;
+  touch-action: none;
+  cursor: grab;
+  user-select: none;
+  background: color-mix(in srgb, var(--background) 88%, var(--muted));
+}
+
+.chat-markdown-mermaid-overlay-scene[data-panning="true"] {
+  cursor: grabbing;
+}
+
+.chat-markdown-mermaid-overlay-canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform-origin: 0 0;
+}
+
+.chat-markdown-mermaid-overlay-canvas svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  background: transparent !important;
+}
+
 /* Diagnostics-style tables: row separators only, uppercase headers, and a
    scroll-fade container for horizontal overflow. The root chat-markdown
    wrapping rules (overflow-wrap: anywhere) would let columns shrink to single

--- a/apps/web/src/lib/mermaidRendering.test.ts
+++ b/apps/web/src/lib/mermaidRendering.test.ts
@@ -5,6 +5,7 @@ import {
   __setMermaidLoaderForTests,
   isMermaidFenceLanguage,
   mermaidSourceAsMarkdownFence,
+  prepareMermaidOverlaySvg,
   remapMermaidSvgIds,
   renderMermaidSvg,
   sanitizeMermaidSvg,
@@ -72,6 +73,22 @@ describe("remapMermaidSvgIds", () => {
     const svg = `<svg id="flowchart" ><g id="flowchart-A" /></svg>`;
     expect(remapMermaidSvgIds(svg, "-x")).toBe(
       `<svg id="flowchart-x" ><g id="flowchart-A-x" /></svg>`,
+    );
+  });
+
+  it("rewrites mermaid theme selectors so overlay labels keep their colors", () => {
+    const svg = `<svg id="t3-mermaid-1"><style>#t3-mermaid-1{fill:#1a1a1a;}#t3-mermaid-1 .nodeLabel{color:#ccc;}</style></svg>`;
+    expect(remapMermaidSvgIds(svg, "-ov")).toBe(
+      `<svg id="t3-mermaid-1-ov"><style>#t3-mermaid-1-ov{fill:#1a1a1a;}#t3-mermaid-1-ov .nodeLabel{color:#ccc;}</style></svg>`,
+    );
+  });
+});
+
+describe("prepareMermaidOverlaySvg", () => {
+  it("pins intrinsic width/height and drops mermaid's shrink-to-fit sizing", () => {
+    const svg = `<svg id="t3-mermaid-1" width="100%" viewBox="0 0 240 80" style="max-width: 240px; background: white;"></svg>`;
+    expect(prepareMermaidOverlaySvg(svg, "-ov")).toBe(
+      `<svg width="240" height="80" id="t3-mermaid-1-ov" viewBox="0 0 240 80" style="background: white"></svg>`,
     );
   });
 });

--- a/apps/web/src/lib/mermaidRendering.test.ts
+++ b/apps/web/src/lib/mermaidRendering.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  __resetMermaidRenderingForTests,
+  __setMermaidLoaderForTests,
+  isMermaidFenceLanguage,
+  mermaidSourceAsMarkdownFence,
+  renderMermaidSvg,
+  sanitizeMermaidSvg,
+  type MermaidRuntime,
+} from "./mermaidRendering";
+
+function fakeRuntime(overrides: Partial<MermaidRuntime> = {}): MermaidRuntime {
+  return {
+    initialize: vi.fn(),
+    parse: vi.fn(async () => true),
+    render: vi.fn(async () => ({ svg: "<svg>ok</svg>" })),
+    ...overrides,
+  };
+}
+
+describe("isMermaidFenceLanguage", () => {
+  it("accepts mermaid and the mmd alias, ignoring case", () => {
+    expect(isMermaidFenceLanguage("mermaid")).toBe(true);
+    expect(isMermaidFenceLanguage("MERMAID")).toBe(true);
+    expect(isMermaidFenceLanguage(" mmd ")).toBe(true);
+  });
+
+  it("rejects ordinary fence languages", () => {
+    expect(isMermaidFenceLanguage("ts")).toBe(false);
+    expect(isMermaidFenceLanguage("text")).toBe(false);
+    expect(isMermaidFenceLanguage(undefined)).toBe(false);
+  });
+});
+
+describe("mermaidSourceAsMarkdownFence", () => {
+  it("wraps source in a mermaid fence", () => {
+    expect(mermaidSourceAsMarkdownFence("graph TD\n  A --> B\n")).toBe(
+      "```mermaid\ngraph TD\n  A --> B\n```",
+    );
+  });
+
+  it("lengthens the fence when the source contains backticks", () => {
+    expect(mermaidSourceAsMarkdownFence("graph TD\n  A[```]\n")).toBe(
+      "````mermaid\ngraph TD\n  A[```]\n````",
+    );
+  });
+});
+
+describe("sanitizeMermaidSvg", () => {
+  it("strips script tags, event handlers, and javascript hrefs", () => {
+    const dirty = `<svg><script>alert(1)</script><a href="javascript:alert(1)" onclick="alert(1)">x</a><script src="x.js"/></svg>`;
+    expect(sanitizeMermaidSvg(dirty)).toBe(`<svg><a>x</a></svg>`);
+  });
+
+  it("leaves mermaid marker urls and ordinary attributes alone", () => {
+    const svg = `<svg><path marker-end="url(#arrow)" class="edge" /></svg>`;
+    expect(sanitizeMermaidSvg(svg)).toBe(svg);
+  });
+});
+
+describe("renderMermaidSvg", () => {
+  afterEach(() => {
+    __resetMermaidRenderingForTests();
+  });
+
+  it("initializes mermaid in strict mode and caches the sanitized svg", async () => {
+    const runtime = fakeRuntime({
+      render: vi.fn(async () => ({
+        svg: `<svg onclick="alert(1)">ok</svg>`,
+      })),
+    });
+    __setMermaidLoaderForTests(async () => runtime);
+
+    const first = await renderMermaidSvg("graph TD; A-->B;", "dark");
+    const second = await renderMermaidSvg("graph TD; A-->B;", "dark");
+
+    expect(first).toBe("<svg>ok</svg>");
+    expect(second).toBe(first);
+    expect(runtime.initialize).toHaveBeenCalledTimes(1);
+    expect(runtime.render).toHaveBeenCalledTimes(1);
+    expect(runtime.initialize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        securityLevel: "strict",
+        startOnLoad: false,
+        suppressErrorRendering: true,
+        theme: "dark",
+      }),
+    );
+    const config = (runtime.initialize as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
+      secure: string[];
+    };
+    expect(config.secure).toContain("securityLevel");
+  });
+
+  it("serializes concurrent renders so mermaid's global config cannot race", async () => {
+    const order: string[] = [];
+    let releaseFirst: (() => void) | undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const runtime = fakeRuntime({
+      render: vi.fn(async (id: string) => {
+        order.push(`start:${id}`);
+        if (id === "t3-mermaid-1") await firstGate;
+        order.push(`end:${id}`);
+        return { svg: `<svg>${id}</svg>` };
+      }),
+    });
+    __setMermaidLoaderForTests(async () => runtime);
+
+    const first = renderMermaidSvg("graph TD; A-->B;", "light");
+    const second = renderMermaidSvg("graph TD; A-->C;", "light");
+    await vi.waitFor(() => {
+      expect(order).toEqual(["start:t3-mermaid-1"]);
+    });
+    releaseFirst?.();
+    await Promise.all([first, second]);
+    expect(order).toEqual([
+      "start:t3-mermaid-1",
+      "end:t3-mermaid-1",
+      "start:t3-mermaid-2",
+      "end:t3-mermaid-2",
+    ]);
+  });
+
+  it("wraps parse failures so callers can fall back to the source", async () => {
+    const runtime = fakeRuntime({
+      parse: vi.fn(async () => {
+        throw new Error("Parse error on line 2");
+      }),
+    });
+    __setMermaidLoaderForTests(async () => runtime);
+
+    await expect(renderMermaidSvg("not a diagram", "light")).rejects.toThrow(
+      "Parse error on line 2",
+    );
+    expect(runtime.render).not.toHaveBeenCalled();
+  });
+
+  it("retries loading mermaid after a failed import", async () => {
+    let attempts = 0;
+    __setMermaidLoaderForTests(async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error("chunk failed");
+      return fakeRuntime();
+    });
+
+    await expect(renderMermaidSvg("graph TD; A-->B;", "light")).rejects.toThrow("chunk failed");
+    await expect(renderMermaidSvg("graph TD; A-->B;", "light")).resolves.toBe("<svg>ok</svg>");
+    expect(attempts).toBe(2);
+  });
+});

--- a/apps/web/src/lib/mermaidRendering.test.ts
+++ b/apps/web/src/lib/mermaidRendering.test.ts
@@ -5,6 +5,7 @@ import {
   __setMermaidLoaderForTests,
   isMermaidFenceLanguage,
   mermaidSourceAsMarkdownFence,
+  remapMermaidSvgIds,
   renderMermaidSvg,
   sanitizeMermaidSvg,
   type MermaidRuntime,
@@ -56,6 +57,22 @@ describe("sanitizeMermaidSvg", () => {
   it("leaves mermaid marker urls and ordinary attributes alone", () => {
     const svg = `<svg><path marker-end="url(#arrow)" class="edge" /></svg>`;
     expect(sanitizeMermaidSvg(svg)).toBe(svg);
+  });
+});
+
+describe("remapMermaidSvgIds", () => {
+  it("suffixes ids and url/href references so overlay clones do not collide", () => {
+    const svg = `<svg id="t3-mermaid-1"><defs><marker id="arrow" /></defs><path marker-end="url(#arrow)" href="#arrow" xlink:href="#arrow" /></svg>`;
+    expect(remapMermaidSvgIds(svg, "-ov")).toBe(
+      `<svg id="t3-mermaid-1-ov"><defs><marker id="arrow-ov" /></defs><path marker-end="url(#arrow-ov)" href="#arrow-ov" xlink:href="#arrow-ov" /></svg>`,
+    );
+  });
+
+  it("rewrites longer ids first so prefixes are not partially replaced", () => {
+    const svg = `<svg id="flowchart" ><g id="flowchart-A" /></svg>`;
+    expect(remapMermaidSvgIds(svg, "-x")).toBe(
+      `<svg id="flowchart-x" ><g id="flowchart-A-x" /></svg>`,
+    );
   });
 });
 

--- a/apps/web/src/lib/mermaidRendering.test.ts
+++ b/apps/web/src/lib/mermaidRendering.test.ts
@@ -82,6 +82,13 @@ describe("remapMermaidSvgIds", () => {
       `<svg id="t3-mermaid-1-ov"><style>#t3-mermaid-1-ov{fill:#1a1a1a;}#t3-mermaid-1-ov .nodeLabel{color:#ccc;}</style></svg>`,
     );
   });
+
+  it("does not rewrite hex colors that share an id token", () => {
+    const svg = `<svg id="fff"><style>#fff{fill:#fff;stroke: #fff;}#fff .nodeLabel{color:#ccc;}</style><path fill="#fff,#000"/></svg>`;
+    expect(remapMermaidSvgIds(svg, "-ov")).toBe(
+      `<svg id="fff-ov"><style>#fff-ov{fill:#fff;stroke: #fff;}#fff-ov .nodeLabel{color:#ccc;}</style><path fill="#fff,#000"/></svg>`,
+    );
+  });
 });
 
 describe("prepareMermaidOverlaySvg", () => {
@@ -125,6 +132,20 @@ describe("renderMermaidSvg", () => {
       secure: string[];
     };
     expect(config.secure).toContain("securityLevel");
+  });
+
+  it("does not reuse a cached svg for a different source of the same length", async () => {
+    const runtime = fakeRuntime({
+      render: vi.fn(async (_id: string, text: string) => ({ svg: `<svg>${text}</svg>` })),
+    });
+    __setMermaidLoaderForTests(async () => runtime);
+
+    const first = await renderMermaidSvg("AAAA", "light");
+    const second = await renderMermaidSvg("BBBB", "light");
+
+    expect(first).toBe("<svg>AAAA</svg>");
+    expect(second).toBe("<svg>BBBB</svg>");
+    expect(runtime.render).toHaveBeenCalledTimes(2);
   });
 
   it("serializes concurrent renders so mermaid's global config cannot race", async () => {

--- a/apps/web/src/lib/mermaidRendering.test.ts
+++ b/apps/web/src/lib/mermaidRendering.test.ts
@@ -5,6 +5,7 @@ import {
   __setMermaidLoaderForTests,
   isMermaidFenceLanguage,
   mermaidSourceAsMarkdownFence,
+  peekCachedMermaidSvg,
   prepareMermaidOverlaySvg,
   remapMermaidSvgIds,
   renderMermaidSvg,
@@ -55,6 +56,11 @@ describe("sanitizeMermaidSvg", () => {
     expect(sanitizeMermaidSvg(dirty)).toBe(`<svg><a>x</a></svg>`);
   });
 
+  it("strips foreignObject, object, and data:text/html urls", () => {
+    const dirty = `<svg><foreignObject><div>x</div></foreignObject><object data="x"></object><image src="data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg=="/></svg>`;
+    expect(sanitizeMermaidSvg(dirty)).toBe(`<svg><image/></svg>`);
+  });
+
   it("leaves mermaid marker urls and ordinary attributes alone", () => {
     const svg = `<svg><path marker-end="url(#arrow)" class="edge" /></svg>`;
     expect(sanitizeMermaidSvg(svg)).toBe(svg);
@@ -80,6 +86,13 @@ describe("remapMermaidSvgIds", () => {
     const svg = `<svg id="t3-mermaid-1"><style>#t3-mermaid-1{fill:#1a1a1a;}#t3-mermaid-1 .nodeLabel{color:#ccc;}</style></svg>`;
     expect(remapMermaidSvgIds(svg, "-ov")).toBe(
       `<svg id="t3-mermaid-1-ov"><style>#t3-mermaid-1-ov{fill:#1a1a1a;}#t3-mermaid-1-ov .nodeLabel{color:#ccc;}</style></svg>`,
+    );
+  });
+
+  it("rewrites quoted url() refs and single-quoted ids", () => {
+    const svg = `<svg id='grad'><defs><linearGradient id="fill" /></defs><path style="fill:url('#fill')" marker-end="url('#fill')" href='#grad' /></svg>`;
+    expect(remapMermaidSvgIds(svg, "-ov")).toBe(
+      `<svg id='grad-ov'><defs><linearGradient id="fill-ov" /></defs><path style="fill:url('#fill-ov')" marker-end="url('#fill-ov')" href='#grad-ov' /></svg>`,
     );
   });
 
@@ -118,11 +131,13 @@ describe("renderMermaidSvg", () => {
 
     expect(first).toBe("<svg>ok</svg>");
     expect(second).toBe(first);
+    expect(peekCachedMermaidSvg("graph TD; A-->B;", "dark")).toBe(first);
     expect(runtime.initialize).toHaveBeenCalledTimes(1);
     expect(runtime.render).toHaveBeenCalledTimes(1);
     expect(runtime.initialize).toHaveBeenCalledWith(
       expect.objectContaining({
         securityLevel: "strict",
+        htmlLabels: false,
         startOnLoad: false,
         suppressErrorRendering: true,
         theme: "dark",
@@ -132,6 +147,7 @@ describe("renderMermaidSvg", () => {
       secure: string[];
     };
     expect(config.secure).toContain("securityLevel");
+    expect(config.secure).toContain("htmlLabels");
   });
 
   it("does not reuse a cached svg for a different source of the same length", async () => {

--- a/apps/web/src/lib/mermaidRendering.test.ts
+++ b/apps/web/src/lib/mermaidRendering.test.ts
@@ -61,6 +61,11 @@ describe("sanitizeMermaidSvg", () => {
     expect(sanitizeMermaidSvg(dirty)).toBe(`<svg><image/></svg>`);
   });
 
+  it("strips unclosed dangerous opening tags", () => {
+    const dirty = `<svg><iframe src="https://evil.example"><foreignObject><div>x</div></svg>`;
+    expect(sanitizeMermaidSvg(dirty)).toBe(`<svg><div>x</div></svg>`);
+  });
+
   it("leaves mermaid marker urls and ordinary attributes alone", () => {
     const svg = `<svg><path marker-end="url(#arrow)" class="edge" /></svg>`;
     expect(sanitizeMermaidSvg(svg)).toBe(svg);

--- a/apps/web/src/lib/mermaidRendering.ts
+++ b/apps/web/src/lib/mermaidRendering.ts
@@ -119,6 +119,36 @@ export function sanitizeMermaidSvg(svg: string): string {
     );
 }
 
+/**
+ * Inline chat and the expand overlay both mount the same mermaid SVG. Rewrite
+ * ids so marker/gradient `url(#…)` refs in the overlay do not collide with the
+ * preview still on the page.
+ */
+export function remapMermaidSvgIds(svg: string, suffix: string): string {
+  if (suffix.length === 0) return svg;
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  for (const match of svg.matchAll(/\bid="([^"]+)"/g)) {
+    const id = match[1];
+    if (id == null || id.length === 0 || seen.has(id)) continue;
+    seen.add(id);
+    ids.push(id);
+  }
+  ids.sort((left, right) => right.length - left.length);
+  let remapped = svg;
+  for (const id of ids) {
+    const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    remapped = remapped.replace(new RegExp(`id="${escaped}"`, "g"), `id="${id}${suffix}"`);
+    remapped = remapped.replace(new RegExp(`url\\(#${escaped}\\)`, "g"), `url(#${id}${suffix})`);
+    remapped = remapped.replace(new RegExp(`href="#${escaped}"`, "g"), `href="#${id}${suffix}"`);
+    remapped = remapped.replace(
+      new RegExp(`xlink:href="#${escaped}"`, "g"),
+      `xlink:href="#${id}${suffix}"`,
+    );
+  }
+  return remapped;
+}
+
 export class MermaidRenderError extends Error {
   override readonly name = "MermaidRenderError";
 

--- a/apps/web/src/lib/mermaidRendering.ts
+++ b/apps/web/src/lib/mermaidRendering.ts
@@ -1,0 +1,172 @@
+/**
+ * Lazy mermaid rendering for chat markdown fences.
+ *
+ * Web and desktop share this path (desktop wraps the web client). Mobile has
+ * no DOM mermaid runtime, so mermaid fences stay ordinary code blocks there.
+ */
+import { fnv1a32 } from "./diffRendering";
+import { LRUCache } from "./lruCache";
+
+const MAX_MERMAID_CACHE_ENTRIES = 80;
+const MAX_MERMAID_CACHE_MEMORY_BYTES = 8 * 1024 * 1024;
+
+const mermaidSvgCache = new LRUCache<string>(
+  MAX_MERMAID_CACHE_ENTRIES,
+  MAX_MERMAID_CACHE_MEMORY_BYTES,
+);
+
+const MERMAID_FENCE_LANGUAGES = new Set(["mermaid", "mmd"]);
+
+export type MermaidColorScheme = "light" | "dark";
+
+export interface MermaidRuntime {
+  initialize: (config: Record<string, unknown>) => void;
+  parse: (text: string) => Promise<unknown>;
+  render: (id: string, text: string) => Promise<{ svg: string }>;
+}
+
+let mermaidRuntimePromise: Promise<MermaidRuntime> | null = null;
+let renderQueue: Promise<void> = Promise.resolve();
+let mermaidRenderSeq = 0;
+
+function defaultLoadMermaid(): Promise<MermaidRuntime> {
+  return import("mermaid").then((module) => module.default as MermaidRuntime);
+}
+
+let loadMermaid = defaultLoadMermaid;
+
+function getMermaidRuntime(): Promise<MermaidRuntime> {
+  mermaidRuntimePromise ??= loadMermaid().then(
+    (runtime) => runtime,
+    (error: unknown) => {
+      mermaidRuntimePromise = null;
+      throw error;
+    },
+  );
+  return mermaidRuntimePromise;
+}
+
+function enqueueMermaidWork<T>(work: () => Promise<T>): Promise<T> {
+  const run = renderQueue.then(work, work);
+  renderQueue = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+
+function mermaidConfig(theme: MermaidColorScheme): Record<string, unknown> {
+  return {
+    startOnLoad: false,
+    securityLevel: "strict",
+    // Diagram `%%{init}%%` / frontmatter must not be able to loosen this.
+    secure: ["secure", "securityLevel", "startOnLoad", "maxTextSize", "htmlLabels"],
+    suppressErrorRendering: true,
+    logLevel: "fatal",
+    theme: theme === "dark" ? "dark" : "neutral",
+    fontFamily: "ui-sans-serif, system-ui, sans-serif",
+    flowchart: { useMaxWidth: true },
+    sequence: { useMaxWidth: true },
+    gantt: { useMaxWidth: true },
+    class: { useMaxWidth: true },
+    state: { useMaxWidth: true },
+    er: { useMaxWidth: true },
+    pie: { useMaxWidth: true },
+    journey: { useMaxWidth: true },
+    gitGraph: { useMaxWidth: true },
+  };
+}
+
+function nextMermaidDomId(): string {
+  mermaidRenderSeq += 1;
+  return `t3-mermaid-${mermaidRenderSeq}`;
+}
+
+function createMermaidCacheKey(code: string, theme: MermaidColorScheme): string {
+  return `${fnv1a32(code).toString(36)}:${code.length}:${theme}`;
+}
+
+export function isMermaidFenceLanguage(language: string | undefined): boolean {
+  if (!language) return false;
+  return MERMAID_FENCE_LANGUAGES.has(language.trim().toLowerCase());
+}
+
+export function mermaidSourceAsMarkdownFence(code: string): string {
+  const body = code.replace(/\n$/, "");
+  const longestRun = [...(body.match(/`{3,}/g) ?? [])].reduce(
+    (max, run) => Math.max(max, run.length),
+    0,
+  );
+  const fence = "`".repeat(Math.max(3, longestRun + 1));
+  return `${fence}mermaid\n${body}\n${fence}`;
+}
+
+/**
+ * Strict-mode mermaid should not emit scripts, but the SVG still lands in the
+ * chat DOM via innerHTML. Strip the obvious handlers so a mermaid bug cannot
+ * become an XSS gadget.
+ */
+export function sanitizeMermaidSvg(svg: string): string {
+  return svg
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "")
+    .replace(/<script\b[^>]*\/>/gi, "")
+    .replace(/<iframe\b[^>]*>[\s\S]*?<\/iframe>/gi, "")
+    .replace(/<iframe\b[^>]*\/>/gi, "")
+    .replace(/\s+on[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, "")
+    .replace(
+      /\s+(?:xlink:)?href\s*=\s*(?:"javascript:[^"]*"|'javascript:[^']*'|javascript:\S+)/gi,
+      "",
+    );
+}
+
+export class MermaidRenderError extends Error {
+  override readonly name = "MermaidRenderError";
+
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : "Couldn't render this diagram.");
+    this.cause = cause;
+  }
+}
+
+export async function renderMermaidSvg(code: string, theme: MermaidColorScheme): Promise<string> {
+  const trimmed = code.trim();
+  if (trimmed.length === 0) {
+    throw new MermaidRenderError(new Error("Diagram is empty."));
+  }
+
+  const cacheKey = createMermaidCacheKey(trimmed, theme);
+  const cached = mermaidSvgCache.get(cacheKey);
+  if (cached != null) return cached;
+
+  const svg = await enqueueMermaidWork(async () => {
+    const cachedDuringWait = mermaidSvgCache.get(cacheKey);
+    if (cachedDuringWait != null) return cachedDuringWait;
+
+    const mermaid = await getMermaidRuntime();
+    mermaid.initialize(mermaidConfig(theme));
+    try {
+      await mermaid.parse(trimmed);
+      const { svg } = await mermaid.render(nextMermaidDomId(), trimmed);
+      const sanitized = sanitizeMermaidSvg(svg);
+      mermaidSvgCache.set(cacheKey, sanitized, Math.max(sanitized.length * 2, trimmed.length));
+      return sanitized;
+    } catch (cause) {
+      throw new MermaidRenderError(cause);
+    }
+  });
+
+  return svg;
+}
+
+export function __setMermaidLoaderForTests(loader: (() => Promise<MermaidRuntime>) | null): void {
+  loadMermaid = loader ?? defaultLoadMermaid;
+  mermaidRuntimePromise = null;
+}
+
+export function __resetMermaidRenderingForTests(): void {
+  mermaidSvgCache.clear();
+  mermaidRuntimePromise = null;
+  renderQueue = Promise.resolve();
+  mermaidRenderSeq = 0;
+  loadMermaid = defaultLoadMermaid;
+}

--- a/apps/web/src/lib/mermaidRendering.ts
+++ b/apps/web/src/lib/mermaidRendering.ts
@@ -6,6 +6,7 @@
  */
 import { fnv1a32 } from "./diffRendering";
 import { LRUCache } from "./lruCache";
+import { mermaidSvgContentSize } from "./mermaidViewport";
 
 const MAX_MERMAID_CACHE_ENTRIES = 80;
 const MAX_MERMAID_CACHE_MEMORY_BYTES = 8 * 1024 * 1024;
@@ -121,8 +122,10 @@ export function sanitizeMermaidSvg(svg: string): string {
 
 /**
  * Inline chat and the expand overlay both mount the same mermaid SVG. Rewrite
- * ids so marker/gradient `url(#…)` refs in the overlay do not collide with the
- * preview still on the page.
+ * ids so marker/gradient `url(#…)` refs and the `<style>` selectors mermaid
+ * emits (`#t3-mermaid-1 .nodeLabel`) do not collide with the preview still on
+ * the page. Skipping the stylesheet is what turned overlay nodes into black
+ * boxes with inherited (also black) label text.
  */
 export function remapMermaidSvgIds(svg: string, suffix: string): string {
   if (suffix.length === 0) return svg;
@@ -138,15 +141,50 @@ export function remapMermaidSvgIds(svg: string, suffix: string): string {
   let remapped = svg;
   for (const id of ids) {
     const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    remapped = remapped.replace(new RegExp(`id="${escaped}"`, "g"), `id="${id}${suffix}"`);
-    remapped = remapped.replace(new RegExp(`url\\(#${escaped}\\)`, "g"), `url(#${id}${suffix})`);
-    remapped = remapped.replace(new RegExp(`href="#${escaped}"`, "g"), `href="#${id}${suffix}"`);
+    const next = `${id}${suffix}`;
+    remapped = remapped.replace(new RegExp(`id="${escaped}"`, "g"), `id="${next}"`);
+    remapped = remapped.replace(new RegExp(`url\\(#${escaped}\\)`, "g"), `url(#${next})`);
+    remapped = remapped.replace(new RegExp(`href="#${escaped}"`, "g"), `href="#${next}"`);
     remapped = remapped.replace(
       new RegExp(`xlink:href="#${escaped}"`, "g"),
-      `xlink:href="#${id}${suffix}"`,
+      `xlink:href="#${next}"`,
     );
+    // Mermaid themes live in a <style> block keyed by the root svg id.
+    remapped = remapped.replace(new RegExp(`#${escaped}(?=[^A-Za-z0-9_-]|$)`, "g"), `#${next}`);
   }
   return remapped;
+}
+
+/**
+ * Mermaid emits `width="100%"` plus an inline max-width so the chat preview can
+ * shrink. The overlay needs a real pixel box or scale() has nothing to zoom.
+ */
+export function pinMermaidSvgIntrinsicSize(svg: string): string {
+  const size = mermaidSvgContentSize(svg);
+  if (size == null) return svg;
+  return svg.replace(/<svg\b([^>]*)>/i, (_full, attrs: string) => {
+    let next = attrs
+      .replace(/\swidth\s*=\s*("[^"]*"|'[^']*')/i, "")
+      .replace(/\sheight\s*=\s*("[^"]*"|'[^']*')/i, "");
+    next = next.replace(
+      /\sstyle\s*=\s*("([^"]*)"|'([^']*)')/i,
+      (_styleFull, _quoted, double: string | undefined, single: string | undefined) => {
+        const style = (double ?? single ?? "")
+          .replace(/max-width\s*:\s*[^;]+;?/gi, "")
+          .replace(/max-height\s*:\s*[^;]+;?/gi, "")
+          .replace(/(?:^|;)\s*width\s*:\s*[^;]+;?/gi, ";")
+          .replace(/(?:^|;)\s*height\s*:\s*[^;]+;?/gi, ";")
+          .replace(/^;+|;+$/g, "")
+          .trim();
+        return style.length > 0 ? ` style="${style}"` : "";
+      },
+    );
+    return `<svg width="${size.width}" height="${size.height}"${next}>`;
+  });
+}
+
+export function prepareMermaidOverlaySvg(svg: string, suffix: string): string {
+  return pinMermaidSvgIntrinsicSize(remapMermaidSvgIds(svg, suffix));
 }
 
 export class MermaidRenderError extends Error {

--- a/apps/web/src/lib/mermaidRendering.ts
+++ b/apps/web/src/lib/mermaidRendering.ts
@@ -55,17 +55,22 @@ function enqueueMermaidWork<T>(work: () => Promise<T>): Promise<T> {
   return run;
 }
 
+const MERMAID_MAX_TEXT_SIZE = 50_000;
+
 function mermaidConfig(theme: MermaidColorScheme): Record<string, unknown> {
   return {
     startOnLoad: false,
     securityLevel: "strict",
-    // Diagram `%%{init}%%` / frontmatter must not be able to loosen this.
+    // Mermaid defaults htmlLabels to true (foreignObject HTML). Lock it off so
+    // `%%{init}%%` / frontmatter cannot turn it back on either.
+    htmlLabels: false,
+    maxTextSize: MERMAID_MAX_TEXT_SIZE,
     secure: ["secure", "securityLevel", "startOnLoad", "maxTextSize", "htmlLabels"],
     suppressErrorRendering: true,
     logLevel: "fatal",
     theme: theme === "dark" ? "dark" : "neutral",
     fontFamily: "ui-sans-serif, system-ui, sans-serif",
-    flowchart: { useMaxWidth: true },
+    flowchart: { htmlLabels: false, useMaxWidth: true },
     sequence: { useMaxWidth: true },
     gantt: { useMaxWidth: true },
     class: { useMaxWidth: true },
@@ -88,6 +93,12 @@ function createMermaidCacheKey(code: string, theme: MermaidColorScheme): string 
   return `${theme}:${code}`;
 }
 
+export function peekCachedMermaidSvg(code: string, theme: MermaidColorScheme): string | null {
+  const trimmed = code.trim();
+  if (trimmed.length === 0) return null;
+  return mermaidSvgCache.get(createMermaidCacheKey(trimmed, theme));
+}
+
 export function isMermaidFenceLanguage(language: string | undefined): boolean {
   if (!language) return false;
   return MERMAID_FENCE_LANGUAGES.has(language.trim().toLowerCase());
@@ -103,22 +114,26 @@ export function mermaidSourceAsMarkdownFence(code: string): string {
   return `${fence}mermaid\n${body}\n${fence}`;
 }
 
+const DANGEROUS_SVG_TAGS = "script|iframe|object|embed|foreignObject|form|link|meta|base";
+const DANGEROUS_SVG_URL = "(?:javascript|vbscript|data\\s*:\\s*text\\s*/\\s*html)";
+
 /**
  * Strict-mode mermaid should not emit scripts, but the SVG still lands in the
  * chat DOM via innerHTML. Strip the obvious handlers so a mermaid bug cannot
  * become an XSS gadget.
  */
 export function sanitizeMermaidSvg(svg: string): string {
+  const tagged = new RegExp(`<(${DANGEROUS_SVG_TAGS})\\b[^>]*>[\\s\\S]*?</\\1>`, "gi");
+  const selfClosing = new RegExp(`<(${DANGEROUS_SVG_TAGS})\\b[^>]*/>`, "gi");
+  const dangerousUrl = new RegExp(
+    `\\s+(?:xlink:)?(?:href|src)\\s*=\\s*(?:"${DANGEROUS_SVG_URL}[^"]*"|'${DANGEROUS_SVG_URL}[^']*'|${DANGEROUS_SVG_URL}\\S+)`,
+    "gi",
+  );
   return svg
-    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "")
-    .replace(/<script\b[^>]*\/>/gi, "")
-    .replace(/<iframe\b[^>]*>[\s\S]*?<\/iframe>/gi, "")
-    .replace(/<iframe\b[^>]*\/>/gi, "")
+    .replace(tagged, "")
+    .replace(selfClosing, "")
     .replace(/\s+on[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, "")
-    .replace(
-      /\s+(?:xlink:)?href\s*=\s*(?:"javascript:[^"]*"|'javascript:[^']*'|javascript:\S+)/gi,
-      "",
-    );
+    .replace(dangerousUrl, "");
 }
 
 /**
@@ -132,8 +147,8 @@ export function remapMermaidSvgIds(svg: string, suffix: string): string {
   if (suffix.length === 0) return svg;
   const ids: string[] = [];
   const seen = new Set<string>();
-  for (const match of svg.matchAll(/\bid="([^"]+)"/g)) {
-    const id = match[1];
+  for (const match of svg.matchAll(/\bid=(?:"([^"]+)"|'([^']+)')/g)) {
+    const id = match[1] ?? match[2];
     if (id == null || id.length === 0 || seen.has(id)) continue;
     seen.add(id);
     ids.push(id);
@@ -144,11 +159,20 @@ export function remapMermaidSvgIds(svg: string, suffix: string): string {
     const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     const next = `${id}${suffix}`;
     remapped = remapped.replace(new RegExp(`id="${escaped}"`, "g"), `id="${next}"`);
-    remapped = remapped.replace(new RegExp(`url\\(#${escaped}\\)`, "g"), `url(#${next})`);
+    remapped = remapped.replace(new RegExp(`id='${escaped}'`, "g"), `id='${next}'`);
+    remapped = remapped.replace(
+      new RegExp(`url\\(\\s*(['"]?)#${escaped}\\1\\s*\\)`, "g"),
+      `url($1#${next}$1)`,
+    );
     remapped = remapped.replace(new RegExp(`href="#${escaped}"`, "g"), `href="#${next}"`);
+    remapped = remapped.replace(new RegExp(`href='#${escaped}'`, "g"), `href='#${next}'`);
     remapped = remapped.replace(
       new RegExp(`xlink:href="#${escaped}"`, "g"),
       `xlink:href="#${next}"`,
+    );
+    remapped = remapped.replace(
+      new RegExp(`xlink:href='#${escaped}'`, "g"),
+      `xlink:href='#${next}'`,
     );
     // Theme selectors live in <style> (`#id .nodeLabel`). Hex colors are
     // `fill:#fff` / `fill: #fff` / `fill="#fff"`. Only rewrite hashes inside

--- a/apps/web/src/lib/mermaidRendering.ts
+++ b/apps/web/src/lib/mermaidRendering.ts
@@ -4,7 +4,6 @@
  * Web and desktop share this path (desktop wraps the web client). Mobile has
  * no DOM mermaid runtime, so mermaid fences stay ordinary code blocks there.
  */
-import { fnv1a32 } from "./diffRendering";
 import { LRUCache } from "./lruCache";
 import { mermaidSvgContentSize } from "./mermaidViewport";
 
@@ -84,7 +83,9 @@ function nextMermaidDomId(): string {
 }
 
 function createMermaidCacheKey(code: string, theme: MermaidColorScheme): string {
-  return `${fnv1a32(code).toString(36)}:${code.length}:${theme}`;
+  // Include the source itself. A hash+length key can collide and serve the
+  // wrong cached SVG until that entry is evicted.
+  return `${theme}:${code}`;
 }
 
 export function isMermaidFenceLanguage(language: string | undefined): boolean {
@@ -149,8 +150,12 @@ export function remapMermaidSvgIds(svg: string, suffix: string): string {
       new RegExp(`xlink:href="#${escaped}"`, "g"),
       `xlink:href="#${next}"`,
     );
-    // Mermaid themes live in a <style> block keyed by the root svg id.
-    remapped = remapped.replace(new RegExp(`#${escaped}(?=[^A-Za-z0-9_-]|$)`, "g"), `#${next}`);
+    // Theme selectors live in <style> (`#id .nodeLabel`). Hex colors are
+    // `fill:#fff` / `fill: #fff` / `fill="#fff"`. Only rewrite hashes inside
+    // stylesheets, and skip anything after a CSS colon.
+    remapped = remapped.replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, (styleBlock) =>
+      styleBlock.replace(new RegExp(`(?<!:\\s*)#${escaped}(?=[^A-Za-z0-9_-]|$)`, "g"), `#${next}`),
+    );
   }
   return remapped;
 }
@@ -216,7 +221,11 @@ export async function renderMermaidSvg(code: string, theme: MermaidColorScheme):
       await mermaid.parse(trimmed);
       const { svg } = await mermaid.render(nextMermaidDomId(), trimmed);
       const sanitized = sanitizeMermaidSvg(svg);
-      mermaidSvgCache.set(cacheKey, sanitized, Math.max(sanitized.length * 2, trimmed.length));
+      mermaidSvgCache.set(
+        cacheKey,
+        sanitized,
+        Math.max(sanitized.length * 2, trimmed.length) + cacheKey.length,
+      );
       return sanitized;
     } catch (cause) {
       throw new MermaidRenderError(cause);

--- a/apps/web/src/lib/mermaidRendering.ts
+++ b/apps/web/src/lib/mermaidRendering.ts
@@ -124,14 +124,16 @@ const DANGEROUS_SVG_URL = "(?:javascript|vbscript|data\\s*:\\s*text\\s*/\\s*html
  */
 export function sanitizeMermaidSvg(svg: string): string {
   const tagged = new RegExp(`<(${DANGEROUS_SVG_TAGS})\\b[^>]*>[\\s\\S]*?</\\1>`, "gi");
-  const selfClosing = new RegExp(`<(${DANGEROUS_SVG_TAGS})\\b[^>]*/>`, "gi");
+  // Unclosed / self-closing leftovers after the paired pass. `[^>]*` also
+  // matches `/>`, so a separate self-closing pattern is unnecessary.
+  const opening = new RegExp(`<(${DANGEROUS_SVG_TAGS})\\b[^>]*>`, "gi");
   const dangerousUrl = new RegExp(
     `\\s+(?:xlink:)?(?:href|src)\\s*=\\s*(?:"${DANGEROUS_SVG_URL}[^"]*"|'${DANGEROUS_SVG_URL}[^']*'|${DANGEROUS_SVG_URL}\\S+)`,
     "gi",
   );
   return svg
     .replace(tagged, "")
-    .replace(selfClosing, "")
+    .replace(opening, "")
     .replace(/\s+on[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, "")
     .replace(dangerousUrl, "");
 }

--- a/apps/web/src/lib/mermaidViewport.test.ts
+++ b/apps/web/src/lib/mermaidViewport.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  clampMermaidZoom,
+  fitMermaidViewport,
+  MAX_MERMAID_OVERLAY_ZOOM,
+  mermaidSvgContentSize,
+  MIN_MERMAID_OVERLAY_ZOOM,
+  panMermaidViewport,
+  resetMermaidViewport,
+  zoomMermaidViewportAtPoint,
+} from "./mermaidViewport";
+
+describe("clampMermaidZoom", () => {
+  it("keeps in-range zoom unchanged", () => {
+    expect(clampMermaidZoom(1)).toBe(1);
+    expect(clampMermaidZoom(2.5)).toBe(2.5);
+  });
+
+  it("clamps to the overlay min and max", () => {
+    expect(clampMermaidZoom(0)).toBe(MIN_MERMAID_OVERLAY_ZOOM);
+    expect(clampMermaidZoom(100)).toBe(MAX_MERMAID_OVERLAY_ZOOM);
+    expect(clampMermaidZoom(Number.NaN)).toBe(1);
+  });
+});
+
+describe("panMermaidViewport", () => {
+  it("shifts translation without changing zoom", () => {
+    expect(panMermaidViewport({ x: 10, y: 20, zoom: 2 }, 4, -6)).toEqual({
+      x: 14,
+      y: 14,
+      zoom: 2,
+    });
+  });
+
+  it("returns the same viewport when the delta is zero", () => {
+    const viewport = { x: 1, y: 2, zoom: 3 };
+    expect(panMermaidViewport(viewport, 0, 0)).toBe(viewport);
+  });
+});
+
+describe("zoomMermaidViewportAtPoint", () => {
+  it("keeps the focal point stationary", () => {
+    const viewport = { x: 10, y: 20, zoom: 1 };
+    const point = { x: 100, y: 80 };
+    const next = zoomMermaidViewportAtPoint(viewport, 2, point);
+    expect(next.zoom).toBe(2);
+    expect((point.x - next.x) / next.zoom).toBeCloseTo((point.x - viewport.x) / viewport.zoom);
+    expect((point.y - next.y) / next.zoom).toBeCloseTo((point.y - viewport.y) / viewport.zoom);
+  });
+
+  it("does not move when zoom is already at a clamp bound", () => {
+    const viewport = { x: 5, y: 5, zoom: MAX_MERMAID_OVERLAY_ZOOM };
+    expect(zoomMermaidViewportAtPoint(viewport, 99, { x: 40, y: 40 })).toBe(viewport);
+  });
+});
+
+describe("fitMermaidViewport", () => {
+  it("centers a wide diagram and scales it to the scene", () => {
+    const viewport = fitMermaidViewport(
+      { width: 400, height: 300 },
+      { width: 800, height: 100 },
+      0,
+    );
+    expect(viewport.zoom).toBe(0.5);
+    expect(viewport.x).toBe(0);
+    expect(viewport.y).toBe(125);
+  });
+
+  it("falls back to identity when either box is empty", () => {
+    expect(fitMermaidViewport({ width: 0, height: 100 }, { width: 10, height: 10 })).toEqual(
+      resetMermaidViewport(),
+    );
+  });
+});
+
+describe("mermaidSvgContentSize", () => {
+  it("reads viewBox dimensions", () => {
+    expect(mermaidSvgContentSize(`<svg viewBox="0 0 248.22 127" width="100%"></svg>`)).toEqual({
+      width: 248.22,
+      height: 127,
+    });
+  });
+
+  it("falls back to numeric width and height attributes", () => {
+    expect(mermaidSvgContentSize(`<svg width="320px" height="80"></svg>`)).toEqual({
+      width: 320,
+      height: 80,
+    });
+  });
+
+  it("ignores percentage width without a viewBox", () => {
+    expect(mermaidSvgContentSize(`<svg width="100%" height="100%"></svg>`)).toBeNull();
+  });
+});

--- a/apps/web/src/lib/mermaidViewport.test.ts
+++ b/apps/web/src/lib/mermaidViewport.test.ts
@@ -3,8 +3,11 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   clampMermaidZoom,
   fitMermaidViewport,
+  keepMermaidViewportInScene,
   MAX_MERMAID_OVERLAY_ZOOM,
+  mermaidOverlayZoomPercent,
   mermaidSvgContentSize,
+  mermaidViewportContentCenter,
   MIN_MERMAID_OVERLAY_ZOOM,
   panMermaidViewport,
   resetMermaidViewport,
@@ -17,10 +20,10 @@ describe("clampMermaidZoom", () => {
     expect(clampMermaidZoom(2.5)).toBe(2.5);
   });
 
-  it("clamps to the overlay min and max", () => {
-    expect(clampMermaidZoom(0)).toBe(MIN_MERMAID_OVERLAY_ZOOM);
-    expect(clampMermaidZoom(100)).toBe(MAX_MERMAID_OVERLAY_ZOOM);
-    expect(clampMermaidZoom(Number.NaN)).toBe(1);
+  it("clamps relative to the fitted zoom", () => {
+    expect(clampMermaidZoom(0, 0.5)).toBe(0.5 * MIN_MERMAID_OVERLAY_ZOOM);
+    expect(clampMermaidZoom(100, 0.5)).toBe(0.5 * MAX_MERMAID_OVERLAY_ZOOM);
+    expect(clampMermaidZoom(Number.NaN, 0.5)).toBe(0.5);
   });
 });
 
@@ -71,6 +74,38 @@ describe("fitMermaidViewport", () => {
     expect(fitMermaidViewport({ width: 0, height: 100 }, { width: 10, height: 10 })).toEqual(
       resetMermaidViewport(),
     );
+  });
+});
+
+describe("mermaidOverlayZoomPercent", () => {
+  it("treats the fitted zoom as 100%", () => {
+    expect(mermaidOverlayZoomPercent(0.75, 0.75)).toBe(100);
+    expect(mermaidOverlayZoomPercent(1.5, 0.75)).toBe(200);
+  });
+});
+
+describe("keepMermaidViewportInScene", () => {
+  it("pulls a diagram that was translated fully off-canvas back into view", () => {
+    const next = keepMermaidViewportInScene(
+      { x: -4000, y: -4000, zoom: 2 },
+      { width: 400, height: 300 },
+      { width: 200, height: 80 },
+      40,
+    );
+    expect(next.x).toBe(40 - 400);
+    expect(next.y).toBe(40 - 160);
+  });
+});
+
+describe("zoomMermaidViewportAtPoint around the content center", () => {
+  it("keeps the diagram center fixed when zooming from a fitted view", () => {
+    const content = { width: 800, height: 100 };
+    const fitted = fitMermaidViewport({ width: 400, height: 300 }, content, 0);
+    const center = mermaidViewportContentCenter(fitted, content);
+    const next = zoomMermaidViewportAtPoint(fitted, fitted.zoom * 2, center, fitted.zoom);
+    const nextCenter = mermaidViewportContentCenter(next, content);
+    expect(nextCenter.x).toBeCloseTo(center.x);
+    expect(nextCenter.y).toBeCloseTo(center.y);
   });
 });
 

--- a/apps/web/src/lib/mermaidViewport.ts
+++ b/apps/web/src/lib/mermaidViewport.ts
@@ -2,6 +2,7 @@ export const MIN_MERMAID_OVERLAY_ZOOM = 0.25;
 export const MAX_MERMAID_OVERLAY_ZOOM = 8;
 export const MERMAID_OVERLAY_ZOOM_STEP = 1.25;
 export const MERMAID_OVERLAY_FIT_PADDING = 32;
+export const MERMAID_OVERLAY_EDGE_MARGIN = 48;
 
 export interface MermaidViewport {
   readonly x: number;
@@ -23,9 +24,17 @@ export function resetMermaidViewport(): MermaidViewport {
   return { x: 0, y: 0, zoom: 1 };
 }
 
-export function clampMermaidZoom(zoom: number): number {
-  if (!Number.isFinite(zoom)) return 1;
-  return Math.min(MAX_MERMAID_OVERLAY_ZOOM, Math.max(MIN_MERMAID_OVERLAY_ZOOM, zoom));
+export function clampMermaidZoom(zoom: number, fitZoom = 1): number {
+  const origin = Number.isFinite(fitZoom) && fitZoom > 0 ? fitZoom : 1;
+  if (!Number.isFinite(zoom)) return origin;
+  const min = origin * MIN_MERMAID_OVERLAY_ZOOM;
+  const max = origin * MAX_MERMAID_OVERLAY_ZOOM;
+  return Math.min(max, Math.max(min, zoom));
+}
+
+export function mermaidOverlayZoomPercent(zoom: number, fitZoom: number): number {
+  if (!(fitZoom > 0)) return 100;
+  return Math.round((zoom / fitZoom) * 100);
 }
 
 export function panMermaidViewport(
@@ -45,14 +54,45 @@ export function zoomMermaidViewportAtPoint(
   viewport: MermaidViewport,
   nextZoom: number,
   point: Point,
+  fitZoom = 1,
 ): MermaidViewport {
-  const zoom = clampMermaidZoom(nextZoom);
+  const zoom = clampMermaidZoom(nextZoom, fitZoom);
   if (zoom === viewport.zoom) return viewport;
   const scale = zoom / viewport.zoom;
   return {
     x: point.x - (point.x - viewport.x) * scale,
     y: point.y - (point.y - viewport.y) * scale,
     zoom,
+  };
+}
+
+export function mermaidViewportContentCenter(viewport: MermaidViewport, content: Size): Point {
+  return {
+    x: viewport.x + (content.width * viewport.zoom) / 2,
+    y: viewport.y + (content.height * viewport.zoom) / 2,
+  };
+}
+
+/**
+ * Keep at least a sliver of the diagram inside the scene so zoom/pan cannot
+ * send it into empty space.
+ */
+export function keepMermaidViewportInScene(
+  viewport: MermaidViewport,
+  scene: Size,
+  content: Size,
+  margin = MERMAID_OVERLAY_EDGE_MARGIN,
+): MermaidViewport {
+  const visWidth = content.width * viewport.zoom;
+  const visHeight = content.height * viewport.zoom;
+  const minX = margin - visWidth;
+  const maxX = scene.width - margin;
+  const minY = margin - visHeight;
+  const maxY = scene.height - margin;
+  return {
+    x: minX <= maxX ? Math.min(maxX, Math.max(minX, viewport.x)) : (scene.width - visWidth) / 2,
+    y: minY <= maxY ? Math.min(maxY, Math.max(minY, viewport.y)) : (scene.height - visHeight) / 2,
+    zoom: viewport.zoom,
   };
 }
 
@@ -66,9 +106,7 @@ export function fitMermaidViewport(
   }
   const availableWidth = Math.max(1, scene.width - padding * 2);
   const availableHeight = Math.max(1, scene.height - padding * 2);
-  const zoom = clampMermaidZoom(
-    Math.min(availableWidth / content.width, availableHeight / content.height),
-  );
+  const zoom = Math.min(availableWidth / content.width, availableHeight / content.height);
   return {
     x: (scene.width - content.width * zoom) / 2,
     y: (scene.height - content.height * zoom) / 2,

--- a/apps/web/src/lib/mermaidViewport.ts
+++ b/apps/web/src/lib/mermaidViewport.ts
@@ -1,0 +1,108 @@
+export const MIN_MERMAID_OVERLAY_ZOOM = 0.25;
+export const MAX_MERMAID_OVERLAY_ZOOM = 8;
+export const MERMAID_OVERLAY_ZOOM_STEP = 1.25;
+export const MERMAID_OVERLAY_FIT_PADDING = 32;
+
+export interface MermaidViewport {
+  readonly x: number;
+  readonly y: number;
+  readonly zoom: number;
+}
+
+export interface Size {
+  readonly width: number;
+  readonly height: number;
+}
+
+export interface Point {
+  readonly x: number;
+  readonly y: number;
+}
+
+export function resetMermaidViewport(): MermaidViewport {
+  return { x: 0, y: 0, zoom: 1 };
+}
+
+export function clampMermaidZoom(zoom: number): number {
+  if (!Number.isFinite(zoom)) return 1;
+  return Math.min(MAX_MERMAID_OVERLAY_ZOOM, Math.max(MIN_MERMAID_OVERLAY_ZOOM, zoom));
+}
+
+export function panMermaidViewport(
+  viewport: MermaidViewport,
+  dx: number,
+  dy: number,
+): MermaidViewport {
+  if (dx === 0 && dy === 0) return viewport;
+  return { x: viewport.x + dx, y: viewport.y + dy, zoom: viewport.zoom };
+}
+
+/**
+ * Zoom around a point in the scene's client coordinates.
+ * Transform is `translate(x, y) scale(zoom)` with origin at 0,0.
+ */
+export function zoomMermaidViewportAtPoint(
+  viewport: MermaidViewport,
+  nextZoom: number,
+  point: Point,
+): MermaidViewport {
+  const zoom = clampMermaidZoom(nextZoom);
+  if (zoom === viewport.zoom) return viewport;
+  const scale = zoom / viewport.zoom;
+  return {
+    x: point.x - (point.x - viewport.x) * scale,
+    y: point.y - (point.y - viewport.y) * scale,
+    zoom,
+  };
+}
+
+export function fitMermaidViewport(
+  scene: Size,
+  content: Size,
+  padding = MERMAID_OVERLAY_FIT_PADDING,
+): MermaidViewport {
+  if (scene.width <= 0 || scene.height <= 0 || content.width <= 0 || content.height <= 0) {
+    return resetMermaidViewport();
+  }
+  const availableWidth = Math.max(1, scene.width - padding * 2);
+  const availableHeight = Math.max(1, scene.height - padding * 2);
+  const zoom = clampMermaidZoom(
+    Math.min(availableWidth / content.width, availableHeight / content.height),
+  );
+  return {
+    x: (scene.width - content.width * zoom) / 2,
+    y: (scene.height - content.height * zoom) / 2,
+    zoom,
+  };
+}
+
+export function mermaidSvgContentSize(svg: string): Size | null {
+  const viewBox = svg.match(/\bviewBox\s*=\s*["']([^"']+)["']/i);
+  const viewBoxValue = viewBox?.[1];
+  if (viewBoxValue) {
+    const parts = viewBoxValue
+      .trim()
+      .split(/[\s,]+/)
+      .map(Number);
+    const width = parts[2];
+    const height = parts[3];
+    if (
+      parts.length === 4 &&
+      width != null &&
+      height != null &&
+      parts.every(Number.isFinite) &&
+      width > 0 &&
+      height > 0
+    ) {
+      return { width, height };
+    }
+  }
+  const widthMatch = svg.match(/\bwidth\s*=\s*["']([0-9.]+)(?:px)?["']/i);
+  const heightMatch = svg.match(/\bheight\s*=\s*["']([0-9.]+)(?:px)?["']/i);
+  if (widthMatch?.[1] && heightMatch?.[1]) {
+    const width = Number(widthMatch[1]);
+    const height = Number(heightMatch[1]);
+    if (width > 0 && height > 0) return { width, height };
+  }
+  return null;
+}

--- a/apps/web/src/markdown-clipboard.test.ts
+++ b/apps/web/src/markdown-clipboard.test.ts
@@ -22,6 +22,7 @@ class FakeElement {
   constructor(
     readonly tagName: string,
     private readonly classNames: ReadonlyArray<string> = [],
+    private readonly attributes: Record<string, string> = {},
   ) {}
 
   get localName(): string {
@@ -37,12 +38,12 @@ class FakeElement {
     return this;
   }
 
-  getAttribute(): string | null {
-    return null;
+  getAttribute(name: string): string | null {
+    return this.attributes[name] ?? null;
   }
 
-  hasAttribute(): boolean {
-    return false;
+  hasAttribute(name: string): boolean {
+    return name in this.attributes;
   }
 }
 
@@ -91,5 +92,18 @@ describe("serializeRenderedMarkdownFragment", () => {
     const container = new FakeElement("DIV").append(code);
 
     expect(serializeRenderedMarkdownFragment(asNode(container))).toBe("first line\nsecond line");
+  });
+
+  it("serializes a rendered mermaid diagram as a mermaid fence, not svg text", () => {
+    const svg = new FakeElement("SVG").append(new FakeText("A --> B"));
+    const diagram = new FakeElement("DIV", ["chat-markdown-mermaid"], {
+      "data-markdown-copy": "```mermaid\ngraph TD\n  A --> B\n```",
+    }).append(svg);
+    const paragraph = new FakeElement("P").append(new FakeText("See:"));
+    const container = new FakeElement("DIV").append(paragraph, diagram);
+
+    expect(serializeRenderedMarkdownFragment(asNode(container))).toBe(
+      "See:\n\n```mermaid\ngraph TD\n  A --> B\n```",
+    );
   });
 });

--- a/apps/web/src/markdown-clipboard.test.ts
+++ b/apps/web/src/markdown-clipboard.test.ts
@@ -106,4 +106,15 @@ describe("serializeRenderedMarkdownFragment", () => {
       "See:\n\n```mermaid\ngraph TD\n  A --> B\n```",
     );
   });
+
+  it("serializes a mermaid error fallback as the source fence, not the alert copy", () => {
+    const error = new FakeElement("DIV", ["chat-markdown-mermaid-error"], {
+      "data-markdown-copy": "```mermaid\ngraph TD\n  A --> B\n```",
+    }).append(new FakeElement("P").append(new FakeText("Couldn't render this diagram.")));
+    const container = new FakeElement("DIV").append(error);
+
+    expect(serializeRenderedMarkdownFragment(asNode(container))).toBe(
+      "```mermaid\ngraph TD\n  A --> B\n```",
+    );
+  });
 });

--- a/apps/web/src/markdown-clipboard.ts
+++ b/apps/web/src/markdown-clipboard.ts
@@ -322,6 +322,17 @@ export function chatMarkdownClipboardPayload(
     const ancestor = range.commonAncestorContainer;
     const ancestorElement =
       ancestor.nodeType === Node.ELEMENT_NODE ? (ancestor as Element) : ancestor.parentElement;
+    const mermaid = ancestorElement?.closest(
+      ".chat-markdown-mermaid, .chat-markdown-mermaid-error, .chat-markdown-mermaid-pending",
+    );
+    if (mermaid) {
+      const fence = mermaid.getAttribute("data-markdown-copy");
+      if (fence) {
+        texts.push(fence);
+        htmls.push(sanitizedHtmlFrom(container));
+      }
+      continue;
+    }
     if (ancestorElement?.closest("pre")) {
       const text = range.toString();
       if (text) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@
 - [Permission modes](./user/permission-modes.md)
 - [Keyboard shortcuts](./user/keybindings.md)
 - [Organizing threads](./user/thread-sidebar.md)
+- [Chat markdown](./user/markdown.md)
 - [Review usage](./user/usage.md)
 - [Customize a project icon](./user/project-settings.md)
 - [Mobile appearance](./user/mobile-appearance.md)

--- a/docs/user/markdown.md
+++ b/docs/user/markdown.md
@@ -1,0 +1,11 @@
+# Chat markdown
+
+Agent replies can include fenced diagrams. A `mermaid` (or `mmd`) code fence
+renders as a diagram in the conversation. Use the toolbar to switch back to the
+source, copy it, or expand a rendered diagram into a larger overlay.
+
+In the overlay, scroll to zoom and drag to pan. Chat scrolling stays underneath
+until you close the overlay (Escape, the close button, or the backdrop).
+
+Mermaid rendering is available on web and desktop. On mobile, mermaid fences stay
+ordinary code blocks.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -597,6 +597,9 @@ importers:
       lucide-react:
         specifier: ^0.564.0
         version: 0.564.0(react@19.2.6)
+      mermaid:
+        specifier: ^11.16.1
+        version: 11.16.1
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -959,6 +962,9 @@ packages:
 
   '@alchemy.run/node-utils@0.0.5':
     resolution: {integrity: sha512-5agdhQxWBodxa5hDRyjnpx91RTU3g+qd5fxYB7uNDCaOzB0XC47UU/KHR6zf6jhz/NXf61gJS+vhYwn8NHeRoQ==}
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
   '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.170':
     resolution: {integrity: sha512-rwfgArIa5WI0QPNqFsRBgvtSI0mrtpynUm0oK6+l6/KX4hcgnYGEzciZR1bOeD9/7sSZlTdIgt+T9alKeZmXcg==}
@@ -1640,6 +1646,9 @@ packages:
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
 
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
   '@bruits/satteri-darwin-arm64@0.9.3':
     resolution: {integrity: sha512-dRUZZrdwh1asfTOyM1nDNmzolhnHtlIFpqYrl1Tdd3YVcaebKmrfJgGL7NAoGPjbEwYmZxaugrxA0uzw83c0dw==}
     cpu: [arm64]
@@ -1698,6 +1707,9 @@ packages:
   '@capsizecss/unpack@4.0.1':
     resolution: {integrity: sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==}
     engines: {node: '>=18'}
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
   '@clack/core@0.5.0':
     resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
@@ -2745,6 +2757,12 @@ packages:
   '@iarna/toml@2.2.5':
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
 
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.4':
+    resolution: {integrity: sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==}
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -3125,6 +3143,9 @@ packages:
   '@malept/flatpak-bundler@0.4.0':
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
+
+  '@mermaid-js/parser@1.2.0':
+    resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -4818,6 +4839,99 @@ packages:
   '@types/culori@4.0.1':
     resolution: {integrity: sha512-43M51r/22CjhbOXyGT361GZ9vncSVQ39u62x5eJdBQFviI8zWp2X5jzqg7k4M6PVgDQAClpy2bUe2dtwEgEDVQ==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.1':
+    resolution: {integrity: sha512-65Emv9fQiQQqphLlRkuQ5ypPsOmWPhtBGCMv61JDPEPMvsx+gzhGf74yw1a78xFKPj6zw4AgQICJoQv0vK9M2w==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.4':
+    resolution: {integrity: sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -4841,6 +4955,9 @@ packages:
 
   '@types/fs-extra@9.0.13':
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hammerjs@2.0.46':
     resolution: {integrity: sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==}
@@ -4912,6 +5029,9 @@ packages:
 
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -4986,6 +5106,9 @@ packages:
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@vercel/config@0.3.0':
     resolution: {integrity: sha512-Tf5k5y2F478oTiQcU5R8Ntix1UejE6NdduZnI7aa1XXxjCtifX1XdRS/D2uTjiQAwIL3pLa1LSAN80ABbba+TQ==}
@@ -5184,10 +5307,12 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@yuuang/ffi-rs-android-arm64@1.3.2':
     resolution: {integrity: sha512-eDYLT0kVBkp7e2BwdRDmt6N1rkeDPUHDefk3ZX0/nok+GLsqfy1WBoSL3Yg7HVXN1EyW8OBVc2uK8Zq8HbmaSA==}
@@ -5902,6 +6027,10 @@ packages:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
 
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
   commander@9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
@@ -5983,6 +6112,12 @@ packages:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
   cross-dirname@0.1.0:
     resolution: {integrity: sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==}
 
@@ -6034,6 +6169,165 @@ packages:
   culori@4.0.2:
     resolution: {integrity: sha512-1+BhOB8ahCn4O0cep0Sh2l9KCOfOdY+BXJnKMHFFzDEouSr/el18QwXEMRlOj9UY5nCeA8UN3a/82rUWRBeyBw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.34.1:
+    resolution: {integrity: sha512-Lr0RvH9H75y9ar8h9Toy6u4lxRSCcxUq+hHcQ26sVWo6BnaQp1gwEZOYqwuYTZhyW7npyKnNLP8oJ2p1/3OZ7g==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
+
+  dayjs@1.11.22:
+    resolution: {integrity: sha512-1YRnxzt/AabP3GHxnaB9/b+ZScCKu5TeF+co+BWG+lnWVIwEcTFc1FVE0WLNmNO3sA6GGXL40i5qkHfbLzpwrg==}
 
   debounce-fn@4.0.0:
     resolution: {integrity: sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==}
@@ -6096,6 +6390,9 @@ packages:
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -6172,6 +6469,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -7123,6 +7423,9 @@ packages:
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
 
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
   has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
@@ -7246,6 +7549,10 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -7268,6 +7575,9 @@ packages:
 
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
@@ -7303,6 +7613,13 @@ packages:
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
@@ -7552,8 +7869,15 @@ packages:
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
 
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -7569,6 +7893,12 @@ packages:
   lan-network@0.2.1:
     resolution: {integrity: sha512-ONPnazC96VKDntab9j9JKwIWhZ4ZUceB4A9Epu4Ssg0hYFmtHZSeQ+n15nIwTFmcBUKtExOer8WTJ4GF9MO64A==}
     hasBin: true
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   lazy-val@1.0.5:
     resolution: {integrity: sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==}
@@ -7822,6 +8152,9 @@ packages:
     resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
     engines: {node: '>=6'}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
@@ -7901,6 +8234,11 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   marky@1.3.0:
     resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
@@ -7993,6 +8331,9 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  mermaid@11.16.1:
+    resolution: {integrity: sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==}
 
   metro-babel-transformer@0.84.4:
     resolution: {integrity: sha512-rvCfz8snl9h20VcvpOHxZuHP1SlAkv4HXbzw7nyyVwu6Eqo5PRerbakQ9XmUCOsRy70spJ37O+G1TK8oMzo48g==}
@@ -8605,6 +8946,9 @@ packages:
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
+
   path-exists@3.0.0:
     resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
     engines: {node: '>=4'}
@@ -8752,6 +9096,12 @@ packages:
   pngjs@7.0.0:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
     engines: {node: '>=14.19.0'}
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -9314,6 +9664,9 @@ packages:
     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
     engines: {node: '>=8.0'}
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rolldown@1.0.0-rc.17:
     resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -9329,12 +9682,18 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
+
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -9664,6 +10023,9 @@ packages:
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
   sumchecker@3.0.1:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
@@ -9838,6 +10200,10 @@ packages:
 
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
+  ts-dedent@2.3.0:
+    resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
+    engines: {node: '>=6.10'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -10545,6 +10911,11 @@ snapshots:
       is-fullwidth-code-point: 5.1.0
 
   '@alchemy.run/node-utils@0.0.5': {}
+
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.6.0
+      tinyexec: 1.2.4
 
   '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.170':
     optional: true
@@ -11474,6 +11845,8 @@ snapshots:
 
   '@blazediff/core@1.9.1': {}
 
+  '@braintree/sanitize-url@7.1.2': {}
+
   '@bruits/satteri-darwin-arm64@0.9.3':
     optional: true
 
@@ -11513,6 +11886,8 @@ snapshots:
   '@capsizecss/unpack@4.0.1':
     dependencies:
       fontkitten: 1.0.3
+
+  '@chevrotain/types@11.1.2': {}
 
   '@clack/core@0.5.0':
     dependencies:
@@ -12841,6 +13216,14 @@ snapshots:
 
   '@iarna/toml@2.2.5': {}
 
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.4':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
+
   '@img/colour@1.1.0':
     optional: true
 
@@ -13259,6 +13642,10 @@ snapshots:
       tmp-promise: 3.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@mermaid-js/parser@1.2.0':
+    dependencies:
+      '@chevrotain/types': 11.1.2
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
@@ -14998,6 +15385,123 @@ snapshots:
 
   '@types/culori@4.0.1': {}
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.1':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.4': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.1
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -15028,6 +15532,8 @@ snapshots:
   '@types/fs-extra@9.0.13':
     dependencies:
       '@types/node': 24.12.4
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/hammerjs@2.0.46': {}
 
@@ -15104,6 +15610,9 @@ snapshots:
 
   '@types/statuses@2.0.6': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -15161,6 +15670,11 @@ snapshots:
       '@typescript/native-preview-win32-x64': 7.0.0-dev.20260604.1
 
   '@ungap/structured-clone@1.3.1': {}
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   '@vercel/config@0.3.0':
     dependencies:
@@ -16241,6 +16755,8 @@ snapshots:
 
   commander@7.2.0: {}
 
+  commander@8.3.0: {}
+
   commander@9.5.0:
     optional: true
 
@@ -16321,6 +16837,14 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
+
   cross-dirname@0.1.0:
     optional: true
 
@@ -16377,6 +16901,192 @@ snapshots:
 
   culori@4.0.2: {}
 
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.1):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.34.1
+
+  cytoscape-fcose@2.2.0(cytoscape@3.34.1):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.34.1
+
+  cytoscape@3.34.1: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
+
+  dayjs@1.11.22: {}
+
   debounce-fn@4.0.0:
     dependencies:
       mimic-fn: 3.1.0
@@ -16426,6 +17136,10 @@ snapshots:
     optional: true
 
   defu@6.1.7: {}
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
 
   delayed-stream@1.0.0: {}
 
@@ -16491,6 +17205,10 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.4.13:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:
@@ -17753,6 +18471,8 @@ snapshots:
       ufo: 1.6.4
       uncrypto: 0.1.3
 
+  hachure-fill@0.5.2: {}
+
   has-flag@3.0.0: {}
 
   has-flag@4.0.0: {}
@@ -17954,6 +18674,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -17970,6 +18694,8 @@ snapshots:
       queue: 6.0.2
 
   immediate@3.0.6: {}
+
+  import-meta-resolve@4.2.0: {}
 
   indent-string@4.0.0:
     optional: true
@@ -18021,6 +18747,10 @@ snapshots:
       - utf-8-validate
 
   inline-style-parser@0.2.7: {}
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
 
   invariant@2.2.4:
     dependencies:
@@ -18226,9 +18956,15 @@ snapshots:
       readable-stream: 2.3.8
       setimmediate: 1.0.5
 
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  khroma@2.1.0: {}
 
   kleur@3.0.3: {}
 
@@ -18237,6 +18973,10 @@ snapshots:
   kubernetes-types@1.30.0: {}
 
   lan-network@0.2.1: {}
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   lazy-val@1.0.5: {}
 
@@ -18428,6 +19168,8 @@ snapshots:
       p-locate: 3.0.0
       path-exists: 3.0.0
 
+  lodash-es@4.18.1: {}
+
   lodash.debounce@4.0.8: {}
 
   lodash.escaperegexp@4.1.2: {}
@@ -18494,6 +19236,8 @@ snapshots:
       tmpl: 1.0.5
 
   markdown-table@3.0.4: {}
+
+  marked@16.4.2: {}
 
   marky@1.3.0: {}
 
@@ -18686,6 +19430,30 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  mermaid@11.16.1:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.4
+      '@mermaid-js/parser': 1.2.0
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.34.1
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.1)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.1)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.22
+      dompurify: 3.4.13
+      es-toolkit: 1.47.0
+      katex: 0.16.47
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.3.0
+      uuid: 14.0.1
 
   metro-babel-transformer@0.84.4:
     dependencies:
@@ -19532,6 +20300,8 @@ snapshots:
 
   path-browserify@1.0.1: {}
 
+  path-data-parser@0.1.0: {}
+
   path-exists@3.0.0: {}
 
   path-expression-matcher@1.5.0: {}
@@ -19666,6 +20436,13 @@ snapshots:
   pngjs@3.4.0: {}
 
   pngjs@7.0.0: {}
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   postcss@8.5.15:
     dependencies:
@@ -20471,6 +21248,8 @@ snapshots:
       sprintf-js: 1.1.3
     optional: true
 
+  robust-predicates@3.0.3: {}
+
   rolldown@1.0.0-rc.17:
     dependencies:
       '@oxc-project/types': 0.127.0
@@ -20546,6 +21325,13 @@ snapshots:
       fsevents: 2.3.3
     optional: true
 
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
   router@2.2.0:
     dependencies:
       debug: 4.4.3
@@ -20559,6 +21345,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rw@1.3.3: {}
 
   safe-buffer@5.1.2: {}
 
@@ -20949,6 +21737,8 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
+  stylis@4.4.0: {}
+
   sumchecker@3.0.1:
     dependencies:
       debug: 4.4.3
@@ -21116,6 +21906,8 @@ snapshots:
       utf8-byte-length: 1.0.5
 
   ts-algebra@2.0.0: {}
+
+  ts-dedent@2.3.0: {}
 
   tslib@2.8.1: {}
 


### PR DESCRIPTION
## What Changed

Adding Mermaid chart rendering in the chat UI with direct preview and a larger view for zoom and pan.

## Why

Claude's output became unreadable, thus asking for visualizations help. Always copying the mermaid code between T3Code and mermaid.live is not ideal

## UI Changes

https://github.com/user-attachments/assets/c6487081-88af-4aea-a28d-368af35588ae

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Injects mermaid-generated SVG via innerHTML; sanitization and strict mode reduce XSS risk but this is still untrusted model output in the DOM. New mermaid dependency and streaming remount work also affect chat rendering.
> 
> **Overview**
> Chat markdown now renders `mermaid`/`mmd` fences as diagrams on web and desktop (mobile still shows source). Users can toggle source vs diagram, copy the fence, and expand into a pan/zoom overlay.
> 
> Rendering is lazy, LRU-cached, and initialized in mermaid **strict** mode with extra SVG sanitization. Streaming parse failures keep the last good diagram. `ChatMarkdown` reads streaming text from refs so diagram state is not remounted every token.
> 
> Copying a rendered (or failed) diagram pastes the original mermaid fence, not SVG.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a8deffc17032ac2f89078aa634f7bc755e245a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add mermaid diagram rendering, zoom/pan overlay, and source copy to chat markdown
> - Chat markdown detects mermaid/mmd fenced code blocks and renders them inline as SVG diagrams via a new [mermaidRendering.ts](https://github.com/pingdotgg/t3code/pull/7497/files#diff-6da75e84c69f823959f06c85b9f38203674ef9f0f4616e049c3767c4c7833ee1) pipeline with LRU caching, strict-mode init, and SVG sanitization to strip XSS vectors.
> - [MermaidDiagram.tsx](https://github.com/pingdotgg/t3code/pull/7497/files#diff-0f692f7731df02087e1801148ea6a50b693fe2c306f63ccc16132379f2162b83) debounces rendering during streaming and retains last-good state on parse errors; [MermaidOverlay.tsx](https://github.com/pingdotgg/t3code/pull/7497/files#diff-edb52fe8277068468ddd048f3230acda65c48121a3073fd62e7612a558a99b85) provides a modal with wheel/keyboard zoom and pointer panning bounded by [mermaidViewport.ts](https://github.com/pingdotgg/t3code/pull/7497/files#diff-7bce7d9d8e01d0e99715d4ed660ad27118e1393f157a5ede0811d0c3ded949a8).
> - `MarkdownCodeBlock` gains a toolbar toggle between diagram and source code, plus an expand button; wrap-lines control is hidden in diagram view.
> - `ChatMarkdown` now uses refs (`textRef`, `isStreamingRef`, link-metadata maps) to prevent ReactMarkdown remounts during streaming, preserving diagram state across token updates.
> - Clipboard serialization reads `data-markdown-copy` from mermaid surfaces so copying a rendered diagram yields the original fence source, not raw SVG.
> - Risk: `MarkdownCodeBlock` adds three new optional props (`diagram`, `canExpandDiagram`, `onExpandDiagram`); existing callers that render code blocks without these props are unaffected, but any code relying on the absence of a `data-mermaid-view` attribute or the wrap-lines control always being present in the `pre` renderer path should be checked.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a8deff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->