### PR TITLE
fix(web): let new threads honor the project's default model

### DIFF
--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -280,6 +280,14 @@ export function useNewThreadHandler() {
               setModelSelection(emptyStoredDraftThread.draftId, carryModelSelection, {
                 replaceOptions: true,
               });
+            } else if (project?.defaultModelSelection) {
+              // Reusing an empty draft with nothing to carry a selection
+              // from: the project's configured default is a deliberate
+              // per-project choice and takes priority over whatever model
+              // this draft happened to be left on.
+              setModelSelection(emptyStoredDraftThread.draftId, project.defaultModelSelection, {
+                replaceOptions: true,
+              });
             }
           }
           // The workspace context must also ride along here: when projectRef
@@ -345,6 +353,15 @@ export function useNewThreadHandler() {
           interactionMode: latestActiveDraftThread.interactionMode,
           ...pickExplicitWorkspaceOptions(options),
         });
+        if (!carryModelSelection && project?.defaultModelSelection) {
+          // This empty draft (the one already open) has no model selection
+          // of its own yet: the project's configured default is a
+          // deliberate per-project choice and takes priority over whatever
+          // model this draft happened to be left on.
+          setModelSelection(currentRouteTarget.draftId, project.defaultModelSelection, {
+            replaceOptions: true,
+          });
+        }
         return Promise.resolve({
           draftId: currentRouteTarget.draftId,
           threadId: latestActiveDraftThread.threadId,
@@ -416,6 +433,12 @@ export function useNewThreadHandler() {
           // complete snapshot — absent options mean "no options", not "keep
           // whatever sticky state just wrote".
           setModelSelection(draftId, carryModelSelection, { replaceOptions: true });
+        } else if (project?.defaultModelSelection) {
+          // A brand new thread with nothing to carry a selection from: the
+          // project's configured default is a deliberate per-project choice
+          // and takes priority over the sticky map's cross-project "last
+          // used model".
+          setModelSelection(draftId, project.defaultModelSelection, { replaceOptions: true });
         }
         carryComposerContentTo(draftId);
 


### PR DESCRIPTION
## Summary
- The project setting "New threads in this project start with this model. Applies to every checkout in this group." (`ProjectSettingsPanel.tsx`, writes `project.defaultModelSelection`) was effectively never applied once any thread anywhere had picked a model.
- New threads are seeded via `applyStickyState(draftId)` in `useHandleNewThread.ts`, which pulls from a **global**, provider-keyed "last used model" (`stickyModelSelectionByProvider` in `composerDraftStore.ts`) — not scoped to project or thread. The project default was only ever consulted as a last-resort fallback that's effectively dead once the sticky map is populated (i.e. after the user's very first thread ever).
- This fix applies `project.defaultModelSelection` whenever there's no `carryModelSelection` (i.e. no thread/draft currently being viewed to intentionally carry a selection from), across all three new-thread code paths in the hook:
  - Minting a genuinely fresh draft.
  - Reusing a stored-but-empty draft for the project.
  - Reusing the empty draft that's already open.

## Test plan
- [x] `pnpm run typecheck` (apps/web) — passes
- [x] `pnpm run lint -- apps/web/src/hooks/useHandleNewThread.ts` — passes
- [ ] Manual: set a project's default model in Settings, start several threads elsewhere with a different model selected, then create a new thread in that project (via each of: fresh draft, an existing empty draft for the project, and the currently-open empty draft) — each should open with the configured default instead of the last-used model.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix new threads to honor the project's default model selection
> In [useHandleNewThread.ts](https://github.com/pingdotgg/t3code/pull/7551/files#diff-4a13a04822f436fab695948f0596a6fd92885554e031426dac1954a343c98fef), when creating or reusing an empty draft without a carried model selection, the handler now applies `project.defaultModelSelection` with `replaceOptions: true` to the target draft. This covers three cases: reusing an existing empty draft for a project remap, staying on the current route's empty draft during a context update, and creating a brand new draft.
>
> Risk: The project default overrides any previously stored selection or sticky state on empty drafts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 75b13e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to new/reused empty draft initialization in one hook; no auth, persistence, or server API changes.
> 
> **Overview**
> **New threads in a project now honor the configured default model** when the user isn’t carrying a selection from the thread they’re viewing.
> 
> `useHandleNewThread` already seeds drafts from global sticky “last used model” state and only overrides that when `carryModelSelection` is present. This change adds the same kind of override for **`project.defaultModelSelection`** in three paths: resurrecting an empty stored draft, reusing the empty draft already open for that project, and minting a brand-new draft after `applyStickyState`. In each case it runs only when there is **no** carried selection, and uses `setModelSelection` with **`replaceOptions: true`** so the project default is a full snapshot (not merged with stale draft options).
> 
> **Precedence is unchanged for carry-over:** if the user is viewing a thread/draft with a model, that selection still wins over both sticky state and the project default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75b13e33063a474610bb988ed853f9f2700bec65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->