### PR TITLE
fix(keybindings): allow modified tab shortcuts

### DIFF
--- a/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
@@ -8,7 +8,9 @@ import {
   commandLabel,
   keybindingConflictLabels,
   keybindingFromKeyboardEvent,
+  keybindingPillTokenLabel,
   parseWhenExpressionDraft,
+  shouldPreserveKeybindingCaptureFocusNavigation,
   shortcutToKeybindingInput,
   unknownWhenVariables,
   whenAstToExpression,
@@ -62,6 +64,37 @@ describe("KeybindingsSettings.logic", () => {
         "Win32",
       ),
     ).toBe("mod+shift+k");
+  });
+
+  it("captures modified Tab shortcuts while preserving focus navigation", () => {
+    expect(
+      shouldPreserveKeybindingCaptureFocusNavigation({
+        key: "Tab",
+        metaKey: false,
+        ctrlKey: false,
+        altKey: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldPreserveKeybindingCaptureFocusNavigation({
+        key: "Tab",
+        metaKey: false,
+        ctrlKey: true,
+        altKey: false,
+      }),
+    ).toBe(false);
+    expect(
+      keybindingFromKeyboardEvent(
+        { key: "Tab", metaKey: false, ctrlKey: true, altKey: false, shiftKey: true },
+        "MacIntel",
+      ),
+    ).toBe("ctrl+shift+tab");
+  });
+
+  it("formats modified Tab keybinding pills for the current platform", () => {
+    expect(keybindingPillTokenLabel("ctrl", "MacIntel")).toBe("⌃");
+    expect(keybindingPillTokenLabel("ctrl", "Win32")).toBe("Ctrl");
+    expect(keybindingPillTokenLabel("tab", "Win32")).toBe("Tab");
   });
 
   it("serializes shortcuts and when expressions for upserts", () => {

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.ts
@@ -336,3 +336,17 @@ export function keybindingFromKeyboardEvent(
   parts.push(keyToken);
   return parts.join("+");
 }
+
+export function shouldPreserveKeybindingCaptureFocusNavigation(
+  event: Pick<KeyboardEvent, "key" | "metaKey" | "ctrlKey" | "altKey">,
+): boolean {
+  return event.key === "Tab" && !event.metaKey && !event.ctrlKey && !event.altKey;
+}
+
+export function keybindingPillTokenLabel(token: string, platform: string): string {
+  if (token === "mod") return isMacPlatform(platform) ? "⌘" : "Ctrl";
+  if (token === "shift") return "⇧";
+  if (token === "alt") return isMacPlatform(platform) ? "⌥" : "Alt";
+  if (token === "ctrl") return isMacPlatform(platform) ? "⌃" : "Ctrl";
+  return token.slice(0, 1).toUpperCase() + token.slice(1);
+}

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -62,7 +62,9 @@ import {
   isKnownWhenVariable,
   keybindingConflictLabels,
   keybindingFromKeyboardEvent,
+  keybindingPillTokenLabel,
   parseWhenExpressionDraft,
+  shouldPreserveKeybindingCaptureFocusNavigation,
   type KeybindingCommandOption,
   type KeybindingRow,
   type WhenVariableOption,
@@ -80,21 +82,7 @@ function KeybindingPill({ value }: { value: string }) {
     <KbdGroup className="bg-transparent p-0 shadow-none">
       {parts.map((part) => (
         <Kbd key={part} className="min-w-6 justify-center px-1.5">
-          {part === "mod"
-            ? navigator.platform.toLowerCase().includes("mac")
-              ? "⌘"
-              : "Ctrl"
-            : part === "shift"
-              ? "⇧"
-              : part === "alt"
-                ? navigator.platform.toLowerCase().includes("mac")
-                  ? "⌥"
-                  : "Alt"
-                : part === "ctrl"
-                  ? "⌃"
-                  : part.length === 1
-                    ? part.toUpperCase()
-                    : part}
+          {keybindingPillTokenLabel(part, navigator.platform)}
         </Kbd>
       ))}
     </KbdGroup>
@@ -775,7 +763,7 @@ function KeybindingTableRow({
   };
 
   const captureKeybinding = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === "Tab") return;
+    if (shouldPreserveKeybindingCaptureFocusNavigation(event)) return;
     event.preventDefault();
     if (event.key === "Escape") {
       setDraft({ keyDraft: row.key, isRecording: false });
@@ -946,7 +934,7 @@ function NewKeybindingTableRow({
   };
 
   const captureKeybinding = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === "Tab") return;
+    if (shouldPreserveKeybindingCaptureFocusNavigation(event)) return;
     event.preventDefault();
     if (event.key === "Escape") {
       setDraft({ keyDraft: "", isRecording: false });

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -718,6 +718,46 @@ describe("resolveShortcutCommand", () => {
     );
   });
 
+  it("matches Chrome-style thread traversal shortcuts", () => {
+    const keybindings = compile([
+      {
+        shortcut: {
+          key: "tab",
+          metaKey: false,
+          ctrlKey: true,
+          shiftKey: false,
+          altKey: false,
+          modKey: false,
+        },
+        command: "thread.next",
+      },
+      {
+        shortcut: {
+          key: "tab",
+          metaKey: false,
+          ctrlKey: true,
+          shiftKey: true,
+          altKey: false,
+          modKey: false,
+        },
+        command: "thread.previous",
+      },
+    ]);
+
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "Tab", ctrlKey: true }), keybindings, {
+        platform: "MacIntel",
+      }),
+      "thread.next",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "Tab", ctrlKey: true, shiftKey: true }), keybindings, {
+        platform: "Linux",
+      }),
+      "thread.previous",
+    );
+  });
+
   it("matches Option-modified letters using the physical key code on macOS", () => {
     assert.strictEqual(
       resolveShortcutCommand(

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -32,6 +32,9 @@ Modifiers: `mod` (`cmd` on macOS, `ctrl` elsewhere), `cmd` / `meta`, `ctrl` / `c
 
 Examples: `mod+j`, `mod+shift+d`, `ctrl+l`, `cmd+k`.
 
+Modified Tab shortcuts such as `ctrl+tab` and `ctrl+shift+tab` can be recorded in Settings. Plain
+Tab and Shift+Tab continue to move focus instead of being recorded.
+
 ## Commands
 
 Commands are IDs like `terminal.toggle`, `commandPalette.toggle`, `preview.refresh`, and


### PR DESCRIPTION
Ctrl+Tab and Ctrl+Shift+Tab cannot currently be assigned in T3 Code because the keybinding recorder treats every Tab press as focus navigation. This prevents users from choosing the familiar browser-tab shortcuts for thread traversal.

This lets modified Tab presses be recorded as custom keybindings while preserving Tab and Shift+Tab for focus navigation. The existing default bindings are unchanged. Resolver coverage confirms `ctrl+tab` and `ctrl+shift+tab` can invoke `thread.next` and `thread.previous` when configured. Keybinding pills render modified Tab chords consistently across platforms.

## Verification

- `vp test run apps/web/src/components/settings/KeybindingsSettings.logic.test.ts apps/web/src/keybindings.test.ts` (59 passed)
- targeted formatting and lint checks
- web typecheck reaches unrelated current-main errors in `electronPasskeys.test.ts` for the `conditionalUI` property

Built by GPT-5.6-sol via Codex in T3 Code.

# Demo

Screenshots and video by me, not AI. Verified working.

Fixed version:

  
[CleanShot 2026-08-21 at 10.54.48.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/bb5c1d52-a293-4e25-a722-93cec40ecc1c.mp4" />](https://app.graphite.com/user-attachments/video/bb5c1d52-a293-4e25-a722-93cec40ecc1c.mp4)

![CleanShot 2026-08-21 at 10.57.10@2x.png](https://app.graphite.com/user-attachments/assets/5a4f83cd-1d4c-4a34-8f94-b9b70408b4d8.png)





<!-- Macroscope's pull request summary starts here -->

<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->

<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->

> [!NOTE]
> ### Allow modified Tab shortcuts (e.g. Ctrl+Tab) to be captured in keybinding settings
>
> - Plain Tab and Shift+Tab continue to move focus during keybinding capture; modified Tab combinations (e.g. Ctrl+Tab, Ctrl+Shift+Tab) are now recordable via the new `shouldPreserveKeybindingCaptureFocusNavigation` utility.
> - Adds `keybindingPillTokenLabel` to render platform-appropriate symbols in keybinding pills (e.g. `ctrl` → `⌃` on Mac, `Ctrl` on Windows/Linux; `tab` → `Tab`).
> - Both `KeybindingTableRow` and `NewKeybindingTableRow` in [KeybindingsSettings.tsx](https://github.com/pingdotgg/t3code/pull/7548/files#diff-12068495a79a13f54503fa3061aafb91f05537621626906b290ed059e660d4d4) are updated to use these utilities instead of inline logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7127a69.</sup>
>
> <!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->