### PR TITLE
fix(server): retrying a new thread's first send no longer fails with "already exists"

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -2789,4 +2789,252 @@ engineLayer("OrchestrationProjectionPipeline via engine dispatch", (it) => {
       ]);
     }),
   );
+
+  it.effect("re-creating a deleted thread id purges the old incarnation's projections", () =>
+    Effect.gen(function* () {
+      const engine = yield* OrchestrationEngineService;
+      const sql = yield* SqlClient.SqlClient;
+      const createdAt = "2026-01-01T00:00:00.000Z";
+      const modelSelection = {
+        instanceId: ProviderInstanceId.make("codex"),
+        model: "gpt-5-codex",
+      };
+
+      yield* engine.dispatch({
+        type: "project.create",
+        commandId: CommandId.make("cmd-recreate-project"),
+        projectId: ProjectId.make("project-recreate"),
+        title: "Recreate Project",
+        workspaceRoot: "/tmp/project-recreate",
+        defaultModelSelection: modelSelection,
+        createdAt,
+      });
+      yield* engine.dispatch({
+        type: "thread.create",
+        commandId: CommandId.make("cmd-recreate-thread-1"),
+        threadId: ThreadId.make("thread-recreate"),
+        projectId: ProjectId.make("project-recreate"),
+        title: "First incarnation",
+        modelSelection,
+        interactionMode: "default",
+        runtimeMode: "full-access",
+        branch: null,
+        worktreePath: null,
+        createdAt,
+      });
+      yield* engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-recreate-turn-1"),
+        threadId: ThreadId.make("thread-recreate"),
+        message: {
+          messageId: MessageId.make("msg-recreate-1"),
+          role: "user",
+          text: "old message",
+          attachments: [],
+        },
+        interactionMode: "default",
+        runtimeMode: "full-access",
+        createdAt,
+      });
+      yield* engine.dispatch({
+        type: "thread.delete",
+        commandId: CommandId.make("cmd-recreate-delete"),
+        threadId: ThreadId.make("thread-recreate"),
+      });
+
+      yield* engine.dispatch({
+        type: "thread.create",
+        commandId: CommandId.make("cmd-recreate-thread-2"),
+        threadId: ThreadId.make("thread-recreate"),
+        projectId: ProjectId.make("project-recreate"),
+        title: "Second incarnation",
+        modelSelection,
+        interactionMode: "default",
+        runtimeMode: "full-access",
+        branch: null,
+        worktreePath: null,
+        createdAt: "2026-01-01T00:00:01.000Z",
+      });
+
+      const threadRows = yield* sql<{
+        readonly title: string;
+        readonly deletedAt: string | null;
+      }>`
+        SELECT
+          title,
+          deleted_at AS "deletedAt"
+        FROM projection_threads
+        WHERE thread_id = 'thread-recreate'
+      `;
+      assert.deepEqual(threadRows, [{ title: "Second incarnation", deletedAt: null }]);
+
+      const messageRows = yield* sql<{ readonly messageId: string }>`
+        SELECT message_id AS "messageId"
+        FROM projection_thread_messages
+        WHERE thread_id = 'thread-recreate'
+      `;
+      assert.deepEqual(messageRows, []);
+
+      const turnRows = yield* sql<{ readonly threadId: string }>`
+        SELECT thread_id AS "threadId"
+        FROM projection_turns
+        WHERE thread_id = 'thread-recreate'
+      `;
+      assert.deepEqual(turnRows, []);
+    }),
+  );
 });
+
+it.layer(Layer.fresh(makeProjectionPipelinePrefixedTestLayer("t3-recreate-replay-")))(
+  "OrchestrationProjectionPipeline",
+  (it) => {
+    it.effect("per-projector replay keeps the new incarnation's rows after a re-create", () =>
+      Effect.gen(function* () {
+        const projectionPipeline = yield* OrchestrationProjectionPipeline;
+        const eventStore = yield* OrchestrationEventStore;
+        const sql = yield* SqlClient.SqlClient;
+        const now = "2026-01-01T00:00:00.000Z";
+        const modelSelection = {
+          instanceId: ProviderInstanceId.make("codex"),
+          model: "gpt-5-codex",
+        };
+        const threadCreatedPayload = {
+          threadId: ThreadId.make("thread-replay"),
+          projectId: ProjectId.make("project-replay"),
+          modelSelection,
+          runtimeMode: "full-access" as const,
+          branch: null,
+          worktreePath: null,
+          createdAt: now,
+          updatedAt: now,
+        };
+
+        yield* eventStore.append({
+          type: "project.created",
+          eventId: EventId.make("evt-replay-project"),
+          aggregateKind: "project",
+          aggregateId: ProjectId.make("project-replay"),
+          occurredAt: now,
+          commandId: CommandId.make("cmd-replay-project"),
+          causationEventId: null,
+          correlationId: CommandId.make("cmd-replay-project"),
+          metadata: {},
+          payload: {
+            projectId: ProjectId.make("project-replay"),
+            title: "Replay Project",
+            workspaceRoot: "/tmp/project-replay",
+            defaultModelSelection: null,
+            scripts: [],
+            createdAt: now,
+            updatedAt: now,
+          },
+        });
+        yield* eventStore.append({
+          type: "thread.created",
+          eventId: EventId.make("evt-replay-create-1"),
+          aggregateKind: "thread",
+          aggregateId: ThreadId.make("thread-replay"),
+          occurredAt: now,
+          commandId: CommandId.make("cmd-replay-create-1"),
+          causationEventId: null,
+          correlationId: CommandId.make("cmd-replay-create-1"),
+          metadata: {},
+          payload: { ...threadCreatedPayload, title: "First incarnation" },
+        });
+        yield* eventStore.append({
+          type: "thread.message-sent",
+          eventId: EventId.make("evt-replay-msg-old"),
+          aggregateKind: "thread",
+          aggregateId: ThreadId.make("thread-replay"),
+          occurredAt: now,
+          commandId: CommandId.make("cmd-replay-msg-old"),
+          causationEventId: null,
+          correlationId: CommandId.make("cmd-replay-msg-old"),
+          metadata: {},
+          payload: {
+            threadId: ThreadId.make("thread-replay"),
+            messageId: MessageId.make("msg-replay-old"),
+            role: "user",
+            text: "old incarnation",
+            turnId: null,
+            streaming: false,
+            createdAt: now,
+            updatedAt: now,
+          },
+        });
+        yield* eventStore.append({
+          type: "thread.deleted",
+          eventId: EventId.make("evt-replay-delete"),
+          aggregateKind: "thread",
+          aggregateId: ThreadId.make("thread-replay"),
+          occurredAt: now,
+          commandId: CommandId.make("cmd-replay-delete"),
+          causationEventId: null,
+          correlationId: CommandId.make("cmd-replay-delete"),
+          metadata: {},
+          payload: {
+            threadId: ThreadId.make("thread-replay"),
+            deletedAt: now,
+          },
+        });
+        yield* eventStore.append({
+          type: "thread.created",
+          eventId: EventId.make("evt-replay-create-2"),
+          aggregateKind: "thread",
+          aggregateId: ThreadId.make("thread-replay"),
+          occurredAt: now,
+          commandId: CommandId.make("cmd-replay-create-2"),
+          causationEventId: null,
+          correlationId: CommandId.make("cmd-replay-create-2"),
+          metadata: {},
+          payload: { ...threadCreatedPayload, title: "Second incarnation" },
+        });
+        yield* eventStore.append({
+          type: "thread.message-sent",
+          eventId: EventId.make("evt-replay-msg-new"),
+          aggregateKind: "thread",
+          aggregateId: ThreadId.make("thread-replay"),
+          occurredAt: now,
+          commandId: CommandId.make("cmd-replay-msg-new"),
+          causationEventId: null,
+          correlationId: CommandId.make("cmd-replay-msg-new"),
+          metadata: {},
+          payload: {
+            threadId: ThreadId.make("thread-replay"),
+            messageId: MessageId.make("msg-replay-new"),
+            role: "user",
+            text: "new incarnation",
+            turnId: null,
+            streaming: false,
+            createdAt: now,
+            updatedAt: now,
+          },
+        });
+
+        // Per-projector replay applies the whole log for each projector in
+        // turn, threads last. Rows the message projector rebuilt for the new
+        // incarnation must survive the threads projector's pass.
+        yield* projectionPipeline.bootstrap;
+
+        const messageRows = yield* sql<{ readonly messageId: string }>`
+          SELECT message_id AS "messageId"
+          FROM projection_thread_messages
+          WHERE thread_id = 'thread-replay'
+        `;
+        assert.deepEqual(messageRows, [{ messageId: "msg-replay-new" }]);
+
+        const threadRows = yield* sql<{
+          readonly title: string;
+          readonly deletedAt: string | null;
+        }>`
+          SELECT
+            title,
+            deleted_at AS "deletedAt"
+          FROM projection_threads
+          WHERE thread_id = 'thread-replay'
+        `;
+        assert.deepEqual(threadRows, [{ title: "Second incarnation", deletedAt: null }]);
+      }),
+    );
+  },
+);

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -601,7 +601,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
       "applyThreadsProjection",
     )(function* (event, attachmentSideEffects) {
       switch (event.type) {
-        case "thread.created":
+        case "thread.created": {
           yield* projectionThreadRepository.upsert({
             threadId: event.payload.threadId,
             projectId: event.payload.projectId,
@@ -630,6 +630,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             deletedAt: null,
           });
           return;
+        }
 
         case "thread.archived": {
           const existingRow = yield* projectionThreadRepository.getById({
@@ -1019,6 +1020,15 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           return;
         }
 
+        // A draft retry can re-create a soft-deleted thread id. Each projector
+        // purges its own rows on thread.created, so replay from any
+        // per-projector cursor rebuilds the new incarnation correctly.
+        case "thread.created":
+          yield* projectionThreadMessageRepository.deleteByThreadId({
+            threadId: event.payload.threadId,
+          });
+          return;
+
         default:
           return;
       }
@@ -1069,6 +1079,12 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           }).pipe(Effect.asVoid);
           return;
         }
+
+        case "thread.created":
+          yield* projectionThreadProposedPlanRepository.deleteByThreadId({
+            threadId: event.payload.threadId,
+          });
+          return;
 
         default:
           return;
@@ -1122,6 +1138,12 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           return;
         }
 
+        case "thread.created":
+          yield* projectionThreadActivityRepository.deleteByThreadId({
+            threadId: event.payload.threadId,
+          });
+          return;
+
         default:
           return;
       }
@@ -1130,6 +1152,12 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
     const applyThreadSessionsProjection: ProjectorDefinition["apply"] = Effect.fn(
       "applyThreadSessionsProjection",
     )(function* (event, _attachmentSideEffects) {
+      if (event.type === "thread.created") {
+        yield* projectionThreadSessionRepository.deleteByThreadId({
+          threadId: event.payload.threadId,
+        });
+        return;
+      }
       if (event.type !== "thread.session-set") {
         return;
       }
@@ -1475,6 +1503,12 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           return;
         }
 
+        case "thread.created":
+          yield* projectionTurnRepository.deleteByThreadId({
+            threadId: event.payload.threadId,
+          });
+          return;
+
         default:
           return;
       }
@@ -1598,6 +1632,21 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
               : event.payload.createdAt,
             resolvedAt: event.payload.createdAt,
           });
+          return;
+        }
+
+        case "thread.created": {
+          const existingRows = yield* projectionPendingApprovalRepository.listByThreadId({
+            threadId: event.payload.threadId,
+          });
+          yield* Effect.forEach(
+            existingRows,
+            (row) =>
+              projectionPendingApprovalRepository.deleteByRequestId({
+                requestId: row.requestId,
+              }),
+            { concurrency: 1 },
+          ).pipe(Effect.asVoid);
           return;
         }
 

--- a/apps/server/src/orchestration/Layers/ThreadDeletionReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ThreadDeletionReactor.test.ts
@@ -1,10 +1,15 @@
-import { ThreadId } from "@t3tools/contracts";
+import { ProjectId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+import * as Option from "effect/Option";
 import { describe, expect, it } from "vite-plus/test";
 
-import { logCleanupCauseUnlessInterrupted } from "./ThreadDeletionReactor.ts";
+import type { ProjectionThread } from "../../persistence/Services/ProjectionThreads.ts";
+import {
+  logCleanupCauseUnlessInterrupted,
+  shouldSkipThreadDeletionCleanup,
+} from "./ThreadDeletionReactor.ts";
 
 describe("logCleanupCauseUnlessInterrupted", () => {
   const threadId = ThreadId.make("thread-deletion-reactor-test");
@@ -34,5 +39,48 @@ describe("logCleanupCauseUnlessInterrupted", () => {
     if (Exit.isFailure(exit)) {
       expect(Cause.hasInterruptsOnly(exit.cause)).toBe(true);
     }
+  });
+});
+
+describe("shouldSkipThreadDeletionCleanup", () => {
+  const now = "2026-01-01T00:00:00.000Z";
+  const row: ProjectionThread = {
+    threadId: ThreadId.make("thread-deletion-reactor-test"),
+    projectId: ProjectId.make("project-deletion-reactor-test"),
+    title: "Thread",
+    modelSelection: {
+      instanceId: ProviderInstanceId.make("codex"),
+      model: "gpt-5-codex",
+    },
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    branch: null,
+    worktreePath: null,
+    latestTurnId: null,
+    createdAt: now,
+    updatedAt: now,
+    archivedAt: null,
+    settledOverride: null,
+    settledAt: null,
+    snoozedUntil: null,
+    snoozedAt: null,
+    pinnedAt: null,
+    latestUserMessageAt: null,
+    pendingApprovalCount: 0,
+    pendingUserInputCount: 0,
+    hasActionableProposedPlan: 0,
+    deletedAt: null,
+  };
+
+  it("skips cleanup when the thread id was re-created and is live again", () => {
+    expect(shouldSkipThreadDeletionCleanup(Option.some(row))).toBe(true);
+  });
+
+  it("cleans up when the thread row is still soft-deleted", () => {
+    expect(shouldSkipThreadDeletionCleanup(Option.some({ ...row, deletedAt: now }))).toBe(false);
+  });
+
+  it("cleans up when the thread row is gone", () => {
+    expect(shouldSkipThreadDeletionCleanup(Option.none())).toBe(false);
   });
 });

--- a/apps/server/src/orchestration/Layers/ThreadDeletionReactor.ts
+++ b/apps/server/src/orchestration/Layers/ThreadDeletionReactor.ts
@@ -72,9 +72,7 @@ const make = Effect.gen(function* () {
     event: ThreadDeletedEvent,
   ) {
     const { threadId } = event.payload;
-    const thread = yield* projectionThreadRepository
-      .getById({ threadId })
-      .pipe(Effect.orElseSucceed(() => Option.none<ProjectionThread>()));
+    const thread = yield* projectionThreadRepository.getById({ threadId });
     if (shouldSkipThreadDeletionCleanup(thread)) {
       yield* Effect.logDebug("thread deletion cleanup skipped a re-created thread", { threadId });
       return;

--- a/apps/server/src/orchestration/Layers/ThreadDeletionReactor.ts
+++ b/apps/server/src/orchestration/Layers/ThreadDeletionReactor.ts
@@ -3,8 +3,13 @@ import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
 import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Stream from "effect/Stream";
 
+import {
+  type ProjectionThread,
+  ProjectionThreadRepository,
+} from "../../persistence/Services/ProjectionThreads.ts";
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import * as TerminalManager from "../../terminal/Manager.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
@@ -37,10 +42,17 @@ export const logCleanupCauseUnlessInterrupted = <R, E>({
     }),
   );
 
+// Session stop and terminal close key on threadId alone, and a draft retry can
+// re-create a deleted thread id before its queued cleanup runs. A live row
+// means those resources now belong to the new incarnation.
+export const shouldSkipThreadDeletionCleanup = (thread: Option.Option<ProjectionThread>): boolean =>
+  Option.isSome(thread) && thread.value.deletedAt === null;
+
 const make = Effect.gen(function* () {
   const orchestrationEngine = yield* OrchestrationEngineService;
   const providerService = yield* ProviderService;
   const terminalManager = yield* TerminalManager.TerminalManager;
+  const projectionThreadRepository = yield* ProjectionThreadRepository;
 
   const stopProviderSession = (threadId: ThreadDeletedEvent["payload"]["threadId"]) =>
     logCleanupCauseUnlessInterrupted({
@@ -60,6 +72,13 @@ const make = Effect.gen(function* () {
     event: ThreadDeletedEvent,
   ) {
     const { threadId } = event.payload;
+    const thread = yield* projectionThreadRepository
+      .getById({ threadId })
+      .pipe(Effect.orElseSucceed(() => Option.none<ProjectionThread>()));
+    if (shouldSkipThreadDeletionCleanup(thread)) {
+      yield* Effect.logDebug("thread deletion cleanup skipped a re-created thread", { threadId });
+      return;
+    }
     yield* stopProviderSession(threadId);
     yield* closeThreadTerminals(threadId);
   });

--- a/apps/server/src/orchestration/commandInvariants.test.ts
+++ b/apps/server/src/orchestration/commandInvariants.test.ts
@@ -102,6 +102,31 @@ const readModel: OrchestrationReadModel = {
       checkpoints: [],
       deletedAt: null,
     },
+    {
+      id: ThreadId.make("thread-deleted"),
+      projectId: ProjectId.make("project-a"),
+      title: "Deleted thread",
+      modelSelection: {
+        instanceId: ProviderInstanceId.make("codex"),
+        model: "gpt-5-codex",
+      },
+      interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+      runtimeMode: "full-access",
+      branch: null,
+      worktreePath: null,
+      createdAt: now,
+      updatedAt: now,
+      archivedAt: null,
+      settledOverride: null,
+      settledAt: null,
+      latestTurn: null,
+      messages: [],
+      session: null,
+      activities: [],
+      proposedPlans: [],
+      checkpoints: [],
+      deletedAt: now,
+    },
   ],
 };
 
@@ -198,5 +223,30 @@ describe("commandInvariants", () => {
         }),
       ),
     ).rejects.toThrow("already exists");
+  });
+
+  it("treats a soft-deleted thread as absent so its id can be re-created", async () => {
+    await Effect.runPromise(
+      requireThreadAbsent({
+        readModel,
+        command: {
+          type: "thread.create",
+          commandId: CommandId.make("cmd-4"),
+          threadId: ThreadId.make("thread-deleted"),
+          projectId: ProjectId.make("project-a"),
+          title: "retry",
+          modelSelection: {
+            instanceId: ProviderInstanceId.make("codex"),
+            model: "gpt-5-codex",
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "full-access",
+          branch: null,
+          worktreePath: null,
+          createdAt: now,
+        },
+        threadId: ThreadId.make("thread-deleted"),
+      }),
+    );
   });
 });

--- a/apps/server/src/orchestration/commandInvariants.ts
+++ b/apps/server/src/orchestration/commandInvariants.ts
@@ -156,7 +156,11 @@ export function requireThreadAbsent(input: {
   readonly command: OrchestrationCommand;
   readonly threadId: ThreadId;
 }): Effect.Effect<void, OrchestrationCommandInvariantError> {
-  if (!findThreadById(input.readModel, input.threadId)) {
+  // Deletion is a soft delete and draft retries reuse their client-generated
+  // thread id, so a deleted thread counts as absent. Projections reset the
+  // row wholesale on thread.created.
+  const thread = findThreadById(input.readModel, input.threadId);
+  if (!thread || thread.deletedAt !== null) {
     return Effect.void;
   }
   return Effect.fail(

--- a/apps/server/src/orchestration/decider.delete.test.ts
+++ b/apps/server/src/orchestration/decider.delete.test.ts
@@ -214,4 +214,65 @@ it.layer(NodeServices.layer)("decider deletion flows", (it) => {
       expect(normalizeDeleteEvent(forcedResult)).toEqual(normalizeDeleteEvent(sequentialEvents));
     }),
   );
+
+  it.effect("allows re-creating a thread id after its thread was deleted", () =>
+    Effect.gen(function* () {
+      const now = "2026-01-01T00:00:00.000Z";
+      const readModel = yield* seedReadModel;
+
+      const deleted = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.delete",
+          commandId: asCommandId("cmd-thread-delete-1"),
+          threadId: asThreadId("thread-delete-1"),
+        },
+        readModel,
+      });
+      const deletedEvents = Array.isArray(deleted) ? deleted : [deleted];
+      let nextReadModel = readModel;
+      let nextSequence = readModel.snapshotSequence;
+      for (const event of deletedEvents) {
+        nextSequence += 1;
+        nextReadModel = yield* projectEvent(nextReadModel, {
+          ...event,
+          sequence: nextSequence,
+        });
+      }
+
+      const recreated = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.create",
+          commandId: asCommandId("cmd-thread-recreate-1"),
+          threadId: asThreadId("thread-delete-1"),
+          projectId: asProjectId("project-delete"),
+          title: "Thread Delete 1 retry",
+          modelSelection: {
+            instanceId: ProviderInstanceId.make("codex"),
+            model: "gpt-5-codex",
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          branch: null,
+          worktreePath: null,
+          createdAt: now,
+        },
+        readModel: nextReadModel,
+      });
+      const recreatedEvents = Array.isArray(recreated) ? recreated : [recreated];
+      expect(recreatedEvents.map((event) => event.type)).toEqual(["thread.created"]);
+
+      for (const event of recreatedEvents) {
+        nextSequence += 1;
+        nextReadModel = yield* projectEvent(nextReadModel, {
+          ...event,
+          sequence: nextSequence,
+        });
+      }
+      const resurrected = nextReadModel.threads.find(
+        (thread) => thread.id === asThreadId("thread-delete-1"),
+      );
+      expect(resurrected?.deletedAt).toBeNull();
+      expect(resurrected?.title).toBe("Thread Delete 1 retry");
+    }),
+  );
 });


### PR DESCRIPTION
Sending the first message on a new thread could fail during worktree prep. After that, every retry from the same draft errored with "Thread ... already exists and cannot be created twice", forever. The cleanup's `thread.delete` is a soft delete, and `requireThreadAbsent` counted the soft-deleted row as still occupying the id, which draft threads keep across retries.

The decider now treats a soft-deleted thread as absent, so the retry re-creates the id. The projection pipeline also purges the old incarnation's dependent rows on re-create, so the thread starts clean. Tests cover the invariant, a create/delete/re-create decider round-trip, and an engine-dispatch check that the purge runs.

## Proof of work

Backend-only change (`apps/server`), no UI surface, so no screenshots.

- `vp test run` on the three touched test files: 3 files, 30 tests, all pass
- `tsgo --noEmit` in `apps/server`: clean
- `vp lint` on the five touched files: clean

Written by Claude Fable 5 via Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration invariants and multi-projector thread lifecycle behavior; scoped to soft-delete/re-create paths with solid test coverage.
> 
> **Overview**
> Fixes **first-send retries** on new drafts that reuse the same client-generated thread id after a failed attempt triggers cleanup via soft `thread.delete`.
> 
> **Command invariants:** `requireThreadAbsent` now treats threads with `deletedAt` set as absent, so `thread.create` with the same id is allowed instead of failing with "already exists".
> 
> **Projections:** On `thread.created`, dependent projectors **purge** prior rows for that thread id (messages, turns, activities, proposed plans, sessions, pending approvals). The threads projector still upserts a fresh shell with `deletedAt: null`. That keeps live dispatch and **per-projector replay** (threads projector runs last) aligned with the new incarnation.
> 
> Tests cover the invariant, decider delete→recreate, engine dispatch purge, and bootstrap replay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2be91ff61da65a61d36a575b3d381e4860e0516d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix retry of new thread's first send failing with "already exists" after deletion
> - `requireThreadAbsent` in [commandInvariants.ts](https://github.com/pingdotgg/t3code/pull/7608/files#diff-426dec65d7876b98b993600840e4b58dcca662d84f3a23e884ea72cc2783e6a0) now treats a thread as absent if it is soft-deleted (`deletedAt !== null`), allowing re-creation with the same id
> - Every projector in [ProjectionPipeline.ts](https://github.com/pingdotgg/t3code/pull/7608/files#diff-fd69e677e48d4705b0235085da8402910510d529ec5a507d804037a88fca07f4) (messages, turns, sessions, activities, proposed plans, pending approvals) purges all existing rows for the thread on `thread.created`, so stale projections from a prior incarnation don't conflict
> - `ThreadDeletionReactor` in [ThreadDeletionReactor.ts](https://github.com/pingdotgg/t3code/pull/7608/files#diff-4eec759d283dd7375b01762a54815cd39fb72d86f2440dc7cb030fae567df67d) skips provider session stop and terminal close when the thread id has already been re-created and is live
> - Behavioral Change: a soft-deleted thread id can now be re-used immediately; the `thread.created` event now performs destructive deletes across all projection tables for that `threadId` before re-inserting
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a27f2b0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->