### PR TITLE
fix(shared): strip stray quotes from the repaired Windows PATH

### DIFF
--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -347,6 +347,25 @@ describe("DesktopShellEnvironment", () => {
     }),
   );
 
+  // cmd.exe reads a stray quote in PATH as opening a quoted region and stops
+  // resolving every entry after it, so `node` vanishes for npm lifecycle
+  // scripts launched from the integrated terminal. See issue #7543.
+  it.effect("strips stray quotes from the inherited Windows PATH", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = {
+        PATH: 'C:\\cloudflared.exe;C:";C:\\Program Files\\nodejs',
+      };
+
+      yield* runShellEnvironment({
+        env,
+        platform: "win32",
+        handler: () => "",
+      });
+
+      assert.equal(env.PATH, "C:\\cloudflared.exe;C:;C:\\Program Files\\nodejs");
+    }),
+  );
+
   it.effect("prefers login-shell desktop session hints over inherited values on linux", () =>
     Effect.gen(function* () {
       const env: NodeJS.ProcessEnv = {

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -8,6 +8,8 @@ import * as Schema from "effect/Schema";
 import * as ChildProcess from "effect/unstable/process/ChildProcess";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
+import { sanitizePathEntry } from "@t3tools/shared/shell";
+
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 
 type EnvironmentPatch = Record<string, string>;
@@ -163,14 +165,14 @@ const mergePaths = (
     if (Option.isNone(value)) continue;
 
     for (const entry of value.value.split(delimiter)) {
-      const trimmed = entry.trim();
-      if (trimmed.length === 0) continue;
+      const sanitized = sanitizePathEntry(entry.trim(), platform);
+      if (sanitized.length === 0) continue;
 
-      const key = pathComparisonKey(trimmed, platform);
+      const key = pathComparisonKey(sanitized, platform);
       if (key.length === 0 || seen.has(key)) continue;
 
       seen.add(key);
-      entries.push(trimmed);
+      entries.push(sanitized);
     }
   }
 

--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -20,6 +20,7 @@ import {
   resolveKnownWindowsCliDirs,
   resolveSpawnCommand,
   resolveWindowsEnvironment,
+  sanitizePathEntry,
   SpawnExecutableResolution,
   WindowsShellEnvironment,
   type WindowsShellEnvironmentReader,
@@ -312,7 +313,7 @@ describe("mergePathValues", () => {
         "win32",
       ),
     ).toBe(
-      'C:\\Users\\testuser\\AppData\\Roaming\\npm;"C:\\Program Files\\nodejs";C:\\Windows\\System32',
+      "C:\\Users\\testuser\\AppData\\Roaming\\npm;C:\\Program Files\\nodejs;C:\\Windows\\System32",
     );
   });
 
@@ -320,6 +321,39 @@ describe("mergePathValues", () => {
     expect(mergePathValues("/usr/local/bin:/usr/bin", "/usr/bin:/USR/BIN", "linux")).toBe(
       "/usr/local/bin:/usr/bin:/USR/BIN",
     );
+  });
+
+  // A stray quote makes cmd.exe stop resolving every later entry, so `node`
+  // disappears for npm lifecycle scripts and `.cmd` shims. See issue #7543.
+  it("strips a stray quote that would hide later Windows PATH entries", () => {
+    expect(
+      mergePathValues(undefined, 'C:\\cloudflared.exe;C:";C:\\Program Files\\nodejs', "win32"),
+    ).toBe("C:\\cloudflared.exe;C:;C:\\Program Files\\nodejs");
+  });
+
+  it("drops a Windows PATH entry that is nothing but quotes", () => {
+    expect(
+      mergePathValues(undefined, 'C:\\Windows\\System32;";;C:\\Program Files\\Git\\cmd', "win32"),
+    ).toBe("C:\\Windows\\System32;C:\\Program Files\\Git\\cmd");
+  });
+
+  it("keeps quotes on POSIX, where they are legal in a path", () => {
+    expect(mergePathValues(undefined, '/usr/bin:/opt/we"ird/bin', "linux")).toBe(
+      '/usr/bin:/opt/we"ird/bin',
+    );
+  });
+});
+
+describe("sanitizePathEntry", () => {
+  it("removes every quote from a Windows entry", () => {
+    expect(sanitizePathEntry('"C:\\Program Files\\nodejs"', "win32")).toBe(
+      "C:\\Program Files\\nodejs",
+    );
+    expect(sanitizePathEntry('C:"', "win32")).toBe("C:");
+  });
+
+  it("leaves POSIX entries untouched", () => {
+    expect(sanitizePathEntry('/opt/we"ird/bin', "linux")).toBe('/opt/we"ird/bin');
   });
 });
 

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -414,6 +414,18 @@ function normalizePathEntryForComparison(entry: string, platform: NodeJS.Platfor
   return platform === "win32" ? normalized.toLowerCase() : normalized;
 }
 
+// `"` is not a legal character in a Windows path, but cmd.exe reads one in PATH
+// as opening a quoted region: an unbalanced quote swallows every `;` after it,
+// so no directory past that entry ever resolves. PowerShell, bash, and
+// where.exe split on `;` literally, which is why the damage only surfaces once
+// a child cmd.exe runs - an npm lifecycle script, a `.cmd` shim - and reports
+// `'"node"' is not recognized`. Strip the quotes instead of dropping the entry
+// so a correctly quoted "C:\Program Files\nodejs" still resolves. POSIX paths
+// may legitimately contain a quote, so this is Windows-only.
+export function sanitizePathEntry(entry: string, platform: NodeJS.Platform): string {
+  return platform === "win32" ? entry.replaceAll('"', "") : entry;
+}
+
 export function mergePathValues(
   preferredPath: string | undefined,
   inheritedPath: string | undefined,
@@ -427,14 +439,14 @@ export function mergePathValues(
     if (!rawValue) continue;
 
     for (const entry of rawValue.split(delimiter)) {
-      const trimmed = entry.trim();
-      if (trimmed.length === 0) continue;
+      const sanitized = sanitizePathEntry(entry.trim(), platform);
+      if (sanitized.length === 0) continue;
 
-      const normalized = normalizePathEntryForComparison(trimmed, platform);
+      const normalized = normalizePathEntryForComparison(sanitized, platform);
       if (normalized.length === 0 || seen.has(normalized)) continue;
 
       seen.add(normalized);
-      merged.push(trimmed);
+      merged.push(sanitized);
     }
   }
 


### PR DESCRIPTION
Closes #7543.

## Problem

`cmd.exe` reads a `"` in `PATH` as opening a quoted region, so a single unbalanced quote swallows every `;` after it and **no directory past that entry is ever searched**. PowerShell, bash and `where.exe` split on `;` literally, so the damage is invisible until a child `cmd.exe` runs — which is exactly what makes the report so confusing: the same `PATH` works in VS Code's terminal and Windows Terminal.

In T3 Code's integrated terminal the failure lands here:

- the terminal shell is PowerShell, so `npm` resolves and `npm.cmd` reaches Node through `%~dp0\node.exe` without touching `PATH`;
- npm then spawns the lifecycle script through `%ComSpec%`, i.e. `cmd.exe`;
- `node_modules\.bin\next.cmd` has no sibling `node.exe`, so it falls back to `SET "_prog=node"`;
- `cmd.exe` cannot see `C:\Program Files\nodejs` because it sits behind the stray quote.

```
> web@0.1.0 dev
> next dev --port 3002

'"node"' is not recognized as an internal or external command,
operable program or batch file.
```

Both Windows `PATH` merges — `mergePathValues` in `packages/shared/src/shell.ts` (used by `fixPath`) and `mergePaths` in `apps/desktop/src/shell/DesktopShellEnvironment.ts` — already strip quotes to build the dedupe key, then push the **raw** entry into the merged result. So the malformed entry survives the repair pass into `process.env.PATH`, and from there into every integrated terminal (`createTerminalSpawnEnv` inherits the server environment by design) and every agent-spawned process.

Blast radius is wider than the terminal — the same broken `PATH` also killed `pnpm install` and the `oxlint`/`prettier` shims in this repo while I was investigating, all through `cmd.exe`.

## Fix

Sanitize the entry itself rather than only the comparison key. `"` is not a legal character in a Windows path, so removing it is always safe, and stripping rather than dropping the entry keeps a correctly quoted `"C:\Program Files\nodejs"` resolving. POSIX is untouched, where a quote is a legal filename character.

The new `sanitizePathEntry` helper lives in `packages/shared/src/shell.ts` and is shared by both merges, so the server (`npx t3`, WSL host) and the desktop Electron main get the same behavior.

## Verification

A/B on one real `PATH`, changing nothing but the quote:

```
PS> $env:Path = 'C:\Windows\System32;C:\cloudflared.exe;C:";C:\Program Files\nodejs'
PS> cmd /c "node -v"
'node' is not recognized as an internal or external command,
operable program or batch file.

PS> $env:Path = 'C:\Windows\System32;C:\cloudflared.exe;C:;C:\Program Files\nodejs'
PS> cmd /c "node -v"
v22.22.0
```

- `vp test run packages/shared/src/shell.test.ts apps/desktop/src/shell/DesktopShellEnvironment.test.ts` — 49 passed.
- Confirmed the four new assertions fail on `main` and pass with the patch.
- `vp lint` clean and `tsgo --noEmit` clean for `@t3tools/shared` and `@t3tools/desktop`.

No UI surface changes, so no before/after images apply.

## Not included

`resolveWindowsEnvironment`'s `loadProfile: false` probe spawns a PowerShell child that *inherits* T3 Code's own environment, so it can never surface a `PATH` the process does not already have — it cannot repair a stale environment, only a registry read could. That is a separate concern from this one and I left it alone; happy to open it as its own issue if it is wanted.

---

Model: Claude Opus 5 (1M context)
Harness: Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted Windows-only PATH sanitization with tests; no auth or data-path changes.
> 
> **Overview**
> Fixes **#7543** by sanitizing Windows `PATH` segments when they are merged, so stray `"` characters cannot break `cmd.exe` lookup for later entries (e.g. `node` missing in npm lifecycle scripts).
> 
> Adds **`sanitizePathEntry`** in `@t3tools/shared/shell`: on `win32` it removes all double quotes from each segment (illegal in Windows paths); POSIX paths are unchanged. **`mergePathValues`** and desktop **`mergePaths`** now push the sanitized segment into the merged `PATH`, not only use quotes for dedupe keys—so repaired env propagates to integrated terminals and spawned processes.
> 
> Tests cover the malformed `C:"` case, quote-only segments, wrapped `"C:\Program Files\nodejs"`, and desktop shell install on Windows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a757850c7fe21112616268d7cddeaa4825c90af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Strip stray quotes from Windows PATH entries in `mergePaths` and `mergePathValues`
> - Adds `sanitizePathEntry` to [packages/shared/src/shell.ts](https://github.com/pingdotgg/t3code/pull/7544/files#diff-89a91f85db41a9a0912bc86c336bf9429751f3797ee50a089248c68cde8489ce) that removes all double-quote characters from PATH entries on Windows while leaving POSIX entries unchanged.
> - Updates `mergePaths` in [DesktopShellEnvironment.ts](https://github.com/pingdotgg/t3code/pull/7544/files#diff-ed26aa44c93ddc9fedab8bc7cf7aa64c7b0b8fc0e22a3960d5c02c30c940dabd) and `mergePathValues` in the shared shell module to apply `sanitizePathEntry` before deduplication and merging.
> - Behavioral Change: on Windows, merged PATH values will have quotes stripped, and entries that consist entirely of quotes are dropped from the result.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a75785.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->