### PR TITLE
fix(server): report Claude authentication accurately

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -11,6 +11,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as Result from "effect/Result";
+import * as Schema from "effect/Schema";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import {
   createModelCapabilities,
@@ -29,6 +30,7 @@ import {
 } from "@anthropic-ai/claude-agent-sdk";
 
 import {
+  AUTH_PROBE_TIMEOUT_MS,
   buildBooleanOptionDescriptor,
   buildSelectOptionDescriptor,
   buildServerProvider,
@@ -55,6 +57,15 @@ const MINIMUM_CLAUDE_OPUS_5_VERSION = "2.1.219";
 const MINIMUM_CLAUDE_FABLE_5_VERSION = "2.1.169";
 const MINIMUM_CLAUDE_OPUS_4_8_VERSION = "2.1.154";
 const MINIMUM_CLAUDE_OPUS_4_7_VERSION = "2.1.111";
+const MINIMUM_CLAUDE_AUTH_STATUS_VERSION = "2.1.41";
+
+const decodeClaudeAuthStatus = Schema.decodeUnknownOption(
+  Schema.fromJsonString(
+    Schema.Struct({
+      loggedIn: Schema.Boolean,
+    }),
+  ),
+);
 
 const CURRENT_CLAUDE_MODELS = new Set(["claude-fable-5", "claude-opus-5", "claude-sonnet-5"]);
 
@@ -345,6 +356,22 @@ function supportsClaudeOpus48(version: string | null | undefined): boolean {
 
 function supportsClaudeOpus47(version: string | null | undefined): boolean {
   return version ? compareSemverVersions(version, MINIMUM_CLAUDE_OPUS_4_7_VERSION) >= 0 : false;
+}
+
+function supportsClaudeAuthStatus(version: string | null | undefined): boolean {
+  return version ? compareSemverVersions(version, MINIMUM_CLAUDE_AUTH_STATUS_VERSION) >= 0 : false;
+}
+
+function classifyClaudeAuthStatus(
+  result: { readonly stdout: string; readonly code: number } | undefined,
+): "authenticated" | "unauthenticated" | "unknown" {
+  if (!result) return "unknown";
+
+  const decoded = decodeClaudeAuthStatus(result.stdout);
+  const loggedIn = Option.isSome(decoded) ? decoded.value.loggedIn : undefined;
+  if (loggedIn === false) return "unauthenticated";
+  if (loggedIn === true) return result.code === 0 ? "authenticated" : "unknown";
+  return result.code === 1 ? "unauthenticated" : "unknown";
 }
 
 function getBuiltInClaudeModelsForVersion(
@@ -953,6 +980,43 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
       subscriptionType: capabilities.subscriptionType,
       authMethod: capabilities.tokenSource,
     }) ?? apiProviderAuthMetadata(capabilities.apiProvider);
+  const hasExternalApiProvider =
+    capabilities.apiProvider !== undefined && capabilities.apiProvider !== "firstParty";
+
+  if (!hasExternalApiProvider && supportsClaudeAuthStatus(parsedVersion)) {
+    const authProbe = yield* runClaudeCommand(
+      claudeSettings,
+      ["auth", "status"],
+      resolvedEnvironment,
+    ).pipe(Effect.timeoutOption(AUTH_PROBE_TIMEOUT_MS), Effect.result);
+    const authResult =
+      Result.isSuccess(authProbe) && Option.isSome(authProbe.success)
+        ? authProbe.success.value
+        : undefined;
+    const authStatus = classifyClaudeAuthStatus(authResult);
+
+    if (authStatus !== "authenticated") {
+      const isUnauthenticated = authStatus === "unauthenticated";
+      return buildServerProvider({
+        presentation: CLAUDE_PRESENTATION,
+        enabled: claudeSettings.enabled,
+        checkedAt,
+        models,
+        slashCommands: dedupedSlashCommands,
+        skills,
+        probe: {
+          installed: true,
+          version: parsedVersion,
+          status: isUnauthenticated ? "error" : "warning",
+          auth: { status: isUnauthenticated ? "unauthenticated" : "unknown" },
+          message: isUnauthenticated
+            ? "Claude is not authenticated. Run `claude auth login` and try again."
+            : "Could not verify Claude authentication status.",
+        },
+      });
+    }
+  }
+
   return buildServerProvider({
     presentation: CLAUDE_PRESENTATION,
     enabled: claudeSettings.enabled,

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -182,6 +182,51 @@ function mockSpawnerLayer(
   );
 }
 
+function mockClaudeAuthStatusLayer(status: "authenticated" | "unauthenticated") {
+  const loggedIn = status === "authenticated";
+  return mockSpawnerLayer((args) => {
+    const joined = args.join(" ");
+    if (joined === "--version") return { stdout: "2.1.41\n", stderr: "", code: 0 };
+    if (joined === "auth status") {
+      return {
+        stdout: `${JSON.stringify({
+          loggedIn,
+          authMethod: loggedIn ? "claude.ai" : "none",
+        })}\n`,
+        stderr: "",
+        code: loggedIn ? 0 : 1,
+      };
+    }
+    throw new Error(`Unexpected args: ${joined}`);
+  });
+}
+
+function failingClaudeAuthStatusLayer(description: string) {
+  return Layer.succeed(
+    ChildProcessSpawner.ChildProcessSpawner,
+    ChildProcessSpawner.make((command) => {
+      const cmd = command as unknown as { args: ReadonlyArray<string> };
+      if (cmd.args.join(" ") === "--version") {
+        return Effect.succeed(
+          mockHandle({
+            stdout: "2.1.41\n",
+            stderr: "",
+            code: 0,
+          }),
+        );
+      }
+      return Effect.fail(
+        PlatformError.systemError({
+          _tag: "Unknown",
+          module: "ChildProcess",
+          method: "spawn",
+          description,
+        }),
+      );
+    }),
+  );
+}
+
 function recordingMockSpawnerLayer(
   handler: (args: ReadonlyArray<string>) => {
     stdout: string;
@@ -1783,7 +1828,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           Effect.provide(
             mockSpawnerLayer((args) => {
               const joined = args.join(" ");
-              if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
+              if (joined === "--version") return { stdout: "2.1.41\n", stderr: "", code: 0 };
               if (joined === "auth status")
                 return {
                   stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
@@ -1794,6 +1839,136 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             }),
           ),
         ),
+      );
+
+      it.effect(
+        "returns unauthenticated when initialization has no account and the CLI reports logged out",
+        () =>
+          Effect.gen(function* () {
+            const status = yield* checkClaudeProviderStatus(
+              defaultClaudeSettings,
+              claudeCapabilities(),
+            );
+            assert.strictEqual(status.status, "error");
+            assert.strictEqual(status.installed, true);
+            assert.strictEqual(status.auth.status, "unauthenticated");
+            assert.strictEqual(
+              status.message,
+              "Claude is not authenticated. Run `claude auth login` and try again.",
+            );
+          }).pipe(Effect.provide(mockClaudeAuthStatusLayer("unauthenticated"))),
+      );
+
+      it.effect(
+        "prefers the CLI logged-out result over stale initialization account metadata",
+        () =>
+          Effect.gen(function* () {
+            const status = yield* checkClaudeProviderStatus(
+              defaultClaudeSettings,
+              claudeCapabilities({
+                email: "claude@example.com",
+                subscriptionType: "team",
+                apiProvider: "firstParty",
+              }),
+            );
+            assert.strictEqual(status.status, "error");
+            assert.strictEqual(status.auth.status, "unauthenticated");
+          }).pipe(Effect.provide(mockClaudeAuthStatusLayer("unauthenticated"))),
+      );
+
+      it.effect("uses loggedIn=false even when the auth command exits successfully", () =>
+        Effect.gen(function* () {
+          const status = yield* checkClaudeProviderStatus(
+            defaultClaudeSettings,
+            claudeCapabilities({
+              email: "stale@example.com",
+              subscriptionType: "team",
+              apiProvider: "firstParty",
+            }),
+          );
+          assert.strictEqual(status.status, "error");
+          assert.strictEqual(status.auth.status, "unauthenticated");
+        }).pipe(
+          Effect.provide(
+            mockSpawnerLayer((args) => {
+              const joined = args.join(" ");
+              if (joined === "--version") {
+                return { stdout: "2.1.41\n", stderr: "", code: 0 };
+              }
+              if (joined === "auth status") {
+                return {
+                  stdout: '{"loggedIn":false,"authMethod":"none"}\n',
+                  stderr: "",
+                  code: 0,
+                };
+              }
+              throw new Error(`Unexpected args: ${joined}`);
+            }),
+          ),
+        ),
+      );
+
+      it.effect("preserves initialization auth on Claude versions without auth status", () =>
+        Effect.gen(function* () {
+          const status = yield* checkClaudeProviderStatus(
+            defaultClaudeSettings,
+            claudeCapabilities({
+              email: "claude@example.com",
+              subscriptionType: "team",
+              apiProvider: "firstParty",
+            }),
+          );
+          assert.strictEqual(status.status, "ready");
+          assert.strictEqual(status.auth.status, "authenticated");
+        }).pipe(
+          Effect.provide(
+            mockSpawnerLayer((args) => {
+              if (args.join(" ") === "--version") {
+                return { stdout: "2.1.40\n", stderr: "", code: 0 };
+              }
+              throw new Error(`Unexpected args: ${args.join(" ")}`);
+            }),
+          ),
+        ),
+      );
+
+      it.effect("returns unknown when the auth command exits unexpectedly", () =>
+        Effect.gen(function* () {
+          const status = yield* checkClaudeProviderStatus(
+            defaultClaudeSettings,
+            claudeCapabilities(),
+          );
+          assert.strictEqual(status.status, "warning");
+          assert.strictEqual(status.installed, true);
+          assert.strictEqual(status.auth.status, "unknown");
+          assert.strictEqual(status.message, "Could not verify Claude authentication status.");
+        }).pipe(
+          Effect.provide(
+            mockSpawnerLayer((args) => {
+              const joined = args.join(" ");
+              if (joined === "--version") {
+                return { stdout: "2.1.41\n", stderr: "", code: 0 };
+              }
+              if (joined === "auth status") {
+                return { stdout: "", stderr: "unexpected failure", code: 2 };
+              }
+              throw new Error(`Unexpected args: ${joined}`);
+            }),
+          ),
+        ),
+      );
+
+      it.effect("returns unknown when the auth command cannot be started", () =>
+        Effect.gen(function* () {
+          const status = yield* checkClaudeProviderStatus(
+            defaultClaudeSettings,
+            claudeCapabilities(),
+          );
+          assert.strictEqual(status.status, "warning");
+          assert.strictEqual(status.installed, true);
+          assert.strictEqual(status.auth.status, "unknown");
+          assert.strictEqual(status.message, "Could not verify Claude authentication status.");
+        }).pipe(Effect.provide(failingClaudeAuthStatusLayer("spawn auth status failed"))),
       );
 
       it.effect("returns ready and labels Bedrock-backed Claude as authenticated", () =>
@@ -2044,15 +2219,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           assert.strictEqual(status.auth.status, "authenticated");
           assert.strictEqual(status.auth.type, "Claude Max Subscription");
           assert.strictEqual(status.auth.label, "Claude Max Subscription");
-        }).pipe(
-          Effect.provide(
-            mockSpawnerLayer((args) => {
-              const joined = args.join(" ");
-              if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
-              throw new Error(`Unexpected args: ${joined}`);
-            }),
-          ),
-        ),
+        }).pipe(Effect.provide(mockClaudeAuthStatusLayer("authenticated"))),
       );
 
       it.effect("does not duplicate Claude in provider-prefixed subscription names", () =>
@@ -2066,15 +2233,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           assert.strictEqual(status.auth.status, "authenticated");
           assert.strictEqual(status.auth.type, "Claude Max");
           assert.strictEqual(status.auth.label, "Claude Max Subscription");
-        }).pipe(
-          Effect.provide(
-            mockSpawnerLayer((args) => {
-              const joined = args.join(" ");
-              if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
-              throw new Error(`Unexpected args: ${joined}`);
-            }),
-          ),
-        ),
+        }).pipe(Effect.provide(mockClaudeAuthStatusLayer("authenticated"))),
       );
 
       it.effect("returns claude auth email from initialization result", () =>
@@ -2107,7 +2266,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         const claudeConfigDir = "/tmp/t3code-claude-home";
         const recorded = recordingMockSpawnerLayer((args) => {
           const joined = args.join(" ");
-          if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
+          if (joined === "--version") return { stdout: "2.1.41\n", stderr: "", code: 0 };
           if (joined === "auth status")
             return {
               stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
@@ -2127,8 +2286,14 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           );
           assert.strictEqual(status.status, "ready");
           assert.deepStrictEqual(
-            recorded.commands.map((command) => command.env?.CLAUDE_CONFIG_DIR),
-            [claudeConfigDir],
+            recorded.commands.map((command) => ({
+              args: command.args,
+              claudeConfigDir: command.env?.CLAUDE_CONFIG_DIR,
+            })),
+            [
+              { args: ["--version"], claudeConfigDir },
+              { args: ["auth", "status"], claudeConfigDir },
+            ],
           );
         }).pipe(Effect.provide(recorded.layer));
       });


### PR DESCRIPTION
## What Changed

- Probe first-party Claude Code authentication with `claude auth status` using the same configured binary, environment, and `CLAUDE_CONFIG_DIR` used for chats.
- Decode the CLI's `loggedIn` result and report logged-out sessions as unauthenticated instead of trusting stale or incomplete SDK initialization metadata.
- Preserve existing behavior for external API providers and Claude Code versions older than 2.1.41; report probe failures as unknown rather than authenticated.
- Add focused regression coverage for logged-out sessions, stale account metadata, CLI compatibility, config-directory propagation, and probe failures.

## Why

T3 could report Claude as ready and authenticated whenever the SDK initialization probe returned a capabilities object, even if the exact CLI environment used for chats was logged out. The first chat then failed with `authentication_failed`, leaving Settings in direct conflict with the provider process.

This keeps authentication truth at the Claude adapter boundary and follows the CLI's supported auth-status contract without changing client or wire contracts.

Closes #7690.

## Testing

- `vp test run apps/server/src/provider/Layers/ProviderRegistry.test.ts` — 49 passed
- `vp run --filter t3 typecheck` — passed (pre-existing Effect suggestions only)
- Targeted lint and format checks — passed
- `vp run -r test` — local run stopped on the unrelated existing `scripts/build-desktop-artifact.test.ts` cross-architecture Windows assertion; neither that test nor its implementation is changed by this PR

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] UI screenshots are not applicable (server-only change)
- [x] Animation/interaction video is not applicable

Implemented with GPT-5.6 Sol in the Codex harness via T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 35ed708b1f0cd52da9131a9fcddc3d5a20382198. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Probe `claude auth status` in `checkClaudeProviderStatus` and report CLI auth accurately
> - Adds an auth probe to `checkClaudeProviderStatus` that runs `claude auth status` when the CLI version is >= `2.1.41` (`MINIMUM_CLAUDE_AUTH_STATUS_VERSION`) and no external API provider is configured.
> - Adds `decodeClaudeAuthStatus`, `supportsClaudeAuthStatus`, and `classifyClaudeAuthStatus` helpers to parse the CLI's `loggedIn` JSON output and map it to `authenticated`, `unauthenticated`, or `unknown`.
> - When the CLI reports logged out, the provider snapshot now returns early with `status='error'` and `auth.status='unauthenticated'`; unverifiable status yields `status='warning'` and `auth.status='unknown'`.
> - The probe is bounded by `AUTH_PROBE_TIMEOUT_MS` via `Effect.timeoutOption`, and `CLAUDE_CONFIG_DIR` is applied to both `--version` and `auth status` invocations.
> - Risk: the early-return path in `checkClaudeProviderStatus` changes provider snapshot status for logged-out or unknown cases; existing consumers expecting `status='ready'` when the CLI is installed should verify against the new `auth.status` field.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 35ed708.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->