### PR TITLE
fix(web): handle wide ordered-list marker edge cases

### DIFF
--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -24,13 +24,21 @@ describe("orderedListGutterStyle", () => {
   it("accounts for a non-default start attribute", () => {
     // start=95 + 9 items => last marker is "103", three digits.
     expect(orderedListGutterStyle(9, 95)).toEqual({ "--list-gutter": "4ch" });
+    expect(orderedListGutterStyle(5, "999995")).toEqual({ "--list-gutter": "7ch" });
   });
 
   it("scales further for four-digit markers", () => {
     expect(orderedListGutterStyle(1000, undefined)).toEqual({ "--list-gutter": "5ch" });
   });
 
+  it("uses the widest marker and includes a negative start's minus sign", () => {
+    expect(orderedListGutterStyle(1001, -1000)).toEqual({ "--list-gutter": "6ch" });
+    expect(orderedListGutterStyle(3, -15)).toEqual({ "--list-gutter": "4ch" });
+    expect(orderedListGutterStyle(3, -5)).toBeUndefined();
+  });
+
   it("treats a missing/zero item count as a single item", () => {
     expect(orderedListGutterStyle(0, undefined)).toBeUndefined();
+    expect(orderedListGutterStyle(0, 100)).toEqual({ "--list-gutter": "4ch" });
   });
 });

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -157,22 +157,24 @@ function findTaskListMarkerOffset(markdown: string, listItemStart: number): numb
 }
 
 /**
- * The default `1.25rem` marker gutter (`.chat-markdown ol`) fits two-digit
- * decimal markers. Once a list's last item reaches three digits (item 100+),
- * `list-style-position: outside` paints the marker wider than that gutter and
- * the leading digit gets clipped by the item's own overflow. Rather than
- * widening the gutter for every list, only lists whose last marker is 3+
- * digits get a wider `--list-gutter`, sized to that marker's digit count.
+ * The default `1.25rem` marker gutter (`.chat-markdown ol`) fits markers up to
+ * two characters wide. Once a marker reaches three characters (item 100+),
+ * `list-style-position: outside` paints it wider than that gutter and clips
+ * the leading character against the item's own overflow. Rather than widening
+ * the gutter for every list, only lists whose widest marker is 3+ characters
+ * get a wider `--list-gutter`. The width includes a negative marker's minus
+ * sign.
  */
 export function orderedListGutterStyle(
   itemCount: number,
-  start: number | undefined,
+  start: unknown,
 ): { "--list-gutter": string } | undefined {
-  const firstNumber = typeof start === "number" && Number.isFinite(start) ? start : 1;
+  const parsedStart = Number.parseInt(String(start ?? 1), 10);
+  const firstNumber = Number.isNaN(parsedStart) ? 1 : parsedStart;
   const lastNumber = firstNumber + Math.max(itemCount - 1, 0);
-  const digits = String(Math.abs(lastNumber)).length;
-  if (digits <= 2) return undefined;
-  return { "--list-gutter": `${digits + 1}ch` };
+  const markerWidth = Math.max(String(firstNumber).length, String(lastNumber).length);
+  if (markerWidth <= 2) return undefined;
+  return { "--list-gutter": `${markerWidth + 1}ch` };
 }
 
 const CHAT_MARKDOWN_SANITIZE_SCHEMA = {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2040,13 +2040,17 @@ code {
 
 /* --list-gutter defaults to the same 1.25rem as .chat-markdown ul, but
    ChatMarkdown's `ol` renderer widens it (via inline style) for lists whose
-   last marker is 3+ digits, so item 100+ isn't clipped by list-style-position:
+   widest marker is 3+ characters, so item 100+ isn't clipped by list-style-position:
    outside painting the marker past the padding box. Reset it here too so a
    nested ol without its own widened marker doesn't inherit the outer one. */
 .chat-markdown ol {
   --list-gutter: 1.25rem;
   padding-left: var(--list-gutter, 1.25rem);
   list-style-type: decimal;
+}
+
+.chat-markdown ol > li::marker {
+  font-variant-numeric: tabular-nums;
 }
 
 .chat-markdown ul ul {
@@ -2114,7 +2118,6 @@ code {
 
 .chat-markdown section[data-footnotes] ol {
   margin: 0;
-  padding-left: 1.25rem;
 }
 
 .chat-markdown section[data-footnotes] li + li {


### PR DESCRIPTION
## What changed

- Ordered-list gutter sizing now compares the first and last markers, including a negative marker's minus sign.
- Raw HTML `start` values are coerced before sizing the gutter.
- Footnote ordered lists keep their computed gutter instead of resetting to `1.25rem`.
- Decimal markers use tabular numerals so their digits align.

## Why

#6527 landed the core dynamic-gutter fix while #5163 was open, which left the older PR conflicting with `main`. This replacement keeps the current implementation and carries forward the edge cases and marker alignment that are still missing.

## UI changes

The original before/after evidence is preserved in #5163. The replacement is limited to cases not covered by the implementation that has since landed on `main`.

### Before

<img width="762" height="1289" alt="Ordered-list marker clipping before the fix" src="https://github.com/user-attachments/assets/341759a2-555e-460b-bd0c-099c10832eee" />

### After

<img width="764" height="1192" alt="Ordered-list markers after the fix" src="https://github.com/user-attachments/assets/44dd78ce-1ba3-4596-9139-1f95ea33a57f" />

## Verification

- `pnpm exec vp fmt --check apps/web/src/components/ChatMarkdown.tsx apps/web/src/components/ChatMarkdown.test.tsx apps/web/src/index.css`
- `pnpm exec vp lint --report-unused-disable-directives apps/web/src/components/ChatMarkdown.tsx apps/web/src/components/ChatMarkdown.test.tsx`
- `cd apps/web && pnpm exec vp test run --passWithNoTests --project unit src/components/ChatMarkdown.test.tsx`
- `pnpm exec vp run --filter @t3tools/web typecheck`

Supersedes #5163.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ordered-list gutter sizing for wide and negative markers in `ChatMarkdown`
> - `orderedListGutterStyle` now parses `start` via `Number.parseInt` on stringified input (defaulting to 1 on NaN) and sizes the gutter from the widest of the first and last markers, including the minus sign for negative starts
> - CSS updates in [index.css](https://github.com/pingdotgg/t3code/pull/7856/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd): ordered list markers use `font-variant-numeric: tabular-nums`, and footnote ordered lists inherit padding from `.chat-markdown ol` so widened gutters apply instead of the prior fixed `1.25rem`
> - Behavioral Change: second parameter of `orderedListGutterStyle` widens from `number | undefined` to `unknown`; non-numeric inputs are now parsed rather than ignored. Footnote list padding-left no longer hardcodes `1.25rem`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2bd7d91.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only markdown list styling with unit tests; no auth, data, or security impact.
> 
> **Overview**
> Fixes remaining ordered-list marker clipping in chat markdown after the dynamic-gutter work.
> 
> `orderedListGutterStyle` now parses HTML `start` (including string values) and sizes `--list-gutter` from the **widest** of the first and last markers, counting a negative start’s minus sign. Footnote lists no longer force `padding-left: 1.25rem`, so a widened gutter can apply. Decimal markers use `tabular-nums` so digits align.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bd7d91de0677852fd663c673b02863826325600. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->