### PR TITLE
fix(server): alias Grok's product-name model slug to a valid ACP modelId

### DIFF
--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -278,15 +278,17 @@ function modeState(): AcpSchema.SessionModeState {
   };
 }
 
+// Mirrors the real Grok ACP: it only accepts "grok-4.6"/"grok-4.5" as
+// modelIds, never the CLI's own "grok-build" product name (see #7791).
 const grokAcpModels: ReadonlyArray<AcpSchema.ModelInfo> = [
-  { modelId: "grok-build", name: "Grok Build" },
+  { modelId: "grok-4.6", name: "Grok 4.6" },
   { modelId: "grok-mock-alt", name: "Grok Mock Alt" },
 ];
 
 function modelState(): AcpSchema.SessionModelState {
   const modelId = grokAcpModels.some((model) => model.modelId === currentModelId)
     ? currentModelId
-    : "grok-build";
+    : "grok-4.6";
   return {
     currentModelId: modelId,
     availableModels: grokAcpModels,

--- a/apps/server/src/provider/acp/GrokAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.test.ts
@@ -10,8 +10,11 @@ import {
 
 describe("resolveGrokAcpBaseModelId", () => {
   it("normalizes empty and custom Grok model ids", () => {
-    expect(resolveGrokAcpBaseModelId(undefined)).toBe("grok-build");
-    expect(resolveGrokAcpBaseModelId("   ")).toBe("grok-build");
+    // "grok-build" is the CLI's product name, not a modelId its ACP accepts —
+    // it must resolve to a real model alias, not pass through verbatim.
+    expect(resolveGrokAcpBaseModelId(undefined)).toBe("grok-4.6");
+    expect(resolveGrokAcpBaseModelId("   ")).toBe("grok-4.6");
+    expect(resolveGrokAcpBaseModelId("grok-build")).toBe("grok-4.6");
     expect(resolveGrokAcpBaseModelId("  grok-test-custom-model  ")).toBe("grok-test-custom-model");
   });
 });

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -211,6 +211,14 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Partial<
     "opus-4.5-thinking": "claude-opus-4-5",
     "opus-4.5": "claude-opus-4-5",
   },
+  [GROK_DRIVER_KIND]: {
+    // "grok-build" is the Grok Build CLI's own product name, not a model id
+    // its ACP accepts — sending it verbatim as `session/set_model`'s modelId
+    // fails with "unknown model id". Grok's ACP only knows "grok-4.6" and
+    // "grok-4.5"; alias the default/display slug to the current one so the
+    // wire-level id is always valid.
+    "grok-build": "grok-4.6",
+  },
   [OPENCODE_DRIVER_KIND]: {},
 };
 

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -154,4 +154,10 @@ describe("model slug normalization", () => {
     expect(normalizeModelSlug("opus", claude)).toBe("claude-opus-5");
     expect(normalizeCustomModelSlug(" opus ")).toBe("opus");
   });
+
+  it("aliases Grok's product-name slug to a modelId its ACP accepts", () => {
+    const grok = ProviderDriverKind.make("grok");
+
+    expect(normalizeModelSlug("grok-build", grok)).toBe("grok-4.6");
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #7791. Selecting the Grok provider and sending a message fails immediately with `Error: Invalid params at decodeJsonError` — the underlying ACP error is `unknown model id`. Grok's ACP `session/set_model` only accepts `grok-4.6` and `grok-4.5` as modelIds. T3 sends `"grok-build"` (the Grok Build CLI's own product name, not a model id) as the default, and Grok's ACP rejects it outright.

Verified directly against a live ACP probe (per the issue): `"grok-build"` → `unknown model id`; `"grok-4.6"`/`"grok-4.5"` → success.

## Fix

Added a `MODEL_SLUG_ALIASES_BY_PROVIDER` entry for the Grok driver — the same mechanism Claude and Codex already use for their own display/legacy slugs (e.g. Claude's `opus` → `claude-opus-5`) — so `normalizeModelSlug`/`resolveGrokAcpBaseModelId` resolve `"grok-build"` to `"grok-4.6"` before it ever reaches the wire. `DEFAULT_MODEL_BY_PROVIDER`'s display slug is untouched, matching how the other providers' aliasing works.

Also updated `apps/server/scripts/acp-mock-agent.ts`'s mock Grok ACP model list, which previously accepted the never-actually-valid `"grok-build"` — that mock now mirrors the real Grok ACP's behavior (`"grok-4.6"` valid, `"grok-build"` not), which is what let this bug slip past the existing test suite.

## Test plan

- [x] Added a regression test in `packages/shared/src/model.test.ts` asserting `normalizeModelSlug("grok-build", grok)` resolves to `"grok-4.6"`.
- [x] Updated the existing `resolveGrokAcpBaseModelId` test to assert the default (and explicit `"grok-build"`) now resolve to `"grok-4.6"` instead of passing through verbatim.
- [x] `vp test run packages/shared/src/model.test.ts apps/server/src/provider/acp/GrokAcpSupport.test.ts` — passed.
- [x] Full Grok test suite (`GrokAdapter.test.ts`, `GrokProvider.test.ts`, `GrokTextGeneration.test.ts`, `AcpRuntimeModel.test.ts`) run under Linux (these spawn real subprocesses, which needs a POSIX environment) — 56 passed, 0 failed, after updating the mock agent's model list.
- [x] Confirmed Cursor's tests are unaffected: Cursor uses its own dedicated `cursor/list_available_models` RPC, not the generic ACP session-model mechanism the mock's model list change touches.
- [x] `vp run --filter t3 typecheck` — clean.
- [x] `vp lint` on changed files — clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small model-id alias plus mock-agent alignment; no auth or data-path changes. Display default remains grok-build.
> 
> **Overview**
> Fixes Grok ACP `session/set_model` failing with **unknown model id** when the default product slug `grok-build` is sent on the wire.
> 
> Adds a Grok entry in `MODEL_SLUG_ALIASES_BY_PROVIDER` so `normalizeModelSlug` / `resolveGrokAcpBaseModelId` map `grok-build` → `grok-4.6` (the id Grok ACP actually accepts). Display default is unchanged.
> 
> The ACP mock agent now lists `grok-4.6` instead of `grok-build`, matching real Grok ACP so this cannot slip past tests again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e90ce6197297b8ea67660843c1c4788ae1d56e8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Alias Grok's `grok-build` product slug to valid ACP modelId `grok-4.6`
> Adds a `grok-build` → `grok-4.6` entry to `MODEL_SLUG_ALIASES_BY_PROVIDER` in [model.ts](https://github.com/pingdotgg/t3code/pull/7819/files#diff-cff20c6bccac2635a0e8b89343cf21815f9fc219bd536a90f66537a56eac7959) because `grok-build` is a CLI product name, not a valid ACP modelId (ACP only accepts `grok-4.6` and `grok-4.5`). Updates the mock ACP agent in [acp-mock-agent.ts](https://github.com/pingdotgg/t3code/pull/7819/files#diff-8a006152e281284d31dee6c6726df790c3c486b6899a0746f334a8d0663fabc7) and the `resolveGrokAcpBaseModelId` tests in [GrokAcpSupport.test.ts](https://github.com/pingdotgg/t3code/pull/7819/files#diff-b3661353cbf25b4fea31bc2b308896f95c304956a5686b12d112bc372f95a25c) to use `grok-4.6` as the default and fallback modelId instead of `grok-build`. Also adds a normalization test case in [model.test.ts](https://github.com/pingdotgg/t3code/pull/7819/files#diff-698991b568d5a708e88e5354a2d43bf1cd0afbf0bfcabbc07378d2f6847537f0).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e90ce6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->