### PR TITLE
fix(web): retry failed thread bootstraps with a fresh id

### DIFF
--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -7893,6 +7893,89 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       assertTrue(result._tag === "Failure");
       assertTrue(result.failure._tag === "OrchestrationDispatchCommandError");
       assert.include(result.failure.message, "worktree exploded");
+      assert.strictEqual(result.failure.bootstrapThreadDisposition, "deleted");
+      assert.deepEqual(
+        dispatchedCommands.map((command) => command.type),
+        ["thread.create", "thread.delete"],
+      );
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("does not report a deleted bootstrap thread when cleanup fails", () =>
+    Effect.gen(function* () {
+      const dispatchedCommands: Array<OrchestrationCommand> = [];
+      const createWorktree = vi.fn(
+        (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["createWorktree"]>[0]) =>
+          Effect.die(new Error("worktree exploded")),
+      );
+
+      yield* buildAppUnderTest({
+        layers: {
+          gitVcsDriver: {
+            createWorktree,
+          },
+          orchestrationEngine: {
+            dispatch: (command) => {
+              dispatchedCommands.push(command);
+              if (command.type === "thread.delete") {
+                return Effect.fail(
+                  new OrchestrationListenerCallbackError({
+                    listener: "domain-event",
+                    detail: "thread cleanup exploded",
+                  }),
+                );
+              }
+              return Effect.succeed({ sequence: dispatchedCommands.length });
+            },
+            readEvents: () => Stream.empty,
+          },
+        },
+      });
+
+      const createdAt = "2026-01-01T00:00:00.000Z";
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const result = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[ORCHESTRATION_WS_METHODS.dispatchCommand]({
+            type: "thread.turn.start",
+            commandId: CommandId.make("cmd-bootstrap-turn-start-cleanup-defect"),
+            threadId: ThreadId.make("thread-bootstrap-cleanup-defect"),
+            message: {
+              messageId: MessageId.make("msg-bootstrap-cleanup-defect"),
+              role: "user",
+              text: "hello",
+              attachments: [],
+            },
+            modelSelection: defaultModelSelection,
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            bootstrap: {
+              createThread: {
+                projectId: defaultProjectId,
+                title: "Bootstrap Thread",
+                modelSelection: defaultModelSelection,
+                runtimeMode: "full-access",
+                interactionMode: "default",
+                branch: "main",
+                worktreePath: null,
+                createdAt,
+              },
+              prepareWorktree: {
+                projectCwd: "/tmp/project",
+                baseBranch: "main",
+                branch: "t3code/bootstrap-refName",
+              },
+              runSetupScript: false,
+            },
+            createdAt,
+          }),
+        ).pipe(Effect.result),
+      );
+
+      assertTrue(result._tag === "Failure");
+      assertTrue(result.failure._tag === "OrchestrationDispatchCommandError");
+      assert.include(result.failure.message, "worktree exploded");
+      assert.strictEqual(result.failure.bootstrapThreadDisposition, undefined);
       assert.deepEqual(
         dispatchedCommands.map((command) => command.type),
         ["thread.create", "thread.delete"],

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -775,9 +775,9 @@ const makeWsRpcLayer = (
                       threadId: command.threadId,
                     }),
                   ),
-                  Effect.ignoreCause({ log: true }),
+                  Effect.as(true),
                 )
-              : Effect.void;
+              : Effect.succeed(false);
 
           const recordSetupScriptLaunchFailure = (input: {
             readonly error: ProjectSetupScriptRunner.ProjectSetupScriptRunnerError;
@@ -964,7 +964,27 @@ const makeWsRpcLayer = (
               if (Cause.hasInterruptsOnly(cause)) {
                 return Effect.fail(dispatchError);
               }
-              return cleanupCreatedThread().pipe(Effect.flatMap(() => Effect.fail(dispatchError)));
+              return Effect.uninterruptible(cleanupCreatedThread()).pipe(
+                Effect.matchCauseEffect({
+                  onFailure: (cleanupCause) =>
+                    Effect.logWarning("bootstrap thread cleanup failed", {
+                      threadId: command.threadId,
+                      detail: Cause.pretty(cleanupCause),
+                    }).pipe(Effect.flatMap(() => Effect.fail(dispatchError))),
+                  onSuccess: (threadDeleted) =>
+                    Effect.fail(
+                      threadDeleted
+                        ? new OrchestrationDispatchCommandError({
+                            message: dispatchError.message,
+                            ...(dispatchError.cause !== undefined
+                              ? { cause: dispatchError.cause }
+                              : {}),
+                            bootstrapThreadDisposition: "deleted",
+                          })
+                        : dispatchError,
+                    ),
+                }),
+              );
             }),
           );
         });

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -26,6 +26,7 @@ import {
   connectionStatusTitle,
   type EnvironmentConnectionPresentation,
 } from "@t3tools/client-runtime/connection";
+import { wasBootstrapThreadDeleted } from "@t3tools/client-runtime/errors";
 import {
   changeRequestAutoSettles,
   effectiveSettled,
@@ -5454,6 +5455,20 @@ function ChatViewContent(props: ChatViewProps) {
       }
       if (!isAtomCommandInterrupted(failure)) {
         const error = squashAtomCommandFailure(failure);
+        if (isLocalDraftThread && draftId && wasBootstrapThreadDeleted(error)) {
+          const failedDraftSession = getDraftSession(draftId);
+          if (failedDraftSession?.threadId === threadIdForSend) {
+            setLogicalProjectDraftThreadId(
+              failedDraftSession.logicalProjectKey,
+              scopeProjectRef(failedDraftSession.environmentId, failedDraftSession.projectId),
+              draftId,
+              {
+                threadId: newThreadId(),
+                createdAt: new Date().toISOString(),
+              },
+            );
+          }
+        }
         setThreadError(
           threadIdForSend,
           error instanceof Error ? error.message : "Failed to send message.",

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -823,6 +823,43 @@ describe("composerDraftStore project draft thread mapping", () => {
     });
   });
 
+  it("rotates a failed bootstrap thread id without losing its draft", () => {
+    const store = useComposerDraftStore.getState();
+    const retryThreadId = ThreadId.make("thread-retry");
+    store.setProjectDraftThreadId(projectRef, draftId, {
+      threadId,
+      branch: "feature/test",
+      worktreePath: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      envMode: "worktree",
+      startFromOrigin: true,
+      runtimeMode: "approval-required",
+      interactionMode: "plan",
+    });
+    store.setPrompt(draftId, "keep this prompt");
+    markPromotedDraftThread(threadId);
+
+    store.setLogicalProjectDraftThreadId(scopedProjectKey(projectRef), projectRef, draftId, {
+      threadId: retryThreadId,
+      createdAt: "2026-01-01T00:01:00.000Z",
+    });
+
+    expect(useComposerDraftStore.getState().getDraftThread(draftId)).toMatchObject({
+      threadId: retryThreadId,
+      branch: "feature/test",
+      worktreePath: null,
+      createdAt: "2026-01-01T00:01:00.000Z",
+      envMode: "worktree",
+      startFromOrigin: true,
+      runtimeMode: "approval-required",
+      interactionMode: "plan",
+      promotedTo: null,
+    });
+    expect(useComposerDraftStore.getState().getComposerDraft(draftId)?.prompt).toBe(
+      "keep this prompt",
+    );
+  });
+
   it("clears only matching project draft mapping entries", () => {
     const store = useComposerDraftStore.getState();
     store.setProjectDraftThreadId(projectRef, draftId, { threadId });

--- a/packages/client-runtime/src/errors/index.ts
+++ b/packages/client-runtime/src/errors/index.ts
@@ -1,3 +1,4 @@
 export * from "./errorTrace.ts";
+export * from "./orchestration.ts";
 export * from "./safeLog.ts";
 export * from "./transport.ts";

--- a/packages/client-runtime/src/errors/orchestration.test.ts
+++ b/packages/client-runtime/src/errors/orchestration.test.ts
@@ -1,0 +1,23 @@
+import { OrchestrationDispatchCommandError } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { wasBootstrapThreadDeleted } from "./orchestration.ts";
+
+describe("wasBootstrapThreadDeleted", () => {
+  it("accepts only a confirmed deleted bootstrap thread", () => {
+    expect(
+      wasBootstrapThreadDeleted(
+        new OrchestrationDispatchCommandError({
+          message: "Failed to create worktree.",
+          bootstrapThreadDisposition: "deleted",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      wasBootstrapThreadDeleted(
+        new OrchestrationDispatchCommandError({ message: "Failed to create worktree." }),
+      ),
+    ).toBe(false);
+    expect(wasBootstrapThreadDeleted(new Error("connection lost"))).toBe(false);
+  });
+});

--- a/packages/client-runtime/src/errors/orchestration.ts
+++ b/packages/client-runtime/src/errors/orchestration.ts
@@ -1,0 +1,10 @@
+import { OrchestrationDispatchCommandError } from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
+
+const isOrchestrationDispatchCommandError = Schema.is(OrchestrationDispatchCommandError);
+
+export function wasBootstrapThreadDeleted(error: unknown): boolean {
+  return (
+    isOrchestrationDispatchCommandError(error) && error.bootstrapThreadDisposition === "deleted"
+  );
+}

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_RUNTIME_MODE,
   ModelSelection,
   OrchestrationCommand,
+  OrchestrationDispatchCommandError,
   OrchestrationEvent,
   OrchestrationGetFullThreadDiffInput,
   OrchestrationGetTurnDiffInput,
@@ -54,6 +55,19 @@ const decodeThreadCreatedPayload = Schema.decodeUnknownEffect(ThreadCreatedPaylo
 const decodeOrchestrationCommand = Schema.decodeUnknownEffect(OrchestrationCommand);
 const decodeOrchestrationEvent = Schema.decodeUnknownEffect(OrchestrationEvent);
 const decodeThreadMetaUpdatedPayload = Schema.decodeUnknownEffect(ThreadMetaUpdatedPayload);
+const decodeDispatchCommandError = Schema.decodeUnknownEffect(OrchestrationDispatchCommandError);
+
+it.effect("decodes a dispatch error after its bootstrap thread was deleted", () =>
+  Effect.gen(function* () {
+    const error = yield* decodeDispatchCommandError({
+      _tag: "OrchestrationDispatchCommandError",
+      message: "Failed to create worktree.",
+      bootstrapThreadDisposition: "deleted",
+    });
+
+    assert.strictEqual(error.bootstrapThreadDisposition, "deleted");
+  }),
+);
 
 it.effect("parses turn diff input when fromTurnCount <= toTurnCount", () =>
   Effect.gen(function* () {

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -1711,6 +1711,7 @@ export class OrchestrationDispatchCommandError extends Schema.TaggedErrorClass<O
   {
     message: TrimmedNonEmptyString,
     cause: Schema.optional(Schema.Defect()),
+    bootstrapThreadDisposition: Schema.optional(Schema.Literal("deleted")),
   },
 ) {}
 


### PR DESCRIPTION
## Problem

Worktree-backed threads are persisted before Git work starts. That order is intentional because worktree creation can be slow. If Git then fails, the server soft-deletes the new thread, but the web draft keeps its spent ThreadId. Pressing Enter again sends thread.create with the same ID and hits the global uniqueness invariant.

This is an alternative to #7608. Deleted thread IDs remain single-use instead of being resurrected.

## Fix

- Keep thread.create before worktree preparation.
- Mark the existing dispatch error only after the compensating thread.delete completes.
- Keep the same visible DraftId and restored composer content, but rotate it to a fresh ThreadId after that confirmed deletion.
- Do not rotate after interrupts, connection failures, old-server responses, or failed cleanup where server state is uncertain.
- Preserve branch, environment, start-from-origin, runtime, and interaction choices across the retry.

The optional error field is wire-compatible. Old clients ignore it, and new clients connected to old servers keep the current conservative behavior. Web and desktop use the new recovery path. Normal online mobile submissions already mint a fresh ThreadId per explicit submit; queued mobile retries remain unchanged.

## Verification

- 251 focused tests passed across server bootstrap behavior, the orchestration contract, the client error classifier, and the web draft store.
- Targeted formatting and lint passed.
- Server, contracts, and client-runtime typechecks passed. The web package typecheck is currently blocked by two unrelated conditionalUI fixture errors in electronPasskeys.test.ts.

Generated with GPT-5.6 Sol in the Codex harness through T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3381651e0563dbb9d964f7078250b2bbe261be19. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry failed thread bootstraps with a fresh thread ID on web client
> - Extends `OrchestrationDispatchCommandError` with an optional `bootstrapThreadDisposition: "deleted"` field. The server sets this when a failed bootstrap thread is successfully deleted during cleanup.
> - The web client detects this disposition via a new `wasBootstrapThreadDeleted` guard. It rotates the draft's logical project thread ID via `setLogicalProjectDraftThreadId` and preserves the draft content for a fresh retry.
> - Risk: `dispatchBootstrapTurnStart` in [ws.ts](https://github.com/pingdotgg/t3code/pull/7664/files#diff-7f2100e8ffa23a58d9bf425c5b3ceafc39239911ae33bc569291a00ecb8e9125) wraps cleanup in `Effect.uninterruptible` and only sets the disposition field on successful deletion. If cleanup fails, it returns the original dispatch error without the field.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3381651.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when sending from a draft fails because its temporary thread was deleted.
  * Draft sessions now automatically reset and retry with a fresh thread identifier while preserving their settings.
  * Cleanup failures no longer hide the original worktree error.

* **Tests**
  * Added coverage for successful cleanup, cleanup failures, error reporting, and draft retry behavior.

* **Documentation**
  * Exposed additional error details indicating when a temporary thread was deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->