### PR TITLE
fix(server): settle error session exits

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -2714,6 +2714,48 @@ describe("ProviderRuntimeIngestion", () => {
     expect(thread.session?.lastError).toBe("runtime exploded");
   });
 
+  it("settles an active turn when an error session exit arrives without runtime.error", async () => {
+    const harness = await createHarness();
+    const turnId = asTurnId("turn-session-exit-error");
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-session-exit-error-turn-started"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:00.000Z",
+      threadId: asThreadId("thread-1"),
+      turnId,
+    });
+
+    await waitForThread(
+      harness.readModel,
+      (entry) => entry.session?.status === "running" && entry.session.activeTurnId === turnId,
+    );
+
+    harness.emit({
+      type: "session.exited",
+      eventId: asEventId("evt-session-exit-error"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-01-01T00:00:01.000Z",
+      threadId: asThreadId("thread-1"),
+      payload: {
+        reason: "Provider process exited unexpectedly (137).",
+        exitKind: "error",
+      },
+    });
+
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) =>
+        entry.session?.status === "error" &&
+        entry.session.activeTurnId === null &&
+        entry.session.lastError === "Provider process exited unexpectedly (137).",
+    );
+    expect(thread.session?.status).toBe("error");
+    expect(thread.session?.activeTurnId).toBeNull();
+    expect(thread.session?.lastError).toBe("Provider process exited unexpectedly (137).");
+  });
+
   it("records runtime.error activities from the typed payload message", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1572,6 +1572,8 @@ const make = Effect.gen(function* () {
         event.type === "turn.started" ||
         event.type === "turn.completed"
       ) {
+        const unexpectedSessionExit =
+          event.type === "session.exited" && event.payload.exitKind === "error";
         const status = (() => {
           switch (event.type) {
             case "session.state.changed": {
@@ -1593,6 +1595,7 @@ const make = Effect.gen(function* () {
               return activeTurnId !== null ? "running" : hasPendingTurnStart ? "starting" : "ready";
           }
         })();
+        const lifecycleStatus = unexpectedSessionExit ? "error" : status;
         const nextActiveTurnId =
           event.type === "turn.started"
             ? (eventTurnId ?? null)
@@ -1605,14 +1608,18 @@ const make = Effect.gen(function* () {
                 ? null
                 : activeTurnId;
         const lastError =
-          event.type === "session.state.changed" && event.payload.state === "error"
-            ? (event.payload.reason ?? thread.session?.lastError ?? "Provider session error")
-            : event.type === "turn.completed" &&
-                normalizeRuntimeTurnState(event.payload.state) === "failed"
-              ? (event.payload.errorMessage ?? thread.session?.lastError ?? "Turn failed")
-              : status === "ready"
-                ? null
-                : (thread.session?.lastError ?? null);
+          unexpectedSessionExit
+            ? (event.payload.reason ??
+              thread.session?.lastError ??
+              "Provider session exited unexpectedly")
+            : event.type === "session.state.changed" && event.payload.state === "error"
+              ? (event.payload.reason ?? thread.session?.lastError ?? "Provider session error")
+              : event.type === "turn.completed" &&
+                  normalizeRuntimeTurnState(event.payload.state) === "failed"
+                ? (event.payload.errorMessage ?? thread.session?.lastError ?? "Turn failed")
+                : lifecycleStatus === "ready"
+                  ? null
+                  : (thread.session?.lastError ?? null);
 
         if (shouldApplyThreadLifecycle) {
           if (event.type === "turn.started" && acceptedTurnStartedSourcePlan !== null) {
@@ -1641,7 +1648,7 @@ const make = Effect.gen(function* () {
             threadId: thread.id,
             session: {
               threadId: thread.id,
-              status,
+              status: lifecycleStatus,
               providerName: event.provider,
               ...(event.providerInstanceId !== undefined
                 ? { providerInstanceId: event.providerInstanceId }


### PR DESCRIPTION
## Problem

An abruptly terminated provider process can emit a typed session.exited event with exitKind error without a separate runtime.error. The ingestion path treated every session exit as a normal stop, leaving an active turn without an error state.

## Fix

Treat error-classified session exits as an error lifecycle transition, clear the active turn, and preserve the provider exit reason as lastError. Graceful exits remain stopped.

Added a focused regression test covering an active turn followed by an error session exit without runtime.error.

## Verification

- git diff --check passed.
- Focused test, typecheck, and lint commands were attempted but could not run because the checkout had no complete vp installation. Dependency bootstrap exceeded the available timeout.

Model: GPT-5.6 Luna
Harness: OpenCode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider session lifecycle projection, so a misclassified exit could leave threads in error vs stopped incorrectly. Scope is small and covered by a focused test.
> 
> **Overview**
> Treats unexpected provider process exits as a real session **error**, not a graceful stop.
> 
> When `session.exited` arrives with `exitKind: "error"` (even without a separate `runtime.error`), ingestion now sets session status to `error`, clears the active turn, and stores the provider exit reason as `lastError`. Normal exits still map to `stopped`.
> 
> Adds a regression test for an in-flight turn followed by an error-classified session exit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccdecf16800025f3456f72e0fa3639bf2bf89264. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set session status to 'error' on unexpected `session.exited` events in `ProviderRuntimeIngestion`
> When a `session.exited` event arrives with `exitKind='error'`, the ingestion layer now sets the thread session status to `'error'`, clears `activeTurnId` to null, and records `lastError` from the payload reason (or a default message). Non-error exits continue to set status to `'stopped'`. Adds a test verifying this transition.
> - Risk: the dispatched `thread.session.set` command now uses `lifecycleStatus` instead of the previously computed `status`; any downstream consumers expecting `'stopped'` for error exits will see `'error'` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ccdecf1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->