### PR TITLE
fix(git): write commit messages with the thread's provider

### DIFF
--- a/apps/mobile/src/state/use-selected-thread-git-actions.ts
+++ b/apps/mobile/src/state/use-selected-thread-git-actions.ts
@@ -330,6 +330,11 @@ export function useSelectedThreadGitActions() {
             ...(input.commitMessage ? { commitMessage: input.commitMessage } : {}),
             ...(input.featureBranch ? { featureBranch: input.featureBranch } : {}),
             ...(input.filePaths?.length ? { filePaths: [...input.filePaths] } : {}),
+            ...(input.modelSelection
+              ? { modelSelection: input.modelSelection }
+              : selectedThread?.modelSelection
+                ? { modelSelection: selectedThread.modelSelection }
+                : {}),
           });
           if (AsyncResult.isFailure(result)) {
             return result;

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -2218,20 +2218,16 @@ export const make = Effect.gen(function* () {
 
         const textGenerationSettings = yield* serverSettingsService.getSettings.pipe(
           Effect.flatMap((settings) =>
-            settings.sourceControlWriterModelSelection === null
-              ? Effect.succeed({
-                  modelSelection: settings.textGenerationModelSelection,
-                  style: settings.sourceControlWritingStyle,
-                })
-              : providerRegistry.getProviders.pipe(
-                  Effect.map((providers) => ({
-                    modelSelection: ServerSettings.resolveSourceControlWriterModelSelection(
-                      settings,
-                      providers,
-                    ),
-                    style: settings.sourceControlWritingStyle,
-                  })),
+            providerRegistry.getProviders.pipe(
+              Effect.map((providers) => ({
+                modelSelection: ServerSettings.resolveSourceControlWriterModelSelection(
+                  settings,
+                  providers,
+                  input.modelSelection,
                 ),
+                style: settings.sourceControlWritingStyle,
+              })),
+            ),
           ),
           Effect.mapError(
             (cause) =>

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -1002,9 +1002,23 @@ export default function GitActionsControl({
         ? store.getDraftThreadByRef(activeThreadRef)
         : null,
   );
+  const composerDraft = useComposerDraftStore((store) => {
+    if (draftId) {
+      return store.getComposerDraft(draftId);
+    }
+    if (activeThreadRef) {
+      return store.getComposerDraft(activeThreadRef);
+    }
+    return null;
+  });
   const activeServerThread = useThread(activeThreadRef, {
     waitForShell: activeDraftThread !== null,
   });
+  const threadModelSelection =
+    activeServerThread?.modelSelection ??
+    (composerDraft?.activeProvider
+      ? composerDraft.modelSelectionByProvider[composerDraft.activeProvider]
+      : undefined);
   const setDraftThreadContext = useComposerDraftStore((store) => store.setDraftThreadContext);
   const [isCommitDialogOpen, setIsCommitDialogOpen] = useState(false);
   const [dialogCommitMessage, setDialogCommitMessage] = useState("");
@@ -1410,6 +1424,7 @@ export default function GitActionsControl({
         ...(commitMessage ? { commitMessage } : {}),
         ...(featureBranch ? { featureBranch } : {}),
         ...(filePaths ? { filePaths } : {}),
+        ...(threadModelSelection ? { modelSelection: threadModelSelection } : {}),
         onProgress: applyProgressEvent,
       });
 

--- a/apps/web/src/state/sourceControlActions.ts
+++ b/apps/web/src/state/sourceControlActions.ts
@@ -13,6 +13,7 @@ import type {
   GitActionProgressEvent,
   GitResolvePullRequestResult,
   GitStackedAction,
+  ModelSelection,
   SourceControlCloneProtocol,
   SourceControlRepositoryVisibility,
   ThreadId,
@@ -218,6 +219,7 @@ export function useGitStackedAction(scope: SourceControlActionScope) {
       commitMessage?: string;
       featureBranch?: boolean;
       filePaths?: string[];
+      modelSelection?: ModelSelection;
       onProgress?: (event: GitActionProgressEvent) => void;
     }) => {
       if (resolveScope(scope) === null) {
@@ -237,6 +239,7 @@ export function useGitStackedAction(scope: SourceControlActionScope) {
         ...(input.commitMessage ? { commitMessage: input.commitMessage } : {}),
         ...(input.featureBranch ? { featureBranch: true } : {}),
         ...(input.filePaths?.length ? { filePaths: input.filePaths } : {}),
+        ...(input.modelSelection ? { modelSelection: input.modelSelection } : {}),
         ...(input.onProgress ? { onProgress: input.onProgress } : {}),
       });
     },

--- a/packages/client-runtime/src/state/gitActions.ts
+++ b/packages/client-runtime/src/state/gitActions.ts
@@ -41,7 +41,7 @@ export type DefaultBranchConfirmableAction =
 
 export type GitActionRequestInput = Pick<
   GitRunStackedActionInput,
-  "action" | "commitMessage" | "featureBranch" | "filePaths"
+  "action" | "commitMessage" | "featureBranch" | "filePaths" | "modelSelection"
 >;
 
 export function buildGitActionProgressStages(input: {

--- a/packages/client-runtime/src/state/vcsAction.ts
+++ b/packages/client-runtime/src/state/vcsAction.ts
@@ -6,6 +6,7 @@ import {
   type GitRunStackedActionInput,
   type GitRunStackedActionResult,
   GitStackedAction,
+  type ModelSelection,
   WS_METHODS,
 } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
@@ -76,6 +77,7 @@ export interface RunVcsStackedActionInput {
   readonly commitMessage?: string;
   readonly featureBranch?: boolean;
   readonly filePaths?: ReadonlyArray<string>;
+  readonly modelSelection?: ModelSelection;
   readonly onProgress?: (event: GitActionProgressEvent) => void;
 }
 
@@ -463,6 +465,7 @@ export function createVcsActionManager<R, E>(
           ...(input.commitMessage ? { commitMessage: input.commitMessage } : {}),
           ...(input.featureBranch ? { featureBranch: true } : {}),
           ...(input.filePaths?.length ? { filePaths: [...input.filePaths] } : {}),
+          ...(input.modelSelection ? { modelSelection: input.modelSelection } : {}),
         };
         return consumeVcsActionProgress(
           runStreamInEnvironment(

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -1,5 +1,6 @@
 import * as Schema from "effect/Schema";
 import { NonNegativeInt, PositiveInt, ThreadId, TrimmedNonEmptyString } from "./baseSchemas.ts";
+import { ModelSelection } from "./orchestration.ts";
 import { SourceControlProviderError, SourceControlProviderInfo } from "./sourceControl.ts";
 import { VcsDriverKind } from "./vcs.ts";
 
@@ -118,6 +119,9 @@ export const GitRunStackedActionInput = Schema.Struct({
   filePaths: Schema.optional(
     Schema.Array(TrimmedNonEmptyStringSchema).check(Schema.isMinLength(1)),
   ),
+  // Thread's current model. Used to write commit/PR text when no dedicated
+  // source-control writer is configured.
+  modelSelection: Schema.optional(ModelSelection),
 });
 export type GitRunStackedActionInput = typeof GitRunStackedActionInput.Type;
 

--- a/packages/shared/src/serverSettings.test.ts
+++ b/packages/shared/src/serverSettings.test.ts
@@ -264,6 +264,36 @@ describe("serverSettings helpers", () => {
     expect(settings.sourceControlWriterModelSelection).toBe(sourceControlWriterModelSelection);
   });
 
+  it("does not use a preferred fallback whose instance is missing from loaded providers", () => {
+    const preferredFallback = createModelSelection(
+      ProviderInstanceId.make("gone-thread"),
+      "claude-opus-4-6",
+    );
+    const loadedProvider = {
+      instanceId: ProviderInstanceId.make("claude"),
+      driver: ProviderDriverKind.make("claude"),
+      enabled: true,
+      installed: true,
+      version: "1.0.0",
+      status: "ready",
+      auth: { status: "authenticated" },
+      checkedAt: "2026-07-27T00:00:00.000Z",
+      availability: "available",
+      unavailableReason: undefined,
+      models: [],
+      slashCommands: [],
+      skills: [],
+    } satisfies ServerProvider;
+
+    expect(
+      resolveSourceControlWriterModelSelection(
+        DEFAULT_SERVER_SETTINGS,
+        [loadedProvider],
+        preferredFallback,
+      ),
+    ).toBe(DEFAULT_SERVER_SETTINGS.textGenerationModelSelection);
+  });
+
   it("replaces providerInstances maps so omitted instance fields are cleared", () => {
     const codexId = ProviderInstanceId.make("codex");
     const current = {

--- a/packages/shared/src/serverSettings.ts
+++ b/packages/shared/src/serverSettings.ts
@@ -46,22 +46,88 @@ export function isModelSelectionProviderEnabled(
   );
 }
 
+function isWriterProviderUsable(provider: ServerProvider): boolean {
+  return (
+    provider.enabled === true &&
+    isProviderAvailable(provider) &&
+    provider.auth.status !== "unauthenticated"
+  );
+}
+
+function findWriterProvider(
+  providers: ReadonlyArray<ServerProvider> | undefined,
+  selection: ModelSelection,
+): ServerProvider | undefined {
+  return providers?.find((candidate) => candidate.instanceId === selection.instanceId);
+}
+
+function isDedicatedWriterUsable(
+  settings: ServerSettings,
+  selection: ModelSelection,
+  providers?: ReadonlyArray<ServerProvider>,
+): boolean {
+  if (!isModelSelectionProviderEnabled(settings, selection)) {
+    return false;
+  }
+  if (providers === undefined) {
+    return true;
+  }
+  const provider = findWriterProvider(providers, selection);
+  return provider !== undefined && isWriterProviderUsable(provider);
+}
+
+function isFallbackWriterUsable(
+  settings: ServerSettings,
+  selection: ModelSelection,
+  providers?: ReadonlyArray<ServerProvider>,
+): boolean {
+  if (!isModelSelectionProviderEnabled(settings, selection)) {
+    return false;
+  }
+  const provider = findWriterProvider(providers, selection);
+  if (provider === undefined) {
+    return true;
+  }
+  return isWriterProviderUsable(provider);
+}
+
+function firstAvailableWriterModelSelection(
+  providers?: ReadonlyArray<ServerProvider>,
+): ModelSelection | undefined {
+  if (providers === undefined) {
+    return undefined;
+  }
+  for (const provider of providers) {
+    if (!isWriterProviderUsable(provider)) {
+      continue;
+    }
+    const model =
+      provider.models.find((candidate) => candidate.isDefault === true)?.slug ??
+      provider.models[0]?.slug;
+    if (!model) {
+      continue;
+    }
+    return createModelSelection(provider.instanceId, model);
+  }
+  return undefined;
+}
+
 export function resolveSourceControlWriterModelSelection(
   settings: ServerSettings,
   providers?: ReadonlyArray<ServerProvider>,
+  preferredFallback?: ModelSelection | null,
 ): ModelSelection {
-  const selection = settings.sourceControlWriterModelSelection;
-  if (!selection || !isModelSelectionProviderEnabled(settings, selection)) {
+  const dedicated = settings.sourceControlWriterModelSelection;
+  if (dedicated && isDedicatedWriterUsable(settings, dedicated, providers)) {
+    return dedicated;
+  }
+  if (preferredFallback && isFallbackWriterUsable(settings, preferredFallback, providers)) {
+    return preferredFallback;
+  }
+  if (isFallbackWriterUsable(settings, settings.textGenerationModelSelection, providers)) {
     return settings.textGenerationModelSelection;
   }
-  if (providers === undefined) {
-    return selection;
-  }
-
-  const provider = providers.find((candidate) => candidate.instanceId === selection.instanceId);
-  return provider?.enabled === true && isProviderAvailable(provider)
-    ? selection
-    : settings.textGenerationModelSelection;
+  return firstAvailableWriterModelSelection(providers) ?? settings.textGenerationModelSelection;
 }
 
 export interface PersistedServerObservabilitySettings {

--- a/packages/shared/src/serverSettings.ts
+++ b/packages/shared/src/serverSettings.ts
@@ -81,14 +81,7 @@ function isFallbackWriterUsable(
   selection: ModelSelection,
   providers?: ReadonlyArray<ServerProvider>,
 ): boolean {
-  if (!isModelSelectionProviderEnabled(settings, selection)) {
-    return false;
-  }
-  const provider = findWriterProvider(providers, selection);
-  if (provider === undefined) {
-    return true;
-  }
-  return isWriterProviderUsable(provider);
+  return isDedicatedWriterUsable(settings, selection, providers);
 }
 
 function firstAvailableWriterModelSelection(


### PR DESCRIPTION
Commit message generation fell back to the default Codex text-generation model even if you were in a Claude thread. If Codex wasn't signed in, the dialog just failed.

If you haven't picked a dedicated source-control writer, we now use the thread's model. Dedicated writer still wins when it's set and actually usable.

Fixes #7584

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d9a9c5496a9bf016dcf9362215edbab174439e95. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pass thread `modelSelection` through `runStackedAction` for git commit messages
> - Forwards an optional `modelSelection` from the calling thread or composer draft through the mobile hook, web control, web state layer, client-runtime types, VCS action manager, and `gitRunStackedAction` RPC into `GitManager.runStackedAction`.
> - Reworks `resolveSourceControlWriterModelSelection` in [serverSettings.ts](https://github.com/pingdotgg/t3code/pull/7685/files#diff-043ca428f05b5295b6161cdcb2c48bd97c3985f21faa3a8214057decca51518f) to accept a `preferredFallback` and resolve in order: dedicated writer → preferred fallback → `textGenerationModelSelection` → first available provider's default model → `textGenerationModelSelection`.
> - Adds a test in [serverSettings.test.ts](https://github.com/pingdotgg/t3code/pull/7685/files#diff-7e40ca4f652952527cffdd29ffa9e492fa97dfacff250aa1889c5b7aaa1b235e) ensuring a preferred fallback whose provider is not loaded is skipped.
> - Risk: `resolveSourceControlWriterModelSelection` now selects the first available provider's model when neither dedicated writer nor fallback nor `textGenerationModelSelection` is usable, which can change the writer model for setups that previously fell through to a different default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 923a100.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->