### PR TITLE
fix(opencode): parse model IDs containing spaces

### DIFF
--- a/apps/server/src/provider/opencodeRuntime.cliParsers.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.cliParsers.test.ts
@@ -62,6 +62,25 @@ describe("parseModelsCliOutput", () => {
     NodeAssert.equal(Object.keys(result.providers.get("openai")!.models).length, 1);
   });
 
+  it("parses model IDs with spaces without dropping the preceding model", () => {
+    const stdout = [
+      "custom/model-one",
+      JSON.stringify({
+        id: "model-one",
+        providerID: "custom",
+        name: "Model One",
+      }),
+      "custom/Model Two",
+      JSON.stringify({ id: "Model Two", providerID: "custom", name: "Model Two" }),
+    ].join("\n");
+
+    const result = parseModelsCliOutput(stdout);
+    const provider = result.providers.get("custom")!;
+
+    NodeAssert.ok(provider.models["model-one"]);
+    NodeAssert.ok(provider.models["Model Two"]);
+  });
+
   it("handles empty input", () => {
     const result = parseModelsCliOutput("");
     NodeAssert.equal(result.providers.size, 0);

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -196,7 +196,7 @@ function parseServerUrlFromOutput(output: string): string | null {
   return null;
 }
 
-const SLUG_LINE_RE = /^(\S+\/\S+)\s*$/;
+const SLUG_LINE_RE = /^(\S+\/.*\S)\s*$/;
 const AGENT_HEADER_RE = /^(.+)\s+\((\S+)\)\s*$/;
 
 // Agents that are always hidden in OpenCode but the CLI "agent list" command


### PR DESCRIPTION
## What Changed

Update regex to detect opencode models with whitespaces in id.

**Before:**
`my-provider/Kimi K3` model and preceding model `my-provider/grok-4.6` missing
<img width="1512" height="982" alt="shapes at 26-08-21 13 52 00" src="https://github.com/user-attachments/assets/4a8ab98b-d8b6-418b-99b1-79d7a1bfa7bb" />

**After:**
`my-provider/Kimi K3` model and preceding model `my-provider/grok-4.6` correctly discovered and included
<img width="1512" height="982" alt="shapes at 26-08-21 13 53 49" src="https://github.com/user-attachments/assets/52e91e2b-532f-4e2d-b16f-f7a24c3f5da4" />

## Why

- Custom provider for opencode has spaces in model ids, ie `custom-provider/Kimi K3`
- Whitespaces prevents loading of the whitespaced model and its preceding model

## Checklist

- [X] This PR is small and focused
- [X] I explained what changed and why
- [X] I included before/after screenshots for any UI changes
- [ ] ~~I included a video for animation/interaction changes~~

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Parser-only regex tweak with a targeted unit test; no auth, data, or runtime-control changes.
> 
> **Overview**
> Fixes OpenCode CLI model inventory so slugs like `custom/Kimi K3` are recognized instead of being skipped (which also dropped the following model).
> 
> `SLUG_LINE_RE` now allows spaces in the model-id portion after `provider/`, and a unit test covers a spaced ID without losing the previous model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2f5b9a392ab8f9623e95aa984cb4c9a461ba2e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `SLUG_LINE_RE` to parse model IDs containing spaces in opencode runtime
> Broadens the `SLUG_LINE_RE` regex in [opencodeRuntime.ts](https://github.com/pingdotgg/t3code/pull/7834/files#diff-b36408ac400332f121d5c4711ccfe4fd4049772d0f302343ee303670f4198ea8) so the model segment of a provider/model line may include internal spaces, as long as it does not start or end with whitespace. Adds a test case in [opencodeRuntime.cliParsers.test.ts](https://github.com/pingdotgg/t3code/pull/7834/files#diff-89a1591aef6b6557b8380e6b6169a55f61d0231dd60973e337aa2af824bde0f9) verifying that models with spaces in their IDs are parsed correctly and existing models under the same provider are preserved.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d2f5b9a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->