### PR TITLE
feat(swift-ios): paste images from the composer's native menu

### DIFF
--- a/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
@@ -202,7 +202,7 @@ final class FeatureComposerUITextView: UITextView {
     // A SwiftUI drag gesture on the composer never sees drags that start
     // inside this view: the text interaction's own recognizers claim them at
     // the UIKit level. This observing pan reproduces the host's
-    // drag-to-dismiss there — it recognizes alongside everything, cancels
+    // drag-to-dismiss there: it recognizes alongside everything, cancels
     // nothing, and only acts below the scroll cap; a scrollable draft hands
     // dismissal to `keyboardDismissMode = .interactive` instead.
     private let dismissPanDelegate = FeatureComposerDismissPanDelegate()
@@ -244,7 +244,7 @@ final class FeatureComposerUITextView: UITextView {
     // once the cap is hit. Below the cap the pan recognizer must be off
     // entirely: an idle scroll view still swallows vertical drags, which
     // starves the host's drag-to-dismiss-keyboard gesture. A stale offset
-    // from a mid-resize selection change is reset for the same reason — with
+    // from a mid-resize selection change is reset for the same reason; with
     // nothing to scroll, any offset clips the first line under the padding.
     override func layoutSubviews() {
         super.layoutSubviews()
@@ -301,7 +301,7 @@ private final class FeatureComposerDismissPanDelegate: NSObject, UIGestureRecogn
 
 /// Mirrors the thread view's composer drag-to-dismiss thresholds: a clearly
 /// vertical downward drag. While the draft is scrollable, scrolling back
-/// through it never drops the keyboard mid-read — but a drag that *begins*
+/// through it never drops the keyboard mid-read, but a drag that *begins*
 /// with the draft at its top only rubber-bands, which is unambiguous
 /// dismissal intent (and the composer's only escape hatch once it and the
 /// keyboard cover the transcript). `isAtTop` is the position at drag start,

--- a/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
@@ -90,8 +90,11 @@ struct FeatureComposerTextInput: UIViewRepresentable {
             context.coordinator.lastAppliedFocus = focused
             if focused, !textView.isFirstResponder {
                 textView.becomeFirstResponderWhenAttached()
-            } else if !focused, textView.isFirstResponder {
-                textView.resignFirstResponder()
+            } else if !focused {
+                textView.cancelPendingFirstResponder()
+                if textView.isFirstResponder {
+                    textView.resignFirstResponder()
+                }
             }
         }
     }
@@ -173,13 +176,19 @@ final class FeatureComposerUITextView: UITextView {
     private var wantsFirstResponderOnAttach = false
 
     /// Programmatic focus can arrive before the view joins a window (a host
-    /// refocusing right as the composer expands); retry once attached.
+    /// refocusing right as the composer expands); retry once attached. The
+    /// pending request is cancelled if focus clears again before the view
+    /// attaches, so a stale request can never raise the keyboard.
     func becomeFirstResponderWhenAttached() {
         if window != nil {
             becomeFirstResponder()
         } else {
             wantsFirstResponderOnAttach = true
         }
+    }
+
+    func cancelPendingFirstResponder() {
+        wantsFirstResponderOnAttach = false
     }
 
     override func didMoveToWindow() {

--- a/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
@@ -25,7 +25,6 @@ struct FeatureComposerTextInput: UIViewRepresentable {
 
     func makeUIView(context: Context) -> FeatureComposerUITextView {
         let textView = FeatureComposerUITextView()
-        context.coordinator.lastAppliedSelectionRequestID = selectionRequest?.id
         textView.delegate = context.coordinator
         textView.acceptsImages = acceptsImages
         textView.onPasteImages = onPasteImages
@@ -204,8 +203,8 @@ final class FeatureComposerUITextView: UITextView {
     // inside this view: the text interaction's own recognizers claim them at
     // the UIKit level. This observing pan reproduces the host's
     // drag-to-dismiss there: it recognizes alongside everything, cancels
-    // nothing, and only acts below the scroll cap; a scrollable draft hands
-    // dismissal to `keyboardDismissMode = .interactive` instead.
+    // nothing, and dismisses a scrollable draft only when the drag begins at
+    // its top.
     private let dismissPanDelegate = FeatureComposerDismissPanDelegate()
 
     func installDismissPanRecognizer() {
@@ -325,7 +324,9 @@ enum FeatureComposerPasteboardPolicy {
     /// (HEIC screenshots among them), so detection goes through UTType
     /// conformance instead.
     static func containsImage(in pasteboard: UIPasteboard) -> Bool {
-        pasteboard.contains(pasteboardTypes: [UTType.image.identifier])
+        pasteboard.itemProviders.contains {
+            $0.hasItemConformingToTypeIdentifier(UTType.image.identifier)
+        }
     }
 }
 

--- a/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
@@ -1,0 +1,371 @@
+import SwiftUI
+import UIKit
+import UniformTypeIdentifiers
+
+/// The composer's text entry is a UIKit text view because SwiftUI's text
+/// inputs expose no paste hook on iOS: the long-press Paste menu can never
+/// offer an image. Bridging `UITextView` buys the native paste menu, image
+/// paste, and internal scrolling once the draft outgrows its viewport cap.
+struct FeatureComposerTextInput: UIViewRepresentable {
+    @Binding var text: String
+    // A plain binding, not `FocusState`: SwiftUI ignores writes to a
+    // `FocusState` that no `.focused()` view registers with, and a
+    // representable cannot register. The UIKit responder state is the source
+    // of truth and this binding mirrors it for the hosts.
+    @Binding var focused: Bool
+    let placeholder: String
+    let acceptsImages: Bool
+    let selectionRequest: FeatureComposerTextSelectionRequest?
+    let onPasteImages: ([NSItemProvider]) -> Void
+    let onDismissKeyboard: (() -> Void)?
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeUIView(context: Context) -> FeatureComposerUITextView {
+        let textView = FeatureComposerUITextView()
+        context.coordinator.lastAppliedSelectionRequestID = selectionRequest?.id
+        textView.delegate = context.coordinator
+        textView.acceptsImages = acceptsImages
+        textView.onPasteImages = onPasteImages
+        textView.onDismissKeyboard = onDismissKeyboard
+        if onDismissKeyboard != nil {
+            textView.installDismissPanRecognizer()
+        }
+        textView.backgroundColor = .clear
+        textView.textColor = T3Colors.uiTextPrimary
+        textView.tintColor = T3Colors.uiAccent
+        textView.font = UIFont.preferredFont(forTextStyle: .body)
+        textView.adjustsFontForContentSizeCategory = true
+        // Match the metrics of the SwiftUI text field this view replaced so
+        // the swap is invisible: the surrounding paddings stay in SwiftUI.
+        textView.textContainerInset = .zero
+        textView.textContainer.lineFragmentPadding = 0
+        textView.isScrollEnabled = true
+        // Once the draft overflows its cap the drag-to-dismiss gesture loses
+        // to the scroll view, so the scroll view itself takes over keyboard
+        // dismissal the native way.
+        textView.keyboardDismissMode = .interactive
+        textView.accessibilityIdentifier = "message-composer"
+        updateAccessibility(textView)
+        return textView
+    }
+
+    func updateUIView(_ textView: FeatureComposerUITextView, context: Context) {
+        context.coordinator.parent = self
+        textView.acceptsImages = acceptsImages
+        textView.onPasteImages = onPasteImages
+        textView.onDismissKeyboard = onDismissKeyboard
+
+        let shouldApplySelection = selectionRequest.map {
+            context.coordinator.lastAppliedSelectionRequestID != $0.id
+        } ?? false
+        if textView.text != text {
+            let previousText = textView.text ?? ""
+            let selectedRange = textView.selectedRange
+            textView.text = text
+            if !shouldApplySelection {
+                let location = FeatureComposerTextSelectionPolicy.cursorLocationAfterBindingUpdate(
+                    previousText: previousText,
+                    newText: text,
+                    selectedLocation: selectedRange.location
+                )
+                let length = previousText.isEmpty
+                    ? 0
+                    : min(selectedRange.length, text.utf16.count - location)
+                textView.selectedRange = NSRange(location: location, length: length)
+                textView.scrollRangeToVisible(textView.selectedRange)
+            }
+        }
+        if shouldApplySelection, let selectionRequest {
+            let location = min(selectionRequest.location, textView.text.utf16.count)
+            textView.selectedRange = NSRange(location: location, length: 0)
+            textView.scrollRangeToVisible(textView.selectedRange)
+            context.coordinator.lastAppliedSelectionRequestID = selectionRequest.id
+        }
+        updateAccessibility(textView)
+
+        if context.coordinator.lastAppliedFocus != focused {
+            context.coordinator.lastAppliedFocus = focused
+            if focused, !textView.isFirstResponder {
+                textView.becomeFirstResponderWhenAttached()
+            } else if !focused, textView.isFirstResponder {
+                textView.resignFirstResponder()
+            }
+        }
+    }
+
+    func sizeThatFits(
+        _ proposal: ProposedViewSize,
+        uiView: FeatureComposerUITextView,
+        context: Context
+    ) -> CGSize? {
+        guard let width = proposal.width, width.isFinite else { return nil }
+        let fittingSize = uiView.sizeThatFits(
+            CGSize(width: width, height: .greatestFiniteMagnitude)
+        )
+        return CGSize(
+            width: width,
+            height: FeatureComposerTextInputSizing.height(
+                fittingHeight: fittingSize.height,
+                lineHeight: uiView.font?.lineHeight ?? 22
+            )
+        )
+    }
+
+    private func updateAccessibility(_ textView: FeatureComposerUITextView) {
+        textView.accessibilityLabel = "Message agent"
+        textView.accessibilityHint = acceptsImages
+            ? "Enter a message or paste images to attach them."
+            : "Enter a message."
+        textView.accessibilityValue = text.isEmpty ? placeholder : nil
+    }
+
+    final class Coordinator: NSObject, UITextViewDelegate {
+        var parent: FeatureComposerTextInput
+        var lastAppliedFocus: Bool?
+        var lastAppliedSelectionRequestID: UUID?
+
+        init(_ parent: FeatureComposerTextInput) {
+            self.parent = parent
+        }
+
+        func textViewDidChange(_ textView: UITextView) {
+            guard parent.text != textView.text else { return }
+            parent.text = textView.text
+        }
+
+        func textViewDidBeginEditing(_ textView: UITextView) {
+            lastAppliedFocus = true
+            if !parent.focused {
+                parent.focused = true
+            }
+        }
+
+        func textViewDidEndEditing(_ textView: UITextView) {
+            lastAppliedFocus = false
+            if parent.focused {
+                parent.focused = false
+            }
+        }
+    }
+}
+
+/// Advertises image support to the paste menu and routes image pastes out to
+/// the attachment pipeline. Text-only pastes fall through to UIKit untouched.
+final class FeatureComposerUITextView: UITextView {
+    var acceptsImages = false {
+        didSet {
+            guard oldValue != acceptsImages else { return }
+            pasteConfiguration = acceptsImages
+                ? UIPasteConfiguration(
+                    acceptableTypeIdentifiers: [
+                        UTType.image.identifier,
+                        UTType.text.identifier,
+                    ]
+                )
+                : nil
+        }
+    }
+    var onPasteImages: (([NSItemProvider]) -> Void)?
+    var onDismissKeyboard: (() -> Void)?
+    private var wantsFirstResponderOnAttach = false
+
+    /// Programmatic focus can arrive before the view joins a window (a host
+    /// refocusing right as the composer expands); retry once attached.
+    func becomeFirstResponderWhenAttached() {
+        if window != nil {
+            becomeFirstResponder()
+        } else {
+            wantsFirstResponderOnAttach = true
+        }
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        if window != nil, wantsFirstResponderOnAttach {
+            wantsFirstResponderOnAttach = false
+            becomeFirstResponder()
+        }
+    }
+
+    // A SwiftUI drag gesture on the composer never sees drags that start
+    // inside this view: the text interaction's own recognizers claim them at
+    // the UIKit level. This observing pan reproduces the host's
+    // drag-to-dismiss there — it recognizes alongside everything, cancels
+    // nothing, and only acts below the scroll cap; a scrollable draft hands
+    // dismissal to `keyboardDismissMode = .interactive` instead.
+    private let dismissPanDelegate = FeatureComposerDismissPanDelegate()
+
+    func installDismissPanRecognizer() {
+        let pan = UIPanGestureRecognizer(target: self, action: #selector(handleDismissPan))
+        pan.cancelsTouchesInView = false
+        pan.delegate = dismissPanDelegate
+        addGestureRecognizer(pan)
+    }
+
+    private var dismissPanBeganAtTop = false
+
+    @objc private func handleDismissPan(_ recognizer: UIPanGestureRecognizer) {
+        // A fast flick can jump straight from .began to .ended without a
+        // .changed in between, so the end state is evaluated too. The at-top
+        // check is latched at .began: a drag that merely reaches the top
+        // mid-scroll only rubber-bands, instead of yanking the keyboard away
+        // the moment the offset crosses zero.
+        switch recognizer.state {
+        case .began:
+            dismissPanBeganAtTop = contentOffset.y <= 0
+            return
+        case .changed, .ended: break
+        default: return
+        }
+        guard isFirstResponder else { return }
+        let translation = recognizer.translation(in: self)
+        guard FeatureComposerDragDismissPolicy.shouldDismiss(
+            translationX: translation.x,
+            translationY: translation.y,
+            isScrollable: isScrollEnabled,
+            isAtTop: dismissPanBeganAtTop
+        ) else { return }
+        onDismissKeyboard?()
+    }
+
+    // The view is sized to its content up to a cap, so scrolling only exists
+    // once the cap is hit. Below the cap the pan recognizer must be off
+    // entirely: an idle scroll view still swallows vertical drags, which
+    // starves the host's drag-to-dismiss-keyboard gesture. A stale offset
+    // from a mid-resize selection change is reset for the same reason — with
+    // nothing to scroll, any offset clips the first line under the padding.
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        let needsScroll = contentSize.height > bounds.height + 0.5
+        if isScrollEnabled != needsScroll {
+            isScrollEnabled = needsScroll
+        }
+        if !needsScroll, contentOffset.y != 0 {
+            contentOffset.y = 0
+        }
+    }
+
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        if action == #selector(paste(_:)),
+           acceptsImages,
+           FeatureComposerPasteboardPolicy.containsImage(in: UIPasteboard.general) {
+            return true
+        }
+        return super.canPerformAction(action, withSender: sender)
+    }
+
+    // When the pasteboard holds images, only the images attach. Any text
+    // riding along (a copied web image usually brings its URL) is dropped on
+    // purpose: Slack and X do the same, and inserting a stray URL next to an
+    // attached screenshot reads as a bug.
+    override func paste(_ sender: Any?) {
+        guard acceptsImages else {
+            super.paste(sender)
+            return
+        }
+        let imageProviders = UIPasteboard.general.itemProviders.filter {
+            $0.hasItemConformingToTypeIdentifier(UTType.image.identifier)
+        }
+        guard !imageProviders.isEmpty else {
+            super.paste(sender)
+            return
+        }
+        onPasteImages?(imageProviders)
+    }
+}
+
+/// A standalone delegate (rather than the text view itself, whose scroll-view
+/// superclass already takes part in gesture delegation) so the observing pan
+/// reliably recognizes alongside the text interaction's own recognizers
+/// instead of being cancelled by them.
+private final class FeatureComposerDismissPanDelegate: NSObject, UIGestureRecognizerDelegate {
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        true
+    }
+}
+
+/// Mirrors the thread view's composer drag-to-dismiss thresholds: a clearly
+/// vertical downward drag. While the draft is scrollable, scrolling back
+/// through it never drops the keyboard mid-read — but a drag that *begins*
+/// with the draft at its top only rubber-bands, which is unambiguous
+/// dismissal intent (and the composer's only escape hatch once it and the
+/// keyboard cover the transcript). `isAtTop` is the position at drag start,
+/// so a scroll that reaches the top never dismisses mid-gesture.
+enum FeatureComposerDragDismissPolicy {
+    static func shouldDismiss(
+        translationX: CGFloat,
+        translationY: CGFloat,
+        isScrollable: Bool,
+        isAtTop: Bool
+    ) -> Bool {
+        (!isScrollable || isAtTop)
+            && translationY > 8
+            && translationY > abs(translationX)
+    }
+}
+
+enum FeatureComposerPasteboardPolicy {
+    /// `UIPasteboard.hasImages` misses formats that merely conform to image
+    /// (HEIC screenshots among them), so detection goes through UTType
+    /// conformance instead.
+    static func containsImage(in pasteboard: UIPasteboard) -> Bool {
+        pasteboard.contains(pasteboardTypes: [UTType.image.identifier])
+    }
+}
+
+/// A one-shot caret placement, applied by the text input exactly once per
+/// request `id`. Command completion issues one so the caret lands after the
+/// inserted text instead of wherever UIKit leaves it after a programmatic
+/// text replacement.
+struct FeatureComposerTextSelectionRequest: Equatable {
+    let id = UUID()
+    let location: Int
+}
+
+enum FeatureComposerTextSelectionPolicy {
+    /// UTF-16 caret location after `range` (character indices, as produced by
+    /// the trigger parser) is replaced with `replacement`.
+    static func cursorLocation(
+        afterReplacing range: Range<Int>,
+        in text: String,
+        with replacement: String
+    ) -> Int {
+        let lower = min(max(range.lowerBound, 0), text.count)
+        let lowerIndex = text.index(text.startIndex, offsetBy: lower)
+        return text[..<lowerIndex].utf16.count + replacement.utf16.count
+    }
+
+    /// Caret location after the binding changed underneath the text view. A
+    /// restored draft (previous text empty) puts the caret at the end; any
+    /// other external rewrite keeps the caret where it was, clamped into the
+    /// new text.
+    static func cursorLocationAfterBindingUpdate(
+        previousText: String,
+        newText: String,
+        selectedLocation: Int
+    ) -> Int {
+        previousText.isEmpty ? newText.utf16.count : min(selectedLocation, newText.utf16.count)
+    }
+}
+
+/// Cap-then-scroll, the way Messages and Slack grow their composers: the
+/// input tracks its content until it reaches a fixed line cap, then holds
+/// that height and scrolls internally. The cap deliberately ignores the
+/// SwiftUI height proposal: proposals here derive from this view's own
+/// previous answer, so scaling by them feeds back and collapses the input.
+enum FeatureComposerTextInputSizing {
+    static let maximumLines: CGFloat = 12
+
+    static func height(
+        fittingHeight: CGFloat,
+        lineHeight: CGFloat
+    ) -> CGFloat {
+        min(fittingHeight, lineHeight * maximumLines)
+    }
+}

--- a/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
@@ -235,25 +235,25 @@ final class FeatureComposerUITextView: UITextView {
         guard FeatureComposerDragDismissPolicy.shouldDismiss(
             translationX: translation.x,
             translationY: translation.y,
-            isScrollable: isScrollEnabled,
+            isScrollable: contentOverflows,
             isAtTop: dismissPanBeganAtTop
         ) else { return }
         onDismissKeyboard?()
     }
 
-    // The view is sized to its content up to a cap, so scrolling only exists
-    // once the cap is hit. Below the cap the pan recognizer must be off
-    // entirely: an idle scroll view still swallows vertical drags, which
-    // starves the host's drag-to-dismiss-keyboard gesture. A stale offset
-    // from a mid-resize selection change is reset for the same reason; with
-    // nothing to scroll, any offset clips the first line under the padding.
+    // Scrolling stays enabled at every size: toggling `isScrollEnabled` off
+    // stops UITextView from maintaining `contentSize` on some OS versions,
+    // which left long drafts unscrollable on device. Overflow is computed
+    // fresh wherever it matters instead. A stale offset from a mid-resize
+    // selection change is still reset; with nothing to scroll, any offset
+    // clips the first line under the padding.
+    var contentOverflows: Bool {
+        contentSize.height > bounds.height + 0.5
+    }
+
     override func layoutSubviews() {
         super.layoutSubviews()
-        let needsScroll = contentSize.height > bounds.height + 0.5
-        if isScrollEnabled != needsScroll {
-            isScrollEnabled = needsScroll
-        }
-        if !needsScroll, contentOffset.y != 0 {
+        if !contentOverflows, contentOffset.y != 0 {
             contentOffset.y = 0
         }
     }

--- a/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
@@ -43,10 +43,11 @@ struct FeatureComposerTextInput: UIViewRepresentable {
         textView.textContainerInset = .zero
         textView.textContainer.lineFragmentPadding = 0
         textView.isScrollEnabled = true
-        // Once the draft overflows its cap the drag-to-dismiss gesture loses
-        // to the scroll view, so the scroll view itself takes over keyboard
-        // dismissal the native way.
-        textView.keyboardDismissMode = .interactive
+        // Deliberately not `keyboardDismissMode = .interactive`: the capped
+        // input sits directly above the keyboard, so scrolling up through a
+        // long draft drags into the keyboard's frame and yanks it around.
+        // Dismissal belongs to the pan recognizer below, which only fires
+        // for a drag that begins with the draft at its top.
         textView.accessibilityIdentifier = "message-composer"
         updateAccessibility(textView)
         return textView

--- a/apps/swift-ios/Features/Chat/FeatureComposerView.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct FeatureComposerView: View {
     @State private var isManuallyExpanded = false
@@ -7,6 +8,8 @@ struct FeatureComposerView: View {
     @State private var pathEntries: [FeatureComposerPathEntry] = []
     @State private var isPathSearchLoading = false
     @State private var pathSearchError: String?
+    @State private var textSelectionRequest: FeatureComposerTextSelectionRequest?
+    @State private var pasteErrorMessage: String?
     @Binding private var text: String
     @Binding private var selection: FeatureSelection?
     @Binding private var attachments: [FeatureDraftAttachment]
@@ -16,7 +19,7 @@ struct FeatureComposerView: View {
     private let materializesDefaultSelection: Bool
     private let isSending: Bool
     private let isWorking: Bool
-    private let focused: FocusState<Bool>.Binding
+    @Binding private var focused: Bool
     private let contextUsage: Double?
     private let forceExpanded: Bool
     private let pendingApprovals: [FeatureApproval]
@@ -25,6 +28,7 @@ struct FeatureComposerView: View {
     private let powerFeatures: FeatureComposerPowerFeatures
     private let onSend: () -> Void
     private let onStop: () -> Void
+    private let onDismissKeyboard: (() -> Void)?
     private let onApprovalDecision: ((String, FeatureApprovalDecision) -> Void)?
     private let onUserInputSubmit: ((String, [String: FeatureInputAnswer]) -> Void)?
 
@@ -37,7 +41,7 @@ struct FeatureComposerView: View {
         materializesDefaultSelection: Bool = true,
         isSending: Bool,
         isWorking: Bool,
-        focused: FocusState<Bool>.Binding,
+        focused: Binding<Bool>,
         onSend: @escaping () -> Void,
         onStop: @escaping () -> Void,
         contextUsage: Double? = nil,
@@ -46,6 +50,7 @@ struct FeatureComposerView: View {
         pendingUserInputs: [FeatureUserInput] = [],
         isResolvingRequest: Bool = false,
         powerFeatures: FeatureComposerPowerFeatures = .disabled,
+        onDismissKeyboard: (() -> Void)? = nil,
         onApprovalDecision: ((String, FeatureApprovalDecision) -> Void)? = nil,
         onUserInputSubmit: ((String, [String: FeatureInputAnswer]) -> Void)? = nil
     ) {
@@ -57,7 +62,7 @@ struct FeatureComposerView: View {
         self.materializesDefaultSelection = materializesDefaultSelection
         self.isSending = isSending
         self.isWorking = isWorking
-        self.focused = focused
+        _focused = focused
         self.onSend = onSend
         self.onStop = onStop
         self.contextUsage = contextUsage
@@ -66,6 +71,7 @@ struct FeatureComposerView: View {
         self.pendingUserInputs = pendingUserInputs
         self.isResolvingRequest = isResolvingRequest
         self.powerFeatures = powerFeatures
+        self.onDismissKeyboard = onDismissKeyboard
         self.onApprovalDecision = onApprovalDecision
         self.onUserInputSubmit = onUserInputSubmit
     }
@@ -104,9 +110,9 @@ struct FeatureComposerView: View {
                 )
                 .ignoresSafeArea()
             }
-            .onChange(of: focused.wrappedValue) {
+            .onChange(of: focused) {
                 if FeatureComposerCollapsePolicy.shouldCollapse(
-                    isFocused: focused.wrappedValue,
+                    isFocused: focused,
                     textIsEmpty: textIsEmpty,
                     attachmentsAreEmpty: attachments.isEmpty,
                     isAttachmentFlowActive: isAttachmentFlowActive,
@@ -117,6 +123,17 @@ struct FeatureComposerView: View {
             }
             .task(id: pathSearchRequest) {
                 await updatePathSearch()
+            }
+            .alert(
+                "Couldn’t paste image",
+                isPresented: Binding(
+                    get: { pasteErrorMessage != nil },
+                    set: { if !$0 { pasteErrorMessage = nil } }
+                )
+            ) {
+                Button("OK") { pasteErrorMessage = nil }
+            } message: {
+                Text(pasteErrorMessage ?? "")
             }
     }
 
@@ -161,7 +178,7 @@ struct FeatureComposerView: View {
                 isManuallyExpanded = true
                 Task { @MainActor in
                     await Task.yield()
-                    focused.wrappedValue = true
+                    focused = true
                 }
             } label: {
                 Text(isWorking ? "Message to queue…" : "Ask anything…")
@@ -188,26 +205,41 @@ struct FeatureComposerView: View {
                 FeatureAttachmentStrip(attachments: $attachments)
                     .padding(.horizontal, 12)
                     .padding(.top, 3)
+                    .padding(.bottom, 8)
 
                 Divider()
                     .overlay(T3Colors.separator)
                     .padding(.horizontal, 13)
             }
 
-            TextField(
-                isWorking ? "Message to queue…" : "Ask anything…",
-                text: $text,
-                axis: .vertical
-            )
-                .font(T3Typography.composer)
-                .modifier(FeatureComposerGrowingTextInput())
-                .focused(focused)
-                // Return is always editing input. Sending is deliberately button-only.
-                .submitLabel(.return)
+            // Return is always editing input. Sending is deliberately
+            // button-only, which is UITextView's native return behavior.
+            let placeholder = isWorking ? "Message to queue…" : "Ask anything…"
+            ZStack(alignment: .topLeading) {
+                FeatureComposerTextInput(
+                    text: $text,
+                    focused: $focused,
+                    placeholder: placeholder,
+                    acceptsImages: imagesAllowed,
+                    selectionRequest: textSelectionRequest,
+                    onPasteImages: loadPastedImages,
+                    onDismissKeyboard: onDismissKeyboard
+                )
                 .padding(.horizontal, 16)
                 .padding(.top, 14)
-                .padding(.bottom, 7)
-                .frame(minHeight: 62, alignment: .top)
+
+                if text.isEmpty {
+                    Text(placeholder)
+                        .font(T3Typography.composer)
+                        .foregroundStyle(T3Colors.textTertiary)
+                        .padding(.horizontal, 16)
+                        .padding(.top, 14)
+                        .allowsHitTesting(false)
+                        .accessibilityHidden(true)
+                }
+            }
+            .padding(.bottom, 7)
+            .frame(minHeight: 62, alignment: .top)
 
             if !attachments.isEmpty, !imagesAllowed {
                 Label("Choose a model that accepts images", systemImage: "exclamationmark.circle")
@@ -297,7 +329,7 @@ struct FeatureComposerView: View {
     private var isExpanded: Bool {
         forceExpanded
             || isManuallyExpanded
-            || focused.wrappedValue
+            || focused
             || !textIsEmpty
             || !attachments.isEmpty
             || attachmentPreparation.isPreparing
@@ -427,6 +459,13 @@ struct FeatureComposerView: View {
         case let .path(entry):
             replacement = FeatureComposerFileLinkSerializer.markdownLink(for: entry.path) + " "
         }
+        textSelectionRequest = FeatureComposerTextSelectionRequest(
+            location: FeatureComposerTextSelectionPolicy.cursorLocation(
+                afterReplacing: trigger.range,
+                in: text,
+                with: replacement
+            )
+        )
         text = FeatureComposerTriggerParser.replacing(
             trigger.range,
             in: text,
@@ -436,7 +475,7 @@ struct FeatureComposerView: View {
         pathSearchError = nil
         Task { @MainActor in
             await Task.yield()
-            focused.wrappedValue = true
+            focused = true
         }
     }
 
@@ -448,13 +487,45 @@ struct FeatureComposerView: View {
             onSend()
         }
     }
-}
 
-struct FeatureComposerGrowingTextInput: ViewModifier {
-    func body(content: Content) -> some View {
-        content
-            .lineLimit(1...)
-            .layoutPriority(1)
+    /// Attaches images arriving from the text view's paste menu through the
+    /// same preparation pipeline the attachment picker uses, so sending stays
+    /// blocked until every pasted image is processed.
+    private func loadPastedImages(_ providers: [NSItemProvider]) {
+        guard imagesAllowed, !providers.isEmpty else { return }
+
+        let remaining = FeatureImageAttachmentLimits.maximumCount
+            - attachments.count
+            - attachmentPreparation.pendingItemCount
+        guard remaining > 0 else {
+            pasteErrorMessage = "You can attach up to eight images."
+            return
+        }
+        if providers.count > remaining {
+            pasteErrorMessage =
+                "Some images were not attached because the eight-image limit was reached."
+        }
+
+        let accepted = Array(providers.prefix(remaining))
+        let firstOrdinal = attachments.count + attachmentPreparation.pendingItemCount + 1
+        let operation = attachmentPreparation.begin(itemCount: accepted.count)
+        Task { @MainActor in
+            defer { attachmentPreparation.finish(operation) }
+            for (offset, provider) in accepted.enumerated() {
+                do {
+                    let data = try await FeatureImageItemProviderLoader.data(from: provider)
+                    let attachment = try await Task.detached(priority: .userInitiated) {
+                        try FeatureImageProcessor.attachment(
+                            from: data,
+                            ordinal: firstOrdinal + offset
+                        )
+                    }.value
+                    attachments.append(attachment)
+                } catch {
+                    pasteErrorMessage = error.localizedDescription
+                }
+            }
+        }
     }
 }
 

--- a/apps/swift-ios/Features/Chat/ImageAttachmentViews.swift
+++ b/apps/swift-ios/Features/Chat/ImageAttachmentViews.swift
@@ -4,6 +4,12 @@ import SwiftUI
 import UniformTypeIdentifiers
 import UIKit
 
+enum FeatureImageAttachmentLimits {
+    /// Shared by every attachment entry point — picker, camera, files, and
+    /// paste — so their in-flight reservations count against the same cap.
+    static let maximumCount = 8
+}
+
 struct FeatureAttachmentPreparationState: Equatable {
     struct Operation: Hashable {
         fileprivate let id: UUID
@@ -60,7 +66,7 @@ struct FeatureImageAttachmentPicker: View {
         attachments: Binding<[FeatureDraftAttachment]>,
         preparationState: Binding<FeatureAttachmentPreparationState>,
         isFlowActive: Binding<Bool>,
-        maximumCount: Int = 8,
+        maximumCount: Int = FeatureImageAttachmentLimits.maximumCount,
         isEnabled: Bool = true
     ) {
         _attachments = attachments
@@ -289,7 +295,19 @@ struct FeatureImageAttachmentPicker: View {
 private struct FeaturePhotoLibraryItem: @unchecked Sendable {
     let provider: NSItemProvider
 
+    @MainActor
     func loadData() async throws -> Data {
+        try await FeatureImageItemProviderLoader.data(from: provider)
+    }
+}
+
+/// Loads raw image bytes from an `NSItemProvider`, shared by the photo
+/// library picker and the composer's paste path. Main-actor isolated because
+/// providers arrive from main-actor UI callbacks and are not `Sendable`; the
+/// provider does its own work off-thread.
+enum FeatureImageItemProviderLoader {
+    @MainActor
+    static func data(from provider: NSItemProvider) async throws -> Data {
         guard let typeIdentifier = provider.registeredTypeIdentifiers.first(where: { identifier in
             UTType(identifier)?.conforms(to: .image) == true
         }) else {

--- a/apps/swift-ios/Features/Chat/ImageAttachmentViews.swift
+++ b/apps/swift-ios/Features/Chat/ImageAttachmentViews.swift
@@ -5,8 +5,8 @@ import UniformTypeIdentifiers
 import UIKit
 
 enum FeatureImageAttachmentLimits {
-    /// Shared by every attachment entry point — picker, camera, files, and
-    /// paste — so their in-flight reservations count against the same cap.
+    /// Shared by every attachment entry point (picker, camera, files, and
+    /// paste), so their in-flight reservations count against the same cap.
     static let maximumCount = 8
 }
 

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -105,7 +105,10 @@ public struct ThreadDetailView: View {
             .presentationDragIndicator(.visible)
         }
         .alert("Message not sent", isPresented: $sendFailed) {
-            Button("OK") {}
+            // Refocusing happens here rather than when the send fails: the
+            // alert takes first responder from the composer, so a refocus
+            // issued before it presents is lost by the time it dismisses.
+            Button("OK") { composerFocused = true }
         } message: {
             Text("Your draft is still here. Check your connection and try again.")
         }
@@ -453,7 +456,6 @@ public struct ThreadDetailView: View {
                     !pendingIDs.contains($0.id)
                 }
                 sendFailed = true
-                composerFocused = true
             }
             isSending = false
             if !sent {

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -21,7 +21,10 @@ public struct ThreadDetailView: View {
     @State private var didRestoreDraft = false
     @State private var draftSaveTask: Task<Void, Never>?
     @State private var toolSurface: FeatureThreadToolSurface?
-    @FocusState private var composerFocused: Bool
+    // Plain state, not `FocusState`: the composer's UIKit text view owns
+    // focus and mirrors it through this binding, because SwiftUI drops
+    // writes to a `FocusState` no `.focused()` view registers with.
+    @State private var composerFocused = false
 
     public init(
         model: FeatureRootModel,
@@ -360,6 +363,7 @@ public struct ThreadDetailView: View {
                 pendingUserInputs: detail.userInputs,
                 isResolvingRequest: model.isPerformingAction,
                 powerFeatures: composerPowerFeatures,
+                onDismissKeyboard: dismissKeyboard,
                 onApprovalDecision: { id, decision in
                     Task { await model.resolveApproval(id, decision: decision) }
                 },
@@ -367,20 +371,7 @@ public struct ThreadDetailView: View {
                     Task { await model.resolveUserInput(id, answers: answers) }
                 }
             )
-            .simultaneousGesture(composerKeyboardDismissGesture)
         }
-    }
-
-    private var composerKeyboardDismissGesture: some Gesture {
-        DragGesture(minimumDistance: 6, coordinateSpace: .local)
-            .onChanged { value in
-                guard composerFocused,
-                      value.translation.height > 8,
-                      value.translation.height > abs(value.translation.width) else {
-                    return
-                }
-                dismissKeyboard()
-            }
     }
 
     private var composerPowerFeatures: FeatureComposerPowerFeatures {

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -32,7 +32,9 @@ public struct NewThreadView: View {
     @State private var draftSaveTask: Task<Void, Never>?
     @State private var immediateDraftSaveTasks: [String: Task<Void, Never>] = [:]
     @State private var submittedSuccessfully = false
-    @FocusState private var promptFocused: Bool
+    // Plain state, not `FocusState` — see the note on `composerFocused` in
+    // ThreadDetailView.
+    @State private var promptFocused = false
 
     public init(
         model: FeatureRootModel,

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -173,7 +173,9 @@ public struct NewThreadView: View {
             }
         }
         .alert("Couldn’t start task", isPresented: $submissionFailed) {
-            Button("OK") {}
+            // Refocus on dismissal, not on failure: the alert takes first
+            // responder, so an earlier refocus never survives it.
+            Button("OK") { promptFocused = true }
         } message: {
             Text("Check your connection and try again.")
         }
@@ -575,7 +577,6 @@ public struct NewThreadView: View {
             } else {
                 isSubmitting = false
                 submissionFailed = true
-                promptFocused = true
             }
         }
     }

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -85,7 +85,8 @@ public struct NewThreadView: View {
                         onSend: startTask,
                         onStop: {},
                         forceExpanded: true,
-                        powerFeatures: composerPowerFeatures
+                        powerFeatures: composerPowerFeatures,
+                        onDismissKeyboard: { promptFocused = false }
                     )
                 }
                 .background(T3Colors.background)

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -32,7 +32,7 @@ public struct NewThreadView: View {
     @State private var draftSaveTask: Task<Void, Never>?
     @State private var immediateDraftSaveTasks: [String: Task<Void, Never>] = [:]
     @State private var submittedSuccessfully = false
-    // Plain state, not `FocusState` — see the note on `composerFocused` in
+    // Plain state, not `FocusState`; see the note on `composerFocused` in
     // ThreadDetailView.
     @State private var promptFocused = false
 

--- a/apps/swift-ios/Tests/FeatureTests/AttachmentPreparationTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/AttachmentPreparationTests.swift
@@ -1,9 +1,28 @@
 import Foundation
 import Testing
+import UniformTypeIdentifiers
 @testable import T3Code
 
 @Suite("Attachment preparation")
 struct AttachmentPreparationTests {
+    @Test
+    func providerLoaderReadsImageDataRepresentation() async throws {
+        let expected = Data([0x01, 0x02, 0x03])
+        let provider = NSItemProvider(
+            item: expected as NSData,
+            typeIdentifier: UTType.jpeg.identifier
+        )
+
+        #expect(try await FeatureImageItemProviderLoader.data(from: provider) == expected)
+    }
+
+    @Test
+    func providerLoaderRejectsProvidersWithoutImageRepresentations() async {
+        await #expect(throws: FeatureImageAttachmentError.self) {
+            try await FeatureImageItemProviderLoader.data(from: NSItemProvider())
+        }
+    }
+
     @Test
     func overlappingPreparationOnlyFinishesAfterEveryOperation() {
         var state = FeatureAttachmentPreparationState()

--- a/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
@@ -1,50 +1,137 @@
 import SwiftUI
 import Testing
 import UIKit
+import UniformTypeIdentifiers
 @testable import T3Code
 
 @Suite("Composer power features")
 struct FeatureComposerPowerTests {
-    @MainActor
     @Test(
         "Composer input grows past the former seven-line cap",
         .bug("https://github.com/saphid/t3code-personal/issues/105")
     )
     func composerTextInputGrowsBeyondSevenLines() {
-        let sevenLineHeight = composerTextInputHeight(lineCount: 7)
-        let thirtyLineHeight = composerTextInputHeight(lineCount: 30)
-
-        #expect(thirtyLineHeight > sevenLineHeight + 300)
-    }
-
-    @MainActor
-    @Test(
-        "A very tall composer input yields to its viewport",
-        .bug("https://github.com/saphid/t3code-personal/issues/105")
-    )
-    func composerTextInputYieldsToAvailableViewport() {
-        let viewportHeight: CGFloat = 500
-
-        #expect(composerTextInputHeight(lineCount: 100, maximumHeight: viewportHeight) <= viewportHeight)
-    }
-
-    @MainActor
-    private func composerTextInputHeight(
-        lineCount: Int,
-        maximumHeight: CGFloat = .greatestFiniteMagnitude
-    ) -> CGFloat {
-        let text = Array(repeating: "A full visible prompt line", count: lineCount)
-            .joined(separator: "\n")
-        let controller = UIHostingController(
-            rootView: TextField("Ask anything…", text: .constant(text), axis: .vertical)
-                .font(T3Typography.composer)
-                .modifier(FeatureComposerGrowingTextInput())
-                .frame(width: 320)
+        let lineHeight: CGFloat = 22
+        let sevenLines = FeatureComposerTextInputSizing.height(
+            fittingHeight: lineHeight * 7,
+            lineHeight: lineHeight
+        )
+        let elevenLines = FeatureComposerTextInputSizing.height(
+            fittingHeight: lineHeight * 11,
+            lineHeight: lineHeight
         )
 
-        return controller.sizeThatFits(
-            in: CGSize(width: 320, height: maximumHeight)
-        ).height
+        #expect(sevenLines == lineHeight * 7)
+        #expect(elevenLines == lineHeight * 11)
+    }
+
+    @Test(
+        "A very tall composer input caps at its line bound and scrolls inside",
+        .bug("https://github.com/saphid/t3code-personal/issues/105")
+    )
+    func composerTextInputCapsAtItsLineBound() {
+        #expect(
+            FeatureComposerTextInputSizing.height(
+                fittingHeight: 2_200,
+                lineHeight: 22
+            ) == 22 * FeatureComposerTextInputSizing.maximumLines
+        )
+    }
+
+    @Test
+    func replacementCursorLandsAfterInsertedTextInUTF16() {
+        // "🧪 " occupies three characters but four UTF-16 units; the caret
+        // location must count the latter or it drifts on emoji-bearing drafts.
+        let original = "🧪 Use $dep please"
+        let range = 6..<10
+
+        #expect(
+            FeatureComposerTextSelectionPolicy.cursorLocation(
+                afterReplacing: range,
+                in: original,
+                with: "$dependency "
+            ) == "🧪 Use $dependency ".utf16.count
+        )
+    }
+
+    @Test
+    func restoredDraftPlacesCaretAtUTF16End() {
+        #expect(
+            FeatureComposerTextSelectionPolicy.cursorLocationAfterBindingUpdate(
+                previousText: "",
+                newText: "🧪 restored draft",
+                selectedLocation: 0
+            ) == "🧪 restored draft".utf16.count
+        )
+    }
+
+    @Test
+    func externalRewriteClampsCaretIntoTheNewText() {
+        #expect(
+            FeatureComposerTextSelectionPolicy.cursorLocationAfterBindingUpdate(
+                previousText: "a much longer draft",
+                newText: "short",
+                selectedLocation: 19
+            ) == 5
+        )
+    }
+
+    @Test
+    @MainActor
+    func imageCapableComposerAdvertisesImagesToTheNativePasteMenu() {
+        let textView = FeatureComposerUITextView()
+
+        textView.acceptsImages = true
+
+        #expect(
+            textView.pasteConfiguration?.acceptableTypeIdentifiers.contains(
+                UTType.image.identifier
+            ) == true
+        )
+        #expect(
+            textView.pasteConfiguration?.acceptableTypeIdentifiers.contains(
+                UTType.text.identifier
+            ) == true
+        )
+
+        textView.acceptsImages = false
+
+        #expect(textView.pasteConfiguration == nil)
+    }
+
+    @Test
+    func downwardDragDismissalRespectsDraftScrolling() {
+        #expect(FeatureComposerDragDismissPolicy.shouldDismiss(
+            translationX: 2, translationY: 20, isScrollable: false, isAtTop: true
+        ))
+        // Scrolling back through a capped draft must not drop the keyboard…
+        #expect(!FeatureComposerDragDismissPolicy.shouldDismiss(
+            translationX: 2, translationY: 20, isScrollable: true, isAtTop: false
+        ))
+        // …but a drag that begins at the top of the draft only rubber-bands,
+        // and is the capped composer's one escape hatch.
+        #expect(FeatureComposerDragDismissPolicy.shouldDismiss(
+            translationX: 2, translationY: 20, isScrollable: true, isAtTop: true
+        ))
+        // Mostly-horizontal drags are caret adjustments, not dismissals.
+        #expect(!FeatureComposerDragDismissPolicy.shouldDismiss(
+            translationX: 30, translationY: 12, isScrollable: false, isAtTop: true
+        ))
+        #expect(!FeatureComposerDragDismissPolicy.shouldDismiss(
+            translationX: 0, translationY: 8, isScrollable: false, isAtTop: true
+        ))
+    }
+
+    @Test
+    func nativePasteDetectionUsesImageTypeConformance() {
+        let pasteboard = UIPasteboard.withUniqueName()
+        defer { UIPasteboard.remove(withName: pasteboard.name) }
+        pasteboard.items = [
+            [UTType.heic.identifier: Data([0x00])],
+        ]
+
+        #expect(!pasteboard.hasImages)
+        #expect(FeatureComposerPasteboardPolicy.containsImage(in: pasteboard))
     }
 
     @Test

--- a/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
@@ -135,6 +135,18 @@ struct FeatureComposerPowerTests {
     }
 
     @Test
+    func nativePasteDetectionChecksEveryPasteboardItem() {
+        let pasteboard = UIPasteboard.withUniqueName()
+        defer { UIPasteboard.remove(withName: pasteboard.name) }
+        pasteboard.items = [
+            [UTType.plainText.identifier: "caption"],
+            [UTType.png.identifier: Data([0x89, 0x50, 0x4E, 0x47])],
+        ]
+
+        #expect(FeatureComposerPasteboardPolicy.containsImage(in: pasteboard))
+    }
+
+    @Test
     func detectsCommandsModelsSkillsAndPathsAtTheCursor() {
         #expect(
             FeatureComposerTriggerParser.detect(in: "/re")

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -3,3 +3,7 @@
 Messages can contain up to 120,000 characters. If a draft is longer, T3 Code keeps it in the
 composer and shows how many characters need to be removed. Shorten the draft or split it into
 multiple messages, then send again in the same thread.
+
+On SwiftUI mobile, paste an image from the message field's edit menu to attach it. You can
+attach up to eight images to one message. The composer grows to 12 lines, then scrolls within
+the message field.


### PR DESCRIPTION
## What Changed

The composer's text entry is now a UIKit `UITextView` behind a small `UIViewRepresentable` (`FeatureComposerTextInput`) instead of a SwiftUI `TextField`.

That makes image paste work. The text view advertises image support through `UIPasteConfiguration`, so an image on the pasteboard gets a real Paste item in the long-press menu. Pasted images run through the same preparation pipeline as the attachment picker, count against the same 8-image cap, and block sending until processing finishes. Text-only pastes stay on the system path. Text that rides along with a copied image (usually its URL) is dropped on purpose, which is what Slack and X do.

The input grows to a 12-line cap and scrolls internally past it instead of growing without limit, matching Messages and Slack.

Focus handling changes with it. SwiftUI drops writes to a `FocusState` that no `.focused()` view registers with, and a representable can't register one, so the hosts now hold plain `Bool` state and the UIKit responder state is the source of truth. The thread view's swipe-to-dismiss-keyboard moves into the text view as an observing pan recognizer, because drags that start inside a `UITextView` never reach a SwiftUI gesture. Dismissal only fires for a downward drag that begins with the draft scrolled to its top; scrolling back through a long draft never drops the keyboard.

Smaller pieces: command completion (`/`, `@`, `$`) places the caret right after the inserted text using UTF-16 indices, restored drafts put the caret at the end, and the attachment strip gets a little padding before its divider.

This builds on the approach @saphid validated in #5610. It adapts that design onto the current base at about a third of the size, reusing the picker's preparation-state pattern instead of the lifecycle and queue machinery.

## Why

SwiftUI text inputs have no paste hook on iOS (`onPasteCommand` is macOS-only), so the long-press menu can never offer Paste for an image and screenshots can't be attached from the clipboard. Discussed with @t3dotgg on X, who green-lit the refactor ("go nuts - send me the PR when you get it in a good state").

## UI Changes

Before: long-press with an image on the pasteboard offers no Paste.
<!-- drag before-01-no-paste-for-image.jpg here -->

After: Paste appears and the image lands in the attachment strip.
<!-- drag after-02-paste-menu.jpg and after-04-pasted-attachment.jpg here -->

A long draft caps at 12 lines and scrolls inside:
<!-- drag after-05-cap-then-scroll.jpg here -->

Paste interaction video:
<!-- drag paste-interaction.mp4 here -->

## Verification

- Full native suite (`Scripts/ci-test.sh`): 291 tests in 32 suites passed, exit 0. Adds 10 focused tests covering UTF-16 caret policies, the sizing cap, paste-menu advertisement, HEIC pasteboard detection through UTType conformance, the drag-dismiss policy, and item-provider loading.
- Verified live against a disposable backend on an iPhone 17 Pro simulator: paste from the native menu (the image reached the provider, which described the screenshot back), text paste fallback, `/model` completion and caret placement, draft persistence across an app relaunch and a round-trip with the previous build, collapse and expand in both hosts, the working-state placeholder, cap-then-scroll, and drag-to-dismiss for short drafts and for long drafts from the top.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

---
Built with Claude Fable 5 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches composer focus, keyboard dismiss, and image attachment on the main chat input. UIKit bridging can regress caret, paste, and keyboard behavior if the representable sync is wrong.
> 
> **Overview**
> Lets iOS users paste images from the composer’s native edit menu by swapping the SwiftUI `TextField` for a `UITextView` representable.
> 
> Pasted images go through the same attachment pipeline and 8-image cap as the picker. Text-only pastes stay native; accompanying URLs on image copies are dropped. The field grows to 12 lines then scrolls inside.
> 
> Focus is now a plain `Bool` binding (UIKit owns first responder). Keyboard dismiss is an observing pan on the text view that only fires for a downward drag that starts at the top of a scrollable draft. Command completion and restored drafts place the caret with UTF-16-aware policy. Failure alerts refocus after dismiss.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1aef7e8f4cca5c22632e7725272e6405ed5c459e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add native image paste from composer menu in Swift iOS app
> - Replaces the SwiftUI `TextField` in the chat composer with a `UITextView` bridge (`FeatureComposerTextInput`) so the native edit menu can advertise and handle image paste.
> - Routed pasted images through the existing attachment pipeline in `loadPastedImages`, enforcing a shared 8-image cap via `FeatureImageAttachmentLimits.maximumCount` and surfacing load or limit errors in an alert.
> - Switches focus control from `@FocusState` to a plain `Bool` binding mirrored from UIKit's first responder, and moves keyboard-dismiss drag logic into the text view itself.
> - Adds UTF-16-aware caret placement (`FeatureComposerTextSelectionPolicy`) and a one-shot `FeatureComposerTextSelectionRequest` so command completion can position the cursor after inserted text.
> - Composer input grows to at most 12 lines (`FeatureComposerTextInputSizing.maximumLines`) before scrolling internally.
> - Behavioral Change: `ThreadDetailView` and `NewThreadView` now restore focus on the send-failed alert's OK button rather than immediately before the alert; `ThreadDetailView` no longer uses a local SwiftUI drag gesture for keyboard dismissal.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1aef7e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
