### PR TITLE
fix(web): show context usage percent on the meter

### DIFF
--- a/apps/web/src/components/chat/ContextWindowMeter.tsx
+++ b/apps/web/src/components/chat/ContextWindowMeter.tsx
@@ -44,7 +44,7 @@ export function ContextWindowMeter(props: {
             className={cn(
               "rounded-full hover:text-muted-foreground data-pressed:text-muted-foreground",
               usedPercentage
-                ? "h-auto min-h-7 w-7 flex-col gap-px py-px sm:h-auto sm:min-h-7 sm:w-7"
+                ? "h-7 w-auto gap-1 px-1.5 sm:h-7 sm:w-auto"
                 : "size-7",
             )}
             aria-label={

--- a/apps/web/src/components/chat/ContextWindowMeter.tsx
+++ b/apps/web/src/components/chat/ContextWindowMeter.tsx
@@ -1,5 +1,6 @@
 import { Button } from "../ui/button";
 import { type ContextWindowSnapshot, formatContextWindowTokens } from "~/lib/contextWindow";
+import { cn } from "~/lib/utils";
 import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
 import { formatContextWindowCompactionMessage } from "./ContextWindowMeter.logic";
 
@@ -40,7 +41,12 @@ export function ContextWindowMeter(props: {
           <Button
             size="icon-sm"
             variant="ghost-muted"
-            className="size-7 rounded-full hover:text-muted-foreground data-pressed:text-muted-foreground"
+            className={cn(
+              "rounded-full hover:text-muted-foreground data-pressed:text-muted-foreground",
+              usedPercentage
+                ? "h-auto min-h-7 w-7 flex-col gap-px py-px sm:h-auto sm:min-h-7 sm:w-7"
+                : "size-7",
+            )}
             aria-label={
               usage.maxTokens !== null && usedPercentage
                 ? `Context window ${usedPercentage} used`
@@ -75,6 +81,14 @@ export function ContextWindowMeter(props: {
                 />
               </svg>
             </span>
+            {usedPercentage ? (
+              <span
+                aria-hidden="true"
+                className="text-[9px] leading-none tabular-nums text-secondary-label"
+              >
+                {usedPercentage}
+              </span>
+            ) : null}
           </Button>
         }
       />


### PR DESCRIPTION
The context ring already knew the percentage. It just hid it in the hover popover.

The number now sits under the ring at 9px so you can read usage without hovering. The popover still has the token breakdown.

Fixes #7651

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit fc442c3b07602856c932b340600c252a34e38edf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show context usage percentage on `ContextWindowMeter` trigger
> Updates [ContextWindowMeter.tsx](https://github.com/pingdotgg/t3code/pull/7681/files#diff-aea829de2db7f11cd97477231090fa3f2bc72e2b46a5275ed82fd29b0825d2fd) to render the `usedPercentage` value as a small text span next to the ring SVG. The trigger button now uses `cn(...)` to switch from a square `size-7` layout to a wider `h-7 w-auto` layout when `usedPercentage` is present.
>
> Risk: visual sizing of the meter trigger changes when a percentage is available; callers not passing `usedPercentage` keep the original icon-sized button.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c6a6e10.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->