### PR TITLE
fix(web): keep thread sidebar populated across Settings round-trips

### DIFF
--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -23,7 +23,7 @@ import {
   resolveSidebarStageFocusRingOffsetClass,
   useSidebarStageBackdropVariant,
 } from "./SidebarStageBackdrop";
-import { useProjects } from "../state/entities";
+import { useProjects, useThreadShells } from "../state/entities";
 import {
   resolveInitialThreadSidebarWidth,
   resolveThreadSidebarMaximumWidth,
@@ -129,10 +129,12 @@ function SidebarControl() {
 }
 
 // Settings swaps the thread sidebar out of the tree. Keep the lightweight
-// project projection subscribed so returning to a draft never renders the
-// zero-project state while the environment snapshot reconnects.
-function ProjectProjectionRetention() {
+// project and thread-shell projections subscribed so returning to a draft
+// never renders the zero-project/zero-thread state while the environment
+// snapshot reconnects (and never replays the row add animation).
+function SidebarProjectionRetention() {
   useProjects();
+  useThreadShells();
   return null;
 }
 
@@ -210,7 +212,7 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
 
   return (
     <SidebarProvider className="h-dvh! min-h-0!" defaultOpen style={sidebarProviderStyle}>
-      <ProjectProjectionRetention />
+      <SidebarProjectionRetention />
       <Sidebar
         side="left"
         collapsible="offcanvas"


### PR DESCRIPTION
## Problem

Opening Settings and pressing Back briefly renders the thread sidebar empty before rows fade back in. Settings replaces the sidebar in the React tree, which drops the thread-shell projection subscription (the project projection was already retained by #5930). On return, the remounted list replays its FormKit add-animation for rows the user already had.

## Fix

Extended the existing projection-retention component in \AppSidebarLayout.tsx\ to keep \useThreadShells()\ subscribed alongside \useProjects()\, renaming it to \SidebarProjectionRetention\. With the projection kept warm, rows render immediately on Back, so no separate animation workaround is needed.

Fixes #7743

ox-alpha via opencode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI subscription change in sidebar layout only; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes a flash of empty thread rows (and replayed add animations) when leaving Settings and returning to a draft.
> 
> Settings unmounts the thread sidebar, which dropped the `useThreadShells()` subscription. The existing layout-level retention helper now also keeps that projection warm (renamed to `SidebarProjectionRetention`), so rows render immediately on Back.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1757daee554dc065532d40022354b3f15fd2795. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retain thread shells in `SidebarProjectionRetention` to fix empty sidebar
> Renames `ProjectProjectionRetention` to `SidebarProjectionRetention` in [AppSidebarLayout.tsx](https://github.com/pingdotgg/t3code/pull/7864/files#diff-b580a936d60a70bebcccf38ac9a82ca5f4440c99445dbccb0c176ebe5dc1d301) and adds a `useThreadShells()` subscription alongside `useProjects()`. This keeps thread-shell state cached during navigation to Settings, preventing the sidebar from emptying on return.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d1757da.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->