### PR TITLE
fix(server): keep Daybreak models out of legacy models

### DIFF
--- a/apps/server/src/provider/Layers/CodexProvider.test.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.test.ts
@@ -6,16 +6,22 @@ import {
   mapCodexModelCapabilities,
 } from "./CodexProvider.ts";
 
-it("keeps only the GPT-5.6 Codex family out of legacy models", () => {
+it("keeps current Codex models out of legacy models", () => {
   assert.deepStrictEqual(
-    ["gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol", "gpt-5.4"].map((model) => [
-      model,
-      isLegacyCodexModel(model),
-    ]),
+    [
+      "gpt-5.6-luna",
+      "gpt-5.6-terra",
+      "gpt-5.6-sol",
+      "gpt-daybreak-blue-latest",
+      "gpt-daybreak-red-latest",
+      "gpt-5.4",
+    ].map((model) => [model, isLegacyCodexModel(model)]),
     [
       ["gpt-5.6-luna", false],
       ["gpt-5.6-terra", false],
       ["gpt-5.6-sol", false],
+      ["gpt-daybreak-blue-latest", false],
+      ["gpt-daybreak-red-latest", false],
       ["gpt-5.4", true],
     ],
   );

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -62,7 +62,13 @@ const REASONING_EFFORT_LABELS: Readonly<Record<string, string>> = {
 };
 
 const DEFAULT_SERVICE_TIER_ID = "default";
-const CURRENT_CODEX_MODELS = new Set(["gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol"]);
+const CURRENT_CODEX_MODELS = new Set([
+  "gpt-5.6-luna",
+  "gpt-5.6-terra",
+  "gpt-5.6-sol",
+  "gpt-daybreak-blue-latest",
+  "gpt-daybreak-red-latest",
+]);
 
 export function isLegacyCodexModel(model: string): boolean {
   return !CURRENT_CODEX_MODELS.has(model);


### PR DESCRIPTION
Daybreak Blue and Red were classified as legacy because the Codex provider’s current-model allowlist only contained the GPT-5.6 family.

Add `gpt-daybreak-blue-latest` and `gpt-daybreak-red-latest` to the allowlist and cover both with the existing model-classification test.

Validation:
- `vp test run apps/server/src/provider/Layers/CodexProvider.test.ts`
- Server typecheck
- Formatting check

Created with GPT-5.6 Sol using the Codex harness in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 03cd05f851faa7ab0614d2bf9911042a58986307. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `gpt-daybreak-blue-latest` and `gpt-daybreak-red-latest` to `CURRENT_CODEX_MODELS`
> Adds the two Daybreak models to the `CURRENT_CODEX_MODELS` set in [CodexProvider.ts](https://github.com/pingdotgg/t3code/pull/7659/files#diff-c0fb5ae851f722b7ec74cc0b9dab393a72637319c70756f8532c0a4e73ccae53) so `isLegacyCodexModel` returns `false` for them. Updates the corresponding test in [CodexProvider.test.ts](https://github.com/pingdotgg/t3code/pull/7659/files#diff-e4480f09a7643d1d20e19242d87524b912b0f1c6c1c6fd12cc64cc644219643d) to cover both models.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 03cd05f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->