### PR TITLE
chore(desktop): use stable Clerk Electron release

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ overrides:
   '@clerk/clerk-js>@solana/wallet-adapter-react': '-'
   '@clerk/clerk-js>@solana/wallet-standard': '-'
   '@clerk/clerk-js>@wallet-standard/core': '-'
-  '@clerk/electron': 0.0.34-canary.v20260819050620
-  '@clerk/electron-passkeys': 0.0.4-canary.v20260819050620
+  '@clerk/electron': 0.0.34
+  '@clerk/electron-passkeys': 0.0.3
   '@clerk/expo': 4.2.0
   '@clerk/react': 6.14.4
   '@clerk/shared': 4.29.2
@@ -114,11 +114,11 @@ importers:
   apps/desktop:
     dependencies:
       '@clerk/electron':
-        specifier: 0.0.34-canary.v20260819050620
-        version: 0.0.34-canary.v20260819050620(@clerk/electron-passkeys@0.0.4-canary.v20260819050620)(electron-store@8.2.0)(electron@41.5.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 0.0.34
+        version: 0.0.34(@clerk/electron-passkeys@0.0.3)(electron-store@8.2.0)(electron@41.5.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@clerk/electron-passkeys':
-        specifier: 0.0.4-canary.v20260819050620
-        version: 0.0.4-canary.v20260819050620
+        specifier: 0.0.3
+        version: 0.0.3
       '@effect/platform-node':
         specifier: 4.0.0-beta.103
         version: 4.0.0-beta.103(bufferutil@4.1.0)(effect@4.0.0-beta.103(patch_hash=af36b7948b6f9c56623074662b51dade5699880c1a7c71245de73e13c3185fb6))(ioredis@5.11.0)(utf-8-validate@6.0.6)
@@ -520,8 +520,8 @@ importers:
         specifier: ^1.4.1
         version: 1.5.0(@types/react@19.2.16)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@clerk/electron':
-        specifier: 0.0.34-canary.v20260819050620
-        version: 0.0.34-canary.v20260819050620(@clerk/electron-passkeys@0.0.4-canary.v20260819050620)(electron-store@8.2.0)(electron@41.5.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 0.0.34
+        version: 0.0.34(@clerk/electron-passkeys@0.0.3)(electron-store@8.2.0)(electron@41.5.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@clerk/react':
         specifier: 6.14.4
         version: 6.14.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -1721,35 +1721,35 @@ packages:
     resolution: {integrity: sha512-4i4RE+ZQ0hKDDFSRKCISQPBy07SfFeFAhBUhNj2j01Nx2n4pqV+5iyg2Vf27+NKFNkgq7kdmZGvtug24D++8WQ==}
     engines: {node: '>=20.9.0'}
 
-  '@clerk/electron-passkeys-darwin-arm64@0.0.4-canary.v20260819050620':
-    resolution: {integrity: sha512-avxygtEfWBD3YPkxws4lB5mL/75SQvVBMQCg+b1gjFsQInnVOgAqAv4wHR8wgUsEbXY2zEkvqaYjFSnEveC0VA==}
+  '@clerk/electron-passkeys-darwin-arm64@0.0.3':
+    resolution: {integrity: sha512-oAlrd+GLqP0oREP3hNRc6yNZhXGaQgJss9iCWRQqXjpw1yZD1ZU+L+E2Gfg84vMj/NSUhxbU0Djy0RXhmeUwgg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@clerk/electron-passkeys-darwin-x64@0.0.4-canary.v20260819050620':
-    resolution: {integrity: sha512-clShldbwDcC2ek6gJT85QKsMfaPyOhEgfz61u2n3YKivbeui33XjJu261d+LO20mqDjXZy3flLGPTIh/Kii80g==}
+  '@clerk/electron-passkeys-darwin-x64@0.0.3':
+    resolution: {integrity: sha512-0UPAWQEni7o8gjWwd2sP97fPshJmT2w5b8eV/jOPVSP8NqIcFCm5yIFSEx1SfB53LGfzB01A4iEGi2pxiCHqyQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@clerk/electron-passkeys-win32-arm64-msvc@0.0.4-canary.v20260819050620':
-    resolution: {integrity: sha512-alIfXJSxyeulnNeHoT4X7+qO0o9/EBhiRWMhCXwKJIbWfwzqnnVrRH1P7HfYRnDepKhqRzsUaBuYTqQzisHG+A==}
+  '@clerk/electron-passkeys-win32-arm64-msvc@0.0.3':
+    resolution: {integrity: sha512-bbRvifm9A/gfPkwC1UyMyF9sYGEs0aen7J2kCcaOIW3K0PXcAbHtsR/gnx4dT0bjFdd21vSa2zlIdERvHc1BiA==}
     cpu: [arm64]
     os: [win32]
 
-  '@clerk/electron-passkeys-win32-x64-msvc@0.0.4-canary.v20260819050620':
-    resolution: {integrity: sha512-QSKKMCdV9AhOt74ls8ExdwR+2ikoLGgN2LdWIjBgNk6epJVs2L1FXVZOM0ZqfVHFSl5y7vLmlOACR6WyJ2eoLg==}
+  '@clerk/electron-passkeys-win32-x64-msvc@0.0.3':
+    resolution: {integrity: sha512-gFaVqKlOKTF2SJ3lMwkZ0oonycQn93p1qSrp5kzzeZBeQ+tGB3gQnjXecrhQy21AzDUyWqVJJ8KrP2HRAwifWg==}
     cpu: [x64]
     os: [win32]
 
-  '@clerk/electron-passkeys@0.0.4-canary.v20260819050620':
-    resolution: {integrity: sha512-zOoFEsvOrArv7p4ERNAdkGbYoD86ragDhysLG1NdxJm2jnfw+AfwxUv0FkOPZ7iNuQ0rbJaR/urxdvEwVcuKRA==}
+  '@clerk/electron-passkeys@0.0.3':
+    resolution: {integrity: sha512-OHhIe88qDL+FxyBalXdXNHAS5eEramr6Rerp+6iNkfkjqT8rx4hHNmfpmjg5/T1/am8QfknbOBZkqoXZlCrjPg==}
     engines: {node: '>=20.9.0'}
 
-  '@clerk/electron@0.0.34-canary.v20260819050620':
-    resolution: {integrity: sha512-sfKWkH2SigKcxtR+h36G1NGnmMI5xOlwvqHpr3JYcacS/uokQbeAjCCQzEeV/9zqWYtRL4et5wCD13+gWv4b6w==}
+  '@clerk/electron@0.0.34':
+    resolution: {integrity: sha512-ZY6v8G1ArieIWvutMEt5HBJtpHN4ys4F4newNlOTElv//cpW29zaeZ65M8WuKttKr7fB+MH6wzzCoX/Ha+fiSg==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
-      '@clerk/electron-passkeys': 0.0.4-canary.v20260819050620
+      '@clerk/electron-passkeys': 0.0.3
       electron: '>=28'
       electron-store: ^8.2.0
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
@@ -11580,26 +11580,26 @@ snapshots:
       - react
       - react-dom
 
-  '@clerk/electron-passkeys-darwin-arm64@0.0.4-canary.v20260819050620':
+  '@clerk/electron-passkeys-darwin-arm64@0.0.3':
     optional: true
 
-  '@clerk/electron-passkeys-darwin-x64@0.0.4-canary.v20260819050620':
+  '@clerk/electron-passkeys-darwin-x64@0.0.3':
     optional: true
 
-  '@clerk/electron-passkeys-win32-arm64-msvc@0.0.4-canary.v20260819050620':
+  '@clerk/electron-passkeys-win32-arm64-msvc@0.0.3':
     optional: true
 
-  '@clerk/electron-passkeys-win32-x64-msvc@0.0.4-canary.v20260819050620':
+  '@clerk/electron-passkeys-win32-x64-msvc@0.0.3':
     optional: true
 
-  '@clerk/electron-passkeys@0.0.4-canary.v20260819050620':
+  '@clerk/electron-passkeys@0.0.3':
     optionalDependencies:
-      '@clerk/electron-passkeys-darwin-arm64': 0.0.4-canary.v20260819050620
-      '@clerk/electron-passkeys-darwin-x64': 0.0.4-canary.v20260819050620
-      '@clerk/electron-passkeys-win32-arm64-msvc': 0.0.4-canary.v20260819050620
-      '@clerk/electron-passkeys-win32-x64-msvc': 0.0.4-canary.v20260819050620
+      '@clerk/electron-passkeys-darwin-arm64': 0.0.3
+      '@clerk/electron-passkeys-darwin-x64': 0.0.3
+      '@clerk/electron-passkeys-win32-arm64-msvc': 0.0.3
+      '@clerk/electron-passkeys-win32-x64-msvc': 0.0.3
 
-  '@clerk/electron@0.0.34-canary.v20260819050620(@clerk/electron-passkeys@0.0.4-canary.v20260819050620)(electron-store@8.2.0)(electron@41.5.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@clerk/electron@0.0.34(@clerk/electron-passkeys@0.0.3)(electron-store@8.2.0)(electron@41.5.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@clerk/clerk-js': 6.29.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@clerk/react': 6.14.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -11608,7 +11608,7 @@ snapshots:
       react: 19.2.6
       tslib: 2.8.1
     optionalDependencies:
-      '@clerk/electron-passkeys': 0.0.4-canary.v20260819050620
+      '@clerk/electron-passkeys': 0.0.3
       electron-store: 8.2.0
       react-dom: 19.2.6(react@19.2.6)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,8 +25,8 @@ allowBuilds:
 catalog:
   "@clerk/backend": 3.14.0
   "@clerk/clerk-js": 6.29.2
-  "@clerk/electron": 0.0.34-canary.v20260819050620
-  "@clerk/electron-passkeys": 0.0.4-canary.v20260819050620
+  "@clerk/electron": 0.0.34
+  "@clerk/electron-passkeys": 0.0.3
   "@clerk/expo": 4.2.0
   "@clerk/react": 6.14.4
   "@clerk/shared": 4.29.2
@@ -55,8 +55,7 @@ catalog:
 minimumReleaseAgeExclude:
   - "@clerk/backend@3.14.0"
   - "@clerk/clerk-js@6.29.2"
-  - "@clerk/electron@0.0.34-canary.v20260819050620"
-  - "@clerk/electron-passkeys@0.0.4-canary.v20260819050620"
+  - "@clerk/electron@0.0.34"
   - "@clerk/expo@4.2.0"
   - "@clerk/react@6.14.4"
   - "@clerk/shared@4.29.2"
@@ -77,10 +76,6 @@ minimumReleaseAgeExclude:
   - alchemy@2.0.0-beta.65
   - effect@4.0.0-beta.103
   - "@legendapp/list@3.3.5"
-  - "@clerk/electron-passkeys-darwin-arm64@0.0.4-canary.v20260819050620"
-  - "@clerk/electron-passkeys-darwin-x64@0.0.4-canary.v20260819050620"
-  - "@clerk/electron-passkeys-win32-arm64-msvc@0.0.4-canary.v20260819050620"
-  - "@clerk/electron-passkeys-win32-x64-msvc@0.0.4-canary.v20260819050620"
 
 overrides:
   "@clerk/backend": "catalog:"


### PR DESCRIPTION
The passkey autofill fix required a Clerk canary because no stable release contained it. Clerk Electron 0.0.34 now ships the fix.

This moves @clerk/electron to stable 0.0.34 and @clerk/electron-passkeys back to stable 0.0.3. It removes the canary release-age exceptions for the passkey package and its native binaries.

Verified with the focused passkey and DesktopClerk tests, web and desktop typechecks, a production web build, formatting, and a frozen install.

Made with GPT-5.6-sol in T3 Code using the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Clerk Electron auth/passkeys on desktop (and a transitive web dependency), but it is a version pin to stable with the same intended fix rather than new integration logic.
> 
> **Overview**
> Replaces **canary** `@clerk/electron` and `@clerk/electron-passkeys` with **stable** releases now that 0.0.34 includes the passkey autofill fix that previously required a canary.
> 
> Catalog entries, root `pnpm` overrides, and the lockfile are updated so `apps/desktop` and `apps/web` resolve `@clerk/electron@0.0.34` with `@clerk/electron-passkeys@0.0.3` (down from passkeys canary 0.0.4). **minimumReleaseAgeExclude** is adjusted to allow stable `@clerk/electron@0.0.34` and drops the passkeys package and platform-specific native binary exceptions that only applied to the canary versions.
> 
> No application source changes—only workspace dependency configuration and the lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c92923f2455b7afc35b00a7947839d42d2aab3a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin `@clerk/electron` to stable release 0.0.34
> Updates [pnpm-workspace.yaml](https://github.com/pingdotgg/t3code/pull/7602/files#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794c) to use stable releases of `@clerk/electron` (0.0.34) and `@clerk/electron-passkeys` (0.0.3) instead of canary builds. Removes all canary-specific `minimumReleaseAgeExclude` entries for `electron-passkeys` (general and platform-specific), replacing the canary `@clerk/electron` entry with the stable version.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c92923f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->