### PR TITLE
fix(web): align version text with its label

### DIFF
--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -212,7 +212,7 @@ function backgroundActivityProfileSettings(profile: BackgroundActivityProfile) {
 
 function AboutVersionTitle() {
   return (
-    <span className="inline-flex items-center gap-2">
+    <span className="inline-flex items-baseline gap-2">
       <span>Version</span>
       <code className="text-[11px] font-medium text-muted-foreground">{APP_VERSION}</code>
     </span>


### PR DESCRIPTION
The smaller monospace version string in Settings > About sat about two pixels above the label baseline because the row vertically centered text with different font metrics.

Align the two text runs by baseline. The shared title covers stable and nightly versions across local web, hosted web, and desktop.

## Verification

- `vp lint apps/web/src/components/settings/SettingsPanels.tsx --report-unused-disable-directives`
- `vp fmt --check apps/web/src/components/settings/SettingsPanels.tsx`
- `vp run --filter @t3tools/web typecheck`
- Compared stable and nightly version strings in the local web preview

## Screenshot

<img width="838" alt="Version alignment before and after" src="https://github.com/user-attachments/assets/13f3f126-535c-4b9d-9405-dff817d7cc7d" />

---
Built by GPT-5.6 Sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class change in a settings UI title with no behavior or data impact.
> 
> **Overview**
> Fixes a visual misalignment in **Settings → About** where the monospace `APP_VERSION` string sat slightly above the **Version** label.
> 
> `AboutVersionTitle` switches its flex container from **`items-center`** to **`items-baseline`** so the label and version share a baseline instead of being vertically centered across mismatched font metrics. The shared component covers desktop, hosted, and local web About rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 559ca8a7eb0b94ab8f13ab5267a94da0c525984c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix version text alignment in `AboutVersionTitle` settings panel
> Changes the flex alignment in `AboutVersionTitle` from `items-center` to `items-baseline` in [SettingsPanels.tsx](https://github.com/pingdotgg/t3code/pull/7521/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18), so the version text aligns with the typographic baseline of its label rather than being vertically centered.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 559ca8a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->