### PR TITLE
fix(server): pin the Claude CLI verbose setting for text generation

### DIFF
--- a/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.test.ts
@@ -234,7 +234,7 @@ it.layer(ClaudeTextGenerationTestLayer)("ClaudeTextGeneration", (it) => {
             body: "",
           },
         }),
-        argsMustContain: '--settings {"alwaysThinkingEnabled":false}',
+        argsMustContain: '--settings {"verbose":false,"alwaysThinkingEnabled":false}',
         argsMustNotContain: "--effort",
       },
       (textGeneration) =>
@@ -266,7 +266,7 @@ it.layer(ClaudeTextGenerationTestLayer)("ClaudeTextGeneration", (it) => {
             body: "Body",
           },
         }),
-        argsMustContain: '--effort max --settings {"fastMode":true}',
+        argsMustContain: '--effort max --settings {"verbose":false,"fastMode":true}',
       },
       (textGeneration) =>
         Effect.gen(function* () {
@@ -374,6 +374,70 @@ it.layer(ClaudeTextGenerationTestLayer)("ClaudeTextGeneration", (it) => {
           });
 
           expect(generated.title).toBe("New thread");
+        }),
+    ),
+  );
+
+  it.effect("pins verbose output off even without other Claude settings", () =>
+    withFakeClaudeEnv(
+      {
+        output: JSON.stringify({
+          structured_output: {
+            title: "Reconnect failures after restart",
+          },
+        }),
+        argsMustContain: '--settings {"verbose":false}',
+      },
+      (textGeneration) =>
+        Effect.gen(function* () {
+          const generated = yield* textGeneration.generateThreadTitle({
+            cwd: process.cwd(),
+            message: "Please investigate reconnect failures after restarting the session.",
+            modelSelection: {
+              instanceId: ProviderInstanceId.make("claudeAgent"),
+              model: "claude-sonnet-4-6",
+            },
+          });
+
+          expect(generated.title).toBe(sanitizeThreadTitle("Reconnect failures after restart"));
+        }),
+    ),
+  );
+
+  // Guards the assumption behind `verbose: false`: should the CLI ever stream
+  // events despite the pinned setting, this fails loudly instead of silently.
+  it.effect("fails when the CLI streams events instead of the envelope", () =>
+    withFakeClaudeEnv(
+      {
+        output: JSON.stringify([
+          { type: "system", subtype: "init", session_id: "abc" },
+          { type: "assistant", message: { role: "assistant", content: [] } },
+          { type: "user", message: { role: "user", content: [] } },
+          { type: "rate_limit_event", rate_limit: { status: "allowed" } },
+          {
+            type: "result",
+            subtype: "success",
+            is_error: false,
+            result: '{"title":"Reconnect failures after restart"}',
+            structured_output: { title: "Reconnect failures after restart" },
+          },
+        ]),
+      },
+      (textGeneration) =>
+        Effect.gen(function* () {
+          const error = yield* Effect.flip(
+            textGeneration.generateThreadTitle({
+              cwd: process.cwd(),
+              message: "Name this thread.",
+              modelSelection: {
+                instanceId: ProviderInstanceId.make("claudeAgent"),
+                model: "claude-sonnet-4-6",
+              },
+            }),
+          );
+
+          expect(error._tag).toBe("TextGenerationError");
+          expect(error.detail).toContain("unexpected output format");
         }),
     ),
   );

--- a/apps/server/src/textGeneration/ClaudeTextGeneration.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.ts
@@ -143,6 +143,9 @@ export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(fu
     const fastMode =
       fastModeDescriptor?.type === "boolean" ? fastModeDescriptor.currentValue : undefined;
     const settings = {
+      // Pinned: a user-level `verbose` makes the CLI print a stream-event array
+      // instead of the single JSON envelope we parse.
+      verbose: false,
       ...(typeof thinking === "boolean" ? { alwaysThinkingEnabled: thinking } : {}),
       ...(fastMode ? { fastMode: true } : {}),
       ...(ultracode ? { ultracode: true } : {}),


### PR DESCRIPTION
## What Changed

`makeClaudeTextGeneration` now always sets `verbose: false` in the `settings` object it passes to `--settings`. Because the key is always present, the `--settings` payload now goes out on every call instead of only when `thinking`, `fastMode` or `ultracode` are set. Those three are otherwise untouched.

Tests: a new case for the pinned `--settings {"verbose":false}` with no other settings, a new case proving that streamed events fail loudly, and the existing fixtures' `--settings` expectations extended by `verbose`.

Three added lines of production code, the rest is tests.

## Why

Text generation through the Claude CLI fails silently whenever the user has `verbose` enabled in their Claude settings. With `verbose` on, `claude -p --output-format json` prints an array of stream events instead of the flat `{ structured_output }` envelope the decoder expects, so decoding dies with `SchemaError: Expected object`, wrapped in `TextGenerationError: Claude CLI returned unexpected output format`.

That error is only ever swallowed as a log warning, so nothing surfaces to the user. Thread titles, worktree branch names, commit messages and PR bodies just keep falling back to their placeholders (`t3code/<hex>`), permanently, with no indication why.

Pinning the setting is enough — no tolerant parsing of the event array is needed. Measured against Claude CLI 2.1.233, `--settings` beats both the user-level and the project-level settings:

| call (user + project `verbose: true`) | output |
|---|---|
| without `--settings` | `[{"type":"system",…` — array |
| with `--settings {"verbose":false}` | `{"is_error":false,…` — flat object |

The second test holds that assumption in place: if the CLI ever streams events despite the pinned setting, it fails loudly instead of silently.

Other providers are unaffected — Codex, Cursor, Grok and OpenCode parse the response text straight against the output schema, without an envelope.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes — no UI changes
- [ ] I included a video for animation/interaction changes — no motion changes

---

Claude Opus 5 via Claude Code.

_Created with AI assistance (Claude), reviewed by Timo._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to Claude CLI invocation flags for text generation; no auth, data, or cross-provider behavior changes.
> 
> **Overview**
> **Claude text generation** now always passes `--settings` with **`verbose: false`** when invoking the Claude CLI, so user or project `verbose` settings cannot make the CLI return a stream-event JSON array instead of the single `{ structured_output }` envelope the server parses.
> 
> Because `verbose` is always present in the settings object, **`--settings` is sent on every Claude text-generation call**, not only when thinking, fast mode, or ultracode flags are set. Existing tests were updated to expect `verbose:false` alongside those flags.
> 
> New tests cover the minimal `--settings {"verbose":false}` case and assert that stream-style CLI output surfaces a **`TextGenerationError`** with an unexpected output format message instead of failing silently and falling back to placeholders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4ab4290f4e09668ffa7e5f82707b56247799c3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin `verbose:false` in Claude CLI `--settings` for text generation
> - [ClaudeTextGeneration.ts](apps/server/src/textGeneration/ClaudeTextGeneration.ts) now unconditionally sets `verbose:false` in the settings object before merging optional flags, so `--settings` is always passed to the Claude CLI.
> - Updates existing tests to expect `verbose:false` in the settings JSON and adds a new test verifying `--settings {"verbose":false}` is sent even when no other settings are specified.
> - Adds a test asserting that stream-event CLI output fails with a `TextGenerationError` containing 'unexpected output format'.
> - Behavioral Change: all Claude CLI invocations from text generation now include `--settings` with at least `{"verbose":false}`, whereas previously `--settings` could be omitted when no optional flags were set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a4ab429.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->