### PR TITLE
feat(web): confirm before closing a terminal

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3464,7 +3464,7 @@ function ChatViewContent(props: ChatViewProps) {
   const requestCloseTerminal = useCallback(
     (terminalId: string) => {
       const label = activeTerminalLabelsById.get(terminalId) ?? getTerminalLabel(terminalId);
-      void confirmTerminalClose(label).then((confirmed) => {
+      void confirmTerminalClose([label]).then((confirmed) => {
         if (confirmed) closeTerminal(terminalId);
       });
     },
@@ -3473,7 +3473,7 @@ function ChatViewContent(props: ChatViewProps) {
   const requestClosePanelTerminal = useCallback(
     (terminalId: string) => {
       const label = activeTerminalLabelsById.get(terminalId) ?? getTerminalLabel(terminalId);
-      void confirmTerminalClose(label).then((confirmed) => {
+      void confirmTerminalClose([label]).then((confirmed) => {
         if (confirmed) closePanelTerminal(terminalId);
       });
     },
@@ -3562,10 +3562,15 @@ function ChatViewContent(props: ChatViewProps) {
         finishClose();
         return;
       }
-      const label =
+      const activeLabel =
         activeTerminalLabelsById.get(surface.activeTerminalId) ??
         getTerminalLabel(surface.activeTerminalId);
-      void confirmTerminalClose(label).then((confirmed) => {
+      const otherLabels = surface.terminalIds
+        .filter((terminalId) => terminalId !== surface.activeTerminalId)
+        .map(
+          (terminalId) => activeTerminalLabelsById.get(terminalId) ?? getTerminalLabel(terminalId),
+        );
+      void confirmTerminalClose([activeLabel, ...otherLabels]).then((confirmed) => {
         if (confirmed) finishClose();
       });
     },

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3553,11 +3553,28 @@ function ChatViewContent(props: ChatViewProps) {
   const closeRightPanelSurface = useCallback(
     (surface: RightPanelSurface) => {
       if (!activeThreadRef) return;
-      cleanupRightPanelSurfaces([surface]);
-      useRightPanelStore.getState().closeSurface(activeThreadRef, surface.id);
-      syncActivePreviewSurface();
+      const finishClose = () => {
+        cleanupRightPanelSurfaces([surface]);
+        useRightPanelStore.getState().closeSurface(activeThreadRef, surface.id);
+        syncActivePreviewSurface();
+      };
+      if (surface.kind !== "terminal") {
+        finishClose();
+        return;
+      }
+      const label =
+        activeTerminalLabelsById.get(surface.activeTerminalId) ??
+        getTerminalLabel(surface.activeTerminalId);
+      void confirmTerminalClose(label).then((confirmed) => {
+        if (confirmed) finishClose();
+      });
     },
-    [activeThreadRef, cleanupRightPanelSurfaces, syncActivePreviewSurface],
+    [
+      activeThreadRef,
+      activeTerminalLabelsById,
+      cleanupRightPanelSurfaces,
+      syncActivePreviewSurface,
+    ],
   );
   const closeOtherRightPanelSurfaces = useCallback(
     (surface: RightPanelSurface) => {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -196,9 +196,12 @@ import {
 import { useNowMinute } from "../hooks/useNowMinute";
 import { useNewThreadHandler } from "../hooks/useHandleNewThread";
 import { resolveAppModelSelectionForInstance } from "../modelSelection";
-import { confirmTerminalClose } from "../lib/terminalCloseConfirm";
+import { confirmTerminalClose, isTerminalCloseConfirmPending } from "../lib/terminalCloseConfirm";
 import { getTerminalFocusOwner } from "../lib/terminalFocus";
-import { preventRepeatedTerminalCloseShortcut } from "../lib/terminalCloseShortcut";
+import {
+  preventRepeatedTerminalCloseShortcut,
+  preventTerminalCloseShortcut,
+} from "../lib/terminalCloseShortcut";
 import { resolveNewDraftStartFromOrigin } from "../lib/chatThreadActions";
 import {
   derivePhysicalProjectKey,
@@ -4744,6 +4747,13 @@ function ChatViewContent(props: ChatViewProps) {
   useEffect(() => {
     const handler = (event: globalThis.KeyboardEvent) => {
       if (preventRepeatedTerminalCloseShortcut(event, keybindings)) {
+        event.stopPropagation();
+        return;
+      }
+      // While a close confirmation is open, terminal focus has moved to the
+      // dialog, so a deliberate second close shortcut would otherwise fall
+      // through to the native window/tab close accelerator.
+      if (isTerminalCloseConfirmPending() && preventTerminalCloseShortcut(event, keybindings)) {
         event.stopPropagation();
         return;
       }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -46,7 +46,11 @@ import {
 import { CHAT_LIST_ANCHOR_OFFSET } from "@t3tools/shared/chatList";
 import { projectScriptCwd, projectScriptRuntimeEnv } from "@t3tools/shared/projectScripts";
 import { truncate } from "@t3tools/shared/String";
-import { nextTerminalId, resolveTerminalSessionLabel } from "@t3tools/shared/terminalLabels";
+import {
+  getTerminalLabel,
+  nextTerminalId,
+  resolveTerminalSessionLabel,
+} from "@t3tools/shared/terminalLabels";
 import { Debouncer } from "@tanstack/react-pacer";
 import { useAtomValue } from "@effect/atom-react";
 import {
@@ -192,6 +196,7 @@ import {
 import { useNowMinute } from "../hooks/useNowMinute";
 import { useNewThreadHandler } from "../hooks/useHandleNewThread";
 import { resolveAppModelSelectionForInstance } from "../modelSelection";
+import { confirmTerminalClose } from "../lib/terminalCloseConfirm";
 import { getTerminalFocusOwner } from "../lib/terminalFocus";
 import { preventRepeatedTerminalCloseShortcut } from "../lib/terminalCloseShortcut";
 import { resolveNewDraftStartFromOrigin } from "../lib/chatThreadActions";
@@ -3453,6 +3458,24 @@ function ChatViewContent(props: ChatViewProps) {
     },
     [activeRightPanelSurface, activeThreadRef, closeTerminalMutation, storeCloseTerminal],
   );
+  const requestCloseTerminal = useCallback(
+    (terminalId: string) => {
+      const label = activeTerminalLabelsById.get(terminalId) ?? getTerminalLabel(terminalId);
+      void confirmTerminalClose(label).then((confirmed) => {
+        if (confirmed) closeTerminal(terminalId);
+      });
+    },
+    [activeTerminalLabelsById, closeTerminal],
+  );
+  const requestClosePanelTerminal = useCallback(
+    (terminalId: string) => {
+      const label = activeTerminalLabelsById.get(terminalId) ?? getTerminalLabel(terminalId);
+      void confirmTerminalClose(label).then((confirmed) => {
+        if (confirmed) closePanelTerminal(terminalId);
+      });
+    },
+    [activeTerminalLabelsById, closePanelTerminal],
+  );
   const activateRightPanelSurface = useCallback(
     (surface: RightPanelSurface) => {
       if (!activeThreadRef) return;
@@ -4807,11 +4830,11 @@ function ChatViewContent(props: ChatViewProps) {
         event.preventDefault();
         event.stopPropagation();
         if (terminalFocusOwner === "right-panel" && activeRightPanelSurface?.kind === "terminal") {
-          closePanelTerminal(activeRightPanelSurface.activeTerminalId);
+          requestClosePanelTerminal(activeRightPanelSurface.activeTerminalId);
           return;
         }
         if (!terminalUiState.terminalOpen) return;
-        closeTerminal(terminalUiState.activeTerminalId);
+        requestCloseTerminal(terminalUiState.activeTerminalId);
         return;
       }
 
@@ -4860,8 +4883,8 @@ function ChatViewContent(props: ChatViewProps) {
     terminalUiState.terminalOpen,
     terminalUiState.activeTerminalId,
     activeThreadId,
-    closeTerminal,
-    closePanelTerminal,
+    requestCloseTerminal,
+    requestClosePanelTerminal,
     createNewTerminal,
     setTerminalOpen,
     runProjectScript,

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -59,6 +59,7 @@ import {
   type ThreadTerminalGroup,
 } from "../types";
 import { readLocalApi } from "~/localApi";
+import { confirmTerminalClose } from "~/lib/terminalCloseConfirm";
 import { useClientSettings } from "../hooks/useSettings";
 import { useLocalStorage } from "../hooks/useLocalStorage";
 import { useAttachedTerminalSession } from "../state/terminalSessions";
@@ -1275,24 +1276,10 @@ export default function ThreadTerminalDrawer({
   }, [onNewTerminal]);
   const confirmCloseTerminal = useCallback(
     (terminalId: string) => {
-      const localApi = readLocalApi();
-      const close = () => onCloseTerminal(terminalId);
-      if (!localApi) {
-        close();
-        return;
-      }
       const label = terminalLabelById.get(terminalId) ?? getTerminalLabel(terminalId);
-      void localApi.dialogs
-        .confirm(
-          [
-            `Close terminal "${label}"?`,
-            "This stops the running process and clears its history.",
-          ].join("\n"),
-          { variant: "destructive" },
-        )
-        .then((confirmed) => {
-          if (confirmed) close();
-        });
+      void confirmTerminalClose(label).then((confirmed) => {
+        if (confirmed) onCloseTerminal(terminalId);
+      });
     },
     [onCloseTerminal, terminalLabelById],
   );

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -1273,6 +1273,29 @@ export default function ThreadTerminalDrawer({
   const onNewTerminalAction = useCallback(() => {
     onNewTerminal();
   }, [onNewTerminal]);
+  const confirmCloseTerminal = useCallback(
+    (terminalId: string) => {
+      const localApi = readLocalApi();
+      const close = () => onCloseTerminal(terminalId);
+      if (!localApi) {
+        close();
+        return;
+      }
+      const label = terminalLabelById.get(terminalId) ?? getTerminalLabel(terminalId);
+      void localApi.dialogs
+        .confirm(
+          [
+            `Close terminal "${label}"?`,
+            "This stops the running process and clears its history.",
+          ].join("\n"),
+          { variant: "destructive" },
+        )
+        .then((confirmed) => {
+          if (confirmed) close();
+        });
+    },
+    [onCloseTerminal, terminalLabelById],
+  );
 
   useEffect(() => {
     onHeightChangeRef.current = onHeightChange;
@@ -1463,7 +1486,7 @@ export default function ThreadTerminalDrawer({
             <div className="h-4 w-px bg-border/80" />
             <TerminalActionButton
               className="p-1 text-foreground/90 transition-colors hover:bg-accent"
-              onClick={() => onCloseTerminal(resolvedActiveTerminalId)}
+              onClick={() => confirmCloseTerminal(resolvedActiveTerminalId)}
               label={closeTerminalActionLabel}
             >
               <Trash2 className="size-3.25" />
@@ -1598,7 +1621,7 @@ export default function ThreadTerminalDrawer({
                   </TerminalActionButton>
                   <TerminalActionButton
                     className="inline-flex h-full items-center border-l border-border/70 px-1 text-foreground/90 transition-colors hover:bg-accent/70"
-                    onClick={() => onCloseTerminal(resolvedActiveTerminalId)}
+                    onClick={() => confirmCloseTerminal(resolvedActiveTerminalId)}
                     label={closeTerminalActionLabel}
                   >
                     <Trash2 className="size-3.25" />
@@ -1668,7 +1691,7 @@ export default function ThreadTerminalDrawer({
                                       <button
                                         type="button"
                                         className="inline-flex size-3.5 items-center justify-center rounded text-xs font-medium leading-none text-muted-foreground opacity-0 transition hover:bg-accent hover:text-foreground group-hover:opacity-100"
-                                        onClick={() => onCloseTerminal(terminalId)}
+                                        onClick={() => confirmCloseTerminal(terminalId)}
                                         aria-label={closeTerminalLabel}
                                       />
                                     }

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -1277,7 +1277,7 @@ export default function ThreadTerminalDrawer({
   const confirmCloseTerminal = useCallback(
     (terminalId: string) => {
       const label = terminalLabelById.get(terminalId) ?? getTerminalLabel(terminalId);
-      void confirmTerminalClose(label).then((confirmed) => {
+      void confirmTerminalClose([label]).then((confirmed) => {
         if (confirmed) onCloseTerminal(terminalId);
       });
     },

--- a/apps/web/src/lib/terminalCloseConfirm.test.ts
+++ b/apps/web/src/lib/terminalCloseConfirm.test.ts
@@ -31,7 +31,7 @@ describe("terminal close confirmation", () => {
 
     expect(isTerminalCloseConfirmPending()).toBe(false);
 
-    const confirmation = confirmTerminalClose("Terminal 1");
+    const confirmation = confirmTerminalClose(["Terminal 1"]);
     expect(isTerminalCloseConfirmPending()).toBe(true);
 
     settle(true);
@@ -48,7 +48,7 @@ describe("terminal close confirmation", () => {
         }),
     );
 
-    const confirmation = confirmTerminalClose("Terminal 1");
+    const confirmation = confirmTerminalClose(["Terminal 1"]);
     expect(isTerminalCloseConfirmPending()).toBe(true);
 
     reject(new Error("dialog failed"));
@@ -56,10 +56,23 @@ describe("terminal close confirmation", () => {
     expect(isTerminalCloseConfirmPending()).toBe(false);
   });
 
+  it("names every terminal in a multi-terminal close", async () => {
+    confirmMock.mockResolvedValue(true);
+
+    await expect(confirmTerminalClose(["Terminal 1", "Development server"])).resolves.toBe(true);
+    expect(confirmMock).toHaveBeenCalledWith(
+      [
+        "Close 2 terminals?",
+        'This stops their running processes and clears their histories: "Terminal 1", "Development server".',
+      ].join("\n"),
+      { variant: "destructive" },
+    );
+  });
+
   it("closes without prompting when no local API is available", async () => {
     readLocalApiMock.mockReturnValue(undefined);
 
-    await expect(confirmTerminalClose("Terminal 1")).resolves.toBe(true);
+    await expect(confirmTerminalClose(["Terminal 1"])).resolves.toBe(true);
     expect(confirmMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/terminalCloseConfirm.test.ts
+++ b/apps/web/src/lib/terminalCloseConfirm.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const { confirmMock, readLocalApiMock } = vi.hoisted(() => {
+  const confirmMock = vi.fn<(message: string, options?: unknown) => Promise<boolean>>();
+  const readLocalApiMock = vi.fn<
+    () =>
+      | {
+          dialogs: { confirm: (message: string, options?: unknown) => Promise<boolean> };
+        }
+      | undefined
+  >();
+  return { confirmMock, readLocalApiMock };
+});
+
+vi.mock("~/localApi", () => ({
+  readLocalApi: () => readLocalApiMock(),
+}));
+
+import { confirmTerminalClose, isTerminalCloseConfirmPending } from "./terminalCloseConfirm";
+
+describe("terminal close confirmation", () => {
+  beforeEach(() => {
+    confirmMock.mockReset();
+    readLocalApiMock.mockReset();
+    readLocalApiMock.mockReturnValue({ dialogs: { confirm: confirmMock } });
+  });
+
+  it("tracks pending state until the confirmation settles", async () => {
+    let settle: (value: boolean) => void = () => undefined;
+    confirmMock.mockImplementation(() => new Promise<boolean>((resolve) => (settle = resolve)));
+
+    expect(isTerminalCloseConfirmPending()).toBe(false);
+
+    const confirmation = confirmTerminalClose("Terminal 1");
+    expect(isTerminalCloseConfirmPending()).toBe(true);
+
+    settle(true);
+    await expect(confirmation).resolves.toBe(true);
+    expect(isTerminalCloseConfirmPending()).toBe(false);
+  });
+
+  it("clears pending state and resolves false when the dialog rejects", async () => {
+    let reject: (reason?: unknown) => void = () => undefined;
+    confirmMock.mockImplementation(
+      () =>
+        new Promise<boolean>((_resolve, rejectPromise) => {
+          reject = rejectPromise;
+        }),
+    );
+
+    const confirmation = confirmTerminalClose("Terminal 1");
+    expect(isTerminalCloseConfirmPending()).toBe(true);
+
+    reject(new Error("dialog failed"));
+    await expect(confirmation).resolves.toBe(false);
+    expect(isTerminalCloseConfirmPending()).toBe(false);
+  });
+
+  it("closes without prompting when no local API is available", async () => {
+    readLocalApiMock.mockReturnValue(undefined);
+
+    await expect(confirmTerminalClose("Terminal 1")).resolves.toBe(true);
+    expect(confirmMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/terminalCloseConfirm.ts
+++ b/apps/web/src/lib/terminalCloseConfirm.ts
@@ -1,5 +1,12 @@
 import { readLocalApi } from "~/localApi";
 
+let pendingConfirmations = 0;
+
+/** Whether a terminal-close confirmation is currently waiting on the user. */
+export function isTerminalCloseConfirmPending(): boolean {
+  return pendingConfirmations > 0;
+}
+
 /**
  * Shared confirmation for every user-initiated terminal close (drawer buttons,
  * panel buttons, and the `terminal.close` keybinding). Auto-exit cleanup skips
@@ -8,10 +15,15 @@ import { readLocalApi } from "~/localApi";
 export async function confirmTerminalClose(label: string): Promise<boolean> {
   const localApi = readLocalApi();
   if (!localApi) return true;
-  return localApi.dialogs.confirm(
-    [`Close terminal "${label}"?`, "This stops the running process and clears its history."].join(
-      "\n",
-    ),
-    { variant: "destructive" },
-  );
+  pendingConfirmations += 1;
+  try {
+    return await localApi.dialogs.confirm(
+      [`Close terminal "${label}"?`, "This stops the running process and clears its history."].join(
+        "\n",
+      ),
+      { variant: "destructive" },
+    );
+  } finally {
+    pendingConfirmations -= 1;
+  }
 }

--- a/apps/web/src/lib/terminalCloseConfirm.ts
+++ b/apps/web/src/lib/terminalCloseConfirm.ts
@@ -1,0 +1,17 @@
+import { readLocalApi } from "~/localApi";
+
+/**
+ * Shared confirmation for every user-initiated terminal close (drawer buttons,
+ * panel buttons, and the `terminal.close` keybinding). Auto-exit cleanup skips
+ * this path and closes directly.
+ */
+export async function confirmTerminalClose(label: string): Promise<boolean> {
+  const localApi = readLocalApi();
+  if (!localApi) return true;
+  return localApi.dialogs.confirm(
+    [`Close terminal "${label}"?`, "This stops the running process and clears its history."].join(
+      "\n",
+    ),
+    { variant: "destructive" },
+  );
+}

--- a/apps/web/src/lib/terminalCloseConfirm.ts
+++ b/apps/web/src/lib/terminalCloseConfirm.ts
@@ -13,15 +13,25 @@ export function isTerminalCloseConfirmPending(): boolean {
  * the tab strip. Auto-exit cleanup and bulk tab closes skip this path and close
  * directly.
  */
-export async function confirmTerminalClose(label: string): Promise<boolean> {
+export async function confirmTerminalClose(
+  labels: readonly [string, ...string[]],
+): Promise<boolean> {
   const localApi = readLocalApi();
   if (!localApi) return true;
   pendingConfirmations += 1;
   try {
     return await localApi.dialogs.confirm(
-      [`Close terminal "${label}"?`, "This stops the running process and clears its history."].join(
-        "\n",
-      ),
+      labels.length === 1
+        ? [
+            `Close terminal "${labels[0]}"?`,
+            "This stops the running process and clears its history.",
+          ].join("\n")
+        : [
+            `Close ${labels.length} terminals?`,
+            `This stops their running processes and clears their histories: ${labels
+              .map((label) => `"${label}"`)
+              .join(", ")}.`,
+          ].join("\n"),
       { variant: "destructive" },
     );
   } catch {

--- a/apps/web/src/lib/terminalCloseConfirm.ts
+++ b/apps/web/src/lib/terminalCloseConfirm.ts
@@ -8,9 +8,10 @@ export function isTerminalCloseConfirmPending(): boolean {
 }
 
 /**
- * Shared confirmation for every user-initiated terminal close (drawer buttons,
- * panel buttons, and the `terminal.close` keybinding). Auto-exit cleanup skips
- * this path and closes directly.
+ * Confirmation for individual terminal close actions: drawer buttons, panel
+ * buttons, the `terminal.close` keybinding, and closing a terminal surface from
+ * the tab strip. Auto-exit cleanup and bulk tab closes skip this path and close
+ * directly.
  */
 export async function confirmTerminalClose(label: string): Promise<boolean> {
   const localApi = readLocalApi();
@@ -23,6 +24,8 @@ export async function confirmTerminalClose(label: string): Promise<boolean> {
       ),
       { variant: "destructive" },
     );
+  } catch {
+    return false;
   } finally {
     pendingConfirmations -= 1;
   }


### PR DESCRIPTION
## What changed

Closing a terminal stops its running process and deletes its history, but the close buttons (trash in the floating toolbar, trash in the sidebar header, and the per-terminal X) acted immediately with no confirmation.

## How

Wrapped the three user-initiated close actions in `ThreadTerminalDrawer` with the existing `localApi.dialogs.confirm(...)` flow:

- Prompts `Close terminal "<label>"?` with the description `This stops the running process and clears its history.` using the destructive variant.
- Falls back to closing immediately when no local API is available.
- The auto-exit path (process already ended) is intentionally not confirmed.

## Validation

- `apps/web` typecheck passes.

Built with deepseek-v4-pro in the OpenCode harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX-only guard around terminal teardown; no auth or data-path changes, with immediate close preserved when dialogs are unavailable.
> 
> **Overview**
> User-initiated terminal closes now go through a **destructive confirmation** (`confirmTerminalClose`) that names the terminal(s) and warns that closing stops processes and clears history. When no local dialog API exists, close proceeds without prompting.
> 
> **ChatView** routes the `terminal.close` shortcut and right-panel terminal/surface closes through the confirm flow; closing a whole terminal **surface** from the tab strip lists every terminal in that surface. While a confirm dialog is open, **`terminal.close` shortcuts are swallowed** so they do not trigger native window/tab close.
> 
> **ThreadTerminalDrawer** wires the trash and per-tab close controls through the same helper. Auto-exit and other bulk closes that skip this path are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec5d1c0a552c839d5dd1d54e90da588914cab49d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add confirmation dialog before closing a terminal tab or surface
> - Introduces `confirmTerminalClose` in [`terminalCloseConfirm.ts`](https://github.com/pingdotgg/t3code/pull/7592/files#diff-97d7b427d9f5cadc931ebe26d9d7a4345b73a07cb1b2633b35b5ad5d723e0b74), which shows a destructive confirmation dialog with human-readable terminal labels (singular or plural messaging) before any close proceeds.
> - Closing a terminal via the `terminal.close` keybinding, toolbar button, or tab UI in [`ChatViewContent`](https://github.com/pingdotgg/t3code/pull/7592/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) and [`ThreadTerminalDrawer`](https://github.com/pingdotgg/t3code/pull/7592/files#diff-09ca7578f1aa1d1aaf5c36202aad25ecde8fb131a58b0c251fd9c03323eb5636) now routes through the confirmation flow.
> - When closing a right-panel terminal surface that contains multiple tabs, all terminal labels in that surface are listed in the confirmation prompt.
> - While a confirmation dialog is open, subsequent close shortcuts are intercepted via `isTerminalCloseConfirmPending` and `preventTerminalCloseShortcut` to prevent native browser/OS close accelerators from triggering.
> - If no local API is available, `confirmTerminalClose` returns `true` immediately and skips the dialog.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec5d1c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->