### PR TITLE
fix(web): usage hourly breakdown lists every hour chronologically

### DIFF
--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -68,12 +68,15 @@ export function UsagePage() {
         : enumerateHourStarts(window.sinceTime, window.untilTime),
     [window.sinceTime, window.untilTime],
   );
-  // Newest first: the window can run 90 periods, so the interesting end
-  // belongs at the top of the table.
-  const breakdownPeriods = useMemo<readonly (DailyTotals | HourlyTotals)[]>(
-    () => (isPast24Hours ? merged.hourly : merged.daily).toReversed(),
-    [isPast24Hours, merged.daily, merged.hourly],
-  );
+  // The hourly window is small enough to render every period: the table then
+  // reads chronologically like the chart, instead of jumping between the hours
+  // that happened to have activity. Daily windows can run 90 periods, so those
+  // stay newest-first with the interesting end on top.
+  const breakdownPeriods = useMemo<readonly (DailyTotals | HourlyTotals)[]>(() => {
+    if (!isPast24Hours) return merged.daily.toReversed();
+    const byHour = new Map(merged.hourly.map((entry) => [entry.hourStart, entry]));
+    return hours.map((hourStart) => byHour.get(hourStart) ?? zeroHour(hourStart));
+  }, [isPast24Hours, merged.daily, merged.hourly, hours]);
 
   const selectWindow = (days: number) => {
     setWindowSelection({
@@ -433,6 +436,17 @@ export function UsagePage() {
       </div>
     </SidebarInset>
   );
+}
+
+/** A zero-filled hourly period so the breakdown lists every hour in the window. */
+function zeroHour(hourStart: string): HourlyTotals {
+  return {
+    day: "",
+    hourStart,
+    costUsd: 0,
+    totalTokens: 0,
+    byProvider: new Map<UsageProviderKind, { costUsd: number; totalTokens: number }>(),
+  };
 }
 
 /** Brand mark for the harness a row belongs to. */


### PR DESCRIPTION
## Problem

On the Usage page, **Past 24h** + Breakdown **Hour** only lists hours with activity, newest first. With sparse activity the list jumps between distant hours (e.g. `1 PM` → `6 PM`) and reads as mis-ordered, even though the ordering itself is correct and the labels are in the system timezone.

## Fix

Render **every hour in the 24h window** in the breakdown table — zero-filled, in chronological order — matching the chart above it, which already renders all 24 periods. Daily windows (up to 90 periods) keep the existing newest-first behavior.

`breakdownPeriods` now maps the window's hour enumeration to the merged hourly totals, falling back to a zero-filled row for inactive hours. The labels still use `window.timeZone` unchanged.

Closes #7594

Model: deepseek-v4-flash via opencode (OpenCode CLI)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change on the Usage page breakdown table; no API, auth, or data pipeline changes.
> 
> **Overview**
> **Past 24h** usage breakdown (Breakdown → **Hour**) no longer shows only hours that had activity, newest-first. It now walks the full window hour list in **chronological order**, using zero-filled rows for quiet hours so the table matches the hourly chart instead of jumping between sparse timestamps.
> 
> **7/30/90 day** breakdowns are unchanged: still **newest-first** via `merged.daily.toReversed()`.
> 
> Adds a small `zeroHour` helper to build empty `HourlyTotals` rows when merging hourly data by `hourStart`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2119ffbb2594df26238c5bb89448abcdaee806a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix usage hourly breakdown to list all hours chronologically with zero-filled gaps
> In [UsagePage.tsx](https://github.com/pingdotgg/t3code/pull/7595/files#diff-e076db2611ea0a07e1c8ec8571cc21103a2a4c7fc0feb865192fc12c8a18dead), the `breakdownPeriods` memo is reworked so that hourly windows build a `Map` keyed by `hourStart` and align entries to the full hours array, inserting zero-filled rows for hours with no activity. A new `zeroHour` helper constructs empty `HourlyTotals` objects for missing hours. Daily mode is unchanged and continues to display newest-first.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2119ffb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->