### PR TITLE
feat(server): report OpenCode token usage for the context window meter

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -1507,8 +1507,8 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         NodeAssert.ok(usageEvent);
         if (usageEvent.type === "thread.token-usage.updated") {
           NodeAssert.deepEqual(usageEvent.payload.usage, {
-            usedTokens: 10950,
-            lastUsedTokens: 10950,
+            usedTokens: 10900,
+            lastUsedTokens: 10900,
             maxTokens: 200000,
             inputTokens: 1200,
             lastInputTokens: 1200,
@@ -1673,6 +1673,21 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
           lastInputTokens: 250000,
           compactsAutomatically: true,
         },
+      );
+      // A reported `total` wins over the component sum, matching
+      // OpenCode's own overflow check.
+      NodeAssert.equal(
+        normalizeOpenCodeTokenUsage(
+          {
+            total: 5000,
+            input: 100,
+            output: 100,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+          200000,
+        )?.usedTokens,
+        5000,
       );
     }),
   );

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -37,6 +37,7 @@ import {
   isSameOpenCodeDirectory,
   makeOpenCodeAdapter,
   mergeOpenCodeAssistantText,
+  normalizeOpenCodeTokenUsage,
 } from "./OpenCodeAdapter.ts";
 
 // Test-local service tag so the rest of the file can keep using `yield* OpenCodeAdapter`.
@@ -68,6 +69,8 @@ const runtimeMock = {
     closeError: null as Error | null,
     messages: [] as MessageEntry[],
     subscribedEvents: [] as unknown[],
+    providerListCalls: 0,
+    providerList: [] as unknown[],
     sessionGetIds: [] as string[],
     missingSessionIds: new Set<string>(),
     transientErrorSessionIds: new Set<string>(),
@@ -88,6 +91,8 @@ const runtimeMock = {
     this.state.closeError = null;
     this.state.messages = [];
     this.state.subscribedEvents = [];
+    this.state.providerListCalls = 0;
+    this.state.providerList = [];
     this.state.sessionGetIds.length = 0;
     this.state.missingSessionIds.clear();
     this.state.transientErrorSessionIds.clear();
@@ -211,6 +216,12 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
             }
           })(),
         }),
+      },
+      provider: {
+        list: async () => {
+          runtimeMock.state.providerListCalls += 1;
+          return { data: { all: runtimeMock.state.providerList } };
+        },
       },
     }) as unknown as ReturnType<OpenCodeRuntimeShape["createOpenCodeSdkClient"]>,
   loadOpenCodeInventory: () =>
@@ -1439,6 +1450,230 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       NodeAssert.equal(sessions.length, 1);
       NodeAssert.equal(sessions[0]?.threadId, "thread-native-log-failure");
       NodeAssert.deepEqual(closeCallsDuringRun, []);
+    }),
+  );
+
+  it.effect(
+    "emits thread.token-usage.updated with the model context window for completed assistant messages",
+    () =>
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        const threadId = asThreadId("thread-opencode-tokens");
+        runtimeMock.state.providerList = [
+          {
+            id: "anthropic",
+            models: {
+              "claude-sonnet-4-6": { limit: { context: 200000 } },
+            },
+          },
+        ];
+        runtimeMock.state.subscribedEvents = [
+          {
+            type: "message.updated",
+            properties: {
+              sessionID: "http://127.0.0.1:9999/session",
+              info: {
+                id: "msg-tokens-1",
+                role: "assistant",
+                providerID: "anthropic",
+                modelID: "claude-sonnet-4-6",
+                time: { created: 1, completed: 2 },
+                tokens: {
+                  input: 1200,
+                  output: 300,
+                  reasoning: 50,
+                  cache: { read: 9000, write: 400 },
+                },
+              },
+            },
+          },
+        ];
+
+        const eventsFiber = yield* adapter.streamEvents.pipe(
+          Stream.filter((event) => event.threadId === threadId),
+          Stream.take(3),
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+
+        yield* adapter.startSession({
+          provider: ProviderDriverKind.make("opencode"),
+          threadId,
+          runtimeMode: "full-access",
+        });
+
+        const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+        const usageEvent = events.find((event) => event.type === "thread.token-usage.updated");
+        NodeAssert.ok(usageEvent);
+        if (usageEvent.type === "thread.token-usage.updated") {
+          NodeAssert.deepEqual(usageEvent.payload.usage, {
+            usedTokens: 10950,
+            lastUsedTokens: 10950,
+            maxTokens: 200000,
+            inputTokens: 1200,
+            lastInputTokens: 1200,
+            cachedInputTokens: 9000,
+            lastCachedInputTokens: 9000,
+            outputTokens: 300,
+            lastOutputTokens: 300,
+            reasoningOutputTokens: 50,
+            lastReasoningOutputTokens: 50,
+            compactsAutomatically: true,
+          });
+        }
+        NodeAssert.equal(runtimeMock.state.providerListCalls, 1);
+      }),
+  );
+
+  it.effect("does not emit token usage for assistant messages without token data", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-no-tokens");
+      runtimeMock.state.subscribedEvents = [
+        {
+          type: "message.updated",
+          properties: {
+            sessionID: "http://127.0.0.1:9999/session",
+            info: {
+              id: "msg-no-tokens",
+              role: "assistant",
+            },
+          },
+        },
+      ];
+
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(2),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      NodeAssert.deepEqual(
+        events.map((event) => event.type),
+        ["session.started", "thread.started"],
+      );
+      NodeAssert.equal(runtimeMock.state.providerListCalls, 0);
+    }),
+  );
+
+  it.effect("emits token usage once per message and reuses the cached context window", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-token-cache");
+      runtimeMock.state.providerList = [
+        {
+          id: "anthropic",
+          models: {
+            "claude-sonnet-4-6": { limit: { context: 200000 } },
+          },
+        },
+        {
+          id: "openai",
+          models: {
+            "gpt-5": { limit: { context: 400000 } },
+          },
+        },
+      ];
+      const completedAssistant = (
+        id: string,
+        providerID: string,
+        modelID: string,
+        input: number,
+      ) => ({
+        type: "message.updated",
+        properties: {
+          sessionID: "http://127.0.0.1:9999/session",
+          info: {
+            id,
+            role: "assistant",
+            providerID,
+            modelID,
+            time: { created: 1, completed: 2 },
+            tokens: {
+              input,
+              output: 100,
+              reasoning: 0,
+              cache: { read: 0, write: 0 },
+            },
+          },
+        },
+      });
+      runtimeMock.state.subscribedEvents = [
+        completedAssistant("msg-cache-a", "anthropic", "claude-sonnet-4-6", 1000),
+        completedAssistant("msg-cache-a", "anthropic", "claude-sonnet-4-6", 1000),
+        completedAssistant("msg-cache-b", "openai", "gpt-5", 2000),
+      ];
+
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.filter((event) => event.type === "thread.token-usage.updated"),
+        Stream.take(2),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      NodeAssert.equal(events.length, 2);
+      NodeAssert.equal(
+        events[0]?.type === "thread.token-usage.updated"
+          ? events[0].payload.usage.maxTokens
+          : undefined,
+        200000,
+      );
+      NodeAssert.equal(
+        events[1]?.type === "thread.token-usage.updated"
+          ? events[1].payload.usage.maxTokens
+          : undefined,
+        400000,
+      );
+      NodeAssert.equal(runtimeMock.state.providerListCalls, 1);
+    }),
+  );
+
+  it.effect("caps usedTokens at the model context window and drops zero-token usage", () =>
+    Effect.sync(() => {
+      NodeAssert.equal(
+        normalizeOpenCodeTokenUsage({
+          input: 0,
+          output: 0,
+          reasoning: 0,
+          cache: { read: 0, write: 0 },
+        }),
+        undefined,
+      );
+      NodeAssert.deepEqual(
+        normalizeOpenCodeTokenUsage(
+          {
+            input: 250000,
+            output: 0,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+          200000,
+        ),
+        {
+          usedTokens: 200000,
+          lastUsedTokens: 200000,
+          maxTokens: 200000,
+          inputTokens: 250000,
+          lastInputTokens: 250000,
+          compactsAutomatically: true,
+        },
+      );
     }),
   );
 });

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -21,6 +21,7 @@ import {
   ProviderInstanceId,
   ThreadId,
 } from "@t3tools/contracts";
+import type { AssistantMessage } from "@opencode-ai/sdk/v2";
 import { createModelSelection } from "@t3tools/shared/model";
 import { ServerConfig } from "../../config.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
@@ -1766,6 +1767,24 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
           200000,
         )?.usedTokens,
         5000,
+      );
+      // Older OpenCode versions may send a tokens object without the `cache`
+      // sub-object; the snapshot must build without crashing.
+      NodeAssert.deepEqual(
+        normalizeOpenCodeTokenUsage(
+          { input: 100, output: 50 } as unknown as AssistantMessage["tokens"],
+          200000,
+        ),
+        {
+          usedTokens: 150,
+          lastUsedTokens: 150,
+          maxTokens: 200000,
+          inputTokens: 100,
+          lastInputTokens: 100,
+          outputTokens: 50,
+          lastOutputTokens: 50,
+          compactsAutomatically: true,
+        },
       );
     }),
   );

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -1564,6 +1564,84 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("ignores in-progress token updates and still emits when the message completes", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-partial-tokens");
+      runtimeMock.state.providerList = [
+        {
+          id: "anthropic",
+          models: {
+            "claude-sonnet-4-6": { limit: { context: 200000 } },
+          },
+        },
+      ];
+      runtimeMock.state.subscribedEvents = [
+        {
+          type: "message.updated",
+          properties: {
+            sessionID: "http://127.0.0.1:9999/session",
+            info: {
+              id: "msg-partial",
+              role: "assistant",
+              providerID: "anthropic",
+              modelID: "claude-sonnet-4-6",
+              time: { created: 1 },
+              tokens: {
+                input: 100,
+                output: 50,
+                reasoning: 0,
+                cache: { read: 0, write: 0 },
+              },
+            },
+          },
+        },
+        {
+          type: "message.updated",
+          properties: {
+            sessionID: "http://127.0.0.1:9999/session",
+            info: {
+              id: "msg-partial",
+              role: "assistant",
+              providerID: "anthropic",
+              modelID: "claude-sonnet-4-6",
+              time: { created: 1, completed: 2 },
+              tokens: {
+                input: 1000,
+                output: 200,
+                reasoning: 0,
+                cache: { read: 4000, write: 0 },
+              },
+            },
+          },
+        },
+      ];
+
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.filter((event) => event.type === "thread.token-usage.updated"),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      NodeAssert.equal(events.length, 1);
+      const usageEvent = events[0];
+      if (usageEvent?.type === "thread.token-usage.updated") {
+        NodeAssert.equal(usageEvent.payload.usage.usedTokens, 5200);
+        NodeAssert.equal(usageEvent.payload.usage.maxTokens, 200000);
+      }
+      NodeAssert.equal(runtimeMock.state.providerListCalls, 1);
+    }),
+  );
+
   it.effect("emits token usage once per message and reuses the cached context window", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -531,10 +531,11 @@ export function normalizeOpenCodeTokenUsage(
   const maxTokens =
     modelContextWindow !== undefined && modelContextWindow > 0 ? modelContextWindow : undefined;
   const cappedUsedTokens = maxTokens !== undefined ? Math.min(usedTokens, maxTokens) : usedTokens;
-  const inputTokens = tokens.input;
-  const cachedInputTokens = tokens.cache.read;
-  const outputTokens = tokens.output;
-  const reasoningOutputTokens = tokens.reasoning;
+  const cache = tokens.cache;
+  const inputTokens = typeof tokens.input === "number" ? tokens.input : 0;
+  const cachedInputTokens = cache && typeof cache.read === "number" ? cache.read : 0;
+  const outputTokens = typeof tokens.output === "number" ? tokens.output : 0;
+  const reasoningOutputTokens = typeof tokens.reasoning === "number" ? tokens.reasoning : 0;
   return {
     usedTokens: cappedUsedTokens,
     lastUsedTokens: cappedUsedTokens,

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -775,24 +775,29 @@ export function makeOpenCodeAdapter(
         Effect.orElseSucceed((): Provider[] => []),
       );
       for (const provider of providers) {
-        for (const [id, model] of Object.entries(provider.models)) {
-          if (model.limit.context > 0) {
-            context.modelContextWindowById.set(`${provider.id}/${id}`, model.limit.context);
+        for (const [id, model] of Object.entries(provider.models ?? {})) {
+          const contextWindow = model.limit?.context ?? 0;
+          if (contextWindow > 0) {
+            context.modelContextWindowById.set(`${provider.id}/${id}`, contextWindow);
           }
         }
       }
       return context.modelContextWindowById.get(key);
     });
 
-    // OpenCode reports token usage on the `message.updated` event once the
-    // assistant message completes; earlier updates for the same message carry
-    // zero tokens. Emit one `thread.token-usage.updated` per message id.
+    // OpenCode reports token usage on the `message.updated` event as the
+    // assistant message completes. Only completed messages (`time.completed`
+    // set) are counted, so a mid-completion update carrying a partial token
+    // footprint can never consume the message's one-shot emission.
     const emitOpenCodeTokenUsage = Effect.fn("emitOpenCodeTokenUsage")(function* (
       context: OpenCodeSessionContext,
       info: AssistantMessage,
       turnId: TurnId | undefined,
       raw: unknown,
     ) {
+      if (info.time?.completed === undefined) {
+        return;
+      }
       const messageTokens = openCodeMessageTokensTotal(info.tokens);
       if (messageTokens <= 0 || context.tokenUsageEmittedMessageIds.has(info.id)) {
         return;
@@ -993,6 +998,7 @@ export function makeOpenCodeAdapter(
 
         case "message.removed": {
           context.messageRoleById.delete(event.properties.messageID);
+          context.tokenUsageEmittedMessageIds.delete(event.properties.messageID);
           break;
         }
 

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -8,6 +8,7 @@ import {
   RuntimeItemId,
   RuntimeRequestId,
   ThreadId,
+  type ThreadTokenUsageSnapshot,
   type ToolLifecycleItemType,
   TurnId,
   type UserInputQuestion,
@@ -23,7 +24,14 @@ import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
-import type { OpencodeClient, Part, PermissionRequest, QuestionRequest } from "@opencode-ai/sdk/v2";
+import type {
+  AssistantMessage,
+  OpencodeClient,
+  Part,
+  PermissionRequest,
+  Provider,
+  QuestionRequest,
+} from "@opencode-ai/sdk/v2";
 import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
 
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
@@ -233,6 +241,8 @@ interface OpenCodeSessionContext {
   readonly partById: Map<string, Part>;
   readonly emittedTextByPartId: Map<string, string>;
   readonly completedAssistantPartIds: Set<string>;
+  readonly modelContextWindowById: Map<string, number>;
+  readonly tokenUsageEmittedMessageIds: Set<string>;
   readonly turns: Array<OpenCodeTurnSnapshot>;
   activeTurnId: TurnId | undefined;
   activeAgent: string | undefined;
@@ -481,6 +491,62 @@ const isoFromEpochMs = (value: number) =>
     }),
   );
 
+// Wire-shape tolerant: events from older OpenCode versions may omit the
+// token fields entirely, and the event pump must not die on them.
+function openCodeMessageTokensTotal(value: unknown): number {
+  if (!value || typeof value !== "object") {
+    return 0;
+  }
+  const tokens = value as AssistantMessage["tokens"];
+  const cache = tokens.cache;
+  return (
+    (typeof tokens.input === "number" ? tokens.input : 0) +
+    (typeof tokens.output === "number" ? tokens.output : 0) +
+    (typeof tokens.reasoning === "number" ? tokens.reasoning : 0) +
+    (cache && typeof cache.read === "number" ? cache.read : 0) +
+    (cache && typeof cache.write === "number" ? cache.write : 0)
+  );
+}
+
+/**
+ * Map a completed OpenCode assistant message's token usage into the adapter's
+ * thread token-usage snapshot. "Used" is the last request's full token
+ * footprint (input, cached input, output, reasoning) — the closest signal of
+ * how full the model's context window is, matching the semantics the Claude
+ * and Codex adapters report. Capped at the model's context window when known.
+ * Exported for unit testing.
+ */
+export function normalizeOpenCodeTokenUsage(
+  tokens: AssistantMessage["tokens"],
+  modelContextWindow?: number,
+): ThreadTokenUsageSnapshot | undefined {
+  const usedTokens = openCodeMessageTokensTotal(tokens);
+  if (usedTokens <= 0) {
+    return undefined;
+  }
+  const maxTokens =
+    modelContextWindow !== undefined && modelContextWindow > 0 ? modelContextWindow : undefined;
+  const cappedUsedTokens = maxTokens !== undefined ? Math.min(usedTokens, maxTokens) : usedTokens;
+  const inputTokens = tokens.input;
+  const cachedInputTokens = tokens.cache.read;
+  const outputTokens = tokens.output;
+  const reasoningOutputTokens = tokens.reasoning;
+  return {
+    usedTokens: cappedUsedTokens,
+    lastUsedTokens: cappedUsedTokens,
+    ...(maxTokens !== undefined ? { maxTokens } : {}),
+    ...(inputTokens > 0 ? { inputTokens, lastInputTokens: inputTokens } : {}),
+    ...(cachedInputTokens > 0
+      ? { cachedInputTokens, lastCachedInputTokens: cachedInputTokens }
+      : {}),
+    ...(outputTokens > 0 ? { outputTokens, lastOutputTokens: outputTokens } : {}),
+    ...(reasoningOutputTokens > 0
+      ? { reasoningOutputTokens, lastReasoningOutputTokens: reasoningOutputTokens }
+      : {}),
+    compactsAutomatically: true,
+  };
+}
+
 function messageRoleForPart(
   context: OpenCodeSessionContext,
   part: Pick<Part, "messageID" | "type">,
@@ -683,6 +749,71 @@ export function makeOpenCodeAdapter(
       },
     ) => writeNativeEvent(threadId, event).pipe(Effect.catchCause(() => Effect.void));
 
+    // The model slug is per-message (the session can switch models in
+    // flight), so the context window is resolved lazily on the first
+    // completed assistant message and cached for the session lifetime.
+    // Best-effort: a failed lookup means "no percentage" on the meter,
+    // never a broken turn.
+    const resolveModelContextWindow = Effect.fn("resolveModelContextWindow")(function* (
+      context: OpenCodeSessionContext,
+      providerID: string,
+      modelID: string,
+    ) {
+      const key = `${providerID}/${modelID}`;
+      const cached = context.modelContextWindowById.get(key);
+      if (cached !== undefined) {
+        return cached;
+      }
+      const providers = yield* runOpenCodeSdk("provider.list", () =>
+        context.client.provider.list(),
+      ).pipe(
+        Effect.map((response) => response.data?.all ?? []),
+        Effect.orElseSucceed((): Provider[] => []),
+      );
+      for (const provider of providers) {
+        for (const [id, model] of Object.entries(provider.models)) {
+          if (model.limit.context > 0) {
+            context.modelContextWindowById.set(`${provider.id}/${id}`, model.limit.context);
+          }
+        }
+      }
+      return context.modelContextWindowById.get(key);
+    });
+
+    // OpenCode reports token usage on the `message.updated` event once the
+    // assistant message completes; earlier updates for the same message carry
+    // zero tokens. Emit one `thread.token-usage.updated` per message id.
+    const emitOpenCodeTokenUsage = Effect.fn("emitOpenCodeTokenUsage")(function* (
+      context: OpenCodeSessionContext,
+      info: AssistantMessage,
+      turnId: TurnId | undefined,
+      raw: unknown,
+    ) {
+      const messageTokens = openCodeMessageTokensTotal(info.tokens);
+      if (messageTokens <= 0 || context.tokenUsageEmittedMessageIds.has(info.id)) {
+        return;
+      }
+      context.tokenUsageEmittedMessageIds.add(info.id);
+      const modelContextWindow = yield* resolveModelContextWindow(
+        context,
+        info.providerID,
+        info.modelID,
+      );
+      const usage = normalizeOpenCodeTokenUsage(info.tokens, modelContextWindow);
+      if (usage === undefined) {
+        return;
+      }
+      yield* emit({
+        ...(yield* buildEventBase({
+          threadId: context.session.threadId,
+          turnId,
+          raw,
+        })),
+        type: "thread.token-usage.updated",
+        payload: { usage },
+      });
+    });
+
     const emitUnexpectedExit = Effect.fn("emitUnexpectedExit")(function* (
       context: OpenCodeSessionContext,
       message: string,
@@ -851,6 +982,7 @@ export function makeOpenCodeAdapter(
               }
               yield* emitAssistantTextDelta(context, part, turnId, event);
             }
+            yield* emitOpenCodeTokenUsage(context, event.properties.info, turnId, event);
           }
           break;
         }
@@ -1398,6 +1530,8 @@ export function makeOpenCodeAdapter(
           emittedTextByPartId: new Map(),
           messageRoleById: new Map(),
           completedAssistantPartIds: new Set(),
+          modelContextWindowById: new Map(),
+          tokenUsageEmittedMessageIds: new Set(),
           turns: [],
           activeTurnId: undefined,
           activeAgent: undefined,

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -492,17 +492,23 @@ const isoFromEpochMs = (value: number) =>
   );
 
 // Wire-shape tolerant: events from older OpenCode versions may omit the
-// token fields entirely, and the event pump must not die on them.
+// token fields entirely, and the event pump must not die on them. The count
+// mirrors OpenCode's own overflow check (session/overflow.ts `isOverflow`):
+// the reported `total` when present, otherwise input + output + cached
+// input/write. Keeping the same formula means the meter agrees with when
+// OpenCode itself decides the context is full and compacts.
 function openCodeMessageTokensTotal(value: unknown): number {
   if (!value || typeof value !== "object") {
     return 0;
   }
   const tokens = value as AssistantMessage["tokens"];
+  if (typeof tokens.total === "number" && tokens.total > 0) {
+    return tokens.total;
+  }
   const cache = tokens.cache;
   return (
     (typeof tokens.input === "number" ? tokens.input : 0) +
     (typeof tokens.output === "number" ? tokens.output : 0) +
-    (typeof tokens.reasoning === "number" ? tokens.reasoning : 0) +
     (cache && typeof cache.read === "number" ? cache.read : 0) +
     (cache && typeof cache.write === "number" ? cache.write : 0)
   );
@@ -510,11 +516,9 @@ function openCodeMessageTokensTotal(value: unknown): number {
 
 /**
  * Map a completed OpenCode assistant message's token usage into the adapter's
- * thread token-usage snapshot. "Used" is the last request's full token
- * footprint (input, cached input, output, reasoning) — the closest signal of
- * how full the model's context window is, matching the semantics the Claude
- * and Codex adapters report. Capped at the model's context window when known.
- * Exported for unit testing.
+ * thread token-usage snapshot. "Used" is the last request's token footprint,
+ * counted the same way OpenCode's own compaction check counts it, capped at
+ * the model's context window when known. Exported for unit testing.
  */
 export function normalizeOpenCodeTokenUsage(
   tokens: AssistantMessage["tokens"],


### PR DESCRIPTION
OpenCode sessions never report token usage, so the context window meter (used/max + percentage) that the composer shows for Claude and Codex sessions stays hidden for OpenCode threads.

The adapter now normalizes the token usage from each completed assistant message (`message.updated`) into a `thread.token-usage.updated` event, and the existing ingestion pipeline and meter handle the rest.

- Usage is counted the same way OpenCode's own compaction check counts it (`total` when reported, otherwise input + output + cached input/write), capped at the model's context window when known.
- The model's context window comes from `client.provider.list()`, resolved lazily on the first completed message and cached for the session.
- One usage event per message id; assistant messages without token data (older OpenCode versions) are ignored without affecting the event pump.

Generated with Qwen3.8-27B (LM Studio) via opencode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive adapter behavior on the existing event path; failures on provider.list only omit max/cap, and malformed token shapes are handled defensively.
> 
> **Overview**
> OpenCode threads can now drive the composer **context window meter** by emitting **`thread.token-usage.updated`** when assistant messages finish, matching what Claude and Codex adapters already do.
> 
> On completed assistant **`message.updated`** events (`time.completed` set), the adapter maps OpenCode’s `tokens` payload into a **`ThreadTokenUsageSnapshot`** via **`normalizeOpenCodeTokenUsage`**, using the same total formula as OpenCode’s compaction check (`total` when present, else input + output + cache read/write), caps **`usedTokens`** at the model limit when known, and sets **`compactsAutomatically: true`**. **`provider.list`** is called once per session (best-effort) to cache each model’s context window; emissions are **one per message id**, partial in-flight updates are ignored, and **`message.removed`** clears the dedupe set. Missing or zero token data is skipped without breaking the event pump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7592599d417cc58f410831da4a1de7ef733d7087. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Emit `thread.token-usage.updated` for completed OpenCode assistant messages
> - Adds `normalizeOpenCodeTokenUsage` and `openCodeMessageTokensTotal` helpers in [OpenCodeAdapter.ts](https://github.com/pingdotgg/t3code/pull/7616/files#diff-a4267388b15e5043ae1899beded972cbee9e52533ca3d9d65d438a91a9f7fbe7) to compute token totals and build a `ThreadTokenUsageSnapshot` from `AssistantMessage.tokens`
> - On assistant message completion, the event pump resolves the model context window via `client.provider.list` (cached per session in `modelContextWindowById`), normalizes usage, and emits a `thread.token-usage.updated` event once per message using `tokenUsageEmittedMessageIds`
> - In-progress updates are ignored; `message.removed` clears the emission guard for that message
> - Risk: `resolveModelContextWindow` calls `client.provider.list` once per session on first need; if that call fails or returns unexpected data, `maxTokens` will be absent from the emitted snapshot
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7592599.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->