### PR TITLE
fix(files): rescan the workspace when you hit refresh

### DIFF
--- a/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
+++ b/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
@@ -1,6 +1,7 @@
 import { NativeHeaderToolbar, NativeStackScreenOptions } from "../../native/StackHeader";
+import { RegistryContext } from "@effect/atom-react";
 import { StackActions, useNavigation, type StaticScreenProps } from "@react-navigation/native";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { ActivityIndicator, Platform, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import Svg, { Defs, LinearGradient, Rect, Stop } from "react-native-svg";
@@ -251,6 +252,7 @@ export function ThreadFilesTreeScreen(props: ThreadFilesRouteScreenProps) {
     props.route.params,
   );
   const revealedInspectorRef = useRef(false);
+  const registry = useContext(RegistryContext);
   const entriesQuery = useEnvironmentQuery(
     environmentId !== null && cwd !== null && !fileInspector.supported
       ? projectEnvironment.listEntries({
@@ -259,6 +261,12 @@ export function ThreadFilesTreeScreen(props: ThreadFilesRouteScreenProps) {
         })
       : null,
   );
+  const refreshEntries = useCallback(() => {
+    if (environmentId === null || cwd === null) return;
+    registry.refresh(
+      projectEnvironment.listEntries({ environmentId, input: { cwd, refresh: true } }),
+    );
+  }, [cwd, environmentId, registry]);
   const entriesData = entriesQuery.data as ProjectListEntriesResult | null;
   const handleReturnToThread = useCallback(() => {
     if (navigation.canGoBack()) {
@@ -408,7 +416,7 @@ export function ThreadFilesTreeScreen(props: ThreadFilesRouteScreenProps) {
               {
                 accessibilityLabel: "Refresh files",
                 icon: "arrow.clockwise",
-                onPress: entriesQuery.refresh,
+                onPress: refreshEntries,
               },
             ]}
           />
@@ -455,7 +463,7 @@ export function ThreadFilesTreeScreen(props: ThreadFilesRouteScreenProps) {
         searchQuery={searchQuery}
         selectedPath={null}
         onPreviewFile={handlePreviewFile}
-        onRefresh={entriesQuery.refresh}
+        onRefresh={refreshEntries}
         onSelectFile={handleSelectFile}
       />
       <FilesToolbarBottomFade />

--- a/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
+++ b/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
@@ -255,6 +255,7 @@ export function ThreadFilesTreeScreen(props: ThreadFilesRouteScreenProps) {
   const refreshEntriesCommand = useAtomCommand(projectEnvironment.refreshEntries, {
     reportFailure: false,
   });
+  const [isRefreshing, setIsRefreshing] = useState(false);
   const entriesQuery = useEnvironmentQuery(
     environmentId !== null && cwd !== null && !fileInspector.supported
       ? projectEnvironment.listEntries({
@@ -265,7 +266,10 @@ export function ThreadFilesTreeScreen(props: ThreadFilesRouteScreenProps) {
   );
   const refreshEntries = useCallback(() => {
     if (environmentId === null || cwd === null) return;
-    void refreshEntriesCommand({ environmentId, input: { cwd, refresh: true } });
+    setIsRefreshing(true);
+    void refreshEntriesCommand({ environmentId, input: { cwd, refresh: true } }).finally(() => {
+      setIsRefreshing(false);
+    });
   }, [cwd, environmentId, refreshEntriesCommand]);
   const entriesData = entriesQuery.data as ProjectListEntriesResult | null;
   const handleReturnToThread = useCallback(() => {
@@ -459,7 +463,7 @@ export function ThreadFilesTreeScreen(props: ThreadFilesRouteScreenProps) {
       <FileTreeBrowser
         entries={entriesData?.entries ?? []}
         error={entriesQuery.error}
-        isPending={entriesQuery.isPending}
+        isPending={entriesQuery.isPending || isRefreshing}
         searchQuery={searchQuery}
         selectedPath={null}
         onPreviewFile={handlePreviewFile}

--- a/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
+++ b/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
@@ -1,7 +1,6 @@
 import { NativeHeaderToolbar, NativeStackScreenOptions } from "../../native/StackHeader";
-import { RegistryContext } from "@effect/atom-react";
 import { StackActions, useNavigation, type StaticScreenProps } from "@react-navigation/native";
-import { useCallback, useContext, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { ActivityIndicator, Platform, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import Svg, { Defs, LinearGradient, Rect, Stop } from "react-native-svg";
@@ -25,6 +24,7 @@ import { useThreadSelection } from "../../state/use-thread-selection";
 import { useSelectedThreadWorktree } from "../../state/use-selected-thread-worktree";
 import { useEnvironmentQuery } from "../../state/query";
 import { projectEnvironment } from "../../state/projects";
+import { useAtomCommand } from "../../state/use-atom-command";
 import {
   useAdaptiveWorkspaceLayout,
   useAdaptiveWorkspacePaneRole,
@@ -252,7 +252,9 @@ export function ThreadFilesTreeScreen(props: ThreadFilesRouteScreenProps) {
     props.route.params,
   );
   const revealedInspectorRef = useRef(false);
-  const registry = useContext(RegistryContext);
+  const refreshEntriesCommand = useAtomCommand(projectEnvironment.refreshEntries, {
+    reportFailure: false,
+  });
   const entriesQuery = useEnvironmentQuery(
     environmentId !== null && cwd !== null && !fileInspector.supported
       ? projectEnvironment.listEntries({
@@ -263,10 +265,8 @@ export function ThreadFilesTreeScreen(props: ThreadFilesRouteScreenProps) {
   );
   const refreshEntries = useCallback(() => {
     if (environmentId === null || cwd === null) return;
-    registry.refresh(
-      projectEnvironment.listEntries({ environmentId, input: { cwd, refresh: true } }),
-    );
-  }, [cwd, environmentId, registry]);
+    void refreshEntriesCommand({ environmentId, input: { cwd, refresh: true } });
+  }, [cwd, environmentId, refreshEntriesCommand]);
   const entriesData = entriesQuery.data as ProjectListEntriesResult | null;
   const handleReturnToThread = useCallback(() => {
     if (navigation.canGoBack()) {

--- a/apps/mobile/src/features/files/thread-file-navigator-pane.tsx
+++ b/apps/mobile/src/features/files/thread-file-navigator-pane.tsx
@@ -1,6 +1,7 @@
+import { RegistryContext } from "@effect/atom-react";
 import type { EnvironmentId, ProjectListEntriesResult } from "@t3tools/contracts";
 import { SymbolView } from "../../components/AppSymbol";
-import { useCallback, useMemo, useState, type ComponentProps } from "react";
+import { useCallback, useContext, useMemo, useState, type ComponentProps } from "react";
 import { Platform, Pressable, View, type NativeSyntheticEvent } from "react-native";
 import {
   Screen,
@@ -33,12 +34,21 @@ export function ThreadFileNavigatorPane(props: {
   const foregroundColor = String(useThemeColor("--color-foreground"));
   const sheetColor = String(useThemeColor("--color-sheet"));
   const headerScrollEdgeEffects = nativeHeaderScrollEdgeEffects(Platform.OS, Platform.Version);
+  const registry = useContext(RegistryContext);
   const entriesQuery = useEnvironmentQuery(
     projectEnvironment.listEntries({
       environmentId: props.environmentId,
       input: { cwd: props.cwd },
     }),
   );
+  const refreshEntries = useCallback(() => {
+    registry.refresh(
+      projectEnvironment.listEntries({
+        environmentId: props.environmentId,
+        input: { cwd: props.cwd, refresh: true },
+      }),
+    );
+  }, [props.cwd, props.environmentId, registry]);
   const entriesData = entriesQuery.data as ProjectListEntriesResult | null;
   const handlePreviewFile = useCallback(
     (relativePath: string) => {
@@ -58,14 +68,14 @@ export function ThreadFileNavigatorPane(props: {
           accessibilityLabel: "Refresh files",
           icon: { name: "arrow.clockwise", type: "sfSymbol" as const },
           identifier: "thread-file-navigator-refresh",
-          onPress: entriesQuery.refresh,
+          onPress: refreshEntries,
           sharesBackground: false,
           tintColor: foregroundColor,
           type: "button" as const,
           width: 44,
         },
       ] as ComponentProps<typeof ScreenStackHeaderConfig>["headerRightBarButtonItems"],
-    [entriesQuery.refresh, foregroundColor],
+    [foregroundColor, refreshEntries],
   );
 
   const fileTree = (
@@ -76,7 +86,7 @@ export function ThreadFileNavigatorPane(props: {
       searchQuery={searchQuery}
       selectedPath={props.selectedPath}
       onPreviewFile={handlePreviewFile}
-      onRefresh={entriesQuery.refresh}
+      onRefresh={refreshEntries}
       onSelectFile={props.onSelectFile}
     />
   );
@@ -150,7 +160,7 @@ export function ThreadFileNavigatorPane(props: {
             accessibilityLabel="Refresh files"
             hitSlop={8}
             className="h-8 w-8 items-center justify-center rounded-full active:bg-subtle"
-            onPress={entriesQuery.refresh}
+            onPress={refreshEntries}
           >
             <SymbolView name="arrow.clockwise" size={14} tintColor={iconColor} type="monochrome" />
           </Pressable>

--- a/apps/mobile/src/features/files/thread-file-navigator-pane.tsx
+++ b/apps/mobile/src/features/files/thread-file-navigator-pane.tsx
@@ -1,7 +1,6 @@
-import { RegistryContext } from "@effect/atom-react";
 import type { EnvironmentId, ProjectListEntriesResult } from "@t3tools/contracts";
 import { SymbolView } from "../../components/AppSymbol";
-import { useCallback, useContext, useMemo, useState, type ComponentProps } from "react";
+import { useCallback, useMemo, useState, type ComponentProps } from "react";
 import { Platform, Pressable, View, type NativeSyntheticEvent } from "react-native";
 import {
   Screen,
@@ -15,6 +14,7 @@ import { AppText as Text, AppTextInput as TextInput } from "../../components/App
 import { nativeHeaderScrollEdgeEffects } from "../../native/StackHeader";
 import { useThemeColor } from "../../lib/useThemeColor";
 import { projectEnvironment } from "../../state/projects";
+import { useAtomCommand } from "../../state/use-atom-command";
 import { useEnvironmentQuery } from "../../state/query";
 import { useAppearancePreferences } from "../settings/appearance/AppearancePreferencesProvider";
 import { FileTreeBrowser } from "./FileTreeBrowser";
@@ -34,7 +34,9 @@ export function ThreadFileNavigatorPane(props: {
   const foregroundColor = String(useThemeColor("--color-foreground"));
   const sheetColor = String(useThemeColor("--color-sheet"));
   const headerScrollEdgeEffects = nativeHeaderScrollEdgeEffects(Platform.OS, Platform.Version);
-  const registry = useContext(RegistryContext);
+  const refreshEntriesCommand = useAtomCommand(projectEnvironment.refreshEntries, {
+    reportFailure: false,
+  });
   const entriesQuery = useEnvironmentQuery(
     projectEnvironment.listEntries({
       environmentId: props.environmentId,
@@ -42,13 +44,11 @@ export function ThreadFileNavigatorPane(props: {
     }),
   );
   const refreshEntries = useCallback(() => {
-    registry.refresh(
-      projectEnvironment.listEntries({
-        environmentId: props.environmentId,
-        input: { cwd: props.cwd, refresh: true },
-      }),
-    );
-  }, [props.cwd, props.environmentId, registry]);
+    void refreshEntriesCommand({
+      environmentId: props.environmentId,
+      input: { cwd: props.cwd, refresh: true },
+    });
+  }, [props.cwd, props.environmentId, refreshEntriesCommand]);
   const entriesData = entriesQuery.data as ProjectListEntriesResult | null;
   const handlePreviewFile = useCallback(
     (relativePath: string) => {

--- a/apps/mobile/src/features/files/thread-file-navigator-pane.tsx
+++ b/apps/mobile/src/features/files/thread-file-navigator-pane.tsx
@@ -37,6 +37,7 @@ export function ThreadFileNavigatorPane(props: {
   const refreshEntriesCommand = useAtomCommand(projectEnvironment.refreshEntries, {
     reportFailure: false,
   });
+  const [isRefreshing, setIsRefreshing] = useState(false);
   const entriesQuery = useEnvironmentQuery(
     projectEnvironment.listEntries({
       environmentId: props.environmentId,
@@ -44,9 +45,12 @@ export function ThreadFileNavigatorPane(props: {
     }),
   );
   const refreshEntries = useCallback(() => {
+    setIsRefreshing(true);
     void refreshEntriesCommand({
       environmentId: props.environmentId,
       input: { cwd: props.cwd, refresh: true },
+    }).finally(() => {
+      setIsRefreshing(false);
     });
   }, [props.cwd, props.environmentId, refreshEntriesCommand]);
   const entriesData = entriesQuery.data as ProjectListEntriesResult | null;
@@ -82,7 +86,7 @@ export function ThreadFileNavigatorPane(props: {
     <FileTreeBrowser
       entries={entriesData?.entries ?? []}
       error={entriesQuery.error}
-      isPending={entriesQuery.isPending}
+      isPending={entriesQuery.isPending || isRefreshing}
       searchQuery={searchQuery}
       selectedPath={props.selectedPath}
       onPreviewFile={handlePreviewFile}

--- a/apps/server/src/workspace/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.test.ts
@@ -121,6 +121,26 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
         expect(result.truncated).toBe(false);
       }),
     );
+
+    it.effect("rescans files created after the workspace index was cached", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-list-refresh-" });
+        yield* writeTextFile(cwd, "existing.txt");
+
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        yield* workspaceEntries.list({ cwd });
+        yield* writeTextFile(cwd, "created-after-list.txt");
+
+        const cached = yield* workspaceEntries.list({ cwd });
+        expect(cached.entries.some((entry) => entry.path === "created-after-list.txt")).toBe(false);
+
+        const refreshed = yield* workspaceEntries.list({ cwd, refresh: true });
+        expect(refreshed.entries).toContainEqual({
+          path: "created-after-list.txt",
+          kind: "file",
+        });
+      }),
+    );
   });
 
   describe("search", () => {

--- a/apps/server/src/workspace/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.ts
@@ -274,6 +274,9 @@ export const make = Effect.gen(function* () {
 
   const list: WorkspaceEntries["Service"]["list"] = Effect.fn("WorkspaceEntries.list")(
     function* (input) {
+      if (input.refresh === true) {
+        yield* refresh(input.cwd);
+      }
       const normalizedCwd = yield* normalizeWorkspaceRoot(input.cwd);
       return yield* Effect.gen(function* () {
         const searchIndex = yield* WorkspaceSearchIndex.WorkspaceSearchIndex;

--- a/apps/web/src/components/files/projectFilesQueryState.ts
+++ b/apps/web/src/components/files/projectFilesQueryState.ts
@@ -127,8 +127,11 @@ export function useProjectEntriesQuery(
 ): ProjectQueryState<ProjectListEntriesResult> {
   const atom = getProjectEntriesQueryAtom(environmentId, cwd);
   const result = useAtomValue(atom);
-  const refreshAtom = useAtomRefresh(atom);
-  const refresh = useCallback(() => refreshAtom(), [refreshAtom]);
+  const refresh = useCallback(() => {
+    appAtomRegistry.refresh(
+      projectEnvironment.listEntries({ environmentId, input: { cwd, refresh: true } }),
+    );
+  }, [cwd, environmentId]);
   return {
     data: Option.getOrNull(AsyncResult.value(result)),
     error: errorMessage(result),

--- a/apps/web/src/components/files/projectFilesQueryState.ts
+++ b/apps/web/src/components/files/projectFilesQueryState.ts
@@ -7,7 +7,7 @@ import type {
 import * as Cause from "effect/Cause";
 import * as Option from "effect/Option";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 
 import { appAtomRegistry } from "~/rpc/atomRegistry";
 import { projectEnvironment } from "~/state/projects";
@@ -131,13 +131,26 @@ export function useProjectEntriesQuery(
   const refreshEntries = useAtomCommand(projectEnvironment.refreshEntries, {
     reportFailure: false,
   });
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [refreshError, setRefreshError] = useState<string | null>(null);
   const refresh = useCallback(() => {
-    void refreshEntries({ environmentId, input: { cwd, refresh: true } });
+    setIsRefreshing(true);
+    setRefreshError(null);
+    void refreshEntries({ environmentId, input: { cwd, refresh: true } })
+      .then((commandResult) => {
+        const nextError = errorMessage(commandResult);
+        if (nextError !== null) {
+          setRefreshError(nextError);
+        }
+      })
+      .finally(() => {
+        setIsRefreshing(false);
+      });
   }, [cwd, environmentId, refreshEntries]);
   return {
     data: Option.getOrNull(AsyncResult.value(result)),
-    error: errorMessage(result),
-    isPending: result.waiting,
+    error: refreshError ?? errorMessage(result),
+    isPending: result.waiting || isRefreshing,
     refresh,
   };
 }

--- a/apps/web/src/components/files/projectFilesQueryState.ts
+++ b/apps/web/src/components/files/projectFilesQueryState.ts
@@ -11,6 +11,7 @@ import { useCallback } from "react";
 
 import { appAtomRegistry } from "~/rpc/atomRegistry";
 import { projectEnvironment } from "~/state/projects";
+import { useAtomCommand } from "~/state/use-atom-command";
 import { useProjectPathSearch } from "~/state/queries";
 import { executeAtomQuery } from "@t3tools/client-runtime/state/runtime";
 
@@ -127,11 +128,12 @@ export function useProjectEntriesQuery(
 ): ProjectQueryState<ProjectListEntriesResult> {
   const atom = getProjectEntriesQueryAtom(environmentId, cwd);
   const result = useAtomValue(atom);
+  const refreshEntries = useAtomCommand(projectEnvironment.refreshEntries, {
+    reportFailure: false,
+  });
   const refresh = useCallback(() => {
-    appAtomRegistry.refresh(
-      projectEnvironment.listEntries({ environmentId, input: { cwd, refresh: true } }),
-    );
-  }, [cwd, environmentId]);
+    void refreshEntries({ environmentId, input: { cwd, refresh: true } });
+  }, [cwd, environmentId, refreshEntries]);
   return {
     data: Option.getOrNull(AsyncResult.value(result)),
     error: errorMessage(result),

--- a/packages/client-runtime/src/state/projectCommands.ts
+++ b/packages/client-runtime/src/state/projectCommands.ts
@@ -2,9 +2,11 @@ import { type EnvironmentId, type ProjectReadFileResult, WS_METHODS } from "@t3t
 import * as Crypto from "effect/Crypto";
 import { Atom } from "effect/unstable/reactivity";
 
+import { request } from "../rpc/client.ts";
 import {
   createAtomCommandScheduler,
   createEnvironmentCommand,
+  createEnvironmentQueryAtomFamily,
   createEnvironmentRpcCommand,
   createEnvironmentRpcQueryAtomFamily,
 } from "./runtime.ts";
@@ -54,18 +56,37 @@ export function createProjectEnvironmentAtoms<R, E>(
     key: ({ environmentId, input }: { environmentId: string; input: { projectId: string } }) =>
       JSON.stringify([environmentId, input.projectId]),
   };
+  const pendingListEntriesRefresh = new Set<string>();
+  const listEntriesFamily = createEnvironmentQueryAtomFamily(runtime, {
+    label: "environment-data:projects:list-entries",
+    staleTimeMs: 30_000,
+    idleTtlMs: 5 * 60_000,
+    execute: (input: { readonly cwd: string }) => {
+      const refresh = pendingListEntriesRefresh.delete(input.cwd);
+      return request(WS_METHODS.projectsListEntries, {
+        cwd: input.cwd,
+        ...(refresh ? { refresh: true } : {}),
+      });
+    },
+  });
   return {
     searchEntries: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:projects:search-entries",
       tag: WS_METHODS.projectsSearchEntries,
       staleTimeMs: 15_000,
     }),
-    listEntries: createEnvironmentRpcQueryAtomFamily(runtime, {
-      label: "environment-data:projects:list-entries",
-      tag: WS_METHODS.projectsListEntries,
-      staleTimeMs: 30_000,
-      idleTtlMs: 5 * 60_000,
-    }),
+    listEntries: (target: {
+      readonly environmentId: EnvironmentId;
+      readonly input: { readonly cwd: string; readonly refresh?: boolean };
+    }) => {
+      if (target.input.refresh === true) {
+        pendingListEntriesRefresh.add(target.input.cwd);
+      }
+      return listEntriesFamily({
+        environmentId: target.environmentId,
+        input: { cwd: target.input.cwd },
+      });
+    },
     readFile: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:projects:read-file",
       tag: WS_METHODS.projectsReadFile,

--- a/packages/client-runtime/src/state/projectCommands.ts
+++ b/packages/client-runtime/src/state/projectCommands.ts
@@ -1,12 +1,11 @@
 import { type EnvironmentId, type ProjectReadFileResult, WS_METHODS } from "@t3tools/contracts";
 import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
 import { Atom } from "effect/unstable/reactivity";
 
-import { request } from "../rpc/client.ts";
 import {
   createAtomCommandScheduler,
   createEnvironmentCommand,
-  createEnvironmentQueryAtomFamily,
   createEnvironmentRpcCommand,
   createEnvironmentRpcQueryAtomFamily,
 } from "./runtime.ts";
@@ -56,18 +55,24 @@ export function createProjectEnvironmentAtoms<R, E>(
     key: ({ environmentId, input }: { environmentId: string; input: { projectId: string } }) =>
       JSON.stringify([environmentId, input.projectId]),
   };
-  const pendingListEntriesRefresh = new Set<string>();
-  const listEntriesFamily = createEnvironmentQueryAtomFamily(runtime, {
+  const listEntries = createEnvironmentRpcQueryAtomFamily(runtime, {
     label: "environment-data:projects:list-entries",
+    tag: WS_METHODS.projectsListEntries,
     staleTimeMs: 30_000,
     idleTtlMs: 5 * 60_000,
-    execute: (input: { readonly cwd: string }) => {
-      const refresh = pendingListEntriesRefresh.delete(input.cwd);
-      return request(WS_METHODS.projectsListEntries, {
-        cwd: input.cwd,
-        ...(refresh ? { refresh: true } : {}),
-      });
-    },
+  });
+  const refreshEntries = createEnvironmentRpcCommand(runtime, {
+    label: "environment-data:projects:refresh-entries",
+    tag: WS_METHODS.projectsListEntries,
+    onSuccess: (target, registry) =>
+      Effect.sync(() => {
+        registry.refresh(
+          listEntries({
+            environmentId: target.environmentId,
+            input: { cwd: target.input.cwd },
+          }),
+        );
+      }),
   });
   return {
     searchEntries: createEnvironmentRpcQueryAtomFamily(runtime, {
@@ -75,18 +80,8 @@ export function createProjectEnvironmentAtoms<R, E>(
       tag: WS_METHODS.projectsSearchEntries,
       staleTimeMs: 15_000,
     }),
-    listEntries: (target: {
-      readonly environmentId: EnvironmentId;
-      readonly input: { readonly cwd: string; readonly refresh?: boolean };
-    }) => {
-      if (target.input.refresh === true) {
-        pendingListEntriesRefresh.add(target.input.cwd);
-      }
-      return listEntriesFamily({
-        environmentId: target.environmentId,
-        input: { cwd: target.input.cwd },
-      });
-    },
+    listEntries,
+    refreshEntries,
     readFile: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:projects:read-file",
       tag: WS_METHODS.projectsReadFile,

--- a/packages/contracts/src/project.ts
+++ b/packages/contracts/src/project.ts
@@ -72,6 +72,8 @@ export type ProjectSearchContentsResult = typeof ProjectSearchContentsResult.Typ
 
 export const ProjectListEntriesInput = Schema.Struct({
   cwd: TrimmedNonEmptyString,
+  // Explicit Files-panel refresh rescans the index; ordinary reads stay cached.
+  refresh: Schema.optional(Schema.Boolean),
 });
 export type ProjectListEntriesInput = typeof ProjectListEntriesInput.Type;
 


### PR DESCRIPTION
Refresh on the Files panel only re-read the cached search index. Files created outside T3 stayed missing, F5 included.

`projects.listEntries` now takes an optional `refresh` flag. The Files refresh button sets it, and the server scans before listing.

Fixes #6452

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2f8eaaed03ac056a397c2efd425bc7d3ffbec3d8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rescan workspace on files refresh across mobile, web, and server
> - Adds optional `refresh` flag to `ProjectListEntriesInput`; when true, `WorkspaceEntries.list` calls `refresh(cwd)` before returning entries so newly created files appear
> - Introduces `refreshEntries` command in `createProjectEnvironmentAtoms` that issues the refresh RPC and invalidates the `listEntries` query cache on success
> - Mobile `ThreadFilesTreeScreen` and `ThreadFileNavigatorPane`, plus web `useProjectEntriesQuery`, replace `entriesQuery.refresh` with the new command and fold the refresh state into `isPending`
> - Risk: `refreshEntries` uses `reportFailure: false` on mobile, so command errors are swallowed in the UI except where `refreshError` is surfaced (web hook only)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 490c4be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->