### PR TITLE
fix(mobile): drop the dead /model row and re-park the caret on draft switch

### DIFF
--- a/apps/mobile/src/features/threads/use-composer-command-menu.ts
+++ b/apps/mobile/src/features/threads/use-composer-command-menu.ts
@@ -63,11 +63,13 @@ export function useComposerCommandMenu({
       return { start, end: selectionEnd };
     });
   }, [draftMessage.length]);
-  useEffect(() => {
-    if (previousOwnerKeyRef.current === ownerKey) return;
+  // Adjusted while rendering, not in an effect: one committed render with the
+  // previous draft's caret is enough to flash the popover open over a draft
+  // the user never typed a trigger into.
+  if (previousOwnerKeyRef.current !== ownerKey) {
     previousOwnerKeyRef.current = ownerKey;
     setSelection(composerSelectionAtEnd(draftMessage));
-  }, [draftMessage, ownerKey]);
+  }
 
   const trigger = useMemo(() => {
     if (!enabled || selection.start !== selection.end) {
@@ -109,10 +111,14 @@ export function useComposerCommandMenu({
           description: "Switch to default mode",
         },
       ];
+      // On an unsent draft `/model` is a dead row: `onSelect` has no `model`
+      // branch, so it inserts the literal text `/model `, and the `slash-model`
+      // trigger that follows builds no items, closing the menu. The draft screen
+      // has its own model control, so gate the row on an existing thread.
       const builtIn = allBuiltIn.filter(
         (item) =>
           item.command.includes(q) &&
-          (item.command === "model" || onUpdateInteractionMode !== undefined),
+          (item.command === "model" ? hasThread : onUpdateInteractionMode !== undefined),
       );
 
       // A provider expands a slash command only when it opens the whole


### PR DESCRIPTION
## What this PR is now

#8587 landed the draft composer trigger menus, so the original 775-line version of this PR is obsolete. I have rebased onto `main` and cut it down to the two behaviors @juliusmarminge named when reopening it:

> Reopening: #8587 added the draft menus, but this PR also suppresses the nonfunctional /model row on drafts and resets selection synchronously when drafts change. Those details are not in the merged implementation.

One file, `+10 / −4`, both edits in `apps/mobile/src/features/threads/use-composer-command-menu.ts`.

## 1. `/model` is a dead row on the new-task draft screen

`allBuiltIn` let `/model` bypass the capability gate, so it rendered on both surfaces. Selecting it on a draft does nothing useful: `onSelect` has no `model` branch, so it inserts the literal text `/model `, `detectComposerTrigger` then returns a `slash-model` trigger this hook builds no items for, and the menu just closes. The draft screen already has a working model control in the same toolbar ("Choose model"), so the row is redundant as well as inert.

The row is now gated on `hasThread`. `ThreadComposer` passes `hasThread: true` and is unchanged.

One consequence worth naming: with plan mode off, `NewTaskDraftScreen` passes no `onUpdateInteractionMode`, so the built-in list is now empty. Typing `/` mid-line on such a draft — where provider commands are position-gated to column 0 — can produce no menu at all, whereas before it always produced the inert `/model` row. I think no menu beats a row that does nothing, but say the word if you would rather keep something there.

## 2. The caret is re-parked a render too late

The `ownerKey` reset ran in a `useEffect`, which commits after the render that already computed `trigger` from the previous draft's caret offset. Switching drafts could therefore flash the popover open over a draft the user never typed a trigger into. It now adjusts during render, so that pass never reaches the screen. The ref is assigned before `setSelection`, so the restarted render cannot loop — the same shape already used in `HomeScreen.tsx` and `ThreadNavigationSidebar.tsx`.

No path search was ever dispatched in that window — `useComposerPathSearch` debounces its target by 200 ms — so this is a rendering fix only.

## Deliberately out of scope

- **Making `/model` work on mobile.** Nothing in the repo consumes the `slash-model` trigger kind that `packages/shared/src/composerTrigger.ts` produces; only `apps/web`'s `ChatComposer` handles the `model` command, by opening its own picker. So the row is inert in `ThreadComposer` too, not just on drafts. Pre-existing and untouched here — it needs a real mobile model picker wired into the menu. Happy to take that as its own PR.
- **The `items.length > 0` guard** that hides `ComposerCommandPopover`'s loading and empty states at both call sites. Relaxing it is a deliberate UX change to the most-used surface, so it stays its own PR.
- **New tests.** `apps/mobile` has no hook-render harness — no `renderHook`, no testing-library — and `use-composer-command-menu.test.ts` covers only the pure `composerSelectionAtEnd`. Adding that harness, or extracting the built-in filter into a new module to assert one boolean, is more machinery than this change earns. Say the word if you would rather have it.

## Verification

CI on this PR is the gate; I ran no local checks. Statically: `hasThread` was already in the `items` memo's dependency list, `ThreadComposer.tsx` passes `hasThread: true` so its menu is byte-for-byte unchanged, and the clamp effect on `draftMessage.length` is a no-op after the re-park. Happy to add an emulator pass with before/after images if you want them for this one.

Model: Claude Opus 5, harness: Claude Code.
