### PR TITLE
feat(server): add safe service runtime pruning

### DIFF
--- a/apps/server/src/cli/service.test.ts
+++ b/apps/server/src/cli/service.test.ts
@@ -13,6 +13,7 @@ import { afterEach, vi } from "vite-plus/test";
 import packageJson from "../../package.json" with { type: "json" };
 import * as BootService from "../cloud/bootService.ts";
 import {
+  formatServicePruneResult,
   formatServiceStatus,
   offerServiceDuringOnboarding,
   reconcileService,
@@ -85,6 +86,7 @@ function makeTestService(serviceStatus: BootService.BootServiceStatus) {
         };
       }),
     uninstall: Effect.succeed(false),
+    prune: () => Effect.die("Prune is not exercised by this test."),
   });
   return { service, installOptions };
 }
@@ -201,3 +203,24 @@ it.effect("keeps onboarding successful when a newer version appears before insta
     expect(ready).toBe(false);
   }),
 );
+
+it("formats a service runtime prune preview", () => {
+  assert.equal(
+    formatServicePruneResult({ dryRun: true, versions: ["0.0.31", "0.0.32"] }),
+    ["Would prune 2 old T3 Code service runtimes:", "  t3@0.0.31", "  t3@0.0.32"].join("\n"),
+  );
+});
+
+it("formats a completed service runtime prune", () => {
+  assert.equal(
+    formatServicePruneResult({ dryRun: false, versions: ["0.0.31"] }),
+    ["Pruned 1 old T3 Code service runtime:", "  t3@0.0.31"].join("\n"),
+  );
+});
+
+it("reports when there are no old service runtimes", () => {
+  assert.equal(
+    formatServicePruneResult({ dryRun: false, versions: [] }),
+    "No old T3 Code service runtimes found.",
+  );
+});

--- a/apps/server/src/cli/service.ts
+++ b/apps/server/src/cli/service.ts
@@ -90,6 +90,18 @@ export function formatServiceStatus(
   ].join("\n");
 }
 
+export function formatServicePruneResult(result: BootService.BootServicePruneResult): string {
+  if (result.versions.length === 0) {
+    return "No old T3 Code service runtimes found.";
+  }
+  const action = result.dryRun ? "Would prune" : "Pruned";
+  const noun = result.versions.length === 1 ? "runtime" : "runtimes";
+  return [
+    `${action} ${result.versions.length} old T3 Code service ${noun}:`,
+    ...result.versions.map((version) => `  t3@${version}`),
+  ].join("\n");
+}
+
 const runServiceCommand = Effect.fn("cli.service.run")(function* <A, E>(
   flags: { readonly baseDir: Parameters<typeof resolveCliAuthConfig>[0]["baseDir"] },
   run: Effect.Effect<A, E, BootService.BootService>,
@@ -178,6 +190,27 @@ const serviceStatusCommand = Command.make("status", projectLocationFlags).pipe(
   ),
 );
 
+const dryRunFlag = Flag.boolean("dry-run").pipe(
+  Flag.withDescription("Show which runtimes would be removed without changing anything."),
+  Flag.withDefault(false),
+);
+
+const servicePruneCommand = Command.make("prune", {
+  ...projectLocationFlags,
+  dryRun: dryRunFlag,
+}).pipe(
+  Command.withDescription("Remove old T3 Code service runtimes that are safe to discard."),
+  Command.withHandler((flags) =>
+    runServiceCommand(
+      flags,
+      Effect.gen(function* () {
+        const service = yield* BootService.BootService;
+        yield* Console.log(formatServicePruneResult(yield* service.prune(flags)));
+      }),
+    ),
+  ),
+);
+
 export const offerServiceDuringOnboarding = Effect.gen(function* () {
   const service = yield* BootService.BootService;
   const status = yield* service.status;
@@ -252,6 +285,7 @@ export const serviceCommand = Command.make("service").pipe(
     serviceInstallCommand,
     serviceUninstallCommand,
     serviceUpdateCommand,
+    servicePruneCommand,
     serviceStatusCommand,
   ]),
 );

--- a/apps/server/src/cloud/bootService.test.ts
+++ b/apps/server/src/cloud/bootService.test.ts
@@ -441,11 +441,12 @@ it.layer(NodeServices.layer)("boot service install", (it) => {
 
   it.effect("fails closed when service state is missing", () =>
     Effect.gen(function* () {
-      const { service } = yield* makeHarness();
+      const { service, statePath } = yield* makeHarness();
 
-      expect((yield* service.prune({ dryRun: false }).pipe(Effect.flip))._tag).toBe(
-        "BootServicePruneStateError",
-      );
+      expect(yield* service.prune({ dryRun: false }).pipe(Effect.flip)).toMatchObject({
+        _tag: "BootServicePruneStateError",
+        statePath,
+      });
     }),
   );
 

--- a/apps/server/src/cloud/bootService.test.ts
+++ b/apps/server/src/cloud/bootService.test.ts
@@ -182,7 +182,7 @@ const makeHarness = Effect.fn("test.make_boot_service_harness")(function* (
       ),
     );
   const service = yield* makeService();
-  return { service, makeService, fs, statePath, commands, timeouts, control };
+  return { service, makeService, fs, baseDir, statePath, commands, timeouts, control };
 });
 
 it.layer(NodeServices.layer)("boot service install", (it) => {
@@ -387,6 +387,65 @@ it.layer(NodeServices.layer)("boot service install", (it) => {
           "systemctl --user restart t3code.service",
         ]);
       }
+    }),
+  );
+
+  it.effect("prunes old runtimes without restarting the service", () =>
+    Effect.gen(function* () {
+      const { service, fs, baseDir, commands } = yield* makeHarness();
+      yield* service.install();
+      const path = yield* Path.Path;
+      const oldRuntime = pinnedRuntimePaths(path, baseDir, "1.2.2");
+      yield* fs.makeDirectory(path.dirname(oldRuntime.entryPath), { recursive: true });
+      yield* fs.writeFileString(oldRuntime.entryPath, "export {};\n");
+      yield* fs.writeFileString(oldRuntime.sentinelPath, "1.2.2\n");
+      commands.length = 0;
+
+      expect(yield* service.prune({ dryRun: true })).toEqual({
+        dryRun: true,
+        versions: ["1.2.2"],
+      });
+      expect(yield* fs.exists(oldRuntime.versionDir)).toBe(true);
+      expect(yield* service.prune({ dryRun: false })).toEqual({
+        dryRun: false,
+        versions: ["1.2.2"],
+      });
+      expect(yield* fs.exists(oldRuntime.versionDir)).toBe(false);
+      expect(commands).toEqual([]);
+    }),
+  );
+
+  it.effect("refuses to prune while a remote update is pending", () =>
+    Effect.gen(function* () {
+      const { service, fs, statePath } = yield* makeHarness();
+      yield* service.install();
+      // @effect-diagnostics-next-line preferSchemaOverJson:off - fixed launcher-owned test document.
+      const pendingState = JSON.stringify({
+        protocol: SERVICE_LAUNCHER_PROTOCOL,
+        activeVersion: "1.2.3",
+        update: {
+          id: "remote-update",
+          fromVersion: "1.2.3",
+          targetVersion: "1.2.4",
+          dbPath: "/tmp/state.sqlite",
+          status: "pending",
+        },
+      });
+      yield* fs.writeFileString(statePath, pendingState);
+
+      expect((yield* service.prune({ dryRun: false }).pipe(Effect.flip))._tag).toBe(
+        "BootServiceUpdatePendingError",
+      );
+    }),
+  );
+
+  it.effect("fails closed when service state is missing", () =>
+    Effect.gen(function* () {
+      const { service } = yield* makeHarness();
+
+      expect((yield* service.prune({ dryRun: false }).pipe(Effect.flip))._tag).toBe(
+        "BootServicePruneStateError",
+      );
     }),
   );
 

--- a/apps/server/src/cloud/bootService.ts
+++ b/apps/server/src/cloud/bootService.ts
@@ -19,6 +19,8 @@ import {
   ensurePinnedRuntimeInstalled,
   pinnedRuntimePaths,
   PinnedRuntimeInstallError,
+  type PinnedRuntimePruneResult,
+  prunePinnedRuntimes,
 } from "./pinnedRuntime.ts";
 import {
   SERVICE_LAUNCHER_FILE,
@@ -430,6 +432,24 @@ export class BootServiceDowngradeRefusedError extends Schema.TaggedErrorClass<Bo
   }
 }
 
+export class BootServicePruneStateError extends Schema.TaggedErrorClass<BootServicePruneStateError>()(
+  "BootServicePruneStateError",
+  {},
+) {
+  override get message(): string {
+    return "The T3 Code service state is missing or invalid. Run `npx t3@latest service update` before pruning runtimes.";
+  }
+}
+
+export class BootServicePruneError extends Schema.TaggedErrorClass<BootServicePruneError>()(
+  "BootServicePruneError",
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Could not prune T3 Code service runtimes.";
+  }
+}
+
 export type BootServiceError =
   | BootServiceUnsupportedError
   | BootServiceCommandError
@@ -446,6 +466,12 @@ export interface BootServiceStatus {
   readonly logPath: string;
 }
 
+export interface BootServicePruneOptions {
+  readonly dryRun: boolean;
+}
+
+export type BootServicePruneResult = PinnedRuntimePruneResult;
+
 export class BootService extends Context.Service<
   BootService,
   {
@@ -454,6 +480,12 @@ export class BootService extends Context.Service<
     }) => Effect.Effect<BootServicePlan, BootServiceError>;
     readonly uninstall: Effect.Effect<boolean, BootServiceError>;
     readonly status: Effect.Effect<BootServiceStatus, BootServiceError>;
+    readonly prune: (
+      options: BootServicePruneOptions,
+    ) => Effect.Effect<
+      BootServicePruneResult,
+      BootServicePruneStateError | BootServicePruneError | BootServiceUpdatePendingError
+    >;
   }
 >()("t3/cloud/bootService") {}
 
@@ -763,7 +795,35 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
     Effect.withSpan("cloud.boot_service.status"),
   );
 
-  return BootService.of({ install, uninstall, status });
+  const prune: BootService["Service"]["prune"] = Effect.fn("cloud.boot_service.prune")(
+    function* (options) {
+      const stateExists = yield* fs
+        .exists(statePath)
+        .pipe(Effect.mapError((cause) => new BootServicePruneError({ cause })));
+      if (!stateExists) {
+        return yield* new BootServicePruneStateError();
+      }
+      const stateText = yield* fs
+        .readFileString(statePath)
+        .pipe(Effect.mapError((cause) => new BootServicePruneError({ cause })));
+      const state = parseServiceState(stateText);
+      if (state === undefined) {
+        return yield* new BootServicePruneStateError();
+      }
+      if (state.update?.status === "pending") {
+        return yield* new BootServiceUpdatePendingError();
+      }
+      return yield* prunePinnedRuntimes({
+        baseDir: input.baseDir,
+        state,
+        dryRun: options.dryRun,
+        fs,
+        path,
+      }).pipe(Effect.mapError((cause) => new BootServicePruneError({ cause })));
+    },
+  );
+
+  return BootService.of({ install, uninstall, status, prune });
 });
 
 export const layer = (input: {

--- a/apps/server/src/cloud/bootService.ts
+++ b/apps/server/src/cloud/bootService.ts
@@ -434,19 +434,23 @@ export class BootServiceDowngradeRefusedError extends Schema.TaggedErrorClass<Bo
 
 export class BootServicePruneStateError extends Schema.TaggedErrorClass<BootServicePruneStateError>()(
   "BootServicePruneStateError",
-  {},
+  { statePath: Schema.String },
 ) {
   override get message(): string {
-    return "The T3 Code service state is missing or invalid. Run `npx t3@latest service update` before pruning runtimes.";
+    return `The T3 Code service state at '${this.statePath}' is missing or invalid. Run \`npx t3@latest service update\` before pruning runtimes.`;
   }
 }
 
 export class BootServicePruneError extends Schema.TaggedErrorClass<BootServicePruneError>()(
   "BootServicePruneError",
-  { cause: Schema.Defect() },
+  {
+    stage: Schema.Literals(["checking service state", "reading service state", "pruning runtimes"]),
+    path: Schema.String,
+    cause: Schema.Defect(),
+  },
 ) {
   override get message(): string {
-    return "Could not prune T3 Code service runtimes.";
+    return `Could not prune T3 Code service runtimes while ${this.stage} at '${this.path}'.`;
   }
 }
 
@@ -797,18 +801,32 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
 
   const prune: BootService["Service"]["prune"] = Effect.fn("cloud.boot_service.prune")(
     function* (options) {
-      const stateExists = yield* fs
-        .exists(statePath)
-        .pipe(Effect.mapError((cause) => new BootServicePruneError({ cause })));
+      const stateExists = yield* fs.exists(statePath).pipe(
+        Effect.mapError(
+          (cause) =>
+            new BootServicePruneError({
+              stage: "checking service state",
+              path: statePath,
+              cause,
+            }),
+        ),
+      );
       if (!stateExists) {
-        return yield* new BootServicePruneStateError();
+        return yield* new BootServicePruneStateError({ statePath });
       }
-      const stateText = yield* fs
-        .readFileString(statePath)
-        .pipe(Effect.mapError((cause) => new BootServicePruneError({ cause })));
+      const stateText = yield* fs.readFileString(statePath).pipe(
+        Effect.mapError(
+          (cause) =>
+            new BootServicePruneError({
+              stage: "reading service state",
+              path: statePath,
+              cause,
+            }),
+        ),
+      );
       const state = parseServiceState(stateText);
       if (state === undefined) {
-        return yield* new BootServicePruneStateError();
+        return yield* new BootServicePruneStateError({ statePath });
       }
       if (state.update?.status === "pending") {
         return yield* new BootServiceUpdatePendingError();
@@ -819,7 +837,16 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
         dryRun: options.dryRun,
         fs,
         path,
-      }).pipe(Effect.mapError((cause) => new BootServicePruneError({ cause })));
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new BootServicePruneError({
+              stage: "pruning runtimes",
+              path: path.dirname(runtimePaths.versionDir),
+              cause,
+            }),
+        ),
+      );
     },
   );
 

--- a/apps/server/src/cloud/pinnedRuntime.test.ts
+++ b/apps/server/src/cloud/pinnedRuntime.test.ts
@@ -12,7 +12,9 @@ import {
   ensurePinnedRuntimeInstalled,
   pinnedRuntimePaths,
   PinnedRuntimeInstallError,
+  prunePinnedRuntimes,
 } from "./pinnedRuntime.ts";
+import { SERVICE_LAUNCHER_PROTOCOL, type ServiceState } from "./serviceProtocol.ts";
 
 const successfulRunner = (fs: FileSystem.FileSystem, path: Path.Path) =>
   ProcessRunner.ProcessRunner.of({
@@ -36,6 +38,19 @@ const successfulRunner = (fs: FileSystem.FileSystem, path: Path.Path) =>
         };
       }),
   });
+
+const writeCompletedRuntime = Effect.fn("test.write_completed_runtime")(function* (
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  baseDir: string,
+  version: string,
+) {
+  const runtime = pinnedRuntimePaths(path, baseDir, version);
+  yield* fs.makeDirectory(path.dirname(runtime.entryPath), { recursive: true });
+  yield* fs.writeFileString(runtime.entryPath, "export {};\n");
+  yield* fs.writeFileString(runtime.sentinelPath, `${version}\n`);
+  return runtime;
+});
 
 it.layer(NodeServices.layer)("ensurePinnedRuntimeInstalled", (it) => {
   it.effect("validates a staging tree before atomically publishing it", () =>
@@ -171,6 +186,59 @@ it.layer(NodeServices.layer)("ensurePinnedRuntimeInstalled", (it) => {
       yield* Fiber.interrupt(install);
       const versionsDir = path.join(baseDir, "runtime", "versions");
       assert.deepEqual(yield* fs.readDirectory(versionsDir), []);
+    }),
+  );
+});
+
+it.layer(NodeServices.layer)("prunePinnedRuntimes", (it) => {
+  it.effect("removes only completed, unreferenced runtimes older than the active version", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const baseDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-pinned-runtime-prune-" });
+      const removable = yield* writeCompletedRuntime(fs, path, baseDir, "1.8.0");
+      const rollback = yield* writeCompletedRuntime(fs, path, baseDir, "1.9.0");
+      const active = yield* writeCompletedRuntime(fs, path, baseDir, "2.0.0");
+      const newer = yield* writeCompletedRuntime(fs, path, baseDir, "2.1.0");
+      const incomplete = pinnedRuntimePaths(path, baseDir, "1.7.0");
+      yield* fs.makeDirectory(incomplete.versionDir, { recursive: true });
+      const wrongSentinel = yield* writeCompletedRuntime(fs, path, baseDir, "1.6.0");
+      yield* fs.writeFileString(wrongSentinel.sentinelPath, "wrong-version\n");
+      const staging = path.join(path.dirname(active.versionDir), ".staging-install");
+      yield* fs.makeDirectory(staging);
+      const linkedTarget = yield* fs.makeTempDirectoryScoped({ prefix: "t3-runtime-link-target-" });
+      const linkedRuntime = pinnedRuntimePaths(path, baseDir, "1.5.0");
+      yield* fs.symlink(linkedTarget, linkedRuntime.versionDir);
+
+      const state = {
+        protocol: SERVICE_LAUNCHER_PROTOCOL,
+        activeVersion: "2.0.0",
+        update: {
+          id: "committed-update",
+          fromVersion: "1.9.0",
+          targetVersion: "2.0.0",
+          status: "committed",
+        },
+      } satisfies ServiceState;
+
+      const preview = yield* prunePinnedRuntimes({ baseDir, state, dryRun: true, fs, path });
+      assert.deepEqual(preview, { dryRun: true, versions: ["1.8.0"] });
+      assert.isTrue(yield* fs.exists(removable.versionDir));
+
+      const pruned = yield* prunePinnedRuntimes({ baseDir, state, dryRun: false, fs, path });
+      assert.deepEqual(pruned, { dryRun: false, versions: ["1.8.0"] });
+      assert.isFalse(yield* fs.exists(removable.versionDir));
+      for (const preserved of [
+        rollback.versionDir,
+        active.versionDir,
+        newer.versionDir,
+        incomplete.versionDir,
+        wrongSentinel.versionDir,
+        staging,
+        linkedRuntime.versionDir,
+      ]) {
+        assert.isTrue(yield* fs.exists(preserved));
+      }
     }),
   );
 });

--- a/apps/server/src/cloud/pinnedRuntime.ts
+++ b/apps/server/src/cloud/pinnedRuntime.ts
@@ -7,6 +7,11 @@ import * as Option from "effect/Option";
 import * as Semaphore from "effect/Semaphore";
 
 import * as ProcessRunner from "../processRunner.ts";
+import {
+  compareExactServiceVersions,
+  isExactServiceVersion,
+  type ServiceState,
+} from "./serviceProtocol.ts";
 
 /**
  * A pinned runtime is an exact `t3@<version>` npm-installed into
@@ -26,6 +31,11 @@ export interface PinnedRuntimePaths {
   readonly versionDir: string;
   readonly entryPath: string;
   readonly sentinelPath: string;
+}
+
+export interface PinnedRuntimePruneResult {
+  readonly dryRun: boolean;
+  readonly versions: ReadonlyArray<string>;
 }
 
 export function pinnedRuntimePaths(
@@ -220,3 +230,69 @@ const installPinnedRuntime = Effect.fn("cloud.pinned_runtime.ensure_installed")(
 
 export const ensurePinnedRuntimeInstalled = (input: PinnedRuntimeInstallInput) =>
   pinnedRuntimeInstallLock.withPermit(installPinnedRuntime(input));
+
+export const prunePinnedRuntimes = Effect.fn("cloud.pinned_runtime.prune")(function* (input: {
+  readonly baseDir: string;
+  readonly state: ServiceState;
+  readonly dryRun: boolean;
+  readonly fs: FileSystem.FileSystem;
+  readonly path: Path.Path;
+}) {
+  const versionsDir = input.path.join(input.baseDir, PINNED_RUNTIME_DIR, "versions");
+  if (!(yield* input.fs.exists(versionsDir))) {
+    return { dryRun: input.dryRun, versions: [] } satisfies PinnedRuntimePruneResult;
+  }
+
+  const protectedVersions = new Set([
+    input.state.activeVersion,
+    ...(input.state.update === undefined
+      ? []
+      : [input.state.update.fromVersion, input.state.update.targetVersion]),
+  ]);
+  const realVersionsDir = yield* input.fs.realPath(versionsDir);
+  const entries = yield* input.fs.readDirectory(versionsDir);
+  const versions = yield* Effect.filter(entries, (version) =>
+    Effect.gen(function* () {
+      if (
+        !isExactServiceVersion(version) ||
+        protectedVersions.has(version) ||
+        compareExactServiceVersions(version, input.state.activeVersion) >= 0
+      ) {
+        return false;
+      }
+
+      const paths = pinnedRuntimePaths(input.path, input.baseDir, version);
+      const realVersionDir = yield* input.fs.realPath(paths.versionDir).pipe(Effect.option);
+      if (
+        Option.isNone(realVersionDir) ||
+        realVersionDir.value !== input.path.join(realVersionsDir, version)
+      ) {
+        return false;
+      }
+
+      const [entryExists, sentinel] = yield* Effect.all([
+        input.fs.exists(paths.entryPath),
+        input.fs.readFileString(paths.sentinelPath).pipe(Effect.option),
+      ]);
+      return entryExists && Option.isSome(sentinel) && sentinel.value.trim() === version;
+    }),
+  );
+  versions.sort((left, right) => {
+    const precedence = compareExactServiceVersions(left, right);
+    return precedence === 0 ? left.localeCompare(right) : precedence;
+  });
+
+  if (!input.dryRun) {
+    yield* Effect.forEach(
+      versions,
+      (version) =>
+        input.fs.remove(pinnedRuntimePaths(input.path, input.baseDir, version).versionDir, {
+          recursive: true,
+          force: true,
+        }),
+      { discard: true },
+    );
+  }
+
+  return { dryRun: input.dryRun, versions } satisfies PinnedRuntimePruneResult;
+});

--- a/docs/internals/server-updates.md
+++ b/docs/internals/server-updates.md
@@ -54,6 +54,18 @@ snapshot, records rollback, and starts A. A durable restore marker makes an inte
 resume before either version can boot. After commit, B is active and the service manager's normal
 restart policy applies.
 
+## Runtime Pruning
+
+`t3 service prune` removes completed exact-version installs that are older than the active version
+and are not named by the latest update record. It ignores incomplete installs, staging directories,
+symlinks, unexpected directory names, and newer versions. `--dry-run` reports the same candidates
+without removing them.
+
+The command parses launcher-owned state before selecting candidates and refuses to run while an
+update is pending. It does not stop or restart the service. Restricting candidates to versions older
+than the active runtime also keeps a concurrently staged forward-update target outside the prune
+set.
+
 ## Database Rollback
 
 The launcher snapshots `state.sqlite`, `state.sqlite-wal`, and `state.sqlite-shm` after the old

--- a/docs/user/background-service.md
+++ b/docs/user/background-service.md
@@ -39,6 +39,18 @@ and pass `--allow-downgrade`:
 npx t3@1.2.3 service update --allow-downgrade
 ```
 
+Preview old service runtimes that can be removed:
+
+```sh
+npx t3@latest service prune --dry-run
+```
+
+Remove them:
+
+```sh
+npx t3@latest service prune
+```
+
 Stop it and remove it from startup:
 
 ```sh
@@ -47,6 +59,8 @@ npx t3@latest service uninstall
 
 Updating restarts T3 Code briefly. Let active agent work and terminal commands finish first.
 If a remote update is already in progress, wait for it to finish before retrying a local update.
+Pruning does not restart the service. It keeps the active runtime and both versions named by the
+latest update record, and it refuses to run while an update is pending.
 
 The service runs a small stable launcher. Exact T3 Code versions are installed separately, so a
 failed remote candidate can return to the previous version without rewriting the service


### PR DESCRIPTION
## What Changed

- Add `t3 service prune` with a `--dry-run` preview.
- Remove only completed exact-version installs older than the active runtime.
- Keep the active version and both versions referenced by the latest update record, and refuse to prune while an update is pending.
- Ignore staging directories, incomplete installs, symlinks, unexpected directory names, and newer versions.
- Document the command and its update-safety boundary.

## Why

Service updates install immutable runtimes so the launcher can roll back, but old installs currently accumulate without a supported cleanup path. This adds an explicit maintenance command that uses launcher-owned state and does not stop or restart the service.

## Testing

- `pnpm exec vp test run apps/server/src/cloud/pinnedRuntime.test.ts apps/server/src/cloud/bootService.test.ts apps/server/src/cli/service.test.ts` (30 tests)
- `pnpm --filter t3 typecheck`
- Targeted `vp lint` and `vp fmt --check` on the changed files
- `pnpm --filter t3 build:bundle`
- `node apps/server/src/bin.ts service prune --help`
- Manual WSL prototype validation: pruned 11 old nightly runtimes and recovered 6.73 GiB while the service PID, restart count, and HTTP health stayed unchanged

Model and harness: OpenAI Codex; repository toolchain plus manual WSL service validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Prune permanently deletes version directories on disk; safety depends on launcher state and candidate rules, with a known cross-process race if prune runs during an explicit downgrade install.
> 
> **Overview**
> Adds **`t3 service prune`** (with **`--dry-run`**) so users can reclaim disk from accumulated pinned `t3@<version>` installs under the background service without stopping or restarting the unit.
> 
> **`prunePinnedRuntimes`** picks only completed installs (entry + matching `.install-complete` sentinel), skips symlinks/staging/bad names, keeps the active version and both versions from the latest update record, and deletes only versions **older** than active. **`BootService.prune`** reads launcher `service-state.json`, fails closed on missing/invalid state, and blocks while a remote update is **pending**, then delegates removal.
> 
> The CLI adds **`formatServicePruneResult`** for empty, preview, and completed output. User and internals docs describe the safety rules. Tests cover selection edge cases, boot-service integration (no `systemctl`/`launchctl` on prune), pending-update refusal, and formatter behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 976adafd30942d3cab8525923224e5864ce148ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `t3 service prune` command with `--dry-run` for removing old runtime versions
> - Adds `prunePinnedRuntimes` in [pinnedRuntime.ts](https://github.com/pingdotgg/t3code/pull/7811/files#diff-1db0e3a8605ae95c9cf7dba2fdf61ec1d60fad091e74453cf50e53da2b27fa03) which selects exact-version runtime installs older than the active version, requires an entry file and matching sentinel, rejects symlinks, and removes eligible directories only when `dryRun` is false
> - Adds `BootService.prune` in [bootService.ts](https://github.com/pingdotgg/t3code/pull/7811/files#diff-9ec1426b86c5c9f63a503a0c78a87a5165a6460ca539deb5c365bda9ff0576f0) that validates service state, refuses pruning when a remote update is pending, and delegates candidate selection and removal to `prunePinnedRuntimes` without issuing restart or stop commands
> - Adds the `prune` subcommand and `--dry-run` flag to the `t3 service` CLI in [service.ts](https://github.com/pingdotgg/t3code/pull/7811/files#diff-5a6f6fd5c6c125eadf8afec53846bacbb35d859e9044d19c5d15fa945db41f79), plus a result formatter for empty, preview, and completed cases
> - Documents the command, candidate exclusions, and no-restart behavior in [server-updates.md](https://github.com/pingdotgg/t3code/pull/7811/files#diff-7c0f027ad66f6d1cdbd2393faaa39268ca84ae397ace112193caad8e8b9f8fd4) and [background-service.md](https://github.com/pingdotgg/t3code/pull/7811/files#diff-6136efb97cee21cb34d7ea127f69e88cc2cd6419761165abf468d84d78264884)
> - Risk: `BootServicePruneStateError` and `BootServicePruneError` are new tagged error classes; callers that catch prune failures must handle these types. Missing or invalid service state now fails pruning rather than silently selecting runtimes.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 976adaf. 5 files reviewed, 2 issues evaluated, 1 issue filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/server/src/cloud/bootService.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 834](https://github.com/pingdotgg/t3code/blob/dfaba4005d640c7473a6da5bd318326bab86c17c/apps/server/src/cloud/bootService.ts#L834): `prune` deletes candidates based on a state snapshot without coordinating with `install`. A concurrent explicit downgrade can have the old target runtime already complete (or publish it) while the state still names the newer active version, so this call selects and removes that target at line 834. If the downgrade has already copied its launcher and stopped the unit, it then writes state for the deleted version and activates a launcher whose runtime entry no longer exists, leaving the service unable to start. The existing runtime-install semaphore only serializes callers in one process, whereas `service prune` and `service update --allow-downgrade` are separate CLI processes. <b>[ Cross-file consolidated ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->