### PR TITLE
feat(usage): add OpenCode to usage contract and provider presentation

### DIFF
--- a/apps/mobile/src/features/usage/usageProviders.ts
+++ b/apps/mobile/src/features/usage/usageProviders.ts
@@ -5,12 +5,13 @@ import { useAppearancePreferences } from "../settings/appearance/AppearancePrefe
  * Series and table order. The chart stacks providers from the bottom in this
  * order, so it also fixes which band sits on top of the bars.
  */
-export const PROVIDER_ORDER: readonly UsageProviderKind[] = ["codex", "claude", "grok"];
+export const PROVIDER_ORDER: readonly UsageProviderKind[] = ["codex", "claude", "grok", "opencode"];
 
 export const PROVIDER_LABEL: Record<UsageProviderKind, string> = {
   claude: "Claude Code",
   codex: "Codex",
   grok: "Grok Build",
+  opencode: "OpenCode",
 };
 
 /**
@@ -23,5 +24,6 @@ export function useProviderColors(): Record<UsageProviderKind, string> {
     claude: "#d97757",
     codex: scheme === "dark" ? "#e6e6e6" : "#3c3c43",
     grok: scheme === "dark" ? "#a1a1aa" : "#52525b",
+    opencode: "#8b5cf6",
   };
 }

--- a/apps/web/src/components/usage/UsageProviderChart.test.ts
+++ b/apps/web/src/components/usage/UsageProviderChart.test.ts
@@ -87,6 +87,7 @@ describe("buildDayColumns", () => {
       { provider: "codex", value: 10 },
       { provider: "claude", value: 20 },
       { provider: "grok", value: 0 },
+      { provider: "opencode", value: 0 },
     ]);
   });
 

--- a/apps/web/src/components/usage/usageProviders.ts
+++ b/apps/web/src/components/usage/usageProviders.ts
@@ -1,6 +1,6 @@
 import type { UsageProviderKind } from "@t3tools/contracts";
 
-import { ClaudeAI, GrokIcon, type Icon, OpenAI } from "../Icons";
+import { ClaudeAI, GrokIcon, type Icon, OpenAI, OpenCodeIcon } from "../Icons";
 
 type UsageProviderPresentation = {
   readonly label: string;
@@ -29,6 +29,11 @@ export const PROVIDER_PRESENTATION = {
     // Contrast-aware neutral between the Codex series and muted chart chrome.
     color: "color-mix(in oklab, var(--contrast-foreground) 72%, var(--background))",
     mark: GrokIcon,
+  },
+  opencode: {
+    label: "OpenCode",
+    color: "#8b5cf6",
+    mark: OpenCodeIcon,
   },
 } satisfies Record<UsageProviderKind, UsageProviderPresentation>;
 

--- a/packages/contracts/src/usage.ts
+++ b/packages/contracts/src/usage.ts
@@ -21,18 +21,18 @@ import { NonNegativeInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
  * client renders partial coverage when an environment reports an older version
  * rather than failing the whole page.
  */
-export const USAGE_CONTRACT_VERSION = 5 as const;
+export const USAGE_CONTRACT_VERSION = 6 as const;
 
 /**
  * Oldest {@link UsageSummary} version a current client will still merge.
  *
- * v5 only adds `grok` to {@link UsageProviderKind}; v4 Claude/Codex buckets
- * remain valid, so mixed-version environments keep those totals instead of
- * treating every older server as stale.
+ * v5 only adds `grok` to {@link UsageProviderKind}; v6 adds `opencode`.
+ * v4 Claude/Codex buckets remain valid, so mixed-version environments keep
+ * those totals instead of treating every older server as stale.
  */
 export const USAGE_MERGE_COMPATIBLE_SINCE = 4 as const;
 
-export const UsageProviderKind = Schema.Literals(["claude", "codex", "grok"]);
+export const UsageProviderKind = Schema.Literals(["claude", "codex", "grok", "opencode"]);
 export type UsageProviderKind = typeof UsageProviderKind.Type;
 
 /**


### PR DESCRIPTION
## What Changed

Adds OpenCode to the usage contract and to the provider presentation on web and mobile, on top of the Grok support that landed on `main` as v5 in #8358.

- `packages/contracts/src/usage.ts` gains `"opencode"` in `UsageProviderKind` (`["claude", "codex", "grok", "opencode"]`) and bumps `USAGE_CONTRACT_VERSION` from 5 to 6. `USAGE_MERGE_COMPATIBLE_SINCE` stays at 4, so v4 Claude/Codex and v5 Grok buckets remain valid. Clients on an older version show partial coverage rather than failing the page.
- `apps/web/src/components/usage/usageProviders.ts` registers OpenCode as `OpenCode`, violet `#8b5cf6`, with `OpenCodeIcon` alongside the existing `grok` entry. Keeps `codex` color as `var(--contrast-foreground)` from `main` and retains the `providersWithUsage` helper. Order is now `codex, claude, grok, opencode`, so charts, legends, and tables pick it up automatically.
- `apps/mobile/src/features/usage/usageProviders.ts` adds the same order, label, and color for the React Native chart (`grok` stays as the neutral gray, `opencode` is violet).
- `apps/web/src/components/usage/UsageProviderChart.test.ts` now expects zero-valued `grok` and `opencode` bands together.

This is the contract and UI half. The server scan that reads `~/.local/share/opencode/opencode.db` via `node:sqlite` follows next, as drafted in #6040. Keeping the two apart keeps the contract change reviewable and lets existing clients start handling the new provider.

Rebased onto `main` at `f6f2be32d` to resolve conflicts with Grok usage (#8358) and subsequent usage-page refactors (provider filtering, skeleton updates, and `activeProviders`).

## Why

The Usage page now knows `claude`, `codex`, and `grok`. Anyone who works through OpenCode still sees understated cost and token totals. I run OpenCode daily on a Pi and the page tells me I barely used anything. That is not true. My `opencode stats` says otherwise.

OpenCode already reports per-turn usage for the context meter. The Usage page should do the same rollup it does for the other providers, reading the provider's own store so sessions started outside T3 Code still count. That is the `ccusage` approach the existing providers use.

Related: closed #5706 described the gap for Grok and OpenCode. Grok landed in #8358. Open PRs #6040, #6014, and #7221 propose the full OpenCode SQLite scan. None have landed on `main` yet. This starts with the contract so the UI does not need a second pass.

## UI Changes

No visual change until the server emits opencode buckets. When it does, the same chart and tables that render Codex, Claude, and Grok will include OpenCode without extra wiring. `UsagePage` already filters to `activeProviders` on `main`, so the breakdown table only shows providers with activity and its empty-state `colSpan` stays as `activeProviders.length + 3`.

Before: Claude Code, Codex, and Grok Build in the legend (when they have data).

After: legend, chart, and breakdown accept a fourth entry. With empty opencode data the page looks unchanged. With data it shows four bands, as in #6040 screenshots.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (no change until server scan lands)
- [ ] I included a video for animation/interaction changes (not applicable)

Built with opencode + muse-spark-1.2-contributor on t3.

Closes pingdotgg/t3code#7622

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bumping the usage contract version and extending `UsageProviderKind` affects every client and server that serializes or merges usage summaries; the change is additive and merge-compatible, but mismatched versions could still show partial coverage.
> 
> **Overview**
> Extends usage reporting so **OpenCode** is a first-class provider alongside Claude, Codex, and Grok—contract and UI only; no server scan in this diff.
> 
> In **`packages/contracts`**, `UsageProviderKind` gains the `opencode` literal and **`USAGE_CONTRACT_VERSION`** is bumped to **6** (with merge notes that v5 grok and v4 buckets still merge). Web **`usageProviders`** registers OpenCode presentation (label, violet `#8b5cf6`, **`OpenCodeIcon`**), and mobile **`usageProviders`** adds the same label, color, and stack order. Chart tests now expect a zero-valued **opencode** band in day columns.
> 
> Until backends emit `opencode` buckets, the Usage page looks the same; when data arrives, charts and tables pick it up via existing provider-order wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe3155c0b2733ee42ed9d3b54ccacb3a0ef84637. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `opencode` provider to usage contract and provider presentation
> - Extends `UsageProviderKind` schema with the literal `"opencode"` and bumps `USAGE_CONTRACT_VERSION` from 5 to 6 in [usage.ts](https://github.com/pingdotgg/t3code/pull/7623/files#diff-9abc3595e224ffc63bc8ed068d884a2dad83ccb207f0b183e94259fb7f486a13)
> - Adds `opencode` to `PROVIDER_ORDER`, `PROVIDER_LABEL`, and `useProviderColors` (color `#8b5cf6`) in the mobile providers map [usageProviders.ts](https://github.com/pingdotgg/t3code/pull/7623/files#diff-e4cbc6b88dbf7671b63f59c20a7d1383f3b1520abb34598565da5c318178dc01)
> - Adds matching `PROVIDER_PRESENTATION` entry with label, color, and `OpenCodeIcon` in the web providers map [usageProviders.ts](https://github.com/pingdotgg/t3code/pull/7623/files#diff-1239d4db3da7697f4049ced6bc9ed40ea2896435b8994e4558f10ac229c8bfdc)
> - Updates the web chart test to expect an `opencode` band with value 0 [UsageProviderChart.test.ts](https://github.com/pingdotgg/t3code/pull/7623/files#diff-d99d57a044a74f07ecab557801b7fd12fb1f67bae8ad9ced3250e94a252bae18)
> - Risk: clients on contract version 5 will not recognize `opencode` in usage summaries; bumping `USAGE_CONTRACT_VERSION` to 6 means only version-6-aware consumers can parse the new provider kind
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe3155c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->