### PR TITLE
Claude/design agy broker pty

### DIFF
--- a/docs/fork/README.md
+++ b/docs/fork/README.md
@@ -48,7 +48,23 @@ the agent keeps its built-in tools. Routing built-ins through MCP as well is
 later hardening — it buys per-action review instead of standing grants, and is
 not needed to ship.
 
-### 3. Peer fabric — proposal
+### 3. Generic ACP driver — design
+
+[generic-acp-driver.md](./generic-acp-driver.md)
+
+A T3 driver that speaks only the open Agent Client Protocol, so it can drive any
+ACP agent — including the bridge above — with no vendor methods in its core.
+
+Written to be upstream-able. Vendor knowledge lives in **profiles**, which are
+data: a named bundle of command, args, env, capabilities and models. Adding an
+agent is a config entry, never a new adapter.
+
+Why not reuse an existing driver: `CursorAdapter.ts` carries
+`cursor/list_available_models`, `cursor/ask_question`, `cursor/create_plan` and
+`cursor/update_todos`. Those are vendor extensions, not ACP, and matching them
+would mean impersonating another vendor's product in a public repository.
+
+### 4. Peer fabric — proposal
 
 [t3-p2p-proposal.md](./t3-p2p-proposal.md)
 
@@ -57,11 +73,11 @@ mechanism. The gap it addresses is **provisioning**, not transport: before a
 client can connect to a machine, something has to be running there, and today
 that means opening a shell and configuring an address by hand.
 
-Central principle: a peer offers *capabilities* ("this machine will run a
+Central principle: a peer offers _capabilities_ ("this machine will run a
 broker for you"), never access. A peer that runs arbitrary commands is a remote
 shell wearing a fabric costume.
 
-### 4. Broker PTY adapter — documented, not recommended
+### 5. Broker PTY adapter — documented, not recommended
 
 [agy-broker-pty.md](./agy-broker-pty.md)
 

--- a/docs/fork/README.md
+++ b/docs/fork/README.md
@@ -1,0 +1,63 @@
+# Fork-local design docs
+
+Documents specific to the `s243a/t3code` fork. They live here rather than in
+`docs/internals/` — which upstream owns — so provenance stays obvious and
+rebases against upstream stay clean. Nothing here is proposed upstream.
+
+## Goal
+
+Run the Antigravity CLI (`agy`) from a phone, through T3 Code.
+
+## Options, in the order they should be considered
+
+### 1. T3's existing terminal — shipped, zero code
+
+Open a thread terminal on the machine where `agy` lives and type `agy`.
+
+Works on the same machine as the T3 server or a different one, because T3
+expresses remoteness at the connection layer: one server per machine, and a
+client holds many saved environments and connects to each directly. Desktop can
+even start a remote server over SSH and pair it
+([remote access](../user/remote-access.md), Option 3).
+
+Terminal scrollback is persisted to disk and replayed on reattach, so this
+survives disconnects. **Start here.** It costs nothing to find out whether it is
+already enough.
+
+Limits: a terminal is a terminal — no approval cards, no per-turn checkpointing,
+no thread history. `agy`'s permission prompts are answered by typing into its
+TUI, including the ctrl+g expansion needed to read truncated commands before
+approving them.
+
+### 2. ACP bridge — the way to get a real T3 provider
+
+[mcp-to-acp-bridge.md](./mcp-to-acp-bridge.md)
+
+Two routes to making `agy` speak ACP, which is what T3's provider layer
+consumes:
+
+- **Route A, MCP-gated bridge.** Intercept the agent's MCP tool calls and expose
+  them as ACP, turning each call into a permission request. Agent-agnostic;
+  likely its own repository (working name `MCP-to-ACP`).
+- **Route B, `agy`'s local Connect API.** Higher potential fidelity, one agent
+  only, unverified.
+
+Open question that decides Route A's completeness: can the target agent run with
+built-in tools disabled, or restricted to MCP-provided ones? Settle that before
+building.
+
+### 3. Broker PTY adapter — documented, not recommended
+
+[agy-broker-pty.md](./agy-broker-pty.md)
+
+Relay T3's `PtyAdapter` to the SciREPL broker's `/term` endpoint. Written when
+option 1 was believed not to cover cross-host; **it does**, so the transport
+argument for this is gone.
+
+Retained because the constraint analysis is accurate and the narrow remaining
+argument — privilege surface, a machine where you want `agy` reachable but not a
+general-purpose remote dev server — may become concrete later.
+
+## Status
+
+Nothing in options 2 or 3 is implemented. Option 1 needs no implementation.

--- a/docs/fork/README.md
+++ b/docs/fork/README.md
@@ -48,7 +48,20 @@ the agent keeps its built-in tools. Routing built-ins through MCP as well is
 later hardening — it buys per-action review instead of standing grants, and is
 not needed to ship.
 
-### 3. Broker PTY adapter — documented, not recommended
+### 3. Peer fabric — proposal
+
+[t3-p2p-proposal.md](./t3-p2p-proposal.md)
+
+What a P2P layer for T3 should do, at the level of intent rather than
+mechanism. The gap it addresses is **provisioning**, not transport: before a
+client can connect to a machine, something has to be running there, and today
+that means opening a shell and configuring an address by hand.
+
+Central principle: a peer offers *capabilities* ("this machine will run a
+broker for you"), never access. A peer that runs arbitrary commands is a remote
+shell wearing a fabric costume.
+
+### 4. Broker PTY adapter — documented, not recommended
 
 [agy-broker-pty.md](./agy-broker-pty.md)
 

--- a/docs/fork/README.md
+++ b/docs/fork/README.md
@@ -42,9 +42,11 @@ consumes:
 - **Route B, `agy`'s local Connect API.** Higher potential fidelity, one agent
   only, unverified.
 
-Open question that decides Route A's completeness: can the target agent run with
-built-in tools disabled, or restricted to MCP-provided ones? Settle that before
-building.
+Route A has a minimum viable form with no open prerequisites: gate the agent's
+MCP calls as ACP permission requests and take assistant prose from stdout, while
+the agent keeps its built-in tools. Routing built-ins through MCP as well is
+later hardening — it buys per-action review instead of standing grants, and is
+not needed to ship.
 
 ### 3. Broker PTY adapter — documented, not recommended
 

--- a/docs/fork/agy-broker-pty.md
+++ b/docs/fork/agy-broker-pty.md
@@ -1,0 +1,223 @@
+# Stage 2 — running `agy` over a SciREPL broker PTY
+
+> **Fork-local document.** This describes work specific to the `s243a/t3code`
+> fork and is not proposed for upstream. It lives under `docs/fork/` so it stays
+> out of `docs/internals/`, which upstream owns.
+
+## Status
+
+Design only. Nothing here is implemented. Stage 1 (run `agy` in T3 Code's
+existing thread terminal, same machine as the server) needs no code and is the
+current recommended path.
+
+## Sources
+
+Every protocol claim below is sourced to a public document, so this design can
+be published alongside the fork:
+
+- T3 Code's PTY contract — `apps/server/src/terminal/PtyAdapter.ts` (this repo)
+- The broker wire protocol — [`docs/protocol.md`][protocol] §Terminal (`/term`)
+  in the public [SciREPL-MCP][mcp] repository, vendored at
+  `.repos/scirepl-mcp` on the `claude/scirepl-mcp-submodule-gs2ifz` branch
+
+No part of this design derives from SciREPL Pro. The adapter implements T3
+Code's own interface against the published broker protocol; it does not port
+the Pro client.
+
+## Problem
+
+Stage 1 covers the common case: `agy` on the same machine as the T3 server,
+typed into a thread terminal. It works today, survives disconnects, and replays
+scrollback from disk.
+
+It does not cover `agy` running on a **different machine** from the T3 server.
+T3 Code has no cross-host terminal or provider transport at all. The SciREPL
+broker already solves exactly that shape — it spawns a PTY on its own host and
+relays it over a WebSocket — so the gap is a transport adapter, not a feature.
+
+Target topology:
+
+```
+phone ──► T3 server (machine A) ──► broker (machine B) ──► PTY: agy, on B
+          [T3 WS/RPC]              [broker /term WS]
+```
+
+Reverse-worker mode (`/worker`) is explicitly **out of scope**. It exists to
+relay to a third host beyond the broker, and this design does not need that
+indirection: the broker's ordinary `/term` already spawns the PTY on the broker
+host, which is where `agy` runs.
+
+## The seam
+
+`PtyAdapter` is a `Context.Service` with a single method, and T3 already ships
+two implementations (`NodePtyAdapter`, `BunPtyAdapter`) precisely so it can be
+swapped:
+
+```ts
+spawn(input: PtySpawnInput): Effect<PtyProcess, PtySpawnError>
+
+interface PtyProcess {
+  readonly pid: number
+  write(data: string): void
+  resize(cols: number, rows: number): void
+  kill(signal?: string): void
+  onData(cb: (data: string) => void): () => void
+  onExit(cb: (e: PtyExitEvent) => void): () => void
+}
+```
+
+Everything above it — `TerminalManager`, the wire contract, web/desktop/mobile
+UI, disk-persisted scrollback — is transport-agnostic and is reused unchanged.
+A third implementation is the entire feature.
+
+### Call mapping
+
+| `PtyProcess` | Broker `/term` message |
+| --- | --- |
+| construction | `{type:"start", cmd, cols, rows}` → `started` |
+| `write(data)` | `{type:"input", data}` |
+| `resize(c,r)` | `{type:"resize", cols, rows}` |
+| `kill()` | `{type:"stop"}` |
+| `onData(cb)` | `{type:"term", kind:"data"}` |
+| `onExit(cb)` | `{type:"term", kind:"exit"}` |
+
+Message shapes are quoted from [`docs/protocol.md`][protocol] §Terminal.
+
+`NodePtyAdapter` (172 lines) is the structural template: a small class wrapping
+a handle, plus an `Effect.fn` factory returning `PtyAdapter.PtyAdapter.of({ spawn })`.
+
+## Constraints that shape the design
+
+These are the parts that are *not* a mechanical translation. Each one is a real
+mismatch between the two models.
+
+### 1. The adapter is resolved once, not per spawn
+
+`TerminalManager` takes `ptyAdapter` as a constructor option
+(`Manager.ts:1113`) and resolves it once (`Manager.ts:1134`). There is no
+per-session adapter selection.
+
+**Therefore:** do not register `BrokerPtyAdapter` as the service. Register a
+single **delegating** adapter that inspects `PtySpawnInput` — which carries
+`shell`, `args`, `cwd`, `cols`, `rows`, `env` — and routes each spawn to either
+the local node-pty path or the broker path. `Manager.ts` needs no changes.
+
+The routing key should be explicit rather than inferred. An `env` marker set
+when the terminal is opened is the least surprising option, since `env` already
+flows end-to-end through `TerminalOpenInput`.
+
+### 2. The broker hosts exactly one PTY, globally
+
+`termBridge` is a module-level singleton holding one `pty`. A `start` while a
+PTY exists **reattaches to it** rather than spawning a second one, replying
+`started` with `reattached: true`.
+
+T3 supports many terminals across many threads. These models do not agree.
+
+**Therefore:** treat one broker as capacity for exactly one T3 terminal. A
+second broker-routed terminal must fail cleanly at open time with an
+explanatory error — never silently adopt another terminal's session, which
+would cross-wire two threads' output. This is the single most important
+correctness constraint in this design.
+
+### 3. `started` carries no pid
+
+The broker replies `{kind:"started", cmd}`; the pid is logged on the broker host
+but never sent. T3's `PtyProcess.pid` is a required `number`.
+
+**Therefore:** synthesize a stable negative pid per broker session so it cannot
+collide with a real local pid. Consequence to accept: `registerTerminalProcesses`
+feeds `PortScanner`, so **port discovery and preview detection do not work for
+broker terminals**. That is a real feature loss, not a rough edge — it should be
+stated in the UI rather than silently degraded.
+
+### 4. `cwd` is the broker's, not T3's
+
+The broker spawns with `cwd: AGENT_CWD`, its own configured workspace. T3's
+per-terminal `cwd` has no effect.
+
+**Therefore:** the working directory is broker configuration, not T3 state. The
+UI must not imply otherwise — showing a local path for a remote terminal would
+be a lie. Surface the broker's advertised workspace instead, or no path at all.
+
+### 5. `shell` is a path; `cmd` is an allowlist label
+
+T3 passes a resolved shell path (`env.SHELL ?? "bash"`). The broker takes a
+label, validates it against `BROKER_TERM_CMDS`, and rejects anything else with
+`command not allowed: … (allowed: …)`. The `welcome` event advertises the
+permitted set as `cmds`.
+
+**Therefore:** the adapter maps to a label, never a path. Read `cmds` from
+`welcome` and fail the spawn with a clear `PtySpawnError` when the wanted label
+is absent — the allowlist is the broker owner's security boundary and the
+adapter must respect it rather than route around it.
+
+For this fork's purpose the label is `agy`. Keeping `shell` **out** of
+`BROKER_TERM_CMDS` is the deployment's decision and is what makes the remote
+surface meaningfully narrower than an ssh session.
+
+### 6. Grace window versus T3's retention
+
+The two layers disagree about how long a detached session lives:
+
+| | Detached session lifetime |
+| --- | --- |
+| T3 | 128 retained sessions; scrollback persisted to disk; survives server restart |
+| Broker | `BROKER_TERM_GRACE_MS`, default 600000 (10 min), then the PTY is reaped |
+
+T3 is the more durable of the two. After the grace window the broker's PTY is
+gone while T3 still believes the session exists.
+
+**Therefore:** a `start` that returns `started` *without* `reattached: true`
+when T3 expected a live session means the process was reaped. Surface that as an
+exit, so the UI shows a dead terminal instead of a live one that silently lost
+its history. Raising `BROKER_TERM_GRACE_MS` narrows the window but cannot close
+it, and must not be treated as a fix.
+
+### 7. Spawn is a round trip
+
+Local spawn is effectively synchronous. The broker path requires connect →
+`hello` → `start` → `started` before a `PtyProcess` can be returned.
+
+**Therefore:** `spawn` awaits `started` and maps `{kind:"error"}` and connect
+failure onto `PtySpawnError` (which already carries `adapter`, `shell`, `cause`).
+It needs a timeout; an unreachable broker must fail the open rather than hang
+it. `exit` carries `code` only, so `PtyExitEvent.signal` is always `null`.
+
+## What this does not buy
+
+A terminal is a terminal. There are no approval cards, no per-turn
+checkpointing, and no thread history — `agy`'s permission prompts are answered
+by typing into the TUI, including the ctrl+g expansion needed to read truncated
+commands before approving them.
+
+Those require structured output from `agy`, which it does not emit: the broker
+classifies it `format: 'text'` because there is nothing to parse. The blocker is
+[agy's own ACP/JSON-RPC feature request][acp], not the broker and not T3. If
+`agy` ever gains a structured mode, the better integration is a native T3
+provider driver modelled on `GrokDriver` + `GrokAcpSupport`, and this adapter
+becomes redundant rather than a foundation.
+
+## Open questions
+
+1. How does a user mark a terminal as broker-routed? Project setting, per-open
+   choice, or a dedicated environment concept.
+2. Where do the broker URL and token live? They are per-environment secrets and
+   must not land in thread state.
+3. Should the single-PTY limit be enforced at open time in the UI, or surfaced
+   as a spawn error? Failing early is friendlier but needs the capacity check
+   somewhere the client can reach.
+
+## Implementation sketch
+
+One new file, `apps/server/src/terminal/BrokerPtyAdapter.ts`, plus a delegating
+adapter and its wiring. Estimated size comparable to `NodePtyAdapter` (172
+lines). No changes to `Manager.ts`, the terminal contract, or any client.
+
+Tests should follow `NodePtyAdapter.test.ts` and drive a fake broker socket:
+allowlist rejection, reattach detection, grace-window expiry surfaced as exit,
+and the second-terminal refusal from constraint 2.
+
+[protocol]: https://github.com/s243a/SciREPL-MCP/blob/main/docs/protocol.md
+[mcp]: https://github.com/s243a/SciREPL-MCP
+[acp]: https://github.com/google-antigravity/antigravity-cli/issues/31

--- a/docs/fork/agy-broker-pty.md
+++ b/docs/fork/agy-broker-pty.md
@@ -4,11 +4,69 @@
 > fork and is not proposed for upstream. It lives under `docs/fork/` so it stays
 > out of `docs/internals/`, which upstream owns.
 
-## Status
+## Status: not recommended
 
-Design only. Nothing here is implemented. Stage 1 (run `agy` in T3 Code's
-existing thread terminal, same machine as the server) needs no code and is the
-current recommended path.
+**An earlier revision of this document claimed T3 Code has no cross-host
+terminal transport. That was wrong.** T3 already solves the cross-host case,
+and this adapter is not needed to run `agy` on another machine.
+
+The design below is retained because the constraint analysis is accurate and
+would matter if the narrow remaining case (see [Does anything survive?](#does-anything-survive))
+is ever worth building. Nothing here is implemented.
+
+## What T3 already does
+
+T3's remote model puts remoteness at the **connection layer**, never by
+splitting the runtime ([`docs/internals/remote.md`](../internals/remote.md)):
+
+```
+one T3 server per machine = one ExecutionEnvironment
+client keeps a list of known environments and connects to whichever it wants
+```
+
+A client — including the phone — holds many saved environments and talks
+directly to each server. Access methods already shipped: direct LAN, bearer
+pairing, Tailscale serve, T3 Connect relay tunnels, and desktop-managed SSH.
+
+So for `agy` on machine B, controlled from a phone:
+
+1. Run a T3 server on B. The desktop app will even do this for you over SSH —
+   it "probes the host, starts or reuses a remote T3 server, opens a local port
+   forward, and saves the environment"
+   ([remote access](../user/remote-access.md), Option 3).
+2. Pair the phone to that environment. Tailscale pairing goes through the
+   ordinary bearer path.
+3. Open a terminal in a thread on B and type `agy`.
+
+Zero code, on the same machine or a different one. Terminal scrollback is
+persisted to disk and replayed on reattach, so this survives disconnects.
+
+### Why "spawn the broker from a T3 terminal" doesn't rescue the design
+
+It is circular. T3's terminal spawns on **the machine its own server runs on**.
+Using it to start a broker starts that broker on machine A — which does nothing
+to reach machine B. To start the broker on B you need execution on B, and the
+only ways to get it are a T3 server on B (which makes the broker redundant) or
+an out-of-band shell (which is the thing the broker was meant to replace).
+
+## Does anything survive?
+
+Transport was the argument for this adapter, and T3 wins it. Two narrower
+arguments remain, and neither is about reach:
+
+**Privilege surface.** A T3 server on B grants a full login shell, filesystem,
+git, and provider access. The broker with `BROKER_TERM=1` and
+`BROKER_TERM_CMDS=agy` grants exactly one PTY running one named binary, with no
+shell. If B is a machine where you want `agy` reachable but do *not* want a
+general-purpose remote development server, that difference is real — and it is
+a security argument, not a capability one.
+
+**The supervision workflow.** Per-prompt permission review with an audit trail
+has no T3 equivalent. That is a distinct product idea and does not need this
+adapter to exist.
+
+Neither justifies the work today. Revisit only if the privilege-surface
+argument becomes concrete.
 
 ## Sources
 
@@ -17,35 +75,15 @@ be published alongside the fork:
 
 - T3 Code's PTY contract — `apps/server/src/terminal/PtyAdapter.ts` (this repo)
 - The broker wire protocol — [`docs/protocol.md`][protocol] §Terminal (`/term`)
-  in the public [SciREPL-MCP][mcp] repository, vendored at
-  `.repos/scirepl-mcp` on the `claude/scirepl-mcp-submodule-gs2ifz` branch
+  in the public [SciREPL-MCP][mcp] repository
 
-No part of this design derives from SciREPL Pro. The adapter implements T3
+No part of this design derives from SciREPL Pro. The adapter would implement T3
 Code's own interface against the published broker protocol; it does not port
 the Pro client.
 
-## Problem
+---
 
-Stage 1 covers the common case: `agy` on the same machine as the T3 server,
-typed into a thread terminal. It works today, survives disconnects, and replays
-scrollback from disk.
-
-It does not cover `agy` running on a **different machine** from the T3 server.
-T3 Code has no cross-host terminal or provider transport at all. The SciREPL
-broker already solves exactly that shape — it spawns a PTY on its own host and
-relays it over a WebSocket — so the gap is a transport adapter, not a feature.
-
-Target topology:
-
-```
-phone ──► T3 server (machine A) ──► broker (machine B) ──► PTY: agy, on B
-          [T3 WS/RPC]              [broker /term WS]
-```
-
-Reverse-worker mode (`/worker`) is explicitly **out of scope**. It exists to
-relay to a third host beyond the broker, and this design does not need that
-indirection: the broker's ordinary `/term` already spawns the PTY on the broker
-host, which is where `agy` runs.
+# Design, if it were built
 
 ## The seam
 
@@ -67,8 +105,7 @@ interface PtyProcess {
 ```
 
 Everything above it — `TerminalManager`, the wire contract, web/desktop/mobile
-UI, disk-persisted scrollback — is transport-agnostic and is reused unchanged.
-A third implementation is the entire feature.
+UI, disk-persisted scrollback — is transport-agnostic and reused unchanged.
 
 ### Call mapping
 
@@ -82,14 +119,17 @@ A third implementation is the entire feature.
 | `onExit(cb)` | `{type:"term", kind:"exit"}` |
 
 Message shapes are quoted from [`docs/protocol.md`][protocol] §Terminal.
+`NodePtyAdapter` (172 lines) is the structural template.
 
-`NodePtyAdapter` (172 lines) is the structural template: a small class wrapping
-a handle, plus an `Effect.fn` factory returning `PtyAdapter.PtyAdapter.of({ spawn })`.
+Reverse-worker mode (`/worker`) is out of scope: it relays to a third host
+beyond the broker, and the broker's ordinary `/term` already spawns the PTY on
+the broker host, which is where `agy` runs.
 
-## Constraints that shape the design
+## Constraints
 
-These are the parts that are *not* a mechanical translation. Each one is a real
-mismatch between the two models.
+These are the parts that are not a mechanical translation. Each is a real
+mismatch between the two models, and they are the reason this adapter is more
+than an afternoon.
 
 ### 1. The adapter is resolved once, not per spawn
 
@@ -97,14 +137,11 @@ mismatch between the two models.
 (`Manager.ts:1113`) and resolves it once (`Manager.ts:1134`). There is no
 per-session adapter selection.
 
-**Therefore:** do not register `BrokerPtyAdapter` as the service. Register a
-single **delegating** adapter that inspects `PtySpawnInput` — which carries
-`shell`, `args`, `cwd`, `cols`, `rows`, `env` — and routes each spawn to either
-the local node-pty path or the broker path. `Manager.ts` needs no changes.
-
-The routing key should be explicit rather than inferred. An `env` marker set
-when the terminal is opened is the least surprising option, since `env` already
-flows end-to-end through `TerminalOpenInput`.
+**Therefore:** register a single **delegating** adapter that inspects
+`PtySpawnInput` — which carries `shell`, `args`, `cwd`, `cols`, `rows`, `env` —
+and routes each spawn to either the local node-pty path or the broker path. An
+`env` marker is the least surprising routing key, since `env` already flows
+end-to-end through `TerminalOpenInput`. `Manager.ts` needs no changes.
 
 ### 2. The broker hosts exactly one PTY, globally
 
@@ -115,50 +152,39 @@ PTY exists **reattaches to it** rather than spawning a second one, replying
 T3 supports many terminals across many threads. These models do not agree.
 
 **Therefore:** treat one broker as capacity for exactly one T3 terminal. A
-second broker-routed terminal must fail cleanly at open time with an
-explanatory error — never silently adopt another terminal's session, which
-would cross-wire two threads' output. This is the single most important
-correctness constraint in this design.
+second broker-routed terminal must fail cleanly at open time — never silently
+adopt another terminal's session, which would cross-wire two threads' output.
+This is the most important correctness constraint here.
 
 ### 3. `started` carries no pid
 
 The broker replies `{kind:"started", cmd}`; the pid is logged on the broker host
 but never sent. T3's `PtyProcess.pid` is a required `number`.
 
-**Therefore:** synthesize a stable negative pid per broker session so it cannot
-collide with a real local pid. Consequence to accept: `registerTerminalProcesses`
-feeds `PortScanner`, so **port discovery and preview detection do not work for
-broker terminals**. That is a real feature loss, not a rough edge — it should be
-stated in the UI rather than silently degraded.
+**Therefore:** synthesize a stable negative pid so it cannot collide with a real
+local pid. Consequence to accept: `registerTerminalProcesses` feeds
+`PortScanner`, so **port discovery and preview detection do not work for broker
+terminals**. A real feature loss, and it should be stated in the UI rather than
+silently degraded.
 
 ### 4. `cwd` is the broker's, not T3's
 
 The broker spawns with `cwd: AGENT_CWD`, its own configured workspace. T3's
-per-terminal `cwd` has no effect.
-
-**Therefore:** the working directory is broker configuration, not T3 state. The
-UI must not imply otherwise — showing a local path for a remote terminal would
-be a lie. Surface the broker's advertised workspace instead, or no path at all.
+per-terminal `cwd` has no effect. The UI must not show a local path for a remote
+terminal.
 
 ### 5. `shell` is a path; `cmd` is an allowlist label
 
 T3 passes a resolved shell path (`env.SHELL ?? "bash"`). The broker takes a
-label, validates it against `BROKER_TERM_CMDS`, and rejects anything else with
-`command not allowed: … (allowed: …)`. The `welcome` event advertises the
-permitted set as `cmds`.
+label, validates it against `BROKER_TERM_CMDS`, and rejects anything else. The
+`welcome` event advertises the permitted set as `cmds`.
 
-**Therefore:** the adapter maps to a label, never a path. Read `cmds` from
-`welcome` and fail the spawn with a clear `PtySpawnError` when the wanted label
-is absent — the allowlist is the broker owner's security boundary and the
-adapter must respect it rather than route around it.
-
-For this fork's purpose the label is `agy`. Keeping `shell` **out** of
-`BROKER_TERM_CMDS` is the deployment's decision and is what makes the remote
-surface meaningfully narrower than an ssh session.
+**Therefore:** map to a label, never a path. Read `cmds` from `welcome` and fail
+with a clear `PtySpawnError` when the wanted label is absent. The allowlist is
+the broker owner's security boundary; the adapter respects it rather than
+routing around it. This constraint is also the privilege-surface argument above.
 
 ### 6. Grace window versus T3's retention
-
-The two layers disagree about how long a detached session lives:
 
 | | Detached session lifetime |
 | --- | --- |
@@ -168,55 +194,34 @@ The two layers disagree about how long a detached session lives:
 T3 is the more durable of the two. After the grace window the broker's PTY is
 gone while T3 still believes the session exists.
 
-**Therefore:** a `start` that returns `started` *without* `reattached: true`
-when T3 expected a live session means the process was reaped. Surface that as an
-exit, so the UI shows a dead terminal instead of a live one that silently lost
-its history. Raising `BROKER_TERM_GRACE_MS` narrows the window but cannot close
-it, and must not be treated as a fix.
+**Therefore:** a `start` returning `started` *without* `reattached: true` when
+T3 expected a live session means the process was reaped. Surface that as an exit
+so the UI shows a dead terminal rather than a live one that lost its history.
+Raising `BROKER_TERM_GRACE_MS` narrows the window but cannot close it.
 
 ### 7. Spawn is a round trip
 
-Local spawn is effectively synchronous. The broker path requires connect →
-`hello` → `start` → `started` before a `PtyProcess` can be returned.
+Local spawn is effectively synchronous; the broker path needs connect → `hello`
+→ `start` → `started` before returning a `PtyProcess`.
 
 **Therefore:** `spawn` awaits `started` and maps `{kind:"error"}` and connect
-failure onto `PtySpawnError` (which already carries `adapter`, `shell`, `cause`).
-It needs a timeout; an unreachable broker must fail the open rather than hang
-it. `exit` carries `code` only, so `PtyExitEvent.signal` is always `null`.
+failure onto `PtySpawnError`. It needs a timeout — an unreachable broker must
+fail the open rather than hang it. `exit` carries `code` only, so
+`PtyExitEvent.signal` is always `null`.
 
-## What this does not buy
+## What this would not buy
 
-A terminal is a terminal. There are no approval cards, no per-turn
-checkpointing, and no thread history — `agy`'s permission prompts are answered
-by typing into the TUI, including the ctrl+g expansion needed to read truncated
-commands before approving them.
+A terminal is a terminal: no approval cards, no per-turn checkpointing, no
+thread history. `agy`'s permission prompts are answered by typing into the TUI,
+including the ctrl+g expansion needed to read truncated commands before
+approving them.
 
-Those require structured output from `agy`, which it does not emit: the broker
+Those need structured output from `agy`, which it does not emit — the broker
 classifies it `format: 'text'` because there is nothing to parse. The blocker is
 [agy's own ACP/JSON-RPC feature request][acp], not the broker and not T3. If
-`agy` ever gains a structured mode, the better integration is a native T3
-provider driver modelled on `GrokDriver` + `GrokAcpSupport`, and this adapter
-becomes redundant rather than a foundation.
-
-## Open questions
-
-1. How does a user mark a terminal as broker-routed? Project setting, per-open
-   choice, or a dedicated environment concept.
-2. Where do the broker URL and token live? They are per-environment secrets and
-   must not land in thread state.
-3. Should the single-PTY limit be enforced at open time in the UI, or surfaced
-   as a spawn error? Failing early is friendlier but needs the capacity check
-   somewhere the client can reach.
-
-## Implementation sketch
-
-One new file, `apps/server/src/terminal/BrokerPtyAdapter.ts`, plus a delegating
-adapter and its wiring. Estimated size comparable to `NodePtyAdapter` (172
-lines). No changes to `Manager.ts`, the terminal contract, or any client.
-
-Tests should follow `NodePtyAdapter.test.ts` and drive a fake broker socket:
-allowlist rejection, reattach detection, grace-window expiry surfaced as exit,
-and the second-terminal refusal from constraint 2.
+`agy` gains a structured mode, the right integration is a native T3 provider
+driver modelled on `GrokDriver` + `GrokAcpSupport`, and this adapter becomes
+redundant rather than a foundation.
 
 [protocol]: https://github.com/s243a/SciREPL-MCP/blob/main/docs/protocol.md
 [mcp]: https://github.com/s243a/SciREPL-MCP

--- a/docs/fork/agy-broker-pty.md
+++ b/docs/fork/agy-broker-pty.md
@@ -2,7 +2,10 @@
 
 > **Fork-local document.** This describes work specific to the `s243a/t3code`
 > fork and is not proposed for upstream. It lives under `docs/fork/` so it stays
-> out of `docs/internals/`, which upstream owns.
+> out of `docs/internals/`, which upstream owns. See [README](./README.md) for
+> how this relates to the other options, and
+> [mcp-to-acp-bridge.md](./mcp-to-acp-bridge.md) for the route that yields a
+> real T3 provider rather than a terminal.
 
 ## Status: not recommended
 

--- a/docs/fork/generic-acp-driver.md
+++ b/docs/fork/generic-acp-driver.md
@@ -1,0 +1,142 @@
+# A generic ACP driver
+
+> **Fork-local design.** Specific to the `s243a/t3code` fork. Unlike the rest of
+> `docs/fork/`, this one is written to be upstream-able: it implements only the
+> open Agent Client Protocol and names no vendor in its core.
+
+## Why not reuse an existing driver
+
+Pointing T3 at an arbitrary ACP agent through an existing driver's `binaryPath`
+works right up to model discovery, then fails: the Cursor driver calls
+`cursor/list_available_models`, and `CursorAdapter.ts` (1188 lines) also carries
+`cursor/ask_question`, `cursor/create_plan`, and `cursor/update_todos`. Those
+are vendor extensions, not ACP. Satisfying them would mean impersonating another
+vendor's product — a facade over a surface we do not control and cannot track,
+in a public repository, for no benefit.
+
+The right answer is a driver that speaks **only** what the protocol defines.
+
+## What is already generic
+
+Most of the work exists. `AcpSessionRuntime` (1005 lines) is vendor-neutral and
+already exposes the whole protocol surface:
+
+| Concern     | Provided                                                                                                                              |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Lifecycle   | `start`, `prompt`, `cancel`                                                                                                           |
+| Selection   | `setModel`, `setSessionModel`, `setMode`, `setConfigOption`                                                                           |
+| Output      | `getEvents` stream, `getModeState`, `getConfigOptions`                                                                                |
+| Client role | `handleRequestPermission`, `handleElicitation`, `handleReadTextFile`, `handleWriteTextFile`, terminal create/output/wait/kill/release |
+| Extensions  | `handleExtRequest`, `handleUnknownExtRequest`, and notification equivalents                                                           |
+
+`AcpCoreRuntimeEvents` supplies the event constructors T3's orchestration
+consumes — request opened/resolved, plan updated, tool call, assistant item,
+content delta — none of them vendor-flavoured.
+
+The vendor adapters are large because they bolt extensions onto this core, not
+because the core is insufficient. A driver that skips extensions skips most of
+the bulk.
+
+Note especially `handleUnknownExtRequest`. The runtime already anticipated
+agents sending methods it does not know. That is the seam vendor behaviour
+belongs behind — and it argues the generic driver is the shape the ACP layer was
+built for, not a shape being forced onto it.
+
+## What a generic ACP agent actually wants
+
+Designed from the protocol's client role rather than from what existing drivers
+happen to do.
+
+**To be launched the way it expects.** A command, arguments, environment, and a
+working directory. Nothing more — an agent that needs a magic flag is describing
+configuration, not a code path.
+
+**To know what the client will do on its behalf.** ACP negotiates client
+capabilities at initialize, and they are genuine choices, not formalities:
+
+- _Filesystem_ — will the client perform reads and writes the agent requests?
+  Saying yes routes file access through the client, where it can be shown,
+  audited, and refused. Saying no means the agent touches the disk itself and
+  the client never sees it.
+- _Terminal_ — will the client run commands for the agent? Same trade.
+
+These are the single most consequential settings, because they decide whether
+the client is a window onto the agent's work or a participant in it. They
+deserve to be explicit and per-agent, not inferred.
+
+**To be asked for permission in a way it can answer.** Handled by the runtime
+already; the driver's job is to forward decisions faithfully and never invent an
+approval.
+
+**To advertise its own models.** Core ACP returns them in the session response.
+An agent that reports none is not broken — it may genuinely have one mode — so a
+static override belongs in configuration rather than a failure path.
+
+**To be resumed.** `session/load` when the agent supports it, and to be told
+plainly when it does not, rather than silently starting fresh.
+
+## Configuration
+
+The core stays generic and vendor knowledge lives in **data**:
+
+```
+command            required
+args               default []
+env                default {}
+authMethodId       optional — omit when the agent needs no authenticate step
+capabilities       { filesystem: bool, terminal: bool }
+models             optional static list, when the agent advertises none
+profile            optional name selecting a preset of the above
+```
+
+A **profile** is a named bundle of exactly those fields. Adding support for a
+new agent is a config entry, never a new adapter — which is the property the
+vendor drivers lack and the reason they are the size they are.
+
+The rule that keeps this honest: **a profile may only set values a user could
+have typed by hand.** The moment a profile needs code, it is no longer a profile
+and the extension belongs behind `handleUnknownExtRequest`.
+
+This is also the part worth sharing beyond T3. The protocol says how to talk to
+an agent but not how to _launch_ one, so every client reinvents that. A profile
+format is portable in a way an adapter is not.
+
+## Mapping to T3
+
+`ProviderAdapterShape` has thirteen members. Most are bookkeeping over a
+`threadId → runtime` registry: `listSessions`, `hasSession`, `stopSession`,
+`stopAll`, `startSession`. The protocol-facing ones — `sendTurn`,
+`interruptTurn`, `respondToRequest`, `respondToUserInput`, `streamEvents` — map
+onto runtime calls that already exist.
+
+Two need judgement rather than plumbing:
+
+- `readThread` — ACP has no history-read call. Serve T3's own record; do not
+  fabricate one from the agent.
+- `rollbackThread` — T3 checkpoints by diffing the workspace, so this must not
+  try to rewind the agent's internal state. Report unsupported honestly.
+
+`capabilities.sessionModelSwitch` follows from whether the agent answered
+`setSessionModel`, discovered at runtime rather than declared per vendor.
+
+## Deliberately not doing
+
+- **No vendor methods in the core.** Not `cursor/*`, not any other. Unknown
+  extensions are logged and declined, never guessed at.
+- **No pretending to be another binary.** If an agent needs a probe answered,
+  that is the agent's job, not ours to fake.
+- **No model menus we cannot honour.** Advertise what the agent reports or what
+  the user configured; nothing else.
+- **No hidden capability grants.** Filesystem and terminal are off unless
+  configured on. A driver that quietly says yes to both has decided a security
+  question on the user's behalf.
+
+## Open questions
+
+1. Does `AcpSessionRuntime.start` require an `authMethodId`, or tolerate its
+   absence? Its options type lists it as required, which may need a small
+   upstream change for agents with no auth step.
+2. Where do profiles live — settings, or files a user can drop in? Files are
+   friendlier to share; settings are simpler to validate.
+3. Should filesystem and terminal capabilities default off? Safer, but every
+   agent then needs configuration before it does anything useful.

--- a/docs/fork/generic-acp-driver.md
+++ b/docs/fork/generic-acp-driver.md
@@ -103,7 +103,8 @@ format is portable in a way an adapter is not.
 
 ## Mapping to T3
 
-`ProviderAdapterShape` has thirteen members. Most are bookkeeping over a
+`ProviderAdapterShape` has fourteen members: `provider` and `capabilities`, plus
+twelve operational ones. Most of those are bookkeeping over a
 `threadId → runtime` registry: `listSessions`, `hasSession`, `stopSession`,
 `stopAll`, `startSession`. The protocol-facing ones — `sendTurn`,
 `interruptTurn`, `respondToRequest`, `respondToUserInput`, `streamEvents` — map

--- a/docs/fork/mcp-to-acp-bridge.md
+++ b/docs/fork/mcp-to-acp-bridge.md
@@ -131,6 +131,31 @@ callers cannot spoof, and content-free receipts.
 Whether a given agent *can* have built-ins disabled decides only whether this
 hardening is available for it — not whether the bridge works.
 
+### Session correlation must not depend on MCP transport state
+
+ACP is session-oriented: `session/update` and `session/request_permission` all
+carry a session id. The bridge therefore has to map every incoming `tools/call`
+onto the right ACP session.
+
+Do not use MCP transport state for this. The spec has moved *away* from it:
+
+| Revision | Session state |
+| --- | --- |
+| 2024-11-05 | HTTP+SSE, stateful |
+| 2025-03-26 | Streamable HTTP; stateless or stateful via `Mcp-Session-Id` |
+| 2026-07-28 (RC) | core stateless — `initialize` handshake and `Mcp-Session-Id` removed, request metadata inline in `_meta` |
+
+A bridge keyed on `Mcp-Session-Id` inherits a header the newest revision
+deletes. Carry correlation **outside** MCP instead — a per-agent-run endpoint
+URL, path-scoped — which behaves identically across all three revisions.
+
+This also avoids repeating the broker's `termBridge` singleton trap: without
+per-session routing, a second concurrent agent's tool calls land on the first
+agent's ACP session and cross-wire two threads. Same failure shape, same fix.
+
+For the same reason the repository name should stay version-neutral. Spec
+revisions will keep landing.
+
 ### Known risks
 
 - Permission latency is now in the tool-call path. A slow or absent client

--- a/docs/fork/mcp-to-acp-bridge.md
+++ b/docs/fork/mcp-to-acp-bridge.md
@@ -80,38 +80,56 @@ MCP is a *tool* channel, not an agent-output channel. Three gaps:
    is not TUI scraping — but it is per-agent, and it is where the
    agent-agnostic claim thins.
 2. **Built-in tools.** An agent's own file read/write and bash calls are
-   internal and never reach an MCP server. For a coding agent editing a repo
-   that is most of the interesting activity, and it would be invisible.
+   internal and never reach an MCP server, so they produce no `tool_call`
+   event.
 3. **Turn boundaries.** MCP has no notion of a turn. The broker's `/agent`
    lifecycle already supplies start and exit.
 
-Gap 2 is load-bearing. In the SciREPL case the agent drives the notebook
-*exclusively* through broker tools, so the broker sees everything. A coding
-agent editing files does not work that way.
+Gap 2 matters less than it first appears. T3's `CheckpointReactor` captures
+**workspace** checkpoints on turn start and completion — it diffs the
+filesystem, it does not reconstruct state from the tool-call stream. So file
+edits made by built-in tools still show up in T3's diff and checkpoint UI even
+with no `tool_call` event behind them. What is lost is live per-action progress
+cards during the turn, not the record of what changed.
 
-### Making it complete
+### Minimum viable bridge
 
-Disable the agent's built-in tools and have the bridge supply file and shell
-equivalents as MCP tools. The bridge then sees and gates **100%** of what the
-agent does, and emits complete, faithful `tool_call` and permission events with
-no per-agent parsing.
+None of the above is a prerequisite. The smallest useful version:
+
+- spawn the agent and expose an MCP server to it;
+- emit `tool_call` / `tool_call_update` for MCP calls;
+- turn each MCP call into `session/request_permission`;
+- emit `agent_message_chunk` from the agent's stdout.
+
+That already yields a real T3 provider — thread history, checkpoints, diffs,
+and approval cards for everything routed through MCP — while the agent keeps
+using its built-in tools normally under whatever permissions it is configured
+with.
+
+### Optional hardening: route built-ins through MCP too
+
+Disabling the agent's built-in tools and having the bridge supply file and shell
+equivalents as MCP tools is an **upgrade, not a requirement**. It changes the
+security model rather than enabling the feature:
+
+| | Built-ins active | Built-ins disabled |
+| --- | --- | --- |
+| Privileged actions governed by | the agent's own standing permission config | per-action review at the bridge |
+| Bridge sees | MCP calls only | everything |
+
+The second row is why this is worth having eventually: it is the difference
+between granting standing permissions once and reviewing each action, which is
+the posture [`docs/remote-agent-control.md`][control] argues for. Note that a
+headless agent auto-denies permissions it cannot prompt for, so without this the
+agent needs standing grants to do privileged work at all.
 
 SciREPL-MCP already has the right pattern for hardening such tools
 ([`docs/protocol.md`][protocol] §Broker-owned workbook file tools): allowlisted
 host roots, reserved `brokerRoot` / `brokerPath` fields that ordinary MCP
 callers cannot spoof, and content-free receipts.
 
-### The question that decides this route
-
-**Can each target agent be run with built-in tools disabled, or restricted to
-MCP-provided ones?**
-
-- Yes → complete visibility, genuinely agent-agnostic, full permission control.
-- No → partial visibility (MCP tools only) plus per-agent stdout parsing for
-  prose.
-
-Establish this for `agy` before building. It is cheap to check and it changes
-what the thing is.
+Whether a given agent *can* have built-ins disabled decides only whether this
+hardening is available for it — not whether the bridge works.
 
 ### Known risks
 
@@ -151,12 +169,16 @@ Route A hits the built-in-tools wall.
 
 ## Recommendation
 
-Investigate the built-in-tools question for `agy` first — one fact, cheaply
-obtained, that decides whether Route A is complete or partial.
+Build Route A's minimum viable bridge. It does not depend on any unresolved
+question: permission gating over MCP calls works with the agent's built-in tools
+left alone, and T3's workspace checkpoints already cover what the built-ins
+change.
 
-Route A is worth more even in its partial form, because permission gating works
-regardless of the gaps and applies to every MCP-speaking agent. Route B is a
-fallback for `agy` alone.
+Treat routing built-ins through MCP as later hardening, driven by wanting
+per-action review instead of standing grants — not as a gate on shipping.
+
+Route B is a fallback for `agy` alone, worth investigating only if Route A's
+fidelity proves insufficient in practice.
 
 Either route, once it emits ACP, needs the same small piece on this side: a T3
 driver modelled on `GrokDriver` + `GrokAcpSupport`, spawning the bridge instead

--- a/docs/fork/mcp-to-acp-bridge.md
+++ b/docs/fork/mcp-to-acp-bridge.md
@@ -1,0 +1,169 @@
+# Getting real ACP out of `agy` — two routes
+
+> **Fork-local document.** Specific to the `s243a/t3code` fork, not proposed for
+> upstream. See [README](./README.md) for how this relates to the other options.
+
+## Why this exists
+
+Running `agy` in T3 Code's terminal works today and needs no code
+([README](./README.md), option 1). But a terminal is a terminal: no approval
+cards, no per-turn checkpointing, no thread history. `agy`'s permission prompts
+are answered by typing into its TUI.
+
+Everything better requires **ACP**, because that is what T3's provider layer
+consumes. T3 already has the machinery — `provider/acp/`, `AcpSessionRuntime`,
+proven by the Cursor and Grok drivers — so a driver would mirror `GrokDriver`
+(163 lines) plus a `GrokAcpSupport` analogue. `ProviderDriverKind` is an open
+slug and Antigravity already exists as an editor target
+(`packages/contracts/src/editor.ts:53`), so nothing in contracts or clients
+needs to change.
+
+The obstacle is that `agy` does not speak ACP and emits no structured output —
+the broker classifies it `format: 'text'` because there is nothing to parse, and
+[the upstream feature request][acp-issue] is unshipped.
+
+Two routes get there anyway. Route A is agent-agnostic and is the more
+interesting one.
+
+## What ACP actually requires
+
+T3 consumes these, per `apps/server/src/provider/acp/`:
+
+| Method / update | Carries |
+| --- | --- |
+| `session/prompt` | a user turn going in |
+| `session/update` → `agent_message_chunk` | assistant prose |
+| `session/update` → `tool_call`, `tool_call_update` | tool activity |
+| `session/request_permission` | an approval the client must answer |
+| `session/load` | replaying an existing session |
+
+Any bridge is judged on how faithfully it can produce these.
+
+---
+
+## Route A — MCP-gated ACP bridge
+
+**Agent-agnostic. Works with any coding agent that speaks MCP.**
+
+Likely to live in its own repository (working name `MCP-to-ACP`) rather than
+inside the broker, since nothing about it is SciREPL-specific.
+
+### The idea
+
+An MCP server sees every tool call an agent makes: name, arguments, and result.
+It is not an observer but a **gate** — it can withhold the call. The broker
+already demonstrates this shape in `CallToolRequestSchema`, where it validates
+each call against the app's advertised tools and rejects anything else.
+
+So invert the usual framing. Rather than parsing what the agent *says*,
+intercept what the agent *does*, and expose that as ACP:
+
+```
+T3 ──ACP──► bridge ──MCP──► agent (agy, claude, codex, …)
+             │
+             └─ spawns and supervises the agent process
+```
+
+Each `tools/call` becomes a `session/request_permission`, awaited before the
+call is relayed. **This is the valuable part**: an approval card on the phone,
+answered with a tap, for an agent whose own prompts would otherwise be
+auto-denied in headless mode. Tool activity maps to `tool_call` /
+`tool_call_update` with no parsing at all.
+
+### What MCP does not carry
+
+MCP is a *tool* channel, not an agent-output channel. Three gaps:
+
+1. **Assistant prose.** Model text goes to stdout or the TUI, never to the MCP
+   server. `agent_message_chunk` has no source in MCP. For `agy` specifically,
+   headless `-p` stdout *is* the answer as documented plain text — reading that
+   is not TUI scraping — but it is per-agent, and it is where the
+   agent-agnostic claim thins.
+2. **Built-in tools.** An agent's own file read/write and bash calls are
+   internal and never reach an MCP server. For a coding agent editing a repo
+   that is most of the interesting activity, and it would be invisible.
+3. **Turn boundaries.** MCP has no notion of a turn. The broker's `/agent`
+   lifecycle already supplies start and exit.
+
+Gap 2 is load-bearing. In the SciREPL case the agent drives the notebook
+*exclusively* through broker tools, so the broker sees everything. A coding
+agent editing files does not work that way.
+
+### Making it complete
+
+Disable the agent's built-in tools and have the bridge supply file and shell
+equivalents as MCP tools. The bridge then sees and gates **100%** of what the
+agent does, and emits complete, faithful `tool_call` and permission events with
+no per-agent parsing.
+
+SciREPL-MCP already has the right pattern for hardening such tools
+([`docs/protocol.md`][protocol] §Broker-owned workbook file tools): allowlisted
+host roots, reserved `brokerRoot` / `brokerPath` fields that ordinary MCP
+callers cannot spoof, and content-free receipts.
+
+### The question that decides this route
+
+**Can each target agent be run with built-in tools disabled, or restricted to
+MCP-provided ones?**
+
+- Yes → complete visibility, genuinely agent-agnostic, full permission control.
+- No → partial visibility (MCP tools only) plus per-agent stdout parsing for
+  prose.
+
+Establish this for `agy` before building. It is cheap to check and it changes
+what the thing is.
+
+### Known risks
+
+- Permission latency is now in the tool-call path. A slow or absent client
+  stalls the agent mid-turn; the bridge needs a timeout policy and a defined
+  default (deny, per the review policy in
+  [`docs/remote-agent-control.md`][control]).
+- Reimplementing file and shell tools means owning their path-hardening. The
+  workbook file tools are the precedent to copy, not to loosen.
+- An agent that silently falls back to built-ins when an MCP tool fails would
+  punch a hole straight through the gate. Verify per agent.
+
+---
+
+## Route B — `agy`'s local Connect API
+
+**agy-specific. Potentially higher fidelity, much narrower.**
+
+Community adapter [`jameslunardi/agy-agent-acp`][connect] drives `agy`'s local
+Connect API rather than its CLI, and presents ACP on the other side. Other
+adapters ([antigravity-acp][alt1], several `agy-acp` forks) wrap the CLI
+instead.
+
+Attraction: a real API is a sound foundation where scraped terminal output is
+not, and it may carry assistant prose and tool activity together — closing
+Route A's gap 1 and gap 2 at once.
+
+Cost: it is one agent only. Nothing learned transfers to claude, codex, or
+gemini, where Route A would work unchanged.
+
+**Unverified.** Nobody here has confirmed what the Connect API exposes, whether
+it is stable, or whether it is intended for external use. Treat the adapters as
+evidence it is *possible*, not that it is *supportable*. Investigate only if
+Route A hits the built-in-tools wall.
+
+---
+
+## Recommendation
+
+Investigate the built-in-tools question for `agy` first — one fact, cheaply
+obtained, that decides whether Route A is complete or partial.
+
+Route A is worth more even in its partial form, because permission gating works
+regardless of the gaps and applies to every MCP-speaking agent. Route B is a
+fallback for `agy` alone.
+
+Either route, once it emits ACP, needs the same small piece on this side: a T3
+driver modelled on `GrokDriver` + `GrokAcpSupport`, spawning the bridge instead
+of `grok agent stdio`.
+
+[acp-issue]: https://github.com/google-antigravity/antigravity-cli/issues/31
+[protocol]: https://github.com/s243a/SciREPL-MCP/blob/main/docs/protocol.md
+[control]: https://github.com/s243a/SciREPL-MCP/blob/main/docs/remote-agent-control.md
+[connect]: https://github.com/jameslunardi/agy-agent-acp
+[alt1]: https://github.com/shubzkothekar/antigravity-acp

--- a/docs/fork/t3-p2p-proposal.md
+++ b/docs/fork/t3-p2p-proposal.md
@@ -95,6 +95,96 @@ The negative space matters as much as the goal.
   — at the cost of O(N) traffic and crypto per message. For a PTY stream it
   would be pathological. Unicast to a named peer is correct.
 
+## Two planes, so no single dependency owns both
+
+Discovery and transport are separate concerns and want separate interfaces.
+
+- **Directory** — who exists, what they will run, whether you are trusted there,
+  where they were last reachable.
+- **Transport** — how bytes get from here to there.
+
+Keeping them apart is what makes any particular mesh optional. tinc is tempting
+precisely because it can fill both slots — mesh transport plus a broadcast
+channel to gossip over — and that is also how it becomes a dependency nobody
+chose. Behind two interfaces it is one backend among several: Tailscale for
+transport where it already exists, mDNS for a directory on a LAN, T3 Connect's
+relay where NAT is hostile, tinc where someone wants a self-hosted mesh and no
+third party.
+
+Bridging networks then costs nothing conceptually. A peer on the tailnet and a
+peer reachable only over a private mesh are two records with different
+transports, and nothing above cares which is which as long as a name resolves
+to a route.
+
+## Discovery: a hello protocol
+
+Peers announce themselves and answer one question: *who else do you know?* A
+client asks a peer, receives its list, and asks the peers on it in turn. No
+central registry, and no new transport — the exchange rides whatever route
+already reaches each peer.
+
+A peer record carries a stable name, an online hint, and the addresses it was
+last reachable on, each tagged with its transport (`tailscale`, `tinc`, `lan`,
+`relay`) and ordered by most recent success. Names are the identity; addresses
+are cache.
+
+Three properties this must keep, each easy to lose:
+
+**Trust is not transitive.** A peer list is a list of *candidates*, not of
+admitted machines. Peer A naming B tells you B exists; admitting B stays a
+deliberate act with a visible moment of consent. Gossip that also carries trust
+turns one compromised peer into a way to introduce arbitrary machines.
+
+**Status and addresses are hints.** Anything learned second-hand is stale by
+construction — a peer's view of a third machine is as old as its last exchange.
+Show them as hints, verify on connect, and let the connection be the source of
+truth rather than the record.
+
+**Records carry no tokens.** A record saying "machine `sol` exists, reachable
+here, you hold a grant there" is safe to replicate to every peer. A record
+carrying a bearer credential with `terminal:operate` is a shell key on a
+broadcast channel, and a gossip layer will diligently copy it everywhere. The
+fabric mints a scoped, revocable credential when a connection is made; it never
+warehouses one. This is the same rule as "a peer offers capabilities, not
+access", applied to the directory.
+
+## Packaging: standalone first, plugin second
+
+It must work with no T3 present, and plug into T3 when wanted. That ordering is
+a maintenance decision, not a preference: a tool that depends on T3 inherits the
+churn of a fast-moving codebase, and this fork already carries enough of that.
+
+That argues for the shape the ACP bridge already uses in this project — its own
+repository, its own tests, no import of T3, and a protocol boundary rather than
+a code one:
+
+- **A daemon plus a CLI.** The daemon holds the directory, answers hello, and
+  runs on machines with no T3 at all. The CLI is how a person uses it without a
+  GUI, which is also how it stays debuggable.
+- **A library API for embedding**, so a client can use the directory in-process
+  rather than shelling out.
+- **A local HTTP or WebSocket API**, which is what T3 should actually talk to.
+  Then the daemon runs whether or not T3 does, and the plugin is a thin adapter.
+
+On language: TypeScript on Node keeps the embedding option genuinely available,
+since T3 is a pnpm/TypeScript workspace and anything else would force the
+protocol route. Two constraints follow, and they matter more than the language
+choice:
+
+- **No Effect in the core.** T3 runs an Effect v4 *beta*; taking that dependency
+  would tie this tool's maintenance to T3's upgrade schedule, which is the exact
+  coupling being avoided. Plain async, with any Effect wrapping done in the T3
+  adapter.
+- **Few dependencies, and none that assume a host.** The daemon should be
+  installable on a small box — the kind of machine most worth reaching remotely
+  — and start with nothing configured.
+
+The natural attachment point on the T3 side already exists:
+`ConnectionsSettings.tsx` keeps saved remote environments and renders "No saved
+remote environments" when empty. A picker fed by the directory belongs there,
+and beside the pairing-token field, which is where a user currently transcribes
+an address by hand.
+
 ## Implementation options
 
 Three shapes, cheapest first. All satisfy the principles; they differ in what

--- a/docs/fork/t3-p2p-proposal.md
+++ b/docs/fork/t3-p2p-proposal.md
@@ -6,12 +6,17 @@
 
 ## The problem, stated honestly
 
-Earlier in this project I argued against adding P2P to T3, and I stand by the
-reasoning as far as it went: T3 already expresses remoteness at the connection
-layer, Tailscale already solves NAT traversal, and mesh *routing* would buy
-nothing because every hub is directly reachable once an overlay exists.
+Earlier in this project I argued against adding P2P to T3: T3 already expresses
+remoteness at the connection layer, Tailscale already solves NAT traversal, and
+mesh *routing* would buy nothing because every hub is directly reachable once an
+overlay exists.
 
-But that argument was about **transport**, and transport is not the gap.
+That last clause is doing more work than it can carry, and the qualifier belongs
+in the claim: routing buys nothing *where an overlay reaches every machine*. It
+is the machines an overlay cannot reach that most need a fabric. See
+**Deferred: peer relaying** below — the question is open, not closed.
+
+What the argument does establish is that transport is not the **first** gap.
 
 The gap is **provisioning**. Before a client can connect to a machine, something
 has to be *running* on that machine. Today that means: open a shell there,
@@ -184,6 +189,43 @@ The natural attachment point on the T3 side already exists:
 remote environments" when empty. A picker fed by the directory belongs there,
 and beside the pairing-token field, which is where a user currently transcribes
 an address by hand.
+
+## Deferred: peer relaying
+
+Whether peers should carry traffic for each other is **an open question, and a
+follow-on design study after the first prototype ships**. It is recorded here
+rather than decided because the case for it is stronger than the original
+argument against allowed.
+
+The argument against assumed a universal overlay. Where one is partial — which
+is the ordinary state of a mixed home network — relaying is not a luxury:
+
+- **A machine that cannot join the overlay.** An old or locked-down box where
+  Tailscale will not install is exactly the machine worth reaching remotely. If
+  a peer on its LAN can reach both it and you, relaying through that peer is the
+  only path.
+- **Bridging networks.** A peer joined to a tailnet and to a private mesh *is* a
+  relay. Calling those "two records with different transports" describes the
+  directory correctly and quietly assumes someone carries bytes across.
+- **Policy, not just reachability.** ACLs can permit A↔B and deny you↔B.
+- **Discovery already relays.** The hello protocol walks peer lists through
+  intermediaries. Relaying knowledge but refusing to relay bytes is a line drawn
+  by taste rather than principle.
+
+Two conditions look load-bearing enough to write down now, since they decide
+whether relaying stays cheap:
+
+- **End-to-end encrypted, with the relay as a dumb forwarder.** A peer that
+  carries traffic must not be able to read it, or every added peer widens what a
+  single compromise exposes. This also keeps relaying a transport decision
+  rather than a trust one.
+- **Relaying is a capability a peer offers.** It spends bandwidth and exposure,
+  so it belongs beside "will run a broker": explicitly granted, revocable, and
+  used only when no direct route exists.
+
+With both, relaying is a fallback path with an owner rather than the mesh
+routing the original argument rejected. Deferring it is a sequencing decision —
+the prototype should not carry it — not a judgement that it is unnecessary.
 
 ## Implementation options
 

--- a/docs/fork/t3-p2p-proposal.md
+++ b/docs/fork/t3-p2p-proposal.md
@@ -1,0 +1,149 @@
+# A peer fabric for T3 Code
+
+> **Fork-local proposal.** Specific to the `s243a/t3code` fork, not proposed for
+> upstream. Deliberately written at the level of *what it should do*; the
+> implementation section offers options rather than a decision.
+
+## The problem, stated honestly
+
+Earlier in this project I argued against adding P2P to T3, and I stand by the
+reasoning as far as it went: T3 already expresses remoteness at the connection
+layer, Tailscale already solves NAT traversal, and mesh *routing* would buy
+nothing because every hub is directly reachable once an overlay exists.
+
+But that argument was about **transport**, and transport is not the gap.
+
+The gap is **provisioning**. Before a client can connect to a machine, something
+has to be *running* on that machine. Today that means: open a shell there,
+install T3 or the broker, start it, note the address, configure it. T3 has one
+productized escape from this — desktop SSH launch, which starts a remote T3
+server and pairs it — but it is desktop-only, SSH-only, and T3-server-only.
+Nothing general exists for "make this machine start doing something for me."
+
+That is the real friction, and it is worth naming precisely, because a fabric
+that solves it looks nothing like a fabric that solves routing.
+
+## What it should do
+
+**Machines should offer themselves, not be configured.** Owning a machine and
+wanting to use it should be enough. The act of installing the agent on a box is
+the act of making it available; there should be no second step where a human
+transcribes an address into a settings pane. Addresses are an implementation
+detail that leaks today.
+
+**Names should outlive addresses.** A laptop that moves between home, office,
+and tether is the same laptop. Anything a user has named, approved, or scripted
+against must survive the address changing underneath it. If a user ever has to
+re-pair because they changed networks, the design has failed.
+
+**A peer offers capabilities, not access.** This is the load-bearing principle
+and the one most easily lost. "This machine will run a broker for you" is a
+categorically different grant from "this machine will run whatever you send."
+The fabric should carry *specific offers* — run a broker, run a T3 server, run
+this named agent — each independently grantable and revocable. A peer that can
+be asked to run arbitrary commands is a remote shell wearing a fabric costume,
+and every safeguard built above it is theatre.
+
+This mirrors a decision already made well elsewhere in this project:
+`BROKER_TERM_CMDS=agy` is narrow *because naming the command is the security
+boundary*. The fabric should inherit that instinct rather than re-open the
+question.
+
+**Trust should be explicit, per-machine, and revocable.** Adding a peer is a
+deliberate act with a visible moment of consent. Removing one is equally
+deliberate and takes effect everywhere, promptly — a revoked machine should
+lose its grant even if it is currently offline and comes back later. Trust
+should never be transitive: peer A vouching for B must not silently admit B.
+
+**Lifecycle should be owned, not improvised.** If the fabric starts a broker, it
+knows that broker is running, can report its health, can restart it, and can
+stop it. The failure mode to design out is the orphan: a process the user
+started through the fabric and can now only kill by hand. Anything the fabric
+can start, it must be able to see and stop.
+
+**Failure should be legible.** "Peer unreachable" is not an answer. The user
+needs to know whether the machine is asleep, the credential expired, the
+capability was revoked, the process crashed on startup, or the network path is
+down — because those have four different remedies. Most distributed-system
+frustration is diagnostic poverty, not genuine complexity.
+
+**It should degrade to what already works.** The fabric is an accelerant for
+existing paths, never a new dependency. Every machine reachable through it must
+remain reachable without it — by direct pairing, by SSH, by hand. If the fabric
+is down and the user is locked out of their own machine, it has made things
+worse. This also gives an honest migration story: the fabric is a convenience
+layer over primitives that keep working.
+
+## What it should not do
+
+The negative space matters as much as the goal.
+
+- **Not a router.** Peers do not relay for one another. If A cannot reach B,
+  that is a network problem to fix at the network layer, not to paper over with
+  application-level forwarding. Relaying re-introduces the second runtime
+  boundary T3's architecture deliberately avoids, and it makes trust transitive
+  through the back door.
+- **Not a scheduler.** No placement decisions, no "run this wherever is free."
+  The user names the machine. Choosing for them requires a model of their
+  machines the fabric will not have and should not pretend to.
+- **Not a new identity system.** It should ride whatever the user already
+  authenticates with. A fresh credential store is a fresh thing to leak, rotate,
+  and lose.
+- **Not a broadcast medium.** An earlier idea in this project was addressing
+  peers by having every machine attempt decryption of every message. That buys
+  recipient anonymity — a property with no value among machines one person owns
+  — at the cost of O(N) traffic and crypto per message. For a PTY stream it
+  would be pathological. Unicast to a named peer is correct.
+
+## Implementation options
+
+Three shapes, cheapest first. All satisfy the principles; they differ in what
+they assume.
+
+**1. Tailscale-native.** Treat the tailnet as the fabric. Discovery is the
+device list, identity is the node key, reachability is solved. A small agent on
+each machine advertises its capabilities and starts them on request. T3 already
+has the seam: `remote.md` §Endpoint providers exists so contributors can supply
+endpoints without touching the core model, and
+`apps/desktop/src/backend/tailscaleEndpointProvider.ts` is the worked example.
+
+*Assumes:* everything is on one tailnet. *Gets:* almost all the value for a
+fraction of the work, and it composes with what ships today. **This is where I
+would start**, and it may be where it ends.
+
+**2. Broker-mediated.** Extend SciREPL-MCP's reverse-worker idea: machines dial
+out to a coordination point and receive capability requests. Solves the case
+where a machine can reach the network but nothing can reach it, without any
+overlay.
+
+*Assumes:* a coordination point exists and is trusted. *Costs:* that point is
+now infrastructure to run, and it sees metadata about every machine.
+
+**3. Direct peer links.** Explicit pairwise links, each established once and
+remembered — closest to "P2P" in the usual sense, and the most work: NAT
+traversal, key management, liveness, all owned rather than borrowed.
+
+*Worth it only if* the fabric must work for machines that will never share an
+overlay, which is a requirement worth confirming before paying for it.
+
+## How to know it worked
+
+The honest test is not a feature list. It is: **a user with a new machine can
+make it run a broker for them without ever typing an address, and can revoke
+that a week later from a phone, and can explain what went wrong when it
+fails.** If all three hold, the fabric earned its complexity.
+
+A useful smaller milestone: replace the current manual broker startup for a
+single already-tailnetted machine. If it does not clearly beat `ssh box 'start
+the broker'` for that case, the larger version will not beat it either.
+
+## Relationship to the rest of this fork
+
+- [mcp-acp-bridge](https://github.com/s243a/mcp-acp-bridge) is what gets *run*.
+  The fabric is how it gets started somewhere else.
+- [agy-broker-pty.md](./agy-broker-pty.md) — the PTY transport, shelved because
+  T3 already covers cross-host connection. The fabric does not revive it; they
+  address different layers.
+- Command allow/block lists belong to the thing being started, not the fabric.
+  A capability grant says *what may run*; the broker's own list says *what that
+  thing may then do*. Keeping those separate keeps both comprehensible.


### PR DESCRIPTION
docs(fork): design notes for the ACP routes and a peer fabric

Fork-local design notes, written before and during the ACP work. No code, and
nothing here is proposed upstream — `docs/fork/README.md` says so on the way in.

- **`agy-broker-pty.md`** — running an agent that has no ACP support over a
  broker-held PTY, and why T3's existing cross-host support changes that design.
- **`mcp-to-acp-bridge.md`** — fronting any MCP-speaking agent with an ACP
  server, so its tool calls arrive at the client as approval cards.
- **`generic-acp-driver.md`** — treating vendor knowledge as data, which is the
  design the driver PR implements.
- **`t3-p2p-proposal.md`** — a peer fabric scoped to **provisioning, not
  transport**. Earlier reasoning against P2P in T3 was about routing, and
  routing is not the gap: Tailscale already solves reachability. What is missing
  is making a machine start doing something for you without opening a shell
  there. Includes a hello protocol for discovery, and the rules that keep it
  safe — trust does not travel with a peer list, second-hand status is a hint to
  verify on connect, and records never carry tokens, since a credential with
  `terminal:operate` on a gossip channel is a shell key replicated to every peer.

Some of these record corrections to my own earlier conclusions rather than
tidying them away, because the wrong turns are the useful part.

Model: Claude Opus 5 (1M context), harness: Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only under `docs/fork/`; no runtime, API, or security behavior changes in the application.
> 
> **Overview**
> Adds **`docs/fork/`** — fork-local design docs (explicitly not upstream) for running Antigravity **`agy`** from a phone through T3 Code.
> 
> **`README.md`** orders five approaches: use T3’s existing terminal first (no code); then MCP→ACP bridge, generic ACP driver, peer fabric, and a shelved broker PTY path.
> 
> **`mcp-to-acp-bridge.md`** proposes gating MCP tool calls as ACP permission requests (Route A, recommended MVP) vs **`agy`** Connect API (Route B, unverified).
> 
> **`generic-acp-driver.md`** sketches a vendor-neutral ACP driver backed by **profiles** (command/args/env/capabilities) instead of Cursor-style extensions.
> 
> **`agy-broker-pty.md`** documents a **`PtyAdapter`**→SciREPL `/term` mapping but marks it **not recommended** after correcting the earlier “no cross-host terminal” assumption; it keeps constraint analysis for a narrow privilege-surface case.
> 
> **`t3-p2p-proposal.md`** reframes P2P as **provisioning** (machines offer named capabilities, hello discovery, no tokens in gossip) with Tailscale-first implementation options and deferred relaying.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db7406e066a67934a376c8dd8cb3410bf05d9538. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add fork-local design docs for agy broker PTY and T3 integration options
> - Adds [docs/fork/README.md](https://github.com/pingdotgg/t3code/pull/7624/files#diff-ee8ab7bc451506a971b2914f62f8dda89c20a4dd6a6f2e8df3846e23d2b5de84) overview listing five integration options, recommending the zero-code terminal approach
> - Adds [docs/fork/agy-broker-pty.md](https://github.com/pingdotgg/t3code/pull/7624/files#diff-8f164b1fdb6b4fda750ae672c19d4a19f839306cf233b8feb138587aa0e2e439) PTY adapter design proxying T3's `PtyAdapter` to a broker `/term` endpoint; marked not recommended since T3 already covers cross-host terminals
> - Adds [docs/fork/generic-acp-driver.md](https://github.com/pingdotgg/t3code/pull/7624/files#diff-45578e23e4d2e58c7aaf85b7876a2a7e66591f3f3946e9134553357ce06f1d57) design for a vendor-neutral ACP driver using data-only profiles
> - Adds [docs/fork/mcp-to-acp-bridge.md](https://github.com/pingdotgg/t3code/pull/7624/files#diff-ed121aab87f46bad8eee8a1e27c96ae2c9e02619461dd61fd19613c0d80c6a72) describing two routes to expose agy as a T3 provider via ACP, recommending Route A MVP
> - Adds [docs/fork/t3-p2p-proposal.md](https://github.com/pingdotgg/t3code/pull/7624/files#diff-155371e9432e8897fe3b76a171b0b22841155dccf7cacb74e2919b6d0e8a3f5a) proposing a peer fabric for capability provisioning with non-transitive trust
> - Only the terminal-based option (option 1) requires no implementation; options 2 and 3 are unimplemented
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db7406e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->