### PR TITLE
feat(web): add rightPanel.openTerminal keybinding command

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5836,6 +5836,13 @@ export default function ChatView(props: ChatViewProps) {
         return;
       }
 
+      if (command === "rightPanel.openTerminal") {
+        event.preventDefault();
+        event.stopPropagation();
+        addTerminalSurface();
+        return;
+      }
+
       if (command === "rightPanel.close") {
         // Nothing open: leave the event alone so the shortcut keeps its
         // native meaning (close window on desktop, close tab in a browser).

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -52,6 +52,9 @@ successful pick; its hover glow and badge preview the element and color family t
 `rightPanel.toggleMaximized` maximizes or restores the open right panel. It has no default shortcut,
 so add one in **Settings** → **Keybindings** if you want to use it.
 
+`rightPanel.openTerminal` opens a terminal as a right-panel surface for the active thread,
+independent of the bottom drawer, and defaults to `mod+alt+j`.
+
 `rightPanel.close` closes the active right panel tab and defaults to `mod+w`. Press it again to close
 the next tab. With the terminal focused, `mod+w` closes the terminal instead, and with nothing left
 to close it closes the desktop window as before. Browsers reserve `mod+w` for closing their own tab

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -59,6 +59,7 @@ export const STATIC_KEYBINDING_COMMANDS = [
   "terminal.close",
   "rightPanel.toggle",
   "rightPanel.toggleMaximized",
+  "rightPanel.openTerminal",
   "rightPanel.close",
   "diff.toggle",
   "preview.toggle",

--- a/packages/shared/src/keybindings.test.ts
+++ b/packages/shared/src/keybindings.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { DEFAULT_KEYBINDINGS, DEFAULT_RESOLVED_KEYBINDINGS } from "./keybindings.ts";
+
+describe("DEFAULT_KEYBINDINGS", () => {
+  it("binds mod+alt+j to rightPanel.openTerminal", () => {
+    const rules = DEFAULT_KEYBINDINGS.filter((rule) => rule.command === "rightPanel.openTerminal");
+    expect(rules).toEqual([{ key: "mod+alt+j", command: "rightPanel.openTerminal" }]);
+  });
+
+  it("resolves the rightPanel.openTerminal default binding", () => {
+    const binding = DEFAULT_RESOLVED_KEYBINDINGS.find(
+      (rule) => rule.command === "rightPanel.openTerminal",
+    );
+    expect(binding?.shortcut).toEqual({
+      key: "j",
+      metaKey: false,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: true,
+      modKey: true,
+    });
+  });
+});

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -22,6 +22,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+b", command: "sidebar.toggle" },
   { key: "mod+j", command: "terminal.toggle" },
   { key: "mod+alt+b", command: "rightPanel.toggle" },
+  { key: "mod+alt+j", command: "rightPanel.openTerminal" },
   { key: "mod+d", command: "terminal.split", when: "terminalFocus" },
   { key: "mod+shift+d", command: "terminal.splitVertical", when: "terminalFocus" },
   { key: "mod+n", command: "terminal.new", when: "terminalFocus" },


### PR DESCRIPTION
## Problem

There is no way to open a terminal in the right panel from the keyboard. `terminal.new` (mod+n, and mod+j for the drawer) only creates a right-panel terminal when focus is already inside one — the chicken-and-egg problem described in #4790. Every other surface (drawer, diff, preview) has a bindable command; the right-panel terminal did not.

## Fix

Add an additive `rightPanel.openTerminal` command:

- `packages/contracts`: register `rightPanel.openTerminal` in `STATIC_KEYBINDING_COMMANDS`
- `packages/shared`: default binding `mod+alt+j`, mirroring `mod+alt+b` for `rightPanel.toggle`
- `apps/web`: handle the command in `ChatView` by calling the existing `addTerminalSurface()` path

Settings → Keybindings and the command-options list derive from those constants, so the new command appears there automatically and is rebindable like any other. Default bottom-drawer behavior is unchanged.

Closes #4790

## Validation

- New focused test in `packages/shared/src/keybindings.test.ts` asserting the default binding
- Targeted tests pass (contracts keybindings, web keybindings, KeybindingsSettings.logic)
- Lint and typecheck clean for contracts, shared, and apps/web

⌘⌥J on macOS / Ctrl+Alt+J elsewhere opens a terminal as a right-panel surface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive keybinding and handler reusing an existing surface-creation path; no auth, data, or drawer behavior changes.
> 
> **Overview**
> Adds a **`rightPanel.openTerminal`** keybinding so users can open a right-panel terminal from the keyboard without already having terminal focus in that panel (addresses the chicken-and-egg gap vs drawer `mod+j` / in-panel `terminal.new`).
> 
> The command is registered in **`STATIC_KEYBINDING_COMMANDS`**, defaults to **`mod+alt+j`** (alongside **`mod+alt+b`** for toggling the right panel), and is handled in **`ChatView`** by calling the existing **`addTerminalSurface()`** path. User docs describe the command and default shortcut; shared package tests assert the default rule and resolved shortcut shape.
> 
> Bottom-drawer terminal behavior is unchanged; the new binding only adds an explicit, rebindable entry in Settings → Keybindings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1bd21dec502831b3108e140232f202e33e8fd5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `rightPanel.openTerminal` keybinding command with `mod+alt+j` shortcut
> - Registers `rightPanel.openTerminal` in `STATIC_KEYBINDING_COMMANDS` and maps it to `mod+alt+j` in `DEFAULT_KEYBINDINGS` in [keybindings.ts](https://github.com/pingdotgg/t3code/pull/7835/files#diff-43f35e6edaf374f5ed53b0c61409d76e733a1b8e06098a0e8ded132d3b433f06).
> - Adds handler in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/7835/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) that prevents default, stops propagation, and creates the terminal right-panel surface.
> - Documents the command in [keybindings.md](https://github.com/pingdotgg/t3code/pull/7835/files#diff-2858dfbce3443e10e5180f361437183badc111f8cac64cfe3094bae56b568e43) and adds default/resolved binding assertions in [keybindings.test.ts](https://github.com/pingdotgg/t3code/pull/7835/files#diff-ec60ffaf415350ddd328da873e763170510efc9103c7d01dd4495639780771fe).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d1bd21d. 4 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->