### PR TITLE
fix(web): accept case-insensitive VS Code color functions

### DIFF
--- a/apps/web/src/vscodeThemeImport.test.ts
+++ b/apps/web/src/vscodeThemeImport.test.ts
@@ -174,6 +174,20 @@ describe("VS Code theme import", () => {
     expect(green).toBeGreaterThan(red);
   });
 
+  it("accepts case-insensitive CSS color function names", () => {
+    const theme = parseVsCodeThemeFile({
+      name: "Uppercase color function",
+      type: "dark",
+      colors: {
+        "editor.background": "COLOR(SRGB 0 0 0)",
+        "editor.foreground": "COLOR(SRGB 1 1 1)",
+      },
+    });
+
+    expect(asHex(theme.colors.canvas)).toBe("#000000");
+    expect(asHex(theme.colors.text)).toBe("#ffffff");
+  });
+
   it("pairs light and dark files from one family into dual-mode themes", () => {
     const make = (name: string, type: "light" | "dark") =>
       parseVsCodeThemeFile({

--- a/apps/web/src/vscodeThemeImport.ts
+++ b/apps/web/src/vscodeThemeImport.ts
@@ -84,7 +84,7 @@ function parseColorFunction(value: string): VsCodeRgba | null {
 function parseVsCodeColor(value: unknown): VsCodeRgba | null {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
-  if (trimmed.startsWith("color(")) return parseColorFunction(trimmed);
+  if (/^color\(/i.test(trimmed)) return parseColorFunction(trimmed);
   const hex = trimmed.replace(/^#/, "");
   if (!/^(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i.test(hex)) return null;
   const expand = (part: string) =>


### PR DESCRIPTION
## What Changed

Accept uppercase and mixed-case CSS `color()` function names when importing VS Code themes, with a focused regression test.

## Why

The importer’s dispatch guard was case-sensitive even though its `color()` parser accepts case-insensitive syntax. A valid theme using `COLOR(SRGB …)` was rejected as missing an editor background.

## UI Changes

Not applicable.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Model and harness: GPT-5 Codex.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix case-insensitive `color()` parsing in `parseVsCodeColor`
> Updates `parseVsCodeColor` in [vscodeThemeImport.ts](https://github.com/pingdotgg/t3code/pull/7660/files#diff-f0d027dd048c65bb229a173a41aebff4aa275c352db225352e5ceaeeb598f291) to use a case-insensitive regex for CSS `color()` notation instead of `startsWith("color(")`. This fixes parsing of theme values using uppercase variations like `COLOR(SRGB ...)", and adds a corresponding test case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cbfa0f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->