### PR TITLE
fix(desktop): forward Bitbucket auth to WSL

### DIFF
--- a/apps/desktop/src/backend/DesktopBackendConfiguration.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendConfiguration.test.ts
@@ -497,10 +497,16 @@ describe("DesktopBackendConfiguration", () => {
       const previousWslEnv = process.env.WSLENV;
       const previousOpenAiKey = process.env.OPENAI_API_KEY;
       const previousAnthropicKey = process.env.ANTHROPIC_API_KEY;
+      const previousBitbucketAccessToken = process.env.T3CODE_BITBUCKET_ACCESS_TOKEN;
+      const previousBitbucketEmail = process.env.T3CODE_BITBUCKET_EMAIL;
+      const previousBitbucketApiToken = process.env.T3CODE_BITBUCKET_API_TOKEN;
       try {
         process.env.WSLENV = "GOPATH/p:OPENAI_API_KEY/u:EMPTY::AZURE_DEVOPS_EXT_PAT/u";
         process.env.OPENAI_API_KEY = "openai-key";
         process.env.ANTHROPIC_API_KEY = "anthropic-key";
+        process.env.T3CODE_BITBUCKET_ACCESS_TOKEN = "bitbucket-access-token";
+        process.env.T3CODE_BITBUCKET_EMAIL = "developer@example.com";
+        process.env.T3CODE_BITBUCKET_API_TOKEN = "bitbucket-api-token";
 
         yield* Effect.gen(function* () {
           const configuration = yield* DesktopBackendConfiguration.DesktopBackendConfiguration;
@@ -520,13 +526,16 @@ describe("DesktopBackendConfiguration", () => {
           assert.equal(config.httpBaseUrl.href, "http://172.27.0.99:5050/");
           assert.equal(config.env.OPENAI_API_KEY, "openai-key");
           assert.equal(config.env.ANTHROPIC_API_KEY, "anthropic-key");
+          assert.equal(config.env.T3CODE_BITBUCKET_ACCESS_TOKEN, "bitbucket-access-token");
+          assert.equal(config.env.T3CODE_BITBUCKET_EMAIL, "developer@example.com");
+          assert.equal(config.env.T3CODE_BITBUCKET_API_TOKEN, "bitbucket-api-token");
           // The existing WSLENV is preserved byte-for-byte (note the empty
           // "::" segment survives — WSL ignores it, so we don't normalize
-          // it away) and ANTHROPIC_API_KEY is appended. OPENAI_API_KEY is
+          // it away) and missing credentials are appended. OPENAI_API_KEY is
           // already declared, so it isn't forwarded twice.
           assert.equal(
             config.env.WSLENV,
-            "GOPATH/p:OPENAI_API_KEY/u:EMPTY::AZURE_DEVOPS_EXT_PAT/u:ANTHROPIC_API_KEY",
+            "GOPATH/p:OPENAI_API_KEY/u:EMPTY::AZURE_DEVOPS_EXT_PAT/u:ANTHROPIC_API_KEY:T3CODE_BITBUCKET_ACCESS_TOKEN:T3CODE_BITBUCKET_EMAIL:T3CODE_BITBUCKET_API_TOKEN",
           );
         }).pipe(
           Effect.provide(
@@ -549,6 +558,9 @@ describe("DesktopBackendConfiguration", () => {
         restoreEnv("WSLENV", previousWslEnv);
         restoreEnv("OPENAI_API_KEY", previousOpenAiKey);
         restoreEnv("ANTHROPIC_API_KEY", previousAnthropicKey);
+        restoreEnv("T3CODE_BITBUCKET_ACCESS_TOKEN", previousBitbucketAccessToken);
+        restoreEnv("T3CODE_BITBUCKET_EMAIL", previousBitbucketEmail);
+        restoreEnv("T3CODE_BITBUCKET_API_TOKEN", previousBitbucketApiToken);
       }
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );

--- a/apps/desktop/src/backend/DesktopBackendConfiguration.ts
+++ b/apps/desktop/src/backend/DesktopBackendConfiguration.ts
@@ -91,7 +91,13 @@ const DESKTOP_BACKEND_ENV_NAMES = [
 // forward across the wsl.exe boundary without WSLENV. The dev-server URL is
 // handled separately via a `--dev-url` CLI flag because WSLENV translation of
 // URL-shaped values (colons / slashes) is unreliable.
-const WSL_FORWARDED_ENV_NAMES = ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"] as const;
+const WSL_FORWARDED_ENV_NAMES = [
+  "OPENAI_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "T3CODE_BITBUCKET_ACCESS_TOKEN",
+  "T3CODE_BITBUCKET_EMAIL",
+  "T3CODE_BITBUCKET_API_TOKEN",
+] as const;
 
 const WSL_SERVER_SYSTEM_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 


### PR DESCRIPTION
The Windows desktop process did not forward Bitbucket credentials into its managed WSL backend. As a result, Bitbucket requests ran anonymously even when the credentials were configured in the Windows environment, eventually exhausting the anonymous API rate limit.

This adds all three supported Bitbucket credential variables to the existing WSL forwarding allowlist and extends the focused backend configuration test to verify both the child environment and generated `WSLENV`. Secret values remain in the child environment; `WSLENV` contains only their names.

Fixes #7621.

Related: #5840 documents the same missing-credential symptom on macOS. This PR is limited to the Windows/WSL launch path and does not claim to fix the macOS shell-profile path.

Validation:
- `vp test run apps/desktop/src/backend/DesktopBackendConfiguration.test.ts` (23 tests)
- `vp fmt --check apps/desktop/src/backend/DesktopBackendConfiguration.ts apps/desktop/src/backend/DesktopBackendConfiguration.test.ts`
- `vp run --filter @t3tools/desktop typecheck`

Implemented with GPT-5.6 SOL (OpenAI Codex) via pi.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to the existing WSL secret-forwarding list with matching unit test coverage; no new auth logic beyond env propagation.
> 
> **Overview**
> **Windows desktop → WSL backend** now forwards the three supported Bitbucket credential env vars (`T3CODE_BITBUCKET_ACCESS_TOKEN`, `T3CODE_BITBUCKET_EMAIL`, `T3CODE_BITBUCKET_API_TOKEN`) using the same path as existing LLM keys: values on the WSL child `env`, and names appended to `WSLENV` when not already declared.
> 
> The `resolveWsl` WSLENV test was extended to assert those values and the updated `WSLENV` string while still preserving pre-existing entries and avoiding duplicate forwarding for vars already listed (e.g. `OPENAI_API_KEY`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1aa2bfe8de8754bccef1c9700700ffa80da3ceb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Forward `T3CODE_BITBUCKET_*` env vars to WSL in `DesktopBackendConfiguration`
> Extends `WSL_FORWARDED_ENV_NAMES` to also forward `T3CODE_BITBUCKET_ACCESS_TOKEN`, `T3CODE_BITBUCKET_EMAIL`, and `T3CODE_BITBUCKET_API_TOKEN` into the WSL backend environment via `resolveWsl`, and appends their names to `WSLENV` when present. Updates the corresponding test to assert these vars reach `config.env` and that existing `WSLENV` entries are preserved.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1aa2bfe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
