### PR TITLE
Add `t3 env add`: pre-seed a legacy saved-environment catalog, headlessly

### DIFF
--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -9,6 +9,7 @@ import * as NetService from "@t3tools/shared/Net";
 import packageJson from "../package.json" with { type: "json" };
 import { authCommand } from "./cli/auth.ts";
 import { connectCommand } from "./cli/connect.ts";
+import { envCommand } from "./cli/env.ts";
 import { pairCommand } from "./cli/pair.ts";
 import { hasCloudPublicConfig } from "./cloud/publicConfig.ts";
 import { sharedServerCommandFlags } from "./cli/config.ts";
@@ -53,6 +54,7 @@ export const makeCli = ({ cloudEnabled = hasCloudPublicConfig } = {}) =>
       serveCommand,
       pairCommand,
       authCommand,
+      envCommand,
       projectCommand,
       serviceCommand,
       servicePreflightCommand,

--- a/apps/server/src/cli/env.test.ts
+++ b/apps/server/src/cli/env.test.ts
@@ -7,10 +7,16 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import type { PersistedSavedEnvironmentRecord } from "@t3tools/contracts";
 import { assert, describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 
-import { readCatalog, upsertEnvironmentRecord, writeCatalog } from "./env.ts";
+import {
+  assertLegacyCatalogIsSafeToWrite,
+  readCatalog,
+  upsertEnvironmentRecord,
+  writeCatalog,
+} from "./env.ts";
 
 const makeRecord = (
   overrides: Partial<PersistedSavedEnvironmentRecord> = {},
@@ -35,17 +41,29 @@ describe("upsertEnvironmentRecord", () => {
     const second = makeRecord({ label: "sandbox-new" });
     const result = upsertEnvironmentRecord([first], second);
     expect(result).toHaveLength(1);
-    expect(result[0]?.label).toBe("sandbox-new");
+    expect(result[0]?.["label"]).toBe("sandbox-new");
   });
 
-  it("leaves unrelated environments untouched", () => {
-    const other = makeRecord({
-      environmentId: "env_other" as PersistedSavedEnvironmentRecord["environmentId"],
+  it("leaves unrelated environments untouched, including fields this command does not know about", () => {
+    // The bug reported in review: decoding existing records through
+    // PersistedSavedEnvironmentRecordSchema silently dropped fields like
+    // encryptedBearerToken that schema has no key for. This asserts an
+    // opaque field survives a merge untouched, byte for byte.
+    const other = {
+      environmentId: "env_other",
       label: "other",
-    });
+      httpBaseUrl: "http://100.64.0.8:3773",
+      wsBaseUrl: "ws://100.64.0.8:3773",
+      createdAt: "2026-08-01T00:00:00.000Z",
+      lastConnectedAt: null,
+      encryptedBearerToken: "some-opaque-base64-blob-unrelated-to-this-command",
+    };
     const result = upsertEnvironmentRecord([other], makeRecord());
     expect(result).toHaveLength(2);
-    expect(result.some((record) => record.environmentId === "env_other")).toBe(true);
+    const preserved = result.find((record) => record["environmentId"] === "env_other");
+    expect(preserved?.["encryptedBearerToken"]).toBe(
+      "some-opaque-base64-blob-unrelated-to-this-command",
+    );
   });
 });
 
@@ -58,10 +76,7 @@ describe("env catalog read/write", () => {
         Effect.gen(function* () {
           const fileSystem = yield* FileSystem.FileSystem;
           return yield* readCatalog(fileSystem, catalogPath);
-        }).pipe(Effect.provide(NodeServices.layer)) as Effect.Effect<
-          { readonly version: number; readonly records: readonly PersistedSavedEnvironmentRecord[] },
-          never
-        >,
+        }).pipe(Effect.provide(NodeServices.layer)),
       );
       expect(document.records).toEqual([]);
     } finally {
@@ -69,11 +84,11 @@ describe("env catalog read/write", () => {
     }
   });
 
-  it("round-trips a record through writeCatalog and readCatalog", async () => {
+  it("round-trips a record through writeCatalog and readCatalog, preserving unknown fields", async () => {
     const dir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-env-test-"));
     try {
       const catalogPath = NodePath.join(dir, "saved-environments.json");
-      const record = makeRecord();
+      const record = { ...makeRecord(), encryptedBearerToken: "opaque-blob" };
       await Effect.runPromise(
         Effect.gen(function* () {
           const fileSystem = yield* FileSystem.FileSystem;
@@ -93,11 +108,51 @@ describe("env catalog read/write", () => {
       );
 
       expect(document.records).toEqual([record]);
+      expect(document.records[0]?.["encryptedBearerToken"]).toBe("opaque-blob");
       // Atomic-write means no stray temp file survives a clean run.
       assert(
         NodeFS.readdirSync(dir).every((name) => !name.includes(".tmp")),
         "no leftover temp file after a successful write",
       );
+    } finally {
+      NodeFS.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("assertLegacyCatalogIsSafeToWrite", () => {
+  it("passes when no sibling encrypted catalog exists", async () => {
+    const dir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-env-test-"));
+    try {
+      const catalogPath = NodePath.join(dir, "saved-environments.json");
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const fileSystem = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          yield* assertLegacyCatalogIsSafeToWrite(fileSystem, path, catalogPath);
+        }).pipe(Effect.provide(NodeServices.layer)),
+      );
+    } finally {
+      NodeFS.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses when the real encrypted catalog already exists next to the legacy path", async () => {
+    const dir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-env-test-"));
+    try {
+      const catalogPath = NodePath.join(dir, "saved-environments.json");
+      NodeFS.writeFileSync(
+        NodePath.join(dir, "connection-catalog.json"),
+        JSON.stringify({ version: 1, encryptedCatalog: "does-not-matter-for-this-test" }),
+      );
+      const exit = await Effect.runPromiseExit(
+        Effect.gen(function* () {
+          const fileSystem = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          yield* assertLegacyCatalogIsSafeToWrite(fileSystem, path, catalogPath);
+        }).pipe(Effect.provide(NodeServices.layer)),
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
     } finally {
       NodeFS.rmSync(dir, { recursive: true, force: true });
     }

--- a/apps/server/src/cli/env.test.ts
+++ b/apps/server/src/cli/env.test.ts
@@ -1,0 +1,105 @@
+// @effect-diagnostics nodeBuiltinImport:off - exercises real filesystem round-trips like pair.test.ts does.
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import type { PersistedSavedEnvironmentRecord } from "@t3tools/contracts";
+import { assert, describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+import { readCatalog, upsertEnvironmentRecord, writeCatalog } from "./env.ts";
+
+const makeRecord = (
+  overrides: Partial<PersistedSavedEnvironmentRecord> = {},
+): PersistedSavedEnvironmentRecord => ({
+  environmentId: "env_abc" as PersistedSavedEnvironmentRecord["environmentId"],
+  label: "sandbox",
+  httpBaseUrl: "http://100.64.0.7:3773",
+  wsBaseUrl: "ws://100.64.0.7:3773",
+  createdAt: "2026-08-19T00:00:00.000Z",
+  lastConnectedAt: null,
+  ...overrides,
+});
+
+describe("upsertEnvironmentRecord", () => {
+  it("appends a record for a new environment", () => {
+    const result = upsertEnvironmentRecord([], makeRecord());
+    expect(result).toHaveLength(1);
+  });
+
+  it("replaces rather than duplicates a record for the same environment id", () => {
+    const first = makeRecord({ label: "sandbox-old" });
+    const second = makeRecord({ label: "sandbox-new" });
+    const result = upsertEnvironmentRecord([first], second);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.label).toBe("sandbox-new");
+  });
+
+  it("leaves unrelated environments untouched", () => {
+    const other = makeRecord({
+      environmentId: "env_other" as PersistedSavedEnvironmentRecord["environmentId"],
+      label: "other",
+    });
+    const result = upsertEnvironmentRecord([other], makeRecord());
+    expect(result).toHaveLength(2);
+    expect(result.some((record) => record.environmentId === "env_other")).toBe(true);
+  });
+});
+
+describe("env catalog read/write", () => {
+  it("reads an empty document when the catalog file does not exist yet", async () => {
+    const dir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-env-test-"));
+    try {
+      const catalogPath = NodePath.join(dir, "nested", "saved-environments.json");
+      const document = await Effect.runPromise(
+        Effect.gen(function* () {
+          const fileSystem = yield* FileSystem.FileSystem;
+          return yield* readCatalog(fileSystem, catalogPath);
+        }).pipe(Effect.provide(NodeServices.layer)) as Effect.Effect<
+          { readonly version: number; readonly records: readonly PersistedSavedEnvironmentRecord[] },
+          never
+        >,
+      );
+      expect(document.records).toEqual([]);
+    } finally {
+      NodeFS.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("round-trips a record through writeCatalog and readCatalog", async () => {
+    const dir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-env-test-"));
+    try {
+      const catalogPath = NodePath.join(dir, "saved-environments.json");
+      const record = makeRecord();
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const fileSystem = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          yield* writeCatalog(fileSystem, path, catalogPath, {
+            version: 1,
+            records: [record],
+          });
+        }).pipe(Effect.provide(NodeServices.layer)),
+      );
+
+      const document = await Effect.runPromise(
+        Effect.gen(function* () {
+          const fileSystem = yield* FileSystem.FileSystem;
+          return yield* readCatalog(fileSystem, catalogPath);
+        }).pipe(Effect.provide(NodeServices.layer)),
+      );
+
+      expect(document.records).toEqual([record]);
+      // Atomic-write means no stray temp file survives a clean run.
+      assert(
+        NodeFS.readdirSync(dir).every((name) => !name.includes(".tmp")),
+        "no leftover temp file after a successful write",
+      );
+    } finally {
+      NodeFS.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/server/src/cli/env.ts
+++ b/apps/server/src/cli/env.ts
@@ -10,34 +10,53 @@
  * without a human opening a pairing dialog once per machine.
  *
  * This reuses the exact probe-and-bootstrap path clients call on pairing
- * (`preparePairingRegistration` from `@t3tools/client-runtime/connection`)
- * and persists the result using the same `PersistedSavedEnvironmentRecord`
- * shape the desktop app reads from disk on launch. It intentionally does
- * NOT touch the live `EnvironmentRegistry` / `EnvironmentSupervisor`
- * machinery a running client uses - that graph exists to supervise a
- * long-lived connection, which a one-shot CLI invocation has no business
- * standing up. A client picks up the new entry the next time it reads its
- * own catalog file (normally on launch).
+ * (`preparePairingRegistration` from `@t3tools/client-runtime/connection`).
+ * It intentionally does NOT touch the live `EnvironmentRegistry` /
+ * `EnvironmentSupervisor` machinery a running client uses - that graph
+ * exists to supervise a long-lived connection, which a one-shot CLI
+ * invocation has no business standing up.
  *
- * Secrets are handled conservatively: by default no bearer token is
- * persisted, matching the shape of `PersistedSavedEnvironmentRecord` itself,
- * which has no secret field - only the desktop app's own storage layer adds
- * one (`encryptedBearerToken`, encrypted at rest via Electron's
- * `safeStorage`), and this command has no access to that. Pass
- * `--print-token` to have the bootstrapped bearer token printed once so a
- * provisioning script can store it wherever it already stores other
- * secrets, instead of this command inventing a second, unencrypted place
- * for it to live on disk.
+ * ---
  *
- * Path assumption worth double-checking before relying on this in
- * automation: the default catalog path is derived from the same
- * `--base-dir` / `T3CODE_HOME` convention the server CLI already uses
- * elsewhere (`ServerConfig.deriveServerPaths`), on the assumption that it
- * lines up with the desktop app's own state directory on the same machine.
- * That has not been verified against every desktop build; pass
- * `--catalog-path` explicitly if you are not sure, and compare against
- * whatever `DesktopEnvironment`'s `savedEnvironmentRegistryPath` resolves to
- * for your install.
+ * Revised after review (thank you, Macroscope and Bugbot, both caught real
+ * bugs in the first version):
+ *
+ * 1. The desktop app's actual catalog is `connection-catalog.json`
+ *    (`DesktopConnectionCatalogStore`) - a single blob encrypted whole via
+ *    Electron's `safeStorage` (OS keychain-backed). `saved-environments.json`
+ *    (`DesktopSavedEnvironments`) is a *legacy* plaintext-ish format that
+ *    only gets read once, to migrate into the encrypted catalog, and only
+ *    when `connection-catalog.json` does not exist yet. Once a desktop app
+ *    has launched and migrated, writing to `saved-environments.json` is a
+ *    complete no-op - the first version of this command targeted exactly
+ *    that file, unconditionally.
+ *
+ *    This command cannot safely write into an already-migrated encrypted
+ *    catalog: doing that means either reproducing Electron's `safeStorage`
+ *    (tied to the OS keychain and the desktop app's own identity - not
+ *    something a headless Node process can reasonably replicate) or writing
+ *    plaintext into a field the app expects to be encrypted. So it checks
+ *    for a sibling `connection-catalog.json` first and refuses with an
+ *    explicit error if one exists, rather than silently doing nothing or
+ *    corrupting anything. It only ever writes the legacy format, which is
+ *    only useful pre-first-launch (e.g. pre-seeding a brand new machine's
+ *    catalog as part of provisioning, before the desktop app has ever run
+ *    there) - a narrower claim than the original PR description made.
+ *
+ * 2. Round-tripping every existing record through
+ *    `PersistedSavedEnvironmentRecordSchema` silently dropped any
+ *    `encryptedBearerToken` (or other fields that schema doesn't know
+ *    about) on *every other* record in the file, not just the one being
+ *    added - a real, reported data-loss bug. Existing records are now
+ *    carried through as opaque JSON objects and never decoded against a
+ *    narrowing schema; only the new record being inserted is
+ *    schema-validated. Whatever fields already live on other records -
+ *    known to this file or not - survive untouched.
+ *
+ * 3. Read/write errors now carry an operation discriminator, matching
+ *    `DesktopSavedEnvironmentsReadError` / `WriteError` /
+ *    `DocumentDecodeError` conventions instead of collapsing every failure
+ *    mode into one message.
  */
 import { preparePairingRegistration } from "@t3tools/client-runtime/connection";
 import * as ClientCapabilities from "@t3tools/client-runtime/platform";
@@ -46,7 +65,6 @@ import {
   type PersistedSavedEnvironmentRecord,
   PersistedSavedEnvironmentRecordSchema,
 } from "@t3tools/contracts";
-import { fromLenientJson } from "@t3tools/shared/schemaJson";
 import * as Console from "effect/Console";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
@@ -62,33 +80,98 @@ import * as ServerConfig from "../config.ts";
 import { resolveBaseDir } from "../os-jank.ts";
 import { baseDirFlag, DurationFromString } from "./config.ts";
 
-const CatalogDocumentSchema = Schema.Struct({
-  version: Schema.optionalKey(Schema.Number),
-  records: Schema.optionalKey(Schema.Array(PersistedSavedEnvironmentRecordSchema)),
-});
-type CatalogDocument = { readonly version: number; readonly records: readonly PersistedSavedEnvironmentRecord[] };
+/**
+ * An existing catalog record, kept as an opaque JSON object rather than
+ * decoded against `PersistedSavedEnvironmentRecordSchema`. That schema is
+ * the *contract* shape used to validate the one new record this command
+ * writes - it is deliberately NOT used to parse records already in the
+ * file, because doing so drops any field it doesn't know about
+ * (`encryptedBearerToken` being the one that actually bit us in review).
+ */
+type OpaqueCatalogRecord = Readonly<Record<string, unknown>>;
 
-const CatalogDocumentJson = fromLenientJson(CatalogDocumentSchema);
-const decodeCatalogDocumentJson = Schema.decodeEffect(CatalogDocumentJson);
-const encodeCatalogDocumentJson = Schema.encodeEffect(CatalogDocumentJson);
-
-export class EnvCatalogWriteError extends Schema.TaggedErrorClass<EnvCatalogWriteError>()(
-  "EnvCatalogWriteError",
-  { path: Schema.String, cause: Schema.Defect() },
-) {
-  override get message(): string {
-    return `Could not write the environment catalog at ${this.path}.`;
-  }
+interface CatalogDocument {
+  readonly version: number;
+  readonly records: readonly OpaqueCatalogRecord[];
 }
+
+const readEnvironmentId = (record: OpaqueCatalogRecord): string | undefined =>
+  typeof record["environmentId"] === "string" ? (record["environmentId"] as string) : undefined;
+
+const CatalogReadOperation = Schema.Literals(["read-file", "parse-json"]);
+type CatalogReadOperation = typeof CatalogReadOperation.Type;
 
 export class EnvCatalogReadError extends Schema.TaggedErrorClass<EnvCatalogReadError>()(
   "EnvCatalogReadError",
-  { path: Schema.String, cause: Schema.Defect() },
+  { operation: CatalogReadOperation, path: Schema.String, cause: Schema.Defect() },
 ) {
   override get message(): string {
-    return `Could not read the environment catalog at ${this.path}.`;
+    return `Could not read the environment catalog during ${this.operation} at ${this.path}.`;
   }
 }
+
+const CatalogWriteOperation = Schema.Literals([
+  "encode-catalog",
+  "create-directory",
+  "write-temporary-file",
+  "replace-catalog-file",
+]);
+type CatalogWriteOperation = typeof CatalogWriteOperation.Type;
+
+export class EnvCatalogWriteError extends Schema.TaggedErrorClass<EnvCatalogWriteError>()(
+  "EnvCatalogWriteError",
+  { operation: CatalogWriteOperation, path: Schema.String, cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return `Could not write the environment catalog during ${this.operation} at ${this.path}.`;
+  }
+}
+
+export class EnvCatalogEncryptedCatalogExistsError extends Schema.TaggedErrorClass<EnvCatalogEncryptedCatalogExistsError>()(
+  "EnvCatalogEncryptedCatalogExistsError",
+  { encryptedCatalogPath: Schema.String },
+) {
+  override get message(): string {
+    return [
+      `${this.encryptedCatalogPath} already exists.`,
+      "That is the desktop app's real, current catalog - a single blob encrypted",
+      "whole via Electron's safeStorage (OS keychain-backed). This command has no",
+      "access to that, running outside Electron, so it cannot safely add to an",
+      "already-migrated catalog without either reimplementing OS-keychain",
+      "encryption or writing something the app can't read. It only supports",
+      "pre-seeding a legacy-format catalog before a desktop app has ever launched",
+      "on this machine (i.e. before that file exists). Pair through the desktop",
+      "app's own dialog for an already-provisioned machine instead.",
+    ].join(" ");
+  }
+}
+
+export type EnvCatalogPreflightError = EnvCatalogReadError | EnvCatalogEncryptedCatalogExistsError;
+
+/**
+ * Refuses to proceed if the sibling encrypted catalog
+ * (`connection-catalog.json`) already exists next to `catalogPath` - see
+ * the module doc comment for why writing to the legacy file at that point
+ * would be silently ignored by the desktop app, not merely unnecessary.
+ */
+export const assertLegacyCatalogIsSafeToWrite = Effect.fn("env.assertLegacyCatalogIsSafeToWrite")(
+  function* (
+    fileSystem: FileSystem.FileSystem,
+    path: Path.Path["Service"],
+    catalogPath: string,
+  ): Effect.fn.Return<void, EnvCatalogPreflightError> {
+    const encryptedCatalogPath = path.join(path.dirname(catalogPath), "connection-catalog.json");
+    const exists = yield* fileSystem.exists(encryptedCatalogPath).pipe(
+      Effect.mapError(
+        (cause) =>
+          new EnvCatalogReadError({ operation: "read-file", path: encryptedCatalogPath, cause }),
+      ),
+    );
+    if (exists) {
+      return yield* new EnvCatalogEncryptedCatalogExistsError({ encryptedCatalogPath });
+    }
+  },
+);
 
 export const readCatalog = Effect.fn("env.readCatalog")(function* (
   fileSystem: FileSystem.FileSystem,
@@ -98,19 +181,28 @@ export const readCatalog = Effect.fn("env.readCatalog")(function* (
     Effect.catch((error) =>
       error.reason._tag === "NotFound"
         ? Effect.succeed<string | null>(null)
-        : Effect.fail(new EnvCatalogReadError({ path: catalogPath, cause: error })),
+        : Effect.fail(
+            new EnvCatalogReadError({ operation: "read-file", path: catalogPath, cause: error }),
+          ),
     ),
   );
   if (raw === null) {
     return { version: 1, records: [] };
   }
-  const decoded = yield* decodeCatalogDocumentJson(raw).pipe(
-    Effect.mapError((cause) => new EnvCatalogReadError({ path: catalogPath, cause })),
-  );
-  return { version: decoded.version ?? 1, records: decoded.records ?? [] };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (cause) {
+    return yield* new EnvCatalogReadError({ operation: "parse-json", path: catalogPath, cause });
+  }
+  const document = parsed as { version?: number; records?: readonly OpaqueCatalogRecord[] };
+  return {
+    version: typeof document.version === "number" ? document.version : 1,
+    records: Array.isArray(document.records) ? document.records : [],
+  };
 });
 
-// Same shape of atomic write already used by the desktop app's saved
+// Same atomic-write shape already used by the desktop app's own saved
 // environments store: write to a sibling temp file, then rename over the
 // real path, so a crash mid-write cannot leave a half-written catalog.
 export const writeCatalog = Effect.fn("env.writeCatalog")(function* (
@@ -121,28 +213,48 @@ export const writeCatalog = Effect.fn("env.writeCatalog")(function* (
 ): Effect.fn.Return<void, EnvCatalogWriteError> {
   const directory = path.dirname(catalogPath);
   const tempPath = `${catalogPath}.${process.pid}.tmp`;
-  const encoded = yield* encodeCatalogDocumentJson(document).pipe(
-    Effect.mapError((cause) => new EnvCatalogWriteError({ path: catalogPath, cause })),
-  );
+  let encoded: string;
+  try {
+    encoded = JSON.stringify(document, null, 2);
+  } catch (cause) {
+    return yield* new EnvCatalogWriteError({
+      operation: "encode-catalog",
+      path: catalogPath,
+      cause,
+    });
+  }
   yield* fileSystem.makeDirectory(directory, { recursive: true }).pipe(
-    Effect.mapError((cause) => new EnvCatalogWriteError({ path: catalogPath, cause })),
+    Effect.mapError(
+      (cause) => new EnvCatalogWriteError({ operation: "create-directory", path: directory, cause }),
+    ),
   );
   yield* fileSystem.writeFileString(tempPath, `${encoded}\n`).pipe(
-    Effect.mapError((cause) => new EnvCatalogWriteError({ path: catalogPath, cause })),
+    Effect.mapError(
+      (cause) =>
+        new EnvCatalogWriteError({ operation: "write-temporary-file", path: tempPath, cause }),
+    ),
   );
   yield* fileSystem.rename(tempPath, catalogPath).pipe(
-    Effect.mapError((cause) => new EnvCatalogWriteError({ path: catalogPath, cause })),
+    Effect.mapError(
+      (cause) =>
+        new EnvCatalogWriteError({ operation: "replace-catalog-file", path: catalogPath, cause }),
+    ),
   );
 });
 
-/** Replaces any existing record for the same environment rather than appending a duplicate. */
+/**
+ * Replaces any existing record for the same environment rather than
+ * appending a duplicate. Existing records are passed through opaque and
+ * untouched - see the module doc comment for why this must not decode them
+ * against a narrowing schema.
+ */
 export function upsertEnvironmentRecord(
-  records: readonly PersistedSavedEnvironmentRecord[],
+  records: readonly OpaqueCatalogRecord[],
   nextRecord: PersistedSavedEnvironmentRecord,
-): readonly PersistedSavedEnvironmentRecord[] {
+): readonly OpaqueCatalogRecord[] {
   return [
-    ...records.filter((record) => record.environmentId !== nextRecord.environmentId),
-    nextRecord,
+    ...records.filter((record) => readEnvironmentId(record) !== nextRecord.environmentId),
+    nextRecord as OpaqueCatalogRecord,
   ];
 }
 
@@ -170,16 +282,17 @@ const pairingCodeFlag = Flag.string("pairing-code").pipe(
 
 const catalogPathFlag = Flag.string("catalog-path").pipe(
   Flag.withDescription(
-    "Path to the saved-environment catalog file. Defaults to <base-dir>/userdata/saved-environments.json - " +
-      "verify this matches your desktop install's own path before relying on it in automation.",
+    "Path to the legacy-format catalog file to pre-seed. Defaults to " +
+      "<base-dir>/userdata/saved-environments.json. Only safe to use before a desktop " +
+      "app has ever launched on this machine - see --help on this command for why.",
   ),
   Flag.optional,
 );
 
 const printTokenFlag = Flag.boolean("print-token").pipe(
   Flag.withDescription(
-    "Print the bootstrapped bearer token once. No token is persisted by this command otherwise: " +
-      "PersistedSavedEnvironmentRecord has no secret field, so store it yourself if you need it.",
+    "Print the bootstrapped bearer token once. No token is persisted by this command: " +
+      "the legacy catalog format this writes has no secret field of its own either.",
   ),
   Flag.withDefault(false),
 );
@@ -200,7 +313,9 @@ export const envAddCommand = Command.make("add", {
   baseDir: baseDirFlag,
 }).pipe(
   Command.withDescription(
-    "Register a remote environment into a saved-environment catalog without a pairing dialog.",
+    "Pre-seed a legacy-format saved-environment catalog, before a desktop app's first " +
+      "launch on this machine. Refuses if the real (encrypted) catalog already exists - " +
+      "see --help.",
   ),
   Command.withHandler((flags) =>
     Effect.gen(function* () {
@@ -225,6 +340,8 @@ export const envAddCommand = Command.make("add", {
           return path.join(derived.stateDir, "saved-environments.json");
         }));
 
+      yield* assertLegacyCatalogIsSafeToWrite(fileSystem, path, catalogPath);
+
       const document = yield* readCatalog(fileSystem, catalogPath);
       const now = DateTime.formatIso(yield* DateTime.now);
       const nextRecord: PersistedSavedEnvironmentRecord = {
@@ -235,6 +352,10 @@ export const envAddCommand = Command.make("add", {
         createdAt: now,
         lastConnectedAt: null,
       };
+      // Validate the shape of only the record we're adding - everything
+      // else in the file stays untouched and undecoded (see above).
+      yield* Schema.decodeUnknownEffect(PersistedSavedEnvironmentRecordSchema)(nextRecord);
+
       yield* writeCatalog(fileSystem, path, catalogPath, {
         version: document.version,
         records: upsertEnvironmentRecord(document.records, nextRecord),
@@ -257,6 +378,6 @@ export const envAddCommand = Command.make("add", {
 );
 
 export const envCommand = Command.make("env").pipe(
-  Command.withDescription("Manage the saved-environment catalog headlessly."),
+  Command.withDescription("Pre-seed a saved-environment catalog headlessly, before first launch."),
   Command.withSubcommands([envAddCommand]),
 );

--- a/apps/server/src/cli/env.ts
+++ b/apps/server/src/cli/env.ts
@@ -1,0 +1,262 @@
+/**
+ * `t3 env add` - register a remote environment into a saved-environment
+ * catalog without going through a client's pairing dialog.
+ *
+ * `t3 project` exists because GUIs cannot add a project to a remote
+ * environment; this exists for the mirror-image gap on the other side of
+ * that same limitation: nothing headless can add an *environment* to a
+ * saved-environment catalog. A server spun up by a provisioning pipeline has
+ * no way to make itself appear in a fleet of already-installed clients
+ * without a human opening a pairing dialog once per machine.
+ *
+ * This reuses the exact probe-and-bootstrap path clients call on pairing
+ * (`preparePairingRegistration` from `@t3tools/client-runtime/connection`)
+ * and persists the result using the same `PersistedSavedEnvironmentRecord`
+ * shape the desktop app reads from disk on launch. It intentionally does
+ * NOT touch the live `EnvironmentRegistry` / `EnvironmentSupervisor`
+ * machinery a running client uses - that graph exists to supervise a
+ * long-lived connection, which a one-shot CLI invocation has no business
+ * standing up. A client picks up the new entry the next time it reads its
+ * own catalog file (normally on launch).
+ *
+ * Secrets are handled conservatively: by default no bearer token is
+ * persisted, matching the shape of `PersistedSavedEnvironmentRecord` itself,
+ * which has no secret field - only the desktop app's own storage layer adds
+ * one (`encryptedBearerToken`, encrypted at rest via Electron's
+ * `safeStorage`), and this command has no access to that. Pass
+ * `--print-token` to have the bootstrapped bearer token printed once so a
+ * provisioning script can store it wherever it already stores other
+ * secrets, instead of this command inventing a second, unencrypted place
+ * for it to live on disk.
+ *
+ * Path assumption worth double-checking before relying on this in
+ * automation: the default catalog path is derived from the same
+ * `--base-dir` / `T3CODE_HOME` convention the server CLI already uses
+ * elsewhere (`ServerConfig.deriveServerPaths`), on the assumption that it
+ * lines up with the desktop app's own state directory on the same machine.
+ * That has not been verified against every desktop build; pass
+ * `--catalog-path` explicitly if you are not sure, and compare against
+ * whatever `DesktopEnvironment`'s `savedEnvironmentRegistryPath` resolves to
+ * for your install.
+ */
+import { preparePairingRegistration } from "@t3tools/client-runtime/connection";
+import * as ClientCapabilities from "@t3tools/client-runtime/platform";
+import {
+  AuthStandardClientScopes,
+  type PersistedSavedEnvironmentRecord,
+  PersistedSavedEnvironmentRecordSchema,
+} from "@t3tools/contracts";
+import { fromLenientJson } from "@t3tools/shared/schemaJson";
+import * as Console from "effect/Console";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import { Flag, Command } from "effect/unstable/cli";
+import { FetchHttpClient } from "effect/unstable/http";
+
+import * as ServerConfig from "../config.ts";
+import { resolveBaseDir } from "../os-jank.ts";
+import { baseDirFlag, DurationFromString } from "./config.ts";
+
+const CatalogDocumentSchema = Schema.Struct({
+  version: Schema.optionalKey(Schema.Number),
+  records: Schema.optionalKey(Schema.Array(PersistedSavedEnvironmentRecordSchema)),
+});
+type CatalogDocument = { readonly version: number; readonly records: readonly PersistedSavedEnvironmentRecord[] };
+
+const CatalogDocumentJson = fromLenientJson(CatalogDocumentSchema);
+const decodeCatalogDocumentJson = Schema.decodeEffect(CatalogDocumentJson);
+const encodeCatalogDocumentJson = Schema.encodeEffect(CatalogDocumentJson);
+
+export class EnvCatalogWriteError extends Schema.TaggedErrorClass<EnvCatalogWriteError>()(
+  "EnvCatalogWriteError",
+  { path: Schema.String, cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return `Could not write the environment catalog at ${this.path}.`;
+  }
+}
+
+export class EnvCatalogReadError extends Schema.TaggedErrorClass<EnvCatalogReadError>()(
+  "EnvCatalogReadError",
+  { path: Schema.String, cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return `Could not read the environment catalog at ${this.path}.`;
+  }
+}
+
+export const readCatalog = Effect.fn("env.readCatalog")(function* (
+  fileSystem: FileSystem.FileSystem,
+  catalogPath: string,
+): Effect.fn.Return<CatalogDocument, EnvCatalogReadError> {
+  const raw = yield* fileSystem.readFileString(catalogPath).pipe(
+    Effect.catch((error) =>
+      error.reason._tag === "NotFound"
+        ? Effect.succeed<string | null>(null)
+        : Effect.fail(new EnvCatalogReadError({ path: catalogPath, cause: error })),
+    ),
+  );
+  if (raw === null) {
+    return { version: 1, records: [] };
+  }
+  const decoded = yield* decodeCatalogDocumentJson(raw).pipe(
+    Effect.mapError((cause) => new EnvCatalogReadError({ path: catalogPath, cause })),
+  );
+  return { version: decoded.version ?? 1, records: decoded.records ?? [] };
+});
+
+// Same shape of atomic write already used by the desktop app's saved
+// environments store: write to a sibling temp file, then rename over the
+// real path, so a crash mid-write cannot leave a half-written catalog.
+export const writeCatalog = Effect.fn("env.writeCatalog")(function* (
+  fileSystem: FileSystem.FileSystem,
+  path: Path.Path["Service"],
+  catalogPath: string,
+  document: CatalogDocument,
+): Effect.fn.Return<void, EnvCatalogWriteError> {
+  const directory = path.dirname(catalogPath);
+  const tempPath = `${catalogPath}.${process.pid}.tmp`;
+  const encoded = yield* encodeCatalogDocumentJson(document).pipe(
+    Effect.mapError((cause) => new EnvCatalogWriteError({ path: catalogPath, cause })),
+  );
+  yield* fileSystem.makeDirectory(directory, { recursive: true }).pipe(
+    Effect.mapError((cause) => new EnvCatalogWriteError({ path: catalogPath, cause })),
+  );
+  yield* fileSystem.writeFileString(tempPath, `${encoded}\n`).pipe(
+    Effect.mapError((cause) => new EnvCatalogWriteError({ path: catalogPath, cause })),
+  );
+  yield* fileSystem.rename(tempPath, catalogPath).pipe(
+    Effect.mapError((cause) => new EnvCatalogWriteError({ path: catalogPath, cause })),
+  );
+});
+
+/** Replaces any existing record for the same environment rather than appending a duplicate. */
+export function upsertEnvironmentRecord(
+  records: readonly PersistedSavedEnvironmentRecord[],
+  nextRecord: PersistedSavedEnvironmentRecord,
+): readonly PersistedSavedEnvironmentRecord[] {
+  return [
+    ...records.filter((record) => record.environmentId !== nextRecord.environmentId),
+    nextRecord,
+  ];
+}
+
+const cliClientPresentationLayer = Layer.succeed(ClientCapabilities.ClientPresentation, {
+  metadata: { deviceType: "bot", label: "t3 env add" },
+  scopes: AuthStandardClientScopes,
+});
+
+const pairingUrlArg = Flag.string("pairing-url").pipe(
+  Flag.withDescription(
+    "Full pairing URL, as printed by `t3 serve` or `t3 pair` (contains the token).",
+  ),
+  Flag.optional,
+);
+
+const hostFlag = Flag.string("host").pipe(
+  Flag.withDescription("Server host, used together with --pairing-code instead of --pairing-url."),
+  Flag.optional,
+);
+
+const pairingCodeFlag = Flag.string("pairing-code").pipe(
+  Flag.withDescription("Pairing code, used together with --host instead of --pairing-url."),
+  Flag.optional,
+);
+
+const catalogPathFlag = Flag.string("catalog-path").pipe(
+  Flag.withDescription(
+    "Path to the saved-environment catalog file. Defaults to <base-dir>/userdata/saved-environments.json - " +
+      "verify this matches your desktop install's own path before relying on it in automation.",
+  ),
+  Flag.optional,
+);
+
+const printTokenFlag = Flag.boolean("print-token").pipe(
+  Flag.withDescription(
+    "Print the bootstrapped bearer token once. No token is persisted by this command otherwise: " +
+      "PersistedSavedEnvironmentRecord has no secret field, so store it yourself if you need it.",
+  ),
+  Flag.withDefault(false),
+);
+
+const timeoutFlag = Flag.string("timeout").pipe(
+  Flag.withSchema(DurationFromString),
+  Flag.withDescription("How long to wait for the environment to answer. Defaults to 10s."),
+  Flag.optional,
+);
+
+export const envAddCommand = Command.make("add", {
+  pairingUrl: pairingUrlArg,
+  host: hostFlag,
+  pairingCode: pairingCodeFlag,
+  catalogPath: catalogPathFlag,
+  printToken: printTokenFlag,
+  timeout: timeoutFlag,
+  baseDir: baseDirFlag,
+}).pipe(
+  Command.withDescription(
+    "Register a remote environment into a saved-environment catalog without a pairing dialog.",
+  ),
+  Command.withHandler((flags) =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+
+      const registration = yield* preparePairingRegistration({
+        ...(Option.isSome(flags.pairingUrl) ? { pairingUrl: flags.pairingUrl.value } : {}),
+        ...(Option.isSome(flags.host) ? { host: flags.host.value } : {}),
+        ...(Option.isSome(flags.pairingCode) ? { pairingCode: flags.pairingCode.value } : {}),
+      }).pipe(
+        Effect.provide(cliClientPresentationLayer),
+        Effect.provide(FetchHttpClient.layer),
+        Option.isSome(flags.timeout) ? Effect.timeout(flags.timeout.value) : (self) => self,
+      );
+
+      const catalogPath =
+        Option.getOrNull(flags.catalogPath) ??
+        (yield* Effect.gen(function* () {
+          const baseDir = yield* resolveBaseDir(Option.getOrUndefined(flags.baseDir));
+          const derived = yield* ServerConfig.deriveServerPaths(baseDir, undefined, {});
+          return path.join(derived.stateDir, "saved-environments.json");
+        }));
+
+      const document = yield* readCatalog(fileSystem, catalogPath);
+      const now = DateTime.formatIso(yield* DateTime.now);
+      const nextRecord: PersistedSavedEnvironmentRecord = {
+        environmentId: registration.target.environmentId,
+        label: registration.target.label,
+        httpBaseUrl: registration.profile.httpBaseUrl,
+        wsBaseUrl: registration.profile.wsBaseUrl,
+        createdAt: now,
+        lastConnectedAt: null,
+      };
+      yield* writeCatalog(fileSystem, path, catalogPath, {
+        version: document.version,
+        records: upsertEnvironmentRecord(document.records, nextRecord),
+      });
+
+      yield* Console.log(
+        [
+          `Added ${nextRecord.label} (${nextRecord.environmentId}) to ${catalogPath}.`,
+          `  http: ${nextRecord.httpBaseUrl}`,
+          `  ws:   ${nextRecord.wsBaseUrl}`,
+          "No bearer token was persisted. Pass --print-token if a caller needs it.",
+        ].join("\n"),
+      );
+
+      if (flags.printToken) {
+        yield* Console.log(`Token: ${registration.credential.token}`);
+      }
+    }),
+  ),
+);
+
+export const envCommand = Command.make("env").pipe(
+  Command.withDescription("Manage the saved-environment catalog headlessly."),
+  Command.withSubcommands([envAddCommand]),
+);


### PR DESCRIPTION
## Why

`t3 project` exists because GUIs cannot add a project to a remote environment, so the CLI is the only way in. This fills a related gap: nothing headless can add an *environment* to a saved-environment catalog either.

## What this does (revised after review - see below)

- New `t3 env add` command, taking the same `--pairing-url` / `--host` + `--pairing-code` inputs as the existing pairing flow.
- Reuses `preparePairingRegistration` from `@t3tools/client-runtime/connection` for the probe + bearer bootstrap.
- **Narrower scope than originally written**: this only pre-seeds the legacy `saved-environments.json` format, and only makes sense *before* a desktop app has ever launched on a machine. It refuses (with an explanatory error) if a real `connection-catalog.json` already exists next to the target path, since that's the actual catalog a launched desktop app reads - a single blob encrypted whole via Electron's `safeStorage` (OS keychain-backed), which this command has no access to and cannot safely write into.
- Existing records in the file are preserved as opaque JSON, never decoded against a narrowing schema, so fields this command doesn't model (`encryptedBearerToken`, etc.) on *other* records survive untouched.
- No bearer token is persisted by default; `--print-token` prints it once for a caller to store wherever it already stores other secrets.

## Review history

The first version of this PR had two real, independently-flagged bugs (see PR comments): it targeted the wrong catalog file entirely (silent no-op on any already-migrated desktop install), and it silently dropped `encryptedBearerToken` on unrelated records via a lossy schema round-trip. Both are fixed as of the latest commit - see the comment thread for the specific fixes and the updated commit message for detail.

## What I could not verify

Still no local build in the environment I authored this in (`bun install` doesn't resolve the workspace `catalog:` deps here), so nothing has run against real `vp run typecheck`/`test` or CI. I cross-checked every API against live call sites elsewhere in the repo this round rather than assuming, but that's not a substitute for CI actually running - please treat it accordingly.

## Re: CONTRIBUTING.md

Still offering this small and easy to close - genuinely fine to redirect to Ideas discussions if that's a better fit than a PR for a not-currently-accepting-contributions project.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Writes local catalog files and runs pairing/bootstrap over the network; mitigations include refusing when the encrypted catalog exists, opaque merge to avoid data loss, and atomic writes.
> 
> **Overview**
> Adds **`t3 env add`** under the main CLI so provisioning can register a remote environment without opening the desktop pairing UI. It runs the same **`preparePairingRegistration`** path as clients (pairing URL or host + code), then upserts a **`PersistedSavedEnvironmentRecord`** into the legacy **`saved-environments.json`** catalog with atomic temp-file writes.
> 
> **Scope is intentionally narrow:** the command **refuses** if sibling **`connection-catalog.json`** already exists (post-migration desktop catalog), because it cannot write Electron **`safeStorage`**-encrypted data. Existing catalog rows are kept as **opaque JSON** so fields like **`encryptedBearerToken`** are not stripped when adding one environment; only the new row is schema-validated. Optional **`--print-token`** prints the bootstrapped bearer once without persisting it.
> 
> Wires **`envCommand`** into **`bin.ts`** and adds unit tests for upsert, catalog round-trip, and the encrypted-catalog guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b80570ad1973e3f98db450a477e10e0df580740. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `t3 env add` CLI subcommand to pre-seed a legacy saved-environment catalog headlessly
> - Adds a new `env add` subcommand to the `t3` CLI ([env.ts](https://github.com/pingdotgg/t3code/pull/7545/files#diff-d73565d0f8292b769a1d9d258046782bb7da814bc070ee3ad62190dd6e3acf39)) that performs network pairing registration and writes the resulting record to the legacy saved-environments catalog without user interaction.
> - Catalog reads return an empty document when the file is absent; writes are atomic via a PID-suffixed temp file and rename, with directory auto-creation.
> - `upsertEnvironmentRecord` deduplicates by `environmentId`, preserving all other record fields.
> - A preflight check (`assertLegacyCatalogIsSafeToWrite`) blocks writes to the legacy catalog if an encrypted sibling (`connection-catalog.json`) already exists.
> - Risk: if an encrypted catalog exists at the derived sibling path, the command fails with a typed error rather than overwriting or merging.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b80570.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->