### PR TITLE
feat(composer): list skills with slash commands

### DIFF
--- a/apps/mobile/src/features/threads/ComposerCommandPopover.tsx
+++ b/apps/mobile/src/features/threads/ComposerCommandPopover.tsx
@@ -119,6 +119,7 @@ const CommandRow = memo(function CommandRow(props: {
   readonly item: ComposerCommandItem;
   readonly onPress: () => void;
   readonly isLast: boolean;
+  readonly isSlashSkill: boolean;
 }) {
   const iconName = itemIcon(props.item);
   const iconColor = useThemeColor("--color-icon-subtle");
@@ -144,7 +145,14 @@ const CommandRow = memo(function CommandRow(props: {
         <SymbolView name={iconName} size={14} tintColor={iconColor} type="monochrome" />
       ) : null}
       <Text className="shrink-0 text-base font-t3-medium text-foreground" numberOfLines={1}>
-        {props.item.label}
+        {props.isSlashSkill && props.item.type === "skill" ? (
+          <>
+            <Text className="text-foreground-muted">skill:</Text>
+            {props.item.skill.name}
+          </>
+        ) : (
+          props.item.label
+        )}
       </Text>
       {props.item.description ? (
         <Text className="min-w-0 flex-1 text-xs text-foreground-muted" numberOfLines={1}>
@@ -181,6 +189,7 @@ export const ComposerCommandPopover = memo(function ComposerCommandPopover(
               item={item}
               onPress={() => props.onSelect(item)}
               isLast={index === props.items.length - 1}
+              isSlashSkill={props.triggerKind === "slash-command" && item.type === "skill"}
             />
           ))}
         </ScrollView>

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -67,6 +67,7 @@ import {
 import { resolveProviderOptionDescriptors } from "../../lib/providerOptions";
 import { useComposerPathSearch } from "../../state/use-composer-path-search";
 import { ComposerCommandPopover, type ComposerCommandItem } from "./ComposerCommandPopover";
+import { matchesSlashSkillQuery } from "./composerSlashSkillSearch";
 import {
   type ExistingThreadSettingsRouteSession,
   useExistingThreadSettingsRoutePresentation,
@@ -431,13 +432,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
       }
 
       const skillItems = (selectedProviderStatus?.skills ?? [])
-        .filter((skill) => {
-          if (!skill.enabled) return false;
-          if (!q) return true;
-          return [skill.name, skill.displayName, skill.shortDescription, skill.description].some(
-            (value) => value?.toLowerCase().includes(q),
-          );
-        })
+        .filter((skill) => matchesSlashSkillQuery(skill, q))
         .map((skill) => ({
           id: `skill:${skill.name}`,
           type: "skill" as const,

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -430,7 +430,23 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
         });
       }
 
-      return [...builtIn, ...providerCommands];
+      const skillItems = (selectedProviderStatus?.skills ?? [])
+        .filter((skill) => {
+          if (!skill.enabled) return false;
+          if (!q) return true;
+          return [skill.name, skill.displayName, skill.shortDescription, skill.description].some(
+            (value) => value?.toLowerCase().includes(q),
+          );
+        })
+        .map((skill) => ({
+          id: `skill:${skill.name}`,
+          type: "skill" as const,
+          skill,
+          label: `skill:${skill.name}`,
+          description: skill.shortDescription ?? skill.description ?? "",
+        }));
+
+      return [...builtIn, ...providerCommands, ...skillItems];
     }
 
     if (composerTrigger.kind === "skill") {

--- a/apps/mobile/src/features/threads/composerSlashSkillSearch.test.ts
+++ b/apps/mobile/src/features/threads/composerSlashSkillSearch.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { matchesSlashSkillQuery } from "./composerSlashSkillSearch";
+
+const browserSkill = {
+  name: "browser",
+  path: "/skills/browser/SKILL.md",
+  enabled: true,
+  shortDescription: "Open and control the in-app browser",
+};
+
+describe("matchesSlashSkillQuery", () => {
+  it("matches the rendered skill prefix", () => {
+    expect(matchesSlashSkillQuery(browserSkill, "skill")).toBe(true);
+    expect(matchesSlashSkillQuery(browserSkill, "skill:brow")).toBe(true);
+  });
+});

--- a/apps/mobile/src/features/threads/composerSlashSkillSearch.ts
+++ b/apps/mobile/src/features/threads/composerSlashSkillSearch.ts
@@ -1,0 +1,16 @@
+import type { ServerProviderSkill } from "@t3tools/contracts";
+
+export function matchesSlashSkillQuery(skill: ServerProviderSkill, query: string): boolean {
+  if (!skill.enabled) return false;
+  const normalizedQuery = query.toLowerCase();
+  const skillQuery =
+    normalizedQuery === "skill"
+      ? ""
+      : normalizedQuery.startsWith("skill:")
+        ? normalizedQuery.slice("skill:".length)
+        : normalizedQuery;
+  if (!skillQuery) return true;
+  return [skill.name, skill.displayName, skill.shortDescription, skill.description].some((value) =>
+    value?.toLowerCase().includes(skillQuery),
+  );
+}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1117,10 +1117,24 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         }),
       );
       const query = composerTrigger.query.trim().toLowerCase();
-      const slashCommandItems = [...builtInSlashCommandItems, ...providerSlashCommandItems];
-      if (!query) {
-        return slashCommandItems;
-      }
+      const skillItems = searchProviderSkills(selectedProviderStatus?.skills ?? [], query).map(
+        (skill) => ({
+          id: `skill:${selectedProvider}:${skill.name}`,
+          type: "skill" as const,
+          provider: selectedProvider,
+          skill,
+          label: `skill:${skill.name}`,
+          description:
+            skill.shortDescription ??
+            skill.description ??
+            (skill.scope ? `${skill.scope} skill` : ""),
+        }),
+      );
+      const slashCommandItems = [
+        ...builtInSlashCommandItems,
+        ...providerSlashCommandItems,
+        ...skillItems,
+      ];
       return searchSlashCommandItems(slashCommandItems, query);
     }
     if (composerTrigger.kind === "skill") {

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1117,8 +1117,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         }),
       );
       const query = composerTrigger.query.trim().toLowerCase();
-      const skillItems = searchProviderSkills(selectedProviderStatus?.skills ?? [], query).map(
-        (skill) => ({
+      const skillItems = (selectedProviderStatus?.skills ?? [])
+        .filter((skill) => skill.enabled)
+        .map((skill) => ({
           id: `skill:${selectedProvider}:${skill.name}`,
           type: "skill" as const,
           provider: selectedProvider,
@@ -1128,8 +1129,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
             skill.shortDescription ??
             skill.description ??
             (skill.scope ? `${skill.scope} skill` : ""),
-        }),
-      );
+        }));
       const slashCommandItems = [
         ...builtInSlashCommandItems,
         ...providerSlashCommandItems,

--- a/apps/web/src/components/chat/ComposerCommandMenu.test.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.test.tsx
@@ -116,5 +116,6 @@ describe("ComposerCommandMenu", () => {
     expect(markup).toContain('<span class="text-secondary-label">skill:</span>browser');
     expect(markup).toContain("Open and control the in-app browser");
     expect(markup).not.toContain("font-medium text-secondary-label");
+    expect(markup).not.toContain("<svg");
   });
 });

--- a/apps/web/src/components/chat/ComposerCommandMenu.test.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.test.tsx
@@ -86,4 +86,35 @@ describe("ComposerCommandMenu", () => {
     expect(markup).toContain("<svg");
     expect(markup).toContain("text-icon-muted");
   });
+
+  it("renders slash skill results with only the skill prefix dimmed", () => {
+    const markup = renderToStaticMarkup(
+      <ComposerCommandMenu
+        items={[
+          {
+            id: "skill:codex:browser",
+            type: "skill",
+            provider: ProviderDriverKind.make("codex"),
+            skill: {
+              name: "browser",
+              path: "/skills/browser/SKILL.md",
+              enabled: true,
+            },
+            label: "skill:browser",
+            description: "Open and control the in-app browser",
+          },
+        ]}
+        resolvedTheme="dark"
+        isLoading={false}
+        triggerKind="slash-command"
+        activeItemId="skill:codex:browser"
+        onHighlightedItemChange={() => {}}
+        onSelect={() => {}}
+      />,
+    );
+
+    expect(markup).toContain('<span class="text-secondary-label">skill:</span>browser');
+    expect(markup).toContain("Open and control the in-app browser");
+    expect(markup).not.toContain("font-medium text-secondary-label");
+  });
 });

--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -166,7 +166,7 @@ const ComposerCommandMenuItem = memo(function ComposerCommandMenuItem(props: {
           kind={props.item.pathKind}
           theme={props.resolvedTheme}
         />
-      ) : skillSourceKind ? (
+      ) : skillSourceKind && !slashSkill ? (
         <SkillSourceIcon kind={skillSourceKind} />
       ) : null}
       <span className="flex min-w-0 flex-1 items-baseline gap-3">

--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -139,7 +139,8 @@ const ComposerCommandMenuItem = memo(function ComposerCommandMenuItem(props: {
 }) {
   const skillSourceKind =
     props.item.type === "skill" ? resolveProviderSkillSourceKind(props.item.skill) : null;
-  const isSlashSkill = props.triggerKind === "slash-command" && props.item.type === "skill";
+  const slashSkill =
+    props.triggerKind === "slash-command" && props.item.type === "skill" ? props.item.skill : null;
 
   return (
     <CommandItem
@@ -170,10 +171,10 @@ const ComposerCommandMenuItem = memo(function ComposerCommandMenuItem(props: {
       ) : null}
       <span className="flex min-w-0 flex-1 items-baseline gap-3">
         <span className="shrink-0 font-sans text-xs font-medium">
-          {isSlashSkill ? (
+          {slashSkill ? (
             <>
               <span className="text-secondary-label">skill:</span>
-              {props.item.skill.name}
+              {slashSkill.name}
             </>
           ) : (
             props.item.label

--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -99,6 +99,7 @@ export const ComposerCommandMenu = memo(function ComposerCommandMenu(props: {
                 <ComposerCommandMenuItem
                   key={item.id}
                   item={item}
+                  triggerKind={props.triggerKind}
                   resolvedTheme={props.resolvedTheme}
                   isActive={props.activeItemId === item.id}
                   onHighlight={props.onHighlightedItemChange}
@@ -130,6 +131,7 @@ export const ComposerCommandMenu = memo(function ComposerCommandMenu(props: {
 
 const ComposerCommandMenuItem = memo(function ComposerCommandMenuItem(props: {
   item: ComposerCommandItem;
+  triggerKind: ComposerTriggerKind | null;
   resolvedTheme: "light" | "dark";
   isActive: boolean;
   onHighlight: (itemId: string | null) => void;
@@ -137,6 +139,7 @@ const ComposerCommandMenuItem = memo(function ComposerCommandMenuItem(props: {
 }) {
   const skillSourceKind =
     props.item.type === "skill" ? resolveProviderSkillSourceKind(props.item.skill) : null;
+  const isSlashSkill = props.triggerKind === "slash-command" && props.item.type === "skill";
 
   return (
     <CommandItem
@@ -166,7 +169,16 @@ const ComposerCommandMenuItem = memo(function ComposerCommandMenuItem(props: {
         <SkillSourceIcon kind={skillSourceKind} />
       ) : null}
       <span className="flex min-w-0 flex-1 items-baseline gap-3">
-        <span className="shrink-0 font-sans text-xs font-medium">{props.item.label}</span>
+        <span className="shrink-0 font-sans text-xs font-medium">
+          {isSlashSkill ? (
+            <>
+              <span className="text-secondary-label">skill:</span>
+              {props.item.skill.name}
+            </>
+          ) : (
+            props.item.label
+          )}
+        </span>
         <span className="min-w-0 flex-1 truncate text-right text-secondary-label text-xs">
           {props.item.description}
         </span>

--- a/apps/web/src/components/chat/composerSlashCommandSearch.test.ts
+++ b/apps/web/src/components/chat/composerSlashCommandSearch.test.ts
@@ -117,6 +117,27 @@ describe("searchSlashCommandItems", () => {
     ]);
   });
 
+  it("matches skills by their rendered prefix", () => {
+    const items = [
+      {
+        id: "skill:claudeAgent:browser",
+        type: "skill",
+        provider: claudeDriver,
+        skill: {
+          name: "browser",
+          path: "/skills/browser/SKILL.md",
+          enabled: true,
+        },
+        label: "skill:browser",
+        description: "Open and control the in-app browser",
+      },
+    ] satisfies Array<Extract<ComposerCommandItem, { type: "skill" }>>;
+
+    expect(searchSlashCommandItems(items, "/skill:brow").map((item) => item.id)).toEqual([
+      "skill:claudeAgent:browser",
+    ]);
+  });
+
   it("keeps skills alongside commands for an empty slash query", () => {
     const items = [
       {

--- a/apps/web/src/components/chat/composerSlashCommandSearch.test.ts
+++ b/apps/web/src/components/chat/composerSlashCommandSearch.test.ts
@@ -94,6 +94,29 @@ describe("searchSlashCommandItems", () => {
     ]);
   });
 
+  it("matches skills by display name", () => {
+    const items = [
+      {
+        id: "skill:claudeAgent:browser",
+        type: "skill",
+        provider: claudeDriver,
+        skill: {
+          name: "browser",
+          displayName: "Web Navigator",
+          path: "/skills/browser/SKILL.md",
+          enabled: true,
+          shortDescription: "Open and control the in-app browser",
+        },
+        label: "skill:browser",
+        description: "Open and control the in-app browser",
+      },
+    ] satisfies Array<Extract<ComposerCommandItem, { type: "skill" }>>;
+
+    expect(searchSlashCommandItems(items, "navigator").map((item) => item.id)).toEqual([
+      "skill:claudeAgent:browser",
+    ]);
+  });
+
   it("keeps skills alongside commands for an empty slash query", () => {
     const items = [
       {

--- a/apps/web/src/components/chat/composerSlashCommandSearch.test.ts
+++ b/apps/web/src/components/chat/composerSlashCommandSearch.test.ts
@@ -136,6 +136,8 @@ describe("searchSlashCommandItems", () => {
     expect(searchSlashCommandItems(items, "/skill:brow").map((item) => item.id)).toEqual([
       "skill:claudeAgent:browser",
     ]);
+    expect(searchSlashCommandItems(items, "/sk")).toEqual([]);
+    expect(searchSlashCommandItems(items, "/ill")).toEqual([]);
   });
 
   it("keeps skills alongside commands for an empty slash query", () => {

--- a/apps/web/src/components/chat/composerSlashCommandSearch.test.ts
+++ b/apps/web/src/components/chat/composerSlashCommandSearch.test.ts
@@ -33,7 +33,7 @@ describe("searchSlashCommandItems", () => {
         description: "Create distinctive, production-grade frontend interfaces",
       },
     ] satisfies Array<
-      Extract<ComposerCommandItem, { type: "slash-command" | "provider-slash-command" }>
+      Extract<ComposerCommandItem, { type: "slash-command" | "provider-slash-command" | "skill" }>
     >;
 
     expect(searchSlashCommandItems(items, "ui").map((item) => item.id)).toEqual([
@@ -61,11 +61,65 @@ describe("searchSlashCommandItems", () => {
         description: "General GitHub help",
       },
     ] satisfies Array<
-      Extract<ComposerCommandItem, { type: "slash-command" | "provider-slash-command" }>
+      Extract<ComposerCommandItem, { type: "slash-command" | "provider-slash-command" | "skill" }>
     >;
 
     expect(searchSlashCommandItems(items, "gfc").map((item) => item.id)).toEqual([
       "provider-slash-command:claudeAgent:gh-fix-ci",
+    ]);
+  });
+
+  it("includes skills by name and description", () => {
+    const items = [
+      {
+        id: "skill:claudeAgent:browser",
+        type: "skill",
+        provider: claudeDriver,
+        skill: {
+          name: "browser",
+          path: "/skills/browser/SKILL.md",
+          enabled: true,
+          shortDescription: "Open and control the in-app browser",
+        },
+        label: "skill:browser",
+        description: "Open and control the in-app browser",
+      },
+    ] satisfies Array<Extract<ComposerCommandItem, { type: "skill" }>>;
+
+    expect(searchSlashCommandItems(items, "browser").map((item) => item.id)).toEqual([
+      "skill:claudeAgent:browser",
+    ]);
+    expect(searchSlashCommandItems(items, "control").map((item) => item.id)).toEqual([
+      "skill:claudeAgent:browser",
+    ]);
+  });
+
+  it("keeps skills alongside commands for an empty slash query", () => {
+    const items = [
+      {
+        id: "slash:model",
+        type: "slash-command",
+        command: "model",
+        label: "/model",
+        description: "Switch model",
+      },
+      {
+        id: "skill:claudeAgent:unslop",
+        type: "skill",
+        provider: claudeDriver,
+        skill: {
+          name: "unslop",
+          path: "/skills/unslop/SKILL.md",
+          enabled: true,
+        },
+        label: "skill:unslop",
+        description: "Cut AI tells from writing",
+      },
+    ] satisfies Array<Extract<ComposerCommandItem, { type: "slash-command" | "skill" }>>;
+
+    expect(searchSlashCommandItems(items, "").map((item) => item.id)).toEqual([
+      "slash:model",
+      "skill:claudeAgent:unslop",
     ]);
   });
 });

--- a/apps/web/src/components/chat/composerSlashCommandSearch.ts
+++ b/apps/web/src/components/chat/composerSlashCommandSearch.ts
@@ -14,19 +14,9 @@ type SlashSearchItem = Extract<
 
 function scoreSlashCommandItem(item: SlashSearchItem, query: string): number | null {
   if (item.type === "skill") {
-    const scores = [
-      scoreProviderSkill(item.skill, query),
-      scoreQueryMatch({
-        value: item.label.toLowerCase(),
-        query,
-        exactBase: 0,
-        prefixBase: 2,
-        boundaryBase: 4,
-        includesBase: 6,
-        boundaryMarkers: ["-", "_", "/", ":"],
-      }),
-    ].filter((score): score is number => score !== null);
-    return scores.length === 0 ? null : Math.min(...scores);
+    const skillQuery =
+      query === "skill" ? "" : query.startsWith("skill:") ? query.slice("skill:".length) : query;
+    return skillQuery ? scoreProviderSkill(item.skill, skillQuery) : 0;
   }
 
   const primaryValue =

--- a/apps/web/src/components/chat/composerSlashCommandSearch.ts
+++ b/apps/web/src/components/chat/composerSlashCommandSearch.ts
@@ -14,7 +14,19 @@ type SlashSearchItem = Extract<
 
 function scoreSlashCommandItem(item: SlashSearchItem, query: string): number | null {
   if (item.type === "skill") {
-    return scoreProviderSkill(item.skill, query);
+    const scores = [
+      scoreProviderSkill(item.skill, query),
+      scoreQueryMatch({
+        value: item.label.toLowerCase(),
+        query,
+        exactBase: 0,
+        prefixBase: 2,
+        boundaryBase: 4,
+        includesBase: 6,
+        boundaryMarkers: ["-", "_", "/", ":"],
+      }),
+    ].filter((score): score is number => score !== null);
+    return scores.length === 0 ? null : Math.min(...scores);
   }
 
   const primaryValue =

--- a/apps/web/src/components/chat/composerSlashCommandSearch.ts
+++ b/apps/web/src/components/chat/composerSlashCommandSearch.ts
@@ -5,6 +5,7 @@ import {
 } from "@t3tools/shared/searchRanking";
 
 import type { ComposerCommandItem } from "./ComposerCommandMenu";
+import { scoreProviderSkill } from "../../providerSkillSearch";
 
 type SlashSearchItem = Extract<
   ComposerCommandItem,
@@ -12,12 +13,12 @@ type SlashSearchItem = Extract<
 >;
 
 function scoreSlashCommandItem(item: SlashSearchItem, query: string): number | null {
+  if (item.type === "skill") {
+    return scoreProviderSkill(item.skill, query);
+  }
+
   const primaryValue =
-    item.type === "slash-command"
-      ? item.command.toLowerCase()
-      : item.type === "provider-slash-command"
-        ? item.command.name.toLowerCase()
-        : item.skill.name.toLowerCase();
+    item.type === "slash-command" ? item.command.toLowerCase() : item.command.name.toLowerCase();
   const description = item.description.toLowerCase();
 
   const scores = [

--- a/apps/web/src/components/chat/composerSlashCommandSearch.ts
+++ b/apps/web/src/components/chat/composerSlashCommandSearch.ts
@@ -6,12 +6,18 @@ import {
 
 import type { ComposerCommandItem } from "./ComposerCommandMenu";
 
-function scoreSlashCommandItem(
-  item: Extract<ComposerCommandItem, { type: "slash-command" | "provider-slash-command" }>,
-  query: string,
-): number | null {
+type SlashSearchItem = Extract<
+  ComposerCommandItem,
+  { type: "slash-command" | "provider-slash-command" | "skill" }
+>;
+
+function scoreSlashCommandItem(item: SlashSearchItem, query: string): number | null {
   const primaryValue =
-    item.type === "slash-command" ? item.command.toLowerCase() : item.command.name.toLowerCase();
+    item.type === "slash-command"
+      ? item.command.toLowerCase()
+      : item.type === "provider-slash-command"
+        ? item.command.name.toLowerCase()
+        : item.skill.name.toLowerCase();
   const description = item.description.toLowerCase();
 
   const scores = [
@@ -43,18 +49,16 @@ function scoreSlashCommandItem(
 }
 
 export function searchSlashCommandItems(
-  items: ReadonlyArray<
-    Extract<ComposerCommandItem, { type: "slash-command" | "provider-slash-command" }>
-  >,
+  items: ReadonlyArray<SlashSearchItem>,
   query: string,
-): Array<Extract<ComposerCommandItem, { type: "slash-command" | "provider-slash-command" }>> {
+): SlashSearchItem[] {
   const normalizedQuery = normalizeSearchQuery(query, { trimLeadingPattern: /^\/+/ });
   if (!normalizedQuery) {
     return [...items];
   }
 
   const ranked: Array<{
-    item: Extract<ComposerCommandItem, { type: "slash-command" | "provider-slash-command" }>;
+    item: SlashSearchItem;
     score: number;
     tieBreaker: string;
   }> = [];
@@ -73,7 +77,9 @@ export function searchSlashCommandItems(
         tieBreaker:
           item.type === "slash-command"
             ? `0\u0000${item.command}`
-            : `1\u0000${item.command.name}\u0000${item.provider}`,
+            : item.type === "provider-slash-command"
+              ? `1\u0000${item.command.name}\u0000${item.provider}`
+              : `2\u0000${item.skill.name}\u0000${item.provider}`,
       },
       Number.POSITIVE_INFINITY,
     );

--- a/apps/web/src/providerSkillSearch.test.ts
+++ b/apps/web/src/providerSkillSearch.test.ts
@@ -56,4 +56,17 @@ describe("searchProviderSkills", () => {
 
     expect(searchProviderSkills(skills, "ui").map((skill) => skill.name)).toEqual([]);
   });
+
+  it("returns every enabled skill for an empty query", () => {
+    const skills = [
+      makeSkill({ name: "unslop" }),
+      makeSkill({ name: "browser" }),
+      makeSkill({ name: "disabled", enabled: false }),
+    ];
+
+    expect(searchProviderSkills(skills, "").map((skill) => skill.name)).toEqual([
+      "unslop",
+      "browser",
+    ]);
+  });
 });

--- a/apps/web/src/providerSkillSearch.ts
+++ b/apps/web/src/providerSkillSearch.ts
@@ -6,7 +6,7 @@ import {
   scoreQueryMatch,
 } from "@t3tools/shared/searchRanking";
 
-function scoreProviderSkill(skill: ServerProviderSkill, query: string): number | null {
+export function scoreProviderSkill(skill: ServerProviderSkill, query: string): number | null {
   const normalizedName = skill.name.toLowerCase();
   const normalizedLabel = formatProviderSkillDisplayName(skill).toLowerCase();
   const normalizedShortDescription = skill.shortDescription?.toLowerCase() ?? "";


### PR DESCRIPTION
Typing `/` only showed built-in and provider commands, so users had to know about the separate `$` trigger to discover skills.

This adds enabled skills to the slash menu on web and mobile. A bare `/` lists commands and skills together, further typing filters the same list, and selecting a skill still inserts its canonical `$name` token. Skill rows use a muted `skill:` prefix while keeping the skill name at the normal title color.

Tests:
- `vp test run apps/web/src/components/chat/ComposerCommandMenu.test.tsx apps/web/src/components/chat/composerSlashCommandSearch.test.ts apps/web/src/providerSkillSearch.test.ts`
- changed-file `vp lint`
- `vp run --filter @t3tools/mobile typecheck`
- `git diff --check`

Web typecheck still reports the existing `conditionalUI` errors in `src/components/clerk/electronPasskeys.test.ts`. Browser and simulator verification were not run.

before:
<img width="1546" height="248" alt="image" src="https://github.com/user-attachments/assets/41286afc-6e5b-4e05-9357-1d98eafef85c" />
after:
<img width="1562" height="310" alt="image" src="https://github.com/user-attachments/assets/ff596968-b7af-469c-ad27-4f1a1b72f6e5" />


Built with gpt-5.6-sol via Codex in T3 Code.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Composer suggestion UI and ranking only; skill insertion still uses the existing `$name` path, with no auth or data-handling changes.
> 
> **Overview**
> Typing `/` now surfaces **enabled provider skills** next to built-in and provider slash commands on web and mobile, so users don’t need the `$` trigger to discover them. Selecting a skill still inserts the existing `$name` token.
> 
> Slash skill rows show a muted `skill:` prefix plus the skill name (no source icon). Search treats `skill` / `skill:` as a prefix, then ranks by name, display name, and description. Empty `/` keeps commands and skills in one list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6afef2e6439e3458bca2928772cc6d4a9834e72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### List provider skills in slash-command suggestions for mobile and web composers
> - Both `ThreadComposer` (mobile) and `ChatComposer` (web) now build skill items from the selected provider's enabled skills and include them in slash-command results.
> - Mobile uses a new `matchesSlashSkillQuery` util to filter skills; web extends `searchSlashCommandItems` and `scoreSlashCommandItem` to score skill items, with tie-breaker ordering commands before skills.
> - Skill rows render a dimmed `skill:` prefix followed by the skill name, and suppress the source icon on web's `ComposerCommandMenuItem`.
> - Risk: `scoreProviderSkill` in [providerSkillSearch.ts](https://github.com/pingdotgg/t3code/pull/7737/files#diff-c7027add0d9fd7f6342ed3ca346dc48211d2a8694604666875f3b3570d1cedbe) is now exported; existing in-tree callers are unaffected but external consumers of this module's surface may see the new export.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f6afef2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

## request provenance

- requested by: @maria-rcks

<!-- t3bot-requester: discord_user_id=1456050980322808049 github=maria-rcks message_id=1540155490842050570 -->
