### PR TITLE
fix(desktop): restrict editor deep links

### DIFF
--- a/apps/desktop/src/electron/ElectronShell.test.ts
+++ b/apps/desktop/src/electron/ElectronShell.test.ts
@@ -52,6 +52,25 @@ describe("ElectronShell", () => {
     }).pipe(Effect.provide(ElectronShell.layer)),
   );
 
+  it.effect("does not open remote editor URLs with userinfo", () =>
+    Effect.gen(function* () {
+      openExternalMock.mockResolvedValue(undefined);
+
+      const electronShell = yield* ElectronShell.ElectronShell;
+      const results = yield* Effect.all([
+        electronShell.openExternal(
+          "vscode://user@vscode-remote/ssh-remote+example.com/home/user/project",
+        ),
+        electronShell.openExternal(
+          "vscode://:secret@vscode-remote/ssh-remote+example.com/home/user/project",
+        ),
+      ]);
+
+      assert.deepEqual(results, [false, false]);
+      assert.equal(openExternalMock.mock.calls.length, 0);
+    }).pipe(Effect.provide(ElectronShell.layer)),
+  );
+
   it.effect("does not open unsafe external URLs", () =>
     Effect.gen(function* () {
       const electronShell = yield* ElectronShell.ElectronShell;

--- a/apps/desktop/src/electron/ElectronShell.test.ts
+++ b/apps/desktop/src/electron/ElectronShell.test.ts
@@ -36,10 +36,40 @@ describe("ElectronShell", () => {
     }).pipe(Effect.provide(ElectronShell.layer)),
   );
 
+  it.effect("opens remote SSH editor URLs", () =>
+    Effect.gen(function* () {
+      openExternalMock.mockResolvedValue(undefined);
+
+      const electronShell = yield* ElectronShell.ElectronShell;
+      const result = yield* electronShell.openExternal(
+        "vscode://vscode-remote/ssh-remote+example.com/home/user/project",
+      );
+
+      assert.equal(result, true);
+      assert.deepEqual(openExternalMock.mock.calls, [
+        ["vscode://vscode-remote/ssh-remote+example.com/home/user/project"],
+      ]);
+    }).pipe(Effect.provide(ElectronShell.layer)),
+  );
+
   it.effect("does not open unsafe external URLs", () =>
     Effect.gen(function* () {
       const electronShell = yield* ElectronShell.ElectronShell;
       const result = yield* electronShell.openExternal("file:///etc/passwd");
+
+      assert.equal(result, false);
+      assert.equal(openExternalMock.mock.calls.length, 0);
+    }).pipe(Effect.provide(ElectronShell.layer)),
+  );
+
+  it.effect("does not open non-remote editor URLs", () =>
+    Effect.gen(function* () {
+      openExternalMock.mockResolvedValue(undefined);
+
+      const electronShell = yield* ElectronShell.ElectronShell;
+      const result = yield* electronShell.openExternal(
+        "vscode://ms-python.python/some-command?argument=attacker",
+      );
 
       assert.equal(result, false);
       assert.equal(openExternalMock.mock.calls.length, 0);

--- a/apps/desktop/src/electron/ElectronShell.ts
+++ b/apps/desktop/src/electron/ElectronShell.ts
@@ -6,16 +6,19 @@ import * as Option from "effect/Option";
 
 import * as Electron from "electron";
 
-// Remote open-in-editor deep links (`vscode://vscode-remote/ssh-remote+…`)
-// must reach the OS handler; every other non-web scheme stays blocked.
-const SAFE_EXTERNAL_PROTOCOLS = new Set([
-  "http:",
-  "https:",
-  ...REMOTE_CAPABLE_EDITOR_IDS.flatMap((id) => {
+const SAFE_WEB_PROTOCOLS = new Set(["http:", "https:"]);
+const REMOTE_EDITOR_PROTOCOLS = new Set(
+  REMOTE_CAPABLE_EDITOR_IDS.flatMap((id) => {
     const scheme = remoteSchemeForEditor(id);
     return scheme === undefined ? [] : [`${scheme}:`];
   }),
-]);
+);
+
+const isRemoteEditorUrl = (url: URL): boolean =>
+  REMOTE_EDITOR_PROTOCOLS.has(url.protocol) &&
+  url.host === "vscode-remote" &&
+  url.pathname.startsWith("/ssh-remote+") &&
+  url.pathname.length > "/ssh-remote+".length;
 
 export function parseSafeExternalUrl(rawUrl: unknown): Option.Option<string> {
   if (typeof rawUrl !== "string") {
@@ -24,7 +27,9 @@ export function parseSafeExternalUrl(rawUrl: unknown): Option.Option<string> {
 
   try {
     const url = new URL(rawUrl);
-    return SAFE_EXTERNAL_PROTOCOLS.has(url.protocol) ? Option.some(url.href) : Option.none();
+    return SAFE_WEB_PROTOCOLS.has(url.protocol) || isRemoteEditorUrl(url)
+      ? Option.some(url.href)
+      : Option.none();
   } catch {
     return Option.none();
   }

--- a/apps/desktop/src/electron/ElectronShell.ts
+++ b/apps/desktop/src/electron/ElectronShell.ts
@@ -6,6 +6,8 @@ import * as Option from "effect/Option";
 
 import * as Electron from "electron";
 
+// Remote open-in-editor deep links (`vscode://vscode-remote/ssh-remote+…`)
+// must reach the OS handler; every other non-web scheme stays blocked.
 const SAFE_WEB_PROTOCOLS = new Set(["http:", "https:"]);
 const REMOTE_EDITOR_PROTOCOLS = new Set(
   REMOTE_CAPABLE_EDITOR_IDS.flatMap((id) => {
@@ -16,6 +18,8 @@ const REMOTE_EDITOR_PROTOCOLS = new Set(
 
 const isRemoteEditorUrl = (url: URL) =>
   REMOTE_EDITOR_PROTOCOLS.has(url.protocol) &&
+  url.username.length === 0 &&
+  url.password.length === 0 &&
   url.host === "vscode-remote" &&
   url.pathname.startsWith("/ssh-remote+") &&
   url.pathname.length > "/ssh-remote+".length;

--- a/apps/desktop/src/electron/ElectronShell.ts
+++ b/apps/desktop/src/electron/ElectronShell.ts
@@ -14,7 +14,7 @@ const REMOTE_EDITOR_PROTOCOLS = new Set(
   }),
 );
 
-const isRemoteEditorUrl = (url: URL): boolean =>
+const isRemoteEditorUrl = (url: URL) =>
   REMOTE_EDITOR_PROTOCOLS.has(url.protocol) &&
   url.host === "vscode-remote" &&
   url.pathname.startsWith("/ssh-remote+") &&


### PR DESCRIPTION
Editor URI schemes were accepted solely by protocol at the shared Electron external-open boundary. That allowed non-remote editor URLs to reach the operating system handler even though desktop only needs remote SSH workspace links.

Keep HTTP and HTTPS behavior unchanged, but require editor URLs to use the `vscode-remote` authority and an `ssh-remote+` target. Add focused coverage proving valid remote SSH links still open while non-remote editor links are rejected.

Tests:
- `vp test run apps/desktop/src/electron/ElectronShell.test.ts`
- targeted lint and format checks for the two changed files
- `vp run --filter @t3tools/desktop typecheck`

Generated with OpenAI GPT-5.6 Sol via the T3 Code Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens Electron `openExternal` URL allowlisting, a security-sensitive OS-handler boundary. The change is a restriction (not a new open path), but incorrect matching could still block valid remote opens or leak other editor URIs.
> 
> **Overview**
> Tightens `parseSafeExternalUrl` so editor schemes are not treated as generally safe. HTTP/HTTPS stay allowed; editor URLs must be remote SSH deep links (`host` `vscode-remote`, path starting with `/ssh-remote+`, no username/password).
> 
> Non-remote editor URIs (e.g. extension commands) and remote URLs with userinfo are now rejected before `shell.openExternal`. Tests cover the allowed SSH form and those two rejection cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ed1a7815133d18266b63f8865dd425ad032404f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restrict editor deep links to vscode-remote SSH URLs in `ElectronShell.parseSafeExternalUrl`
> - Splits the prior combined protocol allowlist into `SAFE_WEB_PROTOCOLS` (http/https) and `REMOTE_EDITOR_PROTOCOLS` (derived from remote-capable editor IDs).
> - Adds `isRemoteEditorUrl` to validate editor deep links: protocol must be an editor scheme, no username or password in the URL, host must be `vscode-remote`, and pathname must start with `/ssh-remote+` with additional content.
> - `parseSafeExternalUrl` now only accepts http/https URLs or editor links that pass `isRemoteEditorUrl`; other custom-scheme editor links are rejected.
> - Risk: editor deep links that previously relied on protocol-only matching (e.g., extension command invocations or non-SSH remote schemes) are now blocked by `ElectronShell.parseSafeExternalUrl`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ed1a78.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remote SSH development links now open successfully.
  * Non-remote editor links and unsupported URL types remain blocked for improved security.
* **Tests**
  * Added coverage for accepted remote SSH links and rejected non-remote editor links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->