### PR TITLE
fix(server): stop losing OpenCode providers to truncated CLI output

### DIFF
--- a/apps/server/src/provider/opencodeRuntime.cliParsers.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.cliParsers.test.ts
@@ -83,6 +83,49 @@ describe("parseModelsCliOutput", () => {
     NodeAssert.ok(provider.models["claude-haiku-4-5"]);
   });
 
+  it("flags output cut after a slug line as truncated", () => {
+    // How a slow reader sees it: the CLI exits 0 mid-listing, right after a header.
+    const stdout = [
+      "anthropic/claude-sonnet-4-5",
+      JSON.stringify({ id: "claude-sonnet-4-5", providerID: "anthropic", name: "Sonnet 4.5" }),
+      "openai/gpt-4o",
+      "",
+    ].join("\n");
+
+    const result = parseModelsCliOutput(stdout);
+    NodeAssert.equal(result.truncated, true);
+  });
+
+  it("flags output cut inside a model body as truncated", () => {
+    const stdout = [
+      "anthropic/claude-sonnet-4-5",
+      JSON.stringify({ id: "claude-sonnet-4-5", providerID: "anthropic", name: "Sonnet 4.5" }),
+      "openai/gpt-4o",
+      '{ "id": "gpt-4o", "providerID": "op',
+    ].join("\n");
+
+    const result = parseModelsCliOutput(stdout);
+    NodeAssert.equal(result.truncated, true);
+  });
+
+  it("does not flag complete output as truncated", () => {
+    const stdout = [
+      "anthropic/claude-sonnet-4-5",
+      JSON.stringify({ id: "claude-sonnet-4-5", providerID: "anthropic", name: "Sonnet 4.5" }),
+      "",
+    ].join("\n");
+
+    NodeAssert.equal(parseModelsCliOutput(stdout).truncated, false);
+    NodeAssert.equal(parseModelsCliOutput("").truncated, false);
+  });
+
+  it("does not flag a bodyless listing as truncated", () => {
+    // `opencode models` without `--verbose` prints slugs only.
+    const stdout = ["anthropic/claude-sonnet-4-5", "openai/gpt-4o", ""].join("\n");
+
+    NodeAssert.equal(parseModelsCliOutput(stdout).truncated, false);
+  });
+
   it("handles Windows-style CRLF line endings", () => {
     const stdout =
       "anthropic/claude-sonnet-4-5\r\n" +

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -211,6 +211,12 @@ export function parseModelsCliOutput(stdout: string): {
     { readonly id: string; readonly name: string; readonly models: { [key: string]: Model } }
   >;
   readonly connected: ReadonlyArray<string>;
+  /**
+   * The output ended mid-record, so providers printed after the cut are missing. The
+   * CLI prints slug/JSON pairs, so a trailing slug with no body - or with a body that
+   * does not parse - can only mean the output was cut short.
+   */
+  readonly truncated: boolean;
 } {
   const providers = new Map<
     string,
@@ -220,10 +226,19 @@ export function parseModelsCliOutput(stdout: string): {
   let currentSlug: string | null = null;
   const jsonLines: Array<string> = [];
 
+  // `sawBody` keeps a bodyless `opencode models` listing (no `--verbose`) from reading
+  // as truncated, and `lastRecordIncomplete` tracks only the final record because that
+  // is the one a cut lands on.
+  let sawBody = false;
+  let lastRecordIncomplete = false;
+
   const flushModel = () => {
-    if (currentSlug !== null && jsonLines.length > 0) {
+    if (currentSlug !== null) {
       const jsonStr = jsonLines.join("\n").trim();
-      if (jsonStr.length > 0) {
+      if (jsonStr.length === 0) {
+        lastRecordIncomplete = sawBody;
+      } else {
+        sawBody = true;
         try {
           const model = JSON.parse(jsonStr) as Model;
           const separator = currentSlug.indexOf("/");
@@ -237,8 +252,10 @@ export function parseModelsCliOutput(stdout: string): {
             }
             provider.models[modelID] = model;
           }
+          lastRecordIncomplete = false;
         } catch {
           // Skip unparseable model JSON
+          lastRecordIncomplete = true;
         }
       }
     }
@@ -263,7 +280,7 @@ export function parseModelsCliOutput(stdout: string): {
   }
   flushModel();
 
-  return { providers, connected: [...providers.keys()] };
+  return { providers, connected: [...providers.keys()], truncated: lastRecordIncomplete };
 }
 
 /** @internal */
@@ -744,8 +761,15 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
       let agentsResult = initialAgentsResult;
       let skillsResult = initialSkillsResult;
 
-      // Retry once after 1s on transient failures (e.g. SQLite "database is locked")
-      const needsModelsRetry = modelsResult._tag === "Failure" || modelsResult.value.code !== 0;
+      const parseModels = (result: typeof modelsResult) =>
+        result._tag === "Success" && result.value.code === 0
+          ? parseModelsCliOutput(result.value.stdout)
+          : undefined;
+      let parsed = parseModels(modelsResult);
+
+      // Retry once after 1s on transient failures (e.g. SQLite "database is locked") and
+      // on a truncated inventory, which the CLI reports as a clean exit.
+      const needsModelsRetry = parsed === undefined || parsed.truncated;
       const needsAgentsRetry = agentsResult._tag === "Failure" || agentsResult.value.code !== 0;
       const needsSkillsRetry = skillsResult._tag === "Failure" || skillsResult.value.code !== 0;
       if (needsModelsRetry || needsAgentsRetry || needsSkillsRetry) {
@@ -761,6 +785,7 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
         modelsResult = m2;
         agentsResult = a2;
         skillsResult = s2;
+        parsed = parseModels(modelsResult);
       }
 
       if (modelsResult._tag === "Failure") {
@@ -778,7 +803,15 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
         });
       }
 
-      const parsed = parseModelsCliOutput(modelsResult.value.stdout);
+      // Reporting a partial inventory would silently drop every provider printed after
+      // the cut, so surface it instead.
+      if (parsed === undefined || parsed.truncated) {
+        return yield* new OpenCodeRuntimeError({
+          operation: "loadInventoryFromCli",
+          detail: "OpenCode models output ended mid-record, so the inventory is incomplete.",
+        });
+      }
+
       const connected = [...parsed.connected];
       const allProviders: ProviderListResponse["all"] = [...parsed.providers.values()].map(
         (provider) => ({

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -256,4 +256,11 @@ export function buildServerProvider(input: {
 export const collectStreamAsString = <E>(
   stream: Stream.Stream<Uint8Array, E>,
 ): Effect.Effect<string, E> =>
-  collectUint8StreamText({ stream }).pipe(Effect.map((collected) => collected.text));
+  // Drain the process output as fast as it arrives. Folding straight over the stream
+  // backpressures the child once the OS pipe fills, and a CLI that `process.exit()`s
+  // without waiting for stdout to flush then drops whatever is still queued - silently,
+  // with exit code 0. Buffering costs nothing extra here because the fold accumulates
+  // the whole output anyway.
+  collectUint8StreamText({ stream: Stream.buffer(stream, { capacity: "unbounded" }) }).pipe(
+    Effect.map((collected) => collected.text),
+  );


### PR DESCRIPTION
Closes #7539.

Providers I configure in OpenCode were missing from the picker — two local llama.cpp providers and `google-vertex`, with the card reporting "3 upstream providers connected" out of 6. The cache held exactly the first 29 model slugs of `opencode models --verbose`, ending at byte 32540 of the 110KB the CLI prints. Providers were dropped only because they're printed last.

Two things go wrong:

**We read too slowly.** `collectStreamAsString` folds straight over the child's stdout, which backpressures it once the OS pipe fills. OpenCode's CLI ends in `process.exit()` without waiting for stdout to flush, so it drops the queued tail and exits 0. Buffering the stream unbounded fixes it — and costs nothing, since the fold accumulates the whole output anyway. Reading the same command with plain `child_process` gets all 110916 bytes every time.

**We don't notice.** `parseModelsCliOutput` silently discarded the half-written trailing record, so a cut looked like a clean, shorter listing. It now reports `truncated`, which reuses the existing retry and otherwise fails instead of handing back an inventory that's missing providers. Bodyless output (`opencode models` without `--verbose`) is not flagged.

The upstream flush bug is real and recurring (anomalyco/opencode#29330, #14948, #29866, #30831) but we shouldn't be the ones losing the data.

### Testing

- `vp test run src/provider/ src/stream/` — 521 passed, 6 skipped
- Deterministic check: child writes 200KB then exits without flushing, consumer takes 30ms/chunk — unbuffered fold gets 58000/200000, `collectStreamAsString` gets 200000/200000 across repeated runs
- Against the real CLI on a cold cache: unbuffered truncated at 32540 (matching the bad cache byte-for-byte), buffered got all 110916 in 5/5 runs
- All 6 providers now appear

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OpenCode provider inventory loading behavior (retry + hard failure on persistent truncation); broader `collectStreamAsString` buffering affects all provider CLI capture but is low-risk given full-output collection anyway.
> 
> **Overview**
> Fixes **missing OpenCode providers** in the model picker when `opencode models --verbose` stdout is cut off but still exits 0.
> 
> **`collectStreamAsString`** now drains child stdout through an **unbounded buffer** before folding, so a slow consumer does not backpressure the pipe and lose the tail when the CLI exits without flushing.
> 
> **`parseModelsCliOutput`** returns a **`truncated`** flag when verbose output ends on an incomplete slug/JSON pair (including a trailing slug with no body or bad final JSON). **Slug-only** listings without `--verbose` are not treated as truncated.
> 
> **`loadInventoryFromCli`** **retries** the models command after 1s on truncation (same as transient failures) and returns **`OpenCodeRuntimeError`** if output is still incomplete, instead of caching a partial provider list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0d0093e45254ee46c148aa1c28daae184dbd258. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix truncated CLI output causing OpenCode providers to be silently dropped
> - Adds a `truncated` flag to `parseModelsCliOutput` in [opencodeRuntime.ts](https://github.com/pingdotgg/t3code/pull/7540/files#diff-b36408ac400332f121d5c4711ccfe4fd4049772d0f302343ee303670f4198ea8), set when output ends mid-record (trailing slug with no JSON body, or unparseable final JSON).
> - `loadInventoryFromCli` now retries the models command after 1s when output is truncated, and returns an `OpenCodeRuntimeError` if truncation persists, rather than proceeding with a partial inventory.
> - [providerSnapshot.ts](https://github.com/pingdotgg/t3code/pull/7540/files#diff-62373f674410fb63637739f0efeb07b9ef79b579393ae2adf51567de0b812b26) buffers the incoming stream unbounded before collection to prevent partial reads.
> - Behavioral Change: previously, truncated model output was silently accepted as a complete inventory; now it triggers a retry and an error on repeated truncation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c0d0093.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->