### PR TITLE
fix(desktop): stop automatic passkey prompts

### DIFF
--- a/apps/web/src/components/clerk/electronPasskeys.test.ts
+++ b/apps/web/src/components/clerk/electronPasskeys.test.ts
@@ -1,0 +1,60 @@
+import { createPasskeys } from "@clerk/electron/passkeys";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+const publicKeyOptions = {
+  allowCredentials: [],
+  challenge: new Uint8Array([1]),
+  rpId: "clerk.t3.codes",
+  timeout: 60_000,
+  userVerification: "preferred" as const,
+};
+
+const stubNativePasskeys = () => {
+  const get = vi.fn().mockResolvedValue({
+    ok: false,
+    error: { code: "cancelled", message: "user cancelled" },
+  });
+
+  vi.stubGlobal("location", { protocol: "t3code:", hostname: "app" });
+  vi.stubGlobal("window", {
+    PublicKeyCredential: vi.fn(),
+    __clerk_internal_electron_passkeys: {
+      platform: "darwin",
+      electronMajor: 41,
+      get,
+    },
+  });
+
+  return get;
+};
+
+describe("Electron passkeys", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does not send an autofill request to the native bridge", async () => {
+    const get = stubNativePasskeys();
+    const passkeys = createPasskeys();
+
+    const result = await passkeys.get({
+      publicKeyOptions,
+      conditionalUI: true,
+    });
+
+    expect(get).not.toHaveBeenCalled();
+    expect(result.error).toMatchObject({ code: "passkey_operation_aborted" });
+  });
+
+  it("sends an explicit passkey request to the native bridge", async () => {
+    const get = stubNativePasskeys();
+    const passkeys = createPasskeys();
+
+    await passkeys.get({
+      publicKeyOptions,
+      conditionalUI: false,
+    });
+
+    expect(get).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { ClerkProvider } from "@clerk/react";
-import { passkeys as electronPasskeys } from "@clerk/electron/passkeys";
+import { passkeys } from "@clerk/electron/passkeys";
 import { ClerkProvider as ElectronClerkProvider } from "@clerk/electron/react";
 import { createHashHistory, createBrowserHistory } from "@tanstack/react-router";
 
@@ -30,14 +30,9 @@ if (isElectron) {
 
 const clerkPublishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY as string | undefined;
 
-// @clerk/electron reports passkey autofill as supported but executes the
-// "quiet" autofill request as a modal prompt, so Clerk's sign-in form pops an
-// OS passkey dialog the moment it mounts. Report autofill as unsupported; the
-// explicit "Use passkey" button keeps working.
-// Upstream: https://github.com/clerk/javascript/issues/9496
-const passkeys = {
-  ...electronPasskeys,
-  isAutoFillSupported: () => Promise.resolve(false),
+// First Clerk UI build containing https://github.com/clerk/javascript/pull/9500.
+const electronClerkUI = {
+  __internal_clerkUIVersion: "1.30.5-canary.v20260819050620",
 };
 
 const app = <AppRoot router={router} />;
@@ -47,6 +42,7 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     {clerkPublishableKey && hasCloudPublicConfig() ? (
       isElectron ? (
         <ElectronClerkProvider
+          {...electronClerkUI}
           appearance={clerkAppearance}
           publishableKey={clerkPublishableKey}
           passkeys={passkeys}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ overrides:
   '@clerk/clerk-js>@solana/wallet-adapter-react': '-'
   '@clerk/clerk-js>@solana/wallet-standard': '-'
   '@clerk/clerk-js>@wallet-standard/core': '-'
-  '@clerk/electron': 0.0.33
-  '@clerk/electron-passkeys': 0.0.3
+  '@clerk/electron': 0.0.34-canary.v20260819050620
+  '@clerk/electron-passkeys': 0.0.4-canary.v20260819050620
   '@clerk/expo': 4.2.0
   '@clerk/react': 6.14.4
   '@clerk/shared': 4.29.2
@@ -114,11 +114,11 @@ importers:
   apps/desktop:
     dependencies:
       '@clerk/electron':
-        specifier: 0.0.33
-        version: 0.0.33(@clerk/electron-passkeys@0.0.3)(electron-store@8.2.0)(electron@41.5.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 0.0.34-canary.v20260819050620
+        version: 0.0.34-canary.v20260819050620(@clerk/electron-passkeys@0.0.4-canary.v20260819050620)(electron-store@8.2.0)(electron@41.5.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@clerk/electron-passkeys':
-        specifier: 0.0.3
-        version: 0.0.3
+        specifier: 0.0.4-canary.v20260819050620
+        version: 0.0.4-canary.v20260819050620
       '@effect/platform-node':
         specifier: 4.0.0-beta.103
         version: 4.0.0-beta.103(bufferutil@4.1.0)(effect@4.0.0-beta.103(patch_hash=af36b7948b6f9c56623074662b51dade5699880c1a7c71245de73e13c3185fb6))(ioredis@5.11.0)(utf-8-validate@6.0.6)
@@ -520,8 +520,8 @@ importers:
         specifier: ^1.4.1
         version: 1.5.0(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@clerk/electron':
-        specifier: 0.0.33
-        version: 0.0.33(@clerk/electron-passkeys@0.0.3)(electron-store@8.2.0)(electron@41.5.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 0.0.34-canary.v20260819050620
+        version: 0.0.34-canary.v20260819050620(@clerk/electron-passkeys@0.0.4-canary.v20260819050620)(electron-store@8.2.0)(electron@41.5.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@clerk/react':
         specifier: 6.14.4
         version: 6.14.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -1721,35 +1721,35 @@ packages:
     resolution: {integrity: sha512-4i4RE+ZQ0hKDDFSRKCISQPBy07SfFeFAhBUhNj2j01Nx2n4pqV+5iyg2Vf27+NKFNkgq7kdmZGvtug24D++8WQ==}
     engines: {node: '>=20.9.0'}
 
-  '@clerk/electron-passkeys-darwin-arm64@0.0.3':
-    resolution: {integrity: sha512-oAlrd+GLqP0oREP3hNRc6yNZhXGaQgJss9iCWRQqXjpw1yZD1ZU+L+E2Gfg84vMj/NSUhxbU0Djy0RXhmeUwgg==}
+  '@clerk/electron-passkeys-darwin-arm64@0.0.4-canary.v20260819050620':
+    resolution: {integrity: sha512-avxygtEfWBD3YPkxws4lB5mL/75SQvVBMQCg+b1gjFsQInnVOgAqAv4wHR8wgUsEbXY2zEkvqaYjFSnEveC0VA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@clerk/electron-passkeys-darwin-x64@0.0.3':
-    resolution: {integrity: sha512-0UPAWQEni7o8gjWwd2sP97fPshJmT2w5b8eV/jOPVSP8NqIcFCm5yIFSEx1SfB53LGfzB01A4iEGi2pxiCHqyQ==}
+  '@clerk/electron-passkeys-darwin-x64@0.0.4-canary.v20260819050620':
+    resolution: {integrity: sha512-clShldbwDcC2ek6gJT85QKsMfaPyOhEgfz61u2n3YKivbeui33XjJu261d+LO20mqDjXZy3flLGPTIh/Kii80g==}
     cpu: [x64]
     os: [darwin]
 
-  '@clerk/electron-passkeys-win32-arm64-msvc@0.0.3':
-    resolution: {integrity: sha512-bbRvifm9A/gfPkwC1UyMyF9sYGEs0aen7J2kCcaOIW3K0PXcAbHtsR/gnx4dT0bjFdd21vSa2zlIdERvHc1BiA==}
+  '@clerk/electron-passkeys-win32-arm64-msvc@0.0.4-canary.v20260819050620':
+    resolution: {integrity: sha512-alIfXJSxyeulnNeHoT4X7+qO0o9/EBhiRWMhCXwKJIbWfwzqnnVrRH1P7HfYRnDepKhqRzsUaBuYTqQzisHG+A==}
     cpu: [arm64]
     os: [win32]
 
-  '@clerk/electron-passkeys-win32-x64-msvc@0.0.3':
-    resolution: {integrity: sha512-gFaVqKlOKTF2SJ3lMwkZ0oonycQn93p1qSrp5kzzeZBeQ+tGB3gQnjXecrhQy21AzDUyWqVJJ8KrP2HRAwifWg==}
+  '@clerk/electron-passkeys-win32-x64-msvc@0.0.4-canary.v20260819050620':
+    resolution: {integrity: sha512-QSKKMCdV9AhOt74ls8ExdwR+2ikoLGgN2LdWIjBgNk6epJVs2L1FXVZOM0ZqfVHFSl5y7vLmlOACR6WyJ2eoLg==}
     cpu: [x64]
     os: [win32]
 
-  '@clerk/electron-passkeys@0.0.3':
-    resolution: {integrity: sha512-OHhIe88qDL+FxyBalXdXNHAS5eEramr6Rerp+6iNkfkjqT8rx4hHNmfpmjg5/T1/am8QfknbOBZkqoXZlCrjPg==}
+  '@clerk/electron-passkeys@0.0.4-canary.v20260819050620':
+    resolution: {integrity: sha512-zOoFEsvOrArv7p4ERNAdkGbYoD86ragDhysLG1NdxJm2jnfw+AfwxUv0FkOPZ7iNuQ0rbJaR/urxdvEwVcuKRA==}
     engines: {node: '>=20.9.0'}
 
-  '@clerk/electron@0.0.33':
-    resolution: {integrity: sha512-lP2B7wGHwKWrCAh4zPWPfRUIHoxQ1rwG8iiFeLmI8jBjSGcSoPX1N9bIKUCWL+Z9POmC2aRn6yXvL7e9yzfEVw==}
+  '@clerk/electron@0.0.34-canary.v20260819050620':
+    resolution: {integrity: sha512-sfKWkH2SigKcxtR+h36G1NGnmMI5xOlwvqHpr3JYcacS/uokQbeAjCCQzEeV/9zqWYtRL4et5wCD13+gWv4b6w==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
-      '@clerk/electron-passkeys': 0.0.3
+      '@clerk/electron-passkeys': 0.0.4-canary.v20260819050620
       electron: '>=28'
       electron-store: ^8.2.0
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
@@ -11580,26 +11580,26 @@ snapshots:
       - react
       - react-dom
 
-  '@clerk/electron-passkeys-darwin-arm64@0.0.3':
+  '@clerk/electron-passkeys-darwin-arm64@0.0.4-canary.v20260819050620':
     optional: true
 
-  '@clerk/electron-passkeys-darwin-x64@0.0.3':
+  '@clerk/electron-passkeys-darwin-x64@0.0.4-canary.v20260819050620':
     optional: true
 
-  '@clerk/electron-passkeys-win32-arm64-msvc@0.0.3':
+  '@clerk/electron-passkeys-win32-arm64-msvc@0.0.4-canary.v20260819050620':
     optional: true
 
-  '@clerk/electron-passkeys-win32-x64-msvc@0.0.3':
+  '@clerk/electron-passkeys-win32-x64-msvc@0.0.4-canary.v20260819050620':
     optional: true
 
-  '@clerk/electron-passkeys@0.0.3':
+  '@clerk/electron-passkeys@0.0.4-canary.v20260819050620':
     optionalDependencies:
-      '@clerk/electron-passkeys-darwin-arm64': 0.0.3
-      '@clerk/electron-passkeys-darwin-x64': 0.0.3
-      '@clerk/electron-passkeys-win32-arm64-msvc': 0.0.3
-      '@clerk/electron-passkeys-win32-x64-msvc': 0.0.3
+      '@clerk/electron-passkeys-darwin-arm64': 0.0.4-canary.v20260819050620
+      '@clerk/electron-passkeys-darwin-x64': 0.0.4-canary.v20260819050620
+      '@clerk/electron-passkeys-win32-arm64-msvc': 0.0.4-canary.v20260819050620
+      '@clerk/electron-passkeys-win32-x64-msvc': 0.0.4-canary.v20260819050620
 
-  '@clerk/electron@0.0.33(@clerk/electron-passkeys@0.0.3)(electron-store@8.2.0)(electron@41.5.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@clerk/electron@0.0.34-canary.v20260819050620(@clerk/electron-passkeys@0.0.4-canary.v20260819050620)(electron-store@8.2.0)(electron@41.5.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@clerk/clerk-js': 6.29.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@clerk/react': 6.14.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -11608,7 +11608,7 @@ snapshots:
       react: 19.2.6
       tslib: 2.8.1
     optionalDependencies:
-      '@clerk/electron-passkeys': 0.0.3
+      '@clerk/electron-passkeys': 0.0.4-canary.v20260819050620
       electron-store: 8.2.0
       react-dom: 19.2.6(react@19.2.6)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,8 +25,8 @@ allowBuilds:
 catalog:
   "@clerk/backend": 3.14.0
   "@clerk/clerk-js": 6.29.2
-  "@clerk/electron": 0.0.33
-  "@clerk/electron-passkeys": 0.0.3
+  "@clerk/electron": 0.0.34-canary.v20260819050620
+  "@clerk/electron-passkeys": 0.0.4-canary.v20260819050620
   "@clerk/expo": 4.2.0
   "@clerk/react": 6.14.4
   "@clerk/shared": 4.29.2
@@ -55,7 +55,8 @@ catalog:
 minimumReleaseAgeExclude:
   - "@clerk/backend@3.14.0"
   - "@clerk/clerk-js@6.29.2"
-  - "@clerk/electron@0.0.33"
+  - "@clerk/electron@0.0.34-canary.v20260819050620"
+  - "@clerk/electron-passkeys@0.0.4-canary.v20260819050620"
   - "@clerk/expo@4.2.0"
   - "@clerk/react@6.14.4"
   - "@clerk/shared@4.29.2"
@@ -76,6 +77,10 @@ minimumReleaseAgeExclude:
   - alchemy@2.0.0-beta.65
   - effect@4.0.0-beta.103
   - "@legendapp/list@3.3.5"
+  - "@clerk/electron-passkeys-darwin-arm64@0.0.4-canary.v20260819050620"
+  - "@clerk/electron-passkeys-darwin-x64@0.0.4-canary.v20260819050620"
+  - "@clerk/electron-passkeys-win32-arm64-msvc@0.0.4-canary.v20260819050620"
+  - "@clerk/electron-passkeys-win32-x64-msvc@0.0.4-canary.v20260819050620"
 
 overrides:
   "@clerk/backend": "catalog:"


### PR DESCRIPTION
The desktop sign-in form could open the native passkey dialog as soon as it rendered. Stable Clerk Electron does not yet contain [Clerk PR #9500](https://github.com/clerk/javascript/pull/9500), and our local autofill override ran too late to stop the native request.

This pins the first Clerk Electron and UI canary builds that contain the upstream fix. It removes the local override, keeps the non-Electron Clerk packages stable, and adds coverage for both automatic and explicit passkey requests.

Tested:

- `vp test run apps/web/src/components/clerk/electronPasskeys.test.ts apps/desktop/src/app/DesktopClerk.test.ts`
- `pnpm --filter @t3tools/web typecheck`
- `pnpm --filter @t3tools/desktop typecheck`
- `vp fmt --check apps/web/src/main.tsx apps/web/src/components/clerk/electronPasskeys.test.ts pnpm-workspace.yaml`
- Theo verified the Electron sign-in flow with the development Clerk instance

Built with GPT-5.6 Sol in the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Electron sign-in and passkey behavior via pre-release Clerk canaries; risk is limited to desktop auth UX, not broad web auth changes.
> 
> **Overview**
> Fixes **desktop sign-in opening a native passkey dialog on mount** by adopting Clerk’s upstream fix instead of a local shim.
> 
> **Dependency pins:** `@clerk/electron` and `@clerk/electron-passkeys` move to **canary builds** that include [clerk/javascript#9500](https://github.com/clerk/javascript/pull/9500); catalog, lockfile, and `minimumReleaseAgeExclude` are updated accordingly. Other Clerk packages stay on stable versions.
> 
> **Electron bootstrap (`main.tsx`):** Removes the wrapper that forced `isAutoFillSupported` to `false` and wires **`passkeys` directly** from `@clerk/electron/passkeys`. **`ElectronClerkProvider`** now passes **`__internal_clerkUIVersion`** so the embedded Clerk UI matches the canary that contains the same fix.
> 
> **Tests:** New `electronPasskeys.test.ts` asserts **conditional/autofill** `passkeys.get` does **not** hit the native bridge (returns `passkey_operation_aborted`), while **explicit** requests still call the bridge once.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4677f4499d1e99d56f18869fc6a8cc4fb2e72b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop automatic passkey prompts in Electron by aborting conditional UI requests
> - Updates [`electronPasskeys.ts`](https://github.com/pingdotgg/t3code/pull/7522/files#diff-f21f2be81de40cac158cafa648f9df1362a79b070c29c4574976fba2855e2367) so that `createPasskeys().get()` returns a `passkey_operation_aborted` error when `conditionalUI=true`, preventing the browser from triggering automatic passkey prompts in the Electron shell.
> - Upgrades `@clerk/electron` to `0.0.34-canary` and `@clerk/electron-passkeys` to `0.0.4-canary` in [`pnpm-workspace.yaml`](https://github.com/pingdotgg/t3code/pull/7522/files#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794c).
> - Removes the local override that forced `isAutoFillSupported` to `false` in [`main.tsx`](https://github.com/pingdotgg/t3code/pull/7522/files#diff-44decff659436a16ccdaaae62e456cd52d9f206c8628c8ca4447aa268c85e16b), replacing it with the upstream `@clerk/electron/passkeys` implementation and adding an `__internal_clerkUIVersion` prop to `<ElectronClerkProvider>`.
> - Behavioral Change: The Clerk passkeys implementation in Electron now delegates to the upstream library rather than a local stub, which may affect behavior if the upstream implementation changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d4677f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->