### PR TITLE
feat(web): add shortcut to rename active thread

### DIFF
--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -195,6 +195,7 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
 
       assert.equal(defaultsByCommand.get("thread.previous"), "mod+shift+[");
       assert.equal(defaultsByCommand.get("thread.next"), "mod+shift+]");
+      assert.equal(defaultsByCommand.get("thread.rename" as KeybindingCommand), "mod+shift+r");
       assert.equal(defaultsByCommand.get("thread.jump.1"), "mod+1");
       assert.equal(defaultsByCommand.get("thread.jump.9"), "mod+9");
       assert.equal(defaultsByCommand.get("modelPicker.toggle"), "mod+shift+m");
@@ -279,7 +280,7 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
         const { keybindingsConfigPath } = yield* ServerConfig.ServerConfig;
         yield* writeKeybindingsConfig(keybindingsConfigPath, [
           { key: "mod+shift+t", command: "terminal.toggle" },
-          { key: "mod+shift+r", command: "script.run-tests.run" },
+          { key: "mod+shift+z", command: "script.run-tests.run" },
         ]);
 
         yield* Effect.gen(function* () {

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -1138,6 +1138,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
   );
   const router = useRouter();
   const { isMobile, setOpenMobile } = useSidebar();
+  const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const markThreadUnread = useUiStateStore((state) => state.markThreadUnread);
   const setProjectExpanded = useUiStateStore((state) => state.setProjectExpanded);
   const toggleThreadSelection = useThreadSelectionStore((state) => state.toggleThread);
@@ -2002,6 +2003,28 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     setRenamingTitle(title);
     renamingCommittedRef.current = false;
   }, []);
+  useEffect(() => {
+    if (!activeRouteThreadKey) return;
+    const onWindowKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.defaultPrevented || event.repeat) return;
+      const command = resolveShortcutCommand(event, keybindings, {
+        platform: navigator.platform,
+        context: {
+          terminalFocus: isTerminalFocused(),
+          terminalOpen: false,
+          modelPickerOpen: isModelPickerOpen(),
+        },
+      });
+      if (command !== "thread.rename") return;
+      const activeThread = sidebarThreadByKey.get(activeRouteThreadKey);
+      if (!activeThread) return;
+      event.preventDefault();
+      event.stopPropagation();
+      startThreadRename(activeRouteThreadKey, activeThread.title);
+    };
+    window.addEventListener("keydown", onWindowKeyDown);
+    return () => window.removeEventListener("keydown", onWindowKeyDown);
+  }, [activeRouteThreadKey, keybindings, sidebarThreadByKey, startThreadRename]);
 
   const commitRename = useCallback(
     async (threadRef: ScopedThreadRef, newTitle: string, originalTitle: string) => {

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -2000,11 +2000,15 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     renamingInputRef.current = null;
   }, []);
 
-  const startThreadRename = useCallback((threadKey: string, title: string) => {
-    setRenamingThreadKey(threadKey);
-    setRenamingTitle(title);
-    renamingCommittedRef.current = false;
-  }, []);
+  const startThreadRename = useCallback(
+    (threadKey: string, title: string) => {
+      if (renamingThreadKey === threadKey) return;
+      setRenamingThreadKey(threadKey);
+      setRenamingTitle(title);
+      renamingCommittedRef.current = false;
+    },
+    [renamingThreadKey],
+  );
   useEffect(() => {
     if (!activeRouteThreadKey) return;
     const onWindowKeyDown = (event: globalThis.KeyboardEvent) => {
@@ -2019,7 +2023,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       });
       if (command !== "thread.rename") return;
       const activeThread = sidebarThreadByKey.get(activeRouteThreadKey);
-      if (!activeThread) return;
+      if (!activeThread || activeThread.archivedAt !== null) return;
       event.preventDefault();
       event.stopPropagation();
       const activeRowRendered = renderedThreads.some(

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -1077,6 +1077,7 @@ interface SidebarProjectItemProps {
   project: SidebarProjectSnapshot;
   isThreadListExpanded: boolean;
   activeRouteThreadKey: string | null;
+  routeTerminalOpen: boolean;
   openPullRequestsInRightPanel: boolean;
   newThreadShortcutLabel: string | null;
   handleNewThread: ReturnType<typeof useNewThreadHandler>;
@@ -1098,6 +1099,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     project,
     isThreadListExpanded,
     activeRouteThreadKey,
+    routeTerminalOpen,
     openPullRequestsInRightPanel,
     newThreadShortcutLabel,
     handleNewThread,
@@ -2011,7 +2013,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         platform: navigator.platform,
         context: {
           terminalFocus: isTerminalFocused(),
-          terminalOpen: false,
+          terminalOpen: routeTerminalOpen,
           modelPickerOpen: isModelPickerOpen(),
         },
       });
@@ -2020,11 +2022,24 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       if (!activeThread) return;
       event.preventDefault();
       event.stopPropagation();
+      if (!isThreadListExpanded && hasOverflowingThreads) {
+        expandThreadListForProject(project.projectKey);
+      }
       startThreadRename(activeRouteThreadKey, activeThread.title);
     };
     window.addEventListener("keydown", onWindowKeyDown);
     return () => window.removeEventListener("keydown", onWindowKeyDown);
-  }, [activeRouteThreadKey, keybindings, sidebarThreadByKey, startThreadRename]);
+  }, [
+    activeRouteThreadKey,
+    expandThreadListForProject,
+    hasOverflowingThreads,
+    isThreadListExpanded,
+    keybindings,
+    project.projectKey,
+    routeTerminalOpen,
+    sidebarThreadByKey,
+    startThreadRename,
+  ]);
 
   const commitRename = useCallback(
     async (threadRef: ScopedThreadRef, newTitle: string, originalTitle: string) => {
@@ -2804,6 +2819,7 @@ interface SidebarProjectsContentProps {
   expandedThreadListsByProject: ReadonlySet<string>;
   activeRouteProjectKey: string | null;
   routeThreadKey: string | null;
+  routeTerminalOpen: boolean;
   openPullRequestsInRightPanel: boolean;
   newThreadShortcutLabel: string | null;
   commandPaletteShortcutLabel: string | null;
@@ -2846,6 +2862,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     expandedThreadListsByProject,
     activeRouteProjectKey,
     routeThreadKey,
+    routeTerminalOpen,
     openPullRequestsInRightPanel,
     newThreadShortcutLabel,
     commandPaletteShortcutLabel,
@@ -2987,6 +3004,9 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                         activeRouteThreadKey={
                           activeRouteProjectKey === project.projectKey ? routeThreadKey : null
                         }
+                        routeTerminalOpen={
+                          activeRouteProjectKey === project.projectKey ? routeTerminalOpen : false
+                        }
                         openPullRequestsInRightPanel={openPullRequestsInRightPanel}
                         newThreadShortcutLabel={newThreadShortcutLabel}
                         handleNewThread={handleNewThread}
@@ -3019,6 +3039,9 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                 isThreadListExpanded={expandedThreadListsByProject.has(project.projectKey)}
                 activeRouteThreadKey={
                   activeRouteProjectKey === project.projectKey ? routeThreadKey : null
+                }
+                routeTerminalOpen={
+                  activeRouteProjectKey === project.projectKey ? routeTerminalOpen : false
                 }
                 openPullRequestsInRightPanel={openPullRequestsInRightPanel}
                 newThreadShortcutLabel={newThreadShortcutLabel}
@@ -3706,6 +3729,7 @@ export default function LegacySidebar() {
         expandedThreadListsByProject={expandedThreadListsByProject}
         activeRouteProjectKey={activeRouteProjectKey}
         routeThreadKey={routeThreadKey}
+        routeTerminalOpen={routeTerminalOpen}
         openPullRequestsInRightPanel={routeThreadRef !== null}
         newThreadShortcutLabel={newThreadShortcutLabel}
         commandPaletteShortcutLabel={commandPaletteShortcutLabel}

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -1139,7 +1139,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     (settings) => settings.sidebarThreadPreviewCount,
   );
   const router = useRouter();
-  const { isMobile, setOpenMobile } = useSidebar();
+  const { isMobile, open, openMobile, setOpen, setOpenMobile } = useSidebar();
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const markThreadUnread = useUiStateStore((state) => state.markThreadUnread);
   const setProjectExpanded = useUiStateStore((state) => state.setProjectExpanded);
@@ -2022,8 +2022,19 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       if (!activeThread) return;
       event.preventDefault();
       event.stopPropagation();
-      if (!isThreadListExpanded && hasOverflowingThreads) {
+      const activeRowRendered = renderedThreads.some(
+        (thread) =>
+          scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)) === activeRouteThreadKey,
+      );
+      if (!activeRowRendered) {
         expandThreadListForProject(project.projectKey);
+      }
+      if (isMobile ? !openMobile : !open) {
+        if (isMobile) {
+          setOpenMobile(true);
+        } else {
+          setOpen(true);
+        }
       }
       startThreadRename(activeRouteThreadKey, activeThread.title);
     };
@@ -2032,11 +2043,15 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
   }, [
     activeRouteThreadKey,
     expandThreadListForProject,
-    hasOverflowingThreads,
-    isThreadListExpanded,
+    isMobile,
     keybindings,
+    open,
+    openMobile,
     project.projectKey,
+    renderedThreads,
     routeTerminalOpen,
+    setOpen,
+    setOpenMobile,
     sidebarThreadByKey,
     startThreadRename,
   ]);

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -2030,11 +2030,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         expandThreadListForProject(project.projectKey);
       }
       if (isMobile ? !openMobile : !open) {
-        if (isMobile) {
-          setOpenMobile(true);
-        } else {
-          setOpen(true);
-        }
+        (isMobile ? setOpenMobile : setOpen)(true);
       }
       startThreadRename(activeRouteThreadKey, activeThread.title);
     };

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3137,6 +3137,17 @@ export default function Sidebar() {
           modelPickerOpen: isModelPickerOpen(),
         },
       });
+      if (command === "thread.rename") {
+        const activeThread = routeThreadKey ? threadByKey.get(routeThreadKey) : null;
+        if (!activeThread) return;
+        event.preventDefault();
+        event.stopPropagation();
+        startThreadRename(
+          scopeThreadRef(activeThread.environmentId, activeThread.id),
+          activeThread.title,
+        );
+        return;
+      }
       const navigateToThreadKey = (targetThreadKey: string | null) => {
         if (!targetThreadKey) return false;
         const targetThread = threadByKey.get(targetThreadKey);
@@ -3169,6 +3180,7 @@ export default function Sidebar() {
     orderedThreadKeys,
     routeTerminalOpen,
     routeThreadKey,
+    startThreadRename,
     threadByKey,
   ]);
 

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3138,10 +3138,17 @@ export default function Sidebar() {
         },
       });
       if (command === "thread.rename") {
-        const activeThread = routeThreadKey ? threadByKey.get(routeThreadKey) : null;
-        if (!activeThread) return;
+        const activeThread = routeThreadKey
+          ? threads.find(
+              (thread) =>
+                scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)) === routeThreadKey,
+            )
+          : null;
+        if (!activeThread || activeThread.archivedAt !== null) return;
         event.preventDefault();
         event.stopPropagation();
+        if (isSearchingThreads) clearThreadSearch();
+        if (projectScopeKey !== null) setProjectScopeKey(null);
         startThreadRename(
           scopeThreadRef(activeThread.environmentId, activeThread.id),
           activeThread.title,
@@ -3176,11 +3183,15 @@ export default function Sidebar() {
     return () => window.removeEventListener("keydown", onWindowKeyDown);
   }, [
     keybindings,
+    clearThreadSearch,
+    isSearchingThreads,
     navigateToThread,
     orderedThreadKeys,
+    projectScopeKey,
     routeTerminalOpen,
     routeThreadKey,
     startThreadRename,
+    threads,
     threadByKey,
   ]);
 

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1596,7 +1596,7 @@ export default function Sidebar() {
   const projectOrder = useUiStateStore((store) => store.projectOrder);
   const threads = useThreadShells();
   const router = useRouter();
-  const { isMobile, setOpenMobile } = useSidebar();
+  const { isMobile, open, openMobile, setOpen, setOpenMobile } = useSidebar();
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const autoSettleAfterDays = useClientSettings((s) => s.sidebarAutoSettleAfterDays);
   const confirmThreadDelete = useClientSettings((s) => s.confirmThreadDelete);
@@ -3148,17 +3148,18 @@ export default function Sidebar() {
         event.preventDefault();
         event.stopPropagation();
         if (isSearchingThreads) clearThreadSearch();
-        if (
-          projectScopeKey !== null &&
-          (scopedProjectKeys === null ||
-            !scopedProjectKeys.has(`${activeThread.environmentId}:${activeThread.projectId}`))
-        ) {
+        const activeThreadRef = scopeThreadRef(activeThread.environmentId, activeThread.id);
+        if (projectScopeKey !== null && !threadByKey.has(scopedThreadKey(activeThreadRef))) {
           setProjectScopeKey(null);
         }
-        startThreadRename(
-          scopeThreadRef(activeThread.environmentId, activeThread.id),
-          activeThread.title,
-        );
+        if (isMobile ? !openMobile : !open) {
+          if (isMobile) {
+            setOpenMobile(true);
+          } else {
+            setOpen(true);
+          }
+        }
+        startThreadRename(activeThreadRef, activeThread.title);
         return;
       }
       const navigateToThreadKey = (targetThreadKey: string | null) => {
@@ -3191,12 +3192,16 @@ export default function Sidebar() {
     keybindings,
     clearThreadSearch,
     isSearchingThreads,
+    isMobile,
     navigateToThread,
     orderedThreadKeys,
+    open,
+    openMobile,
     projectScopeKey,
     routeTerminalOpen,
     routeThreadKey,
-    scopedProjectKeys,
+    setOpen,
+    setOpenMobile,
     startThreadRename,
     threads,
     threadByKey,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2277,10 +2277,15 @@ export default function Sidebar() {
 
   const [renamingThreadKey, setRenamingThreadKey] = useState<string | null>(null);
   const [renamingTitle, setRenamingTitle] = useState("");
-  const startThreadRename = useCallback((threadRef: ScopedThreadRef, title: string) => {
-    setRenamingThreadKey(scopedThreadKey(threadRef));
-    setRenamingTitle(title);
-  }, []);
+  const startThreadRename = useCallback(
+    (threadRef: ScopedThreadRef, title: string) => {
+      const threadKey = scopedThreadKey(threadRef);
+      if (renamingThreadKey === threadKey) return;
+      setRenamingThreadKey(threadKey);
+      setRenamingTitle(title);
+    },
+    [renamingThreadKey],
+  );
   const cancelThreadRename = useCallback(() => setRenamingThreadKey(null), []);
   const commitThreadRename = useCallback(
     (threadRef: ScopedThreadRef, title: string, originalTitle: string) => {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3148,7 +3148,13 @@ export default function Sidebar() {
         event.preventDefault();
         event.stopPropagation();
         if (isSearchingThreads) clearThreadSearch();
-        if (projectScopeKey !== null) setProjectScopeKey(null);
+        if (
+          projectScopeKey !== null &&
+          (scopedProjectKeys === null ||
+            !scopedProjectKeys.has(`${activeThread.environmentId}:${activeThread.projectId}`))
+        ) {
+          setProjectScopeKey(null);
+        }
         startThreadRename(
           scopeThreadRef(activeThread.environmentId, activeThread.id),
           activeThread.title,
@@ -3190,6 +3196,7 @@ export default function Sidebar() {
     projectScopeKey,
     routeTerminalOpen,
     routeThreadKey,
+    scopedProjectKeys,
     startThreadRename,
     threads,
     threadByKey,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3153,11 +3153,7 @@ export default function Sidebar() {
           setProjectScopeKey(null);
         }
         if (isMobile ? !openMobile : !open) {
-          if (isMobile) {
-            setOpenMobile(true);
-          } else {
-            setOpen(true);
-          }
+          (isMobile ? setOpenMobile : setOpen)(true);
         }
         startThreadRename(activeThreadRef, activeThread.title);
         return;

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -96,6 +96,12 @@ it.effect("parses keybinding rules", () =>
     });
     assert.strictEqual(parsedModelPickerJump.command, "modelPicker.jump.1");
 
+    const parsedThreadRename = yield* decode(KeybindingRule, {
+      key: "mod+shift+r",
+      command: "thread.rename",
+    });
+    assert.strictEqual(parsedThreadRename.command, "thread.rename");
+
     const parsedThreadPrevious = yield* decode(KeybindingRule, {
       key: "mod+shift+[",
       command: "thread.previous",

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -37,6 +37,7 @@ export type ModelPickerJumpKeybindingCommand =
 export const THREAD_KEYBINDING_COMMANDS = [
   "thread.previous",
   "thread.next",
+  "thread.rename",
   ...THREAD_JUMP_KEYBINDING_COMMANDS,
 ] as const;
 export type ThreadKeybindingCommand = (typeof THREAD_KEYBINDING_COMMANDS)[number];

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -46,6 +46,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+o", command: "editor.openFavorite" },
   { key: "mod+shift+[", command: "thread.previous" },
   { key: "mod+shift+]", command: "thread.next" },
+  { key: "mod+shift+r", command: "thread.rename" },
   ...THREAD_JUMP_KEYBINDING_COMMANDS.map((command, index) => ({
     key: `mod+${index + 1}`,
     command,


### PR DESCRIPTION
## Summary
Adds a configurable `thread.rename` command with the default `mod+shift+r`, exposing the existing inline rename flow for the active thread in both sidebar implementations.

## Test plan
- [x] Focused contracts, server, and web keybinding tests (77 passing)
- [x] Web typecheck
- [x] Formatting and diff checks
- [ ] Manual browser screenshot: the controlled local preview timed out while rendering, so no screenshot was attached.

Implemented by GPT-5.6 Luna using Cursor T3 Code.

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `mod+shift+r` shortcut to rename the active thread in the sidebar
> - Adds `thread.rename` to the default keybindings and contract-level `ThreadKeybindingCommand` type, bound to `mod+shift+r`.
> - Both the main [`Sidebar.tsx`](https://github.com/pingdotgg/t3code/pull/7573/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) and [`LegacySidebar.tsx`](https://github.com/pingdotgg/t3code/pull/7573/files#diff-ef6c49faf62e0e2403f09772084537ac313e826ae0f90db230a898204f3bdd86) listen for this shortcut and invoke rename on the active thread.
> - If the sidebar is closed, it is opened automatically; if the active thread's project is collapsed, it is expanded; thread search and project scope are reset as needed so the thread is visible before rename starts.
> - Re-triggering the shortcut when rename is already active is a no-op.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8c94a1a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->