### PR TITLE
feat(swift-ios): filter the new-task project picker and pick its environment

### DIFF
--- a/apps/swift-ios/Features/Workspace/DailyUXModels.swift
+++ b/apps/swift-ios/Features/Workspace/DailyUXModels.swift
@@ -331,17 +331,106 @@ struct DailyUXRecentProject: Equatable {
 /// most recently and keeps every remaining project below in the usual
 /// alphabetical order. A group appears in exactly one section so the list never
 /// repeats itself on the small project counts this picker normally shows.
+/// One entry in the picker's environment selector. `id` is the environment ID
+/// the selection filters by; `name` is what the menu shows.
+struct DailyUXProjectHostOption: Identifiable, Equatable {
+    let id: String
+    let name: String
+}
+
+/// A logical project group can exist on more than one environment, so the
+/// picker names the host each row would actually open on instead of leaving the
+/// destination implicit. The label leads with the environment the composer is
+/// already using when the group exists there — the same choice
+/// `preferredProject(environmentID:)` makes on selection — and counts the
+/// remaining hosts so a shared repository still reads as shared.
+struct DailyUXProjectHostLabels: Equatable {
+    private let namesByEnvironmentID: [String: String]
+
+    init(environments: [FeatureEnvironment]) {
+        namesByEnvironmentID = environments.reduce(into: [String: String]()) { names, environment in
+            guard let name = DailyUXProjectHostLabels.displayName(environment) else { return }
+            names[environment.id] = names[environment.id] ?? name
+        }
+    }
+
+    /// The environments the selector can actually narrow to: the ones that own
+    /// at least one project the picker is showing. Listing an environment that
+    /// cannot change the list would be a dead menu entry, so an environment with
+    /// no projects here — or with no resolvable name — is left out.
+    func environmentOptions(in groups: [DailyUXProjectGroup]) -> [DailyUXProjectHostOption] {
+        var seenIDs = Set<String>()
+        return groups
+            .flatMap(\.projects)
+            .compactMap { project -> DailyUXProjectHostOption? in
+                guard let name = namesByEnvironmentID[project.environmentID],
+                      seenIDs.insert(project.environmentID).inserted else {
+                    return nil
+                }
+                return DailyUXProjectHostOption(id: project.environmentID, name: name)
+            }
+            .sorted { lhs, rhs in
+                let comparison = lhs.name.localizedCaseInsensitiveCompare(rhs.name)
+                return comparison == .orderedSame ? lhs.id < rhs.id : comparison == .orderedAscending
+            }
+    }
+
+    func name(forEnvironmentID environmentID: String) -> String? {
+        namesByEnvironmentID[environmentID]
+    }
+
+    /// Every host the group has a project on, in the group's own project order.
+    func hostNames(for group: DailyUXProjectGroup) -> [String] {
+        var seenNames = Set<String>()
+        return group.projects
+            .compactMap { namesByEnvironmentID[$0.environmentID] }
+            .filter { seenNames.insert($0).inserted }
+    }
+
+    func label(
+        for group: DailyUXProjectGroup,
+        preferredEnvironmentID: String?
+    ) -> String? {
+        let names = hostNames(for: group)
+        let opensOn = group.preferredProject(environmentID: preferredEnvironmentID)
+            .flatMap { namesByEnvironmentID[$0.environmentID] }
+        guard let host = opensOn ?? names.first else { return nil }
+        let elsewhere = names.filter { $0 != host }.count
+        return elsewhere > 0 ? "\(host) +\(elsewhere)" : host
+    }
+
+    /// An environment saved without a name still routes somewhere, so fall back
+    /// to the endpoint's host rather than showing an unlabelled row.
+    private static func displayName(_ environment: FeatureEnvironment) -> String? {
+        let name = environment.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !name.isEmpty { return name }
+        guard let host = URLComponents(string: environment.endpoint)?.host,
+              !host.isEmpty else {
+            return nil
+        }
+        return host
+    }
+}
+
 struct DailyUXProjectPickerSections: Equatable {
     static let recentLimit = 3
 
     let recents: [DailyUXProjectGroup]
     let others: [DailyUXProjectGroup]
 
+    var isEmpty: Bool { recents.isEmpty && others.isEmpty }
+
     init(
         groups: [DailyUXProjectGroup],
         recentGroupIDs: [String],
+        filter: String = "",
+        environmentID: String? = nil,
         limit: Int = DailyUXProjectPickerSections.recentLimit
     ) {
+        let groups = DailyUXProjectPickerSections.matching(
+            DailyUXProjectPickerSections.hosted(groups, on: environmentID),
+            filter: filter
+        )
         let groupsByID = groups.reduce(into: [String: DailyUXProjectGroup]()) {
             $0[$1.id] = $0[$1.id] ?? $1
         }
@@ -357,6 +446,34 @@ struct DailyUXProjectPickerSections: Equatable {
 
         recents = ranked
         others = groups.filter { !seenGroupIDs.contains($0.id) }
+    }
+
+    /// Keep only the groups that actually have a project on the chosen host.
+    private static func hosted(
+        _ groups: [DailyUXProjectGroup],
+        on environmentID: String?
+    ) -> [DailyUXProjectGroup] {
+        guard let environmentID else { return groups }
+        return groups.filter { group in
+            group.projects.contains { $0.environmentID == environmentID }
+        }
+    }
+
+    /// Matching follows the model picker's convention — one trimmed query,
+    /// case-insensitive — but only against the project's own names. Hosts are
+    /// deliberately excluded: the environment selector owns that axis, and
+    /// letting a host name match here made unrelated projects look like hits
+    /// whenever the query happened to be a substring of a machine name.
+    private static func matching(
+        _ groups: [DailyUXProjectGroup],
+        filter: String
+    ) -> [DailyUXProjectGroup] {
+        let query = filter.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return groups }
+        return groups.filter { group in
+            ([group.name] + group.projects.map(\.name))
+                .contains { $0.localizedCaseInsensitiveContains(query) }
+        }
     }
 }
 

--- a/apps/swift-ios/Features/Workspace/DailyUXModels.swift
+++ b/apps/swift-ios/Features/Workspace/DailyUXModels.swift
@@ -338,6 +338,23 @@ struct DailyUXProjectHostOption: Identifiable, Equatable {
     let name: String
 }
 
+enum DailyUXProjectPickerSelection {
+    /// An explicit picker environment wins over the composer's current host;
+    /// "All environments" keeps the composer's host as the fallback.
+    static func target(
+        groupID: String,
+        selectedEnvironmentID: String?,
+        fallbackEnvironmentID: String?,
+        in groups: [DailyUXProjectGroup]
+    ) -> FeatureProject? {
+        DailyUXProjectGrouping.selectionTarget(
+            groupID: groupID,
+            preferredEnvironmentID: selectedEnvironmentID ?? fallbackEnvironmentID,
+            in: groups
+        )
+    }
+}
+
 /// A logical project group can exist on more than one environment, so the
 /// picker names the host each row would actually open on instead of leaving the
 /// destination implicit. The label leads with the environment the composer is
@@ -381,10 +398,10 @@ struct DailyUXProjectHostLabels: Equatable {
 
     /// Every host the group has a project on, in the group's own project order.
     func hostNames(for group: DailyUXProjectGroup) -> [String] {
-        var seenNames = Set<String>()
+        var seenEnvironmentIDs = Set<String>()
         return group.projects
+            .filter { seenEnvironmentIDs.insert($0.environmentID).inserted }
             .compactMap { namesByEnvironmentID[$0.environmentID] }
-            .filter { seenNames.insert($0).inserted }
     }
 
     func label(
@@ -395,7 +412,7 @@ struct DailyUXProjectHostLabels: Equatable {
         let opensOn = group.preferredProject(environmentID: preferredEnvironmentID)
             .flatMap { namesByEnvironmentID[$0.environmentID] }
         guard let host = opensOn ?? names.first else { return nil }
-        let elsewhere = names.filter { $0 != host }.count
+        let elsewhere = max(0, names.count - 1)
         return elsewhere > 0 ? "\(host) +\(elsewhere)" : host
     }
 

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -150,8 +150,8 @@ public struct NewThreadView: View {
                     recentGroupIDs: recentProjectGroupIDs,
                     preferredEnvironmentID: selectedProject?.environmentID,
                     selectionID: selectedProjectGroup?.id,
-                    onSelect: { group in
-                        if selectProjectGroup(group) {
+                    onSelect: { group, environmentID in
+                        if selectProjectGroup(group, environmentID: environmentID) {
                             activePicker = nil
                         }
                     }
@@ -592,14 +592,18 @@ public struct NewThreadView: View {
     }
 
     @discardableResult
-    private func selectProjectGroup(_ group: DailyUXProjectGroup) -> Bool {
-        guard let target = DailyUXProjectGrouping.selectionTarget(
+    private func selectProjectGroup(
+        _ group: DailyUXProjectGroup,
+        environmentID: String?
+    ) -> Bool {
+        guard let target = DailyUXProjectPickerSelection.target(
             groupID: group.id,
-            preferredEnvironmentID: selectedProject?.environmentID,
+            selectedEnvironmentID: environmentID,
+            fallbackEnvironmentID: selectedProject?.environmentID,
             in: creationProjectGroups
         ) else { return false }
         projectSelectionIsExplicit = true
-        guard group.id != selectedProjectGroup?.id else { return true }
+        guard target.id != selectedProject?.id else { return true }
         return selectProject(target.id)
     }
 
@@ -970,7 +974,7 @@ private struct NewTaskProjectPicker: View {
     let recentGroupIDs: [String]
     let preferredEnvironmentID: String?
     let selectionID: String?
-    let onSelect: (DailyUXProjectGroup) -> Void
+    let onSelect: (DailyUXProjectGroup, String?) -> Void
 
     @State private var query = ""
     /// Selector state lives with the sheet: reopening the picker starts from
@@ -1158,7 +1162,7 @@ private struct NewTaskProjectPicker: View {
         )
         let isSelected = group.id == selectionID
         return Button {
-            onSelect(group)
+            onSelect(group, environmentID)
         } label: {
             HStack(spacing: PickerMetrics.rowSpacing) {
                 iconTile("folder")

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -148,6 +148,7 @@ public struct NewThreadView: View {
                     groups: creationProjectGroups,
                     environments: model.snapshot.environments,
                     recentGroupIDs: recentProjectGroupIDs,
+                    preferredEnvironmentID: selectedProject?.environmentID,
                     selectionID: selectedProjectGroup?.id,
                     onSelect: { group in
                         if selectProjectGroup(group) {
@@ -967,8 +968,14 @@ private struct NewTaskProjectPicker: View {
     let groups: [DailyUXProjectGroup]
     let environments: [FeatureEnvironment]
     let recentGroupIDs: [String]
+    let preferredEnvironmentID: String?
     let selectionID: String?
     let onSelect: (DailyUXProjectGroup) -> Void
+
+    @State private var query = ""
+    /// Selector state lives with the sheet: reopening the picker starts from
+    /// every environment again rather than resurrecting a stale narrowing.
+    @State private var environmentID: String?
 
     var body: some View {
         NavigationStack {
@@ -980,38 +987,17 @@ private struct NewTaskProjectPicker: View {
                         description: Text("Reconnect an environment or add a project to continue.")
                     )
                 } else {
-                    let sections = DailyUXProjectPickerSections(
-                        groups: groups,
-                        recentGroupIDs: recentGroupIDs
-                    )
-                    List {
-                        if sections.recents.isEmpty {
-                            ForEach(sections.others) { group in
-                                projectRow(group)
-                            }
-                        } else {
-                            Section("Recent") {
-                                ForEach(sections.recents) { group in
-                                    projectRow(group)
-                                }
-                            }
-
-                            if !sections.others.isEmpty {
-                                Section("Other projects") {
-                                    ForEach(sections.others) { group in
-                                        projectRow(group)
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    .listStyle(.plain)
-                    .scrollContentBackground(.hidden)
+                    projectList
                 }
             }
             .background(T3Colors.background)
             .navigationTitle("Project")
             .navigationBarTitleDisplayMode(.inline)
+            .searchable(
+                text: $query,
+                placement: .navigationBarDrawer(displayMode: .always),
+                prompt: "Filter projects"
+            )
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
@@ -1022,52 +1008,210 @@ private struct NewTaskProjectPicker: View {
         .presentationBackground(T3Colors.background)
     }
 
-    private func projectRow(_ group: DailyUXProjectGroup) -> some View {
-        Button {
-            onSelect(group)
-        } label: {
-            HStack(alignment: .top, spacing: 12) {
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(group.name)
-                        .foregroundStyle(T3Colors.textPrimary)
+    /// The picker paints its own grouped cards rather than leaning on a plain
+    /// List. A plain list row inherits the page background, which on a dark
+    /// appearance is near-black — the rows then read as loose text on a void
+    /// with full-bleed separators. Cards on `T3Colors.surface` keep the rows
+    /// anchored in both appearances, and the hairlines inset past the icon
+    /// column the way the rest of the app groups rows.
+    private enum PickerMetrics {
+        static let cardCorner: CGFloat = 14
+        static let iconTile: CGFloat = 30
+        static let rowSpacing: CGFloat = 12
+        static let hairlineInset: CGFloat = iconTile + rowSpacing
+        static let horizontalPadding: CGFloat = 16
+    }
 
-                    ForEach(group.projects.prefix(2)) { project in
-                        Text(projectLocation(project))
-                            .font(T3Typography.supporting)
-                            .foregroundStyle(T3Colors.textTertiary)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
+    private var hostLabels: DailyUXProjectHostLabels {
+        DailyUXProjectHostLabels(environments: environments)
+    }
+
+    private var environmentOptions: [DailyUXProjectHostOption] {
+        hostLabels.environmentOptions(in: groups)
+    }
+
+    private var selectedEnvironmentName: String {
+        environmentID.flatMap(hostLabels.name(forEnvironmentID:)) ?? "All environments"
+    }
+
+    private var environmentSelector: some View {
+        Menu {
+            Picker("Environment", selection: $environmentID) {
+                Text("All environments").tag(String?.none)
+                ForEach(environmentOptions) { option in
+                    Text(option.name).tag(String?.some(option.id))
+                }
+            }
+        } label: {
+            HStack(spacing: PickerMetrics.rowSpacing) {
+                iconTile("server.rack")
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Environment")
+                        .font(T3Typography.supporting)
+                        .foregroundStyle(T3Colors.textTertiary)
+                    Text(selectedEnvironmentName)
+                        .font(T3Typography.control)
+                        .foregroundStyle(T3Colors.textPrimary)
+                }
+
+                Spacer(minLength: 8)
+
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(T3Colors.textTertiary)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 11)
+            .frame(maxWidth: .infinity)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Environment, \(selectedEnvironmentName)")
+        .modifier(PickerCard())
+    }
+
+    private func iconTile(_ systemName: String) -> some View {
+        RoundedRectangle(cornerRadius: 8, style: .continuous)
+            .fill(T3Colors.accent.opacity(0.14))
+            .frame(width: PickerMetrics.iconTile, height: PickerMetrics.iconTile)
+            .overlay {
+                Image(systemName: systemName)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(T3Colors.accent)
+            }
+    }
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title.uppercased())
+            .font(T3Typography.eyebrow)
+            .kerning(0.6)
+            .foregroundStyle(T3Colors.textTertiary)
+            .padding(.horizontal, 4)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityAddTraits(.isHeader)
+    }
+
+    private func card(_ groups: [DailyUXProjectGroup]) -> some View {
+        VStack(spacing: 0) {
+            ForEach(Array(groups.enumerated()), id: \.element.id) { index, group in
+                projectRow(group)
+
+                if index < groups.count - 1 {
+                    Rectangle()
+                        .fill(T3Colors.separator)
+                        .frame(height: 0.5)
+                        .padding(.leading, PickerMetrics.hairlineInset + 14)
+                }
+            }
+        }
+        .modifier(PickerCard())
+    }
+
+    private var projectList: some View {
+        let sections = DailyUXProjectPickerSections(
+            groups: groups,
+            recentGroupIDs: recentGroupIDs,
+            filter: query,
+            environmentID: environmentID
+        )
+        return ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                if environmentOptions.count > 1 {
+                    environmentSelector
+                }
+
+                if sections.isEmpty {
+                    ContentUnavailableView.search(text: query)
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, 24)
+                } else if sections.recents.isEmpty {
+                    card(sections.others)
+                } else {
+                    VStack(alignment: .leading, spacing: 8) {
+                        sectionHeader("Recent")
+                        card(sections.recents)
                     }
 
-                    if group.projects.count > 2 {
-                        Text("+\(group.projects.count - 2) more locations")
-                            .font(T3Typography.supporting)
-                            .foregroundStyle(T3Colors.textTertiary)
+                    if !sections.others.isEmpty {
+                        VStack(alignment: .leading, spacing: 8) {
+                            sectionHeader("Other projects")
+                            card(sections.others)
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, PickerMetrics.horizontalPadding)
+            .padding(.top, 12)
+            .padding(.bottom, 28)
+        }
+        .scrollContentBackground(.hidden)
+    }
+
+    private func projectRow(_ group: DailyUXProjectGroup) -> some View {
+        // A narrowed list is showing the group *because* of the selected host,
+        // so the row leads with that one rather than the composer's current
+        // environment.
+        let hostLabel = hostLabels.label(
+            for: group,
+            preferredEnvironmentID: environmentID ?? preferredEnvironmentID
+        )
+        let isSelected = group.id == selectionID
+        return Button {
+            onSelect(group)
+        } label: {
+            HStack(spacing: PickerMetrics.rowSpacing) {
+                iconTile("folder")
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(group.name)
+                        .font(T3Typography.control)
+                        .foregroundStyle(T3Colors.textPrimary)
+                        .multilineTextAlignment(.leading)
+
+                    if let hostLabel {
+                        HStack(spacing: 5) {
+                            Image(systemName: "server.rack")
+                                .font(.system(size: 10, weight: .semibold))
+                            Text(hostLabel)
+                                .font(T3Typography.supporting)
+                        }
+                        .foregroundStyle(T3Colors.textSecondary)
+                        .accessibilityElement(children: .ignore)
+                        .accessibilityLabel("Opens on \(hostLabel)")
                     }
                 }
 
                 Spacer(minLength: 10)
 
-                if group.id == selectionID {
-                    Image(systemName: "checkmark")
-                        .font(.system(size: 13, weight: .semibold))
+                if isSelected {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 17, weight: .semibold))
                         .foregroundStyle(T3Colors.accent)
+                        .accessibilityHidden(true)
                 }
             }
-            .frame(minHeight: 46)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            .frame(minHeight: 56)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .accessibilityAddTraits(
-            group.id == selectionID ? .isSelected : []
-        )
-        .listRowBackground(T3Colors.background)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
+}
 
-    private func projectLocation(_ project: FeatureProject) -> String {
-        let environment = environments.first { $0.id == project.environmentID }?.name
-            ?? project.environmentID
-        return "\(environment) · \(project.path)"
+/// One rounded surface with a hairline edge — the grouping the rest of the app
+/// uses, and the thing a plain List row cannot provide on a dark appearance.
+private struct PickerCard: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .background(T3Colors.surface)
+            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .strokeBorder(T3Colors.border, lineWidth: 0.5)
+            }
     }
 }
 

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
@@ -970,6 +970,83 @@ struct DailyUXNewTaskTests {
         )
     }
 
+    @Test(
+        "Project picker selection follows the narrowed environment",
+        .bug("https://github.com/pingdotgg/t3code/pull/7634#discussion_r3818560252")
+    )
+    func projectPickerSelectionFollowsTheNarrowedEnvironment() throws {
+        let studio = rankedEnvironment("studio", name: "Studio")
+        let nightly = rankedEnvironment("nightly", name: "Nightly")
+        let onStudio = rankedProject(
+            "shared-studio",
+            name: "Shared",
+            environmentID: studio.id,
+            repositoryKey: "example.com/acme/shared-repo"
+        )
+        let onNightly = rankedProject(
+            "shared-nightly",
+            name: "Shared",
+            environmentID: nightly.id,
+            repositoryKey: "example.com/acme/shared-repo"
+        )
+        let value = rankedSnapshot(
+            environments: [studio, nightly],
+            projects: [onStudio, onNightly],
+            threads: []
+        )
+        let groups = DailyUXCreationContext.projectGroups(in: value)
+        let group = try #require(groups.first)
+
+        let narrowedTarget = DailyUXProjectPickerSelection.target(
+            groupID: group.id,
+            selectedEnvironmentID: nightly.id,
+            fallbackEnvironmentID: studio.id,
+            in: groups
+        )
+        let allEnvironmentsTarget = DailyUXProjectPickerSelection.target(
+            groupID: group.id,
+            selectedEnvironmentID: nil,
+            fallbackEnvironmentID: studio.id,
+            in: groups
+        )
+
+        #expect(narrowedTarget?.id == onNightly.id)
+        #expect(allEnvironmentsTarget?.id == onStudio.id)
+    }
+
+    @Test(
+        "Project picker host count keeps same-named environments distinct",
+        .bug("https://github.com/pingdotgg/t3code/pull/7634#discussion_r3818560254")
+    )
+    func projectPickerHostCountKeepsSameNamedEnvironmentsDistinct() throws {
+        let primary = rankedEnvironment("primary", name: "Studio")
+        let secondary = rankedEnvironment("secondary", name: "Studio")
+        let onPrimary = rankedProject(
+            "shared-primary",
+            name: "Shared",
+            environmentID: primary.id,
+            repositoryKey: "example.com/acme/shared-repo"
+        )
+        let onSecondary = rankedProject(
+            "shared-secondary",
+            name: "Shared",
+            environmentID: secondary.id,
+            repositoryKey: "example.com/acme/shared-repo"
+        )
+        let value = rankedSnapshot(
+            environments: [primary, secondary],
+            projects: [onPrimary, onSecondary],
+            threads: []
+        )
+        let group = try #require(DailyUXCreationContext.projectGroups(in: value).first)
+        let hostLabels = DailyUXProjectHostLabels(environments: value.environments)
+
+        #expect(hostLabels.hostNames(for: group).count == 2)
+        #expect(
+            hostLabels.label(for: group, preferredEnvironmentID: primary.id) == "Studio +1"
+        )
+    }
+
     @Test
     func projectPickerHostLabelFallsBackToTheEndpointHostAndSkipsUnknownEnvironments() throws {
         let unnamed = FeatureEnvironment(id: "unnamed", name: "  ", endpoint: "https://box.tail.ts.net:3117")

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
@@ -910,6 +910,282 @@ struct DailyUXNewTaskTests {
         #expect(sections.others.isEmpty)
     }
 
+    @Test
+    func projectPickerRowsNameTheHostEachProjectOpensOn() {
+        let studio = rankedEnvironment("studio", name: "Studio")
+        let nightly = rankedEnvironment("nightly", name: "Nightly")
+        let alpha = rankedProject("alpha", name: "Alpha", environmentID: studio.id)
+        let beta = rankedProject("beta", name: "Beta", environmentID: nightly.id)
+        let value = rankedSnapshot(
+            environments: [studio, nightly],
+            projects: [alpha, beta],
+            threads: []
+        )
+        let groups = DailyUXCreationContext.projectGroups(in: value)
+        let hostLabels = DailyUXProjectHostLabels(environments: value.environments)
+
+        #expect(groups.map(\.name) == ["Alpha", "Beta"])
+        #expect(
+            groups.map { hostLabels.label(for: $0, preferredEnvironmentID: nil) }
+                == ["Studio", "Nightly"]
+        )
+    }
+
+    @Test
+    func projectPickerHostLabelLeadsWithTheEnvironmentTheComposerAlreadyUses() throws {
+        let studio = rankedEnvironment("studio", name: "Studio")
+        let nightly = rankedEnvironment("nightly", name: "Nightly")
+        let onStudio = rankedProject(
+            "shared-studio",
+            name: "Shared",
+            environmentID: studio.id,
+            repositoryKey: "example.com/acme/shared-repo"
+        )
+        let onNightly = rankedProject(
+            "shared-nightly",
+            name: "Shared",
+            environmentID: nightly.id,
+            repositoryKey: "example.com/acme/shared-repo"
+        )
+        let value = rankedSnapshot(
+            environments: [studio, nightly],
+            projects: [onStudio, onNightly],
+            threads: []
+        )
+        let groups = DailyUXCreationContext.projectGroups(in: value)
+        let hostLabels = DailyUXProjectHostLabels(environments: value.environments)
+        let group = try #require(groups.first)
+
+        #expect(groups.count == 1)
+        #expect(hostLabels.hostNames(for: group) == ["Nightly", "Studio"])
+        #expect(
+            hostLabels.label(for: group, preferredEnvironmentID: studio.id) == "Studio +1"
+        )
+        #expect(
+            hostLabels.label(for: group, preferredEnvironmentID: nightly.id) == "Nightly +1"
+        )
+        #expect(
+            hostLabels.label(for: group, preferredEnvironmentID: "gone")
+                == hostLabels.label(for: group, preferredEnvironmentID: nil)
+        )
+    }
+
+    @Test
+    func projectPickerHostLabelFallsBackToTheEndpointHostAndSkipsUnknownEnvironments() throws {
+        let unnamed = FeatureEnvironment(id: "unnamed", name: "  ", endpoint: "https://box.tail.ts.net:3117")
+        let alpha = rankedProject("alpha", name: "Alpha", environmentID: unnamed.id)
+        let orphan = rankedProject("orphan", name: "Orphan", environmentID: "orphan-environment")
+        let value = rankedSnapshot(projects: [alpha, orphan], threads: [])
+        let groups = DailyUXCreationContext.projectGroups(in: value)
+        let hostLabels = DailyUXProjectHostLabels(environments: [unnamed])
+        let alphaGroup = try #require(
+            DailyUXProjectGrouping.group(containing: alpha.id, in: groups)
+        )
+        let orphanGroup = try #require(
+            DailyUXProjectGrouping.group(containing: orphan.id, in: groups)
+        )
+
+        #expect(
+            hostLabels.label(for: alphaGroup, preferredEnvironmentID: nil) == "box.tail.ts.net"
+        )
+        #expect(hostLabels.label(for: orphanGroup, preferredEnvironmentID: nil) == nil)
+    }
+
+    @Test
+    func projectPickerFilterNarrowsByProjectNameAndNeverByHost() {
+        let studio = rankedEnvironment("studio", name: "Studio")
+        let nightly = rankedEnvironment("nightly", name: "Nightly")
+        let alpha = rankedProject("alpha", name: "Alpha", environmentID: studio.id)
+        let beta = rankedProject("beta", name: "Beta", environmentID: nightly.id)
+        let gamma = rankedProject("gamma", name: "Gamma", environmentID: studio.id)
+        let value = rankedSnapshot(
+            environments: [studio, nightly],
+            projects: [gamma, alpha, beta],
+            threads: []
+        )
+        let groups = DailyUXCreationContext.projectGroups(in: value)
+
+        func names(filter: String) -> [String] {
+            DailyUXProjectPickerSections(
+                groups: groups,
+                recentGroupIDs: [],
+                filter: filter
+            ).others.map(\.name)
+        }
+
+        #expect(names(filter: "") == ["Alpha", "Beta", "Gamma"])
+        #expect(names(filter: "  ") == ["Alpha", "Beta", "Gamma"])
+        #expect(names(filter: "be") == ["Beta"])
+        #expect(names(filter: "BETA") == ["Beta"])
+        #expect(names(filter: "zzz") == [])
+
+        // The negative case the environment selector replaced: a host name typed
+        // into the text field must not select that host's projects.
+        #expect(names(filter: "nightly") == [])
+        #expect(names(filter: "Studio") == [])
+        #expect(
+            DailyUXProjectPickerSections(
+                groups: groups,
+                recentGroupIDs: [],
+                filter: "nightly"
+            ).isEmpty
+        )
+    }
+
+    @Test
+    func projectPickerEnvironmentSelectorNarrowsToOneHostAndKeepsSections() {
+        let studio = rankedEnvironment("studio", name: "Studio")
+        let nightly = rankedEnvironment("nightly", name: "Nightly")
+        let alpha = rankedProject("alpha", name: "Alpha", environmentID: studio.id)
+        let beta = rankedProject("beta", name: "Beta", environmentID: nightly.id)
+        let gamma = rankedProject("gamma", name: "Gamma", environmentID: nightly.id)
+        let value = rankedSnapshot(
+            environments: [studio, nightly],
+            projects: [gamma, alpha, beta],
+            threads: [
+                rankedThread("gamma-thread", projectID: gamma.id, activity: 30),
+                rankedThread("alpha-thread", projectID: alpha.id, activity: 20),
+            ]
+        )
+        let groups = DailyUXCreationContext.projectGroups(in: value)
+        let recentGroupIDs = DailyUXCreationContext.recentProjects(in: value).map(\.group.id)
+
+        func sections(environmentID: String?) -> DailyUXProjectPickerSections {
+            DailyUXProjectPickerSections(
+                groups: groups,
+                recentGroupIDs: recentGroupIDs,
+                environmentID: environmentID
+            )
+        }
+
+        let all = sections(environmentID: nil)
+        #expect(all.recents.map(\.name) == ["Gamma", "Alpha"])
+        #expect(all.others.map(\.name) == ["Beta"])
+
+        let onNightly = sections(environmentID: nightly.id)
+        #expect(onNightly.recents.map(\.name) == ["Gamma"])
+        #expect(onNightly.others.map(\.name) == ["Beta"])
+
+        let onStudio = sections(environmentID: studio.id)
+        #expect(onStudio.recents.map(\.name) == ["Alpha"])
+        #expect(onStudio.others.isEmpty)
+
+        // A neutral selection is the same list as before the selector existed.
+        #expect(
+            all == DailyUXProjectPickerSections(groups: groups, recentGroupIDs: recentGroupIDs)
+        )
+        #expect(sections(environmentID: "gone").isEmpty)
+    }
+
+    @Test
+    func projectPickerEnvironmentSelectorComposesWithTheTextFilter() {
+        let studio = rankedEnvironment("studio", name: "Studio")
+        let nightly = rankedEnvironment("nightly", name: "Nightly")
+        let studioAtlas = rankedProject("studio-atlas", name: "Atlas", environmentID: studio.id)
+        let nightlyAtlas = rankedProject("nightly-atlas", name: "Atlas", environmentID: nightly.id)
+        let nightlyBeta = rankedProject("nightly-beta", name: "Beta", environmentID: nightly.id)
+        let value = rankedSnapshot(
+            environments: [studio, nightly],
+            projects: [studioAtlas, nightlyAtlas, nightlyBeta],
+            threads: []
+        )
+        let groups = DailyUXCreationContext.projectGroups(in: value)
+
+        func names(filter: String, environmentID: String?) -> [String] {
+            DailyUXProjectPickerSections(
+                groups: groups,
+                recentGroupIDs: [],
+                filter: filter,
+                environmentID: environmentID
+            ).others.map(\.name)
+        }
+
+        #expect(names(filter: "", environmentID: nil) == ["Atlas", "Atlas", "Beta"])
+        #expect(names(filter: "atlas", environmentID: nil) == ["Atlas", "Atlas"])
+        #expect(names(filter: "", environmentID: nightly.id) == ["Atlas", "Beta"])
+        #expect(names(filter: "atlas", environmentID: nightly.id) == ["Atlas"])
+        #expect(names(filter: "beta", environmentID: studio.id) == [])
+    }
+
+    @Test
+    func projectPickerEnvironmentSelectorListsOnlyHostsThatOwnVisibleProjects() {
+        let studio = rankedEnvironment("studio", name: "Studio")
+        let nightly = rankedEnvironment("nightly", name: "Nightly")
+        let idle = rankedEnvironment("idle", name: "Idle Box")
+        let alpha = rankedProject("alpha", name: "Alpha", environmentID: nightly.id)
+        let beta = rankedProject("beta", name: "Beta", environmentID: studio.id)
+        let value = rankedSnapshot(
+            environments: [studio, nightly, idle],
+            projects: [alpha, beta],
+            threads: []
+        )
+        let groups = DailyUXCreationContext.projectGroups(in: value)
+        let hostLabels = DailyUXProjectHostLabels(environments: value.environments)
+
+        let options = hostLabels.environmentOptions(in: groups)
+
+        #expect(options.map(\.name) == ["Nightly", "Studio"])
+        #expect(options.map(\.id) == [nightly.id, studio.id])
+        #expect(hostLabels.environmentOptions(in: []).isEmpty)
+        #expect(hostLabels.name(forEnvironmentID: studio.id) == "Studio")
+        #expect(hostLabels.name(forEnvironmentID: "gone") == nil)
+    }
+
+    @Test
+    func projectPickerFilterKeepsTheRecentSectionAndAnEmptyFilterChangesNothing() {
+        let alpha = rankedProject("alpha", name: "Alpha")
+        let beta = rankedProject("beta", name: "Beta")
+        let gamma = rankedProject("gamma", name: "Gamma")
+        let value = rankedSnapshot(
+            projects: [gamma, alpha, beta],
+            threads: [
+                rankedThread("beta-thread", projectID: beta.id, activity: 30),
+                rankedThread("gamma-thread", projectID: gamma.id, activity: 20),
+            ]
+        )
+        let groups = DailyUXCreationContext.projectGroups(in: value)
+        let recentGroupIDs = DailyUXCreationContext.recentProjects(in: value).map(\.group.id)
+
+        let unfiltered = DailyUXProjectPickerSections(
+            groups: groups,
+            recentGroupIDs: recentGroupIDs,
+            filter: ""
+        )
+        let filtered = DailyUXProjectPickerSections(
+            groups: groups,
+            recentGroupIDs: recentGroupIDs,
+            filter: "a"
+        )
+
+        #expect(unfiltered.recents.map(\.name) == ["Beta", "Gamma"])
+        #expect(unfiltered.others.map(\.name) == ["Alpha"])
+        #expect(
+            unfiltered
+                == DailyUXProjectPickerSections(groups: groups, recentGroupIDs: recentGroupIDs)
+        )
+
+        #expect(filtered.recents.map(\.name) == ["Beta", "Gamma"])
+        #expect(filtered.others.map(\.name) == ["Alpha"])
+        #expect(
+            DailyUXProjectPickerSections(
+                groups: groups,
+                recentGroupIDs: recentGroupIDs,
+                filter: "gam"
+            ).recents.map(\.name) == ["Gamma"]
+        )
+        #expect(
+            DailyUXProjectPickerSections(
+                groups: groups,
+                recentGroupIDs: recentGroupIDs,
+                filter: "gam"
+            ).others.isEmpty
+        )
+    }
+
+    private func rankedEnvironment(_ id: String, name: String) -> FeatureEnvironment {
+        FeatureEnvironment(id: id, name: name, endpoint: "https://\(id).example:3117")
+    }
+
     private func rankedProject(
         _ id: String,
         name: String,


### PR DESCRIPTION
## What Changed

The new-task project picker gets two controls and a surface fix.

- **Environment selector** above the list: "All environments" plus each host that actually owns a visible project. It appears only when more than one host is represented, because with one host it could not narrow anything.
- **Filter field** that matches project names.
- The two axes narrow independently and **compose**; neutral values on both render exactly the list that was there before.
- Rows now name the host they would open on (`Host`, or `Host +N` when the group also exists elsewhere), leading with the environment the composer is already using — the same choice `preferredProject(environmentID:)` makes on selection.
- The list is drawn as **grouped cards** instead of plain `List` rows.

`DailyUXProjectHostLabels` is new and owns host naming; `DailyUXProjectPickerSections` gained the two narrowing axes. 8 new focused tests.

## Why

**Filtering.** There was no way to narrow the list at all.

**Why the selector rather than matching hosts in the text field.** An earlier revision of this work *did* match host names in the search field. It was wrong in practice: a two-letter query selected every project on a machine because the query happened to sit inside the machine name (`"ro"` matched every project on `Alex's MacBook P·ro·`). The list looked broken rather than filtered. Host is a different question from name, so it gets its own control, and the text field deliberately ignores hosts. There is a test asserting that negative.

**Why cards.** The rows were plain `List` rows with `.listRowBackground(T3Colors.background)` — the row background *was* the page background. In light appearance that reads as an acceptable flat list. In dark, `T3Colors.background` is `#0A0A0A`, so row and page are the same near-black, no surface exists under the rows, and `.listStyle(.plain)` runs separators the full width. The result read as loose text floating on a void. Cards on `T3Colors.surface` with a hairline border anchor the rows in **both** appearances, and dividers are inset past the icon column. This is a real defect on the current branch, not a restyle for taste.

## Heads-up for reviewers — this replaces an existing display

This **removes `projectLocation(_:)`** and the per-row location lines it fed (`"<environment> · <path>"`, up to two plus `"+N more locations"`), replacing them with a single host label. That was deliberate — on a phone the two-line-per-location rows crowded the title, and the question being asked at that moment is "which machine will this run on", not "which checkout". But it drops the path detail, it is a product decision on a surface you already shaped, and it is separable from the rest of this PR. If you want the path kept, say so and I will restore it alongside the host label rather than instead of it.

## Exact-head UI proof

Captured from current PR head `ffa19ec6c81cd992e4f6a6ebb6556178613f765e`. Before every capture, the installed `T3Code.debug.dylib` SHA-256 matched the exact-head build artifact: `3c916e22d3f541699fc0792500d571423130a4c9ed9a0be087dc1c644b379f2e`.

| Light | Dark |
|---|---|
| <img src="https://github.com/saphid/t3code/releases/download/pr-7634-evidence-ffa19ec6-20260820/project-picker-light.jpg" width="320"> | <img src="https://github.com/saphid/t3code/releases/download/pr-7634-evidence-ffa19ec6-20260820/project-picker-dark.jpg" width="320"> |

Both frames show one grouped `alpha-ledger` row with `Alex’s MacBook Pro +1`, proving that same-named environments are counted as distinct destinations.

**Interaction proof:** [26.9-second exact-head video](https://github.com/saphid/t3code/releases/download/pr-7634-evidence-ffa19ec6-20260820/project-picker-host-selection.mp4) — filters to `Travel Mac`, selects the shared project, and ends with the composer visibly targeting `Travel Mac`.

## Testing

- Focused suite `T3CodeTests/DailyUXNewTaskTests` on iPhone 17 Pro / iOS 26.5: **37 passed, 0 failed, 0 skipped** (11 `projectPicker*` cases — 3 pre-existing, 8 new).
- New cases cover: host label per row; the `+N` shared-host case and that the label follows the composer's environment; endpoint-host fallback and unknown environments; filtering by name **and the negative — a host name typed into the field matches nothing**; per-host narrowing with the Recent/Other sections preserved; selector × text composition; and that the selector only offers hosts that own visible projects.
- Integrated run on the iOS Simulator against two isolated local T3 environments, in light and dark.

## Limitations

- The selector hides itself when only one host is represented. Consistent with the Add Project environment picker (which hides at `environments.count > 1`), but it does mean a single-host user never discovers the control.
- Selector state is per-sheet; reopening the picker starts from "All environments" again.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes — no motion or transition changes in this PR

Coordination trace: T3 thread 33C247AD-06DD-442D-B688-582FDD789770 · saphid/t3code-personal#123

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only SwiftUI and sectioning logic for task creation; no auth, networking, or persistence changes beyond picker state that resets when the sheet closes.
> 
> **Overview**
> The **new-task project picker** gains **search** (project names only) and an **environment menu** when multiple hosts have visible projects; both filters compose and default to the previous unfiltered list.
> 
> **`DailyUXProjectHostLabels`** drives row subtitles (`Host` or `Host +N`) aligned with the composer’s current environment via `preferredEnvironmentID`, with endpoint-host fallback for unnamed environments. Rows no longer show per-location `environment · path` lines.
> 
> **`DailyUXProjectPickerSections`** applies optional `filter` and `environmentID` before Recent/Other splitting; **`isEmpty`** supports empty search states.
> 
> The picker UI moves from a plain **`List`** to **card-grouped `ScrollView` rows** (surface + inset dividers) and wires **`preferredEnvironmentID`** from `NewThreadView`. Eight new **`DailyUXNewTaskTests`** cover host labels, filtering, and environment narrowing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42533b2317bfc108aa9b4a31d3263419ae6dd1e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add environment selector and text filtering to `NewTaskProjectPicker`
> - Reworks the project picker UI in [NewThreadView.swift](https://github.com/pingdotgg/t3code/pull/7634/files#diff-b6ba9c0744007ccd1dd2c30b31fc66ec800d601a0a3153404e3ee2917cda96c5) into a card-styled `ScrollView` with an environment menu, text search, and per-row host labels showing where a selection opens.
> - Adds `DailyUXProjectHostLabels`, `DailyUXProjectHostOption`, and `DailyUXProjectPickerSelection.target` in [DailyUXModels.swift](https://github.com/pingdotgg/t3code/pull/7634/files#diff-2bae36acfcaa822eaaa43aea2e36dd5ded98f236fd6c38e524e50fbd0c85331e) to compute environment options, resolve a selection target to a specific project on the chosen (or fallback) environment, and label hosts with a `+N` suffix for multi-environment groups.
> - `DailyUXProjectPickerSections` now filters groups by environment first, then by case-insensitive text match against group and project names (hosts excluded).
> - Expands tests in [DailyUXNewTaskTests.swift](https://github.com/pingdotgg/t3code/pull/7634/files#diff-d51f0c7c4aaea5388173f149a61df6d24484136260388c8eba7aa05759d82e59) covering host labeling, environment narrowing, and filter semantics.
> - Behavioral Change: `selectProjectGroup` now compares the resolved target project rather than the group id, so selecting the same resolved project is a no-op; text search no longer matches host names.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ffa19ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

