### PR TITLE
fix(web): widen the sidebar project filter dropdown

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3484,7 +3484,10 @@ export default function Sidebar() {
                     </span>
                     <ChevronDownIcon className="-mr-px size-4 shrink-0" />
                   </MenuTrigger>
-                  <MenuPopup align="start" className="w-(--anchor-width)">
+                  <MenuPopup
+                    align="start"
+                    className="min-w-(--anchor-width) max-w-[min(600px,var(--available-width))]"
+                  >
                     <MenuRadioGroup
                       value={projectScopeKey ?? "all"}
                       onValueChange={(value) =>


### PR DESCRIPTION
## Problem

The sidebar's project filter menu was pinned to the width of its trigger button (`w-(--anchor-width)`), so it inherited the sidebar's width exactly. With a narrow sidebar, long project names — especially `namespace/project-name` style ones — truncate to the point where you can't tell which project you're about to select.

## Fix

The popup now keeps the trigger width as a minimum but grows to fit the longest project name, capped at 600px and clamped to `--available-width` so it can never overflow the viewport.

```diff
-<MenuPopup align="start" className="w-(--anchor-width)">
+<MenuPopup
+  align="start"
+  className="min-w-(--anchor-width) max-w-[min(600px,var(--available-width))]"
+>
```

`MenuPopup` already skips its default `min-w-32` when an explicit width utility is passed, so no conflicting floor is applied.

## Before / after

Same six projects, same 203px sidebar.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/Zandor300/t3code/0bce304/before.png" width="420"> | <img src="https://raw.githubusercontent.com/Zandor300/t3code/0bce304/after.png" width="420"> |

Names longer than the cap still truncate with an ellipsis, so the menu can't run away:

<img src="https://raw.githubusercontent.com/Zandor300/t3code/0bce304/cap.png" width="520">

## Verification

Measured in the dev web client (Chrome, seeded projects, 203px trigger):

- Long names present → popup grows to 417px, full names readable.
- Over-cap name present → popup stops at exactly 600px, computed `min-width: 203px` / `max-width: 600px`, text ellipsises.
- 800px and 640px (overlay sidebar) windows → popup stays fully inside the viewport.
- `vp fmt --check`, `vp lint`, and `@t3tools/web` typecheck pass.

Only surface affected: the web sidebar (desktop wraps it). Mobile has no equivalent menu, and `grep` for `Filter threads by project` finds no other call site. Pure CSS change, no contract or server involvement.

Model: Claude Opus 5 (1M context), harness: T3 Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS class change on one sidebar menu popup; no API, server, or auth impact.
> 
> **Overview**
> The sidebar **Filter threads by project** menu popup no longer locks to the trigger width (`w-(--anchor-width)`). It now uses **`min-w-(--anchor-width)`** so it can grow with long project names, with **`max-w-[min(600px,var(--available-width))]`** so width stays capped and inside the viewport.
> 
> `MenuPopup` already skips its default `min-w-32` when a width utility is present, so this change does not fight the menu component’s width rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b8539972b8821122376cb14f47899f47f486b79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Widen the sidebar project filter dropdown to fit longer project names
> Replaces the fixed anchor-width constraint on the project scope `MenuPopup` in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/7516/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) with a responsive sizing approach: the dropdown now has a minimum width equal to the anchor and a maximum width of the lesser of 600px or the available viewport width.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b85399.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->