### PR TITLE
feat(server): render model reasoning as timeline activities

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -3623,4 +3623,190 @@ describe("ProviderRuntimeIngestion", () => {
     expect(thread.session?.status).toBe("error");
     expect(thread.session?.lastError).toBe("runtime still processed");
   });
+
+  it("projects reasoning deltas into a streaming thinking activity and flushes a thought on turn completion", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-reasoning-delta-1"),
+      provider: ProviderDriverKind.make("opencode"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-reasoning"),
+      itemId: asItemId("reasoning-part-1"),
+      payload: {
+        streamKind: "reasoning_text",
+        delta: "The user wants the answer in metric units.",
+      },
+    });
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-reasoning-delta-2"),
+      provider: ProviderDriverKind.make("opencode"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-reasoning"),
+      itemId: asItemId("reasoning-part-1"),
+      payload: {
+        streamKind: "reasoning_text",
+        delta: " Convert before replying.",
+      },
+    });
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-reasoning-turn-completed"),
+      provider: ProviderDriverKind.make("opencode"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-reasoning"),
+      status: "completed",
+    });
+
+    const thread = await waitForThread(harness.readModel, (entry) =>
+      entry.activities.some(
+        (activity: ProviderRuntimeTestActivity) => activity.kind === "tool.completed",
+      ),
+    );
+
+    const streaming = thread.activities.find(
+      (activity: ProviderRuntimeTestActivity) => activity.id === "evt-reasoning-delta-1:reasoning",
+    );
+    const streamingPayload =
+      streaming?.payload && typeof streaming.payload === "object"
+        ? (streaming.payload as Record<string, unknown>)
+        : undefined;
+    expect(streaming?.kind).toBe("tool.updated");
+    expect(streaming?.summary).toBe("Thinking");
+    expect(streamingPayload?.toolCallId).toBe("reasoning-part-1");
+    expect(streamingPayload?.status).toBe("inProgress");
+    expect(streamingPayload?.detail).toBe("The user wants the answer in metric units.");
+
+    const completed = thread.activities.find(
+      (activity: ProviderRuntimeTestActivity) =>
+        activity.id === "evt-reasoning-turn-completed:reasoning:reasoning-part-1",
+    );
+    const completedPayload =
+      completed?.payload && typeof completed.payload === "object"
+        ? (completed.payload as Record<string, unknown>)
+        : undefined;
+    expect(completed?.kind).toBe("tool.completed");
+    expect(completed?.summary).toBe("Thought");
+    expect(completedPayload?.toolCallId).toBe("reasoning-part-1");
+    expect(completedPayload?.status).toBe("completed");
+    expect(completedPayload?.detail).toBe(
+      "The user wants the answer in metric units. Convert before replying.",
+    );
+  });
+
+  it("flushes a reasoning item.completed using the richer of streamed text and item detail", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-reasoning-item-delta"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-reasoning-item"),
+      itemId: asItemId("reasoning-item-1"),
+      payload: {
+        streamKind: "reasoning_summary_text",
+        delta: "Short streamed summary.",
+      },
+    });
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-reasoning-item-completed"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-reasoning-item"),
+      itemId: asItemId("reasoning-item-1"),
+      payload: {
+        itemType: "reasoning",
+        status: "completed",
+        title: "Reasoning",
+        detail: "Short streamed summary. Plus the fuller reasoning body from the item.",
+      },
+    });
+
+    const thread = await waitForThread(harness.readModel, (entry) =>
+      entry.activities.some(
+        (activity: ProviderRuntimeTestActivity) =>
+          activity.id === "evt-reasoning-item-completed:reasoning:reasoning-item-1",
+      ),
+    );
+    const completed = thread.activities.find(
+      (activity: ProviderRuntimeTestActivity) =>
+        activity.id === "evt-reasoning-item-completed:reasoning:reasoning-item-1",
+    );
+    const completedPayload =
+      completed?.payload && typeof completed.payload === "object"
+        ? (completed.payload as Record<string, unknown>)
+        : undefined;
+    expect(completed?.kind).toBe("tool.completed");
+    expect(completedPayload?.detail).toBe(
+      "Short streamed summary. Plus the fuller reasoning body from the item.",
+    );
+
+    // The turn boundary must not re-flush the already-completed item.
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-reasoning-item-turn-completed"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-reasoning-item"),
+      status: "completed",
+    });
+    const settled = await waitForThread(
+      harness.readModel,
+      (entry) => entry.session?.status === "ready" && entry.session?.activeTurnId === null,
+    );
+    const duplicateFlushes = settled.activities.filter((activity: ProviderRuntimeTestActivity) =>
+      activity.id.startsWith("evt-reasoning-item-turn-completed:reasoning:"),
+    );
+    expect(duplicateFlushes).toHaveLength(0);
+  });
+
+  it("does not emit reasoning activities for assistant text and empty reasoning buffers", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-plain-assistant-delta"),
+      provider: ProviderDriverKind.make("opencode"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-plain"),
+      itemId: asItemId("plain-item-1"),
+      payload: {
+        streamKind: "assistant_text",
+        delta: "just an answer",
+      },
+    });
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-plain-turn-completed"),
+      provider: ProviderDriverKind.make("opencode"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-plain"),
+      status: "completed",
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) => entry.session?.status === "ready" && entry.session?.activeTurnId === null,
+    );
+    const reasoningActivities = thread.activities.filter(
+      (activity: ProviderRuntimeTestActivity) =>
+        activity.summary === "Thinking" || activity.summary === "Thought",
+    );
+    expect(reasoningActivities).toHaveLength(0);
+  });
 });

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -3772,6 +3772,64 @@ describe("ProviderRuntimeIngestion", () => {
     expect(duplicateFlushes).toHaveLength(0);
   });
 
+  it("does not flush the active turn's reasoning on a superseded turn's boundary", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-active-reasoning-delta"),
+      provider: ProviderDriverKind.make("opencode"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-active"),
+      itemId: asItemId("reasoning-active-1"),
+      payload: {
+        streamKind: "reasoning_text",
+        delta: "Active turn reasoning in progress.",
+      },
+    });
+    // A late boundary from a superseded turn must not flush the active buffer.
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-stale-turn-completed"),
+      provider: ProviderDriverKind.make("opencode"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-stale"),
+      status: "completed",
+    });
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-active-turn-completed"),
+      provider: ProviderDriverKind.make("opencode"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-active"),
+      status: "completed",
+    });
+
+    const thread = await waitForThread(harness.readModel, (entry) =>
+      entry.activities.some(
+        (activity: ProviderRuntimeTestActivity) =>
+          activity.id === "evt-active-turn-completed:reasoning:reasoning-active-1",
+      ),
+    );
+    const staleFlushes = thread.activities.filter((activity: ProviderRuntimeTestActivity) =>
+      activity.id.startsWith("evt-stale-turn-completed:reasoning:"),
+    );
+    expect(staleFlushes).toHaveLength(0);
+    const completed = thread.activities.find(
+      (activity: ProviderRuntimeTestActivity) =>
+        activity.id === "evt-active-turn-completed:reasoning:reasoning-active-1",
+    );
+    const completedPayload =
+      completed?.payload && typeof completed.payload === "object"
+        ? (completed.payload as Record<string, unknown>)
+        : undefined;
+    expect(completedPayload?.detail).toBe("Active turn reasoning in progress.");
+  });
+
   it("does not emit reasoning activities for assistant text and empty reasoning buffers", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1042,7 +1042,6 @@ const make = Effect.gen(function* () {
         if (!shouldEmit) {
           return;
         }
-        buffer.emittedLength = buffer.text.length;
         yield* appendReasoningActivity(event, threadId, {
           id: EventId.make(`${event.eventId}:reasoning`),
           createdAt: event.createdAt,
@@ -1058,6 +1057,10 @@ const make = Effect.gen(function* () {
           turnId: buffer.turnId,
           ...reasoningActivitySequence(event),
         });
+        // Advance only after a successful dispatch: a failed append is logged
+        // and skipped upstream, so an eager advance would suppress the retry
+        // a later delta gets for free.
+        buffer.emittedLength = buffer.text.length;
         return;
       }
 
@@ -1071,13 +1074,16 @@ const make = Effect.gen(function* () {
           typeof event.payload.detail === "string" && event.payload.detail.trim().length > 0
             ? event.payload.detail
             : undefined;
-        byKey?.delete(key);
         if (buffer) {
           const text =
             detailFromItem !== undefined && detailFromItem.length > buffer.text.length
               ? detailFromItem
               : buffer.text;
+          // Flush before delete: a failed dispatch is logged and skipped
+          // upstream, and a still-buffered thought gets a second chance at
+          // the turn boundary instead of vanishing.
           yield* flushReasoningBuffer(event, threadId, buffer, text);
+          byKey?.delete(key);
         } else if (detailFromItem !== undefined) {
           yield* flushReasoningBuffer(event, threadId, {
             text: detailFromItem,
@@ -1090,26 +1096,46 @@ const make = Effect.gen(function* () {
         return;
       }
 
-      // Turn and session boundaries flush every open buffer for the thread,
-      // so adapters with no reasoning item lifecycle (OpenCode, Claude)
-      // still land a completed thought row.
+      // Turn boundaries flush the boundary turn's buffers, so adapters with
+      // no reasoning item lifecycle (OpenCode, Claude) still land a completed
+      // thought row. Scoped to the event's turn: a late turn.completed from a
+      // superseded turn must not flush or wipe the active turn's reasoning
+      // (review finding — plan progress in this handler makes the same
+      // distinction). A buffer with no turn attribution flushes on any turn
+      // boundary for the thread; session.exited flushes and drops everything.
       if (
         event.type === "turn.completed" ||
         event.type === "turn.aborted" ||
-        event.type === "session.exited" ||
         event.type === "request.opened" ||
         event.type === "user-input.requested"
       ) {
         const byKey = reasoningBuffersByThread.get(threadId);
         if (byKey) {
-          for (const buffer of byKey.values()) {
+          const boundaryTurnId = toTurnId(event.turnId) ?? null;
+          for (const [key, buffer] of [...byKey.entries()]) {
+            if (
+              buffer.turnId !== null &&
+              boundaryTurnId !== null &&
+              buffer.turnId !== boundaryTurnId
+            ) {
+              continue;
+            }
             yield* flushReasoningBuffer(event, threadId, buffer);
+            byKey.delete(key);
           }
-          byKey.clear();
         }
-        if (event.type === "session.exited") {
-          reasoningBuffersByThread.delete(threadId);
+        return;
+      }
+
+      if (event.type === "session.exited") {
+        const byKey = reasoningBuffersByThread.get(threadId);
+        if (byKey) {
+          for (const [key, buffer] of [...byKey.entries()]) {
+            yield* flushReasoningBuffer(event, threadId, buffer);
+            byKey.delete(key);
+          }
         }
+        reasoningBuffersByThread.delete(threadId);
       }
     });
 

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -49,6 +49,56 @@ import { canReplaceThreadTitle } from "../threadTitles.ts";
 const providerTurnKey = (threadId: ThreadId, turnId: TurnId) => `${threadId}:${turnId}`;
 const providerTaskKey = (threadId: ThreadId, taskId: string) => `${threadId}:${taskId}`;
 
+// --- Reasoning stream projection -------------------------------------------
+// Reasoning arrives as `content.delta` with streamKind "reasoning_text" /
+// "reasoning_summary_text" (all adapters) and, for some adapters, as
+// item lifecycle events with itemType "reasoning". Neither previously reached
+// any activity, so no client ever rendered a thought. Reasoning is buffered
+// per (thread, item-or-turn) and projected into the existing tool activity
+// shape (tool.updated while streaming, tool.completed on flush) so every
+// client — web, desktop, mobile — renders it with zero client changes, and
+// rows sharing a toolCallId collapse exactly like streaming tool output.
+const REASONING_UPDATE_EMIT_THRESHOLD = 600;
+const REASONING_LIVE_DETAIL_LIMIT = 180;
+const REASONING_FINAL_DETAIL_LIMIT = 6_000;
+const REASONING_BUFFER_TEXT_CAP = 60_000;
+
+interface ReasoningBuffer {
+  text: string;
+  /** Buffer length at the last emitted activity; -1 before the first emit. */
+  emittedLength: number;
+  toolCallId: string;
+  turnId: TurnId | null;
+  truncated: boolean;
+}
+
+function isReasoningStreamKind(streamKind: string): boolean {
+  return streamKind === "reasoning_text" || streamKind === "reasoning_summary_text";
+}
+
+function reasoningBufferKey(event: ProviderRuntimeEvent): string {
+  return event.itemId !== undefined
+    ? String(event.itemId)
+    : `reasoning:${event.turnId ?? "session"}`;
+}
+
+/** Streaming rows show the tail: the newest thought is the informative part. */
+function reasoningLiveDetail(text: string): string {
+  const trimmed = text.trim();
+  return trimmed.length > REASONING_LIVE_DETAIL_LIMIT
+    ? `...${trimmed.slice(trimmed.length - (REASONING_LIVE_DETAIL_LIMIT - 3))}`
+    : trimmed;
+}
+
+function reasoningFinalDetail(text: string, truncated: boolean): string {
+  const trimmed = text.trim();
+  const capped =
+    trimmed.length > REASONING_FINAL_DETAIL_LIMIT
+      ? `${trimmed.slice(0, REASONING_FINAL_DETAIL_LIMIT - 3)}...`
+      : trimmed;
+  return truncated ? `${capped}\n\n[reasoning truncated]` : capped;
+}
+
 // Fallback when the in-memory description cache no longer has the task name
 // (server restart, session-exit sweep, TTL/capacity eviction): earlier
 // task.started/task.progress activities for the task are persisted with it.
@@ -895,6 +945,174 @@ const make = Effect.gen(function* () {
       Effect.map((uuid) => CommandId.make(`provider:${event.eventId}:${tag}:${uuid}`)),
     );
 
+  // Open reasoning buffers, keyed by thread then by item-or-turn key. Bounded
+  // by the per-buffer text cap plus flush-on-turn/session-boundary cleanup.
+  const reasoningBuffersByThread = new Map<ThreadId, Map<string, ReasoningBuffer>>();
+
+  const appendReasoningActivity = (
+    event: ProviderRuntimeEvent,
+    threadId: ThreadId,
+    activity: OrchestrationThreadActivity,
+  ) =>
+    providerCommandId(event, "thread-activity-append-reasoning").pipe(
+      Effect.flatMap((commandId) =>
+        orchestrationEngine.dispatch({
+          type: "thread.activity.append",
+          commandId,
+          threadId,
+          activity,
+          createdAt: activity.createdAt,
+        }),
+      ),
+    );
+
+  const reasoningActivitySequence = (event: ProviderRuntimeEvent) => {
+    const eventWithSequence = event as ProviderRuntimeEvent & { sessionSequence?: number };
+    return eventWithSequence.sessionSequence !== undefined
+      ? { sequence: eventWithSequence.sessionSequence }
+      : {};
+  };
+
+  const flushReasoningBuffer = (
+    event: ProviderRuntimeEvent,
+    threadId: ThreadId,
+    buffer: ReasoningBuffer,
+    textOverride?: string,
+  ) => {
+    const text = textOverride ?? buffer.text;
+    if (text.trim().length === 0) {
+      return Effect.void;
+    }
+    return appendReasoningActivity(event, threadId, {
+      id: EventId.make(`${event.eventId}:reasoning:${buffer.toolCallId}`),
+      createdAt: event.createdAt,
+      tone: "tool",
+      kind: "tool.completed",
+      summary: "Thought",
+      payload: {
+        toolCallId: buffer.toolCallId,
+        status: "completed",
+        title: "Thought",
+        detail: reasoningFinalDetail(text, buffer.truncated),
+      },
+      turnId: buffer.turnId ?? toTurnId(event.turnId) ?? null,
+      ...reasoningActivitySequence(event),
+    });
+  };
+
+  const handleReasoningEvent = (threadId: ThreadId, event: ProviderRuntimeEvent) =>
+    Effect.gen(function* () {
+      if (
+        event.type === "content.delta" &&
+        isReasoningStreamKind(event.payload.streamKind) &&
+        event.payload.delta.length > 0
+      ) {
+        let byKey = reasoningBuffersByThread.get(threadId);
+        if (!byKey) {
+          byKey = new Map<string, ReasoningBuffer>();
+          reasoningBuffersByThread.set(threadId, byKey);
+        }
+        const key = reasoningBufferKey(event);
+        let buffer = byKey.get(key);
+        if (!buffer) {
+          buffer = {
+            text: "",
+            emittedLength: -1,
+            toolCallId: key,
+            turnId: toTurnId(event.turnId) ?? null,
+            truncated: false,
+          };
+          byKey.set(key, buffer);
+        }
+        if (buffer.text.length >= REASONING_BUFFER_TEXT_CAP) {
+          buffer.truncated = true;
+        } else {
+          buffer.text += event.payload.delta;
+          if (buffer.text.length > REASONING_BUFFER_TEXT_CAP) {
+            buffer.text = buffer.text.slice(0, REASONING_BUFFER_TEXT_CAP);
+            buffer.truncated = true;
+          }
+        }
+        // First delta surfaces the row immediately; afterwards re-emit only
+        // per threshold so token-sized deltas do not each persist an
+        // activity (same O(N²) guard the tool item.updated path documents).
+        const shouldEmit =
+          buffer.emittedLength < 0 ||
+          buffer.text.length - buffer.emittedLength >= REASONING_UPDATE_EMIT_THRESHOLD;
+        if (!shouldEmit) {
+          return;
+        }
+        buffer.emittedLength = buffer.text.length;
+        yield* appendReasoningActivity(event, threadId, {
+          id: EventId.make(`${event.eventId}:reasoning`),
+          createdAt: event.createdAt,
+          tone: "tool",
+          kind: "tool.updated",
+          summary: "Thinking",
+          payload: {
+            toolCallId: buffer.toolCallId,
+            status: "inProgress",
+            title: "Thinking",
+            detail: reasoningLiveDetail(buffer.text),
+          },
+          turnId: buffer.turnId,
+          ...reasoningActivitySequence(event),
+        });
+        return;
+      }
+
+      // Adapters that close reasoning items explicitly flush that buffer;
+      // the item's own detail wins when it carries more than was streamed.
+      if (event.type === "item.completed" && event.payload.itemType === "reasoning") {
+        const byKey = reasoningBuffersByThread.get(threadId);
+        const key = reasoningBufferKey(event);
+        const buffer = byKey?.get(key);
+        const detailFromItem =
+          typeof event.payload.detail === "string" && event.payload.detail.trim().length > 0
+            ? event.payload.detail
+            : undefined;
+        byKey?.delete(key);
+        if (buffer) {
+          const text =
+            detailFromItem !== undefined && detailFromItem.length > buffer.text.length
+              ? detailFromItem
+              : buffer.text;
+          yield* flushReasoningBuffer(event, threadId, buffer, text);
+        } else if (detailFromItem !== undefined) {
+          yield* flushReasoningBuffer(event, threadId, {
+            text: detailFromItem,
+            emittedLength: -1,
+            toolCallId: key,
+            turnId: toTurnId(event.turnId) ?? null,
+            truncated: false,
+          });
+        }
+        return;
+      }
+
+      // Turn and session boundaries flush every open buffer for the thread,
+      // so adapters with no reasoning item lifecycle (OpenCode, Claude)
+      // still land a completed thought row.
+      if (
+        event.type === "turn.completed" ||
+        event.type === "turn.aborted" ||
+        event.type === "session.exited" ||
+        event.type === "request.opened" ||
+        event.type === "user-input.requested"
+      ) {
+        const byKey = reasoningBuffersByThread.get(threadId);
+        if (byKey) {
+          for (const buffer of byKey.values()) {
+            yield* flushReasoningBuffer(event, threadId, buffer);
+          }
+          byKey.clear();
+        }
+        if (event.type === "session.exited") {
+          reasoningBuffersByThread.delete(threadId);
+        }
+      }
+    });
+
   const turnMessageIdsByTurnKey = yield* Cache.make<string, Set<MessageId>>({
     capacity: TURN_MESSAGE_IDS_BY_TURN_CACHE_CAPACITY,
     timeToLive: TURN_MESSAGE_IDS_BY_TURN_TTL,
@@ -1703,6 +1921,8 @@ const make = Effect.gen(function* () {
           });
         }
       }
+
+      yield* handleReasoningEvent(thread.id, event);
 
       const pauseForUserTurnId =
         event.type === "request.opened" || event.type === "user-input.requested"


### PR DESCRIPTION
Models that stream reasoning (Claude thinking blocks, Codex `item/reasoning/*`, OpenCode reasoning parts, local reasoning models behind OpenCode) currently show nothing in any T3 client — the thinking never renders on web, desktop, or mobile.

### Why

Adapters already emit reasoning. Ingestion drops it in two places:

- `content.delta` with `streamKind: "reasoning_text"` / `"reasoning_summary_text"` has no consumer — the assistant-delta path in `ProviderRuntimeIngestion` matches `assistant_text` exactly.
- `item.started/updated/completed` with `itemType: "reasoning"` fail the `isToolLifecycleItemType` gate in all three activity projections, so they project to `[]`.

(Separately, ClaudeAdapter emits thinking deltas without an `itemId` because `content_block_start` creates no block state for `thinking` blocks — this change works with or without that, by falling back to a per-turn buffer key.)

### What

Server-only, one file plus tests. In `ProviderRuntimeIngestion`:

- Buffer reasoning deltas per `(thread, itemId ?? turn)`.
- While streaming, emit a throttled `tool.updated` activity (summary/title "Thinking", `status: "inProgress"`, detail = tail of the accumulated text). The first delta emits immediately so the row appears; afterwards re-emit only every 600 buffered chars, mirroring the O(N²) persistence guard the tool `item.updated` path documents.
- Flush a `tool.completed` activity (summary/title "Thought", full text capped at 6000 chars) on `item.completed` for a reasoning item (richer of streamed text vs item detail wins, and the buffer is consumed so turn boundaries cannot double-flush), on `turn.completed` / `turn.aborted` / `request.opened` / `user-input.requested`, and on `session.exited` (which also drops the thread's buffers).

Reusing the existing tool activity shape (`tone: "tool"`, `toolCallId` for collapse) means web, desktop, and mobile all render, collapse, and expand the rows with zero client changes — streaming updates collapse into one row via `deriveToolLifecycleCollapseKey`, exactly like streaming tool output.

### Proof

- 3 new tests in `ProviderRuntimeIngestion.test.ts`: streaming + turn-boundary flush; reasoning `item.completed` flush picking the richer text and not double-flushing at the turn boundary; no reasoning activities for plain assistant text. Full file: 52/52 pass. `tsgo --noEmit`: clean.
- Live: OpenCode lane against a local Qwen3.8-27B — "Thinking" streams during the turn and a "Thought" row with the full reasoning body renders in the web timeline (screenshot in a comment below).

### Notes for review

- Reasoning summaries (`reasoning_summary_text`) share the item's buffer with full reasoning text; adapters that emit both for one item interleave. Codex GPT models emit only summaries, so in practice each item carries one kind.
- Two provider-side limits observed while testing, out of scope here: Claude Code CLI redacts thinking text in its stream-json output (`"thinking": ""` with token estimates only), and Codex reasoning items can arrive with empty `content`/`summary` when summaries are not enabled. In both cases this change correctly renders nothing.
- The 6000-char completed-detail cap and the "[reasoning truncated]" marker are deliberate: `payload.detail` persists to the projection table and the event store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds in-memory buffering and new persisted activity payloads on a hot ingestion path; turn-scoping and caps limit wrong-flush and storage blow-up, but timeline volume and ordering still depend on provider event timing.
> 
> **Overview**
> **Provider runtime ingestion** now turns streamed model reasoning into thread timeline activities so web, desktop, and mobile can show “Thinking” / “Thought” without client changes.
> 
> Reasoning from `content.delta` (`reasoning_text` / `reasoning_summary_text`) and `item.completed` with `itemType: "reasoning"` is buffered per thread and item (or per turn when `itemId` is missing). While streaming, ingestion emits throttled **`tool.updated`** rows (summary **Thinking**, `inProgress`, tail-truncated detail); on flush it emits **`tool.completed`** (**Thought**, full text capped at 6k with an optional truncation marker). Flushes happen on reasoning item completion (preferring richer item detail over streamed text), on turn boundaries (`turn.completed` / `turn.aborted` and approval/user-input pauses) scoped to that turn so stale completions cannot wipe active reasoning, and on **`session.exited`** (buffers cleared).
> 
> Reusing the existing tool activity shape and `toolCallId` keeps collapse behavior aligned with streaming tools. **`ProviderRuntimeIngestion.test.ts`** adds coverage for streaming + turn flush, item.completed richness and no double-flush, superseded-turn boundaries, and no noise from plain assistant text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26afe446dbf53161863947dd0b6f9e06c0f68e65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render model reasoning as 'Thinking' and 'Thought' timeline activities
> - Adds `handleReasoningEvent` to [ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/7632/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7) to buffer `reasoning_text` deltas and emit periodic `tool.updated` ('Thinking') activities.
> - Emits a final `tool.completed` ('Thought') activity on `item.completed` or turn/session boundaries, using the richer of buffered or item text.
> - Enforces size limits via `REASONING_BUFFER_TEXT_CAP` (60000) and `REASONING_FINAL_DETAIL_LIMIT` (6000), adding truncation markers when text is capped.
> - Risk: Introduces `reasoningBuffersByThread` state that retains up to 60000 characters per active reasoning stream until flushed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 26afe44.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->