### PR TITLE
fix(server): emit terminal task rows for subagents that survive a stop sweep

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -56,6 +56,8 @@ class FakeClaudeQuery implements AsyncIterable<SDKMessage> {
 
   public readonly interruptCalls: Array<void> = [];
   public readonly stopTaskCalls: Array<string> = [];
+  /** Task ids whose stopTask should reject, modelling a child that refuses. */
+  public readonly stopTaskRejections = new Set<string>();
   public readonly setModelCalls: Array<string | undefined> = [];
   public readonly setPermissionModeCalls: Array<string> = [];
   public readonly setMaxThinkingTokensCalls: Array<number | null> = [];
@@ -101,6 +103,9 @@ class FakeClaudeQuery implements AsyncIterable<SDKMessage> {
 
   readonly stopTask = async (taskId: string): Promise<void> => {
     this.stopTaskCalls.push(taskId);
+    if (this.stopTaskRejections.has(taskId)) {
+      throw new Error(`stopTask refused for ${taskId}`);
+    }
   };
 
   readonly setModel = async (model?: string): Promise<void> => {
@@ -1658,6 +1663,229 @@ describe("ClaudeAdapterLive", () => {
         assert.equal(stoppedTaskEvent.payload.status, "stopped");
         assert.equal(stoppedTaskEvent.payload.taskType, "local_agent");
         assert.equal(stoppedTaskEvent.payload.title, "Agent A");
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("interruptTurn settles a task whose stopTask was refused", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const startedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.type === "task.started"),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "spawn an agent",
+        attachments: [],
+      });
+
+      harness.query.stopTaskRejections.add("task-refuses");
+      harness.query.emit({
+        type: "system",
+        subtype: "task_started",
+        task_id: "task-refuses",
+        description: "Stubborn agent",
+        task_type: "local_agent",
+        uuid: "task-refuses-uuid",
+        session_id: "sdk-session",
+      } as unknown as SDKMessage);
+      yield* Fiber.join(startedFiber);
+
+      const stoppedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.type === "task.completed"),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.interruptTurn(session.threadId);
+
+      assert.deepEqual(harness.query.stopTaskCalls, ["task-refuses"]);
+      assert.equal(harness.query.interruptCalls.length, 1);
+
+      // The refusal must not strand the row: the turn is dead either way.
+      const stopped = Array.from(yield* Fiber.join(stoppedFiber));
+      assert.equal(stopped.length, 1);
+      const stoppedEvent = stopped[0];
+      assert.equal(stoppedEvent?.type, "task.completed");
+      if (stoppedEvent?.type === "task.completed") {
+        assert.equal(String(stoppedEvent.payload.taskId), "task-refuses");
+        assert.equal(stoppedEvent.payload.status, "stopped");
+        assert.equal(stoppedEvent.payload.title, "Stubborn agent");
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("interruptTurn settles a nested task and keeps its owning agent linkage", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      // Two task.started rows: the outer agent, then the one it spawned.
+      const startedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.type === "task.started"),
+        Stream.take(2),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "spawn a fleet",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "system",
+        subtype: "task_started",
+        task_id: "task-outer",
+        tool_use_id: "tool-outer",
+        description: "Outer agent",
+        task_type: "local_agent",
+        uuid: "task-outer-uuid",
+        session_id: "sdk-session",
+      } as unknown as SDKMessage);
+
+      // The nested Task tool call runs inside the outer agent, so its
+      // tool_use block carries parent_tool_use_id.
+      harness.query.emit({
+        type: "stream_event",
+        session_id: "sdk-session",
+        uuid: "stream-nested-task-tool",
+        parent_tool_use_id: "tool-outer",
+        event: {
+          type: "content_block_start",
+          index: 0,
+          content_block: {
+            type: "tool_use",
+            id: "tool-inner",
+            name: "Task",
+            input: { description: "Nested agent" },
+          },
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "system",
+        subtype: "task_started",
+        task_id: "task-nested",
+        tool_use_id: "tool-inner",
+        description: "Nested agent",
+        task_type: "local_agent",
+        uuid: "task-nested-uuid",
+        session_id: "sdk-session",
+      } as unknown as SDKMessage);
+
+      const started = Array.from(yield* Fiber.join(startedFiber));
+      const nestedStart = started[1];
+      assert.equal(nestedStart?.type, "task.started");
+      if (nestedStart?.type === "task.started") {
+        assert.equal(nestedStart.payload.agentId, "task-outer");
+      }
+
+      harness.query.stopTaskRejections.add("task-nested");
+      const stoppedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.type === "task.completed"),
+        Stream.take(2),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.interruptTurn(session.threadId);
+
+      const stopped = Array.from(yield* Fiber.join(stoppedFiber));
+      const nestedStopped = stopped.find(
+        (event) =>
+          event.type === "task.completed" && String(event.payload.taskId) === "task-nested",
+      );
+      assert.equal(nestedStopped?.type, "task.completed");
+      if (nestedStopped?.type === "task.completed") {
+        assert.equal(nestedStopped.payload.status, "stopped");
+        assert.equal(nestedStopped.payload.agentId, "task-outer");
+        assert.equal(nestedStopped.payload.title, "Nested agent");
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("stopSession settles live tasks before session.exited", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      // streamEvents is queue-backed, so consumers compete: run exactly one
+      // at a time: first to receipt the task registration, then to capture
+      // the shutdown ordering.
+      const startedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.type === "task.started"),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "spawn an agent",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "system",
+        subtype: "task_started",
+        task_id: "task-orphan",
+        description: "Orphan agent",
+        task_type: "local_agent",
+        uuid: "task-orphan-uuid",
+        session_id: "sdk-session",
+      } as unknown as SDKMessage);
+      yield* Fiber.join(startedFiber);
+
+      const shutdownFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "session.exited"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.stopSession(THREAD_ID);
+
+      const runtimeEvents = Array.from(yield* Fiber.join(shutdownFiber));
+      const types = runtimeEvents.map((event) => event.type);
+      const stoppedIndex = types.indexOf("task.completed");
+      const exitedIndex = types.indexOf("session.exited");
+      assert.ok(stoppedIndex >= 0, "expected a terminal task row");
+      assert.ok(exitedIndex > stoppedIndex, "terminal task rows must precede session.exited");
+
+      const stoppedEvent = runtimeEvents[stoppedIndex];
+      assert.equal(stoppedEvent?.type, "task.completed");
+      if (stoppedEvent?.type === "task.completed") {
+        assert.equal(String(stoppedEvent.payload.taskId), "task-orphan");
+        assert.equal(stoppedEvent.payload.status, "stopped");
       }
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -65,7 +65,6 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
 import * as Fiber from "effect/Fiber";
-import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
@@ -3089,8 +3088,9 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     // they fall through to the unknown-subtype warning and surface as spurious
     // error rows in client work logs. `background_tasks_changed` is a roster
     // snapshot ({tasks: [...]}) — the task_* lifecycle events carry the
-    // authoritative per-agent data and the typed background_tasks control
-    // request is the reconciliation source. `vcs_state_changed`
+    // authoritative per-agent data, and `settleLiveTasks` closes out whatever
+    // they leave live (the SDK's typed `background_tasks` control request
+    // backgrounds tasks, it is not a roster query). `vcs_state_changed`
     // ({kind: commit|push|rebase}) and `code_change_published`
     // ({provider, url, repo}) are informational CLI notices; the work log
     // already shows the underlying git/gh tool calls.
@@ -3630,6 +3630,35 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     });
   });
 
+  /**
+   * Drains `liveTaskIds`, emitting one synthesized terminal `task.completed`
+   * per task still marked live. Call only where nothing can still be running
+   * (after a turn interrupt, before session exit): a task whose own
+   * task_notification never arrives would otherwise leave a row spinning in
+   * the agent panel for the life of the thread.
+   */
+  const settleLiveTasks = Effect.fn("settleLiveTasks")(function* (context: ClaudeSessionContext) {
+    const taskIds = Array.from(context.liveTaskIds);
+    context.liveTaskIds.clear();
+    for (const taskId of taskIds) {
+      const stamp = yield* makeEventStamp();
+      yield* offerRuntimeEvent({
+        type: "task.completed",
+        eventId: stamp.eventId,
+        provider: PROVIDER,
+        createdAt: stamp.createdAt,
+        threadId: context.session.threadId,
+        ...(context.turnState ? { turnId: asCanonicalTurnId(context.turnState.turnId) } : {}),
+        payload: {
+          taskId: RuntimeTaskId.make(taskId),
+          status: "stopped",
+          ...taskLinkageFor(context.taskAgents, taskId),
+        },
+        providerRefs: nativeProviderRefs(context),
+      });
+    }
+  });
+
   const stopSessionInternal = Effect.fn("stopSessionInternal")(function* (
     context: ClaudeSessionContext,
     options?: { readonly emitExitEvent?: boolean },
@@ -3663,6 +3692,10 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     for (const pending of [...context.pendingUserInputs.values()]) {
       yield* pending.cancel;
     }
+
+    // The session process is going away, so nothing it spawned can still be
+    // running. Settle before completeTurn so the rows keep their turnId.
+    yield* settleLiveTasks(context);
 
     if (context.turnState) {
       yield* completeTurn(context, "interrupted", "Session stopped.");
@@ -4472,49 +4505,19 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       // Stop every live task first (best-effort per task: one refusal must
       // not strand the rest or block the turn interrupt), then interrupt.
       if (context.query.stopTask && context.liveTaskIds.size > 0) {
-        const liveIds = Array.from(context.liveTaskIds);
         // Bounded: a wedged child's stopTask promise may never settle
         // (Effect.ignore handles rejection, not non-resolution), and the
         // parent interrupt below MUST still run — Stop matters most during
         // runaway fleets (review finding). Per-task timeout keeps one hung
         // child from consuming the whole budget.
         yield* Effect.forEach(
-          liveIds,
+          Array.from(context.liveTaskIds),
           (taskId) =>
-            Effect.gen(function* () {
-              const stopAcknowledged = yield* Effect.tryPromise({
-                // Invoke through the query object: SDK methods rely on `this`.
-                try: () => context.query.stopTask!(taskId),
-                catch: () => undefined,
-              }).pipe(
-                Effect.timeoutOption("3 seconds"),
-                Effect.orElseSucceed(() => Option.none()),
-              );
-              if (Option.isNone(stopAcknowledged) || !context.liveTaskIds.delete(taskId)) {
-                return;
-              }
-
-              // stopTask only acknowledges the control request. Its separate
-              // task_notification can lose the race with interrupt(), so make
-              // the acknowledged stop authoritative for the durable UI state.
-              const stamp = yield* makeEventStamp();
-              yield* offerRuntimeEvent({
-                type: "task.completed",
-                eventId: stamp.eventId,
-                provider: PROVIDER,
-                createdAt: stamp.createdAt,
-                threadId: context.session.threadId,
-                ...(context.turnState
-                  ? { turnId: asCanonicalTurnId(context.turnState.turnId) }
-                  : {}),
-                payload: {
-                  taskId: RuntimeTaskId.make(taskId),
-                  status: "stopped",
-                  ...taskLinkageFor(context.taskAgents, taskId),
-                },
-                providerRefs: nativeProviderRefs(context),
-              });
-            }).pipe(Effect.ignore),
+            Effect.tryPromise({
+              // Invoke through the query object: SDK methods rely on `this`.
+              try: () => context.query.stopTask!(taskId),
+              catch: () => undefined,
+            }).pipe(Effect.timeoutOption("3 seconds"), Effect.ignore),
           { concurrency: 8, discard: true },
         ).pipe(Effect.timeoutOption("10 seconds"), Effect.ignore);
       }
@@ -4522,6 +4525,15 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         try: () => context.query.interrupt(),
         catch: (cause) => toRequestError(threadId, "turn/interrupt", cause),
       });
+
+      // stopTask only acknowledges the control request; its task_notification
+      // can be refused, time out, or lose the race with interrupt(). The SDK
+      // exposes no roster query to reconcile against (Query.backgroundTasks
+      // backgrounds tasks, it does not list them), so once the interrupt lands
+      // the turn is dead and T3 has no remaining liveness signal for whatever
+      // is still marked live. Calling those stopped beats a row that counts up
+      // forever.
+      yield* settleLiveTasks(context);
     },
   );
 


### PR DESCRIPTION
Interrupting a turn can leave a spawned subagent's row in the agents panel showing "running" forever: blue dot, duration counting up against the wall clock for the life of the thread. Observed with a nested agent (spawned from inside another subagent), but any task whose stop confirmation goes missing gets stranded the same way.

The interrupt path stops live tasks best-effort: `stopTask` per task with a 3s timeout, and only an acknowledged stop got a synthesized terminal `task.completed`. Every failure mode (refusal, timeout, the id already gone) returned silently, and nothing downstream can recover: `completeTurn` and `stopSessionInternal` never sweep `liveTaskIds`, the client's coordinator cascade only reaches workflow members keyed by `parentAgentId` (which nested agents never carry), and the client's dead-session sweep only fires when the session disconnects, which a turn interrupt does not cause.

I checked whether the SDK offers a roster to reconcile against, since a comment in the adapter called the `background_tasks` control request "the reconciliation source". It is not: per the installed SDK's types, `Query.backgroundTasks` backgrounds in-flight tasks (the Ctrl+B equivalent) and returns a boolean; `BackgroundTaskSummary[]` only appears on stop-hook inputs. There is no on-demand liveness query.

So the fix makes T3's own bookkeeping honest. A shared `settleLiveTasks` drains `liveTaskIds` and emits one synthesized `task.completed { status: "stopped" }` with the task's linkage per remaining id. The interrupt path's stop loop collapses to a pure best-effort sweep (same 3s/10s bounds), then `interrupt()`, then settle: once the interrupt lands the turn is dead and T3 has no remaining liveness signal for anything still marked live. `stopSessionInternal` settles before `completeTurn` (rows keep their `turnId`) and before `session.exited`, where it is unambiguous since the session process is going away. A turn that ends normally still leaves backgrounded tasks live on purpose. The stale comment now says what `background_tasks` actually does.

Left alone, for scope: the client's uncapped 1s duration interval (any future row missing its terminal event still counts up), and the client cascades that cannot reach nested agents. With the server now settling, those are defense-in-depth concerns.

## Verification

In `apps/server`:

- `vp test run src/provider/Layers/ClaudeAdapter.test.ts`: 73 passed (73). Three new tests: a refused `stopTask` still yields a terminal stopped row after interrupt; a nested task keeps its owning-agent linkage on the settled row; `stopSession` emits terminal rows before `session.exited`.
- `tsgo --noEmit`: no errors.
- `vp lint` on both files: one pre-existing warning elsewhere in the file, nothing new. `vp fmt --check`: clean.

Change made by Claude Opus via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes interrupt and session teardown paths in the Claude adapter; incorrect settlement could misreport agent state, but scope is bounded to live-task bookkeeping and is covered by new tests.
> 
> **Overview**
> Fixes agent panel rows that stay **running** forever after **Stop** when the Claude SDK never confirms subagent shutdown (refused `stopTask`, timeout, or missing `task_notification`).
> 
> **`settleLiveTasks`** drains `liveTaskIds` and emits synthesized **`task.completed`** with **`status: "stopped"`** and existing task linkage. **`interruptTurn`** still best-efforts **`stopTask`** (same timeouts), then **`interrupt()`**, then **always** settles remaining live tasks instead of only synthesizing completion when `stopTask` succeeded. **`stopSessionInternal`** settles live tasks before **`completeTurn`** and **`session.exited`**.
> 
> Comments on **`background_tasks_changed`** are corrected: the SDK control is not a roster query. Tests cover refused `stopTask`, nested **`agentId`** on settled rows, and shutdown event ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 287aa51cebbc173b6862c48449a289e558951751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Emit terminal task rows for subagents that survive a stop sweep in `interruptTurn` and `stopSession`
> - Introduces `settleLiveTasks` in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/7585/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc), which drains `liveTaskIds` and emits a synthesized `task.completed` event with status `'stopped'` for each remaining live task.
> - `interruptTurn` now calls `settleLiveTasks` after attempting `stopTask` and invoking `query.interrupt`, guaranteeing terminal task rows even when individual `stopTask` calls reject or time out.
> - `stopSessionInternal` calls `settleLiveTasks` before completing the turn, ensuring task rows are emitted with the current `turnId` before `session.exited`.
> - Adds tests covering: `stopTask` rejection, nested task termination with agent linkage preserved, and correct ordering of task events before `session.exited`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 287aa51.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->