### PR TITLE
feat(web): add model options picker keybinding

### DIFF
--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -198,6 +198,7 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
       assert.equal(defaultsByCommand.get("thread.jump.1"), "mod+1");
       assert.equal(defaultsByCommand.get("thread.jump.9"), "mod+9");
       assert.equal(defaultsByCommand.get("modelPicker.toggle"), "mod+shift+m");
+      assert.equal(defaultsByCommand.get("modelOptionsPicker.toggle"), "mod+shift+,");
       assert.equal(defaultsByCommand.get("themeEditor.toggle"), "mod+alt+shift+t");
       assert.equal(defaultsByCommand.get("filePicker.toggle"), "mod+p");
       assert.equal(defaultsByCommand.get("projectSearch.toggle"), "mod+shift+f");

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4843,6 +4843,14 @@ function ChatViewContent(props: ChatViewProps) {
         return;
       }
 
+      if (command === "modelOptionsPicker.toggle") {
+        if (composerRef.current?.toggleModelOptionsPicker()) {
+          event.preventDefault();
+          event.stopPropagation();
+        }
+        return;
+      }
+
       const scriptId = projectScriptIdFromCommand(command);
       if (!scriptId || !activeProject) return;
       const script = activeProject.scripts.find((entry) => entry.id === scriptId);

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -463,6 +463,7 @@ export interface ChatComposerHandle {
   openModelPicker: () => void;
   toggleModelPicker: () => void;
   isModelPickerOpen: () => boolean;
+  toggleModelOptionsPicker: () => boolean;
   readSnapshot: () => {
     value: string;
     cursor: number;
@@ -951,6 +952,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const [isComposerFooterCompact, setIsComposerFooterCompact] = useState(false);
   const [isComposerPrimaryActionsCompact, setIsComposerPrimaryActionsCompact] = useState(false);
   const [isComposerModelPickerOpen, setIsComposerModelPickerOpen] = useState(false);
+  const [modelOptionsPickerTarget, setModelOptionsPickerTarget] = useState<
+    "expanded" | "compact" | null
+  >(null);
   const [isComposerFocused, setIsComposerFocused] = useState(false);
   const [composerSubmissionError, setComposerSubmissionError] = useState<string | null>(null);
   const [providerInputSubmissionError, setProviderInputSubmissionError] = useState<string | null>(
@@ -965,6 +969,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const isMobileViewport = useMediaQuery("max-sm");
   const isComposerCollapsedMobile =
     isMobileViewport && !forceExpandedOnMobile && !isComposerFocused;
+
+  useEffect(() => {
+    setModelOptionsPickerTarget(null);
+  }, [isComposerFooterCompact]);
 
   // ------------------------------------------------------------------
   // Refs
@@ -1191,18 +1199,14 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // ------------------------------------------------------------------
   const setPromptFromTraits = useCallback(
     (nextPrompt: string) => {
-      if (nextPrompt === promptRef.current) {
-        scheduleComposerFocus();
-        return;
-      }
+      if (nextPrompt === promptRef.current) return;
       promptRef.current = nextPrompt;
       setComposerDraftPrompt(composerDraftTarget, nextPrompt);
       const nextCursor = collapseExpandedComposerCursor(nextPrompt, nextPrompt.length);
       setComposerCursor(nextCursor);
       setComposerTrigger(detectComposerTrigger(nextPrompt, nextPrompt.length));
-      scheduleComposerFocus();
     },
-    [composerDraftTarget, promptRef, scheduleComposerFocus, setComposerDraftPrompt],
+    [composerDraftTarget, promptRef, setComposerDraftPrompt],
   );
 
   const providerTraitsMenuContent = renderProviderTraitsMenuContent({
@@ -1215,6 +1219,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     modelOptions: composerModelOptions?.[selectedInstanceId],
     prompt,
     onPromptChange: setPromptFromTraits,
+    onOptionSelect: scheduleComposerFocus,
+    focusSelectedPrimaryOption: modelOptionsPickerTarget === "compact",
   });
   const providerTraitsPicker = renderProviderTraitsPicker({
     provider: selectedProvider,
@@ -1226,6 +1232,14 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     modelOptions: composerModelOptions?.[selectedInstanceId],
     prompt,
     onPromptChange: setPromptFromTraits,
+    onOptionSelect: scheduleComposerFocus,
+    open: modelOptionsPickerTarget === "expanded",
+    onOpenChange: (open) => {
+      if (open) {
+        setIsComposerModelPickerOpen(false);
+      }
+      setModelOptionsPickerTarget(open ? "expanded" : null);
+    },
   });
   const pendingPrimaryAction = useMemo(
     () =>
@@ -2557,12 +2571,25 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       },
       insertTextAtEnd: insertComposerTextAtEnd,
       openModelPicker: () => {
+        setModelOptionsPickerTarget(null);
         setIsComposerModelPickerOpen(true);
       },
       toggleModelPicker: () => {
+        setModelOptionsPickerTarget(null);
         setIsComposerModelPickerOpen((open) => !open);
       },
       isModelPickerOpen: () => isComposerModelPickerOpen,
+      toggleModelOptionsPicker: () => {
+        if (isComposerCollapsedMobile || isComposerApprovalState) return false;
+        const target = isComposerFooterCompact ? "compact" : "expanded";
+        const available =
+          target === "compact" ? providerTraitsMenuContent !== null : providerTraitsPicker !== null;
+        if (!available) return false;
+
+        setIsComposerModelPickerOpen(false);
+        setModelOptionsPickerTarget((current) => (current === target ? null : target));
+        return true;
+      },
       readSnapshot: () => {
         return readComposerSnapshot();
       },
@@ -2661,10 +2688,14 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       focusComposer,
       isConnecting,
       isComposerApprovalState,
+      isComposerCollapsedMobile,
+      isComposerFooterCompact,
       pendingUserInputs.length,
       projectSelectionRequired,
       applyPromptReplacement,
       isComposerModelPickerOpen,
+      providerTraitsMenuContent,
+      providerTraitsPicker,
       readComposerSnapshot,
       selectedModel,
       selectedModelOptionsForDispatch,
@@ -3169,6 +3200,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                         }
                       : {})}
                     onOpenChange={(open) => {
+                      if (open) {
+                        setModelOptionsPickerTarget(null);
+                      }
                       setIsComposerModelPickerOpen(open);
                     }}
                     getModelDisabledReason={getModelDisabledReason}
@@ -3182,6 +3216,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                     runtimeMode={runtimeMode}
                     showInteractionModeToggle={composerProviderControls.showInteractionModeToggle}
                     traitsMenuContent={providerTraitsMenuContent}
+                    open={modelOptionsPickerTarget === "compact"}
+                    onOpenChange={(open) => {
+                      if (open) {
+                        setIsComposerModelPickerOpen(false);
+                      }
+                      setModelOptionsPickerTarget(open ? "compact" : null);
+                    }}
                     onToggleInteractionMode={toggleInteractionMode}
                     onRuntimeModeChange={handleRuntimeModeChange}
                   />

--- a/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
+++ b/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
@@ -16,11 +16,13 @@ export const CompactComposerControlsMenu = memo(function CompactComposerControls
   runtimeMode: RuntimeMode;
   showInteractionModeToggle: boolean;
   traitsMenuContent?: ReactNode;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   onToggleInteractionMode: () => void;
   onRuntimeModeChange: (mode: RuntimeMode) => void;
 }) {
   return (
-    <Menu>
+    <Menu open={props.open} onOpenChange={props.onOpenChange}>
       <MenuTrigger
         render={
           <Button

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -14,7 +14,7 @@ import {
   getProviderOptionDescriptors,
   isClaudeUltrathinkPrompt,
 } from "@t3tools/shared/model";
-import { memo, useCallback, useState } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 import type { VariantProps } from "class-variance-authority";
 import { ZapIcon } from "lucide-react";
 import { buttonVariants } from "../ui/button";
@@ -212,10 +212,12 @@ export interface TraitsMenuContentProps {
   model: string | null | undefined;
   prompt: string;
   onPromptChange: (prompt: string) => void;
+  onOptionSelect?: () => void;
   modelOptions?: ProviderOptions | null | undefined;
   allowPromptInjectedEffort?: boolean;
   triggerVariant?: VariantProps<typeof buttonVariants>["variant"];
   triggerClassName?: string;
+  focusSelectedPrimaryOption?: boolean;
 }
 
 export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
@@ -225,10 +227,13 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
   model,
   prompt,
   onPromptChange,
+  onOptionSelect,
   modelOptions,
   allowPromptInjectedEffort = true,
+  focusSelectedPrimaryOption = false,
   ...persistence
 }: TraitsMenuContentProps & TraitsPersistence) {
+  const selectedPrimaryOptionRef = useRef<HTMLDivElement>(null);
   const setProviderModelOptions = useComposerDraftStore((store) => store.setProviderModelOptions);
   const updateModelOptions = useCallback(
     (nextOptions: ProviderOptions | undefined) => {
@@ -268,6 +273,22 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
     updateModelOptions(buildProviderOptionSelectionsFromDescriptors(nextDescriptors));
   };
 
+  useEffect(() => {
+    if (!focusSelectedPrimaryOption) return;
+    const timeout = window.setTimeout(() => {
+      const selectedItem = selectedPrimaryOptionRef.current;
+      if (!selectedItem) return;
+      // Base UI enables pointer highlighting on the popup before an item can
+      // become active. Follow that order so arrow navigation starts here.
+      selectedItem
+        .closest('[role="menu"]')
+        ?.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
+      selectedItem.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
+      selectedItem.focus();
+    }, 0);
+    return () => window.clearTimeout(timeout);
+  }, [focusSelectedPrimaryOption]);
+
   const handleSelectChange = (
     descriptor: Extract<ProviderOptionDescriptor, { type: "select" }>,
     value: string,
@@ -279,6 +300,7 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
           ? ULTRATHINK_PROMPT_PREFIX
           : applyClaudePromptEffortPrefix(prompt, "ultrathink");
       onPromptChange(nextPrompt);
+      onOptionSelect?.();
       return;
     }
     if (ultrathinkInBodyText && descriptor.id === primarySelectDescriptor?.id) return;
@@ -287,6 +309,7 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
       onPromptChange(stripped);
     }
     updateDescriptors(replaceDescriptorCurrentValue(descriptors, descriptor.id, value));
+    onOptionSelect?.();
   };
 
   if (!hasAnyControls) {
@@ -323,6 +346,11 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
                     key={option.id}
                     value={option.id}
                     hideIndicator
+                    ref={
+                      descriptor.id === primarySelectDescriptor?.id && selectedValue === option.id
+                        ? selectedPrimaryOptionRef
+                        : undefined
+                    }
                     // Base UI keeps radio menus open by default. Close on pick so
                     // the traits menu behaves like the model picker.
                     closeOnClick
@@ -369,6 +397,7 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
                   updateDescriptors(
                     replaceDescriptorCurrentValue(descriptors, descriptor.id, value === "on"),
                   );
+                  onOptionSelect?.();
                 }}
               >
                 {(["on", "off"] as const).map((value) => (
@@ -449,13 +478,21 @@ export const TraitsPicker = memo(function TraitsPicker({
   model,
   prompt,
   onPromptChange,
+  onOptionSelect,
   modelOptions,
   allowPromptInjectedEffort = true,
   triggerVariant,
   triggerClassName,
+  open,
+  onOpenChange,
   ...persistence
-}: TraitsMenuContentProps & TraitsPersistence) {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
+}: TraitsMenuContentProps &
+  TraitsPersistence & {
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+  }) {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const isMenuOpen = open ?? uncontrolledOpen;
   const { descriptors, primarySelectDescriptor, ultrathinkPromptControlled } =
     getTraitsSectionVisibility({
       provider,
@@ -502,8 +539,11 @@ export const TraitsPicker = memo(function TraitsPicker({
   return (
     <Menu
       open={isMenuOpen}
-      onOpenChange={(open) => {
-        setIsMenuOpen(open);
+      onOpenChange={(nextOpen) => {
+        if (open === undefined) {
+          setUncontrolledOpen(nextOpen);
+        }
+        onOpenChange?.(nextOpen);
       }}
     >
       <MenuTrigger
@@ -541,9 +581,11 @@ export const TraitsPicker = memo(function TraitsPicker({
           model={model}
           prompt={prompt}
           onPromptChange={onPromptChange}
+          {...(onOptionSelect ? { onOptionSelect } : {})}
           modelOptions={modelOptions}
           allowPromptInjectedEffort={allowPromptInjectedEffort}
           {...persistence}
+          focusSelectedPrimaryOption={isMenuOpen}
         />
       </MenuPopup>
     </Menu>

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -585,7 +585,7 @@ export const TraitsPicker = memo(function TraitsPicker({
           modelOptions={modelOptions}
           allowPromptInjectedEffort={allowPromptInjectedEffort}
           {...persistence}
-          focusSelectedPrimaryOption={isMenuOpen}
+          focusSelectedPrimaryOption={open !== undefined && isMenuOpen}
         />
       </MenuPopup>
     </Menu>

--- a/apps/web/src/components/chat/composerProviderState.test.tsx
+++ b/apps/web/src/components/chat/composerProviderState.test.tsx
@@ -5,12 +5,14 @@ import {
   type ProviderOptionSelection,
   type ServerProviderModel,
 } from "@t3tools/contracts";
+import { isValidElement } from "react";
 import {
   getComposerPromptInjectionState,
   getComposerProviderState,
   renderProviderTraitsMenuContent,
   renderProviderTraitsPicker,
 } from "./composerProviderState";
+import { DraftId } from "../../composerDraftStore";
 
 // Everything in composerProviderState is now data-driven by the model's
 // optionDescriptors, so these tests use a single synthetic provider/model and
@@ -244,5 +246,38 @@ describe("provider traits render guards", () => {
 
     expect(renderProviderTraitsPicker(args)).toBeNull();
     expect(renderProviderTraitsMenuContent(args)).toBeNull();
+  });
+
+  it("forwards the option selection handoff to both picker layouts", () => {
+    const onOptionSelect = () => undefined;
+    const args = {
+      provider: PROVIDER,
+      draftId: DraftId.make("draft-1"),
+      model: MODEL,
+      models: modelWith([
+        selectDescriptor("effort", [
+          { id: "low", label: "Low" },
+          { id: "high", label: "High", isDefault: true },
+        ]),
+      ]),
+      modelOptions: undefined,
+      prompt: "",
+      onPromptChange: () => undefined,
+      onOptionSelect,
+    };
+
+    const menuContent = renderProviderTraitsMenuContent(args);
+    const picker = renderProviderTraitsPicker(args);
+
+    expect(
+      isValidElement<{ onOptionSelect?: () => void }>(menuContent)
+        ? menuContent.props.onOptionSelect
+        : undefined,
+    ).toBe(onOptionSelect);
+    expect(
+      isValidElement<{ onOptionSelect?: () => void }>(picker)
+        ? picker.props.onOptionSelect
+        : undefined,
+    ).toBe(onOptionSelect);
   });
 });

--- a/apps/web/src/components/chat/composerProviderState.tsx
+++ b/apps/web/src/components/chat/composerProviderState.tsx
@@ -46,6 +46,10 @@ type TraitsRenderInput = {
   modelOptions: ReadonlyArray<ProviderOptionSelection> | undefined;
   prompt: string;
   onPromptChange: (prompt: string) => void;
+  onOptionSelect?: () => void;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  focusSelectedPrimaryOption?: boolean;
 };
 
 export function getComposerPromptInjectionState(prompt: string): ComposerPromptInjectionState {
@@ -94,6 +98,10 @@ function renderTraitsControl(
     modelOptions,
     prompt,
     onPromptChange,
+    onOptionSelect,
+    open,
+    onOpenChange,
+    focusSelectedPrimaryOption,
   } = input;
   const hasTarget = threadRef !== undefined || draftId !== undefined;
   if (
@@ -113,6 +121,10 @@ function renderTraitsControl(
       modelOptions={modelOptions}
       prompt={prompt}
       onPromptChange={onPromptChange}
+      {...(onOptionSelect ? { onOptionSelect } : {})}
+      {...(open !== undefined ? { open } : {})}
+      {...(onOpenChange ? { onOpenChange } : {})}
+      {...(focusSelectedPrimaryOption !== undefined ? { focusSelectedPrimaryOption } : {})}
     />
   );
 }

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -6,6 +6,7 @@ import {
   type KeybindingWhenNode,
   type ResolvedKeybindingsConfig,
 } from "@t3tools/contracts";
+import { DEFAULT_RESOLVED_KEYBINDINGS } from "@t3tools/shared/keybindings";
 import {
   formatShortcutLabel,
   isChatNewShortcut,
@@ -668,6 +669,43 @@ describe("cross-command precedence", () => {
 });
 
 describe("resolveShortcutCommand", () => {
+  it("resolves the model options picker default only outside terminal focus", () => {
+    const shortcut = event({ key: "<", code: "Comma", metaKey: true, shiftKey: true });
+
+    assert.strictEqual(
+      resolveShortcutCommand(shortcut, DEFAULT_RESOLVED_KEYBINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: false },
+      }),
+      "modelOptionsPicker.toggle",
+    );
+    assert.notStrictEqual(
+      resolveShortcutCommand(shortcut, DEFAULT_RESOLVED_KEYBINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: true },
+      }),
+      "modelOptionsPicker.toggle",
+    );
+  });
+
+  it("resolves a custom model options picker binding", () => {
+    const keybindings = compile([
+      {
+        shortcut: modShortcut("e", { altKey: true }),
+        command: "modelOptionsPicker.toggle",
+        whenAst: whenNot(whenIdentifier("terminalFocus")),
+      },
+    ]);
+
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "e", ctrlKey: true, altKey: true }), keybindings, {
+        platform: "Linux",
+        context: { terminalFocus: false },
+      }),
+      "modelOptionsPicker.toggle",
+    );
+  });
+
   it("returns dynamic script commands", () => {
     const keybindings = compile([{ shortcut: modShortcut("r"), command: "script.setup.run" }]);
 

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -52,6 +52,7 @@ const TERMINAL_DELETE_TO_LINE_START = "\u0015";
 const EVENT_CODE_KEY_ALIASES: Readonly<Record<string, readonly string[]>> = {
   BracketLeft: ["["],
   BracketRight: ["]"],
+  Comma: [","],
   Digit0: ["0"],
   Digit1: ["1"],
   Digit2: ["2"],

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -40,6 +40,8 @@ Commands are IDs like `terminal.toggle`, `commandPalette.toggle`, `preview.refre
 `filePicker.toggle` opens file search for the active project and defaults to `mod+p`.
 `projectSearch.toggle` searches inside the active project's files and defaults to `mod+shift+f`.
 Repeating either shortcut closes that search, and switching shortcuts replaces the open search.
+`modelOptionsPicker.toggle` opens or closes the composer's model options picker and defaults to
+`mod+shift+,`.
 `themeEditor.toggle` opens or closes the floating theme editor and defaults to
 `mod+alt+shift+t`. Select a color label to spotlight the elements that use it; select the label
 again to clear the spotlight. The swatch and hex field keep that color selected while you edit it.

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -96,6 +96,12 @@ it.effect("parses keybinding rules", () =>
     });
     assert.strictEqual(parsedModelPickerToggle.command, "modelPicker.toggle");
 
+    const parsedModelOptionsPickerToggle = yield* decode(KeybindingRule, {
+      key: "mod+shift+,",
+      command: "modelOptionsPicker.toggle",
+    });
+    assert.strictEqual(parsedModelOptionsPickerToggle.command, "modelOptionsPicker.toggle");
+
     const parsedModelPickerJump = yield* decode(KeybindingRule, {
       key: "mod+1",
       command: "modelPicker.jump.1",

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -70,6 +70,7 @@ export const STATIC_KEYBINDING_COMMANDS = [
   "composer.stash",
   "chat.new",
   "chat.newLocal",
+  "modelOptionsPicker.toggle",
   "editor.openFavorite",
   ...MODEL_PICKER_KEYBINDING_COMMANDS,
   ...THREAD_KEYBINDING_COMMANDS,

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -43,6 +43,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+shift+o", command: "chat.new", when: "!terminalFocus" },
   { key: "mod+shift+n", command: "chat.newLocal", when: "!terminalFocus" },
   { key: "mod+shift+m", command: "modelPicker.toggle", when: "!terminalFocus" },
+  { key: "mod+shift+,", command: "modelOptionsPicker.toggle", when: "!terminalFocus" },
   { key: "mod+o", command: "editor.openFavorite" },
   { key: "mod+shift+[", command: "thread.previous" },
   { key: "mod+shift+]", command: "thread.next" },


### PR DESCRIPTION
## What Changed

- Added the configurable `modelOptionsPicker.toggle` command with `mod+shift+,` as its default binding.
- Wired the command to the existing Model Options Picker in the composer.
- Focused the current option when the picker opens and returned focus to the composer after selection.
- Preserved terminal shortcut gating and documented the command.

## Why

Issue #2549 requests keyboard access to reasoning level selection. The existing picker contains model-specific options beyond reasoning level, so the command uses the broader Model Options Picker name.

This is a narrow implementation of the relevant idea from #4271. It does not add option cycling, presets, shortcut badges, other composer shortcuts, or new UI.

Closes #2549.

## UI Changes

No new UI was added. 

https://github.com/user-attachments/assets/73a9ca25-c200-4f26-bd3e-bc5737846495


## Validation

- `vp test run packages/contracts/src/keybindings.test.ts apps/server/src/keybindings.test.ts`
- `vp test run src/keybindings.test.ts src/components/chat/composerProviderState.test.tsx --project unit` from `apps/web`
- `pnpm --filter @t3tools/contracts typecheck`
- `pnpm --filter @t3tools/shared typecheck`
- `pnpm --filter t3 typecheck`
- `pnpm --filter @t3tools/web typecheck`
- Targeted lint and formatting checks for all changed files
- Manual verification of the default shortcut, current-option focus, arrow navigation, selection, composer focus restoration, toggle behavior, custom rebinding, and terminal focus gating

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Model and harness: GPT-5.6 with Codex in T3 Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `modelOptionsPicker.toggle` keybinding with default `mod+shift+,`
> - Registers `modelOptionsPicker.toggle` as a valid keybinding command with a default shortcut of `mod+shift+,` (outside terminal focus).
> - Adds a `toggleModelOptionsPicker()` method to `ChatComposerHandle`, which the window-level keydown handler in `ChatView` calls when the shortcut fires.
> - The composer toggles the model options picker in compact or expanded layout depending on footer state, with mutual exclusivity against the model picker and guards for collapsed mobile and approval states.
> - `TraitsPicker` and `CompactComposerControlsMenu` gain controlled open props, and `TraitsMenuContent` gains an `onOptionSelect` callback that refocuses the composer after selection.
> - Fixes keyboard event parsing so that events with code `Comma` resolve to `,` in shortcut matching.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf4739f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Composer UX and keybinding wiring only; no auth, data, or API surface changes beyond a new command ID.
> 
> **Overview**
> Adds **`modelOptionsPicker.toggle`** with default **`mod+shift+,`** (gated by `!terminalFocus`), registered in contracts/shared defaults and documented in user keybindings.
> 
> **Chat composer** exposes `toggleModelOptionsPicker()` on the composer handle; `ChatView` routes the command there. The picker is driven in **expanded** vs **compact** footer layouts via shared open state, and opening it closes the model picker (and vice versa). Trait pickers gain controlled `open`/`onOpenChange`, **`onOptionSelect`** to refocus the composer after a choice, and keyboard-open **focus on the current primary option** for arrow navigation.
> 
> **Key resolution** maps `Comma` → `","` so `mod+shift+,` matches reliably. Tests cover defaults, shortcut resolution, custom rebinding, and prop forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf4739fa8d5f73de3e8ceac0b3f3e8f99be13987. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->