### PR TITLE
fix(mobile): stop the changed files widget from crashing

### DIFF
--- a/apps/mobile/src/features/review/ReviewSheet.tsx
+++ b/apps/mobile/src/features/review/ReviewSheet.tsx
@@ -398,7 +398,11 @@ export function ReviewSheet(props: ReviewSheetProps) {
       selectedSection,
       draftMessage,
     });
-  const NativeReviewDiffView = resolveNativeReviewDiffView()!;
+  // Resolution returns null while Expo registers the native view (or forever
+  // when the binary lacks it). Rendering a null component type crashes the
+  // app, so callers must fall back — ThreadFeed's ReviewCommentCard does the
+  // same check.
+  const NativeReviewDiffView = resolveNativeReviewDiffView();
   const nativeReviewDiffViewRef = useRef<NativeReviewDiffViewHandle>(null);
   const showcasedReviewDrawRef = useRef<string | null>(null);
   // Native pull-to-refresh on the diff surface (replaces the old Refresh menu item).
@@ -780,7 +784,7 @@ export function ReviewSheet(props: ReviewSheetProps) {
               onRetry={handleRetryEnvironment}
             />
           </View>
-        ) : selectedSection && parsedDiff.kind === "files" ? (
+        ) : selectedSection && parsedDiff.kind === "files" && NativeReviewDiffView ? (
           <View
             className="flex-1"
             style={{
@@ -863,6 +867,19 @@ export function ReviewSheet(props: ReviewSheetProps) {
                 <ScrollView horizontal showsHorizontalScrollIndicator={false} bounces={false}>
                   <Text selectable className="font-mono text-xs leading-relaxed text-foreground">
                     {parsedDiff.text}
+                  </Text>
+                </ScrollView>
+              </View>
+            ) : parsedDiff.kind === "files" ? (
+              // The native diff surface could not be resolved on this binary;
+              // degrade to the raw patch instead of crashing the app.
+              <View className="gap-3 border-b border-border bg-card px-4 py-4">
+                <Text className="text-xs leading-normal text-foreground-muted">
+                  Native diff view unavailable. Showing the raw patch.
+                </Text>
+                <ScrollView horizontal showsHorizontalScrollIndicator={false} bounces={false}>
+                  <Text selectable className="font-mono text-xs leading-relaxed text-foreground">
+                    {selectedSection?.diff ?? ""}
                   </Text>
                 </ScrollView>
               </View>


### PR DESCRIPTION
## Problem

Opening a thread whose agent has made file changes crashes the iPhone app the moment the changed files / diff widget appears, and every reopen of that chat crashes again, permanently burning it (#7800).

`ReviewSheet` rendered `resolveNativeReviewDiffView()!` with a non-null assertion. That resolver is explicitly designed to return `null` — transiently while Expo registers the native view config, and forever when `requireNativeView("T3ReviewDiffSurface")` throws (native module missing from the installed binary). Mounting a component whose type is `null` throws "Element type is invalid", which is a fatal JS exception in release builds. Because the review section for a thread auto-selects from persisted turn checkpoints (`useReviewSections` falls back to `reviewSections[0]`), reopening the chat re-renders the same screen and crashes again.

## Fix

Null-check the resolver in `ReviewSheet`, matching the defensive pattern already used by `ReviewCommentCard` in `ThreadFeed.tsx`. When the native diff surface is unavailable, the sheet now degrades to rendering the raw patch instead of crashing; the "Changed files" navigator (a plain virtualized FlatList) still renders.

Fixes #7800

ox-alpha via opencode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive UI change in the mobile review sheet. It avoids a fatal render crash and does not alter auth, data handling, or native module behavior.
> 
> **Overview**
> Stops the review sheet from crashing when `resolveNativeReviewDiffView()` returns `null` (Expo still registering the view, or the native module missing from the binary).
> 
> `ReviewSheet` no longer non-null-asserts the resolver. If the native surface is unavailable, it shows a selectable raw patch instead of mounting a null component type. The changed-files navigator still renders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f38c5dca05fa2b69affa06d39dff9583e158be5a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix crash in mobile changed files widget when native diff view is unavailable
> The `ReviewSheet` component crashed when a files-kind diff rendered but the native diff view failed to resolve. The non-null assertion on the resolved view is replaced with a nullable variable, and the conditional now checks for both a files-kind diff and a non-null view.
> - Adds a fallback branch for files-kind diffs that renders a notice and the raw patch text when the native diff view is unavailable.
> - Risk: users who previously saw a crash will now see raw patch text instead of the native diff UI in the fallback case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f38c5dc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->