### PR TITLE
fix(web): keep bootstrap errors visible

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -26,6 +26,7 @@ import {
   isBranchMismatchDismissedForSession,
   reconcileMountedTerminalThreadIds,
   reconcileRetainedMountedThreadIds,
+  resolveLocalThreadError,
   resolveThreadMetadataUpdateForNextTurn,
   resolveSendEnvMode,
   scheduleEnvironmentReconnectWarning,
@@ -533,6 +534,28 @@ describe("shouldWriteThreadErrorToCurrentServerThread", () => {
         targetThreadId: threadId,
       }),
     ).toBe(false);
+  });
+});
+
+describe("resolveLocalThreadError", () => {
+  it("keeps a bootstrap error visible when its server thread returns to a draft", () => {
+    expect(
+      resolveLocalThreadError({
+        isServerThread: false,
+        draftEntry: undefined,
+        serverEntry: { message: "git fetch origin failed", at: 1 },
+      }),
+    ).toBe("git fetch origin failed");
+  });
+
+  it("keeps a newer draft-side clear from reviving an old server error", () => {
+    expect(
+      resolveLocalThreadError({
+        isServerThread: false,
+        draftEntry: { message: null, at: 2 },
+        serverEntry: { message: "git fetch origin failed", at: 1 },
+      }),
+    ).toBeNull();
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -138,6 +138,20 @@ export function shouldWriteThreadErrorToCurrentServerThread(input: {
   );
 }
 
+/** Keep errors visible while a failed bootstrap moves a thread back to its draft. */
+export function resolveLocalThreadError(input: {
+  isServerThread: boolean;
+  draftEntry: { readonly message: string | null; readonly at: number } | undefined;
+  serverEntry: { readonly message: string | null; readonly at: number } | undefined;
+}): string | null {
+  if (input.isServerThread) return input.serverEntry?.message ?? null;
+  if (input.draftEntry === undefined) return input.serverEntry?.message ?? null;
+  if (input.serverEntry === undefined || input.draftEntry.at >= input.serverEntry.at) {
+    return input.draftEntry.message;
+  }
+  return input.serverEntry.message;
+}
+
 export function buildThreadTurnInterruptInput(thread: Pick<Thread, "id" | "session">): {
   threadId: ThreadId;
   turnId?: TurnId;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -324,6 +324,7 @@ import {
   deriveLockedProvider,
   readFileAsDataUrl,
   reconcileMountedTerminalThreadIds,
+  resolveLocalThreadError,
   resolveThreadMetadataUpdateForNextTurn,
   resolveSendEnvMode,
   revokeBlobPreviewUrl,
@@ -1481,10 +1482,11 @@ function ChatViewContent(props: ChatViewProps) {
     ? scopeProjectRef(draftThread.environmentId, draftThread.projectId)
     : null;
   const fallbackDraftProject = useProject(fallbackDraftProjectRef);
-  const localDraftError = activeServerThread
-    ? null
-    : ((draftId ? localDraftErrorsByDraftId[draftId]?.message : null) ?? null);
-  const localServerError = localServerErrorsByThreadKey[routeThreadKey]?.message ?? null;
+  const localThreadError = resolveLocalThreadError({
+    isServerThread: activeServerThread !== null,
+    draftEntry: draftId ? localDraftErrorsByDraftId[draftId] : undefined,
+    serverEntry: localServerErrorsByThreadKey[routeThreadKey],
+  });
   // Draft errors are keyed by draftId while server errors are keyed by thread
   // key, so a pending draft entry must migrate when the server thread loads or
   // a failed send would silently disappear on promotion. When both keys hold
@@ -1536,9 +1538,7 @@ function ChatViewContent(props: ChatViewProps) {
   // depend on which route is mounted.
   const isServerThread = activeServerThread !== null;
   const activeThread = activeServerThread ?? localDraftThread;
-  const threadError = isServerThread
-    ? (localServerError ?? activeServerThread?.session?.lastError ?? null)
-    : localDraftError;
+  const threadError = localThreadError ?? activeServerThread?.session?.lastError ?? null;
   // Dismissals can only mask the shown error, never clear it: a server thread
   // keeps its error in session.lastError, so clearing the local shadow would
   // just fall through to the persisted one. Mask the current error until a


### PR DESCRIPTION
When the first send promotes a draft and bootstrap then fails, cleanup returns the thread to draft state. The original failure briefly appeared and then vanished because it was stored under the server thread while draft rendering only read the draft-keyed error.

Draft rendering now uses the newest error entry across both lifecycle keys. This keeps the bootstrap failure visible while allowing a newer clear or retry error to replace it. The change is independent of the underlying Git-fetch fix in #7619 and applies to other first-send bootstrap failures too.

Tests:
- `vp test run apps/web/src/components/ChatView.logic.test.ts` (40 passed)
- targeted lint and format checks for the three changed files
- web TypeScript check

Built with OpenAI Codex using GPT-5.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix bootstrap error visibility in `ChatViewContent` thread error resolution
> - Adds `resolveLocalThreadError` in [ChatView.logic.ts](https://github.com/pingdotgg/t3code/pull/7636/files#diff-464e876afd6be3800453dd8cc94d805066953bed62ffd825bbd6fdfd86f4d114) to pick the visible thread error based on `isServerThread` and draft/server error entries with timestamps.
> - Replaces separate `localDraftError`/`localServerError` derivations in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/7636/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) with a single `localThreadError` computed via the new utility.
> - Keeps a bootstrap server error visible when a thread returns to draft, and prevents older server errors from resurfacing after a newer draft-side clear.
> - Behavioral Change: error precedence is now timestamp-aware; `threadError` still falls back to `activeServerThread?.session?.lastError` only when `localThreadError` is null.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4410e09.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->