### PR TITLE
fix(mobile): stop spinning forever on failed asset previews

### DIFF
--- a/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
+++ b/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
@@ -22,6 +22,7 @@ import { tryOpenExternalUrl } from "../../lib/openExternalUrl";
 import { useThemeColor } from "../../lib/useThemeColor";
 import { useThreadSelection } from "../../state/use-thread-selection";
 import { useSelectedThreadWorktree } from "../../state/use-selected-thread-worktree";
+import type { AssetUrlState } from "../../state/assets";
 import { useEnvironmentQuery } from "../../state/query";
 import { projectEnvironment } from "../../state/projects";
 import {
@@ -87,13 +88,14 @@ function defaultViewMode(path: string | null): FileViewMode {
 
 function FileContent(props: {
   readonly activeMode: FileViewMode;
-  readonly previewUri: string | null;
+  readonly previewStatus: AssetUrlState;
   readonly fileContents: string | null;
   readonly fileError: string | null;
   readonly relativePath: string;
   readonly initialLine: number | null;
   readonly truncated: boolean;
   readonly onRefresh?: () => Promise<void> | void;
+  readonly onRetryPreview: () => void;
 }) {
   const isMarkdown = isMarkdownPreviewFile(props.relativePath);
   const isBrowserFile = isBrowserPreviewFile(props.relativePath);
@@ -101,18 +103,21 @@ function FileContent(props: {
 
   if (props.activeMode === "preview" && isImageFile) {
     if (isSvgImagePreviewFile(props.relativePath)) {
-      return <WorkspaceFileWebPreview uri={props.previewUri} />;
+      return (
+        <WorkspaceFileWebPreview status={props.previewStatus} onRetry={props.onRetryPreview} />
+      );
     }
     return (
       <WorkspaceFileImagePreview
         accessibilityLabel={basename(props.relativePath)}
-        uri={props.previewUri}
+        status={props.previewStatus}
+        onRetry={props.onRetryPreview}
       />
     );
   }
 
   if (props.activeMode === "preview" && isBrowserFile) {
-    return <WorkspaceFileWebPreview uri={props.previewUri} />;
+    return <WorkspaceFileWebPreview status={props.previewStatus} onRetry={props.onRetryPreview} />;
   }
 
   if (props.fileError && props.fileContents === null) {
@@ -489,16 +494,20 @@ export function ThreadFileScreen(props: ThreadFileRouteScreenProps) {
       : defaultViewMode(relativePath);
   const resolvedActiveMode = canPreview ? activeMode : "source";
   const assetPreviewPath = isBrowserFile || isImageFile ? relativePath : null;
-  const assetPreviewUri = useWorkspaceFileAssetUrl({
+  const assetPreview = useWorkspaceFileAssetUrl({
     cwd,
     environmentId,
     relativePath: assetPreviewPath,
     threadId,
   });
-  const previewUri =
-    assetPreviewUri === null || previewRevision === 0
-      ? assetPreviewUri
-      : `${assetPreviewUri}${assetPreviewUri.includes("?") ? "&" : "?"}revision=${previewRevision}`;
+  const previewStatus: AssetUrlState =
+    assetPreview.status._tag !== "Success" || previewRevision === 0
+      ? assetPreview.status
+      : {
+          _tag: "Success",
+          url: `${assetPreview.status.url}${assetPreview.status.url.includes("?") ? "&" : "?"}revision=${previewRevision}`,
+        };
+  const assetPreviewUri = previewStatus._tag === "Success" ? previewStatus.url : null;
   const needsFileContents =
     relativePath !== null &&
     (resolvedActiveMode === "source" || isMarkdownPreviewFile(relativePath));
@@ -650,6 +659,7 @@ export function ThreadFileScreen(props: ThreadFileRouteScreenProps) {
               <NativeHeaderToolbar.MenuAction
                 icon="arrow.clockwise"
                 onPress={() => {
+                  assetPreview.retry();
                   setPreviewRevision((current) => current + 1);
                 }}
               >
@@ -660,13 +670,14 @@ export function ThreadFileScreen(props: ThreadFileRouteScreenProps) {
         </NativeHeaderToolbar>
         <FileContent
           activeMode={resolvedActiveMode}
-          previewUri={previewUri}
+          previewStatus={previewStatus}
           fileContents={fileData?.contents ?? null}
           fileError={fileQuery.error}
           initialLine={targetLine}
           relativePath={relativePath}
           truncated={fileData?.truncated ?? false}
           onRefresh={() => fileQuery.refresh()}
+          onRetryPreview={assetPreview.retry}
         />
       </View>
     </ReviewHighlighterProvider>

--- a/apps/mobile/src/features/files/WorkspaceFileAssetPreviewPlaceholder.tsx
+++ b/apps/mobile/src/features/files/WorkspaceFileAssetPreviewPlaceholder.tsx
@@ -1,0 +1,35 @@
+import { ActivityIndicator, View } from "react-native";
+
+import { AppText as Text } from "../../components/AppText";
+import { EmptyState } from "../../components/EmptyState";
+import type { AssetUrlState } from "../../state/assets";
+
+export function WorkspaceFileAssetPreviewPlaceholder(props: {
+  readonly preparingLabel: string;
+  readonly status: Exclude<AssetUrlState, { readonly _tag: "Success" }>;
+  readonly onRetry: () => void;
+}) {
+  if (props.status._tag === "Loading") {
+    return (
+      <View className="flex-1 items-center justify-center gap-3 bg-card px-6">
+        <ActivityIndicator />
+        <Text className="text-center text-sm text-foreground-muted">{props.preparingLabel}</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View className="flex-1 items-center justify-center bg-card px-6">
+      <EmptyState
+        title="Preview unavailable"
+        detail={
+          props.status._tag === "Disconnected"
+            ? "Reconnect the environment, then retry."
+            : "The preview URL could not be created."
+        }
+        actionLabel="Retry"
+        onAction={props.onRetry}
+      />
+    </View>
+  );
+}

--- a/apps/mobile/src/features/files/WorkspaceFileImagePreview.tsx
+++ b/apps/mobile/src/features/files/WorkspaceFileImagePreview.tsx
@@ -6,7 +6,9 @@ import { AsyncResult } from "effect/unstable/reactivity";
 
 import { AppText as Text } from "../../components/AppText";
 import { EmptyState } from "../../components/EmptyState";
+import type { AssetUrlState } from "../../state/assets";
 import { workspaceFileImageAtom } from "./workspace-file-image-cache";
+import { WorkspaceFileAssetPreviewPlaceholder } from "./WorkspaceFileAssetPreviewPlaceholder";
 
 function ResolvedWorkspaceFileImagePreview(props: {
   readonly accessibilityLabel: string;
@@ -96,23 +98,23 @@ function CachedWorkspaceFileImagePreview(props: {
 
 export function WorkspaceFileImagePreview(props: {
   readonly accessibilityLabel: string;
-  readonly uri: string | null;
+  readonly status: AssetUrlState;
+  readonly onRetry: () => void;
 }) {
-  if (props.uri === null) {
+  if (props.status._tag !== "Success") {
     return (
-      <View className="flex-1 items-center justify-center gap-3 bg-card px-6">
-        <ActivityIndicator />
-        <Text className="text-center text-sm text-foreground-muted">
-          Preparing image preview...
-        </Text>
-      </View>
+      <WorkspaceFileAssetPreviewPlaceholder
+        preparingLabel="Preparing image preview..."
+        status={props.status}
+        onRetry={props.onRetry}
+      />
     );
   }
 
   return (
     <CachedWorkspaceFileImagePreview
       accessibilityLabel={props.accessibilityLabel}
-      uri={props.uri}
+      uri={props.status.url}
     />
   );
 }

--- a/apps/mobile/src/features/files/WorkspaceFileWebPreview.tsx
+++ b/apps/mobile/src/features/files/WorkspaceFileWebPreview.tsx
@@ -4,17 +4,23 @@ import { WebView } from "react-native-webview";
 
 import { AppText as Text } from "../../components/AppText";
 import { LoadingStrip } from "../../components/LoadingStrip";
+import type { AssetUrlState } from "../../state/assets";
+import { WorkspaceFileAssetPreviewPlaceholder } from "./WorkspaceFileAssetPreviewPlaceholder";
 
-export function WorkspaceFileWebPreview(props: { readonly uri: string | null }) {
+export function WorkspaceFileWebPreview(props: {
+  readonly status: AssetUrlState;
+  readonly onRetry: () => void;
+}) {
   const [loadProgress, setLoadProgress] = useState(0);
   const [loadError, setLoadError] = useState<string | null>(null);
 
-  if (props.uri === null) {
+  if (props.status._tag !== "Success") {
     return (
-      <View className="flex-1 items-center justify-center gap-3 bg-card px-6">
-        <ActivityIndicator />
-        <Text className="text-center text-sm text-foreground-muted">Preparing preview...</Text>
-      </View>
+      <WorkspaceFileAssetPreviewPlaceholder
+        preparingLabel="Preparing preview..."
+        status={props.status}
+        onRetry={props.onRetry}
+      />
     );
   }
 
@@ -28,7 +34,7 @@ export function WorkspaceFileWebPreview(props: { readonly uri: string | null }) 
         </View>
       ) : null}
       <WebView
-        source={{ uri: props.uri }}
+        source={{ uri: props.status.url }}
         originWhitelist={["*"]}
         allowsBackForwardNavigationGestures
         allowsFullscreenVideo

--- a/apps/mobile/src/features/files/workspaceFileAssetUrl.ts
+++ b/apps/mobile/src/features/files/workspaceFileAssetUrl.ts
@@ -1,7 +1,7 @@
 import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import { useMemo } from "react";
 
-import { useAssetUrl } from "../../state/assets";
+import { useAssetUrlState } from "../../state/assets";
 import { resolveWorkspaceFilePath } from "./filePath";
 
 export function useWorkspaceFileAssetUrl(props: {
@@ -18,7 +18,7 @@ export function useWorkspaceFileAssetUrl(props: {
     [props.cwd, props.relativePath],
   );
 
-  return useAssetUrl(
+  return useAssetUrlState(
     props.environmentId,
     absolutePath !== null && props.threadId !== null
       ? {

--- a/apps/mobile/src/state/assetUrlState.test.ts
+++ b/apps/mobile/src/state/assetUrlState.test.ts
@@ -47,6 +47,30 @@ describe("resolveAssetUrlState", () => {
     ).toEqual({ _tag: "Failure" });
   });
 
+  it("shows loading again while a failed query is retrying", () => {
+    expect(
+      resolveAssetUrlState({
+        httpBaseUrl: "https://environment.example/",
+        requested: true,
+        result: AsyncResult.failure(Cause.fail(new Error("createUrl failed")), {
+          waiting: true,
+        }),
+      }),
+    ).toEqual({ _tag: "Loading" });
+  });
+
+  it("keeps disconnected copy if the environment drops during a retry", () => {
+    expect(
+      resolveAssetUrlState({
+        httpBaseUrl: null,
+        requested: true,
+        result: AsyncResult.failure(Cause.fail(new Error("createUrl failed")), {
+          waiting: true,
+        }),
+      }),
+    ).toEqual({ _tag: "Disconnected" });
+  });
+
   it("resolves a ready asset URL", () => {
     expect(
       resolveAssetUrlState({

--- a/apps/mobile/src/state/assetUrlState.test.ts
+++ b/apps/mobile/src/state/assetUrlState.test.ts
@@ -37,6 +37,29 @@ describe("resolveAssetUrlState", () => {
     ).toEqual({ _tag: "Disconnected" });
   });
 
+  it("treats a settled failure as disconnected when the environment is gone", () => {
+    expect(
+      resolveAssetUrlState({
+        httpBaseUrl: null,
+        requested: true,
+        result: AsyncResult.failure(Cause.fail(new Error("createUrl failed"))),
+      }),
+    ).toEqual({ _tag: "Disconnected" });
+  });
+
+  it("keeps a successful URL while the asset atom refreshes", () => {
+    expect(
+      resolveAssetUrlState({
+        httpBaseUrl: "https://environment.example/base/",
+        requested: true,
+        result: AsyncResult.success({ relativeUrl: RELATIVE_URL }, { waiting: true }),
+      }),
+    ).toEqual({
+      _tag: "Success",
+      url: "https://environment.example/api/assets/signed-token/preview.png",
+    });
+  });
+
   it("surfaces query failures instead of loading", () => {
     expect(
       resolveAssetUrlState({

--- a/apps/mobile/src/state/assetUrlState.test.ts
+++ b/apps/mobile/src/state/assetUrlState.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vite-plus/test";
+import * as Cause from "effect/Cause";
+import { AsyncResult } from "effect/unstable/reactivity";
+
+import { resolveAssetUrlState } from "./assetUrlState";
+
+const RELATIVE_URL = "/api/assets/signed-token/preview.png";
+
+describe("resolveAssetUrlState", () => {
+  it("treats an unrequested asset as loading", () => {
+    expect(
+      resolveAssetUrlState({
+        httpBaseUrl: null,
+        requested: false,
+        result: AsyncResult.initial(false),
+      }),
+    ).toEqual({ _tag: "Loading" });
+  });
+
+  it("keeps a spinner while the query is pending on a connected environment", () => {
+    expect(
+      resolveAssetUrlState({
+        httpBaseUrl: "https://environment.example/",
+        requested: true,
+        result: AsyncResult.initial(true),
+      }),
+    ).toEqual({ _tag: "Loading" });
+  });
+
+  it("treats a missing connection as disconnected, even while the query is waiting", () => {
+    expect(
+      resolveAssetUrlState({
+        httpBaseUrl: null,
+        requested: true,
+        result: AsyncResult.initial(true),
+      }),
+    ).toEqual({ _tag: "Disconnected" });
+  });
+
+  it("surfaces query failures instead of loading", () => {
+    expect(
+      resolveAssetUrlState({
+        httpBaseUrl: "https://environment.example/",
+        requested: true,
+        result: AsyncResult.failure(Cause.fail(new Error("createUrl failed"))),
+      }),
+    ).toEqual({ _tag: "Failure" });
+  });
+
+  it("resolves a ready asset URL", () => {
+    expect(
+      resolveAssetUrlState({
+        httpBaseUrl: "https://environment.example/base/",
+        requested: true,
+        result: AsyncResult.success({ relativeUrl: RELATIVE_URL }),
+      }),
+    ).toEqual({
+      _tag: "Success",
+      url: "https://environment.example/api/assets/signed-token/preview.png",
+    });
+  });
+
+  it("treats an unresolvable URL as failure", () => {
+    expect(
+      resolveAssetUrlState({
+        httpBaseUrl: "not a URL",
+        requested: true,
+        result: AsyncResult.success({ relativeUrl: RELATIVE_URL }),
+      }),
+    ).toEqual({ _tag: "Failure" });
+  });
+});

--- a/apps/mobile/src/state/assetUrlState.ts
+++ b/apps/mobile/src/state/assetUrlState.ts
@@ -1,0 +1,31 @@
+import { resolveAssetUrl } from "@t3tools/client-runtime/state/assets";
+import { AsyncResult } from "effect/unstable/reactivity";
+
+export type AssetUrlState =
+  | { readonly _tag: "Loading" }
+  | { readonly _tag: "Disconnected" }
+  | { readonly _tag: "Failure" }
+  | { readonly _tag: "Success"; readonly url: string };
+
+export function resolveAssetUrlState(input: {
+  readonly httpBaseUrl: string | null;
+  readonly requested: boolean;
+  readonly result: AsyncResult.AsyncResult<{ readonly relativeUrl: string }, unknown>;
+}): AssetUrlState {
+  if (!input.requested) {
+    return { _tag: "Loading" };
+  }
+  if (input.result._tag === "Failure") {
+    return { _tag: "Failure" };
+  }
+  // Environment queries park on Effect.never while disconnected, so a missing
+  // prepared connection is a terminal state even when the atom still looks waiting.
+  if (input.httpBaseUrl === null) {
+    return { _tag: "Disconnected" };
+  }
+  if (input.result._tag !== "Success") {
+    return { _tag: "Loading" };
+  }
+  const url = resolveAssetUrl(input.httpBaseUrl, input.result.value.relativeUrl);
+  return url === null ? { _tag: "Failure" } : { _tag: "Success", url };
+}

--- a/apps/mobile/src/state/assetUrlState.ts
+++ b/apps/mobile/src/state/assetUrlState.ts
@@ -15,21 +15,21 @@ export function resolveAssetUrlState(input: {
   if (!input.requested) {
     return { _tag: "Loading" };
   }
-  // Retry sets waiting while the previous Failure is still on the atom.
-  if (input.result.waiting) {
-    return input.httpBaseUrl === null ? { _tag: "Disconnected" } : { _tag: "Loading" };
-  }
-  if (input.result._tag === "Failure") {
-    return { _tag: "Failure" };
-  }
   // Environment queries park on Effect.never while disconnected, so a missing
   // prepared connection is a terminal state even when the atom still looks waiting.
   if (input.httpBaseUrl === null) {
     return { _tag: "Disconnected" };
   }
-  if (input.result._tag !== "Success") {
+  if (input.result._tag === "Success") {
+    const url = resolveAssetUrl(input.httpBaseUrl, input.result.value.relativeUrl);
+    return url === null ? { _tag: "Failure" } : { _tag: "Success", url };
+  }
+  // Retry sets waiting while the previous Failure is still on the atom.
+  if (input.result.waiting) {
     return { _tag: "Loading" };
   }
-  const url = resolveAssetUrl(input.httpBaseUrl, input.result.value.relativeUrl);
-  return url === null ? { _tag: "Failure" } : { _tag: "Success", url };
+  if (input.result._tag === "Failure") {
+    return { _tag: "Failure" };
+  }
+  return { _tag: "Loading" };
 }

--- a/apps/mobile/src/state/assetUrlState.ts
+++ b/apps/mobile/src/state/assetUrlState.ts
@@ -15,6 +15,10 @@ export function resolveAssetUrlState(input: {
   if (!input.requested) {
     return { _tag: "Loading" };
   }
+  // Retry sets waiting while the previous Failure is still on the atom.
+  if (input.result.waiting) {
+    return input.httpBaseUrl === null ? { _tag: "Disconnected" } : { _tag: "Loading" };
+  }
   if (input.result._tag === "Failure") {
     return { _tag: "Failure" };
   }

--- a/apps/mobile/src/state/assets.ts
+++ b/apps/mobile/src/state/assets.ts
@@ -1,10 +1,13 @@
-import { useAtomValue } from "@effect/atom-react";
-import { createAssetEnvironmentAtoms, resolveAssetUrl } from "@t3tools/client-runtime/state/assets";
+import { useAtomRefresh, useAtomValue } from "@effect/atom-react";
+import { createAssetEnvironmentAtoms } from "@t3tools/client-runtime/state/assets";
 import type { AssetResource, EnvironmentId } from "@t3tools/contracts";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
 
 import { connectionAtomRuntime } from "../connection/runtime";
+import { resolveAssetUrlState, type AssetUrlState } from "./assetUrlState";
 import { usePreparedConnection } from "./session";
+
+export type { AssetUrlState };
 
 export const assetEnvironment = createAssetEnvironmentAtoms(connectionAtomRuntime);
 
@@ -12,18 +15,35 @@ const EMPTY_ASSET_URL_ATOM = Atom.make(AsyncResult.initial<never, never>(false))
   Atom.withLabel("mobile-asset-url:empty"),
 );
 
+export function useAssetUrlState(
+  environmentId: EnvironmentId | null,
+  resource: AssetResource | null,
+): {
+  readonly retry: () => void;
+  readonly status: AssetUrlState;
+} {
+  const preparedConnection = usePreparedConnection(environmentId);
+  const selectedAtom =
+    environmentId === null || resource === null
+      ? EMPTY_ASSET_URL_ATOM
+      : assetEnvironment.createUrl({ environmentId, input: { resource } });
+  const result = useAtomValue(selectedAtom);
+  const retry = useAtomRefresh(selectedAtom);
+  return {
+    retry,
+    status: resolveAssetUrlState({
+      httpBaseUrl:
+        preparedConnection._tag === "None" ? null : preparedConnection.value.httpBaseUrl,
+      requested: environmentId !== null && resource !== null,
+      result,
+    }),
+  };
+}
+
 export function useAssetUrl(
   environmentId: EnvironmentId | null,
   resource: AssetResource | null,
 ): string | null {
-  const preparedConnection = usePreparedConnection(environmentId);
-  const result = useAtomValue(
-    environmentId === null || resource === null
-      ? EMPTY_ASSET_URL_ATOM
-      : assetEnvironment.createUrl({ environmentId, input: { resource } }),
-  );
-  if (preparedConnection._tag === "None" || result._tag !== "Success") {
-    return null;
-  }
-  return resolveAssetUrl(preparedConnection.value.httpBaseUrl, result.value.relativeUrl);
+  const { status } = useAssetUrlState(environmentId, resource);
+  return status._tag === "Success" ? status.url : null;
 }


### PR DESCRIPTION
Asset preview URLs returning null meant loading, disconnected, and error. The preview screens treated every null as Preparing and spun until you left.

The hook now distinguishes those states. Previews show a short failure and a retry. Favicons still stay quiet when they don't have a URL.

Fixes #7630

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 31b552bd862e89d582a8c7fdb60f9c46cc16e242. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix mobile asset preview spinning forever on failed asset URLs
> - Adds `AssetUrlState` discriminated union and `resolveAssetUrlState` in [assetUrlState.ts](https://github.com/pingdotgg/t3code/pull/7683/files#diff-daa94b937249e95e5dcc28b06531255a24df951ee9f2c30580a2bd548cf5e1ba) to map connection + request state into Loading/Disconnected/Failure/Success
> - Adds `useAssetUrlState` hook in [assets.ts](https://github.com/pingdotgg/t3code/pull/7683/files#diff-7280b54c4da185cc2f02480b46955ab7dc3837e845bad7a70cb77abfa3884c00) exposing status and retry; reimplements `useAssetUrl` on top of it for backward compatibility
> - Updates `WorkspaceFileImagePreview`, `WorkspaceFileWebPreview`, and `FileContent` to render `WorkspaceFileAssetPreviewPlaceholder` with contextual empty state and retry on non-success states; `ThreadFilesRouteScreen` header Refresh now triggers `assetPreview.retry()` and appends a revision query param for cache-busting
> - Adds tests covering `resolveAssetUrlState` across unrequested/loading/disconnected/failure/success/waiting cases in [assetUrlState.test.ts](https://github.com/pingdotgg/t3code/pull/7683/files#diff-c978ce23f649010076c151cf5f47bcac792850968c9e68bdda74894145966216)
> - Behavioral Change: preview components now receive `status: AssetUrlState` + `onRetry` instead of a nullable URL string; callers passing the old props will not compile
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6af0d59.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->