### PR TITLE
fix(web): render oversized terminal graphemes without crashing

### DIFF
--- a/apps/web/src/terminal/ghostty/core.test.ts
+++ b/apps/web/src/terminal/ghostty/core.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { ghosttyCellText } from "./core";
+
+function codepointView(codepoints: ReadonlyArray<number>): DataView {
+  const view = new DataView(new ArrayBuffer(codepoints.length * 4));
+  codepoints.forEach((codepoint, index) => view.setUint32(index * 4, codepoint, true));
+  return view;
+}
+
+describe("ghosttyCellText", () => {
+  it("converts oversized grapheme clusters without hitting engine spread limits", () => {
+    // A program printing one base character followed by a huge run of
+    // combining marks packs the whole cluster into one cell; spreading that
+    // many arguments into String.fromCodePoint once overflows the call stack.
+    const graphemeLength = 130_000;
+    const view = new DataView(new ArrayBuffer(graphemeLength * 4));
+    for (let index = 0; index < graphemeLength; index += 1) {
+      view.setUint32(index * 4, index === 0 ? "a".codePointAt(0)! : 0x301, true);
+    }
+    const text = ghosttyCellText(view, graphemeLength);
+    expect(text.length).toBe(graphemeLength);
+    expect(text.codePointAt(0)).toBe("a".codePointAt(0));
+    expect(text.codePointAt(1)).toBe(0x301);
+    expect(text.codePointAt(graphemeLength - 1)).toBe(0x301);
+  });
+
+  it("converts small clusters including astral codepoints", () => {
+    const text = ghosttyCellText(codepointView([0x1f642, 0x20e3]), 2);
+    expect([...text]).toEqual(["\u{1F642}", "\u{20E3}"]);
+  });
+
+  it("returns an empty string for empty cells", () => {
+    expect(ghosttyCellText(codepointView([]), 0)).toBe("");
+  });
+});

--- a/apps/web/src/terminal/ghostty/core.ts
+++ b/apps/web/src/terminal/ghostty/core.ts
@@ -166,6 +166,27 @@ function sameColor(left: GhosttyColor, right: GhosttyColor): boolean {
   return left.r === right.r && left.g === right.g && left.b === right.b;
 }
 
+/**
+ * A terminal program can print one base character followed by a huge run of
+ * combining marks, packing hundreds of thousands of codepoints into a single
+ * cell that still fits the scrollback buffer. Engines cap spread-call
+ * arguments far below that, so convert in bounded chunks instead of spreading
+ * every codepoint into String.fromCodePoint at once.
+ */
+export function ghosttyCellText(codepointView: DataView, graphemeLength: number): string {
+  const CHUNK_SIZE = 4_096;
+  let text = "";
+  for (let start = 0; start < graphemeLength; start += CHUNK_SIZE) {
+    const count = Math.min(CHUNK_SIZE, graphemeLength - start);
+    const codes = new Array<number>(count);
+    for (let index = 0; index < count; index += 1) {
+      codes[index] = codepointView.getUint32((start + index) * 4, true);
+    }
+    text += String.fromCodePoint(...codes);
+  }
+  return text;
+}
+
 export class GhosttyTerminalCore {
   private readonly runtime: GhosttyRuntime;
   private terminalSlot = 0;
@@ -960,11 +981,7 @@ export class GhosttyTerminalCore {
           // Read through a DataView: the byte-array allocator guarantees no
           // 4-byte alignment, which a Uint32Array view would require.
           const codepointView = this.runtime.view(codepoints, bufferSize);
-          const codes: number[] = [];
-          for (let index = 0; index < graphemeLength; index += 1) {
-            codes.push(codepointView.getUint32(index * 4, true));
-          }
-          text = String.fromCodePoint(...codes);
+          text = ghosttyCellText(codepointView, graphemeLength);
         }
         this.runtime.free(codepoints, bufferSize);
       }


### PR DESCRIPTION
## What Changed

`GhosttyTerminalCore.readRow` no longer spreads every cell codepoint into a single `String.fromCodePoint(...)` call. The conversion is extracted into `ghosttyCellText`, which appends in bounded 4,096-codepoint chunks, with unit tests covering the pathological cluster shape.

## Why

Terminal output is realistically attacker-controlled (build scripts, remote command output, rogue terminal programs). A program can print one base character followed by hundreds of thousands of combining marks; libghostty-vt packs the whole cluster into a single cell (`graphemesLength` ~130k from under 512 KiB of PTY input). The renderer trusted that length, built an array that size, and spread it into `String.fromCodePoint` - which throws `RangeError: Maximum call stack size exceeded` past the engine's argument limit. The exception escapes the uncaught render frame in `surface.ts`, so the terminal surface stops rendering and keeps crashing on reopen while the poisoned output remains buffered.

Chunked conversion removes the crash without changing rendering: normal cells (graphemeLength 0 or 1) never enter the loop.

Found by an automated security review (availability-only impact); validated upstream with a PoC against the real vendored WASM reporting a 130,000-codepoint cell.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes

ox-alpha via opencode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-tested change to string conversion in terminal rendering. It only avoids a stack overflow on oversized cells and does not alter auth, data handling, or normal cell output.
> 
> **Overview**
> Stops the Ghostty renderer from crashing when a cell contains a huge grapheme cluster (one base character plus a massive run of combining marks).
> 
> `readRow` no longer spreads every codepoint into a single `String.fromCodePoint(...)` call. Conversion is extracted to `ghosttyCellText`, which builds the string in 4,096-codepoint chunks. Tests cover the ~130k-codepoint case, astral codepoints, and empty cells.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78f02067be7f0f00d4fd11c6a259ec4b7a72ac3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `GhosttyTerminalCore` crash on oversized terminal graphemes
> - Adds `ghosttyCellText` in [core.ts](https://github.com/pingdotgg/t3code/pull/7809/files#diff-40345426232e3feaf88713623c1f6cc40b4c1730f13cd935fbda4032577864fa), which converts a DataView of 32-bit codepoints into a string in fixed 4096-codepoint chunks to avoid engine spread-call argument limits.
> - Replaces the inlined single-array spread in row cell text extraction with a call to the new utility, so very large grapheme clusters no longer trigger a `RangeError` or stack overflow.
> - Adds tests in [core.test.ts](https://github.com/pingdotgg/t3code/pull/7809/files#diff-a86b849bb1e14d37abeb096c7319a2525bbd7b3d62ecf3ce3faca245526f6a5a) covering a 130,000-codepoint cluster, small astral clusters, and empty cells.
> - Behavioral Change: oversized graphemes now return their full text instead of throwing; cells previously producing a `RangeError` will render successfully.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78f0206.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal text handling for oversized grapheme clusters and astral characters.
  * Prevented issues when processing empty terminal cells.
  * Improved reliability when reading rows containing large amounts of text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->