### PR TITLE
fix(web): switch to plainText mode for composer due to glitching skill invocation in question tool

### DIFF
--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -1559,7 +1559,10 @@ function ComposerPromptEditorInner({
   onCommandKeyDown,
   onPaste,
   editorRef,
-}: ComposerPromptEditorProps) {
+  restoreFocusOnRemountRef,
+}: ComposerPromptEditorProps & {
+  restoreFocusOnRemountRef: React.RefObject<boolean>;
+}) {
   const [editor] = useLexicalComposerContext();
   // Plain mode has no token nodes, so every collapsed<->expanded cursor
   // mapping is a raw clamp. The editor remounts when the mode flips (the
@@ -1678,6 +1681,24 @@ function ComposerPromptEditorInner({
     },
     [clampComposerCursor, editor, expandComposerCursor],
   );
+
+  // The plainText flip remounts the editor (see the LexicalComposer key),
+  // replacing the focused contenteditable and silently dropping focus. Record
+  // focus ownership when this instance unmounts and take it back on the next
+  // mount, so a question opening or resolving mid-typing doesn't eat
+  // keystrokes. Every dep is stable for the lifetime of a mount, so this runs
+  // once per editor instance.
+  useLayoutEffect(() => {
+    if (restoreFocusOnRemountRef.current) {
+      restoreFocusOnRemountRef.current = false;
+      focusAt(snapshotRef.current.cursor);
+    }
+    return () => {
+      // Layout cleanup runs before the old DOM node is detached, so
+      // activeElement still points at it here.
+      restoreFocusOnRemountRef.current = editor.getRootElement() === document.activeElement;
+    };
+  }, [editor, focusAt, restoreFocusOnRemountRef]);
 
   const readSnapshot = useCallback((): {
     value: string;
@@ -1854,6 +1875,9 @@ export function ComposerPromptEditor({
   initialSkillMetadataRef.current = skillMetadataByName(skills);
   const initialPlainTextRef = useRef(plainText);
   initialPlainTextRef.current = plainText;
+  // Survives the plainText remount so the new editor instance knows whether
+  // its predecessor owned focus and should take it back.
+  const restoreFocusOnRemountRef = useRef(false);
   const initialConfig = useMemo<InitialConfigType>(
     () => ({
       namespace: "t3tools-composer-editor",
@@ -1891,6 +1915,7 @@ export function ComposerPromptEditor({
         onChange={onChange}
         onPaste={onPaste}
         editorRef={editorRef}
+        restoreFocusOnRemountRef={restoreFocusOnRemountRef}
         {...(onCommandKeyDown ? { onCommandKeyDown } : {})}
         {...(className ? { className } : {})}
       />

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -822,11 +822,17 @@ function $setComposerEditorPrompt(
   prompt: string,
   terminalContexts: ReadonlyArray<TerminalContextDraft>,
   skillMetadata: ReadonlyMap<string, ComposerSkillMetadata>,
+  plainText: boolean,
 ): void {
   const root = $getRoot();
   root.clear();
   const paragraph = $createParagraphNode();
   root.append(paragraph);
+
+  if (plainText) {
+    $appendTextWithLineBreaks(paragraph, prompt);
+    return;
+  }
 
   const segments = splitPromptIntoComposerSegments(prompt, terminalContexts);
   for (const segment of segments) {
@@ -882,6 +888,13 @@ interface ComposerPromptEditorProps {
   cursor: number;
   terminalContexts: ReadonlyArray<TerminalContextDraft>;
   skills: ReadonlyArray<ServerProviderSkill>;
+  /**
+   * Renders the value as raw text: no mention/skill/terminal-context tokens
+   * and no token plugins. Used for pending-question answers, which only ever
+   * submit plain strings. With no token nodes, collapsed and expanded cursor
+   * offsets coincide, so all cursor mapping reduces to a raw clamp.
+   */
+  plainText?: boolean;
   disabled: boolean;
   placeholder: string;
   className?: string;
@@ -1330,7 +1343,13 @@ function ComposerSurroundSelectionPlugin(props: {
         selectionSnapshot.expandedEnd,
       );
       const nextValue = `${selectionSnapshot.value.slice(0, selectionSnapshot.expandedStart)}${inputData}${selectedText}${surroundCloseSymbol}${selectionSnapshot.value.slice(selectionSnapshot.expandedEnd)}`;
-      $setComposerEditorPrompt(nextValue, terminalContextsRef.current, skillMetadataRef.current);
+      // This plugin only renders in rich (tokenized) mode.
+      $setComposerEditorPrompt(
+        nextValue,
+        terminalContextsRef.current,
+        skillMetadataRef.current,
+        false,
+      );
       const selectionStart = collapseExpandedComposerCursor(
         nextValue,
         selectionSnapshot.expandedStart,
@@ -1531,6 +1550,7 @@ function ComposerPromptEditorInner({
   cursor,
   terminalContexts,
   skills,
+  plainText = false,
   disabled,
   placeholder,
   className,
@@ -1541,8 +1561,14 @@ function ComposerPromptEditorInner({
   editorRef,
 }: ComposerPromptEditorProps) {
   const [editor] = useLexicalComposerContext();
+  // Plain mode has no token nodes, so every collapsed<->expanded cursor
+  // mapping is a raw clamp. The editor remounts when the mode flips (the
+  // LexicalComposer key includes it), so these stay stable per mount.
+  const clampComposerCursor = plainText ? clampExpandedCursor : clampCollapsedComposerCursor;
+  const expandComposerCursor = plainText ? clampExpandedCursor : expandCollapsedComposerCursor;
+  const collapseComposerCursor = plainText ? clampExpandedCursor : collapseExpandedComposerCursor;
   const onChangeRef = useRef(onChange);
-  const initialCursor = clampCollapsedComposerCursor(value, cursor);
+  const initialCursor = clampComposerCursor(value, cursor);
   const terminalContextsSignature = terminalContextSignature(terminalContexts);
   const terminalContextsSignatureRef = useRef(terminalContextsSignature);
   const skillsSignature = skillSignature(skills);
@@ -1551,7 +1577,7 @@ function ComposerPromptEditorInner({
   const snapshotRef = useRef({
     value,
     cursor: initialCursor,
-    expandedCursor: expandCollapsedComposerCursor(value, initialCursor),
+    expandedCursor: expandComposerCursor(value, initialCursor),
     terminalContextIds: terminalContexts.map((context) => context.id),
   });
   const isApplyingControlledUpdateRef = useRef(false);
@@ -1573,7 +1599,7 @@ function ComposerPromptEditorInner({
   }, [disabled, editor]);
 
   useLayoutEffect(() => {
-    const normalizedCursor = clampCollapsedComposerCursor(value, cursor);
+    const normalizedCursor = clampComposerCursor(value, cursor);
     const previousSnapshot = snapshotRef.current;
     const contextsChanged = terminalContextsSignatureRef.current !== terminalContextsSignature;
     const skillsChanged = skillsSignatureRef.current !== skillsSignature;
@@ -1589,7 +1615,7 @@ function ComposerPromptEditorInner({
     snapshotRef.current = {
       value,
       cursor: normalizedCursor,
-      expandedCursor: expandCollapsedComposerCursor(value, normalizedCursor),
+      expandedCursor: expandComposerCursor(value, normalizedCursor),
       terminalContextIds: terminalContexts.map((context) => context.id),
     };
     terminalContextsSignatureRef.current = terminalContextsSignature;
@@ -1606,7 +1632,7 @@ function ComposerPromptEditorInner({
       const shouldRewriteEditorState =
         previousSnapshot.value !== value || contextsChanged || skillsChanged;
       if (shouldRewriteEditorState) {
-        $setComposerEditorPrompt(value, terminalContexts, skillMetadataRef.current);
+        $setComposerEditorPrompt(value, terminalContexts, skillMetadataRef.current, plainText);
       }
       if (shouldRewriteEditorState || isFocused) {
         $setSelectionAtComposerOffset(normalizedCursor);
@@ -1615,13 +1641,23 @@ function ComposerPromptEditorInner({
     queueMicrotask(() => {
       isApplyingControlledUpdateRef.current = false;
     });
-  }, [cursor, editor, skillsSignature, terminalContexts, terminalContextsSignature, value]);
+  }, [
+    clampComposerCursor,
+    cursor,
+    editor,
+    expandComposerCursor,
+    plainText,
+    skillsSignature,
+    terminalContexts,
+    terminalContextsSignature,
+    value,
+  ]);
 
   const focusAt = useCallback(
     (nextCursor: number) => {
       const rootElement = editor.getRootElement();
       if (!rootElement) return;
-      const boundedCursor = clampCollapsedComposerCursor(snapshotRef.current.value, nextCursor);
+      const boundedCursor = clampComposerCursor(snapshotRef.current.value, nextCursor);
       rootElement.focus({ preventScroll: true });
       editor.update(() => {
         $setSelectionAtComposerOffset(boundedCursor);
@@ -1629,7 +1665,7 @@ function ComposerPromptEditorInner({
       snapshotRef.current = {
         value: snapshotRef.current.value,
         cursor: boundedCursor,
-        expandedCursor: expandCollapsedComposerCursor(snapshotRef.current.value, boundedCursor),
+        expandedCursor: expandComposerCursor(snapshotRef.current.value, boundedCursor),
         terminalContextIds: snapshotRef.current.terminalContextIds,
       };
       onChangeRef.current(
@@ -1640,7 +1676,7 @@ function ComposerPromptEditorInner({
         snapshotRef.current.terminalContextIds,
       );
     },
-    [editor],
+    [clampComposerCursor, editor, expandComposerCursor],
   );
 
   const readSnapshot = useCallback((): {
@@ -1652,8 +1688,8 @@ function ComposerPromptEditorInner({
     let snapshot = snapshotRef.current;
     editor.getEditorState().read(() => {
       const nextValue = $getRoot().getTextContent();
-      const fallbackCursor = clampCollapsedComposerCursor(nextValue, snapshotRef.current.cursor);
-      const nextCursor = clampCollapsedComposerCursor(
+      const fallbackCursor = clampComposerCursor(nextValue, snapshotRef.current.cursor);
+      const nextCursor = clampComposerCursor(
         nextValue,
         $readSelectionOffsetFromEditorState(fallbackCursor),
       );
@@ -1675,7 +1711,7 @@ function ComposerPromptEditorInner({
     });
     snapshotRef.current = snapshot;
     return snapshot;
-  }, [editor]);
+  }, [clampComposerCursor, editor]);
 
   useImperativeHandle(
     editorRef,
@@ -1686,65 +1722,66 @@ function ComposerPromptEditorInner({
       focusAt,
       focusAtEnd: () => {
         focusAt(
-          collapseExpandedComposerCursor(
-            snapshotRef.current.value,
-            snapshotRef.current.value.length,
-          ),
+          collapseComposerCursor(snapshotRef.current.value, snapshotRef.current.value.length),
         );
       },
       readSnapshot,
     }),
-    [focusAt, readSnapshot],
+    [collapseComposerCursor, focusAt, readSnapshot],
   );
 
-  const handleEditorChange = useCallback((editorState: EditorState) => {
-    editorState.read(() => {
-      const nextValue = $getRoot().getTextContent();
-      const fallbackCursor = clampCollapsedComposerCursor(nextValue, snapshotRef.current.cursor);
-      const nextCursor = clampCollapsedComposerCursor(
-        nextValue,
-        $readSelectionOffsetFromEditorState(fallbackCursor),
-      );
-      const fallbackExpandedCursor = clampExpandedCursor(
-        nextValue,
-        snapshotRef.current.expandedCursor,
-      );
-      const nextExpandedCursor = clampExpandedCursor(
-        nextValue,
-        $readExpandedSelectionOffsetFromEditorState(fallbackExpandedCursor),
-      );
-      const terminalContextIds = collectTerminalContextIds($getRoot());
-      const previousSnapshot = snapshotRef.current;
-      if (
-        previousSnapshot.value === nextValue &&
-        previousSnapshot.cursor === nextCursor &&
-        previousSnapshot.expandedCursor === nextExpandedCursor &&
-        previousSnapshot.terminalContextIds.length === terminalContextIds.length &&
-        previousSnapshot.terminalContextIds.every((id, index) => id === terminalContextIds[index])
-      ) {
-        return;
-      }
-      if (isApplyingControlledUpdateRef.current) {
-        return;
-      }
-      snapshotRef.current = {
-        value: nextValue,
-        cursor: nextCursor,
-        expandedCursor: nextExpandedCursor,
-        terminalContextIds,
-      };
-      const cursorAdjacentToMention =
-        isCollapsedCursorAdjacentToInlineToken(nextValue, nextCursor, "left") ||
-        isCollapsedCursorAdjacentToInlineToken(nextValue, nextCursor, "right");
-      onChangeRef.current(
-        nextValue,
-        nextCursor,
-        nextExpandedCursor,
-        cursorAdjacentToMention,
-        terminalContextIds,
-      );
-    });
-  }, []);
+  const handleEditorChange = useCallback(
+    (editorState: EditorState) => {
+      editorState.read(() => {
+        const nextValue = $getRoot().getTextContent();
+        const fallbackCursor = clampComposerCursor(nextValue, snapshotRef.current.cursor);
+        const nextCursor = clampComposerCursor(
+          nextValue,
+          $readSelectionOffsetFromEditorState(fallbackCursor),
+        );
+        const fallbackExpandedCursor = clampExpandedCursor(
+          nextValue,
+          snapshotRef.current.expandedCursor,
+        );
+        const nextExpandedCursor = clampExpandedCursor(
+          nextValue,
+          $readExpandedSelectionOffsetFromEditorState(fallbackExpandedCursor),
+        );
+        const terminalContextIds = collectTerminalContextIds($getRoot());
+        const previousSnapshot = snapshotRef.current;
+        if (
+          previousSnapshot.value === nextValue &&
+          previousSnapshot.cursor === nextCursor &&
+          previousSnapshot.expandedCursor === nextExpandedCursor &&
+          previousSnapshot.terminalContextIds.length === terminalContextIds.length &&
+          previousSnapshot.terminalContextIds.every((id, index) => id === terminalContextIds[index])
+        ) {
+          return;
+        }
+        if (isApplyingControlledUpdateRef.current) {
+          return;
+        }
+        snapshotRef.current = {
+          value: nextValue,
+          cursor: nextCursor,
+          expandedCursor: nextExpandedCursor,
+          terminalContextIds,
+        };
+        const cursorAdjacentToMention =
+          !plainText &&
+          (isCollapsedCursorAdjacentToInlineToken(nextValue, nextCursor, "left") ||
+            isCollapsedCursorAdjacentToInlineToken(nextValue, nextCursor, "right"));
+        onChangeRef.current(
+          nextValue,
+          nextCursor,
+          nextExpandedCursor,
+          cursorAdjacentToMention,
+          terminalContextIds,
+        );
+      });
+    },
+    [clampComposerCursor, plainText],
+  );
 
   return (
     <ComposerTerminalContextActionsContext value={terminalContextActions}>
@@ -1774,13 +1811,17 @@ function ComposerPromptEditorInner({
         />
         <OnChangePlugin onChange={handleEditorChange} />
         <ComposerCommandKeyPlugin {...(onCommandKeyDown ? { onCommandKeyDown } : {})} />
-        <ComposerSurroundSelectionPlugin terminalContexts={terminalContexts} skills={skills} />
+        {plainText ? null : (
+          <>
+            <ComposerSurroundSelectionPlugin terminalContexts={terminalContexts} skills={skills} />
+            <ComposerInlineTokenArrowPlugin />
+            <ComposerInlineTokenSelectionNormalizePlugin />
+            <ComposerInlineTokenBackspacePlugin />
+            <ComposerInlineTokenPastePlugin />
+            <ComposerChipSelectionPlugin />
+          </>
+        )}
         <ComposerHomeEndKeyPlugin />
-        <ComposerInlineTokenArrowPlugin />
-        <ComposerInlineTokenSelectionNormalizePlugin />
-        <ComposerInlineTokenBackspacePlugin />
-        <ComposerInlineTokenPastePlugin />
-        <ComposerChipSelectionPlugin />
         <HistoryPlugin />
       </div>
     </ComposerTerminalContextActionsContext>
@@ -1792,6 +1833,7 @@ export function ComposerPromptEditor({
   cursor,
   terminalContexts,
   skills,
+  plainText = false,
   disabled,
   placeholder,
   className,
@@ -1801,9 +1843,17 @@ export function ComposerPromptEditor({
   onPaste,
   editorRef,
 }: ComposerPromptEditorProps) {
+  // The editor remounts when plainText flips (see the LexicalComposer key), so
+  // these refs must track the latest props for the initial editorState to seed
+  // the remounted editor with the current value, not the first-ever one.
   const initialValueRef = useRef(value);
+  initialValueRef.current = value;
   const initialTerminalContextsRef = useRef(terminalContexts);
+  initialTerminalContextsRef.current = terminalContexts;
   const initialSkillMetadataRef = useRef(skillMetadataByName(skills));
+  initialSkillMetadataRef.current = skillMetadataByName(skills);
+  const initialPlainTextRef = useRef(plainText);
+  initialPlainTextRef.current = plainText;
   const initialConfig = useMemo<InitialConfigType>(
     () => ({
       namespace: "t3tools-composer-editor",
@@ -1814,6 +1864,7 @@ export function ComposerPromptEditor({
           initialValueRef.current,
           initialTerminalContextsRef.current,
           initialSkillMetadataRef.current,
+          initialPlainTextRef.current,
         );
       },
       onError: (error) => {
@@ -1824,12 +1875,16 @@ export function ComposerPromptEditor({
   );
 
   return (
-    <LexicalComposer key={COMPOSER_EDITOR_HMR_KEY} initialConfig={initialConfig}>
+    <LexicalComposer
+      key={`${COMPOSER_EDITOR_HMR_KEY}-${plainText ? "plain" : "rich"}`}
+      initialConfig={initialConfig}
+    >
       <ComposerPromptEditorInner
         value={value}
         cursor={cursor}
         terminalContexts={terminalContexts}
         skills={skills}
+        plainText={plainText}
         disabled={disabled}
         placeholder={placeholder}
         onRemoveTerminalContext={onRemoveTerminalContext}

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -1276,8 +1276,15 @@ function ComposerInlineTokenPastePlugin() {
 function ComposerSurroundSelectionPlugin(props: {
   terminalContexts: ReadonlyArray<TerminalContextDraft>;
   skills: ReadonlyArray<ServerProviderSkill>;
+  plainText: boolean;
 }) {
   const [editor] = useLexicalComposerContext();
+  // Surround-typing is not token behavior, so this plugin renders in both
+  // modes. In plain mode there are no token nodes: cursor mapping is a raw
+  // clamp and the mention-boundary guard would false-positive on answer text
+  // that merely looks like a mention, so it is skipped.
+  const collapseCursor = props.plainText ? clampExpandedCursor : collapseExpandedComposerCursor;
+  const touchesMentionBoundary = props.plainText ? () => false : selectionTouchesMentionBoundary;
   const terminalContextsRef = useRef(props.terminalContexts);
   const skillMetadataRef = useRef(skillMetadataByName(props.skills));
   const pendingSurroundSelectionRef = useRef<{
@@ -1324,7 +1331,7 @@ function ComposerSurroundSelectionPlugin(props: {
             return null;
           }
           const value = $getRoot().getTextContent();
-          if (selectionTouchesMentionBoundary(value, range.start, range.end)) {
+          if (touchesMentionBoundary(value, range.start, range.end)) {
             return null;
           }
           return {
@@ -1343,17 +1350,13 @@ function ComposerSurroundSelectionPlugin(props: {
         selectionSnapshot.expandedEnd,
       );
       const nextValue = `${selectionSnapshot.value.slice(0, selectionSnapshot.expandedStart)}${inputData}${selectedText}${surroundCloseSymbol}${selectionSnapshot.value.slice(selectionSnapshot.expandedEnd)}`;
-      // This plugin only renders in rich (tokenized) mode.
       $setComposerEditorPrompt(
         nextValue,
         terminalContextsRef.current,
         skillMetadataRef.current,
-        false,
+        props.plainText,
       );
-      const selectionStart = collapseExpandedComposerCursor(
-        nextValue,
-        selectionSnapshot.expandedStart,
-      );
+      const selectionStart = collapseCursor(nextValue, selectionSnapshot.expandedStart);
       $setSelectionRangeAtComposerOffsets(
         selectionStart + inputData.length,
         selectionStart + inputData.length + selectedText.length,
@@ -1399,7 +1402,7 @@ function ComposerSurroundSelectionPlugin(props: {
           return;
         }
         const value = $getRoot().getTextContent();
-        if (selectionTouchesMentionBoundary(value, range.start, range.end)) {
+        if (touchesMentionBoundary(value, range.start, range.end)) {
           pendingSurroundSelectionRef.current = null;
           pendingDeadKeySelectionRef.current = null;
           return;
@@ -1480,7 +1483,7 @@ function ComposerSurroundSelectionPlugin(props: {
               pendingDeadKeySelection.expandedStart,
               pendingDeadKeySelection.expandedEnd,
             );
-            const replacementStart = collapseExpandedComposerCursor(
+            const replacementStart = collapseCursor(
               currentValue,
               pendingDeadKeySelection.expandedStart,
             );
@@ -1691,14 +1694,19 @@ function ComposerPromptEditorInner({
   useLayoutEffect(() => {
     if (restoreFocusOnRemountRef.current) {
       restoreFocusOnRemountRef.current = false;
-      focusAt(snapshotRef.current.cursor);
+      // Focus at the end: the snapshot cursor was seeded from the previous
+      // mode's stale cursor prop, while both mode transitions settle the
+      // caret at the end (answer end on question open, draft end on resolve).
+      // Placing it there directly leaves no window for keystrokes to land at
+      // a stale offset before the parent's effects run.
+      focusAt(collapseComposerCursor(snapshotRef.current.value, snapshotRef.current.value.length));
     }
     return () => {
       // Layout cleanup runs before the old DOM node is detached, so
       // activeElement still points at it here.
       restoreFocusOnRemountRef.current = editor.getRootElement() === document.activeElement;
     };
-  }, [editor, focusAt, restoreFocusOnRemountRef]);
+  }, [collapseComposerCursor, editor, focusAt, restoreFocusOnRemountRef]);
 
   const readSnapshot = useCallback((): {
     value: string;
@@ -1832,9 +1840,16 @@ function ComposerPromptEditorInner({
         />
         <OnChangePlugin onChange={handleEditorChange} />
         <ComposerCommandKeyPlugin {...(onCommandKeyDown ? { onCommandKeyDown } : {})} />
+        {/* Surround-typing (wrap a selection in brackets/quotes) is plain
+            typing behavior, not token behavior, so it stays mounted in both
+            modes; only the token-dependent plugins are mode-gated. */}
+        <ComposerSurroundSelectionPlugin
+          terminalContexts={terminalContexts}
+          skills={skills}
+          plainText={plainText}
+        />
         {plainText ? null : (
           <>
-            <ComposerSurroundSelectionPlugin terminalContexts={terminalContexts} skills={skills} />
             <ComposerInlineTokenArrowPlugin />
             <ComposerInlineTokenSelectionNormalizePlugin />
             <ComposerInlineTokenBackspacePlugin />

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -973,6 +973,11 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // menus stay closed. Mobile answers questions with a plain input for the
   // same reason.
   const plainAnswerMode = activePendingProgress !== null;
+  // While a question is open, promptRef tracks the answer text the editor is
+  // showing, not the draft. Draft-oriented writers (traits, stash restore)
+  // and the question-ended handoff read and write this ref instead so they
+  // never disturb the answer's caret.
+  const draftPromptRef = useRef(prompt);
   const [composerCursor, setComposerCursor] = useState(() =>
     collapseExpandedComposerCursor(prompt, prompt.length),
   );
@@ -1243,18 +1248,34 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // ------------------------------------------------------------------
   const setPromptFromTraits = useCallback(
     (nextPrompt: string) => {
+      if (plainAnswerMode) {
+        // A trait toggle while a question is open edits the parked draft; the
+        // editor is showing the answer, so leave its caret and focus alone.
+        if (nextPrompt !== draftPromptRef.current) {
+          draftPromptRef.current = nextPrompt;
+          setComposerDraftPrompt(composerDraftTarget, nextPrompt);
+        }
+        return;
+      }
       if (nextPrompt === promptRef.current) {
         scheduleComposerFocus();
         return;
       }
       promptRef.current = nextPrompt;
+      draftPromptRef.current = nextPrompt;
       setComposerDraftPrompt(composerDraftTarget, nextPrompt);
       const nextCursor = collapseExpandedComposerCursor(nextPrompt, nextPrompt.length);
       setComposerCursor(nextCursor);
       setComposerTrigger(detectComposerTrigger(nextPrompt, nextPrompt.length));
       scheduleComposerFocus();
     },
-    [composerDraftTarget, promptRef, scheduleComposerFocus, setComposerDraftPrompt],
+    [
+      composerDraftTarget,
+      plainAnswerMode,
+      promptRef,
+      scheduleComposerFocus,
+      setComposerDraftPrompt,
+    ],
   );
 
   const providerTraitsMenuContent = renderProviderTraitsMenuContent({
@@ -1365,9 +1386,15 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // Sync refs back to parent
   // ------------------------------------------------------------------
   useEffect(() => {
+    draftPromptRef.current = prompt;
+    // In plain answer mode the editor shows the question answer, so a draft
+    // write (trait toggle, stash restore, another device syncing the draft)
+    // must not clobber the answer text or clamp its caret against the draft.
+    // promptRef is restored from the draft when the question resolves.
+    if (plainAnswerMode) return;
     promptRef.current = prompt;
     setComposerCursor((existing) => clampCollapsedComposerCursor(prompt, existing));
-  }, [prompt, promptRef]);
+  }, [plainAnswerMode, prompt, promptRef]);
 
   useEffect(() => {
     if (composerSubmissionError === null) return;
@@ -1443,10 +1470,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       lastSyncedPendingInputRef.current = null;
       if (pendingInputEnded) {
         // The question is gone; hand the composer back to the regular draft
-        // with token-aware cursor state.
-        promptRef.current = prompt;
-        setComposerCursor(collapseExpandedComposerCursor(prompt, prompt.length));
-        setComposerTrigger(detectComposerTrigger(prompt, prompt.length));
+        // with token-aware cursor state. The draft is read from a ref instead
+        // of depending on `prompt` so draft writes while a question is open
+        // don't re-run this effect and yank the answer's caret to the end.
+        const draftPrompt = draftPromptRef.current;
+        promptRef.current = draftPrompt;
+        setComposerCursor(collapseExpandedComposerCursor(draftPrompt, draftPrompt.length));
+        setComposerTrigger(detectComposerTrigger(draftPrompt, draftPrompt.length));
         setComposerHighlightedItemId(null);
       }
       return;
@@ -1478,7 +1508,6 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     activePendingProgress?.customAnswer,
     activePendingProgress?.activeQuestion?.id,
     activePendingUserInput?.requestId,
-    prompt,
     promptRef,
   ]);
 
@@ -2062,7 +2091,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       }
       setIsStashMenuOpen(false);
 
-      const currentPrompt = promptRef.current;
+      // The restore always targets the draft, which is not what promptRef
+      // holds while a question is open (the answer text is showing then).
+      const currentPrompt = draftPromptRef.current;
       // An image-only stash must not append blank lines to whatever is
       // already in the composer.
       const nextPrompt =
@@ -2073,10 +2104,15 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
             : entry.prompt;
       const promptChanged = nextPrompt !== currentPrompt;
       if (promptChanged) {
-        promptRef.current = nextPrompt;
+        draftPromptRef.current = nextPrompt;
         setComposerDraftPrompt(composerDraftTarget, nextPrompt);
-        setComposerCursor(collapseExpandedComposerCursor(nextPrompt, nextPrompt.length));
-        setComposerTrigger(null);
+        // While a question is open the editor keeps showing the answer, so
+        // its caret must stay where the user left it.
+        if (!plainAnswerMode) {
+          promptRef.current = nextPrompt;
+          setComposerCursor(collapseExpandedComposerCursor(nextPrompt, nextPrompt.length));
+          setComposerTrigger(null);
+        }
       }
 
       let unrestoredImageNames: string[] = [];
@@ -2145,7 +2181,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
 
       // Only yank the caret to the end when text was actually inserted;
       // restoring images alone should leave the user where they were typing.
-      if (promptChanged) {
+      if (promptChanged && !plainAnswerMode) {
         window.requestAnimationFrame(() => {
           composerEditorRef.current?.focusAtEnd();
         });
@@ -2155,6 +2191,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       addComposerDraftImages,
       composerDraftTarget,
       composerImagesRef,
+      plainAnswerMode,
       promptRef,
       setComposerDraftPrompt,
       takeStashEntry,

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -968,6 +968,11 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // ------------------------------------------------------------------
   // Composer-local state
   // ------------------------------------------------------------------
+  // Pending-question answers submit plain strings, so while a question is
+  // active the editor renders raw text (no inline tokens) and the trigger
+  // menus stay closed. Mobile answers questions with a plain input for the
+  // same reason.
+  const plainAnswerMode = activePendingProgress !== null;
   const [composerCursor, setComposerCursor] = useState(() =>
     collapseExpandedComposerCursor(prompt, prompt.length),
   );
@@ -1161,7 +1166,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     workspaceEntries.entries,
   ]);
 
-  const composerMenuOpen = Boolean(composerTrigger);
+  const composerMenuOpen = Boolean(composerTrigger) && !plainAnswerMode;
   const composerMenuSearchKey = composerTrigger
     ? `${composerTrigger.kind}:${composerTrigger.query.trim().toLowerCase()}`
     : null;
@@ -1434,7 +1439,16 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   useEffect(() => {
     const nextCustomAnswer = activePendingProgress?.customAnswer;
     if (typeof nextCustomAnswer !== "string") {
+      const pendingInputEnded = lastSyncedPendingInputRef.current !== null;
       lastSyncedPendingInputRef.current = null;
+      if (pendingInputEnded) {
+        // The question is gone; hand the composer back to the regular draft
+        // with token-aware cursor state.
+        promptRef.current = prompt;
+        setComposerCursor(collapseExpandedComposerCursor(prompt, prompt.length));
+        setComposerTrigger(detectComposerTrigger(prompt, prompt.length));
+        setComposerHighlightedItemId(null);
+      }
       return;
     }
 
@@ -1455,19 +1469,16 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     }
 
     promptRef.current = nextCustomAnswer;
-    const nextCursor = collapseExpandedComposerCursor(nextCustomAnswer, nextCustomAnswer.length);
-    setComposerCursor(nextCursor);
-    setComposerTrigger(
-      detectComposerTrigger(
-        nextCustomAnswer,
-        expandCollapsedComposerCursor(nextCustomAnswer, nextCursor),
-      ),
-    );
+    // Plain answer mode: cursor offsets are raw because the editor renders no
+    // inline tokens, and trigger menus never open.
+    setComposerCursor(nextCustomAnswer.length);
+    setComposerTrigger(null);
     setComposerHighlightedItemId(null);
   }, [
     activePendingProgress?.customAnswer,
     activePendingProgress?.activeQuestion?.id,
     activePendingUserInput?.requestId,
+    prompt,
     promptRef,
   ]);
 
@@ -1478,10 +1489,16 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     setComposerHighlightedItemId(null);
     setComposerSubmissionError(null);
     setProviderInputSubmissionError(null);
-    setComposerCursor(collapseExpandedComposerCursor(promptRef.current, promptRef.current.length));
-    setComposerTrigger(detectComposerTrigger(promptRef.current, promptRef.current.length));
+    setComposerCursor(
+      plainAnswerMode
+        ? promptRef.current.length
+        : collapseExpandedComposerCursor(promptRef.current, promptRef.current.length),
+    );
+    setComposerTrigger(
+      plainAnswerMode ? null : detectComposerTrigger(promptRef.current, promptRef.current.length),
+    );
     setIsDragOverComposer(false);
-  }, [draftId, activeThreadId, promptRef]);
+  }, [draftId, activeThreadId, plainAnswerMode, promptRef]);
 
   // ------------------------------------------------------------------
   // Footer compact layout observation
@@ -1610,9 +1627,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     ) => {
       if (activePendingProgress?.activeQuestion && pendingUserInputs.length > 0) {
         setComposerCursor(nextCursor);
-        setComposerTrigger(
-          cursorAdjacentToMention ? null : detectComposerTrigger(nextPrompt, expandedCursor),
-        );
+        // Plain answer mode: no trigger menus over question answers.
+        setComposerTrigger(null);
         onChangeActivePendingUserInputCustomAnswer(
           activePendingProgress.activeQuestion.id,
           nextPrompt,
@@ -1725,9 +1741,11 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     const snapshot = readComposerSnapshot();
     return {
       snapshot,
-      trigger: detectComposerTrigger(snapshot.value, snapshot.expandedCursor),
+      trigger: plainAnswerMode
+        ? null
+        : detectComposerTrigger(snapshot.value, snapshot.expandedCursor),
     };
-  }, [readComposerSnapshot]);
+  }, [plainAnswerMode, readComposerSnapshot]);
 
   const onSelectComposerItem = useCallback(
     (item: ComposerCommandItem) => {
@@ -3220,7 +3238,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                       ? composerTerminalContexts
                       : []
                   }
-                  skills={selectedProviderStatus?.skills ?? []}
+                  skills={plainAnswerMode ? [] : (selectedProviderStatus?.skills ?? [])}
+                  plainText={plainAnswerMode}
                   {...(showMobilePendingAnswerActions ? { className: "max-sm:pb-11" } : {})}
                   onRemoveTerminalContext={removeComposerTerminalContextFromDraft}
                   onChange={onPromptChange}


### PR DESCRIPTION
Closes #7805

When a provider asks a question, the custom-answer composer reused the full prompt editor, so `$skill` syntax turned into skill tokens and opened the picker, even though question responses only ever send plain answer strings. That desynced Lexical cursor state (recursive update crashes), left the picker open after submit, and leaked the previous answer into the next question.

This makes question answers plain text end to end, the way mobile already handles them. The prompt editor gets a `plainText` mode that renders the value as raw text with no inline-token plugins mounted; with no token nodes, collapsed and expanded cursor offsets coincide, so all cursor mapping reduces to a raw clamp. While a question is active, the chat composer enables that mode and keeps every trigger menu (skills, slash commands, file paths) closed over answers, then re-derives normal composer state from the regular draft when the question ends. The editor remounts when the mode flips, which also stops undo history from leaking between an answer and the main draft.

Compared to #7812 (which this replaces), the shared tokenizer and cursor logic stay untouched, and the fix removes the bug class structurally instead of special-casing skill tokens. The trade-off is intentional: no mention/slash pickers inside question answers, matching mobile.

Tests:

- 77 focused web tests (composer-logic, composer-editor-mentions, ComposerPromptEditor, composerSubmission, ComposerPendingUserInputPanel)
- Web typecheck, targeted lint and formatting

Evidence:

- Before: https://github.com/user-attachments/assets/5f35e3a5-20cd-4ad2-b94a-ffebe60be771
- After: pending isolated browser verification

Implemented with Anthropic Claude Fable 5 using Claude Code in T3 Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches composer cursor mapping, remount/focus, and draft vs answer state during pending questions—easy to regress caret, menus, or draft clobbering, but not auth or data-plane.
> 
> **Overview**
> Stops pending-question answers from being tokenized as skills/mentions, which previously desynced Lexical cursor state, left pickers open, and leaked answers between questions.
> 
> `ComposerPromptEditor` gains a `plainText` mode that inserts raw text, skips token plugins, and treats collapsed/expanded cursors as the same offset. The Lexical tree remounts when the mode flips (clearing undo history) and restores focus so a question opening mid-type does not drop keystrokes.
> 
> While a question is active, `ChatComposer` enables that mode, keeps trigger menus closed, and parks the real draft in `draftPromptRef` so trait/stash writes do not move the answer caret. When the question ends, it restores the draft with token-aware cursor/trigger state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96746625340bb96fb33f605e187459a67cc081ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix glitching skill invocation in question tool by adding `plainText` mode to `ComposerPromptEditor`
> - Adds a `plainText` prop to `ComposerPromptEditor` in [ComposerPromptEditor.tsx](https://github.com/pingdotgg/t3code/pull/7818/files#diff-12fcb05b3e147eba955638d8df57440b8cf7f796941af0989c9bfa57b5b4f4a4). When true, the editor remounts (via a `-plain`/`-rich` key suffix), renders prompts as raw text without mention/skill/terminal-context token nodes, and disables token-aware cursor mapping and token-related plugins (arrow, backspace, paste, chip selection).
> - `ChatComposer` in [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/7818/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a) sets `plainAnswerMode` when a pending question is active, passing `plainText={true}` and `skills={[]}` to the editor. Trigger menus are suppressed and cursor offsets are raw during this mode.
> - Draft edits (traits, stash restore, external sync) during a question are parked in `draftPromptRef` so they do not disturb the answer caret. When the question resolves, the draft is restored into `promptRef` and token-aware behavior resumes.
> - Behavioral Change: `$setComposerEditorPrompt` now requires a `plainText` boolean parameter; all internal callers were updated. Editor remounts on mode toggle, with a layout effect restoring focus to end-of-text.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9674662.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->