### PR TITLE
fix(server): normalize full repository URLs in GitLab lookups

### DIFF
--- a/apps/server/src/sourceControl/GitLabCli.test.ts
+++ b/apps/server/src/sourceControl/GitLabCli.test.ts
@@ -1,4 +1,4 @@
-import { assert, it, afterEach, expect, vi } from "@effect/vitest";
+import { assert, it, afterEach, describe, expect, vi } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { ChildProcessSpawner } from "effect/unstable/process";
@@ -386,4 +386,83 @@ layer("GitLabCli.layer", (it) => {
       assert.strictEqual(error.cause, cause);
     }),
   );
+
+  it.effect("normalizes pasted repository URLs before the projects API lookup", () =>
+    Effect.gen(function* () {
+      mockedRun.mockReturnValueOnce(
+        Effect.succeed(
+          processOutput(
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify({
+              path_with_namespace: "group/sub/project",
+              web_url: "https://sourcecontrol.example.com/group/sub/project",
+              http_url_to_repo: "https://sourcecontrol.example.com/group/sub/project.git",
+              ssh_url_to_repo: "git@sourcecontrol.example.com:group/sub/project.git",
+            }),
+          ),
+        ),
+      );
+
+      const result = yield* Effect.gen(function* () {
+        const glab = yield* GitLabCli.GitLabCli;
+        return yield* glab.getRepositoryCloneUrls({
+          cwd: "/repo",
+          repository: "https://sourcecontrol.example.com/group/sub/project/",
+        });
+      });
+
+      assert.deepStrictEqual(result.nameWithOwner, "group/sub/project");
+      expect(mockedRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: "glab",
+          cwd: "/repo",
+          args: ["api", `projects/${encodeURIComponent("group/sub/project")}`],
+        }),
+      );
+    }),
+  );
+});
+
+describe("normalizeGitLabRepositoryPath", () => {
+  it("keeps bare namespace/project paths untouched", () => {
+    expect(GitLabCli.normalizeGitLabRepositoryPath("group/project")).toBe("group/project");
+    expect(GitLabCli.normalizeGitLabRepositoryPath("  group/sub/project  ")).toBe(
+      "group/sub/project",
+    );
+  });
+
+  it("extracts the project path from gitlab.com URLs", () => {
+    expect(GitLabCli.normalizeGitLabRepositoryPath("https://gitlab.com/group/project")).toBe(
+      "group/project",
+    );
+  });
+
+  it("extracts the project path from self-hosted URLs on any hostname", () => {
+    expect(
+      GitLabCli.normalizeGitLabRepositoryPath("https://sourcecontrol.example.com/group/project"),
+    ).toBe("group/project");
+  });
+
+  it("strips a .git suffix", () => {
+    expect(
+      GitLabCli.normalizeGitLabRepositoryPath(
+        "https://sourcecontrol.example.com/group/project.git",
+      ),
+    ).toBe("group/project");
+  });
+
+  it("keeps nested group segments", () => {
+    expect(
+      GitLabCli.normalizeGitLabRepositoryPath("https://gitlab.com/group/sub/team/project"),
+    ).toBe("group/sub/team/project");
+  });
+
+  it("ignores web UI sections and trailing slashes", () => {
+    expect(GitLabCli.normalizeGitLabRepositoryPath("https://gitlab.com/group/project/")).toBe(
+      "group/project",
+    );
+    expect(
+      GitLabCli.normalizeGitLabRepositoryPath("https://gitlab.com/group/project/-/tree/main"),
+    ).toBe("group/project");
+  });
 });

--- a/apps/server/src/sourceControl/GitLabCli.ts
+++ b/apps/server/src/sourceControl/GitLabCli.ts
@@ -390,6 +390,34 @@ function toSummaryWithOptionalUpdatedAt(
   return Option.isSome(updatedAt) ? { ...summary, updatedAt } : summary;
 }
 
+/**
+ * Accept either a bare `namespace/project` path or a pasted repository URL
+ * (any host, since glab resolves against its authenticated default host) and
+ * return the project path `glab api projects/<encoded path>` expects.
+ */
+export function normalizeGitLabRepositoryPath(repository: string): string {
+  const trimmed = repository.trim();
+  if (!/^https?:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+
+  try {
+    const url = new URL(trimmed);
+    const segments = url.pathname.split("/").filter((segment) => segment.length > 0);
+    // Web URLs continue past the project into `/-/tree/main` style sections;
+    // everything from the `-` separator on belongs to the UI, not the project.
+    const separatorIndex = segments.indexOf("-");
+    const projectSegments = separatorIndex > 0 ? segments.slice(0, separatorIndex) : segments;
+    const last = projectSegments.at(-1)?.replace(/\.git$/i, "") ?? "";
+    if (projectSegments.length > 0) {
+      projectSegments[projectSegments.length - 1] = last;
+    }
+    return projectSegments.join("/");
+  } catch {
+    return trimmed;
+  }
+}
+
 function parseRepositoryPath(repository: string): {
   readonly namespacePath: string | null;
   readonly projectPath: string;
@@ -519,7 +547,10 @@ export const make = Effect.gen(function* () {
     getRepositoryCloneUrls: (input) =>
       execute({
         cwd: input.cwd,
-        args: ["api", `projects/${encodeURIComponent(input.repository)}`],
+        args: [
+          "api",
+          `projects/${encodeURIComponent(normalizeGitLabRepositoryPath(input.repository))}`,
+        ],
       }).pipe(
         Effect.map((result) => result.stdout.trim()),
         Effect.flatMap((raw) =>


### PR DESCRIPTION
New-project GitLab lookup sent the entire pasted URL to \glab api projects/<encoded>\ whenever the host wasn't a known one like gitlab.com, so self-hosted instances (e.g. sourcecontrol.example.com) failed on full URLs while bare \group/project\ worked.

This adds \
ormalizeGitLabRepositoryPath\, which parses any http(s) URL and extracts the owner/repo path generically instead of sniffing hostnames. It handles trailing slashes, \.git\ suffixes, nested groups (GitLab supports them), and strips \/-/...\ web UI sections, then encodes the result exactly as the bare-path case does.

Fixes #7849

ox-alpha via opencode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestration interrupt handling (synthetic cancel events) and GitLab project-path parsing used for clone lookups. Logic is localized and covered by tests, but a bad parse or missed pending request could leave prompts stuck or look up the wrong project.
> 
> **Overview**
> Two independent server fixes.
> 
> **Turn interrupt** now closes open user-input prompts after a successful provider interrupt. Some providers drop callbacks without a matching resolution event; the reactor scans thread activities for pending `user-input.requested` items and appends `user-input.resolved` with `cancelled: true`.
> 
> **GitLab clone lookup** no longer sends a full pasted URL to `glab api projects/...`. `normalizeGitLabRepositoryPath` extracts `namespace/project` from any http(s) host (self-hosted included), stripping `.git`, trailing slashes, nested groups, and `/-/...` web UI paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64c066175f7533dca16210eba0290bfe29579d73. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Normalize full repository URLs in `GitLabCli.getRepositoryCloneUrls`
> - Adds `normalizeGitLabRepositoryPath` in [GitLabCli.ts](https://github.com/pingdotgg/t3code/pull/7862/files#diff-89856450646a3d6128d2d758713ca3279cd16397b9535c8549f7a8b450f8c81d): trims input, parses HTTP(S) URLs, drops UI sections (segments starting with `-`), strips case-insensitive `.git` suffix, and returns the `namespace/project` path. Bare paths pass through unchanged.
> - `GitLabCli.make.service.getRepositoryCloneUrls` now encodes the normalized path instead of `input.repository` directly, so pasted clone URLs (including self-hosted) resolve correctly via `glab api projects/<encoded path>`.
> - Adds tests in [GitLabCli.test.ts](https://github.com/pingdotgg/t3code/pull/7862/files#diff-63541ac047c9b524fd8d60d5acab15178eed18d893fc9f96290cfbdafb6af5a0) covering URL extraction, `.git` stripping, nested groups, UI subpaths, and bare-path passthrough.
> - Risk: callers passing repository inputs that previously relied on direct encoding of raw URLs will now hit the correct projects API path; malformed URLs that fail parsing fall back to the trimmed input.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6133897.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->