### PR TITLE
feat(copilot): add GitHub Copilot provider (via @github/copilot-sdk)

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -28,6 +28,7 @@
     "@effect/platform-node-shared": "catalog:",
     "@effect/sql-sqlite-bun": "catalog:",
     "@ff-labs/fff-node": "0.9.4",
+    "@github/copilot-sdk": "^1.0.11",
     "@opencode-ai/sdk": "^1.3.15",
     "@pierre/diffs": "catalog:",
     "effect": "catalog:",

--- a/apps/server/src/provider/Drivers/CopilotDriver.ts
+++ b/apps/server/src/provider/Drivers/CopilotDriver.ts
@@ -1,0 +1,191 @@
+/**
+ * CopilotDriver — `ProviderDriver` for GitHub Copilot, backed by the first-party
+ * `@github/copilot-sdk` (see CopilotAdapter / CopilotProvider). The SDK spawns
+ * and drives the installed `copilot` runtime binary over its typed JSON-RPC
+ * protocol; only the git text-generation path still uses the ACP transport.
+ *
+ * @module provider/Drivers/CopilotDriver
+ */
+import {
+  CopilotSettings,
+  ProviderDriverKind,
+  type ServerProvider,
+  type ServerProviderModel,
+} from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
+import { HttpClient } from "effect/unstable/http";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import * as BackgroundPolicy from "../../background/BackgroundPolicy.ts";
+import { ServerConfig } from "../../config.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
+import { makeCopilotTextGeneration } from "../../textGeneration/CopilotTextGeneration.ts";
+import { ProviderDriverError } from "../Errors.ts";
+import { makeCopilotAdapter } from "../Layers/CopilotAdapter.ts";
+import {
+  buildInitialCopilotProviderSnapshot,
+  checkCopilotProviderStatus,
+  enrichCopilotSnapshot,
+} from "../Layers/CopilotProvider.ts";
+import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
+import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
+import {
+  defaultProviderContinuationIdentity,
+  type ProviderDriver,
+  type ProviderInstance,
+} from "../ProviderDriver.ts";
+import type { ServerProviderDraft } from "../providerSnapshot.ts";
+import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
+import {
+  makeProviderMaintenanceCapabilities,
+  makeStaticProviderMaintenanceResolver,
+  resolveProviderMaintenanceCapabilitiesEffect,
+} from "../providerMaintenance.ts";
+import {
+  haveProviderSnapshotSettingsChanged,
+  makeProviderSnapshotSettingsSource,
+  type ProviderSnapshotSettings,
+} from "../providerUpdateSettings.ts";
+
+const decodeCopilotSettings = Schema.decodeSync(CopilotSettings);
+
+const DRIVER_KIND = ProviderDriverKind.make("copilot");
+
+const UPDATE = makeStaticProviderMaintenanceResolver(
+  makeProviderMaintenanceCapabilities({
+    provider: DRIVER_KIND,
+    packageName: null,
+    updateExecutable: "copilot",
+    updateArgs: ["update"],
+    updateLockKey: "copilot-update",
+  }),
+);
+
+export type CopilotDriverEnv =
+  | BackgroundPolicy.BackgroundPolicy
+  | ChildProcessSpawner.ChildProcessSpawner
+  | Crypto.Crypto
+  | FileSystem.FileSystem
+  | HttpClient.HttpClient
+  | Path.Path
+  | ProviderEventLoggers
+  | ServerConfig
+  | ServerSettingsService;
+
+const withInstanceIdentity =
+  (input: {
+    readonly instanceId: ProviderInstance["instanceId"];
+    readonly displayName: string | undefined;
+    readonly accentColor: string | undefined;
+    readonly continuationGroupKey: string;
+  }) =>
+  (snapshot: ServerProviderDraft): ServerProvider => ({
+    ...snapshot,
+    instanceId: input.instanceId,
+    driver: DRIVER_KIND,
+    ...(input.displayName ? { displayName: input.displayName } : {}),
+    ...(input.accentColor ? { accentColor: input.accentColor } : {}),
+    continuation: { groupKey: input.continuationGroupKey },
+  });
+
+export const CopilotDriver: ProviderDriver<CopilotSettings, CopilotDriverEnv> = {
+  driverKind: DRIVER_KIND,
+  metadata: {
+    displayName: "GitHub Copilot",
+    supportsMultipleInstances: true,
+  },
+  configSchema: CopilotSettings,
+  defaultConfig: (): CopilotSettings => decodeCopilotSettings({}),
+  create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
+    Effect.gen(function* () {
+      const crypto = yield* Crypto.Crypto;
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const httpClient = yield* HttpClient.HttpClient;
+      const eventLoggers = yield* ProviderEventLoggers;
+      const serverSettings = yield* ServerSettingsService;
+      const processEnv = mergeProviderInstanceEnvironment(environment);
+      const continuationIdentity = defaultProviderContinuationIdentity({
+        driverKind: DRIVER_KIND,
+        instanceId,
+      });
+      const stampIdentity = withInstanceIdentity({
+        instanceId,
+        displayName,
+        accentColor,
+        continuationGroupKey: continuationIdentity.continuationKey,
+      });
+      const effectiveConfig = {
+        ...config,
+        enabled,
+      } satisfies CopilotSettings;
+      const maintenanceCapabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
+        binaryPath: effectiveConfig.binaryPath,
+        env: processEnv,
+      });
+      // Remembers the last successfully discovered catalog so a status refresh
+      // whose discovery fails/times out keeps showing the previous models.
+      const discoveredModelsRef = yield* Ref.make<ReadonlyArray<ServerProviderModel>>([]);
+
+      const adapter = yield* makeCopilotAdapter(effectiveConfig, {
+        environment: processEnv,
+        ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
+        instanceId,
+      });
+      const textGeneration = yield* makeCopilotTextGeneration(effectiveConfig, processEnv);
+
+      const checkProvider = checkCopilotProviderStatus(effectiveConfig, processEnv, {
+        discoveredModelsRef,
+      }).pipe(
+        Effect.map(stampIdentity),
+        Effect.provideService(Crypto.Crypto, crypto),
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      );
+
+      const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
+      const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<CopilotSettings>>({
+        maintenanceCapabilities,
+        getSettings: snapshotSettings.getSettings,
+        streamSettings: snapshotSettings.streamSettings,
+        haveSettingsChanged: haveProviderSnapshotSettingsChanged,
+        initialSnapshot: (settings) =>
+          buildInitialCopilotProviderSnapshot(settings.provider).pipe(Effect.map(stampIdentity)),
+        checkProvider,
+        enrichSnapshot: ({ settings, snapshot: currentSnapshot, publishSnapshot }) =>
+          enrichCopilotSnapshot({
+            snapshot: currentSnapshot,
+            maintenanceCapabilities,
+            enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
+            publishSnapshot,
+            stampIdentity,
+            httpClient,
+          }),
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProviderDriverError({
+              driver: DRIVER_KIND,
+              instanceId,
+              detail: "Failed to build the Copilot provider snapshot.",
+              cause,
+            }),
+        ),
+      );
+
+      return {
+        instanceId,
+        driverKind: DRIVER_KIND,
+        continuationIdentity,
+        displayName,
+        accentColor,
+        enabled,
+        snapshot,
+        adapter,
+        textGeneration,
+      } satisfies ProviderInstance;
+    }),
+};

--- a/apps/server/src/provider/Layers/CopilotAdapter.ts
+++ b/apps/server/src/provider/Layers/CopilotAdapter.ts
@@ -1,0 +1,1069 @@
+/**
+ * CopilotAdapter — GitHub Copilot via the first-party `@github/copilot-sdk`.
+ *
+ * Replaces the previous `copilot --acp` (ACP) integration. The SDK spawns and
+ * drives the same `copilot` runtime binary over a typed JSON-RPC protocol,
+ * exposing real per-model capabilities (reasoning effort, context-window tier)
+ * that the ACP path could not drive. One `CopilotClient` (one runtime process)
+ * backs every thread this adapter owns; each thread gets its own
+ * `CopilotSession`.
+ *
+ * @module CopilotAdapter
+ */
+
+import {
+  ApprovalRequestId,
+  type CopilotSettings,
+  EventId,
+  type ProviderApprovalDecision,
+  type ProviderRuntimeEvent,
+  type ProviderSession,
+  type ProviderUserInputAnswers,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  RuntimeRequestId,
+  type ThreadId,
+  type ToolLifecycleItemType,
+  TurnId,
+} from "@t3tools/contracts";
+import type {
+  CopilotSession,
+  MessageOptions,
+  PermissionRequest,
+  PermissionRequestResult,
+  ResumeSessionConfig,
+  SessionConfig,
+  SessionEvent,
+} from "@github/copilot-sdk";
+import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as Queue from "effect/Queue";
+import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
+import * as Stream from "effect/Stream";
+import * as SynchronizedRef from "effect/SynchronizedRef";
+
+import { resolveAttachmentPath } from "../../attachmentStore.ts";
+import { ServerConfig } from "../../config.ts";
+import {
+  ProviderAdapterProcessError,
+  ProviderAdapterRequestError,
+  ProviderAdapterSessionNotFoundError,
+  ProviderAdapterValidationError,
+} from "../Errors.ts";
+import {
+  makeCopilotSdkClient,
+  type CopilotSdkClient,
+  type CopilotSdkError,
+} from "../sdk/CopilotSdkClient.ts";
+import {
+  resolveCopilotSdkTunables,
+  type CopilotContextTier,
+  type CopilotReasoningEffort,
+  type CopilotSdkSessionTunables,
+} from "../sdk/CopilotSdkModels.ts";
+import {
+  makeSdkAssistantItemEvent,
+  makeSdkContentDeltaEvent,
+  makeSdkRequestOpenedEvent,
+  makeSdkRequestResolvedEvent,
+  makeSdkToolCompleteEvent,
+  makeSdkToolProgressEvent,
+  makeSdkToolStartEvent,
+  permissionDetailFromSdk,
+  toolItemTypeFromSdk,
+} from "../sdk/CopilotSdkRuntimeEvents.ts";
+import { type CopilotAdapterShape } from "../Services/CopilotAdapter.ts";
+import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
+
+const PROVIDER = ProviderDriverKind.make("copilot");
+const COPILOT_RESUME_VERSION = 1 as const;
+
+function parseCopilotResume(raw: unknown): { sessionId: string } | undefined {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return undefined;
+  const record = raw as Record<string, unknown>;
+  if (record.schemaVersion !== COPILOT_RESUME_VERSION) return undefined;
+  if (typeof record.sessionId !== "string" || !record.sessionId.trim()) return undefined;
+  return { sessionId: record.sessionId.trim() };
+}
+
+/** Maps a T3 approval decision to the SDK's permission-decision result. */
+function decisionToSdkResult(decision: ProviderApprovalDecision): PermissionRequestResult {
+  switch (decision) {
+    case "accept":
+      return { kind: "approve-once" };
+    case "acceptForSession":
+      return { kind: "approve-for-session" };
+    case "decline":
+    case "cancel":
+    default:
+      return { kind: "reject" };
+  }
+}
+
+interface PendingApproval {
+  readonly resolve: (decision: ProviderApprovalDecision) => void;
+  readonly request: PermissionRequest;
+}
+
+/** Internal event carried from JS callbacks into the Effect consumer fiber. */
+type InternalEvent =
+  | { readonly _tag: "sdk"; readonly event: SessionEvent }
+  | {
+      readonly _tag: "permissionOpened";
+      readonly requestId: ApprovalRequestId;
+      readonly request: PermissionRequest;
+    }
+  | {
+      readonly _tag: "permissionResolved";
+      readonly requestId: ApprovalRequestId;
+      readonly request: PermissionRequest;
+      readonly decision: ProviderApprovalDecision;
+    };
+
+/**
+ * How a turn's completion `Deferred` settled: a normal or aborted idle, or a
+ * provider/runtime error that must surface as a `failed` turn (with a non-empty
+ * message) rather than silently reporting `completed` or wedging the thread.
+ */
+type TurnOutcome = {
+  readonly aborted: boolean;
+  readonly error?: { readonly message: string; readonly detail?: unknown };
+};
+
+interface CopilotSessionContext {
+  readonly threadId: ThreadId;
+  session: ProviderSession;
+  readonly sdkSession: CopilotSession;
+  readonly internalQueue: Queue.Queue<InternalEvent>;
+  consumerFiber: Fiber.Fiber<void, never> | undefined;
+  readonly pendingApprovals: Map<ApprovalRequestId, PendingApproval>;
+  readonly turns: Array<{ id: TurnId; items: Array<unknown> }>;
+  readonly toolItemTypes: Map<string, ToolLifecycleItemType>;
+  activeTurnId: TurnId | undefined;
+  activeTurnCompletion: Deferred.Deferred<TurnOutcome> | undefined;
+  appliedModel: string | undefined;
+  appliedReasoningEffort: string | undefined;
+  appliedContextTier: string | undefined;
+  stopped: boolean;
+}
+
+export interface CopilotAdapterLiveOptions {
+  readonly environment?: NodeJS.ProcessEnv;
+  readonly nativeEventLogPath?: string;
+  readonly nativeEventLogger?: EventNdjsonLogger;
+  readonly instanceId?: typeof ProviderInstanceId.Type;
+}
+
+export function makeCopilotAdapter(
+  copilotSettings: CopilotSettings,
+  options?: CopilotAdapterLiveOptions,
+) {
+  return Effect.gen(function* () {
+    const boundInstanceId = options?.instanceId ?? ProviderInstanceId.make("copilot");
+    const path = yield* Path.Path;
+    const serverConfig = yield* Effect.service(ServerConfig);
+    const crypto = yield* Crypto.Crypto;
+    const adapterScope = yield* Effect.scope;
+
+    const nativeEventLogger =
+      options?.nativeEventLogger ??
+      (options?.nativeEventLogPath !== undefined
+        ? yield* makeEventNdjsonLogger(options.nativeEventLogPath, { stream: "native" })
+        : undefined);
+    const managedNativeEventLogger =
+      options?.nativeEventLogger === undefined ? nativeEventLogger : undefined;
+
+    const sessions = new Map<ThreadId, CopilotSessionContext>();
+    const threadLocksRef = yield* SynchronizedRef.make(new Map<string, Semaphore.Semaphore>());
+    const runtimeEventQueue = yield* Queue.unbounded<ProviderRuntimeEvent>();
+
+    // Lazily-created shared SDK client (one `copilot` runtime process). Created
+    // on first session start and torn down with the adapter scope.
+    const clientRef = yield* SynchronizedRef.make<CopilotSdkClient | undefined>(undefined);
+
+    const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+    const randomUUIDv4 = crypto.randomUUIDv4.pipe(Effect.orDie);
+    const nextEventId = Effect.map(randomUUIDv4, (id) => EventId.make(id));
+    const makeEventStamp = () => Effect.all({ eventId: nextEventId, createdAt: nowIso });
+
+    const offerRuntimeEvent = (event: ProviderRuntimeEvent) =>
+      Queue.offer(runtimeEventQueue, event).pipe(Effect.asVoid);
+
+    // Best-effort NDJSON record of the raw SDK traffic (mirrors the ACP
+    // adapters' native logging), so `nativeEventLogPath` / the driver's
+    // injected logger capture Copilot native events.
+    const logNative = (threadId: ThreadId, method: string, payload: unknown) =>
+      Effect.gen(function* () {
+        if (!nativeEventLogger) return;
+        const observedAt = yield* nowIso;
+        yield* nativeEventLogger.write(
+          {
+            observedAt,
+            event: {
+              id: yield* randomUUIDv4,
+              kind: "notification",
+              provider: PROVIDER,
+              createdAt: observedAt,
+              method,
+              threadId,
+              payload,
+            },
+          },
+          threadId,
+        );
+      }).pipe(
+        Effect.catchCause((cause) =>
+          Effect.logWarning("Failed to write native Copilot notification log.", {
+            cause,
+            threadId,
+            method,
+          }),
+        ),
+      );
+
+    const getClient: Effect.Effect<CopilotSdkClient, CopilotSdkError> =
+      SynchronizedRef.modifyEffect(clientRef, (existing) =>
+        existing
+          ? Effect.succeed([existing, existing] as const)
+          : makeCopilotSdkClient({
+              binaryPath: copilotSettings.binaryPath,
+              ...(options?.environment ? { environment: options.environment } : {}),
+            }).pipe(
+              Effect.provideService(Scope.Scope, adapterScope),
+              Effect.map((client) => [client, client] as const),
+            ),
+      );
+
+    const getThreadSemaphore = (threadId: string) =>
+      SynchronizedRef.modifyEffect(threadLocksRef, (current) => {
+        const existing = Option.fromNullishOr(current.get(threadId));
+        return Option.match(existing, {
+          onNone: () =>
+            Semaphore.make(1).pipe(
+              Effect.map((semaphore) => {
+                const next = new Map(current);
+                next.set(threadId, semaphore);
+                return [semaphore, next] as const;
+              }),
+            ),
+          onSome: (semaphore) => Effect.succeed([semaphore, current] as const),
+        });
+      });
+
+    const withThreadLock = <A, E, R>(threadId: string, effect: Effect.Effect<A, E, R>) =>
+      Effect.flatMap(getThreadSemaphore(threadId), (semaphore) => semaphore.withPermit(effect));
+
+    const requireSession = (
+      threadId: ThreadId,
+    ): Effect.Effect<CopilotSessionContext, ProviderAdapterSessionNotFoundError> => {
+      const ctx = sessions.get(threadId);
+      if (!ctx || ctx.stopped) {
+        return Effect.fail(
+          new ProviderAdapterSessionNotFoundError({ provider: PROVIDER, threadId }),
+        );
+      }
+      return Effect.succeed(ctx);
+    };
+
+    const settlePendingApprovalsAsCancelled = (ctx: CopilotSessionContext) =>
+      Effect.sync(() => {
+        for (const pending of ctx.pendingApprovals.values()) {
+          pending.resolve("cancel");
+        }
+        ctx.pendingApprovals.clear();
+      });
+
+    // ── SDK event → runtime event translation (runs in the Effect consumer) ──
+    const emitSdkEvent = (ctx: CopilotSessionContext, event: SessionEvent) =>
+      Effect.gen(function* () {
+        const base = {
+          provider: PROVIDER,
+          threadId: ctx.threadId,
+          turnId: ctx.activeTurnId,
+        };
+        switch (event.type) {
+          case "assistant.message_start":
+            yield* offerRuntimeEvent(
+              makeSdkAssistantItemEvent({
+                stamp: yield* makeEventStamp(),
+                ...base,
+                itemId: event.data.messageId,
+                lifecycle: "item.started",
+              }),
+            );
+            return;
+          case "assistant.message_delta":
+            if (!event.data.deltaContent) return;
+            yield* offerRuntimeEvent(
+              makeSdkContentDeltaEvent({
+                stamp: yield* makeEventStamp(),
+                ...base,
+                itemId: event.data.messageId,
+                text: event.data.deltaContent,
+                streamKind: "assistant_text",
+                method: "assistant.message_delta",
+                rawPayload: event.data,
+              }),
+            );
+            return;
+          case "assistant.message":
+            yield* offerRuntimeEvent(
+              makeSdkAssistantItemEvent({
+                stamp: yield* makeEventStamp(),
+                ...base,
+                itemId: event.data.messageId,
+                lifecycle: "item.completed",
+              }),
+            );
+            return;
+          case "assistant.reasoning_delta":
+            if (!event.data.deltaContent) return;
+            yield* offerRuntimeEvent(
+              makeSdkContentDeltaEvent({
+                stamp: yield* makeEventStamp(),
+                ...base,
+                itemId: event.data.reasoningId,
+                text: event.data.deltaContent,
+                streamKind: "reasoning_text",
+                method: "assistant.reasoning_delta",
+                rawPayload: event.data,
+              }),
+            );
+            return;
+          case "tool.execution_start": {
+            // Classify the tool once at start and remember it, so the
+            // completion/progress events keep the same item type instead of
+            // collapsing to a generic `dynamic_tool_call`.
+            const itemType = toolItemTypeFromSdk({
+              toolName: event.data.toolName,
+              ...(event.data.mcpServerName ? { mcpServerName: event.data.mcpServerName } : {}),
+            });
+            ctx.toolItemTypes.set(event.data.toolCallId, itemType);
+            yield* offerRuntimeEvent(
+              makeSdkToolStartEvent({
+                stamp: yield* makeEventStamp(),
+                ...base,
+                data: event.data,
+                itemType,
+              }),
+            );
+            return;
+          }
+          case "tool.execution_progress":
+            yield* offerRuntimeEvent(
+              makeSdkToolProgressEvent({
+                stamp: yield* makeEventStamp(),
+                ...base,
+                toolCallId: event.data.toolCallId,
+                itemType: ctx.toolItemTypes.get(event.data.toolCallId) ?? "dynamic_tool_call",
+                detail: event.data.progressMessage,
+                rawPayload: event.data,
+              }),
+            );
+            return;
+          case "tool.execution_complete": {
+            const itemType = ctx.toolItemTypes.get(event.data.toolCallId) ?? "dynamic_tool_call";
+            ctx.toolItemTypes.delete(event.data.toolCallId);
+            yield* offerRuntimeEvent(
+              makeSdkToolCompleteEvent({
+                stamp: yield* makeEventStamp(),
+                ...base,
+                data: event.data,
+                itemType,
+              }),
+            );
+            return;
+          }
+          case "session.idle":
+            // `session.idle` is the SOLE terminal settle point for a turn (see
+            // the `abort` case). Because a turn's guard stays closed until its
+            // own idle settles it, this idle always belongs to the active turn —
+            // an interrupted turn is never force-settled while its idle is still
+            // in flight, so no later turn can be admitted to catch a stale one.
+            if (ctx.activeTurnCompletion) {
+              yield* Deferred.succeed(ctx.activeTurnCompletion, {
+                aborted: event.data?.aborted === true,
+              });
+            }
+            return;
+          case "abort":
+            // Do NOT settle here. `abort` fires when a cancel is requested and is
+            // followed by a `session.idle` (with `aborted: true`); settling on
+            // `abort` would reopen the turn guard before that idle arrives, so the
+            // idle would then settle a newer turn. Let `session.idle` settle it.
+            return;
+          case "session.error": {
+            // A sub-agent scoped error (`agentId` set) belongs to a nested run,
+            // not this turn — never let it fail the root turn.
+            if (event.agentId !== undefined) {
+              yield* Effect.logWarning("Copilot SDK sub-agent session error", {
+                message: event.data.message,
+                errorType: event.data.errorType,
+                agentId: event.agentId,
+              });
+              return;
+            }
+            const message = event.data.message?.trim() || "GitHub Copilot session error.";
+            // A root `session.error` is terminal for the turn here. Even a
+            // `rate_limit` flagged `eligibleForAutoSwitch` does NOT recover: T3
+            // registers no auto-switch handler, so the SDK auto-declines the
+            // switch, the model stays rate-limited, and the turn produces no
+            // output — reporting it as a silent `completed` would bury the rate
+            // limit in the server log. Surface it as a `runtime.error` and settle
+            // the turn as `failed`; without this the failure only hit the log and
+            // the turn either reported `completed` or hung on its `Deferred.await`.
+            // (If T3 ever registers an auto-switch handler so a switch genuinely
+            // continues the turn, revisit this to skip settling when
+            // `event.data.eligibleForAutoSwitch === true`.)
+            yield* offerRuntimeEvent({
+              type: "runtime.error",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: ctx.threadId,
+              payload: { message, class: "provider_error", detail: event.data },
+            });
+            if (ctx.activeTurnCompletion) {
+              yield* Deferred.succeed(ctx.activeTurnCompletion, {
+                aborted: false,
+                error: { message, detail: event.data },
+              });
+            }
+            return;
+          }
+          case "session.shutdown": {
+            // Only a root-session shutdown ends this turn; a sub-agent scoped
+            // shutdown (`agentId` set) leaves the root session running.
+            if (event.agentId !== undefined) return;
+            // The runtime is going away. A crash (`shutdownType: "error"`) is a
+            // transport failure — surface it and fail the in-flight turn; a
+            // routine shutdown mid-turn is treated as an abort. Either way the
+            // active turn must be settled so a lost trailing `session.idle`
+            // doesn't wedge the thread (every later turn rejected as in-progress).
+            if (event.data.shutdownType === "error") {
+              const message =
+                event.data.errorReason?.trim() || "GitHub Copilot runtime shut down unexpectedly.";
+              yield* offerRuntimeEvent({
+                type: "runtime.error",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: ctx.threadId,
+                payload: { message, class: "transport_error", detail: event.data },
+              });
+              if (ctx.activeTurnCompletion) {
+                yield* Deferred.succeed(ctx.activeTurnCompletion, {
+                  aborted: false,
+                  error: { message, detail: event.data },
+                });
+              }
+            } else if (ctx.activeTurnCompletion) {
+              yield* Deferred.succeed(ctx.activeTurnCompletion, { aborted: true });
+            }
+            return;
+          }
+          default:
+            return;
+        }
+      });
+
+    const consumeInternalEvents = (ctx: CopilotSessionContext) =>
+      Stream.fromQueue(ctx.internalQueue).pipe(
+        Stream.runForEach((item) =>
+          Effect.gen(function* () {
+            switch (item._tag) {
+              case "sdk":
+                yield* logNative(ctx.threadId, `session.event:${item.event.type}`, item.event);
+                yield* emitSdkEvent(ctx, item.event);
+                return;
+              case "permissionOpened":
+                yield* logNative(ctx.threadId, "permission.requested", item.request);
+                yield* offerRuntimeEvent(
+                  makeSdkRequestOpenedEvent({
+                    stamp: yield* makeEventStamp(),
+                    provider: PROVIDER,
+                    threadId: ctx.threadId,
+                    turnId: ctx.activeTurnId,
+                    requestId: RuntimeRequestId.make(item.requestId),
+                    request: item.request,
+                    detail: permissionDetailFromSdk(item.request),
+                  }),
+                );
+                return;
+              case "permissionResolved":
+                yield* logNative(ctx.threadId, "permission.completed", {
+                  request: item.request,
+                  decision: item.decision,
+                });
+                yield* offerRuntimeEvent(
+                  makeSdkRequestResolvedEvent({
+                    stamp: yield* makeEventStamp(),
+                    provider: PROVIDER,
+                    threadId: ctx.threadId,
+                    turnId: ctx.activeTurnId,
+                    requestId: RuntimeRequestId.make(item.requestId),
+                    request: item.request,
+                    decision: item.decision,
+                  }),
+                );
+                return;
+            }
+          }),
+        ),
+      );
+
+    const stopSessionInternal = (ctx: CopilotSessionContext) =>
+      Effect.gen(function* () {
+        if (ctx.stopped) return;
+        ctx.stopped = true;
+        yield* settlePendingApprovalsAsCancelled(ctx);
+        if (ctx.activeTurnCompletion) {
+          yield* Deferred.succeed(ctx.activeTurnCompletion, { aborted: true });
+        }
+        yield* Effect.promise(() => ctx.sdkSession.disconnect().catch(() => {}));
+        yield* Queue.shutdown(ctx.internalQueue);
+        if (ctx.consumerFiber) {
+          yield* Fiber.interrupt(ctx.consumerFiber);
+        }
+        sessions.delete(ctx.threadId);
+        yield* offerRuntimeEvent({
+          type: "session.exited",
+          ...(yield* makeEventStamp()),
+          provider: PROVIDER,
+          threadId: ctx.threadId,
+          payload: { exitKind: "graceful" },
+        });
+      });
+
+    const startSession: CopilotAdapterShape["startSession"] = (input) =>
+      withThreadLock(
+        input.threadId,
+        Effect.gen(function* () {
+          if (input.provider !== undefined && input.provider !== PROVIDER) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "startSession",
+              issue: `Expected provider '${PROVIDER}' but received '${input.provider}'.`,
+            });
+          }
+          if (!input.cwd?.trim()) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "startSession",
+              issue: "cwd is required and must be non-empty.",
+            });
+          }
+
+          const cwd = path.resolve(input.cwd.trim());
+          const modelSelection =
+            input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
+          const existing = sessions.get(input.threadId);
+          if (existing && !existing.stopped) {
+            yield* stopSessionInternal(existing);
+          }
+
+          const client = yield* getClient.pipe(
+            Effect.mapError(
+              (cause) =>
+                new ProviderAdapterProcessError({
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  detail: "Failed to start the Copilot SDK runtime client.",
+                  cause,
+                }),
+            ),
+          );
+
+          const tunables = resolveCopilotSdkTunables(modelSelection?.options);
+          const pendingApprovals = new Map<ApprovalRequestId, PendingApproval>();
+          const internalQueue = yield* Queue.unbounded<InternalEvent>();
+          const runtimeMode = input.runtimeMode;
+          const approvalCounter = { value: 0 };
+
+          const onEvent = (event: SessionEvent): void => {
+            Queue.offerUnsafe(internalQueue, { _tag: "sdk", event });
+          };
+
+          const onPermissionRequest = async (
+            request: PermissionRequest,
+          ): Promise<PermissionRequestResult> => {
+            if (runtimeMode === "full-access") {
+              return { kind: "approve-once" };
+            }
+            approvalCounter.value += 1;
+            const requestId = ApprovalRequestId.make(
+              `copilot-perm-${boundInstanceId}-${approvalCounter.value}`,
+            );
+            const decision = await new Promise<ProviderApprovalDecision>((resolve) => {
+              pendingApprovals.set(requestId, { resolve, request });
+              Queue.offerUnsafe(internalQueue, { _tag: "permissionOpened", requestId, request });
+            });
+            pendingApprovals.delete(requestId);
+            Queue.offerUnsafe(internalQueue, {
+              _tag: "permissionResolved",
+              requestId,
+              request,
+              decision,
+            });
+            return decisionToSdkResult(decision);
+          };
+
+          // `reasoningEffort` / `contextTier` are cast to the SDK's own unions
+          // at the boundary (see CopilotSdkModels for why they're mirrored).
+          const baseConfig = {
+            workingDirectory: cwd,
+            streaming: true,
+            onEvent,
+            onPermissionRequest,
+            ...(modelSelection?.model ? { model: modelSelection.model } : {}),
+            ...(tunables.reasoningEffort ? { reasoningEffort: tunables.reasoningEffort } : {}),
+            ...(tunables.contextTier ? { contextTier: tunables.contextTier } : {}),
+          } as unknown as SessionConfig & ResumeSessionConfig;
+
+          const resumeSessionId = parseCopilotResume(input.resumeCursor)?.sessionId;
+          const sdkSession = yield* (
+            resumeSessionId
+              ? client.resumeSession(resumeSessionId, baseConfig as ResumeSessionConfig)
+              : client.createSession(baseConfig as SessionConfig)
+          ).pipe(
+            Effect.mapError(
+              (cause) =>
+                new ProviderAdapterProcessError({
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  detail: "Failed to create or resume the Copilot SDK session.",
+                  cause,
+                }),
+            ),
+          );
+
+          const now = yield* nowIso;
+          const session: ProviderSession = {
+            provider: PROVIDER,
+            providerInstanceId: boundInstanceId,
+            status: "ready",
+            runtimeMode: input.runtimeMode,
+            cwd,
+            model: modelSelection?.model,
+            threadId: input.threadId,
+            resumeCursor: {
+              schemaVersion: COPILOT_RESUME_VERSION,
+              sessionId: sdkSession.sessionId,
+            },
+            createdAt: now,
+            updatedAt: now,
+          };
+
+          const ctx: CopilotSessionContext = {
+            threadId: input.threadId,
+            session,
+            sdkSession,
+            internalQueue,
+            consumerFiber: undefined,
+            pendingApprovals,
+            turns: [],
+            toolItemTypes: new Map(),
+            activeTurnId: undefined,
+            activeTurnCompletion: undefined,
+            appliedModel: modelSelection?.model,
+            appliedReasoningEffort: tunables.reasoningEffort,
+            appliedContextTier: tunables.contextTier,
+            stopped: false,
+          };
+
+          // Fork into the adapter scope, not the `startSession` fiber: a
+          // child fiber would be interrupted when `startSession` returns,
+          // leaving SDK callbacks queued but never drained (so `session.idle`
+          // could never complete a turn). The fiber is torn down explicitly in
+          // `stopSessionInternal`.
+          ctx.consumerFiber = yield* consumeInternalEvents(ctx).pipe(Effect.forkIn(adapterScope));
+          sessions.set(input.threadId, ctx);
+
+          yield* offerRuntimeEvent({
+            type: "session.started",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { resume: { sessionId: sdkSession.sessionId } },
+          });
+          yield* offerRuntimeEvent({
+            type: "session.state.changed",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { state: "ready", reason: "GitHub Copilot SDK session ready" },
+          });
+          yield* offerRuntimeEvent({
+            type: "thread.started",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { providerThreadId: sdkSession.sessionId },
+          });
+
+          return session;
+        }),
+      );
+
+    // Applies a model / tunable change to the live SDK session when it differs
+    // from what's already applied, so we don't disrupt the runtime each turn.
+    const applyModelSelection = (
+      ctx: CopilotSessionContext,
+      model: string | undefined,
+      tunables: CopilotSdkSessionTunables,
+    ) =>
+      Effect.gen(function* () {
+        const targetModel = model?.trim() || ctx.appliedModel;
+        if (!targetModel) return;
+        const changed =
+          targetModel !== ctx.appliedModel ||
+          tunables.reasoningEffort !== ctx.appliedReasoningEffort ||
+          tunables.contextTier !== ctx.appliedContextTier;
+        if (!changed) return;
+        const setModelOptions = {
+          ...(tunables.reasoningEffort ? { reasoningEffort: tunables.reasoningEffort } : {}),
+          ...(tunables.contextTier ? { contextTier: tunables.contextTier } : {}),
+        } as Parameters<CopilotSession["setModel"]>[1];
+        yield* Effect.tryPromise({
+          try: () => ctx.sdkSession.setModel(targetModel, setModelOptions),
+          catch: (cause) =>
+            new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "session/set_model",
+              detail: "Failed to apply the Copilot model selection.",
+              cause,
+            }),
+        });
+        ctx.appliedModel = targetModel;
+        ctx.appliedReasoningEffort = tunables.reasoningEffort;
+        ctx.appliedContextTier = tunables.contextTier;
+      });
+
+    const sendTurn: CopilotAdapterShape["sendTurn"] = (input) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(input.threadId);
+        // One turn at a time per thread. A second concurrent turn would
+        // overwrite `activeTurnCompletion` (stranding the first on its
+        // `Deferred.await`) and misattribute the in-flight SDK events, so
+        // reject it rather than corrupt state. The orchestration layer already
+        // serializes turns, so this is a defensive guard.
+        if (ctx.activeTurnCompletion) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "sendTurn",
+            issue: "A turn is already in progress for this thread.",
+          });
+        }
+        const turnId = TurnId.make(yield* randomUUIDv4);
+        const turnModelSelection =
+          input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
+        const model = turnModelSelection?.model ?? ctx.session.model;
+        // A turn without its own model selection must not wipe the tunables
+        // applied at session start — carry the currently-applied effort/tier
+        // forward rather than resetting them to empty.
+        const tunables: CopilotSdkSessionTunables = turnModelSelection
+          ? resolveCopilotSdkTunables(turnModelSelection.options)
+          : {
+              ...(ctx.appliedReasoningEffort
+                ? { reasoningEffort: ctx.appliedReasoningEffort as CopilotReasoningEffort }
+                : {}),
+              ...(ctx.appliedContextTier
+                ? { contextTier: ctx.appliedContextTier as CopilotContextTier }
+                : {}),
+            };
+
+        // Build + validate prompt and attachments BEFORE touching the live SDK
+        // session. `applyModelSelection` mutates the session's model/tunables, so
+        // if it ran first a turn rejected below would still leave those changes
+        // applied — validate, then apply.
+        const promptText = input.input?.trim() ?? "";
+        const attachments: NonNullable<MessageOptions["attachments"]> = [];
+        if (input.attachments && input.attachments.length > 0) {
+          for (const attachment of input.attachments) {
+            const attachmentPath = resolveAttachmentPath({
+              attachmentsDir: serverConfig.attachmentsDir,
+              attachment,
+            });
+            if (!attachmentPath) {
+              return yield* new ProviderAdapterRequestError({
+                provider: PROVIDER,
+                method: "session/send",
+                detail: `Invalid attachment id '${attachment.id}'.`,
+              });
+            }
+            attachments.push({ type: "file", path: attachmentPath });
+          }
+        }
+
+        if (!promptText && attachments.length === 0) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "sendTurn",
+            issue: "Turn requires non-empty text or attachments.",
+          });
+        }
+
+        yield* applyModelSelection(ctx, model, tunables);
+
+        ctx.activeTurnId = turnId;
+        const completion = yield* Deferred.make<TurnOutcome>();
+        ctx.activeTurnCompletion = completion;
+        ctx.session = { ...ctx.session, activeTurnId: turnId, updatedAt: yield* nowIso };
+
+        yield* offerRuntimeEvent({
+          type: "turn.started",
+          ...(yield* makeEventStamp()),
+          provider: PROVIDER,
+          threadId: input.threadId,
+          turnId,
+          payload: { model: model?.trim() ?? undefined },
+        });
+
+        const messageOptions: MessageOptions = {
+          prompt: promptText,
+          ...(attachments.length > 0 ? { attachments } : {}),
+          agentMode: input.interactionMode === "plan" ? "plan" : "interactive",
+        };
+
+        // Clear the active-turn markers however the turn ends — success,
+        // failure, or interruption while awaiting `completion`. Without this
+        // finalizer an interrupted/failed `sendTurn` would leave
+        // `activeTurnCompletion` set and permanently wedge the session (every
+        // later turn rejected as "already in progress"). Also keeps
+        // `listSessions()` from reporting an idle session as active.
+        const clearActiveTurn = Effect.sync(() => {
+          ctx.activeTurnCompletion = undefined;
+          ctx.activeTurnId = undefined;
+          ctx.session = { ...ctx.session, activeTurnId: undefined };
+        });
+
+        const result = yield* Effect.gen(function* () {
+          yield* Effect.tryPromise({
+            try: () => ctx.sdkSession.send(messageOptions),
+            catch: (cause) =>
+              new ProviderAdapterRequestError({
+                provider: PROVIDER,
+                method: "session/send",
+                detail: "Failed to send the Copilot turn.",
+                cause,
+              }),
+          });
+          return yield* Deferred.await(completion);
+        }).pipe(Effect.ensuring(clearActiveTurn));
+
+        // If the session was stopped or replaced while this turn was in flight
+        // (`stopSessionInternal` settles the deferred and already emitted
+        // `session.exited`), don't mutate the now-detached context or publish a
+        // stale `turn.completed` — those events would arrive after the session's
+        // exit and, on replacement, after the new session's start events.
+        if (ctx.stopped) {
+          return { threadId: input.threadId, turnId, resumeCursor: ctx.session.resumeCursor };
+        }
+
+        ctx.turns.push({ id: turnId, items: [{ prompt: promptText, result }] });
+        ctx.session = {
+          ...ctx.session,
+          updatedAt: yield* nowIso,
+          model: model?.trim(),
+        };
+
+        yield* offerRuntimeEvent({
+          type: "turn.completed",
+          ...(yield* makeEventStamp()),
+          provider: PROVIDER,
+          threadId: input.threadId,
+          turnId,
+          // A provider/runtime error settles the turn as `failed` (the
+          // `runtime.error` was already emitted at the error site); otherwise it
+          // is a clean completion or an abort-driven cancellation.
+          payload: result.error
+            ? { state: "failed", stopReason: "error", errorMessage: result.error.message }
+            : {
+                state: result.aborted ? "cancelled" : "completed",
+                stopReason: result.aborted ? "cancelled" : null,
+              },
+        });
+
+        return { threadId: input.threadId, turnId, resumeCursor: ctx.session.resumeCursor };
+      });
+
+    const interruptTurn: CopilotAdapterShape["interruptTurn"] = (threadId) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        yield* settlePendingApprovalsAsCancelled(ctx);
+        const completion = ctx.activeTurnCompletion;
+        if (!completion) {
+          // No active turn to interrupt; still fire the abort so the runtime
+          // stops any residual work. Any resulting idle finds no active turn.
+          yield* Effect.promise(() => ctx.sdkSession.abort().catch(() => {}));
+          return;
+        }
+        const acknowledged = yield* Effect.promise(() =>
+          ctx.sdkSession.abort().then(
+            () => true,
+            () => false,
+          ),
+        );
+        // On a clean ack we do NOT settle locally: the SDK delivers THIS turn's
+        // own (aborted) `session.idle`, which settles `completion` and only then
+        // reopens the turn guard — so no later turn can be admitted while this
+        // turn's terminal event is still in flight, and the session-scoped idle
+        // (which carries no turn id) can never mis-settle a newer turn. Waiting
+        // for the real idle also keeps the turn honestly "running" while an
+        // attached shell command the abort didn't kill is still finishing.
+        // Only when the abort was NOT acknowledged is an idle not guaranteed, so
+        // settle here to keep `sendTurn` from stranding on its `Deferred.await`.
+        if (!acknowledged) {
+          yield* Deferred.succeed(completion, { aborted: true });
+        }
+      });
+
+    const respondToRequest: CopilotAdapterShape["respondToRequest"] = (
+      threadId,
+      requestId,
+      decision,
+    ) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        const pending = ctx.pendingApprovals.get(requestId);
+        if (!pending) {
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "session/request_permission",
+            detail: `Unknown pending approval request: ${requestId}`,
+          });
+        }
+        // Consume the request atomically: remove it before resolving so a
+        // second `respondToRequest` for the same id reports "unknown" rather
+        // than succeeding with a decision the already-settled promise ignores.
+        yield* Effect.sync(() => {
+          ctx.pendingApprovals.delete(requestId);
+          pending.resolve(decision);
+        });
+      });
+
+    const respondToUserInput: CopilotAdapterShape["respondToUserInput"] = (
+      threadId,
+      requestId,
+      _answers: ProviderUserInputAnswers,
+    ) =>
+      Effect.gen(function* () {
+        yield* requireSession(threadId);
+        return yield* new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "copilot/ask_question",
+          detail: `Structured user input is not supported by the Copilot SDK adapter (request ${requestId}).`,
+        });
+      });
+
+    const readThread: CopilotAdapterShape["readThread"] = (threadId) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        return { threadId, turns: ctx.turns };
+      });
+
+    const rollbackThread: CopilotAdapterShape["rollbackThread"] = (threadId, numTurns) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        if (!Number.isInteger(numTurns) || numTurns < 1) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "rollbackThread",
+            issue: "numTurns must be an integer >= 1.",
+          });
+        }
+        // Roll back the underlying SDK conversation, not just the local turn
+        // list — otherwise the next `send` still carries the discarded turns.
+        // The rewind points are per-user-turn boundaries; rewinding to the one
+        // `numTurns` back (conversation-only) discards that turn and everything
+        // after. Sort by timestamp so ordering doesn't depend on the API's
+        // return order. Only mirror the local turns once the backend rewind
+        // actually lands, so we never report a rollback that didn't happen.
+        const rewound = yield* Effect.tryPromise({
+          try: async () => {
+            const { points, unavailableReason } =
+              await ctx.sdkSession.rpc.history.listRewindPoints();
+            if (unavailableReason || points.length === 0) return false;
+            const ordered = [...points].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+            const target = ordered[Math.max(0, ordered.length - numTurns)];
+            if (!target) return false;
+            const result = await ctx.sdkSession.rpc.history.rewind({
+              eventId: target.eventId,
+              mode: "conversation",
+            });
+            return result.outcome === "success";
+          },
+          catch: (cause) =>
+            new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "history/rewind",
+              detail: "Failed to rewind the Copilot conversation.",
+              cause,
+            }),
+        });
+
+        if (!rewound) {
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "history/rewind",
+            detail: "GitHub Copilot could not roll back the conversation for this session.",
+          });
+        }
+
+        const nextLength = Math.max(0, ctx.turns.length - numTurns);
+        ctx.turns.splice(nextLength);
+        return { threadId, turns: ctx.turns };
+      });
+
+    const stopSession: CopilotAdapterShape["stopSession"] = (threadId) =>
+      withThreadLock(
+        threadId,
+        Effect.gen(function* () {
+          const ctx = yield* requireSession(threadId);
+          yield* stopSessionInternal(ctx);
+        }),
+      );
+
+    const listSessions: CopilotAdapterShape["listSessions"] = () =>
+      Effect.sync(() => Array.from(sessions.values(), (c) => ({ ...c.session })));
+
+    const hasSession: CopilotAdapterShape["hasSession"] = (threadId) =>
+      Effect.sync(() => {
+        const c = sessions.get(threadId);
+        return c !== undefined && !c.stopped;
+      });
+
+    const stopAll: CopilotAdapterShape["stopAll"] = () =>
+      Effect.forEach(sessions.values(), stopSessionInternal, { discard: true });
+
+    yield* Effect.addFinalizer(() =>
+      Effect.forEach(sessions.values(), stopSessionInternal, { discard: true }).pipe(
+        Effect.tap(() => Queue.shutdown(runtimeEventQueue)),
+        Effect.tap(() => managedNativeEventLogger?.close() ?? Effect.void),
+      ),
+    );
+
+    const streamEvents = Stream.fromQueue(runtimeEventQueue);
+
+    return {
+      provider: PROVIDER,
+      capabilities: { sessionModelSwitch: "in-session" },
+      startSession,
+      sendTurn,
+      interruptTurn,
+      readThread,
+      rollbackThread,
+      respondToRequest,
+      respondToUserInput,
+      stopSession,
+      listSessions,
+      hasSession,
+      stopAll,
+      streamEvents,
+    } satisfies CopilotAdapterShape;
+  });
+}

--- a/apps/server/src/provider/Layers/CopilotProvider.test.ts
+++ b/apps/server/src/provider/Layers/CopilotProvider.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { detectCopilotAuthFromEnvironment, parseCopilotVersionOutput } from "./CopilotProvider.ts";
+
+describe("parseCopilotVersionOutput", () => {
+  it("parses the version from `copilot version` output", () => {
+    const parsed = parseCopilotVersionOutput({
+      stdout: "GitHub Copilot CLI 1.0.80\n",
+      stderr: "",
+      code: 0,
+    });
+    expect(parsed.version).toBe("1.0.80");
+    expect(parsed.status).toBe("ready");
+  });
+
+  it("reports a non-zero exit as an error", () => {
+    const parsed = parseCopilotVersionOutput({
+      stdout: "",
+      stderr: "boom",
+      code: 127,
+    });
+    expect(parsed.version).toBeNull();
+    expect(parsed.status).toBe("error");
+    expect(parsed.message).toBeDefined();
+  });
+
+  it("warns when a zero-exit command produces unrecognized output", () => {
+    const parsed = parseCopilotVersionOutput({
+      stdout: "some other tool v9\n",
+      stderr: "",
+      code: 0,
+    });
+    expect(parsed.version).toBeNull();
+    expect(parsed.status).toBe("warning");
+    expect(parsed.message).toBeDefined();
+  });
+
+  it("treats a non-zero exit whose output says 'not found' as a missing binary", () => {
+    const parsed = parseCopilotVersionOutput({
+      stdout: "",
+      stderr: "zsh: command not found: copilot",
+      code: 127,
+    });
+    expect(parsed.status).toBe("error");
+    expect(parsed.message).toContain("not installed");
+  });
+});
+
+describe("detectCopilotAuthFromEnvironment", () => {
+  it("treats a Copilot/GH token as authenticated", () => {
+    expect(detectCopilotAuthFromEnvironment({ COPILOT_GITHUB_TOKEN: "x" }).status).toBe(
+      "authenticated",
+    );
+    expect(detectCopilotAuthFromEnvironment({ GH_TOKEN: "x" }).status).toBe("authenticated");
+    expect(detectCopilotAuthFromEnvironment({ GITHUB_TOKEN: "x" }).status).toBe("authenticated");
+  });
+
+  it("is unknown when no token is present", () => {
+    expect(detectCopilotAuthFromEnvironment({}).status).toBe("unknown");
+    expect(detectCopilotAuthFromEnvironment({ COPILOT_GITHUB_TOKEN: "  " }).status).toBe("unknown");
+  });
+
+  it("does not let a blank higher-precedence token mask a real one", () => {
+    expect(
+      detectCopilotAuthFromEnvironment({ COPILOT_GITHUB_TOKEN: "", GH_TOKEN: "real" }).status,
+    ).toBe("authenticated");
+  });
+});

--- a/apps/server/src/provider/Layers/CopilotProvider.ts
+++ b/apps/server/src/provider/Layers/CopilotProvider.ts
@@ -1,0 +1,450 @@
+/**
+ * CopilotProvider — status checking and model discovery for the GitHub Copilot CLI.
+ *
+ * @module CopilotProvider
+ */
+import type {
+  CopilotSettings,
+  ModelCapabilities,
+  ServerProvider,
+  ServerProviderAuth,
+  ServerProviderModel,
+  ServerProviderState,
+} from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Result from "effect/Result";
+import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
+import { HttpClient } from "effect/unstable/http";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import { createModelCapabilities } from "@t3tools/shared/model";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+
+import {
+  buildServerProvider,
+  collectStreamAsString,
+  isCommandMissingCause,
+  providerModelsFromSettings,
+  type CommandResult,
+  type ServerProviderDraft,
+} from "../providerSnapshot.ts";
+import {
+  enrichProviderSnapshotWithVersionAdvisory,
+  type ProviderMaintenanceCapabilities,
+} from "../providerMaintenance.ts";
+import { makeCopilotSdkClient, resolveCopilotBinaryPath } from "../sdk/CopilotSdkClient.ts";
+import { buildCopilotSdkModels } from "../sdk/CopilotSdkModels.ts";
+
+const COPILOT_PRESENTATION = {
+  displayName: "GitHub Copilot",
+  showInteractionModeToggle: true,
+} as const;
+const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
+  optionDescriptors: [],
+});
+
+const VERSION_TIMEOUT_MS = 8_000;
+const MODEL_DISCOVERY_TIMEOUT_MS = 10_000;
+// Discovery runs under the provider's single refresh permit and the SDK's
+// `start()` is uninterruptible, so the Effect-level discovery timeout can't cut
+// a stalled start. Bound it at the JS level below MODEL_DISCOVERY_TIMEOUT_MS,
+// leaving headroom for the bounded stop-on-failure (CLIENT_STOP_TIMEOUT_MS), so
+// a wedged start + its cleanup stays within the ~10s discovery budget rather
+// than holding the permit for the SDK's much longer internal shutdown timeouts.
+const MODEL_DISCOVERY_START_TIMEOUT_MS = 8_000;
+
+// ── Version parsing ──────────────────────────────────────────────────────────
+
+export interface CopilotVersionResult {
+  readonly version: string | null;
+  readonly status: Exclude<ServerProviderState, "disabled">;
+  readonly auth: ServerProviderAuth;
+  readonly message?: string;
+}
+
+/**
+ * Parse the output of `copilot version`.
+ * Example: `GitHub Copilot CLI 1.0.45`
+ */
+export function parseCopilotVersionOutput(result: CommandResult): CopilotVersionResult {
+  const combined = `${result.stdout}\n${result.stderr}`;
+  const lowerOutput = combined.toLowerCase();
+
+  if (result.code !== 0) {
+    if (
+      isCommandMissingCause({ message: combined }) ||
+      lowerOutput.includes("enoent") ||
+      lowerOutput.includes("not found") ||
+      lowerOutput.includes("command not found")
+    ) {
+      return {
+        version: null,
+        status: "error",
+        auth: { status: "unknown" },
+        message:
+          "GitHub Copilot CLI (`copilot`) is not installed or not on PATH. Run `npm install -g @github/copilot-cli` or download from GitHub.",
+      };
+    }
+    return {
+      version: null,
+      status: "error",
+      auth: { status: "unknown" },
+      message: `Failed to run Copilot CLI health check (exit code ${result.code}).`,
+    };
+  }
+
+  if (
+    lowerOutput.includes("enoent") ||
+    lowerOutput.includes("not found") ||
+    lowerOutput.includes("command not found")
+  ) {
+    return {
+      version: null,
+      status: "error",
+      auth: { status: "unknown" },
+      message: "GitHub Copilot CLI (`copilot`) is not installed or not on PATH.",
+    };
+  }
+
+  const versionMatch = combined.match(/GitHub Copilot CLI\s+(\d+\.\d+\.\d+)/i);
+  const version = versionMatch?.[1]?.trim() ?? null;
+
+  // A zero exit whose output we can't parse a version from is not necessarily
+  // the Copilot CLI (e.g. `binaryPath` points at some other executable). Surface
+  // a warning instead of reporting a healthy install.
+  if (!version) {
+    return {
+      version: null,
+      status: "warning",
+      auth: { status: "unknown" },
+      message:
+        "Could not parse a version from `copilot version`; ensure the configured binary is the GitHub Copilot CLI.",
+    };
+  }
+
+  return {
+    version,
+    status: "ready",
+    auth: { status: "unknown" },
+  };
+}
+
+/**
+ * Detect auth status from environment variables.
+ * The Copilot CLI checks COPILOT_GITHUB_TOKEN, GH_TOKEN, GITHUB_TOKEN in order.
+ */
+export function detectCopilotAuthFromEnvironment(
+  environment: NodeJS.ProcessEnv,
+): ServerProviderAuth {
+  // Pick the first NON-BLANK token in precedence order: a defined-but-empty
+  // COPILOT_GITHUB_TOKEN must not mask a real GH_TOKEN / GITHUB_TOKEN.
+  const token = [
+    environment["COPILOT_GITHUB_TOKEN"],
+    environment["GH_TOKEN"],
+    environment["GITHUB_TOKEN"],
+  ].find((value) => value?.trim());
+  if (token?.trim()) {
+    return { status: "authenticated" };
+  }
+  return { status: "unknown" };
+}
+
+// ── Model discovery ──────────────────────────────────────────────────────────
+
+/**
+ * Discovers the available Copilot models and their per-model capabilities via
+ * the `@github/copilot-sdk` `client.listModels()`. Unlike the retired ACP
+ * probe — which advertised one session-global config-option set for every
+ * model — this reports real per-model reasoning-effort and context-window
+ * support (see {@link buildCopilotSdkModels}). Failures degrade to an empty
+ * list so the caller keeps whatever models it already had.
+ */
+export const discoverCopilotModelsViaSdk = (
+  copilotSettings: CopilotSettings,
+  environment: NodeJS.ProcessEnv = process.env,
+): Effect.Effect<ReadonlyArray<ServerProviderModel>, never> =>
+  makeCopilotSdkClient({
+    binaryPath: copilotSettings.binaryPath,
+    environment,
+    startTimeoutMs: MODEL_DISCOVERY_START_TIMEOUT_MS,
+  }).pipe(
+    Effect.flatMap((client) => client.listModels),
+    Effect.map((models) => buildCopilotSdkModels(models)),
+    Effect.scoped,
+    Effect.catchCause((cause) =>
+      // Never swallow interruption — let refresh/shutdown cancellation propagate
+      // instead of masking it as an empty result.
+      Cause.hasInterrupts(cause)
+        ? Effect.interrupt
+        : Effect.logWarning("Copilot SDK model discovery failed", {
+            cause: Cause.pretty(cause),
+          }).pipe(Effect.as([] as ReadonlyArray<ServerProviderModel>)),
+    ),
+  );
+
+export function getCopilotFallbackModels(
+  copilotSettings: Pick<CopilotSettings, "customModels">,
+): ReadonlyArray<ServerProviderModel> {
+  return providerModelsFromSettings([], copilotSettings.customModels, EMPTY_CAPABILITIES);
+}
+
+// ── Snapshot building ────────────────────────────────────────────────────────
+
+export function buildCopilotProviderSnapshot(input: {
+  readonly checkedAt: string;
+  readonly copilotSettings: CopilotSettings;
+  readonly parsed: CopilotVersionResult;
+  readonly auth?: ServerProviderAuth;
+  readonly discoveredModels?: ReadonlyArray<ServerProviderModel>;
+  readonly discoveryWarning?: string;
+}): ServerProviderDraft {
+  const auth = input.auth ?? input.parsed.auth;
+  const message =
+    [input.parsed.message, input.discoveryWarning]
+      .map((m) => m?.trim())
+      .filter((m): m is string => Boolean(m))
+      .join(" ") || undefined;
+
+  return buildServerProvider({
+    presentation: COPILOT_PRESENTATION,
+    enabled: input.copilotSettings.enabled,
+    checkedAt: input.checkedAt,
+    models: providerModelsFromSettings(
+      input.discoveredModels ?? [],
+      input.copilotSettings.customModels,
+      EMPTY_CAPABILITIES,
+    ),
+    probe: {
+      installed: input.parsed.status !== "error" || !message?.includes("not installed"),
+      version: input.parsed.version,
+      status:
+        input.discoveryWarning && input.parsed.status === "ready" ? "warning" : input.parsed.status,
+      auth,
+      ...(message ? { message } : {}),
+    },
+  });
+}
+
+export function buildInitialCopilotProviderSnapshot(
+  copilotSettings: CopilotSettings,
+): Effect.Effect<ServerProviderDraft> {
+  return Effect.gen(function* () {
+    const checkedAt = yield* Effect.map(DateTime.now, DateTime.formatIso);
+    const models = getCopilotFallbackModels(copilotSettings);
+
+    if (!copilotSettings.enabled) {
+      return buildServerProvider({
+        presentation: COPILOT_PRESENTATION,
+        enabled: false,
+        checkedAt,
+        models,
+        probe: {
+          installed: false,
+          version: null,
+          status: "warning",
+          auth: { status: "unknown" },
+          message: "GitHub Copilot is disabled in T3 Code settings.",
+        },
+      });
+    }
+
+    return buildServerProvider({
+      presentation: COPILOT_PRESENTATION,
+      enabled: true,
+      checkedAt,
+      models,
+      probe: {
+        installed: true,
+        version: null,
+        status: "warning",
+        auth: { status: "unknown" },
+        message: "Checking GitHub Copilot CLI availability...",
+      },
+    });
+  });
+}
+
+// ── Status check ─────────────────────────────────────────────────────────────
+
+const runCopilotVersionCommand = (
+  copilotSettings: CopilotSettings,
+  environment: NodeJS.ProcessEnv = process.env,
+) =>
+  Effect.gen(function* () {
+    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const hostPlatform = yield* HostProcessPlatform;
+    // Resolve the binary the same way the SDK client does, so a GUI-launched
+    // process with a restricted PATH doesn't report an installed CLI as missing.
+    const resolvedBinary = yield* Effect.promise(() =>
+      resolveCopilotBinaryPath(copilotSettings.binaryPath, environment),
+    );
+    const command = ChildProcess.make(resolvedBinary, ["version"], {
+      env: environment,
+      shell: hostPlatform === "win32",
+    });
+    const child = yield* spawner.spawn(command);
+    const [stdout, stderr, exitCode] = yield* Effect.all(
+      [
+        collectStreamAsString(child.stdout),
+        collectStreamAsString(child.stderr),
+        child.exitCode.pipe(Effect.map(Number)),
+      ],
+      { concurrency: "unbounded" },
+    );
+    return { stdout, stderr, code: exitCode } satisfies CommandResult;
+  }).pipe(Effect.scoped);
+
+export const checkCopilotProviderStatus = Effect.fn("checkCopilotProviderStatus")(function* (
+  copilotSettings: CopilotSettings,
+  environment: NodeJS.ProcessEnv = process.env,
+  options?: {
+    // Last-known-good discovered catalog, carried across refreshes so a
+    // transient discovery failure/timeout doesn't make model selection vanish.
+    readonly discoveredModelsRef?: Ref.Ref<ReadonlyArray<ServerProviderModel>>;
+  },
+): Effect.fn.Return<ServerProviderDraft, never, ChildProcessSpawner.ChildProcessSpawner> {
+  const checkedAt = DateTime.formatIso(yield* DateTime.now);
+  const fallbackModels = getCopilotFallbackModels(copilotSettings);
+
+  if (!copilotSettings.enabled) {
+    return buildServerProvider({
+      presentation: COPILOT_PRESENTATION,
+      enabled: false,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: false,
+        version: null,
+        status: "warning",
+        auth: { status: "unknown" },
+        message: "GitHub Copilot is disabled in T3 Code settings.",
+      },
+    });
+  }
+
+  const versionProbe = yield* runCopilotVersionCommand(copilotSettings, environment).pipe(
+    Effect.timeoutOption(VERSION_TIMEOUT_MS),
+    Effect.result,
+  );
+
+  if (Result.isFailure(versionProbe)) {
+    const error = versionProbe.failure;
+    return buildServerProvider({
+      presentation: COPILOT_PRESENTATION,
+      enabled: copilotSettings.enabled,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: !isCommandMissingCause(error),
+        version: null,
+        status: "error",
+        auth: { status: "unknown" },
+        message: isCommandMissingCause(error)
+          ? "GitHub Copilot CLI (`copilot`) is not installed or not on PATH."
+          : "Failed to execute Copilot CLI health check.",
+      },
+    });
+  }
+
+  if (Option.isNone(versionProbe.success)) {
+    return buildServerProvider({
+      presentation: COPILOT_PRESENTATION,
+      enabled: copilotSettings.enabled,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: true,
+        version: null,
+        status: "error",
+        auth: { status: "unknown" },
+        message: "GitHub Copilot CLI timed out while running `copilot version`.",
+      },
+    });
+  }
+
+  const parsed = parseCopilotVersionOutput(versionProbe.success.value);
+  // Check for token-based auth in environment
+  const envAuth = detectCopilotAuthFromEnvironment(environment);
+  const effectiveAuth: ServerProviderAuth =
+    envAuth.status === "authenticated" ? envAuth : parsed.auth;
+
+  // Discover the model catalog during the status check itself (as Cursor/Grok
+  // do), so every refresh carries a live catalog instead of resetting to the
+  // fallback and re-discovering later. The previously discovered catalog is
+  // preserved whenever the fresh probe fails, times out, or comes back empty,
+  // so model selection never disappears on a transient hiccup.
+  const previousModels = options?.discoveredModelsRef
+    ? yield* Ref.get(options.discoveredModelsRef)
+    : ([] as ReadonlyArray<ServerProviderModel>);
+  let discoveredModels = previousModels;
+  let discoveryWarning: string | undefined;
+
+  // Only spawn a runtime for discovery when the CLI is actually healthy: an
+  // errored/timed-out/unparseable `copilot version` (parsed.status !== "ready")
+  // means an SDK session would fail too, so skip it rather than pay a runtime
+  // spawn on every health refresh. (`effectiveAuth` is never "unauthenticated"
+  // on the current probes, so it can't serve as a discovery gate here.)
+  if (parsed.status === "ready") {
+    // `discoverCopilotModelsViaSdk` self-recovers real failures to `[]` and only
+    // fails on interruption (which propagates here), so `None` means the timeout
+    // fired and `Some([])` means "failed or genuinely no models".
+    const discovery = yield* discoverCopilotModelsViaSdk(copilotSettings, environment).pipe(
+      Effect.timeoutOption(MODEL_DISCOVERY_TIMEOUT_MS),
+    );
+    if (Option.isNone(discovery)) {
+      discoveryWarning = `GitHub Copilot model discovery timed out after ${MODEL_DISCOVERY_TIMEOUT_MS}ms${
+        previousModels.length > 0 ? "; using the last known models." : "."
+      }`;
+    } else if (discovery.value.length === 0) {
+      if (previousModels.length === 0) {
+        discoveryWarning = "GitHub Copilot model discovery returned no models.";
+      }
+    } else {
+      discoveredModels = discovery.value;
+      if (options?.discoveredModelsRef) {
+        yield* Ref.set(options.discoveredModelsRef, discoveredModels);
+      }
+    }
+  }
+
+  return buildCopilotProviderSnapshot({
+    checkedAt,
+    copilotSettings,
+    parsed,
+    auth: effectiveAuth,
+    discoveredModels,
+    ...(discoveryWarning ? { discoveryWarning } : {}),
+  });
+});
+
+// ── Background enrichment ────────────────────────────────────────────────────
+
+export const enrichCopilotSnapshot = (input: {
+  readonly snapshot: ServerProvider;
+  readonly maintenanceCapabilities: ProviderMaintenanceCapabilities;
+  readonly enableProviderUpdateChecks?: boolean;
+  readonly publishSnapshot: (snapshot: ServerProvider) => Effect.Effect<void>;
+  readonly stampIdentity?: (snapshot: ServerProvider) => ServerProvider;
+  readonly httpClient: HttpClient.HttpClient;
+}): Effect.Effect<void> => {
+  const { snapshot, publishSnapshot } = input;
+  const stampIdentity = input.stampIdentity ?? ((value) => value);
+
+  // Model discovery happens in `checkCopilotProviderStatus` (like Cursor/Grok),
+  // so enrichment only republishes update/version advisory metadata.
+  return enrichProviderSnapshotWithVersionAdvisory(snapshot, input.maintenanceCapabilities, {
+    enableProviderUpdateChecks: input.enableProviderUpdateChecks,
+  }).pipe(
+    Effect.provideService(HttpClient.HttpClient, input.httpClient),
+    Effect.flatMap((enrichedSnapshot) => publishSnapshot(stampIdentity(enrichedSnapshot))),
+    Effect.catchCause((cause) =>
+      Cause.hasInterrupts(cause)
+        ? Effect.interrupt
+        : Effect.logWarning("Copilot version advisory enrichment failed", {
+            cause: Cause.pretty(cause),
+          }),
+    ),
+  );
+};

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1739,6 +1739,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
               assert.deepStrictEqual(providers.map((provider) => provider.instanceId).toSorted(), [
                 "claudeAgent",
                 "codex",
+                "copilot",
                 "cursor",
                 "grok",
                 "opencode",

--- a/apps/server/src/provider/Services/CopilotAdapter.ts
+++ b/apps/server/src/provider/Services/CopilotAdapter.ts
@@ -1,0 +1,12 @@
+/**
+ * CopilotAdapter — shape type for the GitHub Copilot provider adapter.
+ *
+ * @module CopilotAdapter
+ */
+import type { ProviderAdapterError } from "../Errors.ts";
+import type { ProviderAdapterShape } from "./ProviderAdapter.ts";
+
+/**
+ * CopilotAdapterShape — per-instance Copilot adapter contract.
+ */
+export interface CopilotAdapterShape extends ProviderAdapterShape<ProviderAdapterError> {}

--- a/apps/server/src/provider/builtInDrivers.ts
+++ b/apps/server/src/provider/builtInDrivers.ts
@@ -22,6 +22,7 @@
  */
 import { ClaudeDriver, type ClaudeDriverEnv } from "./Drivers/ClaudeDriver.ts";
 import { CodexDriver, type CodexDriverEnv } from "./Drivers/CodexDriver.ts";
+import { CopilotDriver, type CopilotDriverEnv } from "./Drivers/CopilotDriver.ts";
 import { CursorDriver, type CursorDriverEnv } from "./Drivers/CursorDriver.ts";
 import { GrokDriver, type GrokDriverEnv } from "./Drivers/GrokDriver.ts";
 import { OpenCodeDriver, type OpenCodeDriverEnv } from "./Drivers/OpenCodeDriver.ts";
@@ -35,6 +36,7 @@ import type { AnyProviderDriver } from "./ProviderDriver.ts";
 export type BuiltInDriversEnv =
   | ClaudeDriverEnv
   | CodexDriverEnv
+  | CopilotDriverEnv
   | CursorDriverEnv
   | GrokDriverEnv
   | OpenCodeDriverEnv;
@@ -47,6 +49,7 @@ export type BuiltInDriversEnv =
 export const BUILT_IN_DRIVERS: ReadonlyArray<AnyProviderDriver<BuiltInDriversEnv>> = [
   CodexDriver,
   ClaudeDriver,
+  CopilotDriver,
   CursorDriver,
   GrokDriver,
   OpenCodeDriver,

--- a/apps/server/src/provider/sdk/CopilotSdkClient.test.ts
+++ b/apps/server/src/provider/sdk/CopilotSdkClient.test.ts
@@ -1,0 +1,53 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFSP from "node:fs/promises";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+
+import { assert, describe, it } from "@effect/vitest";
+
+import { resolveCopilotBinaryPath } from "./CopilotSdkClient.ts";
+
+// A name that can't exist in the machine's real PATH / common install dirs, so
+// these tests only see the executables they create and don't pick up a
+// brew/npm-installed `copilot`.
+const BIN = "copilot-resolver-test-bin";
+
+async function makeExecutable(dir: string, name: string): Promise<string> {
+  const filePath = NodePath.join(dir, name);
+  await NodeFSP.writeFile(filePath, "#!/bin/sh\nexit 0\n", "utf8");
+  await NodeFSP.chmod(filePath, 0o755);
+  return filePath;
+}
+
+describe("resolveCopilotBinaryPath", () => {
+  it("returns an explicit path (containing a separator) verbatim", async () => {
+    const explicit = NodePath.join("/opt", "custom", BIN);
+    const resolved = await resolveCopilotBinaryPath(explicit, {});
+    assert.strictEqual(resolved, explicit);
+  });
+
+  it("resolves a bare name against the spawn env PATH", async () => {
+    const dir = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "copilot-resolve-"));
+    const expected = await makeExecutable(dir, BIN);
+    const resolved = await resolveCopilotBinaryPath(BIN, { PATH: dir });
+    assert.strictEqual(resolved, expected);
+  });
+
+  it("skips a directory named like the binary and resolves a real file later in PATH", async () => {
+    const shadowDir = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "copilot-shadow-"));
+    const realDir = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "copilot-real-"));
+    // A directory named like the binary earlier in PATH must not shadow the CLI.
+    await NodeFSP.mkdir(NodePath.join(shadowDir, BIN));
+    const expected = await makeExecutable(realDir, BIN);
+    const resolved = await resolveCopilotBinaryPath(BIN, {
+      PATH: `${shadowDir}${NodePath.delimiter}${realDir}`,
+    });
+    assert.strictEqual(resolved, expected);
+  });
+
+  it("falls back to the bare name when nothing resolves", async () => {
+    const emptyDir = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "copilot-empty-"));
+    const resolved = await resolveCopilotBinaryPath(BIN, { PATH: emptyDir });
+    assert.strictEqual(resolved, BIN);
+  });
+});

--- a/apps/server/src/provider/sdk/CopilotSdkClient.ts
+++ b/apps/server/src/provider/sdk/CopilotSdkClient.ts
@@ -1,0 +1,305 @@
+/**
+ * CopilotSdkClient — scoped Effect wrapper around `@github/copilot-sdk`'s
+ * `CopilotClient`.
+ *
+ * The client spawns and drives the installed `copilot` runtime binary over the
+ * SDK's typed JSON-RPC protocol (`RuntimeConnection.forStdio`), replacing the
+ * generic ACP transport the Copilot provider used previously. It is acquired as
+ * a scoped resource: `start()` on acquire, `stop()` on release.
+ *
+ * @module provider/sdk/CopilotSdkClient
+ */
+import {
+  CopilotClient,
+  RuntimeConnection,
+  type CopilotSession,
+  type GetAuthStatusResponse,
+  type GetStatusResponse,
+  type ModelInfo,
+  type ResumeSessionConfig,
+  type SessionConfig,
+} from "@github/copilot-sdk";
+// Raw fs/path are needed to resolve the runtime binary to an absolute path at
+// the SDK spawn boundary — a plain async callback outside any Effect context.
+// @effect-diagnostics-next-line nodeBuiltinImport:off
+import * as NodeFS from "node:fs";
+// @effect-diagnostics-next-line nodeBuiltinImport:off
+import * as NodePath from "node:path";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+import type * as Scope from "effect/Scope";
+
+export class CopilotSdkError extends Schema.TaggedErrorClass<CopilotSdkError>()("CopilotSdkError", {
+  operation: Schema.String,
+  cause: Schema.optional(Schema.Defect()),
+}) {
+  override get message(): string {
+    return `GitHub Copilot SDK operation '${this.operation}' failed.`;
+  }
+}
+
+function toSdkError(operation: string) {
+  return (cause: unknown): CopilotSdkError => new CopilotSdkError({ operation, cause });
+}
+
+/** Filters a `ProcessEnv` down to the `Record<string, string>` the SDK expects. */
+function toStringEnv(
+  environment: NodeJS.ProcessEnv | undefined,
+): Record<string, string> | undefined {
+  if (!environment) return undefined;
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(environment)) {
+    if (typeof value === "string") out[key] = value;
+  }
+  return out;
+}
+
+async function isExecutable(candidate: string): Promise<boolean> {
+  try {
+    // Must be a regular file, not a directory: a directory named `copilot`
+    // earlier in PATH would otherwise shadow a real CLI later in PATH.
+    const stat = await NodeFS.promises.stat(candidate);
+    if (!stat.isFile()) return false;
+    await NodeFS.promises.access(candidate, NodeFS.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolves the `copilot` runtime binary to an absolute path.
+ *
+ * The SDK spawns the path we give it and does NOT resolve a bare command name
+ * against the connection env's PATH — and a GUI-launched app inherits a minimal
+ * PATH that omits Homebrew/npm dirs. So an unresolved `"copilot"` fails with
+ * "Copilot CLI not found at copilot". We resolve it ourselves against the
+ * spawn env's PATH plus the usual install locations, and hand the SDK an
+ * absolute path. An already-absolute/relative path (contains a separator) is
+ * used verbatim; if nothing resolves we fall back to the bare name so the SDK
+ * still surfaces its own diagnostic.
+ */
+export async function resolveCopilotBinaryPath(
+  binary: string,
+  env: Readonly<Record<string, string | undefined>> | undefined,
+): Promise<string> {
+  if (binary.includes(NodePath.sep) || binary.includes("/")) return binary;
+
+  const home = env?.HOME ?? process.env.HOME ?? "";
+  const pathValue = env?.PATH ?? process.env.PATH ?? "";
+  // A POSIX empty `PATH` component (leading/trailing/`::`) means the current
+  // working directory. We resolve `PATH` ourselves (the SDK does no lookup), so
+  // honor that — dropping empties would make a `copilot` in the CWD unfindable.
+  // `NodePath.resolve(".")` runs only when an empty component is actually present
+  // (a normal PATH never resolves the CWD, so it can't fail on one that's gone).
+  const pathDirs = pathValue
+    .split(NodePath.delimiter)
+    .map((d) => (d === "" ? NodePath.resolve(".") : d.trim()))
+    .filter(Boolean);
+
+  // On Windows an npm-installed `copilot` is a `copilot.cmd` shim: the bare
+  // name never resolves to a file, so probe each PATHEXT suffix (`.CMD`, …) in
+  // addition to the exact name. `NodePath.sep` is the lint-safe platform probe.
+  const isWindows = NodePath.sep === "\\";
+  const pathext = isWindows
+    ? (env?.PATHEXT ?? process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD")
+        .split(";")
+        .map((ext) => ext.trim())
+        .filter(Boolean)
+    : [];
+  const candidateNames = [
+    binary,
+    ...pathext
+      .filter((ext) => !binary.toLowerCase().endsWith(ext.toLowerCase()))
+      .map((ext) => `${binary}${ext}`),
+  ];
+  const commonDirs = [
+    "/opt/homebrew/bin",
+    "/usr/local/bin",
+    "/usr/bin",
+    "/bin",
+    ...(home
+      ? [
+          NodePath.join(home, ".local/bin"),
+          NodePath.join(home, ".bun/bin"),
+          NodePath.join(home, ".volta/bin"),
+          NodePath.join(home, ".npm-global/bin"),
+        ]
+      : []),
+  ];
+
+  const seen = new Set<string>();
+  for (const dir of [...pathDirs, ...commonDirs]) {
+    if (!dir || seen.has(dir)) continue;
+    seen.add(dir);
+    for (const name of candidateNames) {
+      const candidate = NodePath.join(dir, name);
+      if (await isExecutable(candidate)) return candidate;
+    }
+  }
+  return binary;
+}
+
+// `client.start()` spawns the runtime child and awaits the stdio JSON-RPC
+// handshake. It runs inside `acquireRelease`'s *uninterruptible* acquire, so an
+// outer `Effect.timeout` can't cut a stalled start (a slow spawn, a first-run
+// device-auth handshake, or a binary that never completes the handshake). That
+// matters most for discovery, which now runs inside the status check under the
+// provider's single refresh permit — a hung start would otherwise freeze every
+// refresh. Bound it here, at the JS level, where it can actually be enforced.
+// Callers on the refresh path pass a shorter `startTimeoutMs`, and the failure
+// path uses a bounded stop (below), so a stalled start holds the permit only for
+// `startTimeoutMs + CLIENT_STOP_TIMEOUT_MS` — not the SDK's internal shutdown
+// budgets, which `stop()` can otherwise burn (it resolves-with-errors on a hang).
+const CLIENT_START_TIMEOUT_MS = 15_000;
+// Max wait for a graceful `stop()` before hard-killing. `stop()` is bounded so a
+// failed acquire (below) and scope release don't inherit the SDK's own multi-
+// second internal shutdown budgets while holding the provider's refresh permit.
+const CLIENT_STOP_TIMEOUT_MS = 2_000;
+
+const TIMED_OUT = Symbol("timed-out");
+
+/** Rejects if `client.start()` doesn't resolve within `timeoutMs`. */
+async function startClientWithTimeout(client: CopilotClient, timeoutMs: number): Promise<void> {
+  // Raw JS timers (not Effect.sleep): this races plain promises at the JS level
+  // precisely because the uninterruptible acquire is beyond Effect's reach.
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    // @effect-diagnostics-next-line globalTimers:off
+    timer = setTimeout(
+      () => reject(new Error(`Copilot runtime did not start within ${timeoutMs}ms.`)),
+      timeoutMs,
+    );
+    timer.unref?.();
+  });
+  try {
+    await Promise.race([client.start(), timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
+ * Gracefully stops the client, hard-killing if it doesn't settle in time. The
+ * SDK's `stop()` RESOLVES (with an internal `errors[]`) rather than rejecting
+ * when its own shutdown timeouts fire, so a `.catch(() => forceStop())` never
+ * triggers on a hang — only racing it against our own timer catches that.
+ */
+async function stopClientBounded(client: CopilotClient, timeoutMs: number): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<typeof TIMED_OUT>((resolve) => {
+    // @effect-diagnostics-next-line globalTimers:off
+    timer = setTimeout(() => resolve(TIMED_OUT), timeoutMs);
+    timer.unref?.();
+  });
+  try {
+    const outcome = await Promise.race([
+      // Normalize both fulfil and reject to "done" so only the timer can win a hang.
+      client.stop().then(
+        () => "done" as const,
+        () => "done" as const,
+      ),
+      timeout,
+    ]);
+    if (outcome === TIMED_OUT) {
+      await client.forceStop().catch(() => {});
+    }
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export interface CopilotSdkClient {
+  /** Underlying SDK client, for the rare call not wrapped below. */
+  readonly raw: CopilotClient;
+  readonly listModels: Effect.Effect<ReadonlyArray<ModelInfo>, CopilotSdkError>;
+  readonly getAuthStatus: Effect.Effect<GetAuthStatusResponse, CopilotSdkError>;
+  readonly getStatus: Effect.Effect<GetStatusResponse, CopilotSdkError>;
+  readonly createSession: (config: SessionConfig) => Effect.Effect<CopilotSession, CopilotSdkError>;
+  readonly resumeSession: (
+    sessionId: string,
+    config: ResumeSessionConfig,
+  ) => Effect.Effect<CopilotSession, CopilotSdkError>;
+}
+
+export interface CopilotSdkClientInput {
+  readonly binaryPath?: string | null;
+  readonly environment?: NodeJS.ProcessEnv;
+  readonly logLevel?: "none" | "error" | "warning" | "info" | "debug" | "all";
+  /**
+   * Max wait for the runtime's `start()` handshake (default
+   * {@link CLIENT_START_TIMEOUT_MS}). The discovery path passes a value below
+   * its own budget so a stalled start can't hold the provider's refresh permit.
+   */
+  readonly startTimeoutMs?: number;
+}
+
+/**
+ * Acquires a started `CopilotClient` as a scoped resource. The client is
+ * stopped when the enclosing scope closes.
+ */
+export const makeCopilotSdkClient = (
+  input: CopilotSdkClientInput,
+): Effect.Effect<CopilotSdkClient, CopilotSdkError, Scope.Scope> => {
+  const env = toStringEnv(input.environment);
+  const binary = input.binaryPath?.trim() || "copilot";
+
+  const acquire = Effect.tryPromise({
+    try: async () => {
+      const path = await resolveCopilotBinaryPath(binary, env);
+      const client = new CopilotClient({
+        // Env goes ONLY on the stdio connection — the SDK rejects setting it at
+        // both the client level and the connection level, and prefers the
+        // connection-level env for child-process transports.
+        connection: RuntimeConnection.forStdio({ path, ...(env ? { env } : {}) }),
+        ...(input.logLevel ? { logLevel: input.logLevel } : {}),
+      });
+      // `start()` spawns the runtime child process before it resolves; if it
+      // rejects (or times out), `acquireRelease` never gets `client` to register
+      // its release, so stop it here to avoid leaking the process/handshake.
+      try {
+        await startClientWithTimeout(client, input.startTimeoutMs ?? CLIENT_START_TIMEOUT_MS);
+      } catch (error) {
+        await stopClientBounded(client, CLIENT_STOP_TIMEOUT_MS);
+        throw error;
+      }
+      return client;
+    },
+    catch: toSdkError("start"),
+  });
+
+  const release = (client: CopilotClient) =>
+    // Bounded graceful stop with a hard-kill fallback, so a hung `stop()` never
+    // leaves the runtime child alive — or stalls scope teardown — after close.
+    Effect.promise(() => stopClientBounded(client, CLIENT_STOP_TIMEOUT_MS)).pipe(Effect.asVoid);
+
+  return Effect.acquireRelease(acquire, release).pipe(
+    Effect.map(
+      (client): CopilotSdkClient => ({
+        raw: client,
+        listModels: Effect.tryPromise({
+          try: () => client.listModels(),
+          catch: toSdkError("listModels"),
+        }),
+        getAuthStatus: Effect.tryPromise({
+          try: () => client.getAuthStatus(),
+          catch: toSdkError("getAuthStatus"),
+        }),
+        getStatus: Effect.tryPromise({
+          try: () => client.getStatus(),
+          catch: toSdkError("getStatus"),
+        }),
+        createSession: (config) =>
+          Effect.tryPromise({
+            try: () => client.createSession(config),
+            catch: toSdkError("createSession"),
+          }),
+        resumeSession: (sessionId, config) =>
+          Effect.tryPromise({
+            try: () => client.resumeSession(sessionId, config),
+            catch: toSdkError("resumeSession"),
+          }),
+      }),
+    ),
+  );
+};

--- a/apps/server/src/provider/sdk/CopilotSdkModels.test.ts
+++ b/apps/server/src/provider/sdk/CopilotSdkModels.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { ModelInfo } from "@github/copilot-sdk";
+
+import {
+  buildCopilotSdkModelCapabilities,
+  buildCopilotSdkModels,
+  modelSupportsLongContext,
+  resolveCopilotSdkTunables,
+} from "./CopilotSdkModels.ts";
+
+// Fixtures modeled on real `client.listModels()` output (Copilot CLI 1.0.80):
+// a reasoning + long-context model, a reasoning-but-no-long-context model, a
+// plain model with neither lever, and a disabled model.
+const sonnet5 = {
+  id: "claude-sonnet-5",
+  name: "Claude Sonnet 5",
+  supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
+  capabilities: {
+    supports: { vision: true, reasoningEffort: true },
+    limits: { max_context_window_tokens: 1_000_000 },
+  },
+  billing: { tokenPrices: { longContext: { contextMax: 936_000 } } },
+  policy: { state: "enabled", terms: "" },
+} as unknown as ModelInfo;
+
+const sonnet45 = {
+  id: "claude-sonnet-4.5",
+  name: "Claude Sonnet 4.5",
+  capabilities: {
+    supports: { vision: true, reasoningEffort: false },
+    limits: { max_context_window_tokens: 144_000 },
+  },
+  billing: { tokenPrices: {} },
+  policy: { state: "enabled", terms: "" },
+} as unknown as ModelInfo;
+
+const disabledModel = {
+  id: "legacy-model",
+  name: "Legacy",
+  capabilities: {
+    supports: { vision: false, reasoningEffort: false },
+    limits: { max_context_window_tokens: 0 },
+  },
+  policy: { state: "disabled", terms: "" },
+} as unknown as ModelInfo;
+
+describe("modelSupportsLongContext", () => {
+  it("is gated on a longContext billing tier", () => {
+    expect(modelSupportsLongContext(sonnet5)).toBe(true);
+    expect(modelSupportsLongContext(sonnet45)).toBe(false);
+  });
+});
+
+describe("buildCopilotSdkModelCapabilities", () => {
+  it("surfaces reasoning effort and context window for a model that supports both", () => {
+    const caps = buildCopilotSdkModelCapabilities(sonnet5);
+    const descriptors = caps.optionDescriptors ?? [];
+    expect(descriptors.map((d) => d.id)).toEqual(["reasoning_effort", "context_tier"]);
+    const effort = descriptors.find((d) => d.id === "reasoning_effort");
+    expect(effort?.type).toBe("select");
+    if (effort?.type === "select") {
+      expect(effort.options.map((o) => o.id)).toEqual(["low", "medium", "high", "xhigh", "max"]);
+    }
+    const context = descriptors.find((d) => d.id === "context_tier");
+    expect(context?.type).toBe("select");
+    if (context?.type === "select") {
+      expect(context.options.map((o) => o.id)).toEqual(["default", "long_context"]);
+    }
+  });
+
+  it("surfaces nothing for a model with neither lever", () => {
+    expect(buildCopilotSdkModelCapabilities(sonnet45).optionDescriptors ?? []).toEqual([]);
+  });
+});
+
+describe("buildCopilotSdkModels", () => {
+  it("maps models, applies per-model capabilities, and skips disabled models", () => {
+    const models = buildCopilotSdkModels([sonnet5, sonnet45, disabledModel]);
+    expect(models.map((m) => m.slug)).toEqual(["claude-sonnet-5", "claude-sonnet-4.5"]);
+    expect((models[0]?.capabilities?.optionDescriptors ?? []).map((d) => d.id)).toEqual([
+      "reasoning_effort",
+      "context_tier",
+    ]);
+    expect(models[1]?.capabilities?.optionDescriptors ?? []).toEqual([]);
+  });
+
+  it("dedupes by id and tolerates empty input", () => {
+    expect(buildCopilotSdkModels([])).toEqual([]);
+    expect(buildCopilotSdkModels(undefined)).toEqual([]);
+    expect(buildCopilotSdkModels([sonnet5, sonnet5]).map((m) => m.slug)).toEqual([
+      "claude-sonnet-5",
+    ]);
+  });
+});
+
+describe("resolveCopilotSdkTunables", () => {
+  it("extracts reasoning effort and context tier from selections", () => {
+    expect(
+      resolveCopilotSdkTunables([
+        { id: "reasoning_effort", value: "high" },
+        { id: "context_tier", value: "long_context" },
+      ]),
+    ).toEqual({ reasoningEffort: "high", contextTier: "long_context" });
+  });
+
+  it("ignores unknown ids, invalid tiers, and invalid/boolean reasoning efforts", () => {
+    expect(
+      resolveCopilotSdkTunables([
+        { id: "made_up", value: "x" },
+        { id: "context_tier", value: "gigantic" },
+        { id: "reasoning_effort", value: "ludicrous" },
+        { id: "reasoning_effort", value: true },
+      ]),
+    ).toEqual({});
+  });
+
+  it("accepts the 'none' reasoning effort some models advertise", () => {
+    expect(resolveCopilotSdkTunables([{ id: "reasoning_effort", value: "none" }])).toEqual({
+      reasoningEffort: "none",
+    });
+  });
+
+  it("returns empty for empty input", () => {
+    expect(resolveCopilotSdkTunables([])).toEqual({});
+    expect(resolveCopilotSdkTunables(undefined)).toEqual({});
+  });
+});

--- a/apps/server/src/provider/sdk/CopilotSdkModels.ts
+++ b/apps/server/src/provider/sdk/CopilotSdkModels.ts
@@ -1,0 +1,204 @@
+/**
+ * CopilotSdkModels — map `@github/copilot-sdk` `ModelInfo` into T3 Code's
+ * provider model / capability shape.
+ *
+ * Unlike the retired ACP probe — which advertised one session-global config
+ * option set for *every* model — the SDK's `client.listModels()` reports real
+ * per-model capabilities. Each model therefore gets its own tunables:
+ *
+ * - **Reasoning effort** from `ModelInfo.supportedReasoningEfforts` (gated by
+ *   `capabilities.supports.reasoningEffort`). Applied at session/turn time via
+ *   `SessionConfig.reasoningEffort` / `session.setModel(id, { reasoningEffort })`.
+ * - **Context window tier** offered only when the model's billing advertises a
+ *   `longContext` price tier — i.e. the model actually supports `long_context`.
+ *   Applied via `SessionConfig.contextTier` / `session.setModel`. This is the
+ *   lever the ACP path could never drive (the CLI only accepted `--context` as
+ *   an unhonored launch flag); over the SDK it is a first-class option.
+ *
+ * @module provider/sdk/CopilotSdkModels
+ */
+import type { ModelInfo } from "@github/copilot-sdk";
+import type {
+  ModelCapabilities,
+  ProviderOptionDescriptor,
+  ProviderOptionSelection,
+  ServerProviderModel,
+} from "@t3tools/contracts";
+import { createModelCapabilities } from "@t3tools/shared/model";
+
+import { buildSelectOptionDescriptor } from "../providerSnapshot.ts";
+
+/**
+ * The SDK's `ReasoningEffort` / `ContextTier` string unions. Mirrored locally
+ * because `@github/copilot-sdk` does not re-export the type names from its
+ * package root (only the shapes that reference them). `none` is included for
+ * reasoning effort because the CLI advertises it for some models even though
+ * the SDK's own `ReasoningEffort` type omits it.
+ */
+export type CopilotReasoningEffort = "none" | "low" | "medium" | "high" | "xhigh" | "max";
+export type CopilotContextTier = "default" | "long_context";
+
+/** ACP-independent option ids the model picker keys tunables by. */
+export const COPILOT_REASONING_EFFORT_OPTION_ID = "reasoning_effort";
+export const COPILOT_CONTEXT_TIER_OPTION_ID = "context_tier";
+
+/** Reasoning efforts accepted by `SessionConfig.reasoningEffort` / `session.setModel`. */
+const REASONING_EFFORT_VALUES: ReadonlyArray<CopilotReasoningEffort> = [
+  "none",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+];
+
+/** Context tiers accepted by `SessionConfig.contextTier` / `session.setModel`. */
+const CONTEXT_TIER_VALUES: ReadonlyArray<CopilotContextTier> = ["default", "long_context"];
+
+const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({ optionDescriptors: [] });
+
+function reasoningEffortLabel(effort: string): string {
+  switch (effort) {
+    case "none":
+      return "None";
+    case "xhigh":
+      return "Extra high";
+    default:
+      return effort.charAt(0).toUpperCase() + effort.slice(1);
+  }
+}
+
+/**
+ * Whether the model supports the `long_context` tier. The SDK reports a
+ * dedicated `longContext` billing price block for exactly those models, so its
+ * presence is the authoritative gate (verified against Copilot CLI 1.0.80:
+ * present on claude-sonnet-5 / gpt-5.6-terra, absent on claude-sonnet-4.5 /
+ * claude-haiku-4.5).
+ */
+export function modelSupportsLongContext(model: ModelInfo): boolean {
+  return model.billing?.tokenPrices?.longContext !== undefined;
+}
+
+function reasoningEffortChoices(
+  model: ModelInfo,
+): ReadonlyArray<{ value: string; label: string; isDefault?: boolean }> {
+  if (!model.capabilities?.supports?.reasoningEffort) return [];
+  const efforts = model.supportedReasoningEfforts ?? [];
+  const seen = new Set<string>();
+  const defaultEffort = model.defaultReasoningEffort;
+  const choices: Array<{ value: string; label: string; isDefault?: boolean }> = [];
+  for (const effort of efforts) {
+    const value = String(effort).trim();
+    if (!value || seen.has(value)) continue;
+    seen.add(value);
+    choices.push({
+      value,
+      label: reasoningEffortLabel(value),
+      ...(defaultEffort !== undefined && value === defaultEffort ? { isDefault: true } : {}),
+    });
+  }
+  return choices;
+}
+
+/**
+ * Builds the per-model tunable descriptors (reasoning effort, context window)
+ * surfaced in the model picker. Returns empty capabilities when the model has
+ * neither lever.
+ */
+export function buildCopilotSdkModelCapabilities(model: ModelInfo): ModelCapabilities {
+  const optionDescriptors: ProviderOptionDescriptor[] = [];
+
+  const effortChoices = reasoningEffortChoices(model);
+  if (effortChoices.length > 0) {
+    optionDescriptors.push(
+      buildSelectOptionDescriptor({
+        id: COPILOT_REASONING_EFFORT_OPTION_ID,
+        label: "Reasoning Effort",
+        options: effortChoices,
+        description:
+          "How much reasoning effort the model spends before responding. Applied when the session starts and on the next turn after a change.",
+      }),
+    );
+  }
+
+  if (modelSupportsLongContext(model)) {
+    optionDescriptors.push(
+      buildSelectOptionDescriptor({
+        id: COPILOT_CONTEXT_TIER_OPTION_ID,
+        label: "Context Window",
+        options: [
+          { value: "default", label: "Default", isDefault: true },
+          { value: "long_context", label: "Long context" },
+        ],
+        description:
+          "Context window tier. `Long context` unlocks the model's extended context window (higher token limits, different billing). Takes effect on the next new chat.",
+      }),
+    );
+  }
+
+  if (optionDescriptors.length === 0) return EMPTY_CAPABILITIES;
+  return createModelCapabilities({ optionDescriptors });
+}
+
+/**
+ * Maps `client.listModels()` output into `ServerProviderModel`s with per-model
+ * capabilities. Models whose policy is explicitly `disabled` are skipped.
+ */
+export function buildCopilotSdkModels(
+  models: ReadonlyArray<ModelInfo> | null | undefined,
+): ReadonlyArray<ServerProviderModel> {
+  if (!models || models.length === 0) return [];
+  const seen = new Set<string>();
+  const result: ServerProviderModel[] = [];
+  for (const model of models) {
+    const slug = model.id?.trim();
+    if (!slug || seen.has(slug)) continue;
+    if (model.policy?.state === "disabled") continue;
+    seen.add(slug);
+    result.push({
+      slug,
+      name: model.name?.trim() || slug,
+      isCustom: false,
+      capabilities: buildCopilotSdkModelCapabilities(model),
+    });
+  }
+  return result;
+}
+
+export interface CopilotSdkSessionTunables {
+  readonly reasoningEffort?: CopilotReasoningEffort;
+  readonly contextTier?: CopilotContextTier;
+}
+
+/**
+ * Extracts the reasoning-effort / context-tier selections a user made in the
+ * model picker, to feed into `createSession` / `session.setModel`. Selection
+ * ids are the option ids above verbatim, so this is a lookup + validation;
+ * unknown or malformed values are dropped so the SDK never receives an invalid
+ * tunable.
+ */
+export function resolveCopilotSdkTunables(
+  selections: ReadonlyArray<ProviderOptionSelection> | null | undefined,
+): CopilotSdkSessionTunables {
+  if (!selections || selections.length === 0) return {};
+  const tunables: { reasoningEffort?: CopilotReasoningEffort; contextTier?: CopilotContextTier } =
+    {};
+  for (const selection of selections) {
+    const id = selection.id.trim();
+    const value =
+      typeof selection.value === "boolean" ? String(selection.value) : selection.value.trim();
+    if (!value) continue;
+    if (
+      id === COPILOT_REASONING_EFFORT_OPTION_ID &&
+      (REASONING_EFFORT_VALUES as ReadonlyArray<string>).includes(value)
+    ) {
+      tunables.reasoningEffort = value as CopilotReasoningEffort;
+    } else if (
+      id === COPILOT_CONTEXT_TIER_OPTION_ID &&
+      (CONTEXT_TIER_VALUES as ReadonlyArray<string>).includes(value)
+    ) {
+      tunables.contextTier = value as CopilotContextTier;
+    }
+  }
+  return tunables;
+}

--- a/apps/server/src/provider/sdk/CopilotSdkRuntimeEvents.ts
+++ b/apps/server/src/provider/sdk/CopilotSdkRuntimeEvents.ts
@@ -1,0 +1,272 @@
+/**
+ * CopilotSdkRuntimeEvents — translate `@github/copilot-sdk` session events into
+ * T3 Code's canonical `ProviderRuntimeEvent` stream.
+ *
+ * The SDK emits a typed event union (`assistant.message_delta`,
+ * `tool.execution_*`, `session.idle`, …). These builders map the subset the UI
+ * renders into the same `ProviderRuntimeEvent` shapes the ACP path produced, so
+ * nothing downstream (web timeline, orchestration) needs to change. Provenance
+ * is tagged `copilot.sdk.event` / `copilot.sdk.permission`.
+ *
+ * @module provider/sdk/CopilotSdkRuntimeEvents
+ */
+import {
+  type CanonicalRequestType,
+  type EventId,
+  type ProviderApprovalDecision,
+  type ProviderDriverKind,
+  type ProviderRuntimeEvent,
+  type RuntimeContentStreamKind,
+  RuntimeItemId,
+  type RuntimeRequestId,
+  type ThreadId,
+  type ToolLifecycleItemType,
+  type TurnId,
+} from "@t3tools/contracts";
+import type {
+  PermissionRequest,
+  ToolExecutionCompleteData,
+  ToolExecutionStartData,
+} from "@github/copilot-sdk";
+
+export interface CopilotSdkEventStamp {
+  readonly eventId: EventId;
+  readonly createdAt: string;
+}
+
+export interface CopilotSdkEventBase {
+  readonly stamp: CopilotSdkEventStamp;
+  readonly provider: ProviderDriverKind;
+  readonly threadId: ThreadId;
+  readonly turnId: TurnId | undefined;
+}
+
+/** Maps an SDK tool's name/metadata to a canonical timeline item type. */
+export function toolItemTypeFromSdk(data: {
+  readonly toolName: string;
+  readonly mcpServerName?: string;
+}): ToolLifecycleItemType {
+  if (data.mcpServerName) return "mcp_tool_call";
+  const name = data.toolName.toLowerCase();
+  if (/(bash|shell|exec|run_|terminal|command)/.test(name)) return "command_execution";
+  if (/(write|edit|str_replace|create_file|apply_patch|patch|delete|move|rename)/.test(name)) {
+    return "file_change";
+  }
+  // Only actual web fetches/searches — `grep`/`find`/`glob` are local code
+  // searches and fall through to the generic tool-call type.
+  if (/(web_?search|web_?fetch|fetch_?url|http|browse)/.test(name)) return "web_search";
+  if (/(view_image|image)/.test(name)) return "image_view";
+  return "dynamic_tool_call";
+}
+
+/** Maps an SDK permission-request kind to a canonical approval request type. */
+export function requestTypeFromSdkPermissionKind(kind: string): CanonicalRequestType {
+  switch (kind) {
+    case "shell":
+      return "exec_command_approval";
+    case "write":
+      return "file_change_approval";
+    case "read":
+      return "file_read_approval";
+    default:
+      return "dynamic_tool_call";
+  }
+}
+
+/** Short human-readable detail line for a permission request, per kind. */
+export function permissionDetailFromSdk(request: PermissionRequest): string | undefined {
+  switch (request.kind) {
+    case "shell":
+      return request.fullCommandText?.trim() || request.intention?.trim();
+    case "write":
+      return request.fileName?.trim() || request.intention?.trim();
+    case "read":
+      return request.path?.trim() || request.intention?.trim();
+    case "mcp":
+      return `${request.serverName}/${request.toolName}`.trim();
+    default:
+      return undefined;
+  }
+}
+
+export function makeSdkContentDeltaEvent(
+  input: CopilotSdkEventBase & {
+    readonly itemId?: string;
+    readonly text: string;
+    readonly streamKind: RuntimeContentStreamKind;
+    readonly method?: string;
+    readonly rawPayload: unknown;
+  },
+): ProviderRuntimeEvent {
+  return {
+    type: "content.delta",
+    ...input.stamp,
+    provider: input.provider,
+    threadId: input.threadId,
+    turnId: input.turnId,
+    ...(input.itemId ? { itemId: RuntimeItemId.make(input.itemId) } : {}),
+    payload: {
+      streamKind: input.streamKind,
+      delta: input.text,
+    },
+    raw: {
+      source: "copilot.sdk.event",
+      method: input.method ?? "session.event",
+      payload: input.rawPayload,
+    },
+  };
+}
+
+export function makeSdkAssistantItemEvent(
+  input: CopilotSdkEventBase & {
+    readonly itemId: string;
+    readonly lifecycle: "item.started" | "item.completed";
+  },
+): ProviderRuntimeEvent {
+  return {
+    type: input.lifecycle,
+    ...input.stamp,
+    provider: input.provider,
+    threadId: input.threadId,
+    turnId: input.turnId,
+    itemId: RuntimeItemId.make(input.itemId),
+    payload: {
+      itemType: "assistant_message",
+      status: input.lifecycle === "item.completed" ? "completed" : "inProgress",
+    },
+  };
+}
+
+export function makeSdkToolStartEvent(
+  input: CopilotSdkEventBase & {
+    readonly data: ToolExecutionStartData;
+    readonly itemType: ToolLifecycleItemType;
+  },
+): ProviderRuntimeEvent {
+  const itemType = input.itemType;
+  const title = input.data.mcpToolName?.trim() || input.data.toolName.trim();
+  return {
+    // A tool's first appearance is the canonical `item.started`; progress
+    // updates map to `item.updated` and completion to `item.completed`.
+    type: "item.started",
+    ...input.stamp,
+    provider: input.provider,
+    threadId: input.threadId,
+    turnId: input.turnId,
+    itemId: RuntimeItemId.make(input.data.toolCallId),
+    payload: {
+      itemType,
+      status: "inProgress",
+      ...(title ? { title } : {}),
+      ...(input.data.arguments !== undefined ? { data: input.data.arguments } : {}),
+    },
+    raw: {
+      source: "copilot.sdk.event",
+      method: "tool.execution_start",
+      payload: input.data,
+    },
+  };
+}
+
+export function makeSdkToolProgressEvent(
+  input: CopilotSdkEventBase & {
+    readonly toolCallId: string;
+    readonly itemType: ToolLifecycleItemType;
+    readonly detail: string;
+    readonly rawPayload: unknown;
+  },
+): ProviderRuntimeEvent {
+  return {
+    type: "item.updated",
+    ...input.stamp,
+    provider: input.provider,
+    threadId: input.threadId,
+    turnId: input.turnId,
+    itemId: RuntimeItemId.make(input.toolCallId),
+    payload: {
+      itemType: input.itemType,
+      status: "inProgress",
+      ...(input.detail.trim() ? { detail: input.detail.trim() } : {}),
+    },
+    raw: {
+      source: "copilot.sdk.event",
+      method: "tool.execution_progress",
+      payload: input.rawPayload,
+    },
+  };
+}
+
+export function makeSdkToolCompleteEvent(
+  input: CopilotSdkEventBase & {
+    readonly data: ToolExecutionCompleteData;
+    readonly itemType: ToolLifecycleItemType;
+  },
+): ProviderRuntimeEvent {
+  return {
+    type: "item.completed",
+    ...input.stamp,
+    provider: input.provider,
+    threadId: input.threadId,
+    turnId: input.turnId,
+    itemId: RuntimeItemId.make(input.data.toolCallId),
+    payload: {
+      itemType: input.itemType,
+      status: input.data.success ? "completed" : "failed",
+      ...(input.data.error?.message?.trim() ? { detail: input.data.error.message.trim() } : {}),
+    },
+    raw: {
+      source: "copilot.sdk.event",
+      method: "tool.execution_complete",
+      payload: input.data,
+    },
+  };
+}
+
+export function makeSdkRequestOpenedEvent(
+  input: CopilotSdkEventBase & {
+    readonly requestId: RuntimeRequestId;
+    readonly request: PermissionRequest;
+    readonly detail: string | undefined;
+  },
+): ProviderRuntimeEvent {
+  const detail = input.detail?.trim();
+  return {
+    type: "request.opened",
+    ...input.stamp,
+    provider: input.provider,
+    threadId: input.threadId,
+    turnId: input.turnId,
+    requestId: input.requestId,
+    payload: {
+      requestType: requestTypeFromSdkPermissionKind(input.request.kind),
+      ...(detail ? { detail } : {}),
+      args: input.request,
+    },
+    raw: {
+      source: "copilot.sdk.permission",
+      method: "permission.requested",
+      payload: input.request,
+    },
+  };
+}
+
+export function makeSdkRequestResolvedEvent(
+  input: CopilotSdkEventBase & {
+    readonly requestId: RuntimeRequestId;
+    readonly request: PermissionRequest;
+    readonly decision: ProviderApprovalDecision;
+  },
+): ProviderRuntimeEvent {
+  return {
+    type: "request.resolved",
+    ...input.stamp,
+    provider: input.provider,
+    threadId: input.threadId,
+    turnId: input.turnId,
+    requestId: input.requestId,
+    payload: {
+      requestType: requestTypeFromSdkPermissionKind(input.request.kind),
+      decision: input.decision,
+    },
+  };
+}

--- a/apps/server/src/textGeneration/CopilotTextGeneration.ts
+++ b/apps/server/src/textGeneration/CopilotTextGeneration.ts
@@ -1,0 +1,225 @@
+/**
+ * CopilotTextGeneration — Git text generation via the `@github/copilot-sdk`.
+ *
+ * One-shot JSON generation (commit messages, PR content, branch names, thread
+ * titles): spin up an SDK session, `sendAndWait` the prompt, and decode the
+ * assistant's final message as JSON.
+ *
+ * @module CopilotTextGeneration
+ */
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
+import { type CopilotSettings, type ModelSelection, TextGenerationError } from "@t3tools/contracts";
+import { sanitizeBranchFragment, sanitizeFeatureBranchName } from "@t3tools/shared/git";
+import { extractJsonObject } from "@t3tools/shared/schemaJson";
+
+import { type ThreadTitleGenerationResult, type TextGenerationShape } from "./TextGeneration.ts";
+import {
+  buildBranchNamePrompt,
+  buildCommitMessagePrompt,
+  buildPrContentPrompt,
+  buildThreadTitlePrompt,
+} from "./TextGenerationPrompts.ts";
+import {
+  sanitizeCommitSubject,
+  sanitizePrTitle,
+  sanitizeThreadTitle,
+} from "./TextGenerationUtils.ts";
+import { makeCopilotSdkClient } from "../provider/sdk/CopilotSdkClient.ts";
+import { resolveCopilotSdkTunables } from "../provider/sdk/CopilotSdkModels.ts";
+import type { SessionConfig } from "@github/copilot-sdk";
+
+const COPILOT_TIMEOUT_MS = 180_000;
+
+const isTextGenerationError = Schema.is(TextGenerationError);
+
+export const makeCopilotTextGeneration = Effect.fn("makeCopilotTextGeneration")(function* (
+  copilotSettings: CopilotSettings,
+  environment: NodeJS.ProcessEnv = process.env,
+) {
+  // No construction-time effect is needed; the SDK client is created lazily per
+  // request inside `runCopilotJson`.
+  yield* Effect.void;
+
+  const runCopilotJson = <S extends Schema.Top>({
+    operation,
+    cwd,
+    prompt,
+    outputSchemaJson,
+    modelSelection,
+  }: {
+    operation:
+      | "generateCommitMessage"
+      | "generatePrContent"
+      | "generateBranchName"
+      | "generateThreadTitle";
+    cwd: string;
+    prompt: string;
+    outputSchemaJson: S;
+    modelSelection: ModelSelection;
+  }): Effect.Effect<S["Type"], TextGenerationError, S["DecodingServices"]> =>
+    Effect.gen(function* () {
+      const client = yield* makeCopilotSdkClient({
+        binaryPath: copilotSettings.binaryPath,
+        environment,
+      });
+
+      // Forward the caller's selected reasoning-effort / context-tier options
+      // (parity with the interactive adapter and the sibling text generators).
+      const tunables = resolveCopilotSdkTunables(modelSelection.options);
+      const sessionConfig = {
+        workingDirectory: cwd,
+        // One-shot JSON generation must never execute tools: the prompt embeds
+        // untrusted content (staged diffs, PR bodies), so auto-approving would
+        // let prompt injection run shell/file tools in `cwd` unattended. Deny
+        // every request — the model just produces its text answer without them.
+        onPermissionRequest: async () => ({ kind: "reject" as const }),
+        ...(modelSelection.model ? { model: modelSelection.model } : {}),
+        ...(tunables.reasoningEffort ? { reasoningEffort: tunables.reasoningEffort } : {}),
+        ...(tunables.contextTier ? { contextTier: tunables.contextTier } : {}),
+      } as unknown as SessionConfig;
+
+      const session = yield* client.createSession(sessionConfig);
+
+      const rawResult = yield* Effect.tryPromise({
+        try: () =>
+          session
+            .sendAndWait({ prompt, agentMode: "interactive" }, COPILOT_TIMEOUT_MS)
+            .then((message) => (message?.data.content ?? "").trim()),
+        catch: (cause) =>
+          new TextGenerationError({
+            operation,
+            detail: "GitHub Copilot request failed.",
+            cause,
+          }),
+      }).pipe(Effect.ensuring(Effect.promise(() => session.disconnect().catch(() => {}))));
+
+      if (!rawResult) {
+        return yield* new TextGenerationError({
+          operation,
+          detail: "GitHub Copilot returned empty output.",
+        });
+      }
+
+      const decodeOutput = Schema.decodeEffect(Schema.fromJsonString(outputSchemaJson));
+      return yield* decodeOutput(extractJsonObject(rawResult)).pipe(
+        Effect.catchTags({
+          SchemaError: (cause) =>
+            Effect.fail(
+              new TextGenerationError({
+                operation,
+                detail: "GitHub Copilot returned invalid structured output.",
+                cause,
+              }),
+            ),
+        }),
+      );
+    }).pipe(
+      Effect.mapError((cause) =>
+        isTextGenerationError(cause)
+          ? cause
+          : new TextGenerationError({
+              operation,
+              detail: "Copilot text generation failed.",
+              cause,
+            }),
+      ),
+      Effect.scoped,
+    );
+
+  const generateCommitMessage: TextGenerationShape["generateCommitMessage"] = Effect.fn(
+    "CopilotTextGeneration.generateCommitMessage",
+  )(function* (input) {
+    const { prompt, outputSchema } = buildCommitMessagePrompt({
+      branch: input.branch,
+      stagedSummary: input.stagedSummary,
+      stagedPatch: input.stagedPatch,
+      includeBranch: input.includeBranch === true,
+      policy: input.policy,
+    });
+    const generated = yield* runCopilotJson({
+      operation: "generateCommitMessage",
+      cwd: input.cwd,
+      prompt,
+      outputSchemaJson: outputSchema,
+      modelSelection: input.modelSelection,
+    });
+    return {
+      subject: sanitizeCommitSubject(generated.subject),
+      body: generated.body.trim(),
+      ...("branch" in generated && typeof generated.branch === "string"
+        ? { branch: sanitizeFeatureBranchName(generated.branch) }
+        : {}),
+    };
+  });
+
+  const generatePrContent: TextGenerationShape["generatePrContent"] = Effect.fn(
+    "CopilotTextGeneration.generatePrContent",
+  )(function* (input) {
+    const { prompt, outputSchema } = buildPrContentPrompt({
+      baseBranch: input.baseBranch,
+      headBranch: input.headBranch,
+      commitSummary: input.commitSummary,
+      diffSummary: input.diffSummary,
+      diffPatch: input.diffPatch,
+      policy: input.policy,
+      changeRequestTemplate: input.changeRequestTemplate,
+    });
+    const generated = yield* runCopilotJson({
+      operation: "generatePrContent",
+      cwd: input.cwd,
+      prompt,
+      outputSchemaJson: outputSchema,
+      modelSelection: input.modelSelection,
+    });
+    return {
+      title: sanitizePrTitle(generated.title),
+      body: generated.body.trim(),
+    };
+  });
+
+  const generateBranchName: TextGenerationShape["generateBranchName"] = Effect.fn(
+    "CopilotTextGeneration.generateBranchName",
+  )(function* (input) {
+    const { prompt, outputSchema } = buildBranchNamePrompt({
+      message: input.message,
+      attachments: input.attachments,
+    });
+    const generated = yield* runCopilotJson({
+      operation: "generateBranchName",
+      cwd: input.cwd,
+      prompt,
+      outputSchemaJson: outputSchema,
+      modelSelection: input.modelSelection,
+    });
+    return { branch: sanitizeBranchFragment(generated.branch) };
+  });
+
+  const generateThreadTitle: TextGenerationShape["generateThreadTitle"] = Effect.fn(
+    "CopilotTextGeneration.generateThreadTitle",
+  )(function* (input) {
+    const { prompt, outputSchema } = buildThreadTitlePrompt({
+      message: input.message,
+      previousTitle: input.previousTitle,
+      attachments: input.attachments,
+    });
+    const generated = yield* runCopilotJson({
+      operation: "generateThreadTitle",
+      cwd: input.cwd,
+      prompt,
+      outputSchemaJson: outputSchema,
+      modelSelection: input.modelSelection,
+    });
+    return {
+      title: sanitizeThreadTitle(generated.title),
+    } satisfies ThreadTitleGenerationResult;
+  });
+
+  return {
+    generateCommitMessage,
+    generatePrContent,
+    generateBranchName,
+    generateThreadTitle,
+  } satisfies TextGenerationShape;
+});

--- a/apps/web/src/components/chat/providerIconUtils.ts
+++ b/apps/web/src/components/chat/providerIconUtils.ts
@@ -1,5 +1,13 @@
 import { ProviderDriverKind } from "@t3tools/contracts";
-import { ClaudeAI, CursorIcon, GrokIcon, Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import {
+  ClaudeAI,
+  CursorIcon,
+  GithubCopilotIcon,
+  GrokIcon,
+  Icon,
+  OpenAI,
+  OpenCodeIcon,
+} from "../Icons";
 import { PROVIDER_OPTIONS } from "../../session-logic";
 
 export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>> = {
@@ -8,6 +16,7 @@ export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>
   [ProviderDriverKind.make("opencode")]: OpenCodeIcon,
   [ProviderDriverKind.make("cursor")]: CursorIcon,
   [ProviderDriverKind.make("grok")]: GrokIcon,
+  [ProviderDriverKind.make("copilot")]: GithubCopilotIcon,
 };
 
 function isAvailableProviderOption(option: (typeof PROVIDER_OPTIONS)[number]): option is {

--- a/apps/web/src/components/settings/AddProviderInstanceDialog.tsx
+++ b/apps/web/src/components/settings/AddProviderInstanceDialog.tsx
@@ -14,7 +14,7 @@ import { useEnvironmentSettings, useUpdateEnvironmentSettings } from "../../hook
 import { cn } from "../../lib/utils";
 import { normalizeProviderAccentColor } from "../../providerInstances";
 import { Button } from "../ui/button";
-import { ACPRegistryIcon, Gemini, GithubCopilotIcon, PiAgentIcon, type Icon } from "../Icons";
+import { ACPRegistryIcon, Gemini, PiAgentIcon, type Icon } from "../Icons";
 import {
   Dialog,
   DialogDescription,
@@ -78,11 +78,6 @@ interface ComingSoonDriverOption {
 }
 
 const COMING_SOON_DRIVER_OPTIONS: readonly ComingSoonDriverOption[] = [
-  {
-    value: ProviderDriverKind.make("githubCopilot"),
-    label: "Github Copilot",
-    icon: GithubCopilotIcon,
-  },
   {
     value: ProviderDriverKind.make("gemini"),
     label: "Gemini",

--- a/apps/web/src/components/settings/providerDriverMeta.ts
+++ b/apps/web/src/components/settings/providerDriverMeta.ts
@@ -1,13 +1,22 @@
 import {
   ClaudeSettings,
   CodexSettings,
+  CopilotSettings,
   CursorSettings,
   GrokSettings,
   OpenCodeSettings,
   ProviderDriverKind,
 } from "@t3tools/contracts";
 import type * as Schema from "effect/Schema";
-import { ClaudeAI, CursorIcon, GrokIcon, type Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import {
+  ClaudeAI,
+  CursorIcon,
+  GithubCopilotIcon,
+  GrokIcon,
+  type Icon,
+  OpenAI,
+  OpenCodeIcon,
+} from "../Icons";
 
 type ProviderSettingsSchema = {
   readonly fields: Readonly<Record<string, Schema.Top>>;
@@ -66,6 +75,12 @@ export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = 
     label: "OpenCode",
     icon: OpenCodeIcon,
     settingsSchema: OpenCodeSettings,
+  },
+  {
+    value: ProviderDriverKind.make("copilot"),
+    label: "GitHub Copilot",
+    icon: GithubCopilotIcon,
+    settingsSchema: CopilotSettings,
   },
 ];
 

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -52,6 +52,12 @@ export const PROVIDER_OPTIONS: Array<{
     available: true,
     pickerSidebarBadge: "new",
   },
+  {
+    value: ProviderDriverKind.make("copilot"),
+    label: "GitHub Copilot",
+    available: true,
+    pickerSidebarBadge: "new",
+  },
 ];
 
 export type WorkLogToolLifecycleStatus =

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -132,6 +132,7 @@ const CLAUDE_DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
 const CURSOR_DRIVER_KIND = ProviderDriverKind.make("cursor");
 const GROK_DRIVER_KIND = ProviderDriverKind.make("grok");
 const OPENCODE_DRIVER_KIND = ProviderDriverKind.make("opencode");
+const COPILOT_DRIVER_KIND = ProviderDriverKind.make("copilot");
 
 export const DEFAULT_MODEL = "gpt-5.6-sol";
 
@@ -153,6 +154,7 @@ export const DEFAULT_MODEL_BY_PROVIDER: Partial<Record<ProviderDriverKind, strin
   [CURSOR_DRIVER_KIND]: "auto",
   [GROK_DRIVER_KIND]: "grok-build",
   [OPENCODE_DRIVER_KIND]: "openai/gpt-5",
+  [COPILOT_DRIVER_KIND]: "gpt-4.1",
 };
 
 /** Per-provider text generation model defaults. */
@@ -163,6 +165,7 @@ export const DEFAULT_TEXT_GENERATION_MODEL_BY_PROVIDER: Partial<
   [CLAUDE_DRIVER_KIND]: "claude-haiku-4-5",
   [CURSOR_DRIVER_KIND]: "composer-2",
   [OPENCODE_DRIVER_KIND]: "openai/gpt-5",
+  [COPILOT_DRIVER_KIND]: "gpt-4.1-mini",
 };
 
 export const MODEL_SLUG_ALIASES_BY_PROVIDER: Partial<
@@ -212,6 +215,7 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Partial<
     "opus-4.5": "claude-opus-4-5",
   },
   [OPENCODE_DRIVER_KIND]: {},
+  [COPILOT_DRIVER_KIND]: {},
 };
 
 // ── Provider display names ────────────────────────────────────────────
@@ -222,4 +226,5 @@ export const PROVIDER_DISPLAY_NAMES: Partial<Record<ProviderDriverKind, string>>
   [CURSOR_DRIVER_KIND]: "Cursor",
   [GROK_DRIVER_KIND]: "Grok",
   [OPENCODE_DRIVER_KIND]: "OpenCode",
+  [COPILOT_DRIVER_KIND]: "GitHub Copilot",
 };

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -26,6 +26,8 @@ const RuntimeEventRawSource = Schema.Union([
   Schema.Literal("claude.sdk.permission"),
   Schema.Literal("codex.sdk.thread-event"),
   Schema.Literal("opencode.sdk.event"),
+  Schema.Literal("copilot.sdk.event"),
+  Schema.Literal("copilot.sdk.permission"),
   Schema.Literal("acp.jsonrpc"),
   Schema.TemplateLiteral(["acp.", Schema.String, ".extension"]),
 ]);

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -520,6 +520,33 @@ export const OpenCodeSettings = makeProviderSettingsSchema(
 );
 export type OpenCodeSettings = typeof OpenCodeSettings.Type;
 
+export const CopilotSettings = makeProviderSettingsSchema(
+  {
+    enabled: Schema.Boolean.pipe(
+      Schema.withDecodingDefault(Effect.succeed(false)),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+    binaryPath: makeBinaryPathSetting("copilot").pipe(
+      Schema.annotateKey({
+        title: "Binary path",
+        description: "Path to the GitHub Copilot CLI binary used by this instance.",
+        providerSettingsForm: {
+          placeholder: "copilot",
+          clearWhenEmpty: "omit",
+        },
+      }),
+    ),
+    customModels: Schema.Array(Schema.String).pipe(
+      Schema.withDecodingDefault(Effect.succeed([])),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+  },
+  {
+    order: ["binaryPath"],
+  },
+);
+export type CopilotSettings = typeof CopilotSettings.Type;
+
 export const ObservabilitySettings = Schema.Struct({
   otlpTracesUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   otlpMetricsUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
@@ -662,6 +689,7 @@ export const ServerSettings = Schema.Struct({
     cursor: CursorSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     grok: GrokSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     opencode: OpenCodeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+    copilot: CopilotSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   }).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   // New driver-agnostic instance map. Keyed by `ProviderInstanceId`; values
   // are `ProviderInstanceConfig` envelopes. The driver-specific config blob
@@ -809,6 +837,12 @@ const OpenCodeSettingsPatch = Schema.Struct({
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
 });
 
+const CopilotSettingsPatch = Schema.Struct({
+  enabled: Schema.optionalKey(Schema.Boolean),
+  binaryPath: Schema.optionalKey(TrimmedString),
+  customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+});
+
 export const ServerSettingsPatch = Schema.Struct({
   // Server settings
   enableLegacyTokenStreaming: Schema.optionalKey(Schema.Boolean),
@@ -850,6 +884,7 @@ export const ServerSettingsPatch = Schema.Struct({
       cursor: Schema.optionalKey(CursorSettingsPatch),
       grok: Schema.optionalKey(GrokSettingsPatch),
       opencode: Schema.optionalKey(OpenCodeSettingsPatch),
+      copilot: Schema.optionalKey(CopilotSettingsPatch),
     }),
   ),
   // Whole-map replacement for the new instance config. Patching individual

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -464,6 +464,9 @@ importers:
       '@ff-labs/fff-node':
         specifier: 0.9.4
         version: 0.9.4(patch_hash=ab9ff544009e1891cfe3930105862d3699007f38922a79f3c98d90018deca368)
+      '@github/copilot-sdk':
+        specifier: ^1.0.11
+        version: 1.0.11
       '@opencode-ai/sdk':
         specifier: ^1.3.15
         version: 1.15.13
@@ -2736,6 +2739,66 @@ packages:
   '@formkit/auto-animate@0.9.0':
     resolution: {integrity: sha512-VhP4zEAacXS3dfTpJpJ88QdLqMTcabMg0jwpOSxZ/VzfQVfl3GkZSCZThhGC5uhq/TxPHPzW0dzr4H9Bb1OgKA==}
 
+  '@github/copilot-darwin-arm64@1.0.80':
+    resolution: {integrity: sha512-fzn4PnSx3+O/a3ip72KVsjnzORsEygK+0i21bFAnFBYS+0Wi1Pk+o/CmNsJ7aRbf1enSJrcH8UDVkyc9pMGEBg==}
+    cpu: [arm64]
+    os: [darwin]
+    hasBin: true
+
+  '@github/copilot-darwin-x64@1.0.80':
+    resolution: {integrity: sha512-PKsyGk5DccNzR3bYXcYTGB9N6sHzhzGqEwq/2t1qBwqPbrC98Zo2dOT2G40/QYpJ4XdrGmTmdmfPJQ9PJknlIQ==}
+    cpu: [x64]
+    os: [darwin]
+    hasBin: true
+
+  '@github/copilot-linux-arm64@1.0.80':
+    resolution: {integrity: sha512-8oXwN2luyHEjIoSk8AkATBjXDhRoQtuiUvC93GpfQKFHI+I1eoOVwIsAq5fKP8jNCF2rOrYFIcTjwmRt38kCcQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+    hasBin: true
+
+  '@github/copilot-linux-x64@1.0.80':
+    resolution: {integrity: sha512-qv1ytVNwA3IDK7kcQow+fAikD67t42+AQ8X42bK/7oudNiv4frVZMO0yh1DYIebVRcmEhmPvbVPY/ptVUK3cbA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+    hasBin: true
+
+  '@github/copilot-linuxmusl-arm64@1.0.80':
+    resolution: {integrity: sha512-Qjyi+OlVnPC4Lkuy7blDMMwMUQI/yELl7gDnqQlaN8TEbhZqZueuf3p0a+kEjXcNsw4XtNYQc0eMJqSIYy/Pjg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+    hasBin: true
+
+  '@github/copilot-linuxmusl-x64@1.0.80':
+    resolution: {integrity: sha512-rBg8pugf+5FhiZxi2zkOr+rlcOVF6Xg63j1FvryfwPT4DJ2w5Na7O3lpS4sgu8QmsP5H+dAqjlXYLYsvSoVQ0g==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+    hasBin: true
+
+  '@github/copilot-sdk@1.0.11':
+    resolution: {integrity: sha512-ngrnfa9052fLTOMoY0iiQS2B6pFDYJpWNj3syCdjzdje0R5mWoij9b8exJZciLvX7BbJjKz2/lIdwo24av3e3A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@github/copilot-win32-arm64@1.0.80':
+    resolution: {integrity: sha512-+f7Vkd3vt2DYOxRnS8dStvYu3DY638N/AuLuIjxZp1F9GgwCUZK69wspqIxg2L59PmRRQcH4AGTrRDR60ENIZA==}
+    cpu: [arm64]
+    os: [win32]
+    hasBin: true
+
+  '@github/copilot-win32-x64@1.0.80':
+    resolution: {integrity: sha512-PO0kPqhRTWQfsqGaj4UN3cj8ttkcJYy4wmXiArtFm+03AIFu8xTvuhQDPn2xEOsUome7m7t2XomKoavcrCcRsw==}
+    cpu: [x64]
+    os: [win32]
+    hasBin: true
+
+  '@github/copilot@1.0.80':
+    resolution: {integrity: sha512-6tf93ZF56KOiTTAjK/UhLZkl1W543IzaTQly288kockJZFswpRTnQEI00Yvacpb39DTvTYu3/ha9SeKpo/pgZQ==}
+    hasBin: true
+
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
@@ -2974,6 +3037,81 @@ packages:
   '@js-temporal/polyfill@0.5.1':
     resolution: {integrity: sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==}
     engines: {node: '>=12'}
+
+  '@koromix/koffi-darwin-arm64@3.1.5':
+    resolution: {integrity: sha512-IpqITl2fJi3QN9bTtNnygWPdK7ScSjw3xtGu8e6feYGvimCysu+spgI5KyeslY2jTnqxGS9xr8pLAbLhGJ8edA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@koromix/koffi-darwin-x64@3.1.5':
+    resolution: {integrity: sha512-4Tia4BS5EV/+vN9eIrdToanVe+U/2VqTZCBgOzoUbPKjgky51eqM+3J4qdRUvmYJohcJNPob5/hsxeItUZrl1g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@koromix/koffi-freebsd-arm64@3.1.5':
+    resolution: {integrity: sha512-bP94uzseFO79NG3flpU3WxfyvltD+jzC/kN8FDZLi8J0VUZNW1Wmu8yq87KEzjX1qT9KyX4Y+elVbGqHXHTv2Q==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@koromix/koffi-freebsd-ia32@3.1.5':
+    resolution: {integrity: sha512-raFXXAPHzvCQWhaoMUF+Cc2ZWgg2UBU0RVoowHZhaw9nQYPC1pERcPRH+JA+SNIN6g4d2GFW6uPFc+QbUhsagA==}
+    cpu: [ia32]
+    os: [freebsd]
+
+  '@koromix/koffi-freebsd-x64@3.1.5':
+    resolution: {integrity: sha512-h6RyBZmPMBIDWTABkJIhzDdYwSnYAJvTacHpEjbT55Arkmw1H15Rl7CFtXuEuBrqh+uivoCrRgA6vszl9CsJ9g==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@koromix/koffi-linux-arm64@3.1.5':
+    resolution: {integrity: sha512-u0vCmKPu4yQDhl/ri1J6U3vDnvYtYjoZaIWb+oMbRXhVZeiqdE53MGPb+q2A7Dj2n9IbYloAfEICQbL6l0pmiQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@koromix/koffi-linux-ia32@3.1.5':
+    resolution: {integrity: sha512-Xa5JbumWglwPVZgrJcLhqyC1wCWlfm7+C00p3FuOTNGp0qoYuf2/tOoAh0/q7+taVm30cMopu/6lRHwdmF6I/w==}
+    cpu: [ia32]
+    os: [linux]
+
+  '@koromix/koffi-linux-loong64@3.1.5':
+    resolution: {integrity: sha512-F3i2CeTcqVBUQiSRUBSEzX1VgtXmLLiZb/ouZtXHkWpTLhJNd9TH7s3CizTofci0VRqlKdexGUYhK5vzPDAAHA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@koromix/koffi-linux-riscv64@3.1.5':
+    resolution: {integrity: sha512-2TgQuzy+4PfDg+rw3kOmN6lywEWdzKT3eaLPbOp0b/9DaN7CLBJ/QIR5GhGsMNpeI30zU0YzFeYFxoVoJ/LqFw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@koromix/koffi-linux-x64@3.1.5':
+    resolution: {integrity: sha512-2yaIg/1V0m4CiAUMzG4CIlWmq1WJ+QBMlFfaGr9su+OH5fuIqC7V3BbMiB03IwIl1VofIZO5JA4Db4lID8tpbw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@koromix/koffi-openbsd-ia32@3.1.5':
+    resolution: {integrity: sha512-8/OXd+u9omMooykhvdJPEP7u6FFzzrrFo9gOmSHc9/DPt3XkVYOtSsE97PDk6zYaAzwIYHSKjHvIXsfFwFc7sg==}
+    cpu: [ia32]
+    os: [openbsd]
+
+  '@koromix/koffi-openbsd-x64@3.1.5':
+    resolution: {integrity: sha512-SpeqldKkuDk2aTj5PVWumy7eq6Tr2GtBPAOI1NiDHhg8xe433KraxrA9V9UjEd+1+kSGJQGR04nQByN3MPA9PQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@koromix/koffi-win32-arm64@3.1.5':
+    resolution: {integrity: sha512-uej3YAEKAhlfVPoIo5sOwtxhTLRVJ01LgtWrKGpnnAQU3C+Ilmaxdh+Oc2xc1G3NK30N5eCVJpyO9r3pjKC6Vw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@koromix/koffi-win32-ia32@3.1.5':
+    resolution: {integrity: sha512-d42jv2f4PwtJGNJS19Xfn/BRtGsBNNVkw0O0K5tkIGI+yNq4MnPTSUsaGbDIkCLNsCgk/LFqAaE8BExyCdrujA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@koromix/koffi-win32-x64@3.1.5':
+    resolution: {integrity: sha512-Pyo1WEHEP6Ek2NEn2pquwJzSPLOdY4vymoPSz0an1DgvFWSkOyBYYkGVoxL1ajfj5I1pPdXysYqixtVTzAtOfQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@legendapp/list@3.3.5':
     resolution: {integrity: sha512-XTsLYtpg41SVb5uLBYA+YcDSA3w0tgoPq/W8ZggQ2tx+3lrC/rf+ehTP9KYHea9oFaZIuePAgzACs5/auVMJlQ==}
@@ -5184,10 +5322,12 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@yuuang/ffi-rs-android-arm64@1.3.2':
     resolution: {integrity: sha512-eDYLT0kVBkp7e2BwdRDmt6N1rkeDPUHDefk3ZX0/nok+GLsqfy1WBoSL3Yg7HVXN1EyW8OBVc2uK8Zq8HbmaSA==}
@@ -7562,6 +7702,9 @@ packages:
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  koffi@3.1.5:
+    resolution: {integrity: sha512-XVwwrxg0Ca6IEUQF4YtGIU4XN0LSselFYpYvgfhh8wafCunhEEx5hPr7LZhp5QyeFA/LcRsKHTqncCdjWjWAlg==}
 
   kubernetes-types@1.30.0:
     resolution: {integrity: sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==}
@@ -10280,6 +10423,10 @@ packages:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
     engines: {node: '>=14.0.0'}
 
+  vscode-jsonrpc@8.2.1:
+    resolution: {integrity: sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==}
+    engines: {node: '>=14.0.0'}
+
   vscode-languageserver-protocol@3.17.5:
     resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
 
@@ -12835,6 +12982,50 @@ snapshots:
 
   '@formkit/auto-animate@0.9.0': {}
 
+  '@github/copilot-darwin-arm64@1.0.80':
+    optional: true
+
+  '@github/copilot-darwin-x64@1.0.80':
+    optional: true
+
+  '@github/copilot-linux-arm64@1.0.80':
+    optional: true
+
+  '@github/copilot-linux-x64@1.0.80':
+    optional: true
+
+  '@github/copilot-linuxmusl-arm64@1.0.80':
+    optional: true
+
+  '@github/copilot-linuxmusl-x64@1.0.80':
+    optional: true
+
+  '@github/copilot-sdk@1.0.11':
+    dependencies:
+      '@github/copilot': 1.0.80
+      koffi: 3.1.5
+      vscode-jsonrpc: 8.2.1
+      zod: 4.4.3
+
+  '@github/copilot-win32-arm64@1.0.80':
+    optional: true
+
+  '@github/copilot-win32-x64@1.0.80':
+    optional: true
+
+  '@github/copilot@1.0.80':
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      '@github/copilot-darwin-arm64': 1.0.80
+      '@github/copilot-darwin-x64': 1.0.80
+      '@github/copilot-linux-arm64': 1.0.80
+      '@github/copilot-linux-x64': 1.0.80
+      '@github/copilot-linuxmusl-arm64': 1.0.80
+      '@github/copilot-linuxmusl-x64': 1.0.80
+      '@github/copilot-win32-arm64': 1.0.80
+      '@github/copilot-win32-x64': 1.0.80
+
   '@hono/node-server@1.19.14(hono@4.12.27)':
     dependencies:
       hono: 4.12.27
@@ -13014,6 +13205,51 @@ snapshots:
   '@js-temporal/polyfill@0.5.1':
     dependencies:
       jsbi: 4.3.2
+
+  '@koromix/koffi-darwin-arm64@3.1.5':
+    optional: true
+
+  '@koromix/koffi-darwin-x64@3.1.5':
+    optional: true
+
+  '@koromix/koffi-freebsd-arm64@3.1.5':
+    optional: true
+
+  '@koromix/koffi-freebsd-ia32@3.1.5':
+    optional: true
+
+  '@koromix/koffi-freebsd-x64@3.1.5':
+    optional: true
+
+  '@koromix/koffi-linux-arm64@3.1.5':
+    optional: true
+
+  '@koromix/koffi-linux-ia32@3.1.5':
+    optional: true
+
+  '@koromix/koffi-linux-loong64@3.1.5':
+    optional: true
+
+  '@koromix/koffi-linux-riscv64@3.1.5':
+    optional: true
+
+  '@koromix/koffi-linux-x64@3.1.5':
+    optional: true
+
+  '@koromix/koffi-openbsd-ia32@3.1.5':
+    optional: true
+
+  '@koromix/koffi-openbsd-x64@3.1.5':
+    optional: true
+
+  '@koromix/koffi-win32-arm64@3.1.5':
+    optional: true
+
+  '@koromix/koffi-win32-ia32@3.1.5':
+    optional: true
+
+  '@koromix/koffi-win32-x64@3.1.5':
+    optional: true
 
   '@legendapp/list@3.3.5(patch_hash=6befc76c7f590a0b0915b531386ce7e3bbb364612868e1f04e4ac84f60a39ab5)(react-dom@19.2.3(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
     dependencies:
@@ -18234,6 +18470,24 @@ snapshots:
 
   kleur@4.1.5: {}
 
+  koffi@3.1.5:
+    optionalDependencies:
+      '@koromix/koffi-darwin-arm64': 3.1.5
+      '@koromix/koffi-darwin-x64': 3.1.5
+      '@koromix/koffi-freebsd-arm64': 3.1.5
+      '@koromix/koffi-freebsd-ia32': 3.1.5
+      '@koromix/koffi-freebsd-x64': 3.1.5
+      '@koromix/koffi-linux-arm64': 3.1.5
+      '@koromix/koffi-linux-ia32': 3.1.5
+      '@koromix/koffi-linux-loong64': 3.1.5
+      '@koromix/koffi-linux-riscv64': 3.1.5
+      '@koromix/koffi-linux-x64': 3.1.5
+      '@koromix/koffi-openbsd-ia32': 3.1.5
+      '@koromix/koffi-openbsd-x64': 3.1.5
+      '@koromix/koffi-win32-arm64': 3.1.5
+      '@koromix/koffi-win32-ia32': 3.1.5
+      '@koromix/koffi-win32-x64': 3.1.5
+
   kubernetes-types@1.30.0: {}
 
   lan-network@0.2.1: {}
@@ -21575,6 +21829,8 @@ snapshots:
       vscode-uri: 3.1.0
 
   vscode-jsonrpc@8.2.0: {}
+
+  vscode-jsonrpc@8.2.1: {}
 
   vscode-languageserver-protocol@3.17.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,9 @@ allowBuilds:
   electron: true
   electron-winstaller: false
   esbuild: true
+  # Only used by @github/copilot-sdk's experimental in-process FFI transport,
+  # which we don't use (we drive the runtime over stdio). No native build needed.
+  koffi: false
   msgpackr-extract: true
   msw: false
   node-pty: true
@@ -147,6 +150,6 @@ peerDependencyRules:
     vite: "*"
 
 supportedArchitectures:
-  cpu: [current, x64]
-  libc: [current, glibc]
-  os: [current, linux]
+  cpu: [ current, x64 ]
+  libc: [ current, glibc ]
+  os: [ current, linux ]


### PR DESCRIPTION
> **Draft / RFC.** Opening this early for maintainer feedback on integration and conventions. It builds, typechecks, and passes its unit tests, and I've smoke-tested real turns against the live `copilot` CLI — but I'm not confident it hits every T3 convention (multi-surface, receipts, provider parity), so I'd love guidance on what to tighten before it's merge-ready.

## What

Adds **GitHub Copilot** as a first-class provider, alongside Codex / Claude / Cursor / Grok / OpenCode. It's driven by GitHub's first-party [`@github/copilot-sdk`](https://www.npmjs.com/package/@github/copilot-sdk), which spawns and drives the installed `copilot` runtime binary over its typed JSON-RPC protocol (`RuntimeConnection.forStdio`) — the same engine the Copilot CLI/IDE use. No extra runtime download; it reuses whatever `copilot` the user already has (e.g. Homebrew).

## How

- **Provider / driver / adapter** under `apps/server/src/provider/`, plus a small `provider/sdk/` layer:
  - `CopilotSdkClient` — scoped Effect wrapper around `CopilotClient` (start on acquire, stop on release; one shared client per provider instance).
  - `CopilotSdkModels` — maps `client.listModels()` into per-model capabilities: **reasoning effort** from each model's `supportedReasoningEfforts`, and a **context-window tier** gated on the model's `longContext` billing block. Applied via `SessionConfig` / `session.setModel`.
  - `CopilotSdkRuntimeEvents` — translates SDK `SessionEvent`s into the canonical `ProviderRuntimeEvent` stream.
- **Session lifecycle:** per-thread `CopilotSession`, a callback→Effect event bridge (SDK is callback-based, unlike the async-iterable providers), permission requests wired into the existing approval flow, and `send` + `session.idle` turn handling.
- **Model discovery** via `client.listModels()`.
- **Git text generation** (commit messages, PR content, branch names, thread titles) uses the SDK's one-shot `sendAndWait`.
- **Contracts:** adds `copilot.sdk.event` / `copilot.sdk.permission` runtime sources and Copilot settings/model schemas; web wiring for the provider settings + model picker (reuses the generic option-descriptor UI).
- Resolves the `copilot` binary to an absolute path before spawning (a GUI-launched app inherits a minimal PATH), and passes env only on the stdio connection (the SDK rejects env in both places).

## Testing

- `tsgo` typecheck clean (contracts / server / web); targeted lint clean.
- Unit tests for the model→capability mapping, tunable resolution, and provider status parsing (74 provider + text-gen tests green).
- End-to-end smoke test against `copilot` 1.0.80: `createSession` → streaming `send` → `session.idle`, `setModel` with `long_context`, and the permission callback. `listModels()` returns per-model reasoning efforts / context tiers as expected.

## Notes / open questions

- Builds on earlier Copilot-provider groundwork by @its-hmny (credited via `Co-authored-by`); I ported it to the SDK and reworked model discovery + tunables.
- The SDK is callback-based; I bridge its events into an Effect queue. Happy to align that with how you'd prefer provider adapters to consume SDK streams.
- Mobile surface and docs aren't touched yet — guidance welcome on what's expected for a new provider.

_Authored with Claude Opus 4.8 via Claude Code._


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add GitHub Copilot provider via `@github/copilot-sdk`
> - Introduces a full `copilot` provider driver registered in [builtInDrivers.ts](https://github.com/pingdotgg/t3code/pull/7656/files#diff-7bd5dca89e0c2be78fa6adf17c285d16f158d8c8b671b62245d46b910a665c39), wiring together a SDK client, adapter, text generation, and provider snapshot pipeline.
> - [CopilotSdkClient.ts](https://github.com/pingdotgg/t3code/pull/7656/files#diff-ea0a23669eaaa0f0c665b504f46a05d620aad4637bf8e29c5a28021b424ff95f) wraps the SDK with Effect-based methods, binary path resolution, and scoped lifecycle management.
> - [CopilotAdapter.ts](https://github.com/pingdotgg/t3code/pull/7656/files#diff-d1fdd1ff48ff201b33512aada0688992230a399ec0b6482437aabdd0768bc6d9) manages per-thread sessions, streaming runtime events, permission requests, resume cursors, and in-session model switching.
> - [CopilotTextGeneration.ts](https://github.com/pingdotgg/t3code/pull/7656/files#diff-3f55717b198ae96e8c1c6f1acc682bb6da327ec1da696ff426e3b8edc4b53759) implements commit message, PR content, branch name, and thread title generation with schema-validated JSON and a 180s timeout.
> - [CopilotProvider.ts](https://github.com/pingdotgg/t3code/pull/7656/files#diff-a7ca86ea5e4e0462fc38932a09bfc0a947a45493deac41356edd4f39f7e9211f) probes the Copilot CLI for version/auth status and discovers models via the SDK, enriching snapshots asynchronously.
> - Contracts and UI are updated to recognize the `copilot` kind, default to `gpt-4.1` / `gpt-4.1-mini`, and surface the provider in pickers and settings dialogs.
> - Risk: adds `@github/copilot-sdk` dependency and disallows `koffi` builds in [pnpm-workspace.yaml](https://github.com/pingdotgg/t3code/pull/7656/files#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794c); `COPILOT_DRIVER_KIND` defaults in [model.ts](https://github.com/pingdotgg/t3code/pull/7656/files#diff-cff20c6bccac2635a0e8b89343cf21815f9fc219bd536a90f66537a56eac7959) may affect model selection if overrides are absent.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 56d5f9a. 17 files reviewed, 16 issues evaluated, 2 issues filtered, 10 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/server/src/provider/Layers/CopilotAdapter.ts — 3 comments posted, 5 evaluated, 1 filtered</summary>
>
> - [line 447](https://github.com/pingdotgg/t3code/blob/56d5f9acdfe25f231f6235d1a979adabc1f59ed0/apps/server/src/provider/Layers/CopilotAdapter.ts#L447): The adapter constructs or accepts `nativeEventLogger`, but never invokes its `write` method. Therefore configuring `nativeEventLogPath` or injecting a native logger creates/manages the logger while every Copilot SDK event is silently omitted from the native event log. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
> <details>
> <summary>apps/server/src/provider/Layers/CopilotProvider.ts — 2 comments posted, 3 evaluated, 1 filtered</summary>
>
> - [line 115](https://github.com/pingdotgg/t3code/blob/56d5f9acdfe25f231f6235d1a979adabc1f59ed0/apps/server/src/provider/Layers/CopilotProvider.ts#L115): `detectCopilotAuthFromEnvironment` uses nullish coalescing before checking whether a token is nonempty. If `COPILOT_GITHUB_TOKEN` is defined as `""` or whitespace while `GH_TOKEN` or `GITHUB_TOKEN` contains a valid token, the empty first value wins and the function returns `unknown` instead of `authenticated`. Select the first nonblank value rather than the first non-nullish one. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->