### PR TITLE
feat(server): list threads in a T3 state directory

### DIFF
--- a/apps/server/scripts/list-threads.test.ts
+++ b/apps/server/scripts/list-threads.test.ts
@@ -1,0 +1,202 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import * as NodeSqliteClient from "../src/persistence/NodeSqliteClient.ts";
+import { listThreads, ThreadTransferError } from "./thread-transfer.ts";
+
+interface FixtureInput {
+  readonly stateDir: string;
+  readonly projects: ReadonlyArray<{
+    readonly projectId: string;
+    readonly workspaceRoot: string;
+    readonly deletedAt?: string;
+  }>;
+  readonly threads: ReadonlyArray<{
+    readonly threadId: string;
+    readonly projectId: string;
+    readonly title: string;
+    readonly updatedAt: string;
+    readonly deletedAt?: string;
+  }>;
+}
+
+/** Seeds the projection tables `thread:list` reads, mirroring the server's schema. */
+const createFixtureDatabase = Effect.fn("createThreadListFixtureDatabase")(function* (
+  input: FixtureInput,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const databasePath = path.join(input.stateDir, "state.sqlite");
+  yield* fs.makeDirectory(input.stateDir, { recursive: true });
+  yield* Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    yield* sql`CREATE TABLE projection_projects (
+      project_id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      workspace_root TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      deleted_at TEXT
+    )`;
+    yield* sql`CREATE TABLE projection_threads (
+      thread_id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      title TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      deleted_at TEXT
+    )`;
+    for (const project of input.projects) {
+      yield* sql`INSERT INTO projection_projects (
+        project_id, title, workspace_root, updated_at, deleted_at
+      ) VALUES (
+        ${project.projectId}, ${`Project ${project.projectId}`}, ${project.workspaceRoot},
+        '2026-08-20T12:00:00.000Z', ${project.deletedAt ?? null}
+      )`;
+    }
+    for (const thread of input.threads) {
+      yield* sql`INSERT INTO projection_threads (
+        thread_id, project_id, title, updated_at, deleted_at
+      ) VALUES (
+        ${thread.threadId}, ${thread.projectId}, ${thread.title}, ${thread.updatedAt},
+        ${thread.deletedAt ?? null}
+      )`;
+    }
+  }).pipe(Effect.provide(NodeSqliteClient.layer({ filename: databasePath })));
+  return databasePath;
+});
+
+it.layer(NodeServices.layer)("thread list", (it) => {
+  it.effect("lists live projects and threads, newest thread first", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({ prefix: "thread-list-" });
+      const workspace = path.join(root, "workspace");
+      const otherWorkspace = path.join(root, "other");
+      yield* createFixtureDatabase({
+        stateDir: path.join(workspace, ".t3", "userdata"),
+        projects: [
+          { projectId: "project-b", workspaceRoot: otherWorkspace },
+          { projectId: "project-a", workspaceRoot: workspace },
+          {
+            projectId: "project-gone",
+            workspaceRoot: path.join(root, "gone"),
+            deletedAt: "2026-08-21T13:00:00.000Z",
+          },
+        ],
+        threads: [
+          {
+            threadId: "thread-old",
+            projectId: "project-a",
+            title: "Older thread",
+            updatedAt: "2026-08-19T12:00:00.000Z",
+          },
+          {
+            threadId: "thread-new",
+            projectId: "project-b",
+            title: "Newer\tthread",
+            updatedAt: "2026-08-20T12:00:00.000Z",
+          },
+          {
+            threadId: "thread-gone",
+            projectId: "project-a",
+            title: "Deleted thread",
+            updatedAt: "2026-08-21T12:00:00.000Z",
+            deletedAt: "2026-08-21T13:00:00.000Z",
+          },
+        ],
+      });
+
+      const listing = yield* listThreads({ source: workspace });
+      assert.deepStrictEqual(listing, {
+        projects: [
+          {
+            id: "project-b",
+            title: "Project project-b",
+            workspaceRoot: otherWorkspace,
+            updatedAt: "2026-08-20T12:00:00.000Z",
+          },
+          {
+            id: "project-a",
+            title: "Project project-a",
+            workspaceRoot: workspace,
+            updatedAt: "2026-08-20T12:00:00.000Z",
+          },
+        ],
+        threads: [
+          {
+            id: "thread-new",
+            title: "Newer\tthread",
+            projectId: "project-b",
+            projectTitle: "Project project-b",
+            workspaceRoot: otherWorkspace,
+            updatedAt: "2026-08-20T12:00:00.000Z",
+          },
+          {
+            id: "thread-old",
+            title: "Older thread",
+            projectId: "project-a",
+            projectTitle: "Project project-a",
+            workspaceRoot: workspace,
+            updatedAt: "2026-08-19T12:00:00.000Z",
+          },
+        ],
+      });
+    }),
+  );
+
+  it.effect("resolves the base directory, a direct state directory, and --state dev", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({ prefix: "thread-list-state-" });
+      const baseDir = path.join(root, ".t3");
+      const thread = { title: "Thread", updatedAt: "2026-08-20T12:00:00.000Z" };
+      yield* createFixtureDatabase({
+        stateDir: path.join(baseDir, "userdata"),
+        projects: [{ projectId: "project-userdata", workspaceRoot: root }],
+        threads: [{ threadId: "thread-userdata", projectId: "project-userdata", ...thread }],
+      });
+      yield* createFixtureDatabase({
+        stateDir: path.join(baseDir, "dev"),
+        projects: [{ projectId: "project-dev", workspaceRoot: root }],
+        threads: [{ threadId: "thread-dev", projectId: "project-dev", ...thread }],
+      });
+
+      const fromBase = yield* listThreads({ source: baseDir });
+      assert.deepStrictEqual(
+        fromBase.threads.map((entry) => entry.id),
+        ["thread-userdata"],
+      );
+      const fromStateDir = yield* listThreads({ source: path.join(baseDir, "userdata") });
+      assert.deepStrictEqual(fromStateDir, fromBase);
+      const fromDev = yield* listThreads({ source: baseDir, state: "dev" });
+      assert.deepStrictEqual(
+        fromDev.projects.map((entry) => entry.id),
+        ["project-dev"],
+      );
+      assert.deepStrictEqual(
+        fromDev.threads.map((entry) => entry.id),
+        ["thread-dev"],
+      );
+    }),
+  );
+
+  it.effect("reports every location it probed when no database exists", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({ prefix: "thread-list-missing-" });
+      const error = yield* listThreads({ source: root }).pipe(Effect.flip);
+      assert.instanceOf(error, ThreadTransferError);
+      assert.equal(error.operation, "resolve directory");
+      assert.equal(
+        error.detail,
+        `No T3 userdata database found at '${path.join(root, "state.sqlite")}', '${path.join(root, "userdata", "state.sqlite")}', or '${path.join(root, ".t3", "userdata", "state.sqlite")}'.`,
+      );
+    }),
+  );
+});

--- a/apps/server/scripts/list-threads.ts
+++ b/apps/server/scripts/list-threads.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { fromJsonStringPretty } from "@t3tools/shared/schemaJson";
+import * as Console from "effect/Console";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+import { Command, Flag } from "effect/unstable/cli";
+
+import { listThreads, ThreadListing, ThreadTransferState } from "./thread-transfer.ts";
+
+const oneLine = (value: string) => value.replaceAll(/[\r\n\t]+/g, " ");
+const encodeListing = Schema.encodeEffect(fromJsonStringPretty(ThreadListing));
+
+export const listThreadsCommand = Command.make(
+  "list-threads",
+  {
+    source: Flag.string("source").pipe(
+      Flag.withDescription("Workspace root, T3 base directory, or direct state directory."),
+    ),
+    state: Flag.choice("state", ThreadTransferState.literals).pipe(
+      Flag.withDefault("userdata"),
+      Flag.withDescription("State directory below the T3 base directory; defaults to userdata."),
+    ),
+    json: Flag.boolean("json").pipe(
+      Flag.withDefault(false),
+      Flag.withDescription("Print the complete thread list as JSON."),
+    ),
+  },
+  ({ source, state, json }) =>
+    Effect.gen(function* () {
+      const listing = yield* listThreads({ source, state });
+      if (json) {
+        yield* Console.log(yield* encodeListing(listing));
+        return;
+      }
+      if (listing.projects.length === 0) {
+        yield* Console.log("No projects found.");
+      } else {
+        yield* Console.log("PROJECT_ID\tWORKSPACE\tTITLE");
+        for (const project of listing.projects) {
+          yield* Console.log(
+            `${project.id}\t${oneLine(project.workspaceRoot)}\t${oneLine(project.title)}`,
+          );
+        }
+      }
+      yield* Console.log("");
+      if (listing.threads.length === 0) {
+        yield* Console.log("No threads found.");
+        return;
+      }
+      yield* Console.log("THREAD_ID\tPROJECT_ID\tTITLE");
+      for (const thread of listing.threads) {
+        yield* Console.log(`${thread.id}\t${thread.projectId}\t${oneLine(thread.title)}`);
+      }
+    }),
+).pipe(Command.withDescription("List the projects and threads stored in a T3 state directory."));
+
+if (import.meta.main) {
+  Command.run(listThreadsCommand, { version: "0.0.0" }).pipe(
+    Effect.provide(NodeServices.layer),
+    NodeRuntime.runMain,
+  );
+}

--- a/apps/server/scripts/thread-transfer.ts
+++ b/apps/server/scripts/thread-transfer.ts
@@ -1,0 +1,172 @@
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import { isSqlError } from "effect/unstable/sql/SqlError";
+
+import * as NodeSqliteClient from "../src/persistence/NodeSqliteClient.ts";
+
+export const ThreadTransferState = Schema.Literals(["userdata", "dev"]);
+export type ThreadTransferState = typeof ThreadTransferState.Type;
+
+export class ThreadTransferError extends Schema.TaggedErrorClass<ThreadTransferError>()(
+  "ThreadTransferError",
+  {
+    operation: Schema.String,
+    detail: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {
+  override get message(): string {
+    return `${this.operation}: ${this.detail}`;
+  }
+}
+
+export interface ListThreadsInput {
+  /** Workspace root, T3 base directory, or direct state directory. */
+  readonly source: string;
+  readonly state?: ThreadTransferState | undefined;
+}
+
+export const ListedProject = Schema.Struct({
+  id: Schema.String,
+  title: Schema.String,
+  workspaceRoot: Schema.String,
+  updatedAt: Schema.NullOr(Schema.String),
+});
+export type ListedProject = typeof ListedProject.Type;
+
+export const ListedThread = Schema.Struct({
+  id: Schema.String,
+  title: Schema.String,
+  projectId: Schema.String,
+  projectTitle: Schema.String,
+  workspaceRoot: Schema.String,
+  updatedAt: Schema.NullOr(Schema.String),
+});
+export type ListedThread = typeof ListedThread.Type;
+
+/** The live projects of a state directory and the live threads across all its projects. */
+export const ThreadListing = Schema.Struct({
+  projects: Schema.Array(ListedProject),
+  threads: Schema.Array(ListedThread),
+});
+export type ThreadListing = typeof ThreadListing.Type;
+
+interface StateLocation {
+  readonly stateDir: string;
+  readonly databasePath: string;
+  readonly workspaceRoot: string | null;
+}
+
+interface ProjectRow {
+  readonly projectId: string;
+  readonly title: string;
+  readonly workspaceRoot: string;
+  readonly updatedAt: string | null;
+  readonly deletedAt: string | null;
+}
+
+interface ListedThreadRow {
+  readonly threadId: string;
+  readonly projectId: string;
+  readonly title: string;
+  readonly updatedAt: string | null;
+}
+
+const transferError = (operation: string, detail: string, cause?: unknown): ThreadTransferError =>
+  new ThreadTransferError({ operation, detail, ...(cause === undefined ? {} : { cause }) });
+
+/** Runs `effect` against the state database, reporting SQL failures as `operation` errors. */
+const withThreadDatabase =
+  (location: StateLocation, operation: string, access: "read" | "update") =>
+  <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+    effect.pipe(
+      Effect.provideService(SqlClient.SafeIntegers, access === "read"),
+      Effect.provide(
+        NodeSqliteClient.layer({ filename: location.databasePath, readonly: access === "read" }),
+      ),
+      Effect.mapError((cause) =>
+        isSqlError(cause)
+          ? transferError(operation, `Could not ${access} '${location.databasePath}'.`, cause)
+          : cause,
+      ),
+    );
+
+/** Accepts a state directory, a T3 base directory, or a workspace root holding `.t3/`. */
+const resolveStateLocation = Effect.fn("resolveThreadTransferStateLocation")(function* (
+  directory: string,
+  state: ThreadTransferState = "userdata",
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const root = path.resolve(directory);
+  const candidates = [
+    { stateDir: root, workspaceRoot: null },
+    { stateDir: path.join(root, state), workspaceRoot: null },
+    { stateDir: path.join(root, ".t3", state), workspaceRoot: root },
+  ].map(
+    (candidate): StateLocation => ({
+      ...candidate,
+      databasePath: path.join(candidate.stateDir, "state.sqlite"),
+    }),
+  );
+  for (const candidate of candidates) {
+    const exists = yield* fs.exists(candidate.databasePath).pipe(Effect.orElseSucceed(() => false));
+    if (exists) return candidate;
+  }
+  const [direct, base, nested] = candidates.map((candidate) => `'${candidate.databasePath}'`);
+  return yield* transferError(
+    "resolve directory",
+    `No T3 ${state} database found at ${direct}, ${base}, or ${nested}.`,
+  );
+});
+
+export const listThreads = Effect.fn("listThreads")(function* (input: ListThreadsInput) {
+  const location = yield* resolveStateLocation(input.source, input.state);
+  return yield* Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    const projects = yield* sql<ProjectRow>`
+      SELECT
+        project_id AS "projectId",
+        title,
+        workspace_root AS "workspaceRoot",
+        updated_at AS "updatedAt",
+        deleted_at AS "deletedAt"
+      FROM projection_projects`;
+    const projectsById = new Map(projects.map((project) => [project.projectId, project]));
+    const threads = yield* sql<ListedThreadRow>`
+      SELECT thread_id AS "threadId", project_id AS "projectId", title, updated_at AS "updatedAt"
+      FROM projection_threads
+      WHERE deleted_at IS NULL`;
+    const listing: ThreadListing = {
+      projects: projects
+        .filter((project) => project.deletedAt === null)
+        .map((project) => ({
+          id: project.projectId,
+          title: project.title,
+          workspaceRoot: project.workspaceRoot,
+          updatedAt: project.updatedAt,
+        }))
+        .sort((left, right) => left.workspaceRoot.localeCompare(right.workspaceRoot)),
+      threads: threads
+        .map((thread): ListedThread => {
+          const project = projectsById.get(thread.projectId);
+          return {
+            id: thread.threadId,
+            title: thread.title,
+            projectId: thread.projectId,
+            projectTitle: project?.title ?? thread.projectId,
+            workspaceRoot: project?.workspaceRoot ?? "",
+            updatedAt: thread.updatedAt,
+          };
+        })
+        .sort((left, right) => {
+          const updated = (right.updatedAt ?? "").localeCompare(left.updatedAt ?? "");
+          return updated !== 0 ? updated : left.id.localeCompare(right.id);
+        }),
+    };
+    return listing;
+  }).pipe(withThreadDatabase(location, "list threads", "read"));
+});

--- a/docs/internals/scripts.md
+++ b/docs/internals/scripts.md
@@ -63,6 +63,10 @@ authenticated.
 - `vp run lint:mobile`: Mobile native static analysis (`scripts/mobile-native-static-check.ts`).
 - `node apps/server/scripts/t3-sqlite-state.ts <query|exec> --base-dir <path> ...`: Inspects or seeds
   an isolated T3 SQLite database; writes create a private backup first.
+- `vp run thread:list --source <project-dir>`: Lists the projects (id, workspace root, title) and
+  live threads (id, project id, title) of an existing T3 state database. The source can be a workspace containing `.t3`, the T3 base
+  directory, or a direct state directory containing `state.sqlite`. State defaults to `userdata`;
+  pass `--state dev` for a main-checkout dev database. Pass `--json` for structured output.
 
 ## Desktop artifacts
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev:marketing": "vp run --filter @t3tools/marketing dev",
     "dev:desktop": "node scripts/dev-runner.ts dev:desktop",
     "migrate-dev-db": "node apps/server/scripts/migrate-dev-db.ts",
+    "thread:list": "node apps/server/scripts/list-threads.ts",
     "start": "vp run --filter t3 start",
     "start:desktop": "vp run --filter @t3tools/desktop start",
     "start:marketing": "vp run --filter @t3tools/marketing preview",


### PR DESCRIPTION
First of three stacked PRs that let a thread move between T3 state directories (`~/.t3/userdata` ↔ a worktree's `.t3`, `userdata` ↔ `dev`). Stack: this PR → export/import → Orchestrator v2 support.

## Problem

There is no way to see what is inside a T3 state database without opening it by hand. Exporting a thread needs its id, and importing needs the id of the project it should land in, so a transfer workflow needs a listing first.

## Fix

Adds `vp run thread:list --source <dir> [--state dev] [--json]` (`apps/server/scripts/list-threads.ts`). It prints the live projects (id, workspace root, title) and the live threads (id, project id, title, newest first) of a state database, and `--json` gives the same as structured output. The source can be a workspace containing `.t3`, the T3 base directory, or a direct state directory; `--state dev` picks the dev database of a main checkout. The database is opened read-only, so it is safe to run against `~/.t3/userdata`.

`apps/server/scripts/thread-transfer.ts` holds the directory resolution, read-only database access, and the error type; the next PR in the stack reuses those for export and import.

Tests: `apps/server/scripts/list-threads.test.ts` (listing order and deleted rows, directory forms and `--state dev`, missing database error).

Claude Fable 5 via Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New maintainer CLI that only reads projection tables from an existing SQLite file; no writes, auth, or runtime server changes.
> 
> **Overview**
> Adds `vp run thread:list --source <dir>` so maintainers can inspect live projects and threads in a T3 SQLite state database without opening it by hand. This is the first piece of a thread-transfer stack (list → export/import).
> 
> `--source` can be a workspace with `.t3`, a T3 base dir, or a directory that already contains `state.sqlite`. `--state dev` targets the main-checkout dev DB; `--json` prints the full listing. The DB is opened **read-only**. Soft-deleted rows are omitted; threads are newest-first.
> 
> Shared resolution, error type, and read access live in `thread-transfer.ts` for reuse by later export/import PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7acf559e154bea817f3342145f91af32d3bb720. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `list-threads` CLI command to query T3 state database
> - Adds `listThreads` in [thread-transfer.ts](https://github.com/pingdotgg/t3code/pull/7707/files#diff-dd144ec7a471d211663abf974446ba4d90a07712e34cc482cdadfb878016b9ef) and a `list-threads` command in [list-threads.ts](https://github.com/pingdotgg/t3code/pull/7707/files#diff-54a071ca509da68003217927cd5e1e40ad19ec2e3b9aca7a40f98f83f4a1bcc2), exposed via the `thread:list` npm script
> - Probes three locations for `state.sqlite`: direct directory, `<baseDir>/state`, and `<root>/.t3/<state>`. Supports `--source` and `--state` flags with `userdata` as the default state
> - Returns non-deleted projects sorted by `workspaceRoot` and threads sorted by `updatedAt` desc. Outputs a tab-delimited table by default or pretty JSON via `--json`
> - Risk: `withThreadDatabase` now maps `SqlError` to `ThreadTransferError`; check out-of-tree consumers that expect raw `SqlError`
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e7acf55. 3 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->