### PR TITLE
fix(desktop): show onboarding after T3 Connect sign-in

### DIFF
--- a/apps/web/src/cloud/connectOnboarding.ts
+++ b/apps/web/src/cloud/connectOnboarding.ts
@@ -7,6 +7,31 @@ import * as Schema from "effect/Schema";
  */
 export const CONNECT_ONBOARDING_OPT_OUT_STORAGE_KEY = "t3code:connect-onboarding-opt-out:v1";
 
+export const CONNECT_ONBOARDING_AUTH_PENDING_STORAGE_KEY =
+  "t3code:connect-onboarding-auth-pending:v1";
+
+export function markConnectOnboardingAuthPending() {
+  try {
+    window.sessionStorage.setItem(CONNECT_ONBOARDING_AUTH_PENDING_STORAGE_KEY, "1");
+  } catch {
+    // The marker is optional. Storage errors must not stop sign-in.
+  }
+}
+
+export function consumeConnectOnboardingAuthPending() {
+  try {
+    const storage = window.sessionStorage;
+    const isPending = storage.getItem(CONNECT_ONBOARDING_AUTH_PENDING_STORAGE_KEY) === "1";
+    if (isPending) {
+      storage.removeItem(CONNECT_ONBOARDING_AUTH_PENDING_STORAGE_KEY);
+    }
+    return isPending;
+  } catch {
+    // Ignore a marker that cannot be read or removed.
+    return false;
+  }
+}
+
 export const ConnectOnboardingOptOutSchema = Schema.Struct({
   optOutAccounts: Schema.Array(Schema.String),
 });

--- a/apps/web/src/components/clerk/useT3ConnectAuthPrompt.test.tsx
+++ b/apps/web/src/components/clerk/useT3ConnectAuthPrompt.test.tsx
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const clerk = vi.hoisted(() => ({ openSignIn: vi.fn() }));
+
+vi.mock("@clerk/react", () => ({
+  useClerk: () => clerk,
+}));
+
+vi.mock("../../env", () => ({ isElectron: true }));
+
+import { CONNECT_ONBOARDING_AUTH_PENDING_STORAGE_KEY } from "../../cloud/connectOnboarding";
+import { useT3ConnectAuthPrompt } from "./useT3ConnectAuthPrompt";
+
+const sessionStorage = {
+  setItem: vi.fn(),
+};
+
+describe("useT3ConnectAuthPrompt", () => {
+  beforeEach(() => {
+    clerk.openSignIn.mockClear();
+    sessionStorage.setItem.mockClear();
+    vi.stubGlobal("window", {
+      location: { href: "t3code-dev://app/#/settings/connections" },
+      sessionStorage,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("marks onboarding as pending before desktop auth redirects", () => {
+    useT3ConnectAuthPrompt().openAuthPrompt();
+
+    expect(sessionStorage.setItem).toHaveBeenCalledWith(
+      CONNECT_ONBOARDING_AUTH_PENDING_STORAGE_KEY,
+      "1",
+    );
+    expect(sessionStorage.setItem.mock.invocationCallOrder[0]).toBeLessThan(
+      clerk.openSignIn.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(clerk.openSignIn).toHaveBeenCalledWith({
+      forceRedirectUrl: "t3code-dev://app/#/settings/connections",
+      signUpForceRedirectUrl: "t3code-dev://app/#/settings/connections",
+    });
+  });
+
+  it.each(["SecurityError", "QuotaExceededError"])(
+    "opens sign-in when session storage writes fail with %s",
+    (name) => {
+      sessionStorage.setItem.mockImplementationOnce(() => {
+        throw new DOMException("Session storage is unavailable", name);
+      });
+
+      useT3ConnectAuthPrompt().openAuthPrompt();
+
+      expect(clerk.openSignIn).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("opens sign-in when session storage is unavailable", () => {
+    Object.defineProperty(window, "sessionStorage", {
+      get() {
+        throw new DOMException("Session storage is unavailable", "SecurityError");
+      },
+    });
+
+    useT3ConnectAuthPrompt().openAuthPrompt();
+
+    expect(clerk.openSignIn).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/components/clerk/useT3ConnectAuthPrompt.tsx
+++ b/apps/web/src/components/clerk/useT3ConnectAuthPrompt.tsx
@@ -1,11 +1,13 @@
 import { useClerk } from "@clerk/react";
 
+import { markConnectOnboardingAuthPending } from "../../cloud/connectOnboarding";
 import { isElectron } from "../../env";
 import { resolveClerkSignInProps } from "./authRedirect";
 
 export function useT3ConnectAuthPrompt() {
   const clerk = useClerk();
   const openAuthPrompt = () => {
+    markConnectOnboardingAuthPending();
     clerk.openSignIn(resolveClerkSignInProps(window.location.href, isElectron));
   };
   return { authPrompt: null, openAuthPrompt };

--- a/apps/web/src/components/cloud/ConnectOnboardingDialog.test.tsx
+++ b/apps/web/src/components/cloud/ConnectOnboardingDialog.test.tsx
@@ -1,0 +1,152 @@
+import type { ReactElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { reactHookHarness as hooks } from "../../test/reactHookHarness";
+import {
+  consumeConnectOnboardingAuthPending,
+  markConnectOnboardingAuthPending,
+} from "../../cloud/connectOnboarding";
+
+const authState = vi.hoisted(() => ({
+  isLoaded: true,
+  isSignedIn: true,
+  userId: "user-after-desktop-auth" as string | null,
+}));
+
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  const { reactHookHarness } = await import("../../test/reactHookHarness");
+  return {
+    ...actual,
+    useEffect: (effect: () => void | (() => void)) => effect(),
+    useRef: reactHookHarness.useRef,
+    useState: reactHookHarness.useState,
+  };
+});
+
+vi.mock("react/compiler-runtime", async () => {
+  const { reactHookHarness } = await import("../../test/reactHookHarness");
+  return { c: reactHookHarness.useMemoCache };
+});
+
+vi.mock("@clerk/react", () => ({
+  useAuth: () => authState,
+}));
+
+vi.mock("../../cloud/publicConfig", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../cloud/publicConfig")>()),
+  hasCloudPublicConfig: () => true,
+}));
+
+vi.mock("../../cloud/useCloudLinkController", () => ({
+  useCloudLinkController: () => ({
+    linkState: {
+      data: null,
+      isPending: false,
+      target: { environmentId: "local" },
+    },
+    operationError: null,
+    reconcileCloudState: vi.fn(),
+  }),
+}));
+
+vi.mock("../../environments/primary", () => ({
+  usePrimarySessionState: () => ({ data: null, error: null }),
+}));
+
+vi.mock("../../hooks/useLocalStorage", () => ({
+  useLocalStorage: (_key: string, initialValue: unknown) => [initialValue, vi.fn()],
+}));
+
+import { ConnectOnboardingDialog } from "./ConnectOnboardingDialog";
+
+const sessionValues = new Map<string, string>();
+const sessionStorage = {
+  getItem: vi.fn((key: string) => sessionValues.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => sessionValues.set(key, value)),
+  removeItem: vi.fn((key: string) => sessionValues.delete(key)),
+};
+
+function renderConfiguredDialog() {
+  const wrapper = ConnectOnboardingDialog() as ReactElement;
+  const ConfiguredDialog = wrapper.type as () => ReactElement<{ open: boolean }>;
+
+  hooks.beginRender();
+  return ConfiguredDialog();
+}
+
+describe("ConnectOnboardingDialog", () => {
+  beforeEach(() => {
+    hooks.reset();
+    sessionValues.clear();
+    authState.isLoaded = true;
+    authState.isSignedIn = true;
+    authState.userId = "user-after-desktop-auth";
+    vi.stubGlobal("window", { desktopBridge: {}, sessionStorage });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("opens after an in-place desktop sign-in", () => {
+    authState.isSignedIn = false;
+    authState.userId = null;
+    renderConfiguredDialog();
+
+    markConnectOnboardingAuthPending();
+    authState.isSignedIn = true;
+    authState.userId = "user-after-desktop-auth";
+    renderConfiguredDialog();
+    renderConfiguredDialog();
+    const dialog = renderConfiguredDialog();
+
+    expect(dialog.props.open).toBe(true);
+  });
+
+  it("opens when the desktop renderer returns from auth already signed in", () => {
+    markConnectOnboardingAuthPending();
+    renderConfiguredDialog();
+    renderConfiguredDialog();
+    const dialog = renderConfiguredDialog();
+
+    expect(dialog.props.open).toBe(true);
+  });
+
+  it("stays closed on a normal desktop launch with a restored session", () => {
+    renderConfiguredDialog();
+    renderConfiguredDialog();
+    const dialog = renderConfiguredDialog();
+
+    expect(dialog.props.open).toBe(false);
+  });
+
+  it("consumes a saved auth marker only once", () => {
+    markConnectOnboardingAuthPending();
+
+    expect(consumeConnectOnboardingAuthPending()).toBe(true);
+    expect(consumeConnectOnboardingAuthPending()).toBe(false);
+  });
+
+  it.each(["getItem", "removeItem"] as const)(
+    "ignores auth markers when sessionStorage.%s fails",
+    (method) => {
+      markConnectOnboardingAuthPending();
+      sessionStorage[method].mockImplementationOnce(() => {
+        throw new DOMException("Session storage is unavailable", "SecurityError");
+      });
+
+      expect(consumeConnectOnboardingAuthPending()).toBe(false);
+    },
+  );
+
+  it("ignores auth markers when session storage is unavailable", () => {
+    Object.defineProperty(window, "sessionStorage", {
+      get() {
+        throw new DOMException("Session storage is unavailable", "SecurityError");
+      },
+    });
+
+    expect(consumeConnectOnboardingAuthPending()).toBe(false);
+  });
+});

--- a/apps/web/src/components/cloud/ConnectOnboardingDialog.tsx
+++ b/apps/web/src/components/cloud/ConnectOnboardingDialog.tsx
@@ -7,6 +7,7 @@ import {
   CONNECT_ONBOARDING_OPT_OUT_STORAGE_KEY,
   ConnectOnboardingOptOutSchema,
   EMPTY_CONNECT_ONBOARDING_OPT_OUT_STATE,
+  consumeConnectOnboardingAuthPending,
 } from "~/cloud/connectOnboarding";
 import { hasCloudPublicConfig } from "~/cloud/publicConfig";
 import { useCloudLinkController } from "~/cloud/useCloudLinkController";
@@ -36,7 +37,8 @@ import { toastManager } from "../ui/toast";
  * environment (managed tunnel + agent activity, both defaulting on) when the
  * current session is authorized to manage the relay link, then lists the
  * account's T3 Connect environments so every device can be connected right
- * away. A cold load with a restored session does not count as a sign-in.
+ * away. A cold load with a restored session does not count as a sign-in, but
+ * an auth redirect records its pending sign-in across the renderer reload.
  */
 export function ConnectOnboardingDialog() {
   if (!hasCloudPublicConfig()) return null;
@@ -91,10 +93,11 @@ function ConfiguredConnectOnboardingDialog() {
 
   const optOutAccounts = optOutState.optOutAccounts;
 
-  // Every sign-in or account switch that completes during this session
-  // requests the wizard — account transitions clear the connected relay
-  // environments, so each new session starts with no devices to reach. A cold
-  // load observes undefined → account and must not re-prompt.
+  // Every sign-in or account switch requests the wizard. Clerk Electron can
+  // complete auth by reloading the renderer, so the auth prompt stores a
+  // session marker for the initial signed-in snapshot after that redirect. A
+  // normal cold load observes undefined → account without the marker and must
+  // not re-prompt.
   useEffect(() => {
     if (!isLoaded) return;
     // A loaded-but-incomplete snapshot (signed in, user id not yet populated)
@@ -104,7 +107,9 @@ function ConfiguredConnectOnboardingDialog() {
     const previousAccount = observedAccountRef.current;
     const nextAccount = isSignedIn && userId ? userId : null;
     observedAccountRef.current = nextAccount;
-    if (previousAccount !== undefined && previousAccount !== nextAccount && nextAccount !== null) {
+    const authPromptPending = nextAccount !== null ? consumeConnectOnboardingAuthPending() : false;
+    const accountChanged = previousAccount !== undefined && previousAccount !== nextAccount;
+    if (nextAccount !== null && (accountChanged || authPromptPending)) {
       setRequestedAccount(nextAccount);
     }
   }, [isLoaded, isSignedIn, userId]);


### PR DESCRIPTION
Clerk Electron reloads the renderer after sign-in. That reload loses the in-memory account transition, so T3 Connect onboarding stays closed.

Save a one-time session marker before Clerk opens and consume it after sign-in. Storage failures do not stop sign-in or break route loading. Normal restored sessions and opted-out accounts stay quiet. Current auth and routing stay unchanged.

## Verification

- All 14 focused tests pass in `ConnectOnboardingDialog.test.tsx`, `useT3ConnectAuthPrompt.test.tsx`, and `authRedirect.test.ts`.
- Web typecheck, targeted lint, formatting, and `git diff --check` pass.
- Rebased onto current `main` at `b21d87243e`.

Desktop sign-in still needs a real-client pass after this rebase. The images below are from the original PR verification.

## Before

Auth returns to Settings without the onboarding dialog.

![Settings without T3 Connect onboarding](https://files.tslop.org/2026/08/t3code-desktop-auth-before-ac797d00.jpeg)

## After

Auth returns to the same Settings route and opens T3 Connect onboarding.

![T3 Connect onboarding after desktop auth](https://files.tslop.org/2026/08/t3code-desktop-auth-after-b41cb21b.jpeg)

Updated with GPT-5.6 Sol in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized onboarding UX fix using optional sessionStorage; auth and routing behavior are unchanged aside from showing the dialog when the marker is present.
> 
> **Overview**
> **Desktop Clerk sign-in reloads the renderer**, so the in-memory account transition that normally triggers T3 Connect onboarding is lost. This PR bridges that gap with a **one-shot `sessionStorage` marker** set before auth and consumed when the signed-in user is first observed.
> 
> `useT3ConnectAuthPrompt` now calls **`markConnectOnboardingAuthPending()`** immediately before `openSignIn`. **`ConnectOnboardingDialog`** treats **`consumeConnectOnboardingAuthPending()`** the same as an in-session account change when deciding to open the wizard, so onboarding still appears after redirect—even when the first paint is already signed in.
> 
> Marker helpers **fail open**: storage errors do not block sign-in or spuriously open onboarding. **Cold launches with a restored session** (no marker) stay unchanged, and opt-out behavior is untouched. New tests cover marker ordering, single consumption, and storage failure paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cce144090986cb3fe2b0650e3cbf2e3c111c78bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show Connect onboarding after T3 Connect desktop sign-in using a session-storage marker
> - Adds `markConnectOnboardingAuthPending` and `consumeConnectOnboardingAuthPending` in [connectOnboarding.ts](https://github.com/pingdotgg/t3code/pull/7643/files#diff-a286a9c61087db66ac9c7b10849e54ffbb702c76d167f37d3545015f21786382) to record and consume a pending-auth marker in session storage, so onboarding persists across the redirect reload.
> - [useT3ConnectAuthPrompt.tsx](https://github.com/pingdotgg/t3code/pull/7643/files#diff-64619e2c27e9d42f439324bd8ff9fd66e5defba49548f765720c253131bfc1eb) marks pending onboarding before calling Clerk sign-in, and [ConnectOnboardingDialog.tsx](https://github.com/pingdotgg/t3code/pull/7643/files#diff-1709bef12343d5d5282b49ead0ee5486f72301db4d6228a649c648e40818b1fb) consumes the marker to request onboarding for a loaded signed-in account.
> - Storage failures are caught so sign-in proceeds even when session storage is unavailable or writes fail.
> - Risk: `ConfiguredConnectOnboardingDialog` now requests onboarding on any account transition with a marker present; reviewers should confirm normal cold-load restored sessions still do not prompt onboarding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cce1440.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->