### PR TITLE
fix(server): skip disabled text generation fallbacks

### DIFF
--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -1,6 +1,7 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import {
   DEFAULT_SERVER_SETTINGS,
+  DEFAULT_TEXT_GENERATION_MODEL_BY_PROVIDER,
   ProviderDriverKind,
   ProviderInstanceId,
   ServerSettings,
@@ -322,6 +323,62 @@ it.layer(NodeServices.layer)("server settings", (it) => {
           model: "openai/gpt-5.5",
         });
       }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
+  it.effect("does not fall back to a disabled default provider instance", () =>
+    Effect.gen(function* () {
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+      const codexId = ProviderInstanceId.make("codex");
+      const claudeDriver = ProviderDriverKind.make("claudeAgent");
+      const claudeModel = DEFAULT_TEXT_GENERATION_MODEL_BY_PROVIDER[claudeDriver];
+      assert.isDefined(claudeModel);
+
+      const next = yield* serverSettings.updateSettings({
+        providerInstances: {
+          [codexId]: {
+            driver: ProviderDriverKind.make("codex"),
+            enabled: false,
+            config: {},
+          },
+        },
+      });
+
+      assert.deepEqual(next.textGenerationModelSelection, {
+        instanceId: ProviderInstanceId.make("claudeAgent"),
+        model: claudeModel,
+      });
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
+  it.effect("prefers an enabled provider instance when falling back", () =>
+    Effect.gen(function* () {
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+      const codexId = ProviderInstanceId.make("codex");
+      const claudeId = ProviderInstanceId.make("claude_openrouter");
+      const claudeDriver = ProviderDriverKind.make("claudeAgent");
+      const claudeModel = DEFAULT_TEXT_GENERATION_MODEL_BY_PROVIDER[claudeDriver];
+      assert.isDefined(claudeModel);
+
+      const next = yield* serverSettings.updateSettings({
+        providerInstances: {
+          [codexId]: {
+            driver: ProviderDriverKind.make("codex"),
+            enabled: false,
+            config: {},
+          },
+          [claudeId]: {
+            driver: claudeDriver,
+            enabled: true,
+            config: {},
+          },
+        },
+      });
+
+      assert.deepEqual(next.textGenerationModelSelection, {
+        instanceId: claudeId,
+        model: claudeModel,
+      });
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
   it.effect("preserves enabled text generation selections for non-built-in drivers", () =>

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -15,11 +15,13 @@ import {
   DEFAULT_TEXT_GENERATION_MODEL_BY_PROVIDER,
   DEFAULT_MODEL_BY_PROVIDER,
   DEFAULT_SERVER_SETTINGS,
+  defaultInstanceIdForDriver,
   type ModelSelection,
   type ProviderInstanceConfig,
   type ProviderInstanceEnvironmentVariable,
   ProviderDriverKind,
   ProviderInstanceId,
+  resolveProviderInstanceEnabled,
   ServerSettings,
   ServerSettingsError,
   type ServerSettingsPatch,
@@ -238,8 +240,26 @@ function resolveTextGenerationProvider(settings: ServerSettings): ServerSettings
 }
 
 function fallbackTextGenerationProvider(settings: ServerSettings): ServerSettings {
-  const fallbackEntry = Object.entries(settings.providers).find(([, provider]) => provider.enabled);
-  const fallback = fallbackEntry ? ProviderDriverKind.make(fallbackEntry[0]) : undefined;
+  const explicitFallback = Object.entries(settings.providerInstances).find(([, instance]) =>
+    resolveProviderInstanceEnabled(instance),
+  );
+  const legacyFallback = explicitFallback
+    ? undefined
+    : Object.entries(settings.providers).find(([driverId, provider]) => {
+        const instanceId = defaultInstanceIdForDriver(ProviderDriverKind.make(driverId));
+        return settings.providerInstances[instanceId] === undefined && provider.enabled;
+      });
+  const fallback = explicitFallback
+    ? {
+        instanceId: ProviderInstanceId.make(explicitFallback[0]),
+        driver: explicitFallback[1].driver,
+      }
+    : legacyFallback
+      ? {
+          instanceId: defaultInstanceIdForDriver(ProviderDriverKind.make(legacyFallback[0])),
+          driver: ProviderDriverKind.make(legacyFallback[0]),
+        }
+      : undefined;
   if (!fallback) {
     return settings;
   }
@@ -247,10 +267,10 @@ function fallbackTextGenerationProvider(settings: ServerSettings): ServerSetting
   return {
     ...settings,
     textGenerationModelSelection: {
-      instanceId: ProviderInstanceId.make(fallback),
+      instanceId: fallback.instanceId,
       model:
-        DEFAULT_TEXT_GENERATION_MODEL_BY_PROVIDER[fallback] ??
-        DEFAULT_MODEL_BY_PROVIDER[fallback] ??
+        DEFAULT_TEXT_GENERATION_MODEL_BY_PROVIDER[fallback.driver] ??
+        DEFAULT_MODEL_BY_PROVIDER[fallback.driver] ??
         DEFAULT_TEXT_GENERATION_MODEL,
     } satisfies ModelSelection,
   };


### PR DESCRIPTION
Disabling Codex in provider settings could still send title, branch, commit, and PR text generation to Codex because fallback selection read the legacy provider defaults.

Fallback selection now prefers enabled explicit provider instances and only uses a legacy default when that default instance has no explicit entry. Regression coverage includes the reported disabled-Codex state and an enabled custom-instance fallback.

Fixes #7533

Made with gpt-5.6-sol in T3 Code using Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes server settings resolution for text generation routing; wrong fallback logic could send generation to the wrong provider, but scope is limited to fallback when the current selection is disabled.
> 
> **Overview**
> Fixes **text generation model fallback** so disabling a provider instance (e.g. Codex) no longer routes title/branch/commit/PR generation through that provider when the current selection becomes invalid.
> 
> `fallbackTextGenerationProvider` now **prefers the first enabled explicit `providerInstances` entry** (via `resolveProviderInstanceEnabled`) and only uses the legacy `providers` map when there is **no** explicit instance for that driver’s default instance id. Fallback selections set both **instance id** and **default model for that instance’s driver**, not just the driver name.
> 
> Regression tests cover a disabled default Codex instance falling back to Claude, and an enabled custom Claude instance winning over disabled Codex.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0d2c63985c81e9f25b36f6d78e40f24fbab9e2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix text generation fallback to skip disabled provider instances
> - Updates `fallbackTextGenerationProvider` in [serverSettings.ts](https://github.com/pingdotgg/t3code/pull/7535/files#diff-ec910be99e19e00c0e09b15484059b34164d71de8d0026f4ba98471bbbb3680e) to check `providerInstances` first, using `resolveProviderInstanceEnabled` to skip disabled instances.
> - Falls back to legacy `settings.providers` entries only when no corresponding `providerInstances` entry exists for that driver's default instance ID.
> - The resolved fallback now carries a concrete `instanceId` and derives the default model by driver via `DEFAULT_TEXT_GENERATION_MODEL_BY_PROVIDER`.
> - Behavioral Change: A disabled default provider instance is no longer selected as a fallback; an enabled instance is preferred when multiple instances exist.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0d2c63.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->