### PR TITLE
fix(web): show pointer cursor on PR rows and reactions

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestReactions.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestReactions.tsx
@@ -113,7 +113,7 @@ export function PullRequestReactionBar({
                   reaction.viewerHasReacted
                     ? "border-primary/60 bg-primary/10 text-foreground"
                     : "border-border/70 bg-muted/40 text-muted-foreground",
-                  canReact ? "hover:border-primary/60" : "cursor-default",
+                  canReact ? "cursor-pointer hover:border-primary/60" : "cursor-default",
                 )}
                 onClick={() => void toggle(reaction.content, !reaction.viewerHasReacted)}
               />
@@ -135,7 +135,7 @@ export function PullRequestReactionBar({
                 aria-label="Add a reaction"
                 className={cn(
                   PILL_CLASS,
-                  "border-border/70 px-1.5 text-muted-foreground hover:border-primary/60 hover:text-foreground",
+                  "cursor-pointer border-border/70 px-1.5 text-muted-foreground hover:border-primary/60 hover:text-foreground",
                   shown.length === 0 &&
                     !pickerOpen &&
                     "opacity-0 group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:opacity-100",
@@ -157,7 +157,7 @@ export function PullRequestReactionBar({
                     aria-pressed={reacted}
                     aria-label={pullRequestReactionName(content)}
                     className={cn(
-                      "flex size-7 items-center justify-center rounded-md text-base outline-none hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring",
+                      "flex size-7 cursor-pointer items-center justify-center rounded-md text-base outline-none hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring",
                       reacted && "bg-primary/10",
                     )}
                     onClick={() => {

--- a/apps/web/src/components/pullRequest/PullRequestRow.test.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestRow.test.tsx
@@ -1,0 +1,47 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import type { EnvironmentPullRequestEntry } from "./pullRequestList.logic";
+import { PullRequestRow } from "./PullRequestRow";
+
+function entry(number: number): EnvironmentPullRequestEntry {
+  return {
+    environmentId: "env-1" as EnvironmentPullRequestEntry["environmentId"],
+    provider: "github",
+    host: "github.com",
+    projectId: "project-1" as EnvironmentPullRequestEntry["projectId"],
+    projectTitle: "t3code",
+    repository: "pingdotgg/t3code",
+    number,
+    title: "Add the pull requests page",
+    url: `https://github.com/pingdotgg/t3code/pull/${number}`,
+    author: { login: "octocat", name: null, avatarUrl: null },
+    headBranch: `feat/branch-${number}`,
+    baseBranch: "main",
+    state: "open",
+    isDraft: false,
+    mergeability: "mergeable",
+    additions: 1,
+    deletions: 0,
+    createdAt: "2026-07-01T00:00:00Z",
+    updatedAt: "2026-07-02T00:00:00Z",
+    viewerReviewRequested: false,
+    labels: [],
+  };
+}
+
+describe("PullRequestRow interactive cursors", () => {
+  it("shows a pointer on selectable rows", () => {
+    const html = renderToStaticMarkup(
+      <PullRequestRow
+        entry={entry(42)}
+        selected={false}
+        showProjectTitle={false}
+        showProvider={false}
+        onSelect={() => {}}
+      />,
+    );
+
+    expect(html).toContain("cursor-pointer");
+  });
+});

--- a/apps/web/src/components/pullRequest/PullRequestRow.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestRow.tsx
@@ -45,7 +45,7 @@ function PullRequestRowImpl({
       aria-current={selected ? "true" : undefined}
       onClick={() => onSelect(entry)}
       className={cn(
-        "grid w-full grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 rounded-lg px-3 py-2 text-left transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        "grid w-full cursor-pointer grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 rounded-lg px-3 py-2 text-left transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
         // Offscreen rows are skipped for style, layout and paint: a long list costs what the
         // viewport shows, not what the pages have loaded. The intrinsic size keeps the
         // scrollbar honest while a row is skipped.


### PR DESCRIPTION
## Problem

Pull request list rows and reaction controls remain clickable while showing the default cursor. The filter and detail tabs now use shared Button and Toggle primitives on current main, so those already show the correct pointer cursor.

## Fix

- show the pointer cursor on selectable pull request rows
- show the pointer cursor on enabled reaction pills
- show the pointer cursor on the add-reaction trigger and emoji picker options
- preserve the default cursor for disabled reaction pills
- add a focused regression test for selectable rows

## Verification

- `node_modules/.bin/vp test run apps/web/src/components/pullRequest/PullRequestRow.test.tsx apps/web/src/components/pullRequest/pullRequestReactions.logic.test.ts` (14 tests pass)
- targeted formatting passes
- `git diff --check` passes
- web typecheck reaches two unrelated existing errors in `electronPasskeys.test.ts` (`conditionalUI` type mismatch)

Closes #7606

Built with GPT-5.6 Codex in the T3 Code harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only cursor classes and a static HTML regression test; no behavior or data-path changes.
> 
> **Overview**
> **Extends pointer-cursor affordances** on pull request UI so clickable controls no longer show the default arrow.
> 
> `PullRequestRow` row buttons get `cursor-pointer` so selectable list rows read as clickable. In `PullRequestReactions`, the same class is applied to existing reaction pills (when reacting is allowed), the “Add a reaction” trigger, and each emoji in the reaction picker.
> 
> A new `PullRequestRow.test.tsx` uses static markup to assert selectable rows include `cursor-pointer`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb57ab4132d1b567b48723de14ecf4e56c9871f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `cursor-pointer` to `PullRequestRow` and `PullRequestReactionBar` controls
> Adds the `cursor-pointer` utility to the row button in [PullRequestRow.tsx](https://github.com/pingdotgg/t3code/pull/7631/files#diff-73a4c1151b28055e99d6607ece853ca346412cac780011155821d4abec897495) and to reaction pill buttons, the popover trigger, and emoji option buttons in [PullRequestReactions.tsx](https://github.com/pingdotgg/t3code/pull/7631/files#diff-5ba64d3eeb68f09517d147db020c86628c49011253740788459a3fdead63c610). A test in [PullRequestRow.test.tsx](https://github.com/pingdotgg/t3code/pull/7631/files#diff-cf7a9709f842a29d6b2dc1f9b690d2d1034704c6429bb5d1f60225ebd3780d2f) verifies the class is present. No logic or event handling changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eb57ab4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->