### PR TITLE
fix(server): ignore tags during remote fetch

### DIFF
--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -1502,6 +1502,48 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
   });
 
   describe("remote operations", () => {
+    it.effect("fetches remote branches without updating tags", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        const remote = yield* makeTmpDir("git-remote-");
+        const peer = yield* makeTmpDir("git-peer-");
+        const { initialBranch } = yield* initRepoWithCommit(cwd);
+        yield* git(remote, ["init", "--bare"]);
+        yield* git(cwd, ["remote", "add", "origin", remote]);
+        yield* git(cwd, ["push", "-u", "origin", initialBranch]);
+        yield* git(cwd, ["tag", "release"]);
+        yield* git(cwd, ["push", "origin", "refs/tags/release"]);
+        yield* git(remote, ["symbolic-ref", "HEAD", `refs/heads/${initialBranch}`]);
+        const localTagCommit = yield* git(cwd, ["rev-parse", "refs/tags/release"]);
+
+        yield* git(peer, ["clone", remote, "."]);
+        yield* git(peer, ["config", "user.email", "test@test.com"]);
+        yield* git(peer, ["config", "user.name", "Test"]);
+        yield* writeTextFile(peer, "remote-change.txt", "remote\n");
+        yield* git(peer, ["add", "remote-change.txt"]);
+        yield* git(peer, ["commit", "-m", "remote change"]);
+        yield* git(peer, ["push", "origin", initialBranch]);
+        yield* git(peer, ["tag", "--force", "release"]);
+        yield* git(peer, ["push", "--force", "origin", "refs/tags/release"]);
+        const remoteHead = yield* git(peer, ["rev-parse", "HEAD"]);
+        assert.notEqual(localTagCommit, remoteHead);
+
+        // Mirrors users who enable global tag pruning. A normal fetch would
+        // reject the remote's moved tag before updating the tracking branch.
+        yield* git(cwd, ["config", "fetch.prune", "true"]);
+        yield* git(cwd, ["config", "fetch.pruneTags", "true"]);
+
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+        yield* driver.fetchRemote({ cwd, remoteName: "origin" });
+
+        assert.equal(
+          yield* git(cwd, ["rev-parse", `refs/remotes/origin/${initialBranch}`]),
+          remoteHead,
+        );
+        assert.equal(yield* git(cwd, ["rev-parse", "refs/tags/release"]), localTagCommit);
+      }),
+    );
+
     it.effect("creates a worktree from the latest fetched remote commit", () =>
       Effect.gen(function* () {
         const cwd = yield* makeTmpDir();

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -2906,7 +2906,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       yield* executeGit(
         "GitVcsDriver.fetchRemote",
         input.cwd,
-        ["fetch", "--quiet", input.remoteName],
+        ["fetch", "--quiet", "--no-tags", "--no-prune-tags", input.remoteName],
         {
           env: STATUS_UPSTREAM_REFRESH_ENV,
           fallbackErrorDetail: `git fetch ${input.remoteName} failed`,


### PR DESCRIPTION
Worktree preparation refreshes remote branches with `git fetch`, but that command inherits global tag-pruning configuration. If a local tag differs from its remote tag, the branch refresh fails with `would clobber existing tag` even though T3 Code does not need tags for the worktree.

This explicitly disables tag fetching and tag pruning for the remote refresh. A regression test enables `fetch.pruneTags`, moves a remote tag, and verifies the tracking branch updates without changing the local tag.

Tests:
- `vp test run apps/server/src/vcs/GitVcsDriverCore.test.ts` (50 passed)
- targeted lint and format checks for both changed files
- `pnpm --filter t3 typecheck`

Built with OpenAI Codex using GPT-5.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pass `--no-tags` and `--no-prune-tags` to `GitVcsDriverCore.fetchRemote`
> Forces the git fetch call in [GitVcsDriverCore.ts](https://github.com/pingdotgg/t3code/pull/7619/files#diff-1c3e2b9763c6526006485633fb677c83dc54cc1ea5563a1e51aab707c35854d8) to skip fetching and pruning tags, overriding any user-level `fetch.prune`/`fetch.pruneTags` config. Adds an integration test in [GitVcsDriverCore.test.ts](https://github.com/pingdotgg/t3code/pull/7619/files#diff-ac30488287dac9aa8d4cb819c508d77d2e47267d4aae35819e6fa24b86312c26) confirming remote-tracking branches update while local tags stay unchanged.
> - Behavioral Change: `fetchRemote` no longer updates or prunes tags; callers relying on tag updates during remote fetch must do so separately.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a61f4f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->