### PR TITLE
fix(server): price Daybreak models under their LiteLLM alias

### DIFF
--- a/apps/server/src/usage/usagePricing.test.ts
+++ b/apps/server/src/usage/usagePricing.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { lookupRate, parseRateTable } from "./usagePricing.ts";
+
+describe("lookupRate aliasing", () => {
+  const table = parseRateTable({
+    "gpt-5": { input_cost_per_token: 0.00001, output_cost_per_token: 0.00003 },
+    "daybreak-blue-latest": { input_cost_per_token: 0.000002, output_cost_per_token: 0.000006 },
+    "daybreak-red-latest": { input_cost_per_token: 0.000003, output_cost_per_token: 0.000009 },
+  });
+
+  it("resolves Codex's gpt-prefixed Daybreak blue name to LiteLLM's unprefixed rate", () => {
+    const rate = lookupRate(table, "gpt-daybreak-blue-latest");
+
+    expect(rate).toEqual(table.get("daybreak-blue-latest"));
+  });
+
+  it("resolves Codex's gpt-prefixed Daybreak red name to LiteLLM's unprefixed rate", () => {
+    const rate = lookupRate(table, "gpt-daybreak-red-latest");
+
+    expect(rate).toEqual(table.get("daybreak-red-latest"));
+  });
+
+  it("is case-insensitive, consistent with normalizeModelName's lowercasing", () => {
+    const rate = lookupRate(table, "GPT-Daybreak-Blue-Latest");
+
+    expect(rate).toEqual(table.get("daybreak-blue-latest"));
+  });
+
+  it("leaves a real gpt-prefixed model to look up under its own key, unrewritten", () => {
+    const rate = lookupRate(table, "gpt-5");
+
+    expect(rate).toEqual(table.get("gpt-5"));
+  });
+
+  it("does not invent a rate for a real gpt model absent from the table", () => {
+    // Guards against a generic "strip gpt- prefix" implementation, which would
+    // wrongly send "gpt-4" lookups at a hypothetical "4" table entry.
+    expect(lookupRate(table, "gpt-4")).toBeNull();
+  });
+});

--- a/apps/server/src/usage/usagePricing.ts
+++ b/apps/server/src/usage/usagePricing.ts
@@ -98,10 +98,27 @@ const UNPRICEABLE_MODELS = new Set([
   "fable",
 ]);
 
+/**
+ * Known mismatches between the name a provider records and the key LiteLLM
+ * prices it under.
+ *
+ * Codex reports Daybreak usage as `gpt-daybreak-blue-latest` /
+ * `gpt-daybreak-red-latest`, but LiteLLM prices those same models without the
+ * `gpt-` prefix. This is deliberately a two-entry lookup rather than a generic
+ * "strip a leading gpt-" rule: LiteLLM prices real GPT models (`gpt-5`,
+ * `gpt-4`, ...) *with* the prefix intact, so stripping it generically would
+ * send those lookups at the wrong, likely nonexistent, key.
+ */
+const MODEL_NAME_ALIASES: ReadonlyMap<string, string> = new Map([
+  ["gpt-daybreak-blue-latest", "daybreak-blue-latest"],
+  ["gpt-daybreak-red-latest", "daybreak-red-latest"],
+]);
+
 export function lookupRate(table: RateTable, model: string): ModelRate | null {
   const normalized = normalizeModelName(model);
   if (normalized.length === 0 || UNPRICEABLE_MODELS.has(normalized)) return null;
-  return table.get(normalized) ?? null;
+  const aliased = MODEL_NAME_ALIASES.get(normalized) ?? normalized;
+  return table.get(aliased) ?? null;
 }
 
 export interface PricedUsage {


### PR DESCRIPTION
## Summary

Fixes #7752. Codex records Daybreak model usage as `gpt-daybreak-blue-latest` and `gpt-daybreak-red-latest`. LiteLLM's `model_prices_and_context_window.json` publishes rates for these same models under different keys, without the `gpt-` prefix: `daybreak-blue-latest` and `daybreak-red-latest`. Because `lookupRate` in `apps/server/src/usage/usagePricing.ts` looks the model up by its exact normalized name, the mismatch means both models miss the rate table entirely and get reported as unpriced ($0.00), even though token counts are recorded correctly.

## Fix

Added a narrow, explicit two-entry alias map (`MODEL_NAME_ALIASES`) consulted in `lookupRate` after normalization and before the table lookup. This is deliberately not a generic "strip a leading `gpt-`" transform: LiteLLM prices real GPT models (`gpt-5`, `gpt-4`, ...) *with* the `gpt-` prefix intact, so a generic strip would send those lookups at the wrong (and likely nonexistent) key. `normalizeModelName` and `parseRateTable` are unchanged — the alias only applies at lookup time, not when building the table from LiteLLM's document.

## Test plan

- [x] Added `apps/server/src/usage/usagePricing.test.ts` covering: `daybreak-blue-latest`/`daybreak-red-latest` priced correctly via their Codex `gpt-` prefixed names; the alias is case-insensitive; a real `gpt-` model (`gpt-5`) still resolves under its own key and is unaffected by the alias; a real `gpt-` model absent from the table (`gpt-4`) stays unpriced rather than matching a stripped-prefix key. Confirmed the tests fail before the fix and pass after.
- [x] `vp test run apps/server/src/usage/usagePricing.test.ts` — 5 passed.
- [x] `vp lint` on both changed files — clean.
- [x] `vp run --filter t3 typecheck` — clean (only pre-existing, unrelated suggestions in other files).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow lookup-only alias for two model names; no billing write path, auth, or table-parse changes.
> 
> **Overview**
> Fixes Daybreak usage showing as **$0.00** because Codex records `gpt-daybreak-blue-latest` / `gpt-daybreak-red-latest` while LiteLLM prices those models without the `gpt-` prefix.
> 
> `lookupRate` now remaps those two names via an explicit `MODEL_NAME_ALIASES` map after normalization. Real GPT models keep their prefixed keys; there is no generic prefix strip. Tests cover both aliases, case-insensitivity, and that `gpt-5` / missing `gpt-4` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1223d7f070c9e175751238fdc4cde8e2a4ab7caa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix pricing for Daybreak models by aliasing `gpt-daybreak-*` to unprefixed rate keys
> Adds a `MODEL_NAME_ALIASES` map in [usagePricing.ts](https://github.com/pingdotgg/t3code/pull/7802/files#diff-fe836a76687342f066ff2679d4edcb42b28156a016ba013085092c27fc826c66) that maps `gpt-daybreak-blue-latest` and `gpt-daybreak-red-latest` to their unprefixed rate-table keys. `lookupRate` now checks this map after normalization and unpriceable checks, using the aliased key when present and falling back to the normalized name otherwise.
> - Adds vitest coverage for aliasing, case-insensitivity, genuine `gpt-`-prefixed models, and non-stripping of absent entries like `gpt-4`.
> - Risk: only the two explicit `gpt-daybreak-*` names are remapped; other `gpt-`-prefixed model lookups are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1223d7f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->