### PR TITLE
fix(web): stop repeating Bash commands in tool rows

### DIFF
--- a/apps/web/src/session-logic.command-output.test.ts
+++ b/apps/web/src/session-logic.command-output.test.ts
@@ -6,6 +6,7 @@ import { deriveWorkLogEntries } from "./session-logic";
 function makeCommandActivity(
   id: string,
   payload: Record<string, unknown>,
+  overrides: Partial<Pick<OrchestrationThreadActivity, "kind" | "createdAt" | "summary">> = {},
 ): OrchestrationThreadActivity {
   return {
     id: EventId.make(id),
@@ -15,8 +16,78 @@ function makeCommandActivity(
     tone: "tool",
     payload,
     turnId: TurnId.make("turn-1"),
+    ...overrides,
   };
 }
+
+// Claude puts the command in `detail` with a `Bash: ` prefix. The server
+// projects `data.command` onto in-progress updates and keeps
+// `data.input.command` on the completed activity.
+function makeClaudeBashLifecycle(command: string, detail: string): OrchestrationThreadActivity[] {
+  const toolCallId = "toolu_01XghhMudoHnUpdrKNfqgcYW";
+  return [
+    makeCommandActivity(
+      "claude-updated",
+      {
+        itemType: "command_execution",
+        toolCallId,
+        status: "inProgress",
+        detail,
+        data: { command },
+      },
+      { kind: "tool.updated", createdAt: "2026-07-17T10:00:00.000Z", summary: "Command run" },
+    ),
+    makeCommandActivity(
+      "claude-completed",
+      {
+        itemType: "command_execution",
+        toolCallId,
+        status: "completed",
+        detail,
+        data: {
+          toolName: "Bash",
+          input: { command, description: "List files" },
+          result: { type: "tool_result", content: "", is_error: false },
+        },
+      },
+      { kind: "tool.completed", createdAt: "2026-07-17T10:00:01.000Z", summary: "Command run" },
+    ),
+  ];
+}
+
+describe("deriveWorkLogEntries Claude command detail", () => {
+  it("drops the tool-name-prefixed detail that repeats the command", () => {
+    const command = "cd /repo && grep -n -E \"F0[0-9][0-9]\" TRACKER.md | sed -n '1,120p'";
+    const entries = deriveWorkLogEntries(makeClaudeBashLifecycle(command, `Bash: ${command}`));
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.command).toBe(command);
+    expect(entries[0]?.detail).toBeUndefined();
+  });
+
+  it("drops the detail when the server truncated it", () => {
+    const command = `cd /repo && ${"x".repeat(200)} && ls`;
+    const detail = `Bash: ${command}`.slice(0, 177) + "...";
+    const entries = deriveWorkLogEntries(makeClaudeBashLifecycle(command, detail));
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.command).toBe(command);
+    expect(entries[0]?.detail).toBeUndefined();
+  });
+
+  it("reads the command from Claude's completed payload", () => {
+    const [entry] = deriveWorkLogEntries([
+      makeCommandActivity("claude-only-completed", {
+        itemType: "command_execution",
+        detail: "Bash: bun test",
+        data: { toolName: "Bash", input: { command: "bun test" } },
+      }),
+    ]);
+
+    expect(entry?.command).toBe("bun test");
+    expect(entry?.detail).toBeUndefined();
+  });
+});
 
 describe("deriveWorkLogEntries command output", () => {
   it("uses Codex aggregated output instead of repeating the command", () => {

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -1410,6 +1410,8 @@ function extractToolCommand(payload: Record<string, unknown> | null): {
   const item = asRecord(data?.item);
   const itemResult = asRecord(item?.result);
   const itemInput = asRecord(item?.input);
+  // Claude completed activities carry the tool input as `data.input`.
+  const dataInput = asRecord(data?.input);
   const itemType = asTrimmedString(payload?.itemType);
   const detail = asTrimmedString(payload?.detail);
   const candidates: unknown[] = [
@@ -1417,6 +1419,7 @@ function extractToolCommand(payload: Record<string, unknown> | null): {
     itemInput?.command,
     itemResult?.command,
     data?.command,
+    dataInput?.command,
     itemType === "command_execution" && detail ? stripTrailingExitCode(detail).output : null,
   ];
 
@@ -1463,6 +1466,32 @@ function normalizePreviewForComparison(value: string | null | undefined): string
     return null;
   }
   return normalizeCompactToolLabel(normalizeInlinePreview(normalized)).toLowerCase();
+}
+
+/**
+ * True when a normalized `detail` only repeats the normalized command.
+ * Claude writes the command into `detail` as `Bash: <command>`, and the server
+ * truncates long details with a trailing `...`, so both are allowed here.
+ */
+function detailRepeatsCommand(
+  normalizedDetail: string | null,
+  normalizedCommand: string | null,
+): boolean {
+  if (!normalizedDetail || !normalizedCommand) {
+    return false;
+  }
+  if (normalizedDetail === normalizedCommand) {
+    return true;
+  }
+  const withoutToolPrefix = normalizedDetail.replace(/^[a-z][\w.-]*:\s+/, "");
+  if (withoutToolPrefix === normalizedCommand) {
+    return true;
+  }
+  const ellipsis = /\s*(?:\.\.\.|…)$/.exec(withoutToolPrefix);
+  if (!ellipsis || ellipsis.index === 0) {
+    return false;
+  }
+  return normalizedCommand.startsWith(withoutToolPrefix.slice(0, ellipsis.index));
 }
 
 function summarizeToolTextOutput(value: string): string | null {
@@ -1605,7 +1634,8 @@ function extractToolDetail(
     detail &&
     normalizedHeading !== normalizedDetail &&
     (!commandTool ||
-      (normalizedCommand !== normalizedDetail && normalizedRawCommand !== normalizedDetail))
+      (!detailRepeatsCommand(normalizedDetail, normalizedCommand) &&
+        !detailRepeatsCommand(normalizedDetail, normalizedRawCommand)))
   ) {
     return detail;
   }


### PR DESCRIPTION
## What Changed

- `extractToolCommand` now reads `data.input.command`, which is where Claude's completed tool activity carries the command.
- The `detail` redundancy check in `extractToolDetail` now treats a detail that repeats the command with a `ToolName: ` prefix, or with the server's `...` truncation, as redundant and drops it.
- Added regression tests built from a real Claude Bash lifecycle (`tool.updated` + `tool.completed`).

## Why

Claude puts the command into `detail` as `Bash: <command>`. The web compared `detail` to the command with exact equality, so every expanded Bash row showed the command and then `Bash: <command>` again. The completed activity also only carries the command in `data.input.command`, which the web never read, so it fell back to the prefixed (and for long commands, truncated) detail as the command.

Fixing this in the web presentation layer also cleans up already-persisted threads. Mobile has the same symptom with a separate derivation path (`apps/mobile/src/lib/threadActivity.ts`) and is left for a follow-up to keep this PR small.

Closes #7711

## UI Changes

Before:

<img width="780" alt="before" src="https://raw.githubusercontent.com/ishaanko/t3code/48817255b6bf121e3e61793e1c300eb4818670e0/7711-before.png" />

After:

<img width="780" alt="after" src="https://raw.githubusercontent.com/ishaanko/t3code/48817255b6bf121e3e61793e1c300eb4818670e0/7711-after.png" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

---

Changes made by Claude Fable 5 running in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change to work-log derivation; no auth, persistence, or command-execution behavior is affected.
> 
> **Overview**
> Stops Claude Bash work-log rows from showing the command twice (`command` plus `Bash: <command>`).
> 
> `extractToolCommand` now reads `data.input.command` from completed Claude activities, so the real command is used instead of the prefixed/truncated `detail`. Redundant details that only repeat the command (including `ToolName: ` prefixes and server `...` truncation) are dropped. Regression tests cover a Claude `tool.updated` + `tool.completed` lifecycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54baa11b903e07bc08552c1e619821584dc4088b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix repeated Bash commands in tool rows by improving `extractToolDetail`
> - `extractToolCommand` now also reads `data.input.command` from Claude-style completed payloads so the command is found in more cases.
> - New `detailRepeatsCommand` helper detects when a detail string only repeats the command, including tool-name prefixes and truncated details ending with `...` or `…`.
> - `extractToolDetail` uses this helper to drop details that merely restate the command, instead of only checking for exact equality.
> - Risk: `extractToolDetail` now returns `null` in more cases in [session-logic.ts](https://github.com/pingdotgg/t3code/pull/7713/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6); callers that relied on detail text being present for command tools will see fewer populated rows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 54baa11.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->