### PR TITLE
feat(web): open file links in the system browser

### DIFF
--- a/apps/web/src/browser/openFileInPreview.test.ts
+++ b/apps/web/src/browser/openFileInPreview.test.ts
@@ -1,0 +1,186 @@
+import type { AssetCreateUrlResult, ScopedThreadRef } from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
+import { AsyncResult } from "effect/unstable/reactivity";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  beginExternalFileOpen,
+  isBrowserPreviewFile,
+  openFileInExternalBrowser,
+} from "./openFileInPreview";
+
+const threadRef = {
+  environmentId: "local" as ScopedThreadRef["environmentId"],
+  threadId: "thread-1" as ScopedThreadRef["threadId"],
+};
+
+const assetResult = (relativeUrl: string): AssetCreateUrlResult => ({
+  relativeUrl,
+  expiresAt: 1_750_000_000_000,
+});
+
+describe("isBrowserPreviewFile", () => {
+  it.each(["report.html", "doc.HTM", "paper.pdf", "nested/page.html?x=1#top"])(
+    "accepts %s",
+    (path) => expect(isBrowserPreviewFile(path)).toBe(true),
+  );
+  it.each(["notes.md", "index.html.bak", "script.js"])("rejects %s", (path) => {
+    expect(isBrowserPreviewFile(path)).toBe(false);
+  });
+});
+
+describe("beginExternalFileOpen", () => {
+  it("uses the desktop shell without opening a web tab", async () => {
+    const openExternal = vi.fn(async () => undefined);
+    const openWindow = vi.fn();
+    const session = beginExternalFileOpen({ isDesktop: true, openExternal, openWindow });
+
+    await session.open("http://environment.test/report.pdf");
+
+    expect(openExternal).toHaveBeenCalledWith("http://environment.test/report.pdf");
+    expect(openWindow).not.toHaveBeenCalled();
+  });
+
+  it("reserves and isolates a web tab before navigation", async () => {
+    const replace = vi.fn();
+    const close = vi.fn();
+    const tab = { opener: {} as Window | null, location: { replace }, close };
+    const session = beginExternalFileOpen({
+      isDesktop: false,
+      openExternal: vi.fn(),
+      openWindow: () => tab as unknown as Pick<Window, "close" | "location" | "opener">,
+    });
+
+    expect(tab.opener).toBeNull();
+    await session.open("http://environment.test/report.html");
+    expect(replace).toHaveBeenCalledWith("http://environment.test/report.html");
+    session.cancel();
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("reports a blocked web tab", () => {
+    expect(() =>
+      beginExternalFileOpen({
+        isDesktop: false,
+        openExternal: vi.fn(),
+        openWindow: () => null,
+      }),
+    ).toThrow("The browser blocked the new tab.");
+  });
+});
+
+describe("openFileInExternalBrowser", () => {
+  it.each([
+    ["/repo/artifacts/report.html", "/repo", "workspace-file"],
+    ["/tmp/report.html", "/repo", "media-file"],
+    ["/repo-other/report.pdf", "/repo", "media-file"],
+    ["C:/repo/report.pdf", "C:/repo", "workspace-file"],
+    ["C:/temp/report.pdf", "C:/repo", "media-file"],
+  ] as const)(
+    "opens %s using %s and the matching resource scope",
+    async (filePath, workspaceRoot, resourceTag) => {
+      const createAssetUrl = vi.fn(async () =>
+        AsyncResult.success(assetResult("/api/assets/token/report")),
+      );
+      const result = await openFileInExternalBrowser({
+        threadRef,
+        filePath,
+        workspaceRoot,
+        httpBaseUrl: "http://environment.test",
+        createAssetUrl,
+        beginOpen: () => ({ open: vi.fn(async () => undefined), cancel: vi.fn() }),
+      });
+      expect(result._tag).toBe("Success");
+      expect(createAssetUrl).toHaveBeenCalledWith({
+        environmentId: threadRef.environmentId,
+        input: { resource: { _tag: resourceTag, threadId: threadRef.threadId, path: filePath } },
+      });
+    },
+  );
+
+  it("reserves the browser target before requesting the signed URL", async () => {
+    const calls: string[] = [];
+    const open = vi.fn(async (url: string): Promise<void> => {
+      calls.push(`open:${url}`);
+    });
+    const cancel = vi.fn();
+    const createAssetUrl = vi.fn(async () => {
+      calls.push("asset");
+      return AsyncResult.success(assetResult("/api/assets/token/report.html"));
+    });
+
+    const result = await openFileInExternalBrowser({
+      threadRef,
+      workspaceRoot: "/repo",
+      filePath: "/repo/artifacts/report.html",
+      httpBaseUrl: "http://environment.test:1234",
+      createAssetUrl,
+      beginOpen: () => {
+        calls.push("begin");
+        return { open, cancel };
+      },
+    });
+
+    expect(result._tag).toBe("Success");
+    expect(calls).toEqual([
+      "begin",
+      "asset",
+      "open:http://environment.test:1234/api/assets/token/report.html",
+    ]);
+    expect(cancel).not.toHaveBeenCalled();
+  });
+
+  it("closes the reserved target when signed URL creation fails", async () => {
+    const cancel = vi.fn();
+    const result = await openFileInExternalBrowser({
+      threadRef,
+      workspaceRoot: "/repo",
+      filePath: "/repo/artifacts/report.html",
+      httpBaseUrl: "http://environment.test:1234",
+      createAssetUrl: vi.fn(async () =>
+        AsyncResult.failure<AssetCreateUrlResult, Error>(Cause.fail(new Error("missing"))),
+      ),
+      beginOpen: () => ({ open: vi.fn(), cancel }),
+    });
+
+    expect(result._tag).toBe("Failure");
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("closes the reserved target when signed URL creation rejects", async () => {
+    const cancel = vi.fn();
+    const failure = new Error("connection closed");
+    await expect(
+      openFileInExternalBrowser({
+        threadRef,
+        workspaceRoot: "/repo",
+        filePath: "/repo/artifacts/report.html",
+        httpBaseUrl: "http://environment.test:1234",
+        createAssetUrl: vi.fn(async () => Promise.reject(failure)),
+        beginOpen: () => ({ open: vi.fn(), cancel }),
+      }),
+    ).rejects.toBe(failure);
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("closes the reserved target when navigation fails", async () => {
+    const cancel = vi.fn();
+    const failure = new Error("blocked");
+    await expect(
+      openFileInExternalBrowser({
+        threadRef,
+        workspaceRoot: "/repo",
+        filePath: "/repo/artifacts/report.pdf",
+        httpBaseUrl: "http://environment.test:1234",
+        createAssetUrl: vi.fn(async () =>
+          AsyncResult.success(assetResult("/api/assets/token/report.pdf")),
+        ),
+        beginOpen: () => ({
+          open: vi.fn(async () => Promise.reject(failure)),
+          cancel,
+        }),
+      }),
+    ).rejects.toBe(failure);
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/browser/openFileInPreview.ts
+++ b/apps/web/src/browser/openFileInPreview.ts
@@ -51,6 +51,28 @@ export type OpenPreviewMutation<E = unknown> = (input: {
   readonly input: PreviewOpenInput;
 }) => Promise<AtomCommandResult<PreviewSessionSnapshot, E>>;
 
+export interface ExternalFileOpenSession {
+  readonly open: (url: string) => Promise<void>;
+  readonly cancel: () => void;
+}
+
+export function beginExternalFileOpen(input: {
+  readonly isDesktop: boolean;
+  readonly openExternal: (url: string) => Promise<void>;
+  readonly openWindow: () => Pick<Window, "close" | "location" | "opener"> | null;
+}): ExternalFileOpenSession {
+  if (input.isDesktop) {
+    return { open: input.openExternal, cancel: () => undefined };
+  }
+  const tab = input.openWindow();
+  if (!tab) throw new Error("The browser blocked the new tab.");
+  tab.opener = null;
+  return {
+    open: async (url) => tab.location.replace(url),
+    cancel: () => tab.close(),
+  };
+}
+
 export async function openUrlInPreview<E>(input: {
   readonly threadRef: ScopedThreadRef;
   readonly url: string;
@@ -81,35 +103,22 @@ export async function openUrlInPreview<E>(input: {
   });
 }
 
+type CreateAssetUrl<E> = (input: {
+  readonly environmentId: EnvironmentId;
+  readonly input: { readonly resource: AssetResource };
+}) => Promise<AtomCommandResult<AssetCreateUrlResult, E>>;
+
 /**
- * Opens a browser document in the integrated browser. Inside the workspace the
- * page may load sibling assets; a file outside it is served on its own.
+ * Signs a file for the browser. Inside the workspace the page may load sibling
+ * assets; a file outside it is served on its own.
  */
-export async function openFileInPreview<AssetError, PreviewError>(input: {
+async function createFileAssetUrl<E>(input: {
   readonly threadRef: ScopedThreadRef;
   readonly filePath: string;
   readonly workspaceRoot: string | undefined;
   readonly httpBaseUrl: string;
-  readonly createAssetUrl: (input: {
-    readonly environmentId: EnvironmentId;
-    readonly input: { readonly resource: AssetResource };
-  }) => Promise<AtomCommandResult<AssetCreateUrlResult, AssetError>>;
-  readonly openPreview: OpenPreviewMutation<PreviewError>;
-}): Promise<
-  AtomCommandResult<
-    void,
-    AssetError | PreviewError | BrowserPreviewUnavailableError | BrowserSettingsReadError
-  >
-> {
-  if (!isPreviewSupportedInRuntime()) {
-    return AsyncResult.failure(
-      Cause.fail(
-        new BrowserPreviewUnavailableError({
-          message: "The integrated browser is unavailable in this runtime.",
-        }),
-      ),
-    );
-  }
+  readonly createAssetUrl: CreateAssetUrl<E>;
+}): Promise<AtomCommandResult<string, E>> {
   const insideWorkspace =
     mediaFileReference(input.filePath, input.workspaceRoot).relativePath !== undefined;
   const assetResult = await input.createAssetUrl({
@@ -131,9 +140,64 @@ export async function openFileInPreview<AssetError, PreviewError>(input: {
       Cause.die(new Error("The environment returned an invalid asset URL.")),
     );
   }
+  return AsyncResult.success(assetUrl);
+}
+
+/** Opens a browser document in the integrated browser. */
+export async function openFileInPreview<AssetError, PreviewError>(input: {
+  readonly threadRef: ScopedThreadRef;
+  readonly filePath: string;
+  readonly workspaceRoot: string | undefined;
+  readonly httpBaseUrl: string;
+  readonly createAssetUrl: CreateAssetUrl<AssetError>;
+  readonly openPreview: OpenPreviewMutation<PreviewError>;
+}): Promise<
+  AtomCommandResult<
+    void,
+    AssetError | PreviewError | BrowserPreviewUnavailableError | BrowserSettingsReadError
+  >
+> {
+  if (!isPreviewSupportedInRuntime()) {
+    return AsyncResult.failure(
+      Cause.fail(
+        new BrowserPreviewUnavailableError({
+          message: "The integrated browser is unavailable in this runtime.",
+        }),
+      ),
+    );
+  }
+  const assetUrl = await createFileAssetUrl(input);
+  if (assetUrl._tag === "Failure") {
+    return AsyncResult.failure(assetUrl.cause);
+  }
   return openUrlInPreview({
     threadRef: input.threadRef,
-    url: assetUrl,
+    url: assetUrl.value,
     openPreview: input.openPreview,
   });
+}
+
+/** Opens a browser document in a new system browser tab (web) or the default browser (desktop). */
+export async function openFileInExternalBrowser<AssetError>(input: {
+  readonly threadRef: ScopedThreadRef;
+  readonly filePath: string;
+  readonly workspaceRoot: string | undefined;
+  readonly httpBaseUrl: string;
+  readonly createAssetUrl: CreateAssetUrl<AssetError>;
+  /** Runs before the first await so a web click can reserve its tab synchronously. */
+  readonly beginOpen: () => ExternalFileOpenSession;
+}): Promise<AtomCommandResult<void, AssetError>> {
+  const session = input.beginOpen();
+  try {
+    const assetUrl = await createFileAssetUrl(input);
+    if (assetUrl._tag === "Failure") {
+      session.cancel();
+      return AsyncResult.failure(assetUrl.cause);
+    }
+    await session.open(assetUrl.value);
+    return AsyncResult.success(undefined);
+  } catch (cause) {
+    session.cancel();
+    throw cause;
+  }
 }

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -182,7 +182,9 @@ import { writeTextToClipboard } from "../hooks/useCopyToClipboard";
 import { isPreviewSupportedInRuntime } from "../previewStateStore";
 import { isAbsolutePath, resolvePathLinkTarget } from "../terminal-links";
 import {
+  beginExternalFileOpen,
   isBrowserPreviewFile,
+  openFileInExternalBrowser,
   openFileInPreview,
   openUrlInPreview,
   BrowserPreviewUnavailableError,
@@ -1135,6 +1137,7 @@ interface MarkdownFileLinkProps {
   onOpenInPanel: (panelPath: string, line: number | undefined) => void;
   openInEditorMenuLabel: string;
   onOpenInBrowser?: (() => Promise<AtomCommandResult<unknown, unknown>>) | undefined;
+  onOpenInExternalBrowser?: (() => Promise<AtomCommandResult<unknown, unknown>>) | undefined;
   onOpenMedia?: (() => void) | undefined;
   onReveal?: (() => Promise<AtomCommandResult<unknown, unknown>>) | undefined;
   /** Platform-specific menu label ("Reveal in Finder", ...); required for the
@@ -1846,6 +1849,7 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
   onOpenInPanel,
   openInEditorMenuLabel,
   onOpenInBrowser,
+  onOpenInExternalBrowser,
   onOpenMedia,
   onReveal,
   revealLabel,
@@ -1901,43 +1905,52 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
     handleOpenInEditor();
   }, [handleOpenInEditor, line, onOpenInPanel, onOpenMedia, panelPath, threadRef]);
 
-  const handleOpenInBrowser = useCallback(() => {
-    if (!onOpenInBrowser) {
-      return;
-    }
-    void (async () => {
-      try {
-        const result = await onOpenInBrowser();
-        if (result._tag === "Success" || isAtomCommandInterrupted(result)) {
-          return;
-        }
-        reportMarkdownActionFailure(
-          { operation: "open-file-in-browser", target: targetPath },
-          result.cause,
-        );
-        const error = squashAtomCommandFailure(result);
+  const runBrowserOpen = useCallback(
+    (
+      open: () => Promise<AtomCommandResult<unknown, unknown>>,
+      operation: "open-file-in-browser" | "open-file-in-external-browser",
+      title: string,
+    ) => {
+      const report = (cause: unknown, error: unknown) => {
+        reportMarkdownActionFailure({ operation, target: targetPath }, cause);
         toastManager.add(
           stackedThreadToast({
             type: "error",
-            title: "Unable to open file in browser",
+            title,
             description: error instanceof Error ? error.message : "An error occurred.",
           }),
         );
-      } catch (cause) {
-        reportMarkdownActionFailure(
-          { operation: "open-file-in-browser", target: targetPath },
-          cause,
-        );
-        toastManager.add(
-          stackedThreadToast({
-            type: "error",
-            title: "Unable to open file in browser",
-            description: cause instanceof Error ? cause.message : "An error occurred.",
-          }),
-        );
-      }
-    })();
-  }, [onOpenInBrowser, targetPath]);
+      };
+      void (async () => {
+        try {
+          const result = await open();
+          if (result._tag === "Success" || isAtomCommandInterrupted(result)) {
+            return;
+          }
+          report(result.cause, squashAtomCommandFailure(result));
+        } catch (cause) {
+          report(cause, cause);
+        }
+      })();
+    },
+    [targetPath],
+  );
+
+  const handleOpenInBrowser = useCallback(() => {
+    if (onOpenInBrowser) {
+      runBrowserOpen(onOpenInBrowser, "open-file-in-browser", "Unable to open file in browser");
+    }
+  }, [onOpenInBrowser, runBrowserOpen]);
+
+  const handleOpenInExternalBrowser = useCallback(() => {
+    if (onOpenInExternalBrowser) {
+      runBrowserOpen(
+        onOpenInExternalBrowser,
+        "open-file-in-external-browser",
+        "Unable to open file in system browser",
+      );
+    }
+  }, [onOpenInExternalBrowser, runBrowserOpen]);
 
   const handleRevealInFileManager = useCallback(() => {
     if (!onReveal) {
@@ -2029,6 +2042,9 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
             ...(onOpenInBrowser
               ? ([{ id: "open-in-browser", label: "Open in integrated browser" }] as const)
               : []),
+            ...(onOpenInExternalBrowser
+              ? ([{ id: "open-in-external-browser", label: "Open in system browser" }] as const)
+              : []),
             ...(onReveal && revealLabel ? ([{ id: "reveal", label: revealLabel }] as const) : []),
             { id: "copy-relative", label: "Copy relative path" },
             { id: "copy-full", label: "Copy full path" },
@@ -2046,6 +2062,10 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
         }
         if (clicked === "open-in-browser") {
           handleOpenInBrowser();
+          return;
+        }
+        if (clicked === "open-in-external-browser") {
+          handleOpenInExternalBrowser();
           return;
         }
         if (clicked === "reveal") {
@@ -2070,9 +2090,11 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
       displayPath,
       handleCopy,
       handleOpenInBrowser,
+      handleOpenInExternalBrowser,
       handleOpenInEditor,
       handleRevealInFileManager,
       onOpenInBrowser,
+      onOpenInExternalBrowser,
       onOpenMedia,
       onOpen,
       onReveal,
@@ -2197,6 +2219,7 @@ function areMarkdownFileLinkPropsEqual(
     previous.onOpenInPanel === next.onOpenInPanel &&
     previous.openInEditorMenuLabel === next.openInEditorMenuLabel &&
     previous.onOpenInBrowser === next.onOpenInBrowser &&
+    previous.onOpenInExternalBrowser === next.onOpenInExternalBrowser &&
     previous.onOpenMedia === next.onOpenMedia &&
     previous.onReveal === next.onReveal &&
     previous.revealLabel === next.revealLabel &&
@@ -2472,6 +2495,36 @@ function useChatMarkdownState({
     },
     [createAssetUrl, cwd, openPreview, preparedConnection, threadRef],
   );
+  const openMarkdownFileInExternalBrowser = useCallback(
+    (path: string) => {
+      const api = readLocalApi();
+      if (!threadRef || preparedConnection._tag === "None" || !api) {
+        return Promise.resolve(
+          AsyncResult.failure<void, BrowserPreviewUnavailableError>(
+            Cause.fail(
+              new BrowserPreviewUnavailableError({
+                message: "Environment is not connected.",
+              }),
+            ),
+          ),
+        );
+      }
+      return openFileInExternalBrowser({
+        threadRef,
+        filePath: path,
+        workspaceRoot: cwd,
+        httpBaseUrl: preparedConnection.value.httpBaseUrl,
+        createAssetUrl,
+        beginOpen: () =>
+          beginExternalFileOpen({
+            isDesktop: window.desktopBridge !== undefined,
+            openExternal: (url) => api.shell.openExternal(url),
+            openWindow: () => window.open("about:blank", "_blank"),
+          }),
+      });
+    },
+    [createAssetUrl, cwd, preparedConnection, threadRef],
+  );
   const findWorkspaceBasenameMatch = useCallback(
     async (workspaceRelativePath: string) => {
       if (!cwd || environmentId === null || !needsWorkspaceBasenameLookup(workspaceRelativePath)) {
@@ -2588,6 +2641,11 @@ function useChatMarkdownState({
               ? () => openMarkdownFileInPreview(fileLinkMeta.filePath)
               : undefined
           }
+          onOpenInExternalBrowser={
+            threadRef && isBrowserPreviewFile(fileLinkMeta.filePath)
+              ? () => openMarkdownFileInExternalBrowser(fileLinkMeta.filePath)
+              : undefined
+          }
           className={className}
         />
       );
@@ -2598,6 +2656,7 @@ function useChatMarkdownState({
       openFileInPanel,
       openInPreferredEditor,
       openMarkdownFileInPreview,
+      openMarkdownFileInExternalBrowser,
       openMarkdownMedia,
       preferredEditorMenuLabel,
       resolvedTheme,


### PR DESCRIPTION
Chat HTML and PDF file links have no direct action to open the document in the system browser for printing, sharing, or keeping it in a separate tab.

This adds **Open in system browser** to their context menu. Web reserves an opener-isolated tab before requesting the signed asset URL; desktop uses the existing shell opener. Signing and navigation failures close the reserved tab and report an error. Integrated and external browser opens share the existing workspace/media resource selection and signing logic.

Scope: chat file-link menus on web and desktop. The file panel and mobile keep their existing preview/open flows. No provider, wire-contract, server, or orchestration changes. The action uses the selected environment's connection, including supported LAN/Tailscale HTTP connections.

Upstream inline previews (#11265), browser-link preferences (#9339), and outside-workspace support (#9140) do not replace this menu action. The upstream `externalLinkContextMenu` covers external http/https links only; the file-link context menu still has no system-browser action on `main`. Open PR #9533 concerns the file tree and integrated browser, a separate entry point.

## Verification

Head `4edd1ff22c` is rebased without conflicts onto `origin/main` at `b1e223e2b0` (still the tip at last check); `git range-diff` confirms the contribution is unchanged by the rebase.

- `vp test run apps/web/src/browser/openFileInPreview.test.ts apps/web/src/components/ChatMarkdown.test.tsx apps/web/src/components/ChatMarkdown.workspace-images.test.tsx`: **98 tests passed, 3 files**.
- `cd apps/web && vp exec tsc --noEmit`: passed (existing Effect suggestions only).
- `vp lint` on the three changed files: no errors; three warnings in unchanged upstream code.
- `vp fmt --check` on the three changed files and `git diff --check`: passed.
- Latest-head CI: all checks passed or were intentionally skipped; CodeRabbit passed with no new actionable findings. All review threads are resolved.
- Independent read-only reviews of `4edd1ff22c` against `b1e223e2b0`: Claude Fable 5 high (direct Claude Code CLI, exit 0) and GPT-5.6 Sol high (`codex exec review --base origin/main`, read-only, exit 0) — no actionable defects. Standards hash: `144fbf46af335d8d18a95c8d4b4f2e9e0207fa2e`.

## Evidence

The previous worker's real-client screenshots (reported capture date 2026-09-06, disposable backend) are retained. The menu label and opening logic are unchanged by this rebase. These GIFs alternate the original before/after stills every 2.5 seconds; they demonstrate the menu change, not interaction timing. No fresh browser or Electron session was run for this update.

![Before and after: chat file-link menu gains Open in system browser](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/7641-comparison.gif)

Detail of the same file-link menu:

![Menu detail: before and after adding Open in system browser](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/7641-menu-detail.gif)

[Original before screenshot](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/7641-before.png) · [Original after screenshot](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/7641-menu.png)

Retained result screenshot: the PDF rendered in a separate browser tab. Desktop shell forwarding is covered by focused tests.

![PDF rendered in the separate browser tab](https://github.com/saphid/t3code/releases/download/pr-evidence-real-app-20260906/7641-pdf-rendered.png)

Coordination trace: T3 thread aec20b75-b8e4-45a1-9170-9cee5b9a565a

Implementation, rebase, and earlier verification: GPT-6 in the Codex harness (T3 Code); independent review: Claude Fable 5 high via direct Claude Code CLI. Maintenance pass (superseded check, focused checks re-run, GPT-5.6 Sol review, PR update): SWE-2 High in T3 Code via the Cursor harness.
