### PR TITLE
fix(preview): harden SSH forwarding lifecycle

### DIFF
--- a/apps/web/src/browser/browserNavigationRoutes.test.ts
+++ b/apps/web/src/browser/browserNavigationRoutes.test.ts
@@ -8,7 +8,7 @@ import {
   createBrowserNavigationRoute,
   readBrowserNavigationRouteEnvironmentVersion,
   releaseBrowserNavigationRoute,
-  releaseBrowserNavigationRoutesForEnvironment,
+  releaseBrowserNavigationRoutesForEnvironmentEffect,
   reserveBrowserNavigationRouteGeneration,
   resetBrowserNavigationRoutesForTests,
 } from "./browserNavigationRoutes";
@@ -131,7 +131,7 @@ describe("browser navigation routes", () => {
       yield* Effect.promise(() => route.commit("tab-1"));
       yield* Effect.promise(() => route.release());
 
-      yield* Effect.promise(() => releaseBrowserNavigationRoutesForEnvironment(environmentId));
+      yield* releaseBrowserNavigationRoutesForEnvironmentEffect(environmentId);
 
       expect(closes).toBe(1);
       expect(readBrowserNavigationRouteEnvironmentVersion(environmentId)).toBe(version + 1);

--- a/apps/web/src/browser/browserNavigationRoutes.test.ts
+++ b/apps/web/src/browser/browserNavigationRoutes.test.ts
@@ -1,0 +1,121 @@
+import { EnvironmentId, type PreviewUrlResolution } from "@t3tools/contracts";
+import { it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Scope from "effect/Scope";
+import { afterEach, describe, expect } from "vite-plus/test";
+
+import {
+  createBrowserNavigationRoute,
+  readBrowserNavigationRouteEnvironmentVersion,
+  releaseBrowserNavigationRoute,
+  releaseBrowserNavigationRoutesForEnvironment,
+  reserveBrowserNavigationRouteGeneration,
+  resetBrowserNavigationRoutesForTests,
+} from "./browserNavigationRoutes";
+
+const environmentId = EnvironmentId.make("environment-1");
+
+const sshResolution = (resolvedUrl: string): PreviewUrlResolution => ({
+  requestedUrl: "http://localhost:5173",
+  resolvedUrl,
+  resolutionKind: "ssh-forward",
+  environmentId,
+});
+
+const makeTrackedScope = Effect.fn("browserNavigationRoutes.test.makeTrackedScope")(function* (
+  onClose: () => void,
+) {
+  const scope = yield* Scope.make();
+  yield* Scope.addFinalizer(scope, Effect.sync(onClose));
+  return scope;
+});
+
+afterEach(async () => {
+  await resetBrowserNavigationRoutesForTests();
+});
+
+describe("browser navigation routes", () => {
+  it.effect("keeps a replaced route alive until its in-flight navigation finishes", () =>
+    Effect.gen(function* () {
+      let firstCloses = 0;
+      let secondCloses = 0;
+      const first = createBrowserNavigationRoute({
+        environmentId,
+        generation: reserveBrowserNavigationRouteGeneration(),
+        resolution: sshResolution("http://127.0.0.1:41001"),
+        scope: yield* makeTrackedScope(() => firstCloses++),
+      });
+      const second = createBrowserNavigationRoute({
+        environmentId,
+        generation: reserveBrowserNavigationRouteGeneration(),
+        resolution: sshResolution("http://127.0.0.1:41002"),
+        scope: yield* makeTrackedScope(() => secondCloses++),
+      });
+
+      yield* Effect.promise(() => first.commit("tab-1"));
+      yield* Effect.promise(() => second.commit("tab-1"));
+      yield* Effect.promise(() => second.release());
+
+      expect(firstCloses).toBe(0);
+      expect(secondCloses).toBe(0);
+
+      yield* Effect.promise(() => first.release());
+      expect(firstCloses).toBe(1);
+
+      yield* Effect.promise(() => releaseBrowserNavigationRoute("tab-1"));
+      expect(secondCloses).toBe(1);
+    }),
+  );
+
+  it.effect("does not let an older navigation replace a newer committed route", () =>
+    Effect.gen(function* () {
+      let olderCloses = 0;
+      let newerCloses = 0;
+      const olderGeneration = reserveBrowserNavigationRouteGeneration();
+      const newerGeneration = reserveBrowserNavigationRouteGeneration();
+      const newer = createBrowserNavigationRoute({
+        environmentId,
+        generation: newerGeneration,
+        resolution: sshResolution("http://127.0.0.1:41002"),
+        scope: yield* makeTrackedScope(() => newerCloses++),
+      });
+      const older = createBrowserNavigationRoute({
+        environmentId,
+        generation: olderGeneration,
+        resolution: sshResolution("http://127.0.0.1:41001"),
+        scope: yield* makeTrackedScope(() => olderCloses++),
+      });
+
+      yield* Effect.promise(() => newer.commit("tab-1"));
+      yield* Effect.promise(() => newer.release());
+      yield* Effect.promise(() => older.commit("tab-1"));
+      yield* Effect.promise(() => older.release());
+
+      expect(olderCloses).toBe(1);
+      expect(newerCloses).toBe(0);
+
+      yield* Effect.promise(() => releaseBrowserNavigationRoute("tab-1"));
+      expect(newerCloses).toBe(1);
+    }),
+  );
+
+  it.effect("closes routes and invalidates acquisitions when an environment is removed", () =>
+    Effect.gen(function* () {
+      let closes = 0;
+      const version = readBrowserNavigationRouteEnvironmentVersion(environmentId);
+      const route = createBrowserNavigationRoute({
+        environmentId,
+        generation: reserveBrowserNavigationRouteGeneration(),
+        resolution: sshResolution("http://127.0.0.1:41001"),
+        scope: yield* makeTrackedScope(() => closes++),
+      });
+      yield* Effect.promise(() => route.commit("tab-1"));
+      yield* Effect.promise(() => route.release());
+
+      yield* Effect.promise(() => releaseBrowserNavigationRoutesForEnvironment(environmentId));
+
+      expect(closes).toBe(1);
+      expect(readBrowserNavigationRouteEnvironmentVersion(environmentId)).toBe(version + 1);
+    }),
+  );
+});

--- a/apps/web/src/browser/browserNavigationRoutes.test.ts
+++ b/apps/web/src/browser/browserNavigationRoutes.test.ts
@@ -99,6 +99,25 @@ describe("browser navigation routes", () => {
     }),
   );
 
+  it.effect("keeps a removed tab route alive until its in-flight navigation finishes", () =>
+    Effect.gen(function* () {
+      let closes = 0;
+      const route = createBrowserNavigationRoute({
+        environmentId,
+        generation: reserveBrowserNavigationRouteGeneration(),
+        resolution: sshResolution("http://127.0.0.1:41001"),
+        scope: yield* makeTrackedScope(() => closes++),
+      });
+      yield* Effect.promise(() => route.commit("tab-1"));
+
+      yield* Effect.promise(() => releaseBrowserNavigationRoute("tab-1"));
+      expect(closes).toBe(0);
+
+      yield* Effect.promise(() => route.release());
+      expect(closes).toBe(1);
+    }),
+  );
+
   it.effect("closes routes and invalidates acquisitions when an environment is removed", () =>
     Effect.gen(function* () {
       let closes = 0;

--- a/apps/web/src/browser/browserNavigationRoutes.ts
+++ b/apps/web/src/browser/browserNavigationRoutes.ts
@@ -124,7 +124,7 @@ export async function releaseBrowserNavigationRoute(tabId: string): Promise<void
   latestRouteGenerationByTab.set(tabId, ++nextRouteGeneration);
   const matchingRoutes = [...routes].filter((route) => route.tabId === tabId);
   activeRoutes.delete(tabId);
-  await Promise.all(matchingRoutes.map(closeRoute));
+  await Promise.all(matchingRoutes.map(retireRoute));
 }
 
 export async function releaseBrowserNavigationRoutesForEnvironment(

--- a/apps/web/src/browser/browserNavigationRoutes.ts
+++ b/apps/web/src/browser/browserNavigationRoutes.ts
@@ -1,4 +1,5 @@
 import type { EnvironmentId, PreviewUrlResolution } from "@t3tools/contracts";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Scope from "effect/Scope";
@@ -16,7 +17,8 @@ interface ManagedRoute {
   readonly generation: number;
   readonly resolution: PreviewUrlResolution;
   readonly scope: Scope.Closeable;
-  closePromise: Promise<void> | null;
+  readonly closeDeferred: Deferred.Deferred<void>;
+  closeStarted: boolean;
   phase: RoutePhase;
   tabId: string | null;
   useFinished: boolean;
@@ -28,27 +30,26 @@ const environmentVersions = new Map<EnvironmentId, number>();
 const routes = new Set<ManagedRoute>();
 let nextRouteGeneration = 0;
 
-const closeRouteScope = (scope: Scope.Closeable): Promise<void> =>
-  Effect.runPromise(Scope.close(scope, Exit.void));
+const closeRoute = (route: ManagedRoute): Effect.Effect<void> =>
+  Effect.suspend(() => {
+    if (route.closeStarted) return Deferred.await(route.closeDeferred);
+    route.closeStarted = true;
+    route.phase = "closed";
+    routes.delete(route);
+    if (route.tabId !== null && activeRoutes.get(route.tabId) === route) {
+      activeRoutes.delete(route.tabId);
+    }
+    return Scope.close(route.scope, Exit.void).pipe(
+      Effect.onExit((exit) => Deferred.done(route.closeDeferred, exit)),
+    );
+  });
 
-const closeRoute = (route: ManagedRoute): Promise<void> => {
-  if (route.closePromise !== null) return route.closePromise;
-  route.phase = "closed";
-  routes.delete(route);
-  if (route.tabId !== null && activeRoutes.get(route.tabId) === route) {
-    activeRoutes.delete(route.tabId);
-  }
-  route.closePromise = closeRouteScope(route.scope);
-  return route.closePromise;
-};
-
-const retireRoute = async (route: ManagedRoute): Promise<void> => {
-  if (route.phase === "closed") return;
-  route.phase = "retired";
-  if (route.useFinished) {
-    await closeRoute(route);
-  }
-};
+const retireRoute = (route: ManagedRoute): Effect.Effect<void> =>
+  Effect.suspend(() => {
+    if (route.phase === "closed") return closeRoute(route);
+    route.phase = "retired";
+    return route.useFinished ? closeRoute(route) : Effect.void;
+  });
 
 export function readBrowserNavigationRouteEnvironmentVersion(environmentId: EnvironmentId): number {
   return environmentVersions.get(environmentId) ?? 0;
@@ -80,7 +81,8 @@ export function createBrowserNavigationRoute(input: {
     generation: input.generation,
     resolution: input.resolution,
     scope: input.scope,
-    closePromise: null,
+    closeDeferred: Deferred.makeUnsafe(),
+    closeStarted: false,
     phase: "pending",
     tabId: null,
     useFinished: false,
@@ -94,7 +96,7 @@ export function createBrowserNavigationRoute(input: {
       route.tabId = tabId;
       const latestGeneration = latestRouteGenerationByTab.get(tabId) ?? 0;
       if (route.generation < latestGeneration) {
-        await retireRoute(route);
+        await Effect.runPromise(retireRoute(route));
         return;
       }
 
@@ -108,28 +110,37 @@ export function createBrowserNavigationRoute(input: {
         activeRoutes.delete(tabId);
       }
       if (previous !== undefined && previous !== route) {
-        await retireRoute(previous);
+        await Effect.runPromise(retireRoute(previous));
       }
     },
     release: async () => {
       if (route.phase === "closed") return;
       route.useFinished = true;
       if (route.phase === "active") return;
-      await closeRoute(route);
+      await Effect.runPromise(closeRoute(route));
     },
   };
 }
 
-export async function releaseBrowserNavigationRoute(tabId: string): Promise<void> {
-  latestRouteGenerationByTab.set(tabId, ++nextRouteGeneration);
-  const matchingRoutes = [...routes].filter((route) => route.tabId === tabId);
-  activeRoutes.delete(tabId);
-  await Promise.all(matchingRoutes.map(retireRoute));
+const releaseBrowserNavigationRouteEffect = Effect.fn("web.browserNavigationRoutes.releaseTab")(
+  function* (tabId: string) {
+    latestRouteGenerationByTab.set(tabId, ++nextRouteGeneration);
+    const matchingRoutes = [...routes].filter((route) => route.tabId === tabId);
+    activeRoutes.delete(tabId);
+    yield* Effect.forEach(matchingRoutes, retireRoute, {
+      concurrency: "unbounded",
+      discard: true,
+    });
+  },
+);
+
+export function releaseBrowserNavigationRoute(tabId: string): Promise<void> {
+  return Effect.runPromise(releaseBrowserNavigationRouteEffect(tabId));
 }
 
-export async function releaseBrowserNavigationRoutesForEnvironment(
-  environmentId: EnvironmentId,
-): Promise<void> {
+export const releaseBrowserNavigationRoutesForEnvironmentEffect = Effect.fn(
+  "web.browserNavigationRoutes.releaseEnvironment",
+)(function* (environmentId: EnvironmentId) {
   environmentVersions.set(
     environmentId,
     readBrowserNavigationRouteEnvironmentVersion(environmentId) + 1,
@@ -143,14 +154,24 @@ export async function releaseBrowserNavigationRoutesForEnvironment(
       }
     }
   }
-  await Promise.all(matchingRoutes.map(closeRoute));
-}
+  yield* Effect.forEach(matchingRoutes, closeRoute, {
+    concurrency: "unbounded",
+    discard: true,
+  });
+});
 
-export async function resetBrowserNavigationRoutesForTests(): Promise<void> {
-  const existingRoutes = [...routes];
-  activeRoutes.clear();
-  latestRouteGenerationByTab.clear();
-  environmentVersions.clear();
-  await Promise.all(existingRoutes.map(closeRoute));
-  nextRouteGeneration = 0;
+export function resetBrowserNavigationRoutesForTests(): Promise<void> {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const existingRoutes = [...routes];
+      activeRoutes.clear();
+      latestRouteGenerationByTab.clear();
+      environmentVersions.clear();
+      yield* Effect.forEach(existingRoutes, closeRoute, {
+        concurrency: "unbounded",
+        discard: true,
+      });
+      nextRouteGeneration = 0;
+    }),
+  );
 }

--- a/apps/web/src/browser/browserNavigationRoutes.ts
+++ b/apps/web/src/browser/browserNavigationRoutes.ts
@@ -1,0 +1,156 @@
+import type { EnvironmentId, PreviewUrlResolution } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Scope from "effect/Scope";
+
+export interface BrowserNavigationRoute {
+  readonly resolution: PreviewUrlResolution;
+  readonly commit: (tabId: string) => Promise<void>;
+  readonly release: () => Promise<void>;
+}
+
+type RoutePhase = "pending" | "active" | "retired" | "closed";
+
+interface ManagedRoute {
+  readonly environmentId: EnvironmentId;
+  readonly generation: number;
+  readonly resolution: PreviewUrlResolution;
+  readonly scope: Scope.Closeable;
+  closePromise: Promise<void> | null;
+  phase: RoutePhase;
+  tabId: string | null;
+  useFinished: boolean;
+}
+
+const activeRoutes = new Map<string, ManagedRoute>();
+const latestRouteGenerationByTab = new Map<string, number>();
+const environmentVersions = new Map<EnvironmentId, number>();
+const routes = new Set<ManagedRoute>();
+let nextRouteGeneration = 0;
+
+const closeRouteScope = (scope: Scope.Closeable): Promise<void> =>
+  Effect.runPromise(Scope.close(scope, Exit.void));
+
+const closeRoute = (route: ManagedRoute): Promise<void> => {
+  if (route.closePromise !== null) return route.closePromise;
+  route.phase = "closed";
+  routes.delete(route);
+  if (route.tabId !== null && activeRoutes.get(route.tabId) === route) {
+    activeRoutes.delete(route.tabId);
+  }
+  route.closePromise = closeRouteScope(route.scope);
+  return route.closePromise;
+};
+
+const retireRoute = async (route: ManagedRoute): Promise<void> => {
+  if (route.phase === "closed") return;
+  route.phase = "retired";
+  if (route.useFinished) {
+    await closeRoute(route);
+  }
+};
+
+export function readBrowserNavigationRouteEnvironmentVersion(environmentId: EnvironmentId): number {
+  return environmentVersions.get(environmentId) ?? 0;
+}
+
+export function isBrowserNavigationRouteEnvironmentVersionCurrent(
+  environmentId: EnvironmentId,
+  version: number,
+): boolean {
+  return readBrowserNavigationRouteEnvironmentVersion(environmentId) === version;
+}
+
+export function reserveBrowserNavigationRouteGeneration(): number {
+  return ++nextRouteGeneration;
+}
+
+/**
+ * Keeps a committed SSH route alive for its tab. Newer navigation wins, while
+ * an older in-flight navigation keeps its own route until that use finishes.
+ */
+export function createBrowserNavigationRoute(input: {
+  readonly environmentId: EnvironmentId;
+  readonly generation: number;
+  readonly resolution: PreviewUrlResolution;
+  readonly scope: Scope.Closeable;
+}): BrowserNavigationRoute {
+  const route: ManagedRoute = {
+    environmentId: input.environmentId,
+    generation: input.generation,
+    resolution: input.resolution,
+    scope: input.scope,
+    closePromise: null,
+    phase: "pending",
+    tabId: null,
+    useFinished: false,
+  };
+  routes.add(route);
+
+  return {
+    resolution: route.resolution,
+    commit: async (tabId) => {
+      if (route.phase !== "pending") return;
+      route.tabId = tabId;
+      const latestGeneration = latestRouteGenerationByTab.get(tabId) ?? 0;
+      if (route.generation < latestGeneration) {
+        await retireRoute(route);
+        return;
+      }
+
+      latestRouteGenerationByTab.set(tabId, route.generation);
+      const previous = activeRoutes.get(tabId);
+      if (route.resolution.resolutionKind === "ssh-forward") {
+        route.phase = "active";
+        activeRoutes.set(tabId, route);
+      } else {
+        route.phase = "retired";
+        activeRoutes.delete(tabId);
+      }
+      if (previous !== undefined && previous !== route) {
+        await retireRoute(previous);
+      }
+    },
+    release: async () => {
+      if (route.phase === "closed") return;
+      route.useFinished = true;
+      if (route.phase === "active") return;
+      await closeRoute(route);
+    },
+  };
+}
+
+export async function releaseBrowserNavigationRoute(tabId: string): Promise<void> {
+  latestRouteGenerationByTab.set(tabId, ++nextRouteGeneration);
+  const matchingRoutes = [...routes].filter((route) => route.tabId === tabId);
+  activeRoutes.delete(tabId);
+  await Promise.all(matchingRoutes.map(closeRoute));
+}
+
+export async function releaseBrowserNavigationRoutesForEnvironment(
+  environmentId: EnvironmentId,
+): Promise<void> {
+  environmentVersions.set(
+    environmentId,
+    readBrowserNavigationRouteEnvironmentVersion(environmentId) + 1,
+  );
+  const matchingRoutes = [...routes].filter((route) => route.environmentId === environmentId);
+  for (const route of matchingRoutes) {
+    if (route.tabId !== null) {
+      latestRouteGenerationByTab.set(route.tabId, ++nextRouteGeneration);
+      if (activeRoutes.get(route.tabId) === route) {
+        activeRoutes.delete(route.tabId);
+      }
+    }
+  }
+  await Promise.all(matchingRoutes.map(closeRoute));
+}
+
+export async function resetBrowserNavigationRoutesForTests(): Promise<void> {
+  const existingRoutes = [...routes];
+  activeRoutes.clear();
+  latestRouteGenerationByTab.clear();
+  environmentVersions.clear();
+  await Promise.all(existingRoutes.map(closeRoute));
+  nextRouteGeneration = 0;
+}

--- a/apps/web/src/browser/browserTargetResolver.ts
+++ b/apps/web/src/browser/browserTargetResolver.ts
@@ -4,6 +4,7 @@ import {
 } from "@t3tools/client-runtime/preview";
 import {
   createRuntimeCommand,
+  isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
 import type {
@@ -32,6 +33,10 @@ interface AcquiredRoute {
   readonly scope: Scope.Closeable;
 }
 
+export class BrowserNavigationRouteAcquireInterrupted extends Error {
+  override readonly name = "BrowserNavigationRouteAcquireInterrupted";
+}
+
 const acquireRouteCommand = createRuntimeCommand(connectionAtomRuntime, {
   label: "preview route acquisition",
   execute: ({ connection, target }: EnvironmentPortRouteRequest) =>
@@ -58,6 +63,9 @@ export async function acquireBrowserNavigationTarget(
   }
   const result = await acquireRouteCommand.run(appAtomRegistry, { connection, target });
   if (result._tag === "Failure") {
+    if (isAtomCommandInterrupted(result)) {
+      throw new BrowserNavigationRouteAcquireInterrupted();
+    }
     throw squashAtomCommandFailure(result);
   }
 

--- a/apps/web/src/browser/browserTargetResolver.ts
+++ b/apps/web/src/browser/browserTargetResolver.ts
@@ -27,12 +27,6 @@ import {
   type BrowserNavigationRoute,
 } from "./browserNavigationRoutes";
 
-export {
-  releaseBrowserNavigationRoute,
-  resetBrowserNavigationRoutesForTests,
-  type BrowserNavigationRoute,
-} from "./browserNavigationRoutes";
-
 interface AcquiredRoute {
   readonly resolution: PreviewUrlResolution;
   readonly scope: Scope.Closeable;

--- a/apps/web/src/browser/browserTargetResolver.ts
+++ b/apps/web/src/browser/browserTargetResolver.ts
@@ -19,22 +19,24 @@ import * as Scope from "effect/Scope";
 import { connectionAtomRuntime } from "~/connection/runtime";
 import { appAtomRegistry } from "~/rpc/atomRegistry";
 import { readPreparedConnection } from "~/state/session";
+import {
+  createBrowserNavigationRoute,
+  isBrowserNavigationRouteEnvironmentVersionCurrent,
+  readBrowserNavigationRouteEnvironmentVersion,
+  reserveBrowserNavigationRouteGeneration,
+  type BrowserNavigationRoute,
+} from "./browserNavigationRoutes";
+
+export {
+  releaseBrowserNavigationRoute,
+  resetBrowserNavigationRoutesForTests,
+  type BrowserNavigationRoute,
+} from "./browserNavigationRoutes";
 
 interface AcquiredRoute {
   readonly resolution: PreviewUrlResolution;
   readonly scope: Scope.Closeable;
 }
-
-export interface BrowserNavigationRoute {
-  readonly resolution: PreviewUrlResolution;
-  readonly commit: (tabId: string) => Promise<void>;
-  readonly release: () => Promise<void>;
-}
-
-const activeRoutes = new Map<string, Scope.Closeable>();
-
-const closeRouteScope = (scope: Scope.Closeable): Promise<void> =>
-  Effect.runPromise(Scope.close(scope, Exit.void));
 
 const acquireRouteCommand = createRuntimeCommand(connectionAtomRuntime, {
   label: "preview route acquisition",
@@ -54,6 +56,8 @@ export async function acquireBrowserNavigationTarget(
   environmentId: EnvironmentId,
   target: BrowserNavigationTarget,
 ): Promise<BrowserNavigationRoute> {
+  const environmentVersion = readBrowserNavigationRouteEnvironmentVersion(environmentId);
+  const routeGeneration = reserveBrowserNavigationRouteGeneration();
   const connection = readPreparedConnection(environmentId);
   if (connection === null) {
     throw new Error(`Environment ${environmentId} is not connected.`);
@@ -64,29 +68,16 @@ export async function acquireBrowserNavigationTarget(
   }
 
   const acquired = result.value;
-  let ownership: "pending" | "committed" | "released" = "pending";
-  return {
+  if (!isBrowserNavigationRouteEnvironmentVersionCurrent(environmentId, environmentVersion)) {
+    await Effect.runPromise(Scope.close(acquired.scope, Exit.void));
+    throw new Error(`Environment ${environmentId} disconnected during preview route acquisition.`);
+  }
+  return createBrowserNavigationRoute({
+    environmentId,
+    generation: routeGeneration,
     resolution: acquired.resolution,
-    commit: async (tabId) => {
-      if (ownership !== "pending") return;
-      ownership = "committed";
-      const previous = activeRoutes.get(tabId);
-      if (acquired.resolution.resolutionKind === "ssh-forward") {
-        activeRoutes.set(tabId, acquired.scope);
-      } else {
-        activeRoutes.delete(tabId);
-        await closeRouteScope(acquired.scope);
-      }
-      if (previous !== undefined && previous !== acquired.scope) {
-        await closeRouteScope(previous);
-      }
-    },
-    release: async () => {
-      if (ownership !== "pending") return;
-      ownership = "released";
-      await closeRouteScope(acquired.scope);
-    },
-  };
+    scope: acquired.scope,
+  });
 }
 
 export async function acquireDiscoveredServerRoute(
@@ -102,13 +93,6 @@ export async function acquireDiscoveredServerRoute(
   return acquireBrowserNavigationTarget(environmentId, { kind: "url", url });
 }
 
-export async function releaseBrowserNavigationRoute(tabId: string): Promise<void> {
-  const scope = activeRoutes.get(tabId);
-  if (scope === undefined) return;
-  activeRoutes.delete(tabId);
-  await closeRouteScope(scope);
-}
-
 export async function withBrowserNavigationRoute<A>(
   route: BrowserNavigationRoute | undefined,
   use: () => Promise<A>,
@@ -118,10 +102,4 @@ export async function withBrowserNavigationRoute<A>(
   } finally {
     await route?.release();
   }
-}
-
-export async function resetBrowserNavigationRoutesForTests(): Promise<void> {
-  const scopes = [...activeRoutes.values()];
-  activeRoutes.clear();
-  await Promise.all(scopes.map(closeRouteScope));
 }

--- a/apps/web/src/components/preview/closePreviewSession.test.ts
+++ b/apps/web/src/components/preview/closePreviewSession.test.ts
@@ -9,7 +9,7 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 const releaseBrowserNavigationRoute = vi.hoisted(() => vi.fn(async () => undefined));
 
-vi.mock("~/browser/browserTargetResolver", () => ({ releaseBrowserNavigationRoute }));
+vi.mock("~/browser/browserNavigationRoutes", () => ({ releaseBrowserNavigationRoute }));
 
 import {
   applyPreviewServerSnapshot,

--- a/apps/web/src/components/preview/closePreviewSession.ts
+++ b/apps/web/src/components/preview/closePreviewSession.ts
@@ -6,8 +6,8 @@ import type {
   ScopedThreadRef,
 } from "@t3tools/contracts";
 
+import { releaseBrowserNavigationRoute } from "~/browser/browserNavigationRoutes";
 import { beginPreviewSessionClose, cancelPreviewSessionClose } from "~/previewStateStore";
-import { releaseBrowserNavigationRoute } from "~/browser/browserTargetResolver";
 
 interface ClosePreviewSessionInput<E> {
   readonly closePreview: (input: {

--- a/apps/web/src/components/preview/openTerminalLinkInPreview.test.ts
+++ b/apps/web/src/components/preview/openTerminalLinkInPreview.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
 const mocks = vi.hoisted(() => ({
   acquireDiscoveredServerRoute: vi.fn(),
+  BrowserNavigationRouteAcquireInterrupted: class extends Error {},
   commit: vi.fn(async () => undefined),
   release: vi.fn(async () => undefined),
   openBrowser: vi.fn(),
@@ -13,6 +14,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("~/browser/browserTargetResolver", () => ({
   acquireDiscoveredServerRoute: mocks.acquireDiscoveredServerRoute,
+  BrowserNavigationRouteAcquireInterrupted: mocks.BrowserNavigationRouteAcquireInterrupted,
 }));
 
 import {
@@ -154,6 +156,31 @@ describe("openTerminalLinkInPreview", () => {
     expect(reportError).not.toHaveBeenCalled();
     expect(fallbackToBrowser).not.toHaveBeenCalled();
     expect(mocks.release).toHaveBeenCalledOnce();
+  });
+
+  it("does not report or fall back when route acquisition is interrupted", async () => {
+    const fallbackToBrowser = vi.fn();
+    const reportError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mocks.acquireDiscoveredServerRoute.mockRejectedValueOnce(
+      new mocks.BrowserNavigationRouteAcquireInterrupted(),
+    );
+
+    await openTerminalLinkInPreview({
+      url: "http://localhost:5173/",
+      position: { x: 12, y: 34 },
+      threadRef,
+      openPreview: vi.fn(),
+      localApi: {
+        contextMenu: {
+          show: vi.fn(async () => "open-in-preview"),
+        },
+      } as unknown as LocalApi,
+      fallbackToBrowser,
+    });
+
+    expect(reportError).not.toHaveBeenCalled();
+    expect(fallbackToBrowser).not.toHaveBeenCalled();
+    expect(mocks.openPreviewSession).not.toHaveBeenCalled();
   });
 
   it("routes localhost links before opening the preview and retains the route for its tab", async () => {

--- a/apps/web/src/components/preview/openTerminalLinkInPreview.test.ts
+++ b/apps/web/src/components/preview/openTerminalLinkInPreview.test.ts
@@ -1,7 +1,19 @@
 import type { LocalApi, PreviewSessionSnapshot, ScopedThreadRef } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
 import { AsyncResult } from "effect/unstable/reactivity";
-import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const mocks = vi.hoisted(() => ({
+  acquireDiscoveredServerRoute: vi.fn(),
+  commit: vi.fn(async () => undefined),
+  release: vi.fn(async () => undefined),
+  openBrowser: vi.fn(),
+  openPreviewSession: vi.fn(),
+}));
+
+vi.mock("~/browser/browserTargetResolver", () => ({
+  acquireDiscoveredServerRoute: mocks.acquireDiscoveredServerRoute,
+}));
 
 import {
   openTerminalLinkInPreview,
@@ -10,15 +22,16 @@ import {
 } from "./openTerminalLinkInPreview";
 
 vi.mock("~/previewStateStore", () => ({
-  applyPreviewServerSnapshot: vi.fn(),
   isPreviewSupportedInRuntime: () => true,
 }));
 
 vi.mock("~/rightPanelStore", () => ({
   useRightPanelStore: {
-    getState: () => ({ openBrowser: vi.fn() }),
+    getState: () => ({ openBrowser: mocks.openBrowser }),
   },
 }));
+
+vi.mock("./openPreviewSession", () => ({ openPreviewSession: mocks.openPreviewSession }));
 
 const threadRef = {
   environmentId: "local" as ScopedThreadRef["environmentId"],
@@ -33,6 +46,16 @@ const snapshot: PreviewSessionSnapshot = {
   canGoForward: false,
   updatedAt: "2026-06-20T00:00:00.000Z",
 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.acquireDiscoveredServerRoute.mockResolvedValue({
+    resolution: { resolvedUrl: "http://127.0.0.1:42173/" },
+    commit: mocks.commit,
+    release: mocks.release,
+  });
+  mocks.openPreviewSession.mockResolvedValue(AsyncResult.success(snapshot));
+});
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -62,6 +85,7 @@ describe("openTerminalLinkInPreview", () => {
 
     expect(fallbackToBrowser).toHaveBeenCalledOnce();
     expect(openPreview).not.toHaveBeenCalled();
+    expect(mocks.acquireDiscoveredServerRoute).not.toHaveBeenCalled();
     expect(reportError).toHaveBeenCalledOnce();
     const error = reportError.mock.calls[0]?.[0];
     expect(error).toBeInstanceOf(TerminalLinkContextMenuShowError);
@@ -80,12 +104,13 @@ describe("openTerminalLinkInPreview", () => {
     const cause = Cause.combine(Cause.fail(rpcError), Cause.die("preview defect"));
     const fallbackToBrowser = vi.fn();
     const reportError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mocks.openPreviewSession.mockResolvedValueOnce(AsyncResult.failure(cause));
 
     await openTerminalLinkInPreview({
       url: "http://127.0.0.1:5173/",
       position: { x: 12, y: 34 },
       threadRef,
-      openPreview: async () => AsyncResult.failure(cause),
+      openPreview: vi.fn(),
       localApi: {
         contextMenu: {
           show: vi.fn(async () => "open-in-preview"),
@@ -95,6 +120,7 @@ describe("openTerminalLinkInPreview", () => {
     });
 
     expect(fallbackToBrowser).toHaveBeenCalledOnce();
+    expect(mocks.release).toHaveBeenCalledOnce();
     expect(reportError).toHaveBeenCalledOnce();
     const error = reportError.mock.calls[0]?.[0];
     expect(error).toBeInstanceOf(TerminalLinkPreviewOpenError);
@@ -110,12 +136,13 @@ describe("openTerminalLinkInPreview", () => {
   it("does not report or fall back when opening the preview is interrupted", async () => {
     const fallbackToBrowser = vi.fn();
     const reportError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mocks.openPreviewSession.mockResolvedValueOnce(AsyncResult.failure(Cause.interrupt()));
 
     await openTerminalLinkInPreview({
       url: "http://localhost:5173/",
       position: { x: 12, y: 34 },
       threadRef,
-      openPreview: async () => AsyncResult.failure(Cause.interrupt()),
+      openPreview: vi.fn(),
       localApi: {
         contextMenu: {
           show: vi.fn(async () => "open-in-preview"),
@@ -125,6 +152,39 @@ describe("openTerminalLinkInPreview", () => {
     });
 
     expect(reportError).not.toHaveBeenCalled();
+    expect(fallbackToBrowser).not.toHaveBeenCalled();
+    expect(mocks.release).toHaveBeenCalledOnce();
+  });
+
+  it("routes localhost links before opening the preview and retains the route for its tab", async () => {
+    const openPreview = vi.fn();
+    const fallbackToBrowser = vi.fn();
+
+    await openTerminalLinkInPreview({
+      url: "http://localhost:4321/",
+      position: { x: 12, y: 34 },
+      threadRef,
+      openPreview,
+      localApi: {
+        contextMenu: {
+          show: vi.fn(async () => "open-in-preview"),
+        },
+      } as unknown as LocalApi,
+      fallbackToBrowser,
+    });
+
+    expect(mocks.acquireDiscoveredServerRoute).toHaveBeenCalledWith(
+      threadRef.environmentId,
+      "http://localhost:4321/",
+    );
+    expect(mocks.openPreviewSession).toHaveBeenCalledWith({
+      openPreview,
+      threadRef,
+      url: "http://127.0.0.1:42173/",
+    });
+    expect(mocks.commit).toHaveBeenCalledWith("tab-1");
+    expect(mocks.release).toHaveBeenCalledOnce();
+    expect(mocks.openBrowser).toHaveBeenCalledWith(threadRef, "tab-1");
     expect(fallbackToBrowser).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/preview/openTerminalLinkInPreview.ts
+++ b/apps/web/src/components/preview/openTerminalLinkInPreview.ts
@@ -3,9 +3,11 @@ import { isAtomCommandInterrupted } from "@t3tools/client-runtime/state/runtime"
 import { isPreviewableUrl } from "@t3tools/shared/preview";
 import * as Schema from "effect/Schema";
 
+import { acquireDiscoveredServerRoute } from "~/browser/browserTargetResolver";
 import type { OpenPreviewMutation } from "~/browser/openFileInPreview";
-import { applyPreviewServerSnapshot, isPreviewSupportedInRuntime } from "~/previewStateStore";
+import { isPreviewSupportedInRuntime } from "~/previewStateStore";
 import { useRightPanelStore } from "~/rightPanelStore";
+import { openPreviewSession } from "./openPreviewSession";
 
 const terminalLinkErrorContext = {
   environmentId: Schema.String,
@@ -81,25 +83,34 @@ export async function openTerminalLinkInPreview<E>(
   }
 
   if (choice === "open-in-preview") {
-    const result = await input.openPreview({
-      environmentId: input.threadRef.environmentId,
-      input: { threadId: input.threadRef.threadId, url: input.url },
-    });
-    if (result._tag === "Failure") {
-      if (isAtomCommandInterrupted(result)) {
-        return;
+    try {
+      const route = await acquireDiscoveredServerRoute(input.threadRef.environmentId, input.url);
+      try {
+        const result = await openPreviewSession({
+          openPreview: input.openPreview,
+          threadRef: input.threadRef,
+          url: route.resolution.resolvedUrl,
+        });
+        if (result._tag === "Failure") {
+          if (isAtomCommandInterrupted(result)) {
+            return;
+          }
+          throw result.cause;
+        }
+        await route.commit(result.value.tabId);
+        useRightPanelStore.getState().openBrowser(input.threadRef, result.value.tabId);
+      } finally {
+        await route.release();
       }
+    } catch (cause) {
       console.error(
         new TerminalLinkPreviewOpenError({
           ...errorContext,
-          cause: result.cause,
+          cause,
         }),
       );
       input.fallbackToBrowser();
-      return;
     }
-    applyPreviewServerSnapshot(input.threadRef, result.value);
-    useRightPanelStore.getState().openBrowser(input.threadRef, result.value.tabId);
     return;
   }
 

--- a/apps/web/src/components/preview/openTerminalLinkInPreview.ts
+++ b/apps/web/src/components/preview/openTerminalLinkInPreview.ts
@@ -3,7 +3,10 @@ import { isAtomCommandInterrupted } from "@t3tools/client-runtime/state/runtime"
 import { isPreviewableUrl } from "@t3tools/shared/preview";
 import * as Schema from "effect/Schema";
 
-import { acquireDiscoveredServerRoute } from "~/browser/browserTargetResolver";
+import {
+  acquireDiscoveredServerRoute,
+  BrowserNavigationRouteAcquireInterrupted,
+} from "~/browser/browserTargetResolver";
 import type { OpenPreviewMutation } from "~/browser/openFileInPreview";
 import { isPreviewSupportedInRuntime } from "~/previewStateStore";
 import { useRightPanelStore } from "~/rightPanelStore";
@@ -103,6 +106,9 @@ export async function openTerminalLinkInPreview<E>(
         await route.release();
       }
     } catch (cause) {
+      if (cause instanceof BrowserNavigationRouteAcquireInterrupted) {
+        return;
+      }
       console.error(
         new TerminalLinkPreviewOpenError({
           ...errorContext,

--- a/apps/web/src/connection/platform.ts
+++ b/apps/web/src/connection/platform.ts
@@ -42,7 +42,7 @@ import * as Ref from "effect/Ref";
 import * as Stream from "effect/Stream";
 import { FetchHttpClient } from "effect/unstable/http";
 
-import { releaseBrowserNavigationRoutesForEnvironment } from "../browser/browserNavigationRoutes";
+import { releaseBrowserNavigationRoutesForEnvironmentEffect } from "../browser/browserNavigationRoutes";
 import { readDesktopPrimaryBearerToken } from "../environments/primary/desktopAuth";
 import { primaryEnvironmentHttpLayer } from "../environments/primary/httpLayer";
 import {
@@ -611,14 +611,7 @@ const environmentOwnedDataCleanupLayer = Layer.succeed(
           Effect.sync(() => {
             clearComposerDraftsEnvironment(environmentId);
           }),
-          Effect.tryPromise(() => releaseBrowserNavigationRoutesForEnvironment(environmentId)).pipe(
-            Effect.catch((cause) =>
-              Effect.logWarning("Could not release preview routes during environment cleanup.", {
-                environmentId,
-                cause,
-              }),
-            ),
-          ),
+          releaseBrowserNavigationRoutesForEnvironmentEffect(environmentId),
         ],
         { concurrency: "unbounded", discard: true },
       ),

--- a/apps/web/src/connection/platform.ts
+++ b/apps/web/src/connection/platform.ts
@@ -42,6 +42,7 @@ import * as Ref from "effect/Ref";
 import * as Stream from "effect/Stream";
 import { FetchHttpClient } from "effect/unstable/http";
 
+import { releaseBrowserNavigationRoutesForEnvironment } from "../browser/browserNavigationRoutes";
 import { readDesktopPrimaryBearerToken } from "../environments/primary/desktopAuth";
 import { primaryEnvironmentHttpLayer } from "../environments/primary/httpLayer";
 import {
@@ -605,9 +606,22 @@ const environmentOwnedDataCleanupLayer = Layer.succeed(
   EnvironmentOwnedDataCleanup,
   EnvironmentOwnedDataCleanup.of({
     clear: (environmentId) =>
-      Effect.sync(() => {
-        clearComposerDraftsEnvironment(environmentId);
-      }),
+      Effect.all(
+        [
+          Effect.sync(() => {
+            clearComposerDraftsEnvironment(environmentId);
+          }),
+          Effect.tryPromise(() => releaseBrowserNavigationRoutesForEnvironment(environmentId)).pipe(
+            Effect.catch((cause) =>
+              Effect.logWarning("Could not release preview routes during environment cleanup.", {
+                environmentId,
+                cause,
+              }),
+            ),
+          ),
+        ],
+        { concurrency: "unbounded", discard: true },
+      ),
   }),
 );
 

--- a/apps/web/src/previewStateStore.test.ts
+++ b/apps/web/src/previewStateStore.test.ts
@@ -1,6 +1,10 @@
 import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
 import { type EnvironmentId, type PreviewSessionSnapshot, ThreadId } from "@t3tools/contracts";
-import { beforeEach, describe, expect, it } from "vite-plus/test";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const releaseBrowserNavigationRoute = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("./browser/browserNavigationRoutes", () => ({ releaseBrowserNavigationRoute }));
 
 import {
   __testing,
@@ -34,6 +38,7 @@ const makeSnapshot = (overrides: Partial<PreviewSessionSnapshot> = {}): PreviewS
 });
 
 beforeEach(() => {
+  releaseBrowserNavigationRoute.mockClear();
   resetPreviewStateForTests();
 });
 
@@ -202,6 +207,7 @@ describe("previewStateStore (single-tab)", () => {
     const state = readThreadPreviewState(ref);
     expect(state.snapshot).toBeNull();
     expect(state.recentlySeenUrls).toContain("http://localhost:5173/");
+    expect(releaseBrowserNavigationRoute).toHaveBeenCalledWith(snapshot.tabId);
   });
 
   it("optimistically removes a session before the server close event arrives", () => {
@@ -219,6 +225,7 @@ describe("previewStateStore (single-tab)", () => {
     expect(Object.keys(state.sessions)).toEqual([first.tabId]);
     expect(state.activeTabId).toBe(first.tabId);
     expect(state.snapshot?.tabId).toBe(first.tabId);
+    expect(releaseBrowserNavigationRoute).not.toHaveBeenCalled();
   });
 
   it("treats a late server close event after optimistic removal as a no-op", () => {
@@ -367,6 +374,7 @@ describe("previewStateStore (single-tab)", () => {
     expect(state.activeTabId).toBe(active.tabId);
     expect(state.snapshot).toEqual(active);
     expect(state.desktopByTabId[stale.tabId]).toBeUndefined();
+    expect(releaseBrowserNavigationRoute).toHaveBeenCalledWith(stale.tabId);
   });
 
   it("clears stale sessions when an authoritative list is empty", () => {
@@ -386,6 +394,7 @@ describe("previewStateStore (single-tab)", () => {
     applyPreviewServerSnapshot(ref, null);
     const state = readThreadPreviewState(ref);
     expect(state.snapshot).toBeNull();
+    expect(releaseBrowserNavigationRoute).toHaveBeenCalledWith(snapshot.tabId);
   });
 
   it("does not replace a streamed snapshot with older SWR data", () => {
@@ -429,5 +438,6 @@ describe("previewStateStore (single-tab)", () => {
     removePreviewThread(ref);
     const state = readThreadPreviewState(ref);
     expect(state).toEqual(__testing.EMPTY_THREAD_PREVIEW_STATE);
+    expect(releaseBrowserNavigationRoute).toHaveBeenCalledWith(snapshot.tabId);
   });
 });

--- a/apps/web/src/previewStateStore.ts
+++ b/apps/web/src/previewStateStore.ts
@@ -14,6 +14,7 @@ import {
 } from "@t3tools/contracts";
 import { Atom } from "effect/unstable/reactivity";
 
+import { releaseBrowserNavigationRoute } from "./browser/browserNavigationRoutes";
 import { PREVIEW_RECENT_URL_LIMIT } from "./components/preview/previewConstants";
 import { appAtomRegistry } from "./rpc/atomRegistry";
 
@@ -145,6 +146,12 @@ const removeSession = (current: ThreadPreviewState, tabId: string): ThreadPrevie
   };
 };
 
+const releaseRemovedBrowserRoutes = (tabIds: ReadonlyArray<string>): void => {
+  for (const tabId of tabIds) {
+    void releaseBrowserNavigationRoute(tabId).catch(() => undefined);
+  }
+};
+
 export function useThreadPreviewState(ref: ScopedThreadRef | null | undefined): ThreadPreviewState {
   const atom = ref ? previewStateAtom(scopedThreadKey(ref)) : emptyPreviewStateAtom;
   return useAtomValue(atom);
@@ -220,15 +227,20 @@ export function applyPreviewServerEvent(ref: ScopedThreadRef, event: PreviewEven
         return removeSession(current, event.tabId);
     }
   });
+  if (event.type === "closed") {
+    releaseRemovedBrowserRoutes([event.tabId]);
+  }
 }
 
 export function applyPreviewServerSnapshot(
   ref: ScopedThreadRef,
   snapshot: PreviewSessionSnapshot | null,
 ): void {
+  let removedTabIds: string[] = [];
   updateThreadPreviewState(ref, (current) => {
     if (!snapshot && current.snapshot === null) return current;
     if (!snapshot) {
+      removedTabIds = Object.keys(current.sessions);
       return {
         ...current,
         snapshot: null,
@@ -251,6 +263,7 @@ export function applyPreviewServerSnapshot(
       recentlySeenUrls,
     };
   });
+  releaseRemovedBrowserRoutes(removedTabIds);
 }
 
 /**
@@ -291,6 +304,7 @@ export function reconcilePreviewServerSessions(
   ref: ScopedThreadRef,
   snapshots: ReadonlyArray<PreviewSessionSnapshot>,
 ): void {
+  let removedTabIds: string[] = [];
   updateThreadPreviewState(ref, (current) => {
     const sessions: Record<string, PreviewSessionSnapshot> = {};
     let recentlySeenUrls = current.recentlySeenUrls;
@@ -301,6 +315,7 @@ export function reconcilePreviewServerSessions(
       sessions[next.tabId] = next;
       recentlySeenUrls = rememberSnapshotUrl(recentlySeenUrls, next);
     }
+    removedTabIds = Object.keys(current.sessions).filter((tabId) => sessions[tabId] === undefined);
 
     const fallback = latestSnapshot(sessions);
     const activeTabId =
@@ -321,6 +336,7 @@ export function reconcilePreviewServerSessions(
       recentlySeenUrls,
     };
   });
+  releaseRemovedBrowserRoutes(removedTabIds);
 }
 
 export function applyPreviewDesktopState(
@@ -402,6 +418,9 @@ export function rememberPreviewUrl(ref: ScopedThreadRef, url: string): void {
 
 export function removePreviewThread(ref: ScopedThreadRef): void {
   const threadKey = scopedThreadKey(ref);
+  releaseRemovedBrowserRoutes(
+    Object.keys(appAtomRegistry.get(previewStateAtom(threadKey)).sessions),
+  );
   appAtomRegistry.set(previewStateAtom(threadKey), EMPTY_THREAD_PREVIEW_STATE);
   syncActivePreviewThread(threadKey, EMPTY_THREAD_PREVIEW_STATE);
   changedPreviewThreadKeys.delete(threadKey);

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -400,7 +400,9 @@ describe("ssh tunnel scripts", () => {
 
       yield* manager.ensureEnvironment(target);
 
-      assert.equal(spawnedCommands.filter((args) => args.includes("-N")).length, 2);
+      const tunnelCommands = spawnedCommands.filter((args) => args.includes("-N"));
+      assert.equal(tunnelCommands.length, 2);
+      assert.include(tunnelCommands[0] ?? [], "127.0.0.1:41773:127.0.0.1:3773");
       assert.equal(tunnelKillCount, 1);
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
@@ -447,7 +449,7 @@ describe("ssh tunnel scripts", () => {
       assert.equal(first.localPort, second.localPort);
       assert.notEqual(first.leaseId, second.leaseId);
       assert.equal(tunnelSpawnCount, 1);
-      assert.include(forwardArgs[0] ?? [], "127.0.0.1:41773:127.0.0.1:5173");
+      assert.include(forwardArgs[0] ?? [], "127.0.0.1:41773:localhost:5173");
       assert.include(forwardArgs[0] ?? [], "-v");
 
       yield* manager.releasePortForward(first.leaseId);

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -535,15 +535,8 @@ describe("ssh tunnel scripts", () => {
 
     return Effect.gen(function* () {
       const readinessStarted = yield* Deferred.make<void>();
-      const allowReadiness = yield* Deferred.make<void>();
       const readyStderr = Stream.fromEffect(
-        Deferred.succeed(readinessStarted, undefined).pipe(
-          Effect.andThen(Deferred.await(allowReadiness)),
-        ),
-      ).pipe(
-        Stream.map(() =>
-          new TextEncoder().encode("debug1: Local forwarding listening on 127.0.0.1 port 41773.\n"),
-        ),
+        Deferred.succeed(readinessStarted, undefined).pipe(Effect.andThen(Effect.never)),
       );
       const spawner = ChildProcessSpawner.make((command) =>
         Effect.sync(() => {
@@ -573,8 +566,6 @@ describe("ssh tunnel scripts", () => {
       yield* Deferred.await(readinessStarted);
 
       const closeFiber = yield* Effect.forkChild(Scope.close(managerScope, Exit.void));
-      yield* Effect.yieldNow;
-      yield* Deferred.succeed(allowReadiness, undefined);
 
       const acquisitionResult = yield* Fiber.join(acquisitionFiber);
       yield* Fiber.join(closeFiber);

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -1,11 +1,15 @@
 import { assert, describe, it } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as NetService from "@t3tools/shared/Net";
+import * as Context from "effect/Context";
+import * as Deferred from "effect/Deferred";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Result from "effect/Result";
+import * as Scope from "effect/Scope";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
 import { TestClock } from "effect/testing";
@@ -13,6 +17,7 @@ import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import { SshPasswordPrompt } from "./auth.ts";
+import { SshReadinessError } from "./errors.ts";
 import {
   buildRemoteLaunchScript,
   buildRemotePairingScript,
@@ -45,12 +50,18 @@ const makeSuccessfulProcess = (stdout: string) => {
   });
 };
 
-const makeRunningProcess = (onKill: () => void) => {
+const makeRunningProcess = (
+  onKill: () => void,
+  stderr:
+    | string
+    | Stream.Stream<Uint8Array> = "debug1: Local forwarding listening on 127.0.0.1 port 41773.\n",
+  isRunning: Effect.Effect<boolean> = Effect.succeed(true),
+) => {
   let finish: ((exitCode: ChildProcessSpawner.ExitCode) => void) | null = null;
   return ChildProcessSpawner.makeHandle({
     pid: ChildProcessSpawner.ProcessId(123),
     stdout: Stream.empty,
-    stderr: Stream.empty,
+    stderr: typeof stderr === "string" ? Stream.make(new TextEncoder().encode(stderr)) : stderr,
     all: Stream.empty,
     exitCode: Effect.callback<ChildProcessSpawner.ExitCode>((resume) => {
       finish = (exitCode) => resume(Effect.succeed(exitCode));
@@ -58,7 +69,7 @@ const makeRunningProcess = (onKill: () => void) => {
         finish = null;
       });
     }),
-    isRunning: Effect.succeed(true),
+    isRunning,
     kill: () =>
       Effect.sync(() => {
         onKill();
@@ -437,6 +448,7 @@ describe("ssh tunnel scripts", () => {
       assert.notEqual(first.leaseId, second.leaseId);
       assert.equal(tunnelSpawnCount, 1);
       assert.include(forwardArgs[0] ?? [], "127.0.0.1:41773:127.0.0.1:5173");
+      assert.include(forwardArgs[0] ?? [], "-v");
 
       yield* manager.releasePortForward(first.leaseId);
       assert.equal(tunnelKillCount, 0);
@@ -452,6 +464,159 @@ describe("ssh tunnel scripts", () => {
 
       yield* manager.releasePortForward(third.leaseId);
       assert.equal(tunnelKillCount, 2);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.effect("serializes reuse against release of the last lease", () => {
+    let tunnelKillCount = 0;
+    let runningCheck: Effect.Effect<boolean> = Effect.succeed(true);
+    const spawner = ChildProcessSpawner.make((command) =>
+      Effect.sync(() => {
+        const args = commandArgs(command);
+        if (args.includes("-N")) {
+          return makeRunningProcess(
+            () => {
+              tunnelKillCount += 1;
+            },
+            undefined,
+            Effect.suspend(() => runningCheck),
+          );
+        }
+        return makeSuccessfulProcess("\n");
+      }),
+    );
+    const layer = Layer.mergeAll(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      Layer.succeed(HttpClient.HttpClient, testHttpClient),
+      Layer.succeed(NetService.NetService, testNetService),
+      SshPasswordPrompt.disabledLayer,
+      SshEnvironmentManager.layer(),
+    );
+    const target = {
+      alias: "devbox",
+      hostname: "devbox.example.com",
+      username: "julius",
+      port: 2222,
+    } as const;
+
+    return Effect.gen(function* () {
+      const manager = yield* SshEnvironmentManager;
+      const first = yield* manager.acquirePortForward(target, 5173);
+      const runningCheckStarted = yield* Deferred.make<void>();
+      const finishRunningCheck = yield* Deferred.make<boolean>();
+      runningCheck = Deferred.succeed(runningCheckStarted, undefined).pipe(
+        Effect.andThen(Deferred.await(finishRunningCheck)),
+      );
+
+      const secondFiber = yield* Effect.forkChild(manager.acquirePortForward(target, 5173));
+      yield* Deferred.await(runningCheckStarted);
+      const releaseFiber = yield* Effect.forkChild(manager.releasePortForward(first.leaseId));
+      yield* Effect.yieldNow;
+      yield* Deferred.succeed(finishRunningCheck, true);
+
+      const second = yield* Fiber.join(secondFiber);
+      yield* Fiber.join(releaseFiber);
+      assert.equal(tunnelKillCount, 0);
+
+      yield* manager.releasePortForward(second.leaseId);
+      assert.equal(tunnelKillCount, 1);
+    }).pipe(Effect.provide(layer), Effect.scoped);
+  });
+
+  it.effect("cancels a pending port forward when the manager scope closes", () => {
+    let tunnelKillCount = 0;
+    const target = {
+      alias: "devbox",
+      hostname: "devbox.example.com",
+      username: "julius",
+      port: 2222,
+    } as const;
+
+    return Effect.gen(function* () {
+      const readinessStarted = yield* Deferred.make<void>();
+      const allowReadiness = yield* Deferred.make<void>();
+      const readyStderr = Stream.fromEffect(
+        Deferred.succeed(readinessStarted, undefined).pipe(
+          Effect.andThen(Deferred.await(allowReadiness)),
+        ),
+      ).pipe(
+        Stream.map(() =>
+          new TextEncoder().encode("debug1: Local forwarding listening on 127.0.0.1 port 41773.\n"),
+        ),
+      );
+      const spawner = ChildProcessSpawner.make((command) =>
+        Effect.sync(() => {
+          const args = commandArgs(command);
+          if (args.includes("-N")) {
+            return makeRunningProcess(() => {
+              tunnelKillCount += 1;
+            }, readyStderr);
+          }
+          return makeSuccessfulProcess("\n");
+        }),
+      );
+      const layer = Layer.mergeAll(
+        NodeServices.layer,
+        Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Layer.succeed(HttpClient.HttpClient, testHttpClient),
+        Layer.succeed(NetService.NetService, testNetService),
+        SshPasswordPrompt.disabledLayer,
+        SshEnvironmentManager.layer(),
+      );
+      const managerScope = yield* Scope.make("sequential");
+      const context = yield* Layer.buildWithScope(layer, managerScope);
+      const manager = Context.get(context, SshEnvironmentManager);
+      const acquisitionFiber = yield* Effect.forkChild(
+        Effect.result(manager.acquirePortForward(target, 5173)).pipe(Effect.provide(context)),
+      );
+      yield* Deferred.await(readinessStarted);
+
+      const closeFiber = yield* Effect.forkChild(Scope.close(managerScope, Exit.void));
+      yield* Effect.yieldNow;
+      yield* Deferred.succeed(allowReadiness, undefined);
+
+      const acquisitionResult = yield* Fiber.join(acquisitionFiber);
+      yield* Fiber.join(closeFiber);
+      assert(Result.isFailure(acquisitionResult));
+      assert.equal(tunnelKillCount, 1);
+    });
+  });
+
+  it.effect("does not accept an unrelated local listener as SSH forward readiness", () => {
+    let tunnelKillCount = 0;
+    const spawner = ChildProcessSpawner.make((command) =>
+      Effect.sync(() => {
+        const args = commandArgs(command);
+        if (args.includes("-N")) {
+          return makeRunningProcess(() => {
+            tunnelKillCount += 1;
+          }, "bind [127.0.0.1]:41773: Address already in use\n");
+        }
+        return makeSuccessfulProcess("\n");
+      }),
+    );
+    const layer = Layer.mergeAll(
+      NodeServices.layer,
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      Layer.succeed(HttpClient.HttpClient, testHttpClient),
+      Layer.succeed(NetService.NetService, testNetService),
+      SshPasswordPrompt.disabledLayer,
+      SshEnvironmentManager.layer(),
+    );
+    const target = {
+      alias: "devbox",
+      hostname: "devbox.example.com",
+      username: "julius",
+      port: 2222,
+    } as const;
+
+    return Effect.gen(function* () {
+      const manager = yield* SshEnvironmentManager;
+      const error = yield* manager.acquirePortForward(target, 5173).pipe(Effect.flip);
+
+      assert.instanceOf(error, SshReadinessError);
+      assert.equal(tunnelKillCount, 1);
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
 });

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -981,6 +981,7 @@ const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: 
   readonly key: string;
   readonly resolvedTarget: DesktopSshEnvironmentTarget;
   readonly remotePort: number;
+  readonly remoteHost: "127.0.0.1" | "localhost";
   readonly localPort: number;
   readonly httpBaseUrl: string;
   readonly wsBaseUrl: string;
@@ -1031,7 +1032,7 @@ const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: 
     "-n",
     "-N",
     "-L",
-    `127.0.0.1:${input.localPort}:127.0.0.1:${input.remotePort}`,
+    `127.0.0.1:${input.localPort}:${input.remoteHost}:${input.remotePort}`,
     hostSpec,
   ];
   const sshCommand = yield* resolveSshCommand;
@@ -1497,6 +1498,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
           key: input.key,
           resolvedTarget: input.resolvedTarget,
           remotePort,
+          remoteHost: "127.0.0.1",
           localPort,
           httpBaseUrl,
           wsBaseUrl,
@@ -1664,6 +1666,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
           key: input.key,
           resolvedTarget: input.resolvedTarget,
           remotePort: input.remotePort,
+          remoteHost: "localhost",
           localPort,
           httpBaseUrl,
           wsBaseUrl,

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -16,10 +16,11 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
-import * as Schedule from "effect/Schedule";
 import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
 import * as Stream from "effect/Stream";
 import { HttpClient } from "effect/unstable/http";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
@@ -89,6 +90,7 @@ interface SshPortForwardEntry extends SshTunnelEntry {
 
 interface PendingSshPortForward {
   readonly deferred: Deferred.Deferred<SshPortForwardEntry, SshEnvironmentEffectError>;
+  readonly target: DesktopSshEnvironmentTarget;
 }
 
 export interface SshPortForwardLease {
@@ -939,25 +941,38 @@ const reserveLocalTunnelPort = Effect.fn("ssh/tunnel.reserveLocalTunnelPort")(fu
   return yield* net.reserveLoopbackPort();
 });
 
-const waitForTcpForwardReady = Effect.fn("ssh/tunnel.waitForTcpForwardReady")(function* (
+const waitForSshForwardReady = Effect.fn("ssh/tunnel.waitForSshForwardReady")(function* <E>(
+  stderr: Stream.Stream<Uint8Array, E>,
   localPort: number,
 ) {
-  const net = yield* NetService.NetService;
-  const retryPolicy = Schedule.spaced(Duration.millis(50)).pipe(
-    Schedule.take(Math.ceil(SSH_READY_TIMEOUT_MS / 50)),
-  );
-  yield* net.hasListenerOnHost(localPort, "127.0.0.1").pipe(
-    Effect.flatMap((ready) =>
-      ready
-        ? Effect.void
-        : Effect.fail(
-            new SshReadinessError({
-              message: `SSH port forward on 127.0.0.1:${localPort} did not become ready.`,
-            }),
-          ),
+  const readinessMessage = `Local forwarding listening on 127.0.0.1 port ${localPort}`;
+  const readyLine = yield* stderr.pipe(
+    Stream.decodeText(),
+    Stream.splitLines,
+    Stream.filter((line) => line.includes(readinessMessage)),
+    Stream.runHead,
+    Effect.mapError(
+      (cause) =>
+        new SshReadinessError({
+          message: `Failed to observe SSH port forward readiness on 127.0.0.1:${localPort}.`,
+          cause,
+        }),
     ),
-    Effect.retry(retryPolicy),
+    Effect.timeoutOrElse({
+      duration: Duration.millis(SSH_READY_TIMEOUT_MS),
+      orElse: () =>
+        Effect.fail(
+          new SshReadinessError({
+            message: `SSH port forward on 127.0.0.1:${localPort} did not become ready.`,
+          }),
+        ),
+    }),
   );
+  if (Option.isNone(readyLine)) {
+    return yield* new SshReadinessError({
+      message: `SSH port forward on 127.0.0.1:${localPort} exited before becoming ready.`,
+    });
+  }
 });
 
 const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: {
@@ -1004,6 +1019,7 @@ const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: 
     ...baseSshArgs(input.resolvedTarget, {
       batchMode: input.authOptions.batchMode ?? "no",
     }),
+    ...(input.readiness === "tcp" ? ["-v"] : []),
     "-o",
     "ExitOnForwardFailure=yes",
     "-o",
@@ -1073,8 +1089,13 @@ const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: 
     process: child,
     scope,
   };
+  const stderrStreams =
+    input.readiness === "tcp"
+      ? yield* child.stderr.pipe(Stream.broadcastN({ n: 2, capacity: "unbounded" }))
+      : null;
+  const stderrForExit = stderrStreams?.[0] ?? child.stderr;
   const exitFailure = Effect.all(
-    [collectProcessOutput(child.stderr), child.exitCode.pipe(Effect.map(Number))],
+    [collectProcessOutput(stderrForExit), child.exitCode.pipe(Effect.map(Number))],
     { concurrency: "unbounded" },
   ).pipe(
     Effect.mapError(
@@ -1191,7 +1212,9 @@ const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: 
       ),
     );
   } else {
-    yield* observeReadiness(Effect.raceFirst(waitForTcpForwardReady(input.localPort), exitFailure));
+    yield* observeReadiness(
+      Effect.raceFirst(waitForSshForwardReady(stderrStreams![1], input.localPort), exitFailure),
+    );
   }
   return tunnelEntry;
 });
@@ -1208,7 +1231,9 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
   const portForwards = new Map<string, SshPortForwardEntry>();
   const pendingPortForwards = new Map<string, PendingSshPortForward>();
   const portForwardLeases = new Map<string, SshPortForwardEntry>();
+  const portForwardLock = yield* Semaphore.make(1);
   let nextPortForwardLeaseId = 0;
+  let portForwardsClosed = false;
   const authSecrets = new Map<string, string>();
 
   const closeTunnelEntry = Effect.fn("ssh/tunnel.closeTunnelEntry")(function* (
@@ -1281,23 +1306,27 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
 
   yield* Scope.addFinalizer(
     managerScope,
-    Effect.sync(() => ({
-      tunnels: [...tunnels.values()],
-      portForwards: [...portForwards.values()],
-    })).pipe(
-      Effect.flatMap(({ tunnels: tunnelEntries, portForwards: portForwardEntries }) =>
-        Effect.all(
-          [
-            Effect.forEach(tunnelEntries, closeTunnelEntry, { concurrency: "unbounded" }),
-            Effect.forEach(portForwardEntries, closePortForwardEntry, {
+    Effect.gen(function* () {
+      portForwardsClosed = true;
+      yield* Effect.forEach(
+        [...pendingPortForwards.entries()],
+        ([key, pending]) => cancelPendingPortForward(key, pending.target),
+        { concurrency: "unbounded", discard: true },
+      );
+      yield* Effect.all(
+        [
+          Effect.forEach([...tunnels.values()], closeTunnelEntry, {
+            concurrency: "unbounded",
+          }),
+          portForwardLock.withPermit(
+            Effect.forEach([...portForwards.values()], closePortForwardEntry, {
               concurrency: "unbounded",
             }),
-          ],
-          { concurrency: "unbounded" },
-        ),
-      ),
-      Effect.ignore,
-    ),
+          ),
+        ],
+        { concurrency: "unbounded" },
+      );
+    }).pipe(Effect.ignore),
   );
 
   const promptForPassword = Effect.fn("ssh/tunnel.promptForPassword")(function* (
@@ -1621,57 +1650,60 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     const localPort = yield* reserveLocalTunnelPort();
     const httpBaseUrl = `http://127.0.0.1:${localPort}/`;
     const wsBaseUrl = `ws://127.0.0.1:${localPort}/`;
-    const entryScope = yield* Scope.make("sequential");
-    const tunnelEntry = yield* runWithSshAuth({
-      key: input.connectionKey,
-      target: input.resolvedTarget,
-      operation: (authOptions) =>
-        startSshTunnel({
-          key: input.key,
-          resolvedTarget: input.resolvedTarget,
-          remotePort: input.remotePort,
-          localPort,
-          httpBaseUrl,
-          wsBaseUrl,
-          authOptions,
-          remoteServerKind: null,
-          readiness: "tcp",
-        }).pipe(Effect.provideService(Scope.Scope, entryScope)),
-    }).pipe(
-      Effect.onExit((exit) =>
+    return yield* Effect.acquireUseRelease(
+      Scope.make("sequential"),
+      (entryScope) =>
+        Effect.gen(function* () {
+          const tunnelEntry = yield* runWithSshAuth({
+            key: input.connectionKey,
+            target: input.resolvedTarget,
+            operation: (authOptions) =>
+              startSshTunnel({
+                key: input.key,
+                resolvedTarget: input.resolvedTarget,
+                remotePort: input.remotePort,
+                localPort,
+                httpBaseUrl,
+                wsBaseUrl,
+                authOptions,
+                remoteServerKind: null,
+                readiness: "tcp",
+              }).pipe(Effect.provideService(Scope.Scope, entryScope)),
+          });
+          const entry: SshPortForwardEntry = {
+            ...tunnelEntry,
+            connectionKey: input.connectionKey,
+            leases: new Set(),
+          };
+          yield* Scope.addFinalizer(
+            entryScope,
+            Effect.gen(function* () {
+              if (portForwards.get(entry.key) === entry) {
+                portForwards.delete(entry.key);
+              }
+              for (const leaseId of entry.leases) {
+                portForwardLeases.delete(leaseId);
+              }
+              entry.leases.clear();
+              yield* entry.process
+                .kill({
+                  killSignal: "SIGTERM",
+                  forceKillAfter: TUNNEL_SHUTDOWN_TIMEOUT_MS,
+                })
+                .pipe(Effect.ignore);
+            }),
+          );
+          yield* Effect.logInfo("ssh.portForward.create.succeeded", {
+            ...sshTargetLogFields(entry.target),
+            key: entry.key,
+            localPort: entry.localPort,
+            remotePort: entry.remotePort,
+          });
+          return entry;
+        }),
+      (entryScope, exit) =>
         Exit.isSuccess(exit) ? Effect.void : Scope.close(entryScope, Exit.void).pipe(Effect.ignore),
-      ),
     );
-    const entry: SshPortForwardEntry = {
-      ...tunnelEntry,
-      connectionKey: input.connectionKey,
-      leases: new Set(),
-    };
-    yield* Scope.addFinalizer(
-      entryScope,
-      Effect.gen(function* () {
-        if (portForwards.get(entry.key) === entry) {
-          portForwards.delete(entry.key);
-        }
-        for (const leaseId of entry.leases) {
-          portForwardLeases.delete(leaseId);
-        }
-        entry.leases.clear();
-        yield* entry.process
-          .kill({
-            killSignal: "SIGTERM",
-            forceKillAfter: TUNNEL_SHUTDOWN_TIMEOUT_MS,
-          })
-          .pipe(Effect.ignore);
-      }),
-    );
-    yield* Effect.logInfo("ssh.portForward.create.succeeded", {
-      ...sshTargetLogFields(entry.target),
-      key: entry.key,
-      localPort: entry.localPort,
-      remotePort: entry.remotePort,
-    });
-    return entry;
   });
 
   const ensurePortForwardEntry = Effect.fn("ssh/tunnel.portForward.ensure")(function* (input: {
@@ -1684,13 +1716,24 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     SshEnvironmentEffectError,
     SshEnvironmentEffectContext
   > {
+    if (portForwardsClosed) {
+      return yield* makeSshTunnelCancelledError(input.resolvedTarget);
+    }
     const existing = portForwards.get(input.key);
     if (existing !== undefined) {
       const running = yield* existing.process.isRunning.pipe(Effect.orElseSucceed(() => false));
-      if (running) {
+      if (
+        running &&
+        !portForwardsClosed &&
+        portForwards.get(input.key) === existing &&
+        existing.leases.size > 0
+      ) {
         return existing;
       }
       yield* closePortForwardEntry(existing);
+      if (portForwardsClosed) {
+        return yield* makeSshTunnelCancelledError(input.resolvedTarget);
+      }
     }
 
     const pending = pendingPortForwards.get(input.key);
@@ -1701,6 +1744,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     const deferred = yield* Deferred.make<SshPortForwardEntry, SshEnvironmentEffectError>();
     const pendingEntry: PendingSshPortForward = {
       deferred,
+      target: input.resolvedTarget,
     };
     pendingPortForwards.set(input.key, pendingEntry);
     return yield* createPortForwardEntry(input).pipe(
@@ -1743,49 +1787,61 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     const resolvedTarget = yield* resolveManagerTarget(target);
     const connectionKey = targetConnectionKey(resolvedTarget);
     const key = `${connectionKey}\0${remotePort}`;
-    const entry = yield* ensurePortForwardEntry({
-      key,
-      connectionKey,
-      resolvedTarget,
-      remotePort,
-    });
-    nextPortForwardLeaseId += 1;
-    const leaseId = `ssh-port-forward-${nextPortForwardLeaseId}`;
-    entry.leases.add(leaseId);
-    portForwardLeases.set(leaseId, entry);
-    yield* Effect.logInfo("ssh.portForward.acquired", {
-      ...sshTargetLogFields(entry.target),
-      leaseId,
-      localPort: entry.localPort,
-      remotePort: entry.remotePort,
-      references: entry.leases.size,
-    });
-    return {
-      leaseId,
-      localPort: entry.localPort,
-      remotePort: entry.remotePort,
-    };
+    return yield* portForwardLock.withPermit(
+      Effect.gen(function* () {
+        const entry = yield* ensurePortForwardEntry({
+          key,
+          connectionKey,
+          resolvedTarget,
+          remotePort,
+        });
+        if (portForwardsClosed || portForwards.get(key) !== entry) {
+          yield* closePortForwardEntry(entry);
+          return yield* makeSshTunnelCancelledError(resolvedTarget);
+        }
+        nextPortForwardLeaseId += 1;
+        const leaseId = `ssh-port-forward-${nextPortForwardLeaseId}`;
+        entry.leases.add(leaseId);
+        portForwardLeases.set(leaseId, entry);
+        yield* Effect.logInfo("ssh.portForward.acquired", {
+          ...sshTargetLogFields(entry.target),
+          leaseId,
+          localPort: entry.localPort,
+          remotePort: entry.remotePort,
+          references: entry.leases.size,
+        });
+        return {
+          leaseId,
+          localPort: entry.localPort,
+          remotePort: entry.remotePort,
+        };
+      }),
+    );
   });
 
   const releasePortForward = Effect.fn("ssh/tunnel.releasePortForward")(function* (
     leaseId: string,
   ) {
-    const entry = portForwardLeases.get(leaseId);
-    if (entry === undefined) {
-      return;
-    }
-    portForwardLeases.delete(leaseId);
-    entry.leases.delete(leaseId);
-    yield* Effect.logInfo("ssh.portForward.released", {
-      ...sshTargetLogFields(entry.target),
-      leaseId,
-      localPort: entry.localPort,
-      remotePort: entry.remotePort,
-      references: entry.leases.size,
-    });
-    if (entry.leases.size === 0) {
-      yield* closePortForwardEntry(entry);
-    }
+    yield* portForwardLock.withPermit(
+      Effect.gen(function* () {
+        const entry = portForwardLeases.get(leaseId);
+        if (entry === undefined) {
+          return;
+        }
+        portForwardLeases.delete(leaseId);
+        entry.leases.delete(leaseId);
+        yield* Effect.logInfo("ssh.portForward.released", {
+          ...sshTargetLogFields(entry.target),
+          leaseId,
+          localPort: entry.localPort,
+          remotePort: entry.remotePort,
+          references: entry.leases.size,
+        });
+        if (entry.leases.size === 0) {
+          yield* closePortForwardEntry(entry);
+        }
+      }),
+    );
   });
 
   const ensureEnvironment = Effect.fn("ssh/tunnel.ensureEnvironment")(function* (
@@ -1853,29 +1909,32 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     yield* Effect.logInfo("ssh.environment.disconnect.start", sshTargetLogFields(target));
     const resolvedTarget = yield* resolveManagerTarget(target);
     const key = targetConnectionKey(resolvedTarget);
-    const forwardEntries = [...portForwards.values()].filter(
-      (entry) => entry.connectionKey === key,
-    );
     const pendingForwardKeys = [...pendingPortForwards.keys()].filter((forwardKey) =>
       forwardKey.startsWith(`${key}\0`),
     );
+    const forwardEntryCount = [...portForwards.values()].filter(
+      (entry) => entry.connectionKey === key,
+    ).length;
     const entry = tunnels.get(key) ?? null;
     yield* Effect.logDebug("ssh.environment.disconnect.targetResolved", {
       ...sshTargetLogFields(resolvedTarget),
       key,
       hasTunnel: entry !== null,
       hasPendingTunnel: pendingTunnelEntries.has(key),
-      portForwards: forwardEntries.length,
+      portForwards: forwardEntryCount,
       pendingPortForwards: pendingForwardKeys.length,
-    });
-    yield* Effect.forEach(forwardEntries, closePortForwardEntry, {
-      concurrency: "unbounded",
-      discard: true,
     });
     yield* Effect.forEach(
       pendingForwardKeys,
       (forwardKey) => cancelPendingPortForward(forwardKey, resolvedTarget),
       { concurrency: "unbounded", discard: true },
+    );
+    yield* portForwardLock.withPermit(
+      Effect.forEach(
+        [...portForwards.values()].filter((forwardEntry) => forwardEntry.connectionKey === key),
+        closePortForwardEntry,
+        { concurrency: "unbounded", discard: true },
+      ),
     );
     if (entry !== null) {
       yield* closeTunnelEntry(entry);

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -14,6 +14,7 @@ import * as Deferred from "effect/Deferred";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
@@ -91,6 +92,7 @@ interface SshPortForwardEntry extends SshTunnelEntry {
 interface PendingSshPortForward {
   readonly deferred: Deferred.Deferred<SshPortForwardEntry, SshEnvironmentEffectError>;
   readonly target: DesktopSshEnvironmentTarget;
+  creatorFiber: Fiber.Fiber<SshPortForwardEntry, SshEnvironmentEffectError> | null;
 }
 
 export interface SshPortForwardLease {
@@ -1302,6 +1304,9 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     }
     pendingPortForwards.delete(key);
     yield* Deferred.fail(pending.deferred, makeSshTunnelCancelledError(target)).pipe(Effect.ignore);
+    if (pending.creatorFiber !== null) {
+      yield* Fiber.interrupt(pending.creatorFiber);
+    }
   });
 
   yield* Scope.addFinalizer(
@@ -1745,9 +1750,10 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     const pendingEntry: PendingSshPortForward = {
       deferred,
       target: input.resolvedTarget,
+      creatorFiber: null,
     };
     pendingPortForwards.set(input.key, pendingEntry);
-    return yield* createPortForwardEntry(input).pipe(
+    const creatorFiber = yield* createPortForwardEntry(input).pipe(
       Effect.flatMap((entry) => {
         if (pendingPortForwards.get(input.key) !== pendingEntry) {
           return closePortForwardEntry(entry).pipe(
@@ -1770,9 +1776,21 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
           if (pendingPortForwards.get(input.key) === pendingEntry) {
             pendingPortForwards.delete(input.key);
           }
-        }).pipe(Effect.andThen(Deferred.done(deferred, exit))),
+        }).pipe(
+          Effect.andThen(
+            Exit.hasInterrupts(exit)
+              ? Deferred.fail(deferred, makeSshTunnelCancelledError(input.resolvedTarget))
+              : Deferred.done(deferred, exit),
+          ),
+        ),
       ),
+      Effect.forkIn(managerScope, { startImmediately: true }),
     );
+    pendingEntry.creatorFiber = creatorFiber;
+    if (pendingPortForwards.get(input.key) !== pendingEntry) {
+      yield* Fiber.interrupt(creatorFiber);
+    }
+    return yield* Deferred.await(deferred);
   });
 
   const acquirePortForward = Effect.fn("ssh/tunnel.acquirePortForward")(function* (

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -1645,6 +1645,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
   const createPortForwardEntry = Effect.fn("ssh/tunnel.portForward.create")(function* (input: {
     readonly key: string;
     readonly connectionKey: string;
+    readonly entryScope: Scope.Closeable;
     readonly resolvedTarget: DesktopSshEnvironmentTarget;
     readonly remotePort: number;
   }): Effect.fn.Return<
@@ -1655,60 +1656,52 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     const localPort = yield* reserveLocalTunnelPort();
     const httpBaseUrl = `http://127.0.0.1:${localPort}/`;
     const wsBaseUrl = `ws://127.0.0.1:${localPort}/`;
-    return yield* Effect.acquireUseRelease(
-      Scope.make("sequential"),
-      (entryScope) =>
-        Effect.gen(function* () {
-          const tunnelEntry = yield* runWithSshAuth({
-            key: input.connectionKey,
-            target: input.resolvedTarget,
-            operation: (authOptions) =>
-              startSshTunnel({
-                key: input.key,
-                resolvedTarget: input.resolvedTarget,
-                remotePort: input.remotePort,
-                localPort,
-                httpBaseUrl,
-                wsBaseUrl,
-                authOptions,
-                remoteServerKind: null,
-                readiness: "tcp",
-              }).pipe(Effect.provideService(Scope.Scope, entryScope)),
-          });
-          const entry: SshPortForwardEntry = {
-            ...tunnelEntry,
-            connectionKey: input.connectionKey,
-            leases: new Set(),
-          };
-          yield* Scope.addFinalizer(
-            entryScope,
-            Effect.gen(function* () {
-              if (portForwards.get(entry.key) === entry) {
-                portForwards.delete(entry.key);
-              }
-              for (const leaseId of entry.leases) {
-                portForwardLeases.delete(leaseId);
-              }
-              entry.leases.clear();
-              yield* entry.process
-                .kill({
-                  killSignal: "SIGTERM",
-                  forceKillAfter: TUNNEL_SHUTDOWN_TIMEOUT_MS,
-                })
-                .pipe(Effect.ignore);
-            }),
-          );
-          yield* Effect.logInfo("ssh.portForward.create.succeeded", {
-            ...sshTargetLogFields(entry.target),
-            key: entry.key,
-            localPort: entry.localPort,
-            remotePort: entry.remotePort,
-          });
-          return entry;
-        }),
-      (entryScope, exit) =>
-        Exit.isSuccess(exit) ? Effect.void : Scope.close(entryScope, Exit.void).pipe(Effect.ignore),
+    const tunnelEntry = yield* runWithSshAuth({
+      key: input.connectionKey,
+      target: input.resolvedTarget,
+      operation: (authOptions) =>
+        startSshTunnel({
+          key: input.key,
+          resolvedTarget: input.resolvedTarget,
+          remotePort: input.remotePort,
+          localPort,
+          httpBaseUrl,
+          wsBaseUrl,
+          authOptions,
+          remoteServerKind: null,
+          readiness: "tcp",
+        }).pipe(Effect.provideService(Scope.Scope, input.entryScope)),
+    });
+    const entry: SshPortForwardEntry = {
+      ...tunnelEntry,
+      connectionKey: input.connectionKey,
+      leases: new Set(),
+    };
+    yield* Scope.addFinalizer(
+      input.entryScope,
+      Effect.gen(function* () {
+        if (portForwards.get(entry.key) === entry) {
+          portForwards.delete(entry.key);
+        }
+        for (const leaseId of entry.leases) {
+          portForwardLeases.delete(leaseId);
+        }
+        entry.leases.clear();
+        yield* entry.process
+          .kill({
+            killSignal: "SIGTERM",
+            forceKillAfter: TUNNEL_SHUTDOWN_TIMEOUT_MS,
+          })
+          .pipe(Effect.ignore);
+      }),
     );
+    yield* Effect.logInfo("ssh.portForward.create.succeeded", {
+      ...sshTargetLogFields(entry.target),
+      key: entry.key,
+      localPort: entry.localPort,
+      remotePort: entry.remotePort,
+    });
+    return entry;
   });
 
   const ensurePortForwardEntry = Effect.fn("ssh/tunnel.portForward.ensure")(function* (input: {
@@ -1753,16 +1746,21 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       creatorFiber: null,
     };
     pendingPortForwards.set(input.key, pendingEntry);
-    const creatorFiber = yield* createPortForwardEntry(input).pipe(
-      Effect.flatMap((entry) => {
-        if (pendingPortForwards.get(input.key) !== pendingEntry) {
-          return closePortForwardEntry(entry).pipe(
-            Effect.andThen(Effect.fail(makeSshTunnelCancelledError(input.resolvedTarget))),
-          );
-        }
-        portForwards.set(input.key, entry);
-        return Effect.succeed(entry);
-      }),
+    const creatorFiber = yield* Effect.acquireUseRelease(
+      Scope.make("sequential"),
+      (entryScope) =>
+        createPortForwardEntry({ ...input, entryScope }).pipe(
+          Effect.flatMap((entry) => {
+            if (pendingPortForwards.get(input.key) !== pendingEntry) {
+              return Effect.fail(makeSshTunnelCancelledError(input.resolvedTarget));
+            }
+            portForwards.set(input.key, entry);
+            return Effect.succeed(entry);
+          }),
+        ),
+      (entryScope, exit) =>
+        Exit.isSuccess(exit) ? Effect.void : Scope.close(entryScope, Exit.void).pipe(Effect.ignore),
+    ).pipe(
       Effect.tapError((cause) =>
         Effect.logWarning("ssh.portForward.create.failed", {
           ...sshTargetLogFields(input.resolvedTarget),


### PR DESCRIPTION
This is a companion fix for #4039 and targets its feature branch. Review feedback identified lifecycle races that could leak SSH forwards or let stale navigation state replace newer routes.

The change:

- waits for OpenSSH's forward-ready signal instead of accepting any listener on the reserved port
- serializes forward reuse and final lease release
- cancels pending forwards during manager shutdown and closes interrupted setup scopes
- closes ready forwards if setup is interrupted before registration
- makes newer tab navigations win while keeping routes alive until in-flight work finishes
- releases routes after authoritative tab removal and environment removal
- interrupts pending SSH setup before shutdown waits on the forwarding lock
- keeps environment-owned route cleanup inside the caller's Effect runtime
- points preview-close consumers at the canonical route lifecycle module
- routes clickable terminal links through the environment port router
- resolves preview forward targets through remote `localhost` for IPv4 and IPv6 dev servers
- treats interrupted route acquisition as cancellation instead of opening a useless browser tab

Validation:

- `vp test run packages/ssh/src/tunnel.test.ts apps/web/src/browser/browserNavigationRoutes.test.ts apps/web/src/previewStateStore.test.ts apps/web/src/components/preview/closePreviewSession.test.ts` (44 tests passed)
- `vp run --log grouped -F @t3tools/web -F @t3tools/ssh typecheck`
- focused terminal-link and SSH forwarding regression suites
- targeted formatting and lint for the changed files
- direct Nova-to-Showtime SSH forwarding smoke test returned HTTP 200
- `git diff --check`

Produced by GPT-5.6 Sol in Codex through T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix SSH port-forward race conditions and centralize browser navigation route lifecycle
> - Adds a `Semaphore` to `SshEnvironmentManager.make` in [tunnel.ts](https://github.com/pingdotgg/t3code/pull/7639/files#diff-7338be65675ab0699d0c8c6426e54f3421747885231f9bbb0ace4ec129cb2072) so port-forward acquire/release are serialized, pending creations are canceled on shutdown, and resources are not leaked or resurrected after manager close.
> - Replaces TCP listener readiness polling with `waitForSshForwardReady`, which tails SSH stderr for the bound-port readiness line, avoiding false positives from unrelated local listeners.
> - Introduces centralized managed routes in [browserNavigationRoutes.ts](https://github.com/pingdotgg/t3code/pull/7639/files#diff-2dc58f4c7088ab43a5bfead01b019c6a83a1229064df67de83865bb698089465) with per-tab generation ordering so newer navigations replace older ones, only ssh-forward routes stay active, and retired routes defer closure until in-flight use finishes.
> - Updates [previewStateStore.ts](https://github.com/pingdotgg/t3code/pull/7639/files#diff-19016f363ca68fddd6b79d0f335f7f9326088012252aa66466c2fd609178851d) and [platform.ts](https://github.com/pingdotgg/t3code/pull/7639/files#diff-11f2bf026d367970576edae81c8c89f388524df2325db0c3dfb4b953437fbc4c) to release browser routes when tabs close, snapshots clear, sessions reconcile, threads remove, or environments clean up.
> - Risk: `acquireBrowserNavigationTarget` now throws `BrowserNavigationRouteAcquireInterrupted` on stale environment versions; callers like `openTerminalLinkInPreview` silently exit instead of falling back to the browser on interruption.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c20acc8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches SSH tunnel lifecycle and preview navigation ownership, where races can leak forwards or drop live routes. Readiness now depends on OpenSSH verbose stderr, so mismatched SSH output can fail or delay forwards.
> 
> **Overview**
> Fixes SSH preview-forward leaks and stale-navigation races by coordinating route lifetime per tab and tightening tunnel setup/teardown.
> 
> **Preview routes** now live in `browserNavigationRoutes`: newer navigations win, replaced/removed routes stay open until in-flight work finishes, and environment cleanup invalidates in-progress acquisitions. Preview state, session close, and terminal-link open now acquire/commit/release through that module (including interrupt-safe fallbacks).
> 
> **SSH port forwards** wait for OpenSSH’s `Local forwarding listening…` stderr line instead of any local listener, serialize acquire/release with a lock, and cancel pending setup on manager shutdown so interrupted tunnels actually die. Preview forwards bind `localhost` on the remote side and spawn with `-v`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c20acc8796c33b1a14052323dbf940fb5faebac8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->