### PR TITLE
fix(web): model picker no longer shows a double border

### DIFF
--- a/apps/web/src/components/chat/ModelPickerContent.tsx
+++ b/apps/web/src/components/chat/ModelPickerContent.tsx
@@ -599,7 +599,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
   return (
     <TooltipProvider delay={0}>
       <div
-        className="dropdown-glass relative flex h-screen max-h-86.5 w-screen max-w-90 flex-row overflow-hidden rounded-lg text-popover-foreground shadow-[0_16px_40px_-18px_rgb(0_0_0/55%)] [clip-path:inset(0_round_var(--radius-lg))] dark:shadow-[0_18px_44px_-18px_rgb(0_0_0/80%)]"
+        className="relative flex h-screen max-h-86.5 w-screen max-w-90 flex-row overflow-hidden"
         data-model-picker-content="true"
       >
         {/* Sidebar */}

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -186,8 +186,8 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
       </PopoverTrigger>
       <PopoverPopup
         align="start"
-        className="border-0 bg-transparent p-0 shadow-none before:hidden [-webkit-backdrop-filter:none]! [--viewport-inline-padding:0] [backdrop-filter:none]!"
-        viewportClassName="rounded-lg !overflow-hidden p-0"
+        className="before:hidden [--viewport-inline-padding:0]"
+        viewportClassName="!overflow-hidden rounded-[calc(var(--radius-lg)-1px)] p-0 [clip-path:inset(0_round_calc(var(--radius-lg)-1px))]"
       >
         <ModelPickerContent
           activeInstanceId={activeInstanceId}


### PR DESCRIPTION
The model picker wrapped the same surface in two glass containers, leaving a doubled rounded border in both light and dark themes.

The popover now owns the glass background, border, clipping, and shadow. The picker content only controls layout, so the menu has one clean edge without changing its dimensions or selection behavior.

## Verification

- `vp lint apps/web/src/components/chat/ModelPickerContent.tsx apps/web/src/components/chat/ProviderModelPicker.tsx`
- `vp fmt --check apps/web/src/components/chat/ModelPickerContent.tsx apps/web/src/components/chat/ProviderModelPicker.tsx`
- Verified the model picker locally in light and dark modes with before/after browser captures.
- `vp run --filter @t3tools/web typecheck` is currently blocked by pre-existing `conditionalUI` errors in `apps/web/src/components/clerk/electronPasskeys.test.ts` at lines 42 and 55.

## Screenshots

| Before | After |
| --- | --- |
| Light mode<br><img width="450" alt="Model picker before the fix in light mode" src="https://github.com/user-attachments/assets/b0c389aa-9722-4b42-8bfd-685c636c0363" /> | Light mode<br><img width="450" alt="Model picker after the fix in light mode" src="https://github.com/user-attachments/assets/8b45f75f-81a7-4ab5-940c-b9a0c7f2370a" /> |
| Dark mode<br><img width="450" alt="Model picker before the fix in dark mode" src="https://github.com/user-attachments/assets/9ef84714-d4bc-4d89-855c-92df79c144f0" /> | Dark mode<br><img width="450" alt="Model picker after the fix in dark mode" src="https://github.com/user-attachments/assets/d012a05f-4c5c-4008-a6c8-177d95848aec" /> |

---
Built by GPT-5.6 Sol in T3 Code through the Codex harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure CSS/layout tweak on the model picker popover. No logic, auth, or data-handling changes.
> 
> **Overview**
> Stops the model picker from stacking two glass surfaces, which produced a doubled rounded border in light and dark themes.
> 
> `ModelPickerContent` now only handles layout. Glass background, border, clip, and shadow live on the popover viewport so the menu has a single clean edge without changing size or selection behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab57134e868fae3744d38e8fe37df8bac5834a99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->