### PR TITLE
fix(server): resolve partial clone repository identities

### DIFF
--- a/apps/server/src/project/RepositoryIdentityResolver.test.ts
+++ b/apps/server/src/project/RepositoryIdentityResolver.test.ts
@@ -61,6 +61,26 @@ it.layer(NodeServices.layer)("RepositoryIdentityResolverLive", (it) => {
     }).pipe(Effect.provide(RepositoryIdentityResolver.layer)),
   );
 
+  it.effect("resolves a promisor remote reported with a partial-clone annotation", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const cwd = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-repository-identity-partial-clone-test-",
+      });
+
+      yield* git(cwd, ["init"]);
+      yield* git(cwd, ["remote", "add", "origin", "git@github.com:T3Tools/t3code.git"]);
+      yield* git(cwd, ["config", "remote.origin.promisor", "true"]);
+      yield* git(cwd, ["config", "remote.origin.partialclonefilter", "blob:none"]);
+
+      const resolver = yield* RepositoryIdentityResolver.RepositoryIdentityResolver;
+      const identity = yield* resolver.resolve(cwd);
+
+      expect(identity?.canonicalKey).toBe("github.com/t3tools/t3code");
+      expect(identity?.locator.remoteName).toBe("origin");
+    }).pipe(Effect.provide(RepositoryIdentityResolver.layer)),
+  );
+
   it.effect("returns the git top-level root path when resolving from a nested workspace", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;

--- a/apps/server/src/project/RepositoryIdentityResolver.ts
+++ b/apps/server/src/project/RepositoryIdentityResolver.ts
@@ -34,7 +34,10 @@ function parseRemoteFetchUrls(stdout: string): Map<string, string> {
   for (const line of stdout.split("\n")) {
     const trimmed = line.trim();
     if (trimmed.length === 0) continue;
-    const match = /^(\S+)\s+(\S+)\s+\((fetch|push)\)$/.exec(trimmed);
+    // Partial clones append annotations such as `[blob:none]` after the
+    // direction. Keep accepting the stable remote/name fields while ignoring
+    // Git's optional transport metadata.
+    const match = /^(\S+)\s+(\S+)\s+\((fetch|push)\)(?:\s+\[[^\]]+\])*$/.exec(trimmed);
     if (!match) continue;
     const [, remoteName = "", remoteUrl = "", direction = ""] = match;
     if (direction !== "fetch" || remoteName.length === 0 || remoteUrl.length === 0) {


### PR DESCRIPTION
## What

Resolve repository identity for Git partial clones whose `git remote -v` fetch line includes transport metadata such as `[blob:none]`.

## Why

The parser previously required `(fetch)` to be the end of the line. For partial clones, that left `repositoryIdentity` empty, so projects on those machines could not group with normal clones of the same repository.

## Validation

- `vp test apps/server/src/project/RepositoryIdentityResolver.test.ts` (8 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow parser change in project identity resolution with a targeted test; no auth, data, or broad API surface impact.
> 
> **Overview**
> **Repository identity resolution** now tolerates Git partial-clone metadata on `git remote -v` lines (e.g. `[blob:none]` after `(fetch)`), so those workspaces get the same canonical identity as full clones.
> 
> `parseRemoteFetchUrls` in `RepositoryIdentityResolver` extends the line regex to accept zero or more bracketed annotations after the fetch/push direction while still extracting remote name and URL. A new integration test configures `remote.origin.promisor` and `partialclonefilter` and asserts the expected GitHub canonical key and `origin` locator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adbf94c81b0ee64f1da092fa7b12bc14e28d13a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->