### PR TITLE
feat(swift-ios): attach images pasted into the composer

### DIFF
--- a/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
@@ -61,24 +61,20 @@ struct FeatureComposerTextInput: UIViewRepresentable {
         let shouldApplySelection = selectionRequest.map {
             context.coordinator.lastAppliedSelectionRequestID != $0.id
         } ?? false
-        if textView.text != text {
-            let previousText = textView.text ?? ""
-            let selectedRange = textView.selectedRange
-            textView.text = text
-            if !shouldApplySelection {
-                let location = FeatureComposerTextSelectionPolicy.cursorLocationAfterBindingUpdate(
-                    previousText: previousText,
-                    newText: text,
-                    selectedLocation: selectedRange.location
-                )
-                let length = previousText.isEmpty
-                    ? 0
-                    : min(selectedRange.length, text.utf16.count - location)
-                textView.selectedRange = NSRange(location: location, length: length)
-                textView.scrollRangeToVisible(textView.selectedRange)
-            }
+        let hasMarkedText = textView.markedTextRange != nil
+        if case .applyExternal(let externalText) = context.coordinator.reconciliation
+            .externalTextDidChange(
+                editorText: textView.text,
+                bindingText: text,
+                hasMarkedText: hasMarkedText
+            ) {
+            context.coordinator.apply(
+                externalText,
+                to: textView,
+                preserveSelection: !shouldApplySelection
+            )
         }
-        if shouldApplySelection, let selectionRequest {
+        if shouldApplySelection, !hasMarkedText, let selectionRequest {
             let location = min(selectionRequest.location, textView.text.utf16.count)
             textView.selectedRange = NSRange(location: location, length: 0)
             textView.scrollRangeToVisible(textView.selectedRange)
@@ -129,14 +125,46 @@ struct FeatureComposerTextInput: UIViewRepresentable {
         var parent: FeatureComposerTextInput
         var lastAppliedFocus: Bool?
         var lastAppliedSelectionRequestID: UUID?
+        var reconciliation = FeatureComposerTextReconciliation()
 
         init(_ parent: FeatureComposerTextInput) {
             self.parent = parent
         }
 
         func textViewDidChange(_ textView: UITextView) {
-            guard parent.text != textView.text else { return }
-            parent.text = textView.text
+            switch reconciliation.editorTextDidChange(
+                textView.text,
+                hasMarkedText: textView.markedTextRange != nil
+            ) {
+            case .none:
+                break
+            case .applyExternal(let text):
+                apply(text, to: textView, preserveSelection: true)
+            case .publish(let text):
+                guard parent.text != text else { return }
+                parent.text = text
+            }
+        }
+
+        func apply(
+            _ text: String,
+            to textView: UITextView,
+            preserveSelection: Bool
+        ) {
+            let previousText = textView.text ?? ""
+            let selectedRange = textView.selectedRange
+            textView.text = text
+            guard preserveSelection else { return }
+            let location = FeatureComposerTextSelectionPolicy.cursorLocationAfterBindingUpdate(
+                previousText: previousText,
+                newText: text,
+                selectedLocation: selectedRange.location
+            )
+            let length = previousText.isEmpty
+                ? 0
+                : min(selectedRange.length, text.utf16.count - location)
+            textView.selectedRange = NSRange(location: location, length: length)
+            textView.scrollRangeToVisible(textView.selectedRange)
         }
 
         func textViewDidBeginEditing(_ textView: UITextView) {
@@ -155,8 +183,44 @@ struct FeatureComposerTextInput: UIViewRepresentable {
     }
 }
 
+struct FeatureComposerTextReconciliation {
+    enum Action: Equatable {
+        case none
+        case applyExternal(String)
+        case publish(String)
+    }
+
+    private(set) var pendingExternalText: String?
+
+    mutating func externalTextDidChange(
+        editorText: String,
+        bindingText: String,
+        hasMarkedText: Bool
+    ) -> Action {
+        guard editorText != bindingText else {
+            pendingExternalText = nil
+            return .none
+        }
+        guard !hasMarkedText else {
+            pendingExternalText = bindingText
+            return .none
+        }
+        pendingExternalText = nil
+        return .applyExternal(bindingText)
+    }
+
+    mutating func editorTextDidChange(_ editorText: String, hasMarkedText: Bool) -> Action {
+        if let pendingExternalText {
+            guard !hasMarkedText else { return .none }
+            self.pendingExternalText = nil
+            return editorText == pendingExternalText ? .none : .applyExternal(pendingExternalText)
+        }
+        return .publish(editorText)
+    }
+}
+
 /// Advertises image support to the paste menu and routes image pastes out to
-/// the attachment pipeline. Text-only pastes fall through to UIKit untouched.
+/// the attachment pipeline. Text-only pastes are normalized to composer style.
 final class FeatureComposerUITextView: UITextView {
     var acceptsImages = false {
         didSet {
@@ -285,17 +349,53 @@ final class FeatureComposerUITextView: UITextView {
     // attached screenshot reads as a bug.
     override func paste(_ sender: Any?) {
         guard acceptsImages else {
-            super.paste(sender)
+            pastePlainText(sender)
             return
         }
         let imageProviders = UIPasteboard.general.itemProviders.filter {
             $0.hasItemConformingToTypeIdentifier(UTType.image.identifier)
         }
         guard !imageProviders.isEmpty else {
-            super.paste(sender)
+            pastePlainText(sender)
             return
         }
         onPasteImages?(imageProviders)
+    }
+
+    private func pastePlainText(_ sender: Any?) {
+        let plainFont = font ?? UIFont.preferredFont(forTextStyle: .body)
+        let plainTextColor = textColor ?? .label
+        super.paste(sender)
+        if restorePlainTextStyle(font: plainFont, textColor: plainTextColor) {
+            delegate?.textViewDidChange?(self)
+        }
+    }
+
+    /// Removes pasted inline attachments together with their object-replacement
+    /// characters before stripping rich-text styling from the draft.
+    @discardableResult
+    func restorePlainTextStyle(font: UIFont, textColor: UIColor) -> Bool {
+        let fullRange = NSRange(location: 0, length: textStorage.length)
+        var attachmentRanges: [NSRange] = []
+        textStorage.enumerateAttribute(.attachment, in: fullRange) { value, range, _ in
+            if value != nil {
+                attachmentRanges.append(range)
+            }
+        }
+        for range in attachmentRanges.reversed() {
+            textStorage.deleteCharacters(in: range)
+        }
+
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: textColor,
+        ]
+        textStorage.setAttributes(
+            attributes,
+            range: NSRange(location: 0, length: textStorage.length)
+        )
+        typingAttributes = attributes
+        return !attachmentRanges.isEmpty
     }
 }
 
@@ -385,11 +485,16 @@ enum FeatureComposerTextSelectionPolicy {
 /// previous answer, so scaling by them feeds back and collapses the input.
 enum FeatureComposerTextInputSizing {
     static let maximumLines: CGFloat = 12
+    private static let minimumInputHeight = T3Metrics.minimumTapTarget
 
     static func height(
         fittingHeight: CGFloat,
         lineHeight: CGFloat
     ) -> CGFloat {
-        min(fittingHeight, lineHeight * maximumLines)
+        let lineHeight = lineHeight > 0 ? lineHeight : 22
+        return min(
+            max(fittingHeight, lineHeight, minimumInputHeight),
+            lineHeight * maximumLines
+        )
     }
 }

--- a/apps/swift-ios/Features/Chat/FeatureComposerView.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerView.swift
@@ -10,6 +10,10 @@ struct FeatureComposerView: View {
     @State private var pathSearchError: String?
     @State private var textSelectionRequest: FeatureComposerTextSelectionRequest?
     @State private var imageIntakeErrorMessage: String?
+    @State private var activeAttachmentContextID: String
+    @State private var imageIntakeTasks: [
+        FeatureAttachmentPreparationState.Operation: Task<Void, Never>
+    ] = [:]
     @Binding private var text: String
     @Binding private var selection: FeatureSelection?
     @Binding private var attachments: [FeatureDraftAttachment]
@@ -26,6 +30,7 @@ struct FeatureComposerView: View {
     private let pendingUserInputs: [FeatureUserInput]
     private let isResolvingRequest: Bool
     private let powerFeatures: FeatureComposerPowerFeatures
+    private let attachmentContextID: String
     private let onSend: () -> Void
     private let onStop: () -> Void
     private let onDismissKeyboard: (() -> Void)?
@@ -36,6 +41,7 @@ struct FeatureComposerView: View {
         text: Binding<String>,
         selection: Binding<FeatureSelection?>,
         attachments: Binding<[FeatureDraftAttachment]>,
+        attachmentContextID: String,
         providers: [FeatureProvider],
         threadSelection: FeatureSelection?,
         materializesDefaultSelection: Bool = true,
@@ -57,6 +63,8 @@ struct FeatureComposerView: View {
         _text = text
         _selection = selection
         _attachments = attachments
+        _activeAttachmentContextID = State(initialValue: attachmentContextID)
+        self.attachmentContextID = attachmentContextID
         self.providers = providers
         self.threadSelection = threadSelection
         self.materializesDefaultSelection = materializesDefaultSelection
@@ -128,6 +136,13 @@ struct FeatureComposerView: View {
             }
             .task(id: pathSearchRequest) {
                 await updatePathSearch()
+            }
+            .onChange(of: attachmentContextID) { _, attachmentContextID in
+                activeAttachmentContextID = attachmentContextID
+                cancelImageIntake()
+            }
+            .onDisappear {
+                cancelImageIntake()
             }
             .alert(
                 "Couldn’t add image",
@@ -527,8 +542,12 @@ struct FeatureComposerView: View {
             Result { try FeatureImageItemProviderLoader.start(from: provider) }
         }
         let operation = attachmentPreparation.begin(itemCount: accepted.count)
-        Task { @MainActor in
-            defer { attachmentPreparation.finish(operation) }
+        let startedContextID = activeAttachmentContextID
+        let task = Task { @MainActor in
+            defer {
+                attachmentPreparation.finish(operation)
+                imageIntakeTasks.removeValue(forKey: operation)
+            }
             for (offset, load) in loads.enumerated() {
                 do {
                     let data = try await load.get().data()
@@ -538,12 +557,34 @@ struct FeatureComposerView: View {
                             ordinal: plan.firstOrdinal + offset
                         )
                     }.value
+                    guard FeatureComposerImageIntakeLifecycle.acceptsResult(
+                        startedContextID: startedContextID,
+                        activeContextID: activeAttachmentContextID,
+                        isCancelled: Task.isCancelled
+                    ) else { return }
                     attachments.append(attachment)
+                } catch is CancellationError {
+                    return
                 } catch {
+                    guard FeatureComposerImageIntakeLifecycle.acceptsResult(
+                        startedContextID: startedContextID,
+                        activeContextID: activeAttachmentContextID,
+                        isCancelled: Task.isCancelled
+                    ) else { return }
                     imageIntakeErrorMessage = error.localizedDescription
                 }
+                attachmentPreparation.completeItem(operation)
             }
         }
+        imageIntakeTasks[operation] = task
+    }
+
+    private func cancelImageIntake() {
+        for (operation, task) in imageIntakeTasks {
+            task.cancel()
+            attachmentPreparation.finish(operation)
+        }
+        imageIntakeTasks.removeAll()
     }
 
     /// A drop is refused outright when images are not accepted, so the drag
@@ -552,6 +593,16 @@ struct FeatureComposerView: View {
         guard imagesAllowed, !providers.isEmpty else { return false }
         attachImageProviders(providers)
         return true
+    }
+}
+
+enum FeatureComposerImageIntakeLifecycle {
+    static func acceptsResult(
+        startedContextID: String,
+        activeContextID: String,
+        isCancelled: Bool
+    ) -> Bool {
+        !isCancelled && startedContextID == activeContextID
     }
 }
 

--- a/apps/swift-ios/Features/Chat/ImageAttachmentViews.swift
+++ b/apps/swift-ios/Features/Chat/ImageAttachmentViews.swift
@@ -39,6 +39,15 @@ struct FeatureAttachmentPreparationState: Equatable {
     mutating func finish(_ operation: Operation) {
         pendingItemsByOperation.removeValue(forKey: operation)
     }
+
+    mutating func completeItem(_ operation: Operation) {
+        guard let pendingCount = pendingItemsByOperation[operation] else { return }
+        if pendingCount > 1 {
+            pendingItemsByOperation[operation] = pendingCount - 1
+        } else {
+            pendingItemsByOperation.removeValue(forKey: operation)
+        }
+    }
 }
 
 struct FeatureImageAttachmentPicker: View {
@@ -222,6 +231,7 @@ struct FeatureImageAttachmentPicker: View {
                 } catch {
                     errorMessage = error.localizedDescription
                 }
+                preparationState.completeItem(operation)
             }
         }
     }
@@ -247,6 +257,7 @@ struct FeatureImageAttachmentPicker: View {
                     return data
                 }.value
                 try await appendImage(data)
+                preparationState.completeItem(operation)
             } catch {
                 errorMessage = error.localizedDescription
             }
@@ -274,6 +285,7 @@ struct FeatureImageAttachmentPicker: View {
                             return try Data(contentsOf: url, options: .mappedIfSafe)
                         }.value
                         try await appendImage(data)
+                        preparationState.completeItem(operation)
                     } catch {
                         errorMessage = error.localizedDescription
                         break

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -352,6 +352,7 @@ public struct ThreadDetailView: View {
                 text: $draft,
                 selection: $selection,
                 attachments: $attachments,
+                attachmentContextID: thread.id,
                 providers: threadProviders,
                 threadSelection: currentSelection,
                 materializesDefaultSelection: false,

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -77,6 +77,7 @@ public struct NewThreadView: View {
                         text: $prompt,
                         selection: selectionBinding,
                         attachments: $attachments,
+                        attachmentContextID: projectID,
                         providers: creationProviders,
                         threadSelection: nil,
                         isSending: isSubmitting,

--- a/apps/swift-ios/Tests/FeatureTests/AttachmentPreparationTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/AttachmentPreparationTests.swift
@@ -61,6 +61,21 @@ struct AttachmentPreparationTests {
         #expect(state.pendingItemCount == 0)
     }
 
+    @Test(
+        "Completed items stop counting against overlapping preparation",
+        .bug("https://github.com/saphid/t3code-personal/issues/126#issuecomment-5351317338")
+    )
+    func completedItemsLeaveOnlyRemainingWorkPending() {
+        var state = FeatureAttachmentPreparationState()
+        let operation = state.begin(itemCount: 4)
+
+        state.completeItem(operation)
+        state.completeItem(operation)
+
+        #expect(state.pendingItemCount == 2)
+        #expect(state.statusLabel == "Preparing 2 images…")
+    }
+
     @Test
     func textOnlySubmissionWaitsForSelectedImagePreparation() {
         var state = FeatureAttachmentPreparationState()

--- a/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
@@ -38,6 +38,19 @@ struct FeatureComposerPowerTests {
         )
     }
 
+    @Test(
+        "An empty composer keeps its full tap target",
+        .bug("https://github.com/pingdotgg/t3code/pull/7601#discussion_r3816978964")
+    )
+    func composerTextInputKeepsMinimumTapHeight() {
+        #expect(
+            FeatureComposerTextInputSizing.height(
+                fittingHeight: 8,
+                lineHeight: 20
+            ) == T3Metrics.minimumTapTarget
+        )
+    }
+
     @Test
     func replacementCursorLandsAfterInsertedTextInUTF16() {
         // "🧪 " occupies three characters but four UTF-16 units; the caret
@@ -165,6 +178,124 @@ struct FeatureComposerPowerTests {
         ]
 
         #expect(FeatureComposerPasteboardPolicy.containsImage(in: pasteboard))
+    }
+
+    @Test(
+        "Text paste discards rich formatting",
+        .bug("https://github.com/pingdotgg/t3code/pull/7601#discussion_r3816978970")
+    )
+    @MainActor
+    func textPasteDiscardsRichFormatting() {
+        let font = UIFont.preferredFont(forTextStyle: .body)
+        let textColor = UIColor.label
+        let textView = FeatureComposerUITextView()
+        textView.attributedText = NSAttributedString(
+            string: "pasted text",
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 30, weight: .bold),
+                .foregroundColor: UIColor.systemRed,
+            ]
+        )
+
+        textView.restorePlainTextStyle(font: font, textColor: textColor)
+
+        let attributes = textView.textStorage.attributes(at: 0, effectiveRange: nil)
+        #expect(attributes[.font] as? UIFont == font)
+        #expect(attributes[.foregroundColor] as? UIColor == textColor)
+        #expect(textView.typingAttributes[.font] as? UIFont == font)
+        #expect(textView.typingAttributes[.foregroundColor] as? UIColor == textColor)
+    }
+
+    @Test(
+        "Text paste removes inline attachments without leaving replacement characters",
+        .bug("https://github.com/pingdotgg/t3code/pull/7601#discussion_r3819336539")
+    )
+    @MainActor
+    func textPasteRemovesInlineAttachmentsCleanly() {
+        let textView = FeatureComposerUITextView()
+        let pastedText = NSMutableAttributedString(string: "before ")
+        pastedText.append(NSAttributedString(attachment: NSTextAttachment()))
+        pastedText.append(NSAttributedString(string: " after"))
+        textView.attributedText = pastedText
+
+        let removedAttachment = textView.restorePlainTextStyle(
+            font: .preferredFont(forTextStyle: .body),
+            textColor: .label
+        )
+
+        #expect(removedAttachment)
+        #expect(textView.text == "before  after")
+        #expect(textView.text.contains("\u{FFFC}") == false)
+        var stillHasAttachment = false
+        textView.textStorage.enumerateAttribute(
+            .attachment,
+            in: NSRange(location: 0, length: textView.textStorage.length)
+        ) { value, _, _ in
+            stillHasAttachment = stillHasAttachment || value != nil
+        }
+        #expect(stillHasAttachment == false)
+    }
+
+    @Test(
+        "An external clear wins after marked text finishes",
+        .bug("https://github.com/saphid/t3code-personal/issues/126#issuecomment-5351317338")
+    )
+    func externalTextUpdateReconcilesAfterComposition() {
+        var reconciliation = FeatureComposerTextReconciliation()
+
+        #expect(reconciliation.externalTextDidChange(
+            editorText: "draft候補",
+            bindingText: "",
+            hasMarkedText: true
+        ) == .none)
+        #expect(reconciliation.editorTextDidChange(
+            "stale committed draft",
+            hasMarkedText: true
+        ) == .none)
+        #expect(reconciliation.editorTextDidChange(
+            "stale committed draft",
+            hasMarkedText: false
+        ) == .applyExternal(""))
+        #expect(reconciliation.pendingExternalText == nil)
+    }
+
+    @Test
+    func matchingBindingCancelsADeferredExternalTextUpdate() {
+        var reconciliation = FeatureComposerTextReconciliation()
+
+        #expect(reconciliation.externalTextDidChange(
+            editorText: "draft候補",
+            bindingText: "",
+            hasMarkedText: true
+        ) == .none)
+        #expect(reconciliation.externalTextDidChange(
+            editorText: "draft候補",
+            bindingText: "draft候補",
+            hasMarkedText: true
+        ) == .none)
+        #expect(reconciliation.pendingExternalText == nil)
+    }
+
+    @Test(
+        "Image intake results are ignored after the composer context changes",
+        .bug("https://github.com/saphid/t3code-personal/issues/126#issuecomment-5351317338")
+    )
+    func staleImageIntakeResultIsRejected() {
+        #expect(FeatureComposerImageIntakeLifecycle.acceptsResult(
+            startedContextID: "project-a",
+            activeContextID: "project-a",
+            isCancelled: false
+        ))
+        #expect(FeatureComposerImageIntakeLifecycle.acceptsResult(
+            startedContextID: "project-a",
+            activeContextID: "project-b",
+            isCancelled: false
+        ) == false)
+        #expect(FeatureComposerImageIntakeLifecycle.acceptsResult(
+            startedContextID: "project-a",
+            activeContextID: "project-a",
+            isCancelled: true
+        ) == false)
     }
 
     @Test


### PR DESCRIPTION
## Observed problem and reproduction

Paste an image into the native SwiftUI composer with the long-press menu or Cmd-V. Before this work, image-only pasteboards did nothing because SwiftUI cannot observe paste on iOS and `UITextView` hides its normal Paste entry for image-only content.

The current head also covers related failures found after replacing the editor: marked-text composition could fight external SwiftUI binding changes, rich-text paste could retain attachments or styling, and asynchronous image intake could finish after the composer changed thread or project.

## Cause

The composer used a SwiftUI text input with no UIKit `paste(_:)` hook. Image attachments entered through picker, camera, and Files paths only. Replacing the input exposed ownership gaps around focus, IME reconciliation, paste normalization, task cancellation, and context-scoped result acceptance.

## Change and boundary

The composer now uses a `UITextView` wrapper that offers Paste for image content when the selected model accepts images. Pasted providers use the existing downscale, JPEG re-encode, thumbnail, and `FeatureDraftAttachment` pipeline. Text-only paste delegates to normal behavior, then restores plain composer styling.

A reconciliation state machine defers external rewrites during marked-text composition. Image intake tasks are keyed to the attachment context, cancelled on context change or disappearance, and rejected if stale. Multiple images preserve order up to the existing eight-image limit and disclose overflow.

## Non-goals

No new attachment wire format, server behavior, provider-specific image list, or parallel upload path. Accompanying text from an image-bearing pasteboard is intentionally not inserted because copied images often also carry a URL. React Native mobile, web, and desktop are unchanged.

## Affected areas

Affected client: SwiftUI mobile composer in both existing-thread and new-thread flows.

Platforms: iOS simulator and one physical iPhone acceptance record.

Providers: the UI gates paste on the selected model's existing image capability. No adapter changes.

Contracts/connections: existing attachment upload contracts and connection behavior are reused.

## Validation

Current head: `da648bbd`.

- `xcodebuild test -only-testing:T3CodeTests` on the recorded iOS 26.5 simulator: 291 tests across 33 suites passed, `** TEST SUCCEEDED **`, exit 0.
- Focused `ComposerImagePasteTests`, `FeatureComposerPowerTests`, and `AttachmentPreparationTests`: 22 tests across 3 suites passed, exit 0.
- Simulator with live local backend: long-press Paste created an attachment chip; repeated pastes accumulated; removal and send worked; the backend persisted the image as JPEG. Hardware Cmd-V produced the same attachment.
- Recorded physical-device acceptance: internal Test build 94.

## Risks, untested paths, and known gaps

- An unresolved Cursor Bugbot thread identifies a real ordinal-collision race after failed intake. A concurrent paste or drop can reuse an ordinal still owned by the first operation. This needs code and concurrency coverage.
- Multi-image single-paste behavior is unit-tested but was not exercised on device.
- The physical iOS one-time Allow Paste prompt was not exercised.
- The branch currently conflicts with its target. It was not rebased in this sweep.
- This contribution is superseded in the personal queue by merged upstream PR #7607. No closure or code change was made here.
- Known gaps: no current-head light or dark before/after screenshots; no interaction video; no device proof for a single multi-image paste; no Allow Paste prompt proof; unresolved ordinal-collision code finding.

## Evidence

No current-head screenshots or video are embedded. Earlier light-only captures predated the current editor and growth semantics, so they are intentionally not presented as proof of this head.

## Owning issue and stack

Owning issue: [saphid/t3code-personal#126](https://github.com/saphid/t3code-personal/issues/126). This PR targets the open SwiftUI parent branch and depends on #5178 landing. It is not stacked on #7345. The owning queue marks it superseded by merged #7607. Maintainer edits are enabled.
