### PR TITLE
fix(web): compare client and server versions as semver, not strings

### DIFF
--- a/apps/web/src/versionSkew.test.ts
+++ b/apps/web/src/versionSkew.test.ts
@@ -1,5 +1,10 @@
 import { EnvironmentId } from "@t3tools/contracts";
-import { describe, expect, it } from "vite-plus/test";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+// Pinned so the direction cases below read as fixed versions instead of
+// arithmetic on whatever version this checkout happens to be at.
+const branding = vi.hoisted(() => ({ APP_VERSION: "0.0.34" }));
+vi.mock("./branding", () => branding);
 
 import { APP_VERSION } from "./branding";
 import {
@@ -13,17 +18,62 @@ import {
   serverUpdateGuidance,
 } from "./versionSkew";
 
+const MISMATCH_HINT =
+  "Version mismatch. Try syncing the client and server to the same T3 Code version.";
+
 describe("versionSkew", () => {
+  beforeEach(() => {
+    branding.APP_VERSION = "0.0.34";
+  });
+
   it("does not warn when versions match", () => {
     expect(resolveVersionMismatch(APP_VERSION)).toBeNull();
   });
 
-  it("returns a mismatch when the server version differs from the client", () => {
-    expect(resolveVersionMismatch("9.9.9")).toEqual({
-      clientVersion: APP_VERSION,
-      serverVersion: "9.9.9",
-      hint: "Version mismatch. Try syncing the client and server to the same T3 Code version.",
+  it("returns a mismatch when the server is behind the client", () => {
+    expect(resolveVersionMismatch("0.0.33")).toEqual({
+      clientVersion: "0.0.34",
+      serverVersion: "0.0.33",
+      hint: MISMATCH_HINT,
     });
+  });
+
+  it("does not warn when the server is ahead of the client", () => {
+    expect(resolveVersionMismatch("0.0.35")).toBeNull();
+    expect(resolveVersionMismatch("9.9.9")).toBeNull();
+  });
+
+  it("does not warn when a nightly and a stable build share a core version", () => {
+    expect(resolveVersionMismatch("0.0.34-nightly.20260818.1124")).toBeNull();
+
+    branding.APP_VERSION = "0.0.34-nightly.20260818.1124";
+    expect(resolveVersionMismatch("0.0.34")).toBeNull();
+  });
+
+  it("treats a nightly server built past the client as ahead, not skew", () => {
+    expect(resolveVersionMismatch("0.0.35-nightly.20260818.1124")).toBeNull();
+  });
+
+  it("still warns when a nightly client outruns the server by a release", () => {
+    branding.APP_VERSION = "0.0.35-nightly.20260818.1124";
+
+    expect(resolveVersionMismatch("0.0.34")).toEqual({
+      clientVersion: "0.0.35-nightly.20260818.1124",
+      serverVersion: "0.0.34",
+      hint: MISMATCH_HINT,
+    });
+  });
+
+  it("falls back to string inequality when a version is not semver", () => {
+    expect(resolveVersionMismatch("dev")).toEqual({
+      clientVersion: "0.0.34",
+      serverVersion: "dev",
+      hint: MISMATCH_HINT,
+    });
+
+    branding.APP_VERSION = "dev";
+    expect(resolveVersionMismatch("dev")).toBeNull();
+    expect(resolveVersionMismatch("0.0.34")).toMatchObject({ serverVersion: "0.0.34" });
   });
 
   it("reads the server version from config descriptors", () => {
@@ -36,14 +86,14 @@ describe("versionSkew", () => {
             os: "darwin",
             arch: "arm64",
           },
-          serverVersion: "9.9.9",
+          serverVersion: "0.0.33",
           capabilities: {
             repositoryIdentity: true,
           },
         },
       }),
     ).toMatchObject({
-      serverVersion: "9.9.9",
+      serverVersion: "0.0.33",
     });
   });
 
@@ -70,11 +120,11 @@ describe("versionSkew", () => {
     ).toBe(false);
   });
 
-  it("appends a hint to connection errors when versions differ", () => {
-    const mismatch = resolveVersionMismatch("9.9.9");
+  it("appends a hint to connection errors when the server is behind", () => {
+    const mismatch = resolveVersionMismatch("0.0.33");
 
     expect(appendVersionMismatchHint("Socket closed.", mismatch)).toBe(
-      "Socket closed. Hint: Version mismatch. Try syncing the client and server to the same T3 Code version.",
+      `Socket closed. Hint: ${MISMATCH_HINT}`,
     );
   });
 

--- a/apps/web/src/versionSkew.ts
+++ b/apps/web/src/versionSkew.ts
@@ -1,4 +1,5 @@
 import type { EnvironmentId, ServerConfig, ServerSelfUpdateCapability } from "@t3tools/contracts";
+import { compareSemverVersions, parseSemver } from "@t3tools/shared/semver";
 import * as Schema from "effect/Schema";
 
 import { APP_VERSION } from "./branding";
@@ -23,16 +24,39 @@ function normalizeVersion(version: string | null | undefined): string | null {
   return trimmed && trimmed.length > 0 ? trimmed : null;
 }
 
+/** Core `major.minor.patch`, dropping any prerelease or build suffix. */
+function versionCore(version: string): string {
+  return version.replace(/[-+].*$/, "");
+}
+
+/**
+ * The skew a user can act on: the connected server runs an older T3 Code than
+ * this client, so the server is the side that needs updating.
+ *
+ * Versions compare as semver on their core `major.minor.patch` only. Nightlies
+ * are `<core>-nightly.<date>.<run>` builds of the release they precede, so a
+ * stable client on a nightly server (or the reverse, at the same core) shares a
+ * wire contract and is not skew. A server *ahead* of the client is not skew
+ * either: the client is the stale side, and every consumer of this result tells
+ * the user to update their server. Versions that do not parse as semver fall
+ * back to plain string inequality.
+ */
 export function resolveVersionMismatch(
   serverVersion: string | null | undefined,
 ): VersionMismatch | null {
   const normalizedClientVersion = normalizeVersion(APP_VERSION);
   const normalizedServerVersion = normalizeVersion(serverVersion);
-  if (
-    !normalizedClientVersion ||
-    !normalizedServerVersion ||
-    normalizedClientVersion === normalizedServerVersion
-  ) {
+  if (!normalizedClientVersion || !normalizedServerVersion) {
+    return null;
+  }
+
+  const clientCore = versionCore(normalizedClientVersion);
+  const serverCore = versionCore(normalizedServerVersion);
+  const serverIsBehind =
+    parseSemver(clientCore) && parseSemver(serverCore)
+      ? compareSemverVersions(serverCore, clientCore) < 0
+      : normalizedServerVersion !== normalizedClientVersion;
+  if (!serverIsBehind) {
     return null;
   }
 


### PR DESCRIPTION
The version-mismatch banner compares `APP_VERSION` and `serverVersion` with plain string inequality. Two things go wrong. A nightly and a stable build never string-match ("0.0.34" vs "0.0.34-nightly.20260818.1124"), so a stable client on a nightly server, or the reverse, is permanently flagged even though nightlies are prerelease builds of the same core version and share its wire contract. And the check is direction-blind: a server *newer* than the client also triggers it, while every consumer renders "serverVersion to clientVersion" and offers a server update, which points the wrong way when the client is the stale side.

The repo already ships a nightly-aware comparator, `compareSemverVersions` in `packages/shared/src/semver.ts`; it just was not used here. `resolveVersionMismatch` now compares the core `major.minor.patch` of both versions with it and only reports a mismatch when the server is strictly behind the client. Same core with a prerelease suffix on either side is not skew. A server ahead of the client returns null, since all three consumers (the ChatView banner and both ConnectionsSettings sites) branch on truthiness and have nothing truthful to display for a stale client; no consumer changes were needed. Versions that do not parse as semver keep the old string-inequality behavior. `resolveServerConfigVersionMismatch` is a pass-through and inherits the fix.

## Verification

- `vp test run src/versionSkew.test.ts` in apps/web: 12 passed, covering equal versions, server behind, server ahead, nightly vs stable in both directions, a nightly client a full release ahead (still warns), and unparseable versions both ways
- `tsgo --noEmit` in apps/web: clean
- `vp lint` on both touched files: clean

Change made by Claude Fable 5 and Claude Opus via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to version banner logic with broad test coverage; no auth or data paths touched.
> 
> **Overview**
> **Version mismatch detection** no longer treats any differing client/server version strings as skew. `resolveVersionMismatch` compares **core** `major.minor.patch` via `compareSemverVersions` and only returns a mismatch when the **server is strictly behind** the client—the case where UI already tells users to update the server.
> 
> Stable vs nightly at the same core (e.g. `0.0.34` vs `0.0.34-nightly.…`) no longer triggers a banner. A server **ahead** of the client also returns null so stale clients are not nudged to “update the server.” Unparseable versions still use string inequality.
> 
> Tests pin `APP_VERSION`, mock branding, and cover direction, nightly/stable pairing, and non-semver fallbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cce227bc364ac02d534c5ce0f4a2d7ef304be14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `resolveVersionMismatch` to compare client and server versions as semver
> - Previously compared version strings with plain equality, causing false mismatches when server used a nightly build label but had the same core version as the client.
> - Now strips prerelease/build metadata to extract the `major.minor.patch` core and uses `compareSemverVersions` to only flag a mismatch when the server core is *behind* the client core.
> - A server ahead of the client, or nightly vs stable with matching cores, is treated as compatible.
> - Non-semver versions fall back to plain string inequality as before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7cce227.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->