### PR TITLE
fix(desktop): keep remote connections available during idle sleep

### DIFF
--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -22,6 +22,7 @@ import * as DesktopLinuxUrlHandler from "./DesktopLinuxUrlHandler.ts";
 import * as DesktopObservability from "./DesktopObservability.ts";
 import * as DesktopPreReadyPlatform from "./DesktopPreReadyPlatform.ts";
 import * as DesktopShutdown from "./DesktopShutdown.ts";
+import * as DesktopSleepPrevention from "./DesktopSleepPrevention.ts";
 import * as DesktopServerExposure from "../backend/DesktopServerExposure.ts";
 import * as DesktopAppSettings from "../settings/DesktopAppSettings.ts";
 import * as DesktopShellEnvironment from "../shell/DesktopShellEnvironment.ts";
@@ -149,6 +150,8 @@ const bootstrap = Effect.gen(function* () {
   const wslBackend = yield* DesktopWslBackend.DesktopWslBackend;
   const desktopWindow = yield* DesktopWindow.DesktopWindow;
   yield* logBootstrapInfo("bootstrap start");
+
+  yield* DesktopSleepPrevention.restore();
 
   if (environment.isDevelopment && Option.isNone(environment.configuredBackendPort)) {
     return yield* new DesktopDevelopmentBackendPortRequiredError();

--- a/apps/desktop/src/app/DesktopSleepPrevention.test.ts
+++ b/apps/desktop/src/app/DesktopSleepPrevention.test.ts
@@ -1,0 +1,69 @@
+import { DEFAULT_CLIENT_SETTINGS } from "@t3tools/contracts";
+import { assert, describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+
+import * as ElectronPowerSaveBlocker from "../electron/ElectronPowerSaveBlocker.ts";
+import { setClientSettings } from "../ipc/methods/clientSettings.ts";
+import * as DesktopClientSettings from "../settings/DesktopClientSettings.ts";
+import * as DesktopSleepPrevention from "./DesktopSleepPrevention.ts";
+
+function makeTestLayer(initiallyEnabled: boolean) {
+  const calls: string[] = [];
+  const started = new Set<number>();
+  let nextId = 0;
+  const powerSaveBlocker = ElectronPowerSaveBlocker.make({
+    start: (type) => {
+      const id = nextId++;
+      started.add(id);
+      calls.push(`start:${type}:${id}`);
+      return id;
+    },
+    stop: (id) => {
+      calls.push(`stop:${id}`);
+      return started.delete(id);
+    },
+    isStarted: (id) => started.has(id),
+  });
+  const settings = {
+    ...DEFAULT_CLIENT_SETTINGS,
+    preventSleepForRemoteConnections: initiallyEnabled,
+  };
+
+  return {
+    calls,
+    layer: Layer.mergeAll(
+      DesktopClientSettings.layerTest(Option.some(settings)),
+      Layer.succeed(ElectronPowerSaveBlocker.ElectronPowerSaveBlocker, powerSaveBlocker),
+    ),
+  };
+}
+
+describe("DesktopSleepPrevention", () => {
+  it.effect("restores the persisted assertion before a renderer is involved", () => {
+    const { calls, layer } = makeTestLayer(true);
+
+    return Effect.gen(function* () {
+      yield* DesktopSleepPrevention.restore();
+      assert.deepStrictEqual(calls, ["start:prevent-app-suspension:0"]);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.effect("applies preference changes after the desktop settings write", () => {
+    const { calls, layer } = makeTestLayer(false);
+    const enabledSettings = {
+      ...DEFAULT_CLIENT_SETTINGS,
+      preventSleepForRemoteConnections: true,
+    };
+
+    return Effect.gen(function* () {
+      yield* setClientSettings.handler(enabledSettings);
+
+      const clientSettings = yield* DesktopClientSettings.DesktopClientSettings;
+      const persistedSettings = yield* clientSettings.get;
+      assert.isTrue(Option.getOrThrow(persistedSettings).preventSleepForRemoteConnections);
+      assert.deepStrictEqual(calls, ["start:prevent-app-suspension:0"]);
+    }).pipe(Effect.provide(layer));
+  });
+});

--- a/apps/desktop/src/app/DesktopSleepPrevention.ts
+++ b/apps/desktop/src/app/DesktopSleepPrevention.ts
@@ -1,0 +1,20 @@
+import { DEFAULT_CLIENT_SETTINGS, type ClientSettings } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+
+import * as ElectronPowerSaveBlocker from "../electron/ElectronPowerSaveBlocker.ts";
+import * as DesktopClientSettings from "../settings/DesktopClientSettings.ts";
+
+export const applyClientSettings = Effect.fn("desktop.sleepPrevention.applyClientSettings")(
+  function* (settings: ClientSettings) {
+    const powerSaveBlocker = yield* ElectronPowerSaveBlocker.ElectronPowerSaveBlocker;
+    yield* powerSaveBlocker.setKeepAwake(settings.preventSleepForRemoteConnections);
+  },
+);
+
+/** Restore the assertion before the backend starts, independently of a window. */
+export const restore = Effect.fn("desktop.sleepPrevention.restore")(function* () {
+  const clientSettings = yield* DesktopClientSettings.DesktopClientSettings;
+  const persistedSettings = yield* clientSettings.get;
+  yield* applyClientSettings(Option.getOrElse(persistedSettings, () => DEFAULT_CLIENT_SETTINGS));
+});

--- a/apps/desktop/src/electron/ElectronPowerSaveBlocker.test.ts
+++ b/apps/desktop/src/electron/ElectronPowerSaveBlocker.test.ts
@@ -1,0 +1,69 @@
+import { assert, describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+import * as ElectronPowerSaveBlocker from "./ElectronPowerSaveBlocker.ts";
+
+function makeStubApi() {
+  const calls: string[] = [];
+  const started = new Set<number>();
+  let nextId = 0;
+  const api: ElectronPowerSaveBlocker.PowerSaveBlockerApi = {
+    start: (type) => {
+      const id = nextId++;
+      started.add(id);
+      calls.push(`start:${type}:${id}`);
+      return id;
+    },
+    stop: (id) => {
+      calls.push(`stop:${id}`);
+      return started.delete(id);
+    },
+    isStarted: (id) => started.has(id),
+  };
+  return { api, calls, started };
+}
+
+describe("ElectronPowerSaveBlocker", () => {
+  it.effect("holds one prevent-app-suspension assertion idempotently", () =>
+    Effect.gen(function* () {
+      const { api, calls, started } = makeStubApi();
+      const service = ElectronPowerSaveBlocker.make(api);
+
+      yield* service.setKeepAwake(true);
+      yield* service.setKeepAwake(true);
+
+      assert.deepStrictEqual(calls, ["start:prevent-app-suspension:0"]);
+      assert.strictEqual(started.size, 1);
+    }),
+  );
+
+  it.effect("releases the held assertion idempotently", () =>
+    Effect.gen(function* () {
+      const { api, calls, started } = makeStubApi();
+      const service = ElectronPowerSaveBlocker.make(api);
+
+      yield* service.setKeepAwake(true);
+      yield* service.setKeepAwake(false);
+      yield* service.setKeepAwake(false);
+
+      assert.deepStrictEqual(calls, ["start:prevent-app-suspension:0", "stop:0"]);
+      assert.strictEqual(started.size, 0);
+    }),
+  );
+
+  it.effect("reacquires an assertion Electron no longer reports as active", () =>
+    Effect.gen(function* () {
+      const { api, calls, started } = makeStubApi();
+      const service = ElectronPowerSaveBlocker.make(api);
+
+      yield* service.setKeepAwake(true);
+      started.clear();
+      yield* service.setKeepAwake(true);
+
+      assert.deepStrictEqual(calls, [
+        "start:prevent-app-suspension:0",
+        "start:prevent-app-suspension:1",
+      ]);
+    }),
+  );
+});

--- a/apps/desktop/src/electron/ElectronPowerSaveBlocker.ts
+++ b/apps/desktop/src/electron/ElectronPowerSaveBlocker.ts
@@ -1,0 +1,47 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import * as Electron from "electron";
+
+/** The Electron API subset used by this service, kept injectable for tests. */
+export interface PowerSaveBlockerApi {
+  start(type: "prevent-app-suspension" | "prevent-display-sleep"): number;
+  stop(id: number): boolean;
+  isStarted(id: number): boolean;
+}
+
+/**
+ * Owns the process-wide assertion that lets the display turn off while
+ * preventing automatic system sleep. The OS releases it when T3 Code exits.
+ */
+export class ElectronPowerSaveBlocker extends Context.Service<
+  ElectronPowerSaveBlocker,
+  {
+    readonly setKeepAwake: (keepAwake: boolean) => Effect.Effect<void>;
+  }
+>()("@t3tools/desktop/electron/ElectronPowerSaveBlocker") {}
+
+export const make = (api: PowerSaveBlockerApi): ElectronPowerSaveBlocker["Service"] => {
+  let blockerId: number | null = null;
+
+  const isHeld = () => blockerId !== null && api.isStarted(blockerId);
+
+  return ElectronPowerSaveBlocker.of({
+    setKeepAwake: (keepAwake) =>
+      Effect.sync(() => {
+        if (keepAwake) {
+          if (!isHeld()) {
+            blockerId = api.start("prevent-app-suspension");
+          }
+          return;
+        }
+        if (blockerId !== null && api.isStarted(blockerId)) {
+          api.stop(blockerId);
+        }
+        blockerId = null;
+      }),
+  });
+};
+
+export const layer = Layer.sync(ElectronPowerSaveBlocker, () => make(Electron.powerSaveBlocker));

--- a/apps/desktop/src/ipc/methods/clientSettings.ts
+++ b/apps/desktop/src/ipc/methods/clientSettings.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 
+import * as DesktopSleepPrevention from "../../app/DesktopSleepPrevention.ts";
 import * as DesktopClientSettings from "../../settings/DesktopClientSettings.ts";
 import * as IpcChannels from "../channels.ts";
 import * as DesktopIpc from "../DesktopIpc.ts";
@@ -24,5 +25,6 @@ export const setClientSettings = DesktopIpc.makeIpcMethod({
   handler: Effect.fn("desktop.ipc.clientSettings.set")(function* (settings) {
     const clientSettings = yield* DesktopClientSettings.DesktopClientSettings;
     yield* clientSettings.set(settings);
+    yield* DesktopSleepPrevention.applyClientSettings(settings);
   }),
 });

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -25,6 +25,7 @@ import * as ElectronApp from "./electron/ElectronApp.ts";
 import * as ElectronDialog from "./electron/ElectronDialog.ts";
 import * as ElectronMenu from "./electron/ElectronMenu.ts";
 import * as ElectronPowerMonitor from "./electron/ElectronPowerMonitor.ts";
+import * as ElectronPowerSaveBlocker from "./electron/ElectronPowerSaveBlocker.ts";
 import * as ElectronProtocol from "./electron/ElectronProtocol.ts";
 import * as ElectronSafeStorage from "./electron/ElectronSafeStorage.ts";
 import * as ElectronShell from "./electron/ElectronShell.ts";
@@ -119,6 +120,7 @@ const electronLayer = Layer.mergeAll(
   ElectronDialog.layer,
   ElectronMenu.layer,
   ElectronPowerMonitor.layer,
+  ElectronPowerSaveBlocker.layer,
   ElectronProtocol.layer,
   ElectronSafeStorage.layer,
   ElectronShell.layer,

--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -18,6 +18,7 @@ const clientSettings: ClientSettings = {
   browserDefaultAppearance: "dark",
   browserAutoShowFloatingPreview: false,
   confirmQuit: true,
+  preventSleepForRemoteConnections: false,
   confirmThreadArchive: true,
   confirmThreadDelete: false,
   dismissedProviderUpdateNotificationKeys: [],

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -19,6 +19,7 @@ import {
   AuthStandardClientScopes,
   AuthTerminalOperateScope,
   type AuthClientSession,
+  type ClientSettings,
   type AuthEnvironmentScope,
   type AuthPairingLink,
   type AdvertisedEndpoint,
@@ -37,6 +38,7 @@ import * as DateTime from "effect/DateTime";
 import * as Option from "effect/Option";
 
 import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
+import { useClientSettings, useUpdateClientSettings } from "../../hooks/useSettings";
 import { cn } from "../../lib/utils";
 import { formatElapsedDurationLabel, formatExpiresInLabel } from "../../timestampFormat";
 import { resolveDesktopPairingUrl, resolveHostedPairingUrl } from "./pairingUrls";
@@ -1707,6 +1709,39 @@ function CloudLinkRow({ canManageRelay }: { readonly canManageRelay: boolean }) 
   return hasCloudPublicConfig() ? <ConfiguredCloudLinkRow canManageRelay={canManageRelay} /> : null;
 }
 
+const selectPreventSleepForRemoteConnections = (settings: ClientSettings) =>
+  settings.preventSleepForRemoteConnections;
+
+function DesktopSleepPreventionRow() {
+  const preventSleepForRemoteConnections = useClientSettings(
+    selectPreventSleepForRemoteConnections,
+  );
+  const updateClientSettings = useUpdateClientSettings();
+
+  return (
+    <SettingsRow
+      {...searchableSetting("prevent-automatic-sleep")}
+      description="Keep this computer available to remote clients by preventing automatic idle sleep while T3 Code runs. The display may turn off; closing a laptop lid can still sleep it."
+      status={
+        preventSleepForRemoteConnections ? null : (
+          <span className="block text-warning">
+            Remote connections can become unavailable when this computer sleeps.
+          </span>
+        )
+      }
+      control={
+        <Switch
+          checked={preventSleepForRemoteConnections}
+          onCheckedChange={(checked) =>
+            updateClientSettings({ preventSleepForRemoteConnections: Boolean(checked) })
+          }
+          aria-label="Prevent automatic sleep for remote connections"
+        />
+      }
+    />
+  );
+}
+
 function EmptyRemoteEnvironments({ cloudEnabled = true }: { readonly cloudEnabled?: boolean }) {
   return (
     <Empty className="min-h-52">
@@ -3062,6 +3097,7 @@ export function ConnectionsSettings() {
             ) : null}
             {desktopBridge ? (
               <>
+                <DesktopSleepPreventionRow />
                 {renderNetworkAccessRow()}
                 {renderEndpointRows("endpoint-rail")}
                 {renderTailscaleRow()}

--- a/apps/web/src/components/settings/settingsSearch.test.ts
+++ b/apps/web/src/components/settings/settingsSearch.test.ts
@@ -62,7 +62,9 @@ describe("searchSettings", () => {
 
   it("hides desktop-only settings from browser search", () => {
     expect(SETTINGS_SEARCH_ITEMS.some((item) => item.id === "quit-confirmation")).toBe(true);
+    expect(SETTINGS_SEARCH_ITEMS.some((item) => item.id === "prevent-automatic-sleep")).toBe(true);
     expect(searchSettings("quit confirmation")).toEqual([]);
+    expect(searchSettings("prevent automatic sleep")).toEqual([]);
   });
 
   it("keeps catalog result ids unique", () => {
@@ -73,6 +75,10 @@ describe("searchSettings", () => {
   it("serves anchor props to panels from the catalog", () => {
     expect(searchableSetting("word-wrap")).toEqual({ id: "word-wrap", title: "Word wrap" });
     expect(searchableSetting("archive")).toEqual({ id: "archive", title: "Archived threads" });
+    expect(searchableSetting("prevent-automatic-sleep")).toEqual({
+      id: "prevent-automatic-sleep",
+      title: "Prevent automatic sleep",
+    });
   });
 
   it("routes appearance settings to their current section", () => {

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -238,6 +238,12 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/connections",
   },
   {
+    id: "prevent-automatic-sleep",
+    title: "Prevent automatic sleep",
+    to: "/settings/connections",
+    desktopOnly: true,
+  },
+  {
     id: "archive",
     title: "Archived threads",
     to: "/settings/archived",

--- a/docs/user/remote-access.md
+++ b/docs/user/remote-access.md
@@ -32,6 +32,16 @@ That gives you:
 - transport security at the network layer
 - less exposure than opening the server to the public internet
 
+## Keeping the Desktop Host Awake
+
+In the desktop app, open **Settings** → **Connections** and turn on **Prevent automatic sleep**
+when this computer should remain available to remote clients. T3 Code then holds the operating
+system's native sleep-prevention assertion for as long as the desktop app is running. You do not
+need to run `caffeinate` or change the computer's system sleep schedule.
+
+The display can still turn off. Manually choosing Sleep or closing a laptop lid can still put the
+computer to sleep, which makes its T3 Code environment unavailable until the computer wakes.
+
 ## Enabling Network Access
 
 There are three ways to reach your server from another device: expose the desktop app's backend,
@@ -43,8 +53,9 @@ If you are already running the desktop app and want to make it reachable from ot
 
 1. Open **Settings** → **Connections**.
 2. Under **This environment**, toggle **Network access** on. This will restart the app and run the backend on all network interfaces.
-3. The settings panel will show the default reachable endpoint, with a `+N` control when more endpoints are available. Expand it to inspect alternatives such as loopback, LAN, private-network, or HTTPS endpoints.
-4. Use **Create Link** to generate a pairing link you can share with another device.
+3. Turn on **Prevent automatic sleep** if this computer should stay reachable while unattended.
+4. The settings panel will show the default reachable endpoint, with a `+N` control when more endpoints are available. Expand it to inspect alternatives such as loopback, LAN, private-network, or HTTPS endpoints.
+5. Use **Create Link** to generate a pairing link you can share with another device.
 
 The default endpoint controls the QR code and primary copy action for pairing links. You can change it from the expanded endpoint list. The preference is stored by endpoint type, so choosing the local LAN endpoint survives normal IP address changes when you move between networks.
 

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -35,6 +35,20 @@ describe("ClientSettings word wrap", () => {
   });
 });
 
+describe("ClientSettings remote connection sleep prevention", () => {
+  it("defaults off and preserves an explicit desktop preference", () => {
+    expect(decodeClientSettings({}).preventSleepForRemoteConnections).toBe(false);
+    expect(
+      decodeClientSettings({ preventSleepForRemoteConnections: true })
+        .preventSleepForRemoteConnections,
+    ).toBe(true);
+    expect(
+      decodeClientSettingsPatch({ preventSleepForRemoteConnections: true })
+        .preventSleepForRemoteConnections,
+    ).toBe(true);
+  });
+});
+
 describe("ClientSettings glass opacity", () => {
   it("defaults to a readable translucent surface", () => {
     expect(decodeClientSettings({}).glassOpacity).toBe(80);

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -154,6 +154,12 @@ export const ClientSettingsSchema = Schema.Struct({
   // Desktop-only: require holding the quit shortcut (Cmd/Ctrl+Q) before the
   // app quits; a quick tap only shows a hint. Browser clients ignore it.
   confirmQuit: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  // Desktop-only: hold a native system sleep-prevention assertion while T3
+  // Code is running so a remote client can continue reaching this machine.
+  // This is opt-in because it changes the host's power behavior.
+  preventSleepForRemoteConnections: Schema.Boolean.pipe(
+    Schema.withDecodingDefault(Effect.succeed(false)),
+  ),
   confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   confirmThreadDelete: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   dismissedProviderUpdateNotificationKeys: Schema.Array(TrimmedNonEmptyString).pipe(
@@ -866,6 +872,7 @@ export const ClientSettingsPatch = Schema.Struct({
   browserDefaultAppearance: Schema.optionalKey(PreviewAppearancePreference),
   browserAutoShowFloatingPreview: Schema.optionalKey(Schema.Boolean),
   confirmQuit: Schema.optionalKey(Schema.Boolean),
+  preventSleepForRemoteConnections: Schema.optionalKey(Schema.Boolean),
   confirmThreadArchive: Schema.optionalKey(Schema.Boolean),
   confirmThreadDelete: Schema.optionalKey(Schema.Boolean),
   diffIgnoreWhitespace: Schema.optionalKey(Schema.Boolean),


### PR DESCRIPTION
## Summary

Remote clients lose access when the desktop host enters automatic idle sleep. This adds a desktop-owned, opt-in sleep-prevention assertion so T3 Code can keep the host reachable without requiring users to configure macOS separately.

- add a persisted desktop-only `Prevent automatic sleep` setting under **Settings → Connections → This environment**
- show a persistent amber warning while protection is off
- own Electron's `prevent-app-suspension` blocker in the main process, restore it before the backend starts, and keep it active when the window is closed
- release the assertion immediately when disabled and automatically when T3 Code exits
- document that the display may still turn off and lid-close/manual sleep can still suspend the Mac

The setting defaults off because it changes host power behavior.

This complements and credits #5535 by @leo-mathurin, whose low-level Electron blocker pattern this adapts. That draft protects active local agent turns; this PR covers the distinct remote-host lifecycle, including idle periods with no active turn or open window so iOS clients can reconnect.

## Visual verification

### Before

![Connections settings before sleep prevention](https://raw.githubusercontent.com/ChrisMarstaller/t3code/pr-assets-remote-sleep-20260820/pr-assets/remote-sleep/before.jpg)

### After — protection off

![Persistent warning while sleep prevention is off](https://raw.githubusercontent.com/ChrisMarstaller/t3code/pr-assets-remote-sleep-20260820/pr-assets/remote-sleep/after-off.jpg)

### After — protection enabled and restored after restart

![Sleep prevention enabled](https://raw.githubusercontent.com/ChrisMarstaller/t3code/pr-assets-remote-sleep-20260820/pr-assets/remote-sleep/after-on.jpg)

## Verification

- targeted contracts, desktop service/IPC, settings search, and local API tests pass
- targeted contracts, desktop, and web typechecks pass
- targeted lint on changed TypeScript/TSX files passes
- desktop pack and web production build pass
- `git diff --check` and merge-tree against current `origin/main` pass
- isolated macOS desktop run:
  - baseline had no T3 Code-owned power assertion
  - enabling the setting created an Electron `NoIdleSleepAssertion`
  - the assertion restored on relaunch before the backend became available
  - the assertion and backend listener remained active after the main window closed
  - disabling the setting removed the assertion while the backend stayed online
  - exiting T3 Code released the assertion

Implemented by Codex (GPT-5) using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to desktop power behavior and client settings; defaults off and uses well-tested Electron APIs with unit tests for the blocker and restore path.
> 
> **Overview**
> Adds an **opt-in, desktop-only** way to keep a T3 Code host reachable when it would otherwise idle-sleep, so remote clients stay connected without manual OS tweaks.
> 
> A new persisted client setting `preventSleepForRemoteConnections` (defaults **off**) is exposed in **Settings → Connections** as **Prevent automatic sleep**, with a warning when it is disabled. The main process owns a single idempotent Electron `prevent-app-suspension` assertion via `ElectronPowerSaveBlocker`, restores it during bootstrap before the backend starts, and reapplies it when client settings are saved over IPC.
> 
> User docs for remote access describe the toggle and clarify that the display may still turn off and lid-close/manual sleep can still suspend the machine.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c81f45f6a9114c56635b813217ef5669982b97f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `preventSleepForRemoteConnections` setting to keep remote connections alive during idle sleep
> - Adds `ElectronPowerSaveBlocker` service wrapping Electron's `powerSaveBlocker` API with idempotent hold/release and recovery when the assertion is lost.
> - Introduces `preventSleepForRemoteConnections` boolean field on `ClientSettings` (default `false`) and a patch key for partial updates.
> - `DesktopSleepPrevention.applyClientSettings` effect toggles the OS sleep-prevention assertion based on the setting; `restore` re-applies persisted settings at bootstrap before other init.
> - IPC `clientSettings.set` handler calls `applyClientSettings` after persisting so toggle takes effect immediately.
> - Adds a desktop-only toggle row in Connections settings and a corresponding settings search entry.
> - Behavioral Change: `DesktopApp` bootstrap now calls `DesktopSleepPrevention.restore()` before environment checks and port resolution; existing persisted settings with the new field absent decode to `false`, so sleep prevention is off by default unless the user opts in.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7c81f45. 9 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->