### PR TITLE
fix(web): keyboard hints no longer assume macOS

### DIFF
--- a/apps/web/src/components/chat/ComposerStashMenu.test.tsx
+++ b/apps/web/src/components/chat/ComposerStashMenu.test.tsx
@@ -5,6 +5,31 @@ import { describe, expect, it } from "vite-plus/test";
 import { ComposerStashMenu } from "./ComposerStashMenu";
 
 describe("ComposerStashMenu", () => {
+  it("labels the empty-stash hint with the provided shortcut, or drops it", () => {
+    const withLabel = renderToStaticMarkup(
+      <ComposerStashMenu
+        entries={[]}
+        stashShortcutLabel="Ctrl+S"
+        onRestore={() => {}}
+        onDelete={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(withLabel).toContain("Press Ctrl+S with a prompt");
+
+    const withoutLabel = renderToStaticMarkup(
+      <ComposerStashMenu
+        entries={[]}
+        stashShortcutLabel={null}
+        onRestore={() => {}}
+        onDelete={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(withoutLabel).toContain("Nothing stashed yet.");
+    expect(withoutLabel).not.toContain("Press");
+  });
+
   it("shows saved image thumbnails and incomplete image states", () => {
     const markup = renderToStaticMarkup(
       <ComposerStashMenu

--- a/apps/web/src/components/chat/ComposerStashMenu.tsx
+++ b/apps/web/src/components/chat/ComposerStashMenu.tsx
@@ -29,9 +29,9 @@ function stashEntrySnippet(entry: PromptStashEntry): string {
 }
 
 /**
- * Attached banner listing the stashed prompts. Keyboard-first: opened by ⌘S on an
- * empty composer, navigated with arrows, restored with Enter, dismissed
- * with Escape. The listener runs capture-phase on window so it wins over
+ * Attached banner listing the stashed prompts. Keyboard-first: opened by the
+ * stash shortcut on an empty composer, navigated with arrows, restored with
+ * Enter, dismissed with Escape. The listener runs capture-phase on window so it wins over
  * the Lexical editor's handlers while the menu is open.
  */
 export const ComposerStashMenu = memo(function ComposerStashMenu(props: {

--- a/apps/web/src/components/diffs/DiffCommentAnnotation.test.tsx
+++ b/apps/web/src/components/diffs/DiffCommentAnnotation.test.tsx
@@ -1,6 +1,7 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vite-plus/test";
 
+import { isMacPlatform } from "~/lib/utils";
 import { DiffCommentAnnotation } from "./DiffCommentAnnotation";
 
 const callbacks = {
@@ -21,7 +22,9 @@ describe("DiffCommentAnnotation", () => {
     expect(markup).not.toContain("font-mono");
     expect(markup).not.toContain("Local comment");
     expect(markup).not.toContain("on +78");
-    expect(markup).toContain("⌘/Ctrl Enter to send");
+    expect(markup).toContain(
+      `${isMacPlatform(navigator.platform) ? "\u2318Enter" : "Ctrl+Enter"} to send`,
+    );
     expect(markup).toContain("Add a comment…");
     expect(markup).toContain(">Comment</button>");
     expect(markup).toContain("autofocus");

--- a/apps/web/src/components/diffs/DiffCommentAnnotation.tsx
+++ b/apps/web/src/components/diffs/DiffCommentAnnotation.tsx
@@ -3,6 +3,7 @@ import { useState, type ReactNode } from "react";
 
 import { Button } from "~/components/ui/button";
 import { Textarea } from "~/components/ui/textarea";
+import { isMacPlatform } from "~/lib/utils";
 
 import { isCommentSubmitShortcut } from "./commentSubmitShortcut";
 
@@ -102,7 +103,9 @@ export function DiffCommentAnnotation({
         }}
       />
       <div className="mt-1.5 flex items-center gap-1">
-        <span className="mr-auto text-[10px] text-muted-foreground/70">⌘/Ctrl Enter to send</span>
+        <span className="mr-auto text-[10px] text-muted-foreground/70">
+          {isMacPlatform(navigator.platform) ? "\u2318Enter" : "Ctrl+Enter"} to send
+        </span>
         <Button
           className="text-muted-foreground hover:text-foreground"
           variant="ghost"

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -22,6 +22,7 @@ import {
 } from "react";
 import {
   type KeybindingCommand,
+  type KeybindingShortcut,
   type KeybindingWhenNode,
   type ServerRemoveKeybindingInput,
   type ServerUpsertKeybindingInput,
@@ -34,7 +35,7 @@ import {
 
 import { isElectron } from "../../env";
 import { useOpenInPreferredEditor } from "../../editorPreferences";
-import { formatShortcutLabel } from "../../keybindings";
+import { formatShortcutLabel, formatShortcutLabelParts } from "../../keybindings";
 import { cn } from "../../lib/utils";
 import {
   primaryServerAvailableEditorsAtom,
@@ -73,33 +74,12 @@ import { searchableSetting } from "./settingsSearch";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { useAtomCommand } from "../../state/use-atom-command";
 
-function KeybindingPill({ value }: { value: string }) {
-  // Keys dedupe repeated parts; a literal "+" in a shortcut splits into empty strings.
-  const seenParts = new Map<string, number>();
-  const parts = value.split("+").map((part) => {
-    const seen = seenParts.get(part) ?? 0;
-    seenParts.set(part, seen + 1);
-    return { part, key: seen === 0 ? part : `${part}-${seen}` };
-  });
+function KeybindingPill({ shortcut }: { shortcut: KeybindingShortcut }) {
   return (
     <KbdGroup className="bg-transparent p-0 shadow-none">
-      {parts.map(({ part, key }) => (
-        <Kbd key={key} className="min-w-6 justify-center px-1.5">
-          {part === "mod"
-            ? navigator.platform.toLowerCase().includes("mac")
-              ? "⌘"
-              : "Ctrl"
-            : part === "shift"
-              ? "⇧"
-              : part === "alt"
-                ? navigator.platform.toLowerCase().includes("mac")
-                  ? "⌥"
-                  : "Alt"
-                : part === "ctrl"
-                  ? "⌃"
-                  : part.length === 1
-                    ? part.toUpperCase()
-                    : part}
+      {formatShortcutLabelParts(shortcut).map((part) => (
+        <Kbd key={part} className="min-w-6 justify-center px-1.5">
+          {part}
         </Kbd>
       ))}
     </KbdGroup>
@@ -851,7 +831,7 @@ function KeybindingKeyControl({
             pillClassName,
           )}
         >
-          <KeybindingPill value={row.key} />
+          <KeybindingPill shortcut={row.binding.shortcut} />
         </button>
       ) : (
         <Input

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@t3tools/contracts";
 import {
   formatShortcutLabel,
+  formatShortcutLabelParts,
   isChatNewShortcut,
   isChatNewLocalShortcut,
   isDiffToggleShortcut,
@@ -849,6 +850,31 @@ describe("formatShortcutLabel", () => {
   it("formats labels for plus key", () => {
     assert.strictEqual(formatShortcutLabel(modShortcut("+"), "MacIntel"), "⌘+");
     assert.strictEqual(formatShortcutLabel(modShortcut("+"), "Linux"), "Ctrl++");
+  });
+});
+
+describe("formatShortcutLabelParts", () => {
+  it("splits the chord into one label per key", () => {
+    assert.deepStrictEqual(
+      formatShortcutLabelParts(modShortcut("d", { altKey: true, shiftKey: true }), "MacIntel"),
+      ["\u2325", "\u21e7", "\u2318", "D"],
+    );
+    assert.deepStrictEqual(
+      formatShortcutLabelParts(modShortcut("d", { altKey: true, shiftKey: true }), "Linux"),
+      ["Ctrl", "Alt", "Shift", "D"],
+    );
+  });
+
+  it("keeps the plus key as its own part", () => {
+    assert.deepStrictEqual(formatShortcutLabelParts(modShortcut("+"), "Linux"), ["Ctrl", "+"]);
+  });
+
+  it("names non-printable keys", () => {
+    assert.deepStrictEqual(formatShortcutLabelParts(modShortcut("escape"), "Linux"), [
+      "Ctrl",
+      "Esc",
+    ]);
+    assert.deepStrictEqual(formatShortcutLabelParts(modShortcut(" "), "Linux"), ["Ctrl", "Space"]);
   });
 });
 

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -233,28 +233,34 @@ function formatShortcutKeyLabel(key: string): string {
   return key.slice(0, 1).toUpperCase() + key.slice(1);
 }
 
+/**
+ * One label per key of the chord, modifiers first. Callers that render each key
+ * separately (the keybindings settings pills) need the parts; everything else
+ * wants `formatShortcutLabel`, which joins them the way the platform writes
+ * chords.
+ */
+export function formatShortcutLabelParts(
+  shortcut: KeybindingShortcut,
+  platform = navigator.platform,
+): ReadonlyArray<string> {
+  const useMetaForMod = isMacPlatform(platform);
+  const showMeta = shortcut.metaKey || (shortcut.modKey && useMetaForMod);
+  const showCtrl = shortcut.ctrlKey || (shortcut.modKey && !useMetaForMod);
+
+  const parts: string[] = [];
+  if (showCtrl) parts.push(useMetaForMod ? "\u2303" : "Ctrl");
+  if (shortcut.altKey) parts.push(useMetaForMod ? "\u2325" : "Alt");
+  if (shortcut.shiftKey) parts.push(useMetaForMod ? "\u21e7" : "Shift");
+  if (showMeta) parts.push(useMetaForMod ? "\u2318" : "Meta");
+  parts.push(formatShortcutKeyLabel(shortcut.key));
+  return parts;
+}
+
 export function formatShortcutLabel(
   shortcut: KeybindingShortcut,
   platform = navigator.platform,
 ): string {
-  const keyLabel = formatShortcutKeyLabel(shortcut.key);
-  const useMetaForMod = isMacPlatform(platform);
-  const showMeta = shortcut.metaKey || (shortcut.modKey && useMetaForMod);
-  const showCtrl = shortcut.ctrlKey || (shortcut.modKey && !useMetaForMod);
-  const showAlt = shortcut.altKey;
-  const showShift = shortcut.shiftKey;
-
-  if (useMetaForMod) {
-    return `${showCtrl ? "\u2303" : ""}${showAlt ? "\u2325" : ""}${showShift ? "\u21e7" : ""}${showMeta ? "\u2318" : ""}${keyLabel}`;
-  }
-
-  const parts: string[] = [];
-  if (showCtrl) parts.push("Ctrl");
-  if (showAlt) parts.push("Alt");
-  if (showShift) parts.push("Shift");
-  if (showMeta) parts.push("Meta");
-  parts.push(keyLabel);
-  return parts.join("+");
+  return formatShortcutLabelParts(shortcut, platform).join(isMacPlatform(platform) ? "" : "+");
 }
 
 export function shortcutLabelForCommand(


### PR DESCRIPTION
## UI Changes

No screenshots: the change is text, and the strings are exact. On Windows/Linux:

| Where | Before | After |
| --- | --- | --- |
| Settings → Keybindings pill, `mod+shift+d` | `Ctrl` `⇧` `D` | `Ctrl` `Shift` `D` |
| Settings → Keybindings pill, `mod+esc` | `Ctrl` `esc` | `Ctrl` `Esc` |
| Diff comment composer | `⌘/Ctrl Enter to send` | `Ctrl+Enter to send` |
| Empty prompt stash | `Press ⌘S with a prompt…` | `Press Ctrl+S with a prompt…` |

macOS is unchanged everywhere except the diff comment hint, which loses the
`/Ctrl` half.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes — text-only change, exact strings tabled above
- [ ] I included a video for animation/interaction changes — N/A, no motion

Changes by Claude Opus 5 running in Claude Code.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Text-only UI and label-formatting refactors with no auth, data, or shortcut-matching behavior changes; `KeybindingPill` now expects a `shortcut` prop instead of a string `value`.
> 
> **Overview**
> **Keyboard shortcut hints and labels now follow the host platform** instead of mixing macOS symbols with Windows/Linux text.
> 
> Adds **`formatShortcutLabelParts`** in `keybindings.ts` as the shared source for per-key chord labels; **`formatShortcutLabel`** joins those parts (no separator on Mac, `+` elsewhere). **Settings → Keybindings** pills use the structured shortcut and this helper so non-Mac users see **Ctrl / Alt / Shift** and proper **Esc** labels instead of stray Unicode modifier glyphs.
> 
> **Diff comment composer** replaces the fixed `⌘/Ctrl Enter to send` string with **`⌘Enter` or `Ctrl+Enter`** via `isMacPlatform`. **`ComposerStashMenu`** takes an optional **`stashShortcutLabel`** for the empty-stash hint and falls back to **“Nothing stashed yet.”** when it is null; tests cover both cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3029a5c8f581e49062903f74ad4f517c8c5e3335. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make keyboard shortcut hints platform-aware instead of assuming macOS
> - Introduces `formatShortcutLabelParts` in [keybindings.ts](https://github.com/pingdotgg/t3code/pull/7715/files#diff-0c56a39781768a3ed42f3d306e35b87e9d2426ccb4a81010bc2c4fe735001385), which returns per-key labels (modifiers first) using glyphs on macOS and text names elsewhere; `formatShortcutLabel` now delegates to it
> - Refactors `KeybindingPill` in [KeybindingsSettings.tsx](https://github.com/pingdotgg/t3code/pull/7715/files#diff-12068495a79a13f54503fa3061aafb91f05537621626906b290ed059e660d4d4) to accept a structured `KeybindingShortcut` and render each part via the new formatter instead of a preformatted string
> - Replaces the static `⌘/Ctrl Enter to send` hint in [DiffCommentAnnotation.tsx](https://github.com/pingdotgg/t3code/pull/7715/files#diff-aff2e4a32d36e44417e648f0afbe76bcd3748b758ea88eac7c76fc04c92db458) with a platform-conditional label showing `⌘Enter` on macOS and `Ctrl+Enter` elsewhere
> - Behavioral Change: shortcut pills and inline hints now render different glyphs and join characters depending on platform; reviewers should verify `formatShortcutLabel` still produces the same joined string for existing callers
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3029a5c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->