### PR TITLE
fix(web): show pointer cursor on pull request interactive controls

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestChecksPopover.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestChecksPopover.tsx
@@ -70,7 +70,7 @@ function ChecksBody({ checks }: { checks: ReadonlyArray<PullRequestCheck> }) {
           {check.url === null ? null : (
             <button
               type="button"
-              className="shrink-0 text-primary hover:underline"
+              className="shrink-0 cursor-pointer text-primary hover:underline"
               onClick={() => void readLocalApi()?.shell.openExternal(check.url ?? "")}
             >
               Details

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -1155,7 +1155,7 @@ export function PullRequestDetailPanel({
                         onClick={() => void readLocalApi()?.shell.openExternal(detail.url)}
                         onContextMenu={(event) => openNumberContextMenu(event, detail)}
                         className={cn(
-                          "shrink-0 font-medium underline-offset-2 hover:underline",
+                          "shrink-0 cursor-pointer font-medium underline-offset-2 hover:underline",
                           statePresentation.toneClassName,
                         )}
                         aria-label={`Open pull request #${detail.number} on host`}
@@ -1190,7 +1190,7 @@ export function PullRequestDetailPanel({
                         onClick={() => void readLocalApi()?.shell.openExternal(detail.url)}
                         onContextMenu={(event) => openNumberContextMenu(event, detail)}
                         className={cn(
-                          "shrink-0 font-medium underline-offset-2 hover:underline",
+                          "shrink-0 cursor-pointer font-medium underline-offset-2 hover:underline",
                           statePresentation.toneClassName,
                         )}
                         aria-label={`Open pull request #${detail.number} on host`}

--- a/apps/web/src/components/pullRequest/PullRequestReactions.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestReactions.tsx
@@ -113,7 +113,7 @@ export function PullRequestReactionBar({
                   reaction.viewerHasReacted
                     ? "border-primary/60 bg-primary/10 text-foreground"
                     : "border-border/70 bg-muted/40 text-muted-foreground",
-                  canReact ? "hover:border-primary/60" : "cursor-default",
+                  canReact ? "cursor-pointer hover:border-primary/60" : "cursor-default",
                 )}
                 onClick={() => void toggle(reaction.content, !reaction.viewerHasReacted)}
               />
@@ -135,7 +135,7 @@ export function PullRequestReactionBar({
                 aria-label="Add a reaction"
                 className={cn(
                   PILL_CLASS,
-                  "border-border/70 px-1.5 text-muted-foreground hover:border-primary/60 hover:text-foreground",
+                  "cursor-pointer border-border/70 px-1.5 text-muted-foreground hover:border-primary/60 hover:text-foreground",
                   shown.length === 0 &&
                     !pickerOpen &&
                     "opacity-0 group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:opacity-100",
@@ -157,7 +157,7 @@ export function PullRequestReactionBar({
                     aria-pressed={reacted}
                     aria-label={pullRequestReactionName(content)}
                     className={cn(
-                      "flex size-7 items-center justify-center rounded-md text-base outline-none hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring",
+                      "flex size-7 cursor-pointer items-center justify-center rounded-md text-base outline-none hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring",
                       reacted && "bg-primary/10",
                     )}
                     onClick={() => {

--- a/apps/web/src/components/pullRequest/PullRequestReviewAnnotation.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestReviewAnnotation.tsx
@@ -226,7 +226,7 @@ export function ReviewThreadCard({
         )}
         <button
           type="button"
-          className="hover:text-foreground"
+          className="cursor-pointer hover:text-foreground"
           aria-expanded={expanded}
           onClick={() => setExpanded((current) => !current)}
         >

--- a/apps/web/src/components/pullRequest/PullRequestReviewerPicker.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestReviewerPicker.tsx
@@ -161,7 +161,7 @@ export function PullRequestReviewerPicker({
                 type="button"
                 disabled={pending !== null}
                 onClick={() => void toggle(candidate)}
-                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs hover:bg-accent/60 disabled:opacity-60"
+                className="flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs hover:bg-accent/60 disabled:cursor-not-allowed disabled:opacity-60"
               >
                 <PullRequestActorLabel actor={candidate} className="min-w-0 flex-1 truncate" />
                 {candidate.kind === "team" ? (

--- a/apps/web/src/components/pullRequest/PullRequestRow.test.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestRow.test.tsx
@@ -1,0 +1,47 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import type { EnvironmentPullRequestEntry } from "./pullRequestList.logic";
+import { PullRequestRow } from "./PullRequestRow";
+
+function entry(number: number): EnvironmentPullRequestEntry {
+  return {
+    environmentId: "env-1" as EnvironmentPullRequestEntry["environmentId"],
+    provider: "github",
+    host: "github.com",
+    projectId: "project-1" as EnvironmentPullRequestEntry["projectId"],
+    projectTitle: "t3code",
+    repository: "pingdotgg/t3code",
+    number,
+    title: "Add the pull requests page",
+    url: `https://github.com/pingdotgg/t3code/pull/${number}`,
+    author: { login: "octocat", name: null, avatarUrl: null },
+    headBranch: `feat/branch-${number}`,
+    baseBranch: "main",
+    state: "open",
+    isDraft: false,
+    mergeability: "mergeable",
+    additions: 1,
+    deletions: 0,
+    createdAt: "2026-07-01T00:00:00Z",
+    updatedAt: "2026-07-02T00:00:00Z",
+    viewerReviewRequested: false,
+    labels: [],
+  };
+}
+
+describe("PullRequestRow interactive cursors", () => {
+  it("shows a pointer on selectable rows", () => {
+    const html = renderToStaticMarkup(
+      <PullRequestRow
+        entry={entry(42)}
+        selected={false}
+        showProjectTitle={false}
+        showProvider={false}
+        onSelect={() => {}}
+      />,
+    );
+
+    expect(html).toContain("cursor-pointer");
+  });
+});

--- a/apps/web/src/components/pullRequest/PullRequestRow.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestRow.tsx
@@ -45,7 +45,7 @@ function PullRequestRowImpl({
       aria-current={selected ? "true" : undefined}
       onClick={() => onSelect(entry)}
       className={cn(
-        "grid w-full grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 rounded-lg px-3 py-2 text-left transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        "grid w-full cursor-pointer grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 rounded-lg px-3 py-2 text-left transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
         // Offscreen rows are skipped for style, layout and paint: a long list costs what the
         // viewport shows, not what the pages have loaded. The intrinsic size keeps the
         // scrollbar honest while a row is skipped.

--- a/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
@@ -707,7 +707,7 @@ export function PullRequestSummaryTab({
                     onClick={() => check.url && openCheck(check.url)}
                     className={cn(
                       "flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs",
-                      check.url ? undefined : "cursor-default",
+                      check.url ? "cursor-pointer" : "cursor-default",
                     )}
                   >
                     <PullRequestCheckStatusIcon status={check.status} />

--- a/apps/web/src/components/pullRequest/PullRequestTimelineTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestTimelineTab.tsx
@@ -357,7 +357,7 @@ function CommitEvent({
   return (
     <button
       type="button"
-      className="group relative mb-5 block w-full rounded-sm pl-12 text-left outline-none [contain-intrinsic-block-size:48px] [content-visibility:auto] focus-visible:ring-2 focus-visible:ring-ring"
+      className="group relative mb-5 block w-full cursor-pointer rounded-sm pl-12 text-left outline-none [contain-intrinsic-block-size:48px] [content-visibility:auto] focus-visible:ring-2 focus-visible:ring-ring"
       aria-label={`View commit ${event.id}`}
       onClick={() => onOpen(event.id)}
     >


### PR DESCRIPTION
## Summary
- Add `cursor-pointer` to raw `<button>` controls in the pull request list and detail flow (#7606)
- Covers list rows, PR number links, timeline commits, checks, reactions, reviewer picker, and review thread toggles
- Summary/Timeline/Code tabs already use `Toggle`, which includes `cursor-pointer` on main

## Test plan
- [x] `vp test run apps/web/src/components/pullRequest/PullRequestRow.test.tsx`
- [ ] Open Pull Requests → hover list rows, PR number, timeline commits, checks, reactions, reviewer picker

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tailwind class-only UX polish on pull request UI with no behavior, data, or auth changes.
> 
> **Overview**
> Adds **`cursor-pointer`** to native `<button>` elements across the pull request list and detail flow so hover states read as clickable. Shared **`Button`** / **`Toggle`** already set the pointer; this targets raw buttons that were still using the default arrow cursor.
> 
> Coverage includes list **rows**, **PR number** links, **timeline** commit rows, **check** rows (pointer only when a URL exists; **`cursor-default`** when not), **reactions** and the emoji picker, **reviewer picker** rows (**`disabled:cursor-not-allowed`** while a request is in flight), **review thread** expand/collapse, and check **Details** links in the popover.
> 
> Adds **`PullRequestRow.test.tsx`** to assert selectable rows render with **`cursor-pointer`** in static markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bac1e2c9692d6f03dfc2096b75f0dd9e13552a76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `cursor-pointer` to interactive pull request controls in web UI
> - Adds the `cursor-pointer` utility class to clickable elements across multiple pull request components: the Details button in `ChecksBody`, the host-open button in `PullRequestDetailPanel`, reaction buttons and emoji options in `PullRequestReactionBar`, thread header toggles in `ReviewThreadCard`, candidate buttons in `PullRequestReviewerPicker`, the root button in `PullRequestRow`, and commit event buttons in `CommitEvent`
> - In `PullRequestSummaryTab`, per-check rows now use `cursor-pointer` when a URL is present and `cursor-default` otherwise
> - Adds a test in [PullRequestRow.test.tsx](https://github.com/pingdotgg/t3code/pull/7629/files#diff-cf7a9709f842a29d6b2dc1f9b690d2d1034704c6429bb5d1f60225ebd3780d2f) asserting selectable rows render `cursor-pointer` in static markup
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bac1e2c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->