### PR TITLE
fix(desktop): explain a backend that keeps dying instead of restarting in silence

### DIFF
--- a/apps/desktop/src/backend/DesktopBackendManager.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendManager.test.ts
@@ -123,6 +123,9 @@ interface MakeInstanceInput {
   readonly onPreflightFailed?: (
     failure: DesktopBackendManager.PreflightFailure,
   ) => Effect.Effect<boolean>;
+  readonly onCrashLoop?: (
+    failure: DesktopBackendManager.BackendCrashLoopFailure,
+  ) => Effect.Effect<boolean>;
   readonly config?: DesktopBackendManager.DesktopBackendStartConfig;
   readonly configResolve?: Effect.Effect<
     DesktopBackendManager.DesktopBackendStartConfig,
@@ -176,6 +179,7 @@ function makeTestInstance(input: MakeInstanceInput) {
     ...(input.onReady ? { onReady: () => input.onReady! } : {}),
     ...(input.onShutdown ? { onShutdown: () => input.onShutdown! } : {}),
     ...(input.onPreflightFailed ? { onPreflightFailed: input.onPreflightFailed } : {}),
+    ...(input.onCrashLoop ? { onCrashLoop: input.onCrashLoop } : {}),
   });
 
   return instance.pipe(Effect.provide(servicesLayer));
@@ -1172,6 +1176,234 @@ describe("DesktopBackendManager", () => {
         assert.equal(yield* Queue.size(starts), 0);
         yield* TestClock.adjust(Duration.millis(1));
         assert.equal(yield* Queue.take(starts), 3);
+      }).pipe(Effect.provide(TestClock.layer())),
+    ),
+  );
+
+  it.effect("stops and names the port conflict when the backend keeps dying before readiness", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const starts = yield* Queue.unbounded<number>();
+        const failures = yield* Queue.unbounded<string>();
+        const crashLoops = yield* Queue.unbounded<DesktopBackendManager.BackendCrashLoopFailure>();
+        let startCount = 0;
+
+        const spawnerLayer = Layer.succeed(
+          ChildProcessSpawner.ChildProcessSpawner,
+          ChildProcessSpawner.make(() =>
+            Effect.sync(() => {
+              startCount += 1;
+              return makeProcess({
+                stderr: Stream.make(
+                  new TextEncoder().encode(
+                    "[15:37:22.129] ERROR (#5): ServeError: listen EADDRINUSE: address already in use 0.0.0.0:3773\n",
+                  ),
+                ),
+                exitCode: Queue.offer(starts, startCount).pipe(
+                  Effect.as(ChildProcessSpawner.ExitCode(1)),
+                ),
+              });
+            }),
+          ),
+        );
+
+        const instance = yield* makeTestInstance({
+          spawnerLayer,
+          httpClientLayer: httpClientLayer(() => Effect.never),
+          backendOutputLog: {
+            persistFailure: ({ details }) => Queue.offer(failures, details).pipe(Effect.asVoid),
+          },
+          onCrashLoop: (failure) => Queue.offer(crashLoops, failure).pipe(Effect.as(false)),
+        });
+
+        yield* instance.start;
+        assert.equal(yield* Queue.take(starts), 1);
+        assert.equal(yield* Queue.take(failures), "pid=123 code=1");
+        assert.equal(yield* Queue.size(crashLoops), 0);
+
+        // Four backed-off restarts (500ms, 1s, 2s, 4s) reach the fifth crash.
+        for (const delayMs of [500, 1000, 2000, 4000]) {
+          yield* TestClock.adjust(Duration.millis(delayMs));
+          yield* Queue.take(starts);
+          yield* Queue.take(failures);
+        }
+
+        const failure = yield* Queue.take(crashLoops);
+        assert.equal(failure.attempts, 5);
+        assert.equal(
+          failure.reason,
+          'Port 3773 is already in use, so the backend could not start. Another program is listening on it, often a "t3" server started from a terminal or installed as a background service. Stop it, then start T3 Code again.',
+        );
+
+        const stopped = yield* instance.snapshot;
+        assert.isFalse(stopped.desiredRunning);
+        assert.isFalse(stopped.restartScheduled);
+
+        yield* TestClock.adjust(Duration.minutes(5));
+        assert.equal(startCount, 5);
+        assert.equal(yield* Queue.size(crashLoops), 0);
+
+        // The way back out: an explicit start gets a fresh allowance.
+        yield* instance.start;
+        assert.equal(yield* Queue.take(starts), 6);
+      }).pipe(Effect.provide(TestClock.layer())),
+    ),
+  );
+
+  it.effect("reports the exit reason and the child's last output for an unrecognized crash", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const failures = yield* Queue.unbounded<string>();
+        const crashLoops = yield* Queue.unbounded<DesktopBackendManager.BackendCrashLoopFailure>();
+
+        const spawnerLayer = Layer.succeed(
+          ChildProcessSpawner.ChildProcessSpawner,
+          ChildProcessSpawner.make(() =>
+            Effect.sync(() =>
+              makeProcess({
+                stdout: Stream.make(new TextEncoder().encode("loading bundle\n")),
+                stderr: Stream.make(
+                  new TextEncoder().encode("Error: Cannot find module 'better-sqlite3'\n"),
+                ),
+                exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(1)),
+              }),
+            ),
+          ),
+        );
+
+        const instance = yield* makeTestInstance({
+          spawnerLayer,
+          httpClientLayer: httpClientLayer(() => Effect.never),
+          backendOutputLog: {
+            persistFailure: ({ details }) => Queue.offer(failures, details).pipe(Effect.asVoid),
+          },
+          onCrashLoop: (failure) => Queue.offer(crashLoops, failure).pipe(Effect.as(false)),
+        });
+
+        yield* instance.start;
+        yield* Queue.take(failures);
+        for (const delayMs of [500, 1000, 2000, 4000]) {
+          yield* TestClock.adjust(Duration.millis(delayMs));
+          yield* Queue.take(failures);
+        }
+
+        const failure = yield* Queue.take(crashLoops);
+        assert.equal(
+          failure.reason,
+          "The backend exited 5 times in a row before it was ready (code=1).\n\nLast output:\nloading bundle\nError: Cannot find module 'better-sqlite3'",
+        );
+      }).pipe(Effect.provide(TestClock.layer())),
+    ),
+  );
+
+  it.effect("counts crashes when another listener on the port answers the readiness probe", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const starts = yield* Queue.unbounded<number>();
+        const readies = yield* Queue.unbounded<void>();
+        const exitGate = yield* Queue.unbounded<void>();
+        const failures = yield* Queue.unbounded<string>();
+        const crashLoops = yield* Queue.unbounded<DesktopBackendManager.BackendCrashLoopFailure>();
+
+        let startCount = 0;
+
+        const spawnerLayer = Layer.succeed(
+          ChildProcessSpawner.ChildProcessSpawner,
+          ChildProcessSpawner.make(() =>
+            Effect.gen(function* () {
+              startCount += 1;
+              yield* Queue.offer(starts, startCount);
+              return makeProcess({
+                stderr: Stream.make(
+                  new TextEncoder().encode(
+                    "ERROR: ServeError: listen EADDRINUSE: address already in use 0.0.0.0:3773\n",
+                  ),
+                ),
+                exitCode: Queue.take(exitGate).pipe(Effect.as(ChildProcessSpawner.ExitCode(1))),
+              });
+            }),
+          ),
+        );
+
+        // Default healthy client: the readiness probe is a plain GET against
+        // the port, so whatever already holds it answers 200 for us.
+        const instance = yield* makeTestInstance({
+          spawnerLayer,
+          backendOutputLog: {
+            persistFailure: ({ details }) => Queue.offer(failures, details).pipe(Effect.asVoid),
+          },
+          onReady: Queue.offer(readies, undefined).pipe(Effect.asVoid),
+          onCrashLoop: (failure) => Queue.offer(crashLoops, failure).pipe(Effect.as(false)),
+        });
+
+        yield* instance.start;
+
+        for (let attempt = 1; attempt <= 5; attempt += 1) {
+          assert.equal(yield* Queue.take(starts), attempt);
+          // The occupant answers before our child gets to die on the port.
+          yield* Queue.take(readies);
+          yield* Queue.offer(exitGate, undefined);
+          yield* Queue.take(failures);
+          if (attempt < 5) {
+            // The spoofed readiness resets restartAttempt, so every restart
+            // waits the initial delay rather than backing off.
+            yield* TestClock.adjust(Duration.millis(500));
+          }
+        }
+
+        const failure = yield* Queue.take(crashLoops);
+        assert.equal(failure.attempts, 5);
+        assert.include(failure.reason, "Port 3773 is already in use");
+      }).pipe(Effect.provide(TestClock.layer())),
+    ),
+  );
+
+  it.effect("keeps restarting a backend that crashed after it had been ready", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const starts = yield* Queue.unbounded<number>();
+        const readies = yield* Queue.unbounded<void>();
+        const exitGate = yield* Queue.unbounded<void>();
+        const failures = yield* Queue.unbounded<string>();
+        const crashLoops = yield* Queue.unbounded<DesktopBackendManager.BackendCrashLoopFailure>();
+        let startCount = 0;
+
+        const spawnerLayer = Layer.succeed(
+          ChildProcessSpawner.ChildProcessSpawner,
+          ChildProcessSpawner.make(() =>
+            Effect.gen(function* () {
+              startCount += 1;
+              yield* Queue.offer(starts, startCount);
+              return makeProcess({
+                exitCode: Queue.take(exitGate).pipe(Effect.as(ChildProcessSpawner.ExitCode(1))),
+              });
+            }),
+          ),
+        );
+
+        const instance = yield* makeTestInstance({
+          spawnerLayer,
+          backendOutputLog: {
+            persistFailure: ({ details }) => Queue.offer(failures, details).pipe(Effect.asVoid),
+          },
+          onReady: Queue.offer(readies, undefined).pipe(Effect.asVoid),
+          onCrashLoop: (failure) => Queue.offer(crashLoops, failure).pipe(Effect.as(false)),
+        });
+
+        yield* instance.start;
+
+        // Well past the crash cap: readiness resets the streak every cycle, so
+        // the self-healing restart loop stays in charge.
+        for (let attempt = 1; attempt <= 8; attempt += 1) {
+          assert.equal(yield* Queue.take(starts), attempt);
+          yield* Queue.take(readies);
+          yield* Queue.offer(exitGate, undefined);
+          yield* Queue.take(failures);
+          yield* TestClock.adjust(Duration.millis(500));
+        }
+
+        assert.equal(yield* Queue.size(crashLoops), 0);
+        assert.isTrue((yield* instance.snapshot).desiredRunning);
       }).pipe(Effect.provide(TestClock.layer())),
     ),
   );

--- a/apps/desktop/src/backend/DesktopBackendManager.ts
+++ b/apps/desktop/src/backend/DesktopBackendManager.ts
@@ -60,6 +60,23 @@ const MAX_RESTART_DELAY = Duration.seconds(10);
 // failures may instead provide their own larger retryLimit when they should
 // self-heal for a while but must not leave the app connecting forever.
 const MAX_PREFLIGHT_FAILURE_ATTEMPTS = 5;
+// A child that spawns and then exits before the readiness probe ever answers
+// is not healed by being spawned again. After this many consecutive such exits
+// the instance stops and reports what the child printed instead of restarting
+// in silence. Same allowance as the preflight cap, which with the backoff above
+// is roughly 7.5s of quiet retrying before the user hears about it: long enough
+// for a port that is about to be released, short enough that nobody stares at a
+// dead app for a minute.
+const MAX_CRASH_BEFORE_READY_ATTEMPTS = 5;
+// Child output kept in memory per run so a crash can be explained by more than
+// its exit code. Only the tail matters (whatever it printed on the way down),
+// and the bound keeps a chatty backend from growing the manager's heap.
+const CRASH_OUTPUT_TAIL_CHARS = 4096;
+// How much of that tail reaches the user. A wall of stack frames in a dialog is
+// worse than the last few lines.
+const CRASH_OUTPUT_REPORT_LINES = 3;
+const CRASH_OUTPUT_REPORT_CHARS = 500;
+const PORT_IN_USE_PATTERN = /EADDRINUSE|address already in use/i;
 const DEFAULT_BACKEND_READINESS_TIMEOUT = Duration.minutes(1);
 const DEFAULT_BACKEND_READINESS_INTERVAL = Duration.millis(100);
 const DEFAULT_BACKEND_READINESS_REQUEST_TIMEOUT = Duration.seconds(1);
@@ -110,6 +127,17 @@ export interface PreflightFailure {
   readonly reason: string;
   readonly fatal: boolean;
   readonly retryLimit?: number;
+}
+
+// A child that spawned fine and then died before ever answering the readiness
+// probe, MAX_CRASH_BEFORE_READY_ATTEMPTS times in a row. `reason` is written
+// for a person: it ends up in the primary's error dialog and in the WSL row of
+// Connections settings, so it names the port conflict when the child said
+// EADDRINUSE and otherwise carries the exit reason plus the tail of what the
+// child printed.
+export interface BackendCrashLoopFailure {
+  readonly reason: string;
+  readonly attempts: number;
 }
 
 interface BackendProcessExit {
@@ -294,6 +322,12 @@ export interface BackendInstanceSpec {
   // retries. Returns true when the callback changed configuration and the
   // manager should resolve once more; false stops the failed instance.
   readonly onPreflightFailed?: (failure: PreflightFailure) => Effect.Effect<boolean>;
+  // Fired once the child has crashed before readiness
+  // MAX_CRASH_BEFORE_READY_ATTEMPTS times in a row. Returns true when the
+  // callback fixed something and the manager should keep restarting; false —
+  // and the default when no callback is wired — stops the instance until
+  // someone calls start again.
+  readonly onCrashLoop?: (failure: BackendCrashLoopFailure) => Effect.Effect<boolean>;
 }
 
 interface ActiveBackendRun {
@@ -314,6 +348,9 @@ interface BackendManagerState {
   // Consecutive bounded/fatal preflight failures, reset on a clean or
   // unbounded-transient preflight. restartAttempt counts all restarts.
   readonly preflightFailureAttempt: number;
+  // Consecutive runs whose child exited without ever becoming ready, reset
+  // once a run reports ready.
+  readonly crashAttempt: number;
   readonly restartFiber: Option.Option<Fiber.Fiber<void, never>>;
   readonly nextRunId: number;
 }
@@ -325,6 +362,7 @@ const initialState: BackendManagerState = {
   active: Option.none(),
   restartAttempt: 0,
   preflightFailureAttempt: 0,
+  crashAttempt: 0,
   restartFiber: Option.none(),
   nextRunId: 1,
 };
@@ -341,6 +379,43 @@ const withActiveRun =
 
 const calculateRestartDelay = (attempt: number): Duration.Duration =>
   Duration.min(Duration.times(INITIAL_RESTART_DELAY, 2 ** attempt), MAX_RESTART_DELAY);
+
+// Chunks are decoded one at a time, so a multi-byte character split across a
+// chunk boundary degrades to a replacement character. That is fine for a
+// diagnostic tail and matches how the child log file decodes the same chunks.
+const crashOutputDecoder = new TextDecoder();
+
+const appendCrashOutputTail = (tail: string, chunk: Uint8Array): string => {
+  const next = tail + crashOutputDecoder.decode(chunk);
+  return next.length > CRASH_OUTPUT_TAIL_CHARS
+    ? next.slice(next.length - CRASH_OUTPUT_TAIL_CHARS)
+    : next;
+};
+
+const describeCrashLoop = (input: {
+  readonly attempts: number;
+  readonly port: number;
+  readonly exitReason: string;
+  readonly output: string;
+  readonly portInUse: boolean;
+}): string => {
+  if (input.portInUse) {
+    return `Port ${input.port} is already in use, so the backend could not start. Another program is listening on it, often a "t3" server started from a terminal or installed as a background service. Stop it, then start T3 Code again.`;
+  }
+
+  const printed = input.output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .slice(-CRASH_OUTPUT_REPORT_LINES)
+    .join("\n");
+  const tail =
+    printed.length > CRASH_OUTPUT_REPORT_CHARS
+      ? `…${printed.slice(printed.length - CRASH_OUTPUT_REPORT_CHARS)}`
+      : printed;
+  const detail = tail.length > 0 ? `\n\nLast output:\n${tail}` : "";
+  return `The backend exited ${input.attempts} times in a row before it was ready (${input.exitReason}).${detail}`;
+};
 
 const closeRun = (
   run: ActiveBackendRun,
@@ -721,15 +796,19 @@ export const makeBackendInstance = Effect.fn("makeBackendInstance")(function* (
           .exists(config.value.entryPath)
           .pipe(Effect.orElseSucceed(() => false));
 
-        const resetFatalPreflightCounter =
-          !current.desiredRunning && current.preflightFailureAttempt > 0;
+        // An explicit start on an instance that was not running — a first
+        // launch, or a retry after a failure cap stopped it — gets a fresh
+        // allowance on both failure counters. That is the way back from a
+        // surfaced crash loop.
+        const startedFresh = !current.desiredRunning;
         yield* cancelRestart;
         yield* Ref.update(state, (latest) => ({
           ...latest,
           desiredRunning: true,
           ready: false,
           config: Option.some(config.value),
-          preflightFailureAttempt: resetFatalPreflightCounter ? 0 : latest.preflightFailureAttempt,
+          preflightFailureAttempt: startedFresh ? 0 : latest.preflightFailureAttempt,
+          crashAttempt: startedFresh ? 0 : latest.crashAttempt,
         }));
 
         const preflightFailure = config.value.preflightFailure;
@@ -804,6 +883,9 @@ export const makeBackendInstance = Effect.fn("makeBackendInstance")(function* (
           return;
         }
 
+        // Tail of what this run's child printed, so an exit can be explained
+        // with more than its code. Per run: each child starts clean.
+        const crashOutputTail = yield* Ref.make("");
         const runScope = yield* Scope.make("sequential");
         const runId = yield* Ref.modify(state, (latest) => [
           latest.nextRunId,
@@ -826,55 +908,86 @@ export const makeBackendInstance = Effect.fn("makeBackendInstance")(function* (
         ) {
           yield* mutex.withPermits(1)(
             Effect.gen(function* () {
-              const { isCurrentRun, nextState, pid, exitObserved, stopRequested, wasReady } =
-                yield* Ref.modify(
-                  state,
-                  (
-                    latest,
-                  ): readonly [
-                    {
-                      readonly isCurrentRun: boolean;
-                      readonly nextState: BackendManagerState;
-                      readonly pid: Option.Option<number>;
-                      readonly exitObserved: boolean;
-                      readonly stopRequested: boolean;
-                      readonly wasReady: boolean;
-                    },
-                    BackendManagerState,
-                  ] => {
-                    const currentRun = Option.getOrUndefined(latest.active);
-                    if (currentRun?.id !== runId) {
-                      return [
-                        {
-                          isCurrentRun: false,
-                          nextState: latest,
-                          pid: Option.none<number>(),
-                          exitObserved: false,
-                          stopRequested: false,
-                          wasReady: false,
-                        },
-                        latest,
-                      ] as const;
-                    }
-
-                    const next = {
-                      ...latest,
-                      active: Option.none<ActiveBackendRun>(),
-                      ready: false,
-                    };
+              // Read before the state update below consults it: the output
+              // fibers have already drained by the time finalizeRun runs.
+              const output = yield* Ref.get(crashOutputTail);
+              const portInUse = PORT_IN_USE_PATTERN.test(output);
+              const {
+                isCurrentRun,
+                nextState,
+                pid,
+                exitObserved,
+                stopRequested,
+                wasReady,
+                crashAttempt,
+              } = yield* Ref.modify(
+                state,
+                (
+                  latest,
+                ): readonly [
+                  {
+                    readonly isCurrentRun: boolean;
+                    readonly nextState: BackendManagerState;
+                    readonly pid: Option.Option<number>;
+                    readonly exitObserved: boolean;
+                    readonly stopRequested: boolean;
+                    readonly wasReady: boolean;
+                    readonly crashAttempt: number;
+                  },
+                  BackendManagerState,
+                ] => {
+                  const currentRun = Option.getOrUndefined(latest.active);
+                  if (currentRun?.id !== runId) {
                     return [
                       {
-                        isCurrentRun: true,
-                        nextState: next,
-                        pid: currentRun.pid,
-                        exitObserved: currentRun.exitObserved,
-                        stopRequested: currentRun.stopRequested,
-                        wasReady: latest.ready,
+                        isCurrentRun: false,
+                        nextState: latest,
+                        pid: Option.none<number>(),
+                        exitObserved: false,
+                        stopRequested: false,
+                        wasReady: false,
+                        crashAttempt: 0,
                       },
-                      next,
+                      latest,
                     ] as const;
-                  },
-                );
+                  }
+
+                  // A child we spawned, that we did not ask to stop, that died
+                  // without ever serving. Anything else (a stop, a backend that
+                  // was up and then fell over) leaves the plain restart loop in
+                  // charge.
+                  //
+                  // `ready` is not proof that *this* child served: the probe is
+                  // an unauthenticated GET against the port, so whoever already
+                  // holds it answers 200 on our behalf — precisely the case
+                  // where our child dies on a bind failure. Its own output
+                  // saying the address is taken outranks that, since only this
+                  // child could have printed it.
+                  const crashedBeforeReady =
+                    Option.isSome(currentRun.pid) &&
+                    currentRun.exitObserved &&
+                    !currentRun.stopRequested &&
+                    (!latest.ready || portInUse);
+                  const next = {
+                    ...latest,
+                    active: Option.none<ActiveBackendRun>(),
+                    ready: false,
+                    crashAttempt: crashedBeforeReady ? latest.crashAttempt + 1 : 0,
+                  };
+                  return [
+                    {
+                      isCurrentRun: true,
+                      nextState: next,
+                      pid: currentRun.pid,
+                      exitObserved: currentRun.exitObserved,
+                      stopRequested: currentRun.stopRequested,
+                      wasReady: latest.ready,
+                      crashAttempt: next.crashAttempt,
+                    },
+                    next,
+                  ] as const;
+                },
+              );
 
               if (isCurrentRun) {
                 yield* desktopTelemetryPublisher.removeControlSource(spec.id);
@@ -893,6 +1006,34 @@ export const makeBackendInstance = Effect.fn("makeBackendInstance")(function* (
               }
 
               if (isCurrentRun && nextState.desiredRunning) {
+                if (crashAttempt >= MAX_CRASH_BEFORE_READY_ATTEMPTS) {
+                  const failure: BackendCrashLoopFailure = {
+                    reason: describeCrashLoop({
+                      attempts: crashAttempt,
+                      port: config.value.bootstrap.port,
+                      exitReason: reason,
+                      output,
+                      portInUse,
+                    }),
+                    attempts: crashAttempt,
+                  };
+                  yield* logInstanceError("backend kept exiting before readiness", {
+                    reason: failure.reason,
+                    attempts: failure.attempts,
+                  });
+                  const shouldRestart = yield* spec.onCrashLoop?.(failure) ?? Effect.succeed(false);
+                  // Either way the counter starts over, so a handler that keeps
+                  // us running hears about the next streak instead of every
+                  // crash after the cap.
+                  yield* Ref.update(state, (latest) =>
+                    shouldRestart
+                      ? { ...latest, crashAttempt: 0 }
+                      : { ...latest, crashAttempt: 0, desiredRunning: false, ready: false },
+                  );
+                  if (!shouldRestart) {
+                    return;
+                  }
+                }
                 yield* scheduleRestart(reason);
               }
             }),
@@ -950,7 +1091,10 @@ export const makeBackendInstance = Effect.fn("makeBackendInstance")(function* (
               });
             },
           ),
-          onOutput: (streamName, chunk) => backendOutputLog.writeOutputChunk(streamName, chunk),
+          onOutput: (streamName, chunk) =>
+            Ref.update(crashOutputTail, (tail) => appendCrashOutputTail(tail, chunk)).pipe(
+              Effect.andThen(backendOutputLog.writeOutputChunk(streamName, chunk)),
+            ),
         }).pipe(
           Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
           Effect.provideService(HttpClient.HttpClient, httpClient),

--- a/apps/desktop/src/backend/DesktopBackendPool.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendPool.test.ts
@@ -4,8 +4,11 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
+import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
+import * as TestClock from "effect/testing/TestClock";
 import { HttpClient } from "effect/unstable/http";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
@@ -99,6 +102,123 @@ function makePoolLayer(
   );
 }
 
+const crashingPrimaryConfig: DesktopBackendStartConfig = {
+  executablePath: "/electron",
+  args: ["/server/bin.mjs", "--bootstrap-fd", "3"],
+  entryPath: "/server/bin.mjs",
+  cwd: "/server",
+  env: {},
+  extendEnv: true,
+  bootstrap: {
+    mode: "desktop",
+    noBrowser: true,
+    port: 3773,
+    t3Home: "/tmp/t3",
+    host: "127.0.0.1",
+    desktopBootstrapToken: "token",
+    tailscaleServeEnabled: false,
+    tailscaleServePort: 443,
+  },
+  bootstrapDelivery: "fd3",
+  httpBaseUrl: new URL("http://127.0.0.1:3773"),
+  captureOutput: true,
+  preflightFailure: Option.none(),
+};
+
+// Pool wired to a primary whose child spawns and then dies before it can
+// answer the readiness probe, so the crash-loop path runs end to end.
+function makeCrashingPoolLayer(input: {
+  readonly spawned: Queue.Queue<number>;
+  readonly failures: Queue.Queue<string>;
+  readonly errorBoxes: Queue.Queue<{ readonly title: string; readonly content: string }>;
+}): Layer.Layer<DesktopBackendPool.DesktopBackendPool> {
+  let spawnCount = 0;
+  return DesktopBackendPool.layer.pipe(
+    Layer.provideMerge(
+      Layer.mergeAll(
+        FileSystem.layerNoop({ exists: () => Effect.succeed(true) }),
+        Layer.succeed(
+          ChildProcessSpawner.ChildProcessSpawner,
+          ChildProcessSpawner.make(() =>
+            Effect.sync(() => {
+              spawnCount += 1;
+              return ChildProcessSpawner.makeHandle({
+                pid: ChildProcessSpawner.ProcessId(4242),
+                stdout: Stream.empty,
+                stderr: Stream.make(
+                  new TextEncoder().encode(
+                    "ERROR: listen EADDRINUSE: address already in use 0.0.0.0:3773\n",
+                  ),
+                ),
+                all: Stream.empty,
+                exitCode: Queue.offer(input.spawned, spawnCount).pipe(
+                  Effect.as(ChildProcessSpawner.ExitCode(1)),
+                ),
+                isRunning: Effect.succeed(false),
+                kill: () => Effect.void,
+                stdin: Sink.drain,
+                getInputFd: () => Sink.drain,
+                getOutputFd: () => Stream.empty,
+                unref: Effect.succeed(Effect.void),
+              });
+            }),
+          ),
+        ),
+        Layer.succeed(
+          HttpClient.HttpClient,
+          HttpClient.make(() => Effect.never),
+        ),
+        Layer.succeed(DesktopObservability.DesktopBackendOutputLogFactory, {
+          forInstance: () =>
+            Effect.succeed({
+              beginSession: () => Effect.void,
+              writeOutputChunk: () => Effect.void,
+              persistFailureSnapshot: () => Effect.void,
+              persistFailure: ({ details }) =>
+                Queue.offer(input.failures, details).pipe(Effect.asVoid),
+              discardSession: Effect.void,
+            } satisfies DesktopObservability.DesktopBackendOutputLogShape),
+        } satisfies DesktopObservability.DesktopBackendOutputLogFactory["Service"]),
+        Layer.succeed(DesktopTelemetryPublisher.DesktopTelemetryPublisher, {
+          latest: Effect.succeed(Option.none()),
+          changes: Stream.empty,
+          encoded: Stream.empty,
+          handleControl: () => Effect.void,
+          handleControlForSource: () => Effect.void,
+          removeControlSource: () => Effect.void,
+        }),
+        Layer.succeed(DesktopBackendConfiguration.DesktopBackendConfiguration, {
+          resolvePrimary: Effect.succeed(crashingPrimaryConfig),
+          resolvePrimaryLabel: Effect.succeed("Windows"),
+          resolveWsl: () => Effect.die("unexpected WSL config resolve"),
+        } satisfies DesktopBackendConfiguration.DesktopBackendConfiguration["Service"]),
+        DesktopAppSettings.layerTest(),
+        Layer.succeed(ElectronDialog.ElectronDialog, {
+          pickFolder: () => Effect.die("unexpected folder picker"),
+          pickFiles: () => Effect.die("unexpected file picker"),
+          showMessageBox: () => Effect.die("unexpected message box"),
+          showErrorBox: (title, content) =>
+            Queue.offer(input.errorBoxes, { title, content }).pipe(Effect.asVoid),
+        } satisfies ElectronDialog.ElectronDialog["Service"]),
+        Layer.succeed(DesktopWindow.DesktopWindow, {
+          createMain: Effect.die("unexpected window create"),
+          ensureMain: Effect.die("unexpected window ensure"),
+          revealOrCreateMain: Effect.die("unexpected window reveal"),
+          activate: Effect.die("unexpected window activate"),
+          createMainIfBackendReady: Effect.die("unexpected window create"),
+          showConnectingSplash: Effect.void,
+          handleBackendReady: () => Effect.void,
+          handleBackendNotReady: Effect.void,
+          flushMainWindowBounds: Effect.void,
+          dispatchMenuAction: () => Effect.die("unexpected menu action"),
+          zoomMain: () => Effect.die("unexpected zoom"),
+          syncAppearance: Effect.void,
+        } satisfies DesktopWindow.DesktopWindow["Service"]),
+      ),
+    ),
+  );
+}
+
 describe("DesktopBackendPool", () => {
   it.effect("layerTest exposes registered instances by id", () =>
     Effect.gen(function* () {
@@ -132,6 +252,46 @@ describe("DesktopBackendPool", () => {
         yield* DesktopBackendPool.DesktopBackendPool;
       }).pipe(Effect.provide(DesktopBackendPool.layerTest([]))),
     ).pipe(Effect.map((exit) => assert.equal(exit._tag, "Failure"))),
+  );
+
+  it.effect("tells the user why the primary backend keeps dying instead of looping", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const spawned = yield* Queue.unbounded<number>();
+        const failures = yield* Queue.unbounded<string>();
+        const errorBoxes = yield* Queue.unbounded<{
+          readonly title: string;
+          readonly content: string;
+        }>();
+
+        // The pool layer has to stay built for the whole body: the primary's
+        // run fibers are forked into the layer's scope, so a layer provided to
+        // a narrower effect takes the backend down with it.
+        yield* Effect.gen(function* () {
+          const pool = yield* DesktopBackendPool.DesktopBackendPool;
+          const primary = yield* pool.primary;
+
+          yield* primary.start;
+          assert.equal(yield* Queue.take(spawned), 1);
+          yield* Queue.take(failures);
+          assert.equal(yield* Queue.size(errorBoxes), 0);
+
+          for (const delayMs of [500, 1000, 2000, 4000]) {
+            yield* TestClock.adjust(Duration.millis(delayMs));
+            yield* Queue.take(spawned);
+            yield* Queue.take(failures);
+          }
+
+          const errorBox = yield* Queue.take(errorBoxes);
+          assert.equal(errorBox.title, "T3 Code's backend keeps stopping");
+          assert.include(errorBox.content, "Port 3773 is already in use");
+
+          yield* TestClock.adjust(Duration.minutes(5));
+          assert.equal(yield* Queue.size(spawned), 0);
+          assert.equal(yield* Queue.size(errorBoxes), 0);
+        }).pipe(Effect.provide(makeCrashingPoolLayer({ spawned, failures, errorBoxes })));
+      }).pipe(Effect.provide(TestClock.layer())),
+    ),
   );
 
   it.effect("resolves the primary label lazily after pool layer construction", () =>

--- a/apps/desktop/src/backend/DesktopBackendPool.ts
+++ b/apps/desktop/src/backend/DesktopBackendPool.ts
@@ -275,6 +275,22 @@ export const layer = Layer.effect(
       },
     );
 
+    // The primary spawned fine and then died before ever serving, over and
+    // over. There is no configuration to fall back to here — the reason is
+    // outside the app (a busy port, a backend that cannot boot) — so say what
+    // happened and let the manager stop instead of restarting forever behind a
+    // window that never loads.
+    const handlePrimaryCrashLoop = Effect.fn("desktop.backendPool.primaryCrashLoop")(function* (
+      failure: DesktopBackendManager.BackendCrashLoopFailure,
+    ) {
+      yield* logBackendPoolWarning("primary backend kept exiting before readiness", {
+        reason: failure.reason,
+        attempts: failure.attempts,
+      });
+      yield* electronDialog.showErrorBox("T3 Code's backend keeps stopping", failure.reason);
+      return false;
+    });
+
     const primary = yield* DesktopBackendManager.makeBackendInstance({
       id: DesktopBackendManager.PRIMARY_INSTANCE_ID,
       // Keep this lazy. The pool layer is initialized before startup loads
@@ -299,6 +315,7 @@ export const layer = Layer.effect(
         ),
       onShutdown: () => desktopWindow.handleBackendNotReady,
       onPreflightFailed: handlePrimaryPreflightFailure,
+      onCrashLoop: handlePrimaryCrashLoop,
     });
 
     const instancesRef = yield* SynchronizedRef.make<

--- a/apps/desktop/src/wsl/DesktopWslBackend.ts
+++ b/apps/desktop/src/wsl/DesktopWslBackend.ts
@@ -107,9 +107,10 @@ export const layer = Layer.effect(
     // with different distros, leaving the loser stranded.
     const reconcileMutex = yield* Semaphore.make(1);
 
-    // Last fatal preflight failure from the dual-mode WSL *secondary*, surfaced
-    // inline in Connections settings. The primary's failure is handled by the
-    // pool (dialog + Windows fallback) instead; here the app stays usable on
+    // Last reason the dual-mode WSL *secondary* gave up — a fatal preflight or a
+    // child that kept crashing before it served — surfaced inline in Connections
+    // settings. The primary's failures are handled by the pool (dialog, plus a
+    // Windows fallback for preflight) instead; here the app stays usable on
     // Windows, so we record the reason rather than interrupting. Cleared on any
     // reconcile state change so it reflects the current attempt.
     const preflightErrorRef = yield* Ref.make(Option.none<string>());
@@ -167,6 +168,12 @@ export const layer = Layer.effect(
           // settings can show why the WSL backend never appeared. No dialog or
           // fallback — Windows is the primary and keeps working.
           onPreflightFailed: (failure) =>
+            Ref.set(preflightErrorRef, Option.some(failure.reason)).pipe(Effect.as(false)),
+          // Same row, same silence problem: a secondary that spawns and dies
+          // before serving used to restart forever with nothing to show for
+          // it. Stopping leaves the instance idle, which reconcile picks up as
+          // retryable.
+          onCrashLoop: (failure) =>
             Ref.set(preflightErrorRef, Option.some(failure.reason)).pipe(Effect.as(false)),
           onReady: () => Ref.set(preflightErrorRef, Option.none()),
         })

--- a/docs/user/background-service.md
+++ b/docs/user/background-service.md
@@ -64,6 +64,13 @@ A few more macOS notes:
 
 **Windows** is not supported yet.
 
+## Port Conflicts with the Desktop App
+
+The service and the desktop app both serve T3 Code on port 3773 by default. If the desktop app's
+backend cannot start because that port is already in use, the app says so instead of leaving you on
+a loading screen. Quit whatever is holding the port — this service is a common candidate — then
+start the app again.
+
 ## Using It with T3 Connect
 
 T3 Connect may offer to install the service during setup so the host stays reachable in the


### PR DESCRIPTION
## What Changed

The manager now separates "crashed before it ever served" from "was up and then
fell over". A counter increments when a child that spawned exits without ever
reaching readiness, and resets on readiness, on an explicit `start`, and on any
stop we requested. After five consecutive crash-before-ready runs the manager
builds a reason, logs `backend kept exiting before readiness`, hands the reason
to a new `onCrashLoop` callback, and — unless the handler says otherwise — sets
`desiredRunning: false` instead of scheduling another restart. A backend that
became ready and later died keeps the existing self-healing loop untouched.

Readiness alone does not clear the counter. The readiness probe is an
unauthenticated `GET /.well-known/t3/environment` against the configured port, so
whoever already holds that port answers 200 on our behalf — exactly the case
where our own child is dying on a bind failure. When the child's output says the
address is taken, that outranks the probe, since only that child could have
printed it.

Each run keeps a bounded tail of what its child printed, taken from the chunks
already on their way to `server-child.log`, and that tail feeds both the
classification and the reason. Two shapes reach the user:

    Port 3773 is already in use, so the backend could not start. Another program
    is listening on it, often a "t3" server started from a terminal or installed
    as a background service. Stop it, then start T3 Code again.

    The backend exited 5 times in a row before it was ready (code=1).

    Last output:
    loading bundle
    Error: Cannot find module 'better-sqlite3'

`DesktopBackendPool` shows it to the primary's user through `showErrorBox`. The
WSL secondary instead records it in the ref already backing the Connections
settings row, so Windows stays usable and the existing idle-retry branch still
applies. An explicit `start` re-arms the allowance, which is the way back out.

`onCrashLoop` is a new callback rather than a reuse of `onPreflightFailed`: the
pool's preflight handler is WSL-specific — it says "WSL backend couldn't start"
and persists a Windows fallback — so firing it for a Windows-primary port
conflict would show a wrong message and change a setting for an unrelated reason.

Five crashes, with no time window, because readiness is the window: reaching it
resets the count, which matches the failure mode rather than introducing a second
timing concept. Five mirrors `MAX_PREFLIGHT_FAILURE_ATTEMPTS`, and against the
existing backoff it means roughly 7.5 seconds of quiet retrying before the user
hears anything — enough for a port about to be freed, not enough to stare at a
dead app. 4096 chars are retained per run and the last three lines (500 chars)
reach the reason, since a wall of stack frames in an error box is worse than
none.

Tests: four cases in `DesktopBackendManager.test.ts` and one in
`DesktopBackendPool.test.ts`, all driven by `TestClock`. They assert the callback
stays silent for the first four crashes and fires once on the fifth with the
exact port sentence, that nothing respawns for five minutes afterwards and an
explicit `start` does, that an unrecognized crash reports its exit reason plus
the child's last output, that eight ready-then-die cycles never trip it, that
five crashes still count when an occupant of the port answers the readiness probe
200, and that the pool raises an error box titled `T3 Code's backend keeps
stopping`. Raising the cap to 500 fails the crash-loop tests, dropping the
readiness condition fails the ready-then-die one, and dropping the bind-failure
override fails the occupant one. Targeted run over five desktop suites: 47
passing. `apps/desktop` typecheck, lint and format pass, with only the two
suggestions already present on `main`.

## Why

A primary backend that spawns and then dies before it ever serves restarts
forever with nothing said. The reported case was a WSL distro already holding
port 3773, so the child hit `EADDRINUSE` about 7ms after every spawn, once every
20 seconds, indefinitely. The user saw a window that never worked.

Every ingredient of the explanation was already captured. `server-child.log` held
the child's `listen EADDRINUSE: address already in use 0.0.0.0:3773` for each of
those spawns, and `handlePrimaryPreflightFailure` already knew how to put a
reason in front of the user. Nothing connected the two, because a child that
spawns successfully and then exits never travels the preflight path, and
`scheduleRestart` only ever looked at the exit code.

The readiness carve-out is load-bearing rather than defensive. Readiness is
forked at spawn and stays in flight through the exit observation, the output
drain and `finalizeRun`, and the probe accepts any 2xx from anything listening.
So in the scenario this change exists for, the occupying server answers, the run
is recorded as "was ready", and without the carve-out the counter would reset on
every attempt and the cap would never be reached.

Stopping after the cap rather than looping matches what a fatal preflight failure
already does when its handler declines to recover. The callback's boolean leaves
room for a handler that can actually fix something, and an explicit `start` gives
a fresh allowance — which is how the WSL orchestrator's idle-retry branch gets
the secondary going again without any new machinery.

Not addressed, and worth its own issue: readiness remains spoofable in general.
Because the probe cannot tell who answered, an occupied port already makes the
manager call `onReady`, which opens the main window against a foreign server —
that predates this change and is the likelier explanation for the reported
`PrimaryEnvironmentRequestError` out of a route `beforeLoad` than "no window at
all". Fixing it properly means giving the descriptor something only our own child
could echo back, which is a contracts and server change. Until then a child
crashing for an unrelated reason behind an occupant still resets the counter.
Separately, the port named in the message is the one the backend was configured
to bind rather than one parsed out of the child's output, so a backend printing
`EADDRINUSE` for some other port would name the wrong number.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes — N/A, the only new surface is a native error dialog, quoted above
- [ ] I included a video for animation/interaction changes — N/A, no motion changes

Changes by Claude Opus 5 running in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the desktop backend restart loop: instances without `onCrashLoop` now stop after five pre-readiness crashes instead of looping forever. Crash detection also treats a spoofed readiness probe plus EADDRINUSE as a crash, which is important but easy to get wrong.
> 
> **Overview**
> Stops the desktop backend from restarting forever when a child spawns and dies before it ever serves. After five consecutive crash-before-ready runs, the manager builds a user-facing reason and stops unless `onCrashLoop` asks to keep going.
> 
> Port conflicts (`EADDRINUSE`) get a named message about port 3773; other crashes include the exit reason plus a short tail of child output. The primary shows a native error box titled **T3 Code's backend keeps stopping**. The WSL secondary records the same reason in Connections settings so Windows stays usable. Backends that crash *after* becoming ready still self-heal as before. An explicit `start` resets the allowance.
> 
> Also documents that the background service and desktop app share port 3773.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3035f2dbc1d314dbd7b489f939a93afdef1e6281. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Detect desktop backend crash loops and show an error dialog instead of silently restarting
> - The backend instance now tracks consecutive pre-readiness crashes via `crashAttempt` in `BackendManagerState`, capping at `MAX_CRASH_BEFORE_READY_ATTEMPTS=5` before invoking an optional `onCrashLoop` callback that decides whether to keep restarting
> - `describeCrashLoop` produces a human-readable reason, favoring a port-in-use message when `PORT_IN_USE_PATTERN` matches captured child output, otherwise including the exit reason and a trimmed output tail
> - `DesktopBackendPool.layer` wires an `onCrashLoop` handler that shows an error box titled "T3 Code's backend keeps stopping" and returns `false` to halt restarts; `DesktopWslBackend.layer` records the reason in `preflightErrorRef` for the WSL secondary
> - `finalizeRun` also guards against readiness spoofing: if another process answers the readiness probe on the same port, the crash is still counted as pre-readiness
> - Risk: `BackendInstanceSpec.onCrashLoop` is a new optional field; callers that do not set it default to stopping restarts after 5 crashes (`makeBackendInstance` sets `desiredRunning=false`), which is a behavioral change from the previous silent-restart loop
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3035f2d. 4 files reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>docs/user/background-service.md — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 69](https://github.com/pingdotgg/t3code/blob/3035f2dbc1d314dbd7b489f939a93afdef1e6281/docs/user/background-service.md#L69): The new troubleshooting section says the desktop backend and service conflict on port 3773 by default, but `resolveDesktopBackendPort` scans upward from 3773 and selects the first port available on every probe host when no explicit port is configured. With the background service already on 3773, a normal packaged desktop launch therefore chooses 3774 rather than failing, so users are incorrectly told to stop the service for a conflict the default startup logic avoids. This guidance should be limited to explicitly configured ports or race/WSL cases. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->