### PR TITLE
feat(web): switch recent threads with ctrl+tab

### DIFF
--- a/apps/web/src/components/RecentThreadsSwitcher.tsx
+++ b/apps/web/src/components/RecentThreadsSwitcher.tsx
@@ -196,7 +196,7 @@ function RecentThreadsSwitcherOverlay({
   }, [selectedIndex]);
 
   return (
-    <div className="pointer-events-none fixed inset-0 z-50 flex justify-center">
+    <div className="pointer-events-none fixed inset-0 z-100 flex justify-center px-4">
       <div
         ref={listRef}
         role="listbox"

--- a/apps/web/src/components/RecentThreadsSwitcher.tsx
+++ b/apps/web/src/components/RecentThreadsSwitcher.tsx
@@ -1,0 +1,239 @@
+/**
+ * Alt-tab style switcher over the threads opened this session, newest first.
+ * Ctrl+Tab opens it and advances, Ctrl+Shift+Tab goes back, releasing the
+ * held modifier opens the highlighted thread, Escape cancels. Mounted once at
+ * the root so it works on every route, with or without the sidebar.
+ *
+ * Browsers reserve Ctrl+Tab for their own tab switching, so the default
+ * shortcut only ever reaches us in the desktop app; in a browser the commands
+ * stay inert until the user rebinds them to reachable keys.
+ */
+import { useAtomValue } from "@effect/atom-react";
+import { useNavigate, useParams } from "@tanstack/react-router";
+import { useEffect, useEffectEvent, useRef, useState } from "react";
+
+import {
+  parseScopedThreadKey,
+  scopedThreadKey,
+  scopeProjectRef,
+} from "@t3tools/client-runtime/environment";
+
+import { isCommandPaletteOpen } from "../commandPaletteBus";
+import { recentThreadsDirectionFromCommand, resolveShortcutCommand } from "../keybindings";
+import { isTerminalFocused } from "../lib/terminalFocus";
+import { cn } from "../lib/utils";
+import { useRecentThreadsStore } from "../recentThreadsStore";
+import { readProject, readThreadShell } from "../state/entities";
+import { primaryServerKeybindingsAtom } from "../state/server";
+import { buildThreadRouteParams, resolveThreadRouteTarget } from "../threadRoutes";
+
+interface SwitcherSession {
+  /** Scoped thread keys frozen when the switcher opened, newest visit first. */
+  entries: ReadonlyArray<string>;
+  selectedIndex: number;
+  /** Modifiers held on open; releasing all of them commits the selection. */
+  holdsCtrl: boolean;
+  holdsMeta: boolean;
+  holdsAlt: boolean;
+}
+
+/** Recent thread keys that still resolve to a live, unarchived thread. */
+function liveRecentThreadKeys(): string[] {
+  const live: string[] = [];
+  for (const key of useRecentThreadsStore.getState().recentThreadKeys) {
+    const ref = parseScopedThreadKey(key);
+    if (!ref) continue;
+    const shell = readThreadShell(ref);
+    if (shell === null || shell.archivedAt !== null) continue;
+    live.push(key);
+  }
+  return live;
+}
+
+export function RecentThreadsSwitcher() {
+  const keybindings = useAtomValue(primaryServerKeybindingsAtom);
+  const navigate = useNavigate();
+  const routeTarget = useParams({
+    strict: false,
+    select: (params) => resolveThreadRouteTarget(params),
+  });
+  const [session, setSession] = useState<SwitcherSession | null>(null);
+  const sessionRef = useRef(session);
+  sessionRef.current = session;
+
+  const commit = useEffectEvent((index?: number) => {
+    const current = sessionRef.current;
+    if (!current) return;
+    setSession(null);
+    const key = current.entries[index ?? current.selectedIndex];
+    const ref = key === undefined ? null : parseScopedThreadKey(key);
+    if (!ref || readThreadShell(ref) === null) return;
+    void navigate({ to: "/$environmentId/$threadId", params: buildThreadRouteParams(ref) });
+  });
+
+  const handleWindowKeyDown = useEffectEvent((event: KeyboardEvent) => {
+    const current = sessionRef.current;
+    if (current) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        setSession(null);
+        return;
+      }
+      if (event.key === "Enter") {
+        event.preventDefault();
+        event.stopPropagation();
+        commit();
+        return;
+      }
+    }
+    if (event.defaultPrevented) return;
+    if (event.target instanceof HTMLElement && event.target.closest("[data-keybinding-capture]")) {
+      return;
+    }
+    const direction = recentThreadsDirectionFromCommand(
+      resolveShortcutCommand(event, keybindings, {
+        context: { terminalFocus: isTerminalFocused() },
+      }),
+    );
+    if (direction === null) return;
+    if (!current && isCommandPaletteOpen()) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const step = direction === "next" ? 1 : -1;
+    if (current) {
+      const count = current.entries.length;
+      setSession({
+        ...current,
+        selectedIndex: (current.selectedIndex + step + count) % count,
+      });
+      return;
+    }
+    const entries = liveRecentThreadKeys();
+    const routeThreadKey =
+      routeTarget?.kind === "server" ? scopedThreadKey(routeTarget.threadRef) : null;
+    if (entries.length === 0 || (entries.length === 1 && entries[0] === routeThreadKey)) return;
+    const start =
+      entries[0] === routeThreadKey && direction === "next"
+        ? 1
+        : direction === "next"
+          ? 0
+          : entries.length - 1;
+    setSession({
+      entries,
+      selectedIndex: start,
+      holdsCtrl: event.ctrlKey,
+      holdsMeta: event.metaKey,
+      holdsAlt: event.altKey,
+    });
+  });
+
+  const handleWindowKeyUp = useEffectEvent((event: KeyboardEvent) => {
+    const current = sessionRef.current;
+    if (!current) return;
+    if (!current.holdsCtrl && !current.holdsMeta && !current.holdsAlt) return;
+    const stillHeld =
+      (current.holdsCtrl && event.getModifierState("Control")) ||
+      (current.holdsMeta && event.getModifierState("Meta")) ||
+      (current.holdsAlt && event.getModifierState("Alt"));
+    if (!stillHeld) commit();
+  });
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => handleWindowKeyDown(event);
+    const onKeyUp = (event: KeyboardEvent) => handleWindowKeyUp(event);
+    const onWindowBlur = () => setSession(null);
+    // Capture phase so held-modifier cycling beats focused editors and the
+    // terminal drawer, mirroring the sidebar toggle listener.
+    window.addEventListener("keydown", onKeyDown, true);
+    window.addEventListener("keyup", onKeyUp, true);
+    window.addEventListener("blur", onWindowBlur);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown, true);
+      window.removeEventListener("keyup", onKeyUp, true);
+      window.removeEventListener("blur", onWindowBlur);
+    };
+  }, []);
+
+  if (!session) return null;
+  return (
+    <RecentThreadsSwitcherOverlay
+      entries={session.entries}
+      selectedIndex={session.selectedIndex}
+      onSelect={commit}
+    />
+  );
+}
+
+function RecentThreadsSwitcherOverlay({
+  entries,
+  selectedIndex,
+  onSelect,
+}: {
+  entries: ReadonlyArray<string>;
+  selectedIndex: number;
+  onSelect: (index: number) => void;
+}) {
+  const listRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    listRef.current?.querySelector('[aria-selected="true"]')?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex]);
+
+  return (
+    <div className="pointer-events-none fixed inset-0 z-50 flex justify-center">
+      <div
+        ref={listRef}
+        role="listbox"
+        aria-label="Recent threads"
+        data-testid="recent-threads-switcher"
+        className="dialog-glass pointer-events-auto mt-[14vh] flex h-fit max-h-[60vh] w-full max-w-md flex-col gap-0.5 overflow-y-auto rounded-2xl border p-1.5 shadow-2xl shadow-black/20"
+      >
+        {entries.map((threadKey, index) => (
+          <RecentThreadsSwitcherRow
+            key={threadKey}
+            threadKey={threadKey}
+            selected={index === selectedIndex}
+            onClick={() => onSelect(index)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function RecentThreadsSwitcherRow({
+  threadKey,
+  selected,
+  onClick,
+}: {
+  threadKey: string;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  const ref = parseScopedThreadKey(threadKey);
+  const shell = ref ? readThreadShell(ref) : null;
+  if (!ref || !shell) return null;
+  const projectTitle = readProject(scopeProjectRef(ref.environmentId, shell.projectId))?.title;
+  const description = [projectTitle, shell.branch ? `#${shell.branch}` : null]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <button
+      type="button"
+      role="option"
+      aria-selected={selected}
+      onClick={onClick}
+      className={cn(
+        "flex w-full flex-col items-start gap-0.5 rounded-lg px-3 py-2 text-left",
+        selected ? "bg-accent text-accent-foreground" : "hover:bg-accent/50",
+      )}
+    >
+      <span className="w-full truncate text-sm font-medium">{shell.title}</span>
+      {description.length > 0 ? (
+        <span className="w-full truncate text-xs text-muted-foreground">{description}</span>
+      ) : null}
+    </button>
+  );
+}

--- a/apps/web/src/components/RecentThreadsSwitcher.tsx
+++ b/apps/web/src/components/RecentThreadsSwitcher.tsx
@@ -58,16 +58,28 @@ export function RecentThreadsSwitcher() {
     select: (params) => resolveThreadRouteTarget(params),
   });
   const [session, setSession] = useState<SwitcherSession | null>(null);
+  // Keydown and keyup are native window listeners with no React flush between
+  // them, so the ref is written eagerly on every transition — reading state
+  // through the render-synced ref would let a keyup commit a cancelled session.
   const sessionRef = useRef(session);
-  sessionRef.current = session;
+  const updateSession = (next: SwitcherSession | null) => {
+    sessionRef.current = next;
+    setSession(next);
+  };
+
+  const cancel = useEffectEvent(() => {
+    if (sessionRef.current === null) return;
+    updateSession(null);
+  });
 
   const commit = useEffectEvent((index?: number) => {
     const current = sessionRef.current;
     if (!current) return;
-    setSession(null);
+    updateSession(null);
     const key = current.entries[index ?? current.selectedIndex];
     const ref = key === undefined ? null : parseScopedThreadKey(key);
-    if (!ref || readThreadShell(ref) === null) return;
+    const shell = ref === null ? null : readThreadShell(ref);
+    if (!ref || shell === null || shell.archivedAt !== null) return;
     void navigate({ to: "/$environmentId/$threadId", params: buildThreadRouteParams(ref) });
   });
 
@@ -77,7 +89,7 @@ export function RecentThreadsSwitcher() {
       if (event.key === "Escape") {
         event.preventDefault();
         event.stopPropagation();
-        setSession(null);
+        cancel();
         return;
       }
       if (event.key === "Enter") {
@@ -100,10 +112,13 @@ export function RecentThreadsSwitcher() {
     if (!current && isCommandPaletteOpen()) return;
     event.preventDefault();
     event.stopPropagation();
+    // Swallow key repeats after claiming the shortcut: one step per physical
+    // press keeps held-modifier cycling controllable.
+    if (event.repeat) return;
     const step = direction === "next" ? 1 : -1;
     if (current) {
       const count = current.entries.length;
-      setSession({
+      updateSession({
         ...current,
         selectedIndex: (current.selectedIndex + step + count) % count,
       });
@@ -119,7 +134,7 @@ export function RecentThreadsSwitcher() {
         : direction === "next"
           ? 0
           : entries.length - 1;
-    setSession({
+    updateSession({
       entries,
       selectedIndex: start,
       holdsCtrl: event.ctrlKey,
@@ -142,7 +157,7 @@ export function RecentThreadsSwitcher() {
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => handleWindowKeyDown(event);
     const onKeyUp = (event: KeyboardEvent) => handleWindowKeyUp(event);
-    const onWindowBlur = () => setSession(null);
+    const onWindowBlur = () => cancel();
     // Capture phase so held-modifier cycling beats focused editors and the
     // terminal drawer, mirroring the sidebar toggle listener.
     window.addEventListener("keydown", onKeyDown, true);
@@ -187,7 +202,7 @@ function RecentThreadsSwitcherOverlay({
         role="listbox"
         aria-label="Recent threads"
         data-testid="recent-threads-switcher"
-        className="dialog-glass pointer-events-auto mt-[14vh] flex h-fit max-h-[60vh] w-full max-w-md flex-col gap-0.5 overflow-y-auto rounded-2xl border p-1.5 shadow-2xl shadow-black/20"
+        className="dialog-glass pointer-events-auto mt-[14vh] flex h-fit max-h-[60vh] w-full max-w-md flex-col gap-0.5 overflow-y-auto rounded-2xl border p-1.5"
       >
         {entries.map((threadKey, index) => (
           <RecentThreadsSwitcherRow
@@ -223,10 +238,13 @@ function RecentThreadsSwitcherRow({
     <button
       type="button"
       role="option"
+      // Keyboard interaction is owned by the window listener; keep rows out of
+      // the tab order so focus stays where the user left it.
+      tabIndex={-1}
       aria-selected={selected}
       onClick={onClick}
       className={cn(
-        "flex w-full flex-col items-start gap-0.5 rounded-lg px-3 py-2 text-left",
+        "flex w-full cursor-pointer flex-col items-start gap-0.5 rounded-lg px-3 py-2 text-left",
         selected ? "bg-accent text-accent-foreground" : "hover:bg-accent/50",
       )}
     >

--- a/apps/web/src/components/RecentThreadsSwitcher.tsx
+++ b/apps/web/src/components/RecentThreadsSwitcher.tsx
@@ -31,7 +31,7 @@ import { isPreviewFocused } from "../lib/previewFocus";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { cn } from "../lib/utils";
 import { useRecentThreadsStore } from "../recentThreadsStore";
-import { readProject, readThreadShell, readThreadStatus } from "../state/entities";
+import { readProject, readThreadShell } from "../state/entities";
 import { primaryServerKeybindingsAtom } from "../state/server";
 import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../terminalUiStateStore";
 import { buildThreadRouteParams, resolveThreadRouteTarget } from "../threadRoutes";
@@ -40,7 +40,7 @@ function isLiveRecentThreadKey(key: string): boolean {
   const ref = parseScopedThreadKey(key);
   if (!ref) return false;
   const shell = readThreadShell(ref);
-  return shell !== null && shell.archivedAt === null && readThreadStatus(ref) !== "deleted";
+  return shell !== null && shell.archivedAt === null;
 }
 
 /** Recent thread keys that still resolve to a live, unarchived thread. */

--- a/apps/web/src/components/RecentThreadsSwitcher.tsx
+++ b/apps/web/src/components/RecentThreadsSwitcher.tsx
@@ -20,34 +20,32 @@ import {
 
 import { isCommandPaletteOpen } from "../commandPaletteBus";
 import { recentThreadsDirectionFromCommand, resolveShortcutCommand } from "../keybindings";
+import { isModelPickerOpen } from "../modelPickerVisibility";
+import {
+  type RecentThreadsSwitcherSession,
+  reconcileRecentThreadsSwitcherSession,
+  shouldCommitRecentThreadsSwitcherOnKeyUp,
+} from "../recentThreadsSwitcherLogic";
+import { selectActiveRightPanel, useRightPanelStore } from "../rightPanelStore";
+import { isPreviewFocused } from "../lib/previewFocus";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { cn } from "../lib/utils";
 import { useRecentThreadsStore } from "../recentThreadsStore";
-import { readProject, readThreadShell } from "../state/entities";
+import { readProject, readThreadShell, readThreadStatus } from "../state/entities";
 import { primaryServerKeybindingsAtom } from "../state/server";
+import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../terminalUiStateStore";
 import { buildThreadRouteParams, resolveThreadRouteTarget } from "../threadRoutes";
 
-interface SwitcherSession {
-  /** Scoped thread keys frozen when the switcher opened, newest visit first. */
-  entries: ReadonlyArray<string>;
-  selectedIndex: number;
-  /** Modifiers held on open; releasing all of them commits the selection. */
-  holdsCtrl: boolean;
-  holdsMeta: boolean;
-  holdsAlt: boolean;
+function isLiveRecentThreadKey(key: string): boolean {
+  const ref = parseScopedThreadKey(key);
+  if (!ref) return false;
+  const shell = readThreadShell(ref);
+  return shell !== null && shell.archivedAt === null && readThreadStatus(ref) !== "deleted";
 }
 
 /** Recent thread keys that still resolve to a live, unarchived thread. */
 function liveRecentThreadKeys(): string[] {
-  const live: string[] = [];
-  for (const key of useRecentThreadsStore.getState().recentThreadKeys) {
-    const ref = parseScopedThreadKey(key);
-    if (!ref) continue;
-    const shell = readThreadShell(ref);
-    if (shell === null || shell.archivedAt !== null) continue;
-    live.push(key);
-  }
-  return live;
+  return useRecentThreadsStore.getState().recentThreadKeys.filter(isLiveRecentThreadKey);
 }
 
 export function RecentThreadsSwitcher() {
@@ -57,12 +55,23 @@ export function RecentThreadsSwitcher() {
     strict: false,
     select: (params) => resolveThreadRouteTarget(params),
   });
-  const [session, setSession] = useState<SwitcherSession | null>(null);
+  const routeThreadRef = routeTarget?.kind === "server" ? routeTarget.threadRef : null;
+  const terminalOpen = useTerminalUiStateStore((state) =>
+    routeThreadRef
+      ? selectThreadTerminalUiState(state.terminalUiStateByThreadKey, routeThreadRef).terminalOpen
+      : false,
+  );
+  const previewOpen = useRightPanelStore((state) =>
+    routeThreadRef
+      ? selectActiveRightPanel(state.byThreadKey, routeThreadRef) === "preview"
+      : false,
+  );
+  const [session, setSession] = useState<RecentThreadsSwitcherSession | null>(null);
   // Keydown and keyup are native window listeners with no React flush between
   // them, so the ref is written eagerly on every transition — reading state
   // through the render-synced ref would let a keyup commit a cancelled session.
   const sessionRef = useRef(session);
-  const updateSession = (next: SwitcherSession | null) => {
+  const updateSession = (next: RecentThreadsSwitcherSession | null) => {
     sessionRef.current = next;
     setSession(next);
   };
@@ -72,14 +81,19 @@ export function RecentThreadsSwitcher() {
     updateSession(null);
   });
 
-  const commit = useEffectEvent((index?: number) => {
+  const commit = useEffectEvent((requestedKey?: string) => {
     const current = sessionRef.current;
     if (!current) return;
+    const reconciled = reconcileRecentThreadsSwitcherSession(current, isLiveRecentThreadKey);
     updateSession(null);
-    const key = current.entries[index ?? current.selectedIndex];
-    const ref = key === undefined ? null : parseScopedThreadKey(key);
-    const shell = ref === null ? null : readThreadShell(ref);
-    if (!ref || shell === null || shell.archivedAt !== null) return;
+    if (!reconciled) return;
+    const key =
+      requestedKey !== undefined && reconciled.entries.includes(requestedKey)
+        ? requestedKey
+        : reconciled.entries[reconciled.selectedIndex];
+    if (key === undefined) return;
+    const ref = parseScopedThreadKey(key);
+    if (!ref || !isLiveRecentThreadKey(key)) return;
     void navigate({ to: "/$environmentId/$threadId", params: buildThreadRouteParams(ref) });
   });
 
@@ -105,7 +119,13 @@ export function RecentThreadsSwitcher() {
     }
     const direction = recentThreadsDirectionFromCommand(
       resolveShortcutCommand(event, keybindings, {
-        context: { terminalFocus: isTerminalFocused() },
+        context: {
+          terminalFocus: isTerminalFocused(),
+          terminalOpen,
+          previewFocus: isPreviewFocused(),
+          previewOpen,
+          modelPickerOpen: isModelPickerOpen(),
+        },
       }),
     );
     if (direction === null) return;
@@ -117,10 +137,15 @@ export function RecentThreadsSwitcher() {
     if (event.repeat) return;
     const step = direction === "next" ? 1 : -1;
     if (current) {
-      const count = current.entries.length;
+      const reconciled = reconcileRecentThreadsSwitcherSession(current, isLiveRecentThreadKey);
+      if (!reconciled) {
+        cancel();
+        return;
+      }
+      const count = reconciled.entries.length;
       updateSession({
-        ...current,
-        selectedIndex: (current.selectedIndex + step + count) % count,
+        ...reconciled,
+        selectedIndex: (reconciled.selectedIndex + step + count) % count,
       });
       return;
     }
@@ -140,41 +165,51 @@ export function RecentThreadsSwitcher() {
       holdsCtrl: event.ctrlKey,
       holdsMeta: event.metaKey,
       holdsAlt: event.altKey,
+      holdsShift: event.shiftKey,
+      triggerKey: event.code || event.key,
     });
   });
 
   const handleWindowKeyUp = useEffectEvent((event: KeyboardEvent) => {
     const current = sessionRef.current;
     if (!current) return;
-    if (!current.holdsCtrl && !current.holdsMeta && !current.holdsAlt) return;
-    const stillHeld =
-      (current.holdsCtrl && event.getModifierState("Control")) ||
-      (current.holdsMeta && event.getModifierState("Meta")) ||
-      (current.holdsAlt && event.getModifierState("Alt"));
-    if (!stillHeld) commit();
+    if (shouldCommitRecentThreadsSwitcherOnKeyUp(current, event)) commit();
   });
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => handleWindowKeyDown(event);
     const onKeyUp = (event: KeyboardEvent) => handleWindowKeyUp(event);
+    const onPointerDown = (event: PointerEvent) => {
+      if (
+        event.target instanceof Element &&
+        event.target.closest('[data-testid="recent-threads-switcher"]')
+      ) {
+        return;
+      }
+      cancel();
+    };
     const onWindowBlur = () => cancel();
     // Capture phase so held-modifier cycling beats focused editors and the
     // terminal drawer, mirroring the sidebar toggle listener.
     window.addEventListener("keydown", onKeyDown, true);
     window.addEventListener("keyup", onKeyUp, true);
+    window.addEventListener("pointerdown", onPointerDown, true);
     window.addEventListener("blur", onWindowBlur);
     return () => {
       window.removeEventListener("keydown", onKeyDown, true);
       window.removeEventListener("keyup", onKeyUp, true);
+      window.removeEventListener("pointerdown", onPointerDown, true);
       window.removeEventListener("blur", onWindowBlur);
     };
   }, []);
 
   if (!session) return null;
+  const reconciled = reconcileRecentThreadsSwitcherSession(session, isLiveRecentThreadKey);
+  if (!reconciled) return null;
   return (
     <RecentThreadsSwitcherOverlay
-      entries={session.entries}
-      selectedIndex={session.selectedIndex}
+      entries={reconciled.entries}
+      selectedIndex={reconciled.selectedIndex}
       onSelect={commit}
     />
   );
@@ -187,7 +222,7 @@ function RecentThreadsSwitcherOverlay({
 }: {
   entries: ReadonlyArray<string>;
   selectedIndex: number;
-  onSelect: (index: number) => void;
+  onSelect: (threadKey: string) => void;
 }) {
   const listRef = useRef<HTMLDivElement | null>(null);
 
@@ -196,20 +231,20 @@ function RecentThreadsSwitcherOverlay({
   }, [selectedIndex]);
 
   return (
-    <div className="fixed inset-0 z-100 flex justify-center px-4">
+    <div className="pointer-events-none fixed inset-0 z-100 flex justify-center px-4">
       <div
         ref={listRef}
         role="listbox"
         aria-label="Recent threads"
         data-testid="recent-threads-switcher"
-        className="dialog-glass mt-[14vh] flex h-fit max-h-[60vh] w-full max-w-md flex-col gap-0.5 overflow-y-auto rounded-2xl border p-1.5"
+        className="dialog-glass pointer-events-auto mt-[14vh] flex h-fit max-h-[60vh] w-full max-w-md flex-col gap-0.5 overflow-y-auto rounded-2xl border p-1.5"
       >
         {entries.map((threadKey, index) => (
           <RecentThreadsSwitcherRow
             key={threadKey}
             threadKey={threadKey}
             selected={index === selectedIndex}
-            onClick={() => onSelect(index)}
+            onClick={() => onSelect(threadKey)}
           />
         ))}
       </div>

--- a/apps/web/src/components/RecentThreadsSwitcher.tsx
+++ b/apps/web/src/components/RecentThreadsSwitcher.tsx
@@ -196,13 +196,13 @@ function RecentThreadsSwitcherOverlay({
   }, [selectedIndex]);
 
   return (
-    <div className="pointer-events-none fixed inset-0 z-100 flex justify-center px-4">
+    <div className="fixed inset-0 z-100 flex justify-center px-4">
       <div
         ref={listRef}
         role="listbox"
         aria-label="Recent threads"
         data-testid="recent-threads-switcher"
-        className="dialog-glass pointer-events-auto mt-[14vh] flex h-fit max-h-[60vh] w-full max-w-md flex-col gap-0.5 overflow-y-auto rounded-2xl border p-1.5"
+        className="dialog-glass mt-[14vh] flex h-fit max-h-[60vh] w-full max-w-md flex-col gap-0.5 overflow-y-auto rounded-2xl border p-1.5"
       >
         {entries.map((threadKey, index) => (
           <RecentThreadsSwitcherRow
@@ -238,10 +238,12 @@ function RecentThreadsSwitcherRow({
     <button
       type="button"
       role="option"
-      // Keyboard interaction is owned by the window listener; keep rows out of
-      // the tab order so focus stays where the user left it.
+      // Keyboard interaction is owned by the window listener. Keep rows out of
+      // the tab order and prevent pointer focus so committing preserves the
+      // focus the user had before opening the switcher.
       tabIndex={-1}
       aria-selected={selected}
+      onPointerDown={(event) => event.preventDefault()}
       onClick={onClick}
       className={cn(
         "flex w-full cursor-pointer flex-col items-start gap-0.5 rounded-lg px-3 py-2 text-left",

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
@@ -8,7 +8,9 @@ import {
   commandLabel,
   keybindingConflictLabels,
   keybindingFromKeyboardEvent,
+  keybindingPillTokenLabel,
   parseWhenExpressionDraft,
+  shouldPreserveKeybindingCaptureFocusNavigation,
   shortcutToKeybindingInput,
   unknownWhenVariables,
   whenAstToExpression,
@@ -62,6 +64,37 @@ describe("KeybindingsSettings.logic", () => {
         "Win32",
       ),
     ).toBe("mod+shift+k");
+  });
+
+  it("captures modified Tab shortcuts while preserving focus navigation", () => {
+    expect(
+      shouldPreserveKeybindingCaptureFocusNavigation({
+        key: "Tab",
+        metaKey: false,
+        ctrlKey: false,
+        altKey: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldPreserveKeybindingCaptureFocusNavigation({
+        key: "Tab",
+        metaKey: false,
+        ctrlKey: true,
+        altKey: false,
+      }),
+    ).toBe(false);
+    expect(
+      keybindingFromKeyboardEvent(
+        { key: "Tab", metaKey: false, ctrlKey: true, altKey: false, shiftKey: true },
+        "MacIntel",
+      ),
+    ).toBe("ctrl+shift+tab");
+  });
+
+  it("formats modified Tab keybinding pills for the current platform", () => {
+    expect(keybindingPillTokenLabel("ctrl", "MacIntel")).toBe("⌃");
+    expect(keybindingPillTokenLabel("ctrl", "Win32")).toBe("Ctrl");
+    expect(keybindingPillTokenLabel("tab", "Win32")).toBe("Tab");
   });
 
   it("serializes shortcuts and when expressions for upserts", () => {

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.ts
@@ -336,3 +336,17 @@ export function keybindingFromKeyboardEvent(
   parts.push(keyToken);
   return parts.join("+");
 }
+
+export function shouldPreserveKeybindingCaptureFocusNavigation(
+  event: Pick<KeyboardEvent, "key" | "metaKey" | "ctrlKey" | "altKey">,
+): boolean {
+  return event.key === "Tab" && !event.metaKey && !event.ctrlKey && !event.altKey;
+}
+
+export function keybindingPillTokenLabel(token: string, platform: string): string {
+  if (token === "mod") return isMacPlatform(platform) ? "⌘" : "Ctrl";
+  if (token === "shift") return "⇧";
+  if (token === "alt") return isMacPlatform(platform) ? "⌥" : "Alt";
+  if (token === "ctrl") return isMacPlatform(platform) ? "⌃" : "Ctrl";
+  return token.slice(0, 1).toUpperCase() + token.slice(1);
+}

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -62,7 +62,9 @@ import {
   isKnownWhenVariable,
   keybindingConflictLabels,
   keybindingFromKeyboardEvent,
+  keybindingPillTokenLabel,
   parseWhenExpressionDraft,
+  shouldPreserveKeybindingCaptureFocusNavigation,
   type KeybindingCommandOption,
   type KeybindingRow,
   type WhenVariableOption,
@@ -80,21 +82,7 @@ function KeybindingPill({ value }: { value: string }) {
     <KbdGroup className="bg-transparent p-0 shadow-none">
       {parts.map((part) => (
         <Kbd key={part} className="min-w-6 justify-center px-1.5">
-          {part === "mod"
-            ? navigator.platform.toLowerCase().includes("mac")
-              ? "⌘"
-              : "Ctrl"
-            : part === "shift"
-              ? "⇧"
-              : part === "alt"
-                ? navigator.platform.toLowerCase().includes("mac")
-                  ? "⌥"
-                  : "Alt"
-                : part === "ctrl"
-                  ? "⌃"
-                  : part.length === 1
-                    ? part.toUpperCase()
-                    : part}
+          {keybindingPillTokenLabel(part, navigator.platform)}
         </Kbd>
       ))}
     </KbdGroup>
@@ -775,7 +763,7 @@ function KeybindingTableRow({
   };
 
   const captureKeybinding = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === "Tab") return;
+    if (shouldPreserveKeybindingCaptureFocusNavigation(event)) return;
     event.preventDefault();
     if (event.key === "Escape") {
       setDraft({ keyDraft: row.key, isRecording: false });
@@ -946,7 +934,7 @@ function NewKeybindingTableRow({
   };
 
   const captureKeybinding = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === "Tab") return;
+    if (shouldPreserveKeybindingCaptureFocusNavigation(event)) return;
     event.preventDefault();
     if (event.key === "Escape") {
       setDraft({ keyDraft: "", isRecording: false });

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -27,6 +27,7 @@ import {
   terminalDeleteShortcutData,
   terminalNavigationShortcutData,
   threadJumpCommandForIndex,
+  recentThreadsDirectionFromCommand,
   threadJumpIndexFromCommand,
   threadTraversalDirectionFromCommand,
   type ShortcutEventLike,
@@ -142,6 +143,30 @@ const DEFAULT_BINDINGS = compile([
   { shortcut: modShortcut("o"), command: "editor.openFavorite" },
   { shortcut: modShortcut("[", { shiftKey: true }), command: "thread.previous" },
   { shortcut: modShortcut("]", { shiftKey: true }), command: "thread.next" },
+  {
+    shortcut: {
+      key: "tab",
+      metaKey: false,
+      ctrlKey: true,
+      shiftKey: false,
+      altKey: false,
+      modKey: false,
+    },
+    command: "recentThreads.next",
+    whenAst: whenNot(whenIdentifier("terminalFocus")),
+  },
+  {
+    shortcut: {
+      key: "tab",
+      metaKey: false,
+      ctrlKey: true,
+      shiftKey: true,
+      altKey: false,
+      modKey: false,
+    },
+    command: "recentThreads.previous",
+    whenAst: whenNot(whenIdentifier("terminalFocus")),
+  },
   { shortcut: modShortcut("1"), command: "thread.jump.1" },
   { shortcut: modShortcut("2"), command: "thread.jump.2" },
   { shortcut: modShortcut("3"), command: "thread.jump.3" },
@@ -432,6 +457,34 @@ describe("thread navigation helpers", () => {
     assert.strictEqual(threadTraversalDirectionFromCommand("thread.next"), "next");
     assert.isNull(threadTraversalDirectionFromCommand("thread.jump.1"));
     assert.isNull(threadTraversalDirectionFromCommand(null));
+  });
+
+  it("maps recent-thread commands to directions", () => {
+    assert.strictEqual(recentThreadsDirectionFromCommand("recentThreads.next"), "next");
+    assert.strictEqual(recentThreadsDirectionFromCommand("recentThreads.previous"), "previous");
+    assert.isNull(recentThreadsDirectionFromCommand("thread.next"));
+    assert.isNull(recentThreadsDirectionFromCommand(null));
+  });
+
+  it("resolves ctrl+tab to recent-thread cycling on every platform", () => {
+    const forward = event({ key: "Tab", ctrlKey: true });
+    const backward = event({ key: "Tab", ctrlKey: true, shiftKey: true });
+    for (const platform of ["MacIntel", "Win32"]) {
+      assert.strictEqual(
+        resolveShortcutCommand(forward, DEFAULT_BINDINGS, { platform }),
+        "recentThreads.next",
+      );
+      assert.strictEqual(
+        resolveShortcutCommand(backward, DEFAULT_BINDINGS, { platform }),
+        "recentThreads.previous",
+      );
+    }
+    assert.isNull(
+      resolveShortcutCommand(forward, DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: true },
+      }),
+    );
   });
 
   it("shows jump hints only when configured modifiers match", () => {

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -718,6 +718,46 @@ describe("resolveShortcutCommand", () => {
     );
   });
 
+  it("matches Chrome-style thread traversal shortcuts", () => {
+    const keybindings = compile([
+      {
+        shortcut: {
+          key: "tab",
+          metaKey: false,
+          ctrlKey: true,
+          shiftKey: false,
+          altKey: false,
+          modKey: false,
+        },
+        command: "thread.next",
+      },
+      {
+        shortcut: {
+          key: "tab",
+          metaKey: false,
+          ctrlKey: true,
+          shiftKey: true,
+          altKey: false,
+          modKey: false,
+        },
+        command: "thread.previous",
+      },
+    ]);
+
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "Tab", ctrlKey: true }), keybindings, {
+        platform: "MacIntel",
+      }),
+      "thread.next",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "Tab", ctrlKey: true, shiftKey: true }), keybindings, {
+        platform: "Linux",
+      }),
+      "thread.previous",
+    );
+  });
+
   it("matches Option-modified letters using the physical key code on macOS", () => {
     assert.strictEqual(
       resolveShortcutCommand(

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -288,6 +288,14 @@ export function threadTraversalDirectionFromCommand(
   return null;
 }
 
+export function recentThreadsDirectionFromCommand(
+  command: string | null,
+): "previous" | "next" | null {
+  if (command === "recentThreads.previous") return "previous";
+  if (command === "recentThreads.next") return "next";
+  return null;
+}
+
 export function shouldShowThreadJumpHints(
   event: ShortcutEventLike,
   keybindings: ResolvedKeybindingsConfig,

--- a/apps/web/src/recentThreadsStore.test.ts
+++ b/apps/web/src/recentThreadsStore.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { MAX_RECENT_THREAD_KEYS, withRecentThreadKey } from "./recentThreadsStore";
+
+describe("withRecentThreadKey", () => {
+  it("prepends a newly opened thread", () => {
+    expect(withRecentThreadKey(["env:a"], "env:b")).toEqual(["env:b", "env:a"]);
+  });
+
+  it("moves a revisited thread to the front without duplicating it", () => {
+    expect(withRecentThreadKey(["env:a", "env:b", "env:c"], "env:b")).toEqual([
+      "env:b",
+      "env:a",
+      "env:c",
+    ]);
+  });
+
+  it("returns the same array when the thread is already at the front", () => {
+    const current = ["env:a", "env:b"];
+    expect(withRecentThreadKey(current, "env:a")).toBe(current);
+  });
+
+  it("caps the list at the maximum", () => {
+    const full = Array.from({ length: MAX_RECENT_THREAD_KEYS }, (_, i) => `env:${i}`);
+    const next = withRecentThreadKey(full, "env:new");
+    expect(next).toHaveLength(MAX_RECENT_THREAD_KEYS);
+    expect(next[0]).toBe("env:new");
+    expect(next).not.toContain(`env:${MAX_RECENT_THREAD_KEYS - 1}`);
+  });
+});

--- a/apps/web/src/recentThreadsStore.test.ts
+++ b/apps/web/src/recentThreadsStore.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { MAX_RECENT_THREAD_KEYS, withRecentThreadKey } from "./recentThreadsStore";
+import {
+  MAX_RECENT_THREAD_KEYS,
+  withRecentThreadKey,
+  withoutRecentThreadKey,
+} from "./recentThreadsStore";
 
 describe("withRecentThreadKey", () => {
   it("prepends a newly opened thread", () => {
@@ -26,5 +30,19 @@ describe("withRecentThreadKey", () => {
     expect(next).toHaveLength(MAX_RECENT_THREAD_KEYS);
     expect(next[0]).toBe("env:new");
     expect(next).not.toContain(`env:${MAX_RECENT_THREAD_KEYS - 1}`);
+  });
+});
+
+describe("withoutRecentThreadKey", () => {
+  it("removes a deleted thread without changing the remaining order", () => {
+    expect(withoutRecentThreadKey(["env:a", "env:b", "env:c"], "env:b")).toEqual([
+      "env:a",
+      "env:c",
+    ]);
+  });
+
+  it("returns the same array when the thread is absent", () => {
+    const current = ["env:a", "env:b"];
+    expect(withoutRecentThreadKey(current, "env:c")).toBe(current);
   });
 });

--- a/apps/web/src/recentThreadsStore.ts
+++ b/apps/web/src/recentThreadsStore.ts
@@ -1,0 +1,36 @@
+/**
+ * Session-scoped record of the threads the user opened, most recent first.
+ * Deliberately in-memory: the recent-threads switcher cycles what was
+ * visited since the app loaded, not activity order or a persisted history.
+ */
+import { create } from "zustand";
+
+export const MAX_RECENT_THREAD_KEYS = 50;
+
+/**
+ * Moves an opened thread key to the front. Returns the SAME array when
+ * nothing changed so subscribers keyed on identity skip redundant updates.
+ */
+export function withRecentThreadKey(
+  current: ReadonlyArray<string>,
+  opened: string,
+): ReadonlyArray<string> {
+  if (current[0] === opened) return current;
+  return [opened, ...current.filter((key) => key !== opened)].slice(0, MAX_RECENT_THREAD_KEYS);
+}
+
+interface RecentThreadsStore {
+  /** Scoped thread keys in visit order, newest first. */
+  recentThreadKeys: ReadonlyArray<string>;
+  recordThreadVisit: (threadKey: string) => void;
+}
+
+export const useRecentThreadsStore = create<RecentThreadsStore>((set) => ({
+  recentThreadKeys: [],
+  recordThreadVisit: (threadKey) => {
+    set((state) => {
+      const next = withRecentThreadKey(state.recentThreadKeys, threadKey);
+      return next === state.recentThreadKeys ? state : { recentThreadKeys: next };
+    });
+  },
+}));

--- a/apps/web/src/recentThreadsStore.ts
+++ b/apps/web/src/recentThreadsStore.ts
@@ -19,10 +19,19 @@ export function withRecentThreadKey(
   return [opened, ...current.filter((key) => key !== opened)].slice(0, MAX_RECENT_THREAD_KEYS);
 }
 
+export function withoutRecentThreadKey(
+  current: ReadonlyArray<string>,
+  removed: string,
+): ReadonlyArray<string> {
+  if (!current.includes(removed)) return current;
+  return current.filter((key) => key !== removed);
+}
+
 interface RecentThreadsStore {
   /** Scoped thread keys in visit order, newest first. */
   recentThreadKeys: ReadonlyArray<string>;
   recordThreadVisit: (threadKey: string) => void;
+  forgetThread: (threadKey: string) => void;
 }
 
 export const useRecentThreadsStore = create<RecentThreadsStore>((set) => ({
@@ -30,6 +39,12 @@ export const useRecentThreadsStore = create<RecentThreadsStore>((set) => ({
   recordThreadVisit: (threadKey) => {
     set((state) => {
       const next = withRecentThreadKey(state.recentThreadKeys, threadKey);
+      return next === state.recentThreadKeys ? state : { recentThreadKeys: next };
+    });
+  },
+  forgetThread: (threadKey) => {
+    set((state) => {
+      const next = withoutRecentThreadKey(state.recentThreadKeys, threadKey);
       return next === state.recentThreadKeys ? state : { recentThreadKeys: next };
     });
   },

--- a/apps/web/src/recentThreadsSwitcherLogic.test.ts
+++ b/apps/web/src/recentThreadsSwitcherLogic.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  type RecentThreadsSwitcherSession,
+  reconcileRecentThreadsSwitcherSession,
+  shouldCommitRecentThreadsSwitcherOnKeyUp,
+} from "./recentThreadsSwitcherLogic";
+
+const session = (overrides: Partial<RecentThreadsSwitcherSession> = {}) => ({
+  entries: ["env:a", "env:b", "env:c"],
+  selectedIndex: 1,
+  holdsCtrl: true,
+  holdsMeta: false,
+  holdsAlt: false,
+  holdsShift: false,
+  triggerKey: "Tab",
+  ...overrides,
+});
+
+const keyUp = (key: string, heldModifiers: ReadonlyArray<string> = []) => ({
+  code: key,
+  key,
+  getModifierState: (modifier: string) => heldModifiers.includes(modifier),
+});
+
+describe("recent-thread switcher session", () => {
+  it("keeps the selected thread while filtering entries that are no longer live", () => {
+    expect(
+      reconcileRecentThreadsSwitcherSession(session(), (threadKey) => threadKey !== "env:a"),
+    ).toMatchObject({
+      entries: ["env:b", "env:c"],
+      selectedIndex: 0,
+    });
+  });
+
+  it("selects the nearest remaining thread when the selected entry disappears", () => {
+    expect(
+      reconcileRecentThreadsSwitcherSession(session(), (threadKey) => threadKey !== "env:b"),
+    ).toMatchObject({
+      entries: ["env:a", "env:c"],
+      selectedIndex: 1,
+    });
+  });
+
+  it("cancels when no recent entries remain live", () => {
+    expect(reconcileRecentThreadsSwitcherSession(session(), () => false)).toBeNull();
+  });
+
+  it("commits a held-modifier binding only after every opening modifier is released", () => {
+    expect(shouldCommitRecentThreadsSwitcherOnKeyUp(session(), keyUp("Tab", ["Control"]))).toBe(
+      false,
+    );
+    expect(shouldCommitRecentThreadsSwitcherOnKeyUp(session(), keyUp("ControlLeft"))).toBe(true);
+  });
+
+  it("supports Shift-only and modifier-free bindings", () => {
+    const shiftOnly = session({ holdsCtrl: false, holdsShift: true, triggerKey: "F6" });
+    expect(shouldCommitRecentThreadsSwitcherOnKeyUp(shiftOnly, keyUp("F6", ["Shift"]))).toBe(false);
+    expect(shouldCommitRecentThreadsSwitcherOnKeyUp(shiftOnly, keyUp("ShiftLeft"))).toBe(true);
+
+    const modifierFree = session({ holdsCtrl: false, triggerKey: "F6" });
+    expect(shouldCommitRecentThreadsSwitcherOnKeyUp(modifierFree, keyUp("F5"))).toBe(false);
+    expect(shouldCommitRecentThreadsSwitcherOnKeyUp(modifierFree, keyUp("F6"))).toBe(true);
+  });
+});

--- a/apps/web/src/recentThreadsSwitcherLogic.ts
+++ b/apps/web/src/recentThreadsSwitcherLogic.ts
@@ -1,0 +1,50 @@
+export interface RecentThreadsSwitcherSession {
+  /** Scoped thread keys frozen in visit order while the switcher is open. */
+  entries: ReadonlyArray<string>;
+  selectedIndex: number;
+  /** Modifiers held when the switcher opened. */
+  holdsCtrl: boolean;
+  holdsMeta: boolean;
+  holdsAlt: boolean;
+  holdsShift: boolean;
+  /** Physical key released to commit a binding with no held modifier. */
+  triggerKey: string;
+}
+
+export function reconcileRecentThreadsSwitcherSession(
+  session: RecentThreadsSwitcherSession,
+  isLive: (threadKey: string) => boolean,
+): RecentThreadsSwitcherSession | null {
+  const entries = session.entries.filter(isLive);
+  if (entries.length === 0) return null;
+
+  const selectedKey = session.entries[session.selectedIndex];
+  const liveSelectedIndex = selectedKey === undefined ? -1 : entries.indexOf(selectedKey);
+  const selectedIndex =
+    liveSelectedIndex === -1
+      ? Math.min(Math.max(session.selectedIndex, 0), entries.length - 1)
+      : liveSelectedIndex;
+
+  if (entries.length === session.entries.length && selectedIndex === session.selectedIndex) {
+    return session;
+  }
+  return { ...session, entries, selectedIndex };
+}
+
+export function shouldCommitRecentThreadsSwitcherOnKeyUp(
+  session: RecentThreadsSwitcherSession,
+  event: Pick<KeyboardEvent, "code" | "key" | "getModifierState">,
+): boolean {
+  const hasHeldModifier =
+    session.holdsCtrl || session.holdsMeta || session.holdsAlt || session.holdsShift;
+  if (!hasHeldModifier) {
+    return (event.code || event.key) === session.triggerKey;
+  }
+
+  const stillHeld =
+    (session.holdsCtrl && event.getModifierState("Control")) ||
+    (session.holdsMeta && event.getModifierState("Meta")) ||
+    (session.holdsAlt && event.getModifierState("Alt")) ||
+    (session.holdsShift && event.getModifierState("Shift"));
+  return !stillHeld;
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -19,6 +19,7 @@ import { ConnectOnboardingDialog } from "../components/cloud/ConnectOnboardingDi
 import { RelayClientInstallDialog } from "../components/cloud/RelayClientInstallDialog";
 import { SshPasswordPromptDialog } from "../components/desktop/SshPasswordPromptDialog";
 import { ProviderUpdateLaunchNotification } from "../components/ProviderUpdateLaunchNotification";
+import { RecentThreadsSwitcher } from "../components/RecentThreadsSwitcher";
 import { SlowRpcRequestToastCoordinator } from "../components/SlowRpcRequestToastCoordinator";
 import { ThemeEditorHost } from "../components/settings/ThemeEditorHost";
 import { Button } from "../components/ui/button";
@@ -142,6 +143,7 @@ function RootRouteView() {
         {primaryEnvironmentAuthenticated ? <EventRouter /> : null}
         {primaryEnvironmentAuthenticated ? <ProviderUpdateLaunchNotification /> : null}
         {appShell}
+        <RecentThreadsSwitcher />
         {/* Above the router: a theme draft is judged by walking the app, so the
             editor has to survive navigation away from settings. */}
         <ThemeEditorHost />

--- a/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
@@ -1,9 +1,11 @@
+import { scopedThreadKey } from "@t3tools/client-runtime/environment";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
 
 import ChatView from "../components/ChatView";
 import { threadHasStarted } from "../components/ChatView.logic";
 import { finalizePromotedDraftThreadByRef, useComposerDraftStore } from "../composerDraftStore";
+import { useRecentThreadsStore } from "../recentThreadsStore";
 import { resolveThreadRouteRef, resolveThreadRouteRenderState } from "../threadRoutes";
 import { resolveThreadSyncPhase } from "../threadSync";
 import { SidebarInset } from "~/components/ui/sidebar";
@@ -73,6 +75,14 @@ function ChatThreadRouteView() {
     }
     finalizePromotedDraftThreadByRef(threadRef);
   }, [draftThread, serverThreadStarted, threadRef]);
+
+  const serverThreadShellExists = serverThreadShell !== null;
+  useEffect(() => {
+    if (!threadRef || !serverThreadShellExists) {
+      return;
+    }
+    useRecentThreadsStore.getState().recordThreadVisit(scopedThreadKey(threadRef));
+  }, [serverThreadShellExists, threadRef]);
 
   if (!threadRef) {
     return null;

--- a/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
@@ -78,10 +78,17 @@ function ChatThreadRouteView() {
 
   const serverThreadShellExists = serverThreadShell !== null;
   useEffect(() => {
-    if (!threadRef || !serverThreadShellExists || serverThreadStatus === "deleted") {
+    if (!threadRef) {
       return;
     }
-    useRecentThreadsStore.getState().recordThreadVisit(scopedThreadKey(threadRef));
+    const threadKey = scopedThreadKey(threadRef);
+    if (serverThreadStatus === "deleted") {
+      useRecentThreadsStore.getState().forgetThread(threadKey);
+      return;
+    }
+    if (serverThreadShellExists) {
+      useRecentThreadsStore.getState().recordThreadVisit(threadKey);
+    }
   }, [serverThreadShellExists, serverThreadStatus, threadRef]);
 
   if (!threadRef) {

--- a/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
@@ -78,11 +78,11 @@ function ChatThreadRouteView() {
 
   const serverThreadShellExists = serverThreadShell !== null;
   useEffect(() => {
-    if (!threadRef || !serverThreadShellExists) {
+    if (!threadRef || !serverThreadShellExists || serverThreadStatus === "deleted") {
       return;
     }
     useRecentThreadsStore.getState().recordThreadVisit(scopedThreadKey(threadRef));
-  }, [serverThreadShellExists, threadRef]);
+  }, [serverThreadShellExists, serverThreadStatus, threadRef]);
 
   if (!threadRef) {
     return null;

--- a/apps/web/src/state/entities.ts
+++ b/apps/web/src/state/entities.ts
@@ -222,10 +222,6 @@ export function readThreadShell(ref: ScopedThreadRef): EnvironmentThreadShell | 
   return appAtomRegistry.get(environmentThreadShells.threadShellAtom(ref));
 }
 
-export function readThreadStatus(ref: ScopedThreadRef): EnvironmentThreadStatus {
-  return appAtomRegistry.get(environmentThreadDetails.statusAtom(ref));
-}
-
 /** Whether the environment's server understands thread.settle/unsettle.
     False for pre-settlement servers (capability defaults false on decode),
     so clients under version skew fall back instead of erroring. */

--- a/apps/web/src/state/entities.ts
+++ b/apps/web/src/state/entities.ts
@@ -222,6 +222,10 @@ export function readThreadShell(ref: ScopedThreadRef): EnvironmentThreadShell | 
   return appAtomRegistry.get(environmentThreadShells.threadShellAtom(ref));
 }
 
+export function readThreadStatus(ref: ScopedThreadRef): EnvironmentThreadStatus {
+  return appAtomRegistry.get(environmentThreadDetails.statusAtom(ref));
+}
+
 /** Whether the environment's server understands thread.settle/unsettle.
     False for pre-settlement servers (capability defaults false on decode),
     so clients under version skew fall back instead of erroring. */

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -55,6 +55,13 @@ successful pick; its hover glow and badge preview the element and color family t
 `rightPanel.toggleMaximized` maximizes or restores the open right panel. It has no default shortcut,
 so add one in **Settings** → **Keybindings** if you want to use it.
 
+`recentThreads.next` and `recentThreads.previous` cycle through the threads you opened this
+session, most recent first, defaulting to `ctrl+tab` and `ctrl+shift+tab`. Keep the modifier held
+to preview the list in a small switcher: repeated presses move through it, releasing the modifier
+opens the highlighted thread, `Enter` confirms, and `Escape` cancels. The list starts fresh each
+time the app loads. Browsers reserve `ctrl+tab` for their own tab switching, so these defaults
+work in the desktop app; when running in a browser, bind keys the browser does not claim.
+
 The command palette searches active thread titles, projects, branches, user messages, and final
 agent responses across connected environments. Message matches show one labeled excerpt while
 keeping the thread's project, branch, and machine context visible. Message search begins after two

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -32,6 +32,9 @@ Modifiers: `mod` (`cmd` on macOS, `ctrl` elsewhere), `cmd` / `meta`, `ctrl` / `c
 
 Examples: `mod+j`, `mod+shift+d`, `ctrl+l`, `cmd+k`.
 
+Modified Tab shortcuts such as `ctrl+tab` and `ctrl+shift+tab` can be recorded in Settings. Plain
+Tab and Shift+Tab continue to move focus instead of being recorded.
+
 ## Commands
 
 Commands are IDs like `terminal.toggle`, `commandPalette.toggle`, `preview.refresh`, and

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -73,6 +73,8 @@ export const STATIC_KEYBINDING_COMMANDS = [
   "editor.openFavorite",
   ...MODEL_PICKER_KEYBINDING_COMMANDS,
   ...THREAD_KEYBINDING_COMMANDS,
+  "recentThreads.next",
+  "recentThreads.previous",
 ] as const;
 
 export const SCRIPT_RUN_COMMAND_PATTERN = Schema.TemplateLiteral([

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -46,6 +46,8 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+o", command: "editor.openFavorite" },
   { key: "mod+shift+[", command: "thread.previous" },
   { key: "mod+shift+]", command: "thread.next" },
+  { key: "ctrl+tab", command: "recentThreads.next", when: "!terminalFocus" },
+  { key: "ctrl+shift+tab", command: "recentThreads.previous", when: "!terminalFocus" },
   ...THREAD_JUMP_KEYBINDING_COMMANDS.map((command, index) => ({
     key: `mod+${index + 1}`,
     command,


### PR DESCRIPTION
## What Changed

Ctrl+Tab should return you to threads in the order you were actually using them, not walk the sidebar. This adds an Alt-Tab-style recent-thread switcher: hold Ctrl, press Tab to cycle through the session's most recently visited threads, then release Ctrl to open the highlighted thread.

Depends on #7548, which makes modified Tab chords recordable in Settings. This branch starts at that PR's current head, so its one commit remains visible here until it merges. This reworks #7274 on top of the recorder fix and includes the interaction fixes from its reviews.

## Why

`thread.next` and `thread.previous` follow sidebar order. That makes toggling between two active threads unpredictable as the sidebar changes. A session-scoped MRU keeps the common Ctrl+Tab gesture tied to where you were just working, while the preview makes repeated presses visible before navigation commits.

The defaults are `ctrl+tab` and `ctrl+shift+tab` outside terminal focus. Browsers reserve those chords, so the defaults target the desktop app. Users can bind the new `recentThreads.next` and `recentThreads.previous` commands to other keys.

This implements the MRU and preview follow-up described in discussion #6966 and the recency part of #1014.

## UI Changes

| Before | After |
| --- | --- |
| ![Thread view before opening the recent-thread switcher](https://github.com/user-attachments/assets/57d4d863-75a8-402f-a8f4-68578b442bd3) | ![Recent-thread switcher opened with Ctrl+Tab](https://github.com/user-attachments/assets/dbc80c2e-362f-4db5-92c0-7631c78506ed) |

https://github.com/user-attachments/assets/fad202bd-23f6-4c5c-884a-f45cb247874d

## Verification

- `vp test run apps/web/src/components/settings/KeybindingsSettings.logic.test.ts apps/web/src/keybindings.test.ts apps/web/src/recentThreadsStore.test.ts apps/web/src/recentThreadsSwitcherLogic.test.ts` (72 passed)
- Targeted lint across the changed TypeScript files
- `vp fmt --check` across all 15 changed files
- `vp run --filter @t3tools/web typecheck`
- Clean merge simulation against current `main`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change
- [x] I included a video for the interaction

Built by GPT-5.6 Sol using Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only navigation and in-memory session state; no auth, persistence, or server API changes beyond new keybinding command IDs.
> 
> **Overview**
> Adds an **Alt-Tab-style recent-thread switcher** driven by session-scoped visit order (not sidebar order). New commands `recentThreads.next` / `recentThreads.previous` default to **`ctrl+tab`** and **`ctrl+shift+tab`** (disabled when the terminal is focused). Hold the modifier to open a preview list, tap Tab to cycle, release to navigate; **Enter** confirms and **Escape** cancels.
> 
> A new in-memory **`recentThreadsStore`** records thread visits on the chat route and drops deleted threads. **`RecentThreadsSwitcher`** is mounted at the app root with capture-phase keyboard handling, reconciliation for archived/deleted threads, and click-to-select in the overlay.
> 
> **Keybindings settings** can now record modified Tab chords (plain Tab still moves focus), with shared pill labeling helpers. Contracts and shared defaults register the new commands; user docs describe the behavior and desktop-vs-browser shortcut limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cd3c970b0c48d60658b77ace82b650a4fc2e698. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Ctrl+Tab recent thread switcher with overlay UI
> - Adds a session-scoped recent threads store ([recentThreadsStore.ts](https://github.com/pingdotgg/t3code/pull/7596/files#diff-4dfad8cbe54105eeba125fb56e2bb56816637f1870b78c2146948ce091616b7a)) that tracks visited threads in order, capped at a max size, with actions to record visits and remove deleted threads.
> - Adds a `RecentThreadsSwitcher` component mounted at the app root that handles `ctrl+tab` / `ctrl+shift+tab` to cycle through recent threads, showing an overlay list while the modifier is held; releasing commits navigation, Enter confirms, Escape cancels.
> - Updates keybinding capture in Settings to allow recording modified Tab shortcuts (e.g. `ctrl+tab`) while letting plain Tab continue to move focus.
> - Adds `recentThreads.next` and `recentThreads.previous` as default keybindings gated on `!terminalFocus`.
> - Risk: `ctrl+tab` is intercepted by some browsers and may not work reliably outside the desktop app; documented in [keybindings.md](https://github.com/pingdotgg/t3code/pull/7596/files#diff-2858dfbce3443e10e5180f361437183badc111f8cac64cfe3094bae56b568e43).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6cd3c97.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->