### PR TITLE
fix(web): launcher shortcuts no longer hijack the empty composer

### DIFF
--- a/apps/web/src/components/RightPanelTabs.test.tsx
+++ b/apps/web/src/components/RightPanelTabs.test.tsx
@@ -172,22 +172,36 @@ describe("surface shortcuts", () => {
 });
 
 describe("surface shortcut typing contexts", () => {
-  const targetIn = (selector: string | null) => ({
-    closest: (selectors: string) => (selector === null ? null : { matches: selector }),
+  // Selector-aware stub: closest() only answers when the requested selector
+  // list contains the matched element, like a real DOM would.
+  const makeTarget = (matches: string | null, contenteditableValue?: string | null) => ({
+    closest(selectors: string) {
+      if (matches === null || !selectors.includes(matches)) return null;
+      return {
+        getAttribute: (name: string) =>
+          name === "contenteditable" ? (contenteditableValue ?? null) : null,
+      };
+    },
   });
 
-  it("treats form fields and every contenteditable as typing contexts", () => {
-    expect(surfaceShortcutTargetsTypingContext(targetIn("input"))).toBe(true);
-    expect(surfaceShortcutTargetsTypingContext(targetIn("textarea"))).toBe(true);
-    expect(surfaceShortcutTargetsTypingContext(targetIn("select"))).toBe(true);
+  it("treats form fields and every editable region as typing contexts", () => {
+    expect(surfaceShortcutTargetsTypingContext(makeTarget("input"))).toBe(true);
+    expect(surfaceShortcutTargetsTypingContext(makeTarget("textarea"))).toBe(true);
+    expect(surfaceShortcutTargetsTypingContext(makeTarget("select"))).toBe(true);
     // The chat composer is a contenteditable that sits empty until a draft
     // exists; launcher letters claimed from it redirected prompts into shells.
-    expect(surfaceShortcutTargetsTypingContext(targetIn("[contenteditable]"))).toBe(true);
+    expect(surfaceShortcutTargetsTypingContext(makeTarget("[contenteditable]", "true"))).toBe(true);
+    // An empty attribute value still means editable.
+    expect(surfaceShortcutTargetsTypingContext(makeTarget("[contenteditable]", ""))).toBe(true);
   });
 
-  it("claims letters when focus sits outside any editable", () => {
-    expect(surfaceShortcutTargetsTypingContext(targetIn(null))).toBe(false);
+  it("ignores non-editable regions and bare focus targets", () => {
     expect(surfaceShortcutTargetsTypingContext(null)).toBe(false);
+    expect(surfaceShortcutTargetsTypingContext(makeTarget(null))).toBe(false);
+    // Non-editable islands inside an editable host stay shortcut-reachable.
+    expect(surfaceShortcutTargetsTypingContext(makeTarget("[contenteditable]", "false"))).toBe(
+      false,
+    );
   });
 });
 

--- a/apps/web/src/components/RightPanelTabs.test.tsx
+++ b/apps/web/src/components/RightPanelTabs.test.tsx
@@ -172,15 +172,12 @@ describe("surface shortcuts", () => {
 });
 
 describe("surface shortcut typing contexts", () => {
-  // Selector-aware stub: closest() only answers when the requested selector
-  // list contains the matched element, like a real DOM would.
-  const makeTarget = (matches: string | null, contenteditableValue?: string | null) => ({
+  // Selector-aware stub: closest() answers only tokens the combined selector
+  // would actually match, mirroring how the browser resolves it.
+  const makeTarget = (matches: string | null) => ({
     closest(selectors: string) {
       if (matches === null || !selectors.includes(matches)) return null;
-      return {
-        getAttribute: (name: string) =>
-          name === "contenteditable" ? (contenteditableValue ?? null) : null,
-      };
+      return {};
     },
   });
 
@@ -190,18 +187,14 @@ describe("surface shortcut typing contexts", () => {
     expect(surfaceShortcutTargetsTypingContext(makeTarget("select"))).toBe(true);
     // The chat composer is a contenteditable that sits empty until a draft
     // exists; launcher letters claimed from it redirected prompts into shells.
-    expect(surfaceShortcutTargetsTypingContext(makeTarget("[contenteditable]", "true"))).toBe(true);
-    // An empty attribute value still means editable.
-    expect(surfaceShortcutTargetsTypingContext(makeTarget("[contenteditable]", ""))).toBe(true);
+    // The :not clause sees past contenteditable="false" islands to an editable
+    // host around them, so nested editors stay protected too.
+    expect(surfaceShortcutTargetsTypingContext(makeTarget("[contenteditable]"))).toBe(true);
   });
 
-  it("ignores non-editable regions and bare focus targets", () => {
+  it("claims letters when focus sits outside any editable region", () => {
     expect(surfaceShortcutTargetsTypingContext(null)).toBe(false);
     expect(surfaceShortcutTargetsTypingContext(makeTarget(null))).toBe(false);
-    // Non-editable islands inside an editable host stay shortcut-reachable.
-    expect(surfaceShortcutTargetsTypingContext(makeTarget("[contenteditable]", "false"))).toBe(
-      false,
-    );
   });
 });
 

--- a/apps/web/src/components/RightPanelTabs.test.tsx
+++ b/apps/web/src/components/RightPanelTabs.test.tsx
@@ -2,7 +2,12 @@ import type { DesktopPreviewFavicon, PreviewSessionSnapshot } from "@t3tools/con
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vite-plus/test";
 
-import { RightPanelTabs, surfaceShortcutActionForKey, tabMuteMenuItem } from "./RightPanelTabs";
+import {
+  RightPanelTabs,
+  surfaceShortcutActionForKey,
+  surfaceShortcutTargetsTypingContext,
+  tabMuteMenuItem,
+} from "./RightPanelTabs";
 
 function shortcutEvent(
   key: string,
@@ -163,6 +168,26 @@ describe("surface shortcuts", () => {
     expect(
       surfaceShortcutActionForKey(actions, shortcutEvent("b", { defaultPrevented: true })),
     ).toBeNull();
+  });
+});
+
+describe("surface shortcut typing contexts", () => {
+  const targetIn = (selector: string | null) => ({
+    closest: (selectors: string) => (selector === null ? null : { matches: selector }),
+  });
+
+  it("treats form fields and every contenteditable as typing contexts", () => {
+    expect(surfaceShortcutTargetsTypingContext(targetIn("input"))).toBe(true);
+    expect(surfaceShortcutTargetsTypingContext(targetIn("textarea"))).toBe(true);
+    expect(surfaceShortcutTargetsTypingContext(targetIn("select"))).toBe(true);
+    // The chat composer is a contenteditable that sits empty until a draft
+    // exists; launcher letters claimed from it redirected prompts into shells.
+    expect(surfaceShortcutTargetsTypingContext(targetIn("[contenteditable]"))).toBe(true);
+  });
+
+  it("claims letters when focus sits outside any editable", () => {
+    expect(surfaceShortcutTargetsTypingContext(targetIn(null))).toBe(false);
+    expect(surfaceShortcutTargetsTypingContext(null)).toBe(false);
   });
 });
 

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -194,17 +194,17 @@ export function surfaceShortcutActionForKey<
  * A focused editable is a typing context whether or not it has text yet: an
  * empty chat composer at rest is still where the user's next keystrokes are
  * meant to land, and claiming launcher letters from it would redirect prompts
- * into whatever surface opens. Non-editable islands marked
- * `contenteditable="false"` (chips inside the composer, standalone widgets)
- * stay shortcut-reachable.
+ * into whatever surface opens. The `:not` clause lets `closest` see past
+ * non-editable islands (`contenteditable="false"`) to an editable host around
+ * them, matching ComposerPendingUserInputPanel's typing guard.
  */
 export function surfaceShortcutTargetsTypingContext(
-  target: {
-    closest(selectors: string): { getAttribute(qualifiedName: string): string | null } | null;
-  } | null,
+  target: { closest(selectors: string): unknown } | null,
 ): boolean {
-  const editable = target?.closest("input, textarea, select, [contenteditable]") ?? null;
-  return editable != null && editable.getAttribute("contenteditable") !== "false";
+  return (
+    target?.closest('input, textarea, select, [contenteditable]:not([contenteditable="false"])') !=
+    null
+  );
 }
 
 function DisabledReasonTooltip(props: { reason: string; trigger: ReactElement }) {

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -190,6 +190,18 @@ export function surfaceShortcutActionForKey<
   );
 }
 
+/**
+ * A focused editable is a typing context whether or not it has text yet: an
+ * empty chat composer at rest is still where the user's next keystrokes are
+ * meant to land, and claiming launcher letters from it would redirect prompts
+ * into whatever surface opens.
+ */
+export function surfaceShortcutTargetsTypingContext(
+  target: { closest(selectors: string): unknown } | null,
+): boolean {
+  return target?.closest("input, textarea, select, [contenteditable]") != null;
+}
+
 function DisabledReasonTooltip(props: { reason: string; trigger: ReactElement }) {
   return (
     <Tooltip>
@@ -329,13 +341,7 @@ function RightPanelEmptyState(props: {
       if (!action) return;
       if (document.querySelector(LAUNCHER_SHORTCUT_BLOCKING_LAYERS)) return;
       const target = event.target;
-      if (target instanceof HTMLElement) {
-        if (target.closest("input, textarea, select")) return;
-        // An empty contenteditable (the chat composer at rest) does not
-        // count as typing; letters only become text once a draft exists.
-        const editable = target.isContentEditable ? target : target.closest("[contenteditable]");
-        if (editable && (editable.textContent ?? "").trim().length > 0) return;
-      }
+      if (target instanceof Element && surfaceShortcutTargetsTypingContext(target)) return;
       event.preventDefault();
       event.stopPropagation();
       action.onClick();

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -194,12 +194,17 @@ export function surfaceShortcutActionForKey<
  * A focused editable is a typing context whether or not it has text yet: an
  * empty chat composer at rest is still where the user's next keystrokes are
  * meant to land, and claiming launcher letters from it would redirect prompts
- * into whatever surface opens.
+ * into whatever surface opens. Non-editable islands marked
+ * `contenteditable="false"` (chips inside the composer, standalone widgets)
+ * stay shortcut-reachable.
  */
 export function surfaceShortcutTargetsTypingContext(
-  target: { closest(selectors: string): unknown } | null,
+  target: {
+    closest(selectors: string): { getAttribute(qualifiedName: string): string | null } | null;
+  } | null,
 ): boolean {
-  return target?.closest("input, textarea, select, [contenteditable]") != null;
+  const editable = target?.closest("input, textarea, select, [contenteditable]") ?? null;
+  return editable != null && editable.getAttribute("contenteditable") !== "false";
 }
 
 function DisabledReasonTooltip(props: { reason: string; trigger: ReactElement }) {


### PR DESCRIPTION
## What Changed

The right-panel empty-state launcher's capture-phase keydown handler now treats every contenteditable as a typing context, whether or not it has text. Extracted the guard into an exported, unit-tested helper (`surfaceShortcutTargetsTypingContext`).

## Why

The handler skipped `input/textarea/select` and *non-empty* contenteditables, but deliberately let an **empty** contenteditable through - which is the chat composer's normal at-rest state. Clicking into the composer and starting a prompt with `t`, `b`, `f`, `d`, `p`, or `a` instead triggered the launcher: for `T` that opens a terminal in the workspace, autofocuses it, and the remainder of the prompt plus any Enter presses go to the live shell via `terminalWrite` - accidental command execution and prompt leakage into shell history.

This also contradicted the component's own documented contract ("opens it directly from anywhere outside a typing context"): a focused editable is a typing context even when empty. Launcher letters keep working from any non-editable focus; type-to-focus suppression for launcher keys (ChatView) is unchanged and still correct for that path.

Found by an automated security review (assessed low/same-user); fixed as a UX/input-safety bug.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes

ox-alpha via opencode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes capture-phase keyboard shortcut routing that previously could open a terminal and send leftover keystrokes into a live shell. Scope is small and well-tested, but it sits on a global keydown path.
> 
> **Overview**
> Right-panel launcher letter shortcuts no longer fire while the chat composer (or any other editable) is focused, even when it is empty.
> 
> The capture-phase handler used to skip only form fields and *non-empty* contenteditables, so typing `t`/`b`/`f`/etc. into an at-rest composer opened a surface (and for `T`, dumped the rest of the prompt into a live shell). The guard now treats every `input`, `textarea`, `select`, and `[contenteditable]` (except `contenteditable="false"` islands) as a typing context, matching the composer pending-input shortcut guard. Extracted as `surfaceShortcutTargetsTypingContext` with unit tests. Shortcuts still work from non-editable focus.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce7e61408f302a0c50bf92db65533828b63933bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `RightPanelEmptyState` shortcuts to ignore typing contexts
> - Adds `surfaceShortcutTargetsTypingContext` to identify if focus is inside an `input`, `textarea`, `select`, or editable `contenteditable` host.
> - Updates the `RightPanelEmptyState` keydown handler to use this utility and exit early, preventing letter shortcuts from triggering while typing.
> - Behavioral Change: Widens the `instanceof` guard in `RightPanelEmptyState` from `HTMLElement` to `Element`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce7e614.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard shortcut handling so shortcuts no longer trigger while typing in input fields, text areas, dropdowns, or content-editable areas.
  * Ensured empty chat composer fields are correctly treated as typing contexts.
* **Tests**
  * Added coverage for shortcut behavior across editable and non-editable focus targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->