### PR TITLE
feat(grok): surface Grok skills in the composer $ picker

### DIFF
--- a/apps/server/src/provider/Drivers/GrokDriver.ts
+++ b/apps/server/src/provider/Drivers/GrokDriver.ts
@@ -88,6 +88,7 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
       const httpClient = yield* HttpClient.HttpClient;
       const serverSettings = yield* ServerSettingsService;
+      const { cwd } = yield* ServerConfig;
       const eventLoggers = yield* ProviderEventLoggers;
       const processEnv = mergeProviderInstanceEnvironment(environment);
       const continuationIdentity = defaultProviderContinuationIdentity({
@@ -113,7 +114,7 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
       });
       const textGeneration = yield* makeGrokTextGeneration(effectiveConfig, processEnv);
 
-      const checkProvider = checkGrokProviderStatus(effectiveConfig, processEnv).pipe(
+      const checkProvider = checkGrokProviderStatus(effectiveConfig, processEnv, cwd).pipe(
         Effect.map(stampIdentity),
         Effect.provideService(Crypto.Crypto, crypto),
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),

--- a/apps/server/src/provider/Drivers/GrokSkills.test.ts
+++ b/apps/server/src/provider/Drivers/GrokSkills.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Sink from "effect/Sink";
+import * as Stream from "effect/Stream";
+import { ChildProcessSpawner } from "effect/unstable/process";
 
-import { parseGrokInspectSkills } from "./GrokSkills.ts";
+import { discoverGrokSkills, parseGrokInspectSkills } from "./GrokSkills.ts";
 
 const inspectPayload = (skills: ReadonlyArray<unknown>) => JSON.stringify({ skills });
 
@@ -84,5 +89,47 @@ describe("parseGrokInspectSkills", () => {
     expect(parseGrokInspectSkills("null")).toEqual([]);
     expect(parseGrokInspectSkills(JSON.stringify({ skills: "nope" }))).toEqual([]);
     expect(parseGrokInspectSkills(JSON.stringify({}))).toEqual([]);
+  });
+});
+
+describe("discoverGrokSkills", () => {
+  it.effect("spawns the inspect probe in the configured cwd", () => {
+    const spawnCwds: Array<string | undefined> = [];
+    const spawner = ChildProcessSpawner.make((command) => {
+      spawnCwds.push(command._tag === "StandardCommand" ? command.options.cwd : undefined);
+      return Effect.succeed(
+        ChildProcessSpawner.makeHandle({
+          pid: ChildProcessSpawner.ProcessId(1),
+          exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+          isRunning: Effect.succeed(false),
+          kill: () => Effect.void,
+          unref: Effect.succeed(Effect.void),
+          stdin: Sink.drain,
+          stdout: Stream.encodeText(
+            Stream.make(
+              inspectPayload([
+                {
+                  name: "kept",
+                  source: { type: "project", path: "/workspaces/demo/.grok/skills/kept/SKILL.md" },
+                },
+              ]),
+            ),
+          ),
+          stderr: Stream.empty,
+          all: Stream.empty,
+          getInputFd: () => Sink.drain,
+          getOutputFd: () => Stream.empty,
+        }),
+      );
+    });
+
+    return Effect.gen(function* () {
+      const skills = yield* discoverGrokSkills({ binaryPath: "grok" }, {}, "/workspaces/demo").pipe(
+        Effect.provide(Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner)),
+      );
+
+      expect(spawnCwds).toEqual(["/workspaces/demo"]);
+      expect(skills.map((skill) => skill.name)).toEqual(["kept"]);
+    });
   });
 });

--- a/apps/server/src/provider/Drivers/GrokSkills.test.ts
+++ b/apps/server/src/provider/Drivers/GrokSkills.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { parseGrokInspectSkills } from "./GrokSkills.ts";
+
+const inspectPayload = (skills: ReadonlyArray<unknown>) => JSON.stringify({ skills });
+
+describe("parseGrokInspectSkills", () => {
+  it("maps inspect entries onto provider skills, sorted by name", () => {
+    const skills = parseGrokInspectSkills(
+      inspectPayload([
+        {
+          name: "writing-docs",
+          description: "Write user docs.",
+          source: { type: "user", path: "/home/dev/.grok/skills/writing-docs/SKILL.md" },
+          userInvocable: true,
+        },
+        {
+          name: "deploy",
+          description: "Deploy the app.",
+          source: {
+            type: "plugin",
+            path: "/home/dev/.grok/installed-plugins/pkg/plug/skills/deploy/SKILL.md",
+          },
+          userInvocable: true,
+        },
+      ]),
+    );
+
+    expect(skills).toEqual([
+      {
+        name: "deploy",
+        description: "Deploy the app.",
+        path: "/home/dev/.grok/installed-plugins/pkg/plug/skills/deploy/SKILL.md",
+        scope: "plugin",
+        enabled: true,
+      },
+      {
+        name: "writing-docs",
+        description: "Write user docs.",
+        path: "/home/dev/.grok/skills/writing-docs/SKILL.md",
+        scope: "user",
+        enabled: true,
+      },
+    ]);
+  });
+
+  it("disables skills the CLI marks as not user-invocable", () => {
+    const skills = parseGrokInspectSkills(
+      inspectPayload([
+        {
+          name: "internal-helper",
+          source: { type: "bundled", path: "/opt/grok/bundled/skills/internal-helper/SKILL.md" },
+          userInvocable: false,
+        },
+      ]),
+    );
+
+    expect(skills).toEqual([
+      {
+        name: "internal-helper",
+        path: "/opt/grok/bundled/skills/internal-helper/SKILL.md",
+        scope: "bundled",
+        enabled: false,
+      },
+    ]);
+  });
+
+  it("skips entries without a name or a filesystem path", () => {
+    const skills = parseGrokInspectSkills(
+      inspectPayload([
+        { name: "  ", source: { type: "user", path: "/tmp/skills/a/SKILL.md" } },
+        { name: "no-path", source: { type: "user" } },
+        { name: "no-source" },
+        "not-an-object",
+        { name: "kept", source: { type: "project", path: "/repo/.grok/skills/kept/SKILL.md" } },
+      ]),
+    );
+
+    expect(skills.map((skill) => skill.name)).toEqual(["kept"]);
+  });
+
+  it("returns an empty list for malformed or unexpected output", () => {
+    expect(parseGrokInspectSkills("not json")).toEqual([]);
+    expect(parseGrokInspectSkills("null")).toEqual([]);
+    expect(parseGrokInspectSkills(JSON.stringify({ skills: "nope" }))).toEqual([]);
+    expect(parseGrokInspectSkills(JSON.stringify({}))).toEqual([]);
+  });
+});

--- a/apps/server/src/provider/Drivers/GrokSkills.ts
+++ b/apps/server/src/provider/Drivers/GrokSkills.ts
@@ -1,0 +1,117 @@
+/**
+ * GrokSkills — skill discovery for the `$` picker via `grok inspect --json`.
+ *
+ * Unlike Claude Code, the Grok CLI reports its full skill catalog itself:
+ * `grok inspect --json` returns `skills[]` with `name`, `description`,
+ * `source.type` (`user` / `project` / `bundled` / `plugin`), `source.path`
+ * (the absolute `SKILL.md` path), and `userInvocable`. Asking the CLI beats
+ * scanning the filesystem because the catalog honors Grok's own skill config
+ * (ignore lists, disabled skills) and includes plugin skills, which live
+ * three levels deep under `~/.grok/installed-plugins/` where a flat scan
+ * cannot see them. This mirrors how the Codex app-server reports skills over
+ * `skills/list`. Discovery is best-effort: an older CLI without `inspect`,
+ * a timeout, or malformed output yields an empty list, never a degraded
+ * provider snapshot.
+ *
+ * @module provider/Drivers/GrokSkills
+ */
+import type { GrokSettings, ServerProviderSkill } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Result from "effect/Result";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import { resolveSpawnCommand } from "@t3tools/shared/shell";
+
+import { spawnAndCollect } from "../providerSnapshot.ts";
+
+const GROK_SKILLS_PROBE_TIMEOUT_MS = 4_000;
+
+/**
+ * Map `grok inspect --json` output onto provider skills. Entries without a
+ * name or a filesystem path are skipped; `userInvocable: false` skills are
+ * kept but disabled so pickers that filter on `enabled` hide them.
+ */
+export function parseGrokInspectSkills(stdout: string): ReadonlyArray<ServerProviderSkill> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return [];
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return [];
+  }
+  const entries = (parsed as Record<string, unknown>).skills;
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+
+  const skillsByName = new Map<string, ServerProviderSkill>();
+  for (const entry of entries) {
+    if (typeof entry !== "object" || entry === null) {
+      continue;
+    }
+    const record = entry as Record<string, unknown>;
+    const name = typeof record.name === "string" ? record.name.trim() : "";
+    const source =
+      typeof record.source === "object" && record.source !== null
+        ? (record.source as Record<string, unknown>)
+        : undefined;
+    const path = typeof source?.path === "string" ? source.path.trim() : "";
+    if (!name || !path) {
+      continue;
+    }
+    const scope = typeof source?.type === "string" ? source.type.trim() : "";
+    const description = typeof record.description === "string" ? record.description.trim() : "";
+    skillsByName.set(name, {
+      name,
+      path,
+      enabled: record.userInvocable !== false,
+      ...(scope ? { scope } : {}),
+      ...(description ? { description } : {}),
+    });
+  }
+
+  return [...skillsByName.values()].sort((left, right) => left.name.localeCompare(right.name));
+}
+
+/**
+ * Run `grok inspect --json` and map the reported catalog onto provider
+ * skills. Never fails: any spawn error, non-zero exit, or timeout resolves
+ * to an empty list.
+ */
+export const discoverGrokSkills = Effect.fn("discoverGrokSkills")(function* (
+  grokSettings: Pick<GrokSettings, "binaryPath">,
+  environment: NodeJS.ProcessEnv = process.env,
+): Effect.fn.Return<
+  ReadonlyArray<ServerProviderSkill>,
+  never,
+  ChildProcessSpawner.ChildProcessSpawner
+> {
+  const command = grokSettings.binaryPath || "grok";
+  const inspectResult = yield* Effect.gen(function* () {
+    const spawnCommand = yield* resolveSpawnCommand(command, ["inspect", "--json"], {
+      env: environment,
+    });
+    return yield* spawnAndCollect(
+      command,
+      ChildProcess.make(spawnCommand.command, spawnCommand.args, {
+        env: environment,
+        shell: spawnCommand.shell,
+      }),
+    );
+  }).pipe(Effect.timeoutOption(GROK_SKILLS_PROBE_TIMEOUT_MS), Effect.result);
+
+  if (Result.isFailure(inspectResult) || Option.isNone(inspectResult.success)) {
+    yield* Effect.logDebug("Grok skill discovery failed; continuing without skills.");
+    return [];
+  }
+  const output = inspectResult.success.value;
+  if (output.code !== 0) {
+    yield* Effect.logDebug("Grok skill discovery exited non-zero; continuing without skills.", {
+      exitCode: output.code,
+    });
+    return [];
+  }
+  return parseGrokInspectSkills(output.stdout);
+});

--- a/apps/server/src/provider/Drivers/GrokSkills.ts
+++ b/apps/server/src/provider/Drivers/GrokSkills.ts
@@ -83,6 +83,7 @@ export function parseGrokInspectSkills(stdout: string): ReadonlyArray<ServerProv
 export const discoverGrokSkills = Effect.fn("discoverGrokSkills")(function* (
   grokSettings: Pick<GrokSettings, "binaryPath">,
   environment: NodeJS.ProcessEnv = process.env,
+  cwd?: string,
 ): Effect.fn.Return<
   ReadonlyArray<ServerProviderSkill>,
   never,
@@ -96,6 +97,7 @@ export const discoverGrokSkills = Effect.fn("discoverGrokSkills")(function* (
     return yield* spawnAndCollect(
       command,
       ChildProcess.make(spawnCommand.command, spawnCommand.args, {
+        ...(cwd ? { cwd } : {}),
         env: environment,
         shell: spawnCommand.shell,
       }),

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -162,6 +162,7 @@ const runGrokVersionCommand = (
 export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(function* (
   grokSettings: GrokSettings,
   environment: NodeJS.ProcessEnv = process.env,
+  cwd?: string,
 ): Effect.fn.Return<
   ServerProviderDraft,
   never,
@@ -252,7 +253,7 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
     });
   }
 
-  const skills = yield* discoverGrokSkills(grokSettings, environment);
+  const skills = yield* discoverGrokSkills(grokSettings, environment, cwd);
 
   const discoveryExit = yield* discoverGrokModelsViaAcp(grokSettings, environment).pipe(
     Effect.timeoutOption(GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS),

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -30,6 +30,7 @@ import {
   type ProviderMaintenanceCapabilities,
 } from "../providerMaintenance.ts";
 import { makeGrokAcpRuntime, resolveGrokAcpBaseModelId } from "../acp/GrokAcpSupport.ts";
+import { discoverGrokSkills } from "../Drivers/GrokSkills.ts";
 
 const GROK_PRESENTATION = {
   displayName: "Grok",
@@ -251,6 +252,8 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
     });
   }
 
+  const skills = yield* discoverGrokSkills(grokSettings, environment);
+
   const discoveryExit = yield* discoverGrokModelsViaAcp(grokSettings, environment).pipe(
     Effect.timeoutOption(GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS),
     Effect.exit,
@@ -264,6 +267,7 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
       enabled: grokSettings.enabled,
       checkedAt,
       models: fallbackModels,
+      skills,
       probe: {
         installed: true,
         version,
@@ -282,6 +286,7 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
       enabled: grokSettings.enabled,
       checkedAt,
       models: fallbackModels,
+      skills,
       probe: {
         installed: true,
         version,
@@ -302,6 +307,7 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
     enabled: grokSettings.enabled,
     checkedAt,
     models,
+    skills,
     probe: {
       installed: true,
       version,


### PR DESCRIPTION
Fixes #4109. Related: #4414 (the merged Claude equivalent), #4630 (skill manager), and #5131 / #5503 / #5960 (earlier attempts, see disposition). Decision date: 2026-08-19.

## Outcome

The Grok provider snapshot now carries the CLI's skill catalog, so the composer `$` picker lists Grok skills on web, desktop, and mobile. The provider check runs `grok inspect --json` next to the existing `grok --version` probe and maps the reported `skills[]` onto `ServerProviderSkill`.

This PR does not change: slash commands (the `/` picker), the ACP runtime, the Claude or Codex skill paths, any contract schema, or any client code. The pickers render the new data through the existing provider-agnostic path.

## Before and after

| Failure mode before | Mechanism after |
| --- | --- |
| `checkGrokProviderStatus` never set `skills`, so every Grok snapshot defaulted to `[]` and the `$` picker showed "No skills found" even with a full skill directory on disk. | The provider check asks the CLI for its resolved catalog and attaches it to the post-version snapshot branches. |
| The obvious fix, a Claude-style flat disk scan, cannot see plugin skills (three levels deep under `~/.grok/installed-plugins/`) and ignores Grok's own ignore/disable config. On the machine that produced this PR, a flat scan misses 44 of 75 installed skills. | `grok inspect --json` returns the catalog Grok itself resolved: user, project, bundled, and plugin skills, each with its `SKILL.md` path, description, and `userInvocable` flag. |

## Decisions taken

- **Ask the CLI, do not scan the disk.** House precedent: Claude scans disk only because its handshake omits paths (see the `ClaudeSkills.ts` module doc); Codex asks the app-server over `skills/list`. Grok exposes paths through `inspect`, so asking is the smaller and more correct mechanism.
- **Discovery is best-effort.** An older CLI without `inspect`, a non-zero exit, a 4 s timeout, or malformed JSON yields `[]` with a debug log. Skill discovery can never degrade the provider probe.
- **`userInvocable: false` maps to `enabled: false`, not to omission.** The pickers already filter on `enabled`; the snapshot stays a faithful record of the catalog.
- **Skills attach to the three post-version branches** (ACP discovery failed, ACP timeout, ready), matching how much of the probe succeeded. The disabled and not-installed branches stay empty.
- **No shared code moves.** No `ClaudeSkills.ts` extraction, no `AcpSessionRuntime` change, no new dependency, no driver signature change (`ChildProcessSpawner` was already in the probe's requirements).

## Disposition of the earlier attempts

- #5131 (ACP `availableCommands`): right instinct, but it couples OpenCode into the change and patches the shared `AcpSessionRuntime`. `inspect` yields the same paths without touching shared code.
- #5503: maps every advertised slash command to a skill with a synthetic `acp://` path, so built-ins like `/compact` would appear as skills. Wrong data.
- #5960 (disk scan): asserts four unverified scan roots and misses plugin skills entirely.

## Verification

Ran on Linux, Node v26.7.0, pnpm 11.10.0, grok 1.0.5:

- `vp test run src/provider/Drivers/GrokSkills.test.ts` — 4 passed (field mapping and sort, disabled skills, invalid entries skipped, malformed output).
- `vp test run src/provider/Layers/GrokProvider.test.ts src/provider/Layers/GrokAdapter.test.ts` — 27 passed.
- `tsgo --noEmit` in `apps/server` — no errors in changed files (pre-existing suggestions in unrelated files only).
- Real-CLI check: `grok inspect --json` (grok 1.0.5) returned 75 skills in ~60 ms; the fields map one-to-one onto `ServerProviderSkill`.

Not run: the full monorepo suite (CI owns it) and an in-app screenshot of the populated `$` picker (needs a live instance; I can add one on request).

## Rollout and rollback

Server-side only, ships with the next build. No schema change, no migration, no durable state. Rollback is the previous build; a snapshot produced by this build renders fine on old clients because the `skills` field and its wire schema already exist.

Built with Claude Code (Claude Fable 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Server-only, additive probe after existing version check; discovery failures degrade to empty skills without changing probe outcomes.
> 
> **Overview**
> **Grok provider snapshots now include skills** from `grok inspect --json`, so the existing composer `$` picker can list Grok skills without client or contract changes.
> 
> New **`GrokSkills`** module runs a **best-effort** probe (4s timeout, optional server **`cwd`**) after the version check succeeds. JSON is mapped to **`ServerProviderSkill`** (scope, path, description; **`userInvocable: false`** → **`enabled: false`**). Failures return **`[]`** and only debug logs—probe status is unchanged.
> 
> **`checkGrokProviderStatus`** accepts **`cwd`**; **`GrokDriver`** passes **`ServerConfig.cwd`**. Discovered skills are attached on the post-version paths (ACP error, timeout, and ready), not when Grok is disabled or the CLI is missing.
> 
> Unit tests cover parsing edge cases and that inspect runs in the configured working directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4574ba4eeb39de180a9657b641da49375d35134. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface Grok skills in the composer `$` picker via CLI discovery
> - Adds `discoverGrokSkills` in [GrokSkills.ts](https://github.com/pingdotgg/t3code/pull/7587/files#diff-b9a91917429e16fdadd1583ee3bb784e862cc270fd9ffa70002cf175bbef35ab), which spawns `grok inspect --json` with a 4s timeout and returns a best-effort list of skills, returning empty on any failure.
> - Adds `parseGrokInspectSkills` to map CLI output to `ServerProviderSkill` objects, filtering out malformed/unnamed entries, disabling non-invocable skills, deduplicating by name, and sorting alphabetically.
> - Extends `checkGrokProviderStatus` in [GrokProvider.ts](https://github.com/pingdotgg/t3code/pull/7587/files#diff-d88edf38a3399863fd884b8deb4f8eb57539ca15d41ce6ea03cad4baf62acf0f) to accept an optional `cwd` and populate the provider snapshot with discovered skills across all return paths (success, ACP failure, timeout).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c4574ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->