### PR TITLE
fix(server): still look up PRs after the remote branch is deleted

### DIFF
--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -955,7 +955,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
     }),
   );
 
-  it.effect("status skips the provider lookup for a branch that was never pushed", () =>
+  it.effect("status still looks up PRs for a branch that was never pushed", () =>
     Effect.gen(function* () {
       const repoDir = yield* makeTempDir("t3code-git-manager-");
       yield* initRepo(repoDir);
@@ -970,7 +970,58 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
 
       expect(status.refName).toBe("feature/never-pushed");
       expect(status.pr).toBeNull();
-      expect(ghCalls.filter((call) => call.startsWith("pr list "))).toHaveLength(0);
+      expect(ghCalls.filter((call) => call.startsWith("pr list ")).length).toBeGreaterThan(0);
+    }),
+  );
+
+  it.effect("status still looks up merged PRs after the remote branch is pruned", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      const remoteDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+      yield* runGit(repoDir, ["push", "-u", "origin", "main"]);
+      yield* runGit(repoDir, ["checkout", "-b", "feature/merged-then-deleted"]);
+      // Push without `-u`, then delete the host head and prune. That is the
+      // merged-PR path: GitHub removes the branch, a local prune drops
+      // `refs/remotes/*/feature/merged-then-deleted`, and `@{u}` never existed.
+      yield* runGit(repoDir, ["push", "origin", "feature/merged-then-deleted"]);
+      yield* runGit(repoDir, ["push", "origin", "--delete", "feature/merged-then-deleted"]);
+      yield* runGit(repoDir, ["fetch", "--prune", "origin"]);
+
+      const { manager, ghCalls } = yield* makeManager({
+        ghScenario: {
+          prListSequence: [
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify([
+              {
+                number: 7653,
+                title: "Merged then deleted",
+                url: "https://github.com/pingdotgg/t3code/pull/7653",
+                baseRefName: "main",
+                headRefName: "feature/merged-then-deleted",
+                state: "MERGED",
+                mergedAt: "2026-08-20T10:00:00Z",
+                updatedAt: "2026-08-20T10:00:00Z",
+              },
+            ]),
+          ],
+        },
+      });
+
+      const status = yield* manager.status({ cwd: repoDir });
+
+      expect(status.refName).toBe("feature/merged-then-deleted");
+      expect(status.pr).toEqual({
+        number: 7653,
+        title: "Merged then deleted",
+        url: "https://github.com/pingdotgg/t3code/pull/7653",
+        baseRef: "main",
+        headRef: "feature/merged-then-deleted",
+        state: "merged",
+        updatedAt: "2026-08-20T10:00:00.000Z",
+      });
+      expect(ghCalls.filter((call) => call.startsWith("pr list ")).length).toBeGreaterThan(0);
     }),
   );
 

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -969,11 +969,9 @@ export const make = Effect.gen(function* () {
         ) {
           return { latest: null, headContext };
         }
-        // Only skip when the branch is untracked as well: anything carrying an
-        // upstream keeps the old behaviour.
-        if (details.upstreamRef === null && (yield* isUnpublishedBranch(cwd, headContext))) {
-          return { latest: null, headContext };
-        }
+        // Missing `refs/remotes/*/<branch>` is not enough to skip: GitHub
+        // deletes merged heads, and a local prune then looks identical to a
+        // branch that was never pushed. `gh pr list --head` still finds the PR.
         const latest = yield* findLatestPrForHeadContext(cwd, headContext);
         return { latest, headContext };
       });
@@ -1261,43 +1259,6 @@ export const make = Effect.gen(function* () {
       headRepositoryOwnerLogin: remoteRepository.ownerLogin,
       isCrossRepository,
     } satisfies BranchHeadContext;
-  });
-
-  /**
-   * Whether git has no record of this branch on any remote, so a change request
-   * cannot exist for it and asking the provider is a guaranteed-empty API call.
-   *
-   * `git push` writes the remote-tracking ref even without `-u` (how most
-   * terminal and agent pushes land), which makes this a safer "did it ever
-   * reach the host" test than looking for upstream config, and the glob spans
-   * every remote so a fork branch still counts. A repository that tracks no
-   * remotes at all cannot answer the question, because then every branch looks
-   * unpublished; it, and any failed probe, keeps the lookup.
-   */
-  const isUnpublishedBranch = Effect.fn("isUnpublishedBranch")(function* (
-    cwd: string,
-    headContext: Pick<BranchHeadContext, "headBranch">,
-  ) {
-    if (headContext.headBranch.length === 0) {
-      return false;
-    }
-    const matchesRef = (pattern: string) =>
-      gitCore
-        .execute({
-          operation: "GitManager.isUnpublishedBranch",
-          cwd,
-          args: ["for-each-ref", "--count=1", "--format=%(refname)", pattern],
-          timeoutMs: 5_000,
-        })
-        .pipe(Effect.map((result) => result.stdout.trim().length > 0));
-
-    return yield* Effect.all(
-      [matchesRef("refs/remotes"), matchesRef(`refs/remotes/*/${headContext.headBranch}`)],
-      { concurrency: "unbounded" },
-    ).pipe(
-      Effect.map(([tracksAnyRemote, tracksThisBranch]) => tracksAnyRemote && !tracksThisBranch),
-      Effect.orElseSucceed(() => false),
-    );
   });
 
   const findOpenPr = Effect.fn("findOpenPr")(function* (


### PR DESCRIPTION
After a merge, GitHub often deletes the head branch. A local prune then drops `refs/remotes/*/that-branch`. We treated that as never pushed, skipped `gh pr list`, and the thread fell out of Settled.

Missing remote-tracking refs are not enough to skip the lookup. `gh` still knows about the merged PR.

Fixes #7653

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0927ec8ec4d0db480bb0e86dfa95a487b5f72311. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `GitManager` PR lookup after remote branch deletion
> - Removes the `isUnpublishedBranch` helper and the conditional short-circuit in `make resolvePullRequest` that skipped provider PR lookups when no remote-tracking ref existed for the branch.
> - The provider is now always queried via `findLatestPrForHeadContext`, so merged PRs can still be found after the remote head is deleted and pruned locally.
> - Updates tests to assert that a PR lookup occurs for never-pushed and merged-then-deleted branches, including that merged PR metadata is returned correctly.
> - Risk: branches with no remote-tracking refs now always trigger a provider API call instead of being skipped, which may increase API usage for repositories with many unpushed local branches.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0927ec8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->