### PR TITLE
fix(web): keep sidebar provider icons unobscured

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1563,10 +1563,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                         modelInstanceId
                       }
                       accentColor={providerEntry?.accentColor}
-                      showBadge={showInstanceBadge}
-                      // Glyph dims, badge stays saturated; offset matches the composer trigger.
                       iconClassName="size-3.5 opacity-60"
-                      badgeClassName="right-[-0.1875rem] bottom-[-0.1875rem] h-3 min-w-3 px-0.5 text-[7px]"
                     />
                   </span>
                 ) : null}


### PR DESCRIPTION
The provider-instance badge overlays the small provider icon in sidebar rows, obscuring the familiar provider glyph and adding visual noise.

This stops rendering instance badges in compact sidebar rows. The existing hover tooltip still shows the model and provider-instance name, while badges remain available in the composer and model picker where instance selection matters.

Verification:
- vp run --filter @t3tools/web typecheck
- vp lint --report-unused-disable-directives apps/web/src/components/Sidebar.tsx
- vp fmt --check apps/web/src/components/Sidebar.tsx
- git diff --check

Made with GPT-5 in Codex Desktop.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove badge props from `ProviderInstanceIcon` in `SidebarThreadRow`
> Stops passing `showBadge` and `badgeClassName` to `ProviderInstanceIcon` in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/7705/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) so the provider icon is not obscured by a badge. Badge visibility and styling now rely on the component's internal defaults. No other logic in `SidebarThreadRow` changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 51f7278.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->