### PR TITLE
fix(web/mobile): render project images in nested markdown file previews and harden markdown images

### DIFF
--- a/apps/mobile/src/components/markdownImages.tsx
+++ b/apps/mobile/src/components/markdownImages.tsx
@@ -1,0 +1,164 @@
+import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { useEffect, useRef, useState } from "react";
+import { ActivityIndicator, Image, StyleSheet, View, type ViewStyle } from "react-native";
+import { TouchableOpacity } from "react-native-gesture-handler";
+
+import { useThemeColor } from "../lib/useThemeColor";
+import { useAssetUrlState } from "../state/assets";
+import {
+  MARKDOWN_IMAGE_MAX_WIDTH,
+  resolveMarkdownImageDisplaySize,
+} from "../features/threads/markdownImageSize";
+import { AppText as Text } from "./AppText";
+
+export function ThreadMarkdownImageView(props: {
+  readonly uri: string | null;
+  readonly sourceKey: string;
+  readonly unavailable: boolean;
+  readonly alt: string | null;
+  readonly onPressImage?: ((uri: string) => void) | undefined;
+}) {
+  const codeBackground = useThemeColor("--color-md-code-bg");
+  const [availableWidth, setAvailableWidth] = useState(0);
+  const [sourceSize, setSourceSize] = useState<{ width: number; height: number } | null>(null);
+  const [failedUri, setFailedUri] = useState<string | null>(null);
+  const activeUriRef = useRef(props.uri);
+  activeUriRef.current = props.uri;
+
+  useEffect(() => {
+    setSourceSize(null);
+  }, [props.sourceKey]);
+
+  useEffect(() => {
+    setFailedUri(null);
+  }, [props.uri]);
+
+  const displaySize =
+    sourceSize === null
+      ? null
+      : resolveMarkdownImageDisplaySize({
+          sourceWidth: sourceSize.width,
+          sourceHeight: sourceSize.height,
+          availableWidth,
+        });
+  const failed = props.unavailable || (props.uri !== null && failedUri === props.uri);
+  const placeholderWidth: ViewStyle["width"] =
+    availableWidth > 0 ? Math.min(availableWidth, MARKDOWN_IMAGE_MAX_WIDTH) : "100%";
+  const frameStyle: ViewStyle = displaySize ?? { width: placeholderWidth, aspectRatio: 16 / 9 };
+
+  const image =
+    props.uri === null || failed ? (
+      <View
+        style={{
+          ...frameStyle,
+          borderRadius: 10,
+          backgroundColor: codeBackground,
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        {failed ? (
+          <Text className="text-xs text-foreground-muted">Image unavailable</Text>
+        ) : (
+          <ActivityIndicator />
+        )}
+      </View>
+    ) : (
+      <View
+        style={{
+          ...frameStyle,
+          borderRadius: 10,
+          backgroundColor: codeBackground,
+          alignItems: "center",
+          justifyContent: "center",
+          overflow: "hidden",
+        }}
+      >
+        <Image
+          source={{ uri: props.uri }}
+          resizeMode="contain"
+          accessible={false}
+          onLoad={(event) => {
+            if (activeUriRef.current !== props.uri) return;
+            const { width, height } = event.nativeEvent.source;
+            setSourceSize({ width, height });
+          }}
+          onError={() => setFailedUri(props.uri)}
+          style={{
+            width: "100%",
+            height: "100%",
+            opacity: displaySize === null ? 0 : 1,
+          }}
+        />
+        {displaySize === null ? <ActivityIndicator style={StyleSheet.absoluteFill} /> : null}
+      </View>
+    );
+
+  return (
+    <View
+      onLayout={(event) => setAvailableWidth(event.nativeEvent.layout.width)}
+      style={{ alignSelf: "stretch", gap: 6 }}
+    >
+      {props.uri !== null && !failed && props.onPressImage ? (
+        <TouchableOpacity
+          accessibilityRole="imagebutton"
+          accessibilityLabel={props.alt ?? "Markdown image"}
+          activeOpacity={0.7}
+          onPress={() => props.onPressImage?.(props.uri!)}
+          style={{ alignSelf: "flex-start" }}
+        >
+          {image}
+        </TouchableOpacity>
+      ) : (
+        image
+      )}
+      {props.alt ? (
+        <Text selectable className="text-xs text-foreground-muted">
+          {props.alt}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+export function ThreadMarkdownImageUnavailable(props: { readonly alt: string | null }) {
+  return (
+    <ThreadMarkdownImageView uri={null} sourceKey="unavailable" unavailable alt={props.alt} />
+  );
+}
+
+/** Markdown image whose src is a workspace file. It loads through a signed asset URL. */
+export function ThreadMarkdownImage(props: {
+  readonly environmentId: EnvironmentId;
+  readonly threadId: ThreadId;
+  readonly path: string;
+  readonly alt: string | null;
+  readonly onPressImage?: ((uri: string) => void) | undefined;
+}) {
+  const isSvg = /\.svg$/i.test(props.path);
+  const assetUrl = useAssetUrlState(
+    props.environmentId,
+    // React Native's Image cannot decode SVG, so a signed URL would draw nothing.
+    isSvg
+      ? null
+      : {
+          _tag: "workspace-file",
+          threadId: props.threadId,
+          path: props.path,
+        },
+  );
+
+  if (isSvg) {
+    return <ThreadMarkdownImageUnavailable alt={props.alt} />;
+  }
+
+  return (
+    <ThreadMarkdownImageView
+      uri={assetUrl._tag === "Success" ? assetUrl.url : null}
+      sourceKey={props.path}
+      unavailable={assetUrl._tag === "Failure"}
+      alt={props.alt}
+      onPressImage={props.onPressImage}
+    />
+  );
+}

--- a/apps/mobile/src/components/markdownImages.tsx
+++ b/apps/mobile/src/components/markdownImages.tsx
@@ -138,7 +138,6 @@ export function ThreadMarkdownImage(props: {
   const isSvg = /\.svg$/i.test(props.path);
   const assetUrl = useAssetUrlState(
     props.environmentId,
-    // React Native's Image cannot decode SVG, so a signed URL would draw nothing.
     isSvg
       ? null
       : {

--- a/apps/mobile/src/features/files/FileMarkdownPreview.test.tsx
+++ b/apps/mobile/src/features/files/FileMarkdownPreview.test.tsx
@@ -9,7 +9,10 @@ const testState = vi.hoisted(() => ({
 vi.mock("react", async (importOriginal) => ({
   ...(await importOriginal<typeof import("react")>()),
   useCallback: <Value,>(value: Value) => value,
+  // Effects never run: renderTree does a single render-only pass.
+  useEffect: () => {},
   useMemo: <Value,>(factory: () => Value) => factory(),
+  useRef: <Value,>(initial: Value) => ({ current: initial }),
   useState: <Value,>(initial: Value | (() => Value)) => [
     typeof initial === "function" ? (initial as () => Value)() : initial,
     vi.fn(),
@@ -20,6 +23,7 @@ vi.mock("react-native", () => ({
   Image: "Image",
   RefreshControl: "RefreshControl",
   ScrollView: "ScrollView",
+  StyleSheet: { absoluteFill: {} },
   Text: "Text",
   View: "View",
 }));

--- a/apps/mobile/src/features/files/FileMarkdownPreview.test.tsx
+++ b/apps/mobile/src/features/files/FileMarkdownPreview.test.tsx
@@ -1,0 +1,113 @@
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { isValidElement, type ReactElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const testState = vi.hoisted(() => ({
+  resources: [] as Array<unknown>,
+}));
+
+vi.mock("react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react")>()),
+  useCallback: <Value,>(value: Value) => value,
+  useMemo: <Value,>(factory: () => Value) => factory(),
+  useState: <Value,>(initial: Value | (() => Value)) => [
+    typeof initial === "function" ? (initial as () => Value)() : initial,
+    vi.fn(),
+  ],
+}));
+vi.mock("react-native", () => ({
+  ActivityIndicator: "ActivityIndicator",
+  Image: "Image",
+  RefreshControl: "RefreshControl",
+  ScrollView: "ScrollView",
+  Text: "Text",
+  View: "View",
+}));
+vi.mock("react-native-gesture-handler", () => ({ TouchableOpacity: "TouchableOpacity" }));
+vi.mock("react-native-nitro-markdown", () => ({
+  Markdown: (props: {
+    readonly children: string;
+    readonly renderers: {
+      readonly image: (input: {
+        readonly node: { readonly href: string; readonly alt: string; readonly title: null };
+      }) => ReactNode;
+    };
+  }) => {
+    const match = /!\[([^\]]*)]\(([^)]+)\)/.exec(props.children);
+    return match?.[2]
+      ? props.renderers.image({
+          node: { href: match[2], alt: match[1] ?? "", title: null },
+        })
+      : null;
+  },
+}));
+vi.mock("../../components/AppText", () => ({ AppText: "Text" }));
+vi.mock("../../lib/openExternalUrl", () => ({ tryOpenExternalUrl: vi.fn() }));
+vi.mock("../../lib/useFontFamily", () => ({ useFontFamily: () => "System" }));
+vi.mock("../../lib/useThemeColor", () => ({ useThemeColor: () => "#000" }));
+vi.mock("../../native/SelectableMarkdownText", () => ({
+  hasNativeSelectableMarkdownText: () => false,
+  SelectableMarkdownText: () => null,
+}));
+vi.mock("../../state/assets", () => ({
+  useAssetUrlState: (_environmentId: unknown, resource: unknown) => {
+    testState.resources.push(resource);
+    return { _tag: "Success", url: "https://signed.test/diagram.png" };
+  },
+}));
+vi.mock("../settings/appearance/AppearancePreferencesProvider", () => ({
+  useAppearancePreferences: () => ({ appearance: { baseFontSize: 14 } }),
+}));
+
+import { FileMarkdownPreview } from "./FileMarkdownPreview";
+
+function renderTree(node: ReactNode): void {
+  if (Array.isArray(node)) {
+    node.forEach(renderTree);
+    return;
+  }
+  if (!isValidElement(node)) return;
+  const element = node as ReactElement<Record<string, unknown>>;
+  if (typeof element.type === "function") {
+    const render = element.type as (props: Record<string, unknown>) => ReactNode;
+    renderTree(render(element.props));
+    return;
+  }
+  renderTree(element.props.children as ReactNode);
+}
+
+describe("FileMarkdownPreview workspace images", () => {
+  beforeEach(() => {
+    testState.resources = [];
+  });
+
+  it.each([
+    ["/workspace/project", "docs/README.md", "/workspace/project/docs/images/diagram.png"],
+    [
+      "C:\\Users\\shawn\\project",
+      "docs\\README.md",
+      "C:\\Users\\shawn\\project\\docs\\images\\diagram.png",
+    ],
+  ])(
+    "requests a nested file image beside the document in %s",
+    (cwd, relativePath, expectedPath) => {
+      renderTree(
+        FileMarkdownPreview({
+          cwd,
+          relativePath,
+          environmentId: EnvironmentId.make("environment-1"),
+          threadId: ThreadId.make("thread-1"),
+          markdown: "![diagram](images/diagram.png)",
+        }),
+      );
+
+      expect(testState.resources).toEqual([
+        {
+          _tag: "workspace-file",
+          threadId: ThreadId.make("thread-1"),
+          path: expectedPath,
+        },
+      ]);
+    },
+  );
+});

--- a/apps/mobile/src/features/files/FileMarkdownPreview.tsx
+++ b/apps/mobile/src/features/files/FileMarkdownPreview.tsx
@@ -18,6 +18,7 @@ import { useAppearancePreferences } from "../settings/appearance/AppearancePrefe
 import {
   hasNativeSelectableMarkdownText,
   SelectableMarkdownText,
+  type MarkdownImageRenderer,
   type NativeMarkdownTextStyle,
 } from "../../native/SelectableMarkdownText";
 
@@ -28,7 +29,7 @@ interface MarkdownPreviewStyles {
   readonly nativeTextStyle: NativeMarkdownTextStyle;
 }
 
-function useMarkdownPreviewStyles(): MarkdownPreviewStyles {
+function useMarkdownPreviewStyles(renderImage?: MarkdownImageRenderer): MarkdownPreviewStyles {
   const { appearance } = useAppearancePreferences();
   const markdownFontSizes = useMemo(
     () => resolveMarkdownFontSizes(appearance.baseFontSize),
@@ -68,6 +69,14 @@ function useMarkdownPreviewStyles(): MarkdownPreviewStyles {
           {children}
         </NativeText>
       ),
+      image: ({ node }) =>
+        node.href && renderImage
+          ? (renderImage({
+              href: node.href,
+              alt: node.alt ?? null,
+              title: node.title ?? null,
+            }) ?? undefined)
+          : undefined,
     };
 
     return {
@@ -165,6 +174,7 @@ function useMarkdownPreviewStyles(): MarkdownPreviewStyles {
     mediumFontFamily,
     nativeMarkdownTypography,
     regularFontFamily,
+    renderImage,
     strong,
     boldFontFamily,
   ]);
@@ -173,6 +183,7 @@ function useMarkdownPreviewStyles(): MarkdownPreviewStyles {
 export function FileMarkdownPreview(props: {
   readonly markdown: string;
   readonly onRefresh?: () => Promise<void> | void;
+  readonly renderImage?: MarkdownImageRenderer;
 }) {
   const [isPullRefreshing, setIsPullRefreshing] = useState(false);
   const handlePullToRefresh = useCallback(async () => {
@@ -186,7 +197,7 @@ export function FileMarkdownPreview(props: {
       setIsPullRefreshing(false);
     }
   }, [props.onRefresh]);
-  const styles = useMarkdownPreviewStyles();
+  const styles = useMarkdownPreviewStyles(props.renderImage);
   const onLinkPress = useCallback((href: string) => {
     void tryOpenExternalUrl(href, "markdown-link");
   }, []);
@@ -209,6 +220,7 @@ export function FileMarkdownPreview(props: {
           <SelectableMarkdownText
             markdown={props.markdown}
             onLinkPress={onLinkPress}
+            renderImage={props.renderImage}
             textStyle={styles.nativeTextStyle}
           />
         ) : (

--- a/apps/mobile/src/features/files/FileMarkdownPreview.tsx
+++ b/apps/mobile/src/features/files/FileMarkdownPreview.tsx
@@ -1,3 +1,5 @@
+import { classifyMarkdownImageSource } from "@t3tools/client-runtime/markdown-images";
+import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import { useCallback, useMemo, useState } from "react";
 import {
   Markdown,
@@ -14,6 +16,10 @@ import {
   resolveNativeMarkdownTypography,
 } from "../../lib/appearancePreferences";
 import { useThemeColor } from "../../lib/useThemeColor";
+import {
+  ThreadMarkdownImage,
+  ThreadMarkdownImageUnavailable,
+} from "../../components/markdownImages";
 import { useAppearancePreferences } from "../settings/appearance/AppearancePreferencesProvider";
 import {
   hasNativeSelectableMarkdownText,
@@ -21,6 +27,7 @@ import {
   type MarkdownImageRenderer,
   type NativeMarkdownTextStyle,
 } from "../../native/SelectableMarkdownText";
+import { resolveWorkspaceFilePath } from "./filePath";
 
 interface MarkdownPreviewStyles {
   readonly theme: PartialMarkdownTheme;
@@ -181,9 +188,12 @@ function useMarkdownPreviewStyles(renderImage?: MarkdownImageRenderer): Markdown
 }
 
 export function FileMarkdownPreview(props: {
+  readonly cwd: string;
+  readonly environmentId: EnvironmentId;
   readonly markdown: string;
+  readonly relativePath: string;
+  readonly threadId: ThreadId;
   readonly onRefresh?: () => Promise<void> | void;
-  readonly renderImage?: MarkdownImageRenderer;
 }) {
   const [isPullRefreshing, setIsPullRefreshing] = useState(false);
   const handlePullToRefresh = useCallback(async () => {
@@ -197,7 +207,33 @@ export function FileMarkdownPreview(props: {
       setIsPullRefreshing(false);
     }
   }, [props.onRefresh]);
-  const styles = useMarkdownPreviewStyles(props.renderImage);
+  const renderImage = useMemo<MarkdownImageRenderer>(() => {
+    const lastSeparator = Math.max(
+      props.relativePath.lastIndexOf("/"),
+      props.relativePath.lastIndexOf("\\"),
+    );
+    const imageBaseDir =
+      lastSeparator >= 0
+        ? resolveWorkspaceFilePath(props.cwd, props.relativePath.slice(0, lastSeparator))
+        : props.cwd;
+
+    return (image) => {
+      const imageSource = classifyMarkdownImageSource(image.href, imageBaseDir);
+      if (imageSource._tag === "Direct") return null;
+      if (imageSource._tag === "Blocked") {
+        return <ThreadMarkdownImageUnavailable alt={image.alt} />;
+      }
+      return (
+        <ThreadMarkdownImage
+          environmentId={props.environmentId}
+          threadId={props.threadId}
+          path={imageSource.path}
+          alt={image.alt}
+        />
+      );
+    };
+  }, [props.cwd, props.environmentId, props.relativePath, props.threadId]);
+  const styles = useMarkdownPreviewStyles(renderImage);
   const onLinkPress = useCallback((href: string) => {
     void tryOpenExternalUrl(href, "markdown-link");
   }, []);
@@ -220,7 +256,7 @@ export function FileMarkdownPreview(props: {
           <SelectableMarkdownText
             markdown={props.markdown}
             onLinkPress={onLinkPress}
-            renderImage={props.renderImage}
+            renderImage={renderImage}
             textStyle={styles.nativeTextStyle}
           />
         ) : (

--- a/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
+++ b/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
@@ -1,6 +1,7 @@
 import { NativeHeaderToolbar, NativeStackScreenOptions } from "../../native/StackHeader";
 import { StackActions, useNavigation, type StaticScreenProps } from "@react-navigation/native";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { classifyMarkdownImageSource } from "@t3tools/client-runtime/markdown-images";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ActivityIndicator, Platform, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import Svg, { Defs, LinearGradient, Rect, Stop } from "react-native-svg";
@@ -16,10 +17,15 @@ import { SymbolView } from "../../components/AppSymbol";
 import { AppText as Text, AppTextInput as TextInput } from "../../components/AppText";
 import { EmptyState } from "../../components/EmptyState";
 import { LoadingScreen } from "../../components/LoadingScreen";
+import {
+  ThreadMarkdownImage,
+  ThreadMarkdownImageUnavailable,
+} from "../../components/markdownImages";
 import { resolveFileSelectionNavigationAction } from "../../lib/adaptive-navigation";
 import { copyTextWithHaptic } from "../../lib/copyTextWithHaptic";
 import { tryOpenExternalUrl } from "../../lib/openExternalUrl";
 import { useThemeColor } from "../../lib/useThemeColor";
+import type { MarkdownImageRenderer } from "../../native/SelectableMarkdownText";
 import { useThreadSelection } from "../../state/use-thread-selection";
 import { useSelectedThreadWorktree } from "../../state/use-selected-thread-worktree";
 import { useEnvironmentQuery } from "../../state/query";
@@ -50,6 +56,7 @@ import {
   isImagePreviewFile,
   isMarkdownPreviewFile,
   isSvgImagePreviewFile,
+  resolveWorkspaceFilePath,
 } from "./filePath";
 import { useWorkspaceFileAssetUrl } from "./workspaceFileAssetUrl";
 
@@ -94,6 +101,7 @@ function FileContent(props: {
   readonly initialLine: number | null;
   readonly truncated: boolean;
   readonly onRefresh?: () => Promise<void> | void;
+  readonly renderImage?: MarkdownImageRenderer;
 }) {
   const isMarkdown = isMarkdownPreviewFile(props.relativePath);
   const isBrowserFile = isBrowserPreviewFile(props.relativePath);
@@ -145,7 +153,11 @@ function FileContent(props: {
         </View>
       ) : null}
       {props.activeMode === "preview" && isMarkdown ? (
-        <FileMarkdownPreview markdown={props.fileContents} onRefresh={props.onRefresh} />
+        <FileMarkdownPreview
+          markdown={props.fileContents}
+          onRefresh={props.onRefresh}
+          renderImage={props.renderImage}
+        />
       ) : (
         <SourceFileSurface
           contents={props.fileContents}
@@ -511,6 +523,35 @@ export function ThreadFileScreen(props: ThreadFileRouteScreenProps) {
       : null,
   );
   const fileData = fileQuery.data as ProjectReadFileResult | null;
+  const renderMarkdownImage = useMemo<MarkdownImageRenderer | undefined>(() => {
+    if (environmentId === null || threadId === null || relativePath === null || cwd === null) {
+      return undefined;
+    }
+    const lastSeparator = Math.max(relativePath.lastIndexOf("/"), relativePath.lastIndexOf("\\"));
+    // Relative image sources in a rendered markdown file resolve against its own directory.
+    const imageBaseDir =
+      lastSeparator >= 0
+        ? resolveWorkspaceFilePath(cwd, relativePath.slice(0, lastSeparator))
+        : cwd;
+
+    return (image) => {
+      const imageSource = classifyMarkdownImageSource(image.href, imageBaseDir);
+      if (imageSource._tag === "Direct") {
+        return null;
+      }
+      if (imageSource._tag === "Blocked") {
+        return <ThreadMarkdownImageUnavailable alt={image.alt} />;
+      }
+      return (
+        <ThreadMarkdownImage
+          environmentId={environmentId}
+          threadId={threadId}
+          path={imageSource.path}
+          alt={image.alt}
+        />
+      );
+    };
+  }, [cwd, environmentId, relativePath, threadId]);
 
   const handleSelectFile = useCallback(
     (path: string) => {
@@ -665,6 +706,7 @@ export function ThreadFileScreen(props: ThreadFileRouteScreenProps) {
           fileError={fileQuery.error}
           initialLine={targetLine}
           relativePath={relativePath}
+          renderImage={renderMarkdownImage}
           truncated={fileData?.truncated ?? false}
           onRefresh={() => fileQuery.refresh()}
         />

--- a/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
+++ b/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
@@ -1,7 +1,6 @@
 import { NativeHeaderToolbar, NativeStackScreenOptions } from "../../native/StackHeader";
 import { StackActions, useNavigation, type StaticScreenProps } from "@react-navigation/native";
-import { classifyMarkdownImageSource } from "@t3tools/client-runtime/markdown-images";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { ActivityIndicator, Platform, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import Svg, { Defs, LinearGradient, Rect, Stop } from "react-native-svg";
@@ -17,15 +16,10 @@ import { SymbolView } from "../../components/AppSymbol";
 import { AppText as Text, AppTextInput as TextInput } from "../../components/AppText";
 import { EmptyState } from "../../components/EmptyState";
 import { LoadingScreen } from "../../components/LoadingScreen";
-import {
-  ThreadMarkdownImage,
-  ThreadMarkdownImageUnavailable,
-} from "../../components/markdownImages";
 import { resolveFileSelectionNavigationAction } from "../../lib/adaptive-navigation";
 import { copyTextWithHaptic } from "../../lib/copyTextWithHaptic";
 import { tryOpenExternalUrl } from "../../lib/openExternalUrl";
 import { useThemeColor } from "../../lib/useThemeColor";
-import type { MarkdownImageRenderer } from "../../native/SelectableMarkdownText";
 import { useThreadSelection } from "../../state/use-thread-selection";
 import { useSelectedThreadWorktree } from "../../state/use-selected-thread-worktree";
 import { useEnvironmentQuery } from "../../state/query";
@@ -56,7 +50,6 @@ import {
   isImagePreviewFile,
   isMarkdownPreviewFile,
   isSvgImagePreviewFile,
-  resolveWorkspaceFilePath,
 } from "./filePath";
 import { useWorkspaceFileAssetUrl } from "./workspaceFileAssetUrl";
 
@@ -101,7 +94,9 @@ function FileContent(props: {
   readonly initialLine: number | null;
   readonly truncated: boolean;
   readonly onRefresh?: () => Promise<void> | void;
-  readonly renderImage?: MarkdownImageRenderer;
+  readonly cwd: string;
+  readonly environmentId: EnvironmentId;
+  readonly threadId: ThreadId;
 }) {
   const isMarkdown = isMarkdownPreviewFile(props.relativePath);
   const isBrowserFile = isBrowserPreviewFile(props.relativePath);
@@ -154,9 +149,12 @@ function FileContent(props: {
       ) : null}
       {props.activeMode === "preview" && isMarkdown ? (
         <FileMarkdownPreview
+          cwd={props.cwd}
+          environmentId={props.environmentId}
           markdown={props.fileContents}
+          relativePath={props.relativePath}
+          threadId={props.threadId}
           onRefresh={props.onRefresh}
-          renderImage={props.renderImage}
         />
       ) : (
         <SourceFileSurface
@@ -523,36 +521,6 @@ export function ThreadFileScreen(props: ThreadFileRouteScreenProps) {
       : null,
   );
   const fileData = fileQuery.data as ProjectReadFileResult | null;
-  const renderMarkdownImage = useMemo<MarkdownImageRenderer | undefined>(() => {
-    if (environmentId === null || threadId === null || relativePath === null || cwd === null) {
-      return undefined;
-    }
-    const lastSeparator = Math.max(relativePath.lastIndexOf("/"), relativePath.lastIndexOf("\\"));
-    // Relative image sources in a rendered markdown file resolve against its own directory.
-    const imageBaseDir =
-      lastSeparator >= 0
-        ? resolveWorkspaceFilePath(cwd, relativePath.slice(0, lastSeparator))
-        : cwd;
-
-    return (image) => {
-      const imageSource = classifyMarkdownImageSource(image.href, imageBaseDir);
-      if (imageSource._tag === "Direct") {
-        return null;
-      }
-      if (imageSource._tag === "Blocked") {
-        return <ThreadMarkdownImageUnavailable alt={image.alt} />;
-      }
-      return (
-        <ThreadMarkdownImage
-          environmentId={environmentId}
-          threadId={threadId}
-          path={imageSource.path}
-          alt={image.alt}
-        />
-      );
-    };
-  }, [cwd, environmentId, relativePath, threadId]);
-
   const handleSelectFile = useCallback(
     (path: string) => {
       navigation.navigate("ThreadFile", {
@@ -701,12 +669,14 @@ export function ThreadFileScreen(props: ThreadFileRouteScreenProps) {
         </NativeHeaderToolbar>
         <FileContent
           activeMode={resolvedActiveMode}
+          cwd={cwd}
+          environmentId={environmentId}
           previewUri={previewUri}
           fileContents={fileData?.contents ?? null}
           fileError={fileQuery.error}
           initialLine={targetLine}
           relativePath={relativePath}
-          renderImage={renderMarkdownImage}
+          threadId={threadId}
           truncated={fileData?.truncated ?? false}
           onRefresh={() => fileQuery.refresh()}
         />

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -40,7 +40,6 @@ import {
   type ColorValue,
   useWindowDimensions,
   View,
-  type ViewStyle,
 } from "react-native";
 import { TouchableOpacity } from "react-native-gesture-handler";
 import ImageViewing from "react-native-image-viewing";
@@ -63,6 +62,11 @@ import {
 
 import { AppText as Text } from "../../components/AppText";
 import { CopyTextButton } from "../../components/CopyTextButton";
+import {
+  ThreadMarkdownImage,
+  ThreadMarkdownImageUnavailable,
+  ThreadMarkdownImageView,
+} from "../../components/markdownImages";
 import {
   parseReviewCommentMessageSegments,
   type ReviewInlineComment,
@@ -104,9 +108,8 @@ import {
   WORK_GROUP_TOGGLE_HEIGHT,
 } from "./thread-work-log";
 import { useMarkdownCodeHighlight } from "./markdownCodeHighlightState";
-import { useAssetUrl, useAssetUrlState } from "../../state/assets";
+import { useAssetUrl } from "../../state/assets";
 import { resolveWorkspaceRelativeFilePath } from "../files/filePath";
-import { MARKDOWN_IMAGE_MAX_WIDTH, resolveMarkdownImageDisplaySize } from "./markdownImageSize";
 
 const WIDE_MARKDOWN_BLOCK_OPTIONS = {
   includeOrderedLists: Platform.OS === "android",
@@ -195,146 +198,6 @@ function MessageAttachmentImage(props: {
     <TouchableOpacity activeOpacity={0.7} onPress={() => props.onPressImage(uri)}>
       <Image source={{ uri }} className={props.className} resizeMode="cover" />
     </TouchableOpacity>
-  );
-}
-
-function ThreadMarkdownImageView(props: {
-  readonly uri: string | null;
-  readonly sourceKey: string;
-  readonly unavailable: boolean;
-  readonly alt: string | null;
-  readonly onPressImage: (uri: string) => void;
-}) {
-  const codeBackground = useThemeColor("--color-md-code-bg");
-  const [availableWidth, setAvailableWidth] = useState(0);
-  const [sourceSize, setSourceSize] = useState<{ width: number; height: number } | null>(null);
-  const [failedUri, setFailedUri] = useState<string | null>(null);
-  const activeUriRef = useRef(props.uri);
-  activeUriRef.current = props.uri;
-
-  useEffect(() => {
-    setSourceSize(null);
-  }, [props.sourceKey]);
-
-  useEffect(() => {
-    setFailedUri(null);
-  }, [props.uri]);
-
-  const displaySize =
-    sourceSize === null
-      ? null
-      : resolveMarkdownImageDisplaySize({
-          sourceWidth: sourceSize.width,
-          sourceHeight: sourceSize.height,
-          availableWidth,
-        });
-  const failed = props.unavailable || (props.uri !== null && failedUri === props.uri);
-  const placeholderWidth: ViewStyle["width"] =
-    availableWidth > 0 ? Math.min(availableWidth, MARKDOWN_IMAGE_MAX_WIDTH) : "100%";
-  const frameStyle: ViewStyle = displaySize ?? { width: placeholderWidth, aspectRatio: 16 / 9 };
-
-  return (
-    <View
-      onLayout={(event) => setAvailableWidth(event.nativeEvent.layout.width)}
-      style={{ alignSelf: "stretch", gap: 6 }}
-    >
-      {props.uri === null || failed ? (
-        <View
-          style={{
-            ...frameStyle,
-            borderRadius: 10,
-            backgroundColor: codeBackground,
-            alignItems: "center",
-            justifyContent: "center",
-          }}
-        >
-          {failed ? (
-            <Text className="text-xs text-foreground-muted">Image unavailable</Text>
-          ) : (
-            <ActivityIndicator />
-          )}
-        </View>
-      ) : (
-        <TouchableOpacity
-          accessibilityRole="imagebutton"
-          accessibilityLabel={props.alt ?? "Markdown image"}
-          activeOpacity={0.7}
-          onPress={() => props.onPressImage(props.uri!)}
-          style={{ alignSelf: "flex-start" }}
-        >
-          <View
-            style={{
-              ...frameStyle,
-              borderRadius: 10,
-              backgroundColor: codeBackground,
-              alignItems: "center",
-              justifyContent: "center",
-              overflow: "hidden",
-            }}
-          >
-            <Image
-              source={{ uri: props.uri }}
-              resizeMode="contain"
-              accessible={false}
-              onLoad={(event) => {
-                if (activeUriRef.current !== props.uri) return;
-                const { width, height } = event.nativeEvent.source;
-                setSourceSize({ width, height });
-              }}
-              onError={() => setFailedUri(props.uri)}
-              style={{
-                width: "100%",
-                height: "100%",
-                opacity: displaySize === null ? 0 : 1,
-              }}
-            />
-            {displaySize === null ? <ActivityIndicator style={StyleSheet.absoluteFill} /> : null}
-          </View>
-        </TouchableOpacity>
-      )}
-      {props.alt ? (
-        <Text selectable className="text-xs text-foreground-muted">
-          {props.alt}
-        </Text>
-      ) : null}
-    </View>
-  );
-}
-
-/** Markdown image whose src is a workspace file — loads through a signed asset URL. */
-function ThreadMarkdownImage(props: {
-  readonly environmentId: EnvironmentId;
-  readonly threadId: ThreadId;
-  readonly path: string;
-  readonly alt: string | null;
-  readonly onPressImage: (uri: string) => void;
-}) {
-  const assetUrl = useAssetUrlState(props.environmentId, {
-    _tag: "workspace-file",
-    threadId: props.threadId,
-    path: props.path,
-  });
-
-  return (
-    <ThreadMarkdownImageView
-      uri={assetUrl._tag === "Success" ? assetUrl.url : null}
-      sourceKey={props.path}
-      unavailable={assetUrl._tag === "Failure"}
-      alt={props.alt}
-      onPressImage={props.onPressImage}
-    />
-  );
-}
-
-function ThreadMarkdownImageUnavailable(props: { readonly alt: string | null }) {
-  return (
-    <ThreadMarkdownImageView
-      uri={null}
-      sourceKey="unavailable"
-      unavailable
-      alt={props.alt}
-      onPressImage={() => undefined}
-    />
   );
 }
 

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -19,7 +19,10 @@ import {
   squashAtomCommandFailure,
   type AtomCommandResult,
 } from "@t3tools/client-runtime/state/runtime";
-import { classifyMarkdownImageSource } from "@t3tools/client-runtime/markdown-images";
+import {
+  classifyMarkdownImageSource,
+  markdownImageSourceFragment,
+} from "@t3tools/client-runtime/markdown-images";
 import * as Cause from "effect/Cause";
 import { AsyncResult } from "effect/unstable/reactivity";
 import React, {
@@ -76,7 +79,9 @@ import {
 import { remarkNormalizeListItemIndentation } from "../markdown-list-indentation";
 import {
   extractMarkdownLinkHrefs,
+  isWindowsDrivePathHref,
   normalizeMarkdownLinkDestination,
+  rehypePreserveLocalImageSrc,
   resolveInlineCodeFileLinkMeta,
   resolveMarkdownFileLinkMeta,
   rewriteMarkdownFileUriHref,
@@ -123,6 +128,11 @@ interface ChatMarkdownProps {
   lineBreaks?: boolean;
   /** Parse sanitized raw HTML instead of displaying its source text. */
   parseRawHtml?: boolean;
+  /**
+   * Relative image sources resolve against this directory, defaulting to cwd.
+   * File previews pass the document's directory so nested READMEs find their images.
+   */
+  imageBaseDir?: string | undefined;
 }
 
 const EMPTY_MARKDOWN_SKILLS: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">> = [];
@@ -181,36 +191,6 @@ export function orderedListGutterStyle(
   return { "--list-gutter": `${markerWidth + 1}ch` };
 }
 
-type MarkdownHtmlAstNode = {
-  type?: string;
-  tagName?: string;
-  properties?: Record<string, unknown>;
-  children?: MarkdownHtmlAstNode[];
-};
-
-/** Preserve Windows drive paths through the protocol allowlist in rehype-sanitize. */
-function rehypeNormalizeWindowsImageSrc() {
-  return (tree: MarkdownHtmlAstNode) => {
-    const visit = (node: MarkdownHtmlAstNode) => {
-      const src = node.properties?.src;
-      if (
-        node.type === "element" &&
-        node.tagName === "img" &&
-        typeof src === "string" &&
-        /^[A-Za-z]:[\\/]/.test(src)
-      ) {
-        node.properties = {
-          ...node.properties,
-          src: `file:///${src.replaceAll("\\", "/")}`,
-        };
-      }
-      node.children?.forEach(visit);
-    };
-
-    visit(tree);
-  };
-}
-
 const CHAT_MARKDOWN_SANITIZE_SCHEMA = {
   ...defaultSchema,
   attributes: {
@@ -218,6 +198,7 @@ const CHAT_MARKDOWN_SANITIZE_SCHEMA = {
     "*": (defaultSchema.attributes?.["*"] ?? []).filter((attribute) => attribute !== "title"),
     code: [...(defaultSchema.attributes?.code ?? []), "dataCodeMeta", "dataInlineCode"],
     blockquote: [...(defaultSchema.attributes?.blockquote ?? []), "dataAlert"],
+    img: [...(defaultSchema.attributes?.img ?? []), "dataLocalSrc"],
   },
   protocols: {
     ...defaultSchema.protocols,
@@ -245,7 +226,7 @@ const CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS = [
 
 const CHAT_MARKDOWN_REHYPE_PLUGINS = [
   rehypeRaw,
-  rehypeNormalizeWindowsImageSrc,
+  rehypePreserveLocalImageSrc,
   [rehypeSanitize, CHAT_MARKDOWN_SANITIZE_SCHEMA],
 ] satisfies NonNullable<ReactMarkdownOptions["rehypePlugins"]>;
 
@@ -987,9 +968,15 @@ const CHAT_MARKDOWN_WORKSPACE_IMAGE_CLASS_NAME = cn(
   "my-1 block! rounded-lg border border-border/40",
 );
 
-function ChatMarkdownImageFallback(props: { readonly alt: string }) {
+function ChatMarkdownImageFallback(props: {
+  readonly alt: string;
+  readonly copyMarkdown?: string | undefined;
+}) {
   return (
-    <span className="my-1 inline-flex items-center gap-1.5 rounded-md border border-border/40 bg-muted/40 px-2 py-1 text-xs text-muted-foreground">
+    <span
+      data-markdown-copy={props.copyMarkdown}
+      className="my-1 inline-flex items-center gap-1.5 rounded-md border border-border/40 bg-muted/40 px-2 py-1 text-xs text-muted-foreground"
+    >
       <TriangleAlertIcon aria-hidden className="size-3.5 shrink-0" />
       {props.alt.length > 0 ? `Image unavailable · ${props.alt}` : "Image unavailable"}
     </span>
@@ -1001,6 +988,9 @@ const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(prop
   readonly threadRef: ScopedThreadRef;
   readonly path: string;
   readonly alt: string;
+  /** The DOM src is signed or absent while loading, so copying uses the authored source. */
+  readonly copyMarkdown: string;
+  readonly srcFragment: string;
 }) {
   const assetUrl = useAssetUrlState(props.threadRef.environmentId, {
     _tag: "workspace-file",
@@ -1010,11 +1000,12 @@ const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(prop
   const [failedUrl, setFailedUrl] = useState<string | null>(null);
 
   if (assetUrl._tag === "Failure" || (assetUrl._tag === "Success" && failedUrl === assetUrl.url)) {
-    return <ChatMarkdownImageFallback alt={props.alt} />;
+    return <ChatMarkdownImageFallback alt={props.alt} copyMarkdown={props.copyMarkdown} />;
   }
   if (assetUrl._tag !== "Success") {
     return (
       <span
+        data-markdown-copy={props.copyMarkdown}
         role="status"
         aria-label="Loading image"
         className="my-1 block aspect-video w-full max-w-[30rem] rounded-lg bg-muted/60"
@@ -1023,8 +1014,10 @@ const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(prop
   }
   return (
     <img
-      src={assetUrl.url}
+      // The signed URL replaces the authored source, so restore client-side SVG fragments.
+      src={assetUrl.url + props.srcFragment}
       alt={props.alt}
+      data-markdown-copy={props.copyMarkdown}
       loading="lazy"
       draggable={false}
       className={CHAT_MARKDOWN_WORKSPACE_IMAGE_CLASS_NAME}
@@ -1452,6 +1445,7 @@ function ChatMarkdown({
   className,
   lineBreaks = false,
   parseRawHtml = true,
+  imageBaseDir,
 }: ChatMarkdownProps) {
   const { resolvedTheme } = useTheme();
   const createAssetUrl = useAtomQueryRunner(assetEnvironment.createUrl, {
@@ -1505,6 +1499,8 @@ function ChatMarkdown({
     return buildFileLinkParentSuffixByPath(filePaths);
   }, [inlineCodeFileLinkMetaByText, markdownFileLinkMetaByHref]);
   const markdownUrlTransform = useCallback((href: string) => {
+    // defaultUrlTransform clears drive paths because it reads the drive prefix as a scheme.
+    if (isWindowsDrivePathHref(href)) return href;
     return rewriteMarkdownFileUriHref(href) ?? defaultUrlTransform(href);
   }, []);
   // Re-emit highlighted content as markdown so copying out of the rendered
@@ -1819,9 +1815,15 @@ function ChatMarkdown({
         );
       },
       img({ node: _node, title: _title, src, alt, ...props }) {
-        const srcString = typeof src === "string" ? normalizeMarkdownLinkDestination(src) : "";
+        // The sanitizer removes a drive-path src, so prefer its allowlisted preserved value.
+        const localSrc = (props as Record<string, unknown>)["data-local-src"];
+        const authoredSrc = typeof localSrc === "string" ? localSrc : src;
+        const srcString =
+          typeof authoredSrc === "string" ? normalizeMarkdownLinkDestination(authoredSrc) : "";
+        const classifiedSrc =
+          typeof localSrc === "string" ? srcString.replaceAll("\\", "/") : srcString;
         const altText = alt ?? "";
-        const imageSource = classifyMarkdownImageSource(srcString, cwd);
+        const imageSource = classifyMarkdownImageSource(classifiedSrc, imageBaseDir ?? cwd);
         if (imageSource._tag === "Direct") {
           return (
             <img
@@ -1839,6 +1841,8 @@ function ChatMarkdown({
               threadRef={threadRef}
               path={imageSource.path}
               alt={altText}
+              copyMarkdown={`![${altText}](${srcString})`}
+              srcFragment={markdownImageSourceFragment(classifiedSrc)}
             />
           );
         }
@@ -1884,6 +1888,7 @@ function ChatMarkdown({
     diffThemeName,
     fileLinkParentSuffixByPath,
     inlineCodeFileLinkMetaByText,
+    imageBaseDir,
     isStreaming,
     markdownFileLinkMetaByHref,
     onTaskListChange,

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1908,7 +1908,9 @@ function ChatMarkdown({
             />
           );
         }
-        return <ChatMarkdownImageFallback alt={altText} />;
+        return (
+          <ChatMarkdownImageFallback alt={altText} copyMarkdown={`![${altText}](${srcString})`} />
+        );
       },
       table({ node: _node, ...props }) {
         return <MarkdownTable {...props} />;

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -959,8 +959,11 @@ const MarkdownLinkFavicon = memo(function MarkdownLinkFavicon({ host }: { host: 
   );
 });
 
-const CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME =
-  "h-auto w-auto max-h-[30rem] max-w-[min(100%,30rem)] object-contain";
+const CHAT_MARKDOWN_IMAGE_BOUNDS_CLASS_NAME = "max-h-[30rem] max-w-[min(100%,30rem)]";
+const CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME = cn(
+  "h-auto w-auto object-contain",
+  CHAT_MARKDOWN_IMAGE_BOUNDS_CLASS_NAME,
+);
 
 /**
  * Applies authored image dimensions as inline pixel sizes on rendered images and
@@ -1027,7 +1030,10 @@ const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(prop
         data-markdown-copy={props.copyMarkdown}
         role="status"
         aria-label="Loading image"
-        className="my-1 block aspect-video w-full max-w-[30rem] rounded-lg bg-muted/60"
+        className={cn(
+          "my-1 block aspect-video w-full rounded-lg bg-muted/60",
+          CHAT_MARKDOWN_IMAGE_BOUNDS_CLASS_NAME,
+        )}
         style={props.style}
       />
     );

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1014,11 +1014,13 @@ function authoredImageSizeStyle(
   return style.width === undefined && style.height === undefined ? undefined : style;
 }
 
-// block! outranks the unlayered `.chat-markdown img { display: inline-block }`
-// rule, keeping workspace images on the same block layout as their placeholder.
+// Forced inline-block keeps authored alignment wrappers working despite stray display
+// overrides. align-bottom removes the baseline gap, and every image state shares this layout.
+const CHAT_MARKDOWN_WORKSPACE_IMAGE_LAYOUT_CLASS_NAME = "inline-block! align-bottom";
 const CHAT_MARKDOWN_WORKSPACE_IMAGE_CLASS_NAME = cn(
   CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME,
-  "my-1 block! rounded-lg border border-border/40",
+  CHAT_MARKDOWN_WORKSPACE_IMAGE_LAYOUT_CLASS_NAME,
+  "my-1 rounded-lg border border-border/40",
 );
 
 function ChatMarkdownImageFallback(props: {
@@ -1028,10 +1030,15 @@ function ChatMarkdownImageFallback(props: {
   return (
     <span
       data-markdown-copy={props.copyMarkdown}
-      className="my-1 inline-flex items-center gap-1.5 rounded-md border border-border/40 bg-muted/40 px-2 py-1 text-xs text-muted-foreground"
+      className={cn(
+        CHAT_MARKDOWN_WORKSPACE_IMAGE_LAYOUT_CLASS_NAME,
+        "my-1 rounded-md border border-border/40 bg-muted/40 px-2 py-1 text-xs text-muted-foreground",
+      )}
     >
-      <TriangleAlertIcon aria-hidden className="size-3.5 shrink-0" />
-      {props.alt.length > 0 ? `Image unavailable · ${props.alt}` : "Image unavailable"}
+      <span className="inline-flex items-center gap-1.5">
+        <TriangleAlertIcon aria-hidden className="size-3.5 shrink-0" />
+        {props.alt.length > 0 ? `Image unavailable · ${props.alt}` : "Image unavailable"}
+      </span>
     </span>
   );
 }
@@ -1063,7 +1070,8 @@ const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(prop
         role="status"
         aria-label="Loading image"
         className={cn(
-          "my-1 block aspect-video w-full rounded-lg bg-muted/60",
+          CHAT_MARKDOWN_WORKSPACE_IMAGE_LAYOUT_CLASS_NAME,
+          "my-1 aspect-video w-full rounded-lg bg-muted/60",
           CHAT_MARKDOWN_IMAGE_BOUNDS_CLASS_NAME,
         )}
         style={props.style}

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -28,6 +28,7 @@ import { AsyncResult } from "effect/unstable/reactivity";
 import React, {
   Children,
   Suspense,
+  type CSSProperties,
   type ClipboardEvent as ReactClipboardEvent,
   type MouseEvent as ReactMouseEvent,
   isValidElement,
@@ -961,6 +962,23 @@ const MarkdownLinkFavicon = memo(function MarkdownLinkFavicon({ host }: { host: 
 const CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME =
   "h-auto w-auto max-h-[30rem] max-w-[min(100%,30rem)] object-contain";
 
+/**
+ * Applies authored image dimensions as inline pixel sizes on rendered images and
+ * workspace placeholders. Inline styles beat the default auto-sizing utilities,
+ * while their max-width and max-height caps still clamp oversized images.
+ */
+function authoredImageSizeStyle(
+  width: string | number | undefined,
+  height: string | number | undefined,
+): CSSProperties | undefined {
+  const parsedWidth = Number(width);
+  const parsedHeight = Number(height);
+  const style: CSSProperties = {};
+  if (!Number.isNaN(parsedWidth) && parsedWidth > 0) style.width = parsedWidth;
+  if (!Number.isNaN(parsedHeight) && parsedHeight > 0) style.height = parsedHeight;
+  return style.width === undefined && style.height === undefined ? undefined : style;
+}
+
 // block! outranks the unlayered `.chat-markdown img { display: inline-block }`
 // rule, keeping workspace images on the same block layout as their placeholder.
 const CHAT_MARKDOWN_WORKSPACE_IMAGE_CLASS_NAME = cn(
@@ -991,6 +1009,7 @@ const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(prop
   /** The DOM src is signed or absent while loading, so copying uses the authored source. */
   readonly copyMarkdown: string;
   readonly srcFragment: string;
+  readonly style?: CSSProperties | undefined;
 }) {
   const assetUrl = useAssetUrlState(props.threadRef.environmentId, {
     _tag: "workspace-file",
@@ -1009,6 +1028,7 @@ const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(prop
         role="status"
         aria-label="Loading image"
         className="my-1 block aspect-video w-full max-w-[30rem] rounded-lg bg-muted/60"
+        style={props.style}
       />
     );
   }
@@ -1021,6 +1041,7 @@ const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(prop
       loading="lazy"
       draggable={false}
       className={CHAT_MARKDOWN_WORKSPACE_IMAGE_CLASS_NAME}
+      style={props.style}
       onError={() => setFailedUrl(assetUrl.url)}
     />
   );
@@ -1823,6 +1844,7 @@ function ChatMarkdown({
         const classifiedSrc =
           typeof localSrc === "string" ? srcString.replaceAll("\\", "/") : srcString;
         const altText = alt ?? "";
+        const authoredSizeStyle = authoredImageSizeStyle(props.width, props.height);
         const imageSource = classifyMarkdownImageSource(classifiedSrc, imageBaseDir ?? cwd);
         if (imageSource._tag === "Direct") {
           return (
@@ -1832,6 +1854,7 @@ function ChatMarkdown({
               alt={altText}
               loading="lazy"
               className={cn(props.className, CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME)}
+              style={authoredSizeStyle}
             />
           );
         }
@@ -1843,6 +1866,7 @@ function ChatMarkdown({
               alt={altText}
               copyMarkdown={`![${altText}](${srcString})`}
               srcFragment={markdownImageSourceFragment(classifiedSrc)}
+              style={authoredSizeStyle}
             />
           );
         }

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -977,11 +977,13 @@ function authoredImageSizeStyle(
   const parsedWidth = Number(width);
   const parsedHeight = Number(height);
   const style: CSSProperties = {};
-  if (!Number.isNaN(parsedWidth) && parsedWidth > 0) style.width = parsedWidth;
-  if (!Number.isNaN(parsedHeight) && parsedHeight > 0) style.height = parsedHeight;
+  if (Number.isFinite(parsedWidth) && parsedWidth > 0) style.width = parsedWidth;
+  if (Number.isFinite(parsedHeight) && parsedHeight > 0) style.height = parsedHeight;
   if (style.width !== undefined && style.height !== undefined) {
     style.aspectRatio = `${parsedWidth} / ${parsedHeight}`;
     style.height = "auto";
+    // Translate the height cap into the width axis so tall images shrink proportionally.
+    style.maxWidth = `min(100%, 30rem, ${(30 * parsedWidth) / parsedHeight}rem)`;
   }
   return style.width === undefined && style.height === undefined ? undefined : style;
 }

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -128,10 +128,6 @@ interface ChatMarkdownProps {
   lineBreaks?: boolean;
   /** Parse sanitized raw HTML instead of displaying its source text. */
   parseRawHtml?: boolean;
-  /**
-   * Relative image sources resolve against this directory, defaulting to cwd.
-   * File previews pass the document's directory so nested READMEs find their images.
-   */
   imageBaseDir?: string | undefined;
 }
 
@@ -991,11 +987,6 @@ const CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME = cn(
   CHAT_MARKDOWN_IMAGE_BOUNDS_CLASS_NAME,
 );
 
-/**
- * Applies authored image dimensions to rendered images and workspace placeholders.
- * When both axes are present, the authored ratio keeps either size cap from
- * distorting the box.
- */
 function authoredImageSizeStyle(
   width: string | number | undefined,
   height: string | number | undefined,
@@ -1008,14 +999,11 @@ function authoredImageSizeStyle(
   if (style.width !== undefined && style.height !== undefined) {
     style.aspectRatio = `${parsedWidth} / ${parsedHeight}`;
     style.height = "auto";
-    // Translate the height cap into the width axis so tall images shrink proportionally.
     style.maxWidth = `min(100%, 30rem, ${(30 * parsedWidth) / parsedHeight}rem)`;
   }
   return style.width === undefined && style.height === undefined ? undefined : style;
 }
 
-// Forced inline-block keeps authored alignment wrappers working despite stray display
-// overrides. align-bottom removes the baseline gap, and every image state shares this layout.
 const CHAT_MARKDOWN_WORKSPACE_IMAGE_LAYOUT_CLASS_NAME = "inline-block! align-bottom";
 const CHAT_MARKDOWN_WORKSPACE_IMAGE_CLASS_NAME = cn(
   CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME,
@@ -1048,7 +1036,6 @@ const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(prop
   readonly threadRef: ScopedThreadRef;
   readonly path: string;
   readonly alt: string;
-  /** The DOM src is signed or absent while loading, so copying uses the authored source. */
   readonly copyMarkdown: string;
   readonly srcFragment: string;
   readonly style?: CSSProperties | undefined;
@@ -1071,7 +1058,7 @@ const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(prop
         aria-label="Loading image"
         className={cn(
           CHAT_MARKDOWN_WORKSPACE_IMAGE_LAYOUT_CLASS_NAME,
-          "my-1 aspect-video w-full rounded-lg bg-muted/60",
+          "my-1 aspect-video w-64 max-w-full rounded-lg bg-muted/60",
           CHAT_MARKDOWN_IMAGE_BOUNDS_CLASS_NAME,
         )}
         style={props.style}
@@ -1080,7 +1067,6 @@ const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(prop
   }
   return (
     <img
-      // The signed URL replaces the authored source, so restore client-side SVG fragments.
       src={assetUrl.url + props.srcFragment}
       alt={props.alt}
       data-markdown-copy={props.copyMarkdown}
@@ -1566,7 +1552,6 @@ function ChatMarkdown({
     return buildFileLinkParentSuffixByPath(filePaths);
   }, [inlineCodeFileLinkMetaByText, markdownFileLinkMetaByHref]);
   const markdownUrlTransform = useCallback((href: string) => {
-    // defaultUrlTransform clears drive paths because it reads the drive prefix as a scheme.
     if (isWindowsDrivePathHref(href)) return href;
     return rewriteMarkdownFileUriHref(href) ?? defaultUrlTransform(href);
   }, []);
@@ -1882,7 +1867,6 @@ function ChatMarkdown({
         );
       },
       img({ node, title: _title, src, alt, ...props }) {
-        // The sanitizer removes a drive-path src, so prefer its allowlisted preserved value.
         const localSrc = node?.properties?.dataLocalSrc;
         const authoredSrc = typeof localSrc === "string" ? localSrc : src;
         const srcString =

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -82,7 +82,6 @@ import {
   extractMarkdownLinkHrefs,
   isWindowsDrivePathHref,
   normalizeMarkdownLinkDestination,
-  rehypePreserveLocalImageSrc,
   resolveInlineCodeFileLinkMeta,
   resolveMarkdownFileLinkMeta,
   rewriteMarkdownFileUriHref,
@@ -192,6 +191,33 @@ export function orderedListGutterStyle(
   return { "--list-gutter": `${markerWidth + 1}ch` };
 }
 
+type MarkdownImageHastNode = {
+  type?: string;
+  tagName?: string;
+  properties?: Record<string, unknown>;
+  children?: MarkdownImageHastNode[];
+};
+
+/** Carries raw Windows drive paths through the sanitizer to the image renderer. */
+function rehypePreserveWindowsImageSrc() {
+  return (tree: MarkdownImageHastNode) => {
+    const visit = (node: MarkdownImageHastNode) => {
+      const src = node.properties?.src;
+      if (
+        node.type === "element" &&
+        node.tagName === "img" &&
+        typeof src === "string" &&
+        isWindowsDrivePathHref(src)
+      ) {
+        node.properties = { ...node.properties, dataLocalSrc: src };
+      }
+      node.children?.forEach(visit);
+    };
+
+    visit(tree);
+  };
+}
+
 const CHAT_MARKDOWN_SANITIZE_SCHEMA = {
   ...defaultSchema,
   attributes: {
@@ -227,7 +253,7 @@ const CHAT_MARKDOWN_REMARK_PLUGINS_WITH_BREAKS = [
 
 const CHAT_MARKDOWN_REHYPE_PLUGINS = [
   rehypeRaw,
-  rehypePreserveLocalImageSrc,
+  rehypePreserveWindowsImageSrc,
   [rehypeSanitize, CHAT_MARKDOWN_SANITIZE_SCHEMA],
 ] satisfies NonNullable<ReactMarkdownOptions["rehypePlugins"]>;
 
@@ -1847,9 +1873,9 @@ function ChatMarkdown({
           </code>
         );
       },
-      img({ node: _node, title: _title, src, alt, ...props }) {
+      img({ node, title: _title, src, alt, ...props }) {
         // The sanitizer removes a drive-path src, so prefer its allowlisted preserved value.
-        const localSrc = (props as Record<string, unknown>)["data-local-src"];
+        const localSrc = node?.properties?.dataLocalSrc;
         const authoredSrc = typeof localSrc === "string" ? localSrc : src;
         const srcString =
           typeof authoredSrc === "string" ? normalizeMarkdownLinkDestination(authoredSrc) : "";

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -982,8 +982,10 @@ const MarkdownLinkFavicon = memo(function MarkdownLinkFavicon({ host }: { host: 
 });
 
 const CHAT_MARKDOWN_IMAGE_BOUNDS_CLASS_NAME = "max-h-[30rem] max-w-[min(100%,30rem)]";
+const CHAT_MARKDOWN_IMAGE_ALIGNMENT_CLASS_NAME = "align-bottom";
 const CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME = cn(
   "h-auto w-auto object-contain",
+  CHAT_MARKDOWN_IMAGE_ALIGNMENT_CLASS_NAME,
   CHAT_MARKDOWN_IMAGE_BOUNDS_CLASS_NAME,
 );
 
@@ -993,22 +995,29 @@ function authoredImageSizeStyle(
 ): CSSProperties | undefined {
   const parsedWidth = Number(width);
   const parsedHeight = Number(height);
-  const style: CSSProperties = {};
-  if (Number.isFinite(parsedWidth) && parsedWidth > 0) style.width = parsedWidth;
-  if (Number.isFinite(parsedHeight) && parsedHeight > 0) style.height = parsedHeight;
-  if (style.width !== undefined && style.height !== undefined) {
-    style.aspectRatio = `${parsedWidth} / ${parsedHeight}`;
-    style.height = "auto";
-    style.maxWidth = `min(100%, 30rem, ${(30 * parsedWidth) / parsedHeight}rem)`;
+  const hasWidth = Number.isFinite(parsedWidth) && parsedWidth > 0;
+  const hasHeight = Number.isFinite(parsedHeight) && parsedHeight > 0;
+  if (hasWidth && hasHeight) {
+    return {
+      width: parsedWidth,
+      height: "auto",
+      aspectRatio: `${parsedWidth} / ${parsedHeight}`,
+      maxWidth: `min(100%, 30rem, ${(30 * parsedWidth) / parsedHeight}rem)`,
+    };
   }
-  return style.width === undefined && style.height === undefined ? undefined : style;
+  if (hasWidth) return { maxWidth: `min(100%, 30rem, ${parsedWidth}px)` };
+  if (hasHeight) return { maxHeight: `min(30rem, ${parsedHeight}px)` };
+  return undefined;
 }
 
-const CHAT_MARKDOWN_WORKSPACE_IMAGE_LAYOUT_CLASS_NAME = "inline-block! align-bottom";
+const CHAT_MARKDOWN_WORKSPACE_IMAGE_LAYOUT_CLASS_NAME = cn(
+  "inline-block!",
+  CHAT_MARKDOWN_IMAGE_ALIGNMENT_CLASS_NAME,
+);
 const CHAT_MARKDOWN_WORKSPACE_IMAGE_CLASS_NAME = cn(
   CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME,
   CHAT_MARKDOWN_WORKSPACE_IMAGE_LAYOUT_CLASS_NAME,
-  "my-1 rounded-lg border border-border/40",
+  "rounded-lg border border-border/40",
 );
 
 function ChatMarkdownImageFallback(props: {
@@ -1020,7 +1029,7 @@ function ChatMarkdownImageFallback(props: {
       data-markdown-copy={props.copyMarkdown}
       className={cn(
         CHAT_MARKDOWN_WORKSPACE_IMAGE_LAYOUT_CLASS_NAME,
-        "my-1 rounded-md border border-border/40 bg-muted/40 px-2 py-1 text-xs text-muted-foreground",
+        "rounded-md border border-border/40 bg-muted/40 px-2 py-1 text-xs text-muted-foreground",
       )}
     >
       <span className="inline-flex items-center gap-1.5">
@@ -1058,7 +1067,7 @@ const ChatMarkdownWorkspaceImage = memo(function ChatMarkdownWorkspaceImage(prop
         aria-label="Loading image"
         className={cn(
           CHAT_MARKDOWN_WORKSPACE_IMAGE_LAYOUT_CLASS_NAME,
-          "my-1 aspect-video w-64 max-w-full rounded-lg bg-muted/60",
+          "aspect-video w-64 max-w-full rounded-lg bg-muted/60",
           CHAT_MARKDOWN_IMAGE_BOUNDS_CLASS_NAME,
         )}
         style={props.style}

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -966,9 +966,9 @@ const CHAT_MARKDOWN_IMAGE_SIZE_CLASS_NAME = cn(
 );
 
 /**
- * Applies authored image dimensions as inline pixel sizes on rendered images and
- * workspace placeholders. Inline styles beat the default auto-sizing utilities,
- * while their max-width and max-height caps still clamp oversized images.
+ * Applies authored image dimensions to rendered images and workspace placeholders.
+ * When both axes are present, the authored ratio keeps either size cap from
+ * distorting the box.
  */
 function authoredImageSizeStyle(
   width: string | number | undefined,
@@ -979,6 +979,10 @@ function authoredImageSizeStyle(
   const style: CSSProperties = {};
   if (!Number.isNaN(parsedWidth) && parsedWidth > 0) style.width = parsedWidth;
   if (!Number.isNaN(parsedHeight) && parsedHeight > 0) style.height = parsedHeight;
+  if (style.width !== undefined && style.height !== undefined) {
+    style.aspectRatio = `${parsedWidth} / ${parsedHeight}`;
+    style.height = "auto";
+  }
   return style.width === undefined && style.height === undefined ? undefined : style;
 }
 

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -96,6 +96,12 @@ describe("ChatMarkdown workspace images", () => {
     expect(html).toContain("https://signed.test/workspace-image.svg");
   });
 
+  it("honors authored dimensions on raw workspace images", () => {
+    const html = render('<img src=".t3/workspace-image.svg" alt="sized" width="128" height="96">');
+
+    expect(html).toContain('style="width:128px;height:96px"');
+  });
+
   it("uses a static placeholder while a signed asset URL loads", () => {
     testState.assetState = "loading";
 

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -202,6 +202,12 @@ describe("ChatMarkdown workspace images", () => {
     },
   );
 
+  it("copies the authored workspace source when no thread can sign it", () => {
+    const html = renderWithoutThread("![diagram](images/diagram.png)");
+
+    expect(copiedMarkdownFrom(html)).toBe("![diagram](images/diagram.png)");
+  });
+
   it("uses a static placeholder while a signed asset URL loads", () => {
     testState.assetState = "loading";
 

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -99,7 +99,9 @@ describe("ChatMarkdown workspace images", () => {
   it("honors authored dimensions on raw workspace images", () => {
     const html = render('<img src=".t3/workspace-image.svg" alt="sized" width="128" height="96">');
 
-    expect(html).toContain('style="width:128px;height:auto;aspect-ratio:128 / 96"');
+    expect(html).toContain(
+      'style="width:128px;height:auto;aspect-ratio:128 / 96;max-width:min(100%, 30rem, 40rem)"',
+    );
   });
 
   it("uses a static placeholder while a signed asset URL loads", () => {

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -2,18 +2,20 @@ import { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
+import { serializeRenderedMarkdownFragment } from "../markdown-clipboard";
+
 const testState = vi.hoisted(() => ({
   resources: [] as Array<unknown>,
-  assetState: "success" as "success" | "loading",
+  assetState: "success" as "success" | "loading" | "failure",
 }));
 
 vi.mock("@effect/atom-react", () => ({ useAtomValue: () => null }));
 vi.mock("../assets/assetUrls", () => ({
   useAssetUrlState: (_environmentId: unknown, resource: unknown) => {
     testState.resources.push(resource);
-    return testState.assetState === "loading"
-      ? { _tag: "Loading" }
-      : { _tag: "Success", url: "https://signed.test/workspace-image.svg" };
+    if (testState.assetState === "loading") return { _tag: "Loading" };
+    if (testState.assetState === "failure") return { _tag: "Failure" };
+    return { _tag: "Success", url: "https://signed.test/workspace-image.svg" };
   },
 }));
 vi.mock("../hooks/useTheme", () => ({ useTheme: () => ({ resolvedTheme: "dark" }) }));
@@ -30,6 +32,7 @@ vi.mock("../editorPreferences", () => ({ useOpenInPreferredEditor: () => vi.fn()
 vi.mock("~/lib/openPullRequestLink", () => ({ useOpenChangeRequestLink: () => vi.fn() }));
 
 import ChatMarkdown from "./ChatMarkdown";
+import { FileMarkdownPreview } from "./files/FileMarkdownPreview";
 
 const threadRef = {
   environmentId: EnvironmentId.make("env-windows"),
@@ -46,10 +49,74 @@ function renderWithoutThread(markdown: string): string {
   return renderToStaticMarkup(<ChatMarkdown cwd={"C:\\Users\\shawn\\project"} text={markdown} />);
 }
 
+function renderFilePreview(cwd: string, relativePath: string): string {
+  return renderToStaticMarkup(
+    <FileMarkdownPreview
+      cwd={cwd}
+      relativePath={relativePath}
+      text="![diagram](images/diagram.png)"
+      threadRef={threadRef}
+    />,
+  );
+}
+
+const TEXT_NODE = 3;
+const ELEMENT_NODE = 1;
+
+function copiedMarkdownFrom(html: string): string {
+  const copy = /data-markdown-copy="([^"]*)"/.exec(html)?.[1];
+  expect(copy).toBeDefined();
+  const element = {
+    nodeType: ELEMENT_NODE,
+    childNodes: [],
+    getAttribute: (name: string) => (name === "data-markdown-copy" ? copy : null),
+    hasAttribute: (name: string) => name === "data-markdown-copy",
+  };
+  const container = {
+    childNodes: [element],
+  };
+  vi.stubGlobal("Node", { TEXT_NODE, ELEMENT_NODE });
+  try {
+    return serializeRenderedMarkdownFragment(container as unknown as Node);
+  } finally {
+    vi.unstubAllGlobals();
+  }
+}
+
+function firstInlineStyle(html: string): Record<string, string> {
+  const style = /style="([^"]+)"/.exec(html)?.[1];
+  expect(style).toBeDefined();
+  return Object.fromEntries(
+    (style ?? "").split(";").map((declaration) => {
+      const separator = declaration.indexOf(":");
+      return [declaration.slice(0, separator), declaration.slice(separator + 1)];
+    }),
+  );
+}
+
 describe("ChatMarkdown workspace images", () => {
   beforeEach(() => {
     testState.resources = [];
     testState.assetState = "success";
+  });
+
+  it.each([
+    ["/workspace/project", "docs/README.md", "/workspace/project/docs/images/diagram.png"],
+    [
+      "C:\\Users\\shawn\\project",
+      "docs\\README.md",
+      "C:\\Users\\shawn\\project\\docs\\images\\diagram.png",
+    ],
+  ])("resolves images beside a nested file in %s", (cwd, relativePath, expectedPath) => {
+    renderFilePreview(cwd, relativePath);
+
+    expect(testState.resources).toEqual([
+      {
+        _tag: "workspace-file",
+        threadId: threadRef.threadId,
+        path: expectedPath,
+      },
+    ]);
   });
 
   it("loads every Windows workspace path form through a signed asset URL", () => {
@@ -96,13 +163,44 @@ describe("ChatMarkdown workspace images", () => {
     expect(html).toContain("https://signed.test/workspace-image.svg");
   });
 
-  it("honors authored dimensions on raw workspace images", () => {
-    const html = render('<img src=".t3/workspace-image.svg" alt="sized" width="128" height="96">');
+  it("keeps a tall image placeholder and loaded image at the same proportional bounds", () => {
+    const markdown = '<img src=".t3/workspace-image.svg" alt="sized" width="96" height="128">';
+    const loadedStyle = firstInlineStyle(render(markdown));
+    testState.assetState = "loading";
+    const loadingStyle = firstInlineStyle(render(markdown));
 
-    expect(html).toContain(
-      'style="width:128px;height:auto;aspect-ratio:128 / 96;max-width:min(100%, 30rem, 40rem)"',
-    );
+    expect(loadedStyle).toMatchObject({
+      width: "96px",
+      height: "auto",
+      "aspect-ratio": "96 / 128",
+      "max-width": "min(100%, 30rem, 22.5rem)",
+    });
+    expect(loadingStyle).toEqual(loadedStyle);
   });
+
+  it("retains an authored SVG fragment on the signed URL", () => {
+    const html = render("![logo](icons.svg#logo)");
+
+    expect(testState.resources).toEqual([
+      {
+        _tag: "workspace-file",
+        threadId: threadRef.threadId,
+        path: "C:\\Users\\shawn\\project\\icons.svg",
+      },
+    ]);
+    expect(html).toContain('src="https://signed.test/workspace-image.svg#logo"');
+  });
+
+  it.each(["success", "loading", "failure"] as const)(
+    "copies the authored workspace source while the asset is %s",
+    (assetState) => {
+      testState.assetState = assetState;
+
+      const html = render("![diagram](images/diagram.png#preview)");
+
+      expect(copiedMarkdownFrom(html)).toBe("![diagram](images/diagram.png#preview)");
+    },
+  );
 
   it("uses a static placeholder while a signed asset URL loads", () => {
     testState.assetState = "loading";

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -216,13 +216,16 @@ describe("ChatMarkdown workspace images", () => {
     expect(copiedMarkdownFrom(html)).toBe("![diagram](images/diagram.png)");
   });
 
-  it("uses a static placeholder while a signed asset URL loads", () => {
+  it("uses a static bounded-width placeholder while a signed asset URL loads", () => {
     testState.assetState = "loading";
 
     const html = render("![loading](.t3/workspace-image.svg)");
+    const className = /<span[^>]*aria-label="Loading image"[^>]*class="([^"]*)"/.exec(html)?.[1];
 
     expect(html).toContain('aria-label="Loading image"');
     expect(html).not.toContain("animate-pulse");
+    expect(className?.split(" ")).toContain("w-64");
+    expect(className?.split(" ")).not.toContain("w-full");
   });
 
   it("never passes a workspace source to a raw image when thread context is unavailable", () => {

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -111,18 +111,6 @@ describe("ChatMarkdown workspace images", () => {
     expect(html).not.toContain("animate-pulse");
   });
 
-  it("caps authored dimensions while a workspace image loads", () => {
-    testState.assetState = "loading";
-
-    const html = render(
-      '<img src=".t3/workspace-image.svg" alt="oversized" width="2000" height="1500">',
-    );
-
-    expect(html).toContain('style="width:2000px;height:1500px"');
-    expect(html).toContain("max-w-[min(100%,30rem)]");
-    expect(html).toContain("max-h-[30rem]");
-  });
-
   it("never passes a workspace source to a raw image when thread context is unavailable", () => {
     const html = renderWithoutThread(
       "![file URL](file:///C:/Users/shawn/project/workspace-image.svg)",

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -163,6 +163,14 @@ describe("ChatMarkdown workspace images", () => {
     expect(html).toContain("https://signed.test/workspace-image.svg");
   });
 
+  it("keeps raw workspace images inline for authored paragraph alignment", () => {
+    const html = render('<p align="center"><img src=".t3/workspace-image.svg" alt="logo"></p>');
+    const className = /<img[^>]*class="([^"]*)"/.exec(html)?.[1];
+
+    expect(className?.split(" ")).toContain("inline-block!");
+    expect(className?.split(" ")).not.toContain("block!");
+  });
+
   it("keeps a tall image placeholder and loaded image at the same proportional bounds", () => {
     const markdown = '<img src=".t3/workspace-image.svg" alt="sized" width="96" height="128">';
     const loadedStyle = firstInlineStyle(render(markdown));

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -111,6 +111,18 @@ describe("ChatMarkdown workspace images", () => {
     expect(html).not.toContain("animate-pulse");
   });
 
+  it("caps authored dimensions while a workspace image loads", () => {
+    testState.assetState = "loading";
+
+    const html = render(
+      '<img src=".t3/workspace-image.svg" alt="oversized" width="2000" height="1500">',
+    );
+
+    expect(html).toContain('style="width:2000px;height:1500px"');
+    expect(html).toContain("max-w-[min(100%,30rem)]");
+    expect(html).toContain("max-h-[30rem]");
+  });
+
   it("never passes a workspace source to a raw image when thread context is unavailable", () => {
     const html = renderWithoutThread(
       "![file URL](file:///C:/Users/shawn/project/workspace-image.svg)",

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -99,7 +99,7 @@ describe("ChatMarkdown workspace images", () => {
   it("honors authored dimensions on raw workspace images", () => {
     const html = render('<img src=".t3/workspace-image.svg" alt="sized" width="128" height="96">');
 
-    expect(html).toContain('style="width:128px;height:96px"');
+    expect(html).toContain('style="width:128px;height:auto;aspect-ratio:128 / 96"');
   });
 
   it("uses a static placeholder while a signed asset URL loads", () => {

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -186,6 +186,35 @@ describe("ChatMarkdown workspace images", () => {
     expect(loadingStyle).toEqual(loadedStyle);
   });
 
+  it.each([
+    ["width", "max-width", "min(100%, 30rem, 300px)"],
+    ["height", "max-height", "min(30rem, 300px)"],
+  ])("treats a lone authored %s as a cap", (axis, constraint, expectedValue) => {
+    const markdown = `<img src=".t3/workspace-image.svg" alt="sized" ${axis}="300">`;
+    const loadedStyle = firstInlineStyle(render(markdown));
+    testState.assetState = "loading";
+    const loadingStyle = firstInlineStyle(render(markdown));
+
+    expect(loadedStyle).not.toHaveProperty(axis);
+    expect(loadedStyle).toHaveProperty(constraint, expectedValue);
+    expect(loadingStyle).toEqual(loadedStyle);
+  });
+
+  it("aligns direct and workspace images the same way in inline rows", () => {
+    const html = render(
+      "![remote](https://example.com/badge.svg) ![workspace](.t3/workspace-image.svg)",
+    );
+    const classNames = Array.from(html.matchAll(/<img[^>]*class="([^"]*)"/g), (match) =>
+      match[1]?.split(" "),
+    );
+
+    expect(classNames).toHaveLength(2);
+    for (const classes of classNames) {
+      expect(classes).toContain("align-bottom");
+      expect(classes).not.toContain("my-1");
+    }
+  });
+
   it("retains an authored SVG fragment on the signed URL", () => {
     const html = render("![logo](icons.svg#logo)");
 

--- a/apps/web/src/components/files/FileMarkdownPreview.tsx
+++ b/apps/web/src/components/files/FileMarkdownPreview.tsx
@@ -1,0 +1,34 @@
+import type { ScopedThreadRef } from "@t3tools/contracts";
+
+import ChatMarkdown from "~/components/ChatMarkdown";
+import { resolvePathLinkTarget } from "~/terminal-links";
+
+export function FileMarkdownPreview(props: {
+  readonly cwd: string;
+  readonly relativePath: string;
+  readonly text: string;
+  readonly threadRef: ScopedThreadRef;
+  readonly onTaskListChange?:
+    | ((input: { readonly markerOffset: number; readonly checked: boolean }) => void)
+    | undefined;
+}) {
+  const lastSeparator = Math.max(
+    props.relativePath.lastIndexOf("/"),
+    props.relativePath.lastIndexOf("\\"),
+  );
+  const imageBaseDir =
+    lastSeparator >= 0
+      ? resolvePathLinkTarget(props.relativePath.slice(0, lastSeparator), props.cwd)
+      : props.cwd;
+
+  return (
+    <ChatMarkdown
+      text={props.text}
+      cwd={props.cwd}
+      imageBaseDir={imageBaseDir}
+      threadRef={props.threadRef}
+      className="mx-auto max-w-4xl px-6 py-5"
+      onTaskListChange={props.onTaskListChange}
+    />
+  );
+}

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -18,7 +18,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { isBrowserPreviewFile, openFileInPreview } from "~/browser/openFileInPreview";
 import { useAssetUrlState } from "~/assets/assetUrls";
-import ChatMarkdown from "~/components/ChatMarkdown";
 import { OpenInPicker } from "~/components/chat/OpenInPicker";
 import { useRemoteOpenState } from "~/remoteOpen";
 import { useClientSettings } from "~/hooks/useSettings";
@@ -42,6 +41,7 @@ import { useAtomCommand } from "~/state/use-atom-command";
 import { useAtomQueryRunner } from "~/state/use-atom-query-runner";
 
 import FileBrowserPanel from "./FileBrowserPanel";
+import { FileMarkdownPreview } from "./FileMarkdownPreview";
 import {
   type FileCommentAnnotationEntry,
   type FileCommentAnnotationGroup,
@@ -718,10 +718,6 @@ function RenderedMarkdownSurface({
 > & {
   threadRef: ScopedThreadRef;
 }) {
-  const lastSeparator = Math.max(relativePath.lastIndexOf("/"), relativePath.lastIndexOf("\\"));
-  // Relative image sources resolve against the previewed document, not the project root.
-  const imageBaseDir =
-    lastSeparator >= 0 ? resolvePathLinkTarget(relativePath.slice(0, lastSeparator), cwd) : cwd;
   const saveCoordinator = useFileSaveCoordinator({
     environmentId,
     cwd,
@@ -731,12 +727,11 @@ function RenderedMarkdownSurface({
 
   return (
     <ScrollArea className="min-h-0 flex-1">
-      <ChatMarkdown
+      <FileMarkdownPreview
         text={contents}
         cwd={cwd}
-        imageBaseDir={imageBaseDir}
+        relativePath={relativePath}
         threadRef={threadRef}
-        className="mx-auto max-w-4xl px-6 py-5"
         onTaskListChange={({ markerOffset, checked }) => {
           const currentContents =
             getOptimisticProjectFileQueryData(environmentId, cwd, relativePath)?.contents ??

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -718,6 +718,10 @@ function RenderedMarkdownSurface({
 > & {
   threadRef: ScopedThreadRef;
 }) {
+  const lastSeparator = Math.max(relativePath.lastIndexOf("/"), relativePath.lastIndexOf("\\"));
+  // Relative image sources resolve against the previewed document, not the project root.
+  const imageBaseDir =
+    lastSeparator >= 0 ? resolvePathLinkTarget(relativePath.slice(0, lastSeparator), cwd) : cwd;
   const saveCoordinator = useFileSaveCoordinator({
     environmentId,
     cwd,
@@ -730,6 +734,7 @@ function RenderedMarkdownSurface({
       <ChatMarkdown
         text={contents}
         cwd={cwd}
+        imageBaseDir={imageBaseDir}
         threadRef={threadRef}
         className="mx-auto max-w-4xl px-6 py-5"
         onTaskListChange={({ markerOffset, checked }) => {

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -6,7 +6,6 @@ import ReactMarkdown from "react-markdown";
 import {
   extractMarkdownLinkHrefs,
   isWindowsDrivePathHref,
-  rehypePreserveLocalImageSrc,
   resolveInlineCodeFileLinkMeta,
   resolveMarkdownFileLinkMeta,
   resolveMarkdownFileLinkTarget,
@@ -26,36 +25,6 @@ describe("isWindowsDrivePathHref", () => {
   it("rejects https URLs", () => {
     expect(isWindowsDrivePathHref("https://example.com/image.png")).toBe(false);
   });
-});
-
-describe("rehypePreserveLocalImageSrc", () => {
-  it.each(["C:\\repo\\image.png", "C:%5Crepo%5Cimage.png"])(
-    "preserves the drive source %s",
-    (src) => {
-      const tree = {
-        type: "root",
-        children: [{ type: "element", tagName: "img", properties: { src } }],
-      };
-
-      rehypePreserveLocalImageSrc()(tree);
-
-      expect(tree.children[0]?.properties).toEqual({ src, dataLocalSrc: src });
-    },
-  );
-
-  it.each(["https://example.com/image.png", "images/image.png", "file:///C:/repo/image.png"])(
-    "does not preserve the non-drive source %s",
-    (src) => {
-      const tree = {
-        type: "root",
-        children: [{ type: "element", tagName: "img", properties: { src } }],
-      };
-
-      rehypePreserveLocalImageSrc()(tree);
-
-      expect(tree.children[0]?.properties).toEqual({ src });
-    },
-  );
 });
 
 function renderMarkdownLinkHref(markdown: string): string | undefined {

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -5,12 +5,58 @@ import ReactMarkdown from "react-markdown";
 
 import {
   extractMarkdownLinkHrefs,
+  isWindowsDrivePathHref,
+  rehypePreserveLocalImageSrc,
   resolveInlineCodeFileLinkMeta,
   resolveMarkdownFileLinkMeta,
   resolveMarkdownFileLinkTarget,
   rewriteMarkdownFileUriHref,
   shouldOpenMarkdownFileLinkInEditor,
 } from "./markdown-links";
+
+describe("isWindowsDrivePathHref", () => {
+  it("recognizes plain drive paths", () => {
+    expect(isWindowsDrivePathHref("C:\\repo\\image.png")).toBe(true);
+  });
+
+  it("recognizes percent-encoded drive paths", () => {
+    expect(isWindowsDrivePathHref("C:%5Crepo%5Cimage.png")).toBe(true);
+  });
+
+  it("rejects https URLs", () => {
+    expect(isWindowsDrivePathHref("https://example.com/image.png")).toBe(false);
+  });
+});
+
+describe("rehypePreserveLocalImageSrc", () => {
+  it.each(["C:\\repo\\image.png", "C:%5Crepo%5Cimage.png"])(
+    "preserves the drive source %s",
+    (src) => {
+      const tree = {
+        type: "root",
+        children: [{ type: "element", tagName: "img", properties: { src } }],
+      };
+
+      rehypePreserveLocalImageSrc()(tree);
+
+      expect(tree.children[0]?.properties).toEqual({ src, dataLocalSrc: src });
+    },
+  );
+
+  it.each(["https://example.com/image.png", "images/image.png", "file:///C:/repo/image.png"])(
+    "does not preserve the non-drive source %s",
+    (src) => {
+      const tree = {
+        type: "root",
+        children: [{ type: "element", tagName: "img", properties: { src } }],
+      };
+
+      rehypePreserveLocalImageSrc()(tree);
+
+      expect(tree.children[0]?.properties).toEqual({ src });
+    },
+  );
+});
 
 function renderMarkdownLinkHref(markdown: string): string | undefined {
   let renderedHref: string | undefined;

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -79,7 +79,6 @@ function safeDecode(value: string): string {
   }
 }
 
-/** Returns whether a markdown href decodes to an absolute Windows drive path. */
 export function isWindowsDrivePathHref(href: string): boolean {
   return WINDOWS_DRIVE_PATH_PATTERN.test(safeDecode(href));
 }

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -79,6 +79,42 @@ function safeDecode(value: string): string {
   }
 }
 
+/** Returns whether a markdown href decodes to an absolute Windows drive path. */
+export function isWindowsDrivePathHref(href: string): boolean {
+  return WINDOWS_DRIVE_PATH_PATTERN.test(safeDecode(href));
+}
+
+type MarkdownImageHastNode = {
+  type?: string;
+  tagName?: string;
+  properties?: Record<string, unknown>;
+  children?: MarkdownImageHastNode[];
+};
+
+/**
+ * Runs between rehype-raw and rehype-sanitize. Drive-path image sources parse
+ * as a scheme that the sanitizer strips, so the allowlisted `dataLocalSrc`
+ * property carries them through. The schema already allows `file:` sources.
+ */
+export function rehypePreserveLocalImageSrc() {
+  return (tree: MarkdownImageHastNode) => {
+    const visit = (node: MarkdownImageHastNode) => {
+      const src = node.properties?.src;
+      if (
+        node.type === "element" &&
+        node.tagName === "img" &&
+        typeof src === "string" &&
+        isWindowsDrivePathHref(src)
+      ) {
+        node.properties = { ...node.properties, dataLocalSrc: src };
+      }
+      node.children?.forEach(visit);
+    };
+
+    visit(tree);
+  };
+}
+
 function unwrapMarkdownLinkDestination(value: string): string {
   return value.startsWith("<") && value.endsWith(">") ? value.slice(1, -1) : value;
 }

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -84,37 +84,6 @@ export function isWindowsDrivePathHref(href: string): boolean {
   return WINDOWS_DRIVE_PATH_PATTERN.test(safeDecode(href));
 }
 
-type MarkdownImageHastNode = {
-  type?: string;
-  tagName?: string;
-  properties?: Record<string, unknown>;
-  children?: MarkdownImageHastNode[];
-};
-
-/**
- * Runs between rehype-raw and rehype-sanitize. Drive-path image sources parse
- * as a scheme that the sanitizer strips, so the allowlisted `dataLocalSrc`
- * property carries them through. The schema already allows `file:` sources.
- */
-export function rehypePreserveLocalImageSrc() {
-  return (tree: MarkdownImageHastNode) => {
-    const visit = (node: MarkdownImageHastNode) => {
-      const src = node.properties?.src;
-      if (
-        node.type === "element" &&
-        node.tagName === "img" &&
-        typeof src === "string" &&
-        isWindowsDrivePathHref(src)
-      ) {
-        node.properties = { ...node.properties, dataLocalSrc: src };
-      }
-      node.children?.forEach(visit);
-    };
-
-    visit(tree);
-  };
-}
-
 function unwrapMarkdownLinkDestination(value: string): string {
   return value.startsWith("<") && value.endsWith(">") ? value.slice(1, -1) : value;
 }

--- a/packages/client-runtime/src/markdownImages.test.ts
+++ b/packages/client-runtime/src/markdownImages.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { classifyMarkdownImageSource } from "./markdownImages.js";
+import { classifyMarkdownImageSource, markdownImageSourceFragment } from "./markdownImages.js";
 
 describe("classifyMarkdownImageSource", () => {
   it.each([
@@ -58,5 +58,15 @@ describe("classifyMarkdownImageSource", () => {
     "file://%",
   ])("blocks unsupported or unresolved source %s", (source) => {
     expect(classifyMarkdownImageSource(source)).toEqual({ _tag: "Blocked" });
+  });
+});
+
+describe("markdownImageSourceFragment", () => {
+  it("returns only the fragment from an angle-bracketed source with a query", () => {
+    expect(markdownImageSourceFragment("<icons.svg?version=2#logo>")).toBe("#logo");
+  });
+
+  it("ignores a query when the source has no fragment", () => {
+    expect(markdownImageSourceFragment("icons.svg?version=2")).toBe("");
   });
 });

--- a/packages/client-runtime/src/markdownImages.ts
+++ b/packages/client-runtime/src/markdownImages.ts
@@ -20,11 +20,6 @@ function normalizeSource(value: string): string {
   return trimmed.startsWith("<") && trimmed.endsWith(">") ? trimmed.slice(1, -1) : trimmed;
 }
 
-/**
- * Returns the client-side fragment to append to a signed asset URL. SVG view
- * references such as `icons.svg#logo` must survive the URL swap, while a query
- * addressed to the original server must not.
- */
 export function markdownImageSourceFragment(source: string): string {
   const normalizedSource = normalizeSource(source);
   const hashIndex = normalizedSource.indexOf("#");

--- a/packages/client-runtime/src/markdownImages.ts
+++ b/packages/client-runtime/src/markdownImages.ts
@@ -20,6 +20,17 @@ function normalizeSource(value: string): string {
   return trimmed.startsWith("<") && trimmed.endsWith(">") ? trimmed.slice(1, -1) : trimmed;
 }
 
+/**
+ * Returns the client-side fragment to append to a signed asset URL. SVG view
+ * references such as `icons.svg#logo` must survive the URL swap, while a query
+ * addressed to the original server must not.
+ */
+export function markdownImageSourceFragment(source: string): string {
+  const normalizedSource = normalizeSource(source);
+  const hashIndex = normalizedSource.indexOf("#");
+  return hashIndex >= 0 ? normalizedSource.slice(hashIndex) : "";
+}
+
 function normalizeWindowsDrivePath(value: string): string {
   return /^\/[A-Za-z]:[\\/]/.test(value) ? value.slice(1) : value;
 }


### PR DESCRIPTION
# The problem

- #6433 fixed workspace images in *chat* markdown. File previews still resolve relative images against the project root instead of the previewed document path. This meant that markdown files at the project root would render images properly, by coincidentally always checking `cwd`, but images in nested markdown files like `docs/README.md` would fail.
- This PR also fixes sizing and alignment issues in the PR viewer with markdown images.
- mobile file previews don't render workspace images at all, and several src shapes die before the resolver runs.

# The solution

- Use #6433's `renderImage` wiring for the file sidebar, resolving images based on the location of the document
- The current `ThreadFeed` architecture for chat markdown images is moved into a shared `markdownImages.tsx` to allow file previews and chat to use the same code paths
- This PR also makes it so inline styling rendering is handled correctly, an image with width/height=128 renders at 128x128 in file previews and snippets like `<p align="center">` are centered
- Remove bottom-alignment from PR viewer images so they are aligned the same as on GitHub

## Hardening

- Windows drive paths get stripped before the resolver ever runs. This PR addresses that. 
    - Without the fix, #6433's drive-path support is partially dead code: a Windows-hosted agent posting `![](C:\Users\x\screenshot.png)` renders nothing
- SVG view fragments like `icon.svg#logo` would drop the `#logo` part and never re-append it, changing the client-side rendering
- Mobile fetched SVGs it couldn't draw
    - Mobile currently cannot render SVGs, so instead of fetching them when they can't even display, this PR guards against fetching them
- Copying text with a markdown image would drop the image
    - The clipboard serializer included the expiring asset URL, instead of the original markdown copy. 


# UI Changes
Below is the relevant HTML snippet for the desktop screenshots, with the favicon at `public/icon-512.png` for the root, and `tests/public/icon-512.png` for the nested examples:
```
<div>
  <p align="center">
    <img src="public/icon-512.png" alt="" width="128" height="128" />
  </p>

  <h1 align="center">Tagium</h1>

  <p align="center">
    Local, lossless metadata editing for MP3, FLAC, M4A, and Opus audio files. <br>
    Bring your favorite tracks anywhere you listen.
    <br />
    <a href="https://tagium.app">tagium.app</a>
  </p>
</div>
```

## Web Before, nested readme
Fails to find images, is checking the wrong directory

<img width="554" height="240" alt="SCR-20260822-mwzi" src="https://github.com/user-attachments/assets/c9a56c1b-ba84-4795-9f86-3b9b8cd9fcf6" />

## Web Before, root dir readme

Ignores image height styling

<img width="538" height="641" alt="SCR-20260822-ndfd" src="https://github.com/user-attachments/assets/b1eb1491-5963-4f6e-971e-84c7b3aaadfb" />

## Web After

Now renders at all and at the correct size.

<img width="535" height="327" alt="SCR-20260822-nbpp" src="https://github.com/user-attachments/assets/58c25fee-225e-4021-ba36-a53554088680" />

## PR Viewer before

<img width="1052" height="543" alt="image" src="https://github.com/user-attachments/assets/2212122a-2300-4099-9af1-b3d2994b2c96" />

## PR Viewer after (now identical to GitHub's rendering)

<img width="731" height="259" alt="image" src="https://github.com/user-attachments/assets/016f95a1-c580-426f-9c23-634563bb0d08" />


# Mobile UI changes

Here's the markdown for the below example:

```
# Workspace images in markdown

Relative image paths now resolve through signed asset URLs on iOS.

![Workspace-relative: apps/web/public/apple-touch-icon.png](apps/web/public/apple-touch-icon.png)

![External URL (control)](https://raw.githubusercontent.com/github/explore/main/topics/typescript/typescript.png)
```

## iOS Before
<img width="590" height="1278" alt="ios-workspace-images-before" src="https://github.com/user-attachments/assets/39f7c0f6-85d4-4506-862b-ac44e029b89c" />


## iOS After
<img width="368" height="800" alt="ios-workspace-images-after" src="https://github.com/user-attachments/assets/210b11cb-6436-4bc6-9acf-b315faef0fd8" />

# Scope Notes

- Mobile doesn't really render HTML at all right now, so I treated that as a separate out-of-scope issue. 
- React Natives `<Image>` cannot decode SVGs at all, so SVGs show image not found.

The two above capability gaps are tracked in #7929

# Review
- This could probably use a review from someone on an android client

----

Built with Fable 5 and GPT 5.6 Sol in T3 Code 

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render project images in `FileMarkdownPreview` and harden markdown images
> - Resolves workspace-relative images in `FileMarkdownPreview` relative to the markdown document directory using signed asset URLs.
> - Adds `rehypePreserveWindowsImageSrc` and `isWindowsDrivePathHref` to keep Windows drive path image sources through sanitization.
> - Uses `authoredImageSizeStyle` to apply authored width and height as inline CSS while respecting chat layout bounds.
> - Retains SVG fragments on signed URLs with `markdownImageSourceFragment` and copies the original markdown source on image selection.
> - Risk: SVG images in mobile markdown render an unavailable placeholder instead of loading; check the `.svg` guard in [markdownImages.tsx](https://github.com/pingdotgg/t3code/pull/7857/files#diff-ce9a2f9dc8e1949657cadf90b43b1eed665b6d318b782c116649f8d9a821eddb).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f632e92.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->