### PR TITLE
fix(web): no stale-title flash after renaming a thread

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2382,55 +2382,84 @@ export default function Sidebar() {
 
   const [renamingThreadKey, setRenamingThreadKey] = useState<string | null>(null);
   const [renamingTitle, setRenamingTitle] = useState("");
-  // Bumped whenever a new rename session or submission starts, so a settled
-  // response can tell it is stale and leave a newer editor alone.
-  const renameEpochRef = useRef(0);
+  // Titles committed to the server but not yet reflected by the thread shells
+  // (the store learns about renames via a coalesced server-side stream).
+  // Shown in place of the stored title so confirming a rename never flashes
+  // the old one; dropped once the store catches up, or reverted if the
+  // server rejected the rename.
+  const [optimisticTitles, setOptimisticTitles] = useState<ReadonlyMap<string, string>>(
+    () => new Map(),
+  );
   const startThreadRename = useCallback((threadRef: ScopedThreadRef, title: string) => {
-    renameEpochRef.current += 1;
     setRenamingThreadKey(scopedThreadKey(threadRef));
     setRenamingTitle(title);
   }, []);
   const cancelThreadRename = useCallback(() => setRenamingThreadKey(null), []);
   const commitThreadRename = useCallback(
     (threadRef: ScopedThreadRef, title: string, originalTitle: string) => {
-      void (async () => {
-        const trimmed = title.trim();
-        if (trimmed.length === 0) {
-          setRenamingThreadKey(null);
-          toastManager.add({ type: "warning", title: "Thread title cannot be empty" });
-          return;
-        }
-        if (trimmed === originalTitle) {
-          setRenamingThreadKey(null);
-          return;
-        }
-        // Keep the row's editor showing the typed title until the server
-        // confirms; closing early flashes the stale store title. Only the
-        // latest submission may close it, so a slower earlier response can
-        // never clobber a newer rename.
-        const epoch = ++renameEpochRef.current;
-        try {
-          const result = await updateThreadMetadata({
-            environmentId: threadRef.environmentId,
-            input: { threadId: threadRef.threadId, title: trimmed },
+      const trimmed = title.trim();
+      if (trimmed.length === 0) {
+        setRenamingThreadKey(null);
+        toastManager.add({ type: "warning", title: "Thread title cannot be empty" });
+        return;
+      }
+      if (trimmed === originalTitle) {
+        setRenamingThreadKey(null);
+        return;
+      }
+      const threadKey = scopedThreadKey(threadRef);
+      // Close immediately and show the committed title optimistically:
+      // waiting for the store would flash the old title for a beat. A
+      // rejection reverts to the stored title.
+      setRenamingThreadKey(null);
+      setOptimisticTitles((current) => new Map(current).set(threadKey, trimmed));
+      void updateThreadMetadata({
+        environmentId: threadRef.environmentId,
+        input: { threadId: threadRef.threadId, title: trimmed },
+      }).then((result) => {
+        if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+          setOptimisticTitles((current) => {
+            if (current.get(threadKey) !== trimmed) return current;
+            const next = new Map(current);
+            next.delete(threadKey);
+            return next;
           });
-          if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
-            const error = squashAtomCommandFailure(result);
-            toastManager.add(
-              stackedThreadToast({
-                type: "error",
-                title: "Failed to rename thread",
-                description: error instanceof Error ? error.message : "An error occurred.",
-              }),
-            );
-          }
-        } finally {
-          if (renameEpochRef.current === epoch) setRenamingThreadKey(null);
+          const error = squashAtomCommandFailure(result);
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Failed to rename thread",
+              description: error instanceof Error ? error.message : "An error occurred.",
+            }),
+          );
         }
-      })();
+      });
     },
     [updateThreadMetadata],
   );
+  // Stored title for every known thread, used to retire optimistic rename
+  // titles once the coalesced stream catches up.
+  const threadTitlesByKey = useMemo(() => {
+    const titles = new Map<string, string>();
+    for (const thread of threads) {
+      titles.set(scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)), thread.title);
+    }
+    return titles;
+  }, [threads]);
+  useEffect(() => {
+    if (optimisticTitles.size === 0) return;
+    setOptimisticTitles((current) => {
+      let next: Map<string, string> | null = null;
+      for (const [key, title] of current) {
+        const storedTitle = threadTitlesByKey.get(key);
+        if (storedTitle === undefined || storedTitle === title) {
+          next ??= new Map(current);
+          next.delete(key);
+        }
+      }
+      return next ?? current;
+    });
+  }, [optimisticTitles, threadTitlesByKey]);
 
   const handleThreadClick = useCallback(
     (event: ReactMouseEvent, threadRef: ScopedThreadRef) => {
@@ -3144,7 +3173,7 @@ export default function Sidebar() {
             attemptUnpin(threadRef);
             return;
           case "rename":
-            startThreadRename(threadRef, thread.title);
+            startThreadRename(threadRef, optimisticTitles.get(threadKey) ?? thread.title);
             return;
           case "regenerate-title": {
             if (isRegeneratingTitle) return;
@@ -3264,6 +3293,7 @@ export default function Sidebar() {
       deleteThread,
       handleMultiSelectContextMenu,
       markThreadUnread,
+      optimisticTitles,
       projectCwdByKey,
       serverConfigs,
       startThreadRename,
@@ -3672,6 +3702,13 @@ export default function Sidebar() {
                     // not from the sidebar second-guessing what still matters.
                     const isCard = section === "active" || section === "pinned";
                     const rowVariant = isCard ? "card" : "slim";
+                    // Optimistic renames shadow the stored title until the
+                    // coalesced stream catches up (see optimisticTitles).
+                    const optimisticTitle = optimisticTitles.get(threadKey);
+                    const rowThread =
+                      optimisticTitle === undefined || optimisticTitle === thread.title
+                        ? thread
+                        : { ...thread, title: optimisticTitle };
                     return (
                       <SidebarThreadRow
                         // Keyed per variant on purpose: when a thread settles,
@@ -3681,7 +3718,7 @@ export default function Sidebar() {
                         // are translucent, so a crossing row reads as text
                         // painted over text).
                         key={`${threadKey}:${rowVariant}`}
-                        thread={thread}
+                        thread={rowThread}
                         variant={rowVariant}
                         // Snoozed rows wake; settled rows un-settle (explicit
                         // settles clear the override, auto-settled rows get

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2385,26 +2385,23 @@ export default function Sidebar() {
 
   const [renamingThreadKey, setRenamingThreadKey] = useState<string | null>(null);
   const [renamingTitle, setRenamingTitle] = useState("");
-  // Set when a rename is submitted: the row keeps its inline editor (still
-  // showing what was typed) until the store reflects the rename, so
-  // confirming never flashes the old title. Cleared once the stored title
-  // moves off its pre-rename value - either this rename landed or a racing
-  // change like regeneration won - or when another rename session starts.
-  const [awaitingRename, setAwaitingRename] = useState<{
-    threadKey: string;
-    baseline: string;
-  } | null>(null);
+  // Titles committed but not yet reflected by the thread shells (the store
+  // learns about renames via a coalesced server-side stream). Shown in place
+  // of the stored title so confirming a rename never flashes the old one.
+  // An entry retires as soon as the store moves off its pre-rename value:
+  // either this rename landed or a racing change like regeneration won -
+  // either way that is the visible truth. A second rename before then
+  // overwrites the entry on the same baseline.
+  const [optimisticTitles, setOptimisticTitles] = useState<
+    ReadonlyMap<string, { title: string; baseline: string }>
+  >(() => new Map());
   const startThreadRename = useCallback((threadRef: ScopedThreadRef, title: string) => {
-    setAwaitingRename(null);
     setRenamingThreadKey(scopedThreadKey(threadRef));
     setRenamingTitle(title);
   }, []);
-  const cancelThreadRename = useCallback(() => {
-    setAwaitingRename(null);
-    setRenamingThreadKey(null);
-  }, []);
+  const cancelThreadRename = useCallback(() => setRenamingThreadKey(null), []);
   // Stored title for every known thread, used to tell when the coalesced
-  // stream has caught up with a submitted rename.
+  // stream has caught up with a committed rename.
   const threadTitlesByKey = useMemo(() => {
     const titles = new Map<string, string>();
     for (const thread of threads) {
@@ -2425,19 +2422,27 @@ export default function Sidebar() {
         return;
       }
       const threadKey = scopedThreadKey(threadRef);
-      // Hold the row's editor open until the store catches up; closing now
-      // would flash the stored title for a beat. A rejection closes it.
-      setAwaitingRename({ threadKey, baseline: originalTitle });
+      // Close immediately and keep showing the committed title via the map;
+      // closing without it would flash the stored title for a beat while the
+      // store catches up. A rejection reverts to it.
+      setRenamingThreadKey(null);
+      setOptimisticTitles((current) =>
+        new Map(current).set(threadKey, { title: trimmed, baseline: originalTitle }),
+      );
       void updateThreadMetadata({
         environmentId: threadRef.environmentId,
         input: { threadId: threadRef.threadId, title: trimmed },
       }).then((result) => {
         if (result._tag !== "Failure") return;
-        // Close on every failure, including interrupts: an interrupted
-        // command never ran, so the store will never move off baseline and
-        // only this teardown releases the row's editor.
-        setAwaitingRename((current) => (current?.threadKey === threadKey ? null : current));
-        setRenamingThreadKey((current) => (current === threadKey ? null : current));
+        // Drop the override on every failure, including interrupts: an
+        // interrupted command never ran, so the store will never move off
+        // baseline and only this teardown retires the shown title.
+        setOptimisticTitles((current) => {
+          if (current.get(threadKey)?.title !== trimmed) return current;
+          const next = new Map(current);
+          next.delete(threadKey);
+          return next;
+        });
         if (isAtomCommandInterrupted(result)) return;
         const error = squashAtomCommandFailure(result);
         toastManager.add(
@@ -2452,13 +2457,19 @@ export default function Sidebar() {
     [updateThreadMetadata],
   );
   useEffect(() => {
-    if (awaitingRename === null) return;
-    const storedTitle = threadTitlesByKey.get(awaitingRename.threadKey);
-    if (storedTitle === undefined || storedTitle !== awaitingRename.baseline) {
-      setAwaitingRename(null);
-      setRenamingThreadKey((current) => (current === awaitingRename.threadKey ? null : current));
-    }
-  }, [awaitingRename, threadTitlesByKey]);
+    if (optimisticTitles.size === 0) return;
+    setOptimisticTitles((current) => {
+      let next: Map<string, { title: string; baseline: string }> | null = null;
+      for (const [key, entry] of current) {
+        const storedTitle = threadTitlesByKey.get(key);
+        if (storedTitle === undefined || storedTitle !== entry.baseline) {
+          next ??= new Map(current);
+          next.delete(key);
+        }
+      }
+      return next ?? current;
+    });
+  }, [optimisticTitles, threadTitlesByKey]);
 
   const handleThreadClick = useCallback(
     (event: ReactMouseEvent, threadRef: ScopedThreadRef) => {
@@ -3172,7 +3183,7 @@ export default function Sidebar() {
             attemptUnpin(threadRef);
             return;
           case "rename":
-            startThreadRename(threadRef, thread.title);
+            startThreadRename(threadRef, optimisticTitles.get(threadKey)?.title ?? thread.title);
             return;
           case "regenerate-title": {
             if (isRegeneratingTitle) return;
@@ -3219,7 +3230,9 @@ export default function Sidebar() {
           case "archive": {
             if (confirmThreadArchive) {
               const confirmed = await settlePromise(() =>
-                api.dialogs.confirm(`Archive thread "${thread.title}"?`),
+                api.dialogs.confirm(
+                  `Archive thread "${optimisticTitles.get(threadKey)?.title ?? thread.title}"?`,
+                ),
               );
               if (confirmed._tag === "Failure" || !confirmed.value) return;
             }
@@ -3249,7 +3262,7 @@ export default function Sidebar() {
               const confirmed = await settlePromise(() =>
                 api.dialogs.confirm(
                   [
-                    `Delete thread "${thread.title}"?`,
+                    `Delete thread "${optimisticTitles.get(threadKey)?.title ?? thread.title}"?`,
                     "This permanently clears conversation history for this thread.",
                   ].join("\n"),
                   { variant: "destructive" },
@@ -3292,6 +3305,7 @@ export default function Sidebar() {
       deleteThread,
       handleMultiSelectContextMenu,
       markThreadUnread,
+      optimisticTitles,
       projectCwdByKey,
       serverConfigs,
       startThreadRename,
@@ -3700,6 +3714,13 @@ export default function Sidebar() {
                     // not from the sidebar second-guessing what still matters.
                     const isCard = section === "active" || section === "pinned";
                     const rowVariant = isCard ? "card" : "slim";
+                    // Committed renames shadow the stored title until the
+                    // coalesced stream catches up (see optimisticTitles).
+                    const optimisticTitle = optimisticTitles.get(threadKey)?.title;
+                    const rowThread =
+                      optimisticTitle === undefined || optimisticTitle === thread.title
+                        ? thread
+                        : { ...thread, title: optimisticTitle };
                     return (
                       <SidebarThreadRow
                         // Keyed per variant on purpose: when a thread settles,
@@ -3709,7 +3730,7 @@ export default function Sidebar() {
                         // are translucent, so a crossing row reads as text
                         // painted over text).
                         key={`${threadKey}:${rowVariant}`}
-                        thread={thread}
+                        thread={rowThread}
                         variant={rowVariant}
                         // Snoozed rows wake; settled rows un-settle (explicit
                         // settles clear the override, auto-settled rows get

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2382,24 +2382,26 @@ export default function Sidebar() {
 
   const [renamingThreadKey, setRenamingThreadKey] = useState<string | null>(null);
   const [renamingTitle, setRenamingTitle] = useState("");
-  // Titles committed to the server but not yet reflected by the thread shells
-  // (the store learns about renames via a coalesced server-side stream).
-  // Shown in place of the stored title so confirming a rename never flashes
-  // the old one. `chain` is every title this override chain has committed,
-  // oldest first: the store may deliver them one at a time, so the override
-  // stays up while the store walks the chain and retires when the store
-  // reaches the latest title or lands on anything else (a newer title
-  // change like regeneration won).
-  const [optimisticTitles, setOptimisticTitles] = useState<
-    ReadonlyMap<string, { title: string; chain: readonly string[] }>
-  >(() => new Map());
+  // Set when a rename is submitted: the row keeps its inline editor (still
+  // showing what was typed) until the store reflects the rename, so
+  // confirming never flashes the old title. Cleared once the stored title
+  // moves off its pre-rename value - either this rename landed or a racing
+  // change like regeneration won - or when another rename session starts.
+  const [awaitingRename, setAwaitingRename] = useState<{
+    threadKey: string;
+    baseline: string;
+  } | null>(null);
   const startThreadRename = useCallback((threadRef: ScopedThreadRef, title: string) => {
+    setAwaitingRename(null);
     setRenamingThreadKey(scopedThreadKey(threadRef));
     setRenamingTitle(title);
   }, []);
-  const cancelThreadRename = useCallback(() => setRenamingThreadKey(null), []);
-  // Stored title for every known thread, used to baseline and retire
-  // optimistic rename titles once the coalesced stream catches up.
+  const cancelThreadRename = useCallback(() => {
+    setAwaitingRename(null);
+    setRenamingThreadKey(null);
+  }, []);
+  // Stored title for every known thread, used to tell when the coalesced
+  // stream has caught up with a submitted rename.
   const threadTitlesByKey = useMemo(() => {
     const titles = new Map<string, string>();
     for (const thread of threads) {
@@ -2420,33 +2422,16 @@ export default function Sidebar() {
         return;
       }
       const threadKey = scopedThreadKey(threadRef);
-      // Close immediately and show the committed title optimistically:
-      // waiting for the store would flash the old title for a beat. A
-      // rejection reverts to the stored title.
-      setRenamingThreadKey(null);
-      // Extend any override already in flight so the store can walk through
-      // the intermediate titles without flashing them.
-      setOptimisticTitles((current) => {
-        const existing = current.get(threadKey);
-        const base = existing
-          ? existing.chain
-          : [threadTitlesByKey.get(threadKey) ?? originalTitle];
-        return new Map(current).set(threadKey, {
-          title: trimmed,
-          chain: [...base, trimmed],
-        });
-      });
+      // Hold the row's editor open until the store catches up; closing now
+      // would flash the stored title for a beat. A rejection closes it.
+      setAwaitingRename({ threadKey, baseline: originalTitle });
       void updateThreadMetadata({
         environmentId: threadRef.environmentId,
         input: { threadId: threadRef.threadId, title: trimmed },
       }).then((result) => {
         if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
-          setOptimisticTitles((current) => {
-            if (current.get(threadKey)?.title !== trimmed) return current;
-            const next = new Map(current);
-            next.delete(threadKey);
-            return next;
-          });
+          setAwaitingRename((current) => (current?.threadKey === threadKey ? null : current));
+          setRenamingThreadKey((current) => (current === threadKey ? null : current));
           const error = squashAtomCommandFailure(result);
           toastManager.add(
             stackedThreadToast({
@@ -2458,28 +2443,16 @@ export default function Sidebar() {
         }
       });
     },
-    [threadTitlesByKey, updateThreadMetadata],
+    [updateThreadMetadata],
   );
   useEffect(() => {
-    if (optimisticTitles.size === 0) return;
-    setOptimisticTitles((current) => {
-      let next: Map<string, { title: string; chain: readonly string[] }> | null = null;
-      for (const [key, entry] of current) {
-        const storedTitle = threadTitlesByKey.get(key);
-        // Retire once the store reaches the final link or leaves the chain.
-        // Matching an EARLIER link keeps the override up so intermediate
-        // frames never flash. A rename landing back on an earlier title
-        // leaves a visually inert entry until the next title change, which
-        // is fine: it renders exactly what the store renders.
-        const idx = storedTitle === undefined ? -1 : entry.chain.indexOf(storedTitle);
-        if (idx === -1 || idx === entry.chain.length - 1) {
-          next ??= new Map(current);
-          next.delete(key);
-        }
-      }
-      return next ?? current;
-    });
-  }, [optimisticTitles, threadTitlesByKey]);
+    if (awaitingRename === null) return;
+    const storedTitle = threadTitlesByKey.get(awaitingRename.threadKey);
+    if (storedTitle === undefined || storedTitle !== awaitingRename.baseline) {
+      setAwaitingRename(null);
+      setRenamingThreadKey((current) => (current === awaitingRename.threadKey ? null : current));
+    }
+  }, [awaitingRename, threadTitlesByKey]);
 
   const handleThreadClick = useCallback(
     (event: ReactMouseEvent, threadRef: ScopedThreadRef) => {
@@ -3193,7 +3166,7 @@ export default function Sidebar() {
             attemptUnpin(threadRef);
             return;
           case "rename":
-            startThreadRename(threadRef, optimisticTitles.get(threadKey)?.title ?? thread.title);
+            startThreadRename(threadRef, thread.title);
             return;
           case "regenerate-title": {
             if (isRegeneratingTitle) return;
@@ -3240,9 +3213,7 @@ export default function Sidebar() {
           case "archive": {
             if (confirmThreadArchive) {
               const confirmed = await settlePromise(() =>
-                api.dialogs.confirm(
-                  `Archive thread "${optimisticTitles.get(threadKey)?.title ?? thread.title}"?`,
-                ),
+                api.dialogs.confirm(`Archive thread "${thread.title}"?`),
               );
               if (confirmed._tag === "Failure" || !confirmed.value) return;
             }
@@ -3272,7 +3243,7 @@ export default function Sidebar() {
               const confirmed = await settlePromise(() =>
                 api.dialogs.confirm(
                   [
-                    `Delete thread "${optimisticTitles.get(threadKey)?.title ?? thread.title}"?`,
+                    `Delete thread "${thread.title}"?`,
                     "This permanently clears conversation history for this thread.",
                   ].join("\n"),
                   { variant: "destructive" },
@@ -3315,7 +3286,6 @@ export default function Sidebar() {
       deleteThread,
       handleMultiSelectContextMenu,
       markThreadUnread,
-      optimisticTitles,
       projectCwdByKey,
       serverConfigs,
       startThreadRename,
@@ -3724,13 +3694,6 @@ export default function Sidebar() {
                     // not from the sidebar second-guessing what still matters.
                     const isCard = section === "active" || section === "pinned";
                     const rowVariant = isCard ? "card" : "slim";
-                    // Optimistic renames shadow the stored title until the
-                    // coalesced stream catches up (see optimisticTitles).
-                    const optimisticTitle = optimisticTitles.get(threadKey)?.title;
-                    const rowThread =
-                      optimisticTitle === undefined || optimisticTitle === thread.title
-                        ? thread
-                        : { ...thread, title: optimisticTitle };
                     return (
                       <SidebarThreadRow
                         // Keyed per variant on purpose: when a thread settles,
@@ -3740,7 +3703,7 @@ export default function Sidebar() {
                         // are translucent, so a crossing row reads as text
                         // painted over text).
                         key={`${threadKey}:${rowVariant}`}
-                        thread={rowThread}
+                        thread={thread}
                         variant={rowVariant}
                         // Snoozed rows wake; settled rows un-settle (explicit
                         // settles clear the override, auto-settled rows get

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2391,25 +2391,34 @@ export default function Sidebar() {
     (threadRef: ScopedThreadRef, title: string, originalTitle: string) => {
       void (async () => {
         const trimmed = title.trim();
-        setRenamingThreadKey(null);
         if (trimmed.length === 0) {
+          setRenamingThreadKey(null);
           toastManager.add({ type: "warning", title: "Thread title cannot be empty" });
           return;
         }
-        if (trimmed === originalTitle) return;
-        const result = await updateThreadMetadata({
-          environmentId: threadRef.environmentId,
-          input: { threadId: threadRef.threadId, title: trimmed },
-        });
-        if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
-          const error = squashAtomCommandFailure(result);
-          toastManager.add(
-            stackedThreadToast({
-              type: "error",
-              title: "Failed to rename thread",
-              description: error instanceof Error ? error.message : "An error occurred.",
-            }),
-          );
+        if (trimmed === originalTitle) {
+          setRenamingThreadKey(null);
+          return;
+        }
+        // Keep the row's editor showing the typed title until the server
+        // confirms; closing early flashes the stale store title.
+        try {
+          const result = await updateThreadMetadata({
+            environmentId: threadRef.environmentId,
+            input: { threadId: threadRef.threadId, title: trimmed },
+          });
+          if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+            const error = squashAtomCommandFailure(result);
+            toastManager.add(
+              stackedThreadToast({
+                type: "error",
+                title: "Failed to rename thread",
+                description: error instanceof Error ? error.message : "An error occurred.",
+              }),
+            );
+          }
+        } finally {
+          setRenamingThreadKey(null);
         }
       })();
     },

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2385,16 +2385,26 @@ export default function Sidebar() {
   // Titles committed to the server but not yet reflected by the thread shells
   // (the store learns about renames via a coalesced server-side stream).
   // Shown in place of the stored title so confirming a rename never flashes
-  // the old one; dropped once the store catches up, or reverted if the
-  // server rejected the rename.
-  const [optimisticTitles, setOptimisticTitles] = useState<ReadonlyMap<string, string>>(
-    () => new Map(),
-  );
+  // the old one. `previousTitle` is what the store showed when the override
+  // was set: once the store moves off it (our title landed, or a newer
+  // title change like regeneration won), the override retires.
+  const [optimisticTitles, setOptimisticTitles] = useState<
+    ReadonlyMap<string, { title: string; previousTitle: string }>
+  >(() => new Map());
   const startThreadRename = useCallback((threadRef: ScopedThreadRef, title: string) => {
     setRenamingThreadKey(scopedThreadKey(threadRef));
     setRenamingTitle(title);
   }, []);
   const cancelThreadRename = useCallback(() => setRenamingThreadKey(null), []);
+  // Stored title for every known thread, used to baseline and retire
+  // optimistic rename titles once the coalesced stream catches up.
+  const threadTitlesByKey = useMemo(() => {
+    const titles = new Map<string, string>();
+    for (const thread of threads) {
+      titles.set(scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)), thread.title);
+    }
+    return titles;
+  }, [threads]);
   const commitThreadRename = useCallback(
     (threadRef: ScopedThreadRef, title: string, originalTitle: string) => {
       const trimmed = title.trim();
@@ -2412,14 +2422,19 @@ export default function Sidebar() {
       // waiting for the store would flash the old title for a beat. A
       // rejection reverts to the stored title.
       setRenamingThreadKey(null);
-      setOptimisticTitles((current) => new Map(current).set(threadKey, trimmed));
+      // Baseline against the store's current title: the override retires as
+      // soon as the store moves off it, whichever title change wins.
+      const previousTitle = threadTitlesByKey.get(threadKey) ?? originalTitle;
+      setOptimisticTitles((current) =>
+        new Map(current).set(threadKey, { title: trimmed, previousTitle }),
+      );
       void updateThreadMetadata({
         environmentId: threadRef.environmentId,
         input: { threadId: threadRef.threadId, title: trimmed },
       }).then((result) => {
         if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
           setOptimisticTitles((current) => {
-            if (current.get(threadKey) !== trimmed) return current;
+            if (current.get(threadKey)?.title !== trimmed) return current;
             const next = new Map(current);
             next.delete(threadKey);
             return next;
@@ -2435,24 +2450,15 @@ export default function Sidebar() {
         }
       });
     },
-    [updateThreadMetadata],
+    [threadTitlesByKey, updateThreadMetadata],
   );
-  // Stored title for every known thread, used to retire optimistic rename
-  // titles once the coalesced stream catches up.
-  const threadTitlesByKey = useMemo(() => {
-    const titles = new Map<string, string>();
-    for (const thread of threads) {
-      titles.set(scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)), thread.title);
-    }
-    return titles;
-  }, [threads]);
   useEffect(() => {
     if (optimisticTitles.size === 0) return;
     setOptimisticTitles((current) => {
-      let next: Map<string, string> | null = null;
-      for (const [key, title] of current) {
+      let next: Map<string, { title: string; previousTitle: string }> | null = null;
+      for (const [key, entry] of current) {
         const storedTitle = threadTitlesByKey.get(key);
-        if (storedTitle === undefined || storedTitle === title) {
+        if (storedTitle === undefined || storedTitle !== entry.previousTitle) {
           next ??= new Map(current);
           next.delete(key);
         }
@@ -3173,7 +3179,7 @@ export default function Sidebar() {
             attemptUnpin(threadRef);
             return;
           case "rename":
-            startThreadRename(threadRef, optimisticTitles.get(threadKey) ?? thread.title);
+            startThreadRename(threadRef, optimisticTitles.get(threadKey)?.title ?? thread.title);
             return;
           case "regenerate-title": {
             if (isRegeneratingTitle) return;
@@ -3704,7 +3710,7 @@ export default function Sidebar() {
                     const rowVariant = isCard ? "card" : "slim";
                     // Optimistic renames shadow the stored title until the
                     // coalesced stream catches up (see optimisticTitles).
-                    const optimisticTitle = optimisticTitles.get(threadKey);
+                    const optimisticTitle = optimisticTitles.get(threadKey)?.title;
                     const rowThread =
                       optimisticTitle === undefined || optimisticTitle === thread.title
                         ? thread

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1022,6 +1022,9 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   );
   const handleRenameBlur = useCallback(() => {
     if (!renameCommittedRef.current) {
+      // Mark committed so the blur-commit path cannot resubmit if the editor
+      // is refocused while it waits for the store to catch up.
+      renameCommittedRef.current = true;
       onCommitRename(threadRef, renamingTitle, thread.title);
     }
   }, [onCommitRename, renamingTitle, thread.title, threadRef]);
@@ -2429,18 +2432,21 @@ export default function Sidebar() {
         environmentId: threadRef.environmentId,
         input: { threadId: threadRef.threadId, title: trimmed },
       }).then((result) => {
-        if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
-          setAwaitingRename((current) => (current?.threadKey === threadKey ? null : current));
-          setRenamingThreadKey((current) => (current === threadKey ? null : current));
-          const error = squashAtomCommandFailure(result);
-          toastManager.add(
-            stackedThreadToast({
-              type: "error",
-              title: "Failed to rename thread",
-              description: error instanceof Error ? error.message : "An error occurred.",
-            }),
-          );
-        }
+        if (result._tag !== "Failure") return;
+        // Close on every failure, including interrupts: an interrupted
+        // command never ran, so the store will never move off baseline and
+        // only this teardown releases the row's editor.
+        setAwaitingRename((current) => (current?.threadKey === threadKey ? null : current));
+        setRenamingThreadKey((current) => (current === threadKey ? null : current));
+        if (isAtomCommandInterrupted(result)) return;
+        const error = squashAtomCommandFailure(result);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Failed to rename thread",
+            description: error instanceof Error ? error.message : "An error occurred.",
+          }),
+        );
       });
     },
     [updateThreadMetadata],

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2382,7 +2382,11 @@ export default function Sidebar() {
 
   const [renamingThreadKey, setRenamingThreadKey] = useState<string | null>(null);
   const [renamingTitle, setRenamingTitle] = useState("");
+  // Bumped whenever a new rename session or submission starts, so a settled
+  // response can tell it is stale and leave a newer editor alone.
+  const renameEpochRef = useRef(0);
   const startThreadRename = useCallback((threadRef: ScopedThreadRef, title: string) => {
+    renameEpochRef.current += 1;
     setRenamingThreadKey(scopedThreadKey(threadRef));
     setRenamingTitle(title);
   }, []);
@@ -2401,7 +2405,10 @@ export default function Sidebar() {
           return;
         }
         // Keep the row's editor showing the typed title until the server
-        // confirms; closing early flashes the stale store title.
+        // confirms; closing early flashes the stale store title. Only the
+        // latest submission may close it, so a slower earlier response can
+        // never clobber a newer rename.
+        const epoch = ++renameEpochRef.current;
         try {
           const result = await updateThreadMetadata({
             environmentId: threadRef.environmentId,
@@ -2418,7 +2425,7 @@ export default function Sidebar() {
             );
           }
         } finally {
-          setRenamingThreadKey(null);
+          if (renameEpochRef.current === epoch) setRenamingThreadKey(null);
         }
       })();
     },

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2466,11 +2466,13 @@ export default function Sidebar() {
       let next: Map<string, { title: string; chain: readonly string[] }> | null = null;
       for (const [key, entry] of current) {
         const storedTitle = threadTitlesByKey.get(key);
-        if (
-          storedTitle === undefined ||
-          storedTitle === entry.title ||
-          !entry.chain.includes(storedTitle)
-        ) {
+        // Retire once the store reaches the final link or leaves the chain.
+        // Matching an EARLIER link keeps the override up so intermediate
+        // frames never flash. A rename landing back on an earlier title
+        // leaves a visually inert entry until the next title change, which
+        // is fine: it renders exactly what the store renders.
+        const idx = storedTitle === undefined ? -1 : entry.chain.indexOf(storedTitle);
+        if (idx === -1 || idx === entry.chain.length - 1) {
           next ??= new Map(current);
           next.delete(key);
         }
@@ -3238,7 +3240,9 @@ export default function Sidebar() {
           case "archive": {
             if (confirmThreadArchive) {
               const confirmed = await settlePromise(() =>
-                api.dialogs.confirm(`Archive thread "${thread.title}"?`),
+                api.dialogs.confirm(
+                  `Archive thread "${optimisticTitles.get(threadKey)?.title ?? thread.title}"?`,
+                ),
               );
               if (confirmed._tag === "Failure" || !confirmed.value) return;
             }
@@ -3268,7 +3272,7 @@ export default function Sidebar() {
               const confirmed = await settlePromise(() =>
                 api.dialogs.confirm(
                   [
-                    `Delete thread "${thread.title}"?`,
+                    `Delete thread "${optimisticTitles.get(threadKey)?.title ?? thread.title}"?`,
                     "This permanently clears conversation history for this thread.",
                   ].join("\n"),
                   { variant: "destructive" },

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -571,6 +571,18 @@ interface SidebarDraftRowData {
   composer: ComposerThreadDraftState;
 }
 
+// Committed renames shadow the stored title until the coalesced stream
+// catches up (see optimisticTitles). Shared by list rows and search so a
+// just-renamed thread reads the same everywhere.
+function withOptimisticTitle<T extends EnvironmentThreadShell>(
+  thread: T,
+  entry: { readonly title: string } | undefined,
+): T {
+  return entry === undefined || entry.title === thread.title
+    ? thread
+    : { ...thread, title: entry.title };
+}
+
 // Draft sessions with user content, surfaced above the pinned block so an
 // interrupted "new thread" stays one click away. Self-contained (own store
 // subscription + closing divider) so per-keystroke composer updates
@@ -2108,9 +2120,25 @@ export default function Sidebar() {
   const [threadSearchQuery, setThreadSearchQuery] = useState("");
   const [activeSearchResultIndex, setActiveSearchResultIndex] = useState(0);
   const isSearchingThreads = threadSearchQuery.trim().length > 0;
+  // Titles committed but not yet reflected by the thread shells (the store
+  // learns about renames via a coalesced server-side stream). Shown in place
+  // of the stored title so confirming a rename never flashes the old one.
+  // An entry retires as soon as the store moves off its pre-rename value:
+  // either this rename landed or a racing change like regeneration won -
+  // either way that is the visible truth. A second rename before then
+  // overwrites the entry on the same baseline.
+  const [optimisticTitles, setOptimisticTitles] = useState<
+    ReadonlyMap<string, { title: string; baseline: string }>
+  >(() => new Map());
   const searchableThreads = useMemo(
-    () => [...pinnedThreads, ...activeThreads, ...snoozedThreads, ...settledThreads],
-    [activeThreads, pinnedThreads, settledThreads, snoozedThreads],
+    () =>
+      [...pinnedThreads, ...activeThreads, ...snoozedThreads, ...settledThreads].map((thread) =>
+        withOptimisticTitle(
+          thread,
+          optimisticTitles.get(scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))),
+        ),
+      ),
+    [activeThreads, pinnedThreads, settledThreads, snoozedThreads, optimisticTitles],
   );
   const threadSearchResults = useMemo(
     () => searchSidebarThreadsByTitle(searchableThreads, threadSearchQuery),
@@ -2385,16 +2413,6 @@ export default function Sidebar() {
 
   const [renamingThreadKey, setRenamingThreadKey] = useState<string | null>(null);
   const [renamingTitle, setRenamingTitle] = useState("");
-  // Titles committed but not yet reflected by the thread shells (the store
-  // learns about renames via a coalesced server-side stream). Shown in place
-  // of the stored title so confirming a rename never flashes the old one.
-  // An entry retires as soon as the store moves off its pre-rename value:
-  // either this rename landed or a racing change like regeneration won -
-  // either way that is the visible truth. A second rename before then
-  // overwrites the entry on the same baseline.
-  const [optimisticTitles, setOptimisticTitles] = useState<
-    ReadonlyMap<string, { title: string; baseline: string }>
-  >(() => new Map());
   const startThreadRename = useCallback((threadRef: ScopedThreadRef, title: string) => {
     setRenamingThreadKey(scopedThreadKey(threadRef));
     setRenamingTitle(title);
@@ -2426,9 +2444,14 @@ export default function Sidebar() {
       // closing without it would flash the stored title for a beat while the
       // store catches up. A rejection reverts to it.
       setRenamingThreadKey(null);
-      setOptimisticTitles((current) =>
-        new Map(current).set(threadKey, { title: trimmed, baseline: originalTitle }),
-      );
+      setOptimisticTitles((current) => {
+        // originalTitle is the displayed title, which on a quick second
+        // rename is still the first override; anchor to its baseline (the
+        // last stored value) so this entry survives until the store actually
+        // moves instead of retiring on the very next frame.
+        const baseline = current.get(threadKey)?.baseline ?? originalTitle;
+        return new Map(current).set(threadKey, { title: trimmed, baseline });
+      });
       void updateThreadMetadata({
         environmentId: threadRef.environmentId,
         input: { threadId: threadRef.threadId, title: trimmed },
@@ -3716,11 +3739,7 @@ export default function Sidebar() {
                     const rowVariant = isCard ? "card" : "slim";
                     // Committed renames shadow the stored title until the
                     // coalesced stream catches up (see optimisticTitles).
-                    const optimisticTitle = optimisticTitles.get(threadKey)?.title;
-                    const rowThread =
-                      optimisticTitle === undefined || optimisticTitle === thread.title
-                        ? thread
-                        : { ...thread, title: optimisticTitle };
+                    const rowThread = withOptimisticTitle(thread, optimisticTitles.get(threadKey));
                     return (
                       <SidebarThreadRow
                         // Keyed per variant on purpose: when a thread settles,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -110,10 +110,6 @@ import { useProjects, useThreadShells } from "../state/entities";
 import { environmentServerConfigsAtom, primaryServerKeybindingsAtom } from "../state/server";
 import { vcsEnvironment } from "../state/vcs";
 import { appAtomRegistry } from "../rpc/atomRegistry";
-import {
-  nextOptimisticThreadTitles,
-  withoutOptimisticThreadTitle,
-} from "@t3tools/client-runtime/state/threadShell";
 import { environmentThreadShells, threadEnvironment } from "../state/threads";
 import { useEnvironmentQuery } from "../state/query";
 import { useAtomCommand } from "../state/use-atom-command";
@@ -2409,28 +2405,18 @@ export default function Sidebar() {
       }
       const threadKey = scopedThreadKey(threadRef);
       setRenamingThreadKey(null);
-      appAtomRegistry.set(
-        environmentThreadShells.optimisticTitlesAtom,
-        nextOptimisticThreadTitles(
-          appAtomRegistry.get(environmentThreadShells.optimisticTitlesAtom),
-          threadKey,
-          trimmed,
-          originalTitle,
-        ),
+      environmentThreadShells.setOptimisticThreadTitle(
+        appAtomRegistry,
+        threadKey,
+        trimmed,
+        originalTitle,
       );
       void updateThreadMetadata({
         environmentId: threadRef.environmentId,
         input: { threadId: threadRef.threadId, title: trimmed },
       }).then((result) => {
         if (result._tag !== "Failure") return;
-        appAtomRegistry.set(
-          environmentThreadShells.optimisticTitlesAtom,
-          withoutOptimisticThreadTitle(
-            appAtomRegistry.get(environmentThreadShells.optimisticTitlesAtom),
-            threadKey,
-            trimmed,
-          ),
-        );
+        environmentThreadShells.clearOptimisticThreadTitle(appAtomRegistry, threadKey, trimmed);
         if (isAtomCommandInterrupted(result)) return;
         const error = squashAtomCommandFailure(result);
         toastManager.add(

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2385,11 +2385,13 @@ export default function Sidebar() {
   // Titles committed to the server but not yet reflected by the thread shells
   // (the store learns about renames via a coalesced server-side stream).
   // Shown in place of the stored title so confirming a rename never flashes
-  // the old one. `previousTitle` is what the store showed when the override
-  // was set: once the store moves off it (our title landed, or a newer
-  // title change like regeneration won), the override retires.
+  // the old one. `chain` is every title this override chain has committed,
+  // oldest first: the store may deliver them one at a time, so the override
+  // stays up while the store walks the chain and retires when the store
+  // reaches the latest title or lands on anything else (a newer title
+  // change like regeneration won).
   const [optimisticTitles, setOptimisticTitles] = useState<
-    ReadonlyMap<string, { title: string; previousTitle: string }>
+    ReadonlyMap<string, { title: string; chain: readonly string[] }>
   >(() => new Map());
   const startThreadRename = useCallback((threadRef: ScopedThreadRef, title: string) => {
     setRenamingThreadKey(scopedThreadKey(threadRef));
@@ -2422,12 +2424,18 @@ export default function Sidebar() {
       // waiting for the store would flash the old title for a beat. A
       // rejection reverts to the stored title.
       setRenamingThreadKey(null);
-      // Baseline against the store's current title: the override retires as
-      // soon as the store moves off it, whichever title change wins.
-      const previousTitle = threadTitlesByKey.get(threadKey) ?? originalTitle;
-      setOptimisticTitles((current) =>
-        new Map(current).set(threadKey, { title: trimmed, previousTitle }),
-      );
+      // Extend any override already in flight so the store can walk through
+      // the intermediate titles without flashing them.
+      setOptimisticTitles((current) => {
+        const existing = current.get(threadKey);
+        const base = existing
+          ? existing.chain
+          : [threadTitlesByKey.get(threadKey) ?? originalTitle];
+        return new Map(current).set(threadKey, {
+          title: trimmed,
+          chain: [...base, trimmed],
+        });
+      });
       void updateThreadMetadata({
         environmentId: threadRef.environmentId,
         input: { threadId: threadRef.threadId, title: trimmed },
@@ -2455,10 +2463,14 @@ export default function Sidebar() {
   useEffect(() => {
     if (optimisticTitles.size === 0) return;
     setOptimisticTitles((current) => {
-      let next: Map<string, { title: string; previousTitle: string }> | null = null;
+      let next: Map<string, { title: string; chain: readonly string[] }> | null = null;
       for (const [key, entry] of current) {
         const storedTitle = threadTitlesByKey.get(key);
-        if (storedTitle === undefined || storedTitle !== entry.previousTitle) {
+        if (
+          storedTitle === undefined ||
+          storedTitle === entry.title ||
+          !entry.chain.includes(storedTitle)
+        ) {
           next ??= new Map(current);
           next.delete(key);
         }

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -109,7 +109,12 @@ import { useEnvironments, usePrimaryEnvironmentId } from "../state/environments"
 import { useProjects, useThreadShells } from "../state/entities";
 import { environmentServerConfigsAtom, primaryServerKeybindingsAtom } from "../state/server";
 import { vcsEnvironment } from "../state/vcs";
-import { threadEnvironment } from "../state/threads";
+import { appAtomRegistry } from "../rpc/atomRegistry";
+import {
+  nextOptimisticThreadTitles,
+  withoutOptimisticThreadTitle,
+} from "@t3tools/client-runtime/state/threadShell";
+import { environmentThreadShells, threadEnvironment } from "../state/threads";
 import { useEnvironmentQuery } from "../state/query";
 import { useAtomCommand } from "../state/use-atom-command";
 import {
@@ -569,18 +574,6 @@ interface SidebarDraftRowData {
   draftId: DraftId;
   session: DraftSessionState;
   composer: ComposerThreadDraftState;
-}
-
-// Committed renames shadow the stored title until the coalesced stream
-// catches up (see optimisticTitles). Shared by list rows and search so a
-// just-renamed thread reads the same everywhere.
-function withOptimisticTitle<T extends EnvironmentThreadShell>(
-  thread: T,
-  entry: { readonly title: string } | undefined,
-): T {
-  return entry === undefined || entry.title === thread.title
-    ? thread
-    : { ...thread, title: entry.title };
 }
 
 // Draft sessions with user content, surfaced above the pinned block so an
@@ -2120,25 +2113,9 @@ export default function Sidebar() {
   const [threadSearchQuery, setThreadSearchQuery] = useState("");
   const [activeSearchResultIndex, setActiveSearchResultIndex] = useState(0);
   const isSearchingThreads = threadSearchQuery.trim().length > 0;
-  // Titles committed but not yet reflected by the thread shells (the store
-  // learns about renames via a coalesced server-side stream). Shown in place
-  // of the stored title so confirming a rename never flashes the old one.
-  // An entry retires as soon as the store moves off its pre-rename value:
-  // either this rename landed or a racing change like regeneration won -
-  // either way that is the visible truth. A second rename before then
-  // overwrites the entry on the same baseline.
-  const [optimisticTitles, setOptimisticTitles] = useState<
-    ReadonlyMap<string, { title: string; baseline: string }>
-  >(() => new Map());
   const searchableThreads = useMemo(
-    () =>
-      [...pinnedThreads, ...activeThreads, ...snoozedThreads, ...settledThreads].map((thread) =>
-        withOptimisticTitle(
-          thread,
-          optimisticTitles.get(scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))),
-        ),
-      ),
-    [activeThreads, pinnedThreads, settledThreads, snoozedThreads, optimisticTitles],
+    () => [...pinnedThreads, ...activeThreads, ...snoozedThreads, ...settledThreads],
+    [activeThreads, pinnedThreads, settledThreads, snoozedThreads],
   );
   const threadSearchResults = useMemo(
     () => searchSidebarThreadsByTitle(searchableThreads, threadSearchQuery),
@@ -2418,15 +2395,6 @@ export default function Sidebar() {
     setRenamingTitle(title);
   }, []);
   const cancelThreadRename = useCallback(() => setRenamingThreadKey(null), []);
-  // Stored title for every known thread, used to tell when the coalesced
-  // stream has caught up with a committed rename.
-  const threadTitlesByKey = useMemo(() => {
-    const titles = new Map<string, string>();
-    for (const thread of threads) {
-      titles.set(scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)), thread.title);
-    }
-    return titles;
-  }, [threads]);
   const commitThreadRename = useCallback(
     (threadRef: ScopedThreadRef, title: string, originalTitle: string) => {
       const trimmed = title.trim();
@@ -2440,32 +2408,29 @@ export default function Sidebar() {
         return;
       }
       const threadKey = scopedThreadKey(threadRef);
-      // Close immediately and keep showing the committed title via the map;
-      // closing without it would flash the stored title for a beat while the
-      // store catches up. A rejection reverts to it.
       setRenamingThreadKey(null);
-      setOptimisticTitles((current) => {
-        // originalTitle is the displayed title, which on a quick second
-        // rename is still the first override; anchor to its baseline (the
-        // last stored value) so this entry survives until the store actually
-        // moves instead of retiring on the very next frame.
-        const baseline = current.get(threadKey)?.baseline ?? originalTitle;
-        return new Map(current).set(threadKey, { title: trimmed, baseline });
-      });
+      appAtomRegistry.set(
+        environmentThreadShells.optimisticTitlesAtom,
+        nextOptimisticThreadTitles(
+          appAtomRegistry.get(environmentThreadShells.optimisticTitlesAtom),
+          threadKey,
+          trimmed,
+          originalTitle,
+        ),
+      );
       void updateThreadMetadata({
         environmentId: threadRef.environmentId,
         input: { threadId: threadRef.threadId, title: trimmed },
       }).then((result) => {
         if (result._tag !== "Failure") return;
-        // Drop the override on every failure, including interrupts: an
-        // interrupted command never ran, so the store will never move off
-        // baseline and only this teardown retires the shown title.
-        setOptimisticTitles((current) => {
-          if (current.get(threadKey)?.title !== trimmed) return current;
-          const next = new Map(current);
-          next.delete(threadKey);
-          return next;
-        });
+        appAtomRegistry.set(
+          environmentThreadShells.optimisticTitlesAtom,
+          withoutOptimisticThreadTitle(
+            appAtomRegistry.get(environmentThreadShells.optimisticTitlesAtom),
+            threadKey,
+            trimmed,
+          ),
+        );
         if (isAtomCommandInterrupted(result)) return;
         const error = squashAtomCommandFailure(result);
         toastManager.add(
@@ -2479,20 +2444,6 @@ export default function Sidebar() {
     },
     [updateThreadMetadata],
   );
-  useEffect(() => {
-    if (optimisticTitles.size === 0) return;
-    setOptimisticTitles((current) => {
-      let next: Map<string, { title: string; baseline: string }> | null = null;
-      for (const [key, entry] of current) {
-        const storedTitle = threadTitlesByKey.get(key);
-        if (storedTitle === undefined || storedTitle !== entry.baseline) {
-          next ??= new Map(current);
-          next.delete(key);
-        }
-      }
-      return next ?? current;
-    });
-  }, [optimisticTitles, threadTitlesByKey]);
 
   const handleThreadClick = useCallback(
     (event: ReactMouseEvent, threadRef: ScopedThreadRef) => {
@@ -3206,7 +3157,7 @@ export default function Sidebar() {
             attemptUnpin(threadRef);
             return;
           case "rename":
-            startThreadRename(threadRef, optimisticTitles.get(threadKey)?.title ?? thread.title);
+            startThreadRename(threadRef, thread.title);
             return;
           case "regenerate-title": {
             if (isRegeneratingTitle) return;
@@ -3253,9 +3204,7 @@ export default function Sidebar() {
           case "archive": {
             if (confirmThreadArchive) {
               const confirmed = await settlePromise(() =>
-                api.dialogs.confirm(
-                  `Archive thread "${optimisticTitles.get(threadKey)?.title ?? thread.title}"?`,
-                ),
+                api.dialogs.confirm(`Archive thread "${thread.title}"?`),
               );
               if (confirmed._tag === "Failure" || !confirmed.value) return;
             }
@@ -3285,7 +3234,7 @@ export default function Sidebar() {
               const confirmed = await settlePromise(() =>
                 api.dialogs.confirm(
                   [
-                    `Delete thread "${optimisticTitles.get(threadKey)?.title ?? thread.title}"?`,
+                    `Delete thread "${thread.title}"?`,
                     "This permanently clears conversation history for this thread.",
                   ].join("\n"),
                   { variant: "destructive" },
@@ -3328,7 +3277,6 @@ export default function Sidebar() {
       deleteThread,
       handleMultiSelectContextMenu,
       markThreadUnread,
-      optimisticTitles,
       projectCwdByKey,
       serverConfigs,
       startThreadRename,
@@ -3737,9 +3685,7 @@ export default function Sidebar() {
                     // not from the sidebar second-guessing what still matters.
                     const isCard = section === "active" || section === "pinned";
                     const rowVariant = isCard ? "card" : "slim";
-                    // Committed renames shadow the stored title until the
-                    // coalesced stream catches up (see optimisticTitles).
-                    const rowThread = withOptimisticTitle(thread, optimisticTitles.get(threadKey));
+                    const rowThread = thread;
                     return (
                       <SidebarThreadRow
                         // Keyed per variant on purpose: when a thread settles,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2403,11 +2403,10 @@ export default function Sidebar() {
         setRenamingThreadKey(null);
         return;
       }
-      const threadKey = scopedThreadKey(threadRef);
       setRenamingThreadKey(null);
       environmentThreadShells.setOptimisticThreadTitle(
         appAtomRegistry,
-        threadKey,
+        threadRef,
         trimmed,
         originalTitle,
       );
@@ -2416,7 +2415,7 @@ export default function Sidebar() {
         input: { threadId: threadRef.threadId, title: trimmed },
       }).then((result) => {
         if (result._tag !== "Failure") return;
-        environmentThreadShells.clearOptimisticThreadTitle(appAtomRegistry, threadKey, trimmed);
+        environmentThreadShells.clearOptimisticThreadTitle(appAtomRegistry, threadRef, trimmed);
         if (isAtomCommandInterrupted(result)) return;
         const error = squashAtomCommandFailure(result);
         toastManager.add(

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -165,26 +165,33 @@ export const ChatHeader = memo(function ChatHeader({
   }, [activeThreadId, activeThreadTitle]);
   const commitRename = useCallback(
     (title: string) => {
-      setRenaming(null);
       const resolution = resolveRenameCommit({ title, originalTitle: activeThreadTitle });
       if (resolution.action === "reject-empty") {
+        setRenaming(null);
         toastManager.add({ type: "warning", title: "Thread title cannot be empty" });
         return;
       }
-      if (resolution.action === "noop") return;
+      if (resolution.action === "noop") {
+        setRenaming(null);
+        return;
+      }
+      // Keep the editor showing the typed title until the server confirms;
+      // closing early flashes the stale store title for the whole round-trip.
       void updateThreadMetadata({
         environmentId: activeThreadEnvironmentId,
         input: { threadId: activeThreadId, title: resolution.title },
-      }).then((result) => {
-        if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
-          const error = squashAtomCommandFailure(result);
-          toastManager.add({
-            type: "error",
-            title: "Failed to rename thread",
-            description: error instanceof Error ? error.message : "An error occurred.",
-          });
-        }
-      });
+      })
+        .then((result) => {
+          if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+            const error = squashAtomCommandFailure(result);
+            toastManager.add({
+              type: "error",
+              title: "Failed to rename thread",
+              description: error instanceof Error ? error.message : "An error occurred.",
+            });
+          }
+        })
+        .finally(() => setRenaming(null));
     },
     [activeThreadEnvironmentId, activeThreadId, activeThreadTitle, updateThreadMetadata],
   );

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -154,47 +154,35 @@ export const ChatHeader = memo(function ChatHeader({
   // Inline rename, keyed by thread: navigating away drops an in-progress
   // rename instead of committing stale text. Cleared on thread change (not
   // just hidden) so returning to the thread doesn't revive the old draft.
-  const [renaming, setRenaming] = useState<{ threadId: ThreadId; title: string } | null>(null);
+  // Once submitted (`awaiting`), the editor stays mounted still showing what
+  // was typed until activeThreadTitle moves off its pre-rename value: the
+  // store learns about renames via a coalesced server-side stream, so
+  // closing when the command settles would flash the old title for a beat.
+  // Whatever lands first (this rename or a racing change like regeneration)
+  // becomes the visible truth.
+  const [renaming, setRenaming] = useState<{
+    threadId: ThreadId;
+    title: string;
+    awaiting: { baseline: string } | null;
+  } | null>(null);
   if (renaming !== null && renaming.threadId !== activeThreadId) {
     setRenaming(null);
   }
   const renamingTitle = renaming?.threadId === activeThreadId ? renaming.title : null;
   const renameCommittedRef = useRef(false);
-  // Title committed to the server but not yet reflected by activeThreadTitle
-  // (the store learns about renames via a coalesced server-side stream).
-  // Shown in place of the stored title so confirming a rename never flashes
-  // the old one. `chain` is every title this override chain has committed,
-  // oldest first: the store may deliver them one at a time, so the override
-  // stays up while the store walks the chain and retires when the store
-  // reaches the latest title or lands on anything else (a newer title
-  // change like regeneration won).
-  const [pendingTitle, setPendingTitle] = useState<{
-    threadId: ThreadId;
-    title: string;
-    chain: readonly string[];
-  } | null>(null);
   useEffect(() => {
-    if (pendingTitle === null) return;
-    // Retire once the store reaches the final link or leaves the chain.
-    // Matching an EARLIER link keeps the override up so intermediate frames
-    // never flash. A rename landing back on an earlier title leaves a
-    // visually inert override until the next title change, which is fine:
-    // it renders exactly what the store renders.
-    const idx =
-      pendingTitle.threadId === activeThreadId ? pendingTitle.chain.indexOf(activeThreadTitle) : -1;
-    if (idx === -1 || idx === pendingTitle.chain.length - 1) {
-      setPendingTitle(null);
+    if (renaming?.threadId !== activeThreadId || renaming.awaiting === null) return;
+    if (activeThreadTitle !== renaming.awaiting.baseline) {
+      setRenaming(null);
     }
-  }, [pendingTitle, activeThreadId, activeThreadTitle]);
-  const displayTitle =
-    pendingTitle?.threadId === activeThreadId ? pendingTitle.title : activeThreadTitle;
+  }, [renaming, activeThreadId, activeThreadTitle]);
   const startRename = useCallback(() => {
     renameCommittedRef.current = false;
-    setRenaming({ threadId: activeThreadId, title: displayTitle });
-  }, [activeThreadId, displayTitle]);
+    setRenaming({ threadId: activeThreadId, title: activeThreadTitle, awaiting: null });
+  }, [activeThreadId, activeThreadTitle]);
   const commitRename = useCallback(
     (title: string) => {
-      const resolution = resolveRenameCommit({ title, originalTitle: displayTitle });
+      const resolution = resolveRenameCommit({ title, originalTitle: activeThreadTitle });
       if (resolution.action === "reject-empty") {
         setRenaming(null);
         toastManager.add({ type: "warning", title: "Thread title cannot be empty" });
@@ -204,31 +192,22 @@ export const ChatHeader = memo(function ChatHeader({
         setRenaming(null);
         return;
       }
-      // Close immediately and show the committed title optimistically: the
-      // store title arrives via a coalesced server stream, so waiting for it
-      // would flash the old title for a beat. A rejection reverts to it.
-      setRenaming(null);
-      // Extend any override already in flight so the store can walk through
-      // the intermediate titles without flashing them.
-      setPendingTitle((current) => {
-        const existing = current?.threadId === activeThreadId ? current : null;
-        return {
-          threadId: activeThreadId,
-          title: resolution.title,
-          chain: [...(existing ? existing.chain : [activeThreadTitle]), resolution.title],
-        };
+      // Hold the editor open showing the typed title until the store catches
+      // up; closing now would flash the stored title for a beat. A rejection
+      // closes it and reverts.
+      renameCommittedRef.current = true;
+      setRenaming({
+        threadId: activeThreadId,
+        title: resolution.title,
+        awaiting: { baseline: activeThreadTitle },
       });
       void updateThreadMetadata({
         environmentId: activeThreadEnvironmentId,
         input: { threadId: activeThreadId, title: resolution.title },
       }).then((result) => {
         if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
-          setPendingTitle((current) =>
-            current !== null &&
-            current.threadId === activeThreadId &&
-            current.title === resolution.title
-              ? null
-              : current,
+          setRenaming((current) =>
+            current?.threadId === activeThreadId && current.awaiting !== null ? null : current,
           );
           const error = squashAtomCommandFailure(result);
           toastManager.add({
@@ -239,13 +218,7 @@ export const ChatHeader = memo(function ChatHeader({
         }
       });
     },
-    [
-      activeThreadEnvironmentId,
-      activeThreadId,
-      activeThreadTitle,
-      displayTitle,
-      updateThreadMetadata,
-    ],
+    [activeThreadEnvironmentId, activeThreadId, activeThreadTitle, updateThreadMetadata],
   );
   const { openMenu } = useThreadActionMenu({
     threadRef: isServerThread ? activeThreadRef : null,
@@ -341,31 +314,31 @@ export const ChatHeader = memo(function ChatHeader({
                   <button
                     ref={titleButtonRef}
                     type="button"
-                    aria-label={`Thread actions for ${displayTitle}`}
+                    aria-label={`Thread actions for ${activeThreadTitle}`}
                     aria-haspopup="menu"
                     onClick={openMenuFromTitle}
                     className="group/thread-title inline-flex min-w-0 max-w-full cursor-pointer items-center gap-1 rounded-sm text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
                   />
                 }
               >
-                <h2 className="min-w-0 truncate">{displayTitle}</h2>
+                <h2 className="min-w-0 truncate">{activeThreadTitle}</h2>
                 <ChevronDownIcon
                   aria-hidden
                   className="size-3.5 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover/thread-title:opacity-100 group-focus-visible/thread-title:opacity-100"
                 />
               </TooltipTrigger>
-              <TooltipPopup side="top">{displayTitle}</TooltipPopup>
+              <TooltipPopup side="top">{activeThreadTitle}</TooltipPopup>
             </Tooltip>
           ) : (
             <Tooltip>
               <TooltipTrigger
                 render={
-                  <h2 aria-label={displayTitle} className="min-w-0 flex-1 truncate">
-                    {displayTitle}
+                  <h2 aria-label={activeThreadTitle} className="min-w-0 flex-1 truncate">
+                    {activeThreadTitle}
                   </h2>
                 }
               />
-              <TooltipPopup side="top">{displayTitle}</TooltipPopup>
+              <TooltipPopup side="top">{activeThreadTitle}</TooltipPopup>
             </Tooltip>
           )}
         </WorkspaceBreadcrumbItem>

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -15,6 +15,7 @@ import { ChevronDownIcon } from "lucide-react";
 import {
   memo,
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -159,17 +160,29 @@ export const ChatHeader = memo(function ChatHeader({
   }
   const renamingTitle = renaming?.threadId === activeThreadId ? renaming.title : null;
   const renameCommittedRef = useRef(false);
-  // Bumped whenever a new rename session or submission starts, so a settled
-  // response can tell it is stale and leave a newer editor alone.
-  const renameEpochRef = useRef(0);
+  // Title committed to the server but not yet reflected by activeThreadTitle
+  // (the store learns about renames via a coalesced server-side stream).
+  // Shown in place of the stored title so confirming a rename never flashes
+  // the old one; dropped once the store catches up, or reverted if the
+  // server rejected the rename.
+  const [pendingTitle, setPendingTitle] = useState<{ threadId: ThreadId; title: string } | null>(
+    null,
+  );
+  useEffect(() => {
+    if (pendingTitle === null) return;
+    if (pendingTitle.threadId !== activeThreadId || activeThreadTitle === pendingTitle.title) {
+      setPendingTitle(null);
+    }
+  }, [pendingTitle, activeThreadId, activeThreadTitle]);
+  const displayTitle =
+    pendingTitle?.threadId === activeThreadId ? pendingTitle.title : activeThreadTitle;
   const startRename = useCallback(() => {
-    renameEpochRef.current += 1;
     renameCommittedRef.current = false;
-    setRenaming({ threadId: activeThreadId, title: activeThreadTitle });
-  }, [activeThreadId, activeThreadTitle]);
+    setRenaming({ threadId: activeThreadId, title: displayTitle });
+  }, [activeThreadId, displayTitle]);
   const commitRename = useCallback(
     (title: string) => {
-      const resolution = resolveRenameCommit({ title, originalTitle: activeThreadTitle });
+      const resolution = resolveRenameCommit({ title, originalTitle: displayTitle });
       if (resolution.action === "reject-empty") {
         setRenaming(null);
         toastManager.add({ type: "warning", title: "Thread title cannot be empty" });
@@ -179,28 +192,33 @@ export const ChatHeader = memo(function ChatHeader({
         setRenaming(null);
         return;
       }
-      // Keep the editor showing the typed title until the server confirms;
-      // closing early flashes the stale store title for the whole round-trip.
-      const epoch = ++renameEpochRef.current;
+      // Close immediately and show the committed title optimistically: the
+      // store title arrives via a coalesced server stream, so waiting for it
+      // would flash the old title for a beat. A rejection reverts to it.
+      setRenaming(null);
+      setPendingTitle({ threadId: activeThreadId, title: resolution.title });
       void updateThreadMetadata({
         environmentId: activeThreadEnvironmentId,
         input: { threadId: activeThreadId, title: resolution.title },
-      })
-        .then((result) => {
-          if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
-            const error = squashAtomCommandFailure(result);
-            toastManager.add({
-              type: "error",
-              title: "Failed to rename thread",
-              description: error instanceof Error ? error.message : "An error occurred.",
-            });
-          }
-        })
-        .finally(() => {
-          if (renameEpochRef.current === epoch) setRenaming(null);
-        });
+      }).then((result) => {
+        if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+          setPendingTitle((current) =>
+            current !== null &&
+            current.threadId === activeThreadId &&
+            current.title === resolution.title
+              ? null
+              : current,
+          );
+          const error = squashAtomCommandFailure(result);
+          toastManager.add({
+            type: "error",
+            title: "Failed to rename thread",
+            description: error instanceof Error ? error.message : "An error occurred.",
+          });
+        }
+      });
     },
-    [activeThreadEnvironmentId, activeThreadId, activeThreadTitle, updateThreadMetadata],
+    [activeThreadEnvironmentId, activeThreadId, displayTitle, updateThreadMetadata],
   );
   const { openMenu } = useThreadActionMenu({
     threadRef: isServerThread ? activeThreadRef : null,
@@ -296,31 +314,31 @@ export const ChatHeader = memo(function ChatHeader({
                   <button
                     ref={titleButtonRef}
                     type="button"
-                    aria-label={`Thread actions for ${activeThreadTitle}`}
+                    aria-label={`Thread actions for ${displayTitle}`}
                     aria-haspopup="menu"
                     onClick={openMenuFromTitle}
                     className="group/thread-title inline-flex min-w-0 max-w-full cursor-pointer items-center gap-1 rounded-sm text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
                   />
                 }
               >
-                <h2 className="min-w-0 truncate">{activeThreadTitle}</h2>
+                <h2 className="min-w-0 truncate">{displayTitle}</h2>
                 <ChevronDownIcon
                   aria-hidden
                   className="size-3.5 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover/thread-title:opacity-100 group-focus-visible/thread-title:opacity-100"
                 />
               </TooltipTrigger>
-              <TooltipPopup side="top">{activeThreadTitle}</TooltipPopup>
+              <TooltipPopup side="top">{displayTitle}</TooltipPopup>
             </Tooltip>
           ) : (
             <Tooltip>
               <TooltipTrigger
                 render={
-                  <h2 aria-label={activeThreadTitle} className="min-w-0 flex-1 truncate">
-                    {activeThreadTitle}
+                  <h2 aria-label={displayTitle} className="min-w-0 flex-1 truncate">
+                    {displayTitle}
                   </h2>
                 }
               />
-              <TooltipPopup side="top">{activeThreadTitle}</TooltipPopup>
+              <TooltipPopup side="top">{displayTitle}</TooltipPopup>
             </Tooltip>
           )}
         </WorkspaceBreadcrumbItem>

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -244,6 +244,7 @@ export const ChatHeader = memo(function ChatHeader({
     projectCwd: activeProjectCwd,
     changeRequest,
     onStartRename: startRename,
+    titleOverride: displayTitle,
   });
   const titleButtonRef = useRef<HTMLButtonElement | null>(null);
   const openMenuFromTitle = useCallback(() => {

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -159,7 +159,11 @@ export const ChatHeader = memo(function ChatHeader({
   }
   const renamingTitle = renaming?.threadId === activeThreadId ? renaming.title : null;
   const renameCommittedRef = useRef(false);
+  // Bumped whenever a new rename session or submission starts, so a settled
+  // response can tell it is stale and leave a newer editor alone.
+  const renameEpochRef = useRef(0);
   const startRename = useCallback(() => {
+    renameEpochRef.current += 1;
     renameCommittedRef.current = false;
     setRenaming({ threadId: activeThreadId, title: activeThreadTitle });
   }, [activeThreadId, activeThreadTitle]);
@@ -177,6 +181,7 @@ export const ChatHeader = memo(function ChatHeader({
       }
       // Keep the editor showing the typed title until the server confirms;
       // closing early flashes the stale store title for the whole round-trip.
+      const epoch = ++renameEpochRef.current;
       void updateThreadMetadata({
         environmentId: activeThreadEnvironmentId,
         input: { threadId: activeThreadId, title: resolution.title },
@@ -191,7 +196,9 @@ export const ChatHeader = memo(function ChatHeader({
             });
           }
         })
-        .finally(() => setRenaming(null));
+        .finally(() => {
+          if (renameEpochRef.current === epoch) setRenaming(null);
+        });
     },
     [activeThreadEnvironmentId, activeThreadId, activeThreadTitle, updateThreadMetadata],
   );

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -175,11 +175,14 @@ export const ChatHeader = memo(function ChatHeader({
   } | null>(null);
   useEffect(() => {
     if (pendingTitle === null) return;
-    if (
-      pendingTitle.threadId !== activeThreadId ||
-      activeThreadTitle === pendingTitle.title ||
-      !pendingTitle.chain.includes(activeThreadTitle)
-    ) {
+    // Retire once the store reaches the final link or leaves the chain.
+    // Matching an EARLIER link keeps the override up so intermediate frames
+    // never flash. A rename landing back on an earlier title leaves a
+    // visually inert override until the next title change, which is fine:
+    // it renders exactly what the store renders.
+    const idx =
+      pendingTitle.threadId === activeThreadId ? pendingTitle.chain.indexOf(activeThreadTitle) : -1;
+    if (idx === -1 || idx === pendingTitle.chain.length - 1) {
       setPendingTitle(null);
     }
   }, [pendingTitle, activeThreadId, activeThreadTitle]);

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -163,14 +163,20 @@ export const ChatHeader = memo(function ChatHeader({
   // Title committed to the server but not yet reflected by activeThreadTitle
   // (the store learns about renames via a coalesced server-side stream).
   // Shown in place of the stored title so confirming a rename never flashes
-  // the old one; dropped once the store catches up, or reverted if the
-  // server rejected the rename.
-  const [pendingTitle, setPendingTitle] = useState<{ threadId: ThreadId; title: string } | null>(
-    null,
-  );
+  // the old one. `previousTitle` is what the store showed when the override
+  // was set: once the store moves off it (our title landed, or a newer
+  // title change like regeneration won), the override retires.
+  const [pendingTitle, setPendingTitle] = useState<{
+    threadId: ThreadId;
+    title: string;
+    previousTitle: string;
+  } | null>(null);
   useEffect(() => {
     if (pendingTitle === null) return;
-    if (pendingTitle.threadId !== activeThreadId || activeThreadTitle === pendingTitle.title) {
+    if (
+      pendingTitle.threadId !== activeThreadId ||
+      activeThreadTitle !== pendingTitle.previousTitle
+    ) {
       setPendingTitle(null);
     }
   }, [pendingTitle, activeThreadId, activeThreadTitle]);
@@ -196,7 +202,13 @@ export const ChatHeader = memo(function ChatHeader({
       // store title arrives via a coalesced server stream, so waiting for it
       // would flash the old title for a beat. A rejection reverts to it.
       setRenaming(null);
-      setPendingTitle({ threadId: activeThreadId, title: resolution.title });
+      // Baseline against the store's current title: the override retires as
+      // soon as the store moves off it, whichever title change wins.
+      setPendingTitle({
+        threadId: activeThreadId,
+        title: resolution.title,
+        previousTitle: activeThreadTitle,
+      });
       void updateThreadMetadata({
         environmentId: activeThreadEnvironmentId,
         input: { threadId: activeThreadId, title: resolution.title },
@@ -218,7 +230,13 @@ export const ChatHeader = memo(function ChatHeader({
         }
       });
     },
-    [activeThreadEnvironmentId, activeThreadId, displayTitle, updateThreadMetadata],
+    [
+      activeThreadEnvironmentId,
+      activeThreadId,
+      activeThreadTitle,
+      displayTitle,
+      updateThreadMetadata,
+    ],
   );
   const { openMenu } = useThreadActionMenu({
     threadRef: isServerThread ? activeThreadRef : null,

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -10,10 +10,7 @@ import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
-import {
-  nextOptimisticThreadTitles,
-  withoutOptimisticThreadTitle,
-} from "@t3tools/client-runtime/state/threadShell";
+
 import type { ChangeRequestSettleSource } from "@t3tools/client-runtime/state/thread-settled";
 import { ChevronDownIcon } from "lucide-react";
 import {
@@ -192,27 +189,21 @@ export const ChatHeader = memo(function ChatHeader({
       }
       setRenaming(null);
       const threadKey = scopedThreadKey(activeThreadRef);
-      appAtomRegistry.set(
-        environmentThreadShells.optimisticTitlesAtom,
-        nextOptimisticThreadTitles(
-          appAtomRegistry.get(environmentThreadShells.optimisticTitlesAtom),
-          threadKey,
-          resolution.title,
-          activeThreadTitle,
-        ),
+      environmentThreadShells.setOptimisticThreadTitle(
+        appAtomRegistry,
+        threadKey,
+        resolution.title,
+        activeThreadTitle,
       );
       void updateThreadMetadata({
         environmentId: activeThreadEnvironmentId,
         input: { threadId: activeThreadId, title: resolution.title },
       }).then((result) => {
         if (result._tag !== "Failure") return;
-        appAtomRegistry.set(
-          environmentThreadShells.optimisticTitlesAtom,
-          withoutOptimisticThreadTitle(
-            appAtomRegistry.get(environmentThreadShells.optimisticTitlesAtom),
-            threadKey,
-            resolution.title,
-          ),
+        environmentThreadShells.clearOptimisticThreadTitle(
+          appAtomRegistry,
+          threadKey,
+          resolution.title,
         );
         if (isAtomCommandInterrupted(result)) return;
         const error = squashAtomCommandFailure(result);

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -163,19 +163,22 @@ export const ChatHeader = memo(function ChatHeader({
   // Title committed to the server but not yet reflected by activeThreadTitle
   // (the store learns about renames via a coalesced server-side stream).
   // Shown in place of the stored title so confirming a rename never flashes
-  // the old one. `previousTitle` is what the store showed when the override
-  // was set: once the store moves off it (our title landed, or a newer
-  // title change like regeneration won), the override retires.
+  // the old one. `chain` is every title this override chain has committed,
+  // oldest first: the store may deliver them one at a time, so the override
+  // stays up while the store walks the chain and retires when the store
+  // reaches the latest title or lands on anything else (a newer title
+  // change like regeneration won).
   const [pendingTitle, setPendingTitle] = useState<{
     threadId: ThreadId;
     title: string;
-    previousTitle: string;
+    chain: readonly string[];
   } | null>(null);
   useEffect(() => {
     if (pendingTitle === null) return;
     if (
       pendingTitle.threadId !== activeThreadId ||
-      activeThreadTitle !== pendingTitle.previousTitle
+      activeThreadTitle === pendingTitle.title ||
+      !pendingTitle.chain.includes(activeThreadTitle)
     ) {
       setPendingTitle(null);
     }
@@ -202,12 +205,15 @@ export const ChatHeader = memo(function ChatHeader({
       // store title arrives via a coalesced server stream, so waiting for it
       // would flash the old title for a beat. A rejection reverts to it.
       setRenaming(null);
-      // Baseline against the store's current title: the override retires as
-      // soon as the store moves off it, whichever title change wins.
-      setPendingTitle({
-        threadId: activeThreadId,
-        title: resolution.title,
-        previousTitle: activeThreadTitle,
+      // Extend any override already in flight so the store can walk through
+      // the intermediate titles without flashing them.
+      setPendingTitle((current) => {
+        const existing = current?.threadId === activeThreadId ? current : null;
+        return {
+          threadId: activeThreadId,
+          title: resolution.title,
+          chain: [...(existing ? existing.chain : [activeThreadTitle]), resolution.title],
+        };
       });
       void updateThreadMetadata({
         environmentId: activeThreadEnvironmentId,

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -205,17 +205,20 @@ export const ChatHeader = memo(function ChatHeader({
         environmentId: activeThreadEnvironmentId,
         input: { threadId: activeThreadId, title: resolution.title },
       }).then((result) => {
-        if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
-          setRenaming((current) =>
-            current?.threadId === activeThreadId && current.awaiting !== null ? null : current,
-          );
-          const error = squashAtomCommandFailure(result);
-          toastManager.add({
-            type: "error",
-            title: "Failed to rename thread",
-            description: error instanceof Error ? error.message : "An error occurred.",
-          });
-        }
+        if (result._tag !== "Failure") return;
+        // Close on every failure, including interrupts: an interrupted
+        // command never ran, so the store will never move off baseline and
+        // only this teardown closes the editor.
+        setRenaming((current) =>
+          current?.threadId === activeThreadId && current.awaiting !== null ? null : current,
+        );
+        if (isAtomCommandInterrupted(result)) return;
+        const error = squashAtomCommandFailure(result);
+        toastManager.add({
+          type: "error",
+          title: "Failed to rename thread",
+          description: error instanceof Error ? error.message : "An error occurred.",
+        });
       });
     },
     [activeThreadEnvironmentId, activeThreadId, activeThreadTitle, updateThreadMetadata],

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -5,11 +5,15 @@ import {
   type ResolvedKeybindingsConfig,
   type ThreadId,
 } from "@t3tools/contracts";
-import { scopeThreadRef } from "@t3tools/client-runtime/environment";
+import { scopeThreadRef, scopedThreadKey } from "@t3tools/client-runtime/environment";
 import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
+import {
+  nextOptimisticThreadTitles,
+  withoutOptimisticThreadTitle,
+} from "@t3tools/client-runtime/state/threadShell";
 import type { ChangeRequestSettleSource } from "@t3tools/client-runtime/state/thread-settled";
 import { ChevronDownIcon } from "lucide-react";
 import {
@@ -36,7 +40,8 @@ import { useRemoteOpenState, type RemoteOpenMode } from "../../remoteOpen";
 import { usePrimaryEnvironmentId } from "../../state/environments";
 import { useT3ProjectFileScripts } from "~/hooks/useT3ProjectFileScripts";
 import { useThreadActionMenu } from "~/hooks/useThreadActionMenu";
-import { threadEnvironment } from "../../state/threads";
+import { appAtomRegistry } from "../../rpc/atomRegistry";
+import { environmentThreadShells, threadEnvironment } from "../../state/threads";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { ProjectFavicon } from "../ProjectFavicon";
 import {
@@ -169,37 +174,13 @@ export const ChatHeader = memo(function ChatHeader({
   }
   const renamingTitle = renaming?.threadId === activeThreadId ? renaming.title : null;
   const renameCommittedRef = useRef(false);
-  // Committed but not yet reflected by activeThreadTitle (the store learns
-  // about renames via a coalesced server-side stream). Shown in place of the
-  // stored title so confirming a rename never flashes the old one. Retires
-  // as soon as the store moves off its pre-rename value: either this rename
-  // landed or a racing change like regeneration won - either way that is the
-  // visible truth. A second rename before then overwrites the entry on the
-  // same baseline.
-  const [pendingTitle, setPendingTitle] = useState<{
-    threadId: ThreadId;
-    title: string;
-    baseline: string;
-  } | null>(null);
-  useEffect(() => {
-    if (
-      pendingTitle === null ||
-      pendingTitle.threadId !== activeThreadId ||
-      activeThreadTitle === pendingTitle.baseline
-    ) {
-      return;
-    }
-    setPendingTitle(null);
-  }, [pendingTitle, activeThreadId, activeThreadTitle]);
-  const displayTitle =
-    pendingTitle?.threadId === activeThreadId ? pendingTitle.title : activeThreadTitle;
   const startRename = useCallback(() => {
     renameCommittedRef.current = false;
-    setRenaming({ threadId: activeThreadId, title: displayTitle });
-  }, [activeThreadId, displayTitle]);
+    setRenaming({ threadId: activeThreadId, title: activeThreadTitle });
+  }, [activeThreadId, activeThreadTitle]);
   const commitRename = useCallback(
     (title: string) => {
-      const resolution = resolveRenameCommit({ title, originalTitle: displayTitle });
+      const resolution = resolveRenameCommit({ title, originalTitle: activeThreadTitle });
       if (resolution.action === "reject-empty") {
         setRenaming(null);
         toastManager.add({ type: "warning", title: "Thread title cannot be empty" });
@@ -209,27 +190,29 @@ export const ChatHeader = memo(function ChatHeader({
         setRenaming(null);
         return;
       }
-      // Close immediately and keep showing the committed title via
-      // pendingTitle; closing without it would flash the stored title for a
-      // beat while the store catches up. A rejection reverts to it.
       setRenaming(null);
-      setPendingTitle({
-        threadId: activeThreadId,
-        title: resolution.title,
-        baseline: activeThreadTitle,
-      });
+      const threadKey = scopedThreadKey(activeThreadRef);
+      appAtomRegistry.set(
+        environmentThreadShells.optimisticTitlesAtom,
+        nextOptimisticThreadTitles(
+          appAtomRegistry.get(environmentThreadShells.optimisticTitlesAtom),
+          threadKey,
+          resolution.title,
+          activeThreadTitle,
+        ),
+      );
       void updateThreadMetadata({
         environmentId: activeThreadEnvironmentId,
         input: { threadId: activeThreadId, title: resolution.title },
       }).then((result) => {
         if (result._tag !== "Failure") return;
-        // Drop the override on every failure, including interrupts: an
-        // interrupted command never ran, so the store will never move off
-        // baseline and only this teardown retires the shown title.
-        setPendingTitle((current) =>
-          current?.threadId === activeThreadId && current.title === resolution.title
-            ? null
-            : current,
+        appAtomRegistry.set(
+          environmentThreadShells.optimisticTitlesAtom,
+          withoutOptimisticThreadTitle(
+            appAtomRegistry.get(environmentThreadShells.optimisticTitlesAtom),
+            threadKey,
+            resolution.title,
+          ),
         );
         if (isAtomCommandInterrupted(result)) return;
         const error = squashAtomCommandFailure(result);
@@ -243,8 +226,8 @@ export const ChatHeader = memo(function ChatHeader({
     [
       activeThreadEnvironmentId,
       activeThreadId,
+      activeThreadRef,
       activeThreadTitle,
-      displayTitle,
       updateThreadMetadata,
     ],
   );
@@ -253,7 +236,6 @@ export const ChatHeader = memo(function ChatHeader({
     projectCwd: activeProjectCwd,
     changeRequest,
     onStartRename: startRename,
-    titleOverride: displayTitle,
   });
   const titleButtonRef = useRef<HTMLButtonElement | null>(null);
   const titleMenuTimerRef = useRef<number | null>(null);
@@ -392,7 +374,7 @@ export const ChatHeader = memo(function ChatHeader({
                   <button
                     ref={titleButtonRef}
                     type="button"
-                    aria-label={`Thread actions for ${displayTitle}`}
+                    aria-label={`Thread actions for ${activeThreadTitle}`}
                     aria-haspopup="menu"
                     onClick={openMenuFromTitle}
                     onDoubleClick={handleTitleDoubleClick}
@@ -401,25 +383,25 @@ export const ChatHeader = memo(function ChatHeader({
                   />
                 }
               >
-                <h2 className="min-w-0 truncate">{displayTitle}</h2>
+                <h2 className="min-w-0 truncate">{activeThreadTitle}</h2>
                 <ChevronDownIcon
                   aria-hidden
                   data-thread-title-chevron
                   className="size-3.5 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover/thread-title:opacity-100 group-focus-visible/thread-title:opacity-100"
                 />
               </TooltipTrigger>
-              <TooltipPopup side="top">{displayTitle}</TooltipPopup>
+              <TooltipPopup side="top">{activeThreadTitle}</TooltipPopup>
             </Tooltip>
           ) : (
             <Tooltip>
               <TooltipTrigger
                 render={
-                  <h2 aria-label={displayTitle} className="min-w-0 flex-1 truncate">
-                    {displayTitle}
+                  <h2 aria-label={activeThreadTitle} className="min-w-0 flex-1 truncate">
+                    {activeThreadTitle}
                   </h2>
                 }
               />
-              <TooltipPopup side="top">{displayTitle}</TooltipPopup>
+              <TooltipPopup side="top">{activeThreadTitle}</TooltipPopup>
             </Tooltip>
           )}
         </WorkspaceBreadcrumbItem>

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -154,35 +154,43 @@ export const ChatHeader = memo(function ChatHeader({
   // Inline rename, keyed by thread: navigating away drops an in-progress
   // rename instead of committing stale text. Cleared on thread change (not
   // just hidden) so returning to the thread doesn't revive the old draft.
-  // Once submitted (`awaiting`), the editor stays mounted still showing what
-  // was typed until activeThreadTitle moves off its pre-rename value: the
-  // store learns about renames via a coalesced server-side stream, so
-  // closing when the command settles would flash the old title for a beat.
-  // Whatever lands first (this rename or a racing change like regeneration)
-  // becomes the visible truth.
-  const [renaming, setRenaming] = useState<{
-    threadId: ThreadId;
-    title: string;
-    awaiting: { baseline: string } | null;
-  } | null>(null);
+  const [renaming, setRenaming] = useState<{ threadId: ThreadId; title: string } | null>(null);
   if (renaming !== null && renaming.threadId !== activeThreadId) {
     setRenaming(null);
   }
   const renamingTitle = renaming?.threadId === activeThreadId ? renaming.title : null;
   const renameCommittedRef = useRef(false);
+  // Committed but not yet reflected by activeThreadTitle (the store learns
+  // about renames via a coalesced server-side stream). Shown in place of the
+  // stored title so confirming a rename never flashes the old one. Retires
+  // as soon as the store moves off its pre-rename value: either this rename
+  // landed or a racing change like regeneration won - either way that is the
+  // visible truth. A second rename before then overwrites the entry on the
+  // same baseline.
+  const [pendingTitle, setPendingTitle] = useState<{
+    threadId: ThreadId;
+    title: string;
+    baseline: string;
+  } | null>(null);
   useEffect(() => {
-    if (renaming?.threadId !== activeThreadId || renaming.awaiting === null) return;
-    if (activeThreadTitle !== renaming.awaiting.baseline) {
-      setRenaming(null);
+    if (
+      pendingTitle === null ||
+      pendingTitle.threadId !== activeThreadId ||
+      activeThreadTitle === pendingTitle.baseline
+    ) {
+      return;
     }
-  }, [renaming, activeThreadId, activeThreadTitle]);
+    setPendingTitle(null);
+  }, [pendingTitle, activeThreadId, activeThreadTitle]);
+  const displayTitle =
+    pendingTitle?.threadId === activeThreadId ? pendingTitle.title : activeThreadTitle;
   const startRename = useCallback(() => {
     renameCommittedRef.current = false;
-    setRenaming({ threadId: activeThreadId, title: activeThreadTitle, awaiting: null });
-  }, [activeThreadId, activeThreadTitle]);
+    setRenaming({ threadId: activeThreadId, title: displayTitle });
+  }, [activeThreadId, displayTitle]);
   const commitRename = useCallback(
     (title: string) => {
-      const resolution = resolveRenameCommit({ title, originalTitle: activeThreadTitle });
+      const resolution = resolveRenameCommit({ title, originalTitle: displayTitle });
       if (resolution.action === "reject-empty") {
         setRenaming(null);
         toastManager.add({ type: "warning", title: "Thread title cannot be empty" });
@@ -192,25 +200,27 @@ export const ChatHeader = memo(function ChatHeader({
         setRenaming(null);
         return;
       }
-      // Hold the editor open showing the typed title until the store catches
-      // up; closing now would flash the stored title for a beat. A rejection
-      // closes it and reverts.
-      renameCommittedRef.current = true;
-      setRenaming({
+      // Close immediately and keep showing the committed title via
+      // pendingTitle; closing without it would flash the stored title for a
+      // beat while the store catches up. A rejection reverts to it.
+      setRenaming(null);
+      setPendingTitle({
         threadId: activeThreadId,
         title: resolution.title,
-        awaiting: { baseline: activeThreadTitle },
+        baseline: activeThreadTitle,
       });
       void updateThreadMetadata({
         environmentId: activeThreadEnvironmentId,
         input: { threadId: activeThreadId, title: resolution.title },
       }).then((result) => {
         if (result._tag !== "Failure") return;
-        // Close on every failure, including interrupts: an interrupted
-        // command never ran, so the store will never move off baseline and
-        // only this teardown closes the editor.
-        setRenaming((current) =>
-          current?.threadId === activeThreadId && current.awaiting !== null ? null : current,
+        // Drop the override on every failure, including interrupts: an
+        // interrupted command never ran, so the store will never move off
+        // baseline and only this teardown retires the shown title.
+        setPendingTitle((current) =>
+          current?.threadId === activeThreadId && current.title === resolution.title
+            ? null
+            : current,
         );
         if (isAtomCommandInterrupted(result)) return;
         const error = squashAtomCommandFailure(result);
@@ -221,7 +231,13 @@ export const ChatHeader = memo(function ChatHeader({
         });
       });
     },
-    [activeThreadEnvironmentId, activeThreadId, activeThreadTitle, updateThreadMetadata],
+    [
+      activeThreadEnvironmentId,
+      activeThreadId,
+      activeThreadTitle,
+      displayTitle,
+      updateThreadMetadata,
+    ],
   );
   const { openMenu } = useThreadActionMenu({
     threadRef: isServerThread ? activeThreadRef : null,
@@ -317,31 +333,31 @@ export const ChatHeader = memo(function ChatHeader({
                   <button
                     ref={titleButtonRef}
                     type="button"
-                    aria-label={`Thread actions for ${activeThreadTitle}`}
+                    aria-label={`Thread actions for ${displayTitle}`}
                     aria-haspopup="menu"
                     onClick={openMenuFromTitle}
                     className="group/thread-title inline-flex min-w-0 max-w-full cursor-pointer items-center gap-1 rounded-sm text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
                   />
                 }
               >
-                <h2 className="min-w-0 truncate">{activeThreadTitle}</h2>
+                <h2 className="min-w-0 truncate">{displayTitle}</h2>
                 <ChevronDownIcon
                   aria-hidden
                   className="size-3.5 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover/thread-title:opacity-100 group-focus-visible/thread-title:opacity-100"
                 />
               </TooltipTrigger>
-              <TooltipPopup side="top">{activeThreadTitle}</TooltipPopup>
+              <TooltipPopup side="top">{displayTitle}</TooltipPopup>
             </Tooltip>
           ) : (
             <Tooltip>
               <TooltipTrigger
                 render={
-                  <h2 aria-label={activeThreadTitle} className="min-w-0 flex-1 truncate">
-                    {activeThreadTitle}
+                  <h2 aria-label={displayTitle} className="min-w-0 flex-1 truncate">
+                    {displayTitle}
                   </h2>
                 }
               />
-              <TooltipPopup side="top">{activeThreadTitle}</TooltipPopup>
+              <TooltipPopup side="top">{displayTitle}</TooltipPopup>
             </Tooltip>
           )}
         </WorkspaceBreadcrumbItem>

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -5,7 +5,7 @@ import {
   type ResolvedKeybindingsConfig,
   type ThreadId,
 } from "@t3tools/contracts";
-import { scopeThreadRef, scopedThreadKey } from "@t3tools/client-runtime/environment";
+import { scopeThreadRef } from "@t3tools/client-runtime/environment";
 import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
@@ -188,10 +188,9 @@ export const ChatHeader = memo(function ChatHeader({
         return;
       }
       setRenaming(null);
-      const threadKey = scopedThreadKey(activeThreadRef);
       environmentThreadShells.setOptimisticThreadTitle(
         appAtomRegistry,
-        threadKey,
+        activeThreadRef,
         resolution.title,
         activeThreadTitle,
       );
@@ -202,7 +201,7 @@ export const ChatHeader = memo(function ChatHeader({
         if (result._tag !== "Failure") return;
         environmentThreadShells.clearOptimisticThreadTitle(
           appAtomRegistry,
-          threadKey,
+          activeThreadRef,
           resolution.title,
         );
         if (isAtomCommandInterrupted(result)) return;

--- a/apps/web/src/hooks/useThreadActionMenu.ts
+++ b/apps/web/src/hooks/useThreadActionMenu.ts
@@ -63,10 +63,8 @@ export function useThreadActionMenu(input: {
   /** PR feeding auto-settle classification, as resolved by the caller. */
   readonly changeRequest: ChangeRequestSettleSource | null;
   readonly onStartRename: () => void;
-  /** What the caller currently displays as the title, so confirm dialogs name the thread the way the screen does while a just-committed rename is landing. */
-  readonly titleOverride?: string;
 }) {
-  const { threadRef, projectCwd, changeRequest, onStartRename, titleOverride } = input;
+  const { threadRef, projectCwd, changeRequest, onStartRename } = input;
   const {
     settleThread,
     unsettleThread,
@@ -117,9 +115,7 @@ export function useThreadActionMenu(input: {
         // what the user is looking at.
         const thread = readThreadShell(threadRef);
         if (!thread) return;
-        // Confirm dialogs name the thread the way the screen does: while a
-        // just-committed rename is still landing, that is the override.
-        const shownTitle = titleOverride ?? thread.title;
+        const shownTitle = thread.title;
         const now = new Date();
         const supports = {
           settlement: readEnvironmentSupportsSettlement(threadRef.environmentId),
@@ -333,7 +329,6 @@ export function useThreadActionMenu(input: {
       snoozeThread,
       threadRef,
       timestampFormat,
-      titleOverride,
       unpinThread,
       unsettleThread,
       unsnoozeThread,

--- a/apps/web/src/hooks/useThreadActionMenu.ts
+++ b/apps/web/src/hooks/useThreadActionMenu.ts
@@ -63,8 +63,10 @@ export function useThreadActionMenu(input: {
   /** PR feeding auto-settle classification, as resolved by the caller. */
   readonly changeRequest: ChangeRequestSettleSource | null;
   readonly onStartRename: () => void;
+  /** What the caller currently displays as the title, so confirm dialogs name the thread the way the screen does while a just-committed rename is landing. */
+  readonly titleOverride?: string;
 }) {
-  const { threadRef, projectCwd, changeRequest, onStartRename } = input;
+  const { threadRef, projectCwd, changeRequest, onStartRename, titleOverride } = input;
   const {
     settleThread,
     unsettleThread,
@@ -115,6 +117,9 @@ export function useThreadActionMenu(input: {
         // what the user is looking at.
         const thread = readThreadShell(threadRef);
         if (!thread) return;
+        // Confirm dialogs name the thread the way the screen does: while a
+        // just-committed rename is still landing, that is the override.
+        const shownTitle = titleOverride ?? thread.title;
         const now = new Date();
         const supports = {
           settlement: readEnvironmentSupportsSettlement(threadRef.environmentId),
@@ -259,7 +264,7 @@ export function useThreadActionMenu(input: {
           case "archive": {
             if (confirmThreadArchive) {
               const confirmed = await settlePromise(() =>
-                api.dialogs.confirm(`Archive thread "${thread.title}"?`),
+                api.dialogs.confirm(`Archive thread "${shownTitle}"?`),
               );
               if (confirmed._tag === "Failure" || !confirmed.value) return;
             }
@@ -282,7 +287,7 @@ export function useThreadActionMenu(input: {
               const confirmed = await settlePromise(() =>
                 api.dialogs.confirm(
                   [
-                    `Delete thread "${thread.title}"?`,
+                    `Delete thread "${shownTitle}"?`,
                     "This permanently clears conversation history for this thread.",
                   ].join("\n"),
                   { variant: "destructive" },
@@ -328,6 +333,7 @@ export function useThreadActionMenu(input: {
       snoozeThread,
       threadRef,
       timestampFormat,
+      titleOverride,
       unpinThread,
       unsettleThread,
       unsnoozeThread,

--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -143,6 +143,10 @@
       "types": "./src/state/threadSettled.ts",
       "default": "./src/state/threadSettled.ts"
     },
+    "./state/threadShell": {
+      "types": "./src/state/threadShell.ts",
+      "default": "./src/state/threadShell.ts"
+    },
     "./state/thread-search": {
       "types": "./src/state/threadSearch.ts",
       "default": "./src/state/threadSearch.ts"

--- a/packages/client-runtime/src/state/threadShell.ts
+++ b/packages/client-runtime/src/state/threadShell.ts
@@ -7,7 +7,7 @@ import type {
   ScopedThreadRef,
   ThreadId,
 } from "@t3tools/contracts";
-import { Atom } from "effect/unstable/reactivity";
+import { Atom, AtomRegistry } from "effect/unstable/reactivity";
 
 import type { EnvironmentThreadShell } from "./models.ts";
 import { scopeThreadShell } from "./models.ts";
@@ -139,16 +139,13 @@ export function createEnvironmentThreadShellAtoms(input: {
   // threadKey() so writer and reader cannot drift (threadKey uses \u0000,
   // while scopedThreadKey uses ":").
   const setOptimisticThreadTitle = (
-    registry: { get: (a: Atom.Atom<any>) => any; set: (a: any, v: any) => void },
+    registry: AtomRegistry.AtomRegistry,
     ref: ScopedThreadRef,
     title: string,
     displayedTitle: string,
   ): void => {
     const key = threadKey(ref);
-    const current = registry.get(optimisticTitlesAtom) as ReadonlyMap<
-      string,
-      OptimisticThreadTitle
-    >;
+    const current = registry.get(optimisticTitlesAtom);
     registry.set(
       optimisticTitlesAtom,
       nextOptimisticThreadTitles(current, key, title, displayedTitle),
@@ -156,15 +153,12 @@ export function createEnvironmentThreadShellAtoms(input: {
   };
 
   const clearOptimisticThreadTitle = (
-    registry: { get: (a: Atom.Atom<any>) => any; set: (a: any, v: any) => void },
+    registry: AtomRegistry.AtomRegistry,
     ref: ScopedThreadRef,
     title: string,
   ): void => {
     const key = threadKey(ref);
-    const current = registry.get(optimisticTitlesAtom) as ReadonlyMap<
-      string,
-      OptimisticThreadTitle
-    >;
+    const current = registry.get(optimisticTitlesAtom);
     registry.set(optimisticTitlesAtom, withoutOptimisticThreadTitle(current, key, title));
   };
 

--- a/packages/client-runtime/src/state/threadShell.ts
+++ b/packages/client-runtime/src/state/threadShell.ts
@@ -31,9 +31,15 @@ const EMPTY_THREAD_REFS_BY_PROJECT: ReadonlyMap<
 
 // Single fridge note for rename optimism. Every shell reader shadows through
 // it, so sidebar rows, search, header, and dialogs all show the just-committed
-// title without per surface plumbing. Retires when the store moves off the
-// pre rename baseline, which covers both landing and a racing title change.
-export type OptimisticThreadTitle = { readonly title: string; readonly baseline: string };
+// title without per surface plumbing. Chain tracks every committed title from
+// the baseline through the final value so an intermediate store frame (A -> B
+// -> C) does not flash B. Entry retires when the store reaches the final
+// title or leaves the chain (racing regeneration).
+export type OptimisticThreadTitle = {
+  readonly title: string;
+  readonly baseline: string;
+  readonly chain: ReadonlyArray<string>;
+};
 
 export function nextOptimisticThreadTitles(
   current: ReadonlyMap<string, OptimisticThreadTitle>,
@@ -41,9 +47,11 @@ export function nextOptimisticThreadTitles(
   title: string,
   displayedTitle: string,
 ): ReadonlyMap<string, OptimisticThreadTitle> {
-  const baseline = current.get(key)?.baseline ?? displayedTitle;
+  const existing = current.get(key);
+  const chain = existing ? [...existing.chain, title] : [displayedTitle, title];
+  const baseline = chain[0] ?? displayedTitle;
   const next = new Map(current);
-  next.set(key, { title, baseline });
+  next.set(key, { title, baseline, chain });
   return next;
 }
 
@@ -64,10 +72,6 @@ export function createEnvironmentThreadShellAtoms(input: {
     environmentId: EnvironmentId,
   ) => Atom.Atom<OrchestrationShellSnapshot | null>;
 }) {
-  const optimisticTitlesAtom = Atom.make<ReadonlyMap<string, OptimisticThreadTitle>>(
-    new Map(),
-  ).pipe(Atom.withLabel("optimistic-thread-titles"));
-
   const environmentThreadsAtom = Atom.family((environmentId: EnvironmentId) =>
     Atom.make(
       (get): ReadonlyArray<OrchestrationThreadShell> =>
@@ -84,6 +88,43 @@ export function createEnvironmentThreadShellAtoms(input: {
       return new Map(threads.map((thread) => [thread.id, thread] as const));
     }).pipe(Atom.withLabel(`environment-thread-index:${environmentId}`)),
   );
+
+  const rawOptimisticTitlesAtom = Atom.make<ReadonlyMap<string, OptimisticThreadTitle>>(
+    new Map(),
+  ).pipe(Atom.withLabel("optimistic-thread-titles:raw"));
+
+  // Filter out entries that have fulfilled (store reached final title) or
+  // diverged (store left the chain via regenerate-title or another client).
+  // This is a derived view so the map auto-prunes and `nextOptimistic...`
+  // sees a clean baseline for the next rename.
+  const filteredOptimisticTitlesAtom = Atom.make(
+    (get): ReadonlyMap<string, OptimisticThreadTitle> => {
+      const raw = get(rawOptimisticTitlesAtom);
+      if (raw.size === 0) return raw;
+      let pruned: Map<string, OptimisticThreadTitle> | null = null;
+      for (const [key, entry] of raw) {
+        const ref = parseThreadKey(key);
+        const source = get(environmentThreadIndexAtom(ref.environmentId)).get(ref.threadId);
+        if (source === undefined) {
+          pruned ??= new Map(raw);
+          pruned.delete(key);
+          continue;
+        }
+        const chain = entry.chain ?? [entry.baseline, entry.title];
+        if (!chain.includes(source.title) || source.title === entry.title) {
+          pruned ??= new Map(raw);
+          pruned.delete(key);
+        }
+      }
+      return pruned ?? raw;
+    },
+  ).pipe(Atom.withLabel("optimistic-thread-titles:filtered"));
+
+  const optimisticTitlesAtom = Atom.writable(
+    (get) => get(filteredOptimisticTitlesAtom),
+    (ctx, value: ReadonlyMap<string, OptimisticThreadTitle>) =>
+      ctx.set(rawOptimisticTitlesAtom, value),
+  ).pipe(Atom.withLabel("optimistic-thread-titles"));
 
   const environmentThreadRefsAtom = Atom.family((environmentId: EnvironmentId) => {
     let previous: ReadonlyArray<ScopedThreadRef> = [];
@@ -138,23 +179,30 @@ export function createEnvironmentThreadShellAtoms(input: {
     let previousSource: OrchestrationThreadShell | null = null;
     let previousOptimisticTitle: string | undefined = undefined;
     let previousOptimisticBaseline: string | undefined = undefined;
+    let previousOptimisticChain: ReadonlyArray<string> | undefined = undefined;
     let previousValue: EnvironmentThreadShell | null = null;
     return Atom.make((get) => {
       const source = get(environmentThreadIndexAtom(ref.environmentId)).get(ref.threadId) ?? null;
       const optimistic = get(optimisticTitlesAtom).get(key);
+      const chain = optimistic?.chain;
       if (
         source === previousSource &&
         optimistic?.title === previousOptimisticTitle &&
-        optimistic?.baseline === previousOptimisticBaseline
+        optimistic?.baseline === previousOptimisticBaseline &&
+        chain === previousOptimisticChain
       ) {
         return previousValue;
       }
       previousSource = source;
       previousOptimisticTitle = optimistic?.title;
       previousOptimisticBaseline = optimistic?.baseline;
+      previousOptimisticChain = chain;
       if (source === null) {
         previousValue = null;
-      } else if (optimistic !== undefined && source.title === optimistic.baseline) {
+      } else if (optimistic !== undefined) {
+        // Filtered view guarantees this entry is still pending or
+        // is an intermediate of a chained rename (A->B->C while store
+        // still at A or B). Show the final title.
         previousValue = scopeThreadShell(ref.environmentId, {
           ...source,
           title: optimistic.title,

--- a/packages/client-runtime/src/state/threadShell.ts
+++ b/packages/client-runtime/src/state/threadShell.ts
@@ -95,8 +95,10 @@ export function createEnvironmentThreadShellAtoms(input: {
 
   // Filter out entries that have fulfilled (store reached final title) or
   // diverged (store left the chain via regenerate-title or another client).
-  // This is a derived view so the map auto-prunes and `nextOptimistic...`
-  // sees a clean baseline for the next rename.
+  // Derived view hides stale entries immediately, and schedules a write-back
+  // so the raw map is actually pruned. Without the write-back a later store
+  // title that re-enters the chain (e.g. another client renaming back to the
+  // baseline) would revive a stale optimistic value.
   const filteredOptimisticTitlesAtom = Atom.make(
     (get): ReadonlyMap<string, OptimisticThreadTitle> => {
       const raw = get(rawOptimisticTitlesAtom);
@@ -116,7 +118,13 @@ export function createEnvironmentThreadShellAtoms(input: {
           pruned.delete(key);
         }
       }
-      return pruned ?? raw;
+      if (pruned !== null) {
+        const { registry } = get;
+        const next = pruned;
+        queueMicrotask(() => registry.set(rawOptimisticTitlesAtom, next));
+        return pruned;
+      }
+      return raw;
     },
   ).pipe(Atom.withLabel("optimistic-thread-titles:filtered"));
 
@@ -125,6 +133,35 @@ export function createEnvironmentThreadShellAtoms(input: {
     (ctx, value: ReadonlyMap<string, OptimisticThreadTitle>) =>
       ctx.set(rawOptimisticTitlesAtom, value),
   ).pipe(Atom.withLabel("optimistic-thread-titles"));
+
+  // Named helpers so call sites do not duplicate registry plumbing.
+  const setOptimisticThreadTitle = (
+    registry: { get: (a: Atom.Atom<any>) => any; set: (a: any, v: any) => void },
+    key: string,
+    title: string,
+    displayedTitle: string,
+  ): void => {
+    const current = registry.get(optimisticTitlesAtom) as ReadonlyMap<
+      string,
+      OptimisticThreadTitle
+    >;
+    registry.set(
+      optimisticTitlesAtom,
+      nextOptimisticThreadTitles(current, key, title, displayedTitle),
+    );
+  };
+
+  const clearOptimisticThreadTitle = (
+    registry: { get: (a: Atom.Atom<any>) => any; set: (a: any, v: any) => void },
+    key: string,
+    title: string,
+  ): void => {
+    const current = registry.get(optimisticTitlesAtom) as ReadonlyMap<
+      string,
+      OptimisticThreadTitle
+    >;
+    registry.set(optimisticTitlesAtom, withoutOptimisticThreadTitle(current, key, title));
+  };
 
   const environmentThreadRefsAtom = Atom.family((environmentId: EnvironmentId) => {
     let previous: ReadonlyArray<ScopedThreadRef> = [];
@@ -282,5 +319,7 @@ export function createEnvironmentThreadShellAtoms(input: {
       threadShellsForProjectRefsAtomFamily(projectRefCollectionKey(refs)),
     threadShellAtom: (ref: ScopedThreadRef) => threadShellAtomFamily(threadKey(ref)),
     optimisticTitlesAtom,
+    setOptimisticThreadTitle,
+    clearOptimisticThreadTitle,
   };
 }

--- a/packages/client-runtime/src/state/threadShell.ts
+++ b/packages/client-runtime/src/state/threadShell.ts
@@ -29,12 +29,45 @@ const EMPTY_THREAD_REFS_BY_PROJECT: ReadonlyMap<
   ReadonlyArray<ScopedThreadRef>
 > = new Map();
 
+// Single fridge note for rename optimism. Every shell reader shadows through
+// it, so sidebar rows, search, header, and dialogs all show the just-committed
+// title without per surface plumbing. Retires when the store moves off the
+// pre rename baseline, which covers both landing and a racing title change.
+export type OptimisticThreadTitle = { readonly title: string; readonly baseline: string };
+
+export function nextOptimisticThreadTitles(
+  current: ReadonlyMap<string, OptimisticThreadTitle>,
+  key: string,
+  title: string,
+  displayedTitle: string,
+): ReadonlyMap<string, OptimisticThreadTitle> {
+  const baseline = current.get(key)?.baseline ?? displayedTitle;
+  const next = new Map(current);
+  next.set(key, { title, baseline });
+  return next;
+}
+
+export function withoutOptimisticThreadTitle(
+  current: ReadonlyMap<string, OptimisticThreadTitle>,
+  key: string,
+  title: string,
+): ReadonlyMap<string, OptimisticThreadTitle> {
+  if (current.get(key)?.title !== title) return current;
+  const next = new Map(current);
+  next.delete(key);
+  return next;
+}
+
 export function createEnvironmentThreadShellAtoms(input: {
   readonly catalogValueAtom: Atom.Atom<EnvironmentCatalogState>;
   readonly snapshotAtom: (
     environmentId: EnvironmentId,
   ) => Atom.Atom<OrchestrationShellSnapshot | null>;
 }) {
+  const optimisticTitlesAtom = Atom.make<ReadonlyMap<string, OptimisticThreadTitle>>(
+    new Map(),
+  ).pipe(Atom.withLabel("optimistic-thread-titles"));
+
   const environmentThreadsAtom = Atom.family((environmentId: EnvironmentId) =>
     Atom.make(
       (get): ReadonlyArray<OrchestrationThreadShell> =>
@@ -103,14 +136,32 @@ export function createEnvironmentThreadShellAtoms(input: {
   const threadShellAtomFamily = Atom.family((key: string) => {
     const ref = parseThreadKey(key);
     let previousSource: OrchestrationThreadShell | null = null;
+    let previousOptimisticTitle: string | undefined = undefined;
+    let previousOptimisticBaseline: string | undefined = undefined;
     let previousValue: EnvironmentThreadShell | null = null;
     return Atom.make((get) => {
       const source = get(environmentThreadIndexAtom(ref.environmentId)).get(ref.threadId) ?? null;
-      if (source === previousSource) {
+      const optimistic = get(optimisticTitlesAtom).get(key);
+      if (
+        source === previousSource &&
+        optimistic?.title === previousOptimisticTitle &&
+        optimistic?.baseline === previousOptimisticBaseline
+      ) {
         return previousValue;
       }
       previousSource = source;
-      previousValue = source === null ? null : scopeThreadShell(ref.environmentId, source);
+      previousOptimisticTitle = optimistic?.title;
+      previousOptimisticBaseline = optimistic?.baseline;
+      if (source === null) {
+        previousValue = null;
+      } else if (optimistic !== undefined && source.title === optimistic.baseline) {
+        previousValue = scopeThreadShell(ref.environmentId, {
+          ...source,
+          title: optimistic.title,
+        });
+      } else {
+        previousValue = scopeThreadShell(ref.environmentId, source);
+      }
       return previousValue;
     }).pipe(Atom.withLabel(`environment-thread-shell:${key}`));
   });
@@ -182,5 +233,6 @@ export function createEnvironmentThreadShellAtoms(input: {
     threadShellsForProjectRefsAtom: (refs: ReadonlyArray<ScopedProjectRef>) =>
       threadShellsForProjectRefsAtomFamily(projectRefCollectionKey(refs)),
     threadShellAtom: (ref: ScopedThreadRef) => threadShellAtomFamily(threadKey(ref)),
+    optimisticTitlesAtom,
   };
 }

--- a/packages/client-runtime/src/state/threadShell.ts
+++ b/packages/client-runtime/src/state/threadShell.ts
@@ -135,12 +135,16 @@ export function createEnvironmentThreadShellAtoms(input: {
   ).pipe(Atom.withLabel("optimistic-thread-titles"));
 
   // Named helpers so call sites do not duplicate registry plumbing.
+  // Helpers take ScopedThreadRef and derive the atom-family key with
+  // threadKey() so writer and reader cannot drift (threadKey uses \u0000,
+  // while scopedThreadKey uses ":").
   const setOptimisticThreadTitle = (
     registry: { get: (a: Atom.Atom<any>) => any; set: (a: any, v: any) => void },
-    key: string,
+    ref: ScopedThreadRef,
     title: string,
     displayedTitle: string,
   ): void => {
+    const key = threadKey(ref);
     const current = registry.get(optimisticTitlesAtom) as ReadonlyMap<
       string,
       OptimisticThreadTitle
@@ -153,9 +157,10 @@ export function createEnvironmentThreadShellAtoms(input: {
 
   const clearOptimisticThreadTitle = (
     registry: { get: (a: Atom.Atom<any>) => any; set: (a: any, v: any) => void },
-    key: string,
+    ref: ScopedThreadRef,
     title: string,
   ): void => {
+    const key = threadKey(ref);
     const current = registry.get(optimisticTitlesAtom) as ReadonlyMap<
       string,
       OptimisticThreadTitle


### PR DESCRIPTION
## What Changed

After confirming a thread rename (Enter or clicking away), the new name now appears immediately instead of a split second later. Previously the old name could flash briefly while the app caught up.

If a rename fails (for example a connection drop), the title reverts to what it was and an error message explains what happened. Renaming again immediately after a rename works cleanly, and the archive/delete confirmations show the newest name too.

Applies to renaming from the sidebar and from the chat header.

## Why

The visible title updates a beat after you hit Enter, because the change is confirmed by the server first. Closing the rename box instantly meant briefly showing the old name during that gap. Now the app keeps showing the name you typed until the real one has arrived, so the title never goes backwards.

## UI Changes

No static visual change; only how quickly the title updates after confirming a rename differs.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Built by ox-alpha in opencode.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale-title flash after renaming a thread in `Sidebar` and `ChatHeader`
> - Adds optimistic title handling to the sidebar and chat header so the newly committed title shows immediately after a rename and persists until the store catches up; on failure the title reverts to the stored value
> - Introduces `withOptimisticTitle` helper in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/7822/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) that overrides a thread shell's title with the optimistic entry when available
> - Rewrites `commitThreadRename` and `ChatHeader.commitRename` to close the editor immediately, set a baseline-anchored optimistic title, and call `updateThreadMetadata`; failures (including interrupts) clear the optimistic override and show an error toast
> - Sets `renameCommittedRef.current = true` before `onCommitRename` in `SidebarThreadRow` to prevent duplicate submissions from blur followed by refocus
> - Risk: optimistic title state is anchored to a baseline title; if multiple rapid renames race on the same thread before the store updates, an earlier baseline mismatch could retire the wrong optimistic entry. Review `commitThreadRename` and the retiring effect in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/7822/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 656a84e. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only optimistic title display around rename; no auth or persistence changes. Worst case is a stale title until the next store update or a failed rename revert.
> 
> **Overview**
> Stops the old thread title from flashing after a rename. The editor closes immediately, but the committed name stays on screen until the coalesced store stream actually moves off the pre-rename value.
> 
> Sidebar and chat header both keep a short-lived override (`optimisticTitles` / `pendingTitle`) keyed to a baseline stored title. Search, list rows, and archive/delete confirmations use that name. Failures (including interrupts) drop the override and toast; a second rename before the stream lands reuses the same baseline so it does not retire early.
> 
> Also marks the sidebar rename as committed on blur so a refocus during catch-up cannot submit twice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 656a84e4fd298530e8b95cb93e174c4bcf1591c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

