### PR TITLE
fix(desktop): find linuxbrew node for the WSL backend

### DIFF
--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -116,6 +116,7 @@ describe("ssh tunnel scripts", () => {
     assert.include(script, "remote_node_satisfies_engine()");
     assert.include(script, "function satisfiesSemverRange");
     assert.include(script, "satisfiesSemverRange(rawVersion, range)");
+    assert.include(script, 'prepend_path_if_dir "/home/linuxbrew/.linuxbrew/bin"');
     assert.include(script, 'prepend_path_if_dir "$VOLTA_HOME/bin"');
     assert.include(script, 'prepend_path_if_dir "$HOME/.asdf/shims"');
     assert.include(script, 'prepend_path_if_dir "$HOME/.local/share/mise/shims"');

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -345,6 +345,7 @@ ensure_remote_node_path() {
   prepend_path_if_dir "$HOME/.local/bin"
   prepend_path_if_dir "$HOME/bin"
   prepend_path_if_dir "/opt/homebrew/bin"
+  prepend_path_if_dir "/home/linuxbrew/.linuxbrew/bin"
   prepend_path_if_dir "/usr/local/bin"
   prepend_path_if_dir "/usr/bin"
   prepend_path_if_dir "/bin"


### PR DESCRIPTION
## What Changed

Additional path for Homebrew on Linux was added, so that node installed via brew on all platforms (not just mac) will be detected as a fallback.

## Why

I use Windows through WSL. After turning on the WSL backend, I got the "WSL backend couldn't start" message due to missing `node`. I had node installed via Homebrew for Linux. The brew install only adds the path to `~/.bashrc`, so the login shell didn't have node on the path either. Homebrew on Mac was already covered in the `ensure_remote_node_path` for this exact case.

Note that `/home/linuxbrew/.linuxbrew/bin` is a fixed path for all installs. This is the static directory that brew uses for all Linux installs - it is the direct equivalent of `/opt/homebrew/bin`. In otherwords it isn't anything specific to my setup, machine, or a hallucinated placeholder.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes, not applicable
- [x] I included a video for animation/interaction changes, not applicable


## Workaround

 If others encounter this issues add `eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"` to your bash profile.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small PATH fallback addition in remote shell scripts; no auth, data, or protocol changes.
> 
> **Overview**
> Remote SSH/WSL node discovery now also looks in `/home/linuxbrew/.linuxbrew/bin`, the default Linux Homebrew prefix, next to the existing macOS Homebrew path.
> 
> This lets non-interactive remote shells find Node installed via brew on Linux (including WSL) when brew is only on `~/.bashrc` and not on the login PATH. A unit assertion covers the new path in the generated runner script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f73186893e9738d0e3b91e1660cc8e8c95a70a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Linuxbrew bin path to `ensure_remote_node_path` for WSL backend
> Prepends `/home/linuxbrew/.linuxbrew/bin` to the PATH sequence that `ensure_remote_node_path` searches when locating a usable Node.js on the remote host. This lets the WSL backend discover a Linuxbrew-installed node. Updates the corresponding test assertion in [tunnel.test.ts](https://github.com/pingdotgg/t3code/pull/7827/files#diff-76d3724ec8959625b119aff8272a5d733f73551706a487e303ddbd13e10a06ad).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7f73186.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->