### PR TITLE
feat(swift-ios): attach images dragged onto the composer

### DIFF
--- a/apps/swift-ios/Features/Chat/FeatureComposerImageDrop.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerImageDrop.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// How many of an incoming batch of images the composer can take, separated
+/// from the SwiftUI plumbing so the cap and the overflow accounting can be
+/// tested without a live drag session or pasteboard.
+///
+/// Paste and drop are two doors into the same room: both produce item
+/// providers, both land in the attachment strip, and both must respect the
+/// attachment cap while earlier images are still being prepared.
+struct FeatureComposerImageIntakePlan: Equatable {
+    let acceptedCount: Int
+    let firstOrdinal: Int
+    let droppedCount: Int
+
+    /// Returns nil when nothing can be accepted, either because the batch is
+    /// empty or the cap is already spent by attached and in-flight images.
+    static func forProviders(
+        providerCount: Int,
+        attachmentCount: Int,
+        pendingCount: Int,
+        maximumCount: Int = FeatureImageAttachmentLimits.maximumCount
+    ) -> FeatureComposerImageIntakePlan? {
+        guard providerCount > 0 else { return nil }
+        let remaining = max(0, maximumCount - attachmentCount - pendingCount)
+        let accepted = min(providerCount, remaining)
+        guard accepted > 0 else { return nil }
+
+        return FeatureComposerImageIntakePlan(
+            acceptedCount: accepted,
+            firstOrdinal: attachmentCount + pendingCount + 1,
+            droppedCount: providerCount - accepted
+        )
+    }
+}
+
+/// Accepts images dragged onto the composer from another app.
+///
+/// Registering only `.image` lets the drag session itself reject anything
+/// else, so a dropped PDF never lands and there is no failure to explain
+/// afterwards.
+struct FeatureComposerImageDrop: ViewModifier {
+    let isEnabled: Bool
+    let shape: RoundedRectangle
+    let onDropImages: ([NSItemProvider]) -> Bool
+
+    @State private var isTargeted = false
+
+    func body(content: Content) -> some View {
+        content
+            .overlay {
+                if isTargeted {
+                    shape
+                        .fill(T3Colors.accent.opacity(0.1))
+                        .overlay {
+                            shape.strokeBorder(T3Colors.accent, lineWidth: 2)
+                        }
+                        .allowsHitTesting(false)
+                        .accessibilityHidden(true)
+                }
+            }
+            .animation(.easeOut(duration: 0.12), value: isTargeted)
+            .onDrop(
+                of: [.image],
+                delegate: FeatureComposerImageDropDelegate(
+                    isEnabled: isEnabled,
+                    isTargeted: $isTargeted,
+                    onDropImages: onDropImages
+                )
+            )
+    }
+}
+
+/// Tracks targeting through explicit enter and exit callbacks so the highlight
+/// cannot outlive the session, and states the drop operation outright.
+private struct FeatureComposerImageDropDelegate: DropDelegate {
+    let isEnabled: Bool
+    @Binding var isTargeted: Bool
+    let onDropImages: ([NSItemProvider]) -> Bool
+
+    func validateDrop(info: DropInfo) -> Bool {
+        isEnabled && info.hasItemsConforming(to: [.image])
+    }
+
+    func dropEntered(info: DropInfo) {
+        isTargeted = true
+    }
+
+    // A system-sourced drag (the screenshot thumbnail, Photos) is refused
+    // under SwiftUI's default proposal and the session dies mid-air with the
+    // highlight still lit. Asking for a copy explicitly is what lets it land.
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        DropProposal(operation: .copy)
+    }
+
+    func dropExited(info: DropInfo) {
+        isTargeted = false
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        isTargeted = false
+        return onDropImages(info.itemProviders(for: [.image]))
+    }
+}

--- a/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
@@ -266,6 +266,19 @@ final class FeatureComposerUITextView: UITextView {
         return super.canPerformAction(action, withSender: sender)
     }
 
+    // Drops are the other client of the paste configuration: while editing,
+    // UIKit offers the text view any drag it says it can paste. Declining
+    // image drags leaves them to the composer surface, so one target owns
+    // the session and the highlight; when the text view wins instead, the
+    // image vanishes into UITextView's text-only default and the surface's
+    // highlight never hears that the session ended.
+    override func canPaste(_ itemProviders: [NSItemProvider]) -> Bool {
+        let holdsImage = itemProviders.contains {
+            $0.hasItemConformingToTypeIdentifier(UTType.image.identifier)
+        }
+        return holdsImage ? false : super.canPaste(itemProviders)
+    }
+
     // When the pasteboard holds images, only the images attach. Any text
     // riding along (a copied web image usually brings its URL) is dropped on
     // purpose: Slack and X do the same, and inserting a stray URL next to an

--- a/apps/swift-ios/Features/Chat/FeatureComposerView.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerView.swift
@@ -9,7 +9,7 @@ struct FeatureComposerView: View {
     @State private var isPathSearchLoading = false
     @State private var pathSearchError: String?
     @State private var textSelectionRequest: FeatureComposerTextSelectionRequest?
-    @State private var pasteErrorMessage: String?
+    @State private var imageIntakeErrorMessage: String?
     @Binding private var text: String
     @Binding private var selection: FeatureSelection?
     @Binding private var attachments: [FeatureDraftAttachment]
@@ -125,15 +125,15 @@ struct FeatureComposerView: View {
                 await updatePathSearch()
             }
             .alert(
-                "Couldn’t paste image",
+                "Couldn’t add image",
                 isPresented: Binding(
-                    get: { pasteErrorMessage != nil },
-                    set: { if !$0 { pasteErrorMessage = nil } }
+                    get: { imageIntakeErrorMessage != nil },
+                    set: { if !$0 { imageIntakeErrorMessage = nil } }
                 )
             ) {
-                Button("OK") { pasteErrorMessage = nil }
+                Button("OK") { imageIntakeErrorMessage = nil }
             } message: {
-                Text(pasteErrorMessage ?? "")
+                Text(imageIntakeErrorMessage ?? "")
             }
     }
 
@@ -170,6 +170,13 @@ struct FeatureComposerView: View {
                 .stroke(T3Colors.inputBorder, lineWidth: 1)
         }
         .clipShape(composerShape)
+        .modifier(
+            FeatureComposerImageDrop(
+                isEnabled: imagesAllowed,
+                shape: composerShape,
+                onDropImages: attachDroppedImages
+            )
+        )
     }
 
     private var collapsedComposer: some View {
@@ -222,7 +229,7 @@ struct FeatureComposerView: View {
                     placeholder: placeholder,
                     acceptsImages: imagesAllowed,
                     selectionRequest: textSelectionRequest,
-                    onPasteImages: loadPastedImages,
+                    onPasteImages: attachImageProviders,
                     onDismissKeyboard: onDismissKeyboard
                 )
                 .padding(.horizontal, 16)
@@ -488,44 +495,58 @@ struct FeatureComposerView: View {
         }
     }
 
-    /// Attaches images arriving from the text view's paste menu through the
-    /// same preparation pipeline the attachment picker uses, so sending stays
-    /// blocked until every pasted image is processed.
-    private func loadPastedImages(_ providers: [NSItemProvider]) {
+    /// Attaches images arriving from the text view's paste menu or a drag
+    /// from another app through the same preparation pipeline the attachment
+    /// picker uses, so sending stays blocked until every image is processed.
+    private func attachImageProviders(_ providers: [NSItemProvider]) {
         guard imagesAllowed, !providers.isEmpty else { return }
 
-        let remaining = FeatureImageAttachmentLimits.maximumCount
-            - attachments.count
-            - attachmentPreparation.pendingItemCount
-        guard remaining > 0 else {
-            pasteErrorMessage = "You can attach up to eight images."
+        guard let plan = FeatureComposerImageIntakePlan.forProviders(
+            providerCount: providers.count,
+            attachmentCount: attachments.count,
+            pendingCount: attachmentPreparation.pendingItemCount
+        ) else {
+            imageIntakeErrorMessage = "You can attach up to eight images."
             return
         }
-        if providers.count > remaining {
-            pasteErrorMessage =
+        if plan.droppedCount > 0 {
+            imageIntakeErrorMessage =
                 "Some images were not attached because the eight-image limit was reached."
         }
 
-        let accepted = Array(providers.prefix(remaining))
-        let firstOrdinal = attachments.count + attachmentPreparation.pendingItemCount + 1
+        let accepted = Array(providers.prefix(plan.acceptedCount))
+        // Begin every provider request while the paste or drop callback still
+        // owns access to its item providers. Image processing can finish
+        // asynchronously after the callback returns.
+        let loads = accepted.map { provider in
+            Result { try FeatureImageItemProviderLoader.start(from: provider) }
+        }
         let operation = attachmentPreparation.begin(itemCount: accepted.count)
         Task { @MainActor in
             defer { attachmentPreparation.finish(operation) }
-            for (offset, provider) in accepted.enumerated() {
+            for (offset, load) in loads.enumerated() {
                 do {
-                    let data = try await FeatureImageItemProviderLoader.data(from: provider)
+                    let data = try await load.get().data()
                     let attachment = try await Task.detached(priority: .userInitiated) {
                         try FeatureImageProcessor.attachment(
                             from: data,
-                            ordinal: firstOrdinal + offset
+                            ordinal: plan.firstOrdinal + offset
                         )
                     }.value
                     attachments.append(attachment)
                 } catch {
-                    pasteErrorMessage = error.localizedDescription
+                    imageIntakeErrorMessage = error.localizedDescription
                 }
             }
         }
+    }
+
+    /// A drop is refused outright when images are not accepted, so the drag
+    /// session shows the system's "not allowed" badge instead of a dead drop.
+    private func attachDroppedImages(_ providers: [NSItemProvider]) -> Bool {
+        guard imagesAllowed, !providers.isEmpty else { return false }
+        attachImageProviders(providers)
+        return true
     }
 }
 

--- a/apps/swift-ios/Features/Chat/ImageAttachmentViews.swift
+++ b/apps/swift-ios/Features/Chat/ImageAttachmentViews.swift
@@ -306,25 +306,47 @@ private struct FeaturePhotoLibraryItem: @unchecked Sendable {
 /// providers arrive from main-actor UI callbacks and are not `Sendable`; the
 /// provider does its own work off-thread.
 enum FeatureImageItemProviderLoader {
+    struct Load {
+        fileprivate let values: AsyncThrowingStream<Data, Error>
+
+        @MainActor
+        func data() async throws -> Data {
+            for try await data in values {
+                return data
+            }
+            throw FeatureImageAttachmentError.encodingFailed
+        }
+    }
+
+    /// Starts the provider request before returning. Drop callers use this
+    /// form so access begins within `performDrop`, while the provider grant is
+    /// active.
     @MainActor
-    static func data(from provider: NSItemProvider) async throws -> Data {
+    static func start(from provider: NSItemProvider) throws -> Load {
         guard let typeIdentifier = provider.registeredTypeIdentifiers.first(where: { identifier in
             UTType(identifier)?.conforms(to: .image) == true
         }) else {
             throw FeatureImageAttachmentError.invalidImage
         }
 
-        return try await withCheckedThrowingContinuation { continuation in
+        let values = AsyncThrowingStream<Data, Error> { continuation in
             provider.loadDataRepresentation(forTypeIdentifier: typeIdentifier) { data, error in
                 if let data {
-                    continuation.resume(returning: data)
+                    continuation.yield(data)
+                    continuation.finish()
                 } else {
-                    continuation.resume(
+                    continuation.finish(
                         throwing: error ?? FeatureImageAttachmentError.encodingFailed
                     )
                 }
             }
         }
+        return Load(values: values)
+    }
+
+    @MainActor
+    static func data(from provider: NSItemProvider) async throws -> Data {
+        try await start(from: provider).data()
     }
 }
 

--- a/apps/swift-ios/Tests/FeatureTests/AttachmentPreparationTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/AttachmentPreparationTests.swift
@@ -17,6 +17,20 @@ struct AttachmentPreparationTests {
     }
 
     @Test
+    @MainActor
+    func providerLoadCanStartBeforeItsDataIsAwaited() async throws {
+        let expected = Data([0x01, 0x02, 0x03])
+        let provider = NSItemProvider(
+            item: expected as NSData,
+            typeIdentifier: UTType.jpeg.identifier
+        )
+
+        let load = try FeatureImageItemProviderLoader.start(from: provider)
+
+        #expect(try await load.data() == expected)
+    }
+
+    @Test
     func providerLoaderRejectsProvidersWithoutImageRepresentations() async {
         await #expect(throws: FeatureImageAttachmentError.self) {
             try await FeatureImageItemProviderLoader.data(from: NSItemProvider())

--- a/apps/swift-ios/Tests/FeatureTests/ComposerImageIntakeTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/ComposerImageIntakeTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+@testable import T3Code
+
+@Suite("Composer image intake")
+struct ComposerImageIntakeTests {
+    private static func plan(
+        providerCount: Int,
+        attachmentCount: Int = 0,
+        pendingCount: Int = 0
+    ) -> FeatureComposerImageIntakePlan? {
+        FeatureComposerImageIntakePlan.forProviders(
+            providerCount: providerCount,
+            attachmentCount: attachmentCount,
+            pendingCount: pendingCount
+        )
+    }
+
+    @Test
+    func emptyComposerAcceptsEveryIncomingImage() throws {
+        let plan = try #require(Self.plan(providerCount: 3))
+
+        #expect(plan.acceptedCount == 3)
+        #expect(plan.firstOrdinal == 1)
+        #expect(plan.droppedCount == 0)
+    }
+
+    @Test
+    func ordinalsContinueAfterExistingAndInFlightAttachments() throws {
+        let plan = try #require(
+            Self.plan(providerCount: 1, attachmentCount: 2, pendingCount: 1)
+        )
+
+        // Two attached plus one still preparing means this image is number four.
+        #expect(plan.firstOrdinal == 4)
+    }
+
+    @Test
+    func intakeIsRefusedOnceTheAttachmentCapIsReached() {
+        #expect(Self.plan(providerCount: 1, attachmentCount: 8) == nil)
+    }
+
+    @Test
+    func inFlightPreparationCountsAgainstTheCap() {
+        // Seven attached plus one preparing already fills the eight-image budget.
+        #expect(Self.plan(providerCount: 1, attachmentCount: 7, pendingCount: 1) == nil)
+    }
+
+    @Test
+    func overshootIsTruncatedAndCounted() throws {
+        let plan = try #require(Self.plan(providerCount: 5, attachmentCount: 6))
+
+        #expect(plan.acceptedCount == 2)
+        #expect(plan.droppedCount == 3)
+    }
+
+    @Test
+    func anEmptyBatchYieldsNoPlan() {
+        #expect(Self.plan(providerCount: 0) == nil)
+    }
+}

--- a/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureComposerPowerTests.swift
@@ -100,6 +100,27 @@ struct FeatureComposerPowerTests {
     }
 
     @Test
+    @MainActor
+    func textViewDeclinesImageDropsSoTheComposerSurfaceOwnsThem() {
+        let textView = FeatureComposerUITextView()
+        textView.acceptsImages = true
+
+        let image = NSItemProvider()
+        image.registerDataRepresentation(
+            forTypeIdentifier: UTType.png.identifier,
+            visibility: .all
+        ) { completion in
+            completion(Data([0x89, 0x50, 0x4E, 0x47]), nil)
+            return nil
+        }
+        let text = NSItemProvider(object: "caption" as NSString)
+
+        #expect(!textView.canPaste([image]))
+        #expect(!textView.canPaste([text, image]))
+        #expect(textView.canPaste([text]))
+    }
+
+    @Test
     func downwardDragDismissalRespectsDraftScrolling() {
         #expect(FeatureComposerDragDismissPolicy.shouldDismiss(
             translationX: 2, translationY: 20, isScrollable: false, isAtTop: true

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -4,6 +4,6 @@ Messages can contain up to 120,000 characters. If a draft is longer, T3 Code kee
 composer and shows how many characters need to be removed. Shorten the draft or split it into
 multiple messages, then send again in the same thread.
 
-On SwiftUI mobile, paste an image from the message field's edit menu to attach it. You can
-attach up to eight images to one message. The composer grows to 12 lines, then scrolls within
-the message field.
+On SwiftUI mobile, paste an image from the message field's edit menu or drag an image onto the
+composer to attach it. You can attach up to eight images to one message. The composer grows to
+12 lines, then scrolls within the message field.


### PR DESCRIPTION
> [!NOTE]
> Stacked on #7607. GitHub cannot base a fork PR on another fork branch, so this diff includes #7607's commits until it merges, then collapses to the three commits from 68e62e3ee to eecebf4d2. Review those only.

## Problem

The composer takes images from the photo picker and, with #7607, from the paste menu. Dragging an image from another app onto it does nothing.

## Solution

Dropped images attach through the same intake path as paste. The design follows @saphid's #5610: the drop target registers only `.image`, so the drag session refuses non-images and a rejected PDF never needs an error dialog. An accent highlight marks the composer while a valid drop is over it. Two device-found details keep the session honest. The drop goes through an explicit `DropDelegate` that proposes a copy, since a system-sourced drag (the screenshot thumbnail, Photos) is refused under SwiftUI's default proposal. And the text view declines image drags in `canPaste`: while editing, UIKit offers it any drag its paste configuration (from #7607) says it can paste, and when it won the release it discarded the image through its text-only default while the surface's highlight stayed lit. Text drags and the image paste menu are unchanged.

The cap and ordinal math paste carried inline moved into `FeatureComposerImageIntakePlan`, now shared by paste and drop. Paste behavior is unchanged: eight-image cap, overflow message, and send stays blocked until preparation finishes. When the selected model does not accept images the drop is refused, so the drag shows the system's "not allowed" badge.

## Verification

- Full Swift test suite on the iPhone 17 Pro simulator: 402 passed, 0 failed, 1 skipped.
- On an iPhone 14 Pro with the keyboard up: three screenshots dragged from their thumbnails onto the text area land in the attachment strip one after another, highlight clearing each time.
- New `ComposerImageIntakeTests` cover the cap, in-flight accounting, ordinal continuation, and overshoot truncation.

## UI changes

<!-- 1-before-drop.jpg, 2-two-drops-attached.jpg, 3-three-drops-attached.jpg -->

Built with Claude Fable 5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches image attachment intake and UIKit drop/paste ownership, which can drop or mis-handle files if the session or cap accounting is wrong. No auth or backend changes.
> 
> **Overview**
> Users can drag images from another app onto the iOS composer; they attach through the same pipeline as paste (eight-image cap, overflow alert, send blocked until preparation finishes).
> 
> The drop target accepts only `.image` and shows an accent highlight while targeted. It proposes a **copy** so system drags (screenshot thumbnails, Photos) actually land. The text view **declines image drops** so UIKit does not swallow them as text-only paste while the highlight stays lit.
> 
> Cap and ordinal math now live in `FeatureComposerImageIntakePlan`. Provider loads **start inside the drop/paste callback** so access remains valid after the session ends. Drops are refused when the model does not accept images.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21c16cec1abd446dbbd2eb27d220ac014b5265f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add image drag-and-drop support to the iOS composer
> - Introduces `FeatureComposerImageDrop` view modifier and `FeatureComposerImageDropDelegate` to highlight the composer surface during a valid image drag and forward dropped image `NSItemProviders` to the attach handler
> - Adds `FeatureComposerImageIntakePlan` to compute how many incoming providers fit under the eight-image cap (including in-flight items) and what ordinal to start at, returning `nil` when capacity is exhausted
> - Refactors `FeatureImageItemProviderLoader` so loads can start inside the drop/paste callback via `start(from:)` and be awaited later, sharing one intake path for both paste and drop
> - Overrides `FeatureComposerUITextView.canPaste(_:)` to decline image items so the composer surface owns the drag session and its highlight; non-image pastes still pass through
> - Updates user docs in [composer.md](https://github.com/pingdotgg/t3code/pull/7701/files#diff-6c496fed927e1ba2296273bdfca78fd482921ebd76a32bb9d0c534f7bda35b63) to mention drag-to-attach alongside the existing paste flow
> - Risk: `canPaste` override in `FeatureComposerUITextView` returns `false` whenever any `NSItemProvider` conforms to `UTType.image`; mixed image+text drops will not paste text into the text view
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 21c16ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->


