### PR TITLE
fix(server): replay all un-applied events during projection bootstrap

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -1255,6 +1255,77 @@ it.layer(Layer.fresh(makeProjectionPipelinePrefixedTestLayer("t3-projection-atta
 );
 
 it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
+  it.effect("replays a bootstrap backlog larger than the event store default limit", () =>
+    Effect.gen(function* () {
+      const projectionPipeline = yield* OrchestrationProjectionPipeline;
+      const eventStore = yield* OrchestrationEventStore;
+      const sql = yield* SqlClient.SqlClient;
+      const now = "2026-01-01T00:00:00.000Z";
+      const projectId = ProjectId.make("project-bootstrap-backlog");
+
+      const sequenceRows = yield* sql<{ readonly maxSequence: number | null }>`
+        SELECT MAX(sequence) AS "maxSequence" FROM orchestration_events
+      `;
+      const sequenceBeforeBacklog = sequenceRows[0]?.maxSequence ?? 0;
+      const appendedEvents = yield* Effect.forEach(
+        Array.from({ length: 1_001 }, (_, index) => index),
+        (index) => {
+          const eventId = EventId.make(`evt-bootstrap-backlog-${index}`);
+          const commandId = CommandId.make(`cmd-bootstrap-backlog-${index}`);
+          return eventStore.append({
+            type: "project.created",
+            eventId,
+            aggregateKind: "project",
+            aggregateId: projectId,
+            occurredAt: now,
+            commandId,
+            causationEventId: null,
+            correlationId: CorrelationId.make(commandId),
+            metadata: {},
+            payload: {
+              projectId,
+              title: `Bootstrap backlog ${index}`,
+              workspaceRoot: "/tmp/project-bootstrap-backlog",
+              defaultModelSelection: null,
+              scripts: [],
+              createdAt: now,
+              updatedAt: now,
+            },
+          });
+        },
+      );
+      const lastSequence = appendedEvents[appendedEvents.length - 1]!.sequence;
+
+      yield* Effect.forEach(
+        Object.values(ORCHESTRATION_PROJECTOR_NAMES),
+        (projector) => {
+          const lastAppliedSequence =
+            projector === ORCHESTRATION_PROJECTOR_NAMES.projects
+              ? sequenceBeforeBacklog
+              : lastSequence;
+          return sql`
+            INSERT INTO projection_state (projector, last_applied_sequence, updated_at)
+            VALUES (${projector}, ${lastAppliedSequence}, ${now})
+            ON CONFLICT (projector)
+            DO UPDATE SET
+              last_applied_sequence = excluded.last_applied_sequence,
+              updated_at = excluded.updated_at
+          `;
+        },
+        { discard: true },
+      );
+
+      yield* projectionPipeline.bootstrap;
+
+      const stateRows = yield* sql<{ readonly lastAppliedSequence: number }>`
+        SELECT last_applied_sequence AS "lastAppliedSequence"
+        FROM projection_state
+        WHERE projector = ${ORCHESTRATION_PROJECTOR_NAMES.projects}
+      `;
+      assert.deepEqual(stateRows, [{ lastAppliedSequence: lastSequence }]);
+    }),
+  );
+
   it.effect("resumes from projector last_applied_sequence without replaying older events", () =>
     Effect.gen(function* () {
       const projectionPipeline = yield* OrchestrationProjectionPipeline;

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -1717,9 +1717,6 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
       );
     });
 
-    // Catch-up must replay EVERY un-applied event: `readFromSequence` defaults to a
-    // 1 000-event limit (it still pages internally), and a capped bootstrap would leave
-    // the remaining events un-projected forever once the engine appends its next event.
     const bootstrapProjector = (projector: ProjectorDefinition) =>
       projectionStateRepository
         .getByProjector({

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -1717,6 +1717,9 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
       );
     });
 
+    // Catch-up must replay EVERY un-applied event: `readFromSequence` defaults to a
+    // 1 000-event limit (it still pages internally), and a capped bootstrap would leave
+    // the remaining events un-projected forever once the engine appends its next event.
     const bootstrapProjector = (projector: ProjectorDefinition) =>
       projectionStateRepository
         .getByProjector({
@@ -1727,6 +1730,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             Stream.runForEach(
               eventStore.readFromSequence(
                 Option.isSome(stateRow) ? stateRow.value.lastAppliedSequence : 0,
+                Number.MAX_SAFE_INTEGER,
               ),
               (event) => runProjectorForEvent(projector, event),
             ),


### PR DESCRIPTION
## What Changed

`apps/server/src/orchestration/Layers/ProjectionPipeline.ts`, `bootstrapProjector`: pass `Number.MAX_SAFE_INTEGER` as the `limit` to `eventStore.readFromSequence(lastAppliedSequence, …)` so projection catch-up on startup replays **every** un-applied event instead of the default first 1 000. One argument plus a three-line comment; no other behaviour change. The store still reads in `READ_PAGE_SIZE` (500) pages, so memory stays bounded — this is exactly how the store's own `readAll()` is defined.

## Why

Fixes #7537. `readFromSequence`'s `limit` defaults to `DEFAULT_READ_FROM_SEQUENCE_LIMIT = 1_000`, and bootstrap did not pass one. If more than 1 000 events are un-applied at startup (events appended while the server was down — offline `t3 project` CLI writes, external writers, repeated crash-before-project), only the first 1 000 are projected, `projection_state` advances to `last_applied + 1000`, and the next live event's `runProjectorForEvent` upserts `last_applied_sequence` to the new max — so the gap is never replayed and those projects/threads/messages are permanently missing from the projections (and from invariants such as `requireActiveProjectWorkspaceRootAbsent`).

Verified by reading the shipped bundle (0.0.34-nightly.20260819.1132) and `main`. No existing test encodes the cap (`OrchestrationEngine.test.ts` stubs `readFromSequence: () => Stream.empty`, which accepts any arguments); I did not add a new test for the >1 000 case because I could not run the suite from this environment — happy to add one if you want it.

## UI Changes

None.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (n/a)
- [x] I included a video for animation/interaction changes (n/a)

---
Authorship disclosure: investigated and prepared by Claude (Fable 5) running in Claude Code on the author's machine, at the author's request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration projection bootstrap replay semantics and can increase startup work when large backlogs exist, but scope is limited to catch-up reads and aligns with readAll behavior.
> 
> **Overview**
> Fixes projection bootstrap silently stopping after **1,000** un-applied events when `readFromSequence` used its default limit. **`bootstrapProjector`** now passes **`Number.MAX_SAFE_INTEGER`** as the read limit so startup catch-up replays the full backlog; paging still uses the event store’s page size, so memory stays bounded.
> 
> Adds an integration test that appends **1,001** events behind a lagging projects projector and asserts **`projection_state`** advances to the latest sequence after **`bootstrap`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e84a70e39a6e0447749114253f189e49ab6afad5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix projection bootstrap to replay backlog beyond event store default limit
> Passes `Number.MAX_SAFE_INTEGER` as the explicit limit to `eventStore.readFromSequence` inside the `bootstrapProjector` helper in [ProjectionPipeline.ts](https://github.com/pingdotgg/t3code/pull/7538/files#diff-fd69e677e48d4705b0235085da8402910510d529ec5a507d804037a88fca07f4), so bootstrap processes the full backlog instead of stopping at the event store's default page size. Adds a test in [ProjectionPipeline.test.ts](https://github.com/pingdotgg/t3code/pull/7538/files#diff-929eb6fd844fad565d5af8faa7348834ab85ad5457f22d71861e6ee886a18fda) that appends 1,001 `project.created` events and confirms the `projects` projector catches up to the last sequence. Risk: reading with no practical limit could load a very large event stream into memory during bootstrap for projectors far behind the head sequence.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e84a70e. 1 file reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/server/src/orchestration/Layers/ProjectionPipeline.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 1730](https://github.com/pingdotgg/t3code/blob/e84a70e39a6e0447749114253f189e49ab6afad5/apps/server/src/orchestration/Layers/ProjectionPipeline.ts#L1730): `bootstrapProjector` passes an effectively unbounded limit to a paginated query with no high-water-mark snapshot. `readFromSequence` issues another `WHERE sequence > cursor LIMIT 500` query whenever a page is nonempty, so an external writer that keeps appending enough events to keep pages nonempty makes the stream never terminate. Since engine construction awaits `projectionPipeline.bootstrap` before starting its command worker, this can indefinitely prevent server startup; capture the maximum sequence before replay (or otherwise bound the replay) instead of following a moving tail. <b>[ Already posted ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->