### PR TITLE
fix(web): keep the right panel open when its last tab closes

### DIFF
--- a/apps/web/src/rightPanelStore.test.ts
+++ b/apps/web/src/rightPanelStore.test.ts
@@ -602,12 +602,12 @@ describe("rightPanelStore", () => {
     });
   });
 
-  it("closing the final terminal pane removes its surface and closes the panel", () => {
+  it("closing the final terminal pane removes its surface and keeps the panel open", () => {
     useRightPanelStore.getState().openTerminal(refA, "term-1");
     useRightPanelStore.getState().closeTerminal(refA, "terminal:term-1", "term-1");
 
     expect(selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA)).toEqual({
-      isOpen: false,
+      isOpen: true,
       activeSurfaceId: null,
       surfaces: [],
     });
@@ -623,8 +623,50 @@ describe("rightPanelStore", () => {
     );
   });
 
-  it("closing the final surface closes the panel", () => {
+  it("closing the final surface keeps the panel open on the empty state", () => {
     useRightPanelStore.getState().openTerminal(refA, "term-1");
+    useRightPanelStore.getState().closeSurface(refA, "terminal:term-1");
+
+    expect(selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA)).toEqual({
+      isOpen: true,
+      activeSurfaceId: null,
+      surfaces: [],
+    });
+  });
+
+  it("closing a file opened from the explorer keeps the panel open on the empty state", () => {
+    useRightPanelStore.getState().open(refA, "files");
+    useRightPanelStore.getState().openFile(refA, "src/index.ts");
+    useRightPanelStore.getState().closeSurface(refA, "file:src/index.ts");
+
+    expect(selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA)).toEqual({
+      isOpen: true,
+      activeSurfaceId: null,
+      surfaces: [],
+    });
+  });
+
+  it("closing the final surface of the pull-request list's shared panel closes it", () => {
+    const pullRequestsPanelRef = scopeThreadRef(
+      "env-1" as EnvironmentId,
+      ThreadId.make("pull-requests-panel"),
+    );
+    const target = { projectId: "project-1", repository: "owner/repo", number: 1 };
+    useRightPanelStore.getState().openPullRequest(pullRequestsPanelRef, target);
+    useRightPanelStore.getState().closeSurface(pullRequestsPanelRef, pullRequestSurfaceId(target));
+
+    expect(
+      selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, pullRequestsPanelRef),
+    ).toEqual({
+      isOpen: false,
+      activeSurfaceId: null,
+      surfaces: [],
+    });
+  });
+
+  it("closing the final surface of a hidden panel leaves it hidden", () => {
+    useRightPanelStore.getState().openTerminal(refA, "term-1");
+    useRightPanelStore.getState().close(refA);
     useRightPanelStore.getState().closeSurface(refA, "terminal:term-1");
 
     expect(selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA)).toEqual({
@@ -670,14 +712,14 @@ describe("rightPanelStore", () => {
     });
   });
 
-  it("closing all surfaces closes the panel", () => {
+  it("closing all surfaces keeps the panel open on the empty state", () => {
     useRightPanelStore.getState().openBrowser(refA, "tab-a");
     useRightPanelStore.getState().openFile(refA, "src/index.ts");
 
     useRightPanelStore.getState().closeAllSurfaces(refA);
 
     expect(selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA)).toEqual({
-      isOpen: false,
+      isOpen: true,
       activeSurfaceId: null,
       surfaces: [],
     });

--- a/apps/web/src/rightPanelStore.ts
+++ b/apps/web/src/rightPanelStore.ts
@@ -76,6 +76,23 @@ const RIGHT_PANEL_STORAGE_VERSION = 11;
  */
 const isPullRequestsPanelKey = (threadKey: string) => threadKey.endsWith(":pull-requests-panel");
 
+/**
+ * Closing tabs never hides a thread's panel. An open panel with no surfaces is a
+ * real state that renders the empty-state picker, and it is already the state the
+ * panel opens in on a thread that has no tabs yet, so emptying it by closing the
+ * last tab lands there too instead of collapsing. Visibility stays owned by
+ * `close`/`toggleVisibility`.
+ *
+ * The pull-request list's shared panel is the exception: it renders only while a
+ * change request is selected, so emptying that one still closes it rather than
+ * leaving an open panel with nothing to show.
+ */
+const isOpenAfterClose = (
+  current: ThreadRightPanelState,
+  ref: ScopedThreadRef,
+  remaining: number,
+): boolean => current.isOpen && (remaining > 0 || !isPullRequestsPanelKey(scopedThreadKey(ref)));
+
 export interface ThreadRightPanelState {
   isOpen: boolean;
   activeSurfaceId: string | null;
@@ -471,7 +488,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
               const fallback = surfaces[Math.min(index, surfaces.length - 1)] ?? null;
               return {
                 ...current,
-                isOpen: surfaces.length > 0 && current.isOpen,
+                isOpen: isOpenAfterClose(current, ref, surfaces.length),
                 surfaces,
                 activeSurfaceId:
                   current.activeSurfaceId === surfaceId
@@ -511,12 +528,16 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
             if (index < 0) return current;
             const surfaces = current.surfaces.filter((surface) => surface.id !== surfaceId);
             if (current.activeSurfaceId !== surfaceId) {
-              return { ...current, isOpen: surfaces.length > 0 && current.isOpen, surfaces };
+              return {
+                ...current,
+                isOpen: isOpenAfterClose(current, ref, surfaces.length),
+                surfaces,
+              };
             }
             const fallback = surfaces[Math.min(index, surfaces.length - 1)] ?? null;
             return {
               ...current,
-              isOpen: surfaces.length > 0 && current.isOpen,
+              isOpen: isOpenAfterClose(current, ref, surfaces.length),
               surfaces,
               activeSurfaceId: fallback?.id ?? null,
             };
@@ -556,7 +577,12 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
           byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) =>
             current.surfaces.length === 0
               ? current
-              : { ...current, isOpen: false, surfaces: [], activeSurfaceId: null },
+              : {
+                  ...current,
+                  isOpen: isOpenAfterClose(current, ref, 0),
+                  surfaces: [],
+                  activeSurfaceId: null,
+                },
           ),
         })),
       reconcileBrowserSurfaces: (ref, tabIds) =>


### PR DESCRIPTION
## What Changed

Closing the last tab in the right panel no longer collapses the panel. It now falls back to the empty-state picker, which is the same state the panel already shows when you toggle it open on a thread that has no tabs yet.

The change is in `apps/web/src/rightPanelStore.ts`. `closeSurface`, `closeTerminal`, and `closeAllSurfaces` each forced `isOpen` to false once the last surface was removed. They now go through one helper, `isOpenAfterClose`, so panel visibility is owned by `close` and `toggleVisibility` rather than by tab count.

Fixes #7727.

## Why

The empty state this falls back to already exists and is fully built: `RightPanelEmptyState` in `apps/web/src/components/RightPanelTabs.tsx`, added in #6258. `RightPanelTabs` even hides the add-surface `+` button when there are no surfaces, because the picker cards replace it, and the panel is gated only on `isOpen` and not on surface count. The UI already supported this state; the store was the only thing preventing a closed tab from reaching it.

It is most noticeable with files, because `openFile` deliberately replaces the standalone explorer surface with the file tab (tested in `rightPanelStore.test.ts`). Open the explorer, open a file, close it, and the panel disappears even though you never dismissed the explorer yourself. Closing a lone terminal, diff, or browser tab did the same.

Two deliberate boundaries:

1. `reconcileFileSurfaces` still closes the panel when the workspace goes away. That path reacts to surfaces becoming invalid, not to a user closing a tab.
2. The shared panel on the pull-request list keeps the old behavior, since it renders only while a change request is selected and has no picker to fall back to. Leaving it open would show a blank panel, so `isOpenAfterClose` excludes it via the existing `isPullRequestsPanelKey` check.

Three existing tests asserted the old collapse behavior and are updated here. They predate #6258, which built the empty state but did not revisit the store. Three tests are added: closing a file opened from the explorer, the pull-request panel exception, and a hidden panel staying hidden.

This is client state in `apps/web` with no platform branching, so it applies to the browser app and to the desktop app on Windows, macOS, and Linux. `apps/mobile` does not use this store.

## UI Changes

Before, a file open in the right panel:

![Before: a file open in the right panel](https://raw.githubusercontent.com/moazessam376-dev/t3code/issue-7727-assets/screenshots/before-1-file-open.png)

Closing that one tab removes the entire panel:

![Before: the panel collapsed entirely](https://raw.githubusercontent.com/moazessam376-dev/t3code/issue-7727-assets/screenshots/before-2-panel-collapsed-blurred.png)

After, same starting point:

![After: a file open in the right panel](https://raw.githubusercontent.com/moazessam376-dev/t3code/issue-7727-assets/screenshots/after-1-file-open.png)

Closing the same tab now lands on the picker:

![After: the empty-state picker](https://raw.githubusercontent.com/moazessam376-dev/t3code/issue-7727-assets/screenshots/after-2-empty-state-picker.png)

## Testing

- `apps/web` unit suite: 2653 tests across 270 files pass
- `tsgo --noEmit` on `apps/web` passes
- `vp lint` and `vp fmt --check` pass on both changed files

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only panel visibility in the right-panel store; no auth, persistence version, or data-handling changes. Hidden panels and the PR-list exception are covered by tests.
> 
> **Overview**
> Closing the last right-panel tab no longer collapses the panel. `closeSurface`, `closeTerminal`, and `closeAllSurfaces` now keep `isOpen` when a thread panel is emptied, so users land on the existing empty-state picker instead of losing the panel.
> 
> Visibility is centralized in `isOpenAfterClose`: a hidden panel stays hidden, and the pull-request list’s shared panel still closes when its last tab is gone (it has no picker). Workspace invalidation via `reconcileFileSurfaces` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4edfc7afc53b7f5e2bc0830570989a43aed89a47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep right panel open when its last tab closes
> - Regular right panels now stay open and show an empty state when their last surface closes, instead of closing automatically.
> - Adds `isOpenAfterClose` helper in [rightPanelStore.ts](https://github.com/pingdotgg/t3code/pull/7732/files#diff-c23667fc6a40049fa00d6fba14ae4a097ed3561fcdfb9ec172bc8216cd9f82eb) and applies it to `closeTerminal`, `closeSurface`, and `closeAllSurfaces` handlers.
> - The shared pull-requests panel is an exception: it still closes when emptied.
> - Behavioral Change: `closeAllSurfaces` no longer unconditionally sets `isOpen=false`; regular panels remain open. Reviewers should verify callers relying on panel auto-close now handle the empty state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4edfc7a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
