### PR TITLE
fix(web): show only providers with usage in usage views

### DIFF
--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -53,13 +53,16 @@ vi.mock("../WorkspaceBreadcrumb", () => ({
 vi.mock("../WorkspacePageContainer", () => ({ WorkspacePageContainer: "main" }));
 vi.mock("../WorkspacePageHeader", () => ({ WorkspacePageHeader: "header" }));
 vi.mock("./UsageProviderChart", () => ({ UsageProviderChart: "div" }));
-vi.mock("./usageProviders", () => ({
-  PROVIDER_ORDER: ["codex", "claude"],
-  PROVIDER_PRESENTATION: {
-    codex: { color: "white", label: "Codex", mark: "span" },
-    claude: { color: "orange", label: "Claude Code", mark: "span" },
-  },
-}));
+vi.mock("./usageProviders", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./usageProviders")>();
+  return {
+    ...actual,
+    PROVIDER_PRESENTATION: {
+      codex: { color: "white", label: "Codex", mark: "span" },
+      claude: { color: "orange", label: "Claude Code", mark: "span" },
+    },
+  };
+});
 
 import { UsagePage } from "./UsagePage";
 

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -32,7 +32,7 @@ import {
 import { WorkspacePageContainer } from "../WorkspacePageContainer";
 import { WorkspacePageHeader } from "../WorkspacePageHeader";
 import { UsageProviderChart, type UsageChartMetric } from "./UsageProviderChart";
-import { PROVIDER_ORDER, PROVIDER_PRESENTATION, providersWithUsage } from "./usageProviders";
+import { PROVIDER_PRESENTATION, providersWithUsage } from "./usageProviders";
 
 const WINDOW_OPTIONS = [
   { days: 1, label: "Past 24h" },

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -74,6 +74,16 @@ export function UsagePage() {
     () => (isPast24Hours ? merged.hourly : merged.daily).toReversed(),
     [isPast24Hours, merged.daily, merged.hourly],
   );
+  const activeProviders = useMemo(
+    () =>
+      PROVIDER_ORDER.filter((provider) =>
+        merged.providers.some(
+          (entry) => entry.provider === provider && (entry.totalTokens > 0 || entry.costUsd > 0),
+        ),
+      ),
+    [merged.providers],
+  );
+  const timeValueColumnWidth = `${60 / (activeProviders.length + 2)}%`;
 
   const selectWindow = (days: number) => {
     setWindowSelection({
@@ -331,7 +341,13 @@ export function UsagePage() {
                   </div>
 
                   {breakdown === "model" ? (
-                    <table className="w-full text-sm">
+                    <table className="w-full table-fixed text-sm">
+                      <colgroup>
+                        <col className="w-2/5" />
+                        <col className="w-1/5" />
+                        <col className="w-1/5" />
+                        <col className="w-1/5" />
+                      </colgroup>
                       <thead>
                         <tr className="border-b border-border text-left text-xs text-muted-foreground">
                           <th className="py-2 font-normal">Model</th>
@@ -374,11 +390,19 @@ export function UsagePage() {
                       </tbody>
                     </table>
                   ) : (
-                    <table className="w-full text-sm">
+                    <table className="w-full table-fixed text-sm">
+                      <colgroup>
+                        <col className="w-2/5" />
+                        {activeProviders.map((provider) => (
+                          <col key={provider} style={{ width: timeValueColumnWidth }} />
+                        ))}
+                        <col style={{ width: timeValueColumnWidth }} />
+                        <col style={{ width: timeValueColumnWidth }} />
+                      </colgroup>
                       <thead>
                         <tr className="border-b border-border text-left text-xs text-muted-foreground">
                           <th className="py-2 font-normal">{isPast24Hours ? "Hour" : "Day"}</th>
-                          {PROVIDER_ORDER.map((provider) => (
+                          {activeProviders.map((provider) => (
                             <th key={provider} className="py-2 text-right font-normal">
                               {PROVIDER_PRESENTATION[provider].label}
                             </th>
@@ -390,7 +414,10 @@ export function UsagePage() {
                       <tbody>
                         {breakdownPeriods.length === 0 ? (
                           <tr>
-                            <td colSpan={5} className="py-6 text-center text-muted-foreground">
+                            <td
+                              colSpan={activeProviders.length + 3}
+                              className="py-6 text-center text-muted-foreground"
+                            >
                               No activity in this window.
                             </td>
                           </tr>
@@ -405,7 +432,7 @@ export function UsagePage() {
                                   ? formatHourShort(period.hourStart, window.timeZone)
                                   : formatDayShort(period.day)}
                               </td>
-                              {PROVIDER_ORDER.map((provider) => (
+                              {activeProviders.map((provider) => (
                                 <td
                                   key={provider}
                                   className="py-2 text-right text-muted-foreground tabular-nums"

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -32,7 +32,7 @@ import {
 import { WorkspacePageContainer } from "../WorkspacePageContainer";
 import { WorkspacePageHeader } from "../WorkspacePageHeader";
 import { UsageProviderChart, type UsageChartMetric } from "./UsageProviderChart";
-import { PROVIDER_PRESENTATION, providersWithUsage } from "./usageProviders";
+import { PROVIDER_ORDER, PROVIDER_PRESENTATION, providersWithUsage } from "./usageProviders";
 
 const WINDOW_OPTIONS = [
   { days: 1, label: "Past 24h" },
@@ -227,7 +227,7 @@ export function UsagePage() {
                       </span>
                     </div>
 
-                    {PROVIDER_ORDER.map((provider) => {
+                    {activeProviders.map((provider) => {
                       const totals = merged.providers.find((entry) => entry.provider === provider);
                       const share =
                         metric === "cost" ? (totals?.costShare ?? 0) : (totals?.tokenShare ?? 0);

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -32,7 +32,7 @@ import {
 import { WorkspacePageContainer } from "../WorkspacePageContainer";
 import { WorkspacePageHeader } from "../WorkspacePageHeader";
 import { UsageProviderChart, type UsageChartMetric } from "./UsageProviderChart";
-import { PROVIDER_ORDER, PROVIDER_PRESENTATION } from "./usageProviders";
+import { PROVIDER_ORDER, PROVIDER_PRESENTATION, providersWithUsage } from "./usageProviders";
 
 const WINDOW_OPTIONS = [
   { days: 1, label: "Past 24h" },
@@ -74,15 +74,7 @@ export function UsagePage() {
     () => (isPast24Hours ? merged.hourly : merged.daily).toReversed(),
     [isPast24Hours, merged.daily, merged.hourly],
   );
-  const activeProviders = useMemo(
-    () =>
-      PROVIDER_ORDER.filter((provider) =>
-        merged.providers.some(
-          (entry) => entry.provider === provider && (entry.totalTokens > 0 || entry.costUsd > 0),
-        ),
-      ),
-    [merged.providers],
-  );
+  const activeProviders = useMemo(() => providersWithUsage(merged.providers), [merged.providers]);
   const timeValueColumnWidth = `${60 / (activeProviders.length + 2)}%`;
 
   const selectWindow = (days: number) => {
@@ -286,6 +278,7 @@ export function UsagePage() {
                       {metric === "tokens" ? "processed tokens" : "cost"}
                     </h2>
                     <UsageProviderChart
+                      providers={activeProviders}
                       days={days}
                       daily={merged.daily}
                       hours={hours}

--- a/apps/web/src/components/usage/UsageProviderChart.test.ts
+++ b/apps/web/src/components/usage/UsageProviderChart.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { buildDayColumns, niceScale } from "./UsageProviderChart";
+import { buildDayColumns, niceScale, providersWithUsage } from "./UsageProviderChart";
 
 describe("niceScale", () => {
   it("never puts the peak above the top of the scale", () => {
@@ -93,6 +93,25 @@ describe("buildDayColumns", () => {
       const sum = column.bands.reduce((running, band) => running + band.value, 0);
       expect(column.total).toBeCloseTo(sum, 9);
     }
+  });
+
+  it("omits providers with no usage in the selected window", () => {
+    const claudeOnly = new Map([
+      [
+        "2026-08-01",
+        {
+          day: "2026-08-01",
+          costUsd: 20,
+          totalTokens: 200,
+          byProvider: new Map([
+            ["codex" as const, { costUsd: 0, totalTokens: 0 }],
+            ["claude" as const, { costUsd: 20, totalTokens: 200 }],
+          ]),
+        },
+      ],
+    ]);
+
+    expect(providersWithUsage(buildDayColumns(days, claudeOnly, "cost"))).toEqual(["claude"]);
   });
 });
 

--- a/apps/web/src/components/usage/UsageProviderChart.test.ts
+++ b/apps/web/src/components/usage/UsageProviderChart.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { buildDayColumns, niceScale, providersWithUsage } from "./UsageProviderChart";
+import { buildDayColumns, niceScale } from "./UsageProviderChart";
+import { providersWithUsage } from "./usageProviders";
 
 describe("niceScale", () => {
   it("never puts the peak above the top of the scale", () => {
@@ -94,24 +95,16 @@ describe("buildDayColumns", () => {
       expect(column.total).toBeCloseTo(sum, 9);
     }
   });
+});
 
-  it("omits providers with no usage in the selected window", () => {
-    const claudeOnly = new Map([
-      [
-        "2026-08-01",
-        {
-          day: "2026-08-01",
-          costUsd: 20,
-          totalTokens: 200,
-          byProvider: new Map([
-            ["codex" as const, { costUsd: 0, totalTokens: 0 }],
-            ["claude" as const, { costUsd: 20, totalTokens: 200 }],
-          ]),
-        },
-      ],
-    ]);
-
-    expect(providersWithUsage(buildDayColumns(days, claudeOnly, "cost"))).toEqual(["claude"]);
+describe("providersWithUsage", () => {
+  it("omits providers with no cost or tokens", () => {
+    expect(
+      providersWithUsage([
+        { provider: "codex", costUsd: 0, totalTokens: 0 },
+        { provider: "claude", costUsd: 0, totalTokens: 200 },
+      ]),
+    ).toEqual(["claude"]);
   });
 });
 

--- a/apps/web/src/components/usage/UsageProviderChart.tsx
+++ b/apps/web/src/components/usage/UsageProviderChart.tsx
@@ -186,6 +186,16 @@ export function buildDayColumns(
   return buildPeriodColumns(days, byDay, metric);
 }
 
+export function providersWithUsage(columns: readonly DayColumn[]): readonly UsageProviderKind[] {
+  const active = new Set<UsageProviderKind>();
+  for (const column of columns) {
+    for (const band of column.bands) {
+      if (band.value > 0) active.add(band.provider);
+    }
+  }
+  return PROVIDER_ORDER.filter((provider) => active.has(provider));
+}
+
 export function UsageProviderChart({
   days,
   daily,
@@ -209,9 +219,10 @@ export function UsageProviderChart({
   const tooltipRef = useRef<HTMLDivElement | null>(null);
   const hoverPositionRef = useRef<{ x: number; y: number } | null>(null);
 
-  const { paths, series, stepX, ticks, toY } = useMemo(() => {
+  const { activeProviders, paths, ticks, stepX, toY, series } = useMemo(() => {
     if (periods.length === 0) {
       return {
+        activeProviders: [] as readonly UsageProviderKind[],
         paths: [],
         series: [] as readonly DayColumn[],
         stepX: 0,
@@ -221,6 +232,7 @@ export function UsageProviderChart({
     }
 
     const columns = buildPeriodColumns(periods, byPeriod, metric);
+    const visibleProviders = providersWithUsage(columns);
     // The scale tops out at the largest single provider-period, not the sum:
     // layered series each measure from zero, so a combined peak would leave
     // the plot permanently half empty.
@@ -235,7 +247,8 @@ export function UsageProviderChart({
     const toY = (value: number) =>
       max === 0 ? VIEW_HEIGHT : VIEW_HEIGHT - (value / max) * (VIEW_HEIGHT - PLOT_TOP);
 
-    const built = PROVIDER_ORDER.map((provider, providerIndex) => {
+    const built = visibleProviders.map((provider) => {
+      const providerIndex = PROVIDER_ORDER.indexOf(provider);
       const line = curvePath(
         smoothCurve(
           columns.map((column, periodIndex) => ({
@@ -254,6 +267,7 @@ export function UsageProviderChart({
 
     // Paint the heavier series first so the lighter one is not buried.
     return {
+      activeProviders: visibleProviders,
       paths: built.toSorted((a, b) => b.total - a.total),
       series: columns,
       stepX: step,
@@ -422,7 +436,7 @@ export function UsageProviderChart({
               }}
             >
               <div className="mb-1 text-muted-foreground">{formatTooltipPeriod(hoveredPeriod)}</div>
-              {PROVIDER_ORDER.map((provider) => {
+              {activeProviders.map((provider) => {
                 const { label, mark: Mark } = PROVIDER_PRESENTATION[provider];
                 return (
                   <div key={provider} className="flex items-center justify-between gap-3">

--- a/apps/web/src/components/usage/UsageProviderChart.tsx
+++ b/apps/web/src/components/usage/UsageProviderChart.tsx
@@ -19,6 +19,7 @@ const PLOT_TOP = 8;
 export type UsageChartMetric = "tokens" | "cost";
 
 interface UsageProviderChartProps {
+  readonly providers: readonly UsageProviderKind[];
   readonly days: readonly string[];
   readonly daily: readonly DailyTotals[];
   readonly hours: readonly string[];
@@ -186,17 +187,8 @@ export function buildDayColumns(
   return buildPeriodColumns(days, byDay, metric);
 }
 
-export function providersWithUsage(columns: readonly DayColumn[]): readonly UsageProviderKind[] {
-  const active = new Set<UsageProviderKind>();
-  for (const column of columns) {
-    for (const band of column.bands) {
-      if (band.value > 0) active.add(band.provider);
-    }
-  }
-  return PROVIDER_ORDER.filter((provider) => active.has(provider));
-}
-
 export function UsageProviderChart({
+  providers,
   days,
   daily,
   hours,
@@ -219,10 +211,9 @@ export function UsageProviderChart({
   const tooltipRef = useRef<HTMLDivElement | null>(null);
   const hoverPositionRef = useRef<{ x: number; y: number } | null>(null);
 
-  const { activeProviders, paths, ticks, stepX, toY, series } = useMemo(() => {
+  const { paths, ticks, stepX, toY, series } = useMemo(() => {
     if (periods.length === 0) {
       return {
-        activeProviders: [] as readonly UsageProviderKind[],
         paths: [],
         series: [] as readonly DayColumn[],
         stepX: 0,
@@ -232,7 +223,6 @@ export function UsageProviderChart({
     }
 
     const columns = buildPeriodColumns(periods, byPeriod, metric);
-    const visibleProviders = providersWithUsage(columns);
     // The scale tops out at the largest single provider-period, not the sum:
     // layered series each measure from zero, so a combined peak would leave
     // the plot permanently half empty.
@@ -247,7 +237,7 @@ export function UsageProviderChart({
     const toY = (value: number) =>
       max === 0 ? VIEW_HEIGHT : VIEW_HEIGHT - (value / max) * (VIEW_HEIGHT - PLOT_TOP);
 
-    const built = visibleProviders.map((provider) => {
+    const built = providers.map((provider) => {
       const providerIndex = PROVIDER_ORDER.indexOf(provider);
       const line = curvePath(
         smoothCurve(
@@ -267,14 +257,13 @@ export function UsageProviderChart({
 
     // Paint the heavier series first so the lighter one is not buried.
     return {
-      activeProviders: visibleProviders,
       paths: built.toSorted((a, b) => b.total - a.total),
       series: columns,
       stepX: step,
       ticks: tickValues,
       toY,
     };
-  }, [byPeriod, metric, periods]);
+  }, [byPeriod, metric, periods, providers]);
 
   const format = metric === "tokens" ? formatTokens : formatUsd;
 
@@ -436,7 +425,7 @@ export function UsageProviderChart({
               }}
             >
               <div className="mb-1 text-muted-foreground">{formatTooltipPeriod(hoveredPeriod)}</div>
-              {activeProviders.map((provider) => {
+              {providers.map((provider) => {
                 const { label, mark: Mark } = PROVIDER_PRESENTATION[provider];
                 return (
                   <div key={provider} className="flex items-center justify-between gap-3">

--- a/apps/web/src/components/usage/usageProviders.ts
+++ b/apps/web/src/components/usage/usageProviders.ts
@@ -10,8 +10,8 @@ type UsageProviderPresentation = {
 
 /**
  * Exhaustive presentation for providers supported by the usage contract.
- * Declaration order is reused by every chart, table, legend, and skeleton, so
- * adding a provider only requires its contract support and one entry here.
+ * Declaration order is reused by every chart and table, so adding a provider
+ * only requires its contract support and one entry here.
  */
 export const PROVIDER_PRESENTATION = {
   codex: {
@@ -28,3 +28,19 @@ export const PROVIDER_PRESENTATION = {
 
 /** Stable provider reading order across charts, summaries, tables, and hover rows. */
 export const PROVIDER_ORDER = Object.keys(PROVIDER_PRESENTATION) as UsageProviderKind[];
+
+/** Providers with real activity, independent of the metric currently displayed. */
+export function providersWithUsage(
+  totals: readonly {
+    readonly provider: UsageProviderKind;
+    readonly costUsd: number;
+    readonly totalTokens: number;
+  }[],
+): readonly UsageProviderKind[] {
+  const active = new Set(
+    totals
+      .filter((entry) => entry.totalTokens > 0 || entry.costUsd > 0)
+      .map((entry) => entry.provider),
+  );
+  return PROVIDER_ORDER.filter((provider) => active.has(provider));
+}


### PR DESCRIPTION
## What Changed

- Remove the redundant provider legend from the usage chart.
- Omit zero-value providers from chart series, hover details, and time-breakdown columns.
- Size active time-breakdown columns dynamically while keeping the date column stable.
- Add focused coverage for filtering providers without usage.

## Why

Usage views previously rendered every supported provider even when the selected window contained no data for one of them. That left an empty chart series, zero-value tooltip rows, and unnecessary table columns. Deriving the visible providers from the selected usage window keeps the view focused on actual activity.

## UI Changes

Provider identities remain available in chart hover details and provider summaries. The static chart legend and provider rows or columns with no usage are removed. 

Before:
<img width="1809" height="783" alt="image" src="https://github.com/user-attachments/assets/3e828fb2-7c6d-4938-8d6d-5f198b19e414" />


After:

Multiple Provider:
<img width="1912" height="925" alt="image" src="https://github.com/user-attachments/assets/d78e914a-c254-4d4c-8782-4238cb9c27af" />
One Provider:
<img width="1912" height="925" alt="image" src="https://github.com/user-attachments/assets/2dd3215c-92ce-455b-8efb-1725235385b5" />




## Verification

- `pnpm exec vp test run apps/web/src/components/usage/UsageProviderChart.test.ts` (11 tests passed)
- `pnpm exec vp run --filter @t3tools/web typecheck`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] No animation or interaction video is needed

Created by gpt-5.6-sol using the Codex harness in T3 Code.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only usage display filtering with no auth, data, or API changes. Chart still indexes bands via PROVIDER_ORDER, so inactive providers are omitted from drawing but column data remains full-order.
> 
> **Overview**
> Usage views now show only providers with cost or tokens in the selected window, instead of always listing every supported provider.
> 
> `providersWithUsage` keeps `PROVIDER_ORDER` while dropping zero-activity providers. Summary rows, chart series, hover rows, and time-breakdown columns all use that list. Time tables use `table-fixed` with widths that scale to the active provider count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a36cb7799d8ff15c4f4fb99f316a0aa799ecafa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show only providers with usage in usage views
> - Adds `providersWithUsage` in [usageProviders.ts](https://github.com/pingdotgg/t3code/pull/7563/files#diff-1239d4db3da7697f4049ced6bc9ed40ea2896435b8994e4558f10ac229c8bfdc) to filter providers that have `costUsd > 0` or `totalTokens > 0`, preserving `PROVIDER_ORDER`.
> - [UsagePage.tsx](https://github.com/pingdotgg/t3code/pull/7563/files#diff-e076db2611ea0a07e1c8ec8571cc21103a2a4c7fc0feb865192fc12c8a18dead) computes `activeProviders` from merged totals and uses it across the summary rows, time breakdown table, and provider chart. Column widths and `colSpan` values adjust dynamically to the active provider count.
> - [UsageProviderChart.tsx](https://github.com/pingdotgg/t3code/pull/7563/files#diff-52c28becdc9ddcf01c41d61d218f83687038f2efea310911245393fc696d5c56) accepts a required `providers` prop instead of iterating over the global `PROVIDER_ORDER`, rendering and reporting only the passed providers.
> - Tests in `UsagePage.test.tsx` and `UsageProviderChart.test.ts` updated to use a partial mock of `usageProviders` and verify the new filtering behavior.
> - Behavioral Change: `UsageProviderChart` now requires a `providers` prop; any caller not passing it will fail to compile.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a36cb7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->