### PR TITLE
fix(web): stop dimming unread in-flight sidebar rows

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -29,6 +29,7 @@ import {
   formatWorkingDurationLabel,
   shouldNavigateAfterProjectRemoval,
   shouldClearThreadSelectionOnMouseDown,
+  sidebarRowNeedsAttention,
   sortLogicalProjectsForSidebar,
   sortSettledThreadsForSidebar,
   pinOrderKeyBetween,
@@ -317,6 +318,32 @@ describe("hasUnseenCompletion", () => {
         session: null,
       }),
     ).toBe(false);
+  });
+});
+
+describe("sidebarRowNeedsAttention", () => {
+  const quietRow = {
+    isUnread: false,
+    isWoke: false,
+    isActive: false,
+    isSelected: false,
+  };
+
+  it("lets a read row be dimmed", () => {
+    expect(sidebarRowNeedsAttention(quietRow)).toBe(false);
+  });
+
+  it("keeps an unread row at full contrast", () => {
+    expect(sidebarRowNeedsAttention({ ...quietRow, isUnread: true })).toBe(true);
+  });
+
+  it("keeps a woken row at full contrast", () => {
+    expect(sidebarRowNeedsAttention({ ...quietRow, isWoke: true })).toBe(true);
+  });
+
+  it("exempts the active and selected rows", () => {
+    expect(sidebarRowNeedsAttention({ ...quietRow, isActive: true })).toBe(true);
+    expect(sidebarRowNeedsAttention({ ...quietRow, isSelected: true })).toBe(true);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -268,6 +268,21 @@ export function hasUnseenCompletion(thread: ThreadStatusInput): boolean {
   return completedAt > lastVisitedAt;
 }
 
+/**
+ * Whether a sidebar row is exempt from every dimming treatment: it needs a
+ * human (unread completion, fresh wake) or the user is already on it. Both the
+ * receded surface and the in-flight fade read this, so the two can never
+ * disagree about which rows stay at full contrast.
+ */
+export function sidebarRowNeedsAttention(input: {
+  isUnread: boolean;
+  isWoke: boolean;
+  isActive: boolean;
+  isSelected: boolean;
+}): boolean {
+  return input.isUnread || input.isWoke || input.isActive || input.isSelected;
+}
+
 export function shouldClearThreadSelectionOnMouseDown(target: HTMLElement | null): boolean {
   if (target === null) return true;
   return !target.closest(THREAD_SELECTION_SAFE_SELECTOR);

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -140,6 +140,7 @@ import {
   resolveSidebarThreadStatus,
   searchSidebarThreadsByTitle,
   shouldCreateNewThreadInCurrentProject,
+  sidebarRowNeedsAttention,
   resolveWorkingStartedAt,
   sortLogicalProjectsForSidebar,
   sortPinnedThreadsForSidebar,
@@ -849,8 +850,13 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   // stands out.
   const isInFlight =
     status === "working" || status === "monitoring" || status === "approval" || status === "input";
-  const shouldRecede =
-    (status === "ready" || isInFlight) && !isUnread && !isWoke && !props.isActive && !isSelected;
+  const needsAttention = sidebarRowNeedsAttention({
+    isUnread,
+    isWoke,
+    isActive: props.isActive,
+    isSelected,
+  });
+  const shouldRecede = (status === "ready" || isInFlight) && !needsAttention;
   // Status hues follow the system-wide convention set by sidebar v1 and the
   // mobile Live Activity/widgets (amber approval, indigo input, sky working)
   // so a thread reads the same color everywhere it surfaces.
@@ -1127,10 +1133,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
         : shouldRecede
           ? "text-sidebar-muted-foreground/75 hover:bg-sidebar-row-hover hover:text-sidebar-foreground"
           : "bg-transparent text-sidebar-foreground hover:bg-sidebar-row-hover",
-    isInFlight &&
-      !props.isActive &&
-      !isSelected &&
-      "opacity-70 transition-opacity hover:opacity-100",
+    isInFlight && !needsAttention && "opacity-70 transition-opacity hover:opacity-100",
   );
 
   const title = isRenaming ? (


### PR DESCRIPTION
## What Changed

`SidebarThreadRow` dimmed rows in two independent places, and only one of them
exempted unread rows. `shouldRecede` carried `!isUnread && !isWoke`, while
`rowSurfaceClassName` applied `opacity-70` to the whole row on `isInFlight`
alone. An unread thread whose session was still working, monitoring, or waiting
on approval/input therefore rendered visibly dimmer than an unread `ready`
thread — two rows that both need the user, shown at different prominence.

Both call sites now read one predicate:

```ts
export function sidebarRowNeedsAttention(input: {
  isUnread: boolean
  isWoke: boolean
  isActive: boolean
  isSelected: boolean
}): boolean {
  return input.isUnread || input.isWoke || input.isActive || input.isSelected
}
```

It lives in `Sidebar.logic.ts` next to `hasUnseenCompletion` and is covered by
unit tests. Behaviour changes only for rows that are in flight **and** unread or
woken; read in-flight rows fade exactly as before, and active/selected rows were
already exempt through their own branches.

## Why

The comment above `shouldRecede` already states the rule: prominence is reserved
for rows that need a human — "done (unread), read-but-unsettled, failed, and
freshly woken". The in-flight fade was added separately and never picked up that
guard, so the wrapper opacity silently undid the `text-foreground` the title
class had just resolved for unread rows. That is a missing guard rather than a
deliberate counter-rule, so the fix is to stop expressing the same rule twice
instead of adding a fifth term to a second condition.

Related, not fixed here: the status cascade ranks `working`/`monitoring` above
`isUnread`, so an unread monitoring row shows "Monitoring" instead of the "Done"
pill. #7655 addresses exactly that ordering. With that PR the label carries the
unread signal and this one restores the contrast; together they cover the case.
An always-on unread marker independent of the status slot would be a design
decision and belongs in neither PR.

## Surfaces

- **Web + desktop:** fixed here; desktop wraps the same component.
- **Mobile:** renders its own rows and has no equivalent in-flight opacity.
- **Legacy sidebar:** untouched, it has no second dimming path.
- **Contracts:** unchanged, this is client-side styling.
- **Performance:** one boolean per row render, no new animation.
- **Docs:** no user or internals doc describes this dimming.

## UI Changes

Verified against a dev build on isolated state with a `ready` + unread row and a
`monitoring` + unread row visible at once: before the fix the monitoring row's
title, project and branch render dimmer than the row above it, after the fix
both sit at the same contrast. Screenshots not attached — happy to add them.

Worth knowing when reproducing: `backgroundLiveness` is in-memory only
(`ThreadBackgroundLiveness.ts`), so a monitoring row cannot come from a cloned
database. It needs a live monitor task or a temporary local fixture.

## Verification

- `vp test run apps/web/src/components/Sidebar.logic.test.ts` — 109 passed
- `vp run --filter @t3tools/web typecheck` — clean
- targeted lint and format check on the three touched files

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes — available on request
- [ ] I included a video for animation/interaction changes — not applicable, nothing animates

---

Made with Claude Opus 5 using Claude Code inside T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only sidebar styling with a small shared predicate; behavior changes only for unread/woken in-flight rows, with tests added.
> 
> **Overview**
> Sidebar thread rows used **two separate dimming rules**: `shouldRecede` already skipped unread, woke, active, and selected rows, but in-flight rows also got `opacity-70` whenever `isInFlight` was true. Unread threads still working, monitoring, or waiting on approval/input therefore looked dimmer than unread **ready** rows even though both need attention.
> 
> This PR adds **`sidebarRowNeedsAttention`** in `Sidebar.logic.ts` and uses it for both receded text styling and in-flight opacity. Rows that are unread, freshly woken, active, or selected stay at full contrast; read in-flight rows still fade as before. Unit tests cover the helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db5682f6258c23fe42861f900bda732a1deee216. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop dimming unread in-flight sidebar rows
> - Adds `sidebarRowNeedsAttention` to centralize dimming exemptions for `isUnread`, `isWoke`, `isActive`, and `isSelected` states in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/7734/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a)
> - Updates `shouldRecede` and in-flight opacity fade logic in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/7734/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) to use `!needsAttention` instead of individual inline checks
> - Unread or freshly woke in-flight rows now remain at full contrast instead of fading
> - Risk: `sidebarRowNeedsAttention` must be updated if new row states that require full contrast are introduced
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db5682f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->