### PR TITLE
fix: clarify model sub-providers in pickers

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -75,7 +75,7 @@
     "effect": "catalog:",
     "expo": "~57.0.18",
     "expo-asset": "~57.0.15",
-    "expo-audio": "~57.0.4",
+    "expo-audio": "57.0.4",
     "expo-auth-session": "~57.0.10",
     "expo-blur": "~57.0.2",
     "expo-build-properties": "~57.0.15",

--- a/apps/mobile/src/components/ComposerToolbar.tsx
+++ b/apps/mobile/src/components/ComposerToolbar.tsx
@@ -32,7 +32,7 @@ export function ComposerInlineControl(props: {
   readonly icon?: ComponentProps<typeof SymbolView>["name"];
   readonly iconNode?: ReactNode;
   readonly label: string;
-  readonly maxWidth?: ViewStyle["maxWidth"];
+  readonly maxWidth?: ViewStyle["maxWidth"] | null;
   readonly onPress?: () => void;
   readonly selected?: boolean;
   readonly static?: boolean;
@@ -50,7 +50,10 @@ export function ComposerInlineControl(props: {
       className="h-11 flex-row items-center gap-2 rounded-xl px-2 active:bg-subtle"
       disabled={props.disabled || props.static}
       onPress={props.onPress}
-      style={{ maxWidth: props.maxWidth ?? 190, opacity: props.disabled ? 0.45 : 1 }}
+      style={{
+        maxWidth: props.maxWidth === null ? undefined : (props.maxWidth ?? 190),
+        opacity: props.disabled ? 0.45 : 1,
+      }}
     >
       {props.iconNode ? (
         <View className="size-4 shrink-0 items-center justify-center">{props.iconNode}</View>

--- a/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
+++ b/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
@@ -128,7 +128,6 @@ function ModelRow(props: {
         <View className="flex-row items-center gap-2">
           <Text
             className="min-w-0 shrink text-base font-t3-medium text-foreground"
-            numberOfLines={1}
           >
             {props.option.label}
           </Text>

--- a/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
+++ b/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
@@ -125,10 +125,8 @@ function ModelRow(props: {
       )}
     >
       <View className="min-w-0 flex-1">
-        <View className="flex-row items-center gap-2">
-          <Text
-            className="min-w-0 shrink text-base font-t3-medium text-foreground"
-          >
+        <View className="flex-row flex-wrap items-center gap-2">
+          <Text className="min-w-0 shrink text-base font-t3-medium text-foreground">
             {props.option.label}
           </Text>
           {props.option.isDefault ? (

--- a/apps/mobile/src/lib/modelOptions.test.ts
+++ b/apps/mobile/src/lib/modelOptions.test.ts
@@ -47,7 +47,7 @@ describe("mobile model options", () => {
         providerKey: "codex",
         providerLabel: "Codex",
         models: [
-          { key: "codex:gpt-5.6-sol", label: "GPT-5.6 Sol", subtitle: "", isLegacy: false },
+          { key: "codex:gpt-5.6-sol", label: "GPT-5.6 Sol", subtitle: "Codex", isLegacy: false },
           { key: "codex:gpt-5.4", label: "GPT-5.4", isLegacy: true },
         ],
       },
@@ -89,8 +89,8 @@ describe("mobile model options", () => {
     expect(options).toMatchObject(
       sources.map((source) => ({
         key: `opencode_work:${source.id}/claude-fable-5`,
-        label: "Claude Fable 5",
-        subtitle: source.label,
+        label: `Claude Fable 5 · ${source.label}`,
+        subtitle: "OpenCode Work",
         providerLabel: "OpenCode Work",
         selection: {
           instanceId: "opencode_work",

--- a/apps/mobile/src/lib/modelOptions.test.ts
+++ b/apps/mobile/src/lib/modelOptions.test.ts
@@ -254,8 +254,8 @@ describe("mobile model options", () => {
       const [option] = buildModelOptions(unavailableConfig, selection);
       expect(option).toMatchObject({
         key: `google_work:${selection.model}`,
-        label: model.name,
-        subtitle: "Google",
+        label: `${model.name} · Google`,
+        subtitle: "Google Work",
         providerKey: "google_work",
         providerLabel: "Google Work",
         providerDriver: "antigravity",
@@ -282,6 +282,7 @@ describe("mobile model options", () => {
       const missing = options.find((option) => option.selection.model === selection.model);
       expect(missing).toMatchObject({
         label: selection.model,
+        subtitle: "Google Work",
         providerLabel: "Google Work",
         providerDriver: "antigravity",
         isUnavailable: true,

--- a/apps/mobile/src/lib/modelOptions.test.ts
+++ b/apps/mobile/src/lib/modelOptions.test.ts
@@ -71,7 +71,7 @@ describe("mobile model options", () => {
           auth: { status: "authenticated" },
           models: sources.map((source) => ({
             slug: `${source.id}/claude-fable-5`,
-            name: "Claude Fable 5",
+            name: `${source.label}: Claude Fable 5`,
             subProvider: source.label,
             isCustom: false,
             capabilities: null,

--- a/apps/mobile/src/lib/modelOptions.ts
+++ b/apps/mobile/src/lib/modelOptions.ts
@@ -225,8 +225,8 @@ export function buildModelOptions(
       });
       options.set(key, {
         key,
-        label: model?.name ?? fallbackModelSelection.model,
-        subtitle: model?.subProvider ?? "",
+        label: model ? modelDisplayLabel(model) : fallbackModelSelection.model,
+        subtitle: providerLabel,
         providerKey: fallbackModelSelection.instanceId,
         providerLabel,
         providerDriver,

--- a/apps/mobile/src/lib/modelOptions.ts
+++ b/apps/mobile/src/lib/modelOptions.ts
@@ -39,6 +39,14 @@ function providerDisplayLabel(provider: {
   return provider.instanceId;
 }
 
+function modelDisplayLabel(model: {
+  readonly name: string;
+  readonly subProvider?: string | undefined;
+}): string {
+  const subProvider = model.subProvider?.trim();
+  return subProvider ? `${model.name} · ${subProvider}` : model.name;
+}
+
 function normalizeSelectionOptions(
   selection: ModelSelection,
   capabilities: ModelCapabilities | null,
@@ -168,8 +176,8 @@ export function buildModelOptions(
       const key = `${provider.instanceId}:${model.slug}`;
       options.set(key, {
         key,
-        label: model.name,
-        subtitle: model.subProvider ?? "",
+        label: modelDisplayLabel(model),
+        subtitle: providerLabel,
         providerKey: provider.instanceId,
         providerLabel,
         providerDriver: provider.driver,

--- a/apps/mobile/src/lib/modelOptions.ts
+++ b/apps/mobile/src/lib/modelOptions.ts
@@ -6,6 +6,7 @@ import type {
 import {
   buildExplicitProviderOptionSelectionsFromDescriptors,
   getProviderOptionDescriptors,
+  stripLeadingModelQualifier,
 } from "@t3tools/shared/model";
 
 export type ModelOption = {
@@ -44,7 +45,8 @@ function modelDisplayLabel(model: {
   readonly subProvider?: string | undefined;
 }): string {
   const subProvider = model.subProvider?.trim();
-  return subProvider ? `${model.name} · ${subProvider}` : model.name;
+  const modelName = stripLeadingModelQualifier(model.name, subProvider);
+  return subProvider ? `${modelName} · ${subProvider}` : modelName;
 }
 
 function normalizeSelectionOptions(

--- a/apps/web/src/components/chat/ModelListRow.tsx
+++ b/apps/web/src/components/chat/ModelListRow.tsx
@@ -3,6 +3,7 @@ import { memo } from "react";
 import { StarIcon } from "lucide-react";
 import {
   getDisplayModelName,
+  getModelSourceLabel,
   getTriggerDisplayModelLabel,
   type ModelEsque,
   PROVIDER_ICON_BY_PROVIDER,
@@ -41,9 +42,7 @@ export const ModelListRow = memo(function ModelListRow(props: {
   onToggleFavorite: () => void;
 }) {
   const ProviderIcon = PROVIDER_ICON_BY_PROVIDER[props.driverKind] ?? null;
-  const providerLabel = props.model.subProvider
-    ? `${props.providerDisplayName} · ${props.model.subProvider}`
-    : props.providerDisplayName;
+  const providerLabel = getModelSourceLabel(props.model, props.providerDisplayName);
 
   const row = (
     <ComboboxItem

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -86,6 +86,7 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
     : props.model === ANTIGRAVITY_DEFAULT_MODEL
       ? "Choose model"
       : props.model || "Choose model";
+  const triggerSubProvider = selectedModel?.subProvider?.trim() || null;
   const triggerLabel = selectedModel
     ? `${getTriggerDisplayModelLabel(selectedModel)}${selectedModel.isUnavailable ? " (Unavailable)" : ""}`
     : triggerTitle;
@@ -202,12 +203,15 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
             <TooltipTrigger
               render={
                 <span
-                  className="min-w-0 flex-1 overflow-hidden truncate"
+                  className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden"
                   data-chat-provider-model-picker-label="true"
                 />
               }
             >
-              {props.triggerLabel ?? triggerTitle}
+              <span className="min-w-0 truncate">{props.triggerLabel ?? triggerTitle}</span>
+              {triggerSubProvider && props.triggerLabel === undefined ? (
+                <span className="shrink-0 text-muted-foreground">· {triggerSubProvider}</span>
+              ) : null}
             </TooltipTrigger>
             <TooltipPopup side="top">{props.triggerLabel ?? triggerLabel}</TooltipPopup>
           </Tooltip>

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -210,12 +210,7 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
             >
               <span className="min-w-0 truncate">{props.triggerLabel ?? triggerTitle}</span>
               {triggerSubProvider && props.triggerLabel === undefined ? (
-                <span
-                  className={cn(
-                    "text-muted-foreground",
-                    props.compact ? "min-w-0 truncate" : "shrink-0",
-                  )}
-                >
+                <span className="min-w-0 truncate text-muted-foreground">
                   · {triggerSubProvider}
                 </span>
               ) : null}

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -210,7 +210,14 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
             >
               <span className="min-w-0 truncate">{props.triggerLabel ?? triggerTitle}</span>
               {triggerSubProvider && props.triggerLabel === undefined ? (
-                <span className="shrink-0 text-muted-foreground">· {triggerSubProvider}</span>
+                <span
+                  className={cn(
+                    "text-muted-foreground",
+                    props.compact ? "min-w-0 truncate" : "shrink-0",
+                  )}
+                >
+                  · {triggerSubProvider}
+                </span>
               ) : null}
             </TooltipTrigger>
             <TooltipPopup side="top">{props.triggerLabel ?? triggerLabel}</TooltipPopup>

--- a/apps/web/src/components/chat/providerIconUtils.test.ts
+++ b/apps/web/src/components/chat/providerIconUtils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vite-plus/test";
+import { getModelSourceLabel, getTriggerDisplayModelLabel } from "./providerIconUtils";
+
+describe("model provider display labels", () => {
+  it("qualifies a multi-provider model in the picker trigger", () => {
+    expect(
+      getTriggerDisplayModelLabel({
+        slug: "openai/gpt-5.4",
+        name: "OpenAI: GPT-5.4",
+        shortName: "GPT-5.4",
+        subProvider: "OpenAI",
+      }),
+    ).toBe("GPT-5.4 · OpenAI");
+  });
+
+  it("describes the model source in terms of its runtime", () => {
+    expect(
+      getModelSourceLabel(
+        {
+          slug: "openai/gpt-5.4",
+          name: "GPT-5.4",
+          subProvider: "OpenAI",
+        },
+        "OpenCode",
+      ),
+    ).toBe("OpenCode · OpenAI");
+  });
+
+  it("leaves models without a sub-provider unchanged", () => {
+    const model = { slug: "gpt-5.4", name: "GPT-5.4" };
+
+    expect(getTriggerDisplayModelLabel(model)).toBe("GPT-5.4");
+    expect(getModelSourceLabel(model, "Codex")).toBe("Codex");
+  });
+});

--- a/apps/web/src/components/chat/providerIconUtils.ts
+++ b/apps/web/src/components/chat/providerIconUtils.ts
@@ -1,4 +1,5 @@
 import { ProviderDriverKind } from "@t3tools/contracts";
+import { stripLeadingModelQualifier } from "@t3tools/shared/model";
 import {
   AntigravityIcon,
   ClaudeAI,
@@ -30,26 +31,12 @@ export type ModelEsque = {
   isUnavailable?: boolean | undefined;
 };
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function stripLeadingQualifier(value: string, qualifier: string | null | undefined): string {
-  const trimmedQualifier = qualifier?.trim();
-  if (!trimmedQualifier) {
-    return value;
-  }
-
-  const pattern = new RegExp(`^${escapeRegExp(trimmedQualifier)}(?:\\s*[.:/-]\\s*|\\s+)`, "iu");
-  return value.replace(pattern, "").trim() || value;
-}
-
 export function getDisplayModelName(
   model: ModelEsque,
   options?: { preferShortName?: boolean },
 ): string {
   const name = options?.preferShortName && model.shortName ? model.shortName : model.name;
-  return stripLeadingQualifier(name, model.subProvider);
+  return stripLeadingModelQualifier(name, model.subProvider);
 }
 
 export function getTriggerDisplayModelName(model: ModelEsque): string {

--- a/apps/web/src/components/chat/providerIconUtils.ts
+++ b/apps/web/src/components/chat/providerIconUtils.ts
@@ -57,5 +57,12 @@ export function getTriggerDisplayModelName(model: ModelEsque): string {
 }
 
 export function getTriggerDisplayModelLabel(model: ModelEsque): string {
-  return getTriggerDisplayModelName(model);
+  const modelName = getTriggerDisplayModelName(model);
+  const subProvider = model.subProvider?.trim();
+  return subProvider ? `${modelName} · ${subProvider}` : modelName;
+}
+
+export function getModelSourceLabel(model: ModelEsque, runtimeDisplayName: string): string {
+  const subProvider = model.subProvider?.trim();
+  return subProvider ? `${runtimeDisplayName} · ${subProvider}` : runtimeDisplayName;
 }

--- a/apps/web/src/components/settings/ProjectDefaultsSettings.tsx
+++ b/apps/web/src/components/settings/ProjectDefaultsSettings.tsx
@@ -184,7 +184,7 @@ export function ProjectDefaultsSettings({ category }: { category: ProjectSetting
                     instanceEntries={entries}
                     modelOptionsByInstance={modelOptions}
                     triggerVariant="outline"
-                    triggerClassName={SETTINGS_PICKER_TRIGGER_CLASSNAME}
+                    triggerClassName="min-w-0 max-w-80 shrink text-foreground/90 hover:text-foreground"
                     {...(mixedModel ? { triggerLabel: "Mixed" } : {})}
                     getModelDisabledReason={modelDisabledReason}
                     onOpenProviderSetup={(instanceId) => {

--- a/apps/web/src/components/settings/ProjectDefaultsSettings.tsx
+++ b/apps/web/src/components/settings/ProjectDefaultsSettings.tsx
@@ -176,7 +176,7 @@ export function ProjectDefaultsSettings({ category }: { category: ProjectSetting
             }
             control={
               selection && activeEntry ? (
-                <div className="flex min-w-0 flex-wrap items-center justify-end gap-1.5">
+                <div className="flex min-w-0 flex-wrap items-center justify-end gap-1.5 sm:max-w-[26rem]">
                   <ProviderModelPicker
                     activeInstanceId={selection.instanceId}
                     model={selection.model}
@@ -184,7 +184,7 @@ export function ProjectDefaultsSettings({ category }: { category: ProjectSetting
                     instanceEntries={entries}
                     modelOptionsByInstance={modelOptions}
                     triggerVariant="outline"
-                    triggerClassName="min-w-0 max-w-80 shrink text-foreground/90 hover:text-foreground"
+                    triggerClassName="min-w-0 max-w-full shrink-0 text-foreground/90 hover:text-foreground"
                     {...(mixedModel ? { triggerLabel: "Mixed" } : {})}
                     getModelDisabledReason={modelDisabledReason}
                     onOpenProviderSetup={(instanceId) => {

--- a/apps/web/src/components/settings/ProjectDefaultsSettings.tsx
+++ b/apps/web/src/components/settings/ProjectDefaultsSettings.tsx
@@ -29,6 +29,8 @@ import type { ProjectSettingsCategory } from "./ProjectSettingsPanel";
 import { searchableSetting } from "./settingsSearch";
 import { useSettingsScope } from "./SettingsScopeContext";
 import {
+  SETTINGS_MODEL_CONTROLS_CLASSNAME,
+  SETTINGS_MODEL_PICKER_TRIGGER_CLASSNAME,
   SETTINGS_PICKER_TRIGGER_CLASSNAME,
   SettingResetButton,
   SettingsRow,
@@ -176,7 +178,7 @@ export function ProjectDefaultsSettings({ category }: { category: ProjectSetting
             }
             control={
               selection && activeEntry ? (
-                <div className="flex min-w-0 flex-wrap items-center justify-end gap-1.5 sm:max-w-[26rem]">
+                <div className={`${SETTINGS_MODEL_CONTROLS_CLASSNAME} min-w-0 gap-1.5`}>
                   <ProviderModelPicker
                     activeInstanceId={selection.instanceId}
                     model={selection.model}
@@ -184,7 +186,7 @@ export function ProjectDefaultsSettings({ category }: { category: ProjectSetting
                     instanceEntries={entries}
                     modelOptionsByInstance={modelOptions}
                     triggerVariant="outline"
-                    triggerClassName="min-w-0 max-w-full shrink-0 text-foreground/90 hover:text-foreground"
+                    triggerClassName={SETTINGS_MODEL_PICKER_TRIGGER_CLASSNAME}
                     {...(mixedModel ? { triggerLabel: "Mixed" } : {})}
                     getModelDisabledReason={modelDisabledReason}
                     onOpenProviderSetup={(instanceId) => {

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -148,6 +148,8 @@ import {
 } from "./SettingsPanels.logic";
 import {
   PolicyTooltip,
+  SETTINGS_MODEL_CONTROLS_CLASSNAME,
+  SETTINGS_MODEL_PICKER_TRIGGER_CLASSNAME,
   SETTINGS_PICKER_TRIGGER_CLASSNAME,
   SettingResetButton,
   SettingsPageContainer,
@@ -2794,7 +2796,7 @@ export function GeneralSettingsPanel() {
                 No text generation providers available.
               </span>
             ) : (
-              <div className="flex max-w-full flex-wrap items-center justify-end gap-1.5 sm:max-w-[26rem]">
+              <div className={`${SETTINGS_MODEL_CONTROLS_CLASSNAME} gap-1.5`}>
                 <ProviderModelPicker
                   activeInstanceId={textGenInstanceId}
                   model={textGenModel}
@@ -2802,7 +2804,7 @@ export function GeneralSettingsPanel() {
                   instanceEntries={textGenerationModelInstanceEntries}
                   modelOptionsByInstance={textGenerationModelOptionsByInstance}
                   triggerVariant="outline"
-                  triggerClassName="min-w-0 max-w-full shrink-0 text-foreground/90 hover:text-foreground"
+                  triggerClassName={SETTINGS_MODEL_PICKER_TRIGGER_CLASSNAME}
                   {...(mixedTextGenerationModel ? { triggerLabel: "Mixed" } : {})}
                   getModelDisabledReason={textGenerationModelDisabledReason}
                   {...(environmentId

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -2802,7 +2802,7 @@ export function GeneralSettingsPanel() {
                   instanceEntries={textGenerationModelInstanceEntries}
                   modelOptionsByInstance={textGenerationModelOptionsByInstance}
                   triggerVariant="outline"
-                  triggerClassName={SETTINGS_PICKER_TRIGGER_CLASSNAME}
+                  triggerClassName="min-w-0 max-w-80 shrink text-foreground/90 hover:text-foreground"
                   {...(mixedTextGenerationModel ? { triggerLabel: "Mixed" } : {})}
                   getModelDisabledReason={textGenerationModelDisabledReason}
                   {...(environmentId

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -2794,7 +2794,7 @@ export function GeneralSettingsPanel() {
                 No text generation providers available.
               </span>
             ) : (
-              <div className="flex flex-wrap items-center justify-end gap-1.5">
+              <div className="flex max-w-full flex-wrap items-center justify-end gap-1.5 sm:max-w-[26rem]">
                 <ProviderModelPicker
                   activeInstanceId={textGenInstanceId}
                   model={textGenModel}
@@ -2802,7 +2802,7 @@ export function GeneralSettingsPanel() {
                   instanceEntries={textGenerationModelInstanceEntries}
                   modelOptionsByInstance={textGenerationModelOptionsByInstance}
                   triggerVariant="outline"
-                  triggerClassName="min-w-0 max-w-80 shrink text-foreground/90 hover:text-foreground"
+                  triggerClassName="min-w-0 max-w-full shrink-0 text-foreground/90 hover:text-foreground"
                   {...(mixedTextGenerationModel ? { triggerLabel: "Mixed" } : {})}
                   getModelDisabledReason={textGenerationModelDisabledReason}
                   {...(environmentId

--- a/apps/web/src/components/settings/SourceControlWritingSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlWritingSettings.tsx
@@ -291,7 +291,7 @@ export function SourceControlWritingSettingsSection() {
               Connect an environment to choose its source control writer model.
             </span>
           ) : (
-            <div className="flex flex-wrap items-center justify-end gap-2">
+            <div className="flex max-w-full flex-wrap items-center justify-end gap-2 sm:max-w-[26rem]">
               {usesDedicatedModel && !canEnableDedicatedModel ? (
                 <span className="text-sm text-muted-foreground">
                   No text generation providers available.
@@ -305,7 +305,7 @@ export function SourceControlWritingSettingsSection() {
                   instanceEntries={instanceEntries}
                   modelOptionsByInstance={modelOptionsByInstance}
                   triggerVariant="outline"
-                  triggerClassName="min-w-0 max-w-80 shrink text-foreground/90 hover:text-foreground"
+                  triggerClassName="min-w-0 max-w-full shrink-0 text-foreground/90 hover:text-foreground"
                   triggerAriaLabel="Source control writer model"
                   {...(mixedWriterModel ? { triggerLabel: "Mixed" } : {})}
                   {...(environmentId

--- a/apps/web/src/components/settings/SourceControlWritingSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlWritingSettings.tsx
@@ -33,7 +33,8 @@ import { Textarea } from "../ui/textarea";
 import { toastManager } from "../ui/toast";
 import { Button } from "../ui/button";
 import {
-  SETTINGS_PICKER_TRIGGER_CLASSNAME,
+  SETTINGS_MODEL_CONTROLS_CLASSNAME,
+  SETTINGS_MODEL_PICKER_TRIGGER_CLASSNAME,
   SettingResetButton,
   SettingsRow,
   SettingsSection,
@@ -291,7 +292,7 @@ export function SourceControlWritingSettingsSection() {
               Connect an environment to choose its source control writer model.
             </span>
           ) : (
-            <div className="flex max-w-full flex-wrap items-center justify-end gap-2 sm:max-w-[26rem]">
+            <div className={`${SETTINGS_MODEL_CONTROLS_CLASSNAME} gap-2`}>
               {usesDedicatedModel && !canEnableDedicatedModel ? (
                 <span className="text-sm text-muted-foreground">
                   No text generation providers available.
@@ -305,7 +306,7 @@ export function SourceControlWritingSettingsSection() {
                   instanceEntries={instanceEntries}
                   modelOptionsByInstance={modelOptionsByInstance}
                   triggerVariant="outline"
-                  triggerClassName="min-w-0 max-w-full shrink-0 text-foreground/90 hover:text-foreground"
+                  triggerClassName={SETTINGS_MODEL_PICKER_TRIGGER_CLASSNAME}
                   triggerAriaLabel="Source control writer model"
                   {...(mixedWriterModel ? { triggerLabel: "Mixed" } : {})}
                   {...(environmentId

--- a/apps/web/src/components/settings/SourceControlWritingSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlWritingSettings.tsx
@@ -305,7 +305,7 @@ export function SourceControlWritingSettingsSection() {
                   instanceEntries={instanceEntries}
                   modelOptionsByInstance={modelOptionsByInstance}
                   triggerVariant="outline"
-                  triggerClassName={SETTINGS_PICKER_TRIGGER_CLASSNAME}
+                  triggerClassName="min-w-0 max-w-80 shrink text-foreground/90 hover:text-foreground"
                   triggerAriaLabel="Source control writer model"
                   {...(mixedWriterModel ? { triggerLabel: "Mixed" } : {})}
                   {...(environmentId

--- a/apps/web/src/components/settings/settingsLayout.tsx
+++ b/apps/web/src/components/settings/settingsLayout.tsx
@@ -143,6 +143,11 @@ export function SettingsSearchTarget({
 export const SETTINGS_PICKER_TRIGGER_CLASSNAME =
   "h-8 min-h-8 min-w-0 max-w-none shrink-0 text-foreground/90 hover:text-foreground sm:h-7 sm:min-h-7";
 
+export const SETTINGS_MODEL_PICKER_TRIGGER_CLASSNAME = `${SETTINGS_PICKER_TRIGGER_CLASSNAME} max-w-full`;
+
+export const SETTINGS_MODEL_CONTROLS_CLASSNAME =
+  "flex max-w-full flex-wrap items-center justify-end sm:max-w-[26rem]";
+
 /** Info affordance explaining how a setting interacts with the shared background policy. */
 export function PolicyTooltip({ children }: { readonly children: string }) {
   return (

--- a/apps/web/src/components/settings/settingsLayout.tsx
+++ b/apps/web/src/components/settings/settingsLayout.tsx
@@ -143,7 +143,7 @@ export function SettingsSearchTarget({
 export const SETTINGS_PICKER_TRIGGER_CLASSNAME =
   "h-8 min-h-8 min-w-0 max-w-none shrink-0 text-foreground/90 hover:text-foreground sm:h-7 sm:min-h-7";
 
-export const SETTINGS_MODEL_PICKER_TRIGGER_CLASSNAME = `${SETTINGS_PICKER_TRIGGER_CLASSNAME} max-w-full`;
+export const SETTINGS_MODEL_PICKER_TRIGGER_CLASSNAME = `${SETTINGS_PICKER_TRIGGER_CLASSNAME} max-w-full sm:max-w-full`;
 
 export const SETTINGS_MODEL_CONTROLS_CLASSNAME =
   "flex max-w-full flex-wrap items-center justify-end sm:max-w-[26rem]";

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -14,6 +14,7 @@ import {
   toCustomModelSetting,
   getProviderOptionBooleanSelectionValue,
   getProviderOptionStringSelectionValue,
+  stripLeadingModelQualifier,
 } from "./model.ts";
 
 const codexCaps: ModelCapabilities = createModelCapabilities({
@@ -242,5 +243,18 @@ describe("readCustomModelEntries", () => {
       name: "X",
       capabilities,
     });
+  });
+});
+
+describe("model display normalization", () => {
+  it("removes a repeated provider qualifier", () => {
+    expect(stripLeadingModelQualifier("OpenAI: GPT-5.4", "OpenAI")).toBe("GPT-5.4");
+    expect(stripLeadingModelQualifier("GitHub Copilot / Claude Haiku", "github copilot")).toBe(
+      "Claude Haiku",
+    );
+  });
+
+  it("preserves names without the provider qualifier", () => {
+    expect(stripLeadingModelQualifier("GPT-5.4", "OpenAI")).toBe("GPT-5.4");
   });
 });

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -19,6 +19,23 @@ export interface SelectableModelOption {
   aliases?: ReadonlyArray<string> | undefined;
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function stripLeadingModelQualifier(
+  value: string,
+  qualifier: string | null | undefined,
+): string {
+  const trimmedQualifier = qualifier?.trim();
+  if (!trimmedQualifier) {
+    return value;
+  }
+
+  const pattern = new RegExp(`^${escapeRegExp(trimmedQualifier)}(?:\\s*[.:/-]\\s*|\\s+)`, "iu");
+  return value.replace(pattern, "").trim() || value;
+}
+
 export function createModelCapabilities(input: {
   optionDescriptors: ReadonlyArray<ProviderOptionDescriptor>;
 }): ModelCapabilities {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,7 +321,7 @@ importers:
         specifier: ~57.0.15
         version: 57.0.15(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@7.0.2)
       expo-audio:
-        specifier: ~57.0.4
+        specifier: 57.0.4
         version: 57.0.4(patch_hash=fa9a3e0442ed395d4071bb406e08c3a471c9a84700bdfa0b9ad7ff144c96041a)(expo-asset@57.0.15(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@7.0.2))(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       expo-auth-session:
         specifier: ~57.0.10


### PR DESCRIPTION
## What Changed

- Qualify models exposed through a sub-provider as `Model · sub-provider` in web and mobile selected values.
- Show web picker sources as `OpenCode · sub-provider` so matching model names can be distinguished before selection.
- Remove the arbitrary web trigger width cap, let mobile composer labels use the existing horizontal scroller, and allow mobile picker rows to wrap for longer provider names.
- Add focused coverage for qualified and ordinary model labels.

## Why

Multi-provider runtimes such as OpenCode can expose the same model through different upstream providers. Showing only the model name makes those choices ambiguous, while a `via` phrase is visually heavier than the product’s existing dot-separated label language.

Keeping the sub-provider beside the model makes the selected source explicit without adding another control. The layout changes ensure that information remains readable: web labels expand when space is available, mobile composer labels can scroll with the toolbar, and mobile picker rows grow vertically instead of truncating.

## UI Changes

### Before / after

<img width="1371" height="645" alt="image" src="https://github.com/user-attachments/assets/1d0d5b70-4617-4e71-9d83-bfb2a1c487af" />
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/520dbf81-e75e-4b27-a938-b6a32e6a6242" />
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/9cefc18c-2669-4f83-b1e7-89d5e77247d5" />

## Testing

- `pnpm exec vp test run apps/web/src/components/chat/providerIconUtils.test.ts apps/mobile/src/lib/modelOptions.test.ts`
- Web typecheck
- Mobile typecheck
- Focused formatting and diff checks
- Live web verification with `Claude Haiku 4.5 (latest) · github-copilot`

Mobile simulator verification was not available in the current Linux environment because no Android SDK or emulator is installed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] No video is required because this does not change animation or interaction behavior

Created with GPT-5.6 in the Codex harness.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and layout-only changes to model labels and picker chrome; routing and selection keys are unchanged aside from string formatting.
> 
> **Overview**
> **Disambiguates multi-provider models** (e.g. OpenCode) by showing **`Model · sub-provider`** in selected values and list rows, while list footers / subtitles emphasize the **runtime instance** (`OpenCode Work`, `Codex`, etc.) instead of repeating upstream names.
> 
> Centralizes name cleanup in shared **`stripLeadingModelQualifier`** and wires it through mobile **`buildModelOptions`**, web **`providerIconUtils`**, and picker rows via **`getTriggerDisplayModelLabel`** / **`getModelSourceLabel`**. The web composer trigger splits the short model name and a muted **`· subProvider`** segment; tooltips still use the full qualified label.
> 
> **Layout tweaks** so longer labels stay readable: mobile composer model controls drop fixed **152px** caps (`maxWidth={null}` on **`ComposerInlineControl`**), settings sheet model rows **wrap** badges instead of single-line truncation, and web settings/composer pickers drop tight max-widths in favor of **`SETTINGS_MODEL_*`** wrapping (26rem cap on sm+ in settings).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f28423027e002957902213e20634571ee45e9c45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show model sub-provider labels in mobile and web model pickers
> - Adds shared `stripLeadingModelQualifier` utility in [model.ts](https://github.com/pingdotgg/t3code/pull/7562/files#diff-6319cd97b4ed5842958c7fbc93b4ed733efa158c2b1ad15c1d54bcddea713505) to normalize model names by removing leading provider qualifiers case-insensitively
> - Mobile `modelDisplayLabel` and web `getTriggerDisplayModelLabel`/`getModelSourceLabel` now append the sub-provider (e.g. "Codex") to the normalized model name using a centered dot
> - Mobile `buildModelOptions` uses the provider instance label as the subtitle for both normal and fallback options, replacing raw model names
> - Removes fixed max-width constraints on model picker controls in mobile (`NewTaskDraftScreen`, `ThreadComposer`, `ComposerInlineControl`) and web settings panels; web settings now use shared `SETTINGS_MODEL_CONTROLS_CLASSNAME` and `SETTINGS_MODEL_PICKER_TRIGGER_CLASSNAME` with wrapping and a 26rem small-breakpoint max
> - Mobile `ModelRow` allows model names and badges to wrap onto multiple lines instead of being truncated to one line
> - Risk: callers passing `maxWidth={null}` to `ComposerInlineControl` now get unbounded width instead of the 190pt default; only `NewTaskDraftScreen` and `ThreadComposer` do this and are updated in the same PR
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f284230.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Model pickers now show provider and source details, making similarly named models easier to distinguish.
  - Model labels are normalized for clearer, more consistent display across web and mobile.
  - Web picker triggers include sub-provider information when available.
  - Mobile composer controls can expand beyond the default width when configured.

- **Bug Fixes**
  - Long model names in mobile settings can wrap instead of being truncated.
  - Settings model controls maintain a more consistent responsive layout across screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->