### PR TITLE
fix(server): require operate scope for local server discovery probes

### DIFF
--- a/apps/server/src/auth/RpcAuthorization.test.ts
+++ b/apps/server/src/auth/RpcAuthorization.test.ts
@@ -30,6 +30,12 @@ describe("RPC authorization scopes", () => {
     );
   });
 
+  it("requires operate access for local server discovery probes", () => {
+    expect(requiredScopeForRpcMethod(WS_METHODS.subscribeDiscoveredLocalServers)).toBe(
+      AuthOrchestrationOperateScope,
+    );
+  });
+
   it("allows relay status reads without granting relay installation access", () => {
     expect(requiredScopeForRpcMethod(WS_METHODS.cloudGetRelayClientStatus)).toBe(
       AuthRelayReadScope,

--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -119,7 +119,7 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.previewAutomationRespond]: AuthOrchestrationOperateScope,
   [WS_METHODS.previewAutomationFocusHost]: AuthOrchestrationOperateScope,
   [WS_METHODS.subscribePreviewEvents]: AuthOrchestrationReadScope,
-  [WS_METHODS.subscribeDiscoveredLocalServers]: AuthOrchestrationReadScope,
+  [WS_METHODS.subscribeDiscoveredLocalServers]: AuthOrchestrationOperateScope,
   [WS_METHODS.subscribeServerConfig]: AuthOrchestrationReadScope,
   [WS_METHODS.subscribeServerLifecycle]: AuthOrchestrationReadScope,
   [WS_METHODS.subscribeAuthAccess]: AuthAccessReadScope,


### PR DESCRIPTION
## What Changed

`subscribeDiscoveredLocalServers` now requires `orchestration:operate` instead of `orchestration:read`, and a focused test pins that decision.

## Why

The preview discovery RPC accepts client-supplied `configuredUrls` and probes them with server-side HTTP GETs (`PortScanner.probeWebUrl`), but was authorized with `orchestration:read`. A read-only paired client - or project previewUrl configuration it causes the UI to forward - could make the environment server request arbitrary loopback paths, queries, and ports, crossing the read-only RPC boundary into local network side effects. The documented contract for `orchestration:read` (docs/internals/environment-auth.md) covers snapshots, status, events, configuration, and filesystem/VCS state; probing local services is not a read.

Impact is bounded (auth required, loopback-only hosts, 32 URLs x 2048 chars, GET only, no response body, redirects not followed), so this is a scope-hygiene fix rather than an incident response. Read-only devices lose the Local recommendations list in the preview empty state; every other client is unaffected.

Found by an automated security review; validated with a test that starts a loopback HTTP server, hides it from listener enumeration, and asserts a configured URL still receives a GET.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes

ox-alpha via opencode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches RPC authorization for a method that issues server-side loopback GETs. The change is a one-line scope tightening with a unit test, not a new attack surface.
> 
> **Overview**
> Tightens auth so `subscribeDiscoveredLocalServers` requires `orchestration:operate` instead of `orchestration:read`. That RPC probes client-supplied loopback URLs, which is a side effect, not a snapshot/status read.
> 
> Read-only paired clients lose the Local recommendations list in the preview empty state; other clients are unchanged. A unit test pins the required scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e02277de7cdc8f580c1b7be0425d1774ffede80a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require `AuthOrchestrationOperateScope` for `subscribeDiscoveredLocalServers` RPC
> Updates the `RPC_REQUIRED_SCOPES` mapping in [RpcAuthorization.ts](https://github.com/pingdotgg/t3code/pull/7789/files#diff-ef8e11f5d03122896863286f476eac62b31a12ed508924c3af039ec784a3a4d4) so `WS_METHODS.subscribeDiscoveredLocalServers` requires `AuthOrchestrationOperateScope` instead of `AuthOrchestrationReadScope`. Adds a test case in [RpcAuthorization.test.ts](https://github.com/pingdotgg/t3code/pull/7789/files#diff-e17bae10f41a16e65bd138cc4d74a7166e65e70b633bc808d7f0fc95401af970) asserting the new scope. Risk: clients with only read scope can no longer subscribe to local server discovery probes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e02277d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization for local server discovery subscriptions by requiring elevated orchestration permissions.

* **Tests**
  * Added coverage to verify that unauthorized subscriptions are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->