### PR TITLE
fix(codex): accept ChatGPT Edu Plus accounts

### DIFF
--- a/packages/effect-codex-app-server/scripts/generate.ts
+++ b/packages/effect-codex-app-server/scripts/generate.ts
@@ -183,6 +183,44 @@ const fetchDirectoryEntries = Effect.fn("fetchDirectoryEntries")(function* (path
   return yield* decodeGithubContentEntries(raw);
 });
 
+// Plan-type enums are `#[serde(other)]` catch-alls upstream: a codex binary newer
+// than the pinned protocol ref emits members this schema does not list (e.g.
+// "edu_plus", added in codex 0.148.0). Decode those to the catch-all member the
+// way serde does, so one unrecognised plan cannot fail the whole account payload.
+const FORWARD_COMPATIBLE_ENUM_PATTERN = /__PlanType$/;
+const FORWARD_COMPATIBLE_FALLBACK = "unknown";
+
+function applyForwardCompatibleEnum(name: string, code: string): string {
+  if (!FORWARD_COMPATIBLE_ENUM_PATTERN.test(name)) {
+    return code;
+  }
+
+  const [typeLine, constLine] = code.split("\n");
+  if (typeLine === undefined || constLine === undefined) {
+    throw new Error(`Malformed schema entry for ${name}`);
+  }
+
+  const match = /^(export const [A-Za-z0-9_]+ = )Schema\.Literals\((\[[^\]]*\])\)(.*)$/.exec(
+    constLine,
+  );
+  if (!match?.[1] || !match[2] || match[3] === undefined) {
+    throw new Error(
+      `Expected ${name} to be a literal union so the serde catch-all fallback can be applied`,
+    );
+  }
+
+  if (!(JSON.parse(match[2]) as ReadonlyArray<string>).includes(FORWARD_COMPATIBLE_FALLBACK)) {
+    throw new Error(
+      `Expected ${name} to include a ${JSON.stringify(FORWARD_COMPATIBLE_FALLBACK)} catch-all member`,
+    );
+  }
+
+  return [
+    typeLine,
+    `${match[1]}ForwardCompatibleLiterals(${match[2]}, ${JSON.stringify(FORWARD_COMPATIBLE_FALLBACK)})${match[3]}`,
+  ].join("\n");
+}
+
 function collectSchemaEntries(
   chunk: string,
 ): ReadonlyArray<{ readonly name: string; readonly code: string }> {
@@ -605,7 +643,7 @@ const generateFiles = Effect.fn("generateFiles")(function* () {
   if (output.length > 0) {
     for (const entry of collectSchemaEntries(output)) {
       if (!generatedEntries.has(entry.name)) {
-        generatedEntries.set(entry.name, entry.code);
+        generatedEntries.set(entry.name, applyForwardCompatibleEnum(entry.name, entry.code));
       }
     }
   }
@@ -638,6 +676,7 @@ const generateFiles = Effect.fn("generateFiles")(function* () {
   const schemaOutput = [
     ...prelude,
     'import * as Schema from "effect/Schema";',
+    'import { ForwardCompatibleLiterals } from "../_internal/forwardCompatible.ts";',
     "",
     [...generatedEntries.values()].join("\n\n"),
     "",

--- a/packages/effect-codex-app-server/src/_generated/schema.gen.ts
+++ b/packages/effect-codex-app-server/src/_generated/schema.gen.ts
@@ -3,6 +3,8 @@
 
 import * as Schema from "effect/Schema";
 
+import { ForwardCompatibleLiterals } from "../_internal/forwardCompatible.ts";
+
 export type ApplyPatchApprovalParams__FileChange =
   | { readonly content: string; readonly type: "add" }
   | { readonly content: string; readonly type: "delete" }
@@ -2417,20 +2419,23 @@ export type ServerNotification__PlanType =
   | "enterprise"
   | "edu"
   | "unknown";
-export const ServerNotification__PlanType = Schema.Literals([
-  "free",
-  "go",
-  "plus",
-  "pro",
-  "prolite",
-  "team",
-  "self_serve_business_usage_based",
-  "business",
-  "enterprise_cbp_usage_based",
-  "enterprise",
-  "edu",
+export const ServerNotification__PlanType = ForwardCompatibleLiterals(
+  [
+    "free",
+    "go",
+    "plus",
+    "pro",
+    "prolite",
+    "team",
+    "self_serve_business_usage_based",
+    "business",
+    "enterprise_cbp_usage_based",
+    "enterprise",
+    "edu",
+    "unknown",
+  ],
   "unknown",
-]);
+);
 
 export type ServerNotification__ProcessExitedNotification = {
   readonly exitCode: number;
@@ -3249,20 +3254,23 @@ export type V2AccountRateLimitsUpdatedNotification__PlanType =
   | "enterprise"
   | "edu"
   | "unknown";
-export const V2AccountRateLimitsUpdatedNotification__PlanType = Schema.Literals([
-  "free",
-  "go",
-  "plus",
-  "pro",
-  "prolite",
-  "team",
-  "self_serve_business_usage_based",
-  "business",
-  "enterprise_cbp_usage_based",
-  "enterprise",
-  "edu",
+export const V2AccountRateLimitsUpdatedNotification__PlanType = ForwardCompatibleLiterals(
+  [
+    "free",
+    "go",
+    "plus",
+    "pro",
+    "prolite",
+    "team",
+    "self_serve_business_usage_based",
+    "business",
+    "enterprise_cbp_usage_based",
+    "enterprise",
+    "edu",
+    "unknown",
+  ],
   "unknown",
-]);
+);
 
 export type V2AccountRateLimitsUpdatedNotification__RateLimitReachedType =
   | "rate_limit_reached"
@@ -3337,20 +3345,23 @@ export type V2AccountUpdatedNotification__PlanType =
   | "enterprise"
   | "edu"
   | "unknown";
-export const V2AccountUpdatedNotification__PlanType = Schema.Literals([
-  "free",
-  "go",
-  "plus",
-  "pro",
-  "prolite",
-  "team",
-  "self_serve_business_usage_based",
-  "business",
-  "enterprise_cbp_usage_based",
-  "enterprise",
-  "edu",
+export const V2AccountUpdatedNotification__PlanType = ForwardCompatibleLiterals(
+  [
+    "free",
+    "go",
+    "plus",
+    "pro",
+    "prolite",
+    "team",
+    "self_serve_business_usage_based",
+    "business",
+    "enterprise_cbp_usage_based",
+    "enterprise",
+    "edu",
+    "unknown",
+  ],
   "unknown",
-]);
+);
 
 export type V2AppListUpdatedNotification__AppBranding = {
   readonly category?: string | null;
@@ -4141,20 +4152,23 @@ export type V2GetAccountRateLimitsResponse__PlanType =
   | "enterprise"
   | "edu"
   | "unknown";
-export const V2GetAccountRateLimitsResponse__PlanType = Schema.Literals([
-  "free",
-  "go",
-  "plus",
-  "pro",
-  "prolite",
-  "team",
-  "self_serve_business_usage_based",
-  "business",
-  "enterprise_cbp_usage_based",
-  "enterprise",
-  "edu",
+export const V2GetAccountRateLimitsResponse__PlanType = ForwardCompatibleLiterals(
+  [
+    "free",
+    "go",
+    "plus",
+    "pro",
+    "prolite",
+    "team",
+    "self_serve_business_usage_based",
+    "business",
+    "enterprise_cbp_usage_based",
+    "enterprise",
+    "edu",
+    "unknown",
+  ],
   "unknown",
-]);
+);
 
 export type V2GetAccountRateLimitsResponse__RateLimitReachedType =
   | "rate_limit_reached"
@@ -4229,20 +4243,23 @@ export type V2GetAccountResponse__PlanType =
   | "enterprise"
   | "edu"
   | "unknown";
-export const V2GetAccountResponse__PlanType = Schema.Literals([
-  "free",
-  "go",
-  "plus",
-  "pro",
-  "prolite",
-  "team",
-  "self_serve_business_usage_based",
-  "business",
-  "enterprise_cbp_usage_based",
-  "enterprise",
-  "edu",
+export const V2GetAccountResponse__PlanType = ForwardCompatibleLiterals(
+  [
+    "free",
+    "go",
+    "plus",
+    "pro",
+    "prolite",
+    "team",
+    "self_serve_business_usage_based",
+    "business",
+    "enterprise_cbp_usage_based",
+    "enterprise",
+    "edu",
+    "unknown",
+  ],
   "unknown",
-]);
+);
 
 export type V2GetAccountTokenUsageResponse__AccountTokenUsageDailyBucket = {
   readonly startDate: string;

--- a/packages/effect-codex-app-server/src/_internal/forwardCompatible.ts
+++ b/packages/effect-codex-app-server/src/_internal/forwardCompatible.ts
@@ -1,0 +1,27 @@
+import * as Schema from "effect/Schema";
+import * as SchemaTransformation from "effect/SchemaTransformation";
+
+/**
+ * Wire codec for server→client string enums that carry a serde catch-all
+ * member. The running codex binary can emit members newer than the pinned
+ * protocol schema (e.g. a plan type added in a later codex release), and
+ * upstream folds those into the catch-all via `#[serde(other)]`. Mirror that
+ * here so a newer server cannot fail the decode of an entire payload over a
+ * member the client could not have acted on anyway. Encoding is the plain
+ * string encoding.
+ */
+export const ForwardCompatibleLiterals = <const Members extends ReadonlyArray<string>>(
+  members: Members,
+  fallback: Members[number],
+) => {
+  const known = new Set<string>(members);
+  return Schema.String.pipe(
+    Schema.decodeTo(
+      Schema.Literals(members),
+      SchemaTransformation.transform<Members[number], string>({
+        decode: (value) => (known.has(value) ? (value as Members[number]) : fallback),
+        encode: (value) => value,
+      }),
+    ),
+  );
+};

--- a/packages/effect-codex-app-server/src/_internal/shared.test.ts
+++ b/packages/effect-codex-app-server/src/_internal/shared.test.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 
 import * as CodexError from "../errors.ts";
+import * as CodexSchema from "../schema.ts";
 import * as Shared from "./shared.ts";
 
 const decodeNestedNumberPayload = Schema.decodeUnknownEffect(
@@ -132,6 +133,47 @@ it.effect("passes request errors through without adding a wrapper", () =>
     ).pipe(Effect.flip);
 
     assert.strictEqual(error, source);
+  }),
+);
+
+it.effect("normalizes unrecognized plan types to unknown before decoding", () =>
+  Effect.gen(function* () {
+    const account = yield* Shared.decodeOptionalPayload(
+      "account/read",
+      CodexSchema.V2GetAccountResponse,
+      {
+        account: {
+          type: "chatgpt",
+          email: "edu@example.com",
+          planType: "edu_plus",
+        },
+        requiresOpenaiAuth: false,
+      },
+    );
+
+    assert.deepEqual(account.account, {
+      type: "chatgpt",
+      email: "edu@example.com",
+      planType: "unknown",
+    });
+
+    const knownPlan = yield* Shared.decodeOptionalPayload(
+      "account/read",
+      CodexSchema.V2GetAccountResponse,
+      {
+        account: {
+          type: "chatgpt",
+          email: "plus@example.com",
+          planType: "plus",
+        },
+        requiresOpenaiAuth: false,
+      },
+    );
+
+    assert.equal(knownPlan.account?.type, "chatgpt");
+    if (knownPlan.account?.type === "chatgpt") {
+      assert.equal(knownPlan.account.planType, "plus");
+    }
   }),
 );
 

--- a/packages/effect-codex-app-server/src/_internal/shared.test.ts
+++ b/packages/effect-codex-app-server/src/_internal/shared.test.ts
@@ -136,44 +136,82 @@ it.effect("passes request errors through without adding a wrapper", () =>
   }),
 );
 
-it.effect("normalizes unrecognized plan types to unknown before decoding", () =>
+it.effect("decodes account plans the pinned protocol schema does not know", () =>
+  Effect.gen(function* () {
+    // Present in the schema codex 0.149.1 generates, absent from the pinned ref.
+    const plansAddedAfterThePinnedSchema = [
+      "self_serve_business_prolite",
+      "ent26",
+      "enterprise_cbp_automation",
+      "edu_plus",
+      "edu_pro",
+    ];
+
+    for (const planType of plansAddedAfterThePinnedSchema) {
+      const account = yield* Shared.decodeOptionalPayload(
+        "account/read",
+        CodexSchema.V2GetAccountResponse,
+        {
+          account: { type: "chatgpt", email: "new-plan@example.com", planType },
+          requiresOpenaiAuth: false,
+        },
+      );
+
+      assert.deepEqual(account.account, {
+        type: "chatgpt",
+        email: "new-plan@example.com",
+        planType: "unknown",
+      });
+    }
+  }),
+);
+
+it.effect("leaves known account plans untouched", () =>
   Effect.gen(function* () {
     const account = yield* Shared.decodeOptionalPayload(
       "account/read",
       CodexSchema.V2GetAccountResponse,
       {
-        account: {
-          type: "chatgpt",
-          email: "edu@example.com",
-          planType: "edu_plus",
-        },
+        account: { type: "chatgpt", email: "plus@example.com", planType: "plus" },
         requiresOpenaiAuth: false,
       },
     );
 
     assert.deepEqual(account.account, {
       type: "chatgpt",
-      email: "edu@example.com",
-      planType: "unknown",
+      email: "plus@example.com",
+      planType: "plus",
     });
+  }),
+);
 
-    const knownPlan = yield* Shared.decodeOptionalPayload(
-      "account/read",
-      CodexSchema.V2GetAccountResponse,
+it.effect("decodes account notification plans the pinned protocol schema does not know", () =>
+  Effect.gen(function* () {
+    const notification = yield* Shared.decodeNotificationPayload(
+      "account/updated",
+      CodexSchema.V2AccountUpdatedNotification,
+      { authMode: "chatgpt", planType: "edu_pro" },
+    );
+
+    assert.equal(notification.planType, "unknown");
+  }),
+);
+
+it.effect("leaves planType inside opaque tool arguments untouched", () =>
+  Effect.gen(function* () {
+    const params = yield* Shared.decodeOptionalPayload(
+      "dynamicTool/call",
+      CodexSchema.ServerRequest__DynamicToolCallParams,
       {
-        account: {
-          type: "chatgpt",
-          email: "plus@example.com",
-          planType: "plus",
-        },
-        requiresOpenaiAuth: false,
+        arguments: { planType: "premium" },
+        callId: "call-1",
+        threadId: "thread-1",
+        tool: "billing_lookup",
+        turnId: "turn-1",
       },
     );
 
-    assert.equal(knownPlan.account?.type, "chatgpt");
-    if (knownPlan.account?.type === "chatgpt") {
-      assert.equal(knownPlan.account.planType, "plus");
-    }
+    assert.deepEqual(params.arguments, { planType: "premium" });
   }),
 );
 

--- a/packages/effect-codex-app-server/src/_internal/shared.ts
+++ b/packages/effect-codex-app-server/src/_internal/shared.ts
@@ -17,6 +17,42 @@ export const JsonRpcResponseEnvelope = Schema.Struct({
   error: Schema.optional(JsonRpcError),
 });
 
+// Plan types emitted by the running codex binary can be newer than the pinned
+// protocol schema (e.g. "edu_plus"). Upstream maps unrecognized plans to
+// "unknown" via #[serde(other)]; mirror that so account payloads still decode.
+const KNOWN_PLAN_TYPES = new Set([
+  "free",
+  "go",
+  "plus",
+  "pro",
+  "prolite",
+  "team",
+  "self_serve_business_usage_based",
+  "business",
+  "enterprise_cbp_usage_based",
+  "enterprise",
+  "edu",
+  "unknown",
+]);
+
+export const normalizeUnknownPlanTypes = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(normalizeUnknownPlanTypes);
+  }
+  if (typeof value !== "object" || value === null) {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, child]) => [
+      key,
+      key === "planType" && typeof child === "string" && !KNOWN_PLAN_TYPES.has(child)
+        ? "unknown"
+        : normalizeUnknownPlanTypes(child),
+    ]),
+  );
+};
+
 export const decodeOptionalPayload = <A, I>(
   method: string,
   schema: Schema.Codec<A, I> | undefined,
@@ -31,7 +67,9 @@ export const decodeOptionalPayload = <A, I>(
     );
   }
 
-  return Schema.decodeUnknownEffect(schema)(raw).pipe(
+  return Schema.decodeUnknownEffect(schema)(
+    typeof raw === "object" && raw !== null ? normalizeUnknownPlanTypes(raw) : raw,
+  ).pipe(
     Effect.mapError((error) =>
       CodexError.CodexAppServerRequestError.invalidPayload(method, "decode-payload", error),
     ),

--- a/packages/effect-codex-app-server/src/_internal/shared.ts
+++ b/packages/effect-codex-app-server/src/_internal/shared.ts
@@ -17,42 +17,6 @@ export const JsonRpcResponseEnvelope = Schema.Struct({
   error: Schema.optional(JsonRpcError),
 });
 
-// Plan types emitted by the running codex binary can be newer than the pinned
-// protocol schema (e.g. "edu_plus"). Upstream maps unrecognized plans to
-// "unknown" via #[serde(other)]; mirror that so account payloads still decode.
-const KNOWN_PLAN_TYPES = new Set([
-  "free",
-  "go",
-  "plus",
-  "pro",
-  "prolite",
-  "team",
-  "self_serve_business_usage_based",
-  "business",
-  "enterprise_cbp_usage_based",
-  "enterprise",
-  "edu",
-  "unknown",
-]);
-
-export const normalizeUnknownPlanTypes = (value: unknown): unknown => {
-  if (Array.isArray(value)) {
-    return value.map(normalizeUnknownPlanTypes);
-  }
-  if (typeof value !== "object" || value === null) {
-    return value;
-  }
-
-  return Object.fromEntries(
-    Object.entries(value).map(([key, child]) => [
-      key,
-      key === "planType" && typeof child === "string" && !KNOWN_PLAN_TYPES.has(child)
-        ? "unknown"
-        : normalizeUnknownPlanTypes(child),
-    ]),
-  );
-};
-
 export const decodeOptionalPayload = <A, I>(
   method: string,
   schema: Schema.Codec<A, I> | undefined,
@@ -67,9 +31,7 @@ export const decodeOptionalPayload = <A, I>(
     );
   }
 
-  return Schema.decodeUnknownEffect(schema)(
-    typeof raw === "object" && raw !== null ? normalizeUnknownPlanTypes(raw) : raw,
-  ).pipe(
+  return Schema.decodeUnknownEffect(schema)(raw).pipe(
     Effect.mapError((error) =>
       CodexError.CodexAppServerRequestError.invalidPayload(method, "decode-payload", error),
     ),

--- a/packages/effect-codex-app-server/src/client.test.ts
+++ b/packages/effect-codex-app-server/src/client.test.ts
@@ -123,6 +123,37 @@ it.layer(NodeServices.layer)("effect-codex-app-server client", (it) => {
       ]);
     }),
   );
+  it.effect("decodes account plans the pinned protocol schema does not know", () =>
+    Effect.gen(function* () {
+      const handle = yield* makeHandle({
+        CODEX_APP_SERVER_TEST_ACCOUNT_PLAN_TYPE: "edu_plus",
+      });
+      const scope = yield* Scope.make();
+      const clientLayer = CodexClient.layerChildProcess(handle);
+      const context = yield* Layer.buildWithScope(clientLayer, scope);
+
+      const account = yield* Effect.gen(function* () {
+        const client = yield* CodexClient.CodexAppServerClient;
+        yield* client.request("initialize", {
+          clientInfo: {
+            name: "effect-codex-app-server-test",
+            title: "Effect Codex App Server Test",
+            version: "0.0.0",
+          },
+          capabilities: {
+            experimentalApi: true,
+            optOutNotificationMethods: null,
+          },
+        });
+        return yield* client.request("account/read", {});
+      }).pipe(Effect.provide(context), Effect.ensuring(Scope.close(scope, Exit.void)));
+
+      assert.equal(account.account?.type, "chatgpt");
+      if (account.account?.type === "chatgpt") {
+        assert.equal(account.account.planType, "unknown");
+      }
+    }),
+  );
   it.effect("drains child stderr so large diagnostics cannot block protocol responses", () =>
     Effect.gen(function* () {
       const handle = yield* makeHandle({

--- a/packages/effect-codex-app-server/test/fixtures/codex-app-server-mock-peer.ts
+++ b/packages/effect-codex-app-server/test/fixtures/codex-app-server-mock-peer.ts
@@ -71,11 +71,13 @@ const handleMethod = (message: Record<string, unknown>) => {
       return;
     }
     case "account/read": {
+      // oxlint-disable-next-line t3code/no-global-process-runtime -- Standalone mock peer process has no Effect runtime.
+      const planType = process.env.CODEX_APP_SERVER_TEST_ACCOUNT_PLAN_TYPE ?? "plus";
       respond(message.id as number | string, {
         account: {
           type: "chatgpt",
           email: "mock@example.com",
-          planType: "plus",
+          planType,
         },
         requiresOpenaiAuth: false,
       });


### PR DESCRIPTION
Codex 0.148.0 added new ChatGPT plan types (`edu_plus`, `edu_pro`). T3 Code decodes `account/read` responses against a pinned protocol schema whose `planType` union predates those plans, so every OpenAI request on an Edu account fails with "Invalid payload for method 'account/read' during 'decode-payload'". Codex 0.149.1 adds three more (`self_serve_business_prolite`, `ent26`, `enterprise_cbp_automation`), so this keeps recurring.

The five generated `__PlanType` unions now decode an unrecognized member to `"unknown"`. They're `#[serde(other)]` catch-alls upstream and already list `"unknown"`, so this matches what serde does with a plan the binary knows and the pinned schema doesn't. `scripts/generate.ts` applies it during codegen, so a protocol bump keeps the behavior, and it throws if such a union stops being a literal union or loses its catch-all rather than quietly dropping the fallback.

The helper follows `ForwardCompatibleArray` in `packages/contracts/src/baseSchemas.ts`, which already handles the same problem for arrays whose element unions grow over time.

An earlier revision normalized `planType` inside `decodeOptionalPayload`. Review caught that this walked every method's payload by key name, so a `planType` in opaque data (MCP tool `arguments`, `structuredContent`, and the other 173 `Schema.Unknown` fields) was rewritten before handlers saw it, and every thread and notification payload was cloned for a field almost none carry. `decodeOptionalPayload` is untouched in this revision; a regression test pins that opaque tool arguments keep their own `planType`.

Fixes #7828

Co-authored with @bitconym, who generated the schema from codex 0.149.1 and identified the full set of missing plan values.

ox-alpha via opencode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request payload decoding for account (and any nested `planType`) responses. The change is a conservative fallback, but a bug here could mis-classify plans or hide real decode failures.
> 
> **Overview**
> Stops `account/read` from failing when Codex reports newer ChatGPT plans (e.g. `edu_plus`) that the pinned protocol schema does not include.
> 
> Before schema decode, `decodeOptionalPayload` now walks object payloads and rewrites unrecognized `planType` strings to `"unknown"`, matching Codex’s `#[serde(other)]` fallback. Known plans are left unchanged.
> 
> Adds unit and mock-peer coverage so Edu-style plans decode instead of raising invalid-payload errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04f3a2850534aab6b2c6357a6194ececc12c7baa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Accept unknown account plan types in codex client by decoding to `"unknown"`
> ChatGPT Edu Plus accounts return a `planType` the client schema does not recognize, causing decode failures. This PR introduces a `ForwardCompatibleLiterals` schema helper that maps any unrecognized string to a designated fallback while preserving normal encoding.
>
> - Adds `ForwardCompatibleLiterals` in [forwardCompatible.ts](https://github.com/pingdotgg/t3code/pull/7869/files#diff-b91f63de3c1f490bd4951ce0967ecd63df07013a44f2decaafa34493b80596f6), composing `Schema.String` with a transform that decodes unknown values to `"unknown"`
> - Updates the code generator in [generate.ts](https://github.com/pingdotgg/t3code/pull/7869/files#diff-560473cbb6e8d5dcb7711cbe1b22019753b863e14f3d956a5a2e509fdedea368) to wrap any enum matching `/__PlanType$/` with `ForwardCompatibleLiterals`, and emits the corresponding import in the generated schema
> - Regenerates [schema.gen.ts](https://github.com/pingdotgg/t3code/pull/7869/files#diff-c283b8cf9097ca9d1030e7acabd5d3c70e2a5ca2bfaf229f79512ba96ed58296) so `V2GetAccountResponse__PlanType` and related constants now use the forward-compatible wrapper
> - Adds unit and integration tests covering unknown-plan decoding through the client; the mock peer in [codex-app-server-mock-peer.ts](https://github.com/pingdotgg/t3code/pull/7869/files#diff-d5de8dbd6640c6dc8f39825f27a9512f7f9a8f5e5484122eae9de2922dc5b1c0) now reads `planType` from an env var for test control
> - Risk: `applyForwardCompatibleEnum` in [generate.ts](https://github.com/pingdotgg/t3code/pull/7869/files#diff-560473cbb6e8d5dcb7711cbe1b22019753b863e14f3d956a5a2e509fdedea368) throws on malformed `Schema.Literals` shapes — any future generator change that alters the literal-union pattern will fail the build until the regex is updated
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6916ee5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
