### PR TITLE
fix(shared): handle semver metadata correctly

### DIFF
--- a/packages/shared/src/semver.test.ts
+++ b/packages/shared/src/semver.test.ts
@@ -69,9 +69,12 @@ describe("semver helpers", () => {
     },
   );
 
-  it.each(["1.2.3-", "1.2.3-+build.1"])("rejects an empty prerelease in %s", (version) => {
-    expect(parseSemver(version)).toBeNull();
-  });
+  it.each(["1.2.3-", "1.2.3-+build.1", "1.2.3-   +build.1"])(
+    "rejects an empty prerelease in %s",
+    (version) => {
+      expect(parseSemver(version)).toBeNull();
+    },
+  );
 
   it("falls back to lexical comparison for malformed numeric segments", () => {
     expect(compareSemverVersions("1.2.3abc", "1.2.10")).toBeGreaterThan(0);

--- a/packages/shared/src/semver.test.ts
+++ b/packages/shared/src/semver.test.ts
@@ -69,6 +69,10 @@ describe("semver helpers", () => {
     },
   );
 
+  it.each(["1.2.3-", "1.2.3-+build.1"])("rejects an empty prerelease in %s", (version) => {
+    expect(parseSemver(version)).toBeNull();
+  });
+
   it("falls back to lexical comparison for malformed numeric segments", () => {
     expect(compareSemverVersions("1.2.3abc", "1.2.10")).toBeGreaterThan(0);
   });

--- a/packages/shared/src/semver.test.ts
+++ b/packages/shared/src/semver.test.ts
@@ -62,6 +62,13 @@ describe("semver helpers", () => {
     expect(compareSemverVersions("1.2.3-alpha-beta", "1.2.3-alpha")).toBeGreaterThan(0);
   });
 
+  it.each(["1.2.3+", "1.2.3+!!!", "1.2.3+foo+bar"])(
+    "rejects malformed build metadata in %s",
+    (version) => {
+      expect(parseSemver(version)).toBeNull();
+    },
+  );
+
   it("falls back to lexical comparison for malformed numeric segments", () => {
     expect(compareSemverVersions("1.2.3abc", "1.2.10")).toBeGreaterThan(0);
   });

--- a/packages/shared/src/semver.test.ts
+++ b/packages/shared/src/semver.test.ts
@@ -69,12 +69,17 @@ describe("semver helpers", () => {
     },
   );
 
-  it.each(["1.2.3-", "1.2.3-+build.1", "1.2.3-   +build.1"])(
-    "rejects an empty prerelease in %s",
-    (version) => {
-      expect(parseSemver(version)).toBeNull();
-    },
-  );
+  it.each([
+    "1.2.3-",
+    "1.2.3-+build.1",
+    "1.2.3-   +build.1",
+    "1.2.3-alpha.+build.1",
+    "1.2.3-alpha..1",
+    "1.2.3-.alpha",
+    "1.2.3-alpha.",
+  ])("rejects an empty prerelease identifier in %s", (version) => {
+    expect(parseSemver(version)).toBeNull();
+  });
 
   it("falls back to lexical comparison for malformed numeric segments", () => {
     expect(compareSemverVersions("1.2.3abc", "1.2.10")).toBeGreaterThan(0);

--- a/packages/shared/src/semver.test.ts
+++ b/packages/shared/src/semver.test.ts
@@ -46,6 +46,22 @@ describe("semver helpers", () => {
     expect(compareSemverVersions("2.1.111-beta.1", "2.1.111")).toBeLessThan(0);
   });
 
+  it("ignores build metadata when comparing version precedence", () => {
+    expect(compareSemverVersions("1.2.3", "1.2.3+build.1")).toBe(0);
+    expect(compareSemverVersions("1.2.3-beta.1+build.2", "1.2.3-beta.1+build.1")).toBe(0);
+  });
+
+  it("preserves hyphens within prerelease identifiers", () => {
+    expect(normalizeSemverVersion("1.2-alpha-beta+build.1")).toBe("1.2.0-alpha-beta+build.1");
+    expect(parseSemver("1.2.3-alpha-beta+build.1")).toEqual({
+      major: 1,
+      minor: 2,
+      patch: 3,
+      prerelease: ["alpha-beta"],
+    });
+    expect(compareSemverVersions("1.2.3-alpha-beta", "1.2.3-alpha")).toBeGreaterThan(0);
+  });
+
   it("falls back to lexical comparison for malformed numeric segments", () => {
     expect(compareSemverVersions("1.2.3abc", "1.2.10")).toBeGreaterThan(0);
   });

--- a/packages/shared/src/semver.ts
+++ b/packages/shared/src/semver.ts
@@ -7,10 +7,30 @@ interface ParsedSemver {
 
 const SEMVER_NUMBER_SEGMENT = /^\d+$/;
 
+function splitSemverVersion(version: string) {
+  const trimmed = version.trim();
+  const buildMetadataIndex = trimmed.indexOf("+");
+  const versionWithoutBuildMetadata =
+    buildMetadataIndex === -1 ? trimmed : trimmed.slice(0, buildMetadataIndex);
+  const buildMetadata =
+    buildMetadataIndex === -1 ? undefined : trimmed.slice(buildMetadataIndex + 1);
+  const prereleaseIndex = versionWithoutBuildMetadata.indexOf("-");
+
+  return {
+    main:
+      prereleaseIndex === -1
+        ? versionWithoutBuildMetadata
+        : versionWithoutBuildMetadata.slice(0, prereleaseIndex),
+    prerelease:
+      prereleaseIndex === -1 ? undefined : versionWithoutBuildMetadata.slice(prereleaseIndex + 1),
+    buildMetadata,
+  };
+}
+
 export function normalizeSemverVersion(version: string): string {
-  const [main, prerelease] = version.trim().split("-", 2);
+  const { main, prerelease, buildMetadata } = splitSemverVersion(version);
   const segments: string[] = [];
-  for (const segment of (main ?? "").split(".")) {
+  for (const segment of main.split(".")) {
     const trimmed = segment.trim();
     if (trimmed.length > 0) {
       segments.push(trimmed);
@@ -26,12 +46,14 @@ export function normalizeSemverVersion(version: string): string {
     segments.push("0");
   }
 
-  return prerelease ? `${segments.join(".")}-${prerelease}` : segments.join(".");
+  const normalizedPrerelease = prerelease ? `-${prerelease}` : "";
+  const normalizedBuildMetadata = buildMetadata ? `+${buildMetadata}` : "";
+  return `${segments.join(".")}${normalizedPrerelease}${normalizedBuildMetadata}`;
 }
 
 export function parseSemver(value: string): ParsedSemver | null {
   const normalized = normalizeSemverVersion(value).replace(/^v/, "");
-  const [main = "", prerelease] = normalized.split("-", 2);
+  const { main, prerelease } = splitSemverVersion(normalized);
   const segments = main.split(".");
   if (segments.length !== 3) {
     return null;

--- a/packages/shared/src/semver.ts
+++ b/packages/shared/src/semver.ts
@@ -54,7 +54,7 @@ export function normalizeSemverVersion(version: string): string {
 
 export function parseSemver(value: string): ParsedSemver | null {
   const { buildMetadata, prerelease: rawPrerelease } = splitSemverVersion(value);
-  if (rawPrerelease === "") {
+  if (rawPrerelease !== undefined && rawPrerelease.trim().length === 0) {
     return null;
   }
   if (buildMetadata !== undefined && !SEMVER_BUILD_METADATA.test(buildMetadata)) {

--- a/packages/shared/src/semver.ts
+++ b/packages/shared/src/semver.ts
@@ -54,7 +54,10 @@ export function normalizeSemverVersion(version: string): string {
 
 export function parseSemver(value: string): ParsedSemver | null {
   const { buildMetadata, prerelease: rawPrerelease } = splitSemverVersion(value);
-  if (rawPrerelease !== undefined && rawPrerelease.trim().length === 0) {
+  if (
+    rawPrerelease !== undefined &&
+    rawPrerelease.split(".").some((segment) => segment.trim().length === 0)
+  ) {
     return null;
   }
   if (buildMetadata !== undefined && !SEMVER_BUILD_METADATA.test(buildMetadata)) {

--- a/packages/shared/src/semver.ts
+++ b/packages/shared/src/semver.ts
@@ -6,6 +6,7 @@ interface ParsedSemver {
 }
 
 const SEMVER_NUMBER_SEGMENT = /^\d+$/;
+const SEMVER_BUILD_METADATA = /^[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*$/;
 
 function splitSemverVersion(version: string) {
   const trimmed = version.trim();
@@ -52,6 +53,11 @@ export function normalizeSemverVersion(version: string): string {
 }
 
 export function parseSemver(value: string): ParsedSemver | null {
+  const { buildMetadata } = splitSemverVersion(value);
+  if (buildMetadata !== undefined && !SEMVER_BUILD_METADATA.test(buildMetadata)) {
+    return null;
+  }
+
   const normalized = normalizeSemverVersion(value).replace(/^v/, "");
   const { main, prerelease } = splitSemverVersion(normalized);
   const segments = main.split(".");

--- a/packages/shared/src/semver.ts
+++ b/packages/shared/src/semver.ts
@@ -53,7 +53,10 @@ export function normalizeSemverVersion(version: string): string {
 }
 
 export function parseSemver(value: string): ParsedSemver | null {
-  const { buildMetadata } = splitSemverVersion(value);
+  const { buildMetadata, prerelease: rawPrerelease } = splitSemverVersion(value);
+  if (rawPrerelease === "") {
+    return null;
+  }
   if (buildMetadata !== undefined && !SEMVER_BUILD_METADATA.test(buildMetadata)) {
     return null;
   }


### PR DESCRIPTION
Provider update checks compare versions through the shared SemVer helper. Build metadata caused a lexical fallback, while hyphenated prerelease identifiers were truncated, which could produce incorrect update advisories.

This centralizes SemVer suffix splitting so prerelease identifiers remain intact and build metadata is preserved during normalization but ignored for precedence comparisons.

Tests:
- ./node_modules/.bin/vp test run packages/shared/src/semver.test.ts
- ./node_modules/.bin/vp test run apps/server/src/provider/providerMaintenance.test.ts
- ./node_modules/.bin/vp run --filter @t3tools/shared typecheck
- targeted formatting and lint checks

Model: gpt-daybreak-blue-latest
Harness: Codex in T3 Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `parseSemver` and `normalizeSemverVersion` to handle semver metadata correctly
> - `normalizeSemverVersion` now preserves build metadata instead of dropping it; output includes `+build` when present.
> - `parseSemver` rejects versions with empty prerelease identifiers (trailing `-`, consecutive dots, empty segments) and invalid build metadata (invalid characters, multiple `+`, empty segments).
> - Adds `splitSemverVersion` helper and `SEMVER_BUILD_METADATA` regex to centralize splitting and validation logic in [semver.ts](https://github.com/pingdotgg/t3code/pull/7666/files#diff-509b00c0da909c9a18e64a8659c9e208b0a7b423de4e59f76e73abd7215f4c15).
> - Risk: `parseSemver` now returns `null` for previously accepted malformed inputs (e.g. `1.0.0-`, `1.0.0+invalid!`); callers that relied on lenient parsing of such strings will see different results.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b150323.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes version comparison and normalization used for provider minimum-version checks; incorrect advisories were the prior failure mode, but stricter rejection of malformed versions could affect edge-case inputs.
> 
> **Overview**
> Fixes shared semver parsing so provider and other version gates compare versions correctly when strings include **build metadata** (`+...`) or **hyphenated prerelease** identifiers.
> 
> **Parsing** now uses a shared `splitSemverVersion` helper that splits at the first `+` and first `-`, instead of splitting only on `-` and truncating prerelease labels like `alpha-beta`. **Normalization** keeps the `+build` suffix on output where it was previously dropped. **Validation** rejects empty prerelease segments and build metadata that does not match the semver character rules.
> 
> **Comparison** behavior aligns with semver precedence: differing build metadata does not change order; hyphenated prereleases are compared as single identifiers. Tests cover these cases and malformed inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1503236c917fc96acf071441d71132e9b66ba03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved semantic version parsing and normalization.
  * Preserved valid build metadata in version values.
  * Rejected malformed build metadata and empty prerelease components.
  * Correctly handled build-metadata precedence and hyphenated prerelease identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->