### PR TITLE
fix(server): load MCP servers declared by Claude plugins

### DIFF
--- a/apps/server/src/provider/Drivers/ClaudeHome.ts
+++ b/apps/server/src/provider/Drivers/ClaudeHome.ts
@@ -34,6 +34,34 @@ export const makeClaudeEnvironment = Effect.fn("makeClaudeEnvironment")(function
   };
 });
 
+/**
+ * Resolve the Claude config directory the CLI would use, matching the
+ * precedence the spawned CLI sees: the instance's `homePath` (exported as
+ * `CLAUDE_CONFIG_DIR` by `makeClaudeEnvironment`), then a `CLAUDE_CONFIG_DIR`
+ * already present in the process environment, then `~/.claude`.
+ */
+export const resolveClaudeConfigDirPath = Effect.fn("resolveClaudeConfigDirPath")(function* (
+  config: Pick<ClaudeSettings, "homePath">,
+  environment: NodeJS.ProcessEnv,
+  cwd?: string,
+): Effect.fn.Return<string, never, Path.Path> {
+  const path = yield* Path.Path;
+  const homePath = config.homePath.trim();
+  if (homePath.length > 0) {
+    return path.resolve(expandHomePath(homePath));
+  }
+  // No tilde expansion here: the spawned CLI receives this env var verbatim
+  // (env vars are never shell-expanded), so a literal `~` must stay literal
+  // for discovery to scan the same directory the runtime would. A relative
+  // value is resolved against the workspace cwd — the subprocess's own cwd —
+  // for the same reason.
+  const environmentConfigDir = environment.CLAUDE_CONFIG_DIR?.trim() ?? "";
+  if (environmentConfigDir.length > 0) {
+    return cwd ? path.resolve(cwd, environmentConfigDir) : path.resolve(environmentConfigDir);
+  }
+  return path.join(NodeOS.homedir(), ".claude");
+});
+
 export const makeClaudeContinuationGroupKey = Effect.fn("makeClaudeContinuationGroupKey")(
   function* (config: Pick<ClaudeSettings, "homePath">): Effect.fn.Return<string, never, Path.Path> {
     const resolvedHomePath = yield* resolveClaudeHomePath(config);

--- a/apps/server/src/provider/Drivers/ClaudePlugins.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudePlugins.test.ts
@@ -1,0 +1,247 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+import { discoverClaudePluginMcpServers } from "./ClaudePlugins.ts";
+
+const writeJson = Effect.fn(function* (filePath: string, value: unknown) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  yield* fs.makeDirectory(path.dirname(filePath), { recursive: true });
+  // @effect-diagnostics-next-line preferSchemaOverJson:off - fixture mirrors files the Claude CLI wrote.
+  yield* fs.writeFileString(filePath, JSON.stringify(value));
+});
+
+/**
+ * Lay out a Claude config dir the way the CLI does: `settings.json` decides
+ * which plugins are on, `plugins/installed_plugins.json` says where they live,
+ * and each install directory carries its own `.mcp.json`.
+ */
+const writePlugin = Effect.fn(function* (input: {
+  readonly configDir: string;
+  readonly pluginId: string;
+  readonly mcpDocument?: unknown;
+}) {
+  const path = yield* Path.Path;
+  const installPath = path.join(input.configDir, "plugins", "cache", input.pluginId);
+  if (input.mcpDocument !== undefined) {
+    yield* writeJson(path.join(installPath, ".mcp.json"), input.mcpDocument);
+  }
+  return installPath;
+});
+
+it.layer(NodeServices.layer)("discoverClaudePluginMcpServers", (it) => {
+  it.effect("names servers the way the interactive CLI does, across both file shapes", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-plugins-" });
+      const configDir = path.join(tempDir, "claude-home");
+
+      // Bare map of server name to config, as the official Linear plugin ships.
+      const linearInstall = yield* writePlugin({
+        configDir,
+        pluginId: "linear",
+        mcpDocument: { linear: { type: "http", url: "https://mcp.linear.app/mcp" } },
+      });
+      // Wrapped in `mcpServers`, as the official Vercel plugin ships, with an
+      // extra key the CLI tolerates.
+      const vercelInstall = yield* writePlugin({
+        configDir,
+        pluginId: "vercel",
+        mcpDocument: {
+          mcpServers: {
+            vercel: { type: "http", url: "https://mcp.vercel.com", note: "official server" },
+          },
+        },
+      });
+
+      yield* writeJson(path.join(configDir, "settings.json"), {
+        enabledPlugins: {
+          "linear@claude-plugins-official": true,
+          "vercel@claude-plugins-official": true,
+        },
+      });
+      yield* writeJson(path.join(configDir, "plugins", "installed_plugins.json"), {
+        version: 2,
+        plugins: {
+          "linear@claude-plugins-official": [{ scope: "user", installPath: linearInstall }],
+          "vercel@claude-plugins-official": [{ scope: "user", installPath: vercelInstall }],
+        },
+      });
+
+      const servers = yield* discoverClaudePluginMcpServers({ homePath: configDir });
+
+      assert.deepEqual(servers, {
+        // Stored MCP OAuth tokens are keyed by server name, so these names are
+        // load-bearing, not cosmetic.
+        "plugin:linear:linear": { type: "http", url: "https://mcp.linear.app/mcp" },
+        "plugin:vercel:vercel": {
+          type: "http",
+          url: "https://mcp.vercel.com",
+          note: "official server",
+        },
+      });
+    }),
+  );
+
+  it.effect("expands ${CLAUDE_PLUGIN_ROOT} the way the CLI's plugin loader would", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-plugins-" });
+      const configDir = path.join(tempDir, "claude-home");
+
+      const installPath = yield* writePlugin({
+        configDir,
+        pluginId: "fakechat",
+        mcpDocument: {
+          mcpServers: {
+            fakechat: {
+              command: "bun",
+              args: ["run", "--cwd", "${CLAUDE_PLUGIN_ROOT}", "--silent", "start"],
+              env: { FIXTURES: "${CLAUDE_PLUGIN_ROOT}/fixtures" },
+            },
+          },
+        },
+      });
+      yield* writeJson(path.join(configDir, "settings.json"), {
+        enabledPlugins: { "fakechat@claude-plugins-official": true },
+      });
+      yield* writeJson(path.join(configDir, "plugins", "installed_plugins.json"), {
+        version: 2,
+        plugins: {
+          "fakechat@claude-plugins-official": [{ scope: "user", installPath }],
+        },
+      });
+
+      const servers = yield* discoverClaudePluginMcpServers({ homePath: configDir });
+
+      // Registration goes over the control channel, which does no substitution:
+      // a placeholder left intact reaches the child verbatim and the server dies.
+      assert.deepEqual(servers, {
+        "plugin:fakechat:fakechat": {
+          command: "bun",
+          args: ["run", "--cwd", installPath, "--silent", "start"],
+          env: { FIXTURES: `${installPath}/fixtures` },
+        },
+      });
+    }),
+  );
+
+  it.effect("skips plugins that are disabled, absent, or declare no servers", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-plugins-" });
+      const configDir = path.join(tempDir, "claude-home");
+
+      const disabledInstall = yield* writePlugin({
+        configDir,
+        pluginId: "linear",
+        mcpDocument: { linear: { type: "http", url: "https://mcp.linear.app/mcp" } },
+      });
+      // Enabled, installed, but ships no `.mcp.json` — most plugins.
+      const skillsOnlyInstall = yield* writePlugin({ configDir, pluginId: "ponytail" });
+
+      yield* writeJson(path.join(configDir, "settings.json"), {
+        enabledPlugins: {
+          "linear@claude-plugins-official": false,
+          "ponytail@ponytail": true,
+          // Enabled but missing from the install manifest.
+          "ghost@marketplace": true,
+        },
+      });
+      yield* writeJson(path.join(configDir, "plugins", "installed_plugins.json"), {
+        version: 2,
+        plugins: {
+          "linear@claude-plugins-official": [{ scope: "user", installPath: disabledInstall }],
+          "ponytail@ponytail": [{ scope: "user", installPath: skillsOnlyInstall }],
+        },
+      });
+
+      const servers = yield* discoverClaudePluginMcpServers({ homePath: configDir });
+
+      assert.deepEqual(servers, {});
+    }),
+  );
+
+  it.effect("lets project settings turn off a plugin the user enabled", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-plugins-" });
+      const configDir = path.join(tempDir, "claude-home");
+      const workspace = path.join(tempDir, "workspace");
+
+      const linearInstall = yield* writePlugin({
+        configDir,
+        pluginId: "linear",
+        mcpDocument: { linear: { type: "http", url: "https://mcp.linear.app/mcp" } },
+      });
+      yield* writeJson(path.join(configDir, "settings.json"), {
+        enabledPlugins: { "linear@claude-plugins-official": true },
+      });
+      yield* writeJson(path.join(configDir, "plugins", "installed_plugins.json"), {
+        version: 2,
+        plugins: {
+          "linear@claude-plugins-official": [{ scope: "user", installPath: linearInstall }],
+        },
+      });
+      yield* writeJson(path.join(workspace, ".claude", "settings.json"), {
+        enabledPlugins: { "linear@claude-plugins-official": false },
+      });
+
+      const enabled = yield* discoverClaudePluginMcpServers({ homePath: configDir });
+      assert.deepEqual(Object.keys(enabled), ["plugin:linear:linear"]);
+
+      const disabledByProject = yield* discoverClaudePluginMcpServers(
+        { homePath: configDir },
+        workspace,
+      );
+      assert.deepEqual(disabledByProject, {});
+    }),
+  );
+
+  it.effect("survives malformed manifests and unreadable config dirs", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-claude-plugins-" });
+      const configDir = path.join(tempDir, "claude-home");
+
+      const linearInstall = yield* writePlugin({
+        configDir,
+        pluginId: "linear",
+        mcpDocument: { linear: { type: "http", url: "https://mcp.linear.app/mcp" } },
+      });
+      yield* writeJson(path.join(configDir, "settings.json"), {
+        enabledPlugins: { "linear@claude-plugins-official": true },
+      });
+      yield* fs.writeFileString(
+        path.join(configDir, "plugins", "installed_plugins.json"),
+        "{ not json",
+      );
+
+      assert.deepEqual(yield* discoverClaudePluginMcpServers({ homePath: configDir }), {});
+
+      // A readable manifest pointing at a malformed `.mcp.json` is also inert.
+      yield* writeJson(path.join(configDir, "plugins", "installed_plugins.json"), {
+        version: 2,
+        plugins: {
+          "linear@claude-plugins-official": [{ scope: "user", installPath: linearInstall }],
+        },
+      });
+      yield* fs.writeFileString(path.join(linearInstall, ".mcp.json"), "{{{");
+      assert.deepEqual(yield* discoverClaudePluginMcpServers({ homePath: configDir }), {});
+
+      // And a config dir that does not exist at all yields nothing.
+      assert.deepEqual(
+        yield* discoverClaudePluginMcpServers({ homePath: path.join(tempDir, "missing") }),
+        {},
+      );
+    }),
+  );
+});

--- a/apps/server/src/provider/Drivers/ClaudePlugins.ts
+++ b/apps/server/src/provider/Drivers/ClaudePlugins.ts
@@ -1,0 +1,249 @@
+/**
+ * ClaudePlugins — filesystem discovery of MCP servers contributed by enabled
+ * Claude Code plugins.
+ *
+ * The Claude Agent SDK never wires up plugin-provided MCP servers: a spawned
+ * CLI reports the plugins themselves in its `system/init` handshake, and loads
+ * their skills, commands, and agents, but the servers declared in each
+ * plugin's `.mcp.json` are only registered by the interactive TUI. Every SDK
+ * consumer therefore sees a Linear or Vercel plugin that looks installed while
+ * its tools are absent.
+ *
+ * The adapter closes the gap by resolving those servers here and handing them
+ * to `Query.setMcpServers` once the session is up. Names must match what the
+ * TUI would use — `plugin:<plugin>:<server>` — because stored MCP OAuth tokens
+ * are keyed by server name, so any other name silently re-prompts for auth.
+ * That control-channel path also bypasses the CLI's plugin loader, so the
+ * `${CLAUDE_PLUGIN_ROOT}` expansion the loader performs happens here instead.
+ *
+ * @module provider/Drivers/ClaudePlugins
+ */
+import type { ClaudeSettings } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+import { resolveClaudeConfigDirPath } from "./ClaudeHome.ts";
+
+/**
+ * One plugin-contributed MCP server config, passed through verbatim from the
+ * plugin's `.mcp.json`. Kept opaque on purpose: the CLI owns the schema, and
+ * rewriting the config would change the hash its OAuth token is keyed by.
+ */
+export type ClaudePluginMcpServerConfig = Readonly<Record<string, unknown>>;
+
+function parseJsonObject(contents: string): Record<string, unknown> | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(contents);
+  } catch {
+    return undefined;
+  }
+  return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : undefined;
+}
+
+const readJsonObject = Effect.fn("readJsonObject")(function* (
+  filePath: string,
+): Effect.fn.Return<Record<string, unknown> | undefined, never, FileSystem.FileSystem> {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const contents = yield* fileSystem
+    .readFileString(filePath)
+    .pipe(Effect.orElseSucceed(() => undefined));
+  return contents === undefined ? undefined : parseJsonObject(contents);
+});
+
+/**
+ * Plugin ids (`<plugin>@<marketplace>`) switched on by `enabledPlugins`, read
+ * across the same settings files the CLI merges for the `user`, `project`, and
+ * `local` sources. Later files win, so a project can disable a user plugin.
+ */
+const readEnabledPluginIds = Effect.fn("readEnabledPluginIds")(function* (
+  configDirPath: string,
+  cwd: string | undefined,
+): Effect.fn.Return<ReadonlySet<string>, never, FileSystem.FileSystem | Path.Path> {
+  const path = yield* Path.Path;
+  const settingsPaths = [
+    path.join(configDirPath, "settings.json"),
+    path.join(configDirPath, "settings.local.json"),
+    ...(cwd
+      ? [
+          path.join(cwd, ".claude", "settings.json"),
+          path.join(cwd, ".claude", "settings.local.json"),
+        ]
+      : []),
+  ];
+
+  const enabledById = new Map<string, boolean>();
+  for (const settingsPath of settingsPaths) {
+    const settings = yield* readJsonObject(settingsPath);
+    const enabledPlugins = settings?.enabledPlugins;
+    if (typeof enabledPlugins !== "object" || enabledPlugins === null) {
+      continue;
+    }
+    for (const [pluginId, enabled] of Object.entries(enabledPlugins)) {
+      if (typeof enabled === "boolean") {
+        enabledById.set(pluginId, enabled);
+      }
+    }
+  }
+
+  return new Set([...enabledById].filter(([, enabled]) => enabled).map(([pluginId]) => pluginId));
+});
+
+/**
+ * Install directories per plugin id, from the plugin cache manifest. A plugin
+ * can be installed at more than one scope, so each id keeps every candidate
+ * path in manifest order.
+ */
+const readPluginInstallPaths = Effect.fn("readPluginInstallPaths")(function* (
+  configDirPath: string,
+): Effect.fn.Return<
+  ReadonlyMap<string, ReadonlyArray<string>>,
+  never,
+  FileSystem.FileSystem | Path.Path
+> {
+  const path = yield* Path.Path;
+  const manifest = yield* readJsonObject(
+    path.join(configDirPath, "plugins", "installed_plugins.json"),
+  );
+  const plugins = manifest?.plugins;
+  const installPathsById = new Map<string, ReadonlyArray<string>>();
+  if (typeof plugins !== "object" || plugins === null) {
+    return installPathsById;
+  }
+
+  for (const [pluginId, installs] of Object.entries(plugins)) {
+    if (!Array.isArray(installs)) {
+      continue;
+    }
+    const installPaths = installs.flatMap((install) =>
+      typeof install === "object" &&
+      install !== null &&
+      typeof (install as { installPath?: unknown }).installPath === "string"
+        ? [(install as { installPath: string }).installPath]
+        : [],
+    );
+    if (installPaths.length > 0) {
+      installPathsById.set(pluginId, installPaths);
+    }
+  }
+
+  return installPathsById;
+});
+
+const PLUGIN_ROOT_PLACEHOLDER = "${CLAUDE_PLUGIN_ROOT}";
+
+/**
+ * Expand `${CLAUDE_PLUGIN_ROOT}` in every string the config carries, the way the
+ * CLI's own plugin loader does before spawning a server.
+ *
+ * Registering servers over the control channel skips that loader entirely: a
+ * config handed over with the placeholder intact reaches the child process
+ * verbatim, so a `bun run --cwd ${CLAUDE_PLUGIN_ROOT}` server starts in a
+ * directory that does not exist and dies with "Connection closed". Five of the
+ * official marketplace plugins are built this way.
+ */
+function expandPluginRoot(value: unknown, installPath: string): unknown {
+  if (typeof value === "string") {
+    return value.replaceAll(PLUGIN_ROOT_PLACEHOLDER, installPath);
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => expandPluginRoot(entry, installPath));
+  }
+  if (typeof value === "object" && value !== null) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, expandPluginRoot(entry, installPath)]),
+    );
+  }
+  return value;
+}
+
+/**
+ * Servers declared by one plugin. A plugin `.mcp.json` is accepted both wrapped
+ * in `mcpServers` (as the CLI documents it) and as a bare map of server name to
+ * config, because official plugins ship both shapes.
+ */
+function readDeclaredServers(
+  document: Record<string, unknown>,
+): ReadonlyArray<readonly [string, ClaudePluginMcpServerConfig]> {
+  const wrapped = document.mcpServers;
+  const servers =
+    typeof wrapped === "object" && wrapped !== null && !Array.isArray(wrapped)
+      ? (wrapped as Record<string, unknown>)
+      : document;
+
+  return Object.entries(servers).flatMap(([serverName, config]) => {
+    if (typeof config !== "object" || config === null || Array.isArray(config)) {
+      return [];
+    }
+    // `sdk` servers are in-process objects the CLI cannot reconnect from disk.
+    if ((config as { type?: unknown }).type === "sdk") {
+      return [];
+    }
+    return [[serverName, config as ClaudePluginMcpServerConfig] as const];
+  });
+}
+
+/**
+ * Enumerate MCP servers contributed by enabled plugins, keyed by the
+ * `plugin:<plugin>:<server>` names the interactive CLI uses. Discovery is
+ * best-effort throughout: an unreadable manifest, a missing install directory,
+ * or a malformed `.mcp.json` yields no servers for that plugin rather than
+ * failing session start.
+ */
+export const discoverClaudePluginMcpServers = Effect.fn("discoverClaudePluginMcpServers")(
+  function* (
+    config: Pick<ClaudeSettings, "homePath">,
+    cwd?: string,
+    environment?: NodeJS.ProcessEnv,
+  ): Effect.fn.Return<
+    Readonly<Record<string, ClaudePluginMcpServerConfig>>,
+    never,
+    FileSystem.FileSystem | Path.Path
+  > {
+    const path = yield* Path.Path;
+    const configDirPath = yield* resolveClaudeConfigDirPath(
+      config,
+      environment ?? process.env,
+      cwd,
+    );
+
+    const enabledPluginIds = yield* readEnabledPluginIds(configDirPath, cwd);
+    if (enabledPluginIds.size === 0) {
+      return {};
+    }
+
+    const installPathsById = yield* readPluginInstallPaths(configDirPath);
+    const servers: Record<string, ClaudePluginMcpServerConfig> = {};
+
+    for (const pluginId of [...enabledPluginIds].sort()) {
+      const pluginName = pluginId.split("@")[0]?.trim();
+      if (!pluginName) {
+        continue;
+      }
+
+      for (const installPath of installPathsById.get(pluginId) ?? []) {
+        const document = yield* readJsonObject(path.join(installPath, ".mcp.json"));
+        if (document === undefined) {
+          continue;
+        }
+        const declared = readDeclaredServers(document);
+        if (declared.length === 0) {
+          continue;
+        }
+        for (const [serverName, serverConfig] of declared) {
+          servers[`plugin:${pluginName}:${serverName}`] = expandPluginRoot(
+            serverConfig,
+            installPath,
+          ) as ClaudePluginMcpServerConfig;
+        }
+        // One install per plugin wins; later scopes would only shadow it.
+        break;
+      }
+    }
+
+    return servers;
+  },
+);

--- a/apps/server/src/provider/Drivers/ClaudeSkills.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.ts
@@ -11,15 +11,13 @@
  *
  * @module provider/Drivers/ClaudeSkills
  */
-import * as NodeOS from "node:os";
-
 import type { ClaudeSettings, ServerProviderSkill } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import { parse as parseYamlDocument } from "yaml";
 
-import { expandHomePath } from "../../pathExpansion.ts";
+import { resolveClaudeConfigDirPath } from "./ClaudeHome.ts";
 
 type ClaudeSkillScope = "user" | "project";
 
@@ -55,34 +53,6 @@ function parseSkillFrontmatter(contents: string): SkillFrontmatter {
     ...(description ? { description } : {}),
   };
 }
-
-/**
- * Resolve the Claude config directory the CLI would use, matching the
- * precedence the spawned CLI sees: the instance's `homePath` (exported as
- * `CLAUDE_CONFIG_DIR` by `makeClaudeEnvironment`), then a `CLAUDE_CONFIG_DIR`
- * already present in the process environment, then `~/.claude`.
- */
-const resolveClaudeConfigDirPath = Effect.fn("resolveClaudeConfigDirPath")(function* (
-  config: Pick<ClaudeSettings, "homePath">,
-  environment: NodeJS.ProcessEnv,
-  cwd?: string,
-): Effect.fn.Return<string, never, Path.Path> {
-  const path = yield* Path.Path;
-  const homePath = config.homePath.trim();
-  if (homePath.length > 0) {
-    return path.resolve(expandHomePath(homePath));
-  }
-  // No tilde expansion here: the spawned CLI receives this env var verbatim
-  // (env vars are never shell-expanded), so a literal `~` must stay literal
-  // for discovery to scan the same directory the runtime would. A relative
-  // value is resolved against the workspace cwd — the subprocess's own cwd —
-  // for the same reason.
-  const environmentConfigDir = environment.CLAUDE_CONFIG_DIR?.trim() ?? "";
-  if (environmentConfigDir.length > 0) {
-    return cwd ? path.resolve(cwd, environmentConfigDir) : path.resolve(environmentConfigDir);
-  }
-  return path.join(NodeOS.homedir(), ".claude");
-});
 
 /**
  * Enumerate Claude Code skills from the user config dir, workspace

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -59,7 +59,18 @@ class FakeClaudeQuery implements AsyncIterable<SDKMessage> {
   public readonly setModelCalls: Array<string | undefined> = [];
   public readonly setPermissionModeCalls: Array<string> = [];
   public readonly setMaxThinkingTokensCalls: Array<number | null> = [];
+  public readonly setMcpServersCalls: Array<Record<string, unknown>> = [];
   public closeCalls = 0;
+
+  /**
+   * Resolves on the first `setMcpServers` call. The adapter fires plugin MCP
+   * registration detached from session start, so tests await this instead of
+   * guessing at fiber scheduling.
+   */
+  private resolveFirstSetMcpServers: ((servers: Record<string, unknown>) => void) | undefined;
+  public readonly firstSetMcpServers = new Promise<Record<string, unknown>>((resolve) => {
+    this.resolveFirstSetMcpServers = resolve;
+  });
 
   emit(message: SDKMessage): void {
     if (this.done) {
@@ -114,6 +125,22 @@ class FakeClaudeQuery implements AsyncIterable<SDKMessage> {
   readonly setMaxThinkingTokens = async (maxThinkingTokens: number | null): Promise<void> => {
     this.setMaxThinkingTokensCalls.push(maxThinkingTokens);
   };
+
+  /**
+   * Deliberately a prototype method reading `this`, mirroring the SDK's own
+   * `Query.setMcpServers`. A caller that passes a plain reference instead of
+   * invoking it on the query loses `this` and fails here, the way it fails
+   * against the real SDK.
+   */
+  async setMcpServers(servers: Record<string, unknown>): Promise<{
+    added: Array<string>;
+    removed: Array<string>;
+    errors: Record<string, string>;
+  }> {
+    this.setMcpServersCalls.push(servers);
+    this.resolveFirstSetMcpServers?.(servers);
+    return { added: Object.keys(servers), removed: [], errors: {} };
+  }
 
   readonly close = (): void => {
     this.closeCalls += 1;
@@ -436,6 +463,82 @@ describe("ClaudeAdapterLive", () => {
 
       const createInput = harness.getLastCreateQueryInput();
       assert.equal(createInput?.options.effort, "max");
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("registers MCP servers declared by enabled Claude plugins", () => {
+    // The SDK loads plugins but not the MCP servers they declare, so the
+    // adapter re-applies them over the control channel after session start.
+    const configDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "claude-plugin-mcp-"));
+    const installPath = NodePath.join(configDir, "plugins", "cache", "linear");
+    NodeFS.mkdirSync(installPath, { recursive: true });
+    NodeFS.writeFileSync(
+      NodePath.join(installPath, ".mcp.json"),
+      JSON.stringify({ linear: { type: "http", url: "https://mcp.linear.app/mcp" } }),
+    );
+    NodeFS.writeFileSync(
+      NodePath.join(configDir, "settings.json"),
+      JSON.stringify({ enabledPlugins: { "linear@claude-plugins-official": true } }),
+    );
+    NodeFS.writeFileSync(
+      NodePath.join(configDir, "plugins", "installed_plugins.json"),
+      JSON.stringify({
+        version: 2,
+        plugins: { "linear@claude-plugins-official": [{ scope: "user", installPath }] },
+      }),
+    );
+
+    const harness = makeHarness({ claudeConfig: { homePath: configDir } });
+    return Effect.gen(function* () {
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => NodeFS.rmSync(configDir, { recursive: true, force: true })),
+      );
+
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      // Bounded so a registration that never fires reports itself instead of
+      // hanging until the suite-wide timeout.
+      const servers = yield* Effect.promise(() => harness.query.firstSetMcpServers).pipe(
+        Effect.timeout("5 seconds"),
+      );
+      // The name must match what the interactive CLI uses: stored MCP OAuth
+      // tokens are keyed by server name, so anything else re-prompts for auth.
+      assert.deepEqual(servers, {
+        "plugin:linear:linear": { type: "http", url: "https://mcp.linear.app/mcp" },
+      });
+      // `t3-code` stays out of the call: the SDK merges dynamic servers, and
+      // re-sending it would tear down a connected transport.
+      assert.equal(Object.keys(servers).includes("t3-code"), false);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("leaves the MCP server set alone when no plugin declares one", () => {
+    const configDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "claude-plugin-mcp-none-"));
+    const harness = makeHarness({ claudeConfig: { homePath: configDir } });
+    return Effect.gen(function* () {
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => NodeFS.rmSync(configDir, { recursive: true, force: true })),
+      );
+
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+
+      assert.deepEqual(harness.query.setMcpServersCalls, []);
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -10,6 +10,8 @@ import {
   type CanUseTool,
   query,
   type Options as ClaudeQueryOptions,
+  type McpServerConfig,
+  type McpSetServersResult,
   type PermissionMode,
   type PermissionResult,
   type PermissionUpdate,
@@ -77,6 +79,7 @@ import { ServerConfig } from "../../config.ts";
 import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
 import { resolveClaudeSdkExecutablePath } from "../Drivers/ClaudeExecutable.ts";
 import { makeClaudeEnvironment } from "../Drivers/ClaudeHome.ts";
+import { discoverClaudePluginMcpServers } from "../Drivers/ClaudePlugins.ts";
 import {
   getClaudeModelCapabilities,
   isClaudeUltracodeEffort,
@@ -289,6 +292,13 @@ interface ClaudeQueryRuntime extends AsyncIterable<SDKMessage> {
   readonly setPermissionMode: (mode: PermissionMode) => Promise<void>;
   readonly setMaxThinkingTokens: (maxThinkingTokens: number | null) => Promise<void>;
   readonly getContextUsage?: () => Promise<SDKControlGetContextUsageResponse>;
+  /**
+   * SDK Query.setMcpServers — present on real queries; optional for test
+   * doubles. Used to register plugin-contributed servers the SDK skips.
+   */
+  readonly setMcpServers?: (
+    servers: Record<string, McpServerConfig>,
+  ) => Promise<McpSetServersResult>;
   readonly close: () => void;
 }
 
@@ -4143,6 +4153,27 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         ...(ultracode ? { ultracode: true } : {}),
       };
       const mcpSession = McpProviderSession.readMcpProviderSession(input.threadId);
+      const launchMcpServers: Record<string, McpServerConfig> = mcpSession
+        ? {
+            "t3-code": {
+              type: "http",
+              url: mcpSession.endpoint,
+              headers: {
+                Authorization: mcpSession.authorizationHeader,
+              },
+            },
+          }
+        : {};
+      // The SDK loads plugins but never registers the MCP servers they declare,
+      // so they are re-applied over the control channel once the session is up.
+      const pluginMcpServers = yield* discoverClaudePluginMcpServers(
+        claudeSettings,
+        input.cwd,
+        claudeEnvironment,
+      ).pipe(
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(Path.Path, path),
+      );
       // The attachments dir grant lets the agent Read/copy pasted images at
       // the paths ProviderService injects into the turn text, without an
       // approval prompt. It is a leaf directory holding only attachment
@@ -4176,19 +4207,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         env: claudeEnvironment,
         additionalDirectories,
         ...(Object.keys(extraArgs).length > 0 ? { extraArgs } : {}),
-        ...(mcpSession
-          ? {
-              mcpServers: {
-                "t3-code": {
-                  type: "http",
-                  url: mcpSession.endpoint,
-                  headers: {
-                    Authorization: mcpSession.authorizationHeader,
-                  },
-                },
-              },
-            }
-          : {}),
+        ...(Object.keys(launchMcpServers).length > 0 ? { mcpServers: launchMcpServers } : {}),
       };
 
       yield* Effect.annotateCurrentSpan({
@@ -4214,6 +4233,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         "claude.query.settings_json": encodeJsonStringForDiagnostics(settings) ?? "",
         "claude.query.extra_args_json": encodeJsonStringForDiagnostics(extraArgs) ?? "",
         "claude.query.path_to_executable": claudeBinaryPath,
+        "claude.query.plugin_mcp_servers": Object.keys(pluginMcpServers),
       });
 
       const queryRuntime = yield* Effect.try({
@@ -4230,6 +4250,45 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
             cause,
           }),
       });
+
+      // Registering plugin servers costs a fixed ~6s inside the CLI — the
+      // control call only resolves once every named server has connected — so
+      // it runs detached rather than delaying the turn. Their tools sit behind
+      // tool search, which reads live state, so they become callable the moment
+      // the call lands.
+      // ponytail: a turn that reaches for a plugin tool within the first few
+      // seconds of a brand-new session can still miss it; gate `sendTurn` on
+      // the registration if that shows up in practice.
+      if (Object.keys(pluginMcpServers).length > 0) {
+        // `.bind` is load-bearing: the SDK declares `setMcpServers` on the Query
+        // prototype and it reads `this`, so calling a plain reference throws.
+        const setMcpServers = queryRuntime.setMcpServers?.bind(queryRuntime);
+        if (setMcpServers !== undefined) {
+          runFork(
+            Effect.tryPromise(() =>
+              // `t3-code` is deliberately omitted: the SDK merges dynamic
+              // servers rather than replacing them, and re-sending a connected
+              // server tears its transport down and reconnects it.
+              setMcpServers(pluginMcpServers as Record<string, McpServerConfig>),
+            ).pipe(
+              Effect.flatMap((result) =>
+                Object.keys(result.errors).length > 0
+                  ? Effect.logWarning("Some Claude plugin MCP servers failed to connect.", {
+                      threadId,
+                      errors: result.errors,
+                    })
+                  : Effect.void,
+              ),
+              Effect.catch((cause) =>
+                Effect.logWarning("Failed to register Claude plugin MCP servers.", {
+                  threadId,
+                  cause,
+                }),
+              ),
+            ),
+          );
+        }
+      }
 
       const session: ProviderSession = {
         threadId,


### PR DESCRIPTION
## Problem

A Claude plugin that ships an `.mcp.json` looks installed but its tools never appear. The Agent SDK reports the plugin in its `system/init` handshake and loads its skills, commands, and agents — but only the interactive CLI registers the MCP servers the plugin declares. Every SDK consumer hits this, so a user with the Linear or Vercel plugin enabled gets no Linear or Vercel tools in T3, while the same plugin works in `claude` at the terminal.

Reproduced outside T3 with the same CLI binary — `claude -p --output-format stream-json` reports five plugins and zero `plugin:*` MCP servers, with or without `--setting-sources`, and with `--plugin-dir` too. Nothing T3 passes causes it.

## Fix

`ClaudePlugins.ts` resolves the servers from disk — `enabledPlugins` merged across the user, project, and local settings files, install paths from `plugins/installed_plugins.json`, then each plugin's `.mcp.json` (both the documented `mcpServers` wrapper and the bare map, since official plugins ship both). `ClaudeAdapter` applies them with `Query.setMcpServers` once the session is up.

Three details that are load-bearing:

- **Names must be `plugin:<plugin>:<server>`.** Stored MCP OAuth tokens are keyed by server name, so registering the same URL under any other name comes up `needs-auth` instead of reusing the token the user already has. The launch-time `mcpServers` option can't be used at all here — it silently drops names starting with `plugin:`.
- **Registration runs detached.** The control call doesn't resolve until every named server has connected — a consistent ~6s, and it's the first call that pays it. That's not worth adding to a turn, and the tools sit behind tool search, which reads live state.
- **`${CLAUDE_PLUGIN_ROOT}` is expanded here.** The control-channel path bypasses the CLI's plugin loader, which normally does that substitution. Verified by capturing the child's argv: it receives the literal placeholder. Five official marketplace plugins (`fakechat`, `imessage`, `discord`, `telegram`, `laravel-boost`) build their command with it and would otherwise start in a directory that doesn't exist.

`t3-code` is deliberately left out of the call: the SDK merges dynamic servers rather than replacing them, and re-sending a connected server tears down and reconnects its transport.

`resolveClaudeConfigDirPath` moved from `ClaudeSkills.ts` to `ClaudeHome.ts` so both discoverers share one config-dir precedence rule.

## Verification

With the Linear plugin enabled, the session goes from no `plugin:*` server at all to `plugin:linear:linear` connected, with all 63 `mcp__plugin_linear_linear__*` tools present in its tool list. `reloadPlugins()` was tried as the alternative and rejected — it registers the servers but they never reach the session's tool list.

No UI surface, so no screenshots. Provider-shaped but Claude-specific: plugins are a Claude Code concept, so Codex, Cursor, Grok, and OpenCode need no decision here. A user with no plugin declaring an MCP server takes zero extra work.

Six new tests: server naming across both `.mcp.json` shapes, `${CLAUDE_PLUGIN_ROOT}` expansion in command/args/env, disabled/absent/server-less plugins, project settings overriding user settings, malformed manifests and missing config dirs, plus adapter-level coverage that the call carries the resolved servers and no `t3-code`, and that it doesn't happen at all when nothing declares a server. The adapter test's fake `setMcpServers` is a prototype method reading `this`, mirroring the SDK, so passing an unbound reference fails the test the way it fails in production.

`vp test run` on the four touched suites: 90 passed. Targeted typecheck and lint clean.

Model: Claude Opus 5. Harness: T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Load MCP servers declared by Claude plugins into the Claude adapter
> - Adds `discoverClaudePluginMcpServers` in [ClaudePlugins.ts](https://github.com/pingdotgg/t3code/pull/7542/files#diff-d2ff0667449a162bc8bd2e960e4f0f6cd7c05a28496d9e643b240b3eaf32fd10) to enumerate MCP servers from enabled Claude plugins by reading their `.mcp.json` manifests, expanding `${CLAUDE_PLUGIN_ROOT}`, and filtering disabled plugins and project-level overrides.
> - After creating a Claude query runtime, `ClaudeAdapterLive.makeClaudeAdapter` in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/7542/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc) asynchronously calls `queryRuntime.setMcpServers` to register discovered plugin servers, keyed as `plugin:<plugin>:<server>`.
> - Extracts `resolveClaudeConfigDirPath` from [ClaudeSkills.ts](https://github.com/pingdotgg/t3code/pull/7542/files#diff-df655ed95ed759ff78376524f2ceda1b436b639952ddab7e7e19f618a43e77c3) into [ClaudeHome.ts](https://github.com/pingdotgg/t3code/pull/7542/files#diff-73ba6e23eba4250edbecbe8239d07a8f0556ddef26400793eb1b7432199ea29d) so it can be shared across both drivers.
> - The `t3-code` server is excluded from the plugin registration call to avoid disrupting the existing connection.
> - Risk: Plugin server registration is detached and best-effort — failures log warnings but do not surface errors to the caller.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cca292e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->