### PR TITLE
feat(web): double-click chat header title to rename thread

### DIFF
--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -345,6 +345,7 @@ export const ChatHeader = memo(function ChatHeader({
                     aria-haspopup="menu"
                     onClick={openMenuFromTitle}
                     onDoubleClick={handleTitleDoubleClick}
+                    onBlur={cancelPendingTitleMenu}
                     className="group/thread-title inline-flex min-w-0 max-w-full cursor-pointer items-center gap-1 rounded-sm text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
                   />
                 }

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -15,6 +15,7 @@ import { ChevronDownIcon } from "lucide-react";
 import {
   memo,
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -22,6 +23,7 @@ import {
   type MouseEvent as ReactMouseEvent,
 } from "react";
 import GitActionsControl from "../GitActionsControl";
+import { isTrailingDoubleClick } from "../Sidebar.logic";
 import { type DraftId } from "~/composerDraftStore";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { toastManager } from "../ui/toast";
@@ -87,6 +89,10 @@ export function resolveRenameCommit(input: {
   if (trimmed === input.originalTitle) return { action: "noop" };
   return { action: "commit", title: trimmed };
 }
+
+// How long a click on the thread title waits before opening the action menu,
+// so a double-click-to-rename can cancel it first.
+const TITLE_MENU_OPEN_DELAY_MS = 250;
 
 export function shouldShowOpenInPicker(input: {
   readonly activeProjectName: string | undefined;
@@ -195,11 +201,56 @@ export const ChatHeader = memo(function ChatHeader({
     onStartRename: startRename,
   });
   const titleButtonRef = useRef<HTMLButtonElement | null>(null);
-  const openMenuFromTitle = useCallback(() => {
+  const titleMenuTimerRef = useRef<number | null>(null);
+  // Drop a pending menu-open when the thread changes or the header unmounts,
+  // so it can never fire for a thread the user already left.
+  useEffect(
+    () => () => {
+      if (titleMenuTimerRef.current !== null) {
+        clearTimeout(titleMenuTimerRef.current);
+        titleMenuTimerRef.current = null;
+      }
+    },
+    [activeThreadId],
+  );
+  const openTitleMenuNow = useCallback(() => {
     const rect = titleButtonRef.current?.getBoundingClientRect();
     if (!rect) return;
     openMenu({ x: rect.left, y: rect.bottom + 4 });
   }, [openMenu]);
+  const openMenuFromTitle = useCallback(
+    (event: ReactMouseEvent<HTMLButtonElement>) => {
+      // The trailing click of a double-click belongs to rename, not the menu.
+      if (isTrailingDoubleClick(event.detail)) return;
+      // Keyboard activation and the explicit chevron affordance can never be
+      // the first half of a double-click, so they open without waiting.
+      const clickedChevron =
+        (event.target as HTMLElement).closest("[data-thread-title-chevron]") !== null;
+      if (event.detail === 0 || clickedChevron) {
+        openTitleMenuNow();
+        return;
+      }
+      // A native desktop menu swallows the second click of a double-click, so
+      // the open must stay pending long enough for dblclick to cancel it.
+      if (titleMenuTimerRef.current !== null) clearTimeout(titleMenuTimerRef.current);
+      titleMenuTimerRef.current = window.setTimeout(() => {
+        titleMenuTimerRef.current = null;
+        openTitleMenuNow();
+      }, TITLE_MENU_OPEN_DELAY_MS);
+    },
+    [openTitleMenuNow],
+  );
+  const handleTitleDoubleClick = useCallback(
+    (event: ReactMouseEvent) => {
+      if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+      if (titleMenuTimerRef.current !== null) {
+        clearTimeout(titleMenuTimerRef.current);
+        titleMenuTimerRef.current = null;
+      }
+      startRename();
+    },
+    [startRename],
+  );
   const handleHeaderContextMenu = useCallback(
     (event: ReactMouseEvent) => {
       if (!isServerThread || renamingTitle !== null) return;
@@ -285,6 +336,7 @@ export const ChatHeader = memo(function ChatHeader({
                     aria-label={`Thread actions for ${activeThreadTitle}`}
                     aria-haspopup="menu"
                     onClick={openMenuFromTitle}
+                    onDoubleClick={handleTitleDoubleClick}
                     className="group/thread-title inline-flex min-w-0 max-w-full cursor-pointer items-center gap-1 rounded-sm text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
                   />
                 }
@@ -292,6 +344,7 @@ export const ChatHeader = memo(function ChatHeader({
                 <h2 className="min-w-0 truncate">{activeThreadTitle}</h2>
                 <ChevronDownIcon
                   aria-hidden
+                  data-thread-title-chevron
                   className="size-3.5 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover/thread-title:opacity-100 group-focus-visible/thread-title:opacity-100"
                 />
               </TooltipTrigger>

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -91,8 +91,12 @@ export function resolveRenameCommit(input: {
 }
 
 // How long a click on the thread title waits before opening the action menu,
-// so a double-click-to-rename can cancel it first.
-const TITLE_MENU_OPEN_DELAY_MS = 250;
+// so a double-click-to-rename can cancel it first. Only the native desktop
+// menu needs this: it swallows input while open, so the wait must cover the
+// OS double-click interval. The browser fallback menu keeps seeing DOM
+// events (the second click dismisses it and dblclick still fires), so it
+// opens immediately.
+const TITLE_MENU_OPEN_DELAY_MS = 500;
 
 export function shouldShowOpenInPicker(input: {
   readonly activeProjectName: string | undefined;
@@ -194,7 +198,7 @@ export const ChatHeader = memo(function ChatHeader({
     },
     [activeThreadEnvironmentId, activeThreadId, activeThreadTitle, updateThreadMetadata],
   );
-  const { openMenu } = useThreadActionMenu({
+  const { openMenu, closeMenu } = useThreadActionMenu({
     threadRef: isServerThread ? activeThreadRef : null,
     projectCwd: activeProjectCwd,
     changeRequest,
@@ -202,22 +206,25 @@ export const ChatHeader = memo(function ChatHeader({
   });
   const titleButtonRef = useRef<HTMLButtonElement | null>(null);
   const titleMenuTimerRef = useRef<number | null>(null);
+  const cancelPendingTitleMenu = useCallback(() => {
+    if (titleMenuTimerRef.current === null) return;
+    clearTimeout(titleMenuTimerRef.current);
+    titleMenuTimerRef.current = null;
+  }, []);
   // Drop a pending menu-open when the thread changes or the header unmounts,
   // so it can never fire for a thread the user already left.
   useEffect(
     () => () => {
-      if (titleMenuTimerRef.current !== null) {
-        clearTimeout(titleMenuTimerRef.current);
-        titleMenuTimerRef.current = null;
-      }
+      cancelPendingTitleMenu();
     },
-    [activeThreadId],
+    [activeThreadId, cancelPendingTitleMenu],
   );
   const openTitleMenuNow = useCallback(() => {
+    cancelPendingTitleMenu();
     const rect = titleButtonRef.current?.getBoundingClientRect();
     if (!rect) return;
     openMenu({ x: rect.left, y: rect.bottom + 4 });
-  }, [openMenu]);
+  }, [cancelPendingTitleMenu, openMenu]);
   const openMenuFromTitle = useCallback(
     (event: ReactMouseEvent<HTMLButtonElement>) => {
       // The trailing click of a double-click belongs to rename, not the menu.
@@ -226,30 +233,30 @@ export const ChatHeader = memo(function ChatHeader({
       // the first half of a double-click, so they open without waiting.
       const clickedChevron =
         (event.target as HTMLElement).closest("[data-thread-title-chevron]") !== null;
-      if (event.detail === 0 || clickedChevron) {
+      if (event.detail === 0 || clickedChevron || window.desktopBridge === undefined) {
         openTitleMenuNow();
         return;
       }
-      // A native desktop menu swallows the second click of a double-click, so
-      // the open must stay pending long enough for dblclick to cancel it.
-      if (titleMenuTimerRef.current !== null) clearTimeout(titleMenuTimerRef.current);
+      // Stay pending long enough for dblclick to cancel the open before the
+      // native menu appears and swallows the second click.
+      cancelPendingTitleMenu();
       titleMenuTimerRef.current = window.setTimeout(() => {
         titleMenuTimerRef.current = null;
         openTitleMenuNow();
       }, TITLE_MENU_OPEN_DELAY_MS);
     },
-    [openTitleMenuNow],
+    [cancelPendingTitleMenu, openTitleMenuNow],
   );
   const handleTitleDoubleClick = useCallback(
     (event: ReactMouseEvent) => {
       if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
-      if (titleMenuTimerRef.current !== null) {
-        clearTimeout(titleMenuTimerRef.current);
-        titleMenuTimerRef.current = null;
-      }
+      // The chevron is the explicit menu affordance; only the title text renames.
+      if ((event.target as HTMLElement).closest("[data-thread-title-chevron]") !== null) return;
+      cancelPendingTitleMenu();
+      closeMenu();
       startRename();
     },
-    [startRename],
+    [cancelPendingTitleMenu, closeMenu, startRename],
   );
   const handleHeaderContextMenu = useCallback(
     (event: ReactMouseEvent) => {
@@ -257,10 +264,11 @@ export const ChatHeader = memo(function ChatHeader({
       // The right-side controls (git, scripts, open-in) keep their own
       // behavior; only the breadcrumb area opens the thread menu.
       if ((event.target as HTMLElement).closest("[data-chat-header-actions]")) return;
+      cancelPendingTitleMenu();
       event.preventDefault();
       openMenu({ x: event.clientX, y: event.clientY });
     },
-    [isServerThread, openMenu, renamingTitle],
+    [cancelPendingTitleMenu, isServerThread, openMenu, renamingTitle],
   );
   const handleRenameKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLInputElement>) => {

--- a/apps/web/src/hooks/useThreadActionMenu.ts
+++ b/apps/web/src/hooks/useThreadActionMenu.ts
@@ -335,5 +335,9 @@ export function useThreadActionMenu(input: {
     ],
   );
 
-  return { openMenu };
+  const closeMenu = useCallback(() => {
+    void readLocalApi()?.contextMenu.close();
+  }, []);
+
+  return { openMenu, closeMenu };
 }


### PR DESCRIPTION
## What Changed

Double-clicking the thread title in the chat header now starts renaming, the same way it already does in the sidebar. Right-click > Rename still works, and clicking the chevron next to the title still opens the thread menu instantly.

## Why

The sidebar has always offered double-click-to-rename, but the chat header only offered right-click > Rename. This brings the header to parity so renaming works the same way everywhere.

## UI Changes

https://github.com/user-attachments/assets/25598c92-8fa7-4af5-8a69-6d0014d700dd

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included a video for animation/interaction changes

Built by ox-alpha (x-preview-f-free) in opencode.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI interaction-only change in the chat header; no auth, data, or backend behavior is affected. Desktop single-click menu open is delayed by 500ms, which is the main UX risk.
> 
> **Overview**
> Double-clicking the thread title in the chat header now starts inline rename, matching the sidebar. Right-click rename still works; the chevron and keyboard activation still open the action menu immediately.
> 
> On desktop, a single click on the title waits 500ms before opening the native menu so a double-click can cancel it first (the native menu swallows the second click). Browser fallback menus open immediately. Pending opens are cleared on blur, thread change, unmount, context menu, or rename start.
> 
> `useThreadActionMenu` now exposes `closeMenu` so rename can dismiss an already-open native menu.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4969cae48662cb500adc6a3da1e7d4d902e04742. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add double-click-to-rename to chat header thread title on desktop
> - Double-clicking the title text in `ChatHeader` starts a thread rename and cancels any pending menu open. The chevron icon and keyboard activation are excluded from rename and open the menu immediately.
> - On desktop, single-click opens the thread action menu after a 500ms delay (`TITLE_MENU_OPEN_DELAY_MS`) so a double-click can cancel it. In the browser fallback (no `desktopBridge`), the menu opens immediately.
> - Adds `closeMenu` to `useThreadActionMenu` so the header can programmatically dismiss the native context menu when rename starts.
> - Pending delayed opens are canceled on blur, thread change, unmount, context menu open, or rename start.
> - Behavioral Change: single-clicking the title on desktop now has a 500ms delay before the action menu appears; clicking the chevron avoids this delay.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4969cae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->