### PR TITLE
feat(composer): drop non-image files as filesystem paths

### DIFF
--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -5,7 +5,7 @@ import type {
   DesktopPreviewTabState,
 } from "@t3tools/contracts";
 import { exposeClerkBridge } from "@clerk/electron/preload";
-import { contextBridge, ipcRenderer } from "electron";
+import { contextBridge, ipcRenderer, webUtils } from "electron";
 
 import * as IpcChannels from "./ipc/channels.ts";
 
@@ -34,6 +34,15 @@ contextBridge.exposeInMainWorld("desktopBridge", {
       return null;
     }
     return result as ReturnType<DesktopBridge["getAppBranding"]>;
+  },
+  getPathForFile: (file: File) => {
+    // Throws for a File that never came from the OS (e.g. built by the page).
+    try {
+      const path = webUtils.getPathForFile(file);
+      return path.length > 0 ? path : null;
+    } catch {
+      return null;
+    }
   },
   getSystemLocale: () => {
     const result = ipcRenderer.sendSync(IpcChannels.GET_SYSTEM_LOCALE_CHANNEL);

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -2565,34 +2565,41 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   };
 
   /**
-   * Insert dropped non-image files as filesystem paths. Only the desktop app
-   * can resolve a path from a dropped File, so in a browser tab this reports
-   * why nothing was inserted instead of silently swallowing the drop.
+   * Insert dropped non-image files as filesystem paths, reporting to a toast
+   * rather than the thread error banner: a mixed drop's images own that banner,
+   * and a path failure there would read as though the whole drop failed. Only
+   * the desktop app can resolve a path from a dropped File, so in a browser tab
+   * this says so instead of silently swallowing the drop. Returns whether text
+   * was actually inserted.
    */
-  const insertDroppedFilePaths = (files: File[]) => {
+  const insertDroppedFilePaths = (files: File[], hadImages: boolean): boolean => {
+    const reportFailure = (description: string) => {
+      toastManager.add({ type: "error", title: "Unable to add to chat", description });
+    };
     const resolvePath = window.desktopBridge?.getPathForFile;
     if (!resolvePath) {
-      setThreadError(
-        activeThreadId,
+      reportFailure(
         "Attaching files by path needs the desktop app. Paste an image, or type the path.",
       );
-      return;
+      return false;
     }
     const paths = files
       .map((file) => resolvePath(file))
       .filter((path): path is string => path !== null);
     const text = formatDroppedFilePaths(paths);
     if (text.length === 0) {
-      setThreadError(activeThreadId, "Could not read the location of the dropped file(s).");
-      return;
+      reportFailure("Could not read the location of the dropped file(s).");
+      return false;
     }
     if (!insertComposerTextAtEnd(text, { ensureLeadingBoundary: true })) {
-      toastManager.add({
-        type: "error",
-        title: "Unable to add to chat",
-        description: "The composer is busy; try again once it is ready.",
-      });
+      // This refusal comes from the same composer state that already rejected
+      // the images, so one drop never says it twice.
+      if (!hadImages) {
+        reportFailure("The composer is busy; try again once it is ready.");
+      }
+      return false;
     }
+    return true;
   };
 
   const insertComposerTextAtEnd = (
@@ -2725,17 +2732,17 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         if (images.length > 0) {
           void addComposerImages(images);
         }
-        if (nonImages.length > 0) {
-          // Deliberately no focusComposer() on this path. `applyPromptReplacement`
-          // focuses on the next frame, once Lexical has reconciled; focusing
-          // synchronously here makes the not-yet-reconciled editor sync its stale
-          // empty state back over the text we just inserted, so the drop looks
-          // like it silently did nothing. Same footgun the file-tree mention drop
-          // documents in makeComposerMentionDragHandlers.
-          insertDroppedFilePaths(nonImages);
-          return;
+        const insertedPath =
+          nonImages.length > 0 && insertDroppedFilePaths(nonImages, images.length > 0);
+        // Focus unless a path just landed. `applyPromptReplacement` focuses on the
+        // next frame, once Lexical has reconciled; focusing synchronously right
+        // after the insert makes the not-yet-reconciled editor sync its stale empty
+        // state back over the text, so the drop looks like it silently did nothing
+        // — the footgun makeComposerMentionDragHandlers documents for the mention
+        // drop. Nothing inserted means nothing to lose, so focus as before.
+        if (!insertedPath) {
+          focusComposer();
         }
-        focusComposer();
       },
       insertTextAtEnd: insertComposerTextAtEnd,
       openModelPicker: () => {

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -122,6 +122,7 @@ import {
   submitComposerDraft,
 } from "./composerSubmission";
 import { ComposerPromptLengthValidation } from "./ComposerPromptLengthValidation";
+import { formatDroppedFilePaths } from "./droppedFilePaths";
 
 type ComposerCommandMenuPosition = {
   bottom: number;
@@ -2563,6 +2564,37 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     void addComposerImages(imageFiles);
   };
 
+  /**
+   * Insert dropped non-image files as filesystem paths. Only the desktop app
+   * can resolve a path from a dropped File, so in a browser tab this reports
+   * why nothing was inserted instead of silently swallowing the drop.
+   */
+  const insertDroppedFilePaths = (files: File[]) => {
+    const resolvePath = window.desktopBridge?.getPathForFile;
+    if (!resolvePath) {
+      setThreadError(
+        activeThreadId,
+        "Attaching files by path needs the desktop app. Paste an image, or type the path.",
+      );
+      return;
+    }
+    const paths = files
+      .map((file) => resolvePath(file))
+      .filter((path): path is string => path !== null);
+    const text = formatDroppedFilePaths(paths);
+    if (text.length === 0) {
+      setThreadError(activeThreadId, "Could not read the location of the dropped file(s).");
+      return;
+    }
+    if (!insertComposerTextAtEnd(text, { ensureLeadingBoundary: true })) {
+      toastManager.add({
+        type: "error",
+        title: "Unable to add to chat",
+        description: "The composer is busy; try again once it is ready.",
+      });
+    }
+  };
+
   const insertComposerTextAtEnd = (
     text: string,
     options?: { ensureLeadingBoundary?: boolean },
@@ -2686,7 +2718,23 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         composerEditorRef.current?.focusAt(cursor);
       },
       addDroppedFiles: (files: File[]) => {
-        void addComposerImages(files);
+        // Images become attachments; everything else (audio, PDF, video, …) is
+        // handed over as a path so the agent opens it from disk itself.
+        const images = files.filter((file) => file.type.startsWith("image/"));
+        const nonImages = files.filter((file) => !file.type.startsWith("image/"));
+        if (images.length > 0) {
+          void addComposerImages(images);
+        }
+        if (nonImages.length > 0) {
+          // Deliberately no focusComposer() on this path. `applyPromptReplacement`
+          // focuses on the next frame, once Lexical has reconciled; focusing
+          // synchronously here makes the not-yet-reconciled editor sync its stale
+          // empty state back over the text we just inserted, so the drop looks
+          // like it silently did nothing. Same footgun the file-tree mention drop
+          // documents in makeComposerMentionDragHandlers.
+          insertDroppedFilePaths(nonImages);
+          return;
+        }
         focusComposer();
       },
       insertTextAtEnd: insertComposerTextAtEnd,

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -2592,9 +2592,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       return false;
     }
     if (!insertComposerTextAtEnd(text, { ensureLeadingBoundary: true })) {
-      // This refusal comes from the same composer state that already rejected
-      // the images, so one drop never says it twice.
-      if (!hadImages) {
+      // Pending plan questions is the ONLY refusal `addComposerImages` shares
+      // with the insert, so that is the only case a mixed drop has already been
+      // told about. Staying silent for the others — connecting, approval,
+      // project selection — would attach the images and drop the paths without
+      // a word, which is the failure this whole branch exists to avoid.
+      const alreadyReported = hadImages && pendingUserInputs.length > 0;
+      if (!alreadyReported) {
         reportFailure("The composer is busy; try again once it is ready.");
       }
       return false;

--- a/apps/web/src/components/chat/droppedFilePaths.test.ts
+++ b/apps/web/src/components/chat/droppedFilePaths.test.ts
@@ -7,6 +7,14 @@ describe("quoteDroppedFilePath", () => {
     expect(quoteDroppedFilePath("/Users/me/notes.pdf")).toBe("/Users/me/notes.pdf");
   });
 
+  it("escapes a double quote inside a quoted path", () => {
+    expect(quoteDroppedFilePath('/tmp/a " b.pdf')).toBe('"/tmp/a \\" b.pdf"');
+  });
+
+  it("leaves a double quote alone when there is no whitespace to quote for", () => {
+    expect(quoteDroppedFilePath('/tmp/a"b.pdf')).toBe('/tmp/a"b.pdf');
+  });
+
   it("quotes a path containing spaces", () => {
     expect(quoteDroppedFilePath("/Users/me/Voice Memos/note 1.m4a")).toBe(
       '"/Users/me/Voice Memos/note 1.m4a"',
@@ -17,6 +25,10 @@ describe("quoteDroppedFilePath", () => {
 describe("formatDroppedFilePaths", () => {
   it("joins several paths with a space", () => {
     expect(formatDroppedFilePaths(["/a/one.opus", "/b/two.pdf"])).toBe("/a/one.opus /b/two.pdf");
+  });
+
+  it("preserves a trailing space in a filename instead of trimming it", () => {
+    expect(formatDroppedFilePaths(["/tmp/report "])).toBe('"/tmp/report "');
   });
 
   it("skips empty and whitespace-only entries", () => {

--- a/apps/web/src/components/chat/droppedFilePaths.test.ts
+++ b/apps/web/src/components/chat/droppedFilePaths.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { formatDroppedFilePaths, quoteDroppedFilePath } from "./droppedFilePaths";
+
+describe("quoteDroppedFilePath", () => {
+  it("leaves a path without whitespace alone", () => {
+    expect(quoteDroppedFilePath("/Users/me/notes.pdf")).toBe("/Users/me/notes.pdf");
+  });
+
+  it("quotes a path containing spaces", () => {
+    expect(quoteDroppedFilePath("/Users/me/Voice Memos/note 1.m4a")).toBe(
+      '"/Users/me/Voice Memos/note 1.m4a"',
+    );
+  });
+});
+
+describe("formatDroppedFilePaths", () => {
+  it("joins several paths with a space", () => {
+    expect(formatDroppedFilePaths(["/a/one.opus", "/b/two.pdf"])).toBe("/a/one.opus /b/two.pdf");
+  });
+
+  it("skips empty and whitespace-only entries", () => {
+    expect(formatDroppedFilePaths(["", "   ", "/a/one.opus"])).toBe("/a/one.opus");
+  });
+
+  it("returns an empty string when nothing resolved", () => {
+    expect(formatDroppedFilePaths([])).toBe("");
+  });
+});

--- a/apps/web/src/components/chat/droppedFilePaths.ts
+++ b/apps/web/src/components/chat/droppedFilePaths.ts
@@ -1,0 +1,31 @@
+/**
+ * Files dropped from the OS that aren't images are handed to the agent by
+ * *path*, not by content: it can open the file itself, so a 40MB recording or
+ * a PDF never has to cross the wire as an attachment. This mirrors dropping a
+ * file into a terminal, where the shell receives the path.
+ *
+ * Paths are only available in the desktop app (Electron's `webUtils`); in a
+ * browser tab the File object carries no filesystem path at all.
+ */
+
+/**
+ * Quote a path for the prompt when whitespace would make where it ends
+ * ambiguous. This is prompt text, not a shell command — the goal is a clear
+ * boundary for the reader, not shell-injection safety.
+ */
+export function quoteDroppedFilePath(path: string): string {
+  return /\s/.test(path) ? `"${path}"` : path;
+}
+
+/**
+ * The text inserted into the composer for a set of dropped paths. Empty and
+ * whitespace-only paths are dropped (a bridge that can't resolve a file
+ * returns null, which the caller filters, but be defensive about "" too).
+ */
+export function formatDroppedFilePaths(paths: ReadonlyArray<string>): string {
+  return paths
+    .map((path) => path.trim())
+    .filter((path) => path.length > 0)
+    .map(quoteDroppedFilePath)
+    .join(" ");
+}

--- a/apps/web/src/components/chat/droppedFilePaths.ts
+++ b/apps/web/src/components/chat/droppedFilePaths.ts
@@ -14,18 +14,25 @@
  * boundary for the reader, not shell-injection safety.
  */
 export function quoteDroppedFilePath(path: string): string {
-  return /\s/.test(path) ? `"${path}"` : path;
+  if (!/\s/.test(path)) {
+    return path;
+  }
+  // A double quote is legal in a POSIX filename, so escape any before wrapping —
+  // otherwise the first inner quote reads as the closing delimiter.
+  return `"${path.replace(/"/g, '\\"')}"`;
 }
 
 /**
- * The text inserted into the composer for a set of dropped paths. Empty and
- * whitespace-only paths are dropped (a bridge that can't resolve a file
+ * The text inserted into the composer for a set of dropped paths. Entries that
+ * are empty or all whitespace are skipped (a bridge that can't resolve a file
  * returns null, which the caller filters, but be defensive about "" too).
+ * A path that survives is never altered: leading and trailing spaces are legal
+ * in a filename, so trimming one would point the agent at a file that does not
+ * exist. Quoting keeps such a path readable instead.
  */
 export function formatDroppedFilePaths(paths: ReadonlyArray<string>): string {
   return paths
-    .map((path) => path.trim())
-    .filter((path) => path.length > 0)
+    .filter((path) => path.trim().length > 0)
     .map(quoteDroppedFilePath)
     .join(" ");
 }

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1070,6 +1070,13 @@ export interface DesktopBridge {
    * regardless of OS settings.
    */
   getSystemLocale?: () => string | null;
+  /**
+   * The filesystem path of a dropped/pasted `File`, which the renderer cannot
+   * read for itself (Electron removed `File.path` in v32). Returns null when
+   * the object has no path — e.g. a file synthesised in-page rather than
+   * dragged in from the OS.
+   */
+  getPathForFile?: (file: File) => string | null;
   // One bootstrap per pool instance currently registered with bootstrap
   // info (omits instances whose backend hasn't produced a config yet).
   // The primary backend is identified by id === PRIMARY_LOCAL_ENVIRONMENT_ID.


### PR DESCRIPTION
## What changed

Dropping an audio file, PDF or video onto the composer is rejected with *"Unsupported file type … Please attach image files only."* Images still become attachments; **everything else now inserts its filesystem path as text**, so the agent opens the file from disk itself and a 40MB recording never has to cross the wire as an attachment — the same thing dropping a file into a terminal does.

- `ChatComposer.tsx`: `addDroppedFiles` splits the drop — images keep the existing attachment path, non-images go to `insertDroppedFilePaths`, which resolves each path and appends it to the prompt.
- `droppedFilePaths.ts` (new, + unit tests): formats the paths — quotes one containing whitespace so where it ends stays unambiguous, skips unresolvable entries.
- `preload.ts` / `contracts/ipc.ts`: the renderer cannot read a dropped file's path (Electron removed `File.path` in v32), so preload exposes `webUtils.getPathForFile` through the desktop bridge as an optional member. In a browser tab, where no path exists, the drop says so instead of failing silently.

One subtlety worth flagging for review: the path branch deliberately does **not** call `focusComposer()`. Focusing synchronously after the insert makes the not-yet-reconciled Lexical editor sync its stale empty state back over the text — the insert reports success and the composer stays empty. That is the same footgun `makeComposerMentionDragHandlers` already documents for the file-tree mention drop, which is why that path does not focus either; `applyPromptReplacement` focuses on the next frame instead.

## Why

Attaching a voice memo, a PDF or a screen recording is a normal thing to want, and the agent can already read any of them from disk — it just needed the path. Sending the bytes would be the expensive way to do the same thing.

+126 / −2 across five files, no new dependencies.

## Before / after

Dropping `standup note.m4a` onto the composer:

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/nioasoft/t3code/rtl-pr-assets/drop-before.png) | ![after](https://raw.githubusercontent.com/nioasoft/t3code/rtl-pr-assets/drop-after.png) |

## Test plan

- [x] `vp test` (238 web unit tests incl. 5 new for `droppedFilePaths`), `tsgo --noEmit` for `apps/web` **and** `apps/desktop`, `vp lint`, `vp fmt --check` — all green
- [x] Desktop app: dropped an audio file onto the composer, path inserted and the agent read the file from it; dropped an image, still attaches as before
- [x] Browser tab (no desktop bridge): reports that the path needs the desktop app rather than doing nothing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Composer UX plus a small optional preload helper; no auth, IPC command, or file-content handling changes. Browser drops now toast instead of ignoring non-images.
> 
> **Overview**
> Dropping PDFs, audio, video, and other non-images onto the composer now inserts their OS paths as prompt text so the agent can open them from disk. Images still attach as before.
> 
> The desktop preload exposes `getPathForFile` via Electron `webUtils` (needed after `File.path` was removed). Paths with whitespace are quoted. Browser tabs toast that path attach needs the desktop app instead of failing silently.
> 
> Focus is skipped after a successful path insert so Lexical does not overwrite the new text with a stale empty editor state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4186b1a88fdbce1c958e07c9d10fedf2fe66cc5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Insert dropped non-image files as filesystem paths in `ChatComposer`
> - Adds `desktopBridge.getPathForFile` via Electron `webUtils` in [preload.ts](https://github.com/pingdotgg/t3code/pull/7749/files#diff-eae0078d2bf4ac4beed2884f918b2816a97752917390f09980ba2cfad8c42cac) to resolve a `File` object's OS path, returning `null` on error or empty results
> - Adds `formatDroppedFilePaths` and `quoteDroppedFilePath` in [droppedFilePaths.ts](https://github.com/pingdotgg/t3code/pull/7749/files#diff-3b1c46ba1728118957ed7272aefe0d2fcab6f06d955da9316f642c9a94ba1147) to quote paths containing whitespace and join valid entries into a single string
> - Reworks `ChatComposer.addDroppedFiles` in [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/7749/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a) to split dropped files into images (attached as before) and non-images (inserted as formatted path text); errors are surfaced via toasts
> - Suppresses composer focus after a path insert to avoid a Lexical reconciliation race that discards the inserted text
> - Risk: dropping non-image files in the web build (no desktop bridge) now shows a toast instead of silently ignoring them; focus behavior after mixed drops changed to skip focus when path text was inserted
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 82f2be0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->