### PR TITLE
fix(shared): stop putting %APPDATA%\npm ahead of PATH on Windows

### DIFF
--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -473,6 +473,8 @@ effectIt.layer(NodeServices.layer)("resolveWindowsEnvironment", (it) => {
         ),
       ).toEqual({
         PATH: [
+          "C:\\Shell\\Bin",
+          "C:\\Windows\\System32",
           "C:\\Users\\testuser\\AppData\\Roaming\\npm",
           "C:\\Users\\testuser\\AppData\\Local\\Programs\\nodejs",
           "C:\\Users\\testuser\\AppData\\Local\\Volta\\bin",
@@ -480,8 +482,6 @@ effectIt.layer(NodeServices.layer)("resolveWindowsEnvironment", (it) => {
           "C:\\Users\\testuser\\.local\\bin",
           "C:\\Users\\testuser\\.bun\\bin",
           "C:\\Users\\testuser\\scoop\\shims",
-          "C:\\Shell\\Bin",
-          "C:\\Windows\\System32",
         ].join(";"),
       });
       expect(readEnvironment).toHaveBeenCalledTimes(1);
@@ -522,6 +522,7 @@ effectIt.layer(NodeServices.layer)("resolveWindowsEnvironment", (it) => {
         PATH: [
           "C:\\Profile\\Node",
           "C:\\Windows\\System32",
+          "C:\\Shell\\Bin",
           "C:\\Users\\testuser\\AppData\\Roaming\\npm",
           "C:\\Users\\testuser\\AppData\\Local\\Programs\\nodejs",
           "C:\\Users\\testuser\\AppData\\Local\\Volta\\bin",
@@ -529,7 +530,6 @@ effectIt.layer(NodeServices.layer)("resolveWindowsEnvironment", (it) => {
           "C:\\Users\\testuser\\.local\\bin",
           "C:\\Users\\testuser\\.bun\\bin",
           "C:\\Users\\testuser\\scoop\\shims",
-          "C:\\Shell\\Bin",
         ].join(";"),
         FNM_DIR: "C:\\Users\\testuser\\AppData\\Roaming\\fnm",
         FNM_MULTISHELL_PATH: "C:\\Users\\testuser\\AppData\\Local\\fnm_multishells\\123",
@@ -566,15 +566,42 @@ effectIt.layer(NodeServices.layer)("resolveWindowsEnvironment", (it) => {
         ),
       ).toEqual({
         PATH: [
+          "C:\\Windows\\System32",
           "C:\\Users\\testuser\\AppData\\Roaming\\npm",
           "C:\\Users\\testuser\\.local\\bin",
           "C:\\Users\\testuser\\.bun\\bin",
           "C:\\Users\\testuser\\scoop\\shims",
-          "C:\\Windows\\System32",
         ].join(";"),
         FNM_DIR: "C:\\Users\\testuser\\AppData\\Roaming\\fnm",
       });
       expect(commandAvailable).toHaveBeenCalledTimes(1);
+    }),
+  );
+
+  it.effect("keeps existing PATH entries ahead of known CLI fallbacks like %APPDATA%\\npm", () =>
+    Effect.gen(function* () {
+      const readEnvironment = vi.fn(
+        (_names: ReadonlyArray<string>, options?: { loadProfile?: boolean }) =>
+          options?.loadProfile
+            ? { PATH: "C:\\Profile\\Bin" }
+            : { PATH: "C:\\Users\\testuser\\AppData\\Local\\Programs\\OpenAI\\Codex\\bin" },
+      );
+      const commandAvailable = vi.fn(() => Effect.succeed(true));
+
+      const resolved = yield* withWindowsEnvironmentMocks(
+        resolveWindowsEnvironment({
+          PATH: "C:\\Users\\testuser\\AppData\\Local\\Programs\\OpenAI\\Codex\\bin;C:\\Windows\\System32",
+          APPDATA: "C:\\Users\\testuser\\AppData\\Roaming",
+        }),
+        readEnvironment,
+        commandAvailable,
+      );
+      const pathEntries = resolved.PATH?.split(";") ?? [];
+
+      expect(pathEntries[0]).toBe(
+        "C:\\Users\\testuser\\AppData\\Local\\Programs\\OpenAI\\Codex\\bin",
+      );
+      expect(pathEntries.indexOf("C:\\Users\\testuser\\AppData\\Roaming\\npm")).toBeGreaterThan(0);
     }),
   );
 });

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -724,7 +724,8 @@ export const resolveWindowsEnvironment = Effect.fn("shell.resolveWindowsEnvironm
   }).PATH;
   const mergedPath = mergePathValues(shellPath, inheritedPath, "win32");
   const knownCliPath = resolveKnownWindowsCliDirs(env).join(WINDOWS_PATH_DELIMITER);
-  const baselinePath = mergePathValues(knownCliPath, mergedPath, "win32");
+  // Known CLI dirs are fallbacks so later npm/volta/pnpm/scoop dirs cannot steal names already on PATH.
+  const baselinePath = mergePathValues(mergedPath, knownCliPath, "win32");
   const baselinePatch: Partial<NodeJS.ProcessEnv> = baselinePath ? { PATH: baselinePath } : {};
   const baselineEnv = mergeWindowsEnv(env, baselinePatch);
 


### PR DESCRIPTION
On Windows we prepended `%APPDATA%\npm` to PATH before the user's own entries. A stale `codex.cmd` shim then beat the real installer binary, and the Codex probe died on a JSON parse of the login TUI.

Known CLI dirs are fallbacks now, not prefixes.

Fixes #7570

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 479917ab23b79cf29ed0ac6ca3ded2a5508323f7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `resolveWindowsEnvironment` to append `%APPDATA%\npm` after existing PATH on Windows
> Reverses the argument order when building `baselinePath` in [shell.ts](https://github.com/pingdotgg/t3code/pull/7687/files#diff-89a91f85db41a9a0912bc86c336bf9429751f3797ee50a089248c68cde8489ce) so that known CLI fallback directories (npm, Volta, pnpm, Scoop) are appended after the shell and inherited PATH entries instead of before them.
> - Updates tests in [shell.test.ts](https://github.com/pingdotgg/t3code/pull/7687/files#diff-024b87c2c05ce19f7366c156ab261b505a48c5dcc47f564611041c74af49c9f4) to expect existing PATH entries ahead of fallbacks and adds a new test asserting `%APPDATA%\npm` appears later in PATH.
> - Behavioral Change: Windows PATH resolution now preserves user/shell PATH ordering; previously these fallback dirs took precedence over entries already in PATH.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 479917a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->