### PR TITLE
fix(desktop): stop Clerk virtual-router navigation from hard-reloading the app

### DIFF
--- a/apps/web/src/components/clerk/clerkRouterBridge.test.ts
+++ b/apps/web/src/components/clerk/clerkRouterBridge.test.ts
@@ -6,7 +6,7 @@ import { createClerkRouterBridge } from "./clerkRouterBridge";
 describe("createClerkRouterBridge", () => {
   it("absorbs a Clerk virtual-router path instead of feeding it to the app history", () => {
     const history = createMemoryHistory({ initialEntries: ["/settings/connections"] });
-    const { routerPush } = createClerkRouterBridge(history);
+    const { routerPush } = createClerkRouterBridge(history, true);
 
     routerPush("/CLERK-ROUTER/VIRTUAL/sign-up#/continue");
 
@@ -18,7 +18,7 @@ describe("createClerkRouterBridge", () => {
 
   it("absorbs a Clerk virtual-router path even when the marker appears after a hash", () => {
     const history = createMemoryHistory({ initialEntries: ["/settings/connections"] });
-    const { routerReplace } = createClerkRouterBridge(history);
+    const { routerReplace } = createClerkRouterBridge(history, true);
 
     routerReplace("/#/CLERK-ROUTER/VIRTUAL/factor-one");
 
@@ -27,24 +27,37 @@ describe("createClerkRouterBridge", () => {
 
   it("forwards a genuine in-app navigation to the real router history", () => {
     const history = createMemoryHistory({ initialEntries: ["/"] });
-    const { routerReplace } = createClerkRouterBridge(history);
+    const { routerReplace } = createClerkRouterBridge(history, true);
 
     routerReplace("/settings/connections");
 
     expect(history.location.pathname).toBe("/settings/connections");
   });
 
-  it("unwraps a hash-embedded real destination instead of double-hashing it", () => {
+  it("unwraps a hash-embedded real destination on Electron instead of double-hashing it", () => {
     // authRedirect.ts builds Electron redirect targets as
     // t3code://app/#/current-page; clerk-js hands this bridge everything
     // after the origin, hash included. Pushing that string unmodified into
     // a hash history would land on "/#/#/settings/connections" and resolve
     // to the wrong page.
     const history = createMemoryHistory({ initialEntries: ["/"] });
-    const { routerPush } = createClerkRouterBridge(history);
+    const { routerPush } = createClerkRouterBridge(history, true);
 
     routerPush("/#/settings/connections");
 
     expect(history.location.pathname).toBe("/settings/connections");
+  });
+
+  it("preserves a literal fragment on browser history instead of treating it as Electron hash routing", () => {
+    // Only Electron uses hash history. On browser history a "#" is a real
+    // URL fragment, not a routing convention - stripping everything before
+    // it would push just the fragment ("section") instead of the real path.
+    const history = createMemoryHistory({ initialEntries: ["/"] });
+    const { routerPush } = createClerkRouterBridge(history, false);
+
+    routerPush("/settings/profile#section");
+
+    expect(history.location.pathname).toBe("/settings/profile");
+    expect(history.location.hash).toBe("#section");
   });
 });

--- a/apps/web/src/components/clerk/clerkRouterBridge.test.ts
+++ b/apps/web/src/components/clerk/clerkRouterBridge.test.ts
@@ -1,0 +1,50 @@
+import { createMemoryHistory } from "@tanstack/react-router";
+import { describe, expect, it } from "vite-plus/test";
+
+import { createClerkRouterBridge } from "./clerkRouterBridge";
+
+describe("createClerkRouterBridge", () => {
+  it("absorbs a Clerk virtual-router path instead of feeding it to the app history", () => {
+    const history = createMemoryHistory({ initialEntries: ["/settings/connections"] });
+    const { routerPush } = createClerkRouterBridge(history);
+
+    routerPush("/CLERK-ROUTER/VIRTUAL/sign-up#/continue");
+
+    // The app-router-bound history must be untouched: if it had received
+    // this path, the app's router would try to match it and, finding
+    // nothing real, blank the whole UI behind the modal to "Not Found".
+    expect(history.location.pathname).toBe("/settings/connections");
+  });
+
+  it("absorbs a Clerk virtual-router path even when the marker appears after a hash", () => {
+    const history = createMemoryHistory({ initialEntries: ["/settings/connections"] });
+    const { routerReplace } = createClerkRouterBridge(history);
+
+    routerReplace("/#/CLERK-ROUTER/VIRTUAL/factor-one");
+
+    expect(history.location.pathname).toBe("/settings/connections");
+  });
+
+  it("forwards a genuine in-app navigation to the real router history", () => {
+    const history = createMemoryHistory({ initialEntries: ["/"] });
+    const { routerReplace } = createClerkRouterBridge(history);
+
+    routerReplace("/settings/connections");
+
+    expect(history.location.pathname).toBe("/settings/connections");
+  });
+
+  it("unwraps a hash-embedded real destination instead of double-hashing it", () => {
+    // authRedirect.ts builds Electron redirect targets as
+    // t3code://app/#/current-page; clerk-js hands this bridge everything
+    // after the origin, hash included. Pushing that string unmodified into
+    // a hash history would land on "/#/#/settings/connections" and resolve
+    // to the wrong page.
+    const history = createMemoryHistory({ initialEntries: ["/"] });
+    const { routerPush } = createClerkRouterBridge(history);
+
+    routerPush("/#/settings/connections");
+
+    expect(history.location.pathname).toBe("/settings/connections");
+  });
+});

--- a/apps/web/src/components/clerk/clerkRouterBridge.ts
+++ b/apps/web/src/components/clerk/clerkRouterBridge.ts
@@ -32,15 +32,22 @@ const CLERK_VIRTUAL_PATH_MARKER = "CLERK-ROUTER/VIRTUAL/";
  * unmounted history that clerk-js can still push/replace freely, while a
  * real path goes through the app's own history as a normal SPA transition.
  *
- * A real destination can still carry a leading "#" here: the app's own
- * redirect-target construction (authRedirect.ts) builds Electron redirect
- * URLs as t3code://app/#/current-page, and clerk-js hands this bridge
- * everything after the origin, hash included. Electron's history is a hash
- * history, so pushing that string unmodified would double the hash
+ * A real destination can still carry a leading "#" here on Electron: the
+ * app's own redirect-target construction (authRedirect.ts) builds Electron
+ * redirect URLs as t3code://app/#/current-page, and clerk-js hands this
+ * bridge everything after the origin, hash included. Electron's history is
+ * a hash history, so pushing that string unmodified would double the hash
  * (history.createHref would read back as "/#/#/current-page"). The part
  * after the first "#" is the actual in-app path the hash history expects.
+ * This only applies when the real history is hash-based: on browser history
+ * a "#" is a genuine fragment (e.g. "/settings/profile#section"), and
+ * stripping everything before it would push just "section" instead of the
+ * real path.
  */
-export function createClerkRouterBridge(history: RouterHistory): {
+export function createClerkRouterBridge(
+  history: RouterHistory,
+  isHashHistory: boolean,
+): {
   routerPush: ClerkRouterFn;
   routerReplace: ClerkRouterFn;
 } {
@@ -49,6 +56,9 @@ export function createClerkRouterBridge(history: RouterHistory): {
   function resolveDestination(to: string): { target: RouterHistory; path: string } {
     if (to.includes(CLERK_VIRTUAL_PATH_MARKER)) {
       return { target: virtualHistory, path: to };
+    }
+    if (!isHashHistory) {
+      return { target: history, path: to };
     }
     const hashIndex = to.indexOf("#");
     const path = hashIndex === -1 ? to : to.slice(hashIndex + 1) || "/";

--- a/apps/web/src/components/clerk/clerkRouterBridge.ts
+++ b/apps/web/src/components/clerk/clerkRouterBridge.ts
@@ -1,0 +1,68 @@
+import type { ClerkProviderProps } from "@clerk/react";
+import { createMemoryHistory, type RouterHistory } from "@tanstack/react-router";
+
+type ClerkRouterFn = NonNullable<ClerkProviderProps["routerPush"]>;
+
+// The same marker clerk-js's own internals use to recognize a synthetic
+// modal-router path (see @clerk/shared's url.js and queryStateParams.js,
+// both matching this literal prefix to strip it back out). Reused here
+// instead of asking the app's router whether it recognizes the path: this
+// app's route tree has param routes (e.g. /$environmentId/$threadId), and
+// TanStack Router's route matching is fuzzy by default, so a virtual path
+// like /CLERK-ROUTER/VIRTUAL/sign-up can spuriously match one of those as a
+// real route with a wildcard remainder. Checking Clerk's own marker instead
+// is exact and doesn't depend on what routes the app happens to have.
+const CLERK_VIRTUAL_PATH_MARKER = "CLERK-ROUTER/VIRTUAL/";
+
+/**
+ * Without routerPush/routerReplace, clerk-js falls back to a hard window
+ * navigation whenever it needs to move to a step it treats as outside its
+ * virtual modal router (sign-up transfer, MFA factors, password reset). In
+ * Electron that hands the app's custom scheme a URL like
+ * t3code://app/CLERK-ROUTER/VIRTUAL/sign-up#/continue, which the protocol
+ * handler can't resolve, and the hard navigation tears down the mounted
+ * React tree (and the Clerk modal with it), dropping the user back to
+ * signed-out. So routerPush/routerReplace must always be given.
+ *
+ * But clerk-js also uses routerPush/routerReplace for those same synthetic
+ * virtual-router paths, which never correspond to a real app route. Forwarding
+ * one into the app's own history makes the app's TanStack Router try to
+ * match it and, finding nothing real, blank the whole UI behind the Clerk
+ * modal to "Not Found". So a virtual path is absorbed into an isolated,
+ * unmounted history that clerk-js can still push/replace freely, while a
+ * real path goes through the app's own history as a normal SPA transition.
+ *
+ * A real destination can still carry a leading "#" here: the app's own
+ * redirect-target construction (authRedirect.ts) builds Electron redirect
+ * URLs as t3code://app/#/current-page, and clerk-js hands this bridge
+ * everything after the origin, hash included. Electron's history is a hash
+ * history, so pushing that string unmodified would double the hash
+ * (history.createHref would read back as "/#/#/current-page"). The part
+ * after the first "#" is the actual in-app path the hash history expects.
+ */
+export function createClerkRouterBridge(history: RouterHistory): {
+  routerPush: ClerkRouterFn;
+  routerReplace: ClerkRouterFn;
+} {
+  const virtualHistory = createMemoryHistory({ initialEntries: ["/"] });
+
+  function resolveDestination(to: string): { target: RouterHistory; path: string } {
+    if (to.includes(CLERK_VIRTUAL_PATH_MARKER)) {
+      return { target: virtualHistory, path: to };
+    }
+    const hashIndex = to.indexOf("#");
+    const path = hashIndex === -1 ? to : to.slice(hashIndex + 1) || "/";
+    return { target: history, path };
+  }
+
+  return {
+    routerPush: (to) => {
+      const { target, path } = resolveDestination(to);
+      target.push(path);
+    },
+    routerReplace: (to) => {
+      const { target, path } = resolveDestination(to);
+      target.replace(path);
+    },
+  };
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -17,11 +17,13 @@ import {
 } from "./lib/windowControlsOverlay";
 import { AppRoot } from "./AppRoot";
 import { clerkAppearance } from "./components/clerk/clerkAppearance";
+import { createClerkRouterBridge } from "./components/clerk/clerkRouterBridge";
 
 // Electron loads the app from a file-backed shell, so hash history avoids path resolution issues.
 const history = isElectron ? createHashHistory() : createBrowserHistory();
 
 const router = getRouter(history);
+const clerkRouter = createClerkRouterBridge(history);
 
 if (isElectron) {
   syncDocumentElectronPlatformClasses(navigator.platform);
@@ -46,11 +48,18 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
           appearance={clerkAppearance}
           publishableKey={clerkPublishableKey}
           passkeys={passkeys}
+          routerPush={clerkRouter.routerPush}
+          routerReplace={clerkRouter.routerReplace}
         >
           <ManagedRelayAuthProvider>{app}</ManagedRelayAuthProvider>
         </ElectronClerkProvider>
       ) : (
-        <ClerkProvider appearance={clerkAppearance} publishableKey={clerkPublishableKey}>
+        <ClerkProvider
+          appearance={clerkAppearance}
+          publishableKey={clerkPublishableKey}
+          routerPush={clerkRouter.routerPush}
+          routerReplace={clerkRouter.routerReplace}
+        >
           <ManagedRelayAuthProvider>{app}</ManagedRelayAuthProvider>
         </ClerkProvider>
       )

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -23,7 +23,7 @@ import { createClerkRouterBridge } from "./components/clerk/clerkRouterBridge";
 const history = isElectron ? createHashHistory() : createBrowserHistory();
 
 const router = getRouter(history);
-const clerkRouter = createClerkRouterBridge(history);
+const clerkRouter = createClerkRouterBridge(history, isElectron);
 
 if (isElectron) {
   syncDocumentElectronPlatformClasses(navigator.platform);


### PR DESCRIPTION
## Problem

T3 Connect sign-in on the desktop app dead-ends whenever sign-in needs a second step: a first-time sign-up transfer, an MFA factor, or a password reset. Clerk had no `routerPush`/`routerReplace`, so clerk-js fell back to a hard window navigation to a synthetic path like `t3code://app/CLERK-ROUTER/VIRTUAL/sign-up#/continue`. Electron's protocol handler can't resolve that. The navigation tears down the whole React tree, including the mounted sign-in modal, and drops the user back to signed-out.

Fixes #7512

## Fix

Bridge Clerk's navigation into the app's own history instead of leaving it to fall back to `window.location`. A genuine in-app destination goes through the real TanStack Router history as a normal SPA transition. A Clerk virtual-router path never corresponds to a real app route, so pushing one into the app's own router-bound history would just move the problem: the app's router would fail to match it and blank the whole UI behind the modal to "Not Found" instead. It's absorbed into a separate, unmounted history instead, detected by the same marker clerk-js's own internals use to recognize a virtual-router path.

An earlier version of this fix tried asking the app's router whether it recognized a path, using it as the real/virtual signal. That broke against the app's real route tree: a param route (`/$environmentId/$threadId`) fuzzy-matched Clerk's virtual paths as real, silently reintroducing the same bug. Checking Clerk's own marker directly avoids depending on what routes the app happens to have.

## Testing

- `vp test run apps/web/src/components/clerk/clerkRouterBridge.test.ts`: 4 passed, covering a virtual path with the marker before and after a hash, a real in-app navigation, and a real Electron redirect target that embeds its path after a hash (`t3code://app/#/settings`, built by `authRedirect.ts`) to confirm it lands on the right page instead of the app root.
- `vp run --filter @t3tools/web typecheck`: clean

---
Model: Claude Sonnet 5. Harness: Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication navigation on both Electron and web; incorrect path routing could break sign-in redirects or in-app navigation, though behavior is covered by focused unit tests.
> 
> **Overview**
> Fixes desktop T3 Connect sign-in dead-ends on multi-step flows (sign-up transfer, MFA, password reset) by supplying **`routerPush` / `routerReplace`** to Clerk instead of letting clerk-js hard-navigate to unresolvable `t3code://…/CLERK-ROUTER/VIRTUAL/…` URLs that tear down the React tree.
> 
> Adds **`createClerkRouterBridge`**, which routes Clerk’s navigation calls: paths containing Clerk’s **`CLERK-ROUTER/VIRTUAL/`** marker go to an isolated in-memory history so the real TanStack Router history stays put (avoiding a **Not Found** blank behind the modal); real app paths use the app history. On Electron hash history, hash-prefixed destinations from redirects like `/#/settings/…` are unwrapped so routes don’t double-hash; browser history still keeps literal URL fragments.
> 
> Wires the bridge into **`ElectronClerkProvider`** and **`ClerkProvider`** in `main.tsx`, with unit tests for virtual paths, real navigation, Electron hash unwrapping, and browser fragments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf9cb6c3a9378cea9d4186faf1035b87f1900ddd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Clerk virtual-router navigation from hard-reloading the app
> - Introduces `createClerkRouterBridge` in [clerkRouterBridge.ts](https://github.com/pingdotgg/t3code/pull/7605/files#diff-4b27621d6020353dd15817d0fd519c5c4ceb6957b16e9b7f17c26d84886b1853) that produces `routerPush`/`routerReplace` functions for Clerk providers.
> - Paths containing the `CLERK-ROUTER/VIRTUAL/` marker are absorbed into an isolated in-memory history, preventing them from reaching the app router and triggering a hard reload.
> - On hash-based (Electron) histories, the bridge strips the leading `/#` prefix before forwarding to the real history; on browser histories, paths are forwarded unchanged.
> - [main.tsx](https://github.com/pingdotgg/t3code/pull/7605/files#diff-44decff659436a16ccdaaae62e456cd52d9f206c8628c8ca4447aa268c85e16b) passes the bridge's `routerPush`/`routerReplace` to both `ElectronClerkProvider` and `ClerkProvider`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf9cb6c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->