### PR TITLE
feat: download workspace files and copy them as files on desktop

### DIFF
--- a/apps/desktop/src/ipc/DesktopIpcHandlers.ts
+++ b/apps/desktop/src/ipc/DesktopIpcHandlers.ts
@@ -43,6 +43,7 @@ import {
   setTheme,
   showContextMenu,
 } from "./methods/window.ts";
+import { copyFileToClipboard } from "./methods/fileClipboard.ts";
 import * as PreviewIpc from "./methods/preview.ts";
 import { getWslState, setWslBackendEnabled, setWslDistro, setWslOnly } from "./methods/wsl.ts";
 
@@ -86,6 +87,7 @@ export const installDesktopIpcHandlers = Effect.fn("desktop.ipc.installHandlers"
   yield* ipc.handle(setTheme);
   yield* ipc.handle(showContextMenu);
   yield* ipc.handle(openExternal);
+  yield* ipc.handle(copyFileToClipboard);
   yield* ipc.handle(probeRemoteEditors);
   yield* ipc.handle(getUpdateState);
   yield* ipc.handle(setUpdateChannel);

--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -42,6 +42,7 @@ export const SET_WSL_BACKEND_ENABLED_CHANNEL = "desktop:set-wsl-backend-enabled"
 export const SET_WSL_DISTRO_CHANNEL = "desktop:set-wsl-distro";
 export const SET_WSL_ONLY_CHANNEL = "desktop:set-wsl-only";
 export const SSH_PASSWORD_PROMPT_CANCELLED_RESULT = "ssh-password-prompt-cancelled";
+export const COPY_FILE_TO_CLIPBOARD_CHANNEL = "desktop:copy-file-to-clipboard";
 export const PREVIEW_CREATE_TAB_CHANNEL = "desktop:preview-create-tab";
 export const PREVIEW_CLOSE_TAB_CHANNEL = "desktop:preview-close-tab";
 export const PREVIEW_REGISTER_WEBVIEW_CHANNEL = "desktop:preview-register-webview";

--- a/apps/desktop/src/ipc/methods/fileClipboard.test.ts
+++ b/apps/desktop/src/ipc/methods/fileClipboard.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { fileReferenceClipboardPayload, sanitizeClipboardFileName } from "./fileClipboard.ts";
+
+describe("sanitizeClipboardFileName", () => {
+  it("strips path separators and NUL bytes", () => {
+    expect(sanitizeClipboardFileName("../secrets/key.pem")).toBe(".._secrets_key.pem");
+    expect(sanitizeClipboardFileName("a\\b:c\0d.csv")).toBe("a_b_c_d.csv");
+  });
+
+  it("falls back for names that reduce to nothing", () => {
+    expect(sanitizeClipboardFileName("..")).toBe("download");
+  });
+});
+
+describe("fileReferenceClipboardPayload", () => {
+  it("emits an escaped NSFilenamesPboardType plist on macOS", () => {
+    const payload = fileReferenceClipboardPayload("darwin", "/tmp/a & b.csv");
+    expect(payload.format).toBe("NSFilenamesPboardType");
+    const plist = payload.buffer.toString("utf8");
+    expect(plist).toContain("<string>/tmp/a &amp; b.csv</string>");
+    expect(plist).toContain('<plist version="1.0">');
+  });
+
+  it("emits a wide-character DROPFILES struct on Windows", () => {
+    const payload = fileReferenceClipboardPayload("win32", String.raw`C:\tmp\a.csv`);
+    expect(payload.format).toBe("CF_HDROP");
+    expect(payload.buffer.readUInt32LE(0)).toBe(20);
+    expect(payload.buffer.readUInt32LE(16)).toBe(1);
+    expect(payload.buffer.subarray(20).toString("utf16le")).toBe("C:\\tmp\\a.csv\0\0");
+  });
+
+  it("emits the GNOME copied-files convention on Linux", () => {
+    const payload = fileReferenceClipboardPayload("linux", "/tmp/relatório final.csv");
+    expect(payload.format).toBe("x-special/gnome-copied-files");
+    expect(payload.buffer.toString("utf8")).toBe("copy\nfile:///tmp/relat%C3%B3rio%20final.csv");
+  });
+});

--- a/apps/desktop/src/ipc/methods/fileClipboard.ts
+++ b/apps/desktop/src/ipc/methods/fileClipboard.ts
@@ -1,0 +1,155 @@
+import * as NodeURL from "node:url";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+
+import * as Electron from "electron";
+
+import * as DesktopEnvironment from "../../app/DesktopEnvironment.ts";
+import * as IpcChannels from "../channels.ts";
+import * as DesktopIpc from "../DesktopIpc.ts";
+
+const CopyFileToClipboardInput = Schema.Struct({
+  url: Schema.String.check(Schema.isTrimmed()).check(Schema.isNonEmpty()),
+  fileName: Schema.String.check(Schema.isTrimmed()).check(Schema.isNonEmpty()),
+});
+
+export class DesktopFileClipboardError extends Schema.TaggedErrorClass<DesktopFileClipboardError>()(
+  "DesktopFileClipboardError",
+  {
+    reason: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {
+  override get message(): string {
+    return this.reason;
+  }
+}
+
+// The staged copy lives under the desktop state dir so the clipboard reference
+// stays valid after the renderer navigates or the remote environment goes away.
+const FILE_CLIPBOARD_DIR_NAME = "file-clipboard";
+
+export function sanitizeClipboardFileName(fileName: string): string {
+  const sanitized = fileName.replaceAll("\u0000", "_").replace(/[\\/:]/g, "_");
+  return sanitized === "" || /^\.+$/.test(sanitized) ? "download" : sanitized;
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+// Each platform expects a different raw clipboard format for "a file was
+// copied": an NSFilenamesPboardType plist on macOS, a CF_HDROP DROPFILES
+// struct on Windows, and the GNOME copied-files convention elsewhere.
+export function fileReferenceClipboardPayload(
+  platform: NodeJS.Platform,
+  filePath: string,
+): { readonly format: string; readonly buffer: Buffer } {
+  switch (platform) {
+    case "darwin": {
+      const plist = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+        '<plist version="1.0">',
+        "<array>",
+        `<string>${escapeXml(filePath)}</string>`,
+        "</array>",
+        "</plist>",
+      ].join("\n");
+      return { format: "NSFilenamesPboardType", buffer: Buffer.from(plist, "utf8") };
+    }
+    case "win32": {
+      // DROPFILES header: pFiles (offset to the path list), pt.x, pt.y, fNC,
+      // fWide, followed by a UTF-16LE double-null-terminated path list.
+      const header = Buffer.alloc(20);
+      header.writeUInt32LE(20, 0);
+      header.writeUInt32LE(1, 16);
+      const paths = Buffer.from(`${filePath}\0\0`, "utf16le");
+      return { format: "CF_HDROP", buffer: Buffer.concat([header, paths]) };
+    }
+    default: {
+      const uri = NodeURL.pathToFileURL(filePath).href;
+      return {
+        format: "x-special/gnome-copied-files",
+        buffer: Buffer.from(`copy\n${uri}`, "utf8"),
+      };
+    }
+  }
+}
+
+export const copyFileToClipboard = DesktopIpc.makeIpcMethod({
+  channel: IpcChannels.COPY_FILE_TO_CLIPBOARD_CHANNEL,
+  payload: CopyFileToClipboardInput,
+  result: Schema.Void,
+  handler: Effect.fn("desktop.ipc.fileClipboard.copyFileToClipboard")(function* ({
+    url,
+    fileName,
+  }) {
+    const parsedUrl = yield* Effect.try({
+      try: () => new URL(url),
+      catch: (cause) => new DesktopFileClipboardError({ reason: "Invalid file URL.", cause }),
+    });
+    if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+      return yield* new DesktopFileClipboardError({
+        reason: "Only http and https file URLs can be copied.",
+      });
+    }
+
+    const environment = yield* DesktopEnvironment.DesktopEnvironment;
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const stagingDir = path.join(environment.stateDir, FILE_CLIPBOARD_DIR_NAME);
+
+    const bytes = yield* Effect.tryPromise({
+      try: async () => {
+        const response = await Electron.net.fetch(parsedUrl.href);
+        if (!response.ok) {
+          throw new Error(`The file request failed with status ${response.status}.`);
+        }
+        return new Uint8Array(await response.arrayBuffer());
+      },
+      catch: (cause) =>
+        new DesktopFileClipboardError({ reason: "Failed to download the file.", cause }),
+    });
+
+    // Replace any previously staged copy; its clipboard reference is
+    // superseded by the write below.
+    const targetPath = path.join(stagingDir, sanitizeClipboardFileName(fileName));
+    yield* fileSystem
+      .remove(stagingDir, { recursive: true })
+      .pipe(Effect.orElseSucceed(() => undefined));
+    yield* fileSystem
+      .makeDirectory(stagingDir, { recursive: true })
+      .pipe(
+        Effect.mapError(
+          (cause) => new DesktopFileClipboardError({ reason: "Failed to stage the file.", cause }),
+        ),
+      );
+    yield* fileSystem
+      .writeFile(targetPath, bytes)
+      .pipe(
+        Effect.mapError(
+          (cause) => new DesktopFileClipboardError({ reason: "Failed to stage the file.", cause }),
+        ),
+      );
+
+    const platform = yield* HostProcessPlatform;
+    const payload = fileReferenceClipboardPayload(platform, targetPath);
+    yield* Effect.try({
+      try: () => Electron.clipboard.writeBuffer(payload.format, payload.buffer),
+      catch: (cause) =>
+        new DesktopFileClipboardError({
+          reason: "Failed to write the file to the clipboard.",
+          cause,
+        }),
+    });
+  }),
+});

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -109,6 +109,8 @@ contextBridge.exposeInMainWorld("desktopBridge", {
       ...(position === undefined ? {} : { position }),
     }),
   openExternal: (url: string) => ipcRenderer.invoke(IpcChannels.OPEN_EXTERNAL_CHANNEL, url),
+  copyFileToClipboard: (input) =>
+    ipcRenderer.invoke(IpcChannels.COPY_FILE_TO_CLIPBOARD_CHANNEL, input),
   probeRemoteEditors: () => ipcRenderer.invoke(IpcChannels.PROBE_REMOTE_EDITORS_CHANNEL, undefined),
   onMenuAction: (listener) => {
     const wrappedListener = (_event: Electron.IpcRendererEvent, action: unknown) => {

--- a/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
+++ b/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
@@ -1,7 +1,7 @@
 import { NativeHeaderToolbar, NativeStackScreenOptions } from "../../native/StackHeader";
 import { StackActions, useNavigation, type StaticScreenProps } from "@react-navigation/native";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ActivityIndicator, Platform, View } from "react-native";
+import { ActivityIndicator, Alert, Platform, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import Svg, { Defs, LinearGradient, Rect, Stop } from "react-native-svg";
 import {
@@ -24,6 +24,9 @@ import { useThreadSelection } from "../../state/use-thread-selection";
 import { useSelectedThreadWorktree } from "../../state/use-selected-thread-worktree";
 import { useEnvironmentQuery } from "../../state/query";
 import { projectEnvironment } from "../../state/projects";
+import { assetEnvironment } from "../../state/assets";
+import { usePreparedConnection } from "../../state/session";
+import { useAtomQueryRunner } from "../../state/use-atom-query-runner";
 import {
   useAdaptiveWorkspaceLayout,
   useAdaptiveWorkspacePaneRole,
@@ -51,6 +54,7 @@ import {
   isMarkdownPreviewFile,
   isSvgImagePreviewFile,
 } from "./filePath";
+import { shareWorkspaceFile, WorkspaceFileShareInterrupted } from "./shareWorkspaceFile";
 import { useWorkspaceFileAssetUrl } from "./workspaceFileAssetUrl";
 
 type FileViewMode = "preview" | "source";
@@ -495,6 +499,35 @@ export function ThreadFileScreen(props: ThreadFileRouteScreenProps) {
     relativePath: assetPreviewPath,
     threadId,
   });
+  const createAssetUrl = useAtomQueryRunner(assetEnvironment.createUrl, {
+    reportFailure: false,
+  });
+  const preparedConnection = usePreparedConnection(environmentId);
+  const downloadHttpBaseUrl =
+    preparedConnection._tag === "Some" ? preparedConnection.value.httpBaseUrl : null;
+  const handleDownloadFile = useCallback(() => {
+    if (
+      environmentId === null ||
+      threadId === null ||
+      relativePath === null ||
+      downloadHttpBaseUrl === null
+    ) {
+      return;
+    }
+    void shareWorkspaceFile({
+      environmentId,
+      threadId,
+      path: relativePath,
+      httpBaseUrl: downloadHttpBaseUrl,
+      createAssetUrl,
+    }).catch((cause: unknown) => {
+      if (cause instanceof WorkspaceFileShareInterrupted) return;
+      Alert.alert(
+        "Unable to download file",
+        cause instanceof Error ? cause.message : "An error occurred.",
+      );
+    });
+  }, [createAssetUrl, downloadHttpBaseUrl, environmentId, relativePath, threadId]);
   const previewUri =
     assetPreviewUri === null || previewRevision === 0
       ? assetPreviewUri
@@ -636,6 +669,14 @@ export function ThreadFileScreen(props: ThreadFileRouteScreenProps) {
             >
               Copy path
             </NativeHeaderToolbar.MenuAction>
+            {downloadHttpBaseUrl !== null ? (
+              <NativeHeaderToolbar.MenuAction
+                icon="square.and.arrow.down"
+                onPress={handleDownloadFile}
+              >
+                Download
+              </NativeHeaderToolbar.MenuAction>
+            ) : null}
             {isBrowserFile && typeof assetPreviewUri === "string" ? (
               <NativeHeaderToolbar.MenuAction
                 icon="safari"

--- a/apps/mobile/src/features/files/shareWorkspaceFile.ts
+++ b/apps/mobile/src/features/files/shareWorkspaceFile.ts
@@ -1,0 +1,73 @@
+import { resolveAssetUrl } from "@t3tools/client-runtime/state/assets";
+import type { AtomCommandResult } from "@t3tools/client-runtime/state/runtime";
+import {
+  isAtomCommandInterrupted,
+  squashAtomCommandFailure,
+} from "@t3tools/client-runtime/state/runtime";
+import type {
+  AssetCreateUrlResult,
+  AssetResource,
+  EnvironmentId,
+  ThreadId,
+} from "@t3tools/contracts";
+
+export type CreateAssetUrlRunner = (input: {
+  readonly environmentId: EnvironmentId;
+  readonly input: { readonly resource: AssetResource };
+}) => Promise<AtomCommandResult<AssetCreateUrlResult, unknown>>;
+
+const SHARE_CACHE_DIRECTORY = "workspace-file-shares";
+
+export class WorkspaceFileShareInterrupted extends Error {}
+
+function failureMessage(cause: unknown): string {
+  return cause instanceof Error ? cause.message : "An error occurred.";
+}
+
+/**
+ * Downloads a workspace file through a signed asset URL into the app cache and
+ * hands it to the OS share sheet (Save to Files, AirDrop, other apps).
+ * Throws with a user-presentable message; throws WorkspaceFileShareInterrupted
+ * when the underlying request was interrupted and no feedback is warranted.
+ */
+export async function shareWorkspaceFile(input: {
+  readonly environmentId: EnvironmentId;
+  readonly threadId: ThreadId;
+  readonly path: string;
+  readonly httpBaseUrl: string;
+  readonly createAssetUrl: CreateAssetUrlRunner;
+}): Promise<void> {
+  const assetResult = await input.createAssetUrl({
+    environmentId: input.environmentId,
+    input: {
+      resource: {
+        _tag: "workspace-file-download",
+        threadId: input.threadId,
+        path: input.path,
+      },
+    },
+  });
+  if (assetResult._tag === "Failure") {
+    if (isAtomCommandInterrupted(assetResult)) {
+      throw new WorkspaceFileShareInterrupted();
+    }
+    throw new Error(failureMessage(squashAtomCommandFailure(assetResult)));
+  }
+  const url = resolveAssetUrl(input.httpBaseUrl, assetResult.value.relativeUrl);
+  if (url === null) {
+    throw new Error("The environment returned an invalid asset URL.");
+  }
+
+  const { Directory, File, Paths } = await import("expo-file-system");
+  const directory = new Directory(Paths.cache, SHARE_CACHE_DIRECTORY);
+  directory.create({ intermediates: true, idempotent: true });
+  const fileName = input.path.split(/[\\/]/).pop() ?? "download";
+  const target = new File(directory, fileName);
+  if (target.exists) {
+    target.delete();
+  }
+  const downloaded = await File.downloadFileAsync(url, target);
+
+  const Sharing = await import("expo-sharing");
+  await Sharing.shareAsync(downloaded.uri);
+}

--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -184,6 +184,63 @@ describe("AssetAccess", () => {
     }).pipe(Effect.provide(testLayer)),
   );
 
+  it.effect("issues download URLs for non-preview workspace files", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-download-",
+      });
+      const csvPath = path.join(root, "data", "results.csv");
+      const siblingPath = path.join(root, "data", "other.csv");
+      yield* fileSystem.makeDirectory(path.join(root, "data"), { recursive: true });
+      yield* fileSystem.writeFileString(csvPath, "a,b\n1,2\n");
+      yield* fileSystem.writeFileString(siblingPath, "c,d\n3,4\n");
+      const canonicalCsvPath = yield* fileSystem.realPath(csvPath);
+
+      const result = yield* issueAssetUrl({
+        resource: {
+          _tag: "workspace-file-download",
+          threadId: ThreadId.make("thread-1"),
+          path: "data/results.csv",
+        },
+        workspaceRoot: root,
+      });
+      expect(result.relativeUrl.endsWith("/results.csv")).toBe(true);
+      const suffix = result.relativeUrl.slice(`${ASSET_ROUTE_PREFIX}/`.length);
+      const separatorIndex = suffix.indexOf("/");
+      const token = suffix.slice(0, separatorIndex);
+
+      expect(yield* resolveAsset(token, "results.csv")).toEqual({
+        kind: "file",
+        path: canonicalCsvPath,
+        downloadFileName: "results.csv",
+      });
+      expect(yield* resolveAsset(token, "other.csv")).toBeNull();
+      expect(yield* resolveAsset(token, "../results.csv")).toBeNull();
+      expect(yield* resolveAsset(`${token}tampered`, "results.csv")).toBeNull();
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("rejects downloads outside the authorized root", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-download-root-",
+      });
+
+      const error = yield* issueAssetUrl({
+        resource: {
+          _tag: "workspace-file-download",
+          threadId: ThreadId.make("thread-1"),
+          path: "../outside.csv",
+        },
+        workspaceRoot: root,
+      }).pipe(Effect.flip);
+      expect(error._tag).toBe("AssetWorkspacePathValidationError");
+    }).pipe(Effect.provide(testLayer)),
+  );
+
   it.effect("issues exact attachment capabilities by attachment id", () =>
     Effect.gen(function* () {
       const config = yield* ServerConfig.ServerConfig;

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -77,6 +77,13 @@ const AssetClaimsSchema = Schema.Union([
   }),
   Schema.Struct({
     version: Schema.Literal(1),
+    kind: Schema.Literal("workspace-file-download"),
+    workspaceRoot: Schema.String,
+    relativePath: Schema.String,
+    expiresAt: Schema.Number,
+  }),
+  Schema.Struct({
+    version: Schema.Literal(1),
     kind: Schema.Literal("attachment"),
     attachmentId: Schema.String,
     expiresAt: Schema.Number,
@@ -95,7 +102,12 @@ const AssetClaimsJson = Schema.fromJsonString(AssetClaimsSchema);
 const decodeAssetClaims = Schema.decodeUnknownOption(AssetClaimsJson);
 const encodeAssetClaims = Schema.encodeSync(AssetClaimsJson);
 
-export type ResolvedAsset = { readonly kind: "file"; readonly path: string };
+export type ResolvedAsset = {
+  readonly kind: "file";
+  readonly path: string;
+  // Present when the asset must be served as a download instead of inline.
+  readonly downloadFileName?: string;
+};
 
 function decodeClaims(encodedPayload: string): AssetClaims | null {
   try {
@@ -180,7 +192,8 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
   let sourcePath: string | undefined;
 
   switch (input.resource._tag) {
-    case "workspace-file": {
+    case "workspace-file":
+    case "workspace-file-download": {
       if (!input.workspaceRoot) {
         return yield* new AssetWorkspaceContextNotFoundError({
           resource: input.resource,
@@ -209,7 +222,10 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
               }),
           ),
         );
-      if (!isWorkspacePreviewEntryPath(resolved.relativePath)) {
+      if (
+        input.resource._tag === "workspace-file" &&
+        !isWorkspacePreviewEntryPath(resolved.relativePath)
+      ) {
         return yield* new AssetPreviewTypeValidationError({
           resource: input.resource,
         });
@@ -240,21 +256,30 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
             }),
         ),
       );
-      claims = isWorkspaceImagePreviewPath(resolved.relativePath)
-        ? {
-            version: 1,
-            kind: "workspace-file-exact",
-            workspaceRoot: canonicalWorkspaceRoot,
-            relativePath: resolved.relativePath,
-            expiresAt,
-          }
-        : {
-            version: 1,
-            kind: "workspace-file",
-            workspaceRoot: canonicalWorkspaceRoot,
-            baseRelativePath: path.dirname(resolved.relativePath),
-            expiresAt,
-          };
+      claims =
+        input.resource._tag === "workspace-file-download"
+          ? {
+              version: 1,
+              kind: "workspace-file-download",
+              workspaceRoot: canonicalWorkspaceRoot,
+              relativePath: resolved.relativePath,
+              expiresAt,
+            }
+          : isWorkspaceImagePreviewPath(resolved.relativePath)
+            ? {
+                version: 1,
+                kind: "workspace-file-exact",
+                workspaceRoot: canonicalWorkspaceRoot,
+                relativePath: resolved.relativePath,
+                expiresAt,
+              }
+            : {
+                version: 1,
+                kind: "workspace-file",
+                workspaceRoot: canonicalWorkspaceRoot,
+                baseRelativePath: path.dirname(resolved.relativePath),
+                expiresAt,
+              };
       fileName = path.basename(resolved.relativePath);
       break;
     }
@@ -444,15 +469,20 @@ export const resolveAsset = Effect.fn("AssetAccess.resolveAsset")(function* (
   const decodedPath = decodeRelativePath(relativePath);
   if (decodedPath === null) return null;
   const path = yield* Path.Path;
-  if (claims.kind === "workspace-file-exact") {
+  if (claims.kind === "workspace-file-exact" || claims.kind === "workspace-file-download") {
     if (decodedPath !== path.basename(claims.relativePath)) return null;
     const exactWorkspaceFile = yield* resolveCanonicalWorkspaceFileForRequest({
       workspaceRoot: claims.workspaceRoot,
       relativePath: claims.relativePath,
     });
-    return exactWorkspaceFile
-      ? ({ kind: "file", path: exactWorkspaceFile } satisfies ResolvedAsset)
-      : null;
+    if (!exactWorkspaceFile) return null;
+    return claims.kind === "workspace-file-download"
+      ? ({
+          kind: "file",
+          path: exactWorkspaceFile,
+          downloadFileName: path.basename(claims.relativePath),
+        } satisfies ResolvedAsset)
+      : ({ kind: "file", path: exactWorkspaceFile } satisfies ResolvedAsset);
   }
   const segments = decodedPath.split(/[\\/]/);
   if (

--- a/apps/server/src/http.test.ts
+++ b/apps/server/src/http.test.ts
@@ -44,4 +44,23 @@ describe("assetResponseHeaders", () => {
       "X-Content-Type-Options": "nosniff",
     });
   });
+
+  it("marks downloads as attachments with a safe filename", () => {
+    expect(assetResponseHeaders("/workspace/results.csv", "results.csv")).toMatchObject({
+      "Content-Disposition": `attachment; filename="results.csv"; filename*=UTF-8''results.csv`,
+    });
+  });
+
+  it("escapes filenames that break the quoted-string form", () => {
+    const headers = assetResponseHeaders("/workspace/relatório.csv", 'rela"tório\r\n.csv');
+    expect(headers["Content-Disposition"]).toBe(
+      `attachment; filename="rela_t_rio__.csv"; filename*=UTF-8''rela%22t%C3%B3rio%0D%0A.csv`,
+    );
+  });
+
+  it("keeps the SVG sandbox policy on downloaded SVGs", () => {
+    expect(assetResponseHeaders("/workspace/chart.svg", "chart.svg")).toHaveProperty(
+      "Content-Security-Policy",
+    );
+  });
 });

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -45,14 +45,29 @@ const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "::1", "localhost"]);
 const DESKTOP_RENDERER_ORIGINS = ["t3code://app", "t3code-dev://app"];
 const SVG_CONTENT_SECURITY_POLICY = "default-src 'none'; style-src 'unsafe-inline'; sandbox";
 
-export function assetResponseHeaders(filePath: string): Record<string, string> {
+export function assetResponseHeaders(
+  filePath: string,
+  downloadFileName?: string,
+): Record<string, string> {
   return {
     "Cache-Control": "private, max-age=3600",
     "X-Content-Type-Options": "nosniff",
+    ...(downloadFileName ? { "Content-Disposition": contentDisposition(downloadFileName) } : {}),
     ...(filePath.toLowerCase().endsWith(".svg")
       ? { "Content-Security-Policy": SVG_CONTENT_SECURITY_POLICY }
       : {}),
   };
+}
+
+// RFC 6266 attachment disposition with an RFC 5987 UTF-8 fallback for
+// filenames that do not survive the quoted-string form.
+function contentDisposition(fileName: string): string {
+  const asciiFileName = fileName.replace(/["\\\r\n]/g, "_").replace(/[^ -~]/g, "_");
+  const encodedFileName = encodeURIComponent(fileName).replace(
+    /['()*]/g,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+  return `attachment; filename="${asciiFileName}"; filename*=UTF-8''${encodedFileName}`;
 }
 
 export const httpCompressionLayer = HttpRouter.middleware(HttpMiddleware.compression(), {
@@ -219,7 +234,7 @@ export const assetRouteLayer = HttpRouter.add(
     }
     return yield* HttpServerResponse.file(asset.path, {
       status: 200,
-      headers: assetResponseHeaders(asset.path),
+      headers: assetResponseHeaders(asset.path, asset.downloadFileName),
     }).pipe(
       Effect.orElseSucceed(() => HttpServerResponse.text("Internal Server Error", { status: 500 })),
     );

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -97,6 +97,12 @@ import {
   pickWorkspaceBasenameMatch,
   WORKSPACE_BASENAME_LOOKUP_LIMIT,
 } from "../workspaceBasenameLookup";
+import {
+  canCopyWorkspaceFileToClipboard,
+  copyWorkspaceFileToClipboard,
+  downloadWorkspaceFile,
+  type WorkspaceFileTransferAction,
+} from "../workspaceFileTransfer";
 import { useOpenChangeRequestLink } from "~/lib/openPullRequestLink";
 import { writeTextToClipboard } from "../hooks/useCopyToClipboard";
 import { isPreviewSupportedInRuntime } from "../previewStateStore";
@@ -822,6 +828,7 @@ interface MarkdownFileLinkProps {
   onOpen: (targetPath: string) => Promise<AtomCommandResult<unknown, unknown>>;
   onOpenInPanel: (workspaceRelativePath: string, line: number | undefined) => void;
   onOpenInBrowser?: (() => Promise<AtomCommandResult<unknown, unknown>>) | undefined;
+  onFileTransfer?: ((action: WorkspaceFileTransferAction) => void) | undefined;
   className?: string | undefined;
 }
 
@@ -1128,6 +1135,7 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
   onOpen,
   onOpenInPanel,
   onOpenInBrowser,
+  onFileTransfer,
   className,
 }: MarkdownFileLinkProps) {
   const handleOpenInEditor = useCallback(() => {
@@ -1267,6 +1275,10 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
               : []),
             { id: "copy-relative", label: "Copy relative path" },
             { id: "copy-full", label: "Copy full path" },
+            ...(onFileTransfer ? ([{ id: "download", label: "Download file" }] as const) : []),
+            ...(onFileTransfer && canCopyWorkspaceFileToClipboard()
+              ? ([{ id: "copy-file", label: "Copy file" }] as const)
+              : []),
           ] as const,
           { x: event.clientX, y: event.clientY },
         );
@@ -1285,6 +1297,10 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
         }
         if (clicked === "copy-full") {
           handleCopy(targetPath, "Full path");
+          return;
+        }
+        if (clicked === "download" || clicked === "copy-file") {
+          onFileTransfer?.(clicked);
         }
       } catch (cause) {
         reportMarkdownActionFailure(
@@ -1293,7 +1309,15 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
         );
       }
     },
-    [displayPath, handleCopy, handleOpenInBrowser, handleOpenInEditor, onOpenInBrowser, targetPath],
+    [
+      displayPath,
+      handleCopy,
+      handleOpenInBrowser,
+      handleOpenInEditor,
+      onFileTransfer,
+      onOpenInBrowser,
+      targetPath,
+    ],
   );
 
   return (
@@ -1349,6 +1373,7 @@ function areMarkdownFileLinkPropsEqual(
     previous.onOpen === next.onOpen &&
     previous.onOpenInPanel === next.onOpenInPanel &&
     previous.onOpenInBrowser === next.onOpenInBrowser &&
+    previous.onFileTransfer === next.onFileTransfer &&
     previous.className === next.className
   );
 }
@@ -1473,6 +1498,21 @@ function ChatMarkdown({
     },
     [createAssetUrl, openPreview, preparedConnection, threadRef],
   );
+  const transferMarkdownFile = useCallback(
+    (action: WorkspaceFileTransferAction, filePath: string) => {
+      if (!threadRef || preparedConnection._tag === "None") return;
+      const input = {
+        threadRef,
+        filePath,
+        httpBaseUrl: preparedConnection.value.httpBaseUrl,
+        createAssetUrl,
+      };
+      void (action === "download"
+        ? downloadWorkspaceFile(input)
+        : copyWorkspaceFileToClipboard(input));
+    },
+    [createAssetUrl, preparedConnection, threadRef],
+  );
   // A bare filename resolves to the workspace root, which is rarely where the
   // file is, so ask the index before opening.
   const openFileInPanel = useCallback(
@@ -1547,6 +1587,9 @@ function ChatMarkdown({
             isBrowserPreviewFile(fileLinkMeta.filePath)
               ? () => openMarkdownFileInPreview(fileLinkMeta.filePath)
               : undefined
+          }
+          onFileTransfer={
+            threadRef ? (action) => transferMarkdownFile(action, fileLinkMeta.filePath) : undefined
           }
           className={className}
         />
@@ -1780,6 +1823,7 @@ function ChatMarkdown({
     skills,
     text,
     threadRef,
+    transferMarkdownFile,
   ]);
   /* eslint-enable react/no-unstable-nested-components */
 

--- a/apps/web/src/components/files/FileBrowserPanel.tsx
+++ b/apps/web/src/components/files/FileBrowserPanel.tsx
@@ -18,6 +18,10 @@ import { useTheme } from "~/hooks/useTheme";
 import { cn } from "~/lib/utils";
 import { readLocalApi } from "~/localApi";
 import { T3_PIERRE_ICONS } from "~/pierre-icons";
+import {
+  canCopyWorkspaceFileToClipboard,
+  type WorkspaceFileTransferAction,
+} from "~/workspaceFileTransfer";
 
 import { createFileTreeDragMentionController } from "./fileTreeDragMention";
 import { useProjectEntriesQuery } from "./projectFilesQueryState";
@@ -31,6 +35,10 @@ interface FileBrowserPanelProps {
   /** Bumped when the same path should be revealed again (e.g. re-opened from search). */
   selectedPathRevealId: number;
   onOpenFile: (relativePath: string) => void;
+  /** Present when the host surface can download/copy workspace files. */
+  onFileTransfer?:
+    | ((action: WorkspaceFileTransferAction, relativePath: string) => void)
+    | undefined;
 }
 
 const TREE_UNSAFE_CSS = `
@@ -105,6 +113,7 @@ export default function FileBrowserPanel({
   selectedPath,
   selectedPathRevealId,
   onOpenFile,
+  onFileTransfer,
 }: FileBrowserPanelProps) {
   const { resolvedTheme } = useTheme();
   const composerRef = useComposerHandleContext();
@@ -150,14 +159,24 @@ export default function FileBrowserPanel({
     const position = pointerIsFresh
       ? { x: pointer.x, y: pointer.y }
       : { x: anchorRect.left, y: anchorRect.bottom };
+    const canTransfer =
+      onFileTransfer !== undefined && entryKindsRef.current.get(relativePath) === "file";
     try {
       const clicked = await api.contextMenu.show(
         [
           { id: "copy-mention", label: "Copy mention" },
           { id: "add-to-chat", label: "Add to chat" },
+          ...(canTransfer ? ([{ id: "download", label: "Download file" }] as const) : []),
+          ...(canTransfer && canCopyWorkspaceFileToClipboard()
+            ? ([{ id: "copy-file", label: "Copy file" }] as const)
+            : []),
         ],
         position,
       );
+      if (clicked === "download" || clicked === "copy-file") {
+        onFileTransfer?.(clicked, relativePath);
+        return;
+      }
       if (clicked === "copy-mention") {
         try {
           await writeTextToClipboard(mention);

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -12,7 +12,16 @@ import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
-import { ChevronRight, Code2, Eye, FolderTree, Globe2, LoaderCircle } from "lucide-react";
+import {
+  ChevronRight,
+  Code2,
+  Copy,
+  Download,
+  Eye,
+  FolderTree,
+  Globe2,
+  LoaderCircle,
+} from "lucide-react";
 import * as Schema from "effect/Schema";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -35,6 +44,12 @@ import { stackedThreadToast, toastManager } from "~/components/ui/toast";
 import { type DraftId, useComposerDraftStore } from "~/composerDraftStore";
 import { buildFileReviewComment } from "~/reviewCommentContext";
 import { assetEnvironment } from "~/state/assets";
+import {
+  canCopyWorkspaceFileToClipboard,
+  copyWorkspaceFileToClipboard,
+  downloadWorkspaceFile,
+  type WorkspaceFileTransferAction,
+} from "~/workspaceFileTransfer";
 import { useEnvironmentHttpBaseUrl, usePrimaryEnvironmentId } from "~/state/environments";
 import { previewEnvironment } from "~/state/preview";
 import { projectEnvironment } from "~/state/projects";
@@ -856,6 +871,42 @@ export default function FilePreviewPanel({
     })();
   }, [absolutePath, createAssetUrl, environmentHttpBaseUrl, openPreview, threadRef]);
 
+  const handleDownloadFile = useCallback(() => {
+    if (!absolutePath || !environmentHttpBaseUrl) return;
+    void downloadWorkspaceFile({
+      threadRef,
+      filePath: absolutePath,
+      httpBaseUrl: environmentHttpBaseUrl,
+      createAssetUrl,
+    });
+  }, [absolutePath, createAssetUrl, environmentHttpBaseUrl, threadRef]);
+
+  const handleCopyFile = useCallback(() => {
+    if (!absolutePath || !environmentHttpBaseUrl) return;
+    void copyWorkspaceFileToClipboard({
+      threadRef,
+      filePath: absolutePath,
+      httpBaseUrl: environmentHttpBaseUrl,
+      createAssetUrl,
+    });
+  }, [absolutePath, createAssetUrl, environmentHttpBaseUrl, threadRef]);
+
+  const handleTreeFileTransfer = useCallback(
+    (action: WorkspaceFileTransferAction, treeRelativePath: string) => {
+      if (!environmentHttpBaseUrl) return;
+      const input = {
+        threadRef,
+        filePath: treeRelativePath,
+        httpBaseUrl: environmentHttpBaseUrl,
+        createAssetUrl,
+      };
+      void (action === "download"
+        ? downloadWorkspaceFile(input)
+        : copyWorkspaceFileToClipboard(input));
+    },
+    [createAssetUrl, environmentHttpBaseUrl, threadRef],
+  );
+
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
       {relativePath ? (
@@ -959,6 +1010,44 @@ export default function FilePreviewPanel({
                 }
               />
               <TooltipPopup>Open file in preview browser</TooltipPopup>
+            </Tooltip>
+          ) : null}
+          {absolutePath && environmentHttpBaseUrl ? (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Toggle
+                    className="shrink-0"
+                    pressed={false}
+                    onPressedChange={handleDownloadFile}
+                    aria-label="Download file"
+                    variant="ghost"
+                    size="sm"
+                  >
+                    <Download className="size-3.5" />
+                  </Toggle>
+                }
+              />
+              <TooltipPopup>Download file</TooltipPopup>
+            </Tooltip>
+          ) : null}
+          {absolutePath && environmentHttpBaseUrl && canCopyWorkspaceFileToClipboard() ? (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Toggle
+                    className="shrink-0"
+                    pressed={false}
+                    onPressedChange={handleCopyFile}
+                    aria-label="Copy file"
+                    variant="ghost"
+                    size="sm"
+                  >
+                    <Copy className="size-3.5" />
+                  </Toggle>
+                }
+              />
+              <TooltipPopup>Copy file</TooltipPopup>
             </Tooltip>
           ) : null}
           <Tooltip>
@@ -1080,6 +1169,7 @@ export default function FilePreviewPanel({
               selectedPath={relativePath}
               selectedPathRevealId={revealRequestId}
               onOpenFile={onOpenFile}
+              onFileTransfer={environmentHttpBaseUrl ? handleTreeFileTransfer : undefined}
             />
           </aside>
         ) : null}

--- a/apps/web/src/workspaceFileTransfer.ts
+++ b/apps/web/src/workspaceFileTransfer.ts
@@ -1,0 +1,110 @@
+import type {
+  AssetCreateUrlResult,
+  AssetResource,
+  EnvironmentId,
+  ScopedThreadRef,
+} from "@t3tools/contracts";
+import {
+  type AtomCommandResult,
+  isAtomCommandInterrupted,
+  squashAtomCommandFailure,
+} from "@t3tools/client-runtime/state/runtime";
+
+import { resolveAssetUrl } from "~/assets/assetUrls";
+import { toastManager } from "~/components/ui/toast";
+
+export type WorkspaceFileTransferAction = "download" | "copy-file";
+
+export type CreateAssetUrlRunner = (input: {
+  readonly environmentId: EnvironmentId;
+  readonly input: { readonly resource: AssetResource };
+}) => Promise<AtomCommandResult<AssetCreateUrlResult, unknown>>;
+
+export interface WorkspaceFileTransferInput {
+  readonly threadRef: ScopedThreadRef;
+  readonly filePath: string;
+  readonly httpBaseUrl: string;
+  readonly createAssetUrl: CreateAssetUrlRunner;
+}
+
+export function workspaceFileDownloadName(filePath: string): string {
+  return filePath.split(/[\\/]/).pop() ?? filePath;
+}
+
+function reportFailure(title: string, cause: unknown): void {
+  toastManager.add({
+    type: "error",
+    title,
+    description: cause instanceof Error ? cause.message : "An error occurred.",
+  });
+}
+
+// Mints a short-lived signed download URL. The server marks it with a
+// Content-Disposition attachment header, so it needs no auth header and can
+// be handed straight to the browser (works over relay/tunnel connections).
+async function createWorkspaceFileDownloadUrl(
+  input: WorkspaceFileTransferInput,
+): Promise<string | null> {
+  const assetResult = await input.createAssetUrl({
+    environmentId: input.threadRef.environmentId,
+    input: {
+      resource: {
+        _tag: "workspace-file-download",
+        threadId: input.threadRef.threadId,
+        path: input.filePath,
+      },
+    },
+  });
+  if (assetResult._tag === "Failure") {
+    if (!isAtomCommandInterrupted(assetResult)) {
+      reportFailure("Unable to prepare download", squashAtomCommandFailure(assetResult));
+    }
+    return null;
+  }
+  const assetUrl = resolveAssetUrl(input.httpBaseUrl, assetResult.value.relativeUrl);
+  if (assetUrl === null) {
+    reportFailure(
+      "Unable to prepare download",
+      new Error("The environment returned an invalid asset URL."),
+    );
+  }
+  return assetUrl;
+}
+
+export async function downloadWorkspaceFile(input: WorkspaceFileTransferInput): Promise<void> {
+  const url = await createWorkspaceFileDownloadUrl(input);
+  if (url === null) return;
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  // Ignored cross-origin; the server's attachment disposition still forces a
+  // download there.
+  anchor.download = workspaceFileDownloadName(input.filePath);
+  anchor.rel = "noopener";
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+}
+
+export function canCopyWorkspaceFileToClipboard(): boolean {
+  return typeof window !== "undefined" && window.desktopBridge?.copyFileToClipboard !== undefined;
+}
+
+export async function copyWorkspaceFileToClipboard(
+  input: WorkspaceFileTransferInput,
+): Promise<void> {
+  const copyFileToClipboard = window.desktopBridge?.copyFileToClipboard;
+  if (!copyFileToClipboard) return;
+  const url = await createWorkspaceFileDownloadUrl(input);
+  if (url === null) return;
+  const fileName = workspaceFileDownloadName(input.filePath);
+  try {
+    await copyFileToClipboard({ url, fileName });
+    toastManager.add({
+      type: "success",
+      title: "File copied",
+      description: fileName,
+    });
+  } catch (cause) {
+    reportFailure("Unable to copy file", cause);
+  }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@
 - [Customize a project icon](./user/project-settings.md)
 - [Mobile appearance](./user/mobile-appearance.md)
 - [Remote access](./user/remote-access.md)
+- [Downloading files](./user/file-downloads.md)
 - [Keeping app and server in sync](./user/updating.md)
 - [Source control integrations](./user/source-control.md)
 - [Background service (Linux)](./user/background-service.md)

--- a/docs/user/file-downloads.md
+++ b/docs/user/file-downloads.md
@@ -1,0 +1,17 @@
+# Downloading Files
+
+When an agent writes a file on the machine running your T3 Code server — a CSV, an image, a report — you can save it to the device you're using, even when you're connected remotely over your local network, a tailnet, or T3 Connect.
+
+## Download a file
+
+- **Chat**: right-click any file chip in a message and choose **Download file**.
+- **Files panel**: open a file and use the download button in the header, or right-click a file in the file tree and choose **Download file**.
+- **Mobile**: open a file, then choose **Download** from the file actions menu. The share sheet lets you save it to Files or send it to another app.
+
+Downloads work for any file inside the project workspace, including types the file preview can't render.
+
+## Copy a file to the clipboard (desktop)
+
+On the desktop app, the same menus offer **Copy file**. This puts the file itself on your clipboard — not its contents — so you can paste it into Finder or Explorer, drop it into an email, or attach it in another app. The file is fetched from the connected environment first, so it works with remote servers too.
+
+On Linux, pasting the copied file is supported in file managers that understand the GNOME clipboard convention.

--- a/packages/contracts/src/assets.ts
+++ b/packages/contracts/src/assets.ts
@@ -10,6 +10,12 @@ export const AssetResource = Schema.Union([
     threadId: ThreadId,
     path: TrimmedNonEmptyString.check(Schema.isMaxLength(ASSET_PATH_MAX_LENGTH)),
   }),
+  // Served with a Content-Disposition attachment header and without the
+  // preview file-type restriction, so any workspace file can be saved locally.
+  Schema.TaggedStruct("workspace-file-download", {
+    threadId: ThreadId,
+    path: TrimmedNonEmptyString.check(Schema.isMaxLength(ASSET_PATH_MAX_LENGTH)),
+  }),
   Schema.TaggedStruct("attachment", {
     attachmentId: TrimmedNonEmptyString.check(Schema.isMaxLength(256)),
   }),

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1119,6 +1119,13 @@ export interface DesktopBridge {
   ) => Promise<T | null>;
   openExternal: (url: string) => Promise<boolean>;
   /**
+   * Download a file URL in the main process and place the saved copy on the
+   * OS clipboard as a file reference (pasteable in Finder/Explorer, unlike a
+   * text or image clipboard write). Optional: older desktop builds lack it,
+   * and web builds have it undefined.
+   */
+  copyFileToClipboard?: (input: { url: string; fileName: string }) => Promise<void>;
+  /**
    * Probe this desktop machine for installed remote-capable editor CLIs
    * (used for remote open-in-editor deep links). Optional: older desktop
    * builds lack it; callers fall back to VS Code only.


### PR DESCRIPTION
## Problem

When an agent writes a CSV, image, or any other file on a remote environment, there is no way to get that file onto the device you're using. The signed asset URL pipeline only serves preview types (html/pdf/images) inline, so a CSV can't even be fetched.

## What this does

**Server / contracts**
- New `workspace-file-download` variant on `AssetResource`. It issues an exact-file signed claim like `workspace-file-exact`, but skips the preview-extension allowlist and resolves with a download marker.
- The `/api/assets` route serves those with `Content-Disposition: attachment` (RFC 6266 with an RFC 5987 UTF-8 filename fallback). Everything else about the pipeline is unchanged: HMAC-signed 1h tokens, realpath-based root containment, streaming via `HttpServerResponse.file`. Because the token is embedded in the URL, downloads need no auth header and work over local, relay, and tunnel connections alike.

**Web**
- New **Download file** action in the chat file-chip context menu, the file preview panel header, and the file browser tree context menu. It mints a fresh signed URL and hands it to the browser; the attachment header does the rest (in the desktop app, Electron shows the native save dialog).

**Desktop**
- New **Copy file** action in the same places. A new IPC method downloads the signed URL in the main process, stages the file under `<state dir>/file-clipboard/`, and writes a real file reference to the OS clipboard — `NSFilenamesPboardType` plist on macOS, a `CF_HDROP` DROPFILES struct on Windows, and `x-special/gnome-copied-files` on Linux — so you can paste the file itself into Finder/Explorer. The staged copy is replaced on the next copy.
- Exposed as an optional `desktopBridge.copyFileToClipboard`, so older desktop builds and plain web simply don't show the action.

**Mobile**
- New **Download** action in the file screen's actions menu: downloads through the same signed URL into the app cache and opens the OS share sheet (Save to Files, AirDrop, etc.).

**Docs**
- `docs/user/file-downloads.md`, linked from the docs index.

## Notes / decisions

- Downloads are workspace-scoped and thread-authorized exactly like previews: the URL is only minted over the authenticated WS RPC (`assets.createUrl`, orchestration read scope), and the resolved path is re-canonicalized per request.
- Deliberately not added in this PR to keep it contained: download actions on the per-turn changed-files tree and diff-panel file headers (easy follow-ups on top of the shared `workspaceFileTransfer` helper).
- Linux clipboard paste uses the GNOME copied-files convention; file managers that only read `text/uri-list` won't see it (Electron's clipboard API can only write one raw format).

## Testing

- `vp test run apps/server/src/assets/AssetAccess.test.ts apps/server/src/http.test.ts apps/desktop/src/ipc/methods/fileClipboard.test.ts` — new coverage for issuing/resolving download URLs (including traversal and tampered-token rejection), the Content-Disposition headers, filename sanitization, and the per-platform clipboard payloads.
- Targeted typecheck and lint for contracts, server, web, desktop, and mobile.

Built by Claude Fable 5 running in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches signed asset issuance/resolution and file-serving headers (path containment still enforced); desktop main-process fetch + clipboard staging adds new attack surface for malicious URLs if validation were bypassed.
> 
> **Overview**
> Adds end-to-end **workspace file export** so remote agent output (CSVs, reports, etc.) can be saved on the client device, not only previewable types.
> 
> **Server & contracts:** New `workspace-file-download` on `AssetResource` issues signed exact-file URLs without the preview extension allowlist. Resolved assets can carry `downloadFileName`; `/api/assets` responds with `Content-Disposition: attachment` (safe ASCII + UTF-8 filename).
> 
> **Web:** Shared `workspaceFileTransfer` mints download URLs and triggers browser download or desktop clipboard copy. **Download** / **Copy file** appear on chat file chips, file preview header, and file tree context menus (copy only when `desktopBridge.copyFileToClipboard` exists).
> 
> **Desktop:** IPC `copyFileToClipboard` fetches the signed URL in the main process, stages under state dir `file-clipboard/`, and writes OS-specific file clipboard formats (macOS plist, Windows `CF_HDROP`, Linux GNOME copied-files).
> 
> **Mobile:** **Download** on the file screen uses the same signed URL, caches via expo-file-system, and opens the share sheet.
> 
> Docs: `docs/user/file-downloads.md` linked from the docs index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7496fd93e9389d29a85e3675d4c14d74d3fad3f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add workspace file download and copy-to-clipboard across desktop, web, and mobile
> - Adds a signed `workspace-file-download` asset type on the server that serves files with `Content-Disposition: attachment` headers, enabling browser-initiated downloads.
> - Web surfaces (chat markdown file chips and the file browser/preview panels) gain Download and Copy context menu actions via a new [workspaceFileTransfer.ts](https://github.com/pingdotgg/t3code/pull/7575/files#diff-58a6ef845674f331dd9228320ed66fa58ebdb65f6bbb826045adc80e8036e147) module.
> - Desktop (Electron) exposes a `copyFileToClipboard` IPC handler in [fileClipboard.ts](https://github.com/pingdotgg/t3code/pull/7575/files#diff-863d685c0fa31953145966f0d00694353f3cec3461a8dd58843b9aa3aa7d7c21) that downloads a file and writes a native file reference to the OS clipboard (NSFilenamesPboardType on macOS, CF_HDROP on Windows, gnome-copied-files on Linux).
> - Mobile adds a Download action on the file preview screen that downloads the file and invokes the OS share sheet via a new [shareWorkspaceFile.ts](https://github.com/pingdotgg/t3code/pull/7575/files#diff-90acfcacd3a76b4bdc2e4fea85f656b54c6041b856cdbb5f6b53ed3086315916) module.
> - Risk: the desktop clipboard path stages files under a persistent state directory; stale files are not cleaned up automatically.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7496fd9. 16 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->