### PR TITLE
fix(server): name the process holding the port instead of a raw ServeError

### DIFF
--- a/apps/server/src/portInUse.test.ts
+++ b/apps/server/src/portInUse.test.ts
@@ -1,0 +1,150 @@
+// @effect-diagnostics nodeBuiltinImport:off - the bind failure is only real against an occupied TCP port.
+import * as NodeHttp from "node:http";
+import * as NodeNet from "node:net";
+
+import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { ServeError } from "effect/unstable/http/HttpServerError";
+
+import * as ServerConfig from "./config.ts";
+import { explainPortInUse } from "./portInUse.ts";
+import { persistServerRuntimeState } from "./serverRuntimeState.ts";
+
+const TestLayer = ServerConfig.layerTest(process.cwd(), { prefix: "t3-port-in-use-" }).pipe(
+  Layer.provideMerge(NodeServices.layer),
+);
+
+/** Holds a loopback port for the duration of the test scope. */
+const occupyLoopbackPort = Effect.acquireRelease(
+  Effect.callback<NodeNet.Server>((resume) => {
+    const server = NodeNet.createServer();
+    server.listen(0, "127.0.0.1", () => {
+      resume(Effect.succeed(server));
+    });
+  }),
+  (server) =>
+    Effect.callback<void>((resume) => {
+      server.close(() => {
+        resume(Effect.void);
+      });
+    }),
+).pipe(Effect.map((server) => (server.address() as NodeNet.AddressInfo).port));
+
+const bindHttpServer = (port: number) =>
+  Layer.launch(NodeHttpServer.layer(() => NodeHttp.createServer(), { host: "127.0.0.1", port }));
+
+const configForPort = (port: number) =>
+  Effect.map(ServerConfig.ServerConfig, (config) => ServerConfig.make({ ...config, port }));
+
+it.effect("names the T3 server holding the port when server-runtime.json agrees", () =>
+  Effect.gen(function* () {
+    const port = yield* occupyLoopbackPort;
+    const config = yield* configForPort(port);
+    yield* persistServerRuntimeState({
+      path: config.serverRuntimeStatePath,
+      state: {
+        version: 1,
+        pid: 424242,
+        port,
+        origin: `http://127.0.0.1:${port}`,
+        startedAt: "2026-08-20T13:29:55.900Z",
+      },
+    });
+
+    const error = yield* explainPortInUse(bindHttpServer(port)).pipe(
+      Effect.provideService(ServerConfig.ServerConfig, config),
+      Effect.flip,
+    );
+
+    if (error._tag !== "PortInUseError") {
+      return assert.fail(`Expected PortInUseError, got ${error._tag}`);
+    }
+    assert.strictEqual(error.holderPid, 424242);
+    assert.strictEqual(
+      error.message,
+      `Port ${port} on 127.0.0.1 is already in use by a running T3 Code server (pid 424242 per server-runtime.json). Stop that server first; 't3 service status' finds it when it is the background service. If that pid is not actually a T3 server (stale descriptor, reused pid), delete '${config.serverRuntimeStatePath}' and retry.`,
+    );
+  }).pipe(Effect.scoped, Effect.provide(TestLayer)),
+);
+
+it.effect("names only the port when no server-runtime.json exists", () =>
+  Effect.gen(function* () {
+    const port = yield* occupyLoopbackPort;
+    const config = yield* configForPort(port);
+
+    const error = yield* explainPortInUse(bindHttpServer(port)).pipe(
+      Effect.provideService(ServerConfig.ServerConfig, config),
+      Effect.flip,
+    );
+
+    assert.strictEqual(error._tag, "PortInUseError");
+    assert.strictEqual(
+      error.message,
+      `Port ${port} on 127.0.0.1 is already in use. Stop whatever is listening there, or start T3 Code on another port with --port; 't3 service status' says whether the T3 Code background service is holding it.`,
+    );
+  }).pipe(Effect.scoped, Effect.provide(TestLayer)),
+);
+
+it.effect("claims no culprit when server-runtime.json describes another port", () =>
+  Effect.gen(function* () {
+    const port = yield* occupyLoopbackPort;
+    const config = yield* configForPort(port);
+    yield* persistServerRuntimeState({
+      path: config.serverRuntimeStatePath,
+      state: {
+        version: 1,
+        pid: 424242,
+        port: port + 1,
+        origin: `http://127.0.0.1:${port + 1}`,
+        startedAt: "2026-08-20T13:29:55.900Z",
+      },
+    });
+
+    const error = yield* explainPortInUse(bindHttpServer(port)).pipe(
+      Effect.provideService(ServerConfig.ServerConfig, config),
+      Effect.flip,
+    );
+
+    assert.strictEqual(error._tag, "PortInUseError");
+    assert.notInclude(error.message, "424242");
+    assert.include(error.message, `Port ${port} on 127.0.0.1 is already in use.`);
+  }).pipe(Effect.scoped, Effect.provide(TestLayer)),
+);
+
+it.effect("explains the EADDRINUSE defect Bun throws instead of failing", () =>
+  Effect.gen(function* () {
+    const config = yield* configForPort(3773);
+    const defect = Object.assign(new Error("Failed to start server. Is port 3773 in use?"), {
+      code: "EADDRINUSE",
+    });
+
+    const error = yield* explainPortInUse(Effect.die(defect)).pipe(
+      Effect.provideService(ServerConfig.ServerConfig, config),
+      Effect.flip,
+    );
+
+    assert.strictEqual(error._tag, "PortInUseError");
+    assert.include(error.message, "Port 3773 on 127.0.0.1 is already in use.");
+  }).pipe(Effect.scoped, Effect.provide(TestLayer)),
+);
+
+it.effect("leaves other bind failures alone", () =>
+  Effect.gen(function* () {
+    const config = yield* configForPort(80);
+    const serveError = new ServeError({
+      cause: Object.assign(new Error("listen EACCES: permission denied 0.0.0.0:80"), {
+        code: "EACCES",
+      }),
+    });
+
+    const error = yield* explainPortInUse(Effect.fail(serveError)).pipe(
+      Effect.provideService(ServerConfig.ServerConfig, config),
+      Effect.flip,
+    );
+
+    assert.strictEqual(error, serveError);
+  }).pipe(Effect.scoped, Effect.provide(TestLayer)),
+);

--- a/apps/server/src/portInUse.ts
+++ b/apps/server/src/portInUse.ts
@@ -1,0 +1,79 @@
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Predicate from "effect/Predicate";
+import * as Schema from "effect/Schema";
+
+import * as ServerConfig from "./config.ts";
+import { readPersistedServerRuntimeState } from "./serverRuntimeState.ts";
+
+/**
+ * Raised instead of the platform's `ServeError` when the HTTP server cannot
+ * bind. `holderPid` is only set when server-runtime.json names the same port,
+ * which is as close to proof of a culprit as we get: the descriptor can be
+ * stale or carry a reused pid, so the message says how to check.
+ */
+export class PortInUseError extends Schema.TaggedErrorClass<PortInUseError>()("PortInUseError", {
+  host: Schema.String,
+  port: Schema.Int,
+  holderPid: Schema.optional(Schema.Int),
+  serverRuntimeStatePath: Schema.String,
+  cause: Schema.Defect(),
+}) {
+  override get message(): string {
+    const address = `Port ${this.port} on ${this.host} is already in use`;
+    if (this.holderPid === undefined) {
+      return `${address}. Stop whatever is listening there, or start T3 Code on another port with --port; 't3 service status' says whether the T3 Code background service is holding it.`;
+    }
+    return `${address} by a running T3 Code server (pid ${this.holderPid} per server-runtime.json). Stop that server first; 't3 service status' finds it when it is the background service. If that pid is not actually a T3 server (stale descriptor, reused pid), delete '${this.serverRuntimeStatePath}' and retry.`;
+  }
+}
+
+/**
+ * The bind failure reaches us wrapped: `@effect/platform-node` puts the errno
+ * error inside a `ServeError`, Bun throws it as a defect. Both keep the
+ * original under `cause`, so walk that chain. The depth cap is there because
+ * nothing forbids a cyclic `cause`.
+ */
+const isAddressInUse = (value: unknown): boolean => {
+  let current: unknown = value;
+  for (let depth = 0; depth < 4 && Predicate.isObject(current); depth++) {
+    if (Predicate.hasProperty(current, "code") && current.code === "EADDRINUSE") {
+      return true;
+    }
+    current = Predicate.hasProperty(current, "cause") ? current.cause : undefined;
+  }
+  return false;
+};
+
+const reportsAddressInUse = <E>(cause: Cause.Cause<E>): boolean =>
+  cause.reasons.some((reason) =>
+    Cause.isFailReason(reason)
+      ? isAddressInUse(reason.error)
+      : Cause.isDieReason(reason) && isAddressInUse(reason.defect),
+  );
+
+/**
+ * Replaces an EADDRINUSE bind failure with a message that names the port and,
+ * when server-runtime.json corroborates it, the process holding it. Every
+ * other failure passes through untouched.
+ */
+export const explainPortInUse = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+  Effect.catchCauseIf(effect, reportsAddressInUse, (cause) =>
+    Effect.gen(function* () {
+      const config = yield* ServerConfig.ServerConfig;
+      const persisted = yield* readPersistedServerRuntimeState(config.serverRuntimeStatePath);
+      const holderPid =
+        Option.isSome(persisted) && persisted.value.port === config.port
+          ? persisted.value.pid
+          : undefined;
+
+      return yield* new PortInUseError({
+        host: config.host ?? "127.0.0.1",
+        port: config.port,
+        ...(holderPid === undefined ? {} : { holderPid }),
+        serverRuntimeStatePath: config.serverRuntimeStatePath,
+        cause: Cause.squash(cause),
+      });
+    }),
+  );

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -20,6 +20,7 @@ import {
 } from "./http.ts";
 import { guardHttpResponseWriteErrors } from "./httpResponseErrorGuard.ts";
 import { fixPath } from "./os-jank.ts";
+import { explainPortInUse } from "./portInUse.ts";
 import { websocketRpcRouteLayer } from "./ws.ts";
 import * as ExternalLauncher from "./process/externalLauncher.ts";
 import { pullRequestHttpApiLayer } from "./pullRequest/http.ts";
@@ -685,5 +686,8 @@ export const makeServerLayer = Layer.unwrap(
   }),
 );
 
-// The CLI supplies configuration.
-export const runServer = Layer.launch(makeServerLayer);
+// The CLI supplies configuration. The bind happens while `HttpServerLive`
+// builds, so `Layer.launch` is the first point where that failure is an
+// ordinary Effect error again; catching on the layer itself would erase its
+// `HttpServer` output type.
+export const runServer = Layer.launch(makeServerLayer).pipe(explainPortInUse);


### PR DESCRIPTION
## What Changed

A bind failure carrying `EADDRINUSE` now fails as `PortInUseError`, which names
the port and, when `server-runtime.json` corroborates it, the process holding it.
Every other bind failure passes through untouched, and the original `ServeError`
and errno error stay attached as `cause`, so nothing is lost for debugging.

Corroborated:

    Port 3773 on 127.0.0.1 is already in use by a running T3 Code server (pid
    1080 per server-runtime.json). Stop that server first; 't3 service status'
    finds it when it is the background service. If that pid is not actually a T3
    server (stale descriptor, reused pid), delete '<path>' and retry.

When the state file is missing or names a different port, no culprit is invented:

    Port 3773 on 127.0.0.1 is already in use. Stop whatever is listening there,
    or start T3 Code on another port with --port; 't3 service status' says
    whether the T3 Code background service is holding it.

`holderPid` is set only when the persisted state parses and its port matches the
one being bound. That is the same shape — and the same hedge about stale
descriptors and reused pids — that `migrate-dev-db.ts` already uses for a
database held open by a running server.

`explainPortInUse` wraps `runServer` rather than `HttpServerLive`. Wrapping the
layer is the more precise spot, but `Layer.catchCause` types the recovery as
`Layer<ROut & ROut2>` and a failing fallback layer has `ROut2 = never`, which
collapses the `HttpServer` output to `never`. `Layer.launch` is the first point
where the failure is an ordinary Effect error again, and `ServerConfig` is
already in its requirement channel, so no new requirement reaches `bin.ts`. The
predicate walks the `cause` chain for `code === "EADDRINUSE"` across both `Fail`
and `Die`, since `@effect/platform-node` fails the layer build with a `ServeError`
while `BunHttpServer` throws the errno error as a defect. Catching at `runServer`
is marginally broader than the bind alone; the only other server built during
startup is in the CLI auth flow, and the EADDRINUSE predicate keeps an unrelated
failure from being relabeled.

Tests: five cases in `portInUse.test.ts`, three of which build a real
`NodeHttpServer.layer` against a port held by a live `net.Server`, so the failure
under test is a genuine EADDRINUSE rather than a synthetic cause. They assert the
full corroborated message, the full degraded message, that a state file naming
another port does not produce a pid, that a Bun-shaped defect is still explained,
and that a `ServeError` wrapping `EACCES` comes through identical. Stubbing
`explainPortInUse` to identity fails four of the five. `server.test.ts` (124) and
`bin.test.ts` (17) pass, as do `apps/server` typecheck, lint and format. No
pre-existing failures on this path.

## Why

`ServeError` names nothing. A user running the background service in WSL, with
the desktop app launching its own backend into the same distro on the same port,
got only this — in a log file they had to know to look for:

    ERROR (#5): ServeError:
        at Server.onError (.../@effect/platform-node/dist/NodeHttpServer.js:74:26)
      [cause]: Error: listen EADDRINUSE: address already in use 0.0.0.0:3773

The server knows which port it was told to bind, and `server-runtime.json` is
already read by `t3 triage` and `t3 pair` to find a live server, so the answer to
"who has it" is one file read away at exactly the moment it matters.

The message names the service explicitly because that is the common way to end up
with a T3 Code server you forgot about, but it has to stay correct for a plain
`npx t3` on a busy port, which is why the degraded variant claims nothing it
cannot support.

Not addressed: the pid is not liveness-checked. `triage.ts` and
`migrate-dev-db.ts` both `process.kill(pid, 0)` before claiming a server runs, so
there is precedent, but a second heuristic with its own false positives did not
earn its place next to a message that already hedges. Separately,
`cli/config.ts:262-265` returns `DEFAULT_PORT` with no availability check in
`desktop` mode where `web` mode calls `findAvailablePort` — that is why the
reported user hit this on every relaunch, and it is a different fix.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes — N/A, server-only
- [ ] I included a video for animation/interaction changes — N/A, server-only

Changes by Claude Opus 5 running in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Error-path only: remaps EADDRINUSE after bind fails and does not change listen, auth, or persistence. Holder pid is not liveness-checked, which the message already hedges.
> 
> **Overview**
> When the HTTP server fails to bind with `EADDRINUSE`, startup now fails as `PortInUseError` instead of a raw `ServeError`. The message names the port and, if `server-runtime.json` lists the same port, the recorded pid—plus how to stop the background service or drop a stale descriptor. Other bind failures are unchanged.
> 
> `explainPortInUse` wraps `runServer` after `Layer.launch` so Node `ServeError` and Bun defects both get rewritten without collapsing the `HttpServer` layer type. Tests occupy a real loopback port and cover corroborated pid, missing/mismatched state, Bun-shaped defects, and non-EADDRINUSE errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d78054788d6b9ff4a6ca392fe7b49632f7a70db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace raw `ServeError` with `PortInUseError` naming the process holding the port
> - Introduces `PortInUseError` in [portInUse.ts](https://github.com/pingdotgg/t3code/pull/7703/files#diff-d2671c5deb13c82e40bc455ab5f494fadca6306e0c3d4d14b021a705f51ab595), carrying host, port, optional `holderPid`, and a human-readable message with remediation steps when a pid is known.
> - Adds `explainPortInUse`, an effect transformer that detects `EADDRINUSE` through up to three nested causes, reads `server-runtime.json`, and fails with `PortInUseError` including the persisted pid when the port matches.
> - Wraps `Layer.launch(makeServerLayer)` in [server.ts](https://github.com/pingdotgg/t3code/pull/7703/files#diff-a8f34e8f17024480f0ca046c8ea4a8af3b525fe68940b703ba496fa4aa4ddfbd) with `explainPortInUse` so server startup surfaces the holder pid instead of a raw platform error.
> - Behavioral Change: non-EADDRINUSE bind failures (e.g. `EACCES`) pass through unchanged; the pid is only included when `server-runtime.json` exists and refers to the same port.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5d78054.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->