### PR TITLE
fix(mobile): stop silently swallowing taps on out-of-workspace file links

### DIFF
--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -27,6 +27,7 @@ import {
 } from "react-native-nitro-markdown";
 import {
   ActivityIndicator,
+  Alert,
   Image,
   Platform,
   type LayoutChangeEvent,
@@ -1403,7 +1404,15 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
             path: relativePath.split("/").filter((segment) => segment.length > 0),
             ...(presentation.line ? { line: String(presentation.line) } : {}),
           });
+          return;
         }
+        // The link renders as a file (icon + label) but points outside the
+        // workspace, so there is nothing on-device to navigate to. Say so
+        // instead of swallowing the tap.
+        Alert.alert(
+          "Can't open this file",
+          "It lives outside the project folder, so it isn't available here.",
+        );
         return;
       }
 


### PR DESCRIPTION
Markdown file links that point outside the current workspace (e.g. \ile:///C:/temp/preview.png\) render on mobile as tappable file links with an icon, but tapping did nothing — no navigation, no feedback.

The tap handler in ThreadFeed already resolved the path against the workspace root and navigated when it matched; it just returned silently otherwise. Now, when the destination can't be resolved inside the workspace, the handler shows an alert explaining the file lives outside the project folder and isn't available on-device. Both tap paths (the custom markdown link renderer and the native markdown text rows) go through this same handler, so one change covers them all. I considered wiring up a real preview via the server's project-scoped readFile RPC or making the renderer drop the tappable styling for unresolvable paths, but both need new machinery (server contract changes or threading workspaceRoot into pure render helpers) for little gain.

Fixes #7798

ox-alpha via opencode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Interrupt now synthesizes `user-input.resolved` activities, which can hide still-open prompts if request tracking is wrong. The mobile alert also runs after successful in-workspace navigation because it is not gated on a missing relative path.
> 
> **Overview**
> **Turn interrupt now cancels open user-input requests.** After `interruptTurn` succeeds, `ProviderCommandReactor` walks thread activities for unresolved `user-input.requested` items (skipping already resolved or stale-failed ones) and appends `user-input.resolved` with `cancelled: true`. That covers providers that drop callbacks without a matching resolution event. Tests seed a pending request and assert the cancelled activity.
> 
> **Mobile markdown file links** that cannot be resolved inside the workspace now show an `Alert` instead of a silent tap. **Bug:** the alert is not in an `else` of the `relativePath` check, so in-workspace file navigation would still pop “Can't open this file.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c835d25e338ec509c3fafea972c3b282c9fe008. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix silent tap handling on out-of-workspace file links in `ThreadFeed`
> - Adds an `Alert.alert` call in the markdown link press handler in [ThreadFeed.tsx](https://github.com/pingdotgg/t3code/pull/7859/files#diff-97b9e47f1a8b00c4bb1a972e454769238aaceb538a03329f461e5c5d34cf7245) when a file-styled link resolves outside the workspace, so the user gets feedback instead of a silent no-op.
> - Adds an early return after navigating to an in-workspace file to prevent the handler from continuing to process the link.
> - Risk: standard `href` links are unaffected, but any existing reliance on the handler running to completion after a file navigation will now stop early.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d22d6f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->