### PR TITLE
feat(swift-ios): show what's new for the running build in Settings

### DIFF
--- a/apps/swift-ios/Features/Settings/SettingsView.swift
+++ b/apps/swift-ios/Features/Settings/SettingsView.swift
@@ -6,9 +6,11 @@ public struct SettingsView: View {
     @State private var settings: FeatureSettings
     @State private var isSaving = false
     @State private var saveErrorMessage: String?
+    private let whatsNewChangelog: WhatsNewChangelog?
 
     public init(model: FeatureRootModel) {
         self.model = model
+        whatsNewChangelog = WhatsNewChangelog.load(info: Bundle.main.infoDictionary)
         _settings = State(initialValue: model.snapshot.settings)
     }
 
@@ -233,10 +235,6 @@ public struct SettingsView: View {
         let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
             ?? "?"
         return "\(version) (\(build))"
-    }
-
-    private var whatsNewChangelog: WhatsNewChangelog? {
-        WhatsNewChangelog.load(info: Bundle.main.infoDictionary)
     }
 
     /// Like `appVersionLabel`, but `nil` rather than `?` when a build did not

--- a/apps/swift-ios/Features/Settings/SettingsView.swift
+++ b/apps/swift-ios/Features/Settings/SettingsView.swift
@@ -186,6 +186,22 @@ public struct SettingsView: View {
                     settingsDivider
                     SettingsValueRow(title: "Commit", value: appCommit)
                 }
+                if let changelog = whatsNewChangelog {
+                    settingsDivider
+                    NavigationLink {
+                        WhatsNewView(
+                            presentation: changelog.presentation(info: Bundle.main.infoDictionary),
+                            runningBuildLabel: whatsNewBuildLabel,
+                            appName: appDisplayName
+                        )
+                    } label: {
+                        SettingsNavigationRow(
+                            title: "What's New",
+                            systemImage: "sparkles"
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
                 settingsDivider
                 Link(destination: URL(string: "https://github.com/pingdotgg/t3code")!) {
                     SettingsNavigationRow(
@@ -217,6 +233,17 @@ public struct SettingsView: View {
         let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
             ?? "?"
         return "\(version) (\(build))"
+    }
+
+    private var whatsNewChangelog: WhatsNewChangelog? {
+        WhatsNewChangelog.load(info: Bundle.main.infoDictionary)
+    }
+
+    /// Like `appVersionLabel`, but `nil` rather than `?` when a build did not
+    /// record its identity — the What's New header omits the line instead of
+    /// showing placeholders.
+    private var whatsNewBuildLabel: String? {
+        WhatsNewChangelog.buildLabel(info: Bundle.main.infoDictionary)
     }
 
     private var appCommit: String? {

--- a/apps/swift-ios/Features/Settings/WhatsNewChangelog.swift
+++ b/apps/swift-ios/Features/Settings/WhatsNewChangelog.swift
@@ -1,0 +1,231 @@
+import Foundation
+import UIKit
+
+/// The changelog a build carries: what shipped in the running build, and what
+/// shipped in the builds before it.
+///
+/// The payload rides in the app bundle as base64-encoded JSON under the
+/// `T3BuildChangelog` Info.plist key, expanded from the `T3_BUILD_CHANGELOG`
+/// build setting at build time — the same injection-only shape used to record
+/// build identity. Each publisher appends its own build to the history it
+/// inherited, so the newest build leads and every earlier build rides along:
+///
+/// ```json
+/// {"builds":[
+///   {"version":"0.1.0","build":"90","entries":[{"title":"…","summary":"…"}]},
+///   {"version":"0.1.0","build":"89","entries":[{"title":"…"}]}
+/// ]}
+/// ```
+///
+/// A build that injects nothing simply has no changelog, and the Settings entry
+/// point hides rather than showing a placeholder.
+struct WhatsNewChangelog: Equatable, Sendable {
+    /// A screenshot a build shipped in its bundle, referenced by file name.
+    ///
+    /// A build may ship one file per appearance. `darkName` is optional, so an
+    /// entry that only ever recorded one screenshot keeps showing it in both
+    /// appearances rather than showing nothing in one of them.
+    struct Image: Codable, Equatable, Sendable {
+        let name: String
+        let darkName: String?
+        let caption: String?
+
+        func name(inDarkMode isDark: Bool) -> String {
+            guard isDark, let darkName else { return name }
+            return darkName
+        }
+    }
+
+    struct Entry: Codable, Equatable, Sendable {
+        let title: String
+        let summary: String?
+        /// Long-form copy shown when the entry is opened. An entry without it
+        /// stays inert — no chevron, nothing to tap.
+        let detail: String?
+        /// SF Symbol recorded by the publisher; ignored when the running OS
+        /// does not have it, so a typo degrades to the default rather than to
+        /// an empty tile.
+        let symbol: String?
+        /// Screenshots shipped in the app bundle for this entry, shown on the
+        /// detail page. Absent for entries that ship none.
+        let images: [Image]?
+
+        var hasDetail: Bool { detail != nil || !(images ?? []).isEmpty }
+
+        var symbolName: String {
+            guard let symbol, UIImage(systemName: symbol) != nil else { return "sparkles" }
+            return symbol
+        }
+    }
+
+    struct Build: Codable, Equatable, Sendable {
+        let version: String?
+        let build: String?
+        let entries: [Entry]
+
+        /// `0.1.0 (89)` when both are recorded, and the best of the two when
+        /// only one is.
+        var label: String? {
+            switch (version, build) {
+            case let (version?, build?): "\(version) (\(build))"
+            case let (nil, build?): "Build \(build)"
+            case let (version?, nil): version
+            case (nil, nil): nil
+            }
+        }
+
+        var buildNumber: Int? { build.flatMap(Int.init) }
+    }
+
+    /// Newest build first.
+    let builds: [Build]
+
+    static let infoDictionaryKey = "T3BuildChangelog"
+
+    static func load(info: [String: Any]?) -> WhatsNewChangelog? {
+        guard let encoded = info?[infoDictionaryKey] as? String else { return nil }
+        return decode(encoded, info: info)
+    }
+
+    /// Decodes an embedded payload, returning `nil` for anything a build can
+    /// plausibly leave behind: an absent value, an unexpanded `$(…)` setting,
+    /// something that is not base64 JSON, or a changelog with nothing to say.
+    ///
+    /// A payload carrying bare `entries` instead of `builds` is the single-build
+    /// shape this feature shipped with first; it is read as the running build's
+    /// own entries.
+    static func decode(_ encoded: String, info: [String: Any]? = nil) -> WhatsNewChangelog? {
+        let trimmed = encoded.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              !trimmed.hasPrefix("$("),
+              let data = Data(base64Encoded: trimmed),
+              let payload = try? JSONDecoder().decode(Payload.self, from: data)
+        else { return nil }
+
+        let decoded: [Build]
+        if let builds = payload.builds {
+            decoded = builds
+        } else if let entries = payload.entries {
+            decoded = [
+                Build(
+                    version: metadataValue("CFBundleShortVersionString", info: info),
+                    build: metadataValue("CFBundleVersion", info: info),
+                    entries: entries
+                )
+            ]
+        } else {
+            return nil
+        }
+
+        let builds = decoded.compactMap(\.normalized)
+        guard !builds.isEmpty else { return nil }
+        return WhatsNewChangelog(builds: ordered(builds))
+    }
+
+    /// Splits the history into the running build and everything before it. When
+    /// the payload does not name the running build, nothing is claimed as
+    /// current and the whole history reads as earlier builds.
+    func presentation(info: [String: Any]?) -> WhatsNewPresentation {
+        guard let runningBuild = Self.metadataValue("CFBundleVersion", info: info),
+              let index = builds.firstIndex(where: { $0.build == runningBuild })
+        else { return WhatsNewPresentation(current: nil, earlier: builds) }
+
+        var earlier = builds
+        let current = earlier.remove(at: index)
+        return WhatsNewPresentation(current: current, earlier: earlier)
+    }
+
+    /// `0.1.0 (29)` for the running bundle, or `nil` when either value is
+    /// missing or unexpanded.
+    static func buildLabel(info: [String: Any]?) -> String? {
+        guard let version = metadataValue("CFBundleShortVersionString", info: info),
+              let build = metadataValue("CFBundleVersion", info: info)
+        else { return nil }
+        return "\(version) (\(build))"
+    }
+
+    /// Newest build number first. Builds without a numeric build number keep
+    /// their payload order and sit after the numbered ones, so a malformed
+    /// entry never reshuffles the real history.
+    private static func ordered(_ builds: [Build]) -> [Build] {
+        builds.enumerated()
+            .sorted { lhs, rhs in
+                switch (lhs.element.buildNumber, rhs.element.buildNumber) {
+                case let (left?, right?) where left != right: left > right
+                case (nil, .some): false
+                case (.some, nil): true
+                default: lhs.offset < rhs.offset
+                }
+            }
+            .map(\.element)
+    }
+
+    private static func metadataValue(_ key: String, info: [String: Any]?) -> String? {
+        guard let value = info?[key] as? String else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !trimmed.hasPrefix("$(") else { return nil }
+        return trimmed
+    }
+
+    private struct Payload: Decodable {
+        let builds: [Build]?
+        let entries: [Entry]?
+    }
+}
+
+struct WhatsNewPresentation: Equatable, Sendable {
+    let current: WhatsNewChangelog.Build?
+    let earlier: [WhatsNewChangelog.Build]
+}
+
+extension WhatsNewChangelog.Build {
+    /// Drops builds that say nothing once their entries are cleaned up, and
+    /// treats a blank version or build as unrecorded.
+    var normalized: WhatsNewChangelog.Build? {
+        let entries = entries.compactMap(\.normalized)
+        guard !entries.isEmpty else { return nil }
+        return WhatsNewChangelog.Build(
+            version: version?.trimmedOrNil,
+            build: build?.trimmedOrNil,
+            entries: entries
+        )
+    }
+}
+
+extension WhatsNewChangelog.Entry {
+    /// Drops entries with no title and treats a blank summary as absent, so a
+    /// sloppy payload degrades to fewer rows instead of empty ones.
+    var normalized: WhatsNewChangelog.Entry? {
+        guard let title = title.trimmedOrNil else { return nil }
+        let images = (images ?? []).compactMap(\.normalized).prefix(Self.maximumImages)
+        return WhatsNewChangelog.Entry(
+            title: title,
+            summary: summary?.trimmedOrNil,
+            detail: detail?.trimmedOrNil,
+            symbol: symbol?.trimmedOrNil,
+            images: images.isEmpty ? nil : Array(images)
+        )
+    }
+
+    /// A changelog entry is a release note, not a gallery; anything past this
+    /// is dropped so a runaway payload cannot build an unbounded screen.
+    static let maximumImages = 6
+}
+
+extension WhatsNewChangelog.Image {
+    var normalized: WhatsNewChangelog.Image? {
+        guard let name = name.trimmedOrNil else { return nil }
+        return WhatsNewChangelog.Image(
+            name: name,
+            darkName: darkName?.trimmedOrNil,
+            caption: caption?.trimmedOrNil
+        )
+    }
+}
+
+private extension String {
+    var trimmedOrNil: String? {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/apps/swift-ios/Features/Settings/WhatsNewChangelog.swift
+++ b/apps/swift-ios/Features/Settings/WhatsNewChangelog.swift
@@ -82,9 +82,12 @@ struct WhatsNewChangelog: Equatable, Sendable {
 
     static let infoDictionaryKey = "T3BuildChangelog"
 
-    static func load(info: [String: Any]?) -> WhatsNewChangelog? {
+    static func load(
+        info: [String: Any]?,
+        imageDirectory: URL = Bundle.main.bundleURL
+    ) -> WhatsNewChangelog? {
         guard let encoded = info?[infoDictionaryKey] as? String else { return nil }
-        return decode(encoded, info: info)
+        return decode(encoded, info: info)?.filteringUnavailableImages(in: imageDirectory)
     }
 
     /// Decodes an embedded payload, returning `nil` for anything a build can
@@ -170,6 +173,32 @@ struct WhatsNewChangelog: Equatable, Sendable {
     private struct Payload: Decodable {
         let builds: [Build]?
         let entries: [Entry]?
+    }
+
+    /// Bundle image references are presentation content only after they decode.
+    /// Filtering once at load time keeps malformed image-only entries inert and
+    /// avoids repeating file work whenever SwiftUI reevaluates a row.
+    private func filteringUnavailableImages(in directory: URL) -> WhatsNewChangelog {
+        WhatsNewChangelog(
+            builds: builds.map { build in
+                Build(
+                    version: build.version,
+                    build: build.build,
+                    entries: build.entries.map { entry in
+                        let images = (entry.images ?? []).filter {
+                            WhatsNewImageStore.image(named: $0.name, in: directory) != nil
+                        }
+                        return Entry(
+                            title: entry.title,
+                            summary: entry.summary,
+                            detail: entry.detail,
+                            symbol: entry.symbol,
+                            images: images.isEmpty ? nil : images
+                        )
+                    }
+                )
+            }
+        )
     }
 }
 

--- a/apps/swift-ios/Features/Settings/WhatsNewImageStore.swift
+++ b/apps/swift-ios/Features/Settings/WhatsNewImageStore.swift
@@ -1,0 +1,78 @@
+import Foundation
+import UIKit
+
+/// Resolves the screenshots a build shipped alongside its changelog.
+///
+/// Images are **not** carried in the payload. The changelog is a base64 string
+/// on an Info.plist key, and the history is append-only, so an inline image
+/// would weigh on every future build forever — and `xcodebuild` arguments are
+/// bounded by `ARG_MAX` (1 MB total on this platform), which a couple of
+/// screenshots exhaust. Publishers instead drop the PNGs into the bundle
+/// before the archive is signed and reference them by file name.
+enum WhatsNewImageStore {
+    /// A single screenshot larger than this is ignored rather than loaded; a
+    /// changelog must never be able to stall or exhaust the app.
+    static let maximumImageBytes = 8 * 1024 * 1024
+
+    /// Resolves a payload-supplied file name inside `directory`, or `nil` when
+    /// the name is unusable, missing, not a regular file, or oversized.
+    ///
+    /// Names are treated as plain file names inside the bundle: anything with a
+    /// path separator, any relative traversal, and any control character is
+    /// rejected outright rather than resolved.
+    static func imageURL(named name: String, in directory: URL) -> URL? {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              trimmed != ".",
+              trimmed != "..",
+              !trimmed.contains("/"),
+              !trimmed.contains("\\"),
+              trimmed.unicodeScalars.allSatisfy({ !CharacterSet.controlCharacters.contains($0) })
+        else { return nil }
+
+        let url = directory.appendingPathComponent(trimmed, isDirectory: false)
+        guard let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]),
+              values.isRegularFile == true,
+              let size = values.fileSize,
+              size > 0,
+              size <= maximumImageBytes
+        else { return nil }
+
+        return url
+    }
+
+    /// The decoded screenshot, or `nil` when the file is missing, oversized, or
+    /// not an image the platform can read — in which case the detail page
+    /// simply renders without it.
+    static func image(named name: String, in directory: URL) -> UIImage? {
+        guard let url = imageURL(named: name, in: directory) else { return nil }
+        return UIImage(contentsOfFile: url.path)
+    }
+
+    static func image(named name: String, in bundle: Bundle = .main) -> UIImage? {
+        image(named: name, in: bundle.bundleURL)
+    }
+
+    /// The variant matching the current appearance, falling back to the light
+    /// one whenever the dark variant is absent from the payload *or* missing
+    /// from the bundle — a build that shipped a single screenshot still shows
+    /// it in dark mode rather than showing nothing.
+    static func image(
+        for image: WhatsNewChangelog.Image,
+        isDark: Bool,
+        in directory: URL
+    ) -> UIImage? {
+        let resolved = image.name(inDarkMode: isDark)
+        if let loaded = self.image(named: resolved, in: directory) { return loaded }
+        guard resolved != image.name else { return nil }
+        return self.image(named: image.name, in: directory)
+    }
+
+    static func image(
+        for image: WhatsNewChangelog.Image,
+        isDark: Bool,
+        in bundle: Bundle = .main
+    ) -> UIImage? {
+        self.image(for: image, isDark: isDark, in: bundle.bundleURL)
+    }
+}

--- a/apps/swift-ios/Features/Settings/WhatsNewView.swift
+++ b/apps/swift-ios/Features/Settings/WhatsNewView.swift
@@ -1,0 +1,284 @@
+import SwiftUI
+
+/// What shipped in this build, followed by the builds before it.
+///
+/// The layout follows the shape people expect from a release-notes screen: a
+/// hero title, one grouped card per build, and a row per entry carrying an
+/// accent icon tile, a title, and a one-line summary. Entries that recorded
+/// long-form copy open it; the rest stay inert.
+struct WhatsNewView: View {
+    let presentation: WhatsNewPresentation
+    let runningBuildLabel: String?
+    let appName: String
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 28) {
+                hero
+
+                if let current = presentation.current {
+                    buildSection(
+                        eyebrow: "In this build",
+                        label: current.label ?? runningBuildLabel,
+                        build: current
+                    )
+                }
+
+                if !presentation.earlier.isEmpty {
+                    VStack(alignment: .leading, spacing: 20) {
+                        Text("Earlier builds")
+                            .font(T3Typography.threadHeading3)
+                            .foregroundStyle(T3Colors.textPrimary)
+
+                        ForEach(Array(presentation.earlier.enumerated()), id: \.offset) { _, build in
+                            buildSection(eyebrow: nil, label: build.label, build: build)
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 8)
+            .padding(.bottom, 32)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(T3Colors.background)
+        .navigationTitle("What's New")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var hero: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("What's New")
+                .font(T3Typography.threadHeading1)
+                .foregroundStyle(T3Colors.textPrimary)
+            Text(heroSubtitle)
+                .font(T3Typography.supporting)
+                .foregroundStyle(T3Colors.textSecondary)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private var heroSubtitle: String {
+        guard let label = presentation.current?.label ?? runningBuildLabel else {
+            return "Everything recorded for \(appName)."
+        }
+        return "\(appName) \(label)"
+    }
+
+    @ViewBuilder
+    private func buildSection(
+        eyebrow: String?,
+        label: String?,
+        build: WhatsNewChangelog.Build
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if eyebrow != nil || label != nil {
+                HStack(spacing: 8) {
+                    if let eyebrow {
+                        Text(eyebrow.uppercased())
+                            .font(T3Typography.eyebrow)
+                            .foregroundStyle(T3Colors.accent)
+                    }
+                    if let label {
+                        Text(label)
+                            .font(T3Typography.supportingStrong)
+                            .foregroundStyle(T3Colors.textSecondary)
+                    }
+                }
+                .accessibilityElement(children: .combine)
+            }
+
+            VStack(spacing: 0) {
+                ForEach(Array(build.entries.enumerated()), id: \.offset) { index, entry in
+                    if index > 0 {
+                        Divider()
+                            .overlay(T3Colors.separator)
+                            .padding(.leading, 66)
+                    }
+                    entryRow(entry, buildLabel: label)
+                }
+            }
+            .background(T3Colors.surface, in: RoundedRectangle(cornerRadius: 18))
+        }
+    }
+
+    @ViewBuilder
+    private func entryRow(_ entry: WhatsNewChangelog.Entry, buildLabel: String?) -> some View {
+        if entry.hasDetail {
+            NavigationLink {
+                WhatsNewDetailView(entry: entry, buildLabel: buildLabel)
+            } label: {
+                entryLabel(entry, showsChevron: true)
+            }
+            .buttonStyle(.plain)
+        } else {
+            entryLabel(entry, showsChevron: false)
+        }
+    }
+
+    private func entryLabel(
+        _ entry: WhatsNewChangelog.Entry,
+        showsChevron: Bool
+    ) -> some View {
+        HStack(alignment: .top, spacing: 14) {
+            WhatsNewSymbolTile(systemName: entry.symbolName, size: 38)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(entry.title)
+                    .font(T3Typography.threadHeading4)
+                    .foregroundStyle(T3Colors.textPrimary)
+                    .fixedSize(horizontal: false, vertical: true)
+                if let summary = entry.summary {
+                    Text(summary)
+                        .font(T3Typography.supporting)
+                        .foregroundStyle(T3Colors.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            Spacer(minLength: 8)
+
+            if showsChevron {
+                Image(systemName: "chevron.right")
+                    .font(T3Typography.supportingStrong)
+                    .foregroundStyle(T3Colors.textTertiary)
+                    .padding(.top, 2)
+                    .accessibilityHidden(true)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
+    }
+}
+
+/// The long-form copy a publisher recorded for one entry, plus any screenshots
+/// that build shipped for it.
+struct WhatsNewDetailView: View {
+    let entry: WhatsNewChangelog.Entry
+    let buildLabel: String?
+
+    private struct LoadedImage: Identifiable {
+        let id: Int
+        let image: UIImage
+        let caption: String?
+
+        var aspectRatio: CGFloat {
+            guard image.size.width > 0, image.size.height > 0 else { return 1 }
+            return image.size.width / image.size.height
+        }
+    }
+
+    @SwiftUI.Environment(\.colorScheme) private var colorScheme
+    @State private var loadedImages: [LoadedImage] = []
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                WhatsNewSymbolTile(systemName: entry.symbolName, size: 56)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    if let buildLabel {
+                        Text(buildLabel.uppercased())
+                            .font(T3Typography.eyebrow)
+                            .foregroundStyle(T3Colors.accent)
+                    }
+                    Text(entry.title)
+                        .font(T3Typography.threadHeading1)
+                        .foregroundStyle(T3Colors.textPrimary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    if let summary = entry.summary {
+                        Text(summary)
+                            .font(T3Typography.threadBody)
+                            .foregroundStyle(T3Colors.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                .accessibilityElement(children: .combine)
+
+                if entry.detail != nil || !loadedImages.isEmpty {
+                    Divider()
+                        .overlay(T3Colors.separator)
+                }
+
+                if let detail = entry.detail {
+                    Text(detail)
+                        .font(T3Typography.threadBody)
+                        .foregroundStyle(T3Colors.textPrimary)
+                        .lineSpacing(3)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                ForEach(loadedImages) { loaded in
+                    VStack(alignment: .leading, spacing: 8) {
+                        Image(uiImage: loaded.image)
+                            .resizable()
+                            // Height follows the image's own ratio, so the
+                            // rounded border always hugs the screenshot no
+                            // matter what the scroll view proposes.
+                            .aspectRatio(loaded.aspectRatio, contentMode: .fit)
+                            .frame(maxWidth: .infinity)
+                            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                            .overlay {
+                                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                                    .strokeBorder(T3Colors.border)
+                            }
+                            .accessibilityLabel(loaded.caption ?? "Screenshot of \(entry.title)")
+
+                        if let caption = loaded.caption {
+                            Text(caption)
+                                .font(T3Typography.supporting)
+                                .foregroundStyle(T3Colors.textSecondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                    .padding(.top, 2)
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 8)
+            .padding(.bottom, 32)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(T3Colors.background)
+        .navigationTitle(entry.title)
+        .navigationBarTitleDisplayMode(.inline)
+        // Keyed on the appearance so switching between light and dark reloads
+        // the screenshots that match it.
+        .task(id: colorScheme) { loadImages() }
+    }
+
+    /// Screenshots that cannot be resolved are simply skipped — a missing or
+    /// malformed file leaves the page exactly as it would have been without it.
+    private func loadImages() {
+        guard let images = entry.images else {
+            loadedImages = []
+            return
+        }
+        let isDark = colorScheme == .dark
+        loadedImages = images.enumerated().compactMap { index, image in
+            guard let loaded = WhatsNewImageStore.image(for: image, isDark: isDark)
+            else { return nil }
+            return LoadedImage(id: index, image: loaded, caption: image.caption)
+        }
+    }
+}
+
+private struct WhatsNewSymbolTile: View {
+    let systemName: String
+    let size: CGFloat
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: size * 0.28, style: .continuous)
+            .fill(T3Colors.accent.opacity(0.14))
+            .frame(width: size, height: size)
+            .overlay {
+                Image(systemName: systemName)
+                    .font(.system(size: size * 0.45, weight: .semibold))
+                    .foregroundStyle(T3Colors.accent)
+            }
+            .accessibilityHidden(true)
+    }
+}

--- a/apps/swift-ios/Features/Settings/WhatsNewView.swift
+++ b/apps/swift-ios/Features/Settings/WhatsNewView.swift
@@ -44,6 +44,8 @@ struct WhatsNewView: View {
         .background(T3Colors.background)
         .navigationTitle("What's New")
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar(.visible, for: .navigationBar)
+        .t3NavigationChrome()
     }
 
     private var hero: some View {
@@ -245,6 +247,8 @@ struct WhatsNewDetailView: View {
         .background(T3Colors.background)
         .navigationTitle(entry.title)
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar(.visible, for: .navigationBar)
+        .t3NavigationChrome()
         // Keyed on the appearance so switching between light and dark reloads
         // the screenshots that match it.
         .task(id: colorScheme) { loadImages() }

--- a/apps/swift-ios/Resources/Info.plist
+++ b/apps/swift-ios/Resources/Info.plist
@@ -34,6 +34,8 @@
             </dict>
         </dict>
     </dict>
+    <key>T3BuildChangelog</key>
+    <string>$(T3_BUILD_CHANGELOG)</string>
     <key>T3GitCommit</key>
     <string>$(T3_GIT_COMMIT)</string>
     <key>T3ConnectClerkJWTTemplate</key>

--- a/apps/swift-ios/Tests/FeatureTests/WhatsNewChangelogTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/WhatsNewChangelogTests.swift
@@ -1,0 +1,394 @@
+import Foundation
+import Testing
+import UIKit
+@testable import T3Code
+
+@Suite("What's New changelog")
+struct WhatsNewChangelogTests {
+    private let runningBundle: [String: Any] = [
+        "CFBundleShortVersionString": "0.1.0",
+        "CFBundleVersion": "90",
+    ]
+
+    private func embedded(_ json: String) -> String {
+        Data(json.utf8).base64EncodedString()
+    }
+
+    private func payload(_ json: String) -> [String: Any] {
+        var info = runningBundle
+        info[WhatsNewChangelog.infoDictionaryKey] = embedded(json)
+        return info
+    }
+
+    private let history = """
+        {"builds":[
+          {"version":"0.1.0","build":"88","entries":[{"title":"Command drawer"}]},
+          {"version":"0.1.0","build":"90","entries":[
+            {"title":"What's New history","summary":"Every build's entries ride along."},
+            {"title":"Done for a duration"}
+          ]},
+          {"version":"0.1.0","build":"89","entries":[{"title":"Inline workspace images"}]}
+        ]}
+        """
+
+    @Test
+    func decodesEveryRecordedBuildNewestFirst() {
+        let changelog = WhatsNewChangelog.decode(embedded(history))
+
+        #expect(changelog?.builds.map(\.build) == ["90", "89", "88"])
+        #expect(changelog?.builds.first?.entries.count == 2)
+        #expect(changelog?.builds.first?.entries.first?.title == "What's New history")
+        #expect(
+            changelog?.builds.first?.entries.first?.summary == "Every build's entries ride along."
+        )
+        #expect(changelog?.builds.last?.entries.map(\.title) == ["Command drawer"])
+    }
+
+    @Test
+    func leadsWithTheRunningBuildAndKeepsTheRestAsHistory() {
+        let presentation = WhatsNewChangelog.load(info: payload(history))?
+            .presentation(info: runningBundle)
+
+        #expect(presentation?.current?.build == "90")
+        #expect(presentation?.current?.label == "0.1.0 (90)")
+        #expect(presentation?.current?.entries.count == 2)
+        #expect(presentation?.earlier.map(\.build) == ["89", "88"])
+        #expect(presentation?.earlier.map(\.label) == ["0.1.0 (89)", "0.1.0 (88)"])
+    }
+
+    @Test
+    func readsEverythingAsHistoryWhenThePayloadDoesNotNameTheRunningBuild() {
+        let json = """
+            {"builds":[
+              {"version":"0.1.0","build":"89","entries":[{"title":"Inline workspace images"}]},
+              {"version":"0.1.0","build":"88","entries":[{"title":"Command drawer"}]}
+            ]}
+            """
+
+        let presentation = WhatsNewChangelog.decode(embedded(json))?
+            .presentation(info: runningBundle)
+
+        #expect(presentation?.current == nil)
+        #expect(presentation?.earlier.map(\.build) == ["89", "88"])
+    }
+
+    @Test
+    func readsTheSingleBuildPayloadAsTheRunningBuild() {
+        let json = #"{"entries":[{"title":"What's New screen","summary":"Opens from About."}]}"#
+
+        let presentation = WhatsNewChangelog.load(info: payload(json))?
+            .presentation(info: runningBundle)
+
+        #expect(presentation?.current?.build == "90")
+        #expect(presentation?.current?.label == "0.1.0 (90)")
+        #expect(presentation?.current?.entries.map(\.title) == ["What's New screen"])
+        #expect(presentation?.earlier.isEmpty == true)
+    }
+
+    @Test
+    func keepsUnnumberedBuildsAfterTheNumberedHistoryInPayloadOrder() {
+        let json = """
+            {"builds":[
+              {"version":"0.1.0","entries":[{"title":"Unnumbered first"}]},
+              {"build":"5","entries":[{"title":"Numbered"}]},
+              {"entries":[{"title":"Unnumbered second"}]}
+            ]}
+            """
+
+        let changelog = WhatsNewChangelog.decode(embedded(json))
+
+        #expect(
+            changelog?.builds.flatMap({ $0.entries.map(\.title) })
+                == ["Numbered", "Unnumbered first", "Unnumbered second"]
+        )
+        #expect(changelog?.builds.map(\.label) == ["Build 5", "0.1.0", nil])
+    }
+
+    @Test
+    func readsOptionalDetailAndSymbolWhenAPublisherRecordsThem() {
+        let json = """
+            {"builds":[{"version":"0.1.0","build":"90","entries":[
+              {
+                "title":"What's New history",
+                "summary":"Every build's entries ride along.",
+                "detail":"  Each publisher appends its build to the history it inherited.  ",
+                "symbol":"clock.arrow.circlepath"
+              }
+            ]}]}
+            """
+
+        let entry = WhatsNewChangelog.decode(embedded(json))?.builds.first?.entries.first
+
+        #expect(entry?.hasDetail == true)
+        #expect(entry?.detail == "Each publisher appends its build to the history it inherited.")
+        #expect(entry?.symbolName == "clock.arrow.circlepath")
+    }
+
+    @Test
+    func leavesEntriesInertWhenTheyRecordNoDetailAndFallsBackToTheDefaultSymbol() {
+        let json = """
+            {"builds":[{"version":"0.1.0","build":"90","entries":[
+              {"title":"No detail recorded"},
+              {"title":"Blank detail","detail":"   ","symbol":"   "},
+              {"title":"Unknown symbol","symbol":"not.a.real.sf.symbol.name"}
+            ]}]}
+            """
+
+        let entries = WhatsNewChangelog.decode(embedded(json))?.builds.first?.entries
+
+        #expect(entries?.count == 3)
+        #expect(entries?.allSatisfy { !$0.hasDetail } == true)
+        #expect(entries?.allSatisfy { $0.detail == nil } == true)
+        #expect(entries?.map(\.symbolName) == ["sparkles", "sparkles", "sparkles"])
+    }
+
+    @Test
+    func rendersPayloadsWrittenBeforeDetailAndSymbolExistedExactlyAsBefore() {
+        let entry = WhatsNewChangelog.load(info: payload(history))?
+            .presentation(info: runningBundle)
+            .current?
+            .entries
+            .first
+
+        #expect(entry?.title == "What's New history")
+        #expect(entry?.summary == "Every build's entries ride along.")
+        #expect(entry?.detail == nil)
+        #expect(entry?.hasDetail == false)
+        #expect(entry?.symbolName == "sparkles")
+    }
+
+    @Test
+    func readsOptionalImagesAndMakesImageOnlyEntriesOpenable() {
+        let json = """
+            {"builds":[{"version":"0.1.0","build":"90","entries":[
+              {"title":"With pictures","images":[
+                {"name":"  whatsnew-90-history.png  ","caption":"  The history screen.  "},
+                {"name":"whatsnew-90-detail.png"},
+                {"name":"   "}
+              ]},
+              {"title":"Pictures only","images":[{"name":"whatsnew-90-only.png"}]}
+            ]}]}
+            """
+
+        let entries = WhatsNewChangelog.decode(embedded(json))?.builds.first?.entries
+
+        #expect(entries?.first?.images?.count == 2)
+        #expect(entries?.first?.images?.first?.name == "whatsnew-90-history.png")
+        #expect(entries?.first?.images?.first?.caption == "The history screen.")
+        #expect(entries?.first?.images?.last?.caption == nil)
+        // An entry that ships only screenshots still has something to show.
+        #expect(entries?.last?.detail == nil)
+        #expect(entries?.last?.hasDetail == true)
+    }
+
+    @Test
+    func picksTheDarkVariantOnlyInDarkModeAndOnlyWhenRecorded() {
+        let json = """
+            {"builds":[{"build":"90","entries":[{"title":"Appearance","images":[
+              {"name":"shot.png","darkName":"  shot-dark.png  ","caption":"Both variants."},
+              {"name":"single.png"},
+              {"name":"blank-dark.png","darkName":"   "}
+            ]}]}]}
+            """
+
+        let images = WhatsNewChangelog.decode(embedded(json))?
+            .builds.first?.entries.first?.images
+
+        #expect(images?.count == 3)
+        // Recorded dark variant, whitespace trimmed.
+        #expect(images?.first?.darkName == "shot-dark.png")
+        #expect(images?.first?.name(inDarkMode: true) == "shot-dark.png")
+        #expect(images?.first?.name(inDarkMode: false) == "shot.png")
+        // No dark variant recorded: the one screenshot serves both appearances.
+        #expect(images?[1].darkName == nil)
+        #expect(images?[1].name(inDarkMode: true) == "single.png")
+        #expect(images?[1].name(inDarkMode: false) == "single.png")
+        // A blank dark name counts as unrecorded rather than as a file name.
+        #expect(images?[2].darkName == nil)
+        #expect(images?[2].name(inDarkMode: true) == "blank-dark.png")
+    }
+
+    @Test
+    func fallsBackToTheLightFileWhenTheDarkOneIsNamedButNotShipped() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("whats-new-appearance-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let light = try #require(UIImage(systemName: "sun.max")?.pngData())
+        let dark = try #require(UIImage(systemName: "moon.stars")?.pngData())
+        try light.write(to: directory.appendingPathComponent("shot.png"))
+        try dark.write(to: directory.appendingPathComponent("shot-dark.png"))
+        try light.write(to: directory.appendingPathComponent("single.png"))
+
+        let bothVariants = WhatsNewChangelog.Image(
+            name: "shot.png",
+            darkName: "shot-dark.png",
+            caption: nil
+        )
+        let lightOnly = WhatsNewChangelog.Image(name: "single.png", darkName: nil, caption: nil)
+        let darkMissing = WhatsNewChangelog.Image(
+            name: "single.png",
+            darkName: "single-dark.png",
+            caption: nil
+        )
+        let nothingShipped = WhatsNewChangelog.Image(
+            name: "absent.png",
+            darkName: "absent-dark.png",
+            caption: nil
+        )
+
+        let darkBytes = WhatsNewImageStore
+            .image(for: bothVariants, isDark: true, in: directory)?.pngData()
+        let lightBytes = WhatsNewImageStore
+            .image(for: bothVariants, isDark: false, in: directory)?.pngData()
+        #expect(darkBytes != nil)
+        #expect(lightBytes != nil)
+        #expect(darkBytes != lightBytes)
+
+        // One recorded screenshot serves both appearances.
+        #expect(WhatsNewImageStore.image(for: lightOnly, isDark: true, in: directory) != nil)
+        // A dark variant that was named but never shipped falls back to the light file.
+        #expect(WhatsNewImageStore.image(for: darkMissing, isDark: true, in: directory) != nil)
+        // Neither variant shipped: still no image, still no broken page.
+        #expect(WhatsNewImageStore.image(for: nothingShipped, isDark: true, in: directory) == nil)
+        #expect(WhatsNewImageStore.image(for: nothingShipped, isDark: false, in: directory) == nil)
+    }
+
+    @Test
+    func capsTheNumberOfImagesAnEntryCanBuild() {
+        let names = (1...10).map { #"{"name":"shot-\#($0).png"}"# }.joined(separator: ",")
+        let json = #"{"builds":[{"build":"90","entries":[{"title":"Gallery","images":[\#(names)]}]}]}"#
+
+        let entry = WhatsNewChangelog.decode(embedded(json))?.builds.first?.entries.first
+
+        #expect(entry?.images?.count == WhatsNewChangelog.Entry.maximumImages)
+        #expect(entry?.images?.first?.name == "shot-1.png")
+    }
+
+    @Test
+    func rendersPayloadsWithoutImagesExactlyAsBefore() {
+        let entry = WhatsNewChangelog.load(info: payload(history))?
+            .presentation(info: runningBundle)
+            .current?
+            .entries
+            .first
+
+        #expect(entry?.images == nil)
+        #expect(entry?.hasDetail == false)
+        #expect(entry?.title == "What's New history")
+        #expect(entry?.summary == "Every build's entries ride along.")
+    }
+
+    @Test
+    func resolvesOnlyUsableImageFilesFromTheBundleDirectory() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("whats-new-images-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let png = try #require(UIImage(systemName: "sparkles")?.pngData())
+        try png.write(to: directory.appendingPathComponent("good.png"))
+        try Data("not an image".utf8).write(to: directory.appendingPathComponent("bogus.png"))
+        try Data(count: WhatsNewImageStore.maximumImageBytes + 1)
+            .write(to: directory.appendingPathComponent("huge.png"))
+        try Data().write(to: directory.appendingPathComponent("empty.png"))
+
+        // Usable file resolves and decodes.
+        #expect(WhatsNewImageStore.imageURL(named: "good.png", in: directory) != nil)
+        #expect(WhatsNewImageStore.image(named: "good.png", in: directory) != nil)
+        // Everything a sloppy or hostile payload can name resolves to nothing.
+        #expect(WhatsNewImageStore.imageURL(named: "huge.png", in: directory) == nil)
+        #expect(WhatsNewImageStore.imageURL(named: "empty.png", in: directory) == nil)
+        #expect(WhatsNewImageStore.imageURL(named: "missing.png", in: directory) == nil)
+        #expect(WhatsNewImageStore.imageURL(named: "", in: directory) == nil)
+        #expect(WhatsNewImageStore.imageURL(named: "   ", in: directory) == nil)
+        #expect(WhatsNewImageStore.imageURL(named: "..", in: directory) == nil)
+        #expect(WhatsNewImageStore.imageURL(named: "../good.png", in: directory) == nil)
+        #expect(WhatsNewImageStore.imageURL(named: "nested/good.png", in: directory) == nil)
+        #expect(WhatsNewImageStore.imageURL(named: "good\u{0}.png", in: directory) == nil)
+        // A file that exists but is not an image renders as no image at all.
+        #expect(WhatsNewImageStore.image(named: "bogus.png", in: directory) == nil)
+    }
+
+    @Test
+    func treatsAnythingABuildMightLeaveBehindAsNoChangelog() {
+        let payloads: [String] = [
+            "$(T3_BUILD_CHANGELOG)",
+            "",
+            "   ",
+            "not base64 at all!!",
+            embedded("this is not json"),
+            embedded(#"{"builds":[]}"#),
+            embedded(#"{"entries":[]}"#),
+            embedded(#"{"builds":[{"build":"90","entries":[{"title":"   "}]}]}"#),
+            embedded(#"{"releases":[]}"#),
+        ]
+
+        for payload in payloads {
+            #expect(
+                WhatsNewChangelog.decode(payload) == nil,
+                "expected no changelog for \(payload)"
+            )
+        }
+    }
+
+    @Test
+    func readsThePayloadFromTheBundleKeyAndHidesWhenItIsAbsent() {
+        #expect(WhatsNewChangelog.load(info: payload(history))?.builds.count == 3)
+        #expect(WhatsNewChangelog.load(info: runningBundle) == nil)
+        #expect(WhatsNewChangelog.load(info: nil) == nil)
+        #expect(
+            WhatsNewChangelog.load(info: [WhatsNewChangelog.infoDictionaryKey: 42]) == nil
+        )
+    }
+
+    @Test
+    func trimsEntryTextAndDropsTitlelessEntriesAndEmptyBuilds() {
+        let json = """
+            {"builds":[
+              {"build":"  90  ","version":"  0.1.0  ","entries":[
+                {"title":"  Recent projects  ","summary":"  Picker remembers what you opened.  "},
+                {"title":"","summary":"orphan summary"},
+                {"title":"Timestamps","summary":"   "}
+              ]},
+              {"build":"89","entries":[{"title":"  "}]}
+            ]}
+            """
+
+        let changelog = WhatsNewChangelog.decode(embedded(json))
+
+        #expect(changelog?.builds.count == 1)
+        #expect(changelog?.builds.first?.build == "90")
+        #expect(changelog?.builds.first?.version == "0.1.0")
+        #expect(changelog?.builds.first?.entries.count == 2)
+        #expect(changelog?.builds.first?.entries.first?.title == "Recent projects")
+        #expect(
+            changelog?.builds.first?.entries.first?.summary == "Picker remembers what you opened."
+        )
+        #expect(changelog?.builds.first?.entries.last?.summary == nil)
+    }
+
+    @Test
+    func buildLabelCombinesVersionAndBuildOnlyWhenBothAreRecorded() {
+        #expect(WhatsNewChangelog.buildLabel(info: runningBundle) == "0.1.0 (90)")
+        #expect(
+            WhatsNewChangelog.buildLabel(
+                info: [
+                    "CFBundleShortVersionString": "$(MARKETING_VERSION)",
+                    "CFBundleVersion": "90",
+                ]
+            ) == nil
+        )
+        #expect(
+            WhatsNewChangelog.buildLabel(info: ["CFBundleShortVersionString": "0.1.0"]) == nil
+        )
+        #expect(WhatsNewChangelog.buildLabel(info: nil) == nil)
+    }
+}

--- a/apps/swift-ios/Tests/FeatureTests/WhatsNewChangelogTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/WhatsNewChangelogTests.swift
@@ -318,6 +318,38 @@ struct WhatsNewChangelogTests {
     }
 
     @Test
+    func onlyDecodedBundleImagesMakeImageOnlyEntriesOpenable() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("whats-new-openable-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let png = try #require(UIImage(systemName: "sparkles")?.pngData())
+        try png.write(to: directory.appendingPathComponent("good.png"))
+        try Data("not an image".utf8).write(to: directory.appendingPathComponent("bogus.png"))
+
+        let json = """
+            {"builds":[{"build":"90","entries":[
+              {"title":"Missing only","images":[{"name":"missing.png"}]},
+              {"title":"Undecodable only","images":[{"name":"bogus.png"}]},
+              {"title":"Decoded image","images":[{"name":"good.png"}]},
+              {"title":"Text detail","detail":"Still opens.","images":[{"name":"missing.png"}]}
+            ]}]}
+            """
+
+        let entries = WhatsNewChangelog.load(
+            info: payload(json),
+            imageDirectory: directory
+        )?.builds.first?.entries
+
+        #expect(entries?.map(\.hasDetail) == [false, false, true, true])
+        #expect(entries?.map { $0.images?.count } == [nil, nil, 1, nil])
+    }
+
+    @Test
     func treatsAnythingABuildMightLeaveBehindAsNoChangelog() {
         let payloads: [String] = [
             "$(T3_BUILD_CHANGELOG)",


### PR DESCRIPTION
## What this does

Adds **Settings › About › What's New** to the native SwiftUI iOS client: a
release-notes page showing what shipped in the running build, followed by every
earlier build below it, newest first.

A build records its changelog the same way it already records its commit — an
`Info.plist` value expanded at build time, here `T3_BUILD_CHANGELOG` carrying
base64 JSON:

```json
{"builds":[
  {"version":"0.1.0","build":"96","entries":[
    {
      "title":"Appearance-aware screenshots",
      "summary":"Pictures follow the theme you chose.",
      "detail":"Long-form copy, shown when the row is opened. Optional.",
      "symbol":"circle.lefthalf.filled",
      "images":[{"name":"whatsnew-96-list.png","darkName":"whatsnew-96-list-dark.png","caption":"The list."}]
    }
  ]},
  {"version":"0.1.0","build":"95","entries":[{"title":"An earlier change"}]}
]}
```

Each publisher appends its own build to the history it inherited, so the
changelog travels with the app: no network call, no bundled fixture, no
server contract. Builds are ordered by build number rather than by payload
order, so appending is always safe, and the running build is identified by
`CFBundleVersion`.

Only `title` is required. `detail` is what makes a row open a detail page —
rows without it are plain views rather than disabled buttons, so they neither
show a chevron nor respond to a tap.

## Why screenshots are referenced rather than inlined

Entries may carry screenshots, shown on the detail page. They are **named**,
not embedded, and that is the one design decision here worth stating:

- the history is append-only, so an inline image would be re-injected into every
  future build forever;
- `xcodebuild` arguments are bounded by `ARG_MAX` (1 MB on macOS), which a
  couple of base64 screenshots exhaust — the failure would surface at archive
  time as a shell error;
- adding files to an already-signed `.app` invalidates its signature, so the
  only safe point is before the archive.

Files placed under `apps/swift-ios/Resources/` are copied into the bundle
automatically (it is a synchronized root group) and flattened to the bundle
root, so a build ships its PNGs and the payload names them. The payload for the
media below is **1,366 bytes of JSON**; the three screenshots it references are
209 KB.

Each image may also name a `darkName`. The detail page loads the variant
matching the current appearance and reloads when that changes.

## Failure behaviour

Every way a payload can be wrong degrades instead of breaking, because a
changelog is not worth a broken screen:

| Input | Result |
|---|---|
| absent, empty, or unexpanded `$(T3_BUILD_CHANGELOG)` | no row in Settings at all |
| not base64, not JSON, or no usable entries | no row |
| unknown or misspelled SF Symbol | falls back to `sparkles` |
| image missing, empty, >8 MB, undecodable, or named with `/` or `..` | that image is skipped; the page renders as if it were never named |
| `darkName` recorded but not shipped | falls back to the light file |
| no `darkName` recorded | the single file is shown in both appearances |
| more than six images on one entry | extras dropped |

Path separators and traversal are rejected before touching the filesystem.

## Test evidence

Focused suite rerun on exact head `8a363ad8f0ec4b417faa01926f03179f220c928d` with isolated
DerivedData via the repository's iOS build hygiene wrapper.

Focused suite — `WhatsNewChangelogTests`, 19 cases:

```
result: Passed   totalTestCount: 19   passed: 19   failed: 0   skipped: 0
```

The full-bundle result below was recorded on the original feature head; the
exact-head focused suite above covers the review fix.

Full unit bundle — `T3CodeTests`:

```
result: Passed   totalTestCount: 407   passed: 406   failed: 0   skipped: 1
```

The single skip is pre-existing and environment-gated, not introduced here.

The focused cases cover build ordering and the running-build split (including a
payload that does not name the running build), the single-build payload shape,
trimming and the dropping of title-less entries and empty builds, every
"no changelog" input above, symbol fallback, the image cap, name validation
against a real temporary directory (missing, empty, oversized, undecodable,
traversal, control characters), production-load filtering that leaves missing or
undecodable image-only entries inert while valid-image and text-detail entries
still open, and appearance resolution — asserting that the
dark and light loads return *different* bytes, that a named-but-unshipped dark
variant falls back to the light file, and that payloads written before `detail`,
`symbol` and `images` existed still render exactly as they did.

## Media

Raw `simctl` screenshots from a canonical proof simulator against this feature,
with the installed binary hash-verified against the build product immediately
before every capture. Real local server, real pairing. Both appearances.

### Detail page — two screenshots with captions

The embedded pictures are themselves the light and dark variants: switching the
device appearance swapped them live, on the same page, without leaving it.

| Light | Dark |
|---|---|
| <img src="https://raw.githubusercontent.com/saphid/t3code/fe410126047bae36efe744c9f80d65175f2cfd90/.github/pr-assets/swiftui-whats-new/detail-images-light.png" width="330"> | <img src="https://raw.githubusercontent.com/saphid/t3code/fe410126047bae36efe744c9f80d65175f2cfd90/.github/pr-assets/swiftui-whats-new/detail-images-dark.png" width="330"> |

### Detail page — one screenshot, no dark variant recorded

The fallback: the single file is shown in both appearances rather than the page
losing its picture in one of them.

| Light | Dark |
|---|---|
| <img src="https://raw.githubusercontent.com/saphid/t3code/fe410126047bae36efe744c9f80d65175f2cfd90/.github/pr-assets/swiftui-whats-new/single-image-light.png" width="330"> | <img src="https://raw.githubusercontent.com/saphid/t3code/fe410126047bae36efe744c9f80d65175f2cfd90/.github/pr-assets/swiftui-whats-new/single-image-dark.png" width="330"> |

The list screen appears inside those screenshots — it is what the embedded
pictures show, in each appearance: a hero header, an accent `IN THIS BUILD`
eyebrow, and one grouped card per build with an accent symbol tile per entry.

## Scope and limitations

- Touches only `apps/swift-ios`. Two existing files change: `SettingsView`
  gains the About row and two private helpers, `Info.plist` gains one key. The
  rest is new: the payload model, an image store, the view, and the tests.
- No `project.pbxproj` change — the new files land through the existing
  synchronized groups.
- Nothing produces a changelog in-tree. Like `T3_GIT_COMMIT`, the value is
  supplied by whoever builds; a build that supplies nothing simply has no row.
  That is deliberate rather than an omission, but it does mean this ships a
  consumer without a producer.
- The screenshots a build ships are the builder's own files, dropped into
  `Resources/` before archiving; none are committed here.
- Not verified: Dynamic Type at accessibility sizes, iPad layout, and VoiceOver
  reading order. Appearance was driven at device level (`simctl ui appearance`),
  which feeds the same `colorScheme` the app's own Theme picker does; the picker
  itself was not separately exercised on screen.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Settings-only feature with no network or auth changes; malformed payloads and image paths degrade gracefully, with broad unit test coverage.
> 
> **Overview**
> Adds **Settings › About › What's New** when a build injects a changelog via the new `T3BuildChangelog` / `T3_BUILD_CHANGELOG` Info.plist hook (base64 JSON, same pattern as `T3GitCommit`).
> 
> **`WhatsNewChangelog`** decodes multi-build or legacy single-build payloads, orders by build number, splits “in this build” vs earlier history using `CFBundleVersion`, and normalizes or drops bad entries. Optional **detail**, SF Symbols, and bundle **screenshots** (by filename, with optional `darkName`) make rows navigable to **`WhatsNewDetailView`**.
> 
> **`WhatsNewImageStore`** loads images from the bundle with path traversal rejection, size caps, and light/dark fallback. **`SettingsView`** only shows the link when a valid changelog exists. **`Info.plist`** gains the injection key. **`WhatsNewChangelogTests`** (18 cases) cover decoding, presentation, images, and failure modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a363ad8f0ec4b417faa01926f03179f220c928d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Coordination trace: T3 thread AAB19653-BB39-4C65-BAC2-A702B8D1CD6F · saphid/t3code-personal#118


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add "What's New" release notes screen to Settings for the running build
> - Introduces a `WhatsNewChangelog` model that decodes a base64 JSON changelog from the `T3BuildChangelog` Info.plist key, splitting builds into current (matching `CFBundleVersion`) and earlier sets.
> - Adds `WhatsNewView` and `WhatsNewDetailView` screens in Settings, rendering release notes with hero headers, symbol tiles, and screenshot galleries.
> - Adds `WhatsNewImageStore` to validate and load changelog screenshots, rejecting unsafe filenames and oversized files (>8 MB), with dark/light fallback.
> - `SettingsView` conditionally shows a "What's New" navigation link only when a valid changelog payload is present.
> - Behavioral Change: the "What's New" row only appears when `T3BuildChangelog` is injected at build time; absent or invalid payloads keep the UI hidden.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a363ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->