### PR TITLE
fix(web): stop tool-name prefix from duplicating command detail

### DIFF
--- a/apps/server/src/orchestration/ActivityPayloadProjection.test.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.test.ts
@@ -126,7 +126,7 @@ describe("projectActivityPayload", () => {
 
     expect(claude.payload).toMatchObject({
       toolCallId: "claude-call-1",
-      data: { command: "vp test run" },
+      data: { toolName: "Bash", command: "vp test run" },
     });
     expect(openCode.payload).toMatchObject({
       toolCallId: "opencode-call-1",
@@ -134,6 +134,23 @@ describe("projectActivityPayload", () => {
     });
     expect(JSON.stringify(claude.payload).length).toBeLessThan(200);
     expect(JSON.stringify(openCode.payload).length).toBeLessThan(200);
+  });
+
+  it("preserves toolName for command activities so the web client can recognize a redundant heading in detail", () => {
+    const projected = projectActivityPayload(
+      activity({
+        itemType: "command_execution",
+        detail: 'Bash: cd project && grep -n "TODO" file.md',
+        data: {
+          toolName: "Bash",
+          command: 'cd project && grep -n "TODO" file.md',
+        },
+      }),
+    );
+
+    expect(projected.payload).toMatchObject({
+      data: { toolName: "Bash" },
+    });
   });
 
   it("slims Codex-shaped mcp_tool_call items to rendered fields plus a result summary", () => {

--- a/apps/server/src/orchestration/ActivityPayloadProjection.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.ts
@@ -375,6 +375,12 @@ export function projectActivityPayload(
   if ("kind" in data) {
     projectedData.kind = data.kind;
   }
+  if ("toolName" in data) {
+    // The web client needs this to recognize a "<toolName>: " heading some
+    // providers bake into payload.detail as redundant with the command
+    // preview it renders separately (see extractToolDetail).
+    projectedData.toolName = data.toolName;
+  }
 
   const rawOutput = projectRawOutput(data.rawOutput) ?? projectAcpContent(data.content);
   if (rawOutput) {

--- a/apps/web/src/session-logic.command-output.test.ts
+++ b/apps/web/src/session-logic.command-output.test.ts
@@ -82,4 +82,22 @@ describe("deriveWorkLogEntries command output", () => {
     expect(entry?.command).toBe("true");
     expect(entry?.detail).toBeUndefined();
   });
+
+  it("drops duplicated command detail when it only differs by a toolName prefix", () => {
+    const [entry] = deriveWorkLogEntries([
+      makeCommandActivity("bash-prefixed-command", {
+        itemType: "command_execution",
+        title: "Command run",
+        detail: 'Bash: cd project && grep -n "TODO" file.md',
+        data: {
+          toolName: "Bash",
+          kind: "execute",
+          command: 'cd project && grep -n "TODO" file.md',
+        },
+      }),
+    ]);
+
+    expect(entry?.command).toBe('cd project && grep -n "TODO" file.md');
+    expect(entry?.detail).toBeUndefined();
+  });
 });

--- a/apps/web/src/session-logic.command-output.test.ts
+++ b/apps/web/src/session-logic.command-output.test.ts
@@ -84,15 +84,13 @@ describe("deriveWorkLogEntries command output", () => {
   });
 
   it("drops duplicated command detail when it only differs by a toolName prefix", () => {
-    // Matches the wire shape after server-side payload projection drops
-    // data.toolName (see ActivityPayloadProjection.ts) — detail keeps its
-    // "Bash: " heading, but data only carries the bare command.
     const [entry] = deriveWorkLogEntries([
       makeCommandActivity("bash-prefixed-command", {
         itemType: "command_execution",
         title: "Command run",
         detail: 'Bash: cd project && grep -n "TODO" file.md',
         data: {
+          toolName: "Bash",
           kind: "execute",
           command: 'cd project && grep -n "TODO" file.md',
         },
@@ -103,13 +101,14 @@ describe("deriveWorkLogEntries command output", () => {
     expect(entry?.detail).toBeUndefined();
   });
 
-  it("keeps detail that merely happens to contain the command as a suffix", () => {
+  it("keeps a labeled detail that merely ends with the command text", () => {
     const [entry] = deriveWorkLogEntries([
       makeCommandActivity("unrelated-suffix-match", {
         itemType: "command_execution",
         title: "Command run",
-        detail: "warning: deprecated flag used in: true",
+        detail: "warning: true",
         data: {
+          toolName: "Bash",
           kind: "execute",
           command: "true",
         },
@@ -117,6 +116,6 @@ describe("deriveWorkLogEntries command output", () => {
     ]);
 
     expect(entry?.command).toBe("true");
-    expect(entry?.detail).toBe("warning: deprecated flag used in: true");
+    expect(entry?.detail).toBe("warning: true");
   });
 });

--- a/apps/web/src/session-logic.command-output.test.ts
+++ b/apps/web/src/session-logic.command-output.test.ts
@@ -84,13 +84,15 @@ describe("deriveWorkLogEntries command output", () => {
   });
 
   it("drops duplicated command detail when it only differs by a toolName prefix", () => {
+    // Matches the wire shape after server-side payload projection drops
+    // data.toolName (see ActivityPayloadProjection.ts) — detail keeps its
+    // "Bash: " heading, but data only carries the bare command.
     const [entry] = deriveWorkLogEntries([
       makeCommandActivity("bash-prefixed-command", {
         itemType: "command_execution",
         title: "Command run",
         detail: 'Bash: cd project && grep -n "TODO" file.md',
         data: {
-          toolName: "Bash",
           kind: "execute",
           command: 'cd project && grep -n "TODO" file.md',
         },
@@ -99,5 +101,22 @@ describe("deriveWorkLogEntries command output", () => {
 
     expect(entry?.command).toBe('cd project && grep -n "TODO" file.md');
     expect(entry?.detail).toBeUndefined();
+  });
+
+  it("keeps detail that merely happens to contain the command as a suffix", () => {
+    const [entry] = deriveWorkLogEntries([
+      makeCommandActivity("unrelated-suffix-match", {
+        itemType: "command_execution",
+        title: "Command run",
+        detail: "warning: deprecated flag used in: true",
+        data: {
+          kind: "execute",
+          command: "true",
+        },
+      }),
+    ]);
+
+    expect(entry?.command).toBe("true");
+    expect(entry?.detail).toBe("warning: deprecated flag used in: true");
   });
 });

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -1586,22 +1586,18 @@ function isCommandToolDetail(payload: Record<string, unknown> | null, heading: s
 }
 
 // Some providers bake a "<ToolName>: " heading onto payload.detail while the
-// command preview stays bare, e.g. detail "Bash: ls" vs command "ls". That
-// prefix doesn't survive as its own field through server-side payload
-// projection, so match it structurally against the already-projected detail
-// and command strings instead of trusting a toolName field.
-function isToolNamePrefixedDuplicate(
-  normalizedDetail: string | null,
-  normalizedTarget: string | null,
-): boolean {
-  if (!normalizedDetail || !normalizedTarget || normalizedDetail === normalizedTarget) {
-    return false;
+// command preview stays bare, e.g. detail "Bash: ls" vs command "ls".
+// payload.data.toolName carries that same name (preserved through server-side
+// payload projection), so strip exactly that prefix before comparing, rather
+// than guessing at an arbitrary "word:" heading — a detail like "warning:
+// true" must stay visible even when the command happens to be "true".
+function stripToolNamePrefix(value: string, payload: Record<string, unknown> | null): string {
+  const toolName = asTrimmedString(asRecord(payload?.data)?.toolName);
+  if (!toolName) {
+    return value;
   }
-  if (!normalizedDetail.endsWith(normalizedTarget)) {
-    return false;
-  }
-  const prefix = normalizedDetail.slice(0, normalizedDetail.length - normalizedTarget.length);
-  return /^[a-z0-9][a-z0-9 _-]*:\s+$/.test(prefix);
+  const prefix = `${toolName}: `;
+  return value.toLowerCase().startsWith(prefix.toLowerCase()) ? value.slice(prefix.length) : value;
 }
 
 function extractToolDetail(
@@ -1611,7 +1607,9 @@ function extractToolDetail(
   const rawDetail = asTrimmedString(payload?.detail);
   const detail = rawDetail ? stripTrailingExitCode(rawDetail).output : null;
   const normalizedHeading = normalizePreviewForComparison(heading);
-  const normalizedDetail = normalizePreviewForComparison(detail);
+  const normalizedDetail = normalizePreviewForComparison(
+    detail ? stripToolNamePrefix(detail, payload) : detail,
+  );
   const commandTool = isCommandToolDetail(payload, heading);
   const commandPreview = commandTool
     ? extractToolCommand(payload)
@@ -1624,10 +1622,7 @@ function extractToolDetail(
     detail &&
     normalizedHeading !== normalizedDetail &&
     (!commandTool ||
-      (normalizedCommand !== normalizedDetail &&
-        normalizedRawCommand !== normalizedDetail &&
-        !isToolNamePrefixedDuplicate(normalizedDetail, normalizedCommand) &&
-        !isToolNamePrefixedDuplicate(normalizedDetail, normalizedRawCommand)))
+      (normalizedCommand !== normalizedDetail && normalizedRawCommand !== normalizedDetail))
   ) {
     return detail;
   }

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -1585,6 +1585,18 @@ function isCommandToolDetail(payload: Record<string, unknown> | null, heading: s
   );
 }
 
+function stripLeadingToolNamePrefix(
+  value: string,
+  payload: Record<string, unknown> | null,
+): string {
+  const toolName = asTrimmedString(asRecord(payload?.data)?.toolName);
+  if (!toolName) {
+    return value;
+  }
+  const prefix = `${toolName}: `;
+  return value.toLowerCase().startsWith(prefix.toLowerCase()) ? value.slice(prefix.length) : value;
+}
+
 function extractToolDetail(
   payload: Record<string, unknown> | null,
   heading: string,
@@ -1592,7 +1604,9 @@ function extractToolDetail(
   const rawDetail = asTrimmedString(payload?.detail);
   const detail = rawDetail ? stripTrailingExitCode(rawDetail).output : null;
   const normalizedHeading = normalizePreviewForComparison(heading);
-  const normalizedDetail = normalizePreviewForComparison(detail);
+  const normalizedDetail = normalizePreviewForComparison(
+    detail ? stripLeadingToolNamePrefix(detail, payload) : detail,
+  );
   const commandTool = isCommandToolDetail(payload, heading);
   const commandPreview = commandTool
     ? extractToolCommand(payload)

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -1585,16 +1585,23 @@ function isCommandToolDetail(payload: Record<string, unknown> | null, heading: s
   );
 }
 
-function stripLeadingToolNamePrefix(
-  value: string,
-  payload: Record<string, unknown> | null,
-): string {
-  const toolName = asTrimmedString(asRecord(payload?.data)?.toolName);
-  if (!toolName) {
-    return value;
+// Some providers bake a "<ToolName>: " heading onto payload.detail while the
+// command preview stays bare, e.g. detail "Bash: ls" vs command "ls". That
+// prefix doesn't survive as its own field through server-side payload
+// projection, so match it structurally against the already-projected detail
+// and command strings instead of trusting a toolName field.
+function isToolNamePrefixedDuplicate(
+  normalizedDetail: string | null,
+  normalizedTarget: string | null,
+): boolean {
+  if (!normalizedDetail || !normalizedTarget || normalizedDetail === normalizedTarget) {
+    return false;
   }
-  const prefix = `${toolName}: `;
-  return value.toLowerCase().startsWith(prefix.toLowerCase()) ? value.slice(prefix.length) : value;
+  if (!normalizedDetail.endsWith(normalizedTarget)) {
+    return false;
+  }
+  const prefix = normalizedDetail.slice(0, normalizedDetail.length - normalizedTarget.length);
+  return /^[a-z0-9][a-z0-9 _-]*:\s+$/.test(prefix);
 }
 
 function extractToolDetail(
@@ -1604,9 +1611,7 @@ function extractToolDetail(
   const rawDetail = asTrimmedString(payload?.detail);
   const detail = rawDetail ? stripTrailingExitCode(rawDetail).output : null;
   const normalizedHeading = normalizePreviewForComparison(heading);
-  const normalizedDetail = normalizePreviewForComparison(
-    detail ? stripLeadingToolNamePrefix(detail, payload) : detail,
-  );
+  const normalizedDetail = normalizePreviewForComparison(detail);
   const commandTool = isCommandToolDetail(payload, heading);
   const commandPreview = commandTool
     ? extractToolCommand(payload)
@@ -1619,7 +1624,10 @@ function extractToolDetail(
     detail &&
     normalizedHeading !== normalizedDetail &&
     (!commandTool ||
-      (normalizedCommand !== normalizedDetail && normalizedRawCommand !== normalizedDetail))
+      (normalizedCommand !== normalizedDetail &&
+        normalizedRawCommand !== normalizedDetail &&
+        !isToolNamePrefixedDuplicate(normalizedDetail, normalizedCommand) &&
+        !isToolNamePrefixedDuplicate(normalizedDetail, normalizedRawCommand)))
   ) {
     return detail;
   }


### PR DESCRIPTION
## Summary

Fixes #7711. `item.completed` payloads for Bash tool calls carry the same command in two places: `payload.data.input.command` (bare) and `payload.detail` (the same command with a `Bash: ` prefix baked in). `extractToolDetail` in `apps/web/src/session-logic.ts` is supposed to suppress `detail` when it's redundant with the already-rendered command preview, but it only stripped a trailing `complete`/`completed` suffix before comparing — never the leading `<toolName>: ` prefix. So the normalized command and normalized detail never matched, and the redundant detail line rendered a second time under every Bash tool call.

## Fix

Strip a leading `"<toolName>: "` prefix (read from `payload.data.toolName`) from `detail` before the redundancy comparison in `extractToolDetail`.

## Test plan

- [x] Added a regression test in `session-logic.command-output.test.ts` reproducing the exact payload shape from the issue (command in `data.command`, detail prefixed with `Bash: `); confirmed it fails before the fix and passes after.
- [x] `vp test run apps/web/src/session-logic.command-output.test.ts apps/web/src/session-logic.test.ts` — 79 passed.
- [x] `vp run --filter @t3tools/web typecheck` — clean.
- [x] `vp lint` on changed files — clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small display-only change in work-log detail comparison, with a targeted regression test and no auth or data-handling impact.
> 
> **Overview**
> Stops work-log command rows from repeating the same command under Bash (and similar) tool calls.
> 
> `extractToolDetail` already hid `detail` when it matched the command preview, but payloads often prefix detail with `"<toolName>: "`. The comparison now strips that prefix (from `data.toolName`) so redundant detail is dropped. Adds a regression test for the Bash-prefixed payload shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8af60d9ceba481049f52d38bee2042349966f94. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Strip tool-name prefix from command detail in web output
> - Server's `projectActivityPayload` now propagates `data.toolName` into the projected payload for non-`mcp_tool_call` items, so the web client can detect redundant headings.
> - Web client adds `stripToolNamePrefix` helper in [session-logic.ts](https://github.com/pingdotgg/t3code/pull/7799/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) which removes a case-insensitive `<toolName>: ` prefix from a string; `extractToolDetail` applies it before comparing detail to the command preview.
> - Detail that only differs from the command by a matching tool-name prefix is now treated as a duplicate and omitted; unrelated labeled details such as `warning: true` are preserved.
> - Risk: `stripToolNamePrefix` only strips when the prefix exactly matches `payload.data.toolName`; mislabeled or missing `toolName` values will leave the prefix visible rather than dropping the detail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b5e461.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->