### PR TITLE
fix(web): refresh diffs after sibling thread turns

### DIFF
--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -28,6 +28,7 @@ import { openDiffFilePrimaryAction } from "../diffFileActions";
 import { useCheckpointDiff } from "~/lib/checkpointDiffState";
 import { cn } from "~/lib/utils";
 import { selectThreadDiffPanelSelection, useDiffPanelStore } from "../diffPanelStore";
+import { advanceGitDiffRefreshTracker, type GitDiffRefreshTracker } from "../lib/diffPanelRefresh";
 import { useTheme } from "../hooks/useTheme";
 import {
   buildFileDiffRenderKey,
@@ -39,7 +40,7 @@ import {
 } from "../lib/diffRendering";
 import { areAllDiffFilesCollapsed, toggleAllDiffFiles } from "../lib/diffCollapse";
 import { useTurnDiffSummaries } from "../hooks/useTurnDiffSummaries";
-import { useProject, useThread } from "../state/entities";
+import { useProject, useThread, useThreadShellsForProjectRefs } from "../state/entities";
 import { resolveThreadRouteRef } from "../threadRoutes";
 import { useClientSettings } from "../hooks/useSettings";
 import { formatShortTimestamp } from "../timestampFormat";
@@ -117,6 +118,7 @@ export default function DiffPanel({
     readonly threadKey: string | null;
     readonly turnId: TurnId | null;
   } | null>(null);
+  const siblingTurnRefreshTrackerRef = useRef<GitDiffRefreshTracker | null>(null);
 
   const routeThreadRef = useParams({
     strict: false,
@@ -125,14 +127,22 @@ export default function DiffPanel({
   const activeThreadId = routeThreadRef?.threadId ?? null;
   const activeThread = useThread(routeThreadRef);
   const activeProjectId = activeThread?.projectId ?? null;
-  const activeProject = useProject(
-    activeThread && activeProjectId
-      ? {
-          environmentId: activeThread.environmentId,
-          projectId: activeProjectId,
-        }
-      : null,
+  const activeProjectRef = useMemo(
+    () =>
+      activeThread && activeProjectId
+        ? {
+            environmentId: activeThread.environmentId,
+            projectId: activeProjectId,
+          }
+        : null,
+    [activeProjectId, activeThread?.environmentId],
   );
+  const activeProject = useProject(activeProjectRef);
+  const activeProjectRefs = useMemo(
+    () => (activeProjectRef === null ? [] : [activeProjectRef]),
+    [activeProjectRef],
+  );
+  const activeProjectThreads = useThreadShellsForProjectRefs(activeProjectRefs);
   const activeCwd = activeThread?.worktreePath ?? activeProject?.workspaceRoot;
   const activeRepositoryRoot = activeThread?.worktreePath
     ? undefined
@@ -307,6 +317,37 @@ export default function DiffPanel({
     refreshBranchDiffPreview();
     lastCompletedTurnRefreshRef.current = current;
   }, [activeThreadRefreshKey, canRefreshGitDiff, latestTurn?.turnId, refreshBranchDiffPreview]);
+
+  useEffect(() => {
+    if (
+      !canRefreshGitDiff ||
+      !activeThread ||
+      !activeProject ||
+      !activeCwd ||
+      !activeThreadRefreshKey
+    ) {
+      return;
+    }
+    const result = advanceGitDiffRefreshTracker(siblingTurnRefreshTrackerRef.current, {
+      scopeKey: `${activeThread.environmentId}:${activeCwd}`,
+      cwd: activeCwd,
+      workspaceRoot: activeProject.workspaceRoot,
+      activeThreadId: activeThread.id,
+      threads: activeProjectThreads,
+    });
+    siblingTurnRefreshTrackerRef.current = result.next;
+    if (result.shouldRefresh) {
+      refreshBranchDiffPreview();
+    }
+  }, [
+    activeCwd,
+    activeProject,
+    activeProjectThreads,
+    activeThread,
+    activeThreadRefreshKey,
+    canRefreshGitDiff,
+    refreshBranchDiffPreview,
+  ]);
 
   const selectedGitSource = branchDiffPreview.data?.sources.find(
     (source) => source.kind === (selectedGitScope === "unstaged" ? "working-tree" : "branch-range"),

--- a/apps/web/src/lib/diffPanelRefresh.test.ts
+++ b/apps/web/src/lib/diffPanelRefresh.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vite-plus/test";
+import { advanceGitDiffRefreshTracker, type GitDiffRefreshTracker } from "./diffPanelRefresh";
+
+const WORKSPACE_ROOT = "/repo";
+
+function thread(input: {
+  id: string;
+  turnId?: string;
+  completedAt?: string | null;
+  worktreePath?: string | null;
+}) {
+  return {
+    id: input.id,
+    worktreePath: input.worktreePath ?? null,
+    latestTurn: input.turnId
+      ? {
+          turnId: input.turnId,
+          completedAt:
+            input.completedAt === undefined ? "2026-08-20T12:00:00.000Z" : input.completedAt,
+        }
+      : null,
+  };
+}
+
+function advance(
+  previous: GitDiffRefreshTracker | null,
+  threads: ReturnType<typeof thread>[],
+  overrides: Partial<{
+    scopeKey: string;
+    cwd: string;
+    activeThreadId: string;
+  }> = {},
+) {
+  return advanceGitDiffRefreshTracker(previous, {
+    scopeKey: overrides.scopeKey ?? `environment:${WORKSPACE_ROOT}`,
+    cwd: overrides.cwd ?? WORKSPACE_ROOT,
+    workspaceRoot: WORKSPACE_ROOT,
+    activeThreadId: overrides.activeThreadId ?? "active",
+    threads,
+  });
+}
+
+describe("advanceGitDiffRefreshTracker", () => {
+  it("baselines existing sibling completions without refreshing", () => {
+    const result = advance(null, [
+      thread({ id: "active" }),
+      thread({ id: "sibling", turnId: "1" }),
+    ]);
+
+    expect(result.shouldRefresh).toBe(false);
+    expect(result.next.completedTurnIdByThread.get("sibling")).toBe("1");
+  });
+
+  it("refreshes when a sibling completes a new turn in the same checkout", () => {
+    const baseline = advance(null, [thread({ id: "sibling", turnId: "1" })]).next;
+    const result = advance(baseline, [thread({ id: "sibling", turnId: "2" })]);
+
+    expect(result.shouldRefresh).toBe(true);
+    expect(result.next.completedTurnIdByThread.get("sibling")).toBe("2");
+  });
+
+  it("waits for a running sibling turn to complete", () => {
+    const baseline = advance(null, [thread({ id: "sibling", turnId: "1" })]).next;
+    const running = advance(baseline, [thread({ id: "sibling", turnId: "2", completedAt: null })]);
+    const completed = advance(running.next, [thread({ id: "sibling", turnId: "2" })]);
+
+    expect(running.shouldRefresh).toBe(false);
+    expect(completed.shouldRefresh).toBe(true);
+  });
+
+  it("ignores completions from the active thread and other worktrees", () => {
+    const baseline = advance(null, []).next;
+    const result = advance(baseline, [
+      thread({ id: "active", turnId: "1" }),
+      thread({ id: "other-worktree", turnId: "1", worktreePath: "/repo-worktree" }),
+    ]);
+
+    expect(result.shouldRefresh).toBe(false);
+    expect(result.next.completedTurnIdByThread.size).toBe(0);
+  });
+
+  it("re-baselines instead of refreshing when the active checkout changes", () => {
+    const baseline = advance(null, [thread({ id: "sibling", turnId: "1" })]).next;
+    const result = advance(
+      baseline,
+      [thread({ id: "worktree-sibling", turnId: "1", worktreePath: "/repo-worktree" })],
+      { scopeKey: "environment:/repo-worktree", cwd: "/repo-worktree" },
+    );
+
+    expect(result.shouldRefresh).toBe(false);
+    expect(result.next.completedTurnIdByThread.get("worktree-sibling")).toBe("1");
+  });
+});

--- a/apps/web/src/lib/diffPanelRefresh.ts
+++ b/apps/web/src/lib/diffPanelRefresh.ts
@@ -1,0 +1,57 @@
+interface DiffRefreshThread {
+  readonly id: string;
+  readonly worktreePath: string | null;
+  readonly latestTurn: {
+    readonly turnId: string;
+    readonly completedAt: string | null;
+  } | null;
+}
+
+export interface GitDiffRefreshTracker {
+  readonly scopeKey: string;
+  readonly completedTurnIdByThread: ReadonlyMap<string, string>;
+}
+
+interface AdvanceGitDiffRefreshTrackerInput {
+  readonly scopeKey: string;
+  readonly cwd: string;
+  readonly workspaceRoot: string;
+  readonly activeThreadId: string;
+  readonly threads: ReadonlyArray<DiffRefreshThread>;
+}
+
+/** Tracks completed sibling turns that could have changed the active checkout. */
+export function advanceGitDiffRefreshTracker(
+  previous: GitDiffRefreshTracker | null,
+  input: AdvanceGitDiffRefreshTrackerInput,
+): {
+  readonly next: GitDiffRefreshTracker;
+  readonly shouldRefresh: boolean;
+} {
+  const sameScope = previous?.scopeKey === input.scopeKey;
+  const completedTurnIdByThread = new Map(sameScope ? previous.completedTurnIdByThread : undefined);
+  let shouldRefresh = false;
+
+  for (const thread of input.threads) {
+    const latestTurn = thread.latestTurn;
+    const threadCwd = thread.worktreePath ?? input.workspaceRoot;
+    if (
+      thread.id === input.activeThreadId ||
+      threadCwd !== input.cwd ||
+      latestTurn === null ||
+      latestTurn.completedAt === null
+    ) {
+      continue;
+    }
+
+    if (sameScope && completedTurnIdByThread.get(thread.id) !== latestTurn.turnId) {
+      shouldRefresh = true;
+    }
+    completedTurnIdByThread.set(thread.id, latestTurn.turnId);
+  }
+
+  return {
+    next: { scopeKey: input.scopeKey, completedTurnIdByThread },
+    shouldRefresh,
+  };
+}


### PR DESCRIPTION
## Problem

Working tree and branch diff previews only refreshed after the active thread completed a turn. When another T3 thread committed changes in the same checkout, an already-open diff panel could keep showing files that Git no longer considered changed.

## Fix

Track completed turns from sibling threads in the active project and refresh the Git diff once when a sibling sharing the same checkout settles. Completions from the active thread and separate worktrees are ignored, and changing checkouts establishes a fresh baseline instead of issuing a redundant request.

This remains event-driven and does not add Git polling.

## Validation

- `../../node_modules/.bin/vp test run src/lib/diffPanelRefresh.test.ts --project unit` (5 tests)
- `./node_modules/.bin/vp run --filter @t3tools/web typecheck`
- `./node_modules/.bin/vp lint --report-unused-disable-directives apps/web/src/components/DiffPanel.tsx apps/web/src/lib/diffPanelRefresh.ts apps/web/src/lib/diffPanelRefresh.test.ts`
- `./node_modules/.bin/vp fmt --check apps/web/src/components/DiffPanel.tsx apps/web/src/lib/diffPanelRefresh.ts apps/web/src/lib/diffPanelRefresh.test.ts`

Visual browser verification could not be captured because the collaborative preview snapshot backend failed even on a static route and the fallback in-app browser had no connected instance.

Built with GPT-5.6-Sol using the Codex harness in T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refresh `DiffPanel` branch diff preview when sibling threads complete turns
> - Adds `advanceGitDiffRefreshTracker` in [diffPanelRefresh.ts](https://github.com/pingdotgg/t3code/pull/7694/files#diff-23876fe58ef2abcca0c7a8e5322defd9ac6a5cf4c0401059e7b3477636749697), a pure utility that tracks last completed sibling turn IDs per scope and signals `shouldRefresh` when a sibling in the same checkout completes a new turn
> - Integrates the tracker into [DiffPanel.tsx](https://github.com/pingdotgg/t3code/pull/7694/files#diff-432b64436ab58eaa9098a7db8382164d4d30470236045f6b3844eef9f8a257f3) via `siblingTurnRefreshTrackerRef` and a `useEffect` that derives `activeProjectRef` and `activeProjectThreads`, then calls `refreshBranchDiffPreview` when the tracker signals a refresh
> - Ignores the active thread and threads from other worktrees; re-baselines the tracker when the active checkout scope changes
> - Adds tests in [diffPanelRefresh.test.ts](https://github.com/pingdotgg/t3code/pull/7694/files#diff-932453f85c3483dd350b82f2320765db450b9f377320b3a489bd206c6ad2423f) covering baseline, sibling completion, running siblings, cross-worktree filtering, and scope-change re-baselining
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 88e9c23.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->