### PR TITLE
fix(web): new threads honor the project default model

### DIFF
--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -101,9 +101,11 @@ export function useNewThreadHandler() {
       const currentRouteTarget = getCurrentRouteTarget();
       // A new thread carries the user's *working mode* from the thread being
       // viewed: model (including options like reasoning effort and context
-      // window), permission mode, and interaction mode. Branch, worktree, and
-      // env mode never carry implicitly — those come from the configured
-      // defaults unless the caller passes them explicitly.
+      // window), permission mode, and interaction mode. The target project's
+      // configured default model, when set, outranks the carried model (see
+      // modelSelectionOverride below). Branch, worktree, and env mode never
+      // carry implicitly — those come from the configured defaults unless the
+      // caller passes them explicitly.
       const carrySourceShell =
         currentRouteTarget?.kind === "server"
           ? readThreadShell(currentRouteTarget.threadRef)
@@ -161,6 +163,12 @@ export function useNewThreadHandler() {
           candidate.id === projectRef.projectId &&
           candidate.environmentId === projectRef.environmentId,
       );
+      // A project default model is a pin: new threads in that project start
+      // on it, beating both the globally sticky pick and the selection
+      // carried from the viewed thread. That keeps a project bound to its
+      // configured provider instance (subscription) no matter where the user
+      // just worked. Projects without a pin keep sticky + carry behavior.
+      const modelSelectionOverride = project?.defaultModelSelection ?? carryModelSelection;
       // The shared resolver owns the priority order. The t3.json read is
       // skipped entirely when a higher-priority source decides, and its
       // query atom caches per project after the first call.
@@ -273,11 +281,11 @@ export function useNewThreadHandler() {
               ...(carryRuntimeMode ? { runtimeMode: carryRuntimeMode } : {}),
               ...(carryInteractionMode ? { interactionMode: carryInteractionMode } : {}),
             });
-            if (carryModelSelection) {
-              // The carried selection is a complete snapshot of the viewed
-              // thread's model state: absent options mean "no options", not
-              // "keep the stale draft's options".
-              setModelSelection(emptyStoredDraftThread.draftId, carryModelSelection, {
+            if (modelSelectionOverride) {
+              // The selection is a complete snapshot of the pinned or viewed
+              // model state: absent options mean "no options", not "keep the
+              // stale draft's options".
+              setModelSelection(emptyStoredDraftThread.draftId, modelSelectionOverride, {
                 replaceOptions: true,
               });
             }
@@ -345,6 +353,14 @@ export function useNewThreadHandler() {
           interactionMode: latestActiveDraftThread.interactionMode,
           ...pickExplicitWorkspaceOptions(options),
         });
+        if (modelSelectionOverride) {
+          // Reusing the viewed draft is still a new-thread request, so it
+          // resets to the project pin when one is set. Without a pin the
+          // override is this draft's own selection and the write no-ops.
+          setModelSelection(currentRouteTarget.draftId, modelSelectionOverride, {
+            replaceOptions: true,
+          });
+        }
         return Promise.resolve({
           draftId: currentRouteTarget.draftId,
           threadId: latestActiveDraftThread.threadId,
@@ -409,13 +425,13 @@ export function useNewThreadHandler() {
           ...(carryInteractionMode ? { interactionMode: carryInteractionMode } : {}),
         });
         applyStickyState(draftId);
-        if (carryModelSelection) {
-          // After sticky state so the viewed thread's exact selection
-          // (model + options like effort and context window) wins over the
-          // globally sticky one. replaceOptions: the carried selection is a
-          // complete snapshot — absent options mean "no options", not "keep
-          // whatever sticky state just wrote".
-          setModelSelection(draftId, carryModelSelection, { replaceOptions: true });
+        if (modelSelectionOverride) {
+          // After sticky state so the pin (or, without one, the viewed
+          // thread's exact selection with options like effort and context
+          // window) wins over the globally sticky one. replaceOptions: the
+          // override is a complete snapshot, absent options mean "no
+          // options", not "keep whatever sticky state just wrote".
+          setModelSelection(draftId, modelSelectionOverride, { replaceOptions: true });
         }
         carryComposerContentTo(draftId);
 


### PR DESCRIPTION
Fixes #5796

## Problem

A project's configured default model (Project settings) stores a full `ModelSelection`, including the provider instance, i.e. which subscription runs the thread. New threads on web/desktop ignored it: fresh drafts were seeded from the globally sticky last-used selection and from the thread being viewed, both of which follow recent activity across projects. Working in a project pinned to a work subscription and then opening a new thread in a project pinned to a personal one started the thread on the work account.

## Fix

`useNewThreadHandler` now resolves one override, `project.defaultModelSelection ?? carryModelSelection`, and writes it wherever the handler previously wrote the carried selection: the mint-fresh path (after sticky state), the empty-stored-draft reuse path, and the viewed-draft reuse path. A configured project default acts as a pin: every new-thread request in that project starts on it, beating sticky and carry. Projects without a pin keep the existing sticky + carry behavior, and an explicit pick in the composer afterwards still wins for that draft because it writes the draft directly.

## Why this shape

Two open PRs already target this bug; this one deliberately sits between them.

- #6011 (thanks @anirudhsama) contains essentially this web change, but bundles a large mobile rework into the same PR. Mobile already resolves draft, then project default, then server default on its own, and repo convention is one concern per PR.
- #6593 (thanks @mrmg) fixes the same flow plus edge cases: retroactive reseeding of stale persisted drafts, a new persisted `modelSelectionExplicit` flag, render-time precedence overrides in ChatComposer/ChatView, and pin-clear sticky restore. That is ~1.2k lines across seven files for what is at its core a seeding-order bug, and the render-time override machinery introduces a second source of truth for what the composer displays versus what the draft stores.

This PR keeps the model small: the pin is applied once, at the moment a new-thread request seeds a draft. No schema changes, no new persisted flags, no render-time overrides. Drafts seeded before this fix heal on the next new-thread request in their project. What it deliberately does not cover: a stale unsent draft submitted without ever passing through a new-thread request again, and live re-sync of an open draft when the pin changes in Settings (the wider defaults story is #6539). If maintainers want those edges, #6593 is the thorough version and I am happy to close this in its favor.

## Validation

- `vp test run apps/web/src/composerDraftStore.test.ts` (79 tests pass)
- `vp lint apps/web/src/hooks/useHandleNewThread.ts` and `vp run --filter @t3tools/web typecheck` (clean)
- Integrated web pass against a snapshot of a real database with two Claude instances (personal + Work) and opposite pins on two projects:
  - viewing a Work-subscription thread in project A, then New thread into project B, lands on B's personal pin
  - the reverse direction lands on the Work pin
  - after an explicit Work / Claude Opus 5 pick (global sticky and carry both pointing at Work), New thread into project B still lands on B's pinned personal Claude Fable 5, reusing the stored empty draft correctly

No UI layout changes.

Built with Claude Fable 5 through Claude Code in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core new-thread draft seeding and model selection precedence; behavior change is localized to one hook but affects which provider/subscription every new thread starts on.
> 
> **Overview**
> **New-thread seeding** now treats a project’s configured **default model** as a pin that beats global sticky state and the model carried from the thread you were viewing.
> 
> `useHandleNewThread` resolves `modelSelectionOverride` as `project?.defaultModelSelection ?? carryModelSelection` and applies it (with `replaceOptions: true`) on every path that starts a new thread: minting a fresh draft after sticky state, resurrecting an empty stored draft, and reusing the currently viewed empty draft in the same project. Projects without a pin keep the previous sticky + carry behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 119ffacf3bb06951535c328afeac084775a3dfda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix new threads to use the project's default model selection
> In [`useHandleNewThread.ts`](https://github.com/pingdotgg/t3code/pull/7511/files#diff-4a13a04822f436fab695948f0596a6fd92885554e031426dac1954a343c98fef), the `useNewThreadHandler` hook now prefers `project.defaultModelSelection` over the carried model selection when initializing a new thread. When reusing the currently viewed draft as the thread destination, the model selection is also reset using this override with `replaceOptions: true`. Behavioral Change: new threads in projects with a pinned default model will no longer inherit the previous thread's model selection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 119ffac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->