### PR TITLE
feat(clients): show project and thread in the window title

### DIFF
--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -584,9 +584,10 @@ export const make = Effect.gen(function* () {
       }
     });
 
-    window.on("page-title-updated", (event) => {
+    window.on("page-title-updated", (event, title) => {
       event.preventDefault();
-      window.setTitle(environment.displayName);
+      const trimmed = title.trim();
+      window.setTitle(trimmed === "" ? environment.displayName : trimmed);
     });
     window.on("resize", scheduleBoundsPersist);
     window.on("move", scheduleBoundsPersist);
@@ -660,7 +661,6 @@ export const make = Effect.gen(function* () {
       }
       clearDevelopmentLoadRetry();
       developmentLoadRetryIndex = 0;
-      window.setTitle(environment.displayName);
     });
     window.webContents.on(
       "did-fail-load",

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -453,7 +453,17 @@
         object-fit: contain;
       }
     </style>
-    <title>T3 Code (Alpha)</title>
+    <title>T3 Code</title>
+    <script>
+      (() => {
+        // The desktop preload injects branding before page scripts run, so the
+        // native window title carries the stage label from first paint.
+        const branding = window.desktopBridge?.getAppBranding?.();
+        if (branding?.displayName) {
+          document.title = branding.displayName;
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root">

--- a/apps/web/src/branding.logic.ts
+++ b/apps/web/src/branding.logic.ts
@@ -36,3 +36,19 @@ export function resolveServerBackedAppDisplayName(input: {
     ? input.fallbackDisplayName
     : formatAppDisplayName({ baseName: input.baseName, stageLabel });
 }
+
+export function resolveWindowTitle(input: {
+  readonly appDisplayName: string;
+  readonly projectTitle: string | null;
+  readonly threadTitle: string | null;
+  readonly desktop: boolean;
+}): string {
+  const threadTitle = input.threadTitle?.trim() ?? "";
+  if (threadTitle === "") {
+    return input.appDisplayName;
+  }
+
+  const projectTitle = input.projectTitle?.trim() ?? "";
+  const context = projectTitle === "" ? threadTitle : `${projectTitle} / ${threadTitle}`;
+  return input.desktop ? context : `${context} — ${input.appDisplayName}`;
+}

--- a/apps/web/src/branding.test.ts
+++ b/apps/web/src/branding.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import {
   resolveServerBackedAppDisplayName,
   resolveServerBackedAppStageLabel,
+  resolveWindowTitle,
 } from "./branding.logic";
 
 const originalWindow = globalThis.window;
@@ -112,5 +113,62 @@ describe("branding logic", () => {
         primaryServerVersion: "0.0.28-nightly.20260616",
       }),
     ).toBe("T3 Code (Alpha)");
+  });
+});
+
+describe("resolveWindowTitle", () => {
+  it("falls back to the app display name without an active thread", () => {
+    expect(
+      resolveWindowTitle({
+        appDisplayName: "T3 Code (Nightly)",
+        projectTitle: null,
+        threadTitle: null,
+        desktop: true,
+      }),
+    ).toBe("T3 Code (Nightly)");
+  });
+
+  it("joins project and thread titles on desktop without the app name", () => {
+    expect(
+      resolveWindowTitle({
+        appDisplayName: "T3 Code (Nightly)",
+        projectTitle: "acme-web",
+        threadTitle: "New thread",
+        desktop: true,
+      }),
+    ).toBe("acme-web / New thread");
+  });
+
+  it("keeps the app display name as a suffix on the web", () => {
+    expect(
+      resolveWindowTitle({
+        appDisplayName: "T3 Code (Alpha)",
+        projectTitle: "acme-web",
+        threadTitle: "New thread",
+        desktop: false,
+      }),
+    ).toBe("acme-web / New thread — T3 Code (Alpha)");
+  });
+
+  it("omits the separator without a project title", () => {
+    expect(
+      resolveWindowTitle({
+        appDisplayName: "T3 Code (Nightly)",
+        projectTitle: "  ",
+        threadTitle: "Fix login bug",
+        desktop: true,
+      }),
+    ).toBe("Fix login bug");
+  });
+
+  it("ignores whitespace-only thread titles", () => {
+    expect(
+      resolveWindowTitle({
+        appDisplayName: "T3 Code (Nightly)",
+        projectTitle: "acme-web",
+        threadTitle: "  ",
+        desktop: true,
+      }),
+    ).toBe("T3 Code (Nightly)");
   });
 });

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -85,6 +85,7 @@ import * as Cause from "effect/Cause";
 import * as Schema from "effect/Schema";
 import { AsyncResult } from "effect/unstable/reactivity";
 import { isElectron } from "../env";
+import { clearWindowTitleContext, setWindowTitleContext } from "../windowTitleStore";
 import { readLocalApi } from "../localApi";
 import { useDiffPanelStore } from "../diffPanelStore";
 import {
@@ -1826,6 +1827,12 @@ function ChatViewContent(props: ChatViewProps) {
     [activeThread?.environmentId, activeThread?.projectId],
   );
   const activeProject = useProject(activeProjectRef);
+  const activeProjectTitle = activeProject?.title ?? null;
+  const activeThreadTitle = activeThread?.title ?? null;
+  useEffect(() => {
+    setWindowTitleContext({ projectTitle: activeProjectTitle, threadTitle: activeThreadTitle });
+  }, [activeProjectTitle, activeThreadTitle]);
+  useEffect(() => clearWindowTitleContext, []);
   const handleNewThreadInActiveProject = useCallback(() => {
     startNewThreadForProject(activeProjectRef, handleNewThread);
   }, [activeProjectRef, handleNewThread]);

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -11,7 +11,9 @@ import {
 import { useEffect, useEffectEvent, useRef, useState } from "react";
 
 import { APP_BASE_NAME, APP_DISPLAY_NAME, APP_STAGE_LABEL } from "../branding";
-import { resolveServerBackedAppDisplayName } from "../branding.logic";
+import { resolveServerBackedAppDisplayName, resolveWindowTitle } from "../branding.logic";
+import { isElectron } from "../env";
+import { useWindowTitleContextStore } from "../windowTitleStore";
 import { AppSidebarLayout } from "../components/AppSidebarLayout";
 import { CommandPalette } from "../components/CommandPalette";
 import { ConfirmDialogHost } from "../components/ConfirmDialogHost";
@@ -209,11 +211,17 @@ function FontAppearanceSync() {
 function DocumentTitleSync() {
   const primaryServerVersion =
     useAtomValue(primaryServerConfigAtom)?.environment.serverVersion ?? null;
-  const title = resolveServerBackedAppDisplayName({
-    baseName: APP_BASE_NAME,
-    fallbackDisplayName: APP_DISPLAY_NAME,
-    fallbackStageLabel: APP_STAGE_LABEL,
-    primaryServerVersion,
+  const { projectTitle, threadTitle } = useWindowTitleContextStore();
+  const title = resolveWindowTitle({
+    appDisplayName: resolveServerBackedAppDisplayName({
+      baseName: APP_BASE_NAME,
+      fallbackDisplayName: APP_DISPLAY_NAME,
+      fallbackStageLabel: APP_STAGE_LABEL,
+      primaryServerVersion,
+    }),
+    projectTitle,
+    threadTitle,
+    desktop: isElectron,
   });
 
   useEffect(() => {
@@ -257,6 +265,7 @@ function RootRouteErrorView({ error, reset }: ErrorComponentProps) {
 
   return (
     <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4 py-10 text-foreground sm:px-6">
+      <DocumentTitleSync />
       <div className="pointer-events-none absolute inset-0 opacity-80">
         <div className="absolute inset-x-0 top-0 h-44 bg-[radial-gradient(44rem_16rem_at_top,color-mix(in_srgb,var(--color-red-500)_16%,transparent),transparent)]" />
         <div className="absolute inset-0 bg-[linear-gradient(145deg,color-mix(in_srgb,var(--background)_90%,var(--color-black))_0%,var(--background)_55%)]" />

--- a/apps/web/src/windowTitleStore.ts
+++ b/apps/web/src/windowTitleStore.ts
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+
+export interface WindowTitleContext {
+  projectTitle: string | null;
+  threadTitle: string | null;
+}
+
+/** Active project/thread context mirrored into document.title by the root layout. */
+export const useWindowTitleContextStore = create<WindowTitleContext>()(() => ({
+  projectTitle: null,
+  threadTitle: null,
+}));
+
+export function setWindowTitleContext(context: WindowTitleContext): void {
+  const current = useWindowTitleContextStore.getState();
+  if (
+    current.projectTitle === context.projectTitle &&
+    current.threadTitle === context.threadTitle
+  ) {
+    return;
+  }
+  useWindowTitleContextStore.setState(context);
+}
+
+export function clearWindowTitleContext(): void {
+  setWindowTitleContext({ projectTitle: null, threadTitle: null });
+}


### PR DESCRIPTION
## What Changed

The app window preview now shows both the app name "T3 Code (Nightly)" or "T3 Code" along with the added window title as the project and thread, like `my-project / Fix login bug`. It updates live when a thread is renamed or a generated title streams in and falls back to showing only the app name when no thread is open. Desktop shows both the expected app name and window title. Browser tabs keep the app name as a suffix. This also fixes the bug that caused "T3 Code (Alpha)" to flash as the app title for a split second before the correct app name was applied.

## Why

The title never said what you were working on. Desktop window previews showed only the app name with no expected window title. Multiple web tabs were indistinguishable and anything that keys off the window title, like time trackers and window switchers, got nothing useful. Other apps already do this, like Cursor with the open project and Discord with the active channel (examples below).

## UI Changes

Before, the window preview showed only the app name. After, a second line shows the active project and thread:

| Before | After |
| --- | --- |
| <img width="292" height="221" alt="Window preview showing only the app name" src="https://raw.githubusercontent.com/chasemakes/t3code/pr-evidence/window-title-before.png" /> | <img width="295" height="233" alt="Window preview showing the active project and thread title beneath the app name" src="https://raw.githubusercontent.com/chasemakes/t3code/pr-evidence/window-title-after-thread.png" /> |

## Other App Examples

| Cursor | Discord |
| --- | --- |
| <img width="290" height="230" alt="Cursor window preview showing the open project beneath the app name" src="https://raw.githubusercontent.com/chasemakes/t3code/pr-evidence/example-cursor.png" /> | <img width="288" height="228" alt="Discord window preview showing the active channel beneath the app name" src="https://raw.githubusercontent.com/chasemakes/t3code/pr-evidence/example-discord.png" /> |

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before and after screenshots
- [x] No animation was added, so a video is not applicable

Built with Claude Fable 5 via Claude Code in T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show project and thread context in window title
> - Adds a zustand store ([windowTitleStore.ts](https://github.com/pingdotgg/t3code/pull/7826/files#diff-c556087c1f0a51b09524e6a3d29c6d4ee3d059e5fd638ba43bc79403b565aa40)) that holds the current project and thread titles, with shallow-equality guards to avoid redundant updates
> - `ChatViewContent` ([ChatView.tsx](https://github.com/pingdotgg/t3code/pull/7826/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e)) pushes the active project/thread into the store; `DocumentTitleSync` in [__root.tsx](https://github.com/pingdotgg/t3code/pull/7826/files#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100) combines that with the app display name via the new `resolveWindowTitle` helper and sets `document.title`
> - `resolveWindowTitle` formats titles as `project / thread` (or just `thread` when no project is active) and appends ` — appName` on web only
> - The desktop shell ([DesktopWindow.ts](https://github.com/pingdotgg/t3code/pull/7826/files#diff-d92229c509071d1e9d3595d187fe2f1f13c394b22e1d9d2070ed6fb99678f429)) now follows the renderer's `document.title` instead of unconditionally overwriting it with the app name; [index.html](https://github.com/pingdotgg/t3code/pull/7826/files#diff-6954645055c39fbf3050b489306101f727465101a1172683088448035dc8463f) sets an initial branded title on first paint
> - Risk: `DesktopWindow.make` relies on the `page-title-updated` event payload being non-empty to show context; if the renderer never sets a title, the window falls back to `environment.displayName`
> >
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 62d0b95.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to document/window title formatting and a client-side store; no auth, data, or API behavior is affected.
> 
> **Overview**
> Window and tab titles now reflect the **active project and thread**, updating as you switch threads or titles change.
> 
> **ChatView** pushes the current project/thread into a small **Zustand store**; **DocumentTitleSync** builds `document.title` via **`resolveWindowTitle`** (project/thread only on desktop; web adds ` — app name` for distinguishable tabs). With no thread, the title stays the server-backed app display name.
> 
> The **Electron shell** stops resetting the native title to the app name on load and on **`page-title-updated`** mirrors the renderer title, falling back to **`environment.displayName`** when empty. **`index.html`** drops the hard-coded **(Alpha)** label and sets an early branded title from **`desktopBridge`** to avoid a wrong title flash on boot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62d0b954d19011276142d5760c32405eb4140c94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->