### PR TITLE
fix(web): reject malformed VS Code color functions

### DIFF
--- a/apps/web/src/vscodeThemeImport.test.ts
+++ b/apps/web/src/vscodeThemeImport.test.ts
@@ -174,6 +174,20 @@ describe("VS Code theme import", () => {
     expect(green).toBeGreaterThan(red);
   });
 
+  it("rejects malformed CSS color() notation", () => {
+    for (const color of [
+      "color(srgb 0 0 0 / 1 / 0)",
+      "color(srgb 0wat 0 0)",
+      "color(srgb 0 0 0 / 100% trailing)",
+    ]) {
+      expect(() =>
+        parseVsCodeThemeFile({
+          name: "Malformed color function",
+          colors: { "editor.background": color },
+        }),
+      ).toThrow(/editor\.background/);
+    }
+  });
   it("pairs light and dark files from one family into dual-mode themes", () => {
     const make = (name: string, type: "light" | "dark") =>
       parseVsCodeThemeFile({

--- a/apps/web/src/vscodeThemeImport.test.ts
+++ b/apps/web/src/vscodeThemeImport.test.ts
@@ -179,6 +179,8 @@ describe("VS Code theme import", () => {
       "color(srgb 0 0 0 / 1 / 0)",
       "color(srgb 0wat 0 0)",
       "color(srgb 0 0 0 / 100% trailing)",
+      "color(srgb 1. 0 0)",
+      "color(srgb 1.e2 0 0)",
     ]) {
       expect(() =>
         parseVsCodeThemeFile({

--- a/apps/web/src/vscodeThemeImport.ts
+++ b/apps/web/src/vscodeThemeImport.ts
@@ -23,6 +23,10 @@ import {
 type VsCodeRgba = { r: number; g: number; b: number; a: number };
 type VsCodeRgb = { r: number; g: number; b: number };
 
+const CSS_COLOR_NUMBER =
+  "[+-]?(?:(?:\\d+\\.?\\d*)|(?:\\.\\d+))(?:[eE][+-]?\\d+)?";
+const CSS_COLOR_COMPONENT = new RegExp(`^(${CSS_COLOR_NUMBER})(%)?$`);
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -37,6 +41,14 @@ function encodeGamma(value: number): number {
   return clamped <= 0.0031308 ? clamped * 12.92 : 1.055 * clamped ** (1 / 2.4) - 0.055;
 }
 
+function parseColorComponent(value: string): number | null {
+  const match = CSS_COLOR_COMPONENT.exec(value);
+  if (!match) return null;
+  const number = Number(match[1]);
+  if (!Number.isFinite(number)) return null;
+  return match[2] ? number / 100 : number;
+}
+
 /**
  * `color(display-p3 r g b / a)` shows up in themes authored for wide-gamut
  * displays. Out-of-gamut colors clip to the sRGB edge, which is what a browser
@@ -46,20 +58,15 @@ function parseColorFunction(value: string): VsCodeRgba | null {
   const match = /^color\(\s*(display-p3|srgb)\s+([^)]+)\)$/i.exec(value);
   if (!match) return null;
   const [space, body] = [match[1]!.toLowerCase(), match[2]!];
-  const [channelPart, alphaPart] = body.split("/");
+  const [channelPart, alphaPart, ...extraParts] = body.split("/");
+  if (extraParts.length > 0) return null;
   const channels = channelPart!
     .trim()
     .split(/\s+/)
-    .map((part) => (part.endsWith("%") ? Number.parseFloat(part) / 100 : Number.parseFloat(part)));
-  if (channels.length !== 3 || channels.some((channel) => !Number.isFinite(channel))) return null;
-  const alphaRaw = alphaPart?.trim();
-  const alpha =
-    alphaRaw === undefined
-      ? 1
-      : alphaRaw.endsWith("%")
-        ? Number.parseFloat(alphaRaw) / 100
-        : Number.parseFloat(alphaRaw);
-  if (!Number.isFinite(alpha)) return null;
+    .map(parseColorComponent);
+  if (channels.length !== 3 || channels.some((channel) => channel === null)) return null;
+  const alpha = alphaPart === undefined ? 1 : parseColorComponent(alphaPart.trim());
+  if (alpha === null) return null;
 
   const [red, green, blue] = channels as [number, number, number];
   if (space === "srgb") {

--- a/apps/web/src/vscodeThemeImport.ts
+++ b/apps/web/src/vscodeThemeImport.ts
@@ -24,7 +24,7 @@ type VsCodeRgba = { r: number; g: number; b: number; a: number };
 type VsCodeRgb = { r: number; g: number; b: number };
 
 const CSS_COLOR_NUMBER =
-  "[+-]?(?:(?:\\d+\\.?\\d*)|(?:\\.\\d+))(?:[eE][+-]?\\d+)?";
+  "[+-]?(?:(?:\\d+(?:\\.\\d+)?)|(?:\\.\\d+))(?:[eE][+-]?\\d+)?";
 const CSS_COLOR_COMPONENT = new RegExp(`^(${CSS_COLOR_NUMBER})(%)?$`);
 
 function isRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## What changed

Reject malformed CSS `color()` component and alpha syntax when importing VS Code themes. This includes invalid numeric prefixes, repeated alpha separators, trailing content, and trailing decimal tokens such as `1.`.

## Why

The importer previously accepted malformed values by partially parsing them, which could silently turn an invalid theme color into a different valid color.

## Verification

- Focused parser harness: 5 malformed values rejected; 4 valid lowercase `color()` values accepted.
- `git diff --check`

Model and harness: GPT-5 Codex.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject malformed CSS `color()` values in `parseColorFunction`
> - Hardens parsing of CSS `color()` values in [vscodeThemeImport.ts](https://github.com/pingdotgg/t3code/pull/7661/files#diff-f0d027dd048c65bb229a173a41aebff4aa275c352db225352e5ceaeeb598f291) by adding a `parseColorComponent` helper that uses strict regex.
> - `parseColorFunction` now uses this helper, rejects bodies with more than one slash, and throws on invalid channels or alpha values.
> - Adds tests in [vscodeThemeImport.test.ts](https://github.com/pingdotgg/t3code/pull/7661/files#diff-d690b716e49037069fdbd1c1dbd75556f04ec3c7ed6b8e46ab0f9a7e9cda82ad) to assert `parseVsCodeThemeFile` throws on malformed syntax.
> - Risk: Numeric parsing of color components now rejects malformed values (e.g., trailing characters, `1.`) instead of leniently parsing with `Number.parseFloat`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a53f81e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->