### PR TITLE
fix(web): support Ctrl+V terminal paste on Windows

### DIFF
--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -247,6 +247,11 @@ describe("isTerminalPasteShortcut", () => {
     expect(isTerminalPasteShortcut(event({ ctrlKey: true }), "MacIntel")).toBe(false);
   });
 
+  it("uses Ctrl+V on Windows", () => {
+    expect(isTerminalPasteShortcut(event({ ctrlKey: true }), "Win32")).toBe(true);
+    expect(isTerminalPasteShortcut(event({ metaKey: true }), "Win32")).toBe(false);
+  });
+
   it("preserves Ctrl+V and uses Ctrl+Shift+V elsewhere", () => {
     expect(isTerminalPasteShortcut(event({ ctrlKey: true }), "Linux x86_64")).toBe(false);
     expect(isTerminalPasteShortcut(event({ ctrlKey: true, shiftKey: true }), "Linux x86_64")).toBe(

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -1,4 +1,4 @@
-import { isMacPlatform } from "../../lib/utils";
+import { isMacPlatform, isWindowsPlatform } from "../../lib/utils";
 import { collectWrappedTerminalLinkLine, extractTerminalLinks } from "../../terminal-links";
 import {
   GhosttyTerminalCore,
@@ -345,7 +345,9 @@ export function isTerminalPasteShortcut(
     return event.shiftKey && !event.ctrlKey && !event.metaKey;
   }
   if (key !== "v") return false;
-  return isMacPlatform(platform) ? event.metaKey : event.ctrlKey && event.shiftKey;
+  if (isMacPlatform(platform)) return event.metaKey;
+  if (isWindowsPlatform(platform)) return event.ctrlKey;
+  return event.ctrlKey && event.shiftKey;
 }
 
 export function isTerminalCompositionCommitInput(event: Pick<InputEvent, "inputType">): boolean {


### PR DESCRIPTION
## What Changed

Added Windows-specific terminal paste handling so `Ctrl+V` triggers clipboard paste.

## Why

(This may have been on purpose for Windows so feel free to disregard)

When using WSL from Windows Terminal, `Ctrl+V` is  handled by the Windows terminal as paste before the key reaches Linux. T3’s Windows client should provide the same behavior to avoid friction.

Previously, Windows fell into the generic non-macOS path, so `Ctrl+V` was forwarded to the WSL PTY as control-V and appeared as `^V`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-tested shortcut mapping change with no auth or data-handling impact. Linux still keeps Ctrl+V for the PTY.
> 
> **Overview**
> Treats **Ctrl+V** as clipboard paste on Windows in `isTerminalPasteShortcut`, instead of the previous non-mac path that required **Ctrl+Shift+V** and forwarded Ctrl+V as `^V`.
> 
> macOS stays **Cmd+V**; Linux still uses **Ctrl+Shift+V** so Ctrl+V can reach the PTY. Adds a Windows unit test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a8962d5c1fc403048dd0866819c669dd8871781. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support `Ctrl+V` terminal paste on Windows in `isTerminalPasteShortcut`
> - Updates the `v` key branch of `isTerminalPasteShortcut` in [surface.ts](https://github.com/pingdotgg/t3code/pull/7850/files#diff-036d64ffe3b3b3d167137e8ea29edae7af74a9e0323fc798c4f291992235d267) to return true for `Ctrl+V` on Windows.
> - macOS keeps `Cmd+V`, and other non-mac platforms keep `Ctrl+Shift+V`.
> - Adds a test case in [surface.test.ts](https://github.com/pingdotgg/t3code/pull/7850/files#diff-4739505f766bda541a0cf14a163fb5321204b64183ba45ffcc1a0026ad6e8029) confirming Windows uses `Ctrl+V` (not `Cmd+V`).
> - Risk: Windows users who relied on `Ctrl+Shift+V` now trigger paste with plain `Ctrl+V` via `isTerminalPasteShortcut`, which may conflict with existing `Ctrl+V` bindings in the terminal surface.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9a8962d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->