### PR TITLE
fix(web): add space above composer task tabs

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -2362,6 +2362,17 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       steps={visibleTaskSteps}
     />
   ) : null;
+  const showShoulderTabs =
+    !props.externalDrawerAttached &&
+    !showComposerTopDrawer &&
+    !isTasksDrawerOpen &&
+    !isComposerCollapsedMobile;
+  const hasShoulderTab =
+    showShoulderTabs &&
+    (stashQueue.length > 0 ||
+      (visibleTasksProgress !== null &&
+        visibleTaskSteps !== null &&
+        visibleTasksProgress.totalSteps > 0));
   useEffect(() => {
     if (visibleTasksProgress === null || visibleTaskSteps === null) {
       setIsTasksDrawerOpen(false);
@@ -2813,7 +2824,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       onDragOverCapture={composerMentionDragHandlers.onDragOver}
       onDragLeaveCapture={onComposerMentionDragLeaveCapture}
       onDropCapture={composerMentionDragHandlers.onDrop}
-      className="mx-auto w-full min-w-0 max-w-3xl"
+      className={cn("mx-auto w-full min-w-0 max-w-3xl", hasShoulderTab && "pt-7")}
       data-chat-composer-form="true"
     >
       {showComposerTopDrawer && (!isTasksDrawerOpen || hasBlockingComposerTopDrawer) ? (
@@ -2939,12 +2950,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         />
       ) : null}
       <div className="relative">
-        {visibleTasksProgress &&
-        visibleTaskSteps &&
-        !isTasksDrawerOpen &&
-        !props.externalDrawerAttached &&
-        !showComposerTopDrawer &&
-        !isComposerCollapsedMobile ? (
+        {showShoulderTabs && visibleTasksProgress && visibleTaskSteps ? (
           <ComposerTasksBadge
             expanded={false}
             hasTrailingShoulder={stashQueue.length > 0}
@@ -2954,10 +2960,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
             steps={visibleTaskSteps}
           />
         ) : null}
-        {!props.externalDrawerAttached &&
-        !showComposerTopDrawer &&
-        !isTasksDrawerOpen &&
-        !isComposerCollapsedMobile ? (
+        {showShoulderTabs ? (
           <ComposerStashBadge
             count={stashQueue.length}
             menuOpen={isStashMenuOpen}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -777,10 +777,6 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
     }
   }
 
-  [data-chat-composer-form="true"]:has(.chat-composer-shoulder-tab) {
-    padding-top: 1.75rem;
-  }
-
   .chat-composer-banner-stack-cap {
     --chat-composer-attached-surface: var(--chat-composer-glass-surface, var(--card));
     --chat-composer-attached-outline: var(

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -777,6 +777,10 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
     }
   }
 
+  [data-chat-composer-form="true"]:has(.chat-composer-shoulder-tab) {
+    padding-top: 1.75rem;
+  }
+
   .chat-composer-banner-stack-cap {
     --chat-composer-attached-surface: var(--chat-composer-glass-surface, var(--card));
     --chat-composer-attached-outline: var(


### PR DESCRIPTION
## What Changed

- Reserve the shoulder tab's 28px height in the composer layout.
- Apply the spacing to both task and stash tabs through their shared class.

## Why

Shoulder tabs are absolutely positioned above the composer. The overlay height did not include them, so the last tool row could sit too close to the tab. The form now reserves that space only while a shoulder tab exists.

## UI Changes

| Before | After |
| --- | --- |
| ![Tool row too close to the task tab](https://raw.githubusercontent.com/Bil0000/t3code/pr-assets/7740/7740-before.png) | ![Tool row with more space above the task tab](https://raw.githubusercontent.com/Bil0000/t3code/pr-assets/7740/7740-after.png) |

The browser check measured `28px` between the tool row and task tab. The form's computed top padding changed from `0px` to `28px` only while a shoulder tab was present.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change
- [x] No animation or interaction changed, so no video is needed

Verification:

- `ComposerTasksBadge.test.tsx`: 5 tests passed
- Web typecheck passed
- Changed CSS formatting passed
- Production web build passed
- Independent code review found no issues

Built with GPT-5.6 in the T3 Code Codex harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add top padding for shoulder tabs in ChatComposer
> Consolidates shoulder badge visibility checks into `showShoulderTabs` and `hasShoulderTab` flags in [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/7740/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a). Adds `pt-7` top padding to the composer form when at least one shoulder tab is active.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4aa048d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->