### PR TITLE
fix(desktop): bound backend shutdown wait during quit

### DIFF
--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -1,4 +1,5 @@
 import * as Cause from "effect/Cause";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
@@ -141,6 +142,20 @@ const handleFatalStartupError = Effect.fn("desktop.startup.handleFatalStartupErr
 
 const fatalStartupCause = <E>(stage: string, cause: Cause.Cause<E>) =>
   handleFatalStartupError(stage, Cause.pretty(cause)).pipe(Effect.andThen(Effect.failCause(cause)));
+
+export const stopAllPoolInstances = Effect.fn("desktop.app.stopAllPoolInstances")(
+  function* (): Effect.fn.Return<void, never, DesktopBackendPool.DesktopBackendPool> {
+    // Stop every backend in the pool with a timeout to guarantee the quit
+    // path makes progress even if a backend hangs during teardown.
+    const pool = yield* DesktopBackendPool.DesktopBackendPool;
+    const instances = yield* pool.list;
+    yield* Effect.forEach(
+      instances,
+      (instance) => instance.stop({ timeout: Duration.seconds(5) }),
+      { concurrency: "unbounded" },
+    );
+  },
+);
 
 const bootstrap = Effect.gen(function* () {
   const pool = yield* DesktopBackendPool.DesktopBackendPool;
@@ -313,18 +328,12 @@ const scopedProgram = Effect.scoped(
     const shutdown = yield* DesktopShutdown.DesktopShutdown;
 
     yield* Effect.addFinalizer(() =>
-      Effect.gen(function* () {
-        const pool = yield* DesktopBackendPool.DesktopBackendPool;
-        // Stop every backend in the pool, not just the primary. The
-        // electronApp.quit() path can race ahead of the layer-scope
-        // cascade, so leaving the WSL instance for its parent scope
-        // finalizer means it gets hard-killed by the OS instead of
-        // receiving SIGTERM + grace. Stops run concurrently.
-        const instances = yield* pool.list;
-        yield* Effect.forEach(instances, (instance) => instance.stop(), {
-          concurrency: "unbounded",
-        });
-      }).pipe(Effect.ensuring(shutdown.markComplete)),
+      // Stop every backend in the pool, not just the primary. The
+      // electronApp.quit() path can race ahead of the layer-scope
+      // cascade, so leaving the WSL instance for its parent scope
+      // finalizer means it gets hard-killed by the OS instead of
+      // receiving SIGTERM + grace.
+      stopAllPoolInstances().pipe(Effect.ensuring(shutdown.markComplete)),
     );
 
     yield* startup;

--- a/apps/desktop/src/backend/DesktopBackendManager.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendManager.test.ts
@@ -4,6 +4,7 @@ import {
   DesktopTelemetryControlMessage,
 } from "@t3tools/contracts";
 import { assert, describe, it } from "@effect/vitest";
+import * as Cause from "effect/Cause";
 import * as Deferred from "effect/Deferred";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
@@ -23,6 +24,8 @@ import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstab
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import * as DesktopBackendManager from "./DesktopBackendManager.ts";
+import * as DesktopApp from "../app/DesktopApp.ts";
+import * as DesktopBackendPool from "./DesktopBackendPool.ts";
 import * as DesktopObservability from "../app/DesktopObservability.ts";
 import * as DesktopTelemetryPublisher from "../telemetry/DesktopTelemetryPublisher.ts";
 import * as DesktopWslEnvironment from "../wsl/DesktopWslEnvironment.ts";
@@ -1500,6 +1503,95 @@ describe("DesktopBackendManager", () => {
 
         assert.equal(yield* Queue.size(starts), 0);
         assert.equal((yield* instance.snapshot).desiredRunning, false);
+      }).pipe(Effect.provide(TestClock.layer())),
+    ),
+  );
+
+  it.effect("stopAllPoolInstances stops all backends with timeout", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        // Regression test: validates that stopAllPoolInstances applies a
+        // timeout to each stop call, bounding the wait time even when
+        // backends hang during teardown. This directly tests the actual
+        // implementation used by the quit path.
+        const stopped: string[] = [];
+        const teardownStarted = yield* Deferred.make<void>();
+        const allowTeardown = yield* Deferred.make<void>();
+
+        // Create two instances to simulate pool.list returning multiple backends
+        const makeInstance = (name: string) =>
+          makeTestInstance({
+            spawnerLayer: Layer.succeed(
+              ChildProcessSpawner.ChildProcessSpawner,
+              ChildProcessSpawner.make(() =>
+                Effect.gen(function* () {
+                  const scope = yield* Scope.Scope;
+                  yield* Scope.addFinalizer(
+                    scope,
+                    Deferred.succeed(teardownStarted, undefined).pipe(
+                      Effect.andThen(Deferred.await(allowTeardown)),
+                      Effect.andThen(
+                        Effect.sync(() => {
+                          stopped.push(name);
+                        }),
+                      ),
+                      Effect.asVoid,
+                    ),
+                  );
+                  return makeProcess({
+                    exitCode: Effect.never,
+                  });
+                }),
+              ),
+            ),
+            httpClientLayer: httpClientLayer(() => Effect.never),
+          });
+
+        const instance1 = yield* makeInstance("instance1");
+        const instance2 = yield* makeInstance("instance2");
+
+        yield* instance1.start;
+        yield* instance2.start;
+
+        // Create a mock pool with the instances we just started
+        const mockPool = Layer.succeed(DesktopBackendPool.DesktopBackendPool, {
+          list: Effect.succeed([instance1, instance2]),
+          get: (id: DesktopBackendPool.BackendInstanceId) => Effect.succeed(Option.none()),
+          primary: Effect.failCause(Cause.die(new Error("primary not implemented"))),
+          register: () =>
+            Effect.failCause(
+              Cause.die(
+                new DesktopBackendPool.DesktopBackendPoolInstanceAlreadyRegisteredError({
+                  id: "test",
+                }),
+              ),
+            ),
+          unregister: () =>
+            Effect.failCause(
+              Cause.die(new DesktopBackendPool.DesktopBackendPoolCannotUnregisterPrimaryError()),
+            ),
+        });
+
+        // Call the actual stopAllPoolInstances function with the mock pool provided as a service
+        const quitFiber = yield* DesktopApp.stopAllPoolInstances().pipe(
+          Effect.provide(mockPool),
+          Effect.forkChild,
+        );
+
+        // Wait for teardown to start, then verify quit completes within timeout
+        yield* Deferred.await(teardownStarted).pipe(Effect.timeout("1 second"));
+        yield* TestClock.adjust(Duration.seconds(5));
+
+        // stopAllPoolInstances should complete after timeout, even though teardown is hanging
+        yield* Fiber.join(quitFiber).pipe(Effect.timeout("1 second"));
+        assert.equal(stopped.length, 0, "teardown should not have completed yet");
+
+        // Let teardown finish
+        yield* Deferred.succeed(allowTeardown, undefined);
+        yield* TestClock.adjust(Duration.millis(100));
+
+        // Now both should have stopped
+        assert.equal(stopped.length, 2, "both instances should have stopped");
       }).pipe(Effect.provide(TestClock.layer())),
     ),
   );

--- a/apps/desktop/src/backend/DesktopBackendManager.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendManager.test.ts
@@ -4,7 +4,6 @@ import {
   DesktopTelemetryControlMessage,
 } from "@t3tools/contracts";
 import { assert, describe, it } from "@effect/vitest";
-import * as Cause from "effect/Cause";
 import * as Deferred from "effect/Deferred";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
@@ -1507,18 +1506,17 @@ describe("DesktopBackendManager", () => {
     ),
   );
 
-  it.effect("stopAllPoolInstances stops all backends with timeout", () =>
+  it.effect("stopAllPoolInstances bounds the quit finalizer when backends hang", () =>
     Effect.scoped(
       Effect.gen(function* () {
-        // Regression test: validates that stopAllPoolInstances applies a
-        // timeout to each stop call, bounding the wait time even when
-        // backends hang during teardown. This directly tests the actual
-        // implementation used by the quit path.
-        const stopped: string[] = [];
-        const teardownStarted = yield* Deferred.make<void>();
+        // Each backend's process-scope finalizer reports when it starts and
+        // when it finishes, keyed by instance name, so the test can prove
+        // both backends reached each milestone instead of inferring it from
+        // a shared flag or a clock advance.
+        const teardownStarted = yield* Queue.unbounded<string>();
+        const teardownFinished = yield* Queue.unbounded<string>();
         const allowTeardown = yield* Deferred.make<void>();
 
-        // Create two instances to simulate pool.list returning multiple backends
         const makeInstance = (name: string) =>
           makeTestInstance({
             spawnerLayer: Layer.succeed(
@@ -1528,19 +1526,13 @@ describe("DesktopBackendManager", () => {
                   const scope = yield* Scope.Scope;
                   yield* Scope.addFinalizer(
                     scope,
-                    Deferred.succeed(teardownStarted, undefined).pipe(
+                    Queue.offer(teardownStarted, name).pipe(
                       Effect.andThen(Deferred.await(allowTeardown)),
-                      Effect.andThen(
-                        Effect.sync(() => {
-                          stopped.push(name);
-                        }),
-                      ),
+                      Effect.andThen(Queue.offer(teardownFinished, name)),
                       Effect.asVoid,
                     ),
                   );
-                  return makeProcess({
-                    exitCode: Effect.never,
-                  });
+                  return makeProcess({ exitCode: Effect.never });
                 }),
               ),
             ),
@@ -1553,45 +1545,35 @@ describe("DesktopBackendManager", () => {
         yield* instance1.start;
         yield* instance2.start;
 
-        // Create a mock pool with the instances we just started
         const mockPool = Layer.succeed(DesktopBackendPool.DesktopBackendPool, {
           list: Effect.succeed([instance1, instance2]),
-          get: (id: DesktopBackendPool.BackendInstanceId) => Effect.succeed(Option.none()),
-          primary: Effect.failCause(Cause.die(new Error("primary not implemented"))),
-          register: () =>
-            Effect.failCause(
-              Cause.die(
-                new DesktopBackendPool.DesktopBackendPoolInstanceAlreadyRegisteredError({
-                  id: "test",
-                }),
-              ),
-            ),
-          unregister: () =>
-            Effect.failCause(
-              Cause.die(new DesktopBackendPool.DesktopBackendPoolCannotUnregisterPrimaryError()),
-            ),
+          get: () => Effect.succeed(Option.none()),
+          primary: Effect.die(new Error("primary not implemented")),
+          register: () => Effect.die(new Error("register not implemented")),
+          unregister: () => Effect.die(new Error("unregister not implemented")),
         });
 
-        // Call the actual stopAllPoolInstances function with the mock pool provided as a service
-        const quitFiber = yield* DesktopApp.stopAllPoolInstances().pipe(
-          Effect.provide(mockPool),
-          Effect.forkChild,
-        );
+        // Mirror the quit path: register stopAllPoolInstances as a scope
+        // finalizer and let the scope close run it, rather than calling it
+        // as an ordinary interruptible effect.
+        const quitFiber = yield* Effect.scoped(
+          Effect.addFinalizer(() => DesktopApp.stopAllPoolInstances()),
+        ).pipe(Effect.provide(mockPool), Effect.forkChild);
 
-        // Wait for teardown to start, then verify quit completes within timeout
-        yield* Deferred.await(teardownStarted).pipe(Effect.timeout("1 second"));
+        const started = yield* Queue.takeN(teardownStarted, 2);
+        assert.deepEqual(started.toSorted(), ["instance1", "instance2"]);
+
+        // Both backends are now hung in teardown. Advancing past the 5s
+        // budget must let the quit finalizer return without them.
         yield* TestClock.adjust(Duration.seconds(5));
+        yield* Fiber.join(quitFiber);
+        assert.equal(yield* Queue.size(teardownFinished), 0);
 
-        // stopAllPoolInstances should complete after timeout, even though teardown is hanging
-        yield* Fiber.join(quitFiber).pipe(Effect.timeout("1 second"));
-        assert.equal(stopped.length, 0, "teardown should not have completed yet");
-
-        // Let teardown finish
+        // The timed-out closes keep running in the background and finish
+        // once the backends unblock.
         yield* Deferred.succeed(allowTeardown, undefined);
-        yield* TestClock.adjust(Duration.millis(100));
-
-        // Now both should have stopped
-        assert.equal(stopped.length, 2, "both instances should have stopped");
+        const finished = yield* Queue.takeN(teardownFinished, 2);
+        assert.deepEqual(finished.toSorted(), ["instance1", "instance2"]);
       }).pipe(Effect.provide(TestClock.layer())),
     ),
   );


### PR DESCRIPTION
## Problem

The quit-time finalizer stopped every backend instance in the pool with no timeout. If any one backend didn't exit cleanly, the wait never ended, and the app never called `app.quit()`. Since PR #6562 now destroys the window before this wait, the hang became invisible: holding Cmd+Q looked like it did nothing, and the only way out was a force quit.

Fixes #7598

## Fix

Bound the wait to 5 seconds, matching the identical pattern already used for this same operation in `apps/desktop/src/updates/DesktopUpdates.ts`. On timeout, the close keeps running in the background instead of blocking quit, so a slow-but-healthy shutdown still finishes cleanly, and a genuinely hung one no longer blocks the app from exiting.

Extracted the finalizer's logic into an exported `stopAllPoolInstances` function so it has a real seam to test against.

## Testing

- New test in `DesktopBackendManager.test.ts` calls the real `stopAllPoolInstances` export with a mocked pool whose instances hang past the timeout, and asserts the call still completes on time. Verified by hand that removing the timeout argument makes this test hang, confirming it actually catches a regression.
- `vp test run apps/desktop/src/backend/DesktopBackendManager.test.ts`: 26 passed
- `vp run --filter @t3tools/desktop typecheck`: clean

---
Model: Claude Sonnet 5. Harness: Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes desktop quit/shutdown behavior for all pooled backends; bounded wait reduces hang risk but timed-out teardown may still run in the background.
> 
> **Overview**
> Fixes quit hangs when a backend pool instance never finishes teardown (e.g. after the window is destroyed first), so **Cmd+Q could appear to do nothing** until force quit.
> 
> **Quit finalizer** now goes through exported **`stopAllPoolInstances`**, which stops every pooled backend **concurrently** with a **5s timeout per `instance.stop`**—same pattern as `DesktopUpdates.ts`. After the budget, quit keeps moving instead of waiting forever; slow but healthy shutdown can still finish in the background.
> 
> Adds a **regression test** that calls the real `stopAllPoolInstances` with a mocked pool whose instances hang past the timeout and asserts the call completes on time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6187110d9c21db292f4bae4db70d9f372b2f9f48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound backend shutdown wait to 5 seconds per instance during desktop app quit
> - Extracts a new `stopAllPoolInstances` function in [DesktopApp.ts](https://github.com/pingdotgg/t3code/pull/7599/files#diff-267cf20af5c499f356b88a4bc3d3dec61aa6c7a3398f93f8836975b3bcf764e9) that stops each instance from `DesktopBackendPool` with a 5-second timeout, running stops concurrently.
> - Replaces the inline teardown loop in `scopedProgram`'s finalizer with a call to `stopAllPoolInstances`, preventing the app from hanging indefinitely on quit if a backend fails to stop.
> - Adds a test in [DesktopBackendManager.test.ts](https://github.com/pingdotgg/t3code/pull/7599/files#diff-bce4b7f6b285d268f04bc702d29a17a6a4cf8c42adc9454dff19950eb60e7661) that simulates hanging teardown and verifies the effect completes after the timeout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6187110.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved application shutdown reliability when backend services fail to stop promptly.
  - The app now proceeds with shutdown after a five-second limit instead of waiting indefinitely.
  - Backend cleanup continues in the background and completes when services become available again.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->