### PR TITLE
feat(desktop): coordinate remote server updates

### DIFF
--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -134,6 +134,10 @@ import {
   shouldToastDesktopUpdateActionResult,
 } from "./desktopUpdate.logic";
 import { showDesktopUpdateDownloadedToast } from "./desktopUpdate.toast";
+import {
+  collectRemoteServerUpdateTargets,
+  coordinateDesktopUpdateInstall,
+} from "./desktopUpdate.coordination";
 import { Alert, AlertAction, AlertDescription, AlertTitle } from "./ui/alert";
 import { Button } from "./ui/button";
 import {
@@ -192,7 +196,7 @@ import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { useIsMobile } from "~/hooks/useMediaQuery";
 import { CommandDialogTrigger } from "./ui/command";
 import { useClientSettings, useUpdateClientSettings } from "~/hooks/useSettings";
-import { primaryServerKeybindingsAtom } from "../state/server";
+import { primaryServerKeybindingsAtom, serverEnvironment } from "../state/server";
 import {
   derivePhysicalProjectKey,
   deriveProjectGroupingOverrideKey,
@@ -3078,6 +3082,9 @@ export default function LegacySidebar() {
   const shortcutModifiers = useShortcutModifierState();
   const terminalFocused = useTerminalFocus();
   const { environments } = useEnvironments();
+  const updateServer = useAtomCommand(serverEnvironment.updateServer, {
+    reportFailure: false,
+  });
   const primaryEnvironmentId = usePrimaryEnvironmentId();
   const environmentLabelById = useMemo(
     () =>
@@ -3584,10 +3591,16 @@ export default function LegacySidebar() {
     }
 
     if (desktopUpdateButtonAction === "install") {
+      const targetVersion =
+        desktopUpdateState.downloadedVersion ?? desktopUpdateState.availableVersion;
+      const remoteUpdateTargets = collectRemoteServerUpdateTargets(environments, targetVersion);
       let confirmed = false;
       try {
         confirmed = await ensureLocalApi().dialogs.confirm(
-          getDesktopUpdateInstallConfirmationMessage(desktopUpdateState),
+          getDesktopUpdateInstallConfirmationMessage(
+            desktopUpdateState,
+            remoteUpdateTargets.length,
+          ),
         );
       } catch (error) {
         setDesktopUpdateActionPending(false);
@@ -3604,10 +3617,33 @@ export default function LegacySidebar() {
         setDesktopUpdateActionPending(false);
         return;
       }
-      void bridge
-        .installUpdate()
-        .then((result) => {
-          if (!shouldToastDesktopUpdateActionResult(result)) return;
+
+      let installingDesktop = false;
+      try {
+        const updateResult = await coordinateDesktopUpdateInstall({
+          targets: remoteUpdateTargets,
+          updateServer,
+          installDesktop: () => {
+            installingDesktop = true;
+            return bridge.installUpdate();
+          },
+        });
+        if (updateResult._tag === "RemoteUpdateFailed") {
+          if (!isAtomCommandInterrupted(updateResult.failure.result)) {
+            const error = squashAtomCommandFailure(updateResult.failure.result);
+            toastManager.add(
+              stackedThreadToast({
+                type: "error",
+                title: "Could not update all servers",
+                description: `${updateResult.failure.target.serverLabel}: ${error instanceof Error ? error.message : "Server update failed."}`,
+              }),
+            );
+          }
+          return;
+        }
+
+        const result = updateResult.result;
+        if (shouldToastDesktopUpdateActionResult(result)) {
           const actionError = getDesktopUpdateActionError(result);
           if (!actionError) return;
           toastManager.add(
@@ -3617,23 +3653,26 @@ export default function LegacySidebar() {
               description: actionError,
             }),
           );
-        })
-        .catch((error) => {
-          toastManager.add(
-            stackedThreadToast({
-              type: "error",
-              title: "Could not install update",
-              description: error instanceof Error ? error.message : "An unexpected error occurred.",
-            }),
-          );
-        })
-        .finally(() => setDesktopUpdateActionPending(false));
+        }
+      } catch (error) {
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: installingDesktop ? "Could not install update" : "Could not update all servers",
+            description: error instanceof Error ? error.message : "An unexpected error occurred.",
+          }),
+        );
+      } finally {
+        setDesktopUpdateActionPending(false);
+      }
     }
   }, [
     desktopUpdateActionPending,
     desktopUpdateButtonAction,
     desktopUpdateButtonDisabled,
     desktopUpdateState,
+    environments,
+    updateServer,
   ]);
 
   const expandThreadListForProject = useCallback((projectKey: string) => {

--- a/apps/web/src/components/desktopUpdate.coordination.test.ts
+++ b/apps/web/src/components/desktopUpdate.coordination.test.ts
@@ -1,0 +1,180 @@
+import type { EnvironmentId, ServerConfig } from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
+import { AsyncResult } from "effect/unstable/reactivity";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  collectRemoteServerUpdateTargets,
+  coordinateDesktopUpdateInstall,
+  updateRemoteServersConcurrently,
+  type CoordinatedUpdateEnvironment,
+} from "./desktopUpdate.coordination";
+
+function environment(input: {
+  readonly id: string;
+  readonly label: string;
+  readonly phase?: CoordinatedUpdateEnvironment["connection"]["phase"];
+  readonly serverVersion?: string;
+  readonly selfUpdate?: NonNullable<
+    ServerConfig["environment"]["capabilities"]["serverSelfUpdate"]
+  >;
+}): CoordinatedUpdateEnvironment {
+  const capabilities = input.selfUpdate === undefined ? {} : { serverSelfUpdate: input.selfUpdate };
+  return {
+    environmentId: input.id as EnvironmentId,
+    label: input.label,
+    connection: { phase: input.phase ?? "connected" },
+    serverConfig: {
+      environment: {
+        serverVersion: input.serverVersion ?? "1.0.0",
+        capabilities,
+      },
+    } as ServerConfig,
+  };
+}
+
+describe("desktop update coordination", () => {
+  it("selects every connected self-updatable remote that has not reached the desktop target", () => {
+    const targets = collectRemoteServerUpdateTargets(
+      [
+        environment({ id: "will", label: "Will", selfUpdate: "boot-service" }),
+        environment({ id: "m1", label: "M1", selfUpdate: "respawn" }),
+        environment({
+          id: "current",
+          label: "Current",
+          selfUpdate: "boot-service",
+          serverVersion: "1.1.0",
+        }),
+        environment({
+          id: "offline",
+          label: "Offline",
+          selfUpdate: "boot-service",
+          phase: "offline",
+        }),
+        environment({ id: "desktop", label: "Desktop", selfUpdate: "desktop-managed" }),
+        environment({ id: "manual", label: "Manual" }),
+      ],
+      "1.1.0",
+    );
+
+    expect(targets).toEqual([
+      {
+        environmentId: "will",
+        serverLabel: "Will server",
+        targetVersion: "1.1.0",
+      },
+      {
+        environmentId: "m1",
+        serverLabel: "M1 server",
+        targetVersion: "1.1.0",
+      },
+    ]);
+  });
+
+  it("starts all remote cutovers before waiting for any one environment to reconnect", async () => {
+    let finishWill: (() => void) | undefined;
+    let finishM1: (() => void) | undefined;
+    const updateServer = vi.fn(
+      ({ environmentId }: { readonly environmentId: EnvironmentId }) =>
+        new Promise<ReturnType<typeof AsyncResult.success<void>>>((resolve) => {
+          const finish = () => resolve(AsyncResult.success(undefined));
+          if (environmentId === "will") finishWill = finish;
+          if (environmentId === "m1") finishM1 = finish;
+        }),
+    );
+    const targets = [
+      {
+        environmentId: "will" as EnvironmentId,
+        serverLabel: "Will server",
+        targetVersion: "1.1.0",
+      },
+      { environmentId: "m1" as EnvironmentId, serverLabel: "M1 server", targetVersion: "1.1.0" },
+    ];
+
+    const updates = updateRemoteServersConcurrently(targets, updateServer);
+
+    expect(updateServer).toHaveBeenCalledTimes(2);
+    expect(updateServer).toHaveBeenNthCalledWith(1, {
+      environmentId: "will",
+      input: { targetVersion: "1.1.0" },
+    });
+    expect(updateServer).toHaveBeenNthCalledWith(2, {
+      environmentId: "m1",
+      input: { targetVersion: "1.1.0" },
+    });
+
+    finishWill?.();
+    await Promise.resolve();
+    let completed = false;
+    void updates.then(() => {
+      completed = true;
+    });
+    await Promise.resolve();
+    expect(completed).toBe(false);
+
+    finishM1?.();
+    await expect(updates).resolves.toMatchObject([
+      { target: targets[0], result: { _tag: "Success" } },
+      { target: targets[1], result: { _tag: "Success" } },
+    ]);
+  });
+
+  it("does not install the desktop update when a remote server fails to converge", async () => {
+    const targets = [
+      {
+        environmentId: "will" as EnvironmentId,
+        serverLabel: "Will server",
+        targetVersion: "1.1.0",
+      },
+      {
+        environmentId: "m1" as EnvironmentId,
+        serverLabel: "M1 server",
+        targetVersion: "1.1.0",
+      },
+    ];
+    const updateServer = vi
+      .fn()
+      .mockResolvedValueOnce(AsyncResult.success(undefined))
+      .mockResolvedValueOnce(AsyncResult.failure(Cause.fail(new Error("rollback"))));
+    const installDesktop = vi.fn();
+
+    const result = await coordinateDesktopUpdateInstall({
+      targets,
+      updateServer,
+      installDesktop,
+    });
+
+    expect(result).toMatchObject({
+      _tag: "RemoteUpdateFailed",
+      failure: { target: targets[1], result: { _tag: "Failure" } },
+    });
+    expect(installDesktop).not.toHaveBeenCalled();
+  });
+
+  it("starts the desktop install after every remote server converges", async () => {
+    const targets = [
+      {
+        environmentId: "will" as EnvironmentId,
+        serverLabel: "Will server",
+        targetVersion: "1.1.0",
+      },
+      {
+        environmentId: "m1" as EnvironmentId,
+        serverLabel: "M1 server",
+        targetVersion: "1.1.0",
+      },
+    ];
+    const updateServer = vi.fn().mockResolvedValue(AsyncResult.success(undefined));
+    const installDesktop = vi.fn().mockResolvedValue("accepted");
+
+    const result = await coordinateDesktopUpdateInstall({
+      targets,
+      updateServer,
+      installDesktop,
+    });
+
+    expect(updateServer).toHaveBeenCalledTimes(2);
+    expect(installDesktop).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ _tag: "DesktopInstallStarted", result: "accepted" });
+  });
+});

--- a/apps/web/src/components/desktopUpdate.coordination.ts
+++ b/apps/web/src/components/desktopUpdate.coordination.ts
@@ -1,0 +1,92 @@
+import type { EnvironmentConnectionPhase } from "@t3tools/client-runtime/connection";
+import type { ServerUpdateTarget } from "@t3tools/client-runtime/state/server";
+import type { AtomCommandResult } from "@t3tools/client-runtime/state/runtime";
+import type { EnvironmentId, ServerConfig } from "@t3tools/contracts";
+
+export interface CoordinatedUpdateEnvironment {
+  readonly environmentId: EnvironmentId;
+  readonly label: string;
+  readonly connection: {
+    readonly phase: EnvironmentConnectionPhase;
+  };
+  readonly serverConfig: Pick<ServerConfig, "environment"> | null;
+}
+
+export interface RemoteServerUpdateTarget {
+  readonly environmentId: EnvironmentId;
+  readonly serverLabel: string;
+  readonly targetVersion: string;
+}
+
+export function collectRemoteServerUpdateTargets(
+  environments: ReadonlyArray<CoordinatedUpdateEnvironment>,
+  targetVersion: string | null,
+): ReadonlyArray<RemoteServerUpdateTarget> {
+  if (targetVersion === null) return [];
+
+  return environments.flatMap((environment) => {
+    const descriptor = environment.serverConfig?.environment;
+    const capability = descriptor?.capabilities.serverSelfUpdate;
+    if (
+      environment.connection.phase !== "connected" ||
+      descriptor === undefined ||
+      descriptor.serverVersion === targetVersion ||
+      (capability !== "boot-service" && capability !== "respawn")
+    ) {
+      return [];
+    }
+
+    return [
+      {
+        environmentId: environment.environmentId,
+        serverLabel: `${environment.label} server`,
+        targetVersion,
+      },
+    ];
+  });
+}
+
+export async function updateRemoteServersConcurrently<A, E>(
+  targets: ReadonlyArray<RemoteServerUpdateTarget>,
+  updateServer: (target: ServerUpdateTarget) => Promise<AtomCommandResult<A, E>>,
+): Promise<
+  ReadonlyArray<{
+    readonly target: RemoteServerUpdateTarget;
+    readonly result: AtomCommandResult<A, E>;
+  }>
+> {
+  return Promise.all(
+    targets.map(async (target) => ({
+      target,
+      result: await updateServer({
+        environmentId: target.environmentId,
+        input: { targetVersion: target.targetVersion },
+      }),
+    })),
+  );
+}
+
+export async function coordinateDesktopUpdateInstall<A, E, DesktopResult>(input: {
+  readonly targets: ReadonlyArray<RemoteServerUpdateTarget>;
+  readonly updateServer: (target: ServerUpdateTarget) => Promise<AtomCommandResult<A, E>>;
+  readonly installDesktop: () => Promise<DesktopResult>;
+}): Promise<
+  | {
+      readonly _tag: "RemoteUpdateFailed";
+      readonly failure: {
+        readonly target: RemoteServerUpdateTarget;
+        readonly result: Extract<AtomCommandResult<A, E>, { readonly _tag: "Failure" }>;
+      };
+    }
+  | { readonly _tag: "DesktopInstallStarted"; readonly result: DesktopResult }
+> {
+  const updates = await updateRemoteServersConcurrently(input.targets, input.updateServer);
+  const failure = updates.find(({ result }) => result._tag === "Failure");
+  if (failure?.result._tag === "Failure") {
+    return {
+      _tag: "RemoteUpdateFailed",
+      failure: { target: failure.target, result: failure.result },
+    };
+  }
+  return { _tag: "DesktopInstallStarted", result: await input.installDesktop() };
+}

--- a/apps/web/src/components/desktopUpdate.logic.test.ts
+++ b/apps/web/src/components/desktopUpdate.logic.test.ts
@@ -261,6 +261,20 @@ describe("desktop update UI helpers", () => {
     ).toContain("Install update 1.1.1 and restart T3 Code?");
   });
 
+  it("includes connected remote servers in the hard-cut confirmation", () => {
+    expect(
+      getDesktopUpdateInstallConfirmationMessage(
+        {
+          availableVersion: "1.1.0",
+          downloadedVersion: "1.1.1",
+        },
+        2,
+      ),
+    ).toBe(
+      "Install update 1.1.1 and restart T3 Code?\n\n2 connected remote servers will update to the same version first. Any running tasks in T3 Code, including on those servers, will be interrupted.",
+    );
+  });
+
   it("falls back to generic install confirmation copy when no version is available", () => {
     expect(
       getDesktopUpdateInstallConfirmationMessage({

--- a/apps/web/src/components/desktopUpdate.logic.ts
+++ b/apps/web/src/components/desktopUpdate.logic.ts
@@ -104,8 +104,13 @@ export function getDesktopUpdateButtonTooltip(state: DesktopUpdateState): string
 
 export function getDesktopUpdateInstallConfirmationMessage(
   state: Pick<DesktopUpdateState, "availableVersion" | "downloadedVersion">,
+  remoteServerCount = 0,
 ): string {
   const version = state.downloadedVersion ?? state.availableVersion;
+  if (remoteServerCount > 0) {
+    const serverLabel = remoteServerCount === 1 ? "server" : "servers";
+    return `Install update${version ? ` ${version}` : ""} and restart T3 Code?\n\n${remoteServerCount} connected remote ${serverLabel} will update to the same version first. Any running tasks in T3 Code, including on ${remoteServerCount === 1 ? "that server" : "those servers"}, will be interrupted.`;
+  }
   return `Install update${version ? ` ${version}` : ""} and restart T3 Code?\n\nAny running tasks will be interrupted. Make sure you're ready before continuing.`;
 }
 

--- a/docs/user/updating.md
+++ b/docs/user/updating.md
@@ -31,6 +31,12 @@ The update does not remove saved threads, settings, or project files.
 The available action depends on how that server was started. T3 Code does not update connected
 servers silently in the background.
 
+When you confirm a downloaded desktop update, T3 Code also updates every connected remote server
+that advertises self-update support. Those remote updates start together, and the desktop app waits
+for each server to reconnect on the downloaded version before restarting its local backend. If one
+of those servers fails to update, the desktop install does not start and the failed server is named.
+Offline and manually managed servers are not changed.
+
 An older background-service launcher may ask you to run the exact
 `npx t3@<version> service update` command on the server machine. That one local update installs the
 rollback support needed for later remote updates, including versions that change the database.


### PR DESCRIPTION
## Summary

- update every eligible connected remote T3 server concurrently before restarting the desktop
- wait for remote update commands to complete and abort the desktop install when any server fails
- document coordinated update ordering and the interruption boundary

## Test plan

- [x] pnpm exec vp test run apps/web/src/components/desktopUpdate.logic.test.ts apps/web/src/components/desktopUpdate.coordination.test.ts
- [x] pnpm --filter @t3tools/web typecheck
- [x] targeted vp lint and formatting check
- [x] isolated Electron desktop smoke test

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update eligible remote servers before desktop install in `LegacySidebar`
> - The desktop update install action now collects connected, self-updatable remote servers that are not already at the target version and updates them in parallel before starting the local install.
> - New helpers in [desktopUpdate.coordination.ts](https://github.com/pingdotgg/t3code/pull/7804/files#diff-cb932fed11276b4b033319f7d27d4706ccf5ca86fd1ca75884f69f1ba2237d0e): `collectRemoteServerUpdateTargets` filters eligible servers, `updateRemoteServersConcurrently` runs all updates in parallel, and `coordinateDesktopUpdateInstall` orchestrates the flow and returns a structured failure if any remote update fails.
> - The confirmation dialog copy in `getDesktopUpdateInstallConfirmationMessage` now mentions how many remote servers will update first and warns that tasks on those servers will be interrupted.
> - If any remote server update fails or is cancelled, the desktop install is aborted and an error toast names the failing server. Offline and manually managed servers are skipped.
> - Behavioral Change: `bridge.installUpdate()` is no longer called directly from the install handler; it is invoked only via the `installDesktop` callback after all remote updates succeed. The effect dependency list in [LegacySidebar.tsx](https://github.com/pingdotgg/t3code/pull/7804/files#diff-ef6c49faf62e0e2403f09772084537ac313e826ae0f90db230a898204f3bdd86) now includes `environments` and `updateServer`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4af209a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->