### PR TITLE
fix(web): show the full path in file link tooltips

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1323,8 +1323,10 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
         side="top"
         className="max-w-[min(40rem,calc(100vw-2rem))] font-mono text-[11px] leading-tight"
       >
+        {/* The full path: the chip already shows the shortened form, and a link
+            to the workspace root collapses to a bare label that repeats it. */}
         <div className="overflow-x-auto whitespace-nowrap [scrollbar-color:color-mix(in_srgb,var(--border)_78%,transparent)_transparent] [scrollbar-width:thin] [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-[color-mix(in_srgb,var(--border)_78%,transparent)] [&::-webkit-scrollbar-track]:bg-transparent">
-          {displayPath}
+          {targetPath}
         </div>
       </TooltipPopup>
     </Tooltip>


### PR DESCRIPTION
## The problem

A markdown file link's tooltip shows the **workspace-relative** path — the same
thing the chip already shows in shortened form. When the linked path *is* the
workspace root, `formatWorkspaceRelativePath` collapses it to the bare workspace
label (`filePathDisplay.ts:41-43`), so the chip and its tooltip read the same
single word and the full path is only reachable via right-click → Copy full path.

Asking an agent to print its working directory shows this clearly. With a thread
rooted at `/home/user/Projects/UnifyWeaver/context/claude`, Claude wrote:

> The current working directory is `/home/user/Projects/UnifyWeaver/context/claude`.

which renders as **"The current working directory is 📁claude ."** — so the
sentence as displayed states something that isn't true, and hovering repeats
`claude` rather than resolving it.

## The fix

The tooltip now renders `targetPath`, the same string the existing "Copy full
path" menu item uses. One line, plus a comment saying why.

## Before / after

<img width="1050" height="861" alt="before" src="https://github.com/user-attachments/assets/17d5a07d-6dff-4706-acdc-d5f5d35e15fe" />
<img width="1050" height="861" alt="after" src="https://github.com/user-attachments/assets/07ff41e1-07e5-4d14-ab0a-e4e521da2374" />


## Notes

- Reproduced on unmodified `main` @ 7107a98a2, provider Claude Haiku 4.5, web in
  a browser. Not provider-specific — it's in the markdown link rendering, before
  anything provider-shaped.
- No test added: `filePathDisplay.test.ts` covers the formatter rather than what
  the tooltip renders, and there's no browser-test harness in-tree for this
  component. Happy to add one if you'd like a particular shape.
- Behaviour introduced in #1956; the tooltip has shown the relative path since it
  was added, so this is a long-standing papercut rather than a regression.

Model: Claude Opus 5. Harness: Claude Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show full `targetPath` in `MarkdownFileLink` tooltip
> The file link chip already shows a shortened `displayPath`, so the tooltip now shows the full `targetPath` instead. Changed in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/7741/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c07dbe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line UI tooltip change in markdown file links; no auth, data, or open-path behavior is affected.
> 
> **Overview**
> File-link chips in chat markdown already show a shortened `displayPath`. The hover tooltip now shows `targetPath` (the same full path as “Copy full path”) instead of repeating that shortened form.
> 
> This matters most for workspace-root links, where the relative formatter collapses to the workspace label so the chip and tooltip used to say the same word.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c07dbec25acdaebec9c94d8de42d3484b455dda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->