### PR TITLE
feat(swift-ios): add reliable text and code sizing

### DIFF
--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -2165,6 +2165,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     func saveSettings(_ settings: FeatureSettings) async throws {
         let data = try JSONEncoder().encode(settings)
         settingsStore.set(data, forKey: Self.settingsKey)
+        latestSnapshot?.settings = settings
     }
 
     func setProviderEnabled(environmentID: String, instanceID: String, enabled: Bool) async throws {

--- a/apps/swift-ios/DesignSystem/T3TextScale.swift
+++ b/apps/swift-ios/DesignSystem/T3TextScale.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+import UIKit
+
+enum T3TextSizing {
+    private static let categories: [UIContentSizeCategory] = [
+        .extraSmall,
+        .small,
+        .medium,
+        .large,
+        .extraLarge,
+        .extraExtraLarge,
+        .extraExtraExtraLarge,
+        .accessibilityMedium,
+        .accessibilityLarge,
+        .accessibilityExtraLarge,
+        .accessibilityExtraExtraLarge,
+        .accessibilityExtraExtraExtraLarge,
+    ]
+
+    static func contentSizeCategory(
+        system: UIContentSizeCategory,
+        steps: Int
+    ) -> UIContentSizeCategory {
+        guard steps != 0, let index = categories.firstIndex(of: system) else { return system }
+        return categories[min(categories.count - 1, max(0, index + steps))]
+    }
+}
+
+extension DynamicTypeSize {
+    func t3Shifted(by steps: Int) -> DynamicTypeSize {
+        guard steps != 0 else { return self }
+        let sizes = DynamicTypeSize.allCases
+        guard let index = sizes.firstIndex(of: self) else { return self }
+        return sizes[min(sizes.count - 1, max(0, index + steps))]
+    }
+}
+
+private struct T3CodeSizeStepsKey: EnvironmentKey {
+    static let defaultValue = 0
+}
+
+extension EnvironmentValues {
+    var t3CodeSizeSteps: Int {
+        get { self[T3CodeSizeStepsKey.self] }
+        set { self[T3CodeSizeStepsKey.self] = newValue }
+    }
+}
+
+extension View {
+    func t3AppTextSize(steps: Int) -> some View {
+        modifier(T3AppTextSize(steps: steps))
+    }
+
+    func t3CodeSizing(steps: Int) -> some View {
+        environment(\.t3CodeSizeSteps, steps)
+    }
+
+    func t3CodeTextSize(_ isEnabled: Bool = true) -> some View {
+        modifier(T3CodeTextSize(isEnabled: isEnabled))
+    }
+}
+
+/// Uses the window trait so the preference reaches sheets and UIKit-hosted cells.
+/// Removing the override at zero preserves the reader's system Dynamic Type setting.
+private struct T3AppTextSize: ViewModifier {
+    let steps: Int
+    @State private var systemCategory = UIApplication.shared.preferredContentSizeCategory
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear { apply() }
+            .onChange(of: steps) { _, _ in apply() }
+            .task {
+                for await change in NotificationCenter.default.notifications(
+                    named: UIContentSizeCategory.didChangeNotification
+                ) {
+                    systemCategory = change.userInfo?[
+                        UIContentSizeCategory.newValueUserInfoKey
+                    ] as? UIContentSizeCategory
+                        ?? UIApplication.shared.preferredContentSizeCategory
+                    apply()
+                }
+            }
+    }
+
+    @MainActor
+    private func apply() {
+        let category = T3TextSizing.contentSizeCategory(system: systemCategory, steps: steps)
+        let windows = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+        for window in windows {
+            if steps == 0 {
+                window.traitOverrides.remove(UITraitPreferredContentSizeCategory.self)
+            } else {
+                window.traitOverrides.preferredContentSizeCategory = category
+            }
+        }
+    }
+}
+
+private struct T3CodeTextSize: ViewModifier {
+    @SwiftUI.Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @SwiftUI.Environment(\.t3CodeSizeSteps) private var codeSteps
+    let isEnabled: Bool
+
+    func body(content: Content) -> some View {
+        content.dynamicTypeSize(dynamicTypeSize.t3Shifted(by: isEnabled ? codeSteps : 0))
+    }
+}

--- a/apps/swift-ios/Features/Chat/FeatureComposerRequestViews.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerRequestViews.swift
@@ -49,6 +49,7 @@ struct FeatureComposerApprovalPanel: View {
                         .lineSpacing(3)
                         .fixedSize(horizontal: false, vertical: true)
                         .textSelection(.enabled)
+                        .t3CodeTextSize(approval.kind == .command)
                 }
                 .padding(10)
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/apps/swift-ios/Features/Chat/MarkdownMessageView.swift
+++ b/apps/swift-ios/Features/Chat/MarkdownMessageView.swift
@@ -718,28 +718,31 @@ private struct MarkdownCodeBlockView: View {
                 .fill(T3Colors.separator)
                 .frame(height: 1)
 
-            if wrapsLines {
-                MarkdownInlineText(
-                    renderedCode,
-                    selectionContext: selectionContext,
-                    lineSpacing: 3,
-                    wrapsLines: true
-                )
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(13)
-            } else {
-                ScrollView(.horizontal) {
+            Group {
+                if wrapsLines {
                     MarkdownInlineText(
                         renderedCode,
                         selectionContext: selectionContext,
                         lineSpacing: 3,
-                        wrapsLines: false
+                        wrapsLines: true
                     )
-                        .fixedSize(horizontal: true, vertical: true)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(13)
+                } else {
+                    ScrollView(.horizontal) {
+                        MarkdownInlineText(
+                            renderedCode,
+                            selectionContext: selectionContext,
+                            lineSpacing: 3,
+                            wrapsLines: false
+                        )
+                            .fixedSize(horizontal: true, vertical: true)
+                            .padding(13)
+                    }
+                    .scrollIndicators(.hidden)
                 }
-                .scrollIndicators(.hidden)
             }
+            .t3CodeTextSize()
         }
         .background(T3Colors.surfaceRaised)
         .clipShape(RoundedRectangle(cornerRadius: 10))

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -4,6 +4,7 @@ import UIKit
 
 public struct ThreadDetailView: View {
     @SwiftUI.Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @SwiftUI.Environment(\.t3CodeSizeSteps) private var codeSizeSteps
     @SwiftUI.Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @SwiftUI.Environment(\.openURL) private var parentOpenURL
     @SwiftUI.Environment(\.scenePhase) private var scenePhase
@@ -155,6 +156,7 @@ public struct ThreadDetailView: View {
             }
             .presentationDetents([.large])
             .presentationDragIndicator(.visible)
+            .t3CodeSizing(steps: codeSizeSteps)
         }
         .alert("Message not sent", isPresented: $sendFailed) {
             // Refocusing happens here rather than when the send fails: the
@@ -674,6 +676,7 @@ public struct ThreadDetailView: View {
                     },
                     renderUpdate: timelineRenderUpdate,
                     dynamicTypeSize: dynamicTypeSize,
+                    codeSizeSteps: codeSizeSteps,
                     isWorking: isWorking,
                     isCompacting: isCompacting,
                     activeSubagentCount: detail.activeSubagentCount,
@@ -1326,6 +1329,7 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
     let attachmentContext: FeatureAttachmentContext?
     let renderUpdate: FeatureDetailRenderUpdate?
     let dynamicTypeSize: DynamicTypeSize
+    let codeSizeSteps: Int
     let isWorking: Bool
     let isCompacting: Bool
     let activeSubagentCount: Int
@@ -1364,6 +1368,7 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
             attachmentContext: attachmentContext,
             renderUpdate: renderUpdate,
             dynamicTypeSize: dynamicTypeSize,
+            codeSizeSteps: codeSizeSteps,
             isWorking: isWorking,
             isCompacting: isCompacting,
             activeSubagentCount: activeSubagentCount,
@@ -1417,6 +1422,7 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
         private var currentAttachmentContext: FeatureAttachmentContext?
         private var currentDetailRevision: UInt64?
         private var currentDynamicTypeSize: DynamicTypeSize?
+        private var currentCodeSizeSteps = 0
         private var currentIsWorking = false
         private var currentIsCompacting = false
         private var currentActiveSubagentCount = 0
@@ -1472,6 +1478,7 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
                         attachmentContext: self?.currentAttachmentContext
                     )
                         .frame(maxWidth: .infinity, alignment: .leading)
+                        .environment(\.t3CodeSizeSteps, self?.currentCodeSizeSteps ?? 0)
                 }
                 .margins(.all, 0)
                 cell.backgroundConfiguration = UIBackgroundConfiguration.clear()
@@ -1498,6 +1505,7 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
             attachmentContext: FeatureAttachmentContext?,
             renderUpdate: FeatureDetailRenderUpdate?,
             dynamicTypeSize: DynamicTypeSize,
+            codeSizeSteps: Int,
             isWorking: Bool,
             isCompacting: Bool,
             activeSubagentCount: Int,
@@ -1517,6 +1525,7 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
             let imageContextChanged = currentImageContext != imageContext
                 || currentAttachmentContext != attachmentContext
             let typeSizeChanged = currentDynamicTypeSize != dynamicTypeSize
+                || currentCodeSizeSteps != codeSizeSteps
             let revisionChanged = currentDetailRevision != renderUpdate?.revision
             let workingChanged = currentIsWorking != isWorking
             let workingDetailChanged = currentIsCompacting != isCompacting
@@ -1542,6 +1551,7 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
             currentAttachmentContext = attachmentContext
             currentDetailRevision = renderUpdate?.revision
             currentDynamicTypeSize = dynamicTypeSize
+            currentCodeSizeSteps = codeSizeSteps
             currentIsWorking = isWorking
             currentIsCompacting = isCompacting
             currentActiveSubagentCount = activeSubagentCount
@@ -2601,6 +2611,7 @@ private struct FeatureWorkLogView: View {
                     .lineSpacing(3)
                     .textSelection(.enabled)
                     .padding(.top, 8)
+                    .t3CodeTextSize()
                     .transition(.identity)
                 if FeatureWorkLogMedia.shouldRenderImages(
                     isExpanded: isExpanded,

--- a/apps/swift-ios/Features/Files/FeatureFilesView.swift
+++ b/apps/swift-ios/Features/Files/FeatureFilesView.swift
@@ -356,6 +356,7 @@ private struct FeatureSourceTextView: View {
                             FeatureHighlightedSourceLine(line: line)
                         }
                         .font(T3Typography.code)
+                        .t3CodeTextSize()
                         .fixedSize(horizontal: true, vertical: false)
                         .frame(
                             minWidth: proxy.size.width,

--- a/apps/swift-ios/Features/PullRequests/PullRequestsView.swift
+++ b/apps/swift-ios/Features/PullRequests/PullRequestsView.swift
@@ -1204,6 +1204,7 @@ private struct PullRequestFilesView: View {
                                                 .frame(minWidth: 500, alignment: .leading)
                                         }
                                         .font(T3Typography.code)
+                                        .t3CodeTextSize()
                                         .foregroundStyle(line.foreground)
                                         .padding(.vertical, 2)
                                         .background(line.background)

--- a/apps/swift-ios/Features/Review/FeatureReviewView.swift
+++ b/apps/swift-ios/Features/Review/FeatureReviewView.swift
@@ -446,6 +446,7 @@ private struct FeatureDiffLineRow: View {
             }
         }
         .font(T3Typography.code)
+        .t3CodeTextSize()
         .fixedSize(horizontal: true, vertical: false)
         .frame(
             minWidth: minimumWidth,

--- a/apps/swift-ios/Features/Root/FeatureRootModel.swift
+++ b/apps/swift-ios/Features/Root/FeatureRootModel.swift
@@ -91,6 +91,9 @@ public final class FeatureRootModel {
     private var outboxDrainTask: Task<Void, Never>?
     private var outboxRetryAttempt = 0
     private var outboxGeneration: UInt64 = 0
+    private var lastPersistedSettings = FeatureSettings()
+    private var settingsWriteTask: Task<Void, Error>?
+    private var settingsWriteGeneration: UInt64 = 0
 
     public init(
         client: any FeatureClient,
@@ -855,10 +858,14 @@ public final class FeatureRootModel {
 
     @discardableResult
     public func saveSettings(_ settings: FeatureSettings) async -> Bool {
-        await perform {
-            try await client.saveSettings(settings)
-            snapshot.settings = settings
+        snapshot.settings = settings
+        let saved = await perform {
+            try await enqueueSettingsWrite(settings)
         }
+        if !saved, snapshot.settings == settings {
+            snapshot.settings = lastPersistedSettings
+        }
+        return saved
     }
 
     @discardableResult
@@ -885,25 +892,63 @@ public final class FeatureRootModel {
     /// settings snapshot. Other unsaved Settings edits remain drafts.
     @discardableResult
     public func saveAppearance(_ appearance: FeatureAppearance) async -> Bool {
-        let previous = snapshot.settings
-        guard previous.appearance != appearance else { return true }
+        await savePresentationPreference { $0.appearance = appearance }
+    }
 
+    @discardableResult
+    public func saveTextSizes(
+        textSize: FeatureTextSizeAdjustment,
+        codeSize: FeatureTextSizeAdjustment
+    ) async -> Bool {
+        await savePresentationPreference {
+            $0.textSize = textSize
+            $0.codeSize = codeSize
+        }
+    }
+
+    private func savePresentationPreference(
+        _ change: (inout FeatureSettings) -> Void
+    ) async -> Bool {
+        let previous = snapshot.settings
         var updated = previous
-        updated.appearance = appearance
+        change(&updated)
+        guard updated != previous else { return true }
         snapshot.settings = updated
 
         do {
-            try await client.saveSettings(updated)
+            try await enqueueSettingsWrite(updated)
             return true
         } catch {
             if snapshot.settings == updated {
-                snapshot.settings = previous
+                snapshot.settings = lastPersistedSettings
             }
             if !Self.isBenignCancellation(error) {
                 errorMessage = error.localizedDescription
             }
             return false
         }
+    }
+
+    /// Serializes full-snapshot writes. Only a successful write advances the
+    /// rollback point, so a failed optimistic predecessor is never restored.
+    private func enqueueSettingsWrite(_ settings: FeatureSettings) async throws {
+        let predecessor = settingsWriteTask
+        let write = Task { @MainActor [client] in
+            if let predecessor {
+                _ = await predecessor.result
+            }
+            try await client.saveSettings(settings)
+            lastPersistedSettings = settings
+        }
+        settingsWriteGeneration &+= 1
+        let generation = settingsWriteGeneration
+        settingsWriteTask = write
+        defer {
+            if settingsWriteGeneration == generation {
+                settingsWriteTask = nil
+            }
+        }
+        try await write.value
     }
 
     @discardableResult
@@ -1083,6 +1128,7 @@ public final class FeatureRootModel {
             threadCollectionRevision &+= 1
         }
         snapshot = value
+        lastPersistedSettings = value.settings
         if value.connection.state == .connected
             || value.environments.contains(where: { $0.connectionState == .connected }) {
             scheduleOutboxDrain()

--- a/apps/swift-ios/Features/Root/FeatureRootView.swift
+++ b/apps/swift-ios/Features/Root/FeatureRootView.swift
@@ -42,6 +42,8 @@ public struct FeatureRootView: View {
             }
         }
         .preferredColorScheme(preferredColorScheme)
+        .t3AppTextSize(steps: model.snapshot.settings.textSize.steps)
+        .t3CodeSizing(steps: model.snapshot.settings.codeSize.steps)
         .tint(T3Colors.accent)
         .background(T3Colors.background.ignoresSafeArea())
         .task { await model.start() }

--- a/apps/swift-ios/Features/Settings/SettingsView.swift
+++ b/apps/swift-ios/Features/Settings/SettingsView.swift
@@ -6,12 +6,22 @@ public struct SettingsView: View {
     @State private var settings: FeatureSettings
     @State private var isSaving = false
     @State private var appearanceSaveTask: Task<Bool, Never>?
+    @State private var textSizeSaveTask: Task<Bool, Never>?
     @State private var saveErrorMessage: String?
     @State private var showingDiscardConfirmation = false
 
     public init(model: FeatureRootModel) {
         self.model = model
         _settings = State(initialValue: model.snapshot.settings)
+    }
+
+    static func shouldRollbackTextSizes(
+        currentTextSize: FeatureTextSizeAdjustment,
+        currentCodeSize: FeatureTextSizeAdjustment,
+        failedTextSize: FeatureTextSizeAdjustment,
+        failedCodeSize: FeatureTextSizeAdjustment
+    ) -> Bool {
+        currentTextSize == failedTextSize && currentCodeSize == failedCodeSize
     }
 
     public var body: some View {
@@ -21,6 +31,7 @@ public struct SettingsView: View {
                     connectionSection
                     generalSection
                     preferencesSection
+                    textSizeSection
                     aboutSection
                 }
                 .padding(.top, 24)
@@ -82,10 +93,13 @@ public struct SettingsView: View {
             .onChange(of: settings.appearance) { _, appearance in
                 saveAppearance(appearance)
             }
+            .onChange(of: settings.textSize) { _, _ in saveTextSizes() }
+            .onChange(of: settings.codeSize) { _, _ in saveTextSizes() }
         }
         .interactiveDismissDisabled(isSaving || hasUnsavedChanges)
         .presentationBackground(T3Colors.background)
         .presentationDragIndicator(.visible)
+        .t3CodeSizing(steps: model.snapshot.settings.codeSize.steps)
     }
 
     private var connectionSection: some View {
@@ -182,6 +196,29 @@ public struct SettingsView: View {
                     title: "Live Activities",
                     systemImage: "waveform.path.ecg.rectangle",
                     isOn: $settings.liveActivitiesEnabled
+                )
+            }
+        }
+    }
+
+    private var textSizeSection: some View {
+        SettingsSection(
+            title: "Text & Code",
+            footer: "Sizes stay relative to your iOS Dynamic Type setting. Code size applies to code blocks, diffs, file contents, and tool output."
+        ) {
+            VStack(spacing: 0) {
+                SettingsTextSizePreview()
+                settingsDivider
+                SettingsTextSizeRow(
+                    title: "Text size",
+                    systemImage: "textformat.size",
+                    adjustment: $settings.textSize
+                )
+                settingsDivider
+                SettingsTextSizeRow(
+                    title: "Code size",
+                    systemImage: "chevron.left.forwardslash.chevron.right",
+                    adjustment: $settings.codeSize
                 )
             }
         }
@@ -303,12 +340,39 @@ public struct SettingsView: View {
     }
 
     @MainActor
+    private func saveTextSizes() {
+        let textSize = settings.textSize
+        let codeSize = settings.codeSize
+        let previousSave = textSizeSaveTask
+        textSizeSaveTask = Task {
+            _ = await previousSave?.value
+
+            let didSave = await model.saveTextSizes(textSize: textSize, codeSize: codeSize)
+            if !didSave,
+               Self.shouldRollbackTextSizes(
+                   currentTextSize: settings.textSize,
+                   currentCodeSize: settings.codeSize,
+                   failedTextSize: textSize,
+                   failedCodeSize: codeSize
+               ) {
+                settings.textSize = model.snapshot.settings.textSize
+                settings.codeSize = model.snapshot.settings.codeSize
+                saveErrorMessage = model.errorMessage
+                    ?? "Text size preference could not be saved."
+            }
+            return didSave
+        }
+    }
+
+    @MainActor
     private func save() {
         let pendingAppearanceSave = appearanceSaveTask
+        let pendingTextSizeSave = textSizeSaveTask
         isSaving = true
         Task {
             let appearanceDidSave = await pendingAppearanceSave?.value ?? true
-            if !appearanceDidSave, !hasUnsavedChanges {
+            let textSizeDidSave = await pendingTextSizeSave?.value ?? true
+            if (!appearanceDidSave || !textSizeDidSave), !hasUnsavedChanges {
                 isSaving = false
                 return
             }
@@ -322,6 +386,93 @@ public struct SettingsView: View {
                 saveErrorMessage = model.errorMessage ?? "Settings could not be saved."
             }
         }
+    }
+}
+
+private struct SettingsTextSizePreview: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            Text("Rewrote the failing test and re-ran the suite.")
+                .font(T3Typography.threadBody)
+                .foregroundStyle(T3Colors.textPrimary)
+                .fixedSize(horizontal: false, vertical: true)
+            Text(verbatim: "- expect(total).toBe(41)\n+ expect(total).toBe(42)")
+                .font(T3Typography.code)
+                .foregroundStyle(T3Colors.textSecondary)
+                .t3CodeTextSize()
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    T3Colors.surfaceRaised,
+                    in: RoundedRectangle(cornerRadius: 8, style: .continuous)
+                )
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Preview of the selected text and code sizes")
+    }
+}
+
+private struct SettingsTextSizeRow: View {
+    let title: String
+    let systemImage: String
+    @Binding var adjustment: FeatureTextSizeAdjustment
+
+    private var steps: Binding<Double> {
+        Binding(
+            get: { Double(adjustment.steps) },
+            set: { adjustment = FeatureTextSizeAdjustment(steps: Int($0.rounded())) }
+        )
+    }
+
+    private var valueLabel: String {
+        switch adjustment.steps {
+        case ...(-2): "Much smaller"
+        case -1: "Smaller"
+        case 0: "Default"
+        case 1: "Larger"
+        case 2: "Much larger"
+        default: "Largest"
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 12) {
+                SettingsRowIcon(systemName: systemImage)
+                Text(title)
+                    .font(T3Typography.threadBody)
+                    .foregroundStyle(T3Colors.textPrimary)
+                Spacer(minLength: 12)
+                Text(valueLabel)
+                    .font(T3Typography.supporting)
+                    .foregroundStyle(T3Colors.textSecondary)
+            }
+            .accessibilityHidden(true)
+            HStack(spacing: 12) {
+                Image(systemName: "textformat.size.smaller")
+                    .font(T3Typography.supporting)
+                Slider(
+                    value: steps,
+                    in: Double(FeatureTextSizeAdjustment.range.lowerBound)
+                        ... Double(FeatureTextSizeAdjustment.range.upperBound),
+                    step: 1
+                ) {
+                    Text(title)
+                }
+                .tint(T3Colors.accent)
+                .accessibilityValue(valueLabel)
+                Image(systemName: "textformat.size.larger")
+                    .font(T3Typography.navigationTitle)
+            }
+            .foregroundStyle(T3Colors.textTertiary)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 10)
+        .frame(minHeight: 52)
     }
 }
 

--- a/apps/swift-ios/Features/Shared/FeatureModels.swift
+++ b/apps/swift-ios/Features/Shared/FeatureModels.swift
@@ -979,8 +979,30 @@ public enum FeatureAppearance: String, CaseIterable, Sendable, Codable {
     case dark
 }
 
+public struct FeatureTextSizeAdjustment: Sendable, Equatable, Hashable, Codable {
+    public static let range = -2...3
+    public static let standard = FeatureTextSizeAdjustment(steps: 0)
+
+    public let steps: Int
+
+    public init(steps: Int) {
+        self.steps = min(Self.range.upperBound, max(Self.range.lowerBound, steps))
+    }
+
+    public init(from decoder: any Decoder) throws {
+        try self.init(steps: decoder.singleValueContainer().decode(Int.self))
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(steps)
+    }
+}
+
 public struct FeatureSettings: Sendable, Equatable, Codable {
     public var appearance: FeatureAppearance
+    public var textSize: FeatureTextSizeAdjustment
+    public var codeSize: FeatureTextSizeAdjustment
     public var hapticsEnabled: Bool
     public var notificationsEnabled: Bool
     public var liveActivitiesEnabled: Bool
@@ -988,12 +1010,16 @@ public struct FeatureSettings: Sendable, Equatable, Codable {
 
     public init(
         appearance: FeatureAppearance = .system,
+        textSize: FeatureTextSizeAdjustment = .standard,
+        codeSize: FeatureTextSizeAdjustment = .standard,
         hapticsEnabled: Bool = true,
         notificationsEnabled: Bool = true,
         liveActivitiesEnabled: Bool = true,
         defaultSelection: FeatureSelection? = nil
     ) {
         self.appearance = appearance
+        self.textSize = textSize
+        self.codeSize = codeSize
         self.hapticsEnabled = hapticsEnabled
         self.notificationsEnabled = notificationsEnabled
         self.liveActivitiesEnabled = liveActivitiesEnabled
@@ -1002,6 +1028,8 @@ public struct FeatureSettings: Sendable, Equatable, Codable {
 
     private enum CodingKeys: String, CodingKey {
         case appearance
+        case textSize
+        case codeSize
         case hapticsEnabled
         case notificationsEnabled
         case liveActivitiesEnabled
@@ -1014,6 +1042,14 @@ public struct FeatureSettings: Sendable, Equatable, Codable {
             FeatureAppearance.self,
             forKey: .appearance
         ) ?? .system
+        textSize = try container.decodeIfPresent(
+            FeatureTextSizeAdjustment.self,
+            forKey: .textSize
+        ) ?? .standard
+        codeSize = try container.decodeIfPresent(
+            FeatureTextSizeAdjustment.self,
+            forKey: .codeSize
+        ) ?? .standard
         hapticsEnabled = try container.decodeIfPresent(
             Bool.self,
             forKey: .hapticsEnabled
@@ -1035,6 +1071,8 @@ public struct FeatureSettings: Sendable, Equatable, Codable {
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(appearance, forKey: .appearance)
+        try container.encode(textSize, forKey: .textSize)
+        try container.encode(codeSize, forKey: .codeSize)
         try container.encode(hapticsEnabled, forKey: .hapticsEnabled)
         try container.encode(notificationsEnabled, forKey: .notificationsEnabled)
         try container.encode(liveActivitiesEnabled, forKey: .liveActivitiesEnabled)

--- a/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
@@ -97,6 +97,183 @@ struct FeatureRootModelTests {
     }
 
     @Test
+    func textSizesApplyImmediatelyAndPersist() async {
+        let client = FeatureClientStub()
+        let model = testRootModel(client: client)
+
+        let save = Task {
+            await model.saveTextSizes(
+                textSize: FeatureTextSizeAdjustment(steps: 2),
+                codeSize: FeatureTextSizeAdjustment(steps: -1)
+            )
+        }
+        await Task.yield()
+
+        #expect(model.snapshot.settings.textSize.steps == 2)
+        #expect(model.snapshot.settings.codeSize.steps == -1)
+        #expect(await save.value)
+        #expect(client.savedSettings.last?.textSize.steps == 2)
+        #expect(client.savedSettings.last?.codeSize.steps == -1)
+    }
+
+    @Test
+    func unchangedTextSizesDoNotWrite() async {
+        let client = FeatureClientStub()
+        let model = testRootModel(client: client)
+
+        #expect(await model.saveTextSizes(textSize: .standard, codeSize: .standard))
+        #expect(client.savedSettings.isEmpty)
+    }
+
+    @Test
+    func orderedSettingsWritesPreserveNewerValues() async {
+        let gate = FeatureSettingsSaveGate()
+        let client = FeatureClientStub()
+        client.beforeSaveSettings = { await gate.enter() }
+        let model = testRootModel(client: client)
+        var first = model.snapshot.settings
+        first.hapticsEnabled = false
+
+        let firstSave = Task { await model.saveSettings(first) }
+        await gate.waitUntilCallCount(1)
+        let secondSave = Task {
+            await model.saveTextSizes(
+                textSize: FeatureTextSizeAdjustment(steps: 2),
+                codeSize: FeatureTextSizeAdjustment(steps: -1)
+            )
+        }
+        await Task.yield()
+        #expect(model.snapshot.settings.textSize.steps == 2)
+        gate.releaseFirst()
+        await gate.waitUntilCallCount(2)
+
+        #expect(await firstSave.value)
+        #expect(await secondSave.value)
+        #expect(client.savedSettings.count == 2)
+        #expect(client.savedSettings[1].hapticsEnabled == false)
+        #expect(client.savedSettings[1].textSize.steps == 2)
+    }
+
+    @Test
+    func twoFailedWritesRollbackToTheLastDurableSnapshot() async {
+        let gate = FeatureSettingsSaveGate()
+        let client = FeatureClientStub()
+        client.beforeSaveSettings = {
+            await gate.enter()
+            throw URLError(.cannotConnectToHost)
+        }
+        let model = testRootModel(client: client)
+        let persisted = model.snapshot.settings
+        var first = persisted
+        first.hapticsEnabled = false
+
+        let firstSave = Task { await model.saveSettings(first) }
+        await gate.waitUntilCallCount(1)
+        let secondSave = Task {
+            await model.saveTextSizes(
+                textSize: FeatureTextSizeAdjustment(steps: 2),
+                codeSize: FeatureTextSizeAdjustment(steps: -1)
+            )
+        }
+        await Task.yield()
+        #expect(model.snapshot.settings.textSize.steps == 2)
+        gate.releaseFirst()
+        await gate.waitUntilCallCount(2)
+
+        #expect(await firstSave.value == false)
+        #expect(await secondSave.value == false)
+        #expect(model.snapshot.settings == persisted)
+        #expect(client.savedSettings.isEmpty)
+
+        client.beforeSaveSettings = nil
+        #expect(
+            await model.saveTextSizes(
+                textSize: FeatureTextSizeAdjustment(steps: 1),
+                codeSize: FeatureTextSizeAdjustment(steps: -1)
+            )
+        )
+        #expect(model.snapshot.settings.textSize.steps == 1)
+        #expect(client.savedSettings.count == 1)
+    }
+
+    @Test
+    func successfulSuccessorSupersedesFailedPredecessor() async {
+        let gate = FeatureSettingsSaveGate()
+        let client = FeatureClientStub()
+        client.beforeSaveSettings = {
+            await gate.enter()
+            if gate.callCount == 1 { throw URLError(.cannotConnectToHost) }
+        }
+        let model = testRootModel(client: client)
+        var first = model.snapshot.settings
+        first.hapticsEnabled = false
+        let successor = FeatureSettings(
+            textSize: FeatureTextSizeAdjustment(steps: 2),
+            codeSize: FeatureTextSizeAdjustment(steps: -1),
+            hapticsEnabled: false
+        )
+
+        let firstSave = Task { await model.saveSettings(first) }
+        await gate.waitUntilCallCount(1)
+        let secondSave = Task { await model.saveSettings(successor) }
+        await Task.yield()
+        #expect(model.snapshot.settings == successor)
+        gate.releaseFirst()
+        await gate.waitUntilCallCount(2)
+
+        #expect(await firstSave.value == false)
+        #expect(await secondSave.value)
+        #expect(model.snapshot.settings == successor)
+        #expect(client.savedSettings == [successor])
+    }
+
+    @Test
+    func failedSuccessorRollsBackToSuccessfulPredecessor() async {
+        let gate = FeatureSettingsSaveGate()
+        let client = FeatureClientStub()
+        client.beforeSaveSettings = {
+            await gate.enter()
+            if gate.callCount == 2 { throw URLError(.cannotConnectToHost) }
+        }
+        let model = testRootModel(client: client)
+        var predecessor = model.snapshot.settings
+        predecessor.hapticsEnabled = false
+        var successor = predecessor
+        successor.textSize = FeatureTextSizeAdjustment(steps: 2)
+
+        let firstSave = Task { await model.saveSettings(predecessor) }
+        await gate.waitUntilCallCount(1)
+        let secondSave = Task { await model.saveSettings(successor) }
+        await Task.yield()
+        #expect(model.snapshot.settings == successor)
+        gate.releaseFirst()
+        await gate.waitUntilCallCount(2)
+
+        #expect(await firstSave.value)
+        #expect(await secondSave.value == false)
+        #expect(model.snapshot.settings == predecessor)
+        #expect(client.savedSettings == [predecessor])
+    }
+
+    @Test
+    func localSettingsRestoreOnFailedSaveAndApplyOnSuccess() async {
+        let client = FeatureClientStub()
+        let model = testRootModel(client: client)
+        var updated = model.snapshot.settings
+        updated.hapticsEnabled = false
+        client.beforeSaveSettings = {
+            throw URLError(.cannotConnectToHost)
+        }
+
+        #expect(await model.saveSettings(updated) == false)
+        #expect(model.snapshot.settings.hapticsEnabled)
+
+        client.beforeSaveSettings = nil
+        #expect(await model.saveSettings(updated))
+        #expect(!model.snapshot.settings.hapticsEnabled)
+    }
+
+    @Test
     func backgroundRefreshUsesTheBoundedClientPath() async {
         let client = FeatureClientStub()
         client.backgroundSnapshotValue = FeatureSnapshot(
@@ -3122,6 +3299,7 @@ private final class FeatureClientStub: FeatureClient, T3ConnectCapable {
     var removedEnvironmentID: String?
     var beforeStartTask: (() async throws -> Void)?
     var beforeSendMessage: (() throws -> Void)?
+    var beforeSaveSettings: (@MainActor () async throws -> Void)?
     var loadThreadError: (any Error)?
     var loadThreadHandler: ((String) async throws -> FeatureThreadDetail)?
     var preuploadHandler: ((FeatureUploadAttachment, String) async throws -> FeatureUploadedAttachmentReference?)?
@@ -3323,6 +3501,7 @@ private final class FeatureClientStub: FeatureClient, T3ConnectCapable {
         resolvedInputAnswers = answers
     }
     func saveSettings(_ settings: FeatureSettings) async throws {
+        try await beforeSaveSettings?()
         savedSettings.append(settings)
     }
     func refreshProviders(environmentID: String) async throws -> [FeatureProvider] {
@@ -3337,5 +3516,33 @@ private final class FeatureClientStub: FeatureClient, T3ConnectCapable {
         automaticSettlementChange = change
         if let automaticSettlementError { throw automaticSettlementError }
         return automaticSettlementResult
+    }
+}
+
+@MainActor
+private final class FeatureSettingsSaveGate {
+    private var calls = 0
+    private var firstRelease: CheckedContinuation<Void, Never>?
+    private var callWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+
+    var callCount: Int { calls }
+
+    func enter() async {
+        calls += 1
+        let ready = callWaiters.filter { calls >= $0.0 }
+        callWaiters.removeAll { calls >= $0.0 }
+        ready.forEach { $0.1.resume() }
+        guard calls == 1 else { return }
+        await withCheckedContinuation { firstRelease = $0 }
+    }
+
+    func waitUntilCallCount(_ count: Int) async {
+        guard calls < count else { return }
+        await withCheckedContinuation { callWaiters.append((count, $0)) }
+    }
+
+    func releaseFirst() {
+        firstRelease?.resume()
+        firstRelease = nil
     }
 }

--- a/apps/swift-ios/Tests/FeatureTests/NativeRetryIdentityTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeRetryIdentityTests.swift
@@ -4,6 +4,60 @@ import XCTest
 
 @MainActor
 final class NativeRetryIdentityTests: XCTestCase {
+    func testSavedSettingsSurviveAConnectionRepublish() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-native-settings-republish-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let environment = Environment(
+            id: "environment-settings-republish",
+            label: "Settings republish",
+            httpBaseURL: URL(string: "https://settings-republish.example")!,
+            webSocketBaseURL: URL(string: "wss://settings-republish.example")!
+        )
+        let store = EnvironmentStore(
+            fileURL: directory.appendingPathComponent("environments.json")
+        )
+        try await store.save([environment])
+        try await store.setActiveEnvironment(id: environment.id)
+        let transport = ConcurrentBootstrapHTTPTransport(shell: retryShellSnapshot())
+        let connection = ConcurrentBootstrapWebSocketConnection()
+        let runtime = EnvironmentRuntime(
+            environmentStore: store,
+            credentialStore: InMemoryCredentialStore(
+                credentials: [environment.id: EnvironmentCredential(accessToken: "token")]
+            ),
+            httpTransport: transport,
+            webSocketConnector: ConcurrentBootstrapWebSocketConnector(connection: connection)
+        )
+        let settingsSuite = "t3-native-settings-republish-\(UUID().uuidString)"
+        let settingsStore = UserDefaults(suiteName: settingsSuite)!
+        defer { settingsStore.removePersistentDomain(forName: settingsSuite) }
+        let client = NativeFeatureClient(runtime: runtime, settingsStore: settingsStore)
+        let initial = try await client.initialSnapshot()
+        await connection.waitUntilConnected()
+        var updated = initial.settings
+        updated.textSize = FeatureTextSizeAdjustment(steps: 2)
+        updated.codeSize = FeatureTextSizeAdjustment(steps: -1)
+        try await client.saveSettings(updated)
+        var events = client.events().makeAsyncIterator()
+
+        await connection.failReceive()
+
+        var receivedRepublish = false
+        while let event = await events.next() {
+            guard case let .snapshot(snapshot) = event,
+                  snapshot.connection.state == .reconnecting else {
+                continue
+            }
+            XCTAssertEqual(snapshot.settings.textSize.steps, 2)
+            XCTAssertEqual(snapshot.settings.codeSize.steps, -1)
+            receivedRepublish = true
+            break
+        }
+        XCTAssertTrue(receivedRepublish)
+        await client.disconnect()
+    }
+
     func testConcurrentBootstrapRetriesKeepIndependentStableIdentities() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("t3-native-concurrent-retry-\(UUID().uuidString)")
@@ -294,6 +348,7 @@ private actor ConcurrentBootstrapWebSocketConnection: WebSocketConnection {
     private var connectionWaiters: [CheckedContinuation<Void, Never>] = []
     private var queuedResponses: [Data] = []
     private var receiver: CheckedContinuation<Data, Error>?
+    private var shouldFailNextReceive = false
 
     func send(_ data: Data) async throws {
         let request = try JSONDecoder.t3.decode(JSONValue.self, from: data)
@@ -329,6 +384,10 @@ private actor ConcurrentBootstrapWebSocketConnection: WebSocketConnection {
     }
 
     func receive() async throws -> Data {
+        if shouldFailNextReceive {
+            shouldFailNextReceive = false
+            throw URLError(.networkConnectionLost)
+        }
         if !queuedResponses.isEmpty {
             return queuedResponses.removeFirst()
         }
@@ -340,6 +399,16 @@ private actor ConcurrentBootstrapWebSocketConnection: WebSocketConnection {
     func close() {
         receiver?.resume(throwing: CancellationError())
         receiver = nil
+    }
+
+    func failReceive() {
+        let error = URLError(.networkConnectionLost)
+        if let receiver {
+            self.receiver = nil
+            receiver.resume(throwing: error)
+        } else {
+            shouldFailNextReceive = true
+        }
     }
 
     func waitUntilConnected() async {

--- a/apps/swift-ios/Tests/FeatureTests/TextSizePreferenceTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/TextSizePreferenceTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import SwiftUI
+import Testing
+import UIKit
+@testable import T3Code
+
+@Suite("Text and code size preferences")
+struct TextSizePreferenceTests {
+    @Test
+    func shiftsComposeWithDynamicTypeAndSaturateAtTheEnds() {
+        #expect(DynamicTypeSize.large.t3Shifted(by: 1) == .xLarge)
+        #expect(DynamicTypeSize.small.t3Shifted(by: 1) == .medium)
+        #expect(DynamicTypeSize.large.t3Shifted(by: -2) == .small)
+        #expect(DynamicTypeSize.xSmall.t3Shifted(by: -2) == .xSmall)
+        #expect(DynamicTypeSize.accessibility5.t3Shifted(by: 3) == .accessibility5)
+    }
+
+    @Test
+    func windowCategoryShiftUsesTheSameSaturatingScale() {
+        #expect(T3TextSizing.contentSizeCategory(system: .large, steps: 3) == .extraExtraExtraLarge)
+        #expect(T3TextSizing.contentSizeCategory(system: .large, steps: -2) == .small)
+        #expect(T3TextSizing.contentSizeCategory(system: .extraSmall, steps: -2) == .extraSmall)
+        #expect(
+            T3TextSizing.contentSizeCategory(
+                system: .accessibilityExtraExtraExtraLarge,
+                steps: 3
+            ) == .accessibilityExtraExtraExtraLarge
+        )
+        #expect(T3TextSizing.contentSizeCategory(system: .unspecified, steps: 2) == .unspecified)
+    }
+
+    @Test
+    func adjustmentClampsAndRoundTripsAsAStepCount() throws {
+        #expect(FeatureTextSizeAdjustment(steps: 99).steps == 3)
+        #expect(FeatureTextSizeAdjustment(steps: -99).steps == -2)
+        let encoded = try JSONEncoder.t3.encode(FeatureTextSizeAdjustment(steps: 2))
+        #expect(String(decoding: encoded, as: UTF8.self) == "2")
+        let decoded = try JSONDecoder.t3.decode(
+            FeatureTextSizeAdjustment.self,
+            from: Data("9".utf8)
+        )
+        #expect(decoded.steps == 3)
+    }
+
+    @Test
+    func legacySettingsDecodeAtSystemSizes() throws {
+        let legacy = Data(
+            #"{"appearance":"dark","hapticsEnabled":false,"notificationsEnabled":true}"#.utf8
+        )
+        let decoded = try JSONDecoder.t3.decode(FeatureSettings.self, from: legacy)
+
+        #expect(decoded.appearance == .dark)
+        #expect(decoded.textSize == .standard)
+        #expect(decoded.codeSize == .standard)
+        #expect(!decoded.hapticsEnabled)
+    }
+
+    @Test
+    func settingsRoundTripBothSizeChoices() throws {
+        var settings = FeatureSettings()
+        settings.textSize = FeatureTextSizeAdjustment(steps: 2)
+        settings.codeSize = FeatureTextSizeAdjustment(steps: -1)
+
+        let decoded = try JSONDecoder.t3.decode(
+            FeatureSettings.self,
+            from: JSONEncoder.t3.encode(settings)
+        )
+
+        #expect(decoded.textSize.steps == 2)
+        #expect(decoded.codeSize.steps == -1)
+    }
+
+    @Test
+    func staleFailedSaveCannotRollbackANewerSliderChoice() {
+        #expect(
+            !SettingsView.shouldRollbackTextSizes(
+                currentTextSize: .init(steps: 3),
+                currentCodeSize: .init(steps: 1),
+                failedTextSize: .init(steps: 2),
+                failedCodeSize: .init(steps: 1)
+            )
+        )
+        #expect(
+            SettingsView.shouldRollbackTextSizes(
+                currentTextSize: .init(steps: 2),
+                currentCodeSize: .init(steps: 1),
+                failedTextSize: .init(steps: 2),
+                failedCodeSize: .init(steps: 1)
+            )
+        )
+    }
+}


### PR DESCRIPTION
The native app had no independent text and code size controls. This adds both controls with live previews in Settings, relative to iOS Dynamic Type.

Size changes apply immediately. Ordered settings writes and rollback to the last successful save prevent older failures or reconnects from restoring stale choices. The update preserves the current environment-owned automatic settlement settings.

Validation: 94 focused native tests passed at `dd3fc8b3f42a44f767d7d85c37599c94800c421d`, rebased onto SwiftUI base `614a7b672a86ee638f284298fe26e8b0194e0eaa`. Coverage includes sizing, settings write order and rollback, legacy settings, and reconnect persistence. Live slider Save and relaunch checks on this updated branch remain incomplete.

<details>
<summary>Historical images and videos</summary>

These captures belong to original head `019c8b219d6fac4845f76ac06348bdc57446b7f3`. They were not recaptured or revalidated for the modernized branch.

Light mode before:

![Light mode before](https://github.com/saphid/t3code/releases/download/pr-7612-evidence-019c8b219-20260827/before-light.jpg)

Light mode after:

![Light mode after](https://github.com/saphid/t3code/releases/download/pr-7612-evidence-019c8b219-20260827/after-light.jpg)

Dark mode before:

![Dark mode before](https://github.com/saphid/t3code/releases/download/pr-7612-evidence-019c8b219-20260827/before-dark.jpg)

Dark mode after:

![Dark mode after](https://github.com/saphid/t3code/releases/download/pr-7612-evidence-019c8b219-20260827/after-dark.jpg)

[Before video](https://github.com/saphid/t3code/releases/download/pr-7612-evidence-019c8b219-20260827/before.mp4) · [Interaction video](https://github.com/saphid/t3code/releases/download/pr-7612-evidence-019c8b219-20260827/interaction.mp4)

</details>

Tracking: [native work item](https://github.com/saphid/t3code-personal/issues/129).

Modernized and fixed with GPT-6 in Codex.
