### PR TITLE
fix(web): keep messages clear of composer banners

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -22,6 +22,7 @@ import {
   use,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -68,6 +69,7 @@ import { buildExpandedImagePreview, ExpandedImagePreview } from "./ExpandedImage
 import { ProposedPlanCard } from "./ProposedPlanCard";
 import { ChangedFilesCard } from "./ChangedFilesTree";
 import { shouldAutoExpandChangedFiles } from "./changedFilesPresentation";
+import { keepTimelineEndVisibleAfterOverlayGrowth } from "./timelineScrollAnchoring";
 import { MessageCopyButton } from "./MessageCopyButton";
 import {
   computeStableMessagesTimelineRows,
@@ -286,6 +288,17 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   const disclosureAnchorKeyRef = useRef<string | null>(null);
   const disclosureSettleFrameRef = useRef<number | null>(null);
   const disclosureSettleSecondFrameRef = useRef<number | null>(null);
+  const previousContentInsetEndAdjustmentRef = useRef(contentInsetEndAdjustment);
+
+  useLayoutEffect(() => {
+    keepTimelineEndVisibleAfterOverlayGrowth({
+      timeline: listRef.current,
+      previousOverlayHeight: previousContentInsetEndAdjustmentRef.current,
+      overlayHeight: contentInsetEndAdjustment,
+      followingEnd: liveFollowEnabled && anchorMessageId === null,
+    });
+    previousContentInsetEndAdjustmentRef.current = contentInsetEndAdjustment;
+  }, [anchorMessageId, contentInsetEndAdjustment, listRef, liveFollowEnabled]);
 
   useEffect(() => {
     return () => {

--- a/apps/web/src/components/chat/timelineScrollAnchoring.test.tsx
+++ b/apps/web/src/components/chat/timelineScrollAnchoring.test.tsx
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vite-plus/test";
-import { getAnchoredTurnMetrics, getRowBottom } from "./timelineScrollAnchoring";
+import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  getAnchoredTurnMetrics,
+  getRowBottom,
+  keepTimelineEndVisibleAfterOverlayGrowth,
+} from "./timelineScrollAnchoring";
 
 function buildState({
   positions,
@@ -22,6 +26,33 @@ function buildState({
 }
 
 describe("timeline scroll anchoring", () => {
+  it("keeps the live edge visible when the composer overlay grows", () => {
+    const scrollToEnd = vi.fn();
+
+    keepTimelineEndVisibleAfterOverlayGrowth({
+      timeline: { scrollToEnd },
+      previousOverlayHeight: 120,
+      overlayHeight: 180,
+      followingEnd: true,
+    });
+
+    expect(scrollToEnd).toHaveBeenCalledOnce();
+    expect(scrollToEnd).toHaveBeenCalledWith({ animated: false });
+  });
+
+  it("leaves the scroll position alone while the user reads history", () => {
+    const scrollToEnd = vi.fn();
+
+    keepTimelineEndVisibleAfterOverlayGrowth({
+      timeline: { scrollToEnd },
+      previousOverlayHeight: 120,
+      overlayHeight: 180,
+      followingEnd: false,
+    });
+
+    expect(scrollToEnd).not.toHaveBeenCalled();
+  });
+
   it("measures row bottoms from LegendList row position and size", () => {
     const state = buildState({
       positions: [0, 120],

--- a/apps/web/src/components/chat/timelineScrollAnchoring.ts
+++ b/apps/web/src/components/chat/timelineScrollAnchoring.ts
@@ -19,6 +19,22 @@ export interface AnchoredTurnMetrics {
   readonly scrollDeltaToRevealEnd: number;
 }
 
+export function keepTimelineEndVisibleAfterOverlayGrowth({
+  timeline,
+  previousOverlayHeight,
+  overlayHeight,
+  followingEnd,
+}: {
+  readonly timeline: { scrollToEnd: (options: { animated: boolean }) => unknown } | null;
+  readonly previousOverlayHeight: number;
+  readonly overlayHeight: number;
+  readonly followingEnd: boolean;
+}): void {
+  if (timeline && followingEnd && overlayHeight > previousOverlayHeight) {
+    void timeline.scrollToEnd({ animated: false });
+  }
+}
+
 export function getRowBottom(state: TimelineListMeasurementState, index: number): number | null {
   const top = state.positionAtIndex(index);
   const height = state.sizeAtIndex(index);


### PR DESCRIPTION
## What Changed

- Keep the timeline at the live edge when a composer banner increases the bottom overlay height.
- Preserve the current scroll position while the user reads history or a sent-message anchor is active.

## Why

Composer banners add reserved space after the timeline can already be at the live edge. The list updated its inset but could keep the old scroll offset, which left the last message hidden behind notices such as Server update available.

This fix adjusts the live timeline when that overlay grows. It leaves manual history reading and sent-message anchoring unchanged.

## Checks

- 34 focused tests passed
- Changed-file lint passed
- Web typecheck passed
- Format check passed

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep `MessagesTimeline` scrolled to end when composer overlay height grows
> - Adds `keepTimelineEndVisibleAfterOverlayGrowth` to [timelineScrollAnchoring.ts](https://github.com/pingdotgg/t3code/pull/7792/files#diff-7d5bb365d2e39e9337a3a31436884ed0c0df1127c2033e30a6c027826c46de67), which calls `timeline.scrollToEnd({ animated: false })` when `followingEnd` is true and overlay height increased; otherwise it is a no-op.
> - Wires the utility into [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/7792/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) via a `useLayoutEffect` that tracks the previous overlay height and only fires when live following is active and no anchor message is set.
> - Adds unit tests in [timelineScrollAnchoring.test.tsx](https://github.com/pingdotgg/t3code/pull/7792/files#diff-92c5a90dc099e4f9f9fda6970f96a52190878e696b0350480d1ee1b48f513f0b) covering both the scroll and no-op cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4eb835a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->