### PR TITLE
fix(server): bound OpenCode skill discovery output

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
@@ -239,19 +239,16 @@ it.layer(testLayer)("checkOpenCodeProviderStatus", (it) => {
             name: "openclaw-review",
             description: "Review OpenClaw workflow changes.",
             location: "/Users/test/.agents/skills/openclaw-review/SKILL.md",
-            content: "---\nname: openclaw-review\n---\n",
           },
           {
             name: "openclaw-triage",
             description: "Triage OpenClaw routing issues.",
             location: "/Users/test/.agents/skills/openclaw-triage/SKILL.md",
-            content: "---\nname: openclaw-triage\n---\n",
           },
           {
             name: "missing-location",
             description: "This incomplete SDK row should be skipped.",
             location: "",
-            content: "---\nname: missing-location\n---\n",
           },
         ],
       };

--- a/apps/server/src/provider/opencodeRuntime.cliParsers.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.cliParsers.test.ts
@@ -258,7 +258,7 @@ describe("parseAgentListCliOutput", () => {
 });
 
 describe("parseSkillsCliOutput", () => {
-  it("parses skill metadata from the CLI JSON output", () => {
+  it("parses only skill metadata from the CLI JSON output", () => {
     const result = parseSkillsCliOutput(
       JSON.stringify([
         {
@@ -275,7 +275,6 @@ describe("parseSkillsCliOutput", () => {
         name: "review-pr",
         description: "Review a pull request.",
         location: "/tmp/review-pr/SKILL.md",
-        content: "---\nname: review-pr\n---\n",
       },
     ]);
   });

--- a/apps/server/src/provider/opencodeRuntime.inventory.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.inventory.test.ts
@@ -46,6 +46,48 @@ it.layer(testLayer)("OpenCodeRuntime inventory", (it) => {
     }),
   );
 
+  it.effect("keeps only SDK skill metadata in inventory", () =>
+    Effect.gen(function* () {
+      const runtime = yield* OpenCodeRuntime;
+      const client = {
+        provider: {
+          list: () =>
+            Promise.resolve({
+              data: {
+                connected: ["openai"],
+                all: [],
+                default: {},
+              },
+            }),
+        },
+        app: {
+          agents: () => Promise.resolve({ data: [] }),
+          skills: () =>
+            Promise.resolve({
+              data: [
+                {
+                  name: "review",
+                  description: "Review code changes",
+                  location: "/skills/review/SKILL.md",
+                  content: "unused skill content",
+                },
+              ],
+            }),
+        },
+      } as unknown as OpencodeClient;
+
+      const inventory = yield* runtime.loadOpenCodeInventory(client);
+
+      NodeAssert.deepEqual(inventory.skills, [
+        {
+          name: "review",
+          description: "Review code changes",
+          location: "/skills/review/SKILL.md",
+        },
+      ]);
+    }),
+  );
+
   it.effect("drops oversized CLI skill output without losing the model inventory", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
@@ -101,15 +143,16 @@ it.layer(testLayer)("OpenCodeRuntime inventory", (it) => {
     }),
   );
 
-  it.effect("caps command stdout and stderr when requested", () =>
+  it.effect("caps and drains command stdout and stderr when requested", () =>
     Effect.gen(function* () {
       const runtime = yield* OpenCodeRuntime;
       const executablePath = yield* HostProcessExecutablePath;
+      const outputBytes = 2 * 1024 * 1024;
       const result = yield* runtime.runOpenCodeCommand({
         binaryPath: executablePath,
         args: [
           "-e",
-          'process.stdout.write("o".repeat(128)); process.stderr.write("e".repeat(128));',
+          `process.stdout.write("o".repeat(${outputBytes})); process.stderr.write("e".repeat(${outputBytes}));`,
         ],
         maxOutputBytes: 64,
       });

--- a/apps/server/src/provider/opencodeRuntime.inventory.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.inventory.test.ts
@@ -4,13 +4,20 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import type { OpencodeClient } from "@opencode-ai/sdk/v2";
 import { it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import {
+  HostProcessEnvironment,
+  HostProcessExecutablePath,
+  HostProcessPlatform,
+} from "@t3tools/shared/hostProcess";
 
 import { OpenCodeRuntime, OpenCodeRuntimeLive } from "./opencodeRuntime.ts";
 
 const testLayer = OpenCodeRuntimeLive.pipe(Layer.provideMerge(NodeServices.layer));
 
-it.layer(testLayer)("loadOpenCodeInventory", (it) => {
+it.layer(testLayer)("OpenCodeRuntime inventory", (it) => {
   it.effect("keeps provider inventory when skill discovery fails", () =>
     Effect.gen(function* () {
       const runtime = yield* OpenCodeRuntime;
@@ -36,6 +43,80 @@ it.layer(testLayer)("loadOpenCodeInventory", (it) => {
       NodeAssert.deepEqual(inventory.providerList.connected, ["openai"]);
       NodeAssert.deepEqual(inventory.agents, []);
       NodeAssert.deepEqual(inventory.skills, []);
+    }),
+  );
+
+  it.effect("drops oversized CLI skill output without losing the model inventory", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const hostEnvironment = yield* HostProcessEnvironment;
+      const executablePath = yield* HostProcessExecutablePath;
+      const hostPlatform = yield* HostProcessPlatform;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-opencode-inventory-" });
+      const isWindows = hostPlatform === "win32";
+      const binaryPath = path.join(tempDir, isWindows ? "opencode.cmd" : "opencode");
+      const scriptPath = path.join(tempDir, "opencode.mjs");
+      const oversizedContentBytes = 8 * 1024 * 1024 + 1;
+
+      yield* fs.writeFileString(
+        scriptPath,
+        [
+          'if (process.argv[2] === "models") {',
+          '  process.stdout.write(`openai/gpt-test\\n{"id":"gpt-test","providerID":"openai","name":"GPT Test"}\\n`);',
+          '} else if (process.argv[2] === "debug") {',
+          `  const content = "x".repeat(${oversizedContentBytes});`,
+          '  process.stdout.write(`[{"name":"oversized","content":"${content}"}]`);',
+          "}",
+          "",
+        ].join("\n"),
+      );
+      yield* fs.writeFileString(
+        binaryPath,
+        [
+          ...(isWindows ? ["@echo off"] : ["#!/bin/sh"]),
+          isWindows
+            ? '"%T3_TEST_NODE_BINARY%" "%T3_TEST_OPENCODE_SCRIPT%" %*'
+            : 'exec "$T3_TEST_NODE_BINARY" "$T3_TEST_OPENCODE_SCRIPT" "$@"',
+          "",
+        ].join("\n"),
+      );
+      if (!isWindows) {
+        yield* fs.chmod(binaryPath, 0o755);
+      }
+
+      const runtime = yield* OpenCodeRuntime;
+      const inventory = yield* runtime.loadInventoryFromCli({
+        binaryPath,
+        cwd: tempDir,
+        environment: {
+          ...hostEnvironment,
+          T3_TEST_NODE_BINARY: executablePath,
+          T3_TEST_OPENCODE_SCRIPT: scriptPath,
+        },
+      });
+
+      NodeAssert.deepEqual(inventory.providerList.connected, ["openai"]);
+      NodeAssert.equal(inventory.skills.length, 0);
+    }),
+  );
+
+  it.effect("caps command stdout and stderr when requested", () =>
+    Effect.gen(function* () {
+      const runtime = yield* OpenCodeRuntime;
+      const executablePath = yield* HostProcessExecutablePath;
+      const result = yield* runtime.runOpenCodeCommand({
+        binaryPath: executablePath,
+        args: [
+          "-e",
+          'process.stdout.write("o".repeat(128)); process.stderr.write("e".repeat(128));',
+        ],
+        maxOutputBytes: 64,
+      });
+
+      NodeAssert.equal(result.stdout, "o".repeat(64));
+      NodeAssert.equal(result.stderr, "e".repeat(64));
+      NodeAssert.equal(result.code, 0);
     }),
   );
 });

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -708,7 +708,13 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
 
   const loadSkills = (client: OpencodeClient) =>
     runOpenCodeSdk("app.skills", () => client.app.skills()).pipe(
-      Effect.map((result) => (result.data ?? []) as ReadonlyArray<OpenCodeSkill>),
+      Effect.map((result) =>
+        (result.data ?? []).map((skill) => ({
+          name: skill.name,
+          ...(skill.description === undefined ? {} : { description: skill.description }),
+          location: skill.location,
+        })),
+      ),
       Effect.orElseSucceed((): ReadonlyArray<OpenCodeSkill> => []),
     );
 

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -51,6 +51,7 @@ export function resolveOpenCodeConfigContent(
 const OPENCODE_SERVER_READY_PREFIX = "opencode server listening";
 const DEFAULT_OPENCODE_SERVER_TIMEOUT_MS = 30_000;
 const DEFAULT_HOSTNAME = "127.0.0.1";
+const OPENCODE_SKILL_DISCOVERY_MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
 export interface OpenCodeServerProcess {
   readonly url: string;
   readonly exitCode: Effect.Effect<number, never>;
@@ -124,14 +125,12 @@ export interface OpenCodeSkill {
   readonly name?: string | null;
   readonly description?: string | null;
   readonly location?: string | null;
-  readonly content?: string | null;
 }
 
 const OpenCodeSkillSchema = Schema.Struct({
   name: Schema.optionalKey(Schema.NullOr(Schema.String)),
   description: Schema.optionalKey(Schema.NullOr(Schema.String)),
   location: Schema.optionalKey(Schema.NullOr(Schema.String)),
-  content: Schema.optionalKey(Schema.NullOr(Schema.String)),
 });
 const decodeOpenCodeSkillsCliOutputExit = Schema.decodeUnknownExit(
   Schema.fromJsonString(Schema.Array(OpenCodeSkillSchema)),
@@ -169,6 +168,7 @@ export interface OpenCodeRuntimeShape {
     readonly args: ReadonlyArray<string>;
     readonly environment?: NodeJS.ProcessEnv;
     readonly cwd?: string;
+    readonly maxOutputBytes?: number;
   }) => Effect.Effect<OpenCodeCommandResult, OpenCodeRuntimeError>;
   readonly createOpenCodeSdkClient: (input: {
     readonly baseUrl: string;
@@ -447,8 +447,14 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
           ...(input.environment ? { env: input.environment } : { extendEnv: true }),
         }),
       );
+      const collectOptions =
+        input.maxOutputBytes === undefined ? undefined : { maxBytes: input.maxOutputBytes };
       const [stdout, stderr, code] = yield* Effect.all(
-        [collectStreamAsString(child.stdout), collectStreamAsString(child.stderr), child.exitCode],
+        [
+          collectStreamAsString(child.stdout, collectOptions),
+          collectStreamAsString(child.stderr, collectOptions),
+          child.exitCode,
+        ],
         { concurrency: "unbounded" },
       );
       const exitCode = Number(code);
@@ -732,6 +738,7 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
         runOpenCodeCommand({
           binaryPath: input.binaryPath,
           args: ["debug", "skill"],
+          maxOutputBytes: OPENCODE_SKILL_DISCOVERY_MAX_OUTPUT_BYTES,
           ...commandContext,
         }).pipe(Effect.exit);
 

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -255,5 +255,6 @@ export function buildServerProvider(input: {
 
 export const collectStreamAsString = <E>(
   stream: Stream.Stream<Uint8Array, E>,
+  options?: { readonly maxBytes?: number | undefined },
 ): Effect.Effect<string, E> =>
-  collectUint8StreamText({ stream }).pipe(Effect.map((collected) => collected.text));
+  collectUint8StreamText({ stream, ...options }).pipe(Effect.map((collected) => collected.text));


### PR DESCRIPTION
## Problem

Local OpenCode inventory runs `opencode debug skill` in the workspace and fully collects provider-controlled stdout and stderr. The command includes complete skill content even though the provider snapshot only needs metadata, so oversized repository skills can cause avoidable memory growth during provider refresh.

## Fix

- Cap stdout and stderr at 8 MiB for the skill discovery command only, while continuing to drain the child streams.
- Exclude the unused `content` field from decoded CLI skill records.
- Keep model and agent inventory collection unchanged; oversized optional skill metadata degrades to an empty skill list without losing the model inventory.

## Verification

- `./node_modules/.bin/vp test run apps/server/src/provider/providerSnapshot.test.ts apps/server/src/provider/opencodeRuntime.inventory.test.ts apps/server/src/provider/opencodeRuntime.cliParsers.test.ts apps/server/src/provider/Layers/OpenCodeProvider.test.ts apps/server/src/stream/collectUint8StreamText.test.ts` — 34 tests passed.
- `./node_modules/.bin/vp run --filter t3 typecheck` — passed with existing suggestions outside this diff.
- Targeted Oxlint, Vite+ formatting, and `git diff --check` passed.

Generated with OpenAI GPT-5.6 Sol via the T3 Code Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider inventory collection and process stdout capture. Truncation can empty the skill list on huge CLI JSON, but model inventory is preserved.
> 
> **Overview**
> Stops OpenCode inventory refresh from buffering full skill file bodies. Skill discovery now keeps only name/description/location, and the CLI `debug skill` command caps stdout/stderr at 8 MiB while still draining the child.
> 
> Oversized skill output degrades to an empty skill list instead of failing the whole inventory, so models still load. `runOpenCodeCommand` / `collectStreamAsString` gain an optional output cap used only for this path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ccb5aa77215820df7531cef9dce3c0fb73e939e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound OpenCode skill discovery output to 8 MiB and drop `content` from `OpenCodeSkill`
> - Adds `OPENCODE_SKILL_DISCOVERY_MAX_OUTPUT_BYTES` (8 MiB) and passes it as `maxOutputBytes` to `runOpenCodeCommand` during CLI skill discovery, capping stdout/stderr collection via `collectStreamAsString`.
> - Removes the `content` field from the `OpenCodeSkill` interface, `OpenCodeSkillSchema`, and all skill mapping paths; skill objects now carry only `name`, optional `description`, and `location`.
> - Tests updated to drop `content` from mocked and asserted skills; added coverage for oversized CLI output dropping skills while keeping provider models.
> - Behavioral Change: `OpenCodeSkill` objects no longer include `content`; callers reading that field from `loadOpenCodeInventory` results will break. CLI skill discovery output beyond 8 MiB is truncated, so skills parsed from truncated output may be dropped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ccb5aa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OpenCode skill discovery by excluding unsupported content fields.
  - Prevented oversized command output from disrupting provider and model inventory.
  - Added limits to captured command output for safer, more reliable processing.

- **Tests**
  - Expanded coverage for oversized output, output truncation, and incomplete skill metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->