### PR TITLE
feat(web): hide noisy projects from the pull request list

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestListFilters.test.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestListFilters.test.tsx
@@ -117,14 +117,23 @@ describe("pull request filters menu", () => {
     environmentId: "env-1" as EnvironmentId,
     title: "T3 Code",
     workspaceRoot: "/work/t3code",
+    hideKey: "repository:github.com/acme/t3code",
   };
   const projectTwo = {
     id: "project-2" as ProjectId,
     environmentId: "env-1" as EnvironmentId,
     title: "Popular OSS",
     workspaceRoot: "/work/popular",
+    hideKey: "repository:github.com/acme/popular",
   };
-  const keyTwo = pullRequestProjectKey(projectTwo);
+  const keyTwo = projectTwo.hideKey;
+  /** The same repository held by a second server, so both rows share one hidden state. */
+  const projectTwoElsewhere = {
+    ...projectTwo,
+    id: "project-9" as ProjectId,
+    environmentId: "env-2" as EnvironmentId,
+    title: "Popular OSS · other",
+  };
 
   it("does not emit a change when the selected state is chosen again", () => {
     const onState = vi.fn();
@@ -247,6 +256,27 @@ describe("pull request filters menu", () => {
 
     buttons[1]?.onClick(clickEvent());
     expect(onProject).toHaveBeenCalledWith(projectOne.id, "env-2");
+  });
+
+  it("hides both copies of a repository two servers share", () => {
+    const onHiddenProjectKeys = vi.fn();
+    const rows = findCheckboxItems(
+      menu({ projects: [projectTwo, projectTwoElsewhere], onHiddenProjectKeys }),
+    );
+    expect(rows.map((row) => row.checked)).toEqual([true, true, true]);
+
+    rows[1]?.onCheckedChange?.(false);
+    expect(onHiddenProjectKeys).toHaveBeenCalledWith([projectTwo.hideKey]);
+  });
+
+  it("reads both copies of a shared repository as hidden from the one key", () => {
+    const rows = findCheckboxItems(
+      menu({
+        projects: [projectTwo, projectTwoElsewhere],
+        hiddenProjectKeys: [projectTwo.hideKey],
+      }),
+    );
+    expect(rows.map((row) => row.checked)).toEqual([false, false, false]);
   });
 
   it("does not collide when environment and project ids contain spaces", () => {

--- a/apps/web/src/components/pullRequest/PullRequestListFilters.test.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestListFilters.test.tsx
@@ -42,6 +42,45 @@ function findLabeledGroup(node: ReactNode, label: string): ReactNode {
   return undefined;
 }
 
+interface CheckboxItemProps {
+  readonly checked?: boolean;
+  readonly onCheckedChange?: (checked: boolean) => void;
+  readonly onClick?: () => void;
+  readonly children?: ReactNode;
+}
+
+/** The project rows, in the order the menu lists them: "All projects" first, then the projects. */
+function findCheckboxItems(node: ReactNode): ReadonlyArray<CheckboxItemProps> {
+  const found: CheckboxItemProps[] = [];
+  for (const child of Children.toArray(node)) {
+    if (!isValidElement(child)) continue;
+    const props = child.props as CheckboxItemProps;
+    if (typeof props.checked === "boolean") found.push(props);
+    found.push(...findCheckboxItems(props.children));
+  }
+  return found;
+}
+
+/** The per-row "Only" buttons, in the same order as the rows that carry them. */
+function findOnlyButtons(
+  node: ReactNode,
+): ReadonlyArray<{ readonly onClick: (event: unknown) => void }> {
+  const found: Array<{ readonly onClick: (event: unknown) => void }> = [];
+  for (const child of Children.toArray(node)) {
+    if (!isValidElement(child)) continue;
+    const props = child.props as {
+      readonly children?: ReactNode;
+      readonly onClick?: (event: unknown) => void;
+    };
+    if (child.type === "button" && props.onClick) found.push({ onClick: props.onClick });
+    found.push(...findOnlyButtons(props.children));
+  }
+  return found;
+}
+
+/** Enough of a click for the handler, which only ever stops the row from swallowing it. */
+const clickEvent = () => ({ preventDefault: () => undefined, stopPropagation: () => undefined });
+
 function menu(overrides: Partial<Parameters<typeof PullRequestFiltersMenu>[0]>) {
   return PullRequestFiltersMenu({
     state: "open",
@@ -58,6 +97,8 @@ function menu(overrides: Partial<Parameters<typeof PullRequestFiltersMenu>[0]>) 
     host: undefined,
     hostOptions: [],
     onHost: () => undefined,
+    hiddenProjectKeys: [],
+    onHiddenProjectKeys: () => undefined,
     server: undefined,
     serverOptions: [],
     onServer: () => undefined,
@@ -71,6 +112,20 @@ function menu(overrides: Partial<Parameters<typeof PullRequestFiltersMenu>[0]>) 
 }
 
 describe("pull request filters menu", () => {
+  const projectOne = {
+    id: "project-1" as ProjectId,
+    environmentId: "env-1" as EnvironmentId,
+    title: "T3 Code",
+    workspaceRoot: "/work/t3code",
+  };
+  const projectTwo = {
+    id: "project-2" as ProjectId,
+    environmentId: "env-1" as EnvironmentId,
+    title: "Popular OSS",
+    workspaceRoot: "/work/popular",
+  };
+  const keyTwo = pullRequestProjectKey(projectTwo);
+
   it("does not emit a change when the selected state is chosen again", () => {
     const onState = vi.fn();
     const group = findValueChange(findLabeledGroup(menu({ onState }), "State"));
@@ -109,60 +164,89 @@ describe("pull request filters menu", () => {
     expect(onFilters).toHaveBeenCalledWith({ checks: "failing" });
   });
 
-  it("does not emit a change when the selected project is chosen again", () => {
-    const projectId = "project-1" as ProjectId;
-    const environmentId = "env-1" as EnvironmentId;
-    const onProject = vi.fn();
-    const view = menu({
-      projects: [
-        {
-          id: projectId,
-          environmentId,
-          title: "T3 Code",
-          workspaceRoot: "/work/t3code",
-        },
-      ],
-      projectId,
-      projectEnvironmentId: environmentId,
-      onProject,
-    });
-    const radioGroup = findValueChange(view);
-    expect(radioGroup).toBeDefined();
+  it("hides a project when its row is unchecked", () => {
+    const onHiddenProjectKeys = vi.fn();
+    const rows = findCheckboxItems(
+      menu({ projects: [projectOne, projectTwo], onHiddenProjectKeys }),
+    );
+    expect(rows).toHaveLength(3);
+    expect(rows.map((row) => row.checked)).toEqual([true, true, true]);
 
-    radioGroup?.props.onValueChange(pullRequestProjectKey({ id: projectId, environmentId }));
-    expect(onProject).not.toHaveBeenCalled();
-
-    radioGroup?.props.onValueChange("all");
-    expect(onProject).toHaveBeenCalledWith(undefined, undefined);
+    rows[2]?.onCheckedChange?.(false);
+    expect(onHiddenProjectKeys).toHaveBeenCalledWith([keyTwo]);
   });
 
-  it("passes the environment along so a duplicate project id on another server is told apart", () => {
-    const projectId = "project-1" as ProjectId;
-    const onProject = vi.fn();
-    const view = menu({
-      projects: [
-        {
-          id: projectId,
-          environmentId: "env-1" as EnvironmentId,
-          title: "T3 Code · one",
-          workspaceRoot: "/work/t3code-1",
-        },
-        {
-          id: projectId,
-          environmentId: "env-2" as EnvironmentId,
-          title: "T3 Code · two",
-          workspaceRoot: "/work/t3code-2",
-        },
-      ],
-      onProject,
-    });
-    const radioGroup = findValueChange(view);
-    expect(radioGroup).toBeDefined();
-
-    radioGroup?.props.onValueChange(
-      pullRequestProjectKey({ id: projectId, environmentId: "env-2" as EnvironmentId }),
+  it("brings a hidden project back when its row is checked again", () => {
+    const onHiddenProjectKeys = vi.fn();
+    const rows = findCheckboxItems(
+      menu({
+        projects: [projectOne, projectTwo],
+        hiddenProjectKeys: [keyTwo],
+        onHiddenProjectKeys,
+      }),
     );
-    expect(onProject).toHaveBeenCalledWith(projectId, "env-2");
+    expect(rows.map((row) => row.checked)).toEqual([false, true, false]);
+
+    rows[2]?.onCheckedChange?.(true);
+    expect(onHiddenProjectKeys).toHaveBeenCalledWith([]);
+  });
+
+  it("reads a one-project scope as that project alone being listed", () => {
+    const rows = findCheckboxItems(
+      menu({
+        projects: [projectOne, projectTwo],
+        projectId: projectOne.id,
+        projectEnvironmentId: projectOne.environmentId,
+      }),
+    );
+    expect(rows.map((row) => row.checked)).toEqual([false, true, false]);
+  });
+
+  it("carries a one-project scope into the hidden set rather than discarding it", () => {
+    const onProject = vi.fn();
+    const onHiddenProjectKeys = vi.fn();
+    const rows = findCheckboxItems(
+      menu({
+        projects: [projectOne, projectTwo],
+        projectId: projectOne.id,
+        projectEnvironmentId: projectOne.environmentId,
+        onProject,
+        onHiddenProjectKeys,
+      }),
+    );
+
+    rows[2]?.onCheckedChange?.(true);
+    expect(onProject).toHaveBeenCalledWith(undefined, undefined);
+    expect(onHiddenProjectKeys).toHaveBeenCalledWith([]);
+  });
+
+  it("clears both the scope and the hidden set when all projects is chosen", () => {
+    const onProject = vi.fn();
+    const onHiddenProjectKeys = vi.fn();
+    const rows = findCheckboxItems(
+      menu({
+        projects: [projectOne, projectTwo],
+        projectId: projectOne.id,
+        projectEnvironmentId: projectOne.environmentId,
+        hiddenProjectKeys: [keyTwo],
+        onProject,
+        onHiddenProjectKeys,
+      }),
+    );
+
+    rows[0]?.onClick?.();
+    expect(onProject).toHaveBeenCalledWith(undefined, undefined);
+    expect(onHiddenProjectKeys).toHaveBeenCalledWith([]);
+  });
+
+  it("narrows to one project from its own row, environment and all", () => {
+    const onProject = vi.fn();
+    const duplicate = { ...projectTwo, id: projectOne.id, environmentId: "env-2" as EnvironmentId };
+    const buttons = findOnlyButtons(menu({ projects: [projectOne, duplicate], onProject }));
+    expect(buttons).toHaveLength(2);
+
+    buttons[1]?.onClick(clickEvent());
+    expect(onProject).toHaveBeenCalledWith(projectOne.id, "env-2");
   });
 
   it("does not collide when environment and project ids contain spaces", () => {

--- a/apps/web/src/components/pullRequest/PullRequestListFilters.test.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestListFilters.test.tsx
@@ -46,6 +46,7 @@ interface CheckboxItemProps {
   readonly checked?: boolean;
   readonly onCheckedChange?: (checked: boolean) => void;
   readonly onClick?: () => void;
+  readonly onKeyDown?: (event: unknown) => void;
   readonly children?: ReactNode;
 }
 
@@ -80,6 +81,17 @@ function findOnlyButtons(
 
 /** Enough of a click for the handler, which only ever stops the row from swallowing it. */
 const clickEvent = () => ({ preventDefault: () => undefined, stopPropagation: () => undefined });
+
+/**
+ * Enough of a key press for the row handler. `preventBaseUIHandler` is the one the menu reads:
+ * a handler that only prevents the default still lets the row toggle after it.
+ */
+const keyEvent = (key: string, shiftKey: boolean) => ({
+  key,
+  shiftKey,
+  preventDefault: () => undefined,
+  preventBaseUIHandler: vi.fn(),
+});
 
 function menu(overrides: Partial<Parameters<typeof PullRequestFiltersMenu>[0]>) {
   return PullRequestFiltersMenu({
@@ -315,6 +327,35 @@ describe("pull request filters menu", () => {
       environmentId: "env-2",
       hiddenKeys: [],
     });
+  });
+
+  it("narrows to one project from the keyboard", () => {
+    const onProjectSelection = vi.fn();
+    const rows = findCheckboxItems(
+      menu({ projects: [projectOne, projectTwo], onProjectSelection }),
+    );
+
+    // Arrow keys reach the row but never the button inside it, so the row carries the action.
+    const event = keyEvent("Enter", true);
+    rows[2]?.onKeyDown?.(event);
+    expect(onProjectSelection).toHaveBeenCalledWith({
+      projectId: projectTwo.id,
+      environmentId: projectTwo.environmentId,
+      hiddenKeys: [],
+    });
+    // Without this the row toggles as well and the later of the two selections is what sticks.
+    expect(event.preventBaseUIHandler).toHaveBeenCalled();
+  });
+
+  it("leaves a plain enter to the row's own checkbox", () => {
+    const onProjectSelection = vi.fn();
+    const rows = findCheckboxItems(
+      menu({ projects: [projectOne, projectTwo], onProjectSelection }),
+    );
+
+    rows[2]?.onKeyDown?.(keyEvent("Enter", false));
+    rows[2]?.onKeyDown?.(keyEvent("o", false));
+    expect(onProjectSelection).not.toHaveBeenCalled();
   });
 
   it("hides both copies of a repository two servers share", () => {

--- a/apps/web/src/components/pullRequest/PullRequestListFilters.test.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestListFilters.test.tsx
@@ -98,7 +98,7 @@ function menu(overrides: Partial<Parameters<typeof PullRequestFiltersMenu>[0]>) 
     hostOptions: [],
     onHost: () => undefined,
     hiddenProjectKeys: [],
-    onHiddenProjectKeys: () => undefined,
+    onProjectSelection: () => undefined,
     server: undefined,
     serverOptions: [],
     onServer: () => undefined,
@@ -106,7 +106,6 @@ function menu(overrides: Partial<Parameters<typeof PullRequestFiltersMenu>[0]>) 
     projectId: undefined,
     projectEnvironmentId: undefined,
     unavailable: new Map(),
-    onProject: () => undefined,
     ...overrides,
   });
 }
@@ -174,30 +173,38 @@ describe("pull request filters menu", () => {
   });
 
   it("hides a project when its row is unchecked", () => {
-    const onHiddenProjectKeys = vi.fn();
+    const onProjectSelection = vi.fn();
     const rows = findCheckboxItems(
-      menu({ projects: [projectOne, projectTwo], onHiddenProjectKeys }),
+      menu({ projects: [projectOne, projectTwo], onProjectSelection }),
     );
     expect(rows).toHaveLength(3);
     expect(rows.map((row) => row.checked)).toEqual([true, true, true]);
 
     rows[2]?.onCheckedChange?.(false);
-    expect(onHiddenProjectKeys).toHaveBeenCalledWith([keyTwo]);
+    expect(onProjectSelection).toHaveBeenCalledWith({
+      projectId: undefined,
+      environmentId: undefined,
+      hiddenKeys: [keyTwo],
+    });
   });
 
   it("brings a hidden project back when its row is checked again", () => {
-    const onHiddenProjectKeys = vi.fn();
+    const onProjectSelection = vi.fn();
     const rows = findCheckboxItems(
       menu({
         projects: [projectOne, projectTwo],
         hiddenProjectKeys: [keyTwo],
-        onHiddenProjectKeys,
+        onProjectSelection,
       }),
     );
     expect(rows.map((row) => row.checked)).toEqual([false, true, false]);
 
     rows[2]?.onCheckedChange?.(true);
-    expect(onHiddenProjectKeys).toHaveBeenCalledWith([]);
+    expect(onProjectSelection).toHaveBeenCalledWith({
+      projectId: undefined,
+      environmentId: undefined,
+      hiddenKeys: [],
+    });
   });
 
   it("reads a one-project scope as that project alone being listed", () => {
@@ -211,62 +218,118 @@ describe("pull request filters menu", () => {
     expect(rows.map((row) => row.checked)).toEqual([false, true, false]);
   });
 
-  it("carries a one-project scope into the hidden set rather than discarding it", () => {
-    const onProject = vi.fn();
-    const onHiddenProjectKeys = vi.fn();
+  it("drops a one-project scope and its hidden set in one selection", () => {
+    const onProjectSelection = vi.fn();
     const rows = findCheckboxItems(
       menu({
         projects: [projectOne, projectTwo],
         projectId: projectOne.id,
         projectEnvironmentId: projectOne.environmentId,
-        onProject,
-        onHiddenProjectKeys,
+        onProjectSelection,
       }),
     );
 
     rows[2]?.onCheckedChange?.(true);
-    expect(onProject).toHaveBeenCalledWith(undefined, undefined);
-    expect(onHiddenProjectKeys).toHaveBeenCalledWith([]);
+    // One call, never a scope change followed by a hidden change: two updates would each rebuild
+    // the URL from the committed one and the second would put the scope back.
+    expect(onProjectSelection).toHaveBeenCalledOnce();
+    expect(onProjectSelection).toHaveBeenCalledWith({
+      projectId: undefined,
+      environmentId: undefined,
+      hiddenKeys: [],
+    });
+  });
+
+  it("carries a one-project scope into the hidden set rather than discarding it", () => {
+    const onProjectSelection = vi.fn();
+    const third = {
+      ...projectTwo,
+      id: "project-3" as ProjectId,
+      title: "Third",
+      hideKey: "repository:github.com/acme/third",
+    };
+    const rows = findCheckboxItems(
+      menu({
+        projects: [projectOne, projectTwo, third],
+        projectId: projectOne.id,
+        projectEnvironmentId: projectOne.environmentId,
+        onProjectSelection,
+      }),
+    );
+
+    rows[2]?.onCheckedChange?.(true);
+    expect(onProjectSelection).toHaveBeenCalledWith({
+      projectId: undefined,
+      environmentId: undefined,
+      hiddenKeys: [third.hideKey],
+    });
   });
 
   it("clears both the scope and the hidden set when all projects is chosen", () => {
-    const onProject = vi.fn();
-    const onHiddenProjectKeys = vi.fn();
+    const onProjectSelection = vi.fn();
     const rows = findCheckboxItems(
       menu({
         projects: [projectOne, projectTwo],
         projectId: projectOne.id,
         projectEnvironmentId: projectOne.environmentId,
         hiddenProjectKeys: [keyTwo],
-        onProject,
-        onHiddenProjectKeys,
+        onProjectSelection,
       }),
     );
 
     rows[0]?.onClick?.();
-    expect(onProject).toHaveBeenCalledWith(undefined, undefined);
-    expect(onHiddenProjectKeys).toHaveBeenCalledWith([]);
+    expect(onProjectSelection).toHaveBeenCalledOnce();
+    expect(onProjectSelection).toHaveBeenCalledWith({
+      projectId: undefined,
+      environmentId: undefined,
+      hiddenKeys: [],
+    });
+  });
+
+  it("does not emit a selection when nothing about it would change", () => {
+    const onProjectSelection = vi.fn();
+    const rows = findCheckboxItems(
+      menu({ projects: [projectOne, projectTwo], onProjectSelection }),
+    );
+
+    rows[0]?.onClick?.();
+    expect(onProjectSelection).not.toHaveBeenCalled();
   });
 
   it("narrows to one project from its own row, environment and all", () => {
-    const onProject = vi.fn();
-    const duplicate = { ...projectTwo, id: projectOne.id, environmentId: "env-2" as EnvironmentId };
-    const buttons = findOnlyButtons(menu({ projects: [projectOne, duplicate], onProject }));
+    const onProjectSelection = vi.fn();
+    const duplicate = {
+      ...projectTwo,
+      id: projectOne.id,
+      environmentId: "env-2" as EnvironmentId,
+      hideKey: "repository:github.com/acme/other",
+    };
+    const buttons = findOnlyButtons(
+      menu({ projects: [projectOne, duplicate], onProjectSelection }),
+    );
     expect(buttons).toHaveLength(2);
 
     buttons[1]?.onClick(clickEvent());
-    expect(onProject).toHaveBeenCalledWith(projectOne.id, "env-2");
+    expect(onProjectSelection).toHaveBeenCalledWith({
+      projectId: projectOne.id,
+      environmentId: "env-2",
+      hiddenKeys: [],
+    });
   });
 
   it("hides both copies of a repository two servers share", () => {
-    const onHiddenProjectKeys = vi.fn();
+    const onProjectSelection = vi.fn();
     const rows = findCheckboxItems(
-      menu({ projects: [projectTwo, projectTwoElsewhere], onHiddenProjectKeys }),
+      menu({ projects: [projectTwo, projectTwoElsewhere], onProjectSelection }),
     );
     expect(rows.map((row) => row.checked)).toEqual([true, true, true]);
 
     rows[1]?.onCheckedChange?.(false);
-    expect(onHiddenProjectKeys).toHaveBeenCalledWith([projectTwo.hideKey]);
+    expect(onProjectSelection).toHaveBeenCalledWith({
+      projectId: undefined,
+      environmentId: undefined,
+      hiddenKeys: [projectTwo.hideKey],
+    });
   });
 
   it("reads both copies of a shared repository as hidden from the one key", () => {

--- a/apps/web/src/components/pullRequest/PullRequestListFilters.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestListFilters.tsx
@@ -439,6 +439,21 @@ export function PullRequestFiltersMenu({
                   // The row takes its name from its contents, and the action below carries an
                   // aria-label that would otherwise be folded into it.
                   {...(reason === undefined ? { "aria-label": project.title } : {})}
+                  // The keyboard's way to the row's own action: arrow keys reach the row but
+                  // never the button inside it. A plain letter would be taken by the menu's
+                  // typeahead and a bare Enter is the checkbox's, so the action wears the
+                  // modifier. Only `preventBaseUIHandler` stops the row toggling too — the menu
+                  // reads that, not `defaultPrevented` — and without it the press would both
+                  // narrow and toggle, leaving whichever landed second.
+                  onKeyDown={
+                    reason === undefined
+                      ? (event) => {
+                          if (event.key !== "Enter" || !event.shiftKey) return;
+                          event.preventBaseUIHandler();
+                          onlyProject(project);
+                        }
+                      : undefined
+                  }
                   className={cn(
                     "group/project",
                     reason !== undefined && "data-disabled:pointer-events-auto",
@@ -461,11 +476,11 @@ export function PullRequestFiltersMenu({
                     {reason === undefined ? (
                       <button
                         type="button"
-                        // The row's own checkbox is the keyboard path — unchecking the others
-                        // says the same thing — so this stays out of the tab order rather than
-                        // giving every project two stops.
+                        // Shift+Enter on the row is the keyboard path, so this stays out of the
+                        // tab order rather than giving every project a second stop — and Tab
+                        // inside an open menu closes it rather than moving within it.
                         tabIndex={-1}
-                        aria-label={`List only ${project.title}`}
+                        aria-label={`List only ${project.title}, shift enter`}
                         // The row's checkbox would otherwise swallow the press as a toggle.
                         onClick={(event) => {
                           event.preventDefault();

--- a/apps/web/src/components/pullRequest/PullRequestListFilters.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestListFilters.tsx
@@ -28,6 +28,8 @@ import { InputGroup, InputGroupAddon, InputGroupInput } from "../ui/input-group"
 
 import {
   Menu,
+  MenuCheckboxItem,
+  MenuGroup,
   MenuGroupLabel,
   MenuPopup,
   MenuRadioGroup,
@@ -96,13 +98,6 @@ export function PullRequestSearchInput({
   );
 }
 
-/**
- * Every list filter lives behind the one filter icon so the control row stays two controls
- * wide: the search and this. The trigger carries a dot whenever any filter is off its
- * default, so a narrowed list is never a mystery. Same menu chrome as the detail panel's
- * actions, which also owns its own spacing.
- */
-const ALL_PROJECTS_VALUE = "all";
 /** MenuRadioGroup wants a string, so "every host" wears the one value no host can be. */
 const ALL_HOSTS_VALUE = "";
 /** The same trick for the servers, which are named by an id no empty string can collide with. */
@@ -110,8 +105,8 @@ const ALL_SERVERS_VALUE = "";
 /** The unset value of each narrowing group, which no filter of theirs is named after. */
 const UNFILTERED_VALUE = "all";
 /**
- * A project's own radio value, carrying the server along with the id: the id alone is only
- * unique within its own server, so two rows sharing one would otherwise both read as checked.
+ * A project's own row key, carrying the server along with the id: the id alone is only unique
+ * within its own server, so two rows sharing one would otherwise both read as checked.
  */
 export const pullRequestProjectKey = (project: {
   readonly id: ProjectId;
@@ -187,6 +182,12 @@ function PullRequestFilterRadioGroup<Value extends string>({
   );
 }
 
+/**
+ * Every list filter lives behind the one filter icon so the control row stays two controls
+ * wide: the search and this. The trigger carries a dot whenever any filter is off its
+ * default, so a narrowed list is never a mystery. Same menu chrome as the detail panel's
+ * actions, which also owns its own spacing.
+ */
 export function PullRequestFiltersMenu({
   state,
   stateOptions,
@@ -207,6 +208,8 @@ export function PullRequestFiltersMenu({
   projectEnvironmentId,
   unavailable,
   onProject,
+  hiddenProjectKeys,
+  onHiddenProjectKeys,
 }: {
   state: PullRequestListState;
   stateOptions: ReadonlyArray<PullRequestFilterOption<PullRequestListState>>;
@@ -252,6 +255,9 @@ export function PullRequestFiltersMenu({
   unavailable: ReadonlyMap<string, string>;
   /** The environment comes with the project id, since picking a row picks a specific server's copy of it. */
   onProject: (projectId: ProjectId | undefined, environmentId: EnvironmentId | undefined) => void;
+  /** Projects left out of the list, by `pullRequestProjectKey`. */
+  hiddenProjectKeys: ReadonlyArray<string>;
+  onHiddenProjectKeys: (keys: ReadonlyArray<string>) => void;
 }) {
   const filtered =
     state !== "open" ||
@@ -259,6 +265,7 @@ export function PullRequestFiltersMenu({
     host !== undefined ||
     server !== undefined ||
     projectId !== undefined ||
+    hiddenProjectKeys.length > 0 ||
     Object.keys(filters).length > 0;
   /**
    * Rebuilt rather than spread so an unfiltered group leaves the record instead of lingering in
@@ -270,6 +277,39 @@ export function PullRequestFiltersMenu({
         ([, held]) => held !== undefined,
       ),
     ) as PullRequestListFilters;
+  const scopedKey =
+    projectId === undefined || projectEnvironmentId === undefined
+      ? undefined
+      : pullRequestProjectKey({ id: projectId, environmentId: projectEnvironmentId });
+  const hidden = new Set(hiddenProjectKeys);
+  /** Checked means the listing actually reads it, and a scope reads exactly one. */
+  const listed = (key: string) => (scopedKey === undefined ? !hidden.has(key) : key === scopedKey);
+  const everyProjectListed = scopedKey === undefined && hidden.size === 0;
+  const listEveryProject = () => {
+    if (scopedKey !== undefined) onProject(undefined, undefined);
+    if (hidden.size > 0) onHiddenProjectKeys([]);
+  };
+  /**
+   * A one-project scope says the same thing as hiding every other project, so a click that widens
+   * or narrows it carries on from that set rather than starting over from every project.
+   */
+  const setProjectListed = (key: string, next: boolean) => {
+    const base =
+      scopedKey === undefined
+        ? hiddenProjectKeys
+        : projects.map(pullRequestProjectKey).filter((candidate) => candidate !== scopedKey);
+    if (scopedKey !== undefined) onProject(undefined, undefined);
+    onHiddenProjectKeys(
+      next ? base.filter((candidate) => candidate !== key) : [...new Set([...base, key])],
+    );
+  };
+  const onlyProject = (project: {
+    readonly id: ProjectId;
+    readonly environmentId: EnvironmentId;
+  }) => {
+    if (hidden.size > 0) onHiddenProjectKeys([]);
+    onProject(project.id, project.environmentId);
+  };
   return (
     <Menu>
       <MenuTrigger
@@ -348,35 +388,14 @@ export function PullRequestFiltersMenu({
           </>
         ) : null}
         <MenuSeparator />
-        <MenuRadioGroup
-          value={
-            projectId === undefined || projectEnvironmentId === undefined
-              ? ALL_PROJECTS_VALUE
-              : pullRequestProjectKey({ id: projectId, environmentId: projectEnvironmentId })
-          }
-          onValueChange={(next) => {
-            if (next === ALL_PROJECTS_VALUE) {
-              if (projectId !== undefined) onProject(undefined, undefined);
-              return;
-            }
-            // The value carries both halves, since the id alone cannot tell two servers' rows
-            // apart once they share one.
-            const project = projects.find((candidate) => pullRequestProjectKey(candidate) === next);
-            if (
-              project !== undefined &&
-              (project.id !== projectId || project.environmentId !== projectEnvironmentId)
-            ) {
-              onProject(project.id, project.environmentId);
-            }
-          }}
-        >
+        <MenuGroup>
           <MenuGroupLabel>Project</MenuGroupLabel>
-          <MenuRadioItem value={ALL_PROJECTS_VALUE}>
+          <MenuCheckboxItem checked={everyProjectListed} onClick={listEveryProject}>
             <span className="flex min-w-0 items-center gap-2">
               <LayersIcon aria-hidden className="size-3.5" />
               All projects
             </span>
-          </MenuRadioItem>
+          </MenuCheckboxItem>
           {/* The ones that can be chosen first: a list that opens with three disabled rows reads
               as a broken menu rather than as a workspace with three unreadable repositories. */}
           {projects
@@ -386,12 +405,17 @@ export function PullRequestFiltersMenu({
                 Number(unavailable.has(pullRequestProjectKey(right))),
             )
             .map((project) => {
-              const reason = unavailable.get(pullRequestProjectKey(project));
+              const key = pullRequestProjectKey(project);
+              const reason = unavailable.get(key);
               const item = (
-                <MenuRadioItem
-                  key={pullRequestProjectKey(project)}
-                  value={pullRequestProjectKey(project)}
-                  className={reason !== undefined ? "data-disabled:pointer-events-auto" : undefined}
+                <MenuCheckboxItem
+                  key={key}
+                  checked={listed(key)}
+                  onCheckedChange={(next) => setProjectListed(key, next)}
+                  className={cn(
+                    "group/project",
+                    reason !== undefined && "data-disabled:pointer-events-auto",
+                  )}
                   disabled={reason !== undefined}
                 >
                   <span className="flex min-w-0 flex-1 items-center gap-2">
@@ -407,12 +431,33 @@ export function PullRequestFiltersMenu({
                         Unavailable
                       </span>
                     )}
+                    {reason === undefined ? (
+                      <button
+                        type="button"
+                        // The row's own checkbox is the keyboard path — unchecking the others
+                        // says the same thing — so this stays out of the tab order rather than
+                        // giving every project two stops.
+                        tabIndex={-1}
+                        aria-label={`List only ${project.title}`}
+                        // The row's checkbox would otherwise swallow the press as a toggle.
+                        onClick={(event) => {
+                          event.preventDefault();
+                          event.stopPropagation();
+                          onlyProject(project);
+                        }}
+                        // Highlighted rather than hovered: a menu row highlights under the
+                        // pointer and under arrow keys alike, so both reach the action.
+                        className="pointer-events-none inline-flex shrink-0 cursor-pointer items-center rounded-md bg-transparent px-1.5 text-xs text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-data-highlighted/project:pointer-events-auto group-data-highlighted/project:opacity-100"
+                      >
+                        Only
+                      </button>
+                    ) : null}
                   </span>
-                </MenuRadioItem>
+                </MenuCheckboxItem>
               );
               if (reason === undefined) return item;
               return (
-                <Tooltip key={pullRequestProjectKey(project)}>
+                <Tooltip key={key}>
                   <TooltipTrigger render={item} />
                   <TooltipPopup side="top" className="max-w-80">
                     {reason}
@@ -420,7 +465,7 @@ export function PullRequestFiltersMenu({
                 </Tooltip>
               );
             })}
-        </MenuRadioGroup>
+        </MenuGroup>
       </MenuPopup>
     </Menu>
   );

--- a/apps/web/src/components/pullRequest/PullRequestListFilters.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestListFilters.tsx
@@ -240,6 +240,11 @@ export function PullRequestFiltersMenu({
     readonly environmentId: EnvironmentId;
     readonly title: string;
     readonly workspaceRoot: string;
+    /**
+     * What this project's hidden state is stored under. Two copies of one repository share it, so
+     * a row never reads as shown while the listing has dropped the repository behind it.
+     */
+    readonly hideKey: string;
   }>;
   projectId: ProjectId | undefined;
   /**
@@ -255,7 +260,7 @@ export function PullRequestFiltersMenu({
   unavailable: ReadonlyMap<string, string>;
   /** The environment comes with the project id, since picking a row picks a specific server's copy of it. */
   onProject: (projectId: ProjectId | undefined, environmentId: EnvironmentId | undefined) => void;
-  /** Projects left out of the list, by `pullRequestProjectKey`. */
+  /** Projects left out of the list, by their `hideKey`. */
   hiddenProjectKeys: ReadonlyArray<string>;
   onHiddenProjectKeys: (keys: ReadonlyArray<string>) => void;
 }) {
@@ -281,9 +286,13 @@ export function PullRequestFiltersMenu({
     projectId === undefined || projectEnvironmentId === undefined
       ? undefined
       : pullRequestProjectKey({ id: projectId, environmentId: projectEnvironmentId });
+  const scopedHideKey = projects.find(
+    (candidate) => pullRequestProjectKey(candidate) === scopedKey,
+  )?.hideKey;
   const hidden = new Set(hiddenProjectKeys);
   /** Checked means the listing actually reads it, and a scope reads exactly one. */
-  const listed = (key: string) => (scopedKey === undefined ? !hidden.has(key) : key === scopedKey);
+  const listed = (project: { readonly hideKey: string }, key: string) =>
+    scopedKey === undefined ? !hidden.has(project.hideKey) : key === scopedKey;
   const everyProjectListed = scopedKey === undefined && hidden.size === 0;
   const listEveryProject = () => {
     if (scopedKey !== undefined) onProject(undefined, undefined);
@@ -293,14 +302,14 @@ export function PullRequestFiltersMenu({
    * A one-project scope says the same thing as hiding every other project, so a click that widens
    * or narrows it carries on from that set rather than starting over from every project.
    */
-  const setProjectListed = (key: string, next: boolean) => {
+  const setProjectListed = (hideKey: string, next: boolean) => {
     const base =
       scopedKey === undefined
         ? hiddenProjectKeys
-        : projects.map(pullRequestProjectKey).filter((candidate) => candidate !== scopedKey);
+        : projects.map((candidate) => candidate.hideKey).filter((key) => key !== scopedHideKey);
     if (scopedKey !== undefined) onProject(undefined, undefined);
     onHiddenProjectKeys(
-      next ? base.filter((candidate) => candidate !== key) : [...new Set([...base, key])],
+      next ? base.filter((key) => key !== hideKey) : [...new Set([...base, hideKey])],
     );
   };
   const onlyProject = (project: {
@@ -410,8 +419,11 @@ export function PullRequestFiltersMenu({
               const item = (
                 <MenuCheckboxItem
                   key={key}
-                  checked={listed(key)}
-                  onCheckedChange={(next) => setProjectListed(key, next)}
+                  checked={listed(project, key)}
+                  onCheckedChange={(next) => setProjectListed(project.hideKey, next)}
+                  // The row takes its name from its contents, and the action below carries an
+                  // aria-label that would otherwise be folded into it.
+                  {...(reason === undefined ? { "aria-label": project.title } : {})}
                   className={cn(
                     "group/project",
                     reason !== undefined && "data-disabled:pointer-events-auto",
@@ -447,7 +459,7 @@ export function PullRequestFiltersMenu({
                         }}
                         // Highlighted rather than hovered: a menu row highlights under the
                         // pointer and under arrow keys alike, so both reach the action.
-                        className="pointer-events-none inline-flex shrink-0 cursor-pointer items-center rounded-md bg-transparent px-1.5 text-xs text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-data-highlighted/project:pointer-events-auto group-data-highlighted/project:opacity-100"
+                        className="pointer-events-none inline-flex shrink-0 cursor-pointer items-center self-stretch rounded-md bg-transparent px-1.5 text-xs text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-data-highlighted/project:pointer-events-auto group-data-highlighted/project:opacity-100"
                       >
                         Only
                       </button>

--- a/apps/web/src/components/pullRequest/PullRequestListFilters.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestListFilters.tsx
@@ -488,8 +488,10 @@ export function PullRequestFiltersMenu({
                           onlyProject(project);
                         }}
                         // Highlighted rather than hovered: a menu row highlights under the
-                        // pointer and under arrow keys alike, so both reach the action.
-                        className="pointer-events-none inline-flex shrink-0 cursor-pointer items-center self-stretch rounded-md bg-transparent px-1.5 text-xs text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-data-highlighted/project:pointer-events-auto group-data-highlighted/project:opacity-100"
+                        // pointer and under arrow keys alike, so both reach the action. A touch
+                        // screen highlights nothing, so there it simply stays out — a tap on the
+                        // row hides the project, which is the opposite of what this offers.
+                        className="pointer-events-none inline-flex shrink-0 cursor-pointer items-center self-stretch rounded-md bg-transparent px-1.5 text-xs text-muted-foreground opacity-0 transition-opacity hover:text-foreground max-sm:pointer-events-auto max-sm:opacity-100 group-data-highlighted/project:pointer-events-auto group-data-highlighted/project:opacity-100"
                       >
                         Only
                       </button>

--- a/apps/web/src/components/pullRequest/PullRequestListFilters.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestListFilters.tsx
@@ -207,9 +207,8 @@ export function PullRequestFiltersMenu({
   projectId,
   projectEnvironmentId,
   unavailable,
-  onProject,
   hiddenProjectKeys,
-  onHiddenProjectKeys,
+  onProjectSelection,
 }: {
   state: PullRequestListState;
   stateOptions: ReadonlyArray<PullRequestFilterOption<PullRequestListState>>;
@@ -258,11 +257,22 @@ export function PullRequestFiltersMenu({
    * that says something is missing without saying which.
    */
   unavailable: ReadonlyMap<string, string>;
-  /** The environment comes with the project id, since picking a row picks a specific server's copy of it. */
-  onProject: (projectId: ProjectId | undefined, environmentId: EnvironmentId | undefined) => void;
   /** Projects left out of the list, by their `hideKey`. */
   hiddenProjectKeys: ReadonlyArray<string>;
-  onHiddenProjectKeys: (keys: ReadonlyArray<string>) => void;
+  /**
+   * Which projects the list reads, as one statement. The scope and the hidden set move together
+   * because they answer the same question, and because two separate updates would each rebuild
+   * the URL from the committed one — the second landing on a location the first had not reached
+   * yet, and putting back the scope it had just dropped.
+   *
+   * The environment comes with the project id, since a scope names a specific server's copy. An
+   * absent environment leaves the server scope as it was rather than clearing it.
+   */
+  onProjectSelection: (selection: {
+    readonly projectId: ProjectId | undefined;
+    readonly environmentId: EnvironmentId | undefined;
+    readonly hiddenKeys: ReadonlyArray<string>;
+  }) => void;
 }) {
   const filtered =
     state !== "open" ||
@@ -295,8 +305,8 @@ export function PullRequestFiltersMenu({
     scopedKey === undefined ? !hidden.has(project.hideKey) : key === scopedKey;
   const everyProjectListed = scopedKey === undefined && hidden.size === 0;
   const listEveryProject = () => {
-    if (scopedKey !== undefined) onProject(undefined, undefined);
-    if (hidden.size > 0) onHiddenProjectKeys([]);
+    if (everyProjectListed) return;
+    onProjectSelection({ projectId: undefined, environmentId: undefined, hiddenKeys: [] });
   };
   /**
    * A one-project scope says the same thing as hiding every other project, so a click that widens
@@ -307,17 +317,22 @@ export function PullRequestFiltersMenu({
       scopedKey === undefined
         ? hiddenProjectKeys
         : projects.map((candidate) => candidate.hideKey).filter((key) => key !== scopedHideKey);
-    if (scopedKey !== undefined) onProject(undefined, undefined);
-    onHiddenProjectKeys(
-      next ? base.filter((key) => key !== hideKey) : [...new Set([...base, hideKey])],
-    );
+    onProjectSelection({
+      projectId: undefined,
+      environmentId: undefined,
+      hiddenKeys: next ? base.filter((key) => key !== hideKey) : [...new Set([...base, hideKey])],
+    });
   };
   const onlyProject = (project: {
     readonly id: ProjectId;
     readonly environmentId: EnvironmentId;
   }) => {
-    if (hidden.size > 0) onHiddenProjectKeys([]);
-    onProject(project.id, project.environmentId);
+    if (pullRequestProjectKey(project) === scopedKey && hidden.size === 0) return;
+    onProjectSelection({
+      projectId: project.id,
+      environmentId: project.environmentId,
+      hiddenKeys: [],
+    });
   };
   return (
     <Menu>

--- a/apps/web/src/components/pullRequest/pullRequestProjectAssignment.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestProjectAssignment.logic.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   assignProjectsToEnvironments,
+  pullRequestProjectHideKey,
   resolvePickableEnvironments,
   type AssignableProject,
 } from "./pullRequestProjectAssignment.logic";
@@ -22,6 +23,26 @@ const envs = (...ids: ReadonlyArray<string>) => ids as ReadonlyArray<Environment
 
 const plain = (assignment: Map<EnvironmentId, ProjectId[]>) =>
   Object.fromEntries([...assignment].map(([id, projectIds]) => [id, projectIds]));
+
+describe("what a hidden project is remembered by", () => {
+  it("gives two copies of one repository the same key", () => {
+    expect(pullRequestProjectHideKey(project("a1", "env-1", "github.com/acme/app"))).toBe(
+      pullRequestProjectHideKey(project("a2", "env-2", "github.com/acme/app")),
+    );
+  });
+
+  it("gives a project with no repository identity a key of its own", () => {
+    expect(pullRequestProjectHideKey(project("a1", "env-1"))).not.toBe(
+      pullRequestProjectHideKey(project("a2", "env-1")),
+    );
+  });
+
+  it("keeps a repository key from colliding with a project key", () => {
+    expect(pullRequestProjectHideKey(project("a1", "env-1", "env-1/a1"))).not.toBe(
+      pullRequestProjectHideKey(project("a1", "env-1")),
+    );
+  });
+});
 
 describe("one server per repository", () => {
   it("lets the first server list a repository both hold", () => {

--- a/apps/web/src/components/pullRequest/pullRequestProjectAssignment.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestProjectAssignment.logic.ts
@@ -19,6 +19,21 @@ function repositoryKey(project: AssignableProject): string | undefined {
 }
 
 /**
+ * What a hidden project is remembered by. Two servers holding one repository list it once between
+ * them, so hiding is a statement about the repository rather than about either copy — keyed per
+ * copy, hiding the listed one would leave the other reading as shown while its rows were gone.
+ *
+ * A project with no repository identity is nothing else's copy, so it stands for itself. The
+ * prefixes keep the two kinds of key from ever colliding.
+ */
+export function pullRequestProjectHideKey(project: AssignableProject): string {
+  const key = repositoryKey(project);
+  return key === undefined || key.length === 0
+    ? `project:${project.environmentId}\u0000${project.id}`
+    : `repository:${key}`;
+}
+
+/**
  * Two servers can hold the same repository, and both would list the same pull requests, so one
  * copy is picked by its repository key.
  *

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1537,23 +1537,18 @@ function PullRequestsRouteView() {
       projectId={scopedProjectId}
       projectEnvironmentId={scopedProject?.environmentId}
       unavailable={unavailableProjects}
-      // The environment comes along with the project it belongs to, so a duplicate id on
-      // another server never gets narrowed to by mistake; picking "All projects" leaves the
-      // server scope as it was rather than clearing it.
-      onProject={(projectId, environmentId) =>
-        updateListScope(environmentId === undefined ? { projectId } : { projectId, environmentId })
-      }
       hiddenProjectKeys={activeHiddenProjectKeys}
-      // Keys naming a project this page cannot currently see are carried through untouched: the
-      // menu never showed them, so its answer does not speak for them. `updateListScope` closes a
-      // detail panel and clears a selection whose row may have just left the list.
-      onHiddenProjectKeys={(keys) => {
+      // One navigation for the whole selection. Keys naming a project this page cannot currently
+      // see are carried through untouched: the menu never showed them, so its answer does not
+      // speak for them. `updateListScope` closes a detail panel and clears a selection whose row
+      // may have just left the list.
+      onProjectSelection={({ projectId, environmentId, hiddenKeys }) => {
         setHiddenProjectKeys(
           liveHideKeys === null
-            ? keys
-            : [...keys, ...hiddenProjectKeys.filter((key) => !liveHideKeys.has(key))],
+            ? hiddenKeys
+            : [...hiddenKeys, ...hiddenProjectKeys.filter((key) => !liveHideKeys.has(key))],
         );
-        updateListScope({});
+        updateListScope(environmentId === undefined ? { projectId } : { projectId, environmentId });
       }}
     />
   );

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -100,6 +100,7 @@ import {
 import { useAtomCommand } from "../state/use-atom-command";
 import { cn } from "~/lib/utils";
 import { getSourceControlPresentationForKind } from "~/sourceControlPresentation";
+import { useUiStateStore } from "~/uiStateStore";
 import { COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS } from "~/workspaceTitlebar";
 
 export interface PullRequestsSearch {
@@ -306,6 +307,8 @@ function PullRequestsRouteView() {
     () => resolveProjectScope(search.projectId, projects, projectsKnown),
     [projects, projectsKnown, search.projectId],
   );
+  const hiddenProjectKeys = useUiStateStore((state) => state.hiddenPullRequestProjectKeys);
+  const setHiddenProjectKeys = useUiStateStore((state) => state.setHiddenPullRequestProjectKeys);
   const scopedProject = useMemo(
     () => findScopedProject(projects, scopedEnvironmentId, scopedProjectId),
     [projects, scopedEnvironmentId, scopedProjectId],
@@ -527,15 +530,22 @@ function PullRequestsRouteView() {
     for (const project of projects) {
       totals.set(project.environmentId, (totals.get(project.environmentId) ?? 0) + 1);
     }
+    const hidden = new Set(hiddenProjectKeys);
     return queryEnvironmentIds.flatMap((environmentId) => {
-      const projectIds = assignment.get(environmentId);
-      if (projectIds === undefined) return [];
+      const assigned = assignment.get(environmentId);
+      if (assigned === undefined) return [];
+      const projectIds =
+        hidden.size === 0
+          ? assigned
+          : assigned.filter((id) => !hidden.has(pullRequestProjectKey({ id, environmentId })));
+      // Every project it was going to be asked about is hidden, so it is not read at all.
+      if (projectIds.length === 0) return [];
       // It lists everything it holds anyway, so the filter is left off and a one-server workspace
       // asks exactly the question it asked before.
       if (projectIds.length === (totals.get(environmentId) ?? 0)) return [{ environmentId }];
       return [{ environmentId, projectIds }];
     });
-  }, [projects, projectsKnown, queryEnvironmentIds, scopedProjectId]);
+  }, [hiddenProjectKeys, projects, projectsKnown, queryEnvironmentIds, scopedProjectId]);
   // Part of the scope, since a different split is a different question and its answers must not
   // be filed under the same page state.
   const assignmentKey = useMemo(
@@ -1346,6 +1356,7 @@ function PullRequestsRouteView() {
             search.state !== "open" ||
             search.involvement !== "all" ||
             scopedProjectId !== undefined ||
+            hiddenProjectKeys.length > 0 ||
             search.host !== undefined
           }
           searching={typedQuery.length > 0 && (!querySettled || showingCarried)}
@@ -1475,6 +1486,8 @@ function PullRequestsRouteView() {
       onProject={(projectId, environmentId) =>
         updateListScope(environmentId === undefined ? { projectId } : { projectId, environmentId })
       }
+      hiddenProjectKeys={hiddenProjectKeys}
+      onHiddenProjectKeys={setHiddenProjectKeys}
     />
   );
   const columnProps = {

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1171,12 +1171,18 @@ function PullRequestsRouteView() {
     // The priority reads answer the same question the feed does, so they take the same local
     // narrowing: a host that cannot filter for itself would otherwise put rows into Authored
     // that the filters above just took out of the feed.
-    const narrow = (rows: ReadonlyArray<EnvironmentPullRequestEntry> | undefined) =>
-      rows === undefined || !hasLocalFilters
-        ? rows
-        : rows.filter((entry) =>
+    // The priority reads are their own listings, so a hidden repository has to leave them the way
+    // it leaves the feed: they carry rows the feed has not paged to, and a snapshot of them
+    // predates the hiding entirely.
+    const narrow = (rows: ReadonlyArray<EnvironmentPullRequestEntry> | undefined) => {
+      if (rows === undefined) return rows;
+      const shown = isHiddenEntry === null ? rows : rows.filter((entry) => !isHiddenEntry(entry));
+      return hasLocalFilters
+        ? shown.filter((entry) =>
             matchesPullRequestFilters(entry, localFilters, pullRequestEntryViewer(entry, viewers)),
-          );
+          )
+        : shown;
+    };
     const authored = narrow(
       partitionsWanted ? (authoredQuery.data?.entries ?? held?.authored) : undefined,
     );
@@ -1189,6 +1195,7 @@ function PullRequestsRouteView() {
     return partitionPullRequestsWithPriority(entries, authored, reviewing);
   }, [
     hasLocalFilters,
+    isHiddenEntry,
     localFilters,
     authoredQuery.data?.entries,
     entries,

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -54,7 +54,10 @@ import {
   type PullRequestDiffStats,
   type PullRequestPartitionsSnapshot,
 } from "../components/pullRequest/pullRequestList.logic";
-import { assignProjectsToEnvironments } from "../components/pullRequest/pullRequestProjectAssignment.logic";
+import {
+  assignProjectsToEnvironments,
+  pullRequestProjectHideKey,
+} from "../components/pullRequest/pullRequestProjectAssignment.logic";
 import { PullRequestDetailPanel } from "../components/pullRequest/PullRequestDetailPanel";
 import {
   PullRequestFiltersMenu,
@@ -294,6 +297,7 @@ function PullRequestsRouteView() {
       .map((project) => ({
         id: project.id,
         environmentId: project.environmentId,
+        hideKey: pullRequestProjectHideKey(project),
         title:
           (titleCounts.get(project.title) ?? 0) > 1
             ? `${project.title} · ${environmentLabels.get(project.environmentId) ?? project.environmentId}`
@@ -309,6 +313,44 @@ function PullRequestsRouteView() {
   );
   const hiddenProjectKeys = useUiStateStore((state) => state.hiddenPullRequestProjectKeys);
   const setHiddenProjectKeys = useUiStateStore((state) => state.setHiddenPullRequestProjectKeys);
+  /** Null until the projects have arrived, when nothing can be said about which keys are live. */
+  const liveHideKeys = useMemo(
+    () => (projectsKnown ? new Set(projects.map(pullRequestProjectHideKey)) : null),
+    [projects, projectsKnown],
+  );
+  /**
+   * The hidden keys that name a project this page can currently see. A key is kept in storage
+   * even while it names nothing — a server is disconnected, not gone, and its repositories should
+   * still be hidden when it comes back — but a key nothing answers to must not light the filter
+   * indicator or leave "All projects" reading unchecked over a list that holds every project.
+   */
+  const activeHiddenProjectKeys = useMemo(
+    () =>
+      liveHideKeys === null
+        ? hiddenProjectKeys
+        : hiddenProjectKeys.filter((key) => liveHideKeys.has(key)),
+    [hiddenProjectKeys, liveHideKeys],
+  );
+  const hideKeysByProject = useMemo(
+    () =>
+      new Map(
+        projects.map(
+          (project) =>
+            [pullRequestProjectKey(project), pullRequestProjectHideKey(project)] as const,
+        ),
+      ),
+    [projects],
+  );
+  const isHiddenEntry = useMemo(() => {
+    const hidden = new Set(activeHiddenProjectKeys);
+    if (hidden.size === 0) return null;
+    return (entry: { readonly projectId: ProjectId; readonly environmentId: EnvironmentId }) => {
+      const hideKey = hideKeysByProject.get(
+        pullRequestProjectKey({ id: entry.projectId, environmentId: entry.environmentId }),
+      );
+      return hideKey !== undefined && hidden.has(hideKey);
+    };
+  }, [activeHiddenProjectKeys, hideKeysByProject]);
   const scopedProject = useMemo(
     () => findScopedProject(projects, scopedEnvironmentId, scopedProjectId),
     [projects, scopedEnvironmentId, scopedProjectId],
@@ -530,14 +572,17 @@ function PullRequestsRouteView() {
     for (const project of projects) {
       totals.set(project.environmentId, (totals.get(project.environmentId) ?? 0) + 1);
     }
-    const hidden = new Set(hiddenProjectKeys);
+    const hidden = new Set(activeHiddenProjectKeys);
     return queryEnvironmentIds.flatMap((environmentId) => {
       const assigned = assignment.get(environmentId);
       if (assigned === undefined) return [];
       const projectIds =
         hidden.size === 0
           ? assigned
-          : assigned.filter((id) => !hidden.has(pullRequestProjectKey({ id, environmentId })));
+          : assigned.filter((id) => {
+              const hideKey = hideKeysByProject.get(pullRequestProjectKey({ id, environmentId }));
+              return hideKey === undefined || !hidden.has(hideKey);
+            });
       // Every project it was going to be asked about is hidden, so it is not read at all.
       if (projectIds.length === 0) return [];
       // It lists everything it holds anyway, so the filter is left off and a one-server workspace
@@ -545,7 +590,14 @@ function PullRequestsRouteView() {
       if (projectIds.length === (totals.get(environmentId) ?? 0)) return [{ environmentId }];
       return [{ environmentId, projectIds }];
     });
-  }, [hiddenProjectKeys, projects, projectsKnown, queryEnvironmentIds, scopedProjectId]);
+  }, [
+    activeHiddenProjectKeys,
+    hideKeysByProject,
+    projects,
+    projectsKnown,
+    queryEnvironmentIds,
+    scopedProjectId,
+  ]);
   // Part of the scope, since a different split is a different question and its answers must not
   // be filed under the same page state.
   const assignmentKey = useMemo(
@@ -1003,7 +1055,11 @@ function PullRequestsRouteView() {
   );
 
   const entries = useMemo(() => {
-    const known = ordered?.key === filterKey ? ordered.entries : (listData?.entries ?? []);
+    const read = ordered?.key === filterKey ? ordered.entries : (listData?.entries ?? []);
+    // The request is narrowed too, but not every listing on screen came from a narrowed one: rows
+    // carried over from the previous filters, and the first read of a session taken before the
+    // projects were known, both arrive holding repositories the reader has hidden.
+    const known = isHiddenEntry === null ? read : read.filter((entry) => !isHiddenEntry(entry));
     const involvementEntries = filterPullRequestsByInvolvement(known, viewers, search.involvement);
     // The hosts search more than the row shows — a body, a review, a commit message — so once
     // their answer is in, narrowing it again here would throw away matches the reader asked for.
@@ -1035,6 +1091,7 @@ function PullRequestsRouteView() {
   }, [
     filterKey,
     hasLocalFilters,
+    isHiddenEntry,
     localFilters,
     listData,
     ordered,
@@ -1356,7 +1413,7 @@ function PullRequestsRouteView() {
             search.state !== "open" ||
             search.involvement !== "all" ||
             scopedProjectId !== undefined ||
-            hiddenProjectKeys.length > 0 ||
+            activeHiddenProjectKeys.length > 0 ||
             search.host !== undefined
           }
           searching={typedQuery.length > 0 && (!querySettled || showingCarried)}
@@ -1486,8 +1543,18 @@ function PullRequestsRouteView() {
       onProject={(projectId, environmentId) =>
         updateListScope(environmentId === undefined ? { projectId } : { projectId, environmentId })
       }
-      hiddenProjectKeys={hiddenProjectKeys}
-      onHiddenProjectKeys={setHiddenProjectKeys}
+      hiddenProjectKeys={activeHiddenProjectKeys}
+      // Keys naming a project this page cannot currently see are carried through untouched: the
+      // menu never showed them, so its answer does not speak for them. `updateListScope` closes a
+      // detail panel and clears a selection whose row may have just left the list.
+      onHiddenProjectKeys={(keys) => {
+        setHiddenProjectKeys(
+          liveHideKeys === null
+            ? keys
+            : [...keys, ...hiddenProjectKeys.filter((key) => !liveHideKeys.has(key))],
+        );
+        updateListScope({});
+      }}
     />
   );
   const columnProps = {

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -24,6 +24,7 @@ function makeUiState(overrides: Partial<UiState> = {}): UiState {
     threadLastVisitedAtById: {},
     threadChangedFilesExpandedById: {},
     defaultAdvertisedEndpointKey: null,
+    hiddenPullRequestProjectKeys: [],
     ...overrides,
   };
 }
@@ -183,6 +184,7 @@ describe("parsePersistedState", () => {
           "turn-2": true,
         },
       },
+      hiddenPullRequestProjectKeys: [],
     });
   });
 
@@ -303,6 +305,7 @@ describe("uiStateStore persistence", () => {
           "turn-2": true,
         },
       },
+      hiddenPullRequestProjectKeys: [],
     });
     expect(parsePersistedState(persisted)).toEqual({
       ...state,

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -27,6 +27,7 @@ export interface PersistedUiState {
   defaultAdvertisedEndpointKey?: string | null;
   threadChangedFilesExpansionVersion?: typeof THREAD_CHANGED_FILES_EXPANSION_VERSION;
   threadChangedFilesExpandedById?: Record<string, Record<string, boolean>>;
+  hiddenPullRequestProjectKeys?: string[];
 }
 
 export interface UiProjectState {
@@ -43,7 +44,12 @@ export interface UiEndpointState {
   defaultAdvertisedEndpointKey: string | null;
 }
 
-export interface UiState extends UiProjectState, UiThreadState, UiEndpointState {}
+export interface UiPullRequestState {
+  hiddenPullRequestProjectKeys: string[];
+}
+
+export interface UiState
+  extends UiProjectState, UiThreadState, UiEndpointState, UiPullRequestState {}
 
 const initialState: UiState = {
   projectExpandedById: {},
@@ -51,6 +57,7 @@ const initialState: UiState = {
   threadLastVisitedAtById: {},
   threadChangedFilesExpandedById: {},
   defaultAdvertisedEndpointKey: null,
+  hiddenPullRequestProjectKeys: [],
 };
 
 const LEGACY_PROJECT_CWD_PREFERENCE_PREFIX = "legacy-project-cwd:";
@@ -135,6 +142,7 @@ export function parsePersistedState(parsed: PersistedUiState): UiState {
       parsed.defaultAdvertisedEndpointKey.length > 0
         ? parsed.defaultAdvertisedEndpointKey
         : null,
+    hiddenPullRequestProjectKeys: sanitizeStringArray(parsed.hiddenPullRequestProjectKeys),
   };
 }
 
@@ -207,6 +215,7 @@ export function persistState(state: UiState): void {
         defaultAdvertisedEndpointKey: state.defaultAdvertisedEndpointKey,
         threadChangedFilesExpansionVersion: THREAD_CHANGED_FILES_EXPANSION_VERSION,
         threadChangedFilesExpandedById: state.threadChangedFilesExpandedById,
+        hiddenPullRequestProjectKeys: state.hiddenPullRequestProjectKeys,
       } satisfies PersistedUiState),
     );
     if (!legacyKeysCleanedUp) {
@@ -381,12 +390,22 @@ export function reorderProjects(
   };
 }
 
+export function setHiddenPullRequestProjectKeys(state: UiState, keys: readonly string[]): UiState {
+  const next = [...new Set(keys)].sort();
+  const held = state.hiddenPullRequestProjectKeys;
+  if (next.length === held.length && next.every((key, index) => key === held[index])) {
+    return state;
+  }
+  return { ...state, hiddenPullRequestProjectKeys: next };
+}
+
 interface UiStateStore extends UiState {
   markThreadVisited: (threadId: string, visitedAt: string) => void;
   markThreadUnread: (threadId: string, latestTurnCompletedAt: string | null | undefined) => void;
   setThreadChangedFilesExpanded: (threadId: string, turnId: string, expanded: boolean) => void;
   setDefaultAdvertisedEndpointKey: (key: string | null) => void;
   setProjectExpanded: (projectIds: string | readonly string[], expanded: boolean) => void;
+  setHiddenPullRequestProjectKeys: (keys: readonly string[]) => void;
   reorderProjects: (
     currentProjectOrder: readonly string[],
     draggedProjectIds: readonly string[],
@@ -406,6 +425,8 @@ export const useUiStateStore = create<UiStateStore>((set) => ({
     set((state) => setDefaultAdvertisedEndpointKey(state, key)),
   setProjectExpanded: (projectIds, expanded) =>
     set((state) => setProjectExpanded(state, projectIds, expanded)),
+  setHiddenPullRequestProjectKeys: (keys) =>
+    set((state) => setHiddenPullRequestProjectKeys(state, keys)),
   reorderProjects: (currentProjectOrder, draggedProjectIds, targetProjectIds) =>
     set((state) =>
       reorderProjects(state, currentProjectOrder, draggedProjectIds, targetProjectIds),

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -44,6 +44,10 @@ T3 Code works with the platforms your team already uses:
 - Open the review directly in your browser with one click
 - Command-click (Control-click on Windows and Linux) a pull request number in the sidebar to open it in your browser instead of in T3 Code
 - Check out a teammate's branch to review code locally
+- Leave a repository out of the list from the filter menu's **Project** section — useful when a
+  busy repository you cloned to read buries your own reviews. Uncheck as many as you like; the
+  choice is remembered the next time you open the page, and **All projects** brings them back
+- Pick out a single repository with **Only**, on its row in that same section
 
 **Fix what you wrote, in place**
 


### PR DESCRIPTION
The project filter was all-or-one, so a cloned popular repo drowned the list and the only way out was narrowing to a single project at a time.

The project group is now checkboxes: uncheck a repository and it drops out, and the choice persists in local UI state so it stays muted on the next visit. Each row keeps a hover "Only" action for the single-project scope the radio used to set. A one-project scope and "every other project hidden" are the same statement, so switching between them carries the set across rather than snapping back to all projects.

Hidden projects are subtracted from the per-server project assignment before the request goes out, so a server whose every project is hidden is not read at all. PullRequestListInput already carried projectIds, so nothing changed on the wire or in the server.

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

The pull request list's **Project** filter was a radio group — all projects, or
exactly one. It's now a checkbox list, so any number of projects can be left out.

- Every project starts checked. Unchecking one removes its pull requests from the
  list, and the choice is kept in local UI state so it survives a reload.
- Each row gains an **Only** action on hover, which sets the single-project scope
  the radio used to set. Nothing that could be reached before became unreachable.
- **All projects** at the top clears both the hidden set and any single-project
  scope.

A one-project scope and "every other project hidden" say the same thing, so
moving between them carries the set across instead of snapping back to all
projects.

Hidden projects are subtracted from the per-server project assignment before the
request is sent, so a server whose every project is hidden isn't read at all —
hiding a repository removes a round trip rather than filtering rows after they
arrive.

`PullRequestListInput.projectIds` already existed and the server already narrowed
on it, so this is client-only: no contract change, no server change. Mobile has
no pull request surface, so nothing to mirror there.

5 files, +259 / −93 — three source files and two test files.

## Why

Cloning a busy upstream repository floods the list. Its pull requests bury mine,
and the only escape was narrowing to one project at a time, which hides the other
four I actually want to see. The filter could express "just this one" but not
"anything but this one".

Checkboxes cover both: all-checked is today's default, unchecking is the new
capability, and checking exactly one is the old single-select. Persisting the
choice matters because the problem is durable — a repository worth muting is
still worth muting tomorrow, and re-hiding it every session is the same
annoyance wearing a different hat.

Doing the narrowing in the request rather than over the returned rows keeps it
honest with paging: the list only ever holds a page per repository, so a
client-side filter would quietly shrink pages instead of excluding a repository.

## UI Changes

**Before** — all projects, or one:

<img width="1001" height="782" alt="image" src="https://github.com/user-attachments/assets/0db9671b-babe-4611-97b6-07d8df1c6284" />

**After** — any combination, with `Only` on hover:

<img width="1243" height="762" alt="image" src="https://github.com/user-attachments/assets/0e9460b8-de4c-4038-a4e5-40f060d48dbb" />

**Hover action and hiding a repository:**


https://github.com/user-attachments/assets/dd202b37-d6b1-4c41-a220-fd9504d4bd3c



## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pull-request list query construction, URL scope, and persisted UI state; behavior is well covered by tests but wrong hide-key or merge logic could omit repositories or skew paging.
> 
> **Overview**
> The **Project** filter on the pull requests page switches from a radio group (all vs one) to **checkboxes** so any combination of repositories can be shown or hidden. Hidden choices persist in **`hiddenPullRequestProjectKeys`** in local UI state; each row keeps an **Only** action (click or Shift+Enter) for the old single-project scope, and **All projects** clears both scope and hidden set in one update.
> 
> **`pullRequestProjectHideKey`** keys hiding by repository identity when available (so duplicate clones on two servers share one hidden state), with a per-project fallback. The route applies hidden keys when building **`environmentQueries`** (skipping servers with no visible projects) and filters carried feed/partition rows client-side; **`onProjectSelection`** replaces **`onProject`** so URL scope and hidden keys update atomically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd9ad2ace2089d8aea4f3510394172ae5e01ac93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-project hiding to the pull requests filter with persistent state
> - Replaces the single-select project radio group in `PullRequestFiltersMenu` with checkboxes, allowing users to hide individual repositories from the PR feed.
> - Adds an "Only" button per project row (mouse or Shift+Enter) to scope the view to a single project/environment.
> - Hidden project keys are persisted in `localStorage` via `useUiStateStore` and restored on reload; keys are de-duplicated across environments sharing a repository using `pullRequestProjectHideKey`.
> - Hiding is applied to environment queries, the main feed, and priority partitions (authored/reviewing); the empty-state filtered indicator reflects hidden projects.
> - Behavioral Change: `PullRequestFiltersMenu` now emits `onProjectSelection({projectId, environmentId, hiddenKeys})` instead of `onProject`, and the filter indicator lights when any projects are hidden.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fd9ad2a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->