### PR TITLE
fix(desktop): Linux windows bind to the launcher instead of a generic icon

### DIFF
--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -488,6 +488,40 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
     }).pipe(Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} })))),
   );
 
+  it.effect("keeps the Linux StartupWMClass aligned with the product name", () =>
+    Effect.gen(function* () {
+      const stable = yield* createBuildConfig(
+        "linux",
+        "AppImage",
+        "1.2.3",
+        false,
+        false,
+        undefined,
+        undefined,
+      );
+      const nightly = yield* createBuildConfig(
+        "linux",
+        "AppImage",
+        "1.2.3-nightly.20260413.42",
+        false,
+        false,
+        undefined,
+        undefined,
+      );
+
+      // Electron derives WM_CLASS from the app name, so a StartupWMClass tied
+      // to executableName never matches the window and Linux shells render an
+      // unmatched generic icon next to the launcher.
+      assert.equal(stable.productName, "T3 Code (Alpha)");
+      assert.equal(nightly.productName, "T3 Code (Nightly)");
+      for (const config of [stable, nightly]) {
+        assert.deepStrictEqual((config.linux as Record<string, unknown>).desktop, {
+          entry: { StartupWMClass: config.productName },
+        });
+      }
+    }).pipe(Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} })))),
+  );
+
   it.effect("validates every ASAR-unpacked native in the packaged Windows payload", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -2122,9 +2122,13 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
           schemes: ["t3code", "t3code-dev"],
         },
       ],
+      // Electron derives WM_CLASS from the app name (productName), not from
+      // executableName, so StartupWMClass has to track productName. A
+      // hardcoded "t3code" never matches the window, leaving Linux shells
+      // unable to bind the running app to this launcher.
       desktop: {
         entry: {
-          StartupWMClass: "t3code",
+          StartupWMClass: resolveDesktopProductName(version),
         },
       },
     };


### PR DESCRIPTION
## What Changed

`StartupWMClass` in the generated Linux `.desktop` entry now tracks `resolveDesktopProductName(version)` instead of the hardcoded string `"t3code"`.

One line in `scripts/build-desktop-artifact.ts`, plus a test covering the invariant on both channels.

## Why

Electron derives a window's `WM_CLASS` from the app name (`productName`), not from `executableName`. The build config sets both of these, and they can never agree:

- `productName: resolveDesktopProductName(version)` → `T3 Code (Alpha)` or `T3 Code (Nightly)`
- `linux.desktop.entry.StartupWMClass: "t3code"`

On the shipped 0.0.33 AppImage the running window reports:

```
$ xprop -id <window> WM_CLASS
WM_CLASS(STRING) = "t3 code (alpha)", "T3 Code (Alpha)"
```

while the bundled entry says `StartupWMClass=t3code`. The match therefore always fails, on every channel.

When that match fails, Linux shells cannot associate the running window with its launcher, and fall back to the window's own `_NET_WM_ICON`. This window does not set one (`xprop` reports `_NET_WM_ICON: not found`), so the shell draws a generic icon in a second, unmatched tile beside the pinned launcher.

It also restores the intent already written down in `apps/desktop/src/app/DesktopLinuxUrlHandler.ts`, where the hidden URL-only entry deliberately omits `StartupWMClass` so it "must not compete with it for StartupWMClass matching". That only holds if the main entry's value can actually match a window.

Deriving it from `resolveDesktopProductName(version)` keeps one source of truth with `productName`, so stable, alpha and nightly stay correct without a second constant to keep in sync.

## UI Changes

GNOME on X11 (Ubuntu Dock), T3 Code 0.0.33 AppImage, launched from the pinned launcher. `StartupWMClass` is the only difference between the two runs.

**Before** — the pinned `T3` tile has no running indicator, and the running window shows up as a separate generic tile after the separator:

![before](https://raw.githubusercontent.com/danieljcksn/t3code/screenshots-linux-wmclass/pr-assets/before.png)

**After** — the window binds to the pinned launcher and carries the running indicator; the extra tile is gone:

![after](https://raw.githubusercontent.com/danieljcksn/t3code/screenshots-linux-wmclass/pr-assets/after.png)

## Verification

Verified on a real desktop by editing only `StartupWMClass` in the installed `.desktop` entry and relaunching, isolating it from every other field. `StartupWMClass=t3code` reproduces the duplicate tile; `StartupWMClass=T3 Code (Alpha)` fixes it, which is exactly what this change generates.

I did not run the repo's suite locally: the toolchain wants Node `^24.13.1` and this machine is on 22, so I left the full run to CI. The two touched files parse clean under `tsc`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes (not applicable, no motion involved)

---

Written by Claude Opus 5 (1M context) running in Claude Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Linux `StartupWMClass` to use resolved product name instead of hardcoded `t3code`
> Linux desktop builds now set `desktop.entry.StartupWMClass` to `resolveDesktopProductName(version)` instead of a fixed `"t3code"` value. This makes Electron windows bind to the correct launcher icon on Linux. Adds a test in [build-desktop-artifact.test.ts](https://github.com/pingdotgg/t3code/pull/7668/files#diff-a199d37af35c35dd3b48cf71436cb06b23acccd6857a9fe74db6d48cb73c7663) that verifies `StartupWMClass` matches `productName` for both stable and nightly builds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bddd981.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit bddd981606b2885cb7b19f7ad95c13f5ffb90bb4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->