### PR TITLE
fix(mobile): preserve Android skill chip colors

### DIFF
--- a/apps/mobile/modules/t3-composer-editor/android/src/main/java/expo/modules/t3composereditor/T3ComposerEditorView.kt
+++ b/apps/mobile/modules/t3-composer-editor/android/src/main/java/expo/modules/t3composereditor/T3ComposerEditorView.kt
@@ -21,6 +21,11 @@ import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.views.ExpoView
 import org.json.JSONObject
 import kotlin.math.max
+import kotlin.math.roundToInt
+
+private val cssRgbaColor = Regex(
+  """^rgba\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*([\d.]+)\s*\)$"""
+)
 
 class T3ComposerEditorView(context: Context, appContext: AppContext) : ExpoView(
   context,
@@ -333,12 +338,23 @@ class T3ComposerEditorView(context: Context, appContext: AppContext) : ExpoView(
     editor.invalidate()
   }
 
-  private fun parseColor(value: String, fallback: Int): Int =
-    try {
+  private fun parseColor(value: String, fallback: Int): Int {
+    cssRgbaColor.matchEntire(value)?.destructured?.let { (red, green, blue, alpha) ->
+      val opacity = alpha.toFloatOrNull()?.coerceIn(0f, 1f) ?: return fallback
+      return Color.argb(
+        (opacity * 255).roundToInt(),
+        red.toInt().coerceIn(0, 255),
+        green.toInt().coerceIn(0, 255),
+        blue.toInt().coerceIn(0, 255),
+      )
+    }
+
+    return try {
       Color.parseColor(value)
     } catch (_: Exception) {
       fallback
     }
+  }
 }
 
 private data class ComposerToken(


### PR DESCRIPTION
Closes #7525.

The Android native composer passed default-theme CSS `rgba(...)` tokens to `Color.parseColor`, which does not accept that syntax. The failure was swallowed and the chip kept its pale native fallback background while accepting the light skill foreground, creating the low-contrast inline token.

This teaches the Android composer color parser to convert CSS `rgba(...)` values into ARGB before falling back to `Color.parseColor`. The authored translucent chip background and border now reach the native `ReplacementSpan` unchanged, while hex colors and invalid-value fallback behavior remain intact.

![Android composer before and after](https://raw.githubusercontent.com/sensei-woo/t3code/visuals-android-composer/visuals/android-composer-before-after.svg)

Validation: `pnpm lint:mobile` (source discovery passed; SwiftLint, ktlint, and detekt are not installed in the runner); `git diff --check`.

Model: GPT-5.6 Sol. Harness: ChatGPT Codex Work mode.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Android skill chip colors by adding CSS `rgba()` support to `parseColor`
> Android's `Color.parseColor` does not handle CSS `rgba()` strings, causing skill chip colors to be lost. `T3ComposerEditorView.parseColor` in [T3ComposerEditorView.kt](https://github.com/pingdotgg/t3code/pull/7527/files#diff-dbf8b69facaf4bfdba7369705927677e0a538325ec8355999f2a34f3b9d32e30) now first tries to match a `rgba(r, g, b, a)` regex, parses and clamps all channels, and computes an ARGB value. Non-matching inputs still fall back to `Color.parseColor` or the provided fallback color on failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0261e27.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->