### PR TITLE
fix(web): remove duplicate provider update progress

### DIFF
--- a/apps/web/src/components/ProviderUpdateLaunchNotification.logic.test.ts
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.logic.test.ts
@@ -31,6 +31,7 @@ import {
   parseWslDistroFromInstanceId,
   providerUpdateNotificationKey,
   resolveEnvironmentUpdateRowStatus,
+  shouldShowPrimaryProviderUpdateToast,
   type LocalEnvironmentProvidersInput,
   type LocalEnvironmentUpdateGroup,
   type LocalProviderUpdateOutcome,
@@ -325,6 +326,21 @@ describe("provider update launch notification logic", () => {
       type: "loading",
       title: "Updating provider",
     });
+    expect(shouldShowPrimaryProviderUpdateToast(view)).toBe(false);
+  });
+
+  it("keeps the initial prompt and terminal outcomes visible as toasts", () => {
+    expect(
+      shouldShowPrimaryProviderUpdateToast(
+        getProviderUpdateInitialToastView({
+          updateProviders: [updateCandidate({ driver: driver("codex") })],
+          oneClickProviders: [updateCandidate({ driver: driver("codex") })],
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldShowPrimaryProviderUpdateToast(getProviderUpdateRejectedToastView(1, "boom")),
+    ).toBe(true);
   });
 
   it("uses server failure state for failed progress", () => {

--- a/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
@@ -231,6 +231,10 @@ export function getProviderUpdateInitialToastView(input: {
   };
 }
 
+export function shouldShowPrimaryProviderUpdateToast(view: ProviderUpdateToastView): boolean {
+  return view.phase !== "running";
+}
+
 export function getProviderUpdateRunningToastView(providerCount: number): ProviderUpdateToastView {
   return {
     phase: "running",

--- a/apps/web/src/components/ProviderUpdatePrimaryNotification.tsx
+++ b/apps/web/src/components/ProviderUpdatePrimaryNotification.tsx
@@ -16,7 +16,6 @@ import {
   getProviderUpdateInitialToastView,
   getProviderUpdateProgressToastView,
   getProviderUpdateRejectedToastView,
-  getProviderUpdateRunningToastView,
   providerUpdateNotificationKey,
   shouldShowPrimaryProviderUpdateToast,
   type ProviderUpdateToastView,
@@ -220,10 +219,7 @@ export function ProviderUpdatePrimaryNotification() {
       };
       activeToastRef.current = activeUpdate;
 
-      const runningView = getProviderUpdateRunningToastView(providerCount);
-      if (!shouldShowPrimaryProviderUpdateToast(runningView)) {
-        toastManager.close(toastId);
-      }
+      toastManager.close(toastId);
 
       void (async () => {
         const results = [];

--- a/apps/web/src/components/ProviderUpdatePrimaryNotification.tsx
+++ b/apps/web/src/components/ProviderUpdatePrimaryNotification.tsx
@@ -18,6 +18,7 @@ import {
   getProviderUpdateRejectedToastView,
   getProviderUpdateRunningToastView,
   providerUpdateNotificationKey,
+  shouldShowPrimaryProviderUpdateToast,
   type ProviderUpdateToastView,
 } from "./ProviderUpdateLaunchNotification.logic";
 import { hiddenToastActionProps, stackedThreadToast, toastManager } from "./ui/toast";
@@ -31,7 +32,6 @@ type ActiveProviderUpdateToast =
   | {
       readonly kind: "update";
       readonly key: string;
-      readonly toastId: ProviderUpdateToastId;
       readonly providerInstanceIds: ReadonlySet<ProviderInstanceId>;
       readonly providerCount: number;
     };
@@ -57,20 +57,16 @@ function ProviderUpdateToastIcon({ provider }: { provider: ProviderDriverKind })
   );
 }
 
-function updateProviderUpdateToast(input: {
-  readonly toastId: ProviderUpdateToastId;
+function addProviderUpdateToast(input: {
   readonly view: ProviderUpdateToastView;
-  readonly openSettings: () => void;
+  readonly openSettings: (toastId: ProviderUpdateToastId) => void;
 }) {
   if (input.view.type === "loading" || input.view.type === "success") {
-    toastManager.update(input.toastId, {
+    return toastManager.add({
       type: input.view.type,
       title: input.view.title,
       description: input.view.description,
       timeout: 0,
-      // Base UI merges toast updates and omits `undefined` keys, so `undefined`
-      // would leave the prompt's Update button in place. Replace it with a
-      // defined empty action so the CTA cannot linger while the update runs.
       actionProps: hiddenToastActionProps,
       data: {
         hideCopyButton: true,
@@ -79,11 +75,10 @@ function updateProviderUpdateToast(input: {
           : {}),
       },
     });
-    return;
   }
 
-  toastManager.update(
-    input.toastId,
+  let toastId!: ProviderUpdateToastId;
+  toastId = toastManager.add(
     stackedThreadToast({
       type: input.view.type,
       title: input.view.title,
@@ -91,7 +86,7 @@ function updateProviderUpdateToast(input: {
       timeout: 0,
       actionProps: {
         children: "Settings",
-        onClick: input.openSettings,
+        onClick: () => input.openSettings(toastId),
       },
       actionVariant: "outline",
       data: {
@@ -99,10 +94,7 @@ function updateProviderUpdateToast(input: {
       },
     }),
   );
-}
-
-function isTerminalProviderUpdateToastView(view: ProviderUpdateToastView) {
-  return view.phase === "failed" || view.phase === "unchanged" || view.phase === "succeeded";
+  return toastId;
 }
 
 /**
@@ -126,10 +118,10 @@ export function ProviderUpdatePrimaryNotification() {
   useEffect(() => {
     return () => {
       const activeToast = activeToastRef.current;
-      if (activeToast) {
+      if (activeToast?.kind === "prompt") {
         toastManager.close(activeToast.toastId);
-        activeToastRef.current = null;
       }
+      activeToastRef.current = null;
     };
   }, []);
 
@@ -149,10 +141,14 @@ export function ProviderUpdatePrimaryNotification() {
       const activeToast = activeToastRef.current;
       if (toastId !== undefined) {
         toastManager.close(toastId);
-      } else if (activeToast) {
+      } else if (activeToast?.kind === "prompt") {
         toastManager.close(activeToast.toastId);
       }
-      if (activeToast && (toastId === undefined || activeToast.toastId === toastId)) {
+      if (
+        activeToast &&
+        (toastId === undefined ||
+          (activeToast.kind === "prompt" && activeToast.toastId === toastId))
+      ) {
         activeToastRef.current = null;
       }
       void navigate({ to: "/settings/providers" });
@@ -173,15 +169,12 @@ export function ProviderUpdatePrimaryNotification() {
       providers: activeProviders,
       providerCount: activeToast.providerCount,
     });
-    updateProviderUpdateToast({
-      toastId: activeToast.toastId,
-      view,
-      openSettings: () => openProviderSettings(activeToast.toastId),
-    });
-
-    if (isTerminalProviderUpdateToastView(view)) {
-      activeToastRef.current = null;
+    if (!shouldShowPrimaryProviderUpdateToast(view)) {
+      return;
     }
+
+    addProviderUpdateToast({ view, openSettings: openProviderSettings });
+    activeToastRef.current = null;
   }, [providers, openProviderSettings]);
 
   useEffect(() => {
@@ -219,19 +212,18 @@ export function ProviderUpdatePrimaryNotification() {
 
       const providerCount = oneClickProviders.length;
       const providerInstanceIds = new Set(oneClickProviders.map((provider) => provider.instanceId));
-      activeToastRef.current = {
+      const activeUpdate: ActiveProviderUpdateToast = {
         kind: "update",
         key: notificationKey,
-        toastId,
         providerInstanceIds,
         providerCount,
       };
+      activeToastRef.current = activeUpdate;
 
-      updateProviderUpdateToast({
-        toastId,
-        view: getProviderUpdateRunningToastView(providerCount),
-        openSettings,
-      });
+      const runningView = getProviderUpdateRunningToastView(providerCount);
+      if (!shouldShowPrimaryProviderUpdateToast(runningView)) {
+        toastManager.close(toastId);
+      }
 
       void (async () => {
         const results = [];
@@ -248,16 +240,15 @@ export function ProviderUpdatePrimaryNotification() {
         }
 
         const activeUpdateToast = activeToastRef.current;
-        if (activeUpdateToast?.kind !== "update" || activeUpdateToast.toastId !== toastId) {
+        if (activeUpdateToast !== activeUpdate) {
           return;
         }
 
         const failedMessage = firstFailedProviderUpdateMessage(results);
         if (failedMessage) {
-          updateProviderUpdateToast({
-            toastId,
+          addProviderUpdateToast({
             view: getProviderUpdateRejectedToastView(providerCount, failedMessage),
-            openSettings,
+            openSettings: openProviderSettings,
           });
           activeToastRef.current = null;
           return;
@@ -271,13 +262,8 @@ export function ProviderUpdatePrimaryNotification() {
           providers: updatedProviderSnapshots,
           providerCount,
         });
-        updateProviderUpdateToast({
-          toastId,
-          view,
-          openSettings,
-        });
-
-        if (isTerminalProviderUpdateToastView(view)) {
+        if (shouldShowPrimaryProviderUpdateToast(view)) {
+          addProviderUpdateToast({ view, openSettings: openProviderSettings });
           activeToastRef.current = null;
         }
       })();


### PR DESCRIPTION
## Problem

Starting a one-click provider update kept the initial toast visible as a persistent `Updating provider` status while the sidebar pill showed the same running update. This duplicated progress in two UI locations.

Fixes #7425.

## What changed

- Close the update-available toast when a one-click update starts, leaving the sidebar pill as the canonical running-status UI.
- Preserve terminal success, failure, and unchanged outcome toasts, including transport-level failures.
- Add focused coverage for hiding only the primary running-phase toast while preserving the initial prompt and terminal outcomes.

## UI changes

### Before

The running update appears in both a persistent toast and the sidebar pill.

![Before: provider update shown in both toast and sidebar](https://raw.githubusercontent.com/naveed949/t3code/pr-assets-7761/before.png)

### After

Only the sidebar pill shows the running update.

![After: provider update shown only in the sidebar](https://raw.githubusercontent.com/naveed949/t3code/pr-assets-7761/after.png)

## Verification

- `vp test run apps/web/src/components/ProviderUpdateLaunchNotification.logic.test.ts` — 47 passed
- `vp lint apps/web/src/components/ProviderUpdatePrimaryNotification.tsx apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts apps/web/src/components/ProviderUpdateLaunchNotification.logic.test.ts`
- `vp fmt --check apps/web/src/components/ProviderUpdatePrimaryNotification.tsx apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts apps/web/src/components/ProviderUpdateLaunchNotification.logic.test.ts`
- `vp run --filter @t3tools/web typecheck`
- Manually verified in T3 Code Desktop with one-click Claude provider update

Created by gpt-5.6-sol using the Codex harness in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove duplicate provider update running toast in `ProviderUpdatePrimaryNotification`
> - The primary provider update flow no longer shows a running/loading toast; only the initial prompt and terminal outcome (success/unchanged/failed) toasts appear.
> - Adds `shouldShowPrimaryProviderUpdateToast` to gate toast display by phase, returning false when `view.phase` is `'running'`.
> - Replaces in-place toast updates with `addProviderUpdateToast`, which always creates a new toast and ensures the Settings action closes the specific clicked toast.
> - Removes `updateProviderUpdateToast`, `isTerminalProviderUpdateToastView`, and active `toastId` tracking for the update flow.
> - Risk: `ProviderUpdatePrimaryNotification` no longer displays progress while updates run; callers expecting a visible running toast will not see one.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab1816a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only toast lifecycle change for provider updates; no auth, data, or backend behavior is affected.
> 
> **Overview**
> Stops duplicating one-click provider update progress: the prompt toast is closed when an update starts, and **running-phase** toasts are no longer shown so the sidebar pill is the only in-flight status.
> 
> Terminal success, failure, and unchanged outcomes still appear as new toasts (not in-place updates). `shouldShowPrimaryProviderUpdateToast` gates that, and cleanup only closes prompt toasts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab1816a1bd831e02e5d8928dcfc8625eb3e755f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->