### PR TITLE
fix(server): fall back to local worktree base when origin fails

### DIFF
--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -10687,37 +10687,76 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
   );
 
   it.effect.each([
-    { caseName: "the origin remote is missing", hasOrigin: false },
-    { caseName: "the base branch exists only locally", hasOrigin: true },
-  ])("falls back to the local base branch when $caseName", ({ hasOrigin }) =>
+    "unavailable",
+    "check",
+    "fetch",
+    "branch-missing",
+    "branch-check",
+    "resolve",
+  ] as const)("falls back to the local base branch when origin is $0", (failureStage) =>
     Effect.gen(function* () {
       const dispatchedCommands: Array<OrchestrationCommand> = [];
-      const remoteExists = vi.fn(
-        (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["remoteExists"]>[0]) =>
-          Effect.succeed(hasOrigin),
+      const remoteExists = vi.fn<GitVcsDriver.GitVcsDriver["Service"]["remoteExists"]>(() =>
+        failureStage === "check"
+          ? Effect.fail(
+              new GitCommandError({
+                operation: "GitVcsDriver.remoteExists",
+                command: "git remote get-url origin",
+                cwd: "/tmp/project",
+                detail: "origin check failed",
+              }),
+            )
+          : Effect.succeed(failureStage !== "unavailable"),
       );
-      const fetchRemote = vi.fn(
-        (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["fetchRemote"]>[0]) => Effect.void,
+      const fetchRemote = vi.fn<GitVcsDriver.GitVcsDriver["Service"]["fetchRemote"]>(() =>
+        failureStage === "fetch"
+          ? Effect.fail(
+              new GitCommandError({
+                operation: "GitVcsDriver.fetchRemote",
+                command: "git fetch --quiet origin",
+                cwd: "/tmp/project",
+                detail: "origin fetch failed",
+              }),
+            )
+          : Effect.void,
       );
-      const resolveRemoteTrackingCommit = vi.fn(
-        (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["resolveRemoteTrackingCommit"]>[0]) =>
-          Effect.succeed({
-            commitSha: "0123456789abcdef0123456789abcdef01234567",
-            remoteRefName: "origin/main",
-          }),
+      const remoteBranchExists = vi.fn<GitVcsDriver.GitVcsDriver["Service"]["remoteBranchExists"]>(
+        () =>
+          failureStage === "branch-check"
+            ? Effect.fail(
+                new GitCommandError({
+                  operation: "GitVcsDriver.remoteBranchExists",
+                  command: "git show-ref --verify refs/remotes/origin/personal/test",
+                  cwd: "/tmp/project",
+                  detail: "remote branch check failed",
+                }),
+              )
+            : Effect.succeed(failureStage !== "branch-missing"),
       );
-      const remoteBranchExists = vi.fn(
-        (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["remoteBranchExists"]>[0]) =>
-          Effect.succeed(false),
+      const resolveRemoteTrackingCommit = vi.fn<
+        GitVcsDriver.GitVcsDriver["Service"]["resolveRemoteTrackingCommit"]
+      >(() =>
+        failureStage === "resolve"
+          ? Effect.fail(
+              new GitCommandError({
+                operation: "GitVcsDriver.resolveRemoteTrackingCommit",
+                command: "git rev-parse --verify refs/remotes/origin/personal/test^{commit}",
+                cwd: "/tmp/project",
+                detail: "remote tracking ref does not exist",
+              }),
+            )
+          : Effect.succeed({
+              commitSha: "0123456789abcdef0123456789abcdef01234567",
+              remoteRefName: "origin/personal/test",
+            }),
       );
-      const createWorktree = vi.fn(
-        (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["createWorktree"]>[0]) =>
-          Effect.succeed({
-            worktree: {
-              refName: "t3code/bootstrap-refName",
-              path: "/tmp/bootstrap-worktree",
-            },
-          }),
+      const createWorktree = vi.fn<GitVcsDriver.GitVcsDriver["Service"]["createWorktree"]>(() =>
+        Effect.succeed({
+          worktree: {
+            refName: "t3code/bootstrap-refName",
+            path: "/tmp/bootstrap-worktree",
+          },
+        }),
       );
 
       yield* buildAppUnderTest({
@@ -10742,14 +10781,14 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
 
       const createdAt = "2026-01-01T00:00:00.000Z";
       const wsUrl = yield* getWsServerUrl("/ws");
-      yield* Effect.scoped(
+      const response = yield* Effect.scoped(
         withWsRpcClient(wsUrl, (client) =>
           client[ORCHESTRATION_WS_METHODS.dispatchCommand]({
             type: "thread.turn.start",
-            commandId: CommandId.make("cmd-bootstrap-turn-start-no-origin"),
-            threadId: ThreadId.make("thread-bootstrap-no-origin"),
+            commandId: CommandId.make(`cmd-bootstrap-turn-start-origin-${failureStage}`),
+            threadId: ThreadId.make(`thread-bootstrap-origin-${failureStage}`),
             message: {
-              messageId: MessageId.make("msg-bootstrap-no-origin"),
+              messageId: MessageId.make(`msg-bootstrap-origin-${failureStage}`),
               role: "user",
               text: "hello",
               attachments: [],
@@ -10764,13 +10803,13 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
                 modelSelection: defaultModelSelection,
                 runtimeMode: "full-access",
                 interactionMode: "default",
-                branch: "main",
+                branch: "personal/test",
                 worktreePath: null,
                 createdAt,
               },
               prepareWorktree: {
                 projectCwd: "/tmp/project",
-                baseBranch: "main",
+                baseBranch: "personal/test",
                 branch: "t3code/bootstrap-refName",
                 startFromOrigin: true,
               },
@@ -10780,27 +10819,31 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         ),
       );
 
+      assert.equal(response.sequence, 3);
       assert.deepEqual(remoteExists.mock.calls[0]?.[0], {
         cwd: "/tmp/project",
         remoteName: "origin",
       });
-      assert.equal(fetchRemote.mock.calls.length, hasOrigin ? 1 : 0);
-      assert.equal(remoteBranchExists.mock.calls.length, hasOrigin ? 1 : 0);
-      if (hasOrigin) {
-        assert.deepEqual(remoteBranchExists.mock.calls[0]?.[0], {
-          cwd: "/tmp/project",
-          remoteName: "origin",
-          refName: "main",
-        });
-      }
-      assert.equal(resolveRemoteTrackingCommit.mock.calls.length, 0);
+      assert.equal(
+        fetchRemote.mock.calls.length,
+        ["fetch", "branch-missing", "branch-check", "resolve"].includes(failureStage) ? 1 : 0,
+      );
+      assert.equal(
+        remoteBranchExists.mock.calls.length,
+        ["branch-missing", "branch-check", "resolve"].includes(failureStage) ? 1 : 0,
+      );
+      assert.equal(
+        resolveRemoteTrackingCommit.mock.calls.length,
+        failureStage === "resolve" ? 1 : 0,
+      );
       assert.deepEqual(createWorktree.mock.calls[0]?.[0], {
         cwd: "/tmp/project",
-        refName: "main",
+        refName: "personal/test",
         newRefName: "t3code/bootstrap-refName",
-        baseRefName: "main",
+        baseRefName: "personal/test",
         path: null,
       });
+      assertTrue(dispatchedCommands.every((command) => command.type !== "thread.delete"));
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1113,6 +1113,49 @@ const makeWsRpcLayer = (
                 );
             });
 
+          // Start from origin is a persisted default, so any origin Git failure degrades to the
+          // explicitly selected local base instead of aborting the whole thread bootstrap.
+          const resolveOriginWorktreeBaseRef = Effect.fn("resolveOriginWorktreeBaseRef")(
+            function* (input: { readonly projectCwd: string; readonly baseBranch: string }) {
+              const originAvailable = yield* gitWorkflow.remoteExists({
+                cwd: input.projectCwd,
+                remoteName: "origin",
+              });
+              if (!originAvailable) {
+                return input.baseBranch;
+              }
+              yield* gitWorkflow.fetchRemote({ cwd: input.projectCwd, remoteName: "origin" });
+              const remoteBaseExists = yield* gitWorkflow.remoteBranchExists({
+                cwd: input.projectCwd,
+                refName: input.baseBranch,
+                remoteName: "origin",
+              });
+              if (!remoteBaseExists) {
+                return input.baseBranch;
+              }
+              const resolvedRemoteBase = yield* gitWorkflow.resolveRemoteTrackingCommit({
+                cwd: input.projectCwd,
+                refName: input.baseBranch,
+                fallbackRemoteName: "origin",
+              });
+              return resolvedRemoteBase.commitSha;
+            },
+            (effect, input) =>
+              effect.pipe(
+                Effect.catch((error) =>
+                  Effect.logWarning("could not prepare worktree base from origin", {
+                    threadId: command.threadId,
+                    baseBranch: input.baseBranch,
+                    remoteName: "origin",
+                    operation: error.operation,
+                    exitCode: error.exitCode ?? null,
+                    stdoutLength: error.stdoutLength ?? null,
+                    stderrLength: error.stderrLength ?? null,
+                  }).pipe(Effect.as(input.baseBranch)),
+                ),
+              ),
+          );
+
           const bootstrapProgram = Effect.gen(function* () {
             if (bootstrap?.createThread) {
               const created = yield* dispatchFromClient({
@@ -1137,39 +1180,16 @@ const makeWsRpcLayer = (
             }
 
             if (bootstrap?.prepareWorktree) {
-              let worktreeBaseRef = bootstrap.prepareWorktree.baseBranch;
-              // "Start from origin" is a stored default; repos without the
-              // requested remote branch fall back to the local base branch.
-              const startFromOrigin =
-                bootstrap.prepareWorktree.startFromOrigin === true &&
-                (yield* gitWorkflow.remoteExists({
-                  cwd: bootstrap.prepareWorktree.projectCwd,
-                  remoteName: "origin",
-                }));
-              if (startFromOrigin) {
-                yield* gitWorkflow.fetchRemote({
-                  cwd: bootstrap.prepareWorktree.projectCwd,
-                  remoteName: "origin",
-                });
-                const remoteBaseExists = yield* gitWorkflow.remoteBranchExists({
-                  cwd: bootstrap.prepareWorktree.projectCwd,
-                  refName: bootstrap.prepareWorktree.baseBranch,
-                  remoteName: "origin",
-                });
-                if (remoteBaseExists) {
-                  const resolvedRemoteBase = yield* gitWorkflow.resolveRemoteTrackingCommit({
-                    cwd: bootstrap.prepareWorktree.projectCwd,
-                    refName: bootstrap.prepareWorktree.baseBranch,
-                    fallbackRemoteName: "origin",
-                  });
-                  worktreeBaseRef = resolvedRemoteBase.commitSha;
-                }
-              }
+              const prepareWorktree = bootstrap.prepareWorktree;
+              const worktreeBaseRef =
+                prepareWorktree.startFromOrigin === true
+                  ? yield* resolveOriginWorktreeBaseRef(prepareWorktree)
+                  : prepareWorktree.baseBranch;
               const worktree = yield* gitWorkflow.createWorktree({
-                cwd: bootstrap.prepareWorktree.projectCwd,
+                cwd: prepareWorktree.projectCwd,
                 refName: worktreeBaseRef,
-                newRefName: bootstrap.prepareWorktree.branch,
-                baseRefName: bootstrap.prepareWorktree.baseBranch,
+                newRefName: prepareWorktree.branch,
+                baseRefName: prepareWorktree.baseBranch,
                 path: null,
               });
               targetWorktreePath = worktree.worktree.path;


### PR DESCRIPTION
## What Changed

With **Start from origin** enabled, failures checking origin, fetching, checking the remote branch, or resolving its commit now fall back to the selected local base instead of aborting thread creation. The origin resolution lives in a named `resolveOriginWorktreeBaseRef` `Effect.fn` helper whose `Effect.catch` limits recovery to those Git operations and logs structured diagnostics (operation, exit code, stdout/stderr lengths) without raw command output. Successful origin resolution and later worktree/bootstrap error handling retain their existing behavior.

## Why

Merged PR #8751 already handles missing remote branches, and main handles a missing origin. This PR preserves those paths and contains only the remaining Git-error recovery delta; a valid local base can still start a thread when origin preparation fails. The server bootstrap path serves the existing clients and providers without changing wire contracts or UI controls.

## Verification

Branch is rebased on `origin/main` at `b1e223e2b0` (`ea42f3e2cc`).

- `vp test run apps/server/src/server.test.ts`: 185/186 passed; all six fallback-stage tests (origin `unavailable`, `check`, `fetch`, `branch-missing`, `branch-check`, `resolve`) pass. The one failure, `binds static metadata and bytes to one file across atomic replacement`, is unrelated to this diff and passes in isolation.
- `vp lint apps/server/src/ws.ts apps/server/src/server.test.ts`: 0 errors; warnings are pre-existing outside the diff.
- `vp run typecheck` in `apps/server`: passed; Effect suggestions are pre-existing outside the diff.
- Independent read-only review of the diff vs `b1e223e2b0` by GPT-5.6 Sol (Codex CLI, high effort): exit 0, no actionable findings.

Verification is at the server RPC boundary; no browser or mobile capture was performed (no user-visible change).

Coordination trace: T3 thread f3f55c79-8e0a-4f42-a404-199eba60efec

Model and harness: SWE-2 High via Cursor harness in T3 Code; earlier iteration by Claude Opus 5 / GPT-6 via Codex; independent review by GPT-5.6 Sol via Codex CLI.