### PR TITLE
fix(shared): give CommandResolutionError a message

### DIFF
--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -47,7 +47,11 @@ export type CommandAvailabilityChecker = (
 export class CommandResolutionError extends Data.TaggedError("CommandResolutionError")<{
   readonly command: string;
   readonly reason: "not-found";
-}> {}
+}> {
+  override get message(): string {
+    return `Command "${this.command}" could not be resolved (${this.reason}).`;
+  }
+}
 
 const WINDOWS_SHELL_META_CHARS = /([()\][%!^"`<>&|;, *?])/g;
 


### PR DESCRIPTION
## What Changed

`CommandResolutionError` in `packages/shared/src/shell.ts` now defines an `override get message()` that includes the command name and reason:

```
Command "cursor-agent" could not be resolved (not-found).
```

Four lines, one class, no behavioural change. Nothing reads `.message` today (the only other reference is `Effect.catchTag("CommandResolutionError", ...)` in `apps/server/src/provider/providerMaintenance.ts`), so this is purely a diagnostics fix. Follows the same `override get message(): string` pattern already used by the other error classes in `packages/shared`.

## Why

The class is a `Data.TaggedError` with `command`/`reason` fields but no message, so every span that fails with it is written to `server.trace.ndjson` as a bare

```
"exit":{"_tag":"Failure","cause":"CommandResolutionError: \n    at file:///.../bin.mjs:45981:51\n    at shell.resolveCommandPathForPlatform (..."}
```

On a Windows 11 machine running 0.0.34-nightly.20260819.1132 I counted 114 such `shell.resolveCommandPath`/`shell.resolveCommandPathForPlatform` failure exits in one session (editor discovery + provider binary probes) and there is no way to tell from the trace which command was being looked up. With this change the cause line carries the command and reason, which is what you need when triaging "provider not found" / editor discovery reports.

## UI Changes

None.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (n/a)
- [x] I included a video for animation/interaction changes (n/a)

---
Authorship disclosure: this change was investigated and prepared by Claude (Fable 5) running in Claude Code on the author's machine, at the author's request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-class logging/diagnostics tweak with no change to resolution logic or error handling behavior.
> 
> **Overview**
> **`CommandResolutionError`** in `shell.ts` now implements **`override get message()`**, producing text like `Command "cursor-agent" could not be resolved (not-found).` instead of an empty tagged-error message.
> 
> This is **diagnostics-only**: failure paths and `Effect.catchTag("CommandResolutionError", …)` behavior are unchanged. The goal is readable **`server.trace.ndjson`** / span failure causes when `shell.resolveCommandPath` fails during editor discovery or provider binary probes (especially on Windows).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3efe311e75b0f959f4c4b3267cfd8018fa1c2d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `CommandResolutionError` to expose a formatted error message
> Adds a `message` getter override to `CommandResolutionError` in [shell.ts](https://github.com/pingdotgg/t3code/pull/7502/files#diff-89a91f85db41a9a0912bc86c336bf9429751f3797ee50a089248c68cde8489ce) that returns `Command "${this.command}" could not be resolved (${this.reason}).` instead of the default inherited from `TaggedError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a3efe31.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->