### PR TITLE
fix(server): strip OSC/ANSI escapes from OpenCode CLI inventory and stored agent selections

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -25,6 +25,7 @@ import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import type { OpencodeClient, Part, PermissionRequest, QuestionRequest } from "@opencode-ai/sdk/v2";
 import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
+import { sanitizeTerminalValue } from "@t3tools/shared/stripTerminalEscapes";
 
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
@@ -1472,12 +1473,14 @@ export function makeOpenCodeAdapter(
         });
       }
 
-      const agent = getModelSelectionStringOptionValue(modelSelection, "agent");
-      const variant = getModelSelectionStringOptionValue(modelSelection, "variant");
+      const rawAgent = getModelSelectionStringOptionValue(modelSelection, "agent");
+      const rawVariant = getModelSelectionStringOptionValue(modelSelection, "variant");
+      const agent = rawAgent ? sanitizeTerminalValue(rawAgent) : undefined;
+      const variant = rawVariant ? sanitizeTerminalValue(rawVariant) : undefined;
 
       context.activeTurnId = turnId;
       context.activeAgent = agent ?? (input.interactionMode === "plan" ? "plan" : undefined);
-      context.activeVariant = variant;
+      context.activeVariant = variant || undefined;
       yield* updateProviderSession(
         context,
         {

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -12,6 +12,10 @@ import * as Effect from "effect/Effect";
 import { createModelCapabilities } from "@t3tools/shared/model";
 import { compareSemverVersions } from "@t3tools/shared/semver";
 import {
+  sanitizeTerminalValue,
+  stripTerminalEscapes,
+} from "@t3tools/shared/stripTerminalEscapes";
+import {
   buildServerProvider,
   nonEmptyTrimmed,
   parseGenericCliVersion,
@@ -174,14 +178,18 @@ function openCodeCapabilitiesForModel(input: {
   readonly model: ProviderListResponse["all"][number]["models"][string];
   readonly agents: ReadonlyArray<Agent>;
 }): ModelCapabilities {
-  const variantValues = Object.keys(input.model.variants ?? {});
+  const variantValues = Object.keys(input.model.variants ?? {}).map(sanitizeTerminalValue);
   const defaultVariant = inferDefaultVariant(input.providerID, variantValues);
   const variantOptions = variantValues.map((value) =>
     defaultVariant === value
       ? { id: value, label: titleCaseSlug(value), isDefault: true as const }
       : { id: value, label: titleCaseSlug(value) },
   );
-  const primaryAgents = input.agents.filter(
+  const sanitizedAgents = input.agents.map((agent) => ({
+    ...agent,
+    name: sanitizeTerminalValue(agent.name),
+  }));
+  const primaryAgents = sanitizedAgents.filter(
     (agent) => !agent.hidden && (agent.mode === "primary" || agent.mode === "all"),
   );
   const defaultAgent = inferDefaultAgent(primaryAgents);
@@ -390,7 +398,7 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
     if (versionExit._tag === "Failure") {
       return fallback(Cause.squash(versionExit.cause));
     }
-    version = parseGenericCliVersion(versionExit.value.stdout) ?? null;
+    version = parseGenericCliVersion(stripTerminalEscapes(versionExit.value.stdout)) ?? null;
 
     if (!version) {
       return fallback(

--- a/apps/server/src/provider/opencodeRuntime.cliParsers.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.cliParsers.test.ts
@@ -154,6 +154,30 @@ describe("parseModelsCliOutput", () => {
     NodeAssert.equal(model.id, "qwen/qwen3-coder");
     NodeAssert.equal(model.providerID, "openrouter");
   });
+
+  it("strips OSC title escapes from model slugs (opencode CLI leak)", () => {
+    const stdout = [
+      "\x1b]0;t3code: ready\x07opencode/big-pickle",
+      JSON.stringify({ id: "big-pickle", providerID: "opencode", name: "Big Pickle" }),
+      "\x1b]0;tmp: ready\x07anthropic/claude-sonnet-4-5",
+      JSON.stringify({ id: "claude-sonnet-4-5", providerID: "anthropic", name: "Sonnet" }),
+    ].join("\n");
+
+    const result = parseModelsCliOutput(stdout);
+    NodeAssert.equal(result.providers.size, 2);
+    NodeAssert.ok(result.providers.get("opencode")!.models["big-pickle"]);
+    NodeAssert.ok(result.providers.get("anthropic")!.models["claude-sonnet-4-5"]);
+  });
+
+  it("strips ANSI escapes from model slugs", () => {
+    const stdout = [
+      "\x1b[33mopencode/gpt-5.4\x1b[0m",
+      JSON.stringify({ id: "gpt-5.4", providerID: "opencode", name: "GPT-5.4" }),
+    ].join("\n");
+
+    const result = parseModelsCliOutput(stdout);
+    NodeAssert.ok(result.providers.get("opencode")!.models["gpt-5.4"]);
+  });
 });
 
 describe("parseAgentListCliOutput", () => {
@@ -255,9 +279,47 @@ describe("parseAgentListCliOutput", () => {
     NodeAssert.equal(result[0]!.hidden, true);
     NodeAssert.equal(result[1]!.hidden, false);
   });
+
+  it("strips OSC title escapes leaked by opencode CLI", () => {
+    // opencode <=1.18 writes `ESC ]0;<cwd>: ready BEL` to stdout for every
+    // non-help command — even when stdout is a pipe. Without stripping, the
+    // agent name becomes `ESC]0;...BELbuild` and later fails with
+    // `Agent not found: "ESC]0;...build"`.
+    const stdout = [
+      "\x1b]0;t3code: ready\x07build (primary)",
+      "  " + JSON.stringify([{ permission: "*", action: "allow", pattern: "*" }]),
+      "\x1b]0;tmp: ready\x07explore (subagent)",
+      "  " + JSON.stringify([{ permission: "read", action: "allow", pattern: "*" }]),
+    ].join("\n");
+
+    const result = parseAgentListCliOutput(stdout);
+    NodeAssert.equal(result.length, 2);
+    NodeAssert.equal(result[0]!.name, "build");
+    NodeAssert.equal(result[0]!.mode, "primary");
+    NodeAssert.equal(result[1]!.name, "explore");
+    NodeAssert.equal(result[1]!.mode, "subagent");
+  });
+
+  it("strips ANSI CSI color escapes from agent headers", () => {
+    const stdout = [
+      "\x1b[31mbuild (primary)\x1b[0m",
+      "  " + JSON.stringify([{ permission: "*", action: "allow", pattern: "*" }]),
+    ].join("\n");
+
+    const result = parseAgentListCliOutput(stdout);
+    NodeAssert.equal(result.length, 1);
+    NodeAssert.equal(result[0]!.name, "build");
+  });
 });
 
 describe("parseSkillsCliOutput", () => {
+  it("strips OSC escapes before JSON parsing (opencode CLI leak)", () => {
+    const polluted = "\x1b]0;tmp: ready\x07" + JSON.stringify([{ name: "review-pr", location: "/tmp/x", description: "d", content: "c" }]);
+    const result = parseSkillsCliOutput(polluted);
+    NodeAssert.equal(result.length, 1);
+    NodeAssert.equal(result[0]!.name, "review-pr");
+  });
+
   it("parses skill metadata from the CLI JSON output", () => {
     const result = parseSkillsCliOutput(
       JSON.stringify([

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -34,6 +34,7 @@ import { collectStreamAsString } from "./providerSnapshot.ts";
 import * as NetService from "@t3tools/shared/Net";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
+import { sanitizeTerminalValue, stripTerminalEscapes } from "@t3tools/shared/stripTerminalEscapes";
 const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.fromJsonString(Schema.Unknown));
 const OPENCODE_EMPTY_CONFIG_CONTENT = "{}";
 
@@ -216,7 +217,7 @@ export function parseModelsCliOutput(stdout: string): {
     string,
     { id: string; name: string; models: { [key: string]: Model } }
   >();
-  const lines = stdout.split("\n");
+  const lines = stripTerminalEscapes(stdout).split("\n");
   let currentSlug: string | null = null;
   const jsonLines: Array<string> = [];
 
@@ -269,7 +270,7 @@ export function parseModelsCliOutput(stdout: string): {
 /** @internal */
 export function parseAgentListCliOutput(stdout: string): ReadonlyArray<Agent> {
   const agents: Array<Agent> = [];
-  const lines = stdout.split("\n");
+  const lines = stripTerminalEscapes(stdout).split("\n");
   let currentHeader: { name: string; mode: string } | null = null;
   const blockLines: Array<string> = [];
 
@@ -311,7 +312,8 @@ export function parseAgentListCliOutput(stdout: string): ReadonlyArray<Agent> {
 
 /** @internal */
 export function parseSkillsCliOutput(stdout: string): ReadonlyArray<OpenCodeSkill> {
-  const result = decodeOpenCodeSkillsCliOutputExit(stdout);
+  const clean = stripTerminalEscapes(stdout);
+  const result = decodeOpenCodeSkillsCliOutputExit(clean);
   return Exit.isSuccess(result) ? result.value : [];
 }
 

--- a/apps/server/src/textGeneration/OpenCodeTextGeneration.ts
+++ b/apps/server/src/textGeneration/OpenCodeTextGeneration.ts
@@ -15,6 +15,7 @@ import {
 import { sanitizeBranchFragment, sanitizeFeatureBranchName } from "@t3tools/shared/git";
 import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
 import { extractJsonObject } from "@t3tools/shared/schemaJson";
+import { sanitizeTerminalValue } from "@t3tools/shared/stripTerminalEscapes";
 
 import * as ServerConfig from "../config.ts";
 import { resolveAttachmentPath } from "../attachmentStore.ts";
@@ -408,8 +409,10 @@ export const makeOpenCodeTextGeneration = Effect.fn("makeOpenCodeTextGeneration"
             cwd: input.cwd,
           });
         }
-        const selectedAgent = getModelSelectionStringOptionValue(input.modelSelection, "agent");
-        const selectedVariant = getModelSelectionStringOptionValue(input.modelSelection, "variant");
+        const rawAgent = getModelSelectionStringOptionValue(input.modelSelection, "agent");
+        const rawVariant = getModelSelectionStringOptionValue(input.modelSelection, "variant");
+        const selectedAgent = rawAgent ? sanitizeTerminalValue(rawAgent) : undefined;
+        const selectedVariant = rawVariant ? sanitizeTerminalValue(rawVariant) : undefined;
         const promptContext = {
           operation: input.operation,
           cwd: input.cwd,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -226,6 +226,10 @@
     "./usageFormat": {
       "types": "./src/usageFormat.ts",
       "import": "./src/usageFormat.ts"
+    },
+    "./stripTerminalEscapes": {
+      "types": "./src/stripTerminalEscapes.ts",
+      "import": "./src/stripTerminalEscapes.ts"
     }
   },
   "scripts": {

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -10,6 +10,8 @@ import {
   type ProviderOptionSelection,
 } from "@t3tools/contracts";
 
+import { sanitizeTerminalValue } from "./stripTerminalEscapes.ts";
+
 const DEFAULT_PROVIDER_DRIVER_KIND = ProviderDriverKind.make("codex");
 
 export interface SelectableModelOption {
@@ -45,7 +47,9 @@ export function getProviderOptionStringSelectionValue(
   id: string,
 ): string | undefined {
   const value = getProviderOptionSelectionValue(selections, id);
-  return typeof value === "string" ? value : undefined;
+  if (typeof value !== "string") return undefined;
+  const sanitized = sanitizeTerminalValue(value);
+  return sanitized.length > 0 ? sanitized : undefined;
 }
 
 export function getProviderOptionBooleanSelectionValue(
@@ -254,7 +258,7 @@ export function normalizeCustomModelSlug(model: string | null | undefined): stri
     return null;
   }
 
-  return model.trim() || null;
+  return sanitizeTerminalValue(model) || null;
 }
 
 export function resolveSelectableModel(
@@ -308,7 +312,8 @@ export function resolveModelSlugForProvider(
 /** Trim a string, returning null for empty/missing values. */
 export function trimOrNull<T extends string>(value: T | null | undefined): T | null {
   if (typeof value !== "string") return null;
-  const trimmed = value.trim() as T;
+  const sanitized = sanitizeTerminalValue(value);
+  const trimmed = sanitized.trim() as T;
   return trimmed || null;
 }
 

--- a/packages/shared/src/stripTerminalEscapes.ts
+++ b/packages/shared/src/stripTerminalEscapes.ts
@@ -1,0 +1,38 @@
+/**
+ * Strip terminal escape sequences from captured CLI stdout.
+ *
+ * OpenCode's CLI (and potentially other provider CLIs) can emit OSC title
+ * sequences (`ESC ]0;<title> BEL` / `ESC \`) and ANSI CSI color codes directly
+ * to stdout, even when stdout is a pipe. When T3 Code captures that output
+ * via `ChildProcessSpawner`, those bytes pollute structured parsing — e.g.
+ * `opencode agent list` becomes `\x1b]0;t3code: ready\x07build (primary)`
+ * instead of `build (primary)`, causing the agent inventory to store a
+ * polluted id that later fails with `Agent not found`.
+ *
+ * This is defensive for any provider CLI; the regexes are intentionally
+ * permissive and also handle Ghostty/Zsh title integrations that can leak
+ * through `shell: true` spawns.
+ */
+const OSC_RE = /\x1b\].*?(?:\x07|\x1b\\)/g;
+const CSI_RE = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
+const CHARSET_RE = /\x1b[()][A-Za-z0-9]/g;
+const SINGLE_ESC_RE = /\x1b[@-Z\\-_]/g;
+
+export function stripTerminalEscapes(input: string): string {
+  if (!input || input.indexOf("\x1b") === -1) {
+    return input;
+  }
+  return input
+    .replace(OSC_RE, "")
+    .replace(CSI_RE, "")
+    .replace(CHARSET_RE, "")
+    .replace(SINGLE_ESC_RE, "");
+}
+
+/**
+ * Strip escapes and also trim the result. Useful for single-value fields
+ * like agent/variant names that should never contain control bytes.
+ */
+export function sanitizeTerminalValue(input: string): string {
+  return stripTerminalEscapes(input).trim();
+}


### PR DESCRIPTION
Fixes #7754

### Problem
opencode <=1.18 leaks OSC title `ESC ]0;<cwd>: ready BEL` to stdout for every non-help command even when piped. T3's `runOpenCodeCommand` captures that stdout and `parseModelsCliOutput` / `parseAgentListCliOutput` stored polluted ids like `"\u001b]0;imbios: ready\u0007build"` in `model_selection_json`.

Next `sendTurn` → `session.promptAsync({agent: polluted})` → opencode rejects:

```
Agent not found: "\u001b]0;imbios: ready\u0007build". Available agents: build, explore, general, plan
```

Surfaced as two `session.error` per turn: first the polluted-agent message, second the generic `UnknownError` stack at `SessionPrompt.createUserMessage … SessionHttpApi.promptAsync`.

Repro evidence in ~/.t3/userdata/logs/provider/events.*.log and projection_threads (3 polluted threads at ImBIOS). Also `opencode agent list | cat -v` shows `^[]0;tmp: ready^Gbuild (primary)` even with `env -i`/`TERM=dumb` — leak is in opencode binary, not shell. Same leak pollutes `models --verbose` (model inventory dropped to 0 pre-fix because SLUG_RE didn't match) and `debug skill` (JSON parse failed → skills=[]).

Fork fix already landed in ImBIOS/t3code#2 and ImBIOS:main 30d9c19; this is the upstream PR.

### Fix
- `packages/shared/src/stripTerminalEscapes.ts` — shared OSC/CSI/charset sanitizer (`stripTerminalEscapes`/`sanitizeTerminalValue`)
- `apps/server/src/provider/opencodeRuntime.ts:208,270,312` — strip at entry of `parseModels/Agent/Skills`; keeps `-verbose` from dropping models and skills from degrading
- `apps/server/src/provider/Layers/OpenCodeProvider.ts:164,188,393` — sanitize inventory agent names/variants + `--version` parsing
- `apps/server/src/provider/Layers/OpenCodeAdapter.ts:1476` + `textGeneration/OpenCodeTextGeneration.ts:411` — sanitize stored `agent`/`variant` before `promptAsync` (steer + title generation)
- `packages/shared/src/model.ts:66,313` — sanitize persisted `ProviderOptionSelection` values and model slugs on read (transparently repairs polluted threads without DB migration)
- `opencodeRuntime.cliParsers.test.ts` — regression cases for OSC/ANSI in both parsers

Polluted threads now succeed at runtime via `model.ts` sanitizer; optional manual DB cleanup via strip script (see issue).

### Upstream
Should also be fixed in `sst/opencode` — CLI should write OSC title to `/dev/tty` or `stderr` only when isTTY, not stdout pipe. T3 fix is defensive regardless.

### Verification
- `opencode agent list/models --verbose | cat -v` still shows OSC upstream, but `parse*CliOutput` now returns clean ids
- Manual bun eval for `stripTerminalEscapes` → "opencode/big-pickle", "build"
- New OSC/ANSI regression tests added

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OpenCode inventory parsing and persisted model-option reads. Sanitization is limited to terminal control sequences, but a bad strip could drop or rewrite agent/variant/model ids.
> 
> **Overview**
> Stops OpenCode CLI OSC/ANSI leaks from poisoning model/agent/skill inventory and later `session.promptAsync` calls (`Agent not found` with escape-prefixed names).
> 
> Adds shared `stripTerminalEscapes` / `sanitizeTerminalValue` and applies them when parsing CLI stdout (models, agents, skills, `--version`), when building capability option ids, and when sending stored `agent`/`variant` values. String option reads and model slug normalization also sanitize on the way in, so already-polluted threads work without a DB migration.
> 
> Parser tests cover OSC title sequences and ANSI color codes on slugs and agent headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4871e966be4fa5a3e167f8cbbb361485b7d3e605. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Strip OSC/ANSI escapes from OpenCode CLI stdout and stored agent/variant selections
> - Adds shared utilities `stripTerminalEscapes` and `sanitizeTerminalValue` in [stripTerminalEscapes.ts](https://github.com/pingdotgg/t3code/pull/7755/files#diff-c584c670de9e78120484bc37d112986256440aef3d1a00776cfcb186c57b0948) to remove terminal control sequences from strings captured from CLIs.
> - Applies `stripTerminalEscapes` to raw stdout in `parseModelsCliOutput`, `parseAgentListCliOutput`, `parseSkillsCliOutput`, and `checkOpenCodeProviderStatus` so slugs, agent names, and version strings parse correctly when the CLI leaks OSC/ANSI sequences.
> - Uses `sanitizeTerminalValue` in `getProviderOptionStringSelectionValue`, `normalizeCustomModelSlug`, and `trimOrNull` to clean model slugs and option selections; empty-after-sanitize results become `undefined` or `null`.
> - Sanitizes `agent` and `variant` values read from model selection in `makeOpenCodeAdapter` and `makeOpenCodeTextGeneration` before constructing requests.
> - Behavioral Change: `variant` values that are empty or escape-only now resolve to `undefined` instead of an empty string in [OpenCodeAdapter.ts](https://github.com/pingdotgg/t3code/pull/7755/files#diff-a4267388b15e5043ae1899beded972cbee9e52533ca3d9d65d438a91a9f7fbe7) and [OpenCodeTextGeneration.ts](https://github.com/pingdotgg/t3code/pull/7755/files#diff-69fc85c05aed321735eba7f35bbdfa8200cdfc2c3a52a905e8dacf1ddacbd777); callers relying on raw escape-preserved values will see cleaned strings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4871e96.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->