### PR TITLE
fix(web): show a thread's completion when a watch loop is still live

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -19,6 +19,7 @@ import {
   resolveSidebarStageBadgeLabel,
   resolveThreadRowClassName,
   resolveSidebarThreadStatus,
+  resolveSidebarThreadTopStatusKind,
   resolveThreadStatusPill,
   resolveWorkingStartedAt,
   searchSidebarThreadsByTitle,
@@ -730,8 +731,86 @@ describe("resolveSidebarThreadStatus", () => {
     ).toBe("ready");
   });
 
+  it("keeps pending input and approvals ahead of a live watch loop", () => {
+    expect(
+      resolveSidebarThreadStatus({
+        ...idle,
+        hasPendingUserInput: true,
+        session: null,
+        backgroundLiveness: "monitoring",
+      }),
+    ).toBe("input");
+    expect(
+      resolveSidebarThreadStatus({
+        ...idle,
+        hasPendingApprovals: true,
+        session: null,
+        backgroundLiveness: "monitoring",
+      }),
+    ).toBe("approval");
+  });
+
+  it("reports a live watch loop only when nothing else is happening", () => {
+    expect(
+      resolveSidebarThreadStatus({ ...idle, session: null, backgroundLiveness: "monitoring" }),
+    ).toBe("monitoring");
+    expect(
+      resolveSidebarThreadStatus({ ...idle, session: null, backgroundLiveness: "working" }),
+    ).toBe("working");
+  });
+
   it("defaults to ready with no session", () => {
     expect(resolveSidebarThreadStatus({ ...idle, session: null })).toBe("ready");
+  });
+});
+
+describe("resolveSidebarThreadTopStatusKind", () => {
+  const quiet = { status: "ready" as const, isWoke: false, isUnread: false };
+
+  it("shows an unread completion instead of monitoring, so a watch loop cannot mask it", () => {
+    expect(
+      resolveSidebarThreadTopStatusKind({ ...quiet, status: "monitoring", isUnread: true }),
+    ).toBe("done");
+  });
+
+  it("shows a wake instead of monitoring", () => {
+    expect(
+      resolveSidebarThreadTopStatusKind({ ...quiet, status: "monitoring", isWoke: true }),
+    ).toBe("woke");
+  });
+
+  it("keeps monitoring once the completion has been read", () => {
+    expect(resolveSidebarThreadTopStatusKind({ ...quiet, status: "monitoring" })).toBe(
+      "monitoring",
+    );
+  });
+
+  it("keeps working ahead of an unread completion: background work is still in flight", () => {
+    expect(resolveSidebarThreadTopStatusKind({ ...quiet, status: "working", isUnread: true })).toBe(
+      "working",
+    );
+  });
+
+  it("keeps approval, input, and failure ahead of an unread completion", () => {
+    expect(
+      resolveSidebarThreadTopStatusKind({ ...quiet, status: "approval", isUnread: true }),
+    ).toBe("approval");
+    expect(resolveSidebarThreadTopStatusKind({ ...quiet, status: "input", isUnread: true })).toBe(
+      "input",
+    );
+    expect(resolveSidebarThreadTopStatusKind({ ...quiet, status: "failed", isUnread: true })).toBe(
+      "failed",
+    );
+  });
+
+  it("prefers a wake over an unread completion on a settled thread", () => {
+    expect(resolveSidebarThreadTopStatusKind({ ...quiet, isWoke: true, isUnread: true })).toBe(
+      "woke",
+    );
+  });
+
+  it("returns null for a read, settled thread with nothing live", () => {
+    expect(resolveSidebarThreadTopStatusKind(quiet)).toBeNull();
   });
 });
 
@@ -1097,6 +1176,27 @@ describe("resolveThreadStatusPill", () => {
     ).toMatchObject({ label: "Working", pulse: true });
   });
 
+  it("shows an unread completion ahead of monitoring, then monitoring once it is read", () => {
+    const settledWithWatchLoop = {
+      ...baseThread,
+      session: { ...baseThread.session, status: "idle" as const, activeTurnId: null as never },
+      latestTurn: { completedAt: "2026-03-09T12:00:00.000Z" } as never,
+      backgroundLiveness: "monitoring" as const,
+    };
+
+    expect(
+      resolveThreadStatusPill({
+        thread: { ...settledWithWatchLoop, lastVisitedAt: "2026-03-09T11:00:00.000Z" },
+      }),
+    ).toMatchObject({ label: "Completed" });
+
+    expect(
+      resolveThreadStatusPill({
+        thread: { ...settledWithWatchLoop, lastVisitedAt: "2026-03-09T13:00:00.000Z" },
+      }),
+    ).toMatchObject({ label: "Monitoring" });
+  });
+
   it("shows plan ready when a settled plan turn has a proposed plan ready for follow-up", () => {
     expect(
       resolveThreadStatusPill({
@@ -1199,6 +1299,25 @@ describe("resolveProjectStatusIndicator", () => {
         },
       ]),
     ).toMatchObject({ label: "Pending Approval", dotClass: "bg-amber-500" });
+  });
+
+  it("does not let a monitoring sibling hide a completed thread", () => {
+    expect(
+      resolveProjectStatusIndicator([
+        {
+          label: "Monitoring",
+          colorClass: "text-sky-600",
+          dotClass: "bg-sky-500",
+          pulse: false,
+        },
+        {
+          label: "Completed",
+          colorClass: "text-emerald-600",
+          dotClass: "bg-emerald-500",
+          pulse: false,
+        },
+      ]),
+    ).toMatchObject({ label: "Completed" });
   });
 
   it("prefers plan-ready over completed when no stronger action is needed", () => {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -132,16 +132,17 @@ export interface ThreadStatusPill {
 }
 
 // Rollup order mirrors the per-thread resolver exactly: attention states,
-// then active work, then the actionable plan prompt, then passive
-// monitoring. A Monitoring sibling must never hide a Plan Ready thread.
+// then active work, then the actionable plan prompt, then an unread
+// completion, then passive monitoring. A Monitoring sibling must never hide
+// a Plan Ready or Completed thread.
 const THREAD_STATUS_PRIORITY: Record<ThreadStatusPill["label"], number> = {
   "Pending Approval": 6,
   "Awaiting Input": 5,
   Working: 4,
   Connecting: 4,
   "Plan Ready": 3,
-  Monitoring: 2,
-  Completed: 1,
+  Completed: 2,
+  Monitoring: 1,
 };
 
 type ThreadStatusInput = Pick<
@@ -498,6 +499,42 @@ export function resolveSidebarThreadStatus(thread: SidebarThreadStatusInput): Si
   return "ready";
 }
 
+/** Which signal the sidebar row's top-right label shows, highest priority first. */
+export type SidebarThreadTopStatusKind =
+  | "approval"
+  | "input"
+  | "failed"
+  | "working"
+  | "woke"
+  | "done"
+  | "monitoring"
+  | null;
+
+/**
+ * Attention outranks passive monitoring. `backgroundLiveness: "monitoring"`
+ * means watch loops (a long-running shell) are the ONLY live work, so the
+ * turn has already settled — an unseen completion or a wake is exactly the
+ * news the user is waiting for, and monitoring would otherwise mask it for
+ * as long as the shell lives. `working` still wins: real background work is
+ * in flight, so the thread is not done yet. Monitoring re-appears once the
+ * user has read the completion.
+ */
+export function resolveSidebarThreadTopStatusKind(input: {
+  status: SidebarThreadStatus;
+  isWoke: boolean;
+  isUnread: boolean;
+}): SidebarThreadTopStatusKind {
+  const { isUnread, isWoke, status } = input;
+  if (status === "approval") return "approval";
+  if (status === "input") return "input";
+  if (status === "failed") return "failed";
+  if (status === "working") return "working";
+  if (isWoke) return "woke";
+  if (isUnread) return "done";
+  if (status === "monitoring") return "monitoring";
+  return null;
+}
+
 /** NaN-safe Date.parse for sort comparators: a malformed timestamp must not
     poison the whole ordering, so it sinks to the epoch instead. */
 export function parseTimestampMs(isoDate: string): number {
@@ -705,20 +742,23 @@ export function resolveThreadStatusPill(input: {
     };
   }
 
-  if (thread.backgroundLiveness === "monitoring") {
-    return {
-      label: "Monitoring",
-      colorClass: "text-sky-600 dark:text-sky-300/80",
-      dotClass: "bg-sky-500 dark:bg-sky-300/80",
-      pulse: false,
-    };
-  }
-
+  // Monitoring means watch loops are the only live work, so the turn has
+  // settled: an unseen completion is the news, and monitoring would mask it
+  // for as long as the watch loop lives. Monitoring returns once it is read.
   if (hasUnseenCompletion(thread)) {
     return {
       label: "Completed",
       colorClass: "text-emerald-600 dark:text-emerald-300/90",
       dotClass: "bg-emerald-500 dark:bg-emerald-300/90",
+      pulse: false,
+    };
+  }
+
+  if (thread.backgroundLiveness === "monitoring") {
+    return {
+      label: "Monitoring",
+      colorClass: "text-sky-600 dark:text-sky-300/80",
+      dotClass: "bg-sky-500 dark:bg-sky-300/80",
       pulse: false,
     };
   }

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -132,6 +132,7 @@ import {
   resolveAdjacentThreadId,
   resolveSettledTimestamp,
   resolveSidebarThreadStatus,
+  resolveSidebarThreadTopStatusKind,
   searchSidebarThreadsByTitle,
   shouldCreateNewThreadInCurrentProject,
   resolveWorkingStartedAt,
@@ -836,8 +837,9 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   // Status hues follow the system-wide convention set by sidebar v1 and the
   // mobile Live Activity/widgets (amber approval, indigo input, sky working)
   // so a thread reads the same color everywhere it surfaces.
+  const topStatusKind = resolveSidebarThreadTopStatusKind({ status, isWoke, isUnread });
   const topStatus =
-    status === "working"
+    topStatusKind === "working"
       ? {
           label: "Working",
           icon: "working" as const,
@@ -848,7 +850,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
           // the label at full strength.
           className: cn("text-sky-600 dark:text-sky-400", !props.isActive && "opacity-75"),
         }
-      : status === "monitoring"
+      : topStatusKind === "monitoring"
         ? {
             // Monitoring is calm background presence, not active progress
             // (monitoring-pill D6), so it keeps the label at full strength.
@@ -856,31 +858,31 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
             icon: null,
             className: "text-sky-600 dark:text-sky-400",
           }
-        : status === "approval"
+        : topStatusKind === "approval"
           ? {
               label: "Approval",
               icon: null,
               className: "text-amber-700 dark:text-amber-300",
             }
-          : status === "input"
+          : topStatusKind === "input"
             ? {
                 label: "Input",
                 icon: null,
                 className: "text-indigo-600 dark:text-indigo-300",
               }
-            : status === "failed"
+            : topStatusKind === "failed"
               ? {
                   label: "Failed",
                   icon: null,
                   className: "text-red-700 dark:text-red-300",
                 }
-              : isWoke
+              : topStatusKind === "woke"
                 ? {
                     label: "Woke",
                     icon: "woke" as const,
                     className: "text-amber-700 dark:text-amber-300",
                   }
-                : isUnread
+                : topStatusKind === "done"
                   ? {
                       label: "Done",
                       icon: "done" as const,


### PR DESCRIPTION
## What Changed

The sidebar row has one status slot, and `backgroundLiveness: "monitoring"` claimed it ahead of an unread completion, so a finished turn never announced itself. The label now resolves through a pure `resolveSidebarThreadTopStatusKind` that puts attention states ahead of passive monitoring:

```
approval → input → failed → working → woke → done → monitoring
```

`working` stays ahead of `done` — real background work means the thread is not finished. Every label, icon and class is unchanged; the existing chain is keyed off the resolved kind. The legacy sidebar's `resolveThreadStatusPill` had the same ordering, and `THREAD_STATUS_PRIORITY` is swapped to `Completed: 2, Monitoring: 1` so the project rollup keeps its in-code "mirrors the per-thread resolver exactly" invariant.

## Why

`backgroundLiveness` is defined in `packages/contracts` as *"Native background work alive after the turn settles"*, with `"monitoring"` meaning *"watch loops are the only live work"*. Whenever the row said `Monitoring`, the turn had already settled — so the completion the row exists to announce was unreachable.

Monitors are `local_bash` tasks (`ThreadBackgroundLiveness`: no agent tasks, ≥1 monitor task), so a thread that leaves a dev server, a `tail -f`, or a `gh pr checks --watch` running showed `Monitoring` for as long as that shell lived and could never show `Done` again.

`Sidebar.tsx` already contradicted itself here: `shouldRecede` contains `!isUnread`, deliberately keeping an unread monitoring row at full prominence, while the label hid the reason. `Sidebar.logic.ts` states the principle — *"Unread completion is tracked separately: it describes whether a ready thread needs attention, not what the thread is currently doing"* — and the neighbouring `Plan Ready` branch already encodes it.

`Approval`, `Input`, `Failed` and `Working` already outranked monitoring in `resolveSidebarThreadStatus`. That was untested, so it is pinned now.

## Surfaces

- **Web + desktop:** fixed here; desktop wraps the same component.
- **Mobile:** does not surface `backgroundLiveness` at all, so it has no equivalent label to fix.
- **Entry points:** all three places this status is derived — the current sidebar row, the legacy sidebar pill (still reachable behind the `legacySidebar` setting), and the project rollup.
- **Contracts:** unchanged; this is a client-side precedence bug.
- **Reverse state:** `Done` is an unread state, so opening the thread returns the slot to `Monitoring`. Nothing is permanently hidden either way.
- **Performance:** one pure call per row render, no new animation, no repaint loop.
- **Docs:** no user or internals doc documents these labels, so nothing to update.

## UI Changes

Reproduced against a dev build on an isolated `T3CODE_HOME`: a real turn that leaves a background `sleep` running so the monitor outlives the settled turn, with the thread left before it finished so the completion landed unseen.

Reported by a nightly user (project, title and branch redacted):

<img src="https://raw.githubusercontent.com/liaugust/t3code/pr-assets/sidebar-completion-behind-monitoring/.github/pr-assets/sidebar-completion-behind-monitoring/reported-monitoring.png" width="353">

| Before — turn finished, completion unseen | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/liaugust/t3code/pr-assets/sidebar-completion-behind-monitoring/.github/pr-assets/sidebar-completion-behind-monitoring/card-before.png" width="238"> | <img src="https://raw.githubusercontent.com/liaugust/t3code/pr-assets/sidebar-completion-behind-monitoring/.github/pr-assets/sidebar-completion-behind-monitoring/card-after.png" width="238"> |

Opening the thread reads the completion and monitoring returns to the slot:

<img src="https://raw.githubusercontent.com/liaugust/t3code/pr-assets/sidebar-completion-behind-monitoring/.github/pr-assets/sidebar-completion-behind-monitoring/card-after-read.png" width="238">

Same live thread in every capture; only this diff differs between them. No motion or timing changes, so no video — the label swap is instant in both directions.

A variant showing both signals at once (`Done` plus a monitoring dot) was prototyped and left out: a second text label truncated the project name at the row's 238px width, and a new indicator is a design decision rather than part of this fix.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes — not applicable, no motion or interaction behaviour changed


Built with Claude Opus 5 in T3 Code through the Claude Code harness.