### PR TITLE
fix(server): include commit bodies in style inference

### DIFF
--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -1826,6 +1826,109 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
     }),
   );
 
+  it.effect("uses structured recent commits for repository commit conventions", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      yield* runGit(repoDir, ["checkout", "-b", "style-example"]);
+      NodeFS.writeFileSync(NodePath.join(repoDir, "style.txt"), "example\n");
+      yield* runGit(repoDir, ["add", "style.txt"]);
+      yield* runGit(repoDir, [
+        "commit",
+        "-m",
+        "feat(server): add style example",
+        "-m",
+        "- Explain the reason\n- Preserve body formatting",
+      ]);
+      yield* runGit(repoDir, ["checkout", "main"]);
+      yield* runGit(repoDir, [
+        "merge",
+        "--no-ff",
+        "style-example",
+        "-m",
+        "Merge style example",
+        "-m",
+        "Keep merge body style",
+      ]);
+      NodeFS.writeFileSync(NodePath.join(repoDir, "README.md"), "hello\nworld\n");
+      let commitInstructions: string | undefined;
+      let changeRequestInstructions: string | undefined;
+
+      const { manager } = yield* makeManager({
+        serverSettings: {
+          sourceControlWritingStyle: {
+            mode: "repo_conventions" as const,
+          },
+        },
+        textGeneration: {
+          generateCommitMessage: (input) => {
+            commitInstructions = input.policy?.commitInstructions;
+            changeRequestInstructions = input.policy?.changeRequestInstructions;
+            return Effect.succeed({ subject: "Match repository commit style", body: "" });
+          },
+        },
+      });
+      yield* runStackedAction(manager, {
+        cwd: repoDir,
+        action: "commit",
+      });
+
+      expect(commitInstructions).toContain("Recent commits from this repository:");
+      expect(commitInstructions).toContain("Subject: Merge style example");
+      expect(commitInstructions).toContain("Body: Keep merge body style");
+      expect(commitInstructions).toContain("Subject: feat(server): add style example");
+      expect(commitInstructions).toContain(
+        "Body: - Explain the reason\n- Preserve body formatting",
+      );
+      expect(changeRequestInstructions).toBe(
+        "Follow the repository's established change request title and body style when examples are available.",
+      );
+    }),
+  );
+
+  it.effect("limits repository commit conventions to 10 recent commits", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      for (let index = 1; index <= 10; index += 1) {
+        yield* runGit(repoDir, [
+          "commit",
+          "--allow-empty",
+          "-m",
+          `chore: history ${index}`,
+          "-m",
+          `Explain history ${index}\n${"x".repeat(500)}`,
+        ]);
+      }
+      NodeFS.writeFileSync(NodePath.join(repoDir, "README.md"), "hello\nworld\n");
+      let commitInstructions: string | undefined;
+
+      const { manager } = yield* makeManager({
+        serverSettings: {
+          sourceControlWritingStyle: {
+            mode: "repo_conventions" as const,
+          },
+        },
+        textGeneration: {
+          generateCommitMessage: (input) => {
+            commitInstructions = input.policy?.commitInstructions;
+            return Effect.succeed({ subject: "Limit commit history", body: "" });
+          },
+        },
+      });
+      yield* runStackedAction(manager, {
+        cwd: repoDir,
+        action: "commit",
+      });
+
+      expect(commitInstructions?.match(/^Subject: /gm)).toHaveLength(10);
+      expect(commitInstructions).toContain("Subject: chore: history 10");
+      expect(commitInstructions).not.toContain("Subject: Initial commit");
+      expect(commitInstructions).toContain("[truncated]");
+      expect(commitInstructions?.length).toBeLessThanOrEqual(4_000);
+    }),
+  );
+
   it.effect("uses custom commit message when provided", () =>
     Effect.gen(function* () {
       const repoDir = yield* makeTempDir("t3code-git-manager-");
@@ -2831,6 +2934,73 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         ghCalls.some((call) => call.includes("pr create --base main --head feature-create-pr")),
       ).toBe(true);
       expect(ghCalls.some((call) => call.startsWith("pr view "))).toBe(false);
+    }),
+  );
+
+  it.effect("uses subjects only for repository PR conventions", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      yield* runGit(repoDir, ["checkout", "-b", "feature-pr-style"]);
+      const remoteDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+      NodeFS.writeFileSync(NodePath.join(repoDir, "changes.txt"), "change\n");
+      yield* runGit(repoDir, ["add", "changes.txt"]);
+      yield* runGit(repoDir, [
+        "commit",
+        "-m",
+        "feat(server): add PR style example",
+        "-m",
+        "Commit body must not reach PR instructions",
+      ]);
+      yield* runGit(repoDir, ["push", "-u", "origin", "feature-pr-style"]);
+      yield* runGit(repoDir, ["config", "branch.feature-pr-style.gh-merge-base", "main"]);
+      let commitInstructions: string | undefined;
+      let changeRequestInstructions: string | undefined;
+
+      const { manager } = yield* makeManager({
+        serverSettings: {
+          sourceControlWritingStyle: {
+            mode: "repo_conventions" as const,
+          },
+        },
+        textGeneration: {
+          generatePrContent: (input) => {
+            commitInstructions = input.policy?.commitInstructions;
+            changeRequestInstructions = input.policy?.changeRequestInstructions;
+            return Effect.succeed({
+              title: "Match repository PR style",
+              body: "## Summary\n- Match repository PR style\n\n## Testing\n- Covered by tests",
+            });
+          },
+        },
+        ghScenario: {
+          prListSequence: [
+            "[]",
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify([
+              {
+                number: 89,
+                title: "Match repository PR style",
+                url: "https://github.com/pingdotgg/codething-mvp/pull/89",
+                baseRefName: "main",
+                headRefName: "feature-pr-style",
+              },
+            ]),
+          ],
+        },
+      });
+      yield* runStackedAction(manager, {
+        cwd: repoDir,
+        action: "create_pr",
+      });
+
+      expect(changeRequestInstructions).toContain("Recent commit subjects from this repository:");
+      expect(changeRequestInstructions).toContain("feat(server): add PR style example");
+      expect(changeRequestInstructions).not.toContain("Commit body must not reach PR instructions");
+      expect(commitInstructions).toBe(
+        "Follow the repository's established commit message style when examples are available.",
+      );
     }),
   );
 

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -2953,6 +2953,21 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         "-m",
         "Commit body must not reach PR instructions",
       ]);
+      yield* runGit(repoDir, ["checkout", "-b", "pr-style-example"]);
+      yield* runGit(repoDir, [
+        "commit",
+        "--allow-empty",
+        "-m",
+        "fix(server): preserve authored PR style",
+      ]);
+      yield* runGit(repoDir, ["checkout", "feature-pr-style"]);
+      yield* runGit(repoDir, [
+        "merge",
+        "--no-ff",
+        "pr-style-example",
+        "-m",
+        "Merge noisy PR style example",
+      ]);
       yield* runGit(repoDir, ["push", "-u", "origin", "feature-pr-style"]);
       yield* runGit(repoDir, ["config", "branch.feature-pr-style.gh-merge-base", "main"]);
       let commitInstructions: string | undefined;
@@ -2997,6 +3012,8 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
 
       expect(changeRequestInstructions).toContain("Recent commit subjects from this repository:");
       expect(changeRequestInstructions).toContain("feat(server): add PR style example");
+      expect(changeRequestInstructions).toContain("fix(server): preserve authored PR style");
+      expect(changeRequestInstructions).not.toContain("Merge noisy PR style example");
       expect(changeRequestInstructions).not.toContain("Commit body must not reach PR instructions");
       expect(commitInstructions).toBe(
         "Follow the repository's established commit message style when examples are available.",

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -644,7 +644,7 @@ export const make = Effect.gen(function* () {
       .execute({
         operation: "GitManager.readRecentCommitSubjects",
         cwd,
-        args: ["log", "-n", String(recentCommitCount), "--pretty=format:%s"],
+        args: ["log", "-n", String(recentCommitCount), "--no-merges", "--pretty=format:%s"],
       })
       .pipe(
         Effect.map((result) =>

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -605,24 +605,62 @@ export const make = Effect.gen(function* () {
   const sourceControlProvider = (cwd: string) => sourceControlProviders.resolve({ cwd });
   const serverSettingsService = yield* ServerSettings.ServerSettingsService;
 
+  interface RecentCommit {
+    readonly hash: string;
+    readonly subject: string;
+    readonly body: string;
+  }
+
+  const recentCommitCount = 10;
+  const commitSubjectExampleMaxChars = 120;
+  const commitBodyExampleMaxChars = 160;
+
+  const readRecentCommits = (cwd: string) =>
+    gitCore
+      .execute({
+        operation: "GitManager.readRecentCommits",
+        cwd,
+        args: ["log", "-n", String(recentCommitCount), "--pretty=format:%h%x00%s%x00%b%x00"],
+      })
+      .pipe(
+        Effect.map((result) => {
+          const fields = result.stdout.split("\0");
+          const commits: RecentCommit[] = [];
+          for (let index = 0; index + 2 < fields.length; index += 3) {
+            const hash = fields[index]?.trim() ?? "";
+            const subject = fields[index + 1]?.trim() ?? "";
+            const body = fields[index + 2]?.trim() ?? "";
+            if (hash && subject) {
+              commits.push({ hash, subject, body });
+            }
+          }
+          return commits;
+        }),
+        Effect.orElseSucceed(() => []),
+      );
+
   const readRecentCommitSubjects = (cwd: string) =>
     gitCore
       .execute({
         operation: "GitManager.readRecentCommitSubjects",
         cwd,
-        args: ["log", "-n", "20", "--no-merges", "--pretty=format:%s"],
+        args: ["log", "-n", String(recentCommitCount), "--pretty=format:%s"],
       })
       .pipe(
         Effect.map((result) =>
           result.stdout
             .split("\n")
-            .map((line) => line.trim())
-            .filter((line) => line.length > 0),
+            .map((subject) => subject.trim())
+            .filter(Boolean),
         ),
         Effect.orElseSucceed(() => []),
       );
 
-  const resolveStylePolicy = (cwd: string, style: SourceControlWritingStyleSettings) =>
+  const resolveStylePolicy = (
+    cwd: string,
+    style: SourceControlWritingStyleSettings,
+    consumer: "commit" | "change_request",
+  ) =>
     Effect.gen(function* () {
       switch (style.mode) {
         case "conventional_commits":
@@ -637,15 +675,37 @@ export const make = Effect.gen(function* () {
               : {},
           );
         case "repo_conventions": {
-          const subjects = yield* readRecentCommitSubjects(cwd);
-          if (subjects.length === 0) {
+          if (consumer === "change_request") {
+            const subjects = yield* readRecentCommitSubjects(cwd);
+            if (subjects.length === 0) {
+              return repositoryConventionsTextGenerationPolicy;
+            }
+            const examples = ["Recent commit subjects from this repository:", ...subjects].join(
+              "\n",
+            );
+            return {
+              ...repositoryConventionsTextGenerationPolicy,
+              changeRequestInstructions: `${repositoryConventionsTextGenerationPolicy.changeRequestInstructions}\n\n${examples}`,
+            };
+          }
+
+          const commits = yield* readRecentCommits(cwd);
+          if (commits.length === 0) {
             return repositoryConventionsTextGenerationPolicy;
           }
-          const examples = ["Recent commit subjects from this repository:", ...subjects].join("\n");
+          const examples = [
+            "Recent commits from this repository:",
+            ...commits.map((commit) =>
+              [
+                `Commit ${commit.hash}`,
+                `Subject: ${limitContext(commit.subject, commitSubjectExampleMaxChars)}`,
+                `Body: ${commit.body ? limitContext(commit.body, commitBodyExampleMaxChars) : "(empty)"}`,
+              ].join("\n"),
+            ),
+          ].join("\n\n");
           return {
             ...repositoryConventionsTextGenerationPolicy,
             commitInstructions: `${repositoryConventionsTextGenerationPolicy.commitInstructions}\n\n${examples}`,
-            changeRequestInstructions: `${repositoryConventionsTextGenerationPolicy.changeRequestInstructions}\n\n${examples}`,
           };
         }
       }
@@ -1500,7 +1560,7 @@ export const make = Effect.gen(function* () {
         };
       }
 
-      const policy = yield* resolveStylePolicy(input.cwd, input.settings.style);
+      const policy = yield* resolveStylePolicy(input.cwd, input.settings.style, "commit");
 
       const generated = yield* textGeneration
         .generateCommitMessage({
@@ -1686,7 +1746,7 @@ export const make = Effect.gen(function* () {
     });
     const baseRangeRef = yield* resolveBaseRangeRef(cwd, baseBranch);
     const rangeContext = yield* gitCore.readRangeContext(cwd, baseRangeRef);
-    const policy = yield* resolveStylePolicy(cwd, settings.style);
+    const policy = yield* resolveStylePolicy(cwd, settings.style, "change_request");
     const changeRequestTemplate =
       settings.style.followChangeRequestTemplates && provider.kind === "github"
         ? Option.getOrUndefined(yield* detectPrTemplate(cwd, baseRangeRef, gitCore.execute))


### PR DESCRIPTION
Written by inayayousfi, typed by GPT-5.6 Sol running in OpenCode.
Every call here is inayayousfi's, and no agent acted on its own.

## What Changed

- Give commit message generation 10 structured examples from recent repository history, including hashes, subjects, and bodies.
- Truncate long example fields so all 10 commits remain inside the existing prompt budget.
- Keep pull request generation on subject-only history.

## Why

The repository conventions setting only passed recent subjects to the commit writer. That could teach prefixes and capitalization, but not whether the repository uses commit bodies or how those bodies are formatted.

## Testing

- `vp test run apps/server/src/git/GitManager.test.ts`
- `vp run --filter t3 typecheck`
- Targeted formatting, lint, and whitespace checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect optional AI prompt text for source-control writing style; no auth, persistence, or git mutation behavior.
> 
> **Overview**
> **Repository conventions** style inference now feeds **commit message** generation richer examples from git history, while **PR** generation keeps a narrower signal.
> 
> For commits, `resolveStylePolicy` reads the last **10** commits via a new `readRecentCommits` path (hash, subject, and body) and appends formatted examples to `commitInstructions`, with `limitContext` capping subject/body length so the block stays within roughly a 4k prompt budget. PR flows pass `consumer: "change_request"` and still use **subject-only** history in `changeRequestInstructions`, so commit bodies are not mixed into PR prompts.
> 
> Recent-history sampling drops the old 20-commit / `--no-merges` subject-only path for commits; subject reads are also capped at 10. Tests cover structured commit examples, the 10-commit cap with truncation, and PR instructions excluding commit bodies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af2c1ad7115efbc282b8a9b1c44764f371670c02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Include commit bodies and subjects in repo-conventions style inference
> - Extends `resolveStylePolicy` in [GitManager.ts](https://github.com/pingdotgg/t3code/pull/7650/files#diff-cd0cda31b0a40baa44db979a23ee89f041c9bae39aa597513a8628cccebd0337) with a `consumer` parameter (`commit` | `change_request`) so commit generation and PR generation get different examples
> - For commit generation, reads up to 10 recent commits (hash, subject, body) via the new `readRecentCommits` helper, truncating subject to 120 chars and body to 160 chars, and appends them to `commitInstructions`
> - For PR generation, reads up to 10 recent non-merge commit subjects (no bodies) via `readRecentCommitSubjects` and appends them to `changeRequestInstructions`
> - Both paths fall back to the default policy when no recent commits are found
> - Behavioral Change: `readRecentCommitSubjects` now returns 10 subjects instead of 20 (via the `recentCommitCount` constant); commit body examples are capped at 160 chars and blank bodies become `(empty)`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 17f0bd7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->