### PR TITLE
fix(desktop): stop spellcheck underlines on the composer

### DIFF
--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -1760,6 +1760,10 @@ function ComposerPromptEditorInner({
               data-testid="composer-editor"
               aria-placeholder={placeholder}
               placeholder={<span />}
+              // The app has no UI-language concept, so Chromium only ever has
+              // the OS locale's dictionary and underlines every other language
+              // as misspelled. Every other input here opts out too.
+              spellCheck={false}
               onPaste={onPaste}
             />
           }


### PR DESCRIPTION
## Problem

The desktop composer inherits Chromium spellcheck, whose dictionary list is populated from the OS locale only (and an empty list falls back to `en-US`). T3 Code has no UI-language setting the dictionaries could be derived from, so any text typed in a language other than the OS locale gets underlined as misspelled (#7742).

## Fix

Opt the composer's contenteditable out of spellcheck (`spellCheck={false}`). This matches existing precedent in the repo: every other input and textarea already passes `spellCheck={false}`, the mobile terminal input sets `spellCheckingType = .no`, and #2554 was previously closed as "composer disables spellcheck". One prop fixes both the desktop shell and any browser loading the same web client, without inventing new settings machinery or touching Electron internals.

A dictionary picker / spellcheck toggle would be a bigger product decision; happy to split that out if wanted.

Fixes #7742

ox-alpha via opencode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tiny UI-only prop change on the composer; no auth, data, or editor logic impact.
> 
> **Overview**
> Disables Chromium spellcheck on the composer `ContentEditable` so non-OS-locale text is no longer underlined as misspelled.
> 
> Sets `spellCheck={false}` on the prompt editor, matching other inputs in the app. There is no UI-language setting to drive dictionaries, so this is a one-prop opt-out rather than a new toggle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d68318dd5b40c286bac475feecf24d36ad70fcf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable spellcheck on `ContentEditable` in `ComposerPromptEditorInner`
> Sets `spellCheck={false}` on the `ContentEditable` element in [ComposerPromptEditor.tsx](https://github.com/pingdotgg/t3code/pull/7866/files#diff-12fcb05b3e147eba955638d8df57440b8cf7f796941af0989c9bfa57b5b4f4a4) to stop browser spellcheck underlines. The app currently lacks a UI-language concept, making the default spellchecker inaccurate.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d68318.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->