### PR TITLE
fix(server): price Daybreak usage aliases

### DIFF
--- a/apps/server/src/usage/usagePricing.test.ts
+++ b/apps/server/src/usage/usagePricing.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { lookupRate, type ModelRate, type RateTable } from "./usagePricing.ts";
+
+const blueRate: ModelRate = {
+  inputCostPerToken: 5e-6,
+  outputCostPerToken: 3e-5,
+  cacheReadCostPerToken: 5e-7,
+  cacheCreationCostPerToken: 6.25e-6,
+};
+const redRate: ModelRate = {
+  inputCostPerToken: 1.25e-5,
+  outputCostPerToken: 7.5e-5,
+  cacheReadCostPerToken: 1.25e-6,
+  cacheCreationCostPerToken: 1.5625e-5,
+};
+
+describe("usage pricing", () => {
+  it("resolves Codex Daybreak rollout names to LiteLLM rates", () => {
+    const rates: RateTable = new Map([
+      ["daybreak-blue-latest", blueRate],
+      ["daybreak-red-latest", redRate],
+    ]);
+
+    expect(lookupRate(rates, "gpt-daybreak-blue-latest")).toBe(blueRate);
+    expect(lookupRate(rates, "gpt-daybreak-red-latest")).toBe(redRate);
+  });
+
+  it("prefers an exact rate over a fallback alias", () => {
+    const exactRate: ModelRate = { ...blueRate, inputCostPerToken: 1 };
+    const rates: RateTable = new Map([
+      ["gpt-daybreak-blue-latest", exactRate],
+      ["daybreak-blue-latest", blueRate],
+    ]);
+
+    expect(lookupRate(rates, "gpt-daybreak-blue-latest")).toBe(exactRate);
+  });
+
+  it("keeps unknown models unpriced", () => {
+    expect(lookupRate(new Map(), "unknown-model")).toBeNull();
+  });
+});

--- a/apps/server/src/usage/usagePricing.ts
+++ b/apps/server/src/usage/usagePricing.ts
@@ -98,10 +98,24 @@ const UNPRICEABLE_MODELS = new Set([
   "fable",
 ]);
 
+/**
+ * Codex rollout model names whose LiteLLM price entries use a different alias.
+ * Keep this translation at the pricing boundary so provider model selection stays unchanged.
+ */
+const LITELLM_RATE_ALIASES: Readonly<Record<string, string>> = {
+  "gpt-daybreak-blue-latest": "daybreak-blue-latest",
+  "gpt-daybreak-red-latest": "daybreak-red-latest",
+};
+
 export function lookupRate(table: RateTable, model: string): ModelRate | null {
   const normalized = normalizeModelName(model);
   if (normalized.length === 0 || UNPRICEABLE_MODELS.has(normalized)) return null;
-  return table.get(normalized) ?? null;
+
+  const direct = table.get(normalized);
+  if (direct !== undefined) return direct;
+
+  const alias = LITELLM_RATE_ALIASES[normalized];
+  return alias === undefined ? null : (table.get(alias) ?? null);
 }
 
 export interface PricedUsage {


### PR DESCRIPTION
## Problem

Codex records Daybreak models in rollout transcripts as `gpt-daybreak-blue-latest` and `gpt-daybreak-red-latest`, while LiteLLM publishes their pricing under `daybreak-blue-latest` and `daybreak-red-latest`.

Because Usage performed an exact normalized rate lookup, Daybreak tokens were included in token totals but marked unpriced and contributed `$0.00` to the API-equivalent cost.

Closes #7752

## Fix

Add a small alias fallback at the LiteLLM pricing boundary.

Exact rate-table matches still take precedence, so a future native LiteLLM entry for a Codex slug automatically overrides the fallback. Codex model selection and stored transcript identifiers remain unchanged.

Because Usage calculates pricing when it reads transcripts, this prices existing Daybreak history without a migration.

## Verification

- `vp test run apps/server/src/usage/usagePricing.test.ts apps/server/src/usage/usageAggregation.test.ts`
- `vp lint apps/server/src/usage/usagePricing.ts apps/server/src/usage/usagePricing.test.ts`
- `vp run --filter t3 typecheck`
- Verified in the Usage page with the same 24-hour Daybreak history before and after the change

Built with GPT-5.6 Sol using Codex in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow pricing-lookup change with tests; it only remaps two model names at cost calculation time and does not touch auth, billing charges, or stored transcripts.
> 
> **Overview**
> Fixes Daybreak usage showing as unpriced (`$0.00`) because Codex transcripts use `gpt-daybreak-*-latest` while LiteLLM publishes rates as `daybreak-*-latest`.
> 
> `lookupRate` now falls back to a small alias map after an exact table match. Exact LiteLLM keys still win, and stored model names are unchanged. Existing Daybreak history is priced on read without a migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0a9f50ac8383166d97547f4a2d1f95cd4e3a10d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Daybreak usage aliases to `lookupRate` in `usagePricing`
> Introduces a `LITELLM_RATE_ALIASES` mapping so `gpt-daybreak-blue-latest` and `gpt-daybreak-red-latest` resolve to `daybreak-blue-latest` and `daybreak-red-latest` pricing entries. `lookupRate` first does a direct table lookup, then falls back to the alias mapping; exact table matches always win over aliases. Adds test coverage for alias resolution, exact-match preference, and unknown-model handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b0a9f50.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->