### PR TITLE
fix(mobile): blur composer popover on Android

### DIFF
--- a/apps/mobile/src/components/GlassSurface.tsx
+++ b/apps/mobile/src/components/GlassSurface.tsx
@@ -1,3 +1,4 @@
+import { BlurView } from "expo-blur";
 import { GlassView, isGlassEffectAPIAvailable } from "expo-glass-effect";
 import type { ReactNode } from "react";
 import {
@@ -8,8 +9,9 @@ import {
   type ViewProps,
   type ViewStyle,
 } from "react-native";
-import { useThemeColor } from "../lib/useThemeColor";
 import { useAppearancePreferences } from "../features/settings/appearance/AppearancePreferencesProvider";
+import { appBlurTargetRef } from "../lib/appBlurTarget";
+import { useThemeColor } from "../lib/useThemeColor";
 
 interface GlassSurfaceProps extends Omit<ViewProps, "className"> {
   readonly children: ReactNode;
@@ -18,6 +20,8 @@ interface GlassSurfaceProps extends Omit<ViewProps, "className"> {
   readonly chrome?: "default" | "none";
   /** Styling used only when native Liquid Glass is unavailable. */
   readonly fallbackStyle?: StyleProp<ViewStyle>;
+  /** Opts an Android fallback into the app-level blur target. */
+  readonly androidBlur?: boolean;
 }
 
 export function GlassSurface({
@@ -26,6 +30,7 @@ export function GlassSurface({
   chrome = "default",
   tintColor,
   fallbackStyle,
+  androidBlur = false,
   style,
   ...props
 }: GlassSurfaceProps) {
@@ -68,6 +73,21 @@ export function GlassSurface({
       >
         {children}
       </GlassView>
+    );
+  }
+
+  if (Platform.OS === "android" && androidBlur) {
+    return (
+      <BlurView
+        {...props}
+        blurMethod="dimezisBlurView"
+        blurTarget={appBlurTargetRef}
+        intensity={40}
+        tint={isDarkMode ? "dark" : "light"}
+        style={[surfaceStyle, fallbackStyle, style]}
+      >
+        {children}
+      </BlurView>
     );
   }
 

--- a/apps/mobile/src/features/threads/ComposerCommandPopover.tsx
+++ b/apps/mobile/src/features/threads/ComposerCommandPopover.tsx
@@ -55,7 +55,12 @@ function PopoverSurface(props: { readonly children: React.ReactNode; readonly st
   };
 
   return (
-    <GlassSurface glassEffectStyle="clear" tintColor={tintColor} style={baseStyle}>
+    <GlassSurface
+      androidBlur
+      glassEffectStyle="clear"
+      tintColor={tintColor}
+      style={baseStyle}
+    >
       {props.children}
     </GlassSurface>
   );


### PR DESCRIPTION
Closes #7524.

The composer command popover used `GlassSurface`, whose non-iOS path was only a translucent `View`. On Android, thread content therefore remained sharp behind the skill and command results and competed with the menu text.

This adds an explicit Android blur fallback to `GlassSurface` and opts the composer popover into it. It reuses the app-level `BlurTargetView`, matching the existing Android anchored-menu implementation while leaving iOS and every other glass surface unchanged.

![Android composer before and after](https://raw.githubusercontent.com/sensei-woo/t3code/visuals-android-composer/visuals/android-composer-before-after.svg)

Validation: `pnpm --filter @t3tools/mobile typecheck`; `git diff --check`.

Model: GPT-5.6 Sol. Harness: ChatGPT Codex Work mode.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix blurred background for composer popover on Android
> Adds an `androidBlur` prop to [`GlassSurface`](https://github.com/pingdotgg/t3code/pull/7526/files#diff-536304638d737591690190b947e8aab1060b9ac628ff3215eabe45d7618211a9) that, when true, renders a `BlurView` using the `dimezisBlurView` blur method targeting the app-level blur ref with intensity 40. Previously, Android always rendered a non-blurred fallback view. The [`ComposerCommandPopover`](https://github.com/pingdotgg/t3code/pull/7526/files#diff-681e5c79a2edd21eaf6435ea81e7856f7eccd991762e0af8b833676cada5d5b8) passes `androidBlur` to opt into this behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c4a6150.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->