### PR TITLE
fix(server): unpushed branch no longer breaks thread creation

### DIFF
--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -7598,6 +7598,120 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
+  it.effect(
+    "falls back to the local base branch when the base branch has no remote-tracking branch",
+    () =>
+      Effect.gen(function* () {
+        const dispatchedCommands: Array<OrchestrationCommand> = [];
+        const remoteExists = vi.fn(
+          (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["remoteExists"]>[0]) =>
+            Effect.succeed(true),
+        );
+        const fetchRemote = vi.fn(
+          (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["fetchRemote"]>[0]) => Effect.void,
+        );
+        const resolveRemoteTrackingCommit = vi.fn(
+          (
+            input: Parameters<
+              GitVcsDriver.GitVcsDriver["Service"]["resolveRemoteTrackingCommit"]
+            >[0],
+          ) =>
+            Effect.fail(
+              new GitCommandError({
+                operation: "GitVcsDriver.resolveRemoteTrackingCommit",
+                command: `git rev-parse --verify refs/remotes/origin/${input.refName}^{commit}`,
+                cwd: input.cwd,
+                detail: "fatal: Needed a single revision",
+              }),
+            ),
+        );
+        const createWorktree = vi.fn(
+          (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["createWorktree"]>[0]) =>
+            Effect.succeed({
+              worktree: {
+                refName: "t3code/bootstrap-refName",
+                path: "/tmp/bootstrap-worktree",
+              },
+            }),
+        );
+
+        yield* buildAppUnderTest({
+          layers: {
+            gitVcsDriver: {
+              remoteExists,
+              fetchRemote,
+              resolveRemoteTrackingCommit,
+              createWorktree,
+            },
+            orchestrationEngine: {
+              dispatch: (command) =>
+                Effect.sync(() => {
+                  dispatchedCommands.push(command);
+                  return { sequence: dispatchedCommands.length };
+                }),
+              readEvents: () => Stream.empty,
+            },
+          },
+        });
+
+        const createdAt = "2026-01-01T00:00:00.000Z";
+        const wsUrl = yield* getWsServerUrl("/ws");
+        yield* Effect.scoped(
+          withWsRpcClient(wsUrl, (client) =>
+            client[ORCHESTRATION_WS_METHODS.dispatchCommand]({
+              type: "thread.turn.start",
+              commandId: CommandId.make("cmd-bootstrap-turn-start-untracked-base"),
+              threadId: ThreadId.make("thread-bootstrap-untracked-base"),
+              message: {
+                messageId: MessageId.make("msg-bootstrap-untracked-base"),
+                role: "user",
+                text: "hello",
+                attachments: [],
+              },
+              modelSelection: defaultModelSelection,
+              runtimeMode: "full-access",
+              interactionMode: "default",
+              bootstrap: {
+                createThread: {
+                  projectId: defaultProjectId,
+                  title: "Bootstrap Thread",
+                  modelSelection: defaultModelSelection,
+                  runtimeMode: "full-access",
+                  interactionMode: "default",
+                  branch: "feature/local-only",
+                  worktreePath: null,
+                  createdAt,
+                },
+                prepareWorktree: {
+                  projectCwd: "/tmp/project",
+                  baseBranch: "feature/local-only",
+                  branch: "t3code/bootstrap-refName",
+                  startFromOrigin: true,
+                },
+              },
+              createdAt,
+            }),
+          ),
+        );
+
+        assert.equal(fetchRemote.mock.calls.length, 1);
+        assert.equal(resolveRemoteTrackingCommit.mock.calls.length, 1);
+        assert.deepEqual(createWorktree.mock.calls[0]?.[0], {
+          cwd: "/tmp/project",
+          refName: "feature/local-only",
+          newRefName: "t3code/bootstrap-refName",
+          baseRefName: "feature/local-only",
+          path: null,
+        });
+        // The rollback soft-deletes the thread, which permanently burns its id:
+        // retrying the same bootstrap can never recreate it.
+        assert.deepEqual(
+          dispatchedCommands.map((command) => command.type),
+          ["thread.create", "thread.meta.update", "thread.turn.start"],
+        );
+      }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
   it.effect("records setup-script failures without aborting bootstrap turn start", () =>
     Effect.gen(function* () {
       const dispatchedCommands: Array<OrchestrationCommand> = [];

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -928,12 +928,21 @@ const makeWsRpcLayer = (
                   cwd: bootstrap.prepareWorktree.projectCwd,
                   remoteName: "origin",
                 });
-                const resolvedRemoteBase = yield* gitWorkflow.resolveRemoteTrackingCommit({
-                  cwd: bootstrap.prepareWorktree.projectCwd,
-                  refName: bootstrap.prepareWorktree.baseBranch,
-                  fallbackRemoteName: "origin",
-                });
-                worktreeBaseRef = resolvedRemoteBase.commitSha;
+                // A base branch that was never pushed has no
+                // `refs/remotes/origin/<branch>`, so resolving it exits non-zero.
+                // Fall back to the local base branch instead of failing the whole
+                // bootstrap: that rollback soft-deletes the just-created thread and
+                // permanently burns its id, so the client's retry can never succeed.
+                const resolvedRemoteBase = yield* gitWorkflow
+                  .resolveRemoteTrackingCommit({
+                    cwd: bootstrap.prepareWorktree.projectCwd,
+                    refName: bootstrap.prepareWorktree.baseBranch,
+                    fallbackRemoteName: "origin",
+                  })
+                  .pipe(Effect.option);
+                if (Option.isSome(resolvedRemoteBase)) {
+                  worktreeBaseRef = resolvedRemoteBase.value.commitSha;
+                }
               }
               const worktree = yield* gitWorkflow.createWorktree({
                 cwd: bootstrap.prepareWorktree.projectCwd,


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

`dispatchBootstrapTurnStart` now treats the remote-tracking lookup as optional.
When `resolveRemoteTrackingCommit` fails, the worktree is cut from the local base
branch instead of taking down the whole bootstrap. Repos with no `origin` remote
already behave this way; this extends the same fallback to a base branch that has
no remote-tracking ref.

Tests: new bootstrap case in `server.test.ts` for a base branch with no
remote-tracking ref, asserting the worktree is cut from the local branch and that
no `thread.delete` is dispatched — the rollback is what burns the thread id. Full
`apps/server` suite (2611 passing) plus every other package, typecheck, lint, and
format pass. The two failures in the repo (`ProviderRegistry` codex re-probe and
`Net.findAvailablePort`) reproduce on `main` and are untouched by this change.

## Why

Creating a thread on a local-only branch with "start from origin" enabled fails,
and every retry then fails differently:

    Orchestration command invariant failed (thread.create):
    Thread '<id>' already exists and cannot be created twice.

That invariant error is a red herring. Bootstrap runs `git fetch origin` and then
resolves `refs/remotes/origin/<baseBranch>`. A branch that was never pushed has no
remote-tracking ref, so `git rev-parse --verify` exits non-zero and the whole
bootstrap fails. The rollback dispatches `thread.delete`, which soft-deletes the
thread but leaves its event stream in place, so `requireThreadAbsent` rejects the
retry. Each retry carries a fresh commandId, so receipt idempotency never dedupes
it either. The thread id is burned for good, and the git failure that started it
never reaches the user.

Falling back is the right call rather than surfacing the git error: "start from
origin" is a stored default rather than something chosen per thread, so honoring
it only when a remote base exists matches what the no-remote path already does.

Not addressed: any other bootstrap failure still rolls back into the same
unusable state. Making a soft-deleted thread id reusable is a decision about the
event-sourcing invariant, not this fix.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes — N/A, server-only
- [ ] I included a video for animation/interaction changes — N/A, server-only

Changes by Claude Opus 5 running in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bootstrap git/worktree resolution for thread creation; wrong fallback could point worktrees at unexpected refs, though scope is limited to the optional remote-tracking path.
> 
> **Overview**
> Fixes thread bootstrap failing (and burning the thread id on retry) when **start from origin** is enabled but the chosen base branch has no `origin` tracking ref.
> 
> In `dispatchBootstrapTurnStart`, after `fetchRemote`, **`resolveRemoteTrackingCommit`** is now wrapped in **`Effect.option`**. On success, the worktree still bases off the remote commit SHA; on failure, **`worktreeBaseRef`** stays on the local **`baseBranch`** (same behavior as repos without `origin`).
> 
> Adds a **`server.test`** case that stubs a failed remote-tracking resolve and asserts **`createWorktree`** is called with the local branch as **`refName`** while bootstrap commands complete without rollback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 490657a0b7a929ddf61a06a84cb1c3908e8afeb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix thread creation when base branch has no remote-tracking ref
> When `startFromOrigin=true` and the base branch has no remote-tracking ref, `resolveRemoteTrackingCommit` now uses `Effect.option` so a failure returns `None` instead of aborting. If no remote-tracking commit is found, `worktreeBaseRef` is left unchanged and `createWorktree` falls back to the local base branch.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 490657a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->