### PR TITLE
fix(server): outdated gh no longer reads as "not authenticated"

### DIFF
--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
@@ -381,3 +381,18 @@ it("reports unauthenticated when GitHub JSON has accounts but none are valid", (
     },
   );
 });
+
+it("reports an update hint instead of unauthenticated when gh predates --json", () => {
+  const auth = GitHubSourceControlProvider.discovery.parseAuth(
+    processResult("", {
+      stderr: "unknown flag: --json\n\nUsage:  gh auth status [flags]\n",
+      exitCode: ChildProcessSpawner.ExitCode(1),
+    }),
+  );
+
+  assert.strictEqual(auth.status, "unknown");
+  assert.match(
+    Option.getOrElse(auth.detail, () => ""),
+    /2\.81\.0/,
+  );
+});

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -67,6 +67,16 @@ function parseGitHubAuth(input: SourceControlAuthProbeInput) {
     });
   }
 
+  // gh gained `auth status --json` in 2.81.0. Older versions reject the flag and exit
+  // non-zero, which reads exactly like a signed-out CLI. Name the real problem instead.
+  if (input.exitCode !== 0 && output.includes("unknown flag: --json")) {
+    return providerAuth({
+      status: "unknown",
+      detail:
+        "GitHub CLI is too old to report sign-in status. Update `gh` to 2.81.0 or newer (for example `brew upgrade gh`) and rescan.",
+    });
+  }
+
   if (input.exitCode !== 0) {
     return providerAuth({
       status: "unauthenticated",

--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -240,9 +240,10 @@ function itemSummary({
         </span>
       );
     }
+    const authDetail = optionLabel(auth.detail);
     return (
       <span>
-        Could not verify {item.label}. {item.installHint}
+        Could not verify {item.label}. {authDetail ?? item.installHint}
       </span>
     );
   }

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -67,7 +67,7 @@ Run a quick **Rescan** after setting up a new machine or changing credentials.
 
 ### For GitHub (Recommended for most users)
 
-1. Install the GitHub CLI on the machine running T3 Code:
+1. Install the GitHub CLI (version 2.81.0 or newer) on the machine running T3 Code:
    ```bash
    brew install gh
    ```
@@ -140,6 +140,7 @@ Control settings**.
 **Common issues:**
 
 - **Provider shows "Not authenticated"** – Run the login command for that provider (e.g., `gh auth login`) in a terminal on the server, then rescan in Settings
+- **GitHub says it could not verify sign-in status** – T3 Code needs GitHub CLI 2.81.0 or newer to check sign-in status. Update `gh` (e.g., `brew upgrade gh`), then rescan
 - **Bitbucket not connecting** – Double-check your environment variables are set in the correct shell profile and the server was restarted
 - **Can't push to a remote** – Verify your Git remote URL matches the provider you've authenticated with (SSH vs HTTPS remotes may need different credentials)
 


### PR DESCRIPTION
A user on gh 2.72.0 kept seeing "GitHub: Not authenticated" while `gh` was perfectly logged in. We probe with `gh auth status --json hosts`, but `--json` only exists in gh 2.81.0+. Older versions reject the flag and exit non-zero, and we read that as "signed out".

Now the probe recognizes the `unknown flag: --json` failure and reports it as what it is: an outdated CLI. Settings → Source Control shows "Could not verify GitHub" with an update hint (gh 2.81.0+, e.g. `brew upgrade gh`) instead of the false "Not authenticated" badge. Since the status is now "unknown" rather than "unauthenticated", publish and clone readiness checks no longer block old-gh users who are actually signed in. Docs name the minimum version.

Not installed and not authenticated already had clear warnings; old version was the missing case.

Change made by Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to GitHub auth probe parsing and settings copy; no auth or data-path changes beyond clearer status classification.
> 
> **Overview**
> **GitHub auth discovery** now treats `gh auth status --json` failures that mention `unknown flag: --json` as an **outdated CLI** (status `unknown` with an update-to-**2.81.0+** message), instead of **not authenticated**.
> 
> **Settings → Source Control** surfaces that server-provided `auth.detail` when verification fails, so users see the upgrade hint rather than only the generic install text. **Docs** call out the minimum `gh` version and a troubleshooting entry for “could not verify sign-in status.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d6216306a6c10b2427c197c122fca7ef6958e63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix outdated GitHub CLI reporting as unauthenticated instead of unknown
> - `parseGitHubAuth` in [GitHubSourceControlProvider.ts](https://github.com/pingdotgg/t3code/pull/7588/files#diff-e0f205b78b622887367441bbfc3eb4e71dfcda583b3e98e45ad9a7c72f8002bc) now returns status `unknown` with an update hint when `gh auth status --json` fails due to `unknown flag: --json`, rather than falling through to `unauthenticated`.
> - The settings UI in [SourceControlSettings.tsx](https://github.com/pingdotgg/t3code/pull/7588/files#diff-9f2e55c161725a6350a5fe7b23c2b7ada03b60855000614a443c6253ad64b625) now displays the provider-supplied `auth.detail` message in the 'Could not verify' state, so users see the instruction to upgrade GitHub CLI to 2.81.0+.
> - Docs updated to require GitHub CLI 2.81.0+ and add a troubleshooting note for sign-in verification.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d62163.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->