### PR TITLE
fix(web): update release notes stay open for interaction

### DIFF
--- a/apps/web/src/components/sidebar/SidebarUpdatePill.test.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.test.tsx
@@ -64,22 +64,32 @@ function invokeComponent(element: TestElement): TestElement {
   return component(element.props);
 }
 
-function renderPopover() {
+function renderControl() {
   hooks.beginRender();
   const control = SidebarUpdatePill() as TestElement;
-  const popover = invokeComponent(control);
-  const output = invokeComponent(popover);
+  return invokeComponent(control);
+}
+
+function findTrigger(output: TestElement) {
   const trigger = visitElements(
     output,
     (element) => element.type === "button" && typeof element.props["aria-label"] === "string",
   );
+  if (!trigger) throw new Error("Expected update trigger");
+  return trigger;
+}
+
+function renderPopover() {
+  const popover = renderControl();
+  const output = invokeComponent(popover);
+  const trigger = findTrigger(output);
   const root = visitElements(
     output,
     (element) =>
       typeof element.props.open === "boolean" && typeof element.props.onOpenChange === "function",
   );
 
-  if (!trigger || !root) throw new Error("Expected update popover and trigger");
+  if (!root) throw new Error("Expected update popover");
   return { output, root, trigger };
 }
 
@@ -155,7 +165,7 @@ describe("SidebarUpdatePill release notes popover", () => {
     const { trigger } = renderPopover();
     activateTrigger(trigger, "mouse");
 
-    expect(trigger.props.disabled).toBe(false);
+    expect(trigger.props.disabled).toBeUndefined();
     expect(trigger.props["aria-disabled"]).toBe(true);
     expect(trigger.props.className).toContain("cursor-not-allowed");
     expect(trigger.props.className).not.toContain("cursor-pointer");
@@ -180,10 +190,29 @@ describe("SidebarUpdatePill release notes popover", () => {
     );
     activateTrigger(rerendered.trigger, "mouse");
 
-    expect(rerendered.trigger.props.disabled).toBe(false);
+    expect(rerendered.trigger.props.disabled).toBeUndefined();
     expect(rerendered.trigger.props["aria-disabled"]).toBe(true);
     expect(rerendered.trigger.props.className).toContain("cursor-not-allowed");
     expect(actionButton?.props.disabled).toBe(true);
     expect(testState.downloadUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the stable downloading tooltip trigger keyboard-focusable", () => {
+    testState.desktopUpdate = {
+      ...availableState,
+      status: "downloading",
+      channel: "latest",
+      releaseNotes: [],
+      downloadPercent: 42,
+    };
+
+    const trigger = findTrigger(renderControl());
+    activateTrigger(trigger, "mouse");
+
+    expect(trigger.props.disabled).toBeUndefined();
+    expect(trigger.props["aria-disabled"]).toBe(true);
+    expect(trigger.props.className).toContain("cursor-not-allowed");
+    expect(trigger.props.className).not.toContain("cursor-pointer");
+    expect(testState.downloadUpdate).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.test.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.test.tsx
@@ -141,6 +141,13 @@ describe("SidebarUpdatePill release notes popover", () => {
     expect(preventBaseUIHandler).not.toHaveBeenCalled();
   });
 
+  it("keeps focus on the trigger when the popover opens", () => {
+    const { output } = renderPopover();
+    const popup = visitElements(output, (element) => element.props.initialFocus === false);
+
+    expect(popup).toBeDefined();
+  });
+
   it.each(["touch", "pen"] as const)(
     "opens release notes before acting for a %s click",
     (pointerType) => {

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.test.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.test.tsx
@@ -1,0 +1,189 @@
+import type { DesktopUpdateActionResult, DesktopUpdateState } from "@t3tools/contracts";
+import type { ReactElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { visitElements } from "../../test/reactElementTree";
+import { reactHookHarness as hooks } from "../../test/reactHookHarness";
+
+const testState = vi.hoisted(() => ({
+  desktopUpdate: null as DesktopUpdateState | null,
+  downloadUpdate: vi.fn<() => Promise<DesktopUpdateActionResult>>(),
+}));
+
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  const { reactHookHarness } = await import("../../test/reactHookHarness");
+  return {
+    ...actual,
+    useCallback: reactHookHarness.useCallback,
+    useEffect: () => undefined,
+    useId: () => "sidebar-update-trigger",
+    useRef: reactHookHarness.useRef,
+    useState: reactHookHarness.useState,
+  };
+});
+
+vi.mock("react/compiler-runtime", async () => {
+  const { reactHookHarness } = await import("../../test/reactHookHarness");
+  return { c: reactHookHarness.useMemoCache };
+});
+
+vi.mock("../../env", () => ({ isElectron: true }));
+vi.mock("../../hooks/useMediaQuery", () => ({ useMediaQuery: () => false }));
+vi.mock("../../state/desktopUpdate", () => ({
+  useDesktopUpdateState: () => testState.desktopUpdate,
+}));
+
+import { SidebarUpdatePill } from "./SidebarUpdatePill";
+
+const availableState: DesktopUpdateState = {
+  enabled: true,
+  status: "available",
+  channel: "nightly",
+  currentVersion: "1.0.0-nightly.1",
+  hostArch: "x64",
+  appArch: "x64",
+  runningUnderArm64Translation: false,
+  availableVersion: "1.0.0-nightly.2",
+  downloadedVersion: null,
+  releaseNotes: [{ version: "1.0.0-nightly.2", items: ["fix: keep notes interactive"] }],
+  downloadPercent: null,
+  checkedAt: "2026-08-22T00:00:00.000Z",
+  message: null,
+  errorContext: null,
+  canRetry: false,
+};
+
+type TestElement = ReactElement<Record<string, unknown>>;
+
+function invokeComponent(element: TestElement): TestElement {
+  if (typeof element.type !== "function") {
+    throw new Error("Expected a function component");
+  }
+  const component = element.type as unknown as (props: Record<string, unknown>) => TestElement;
+  return component(element.props);
+}
+
+function renderPopover() {
+  hooks.beginRender();
+  const control = SidebarUpdatePill() as TestElement;
+  const popover = invokeComponent(control);
+  const output = invokeComponent(popover);
+  const trigger = visitElements(
+    output,
+    (element) => element.type === "button" && typeof element.props["aria-label"] === "string",
+  );
+  const root = visitElements(
+    output,
+    (element) =>
+      typeof element.props.open === "boolean" && typeof element.props.onOpenChange === "function",
+  );
+
+  if (!trigger || !root) throw new Error("Expected update popover and trigger");
+  return { output, root, trigger };
+}
+
+function activateTrigger(trigger: TestElement, pointerType: "mouse" | "pen" | "touch") {
+  const preventBaseUIHandler = vi.fn();
+  const onPointerDown = trigger.props.onPointerDown as
+    | ((event: { pointerType: string }) => void)
+    | undefined;
+  const onClick = trigger.props.onClick as
+    | ((event: { preventBaseUIHandler: () => void }) => void)
+    | undefined;
+
+  onPointerDown?.({ pointerType });
+  onClick?.({ preventBaseUIHandler });
+  return preventBaseUIHandler;
+}
+
+function installDesktopBridge() {
+  vi.stubGlobal("window", {
+    desktopBridge: {
+      downloadUpdate: testState.downloadUpdate,
+    },
+  });
+}
+
+describe("SidebarUpdatePill release notes popover", () => {
+  beforeEach(() => {
+    hooks.reset();
+    testState.desktopUpdate = availableState;
+    testState.downloadUpdate.mockReset();
+    testState.downloadUpdate.mockResolvedValue({
+      accepted: true,
+      completed: false,
+      state: availableState,
+    });
+    installDesktopBridge();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("runs the update action on a mouse click", () => {
+    const { trigger } = renderPopover();
+
+    const preventBaseUIHandler = activateTrigger(trigger, "mouse");
+
+    expect(testState.downloadUpdate).toHaveBeenCalledTimes(1);
+    expect(preventBaseUIHandler).not.toHaveBeenCalled();
+  });
+
+  it.each(["touch", "pen"] as const)(
+    "opens release notes before acting for a %s click",
+    (pointerType) => {
+      const { trigger } = renderPopover();
+
+      const preventBaseUIHandler = activateTrigger(trigger, pointerType);
+      const rerendered = renderPopover();
+
+      expect(testState.downloadUpdate).not.toHaveBeenCalled();
+      expect(preventBaseUIHandler).toHaveBeenCalledTimes(1);
+      expect(rerendered.root.props.open).toBe(true);
+    },
+  );
+
+  it("keeps the downloading trigger focusable but marks its action disabled", () => {
+    testState.desktopUpdate = {
+      ...availableState,
+      status: "downloading",
+      downloadPercent: 42,
+    };
+
+    const { trigger } = renderPopover();
+    activateTrigger(trigger, "mouse");
+
+    expect(trigger.props.disabled).toBe(false);
+    expect(trigger.props["aria-disabled"]).toBe(true);
+    expect(trigger.props.className).toContain("cursor-not-allowed");
+    expect(trigger.props.className).not.toContain("cursor-pointer");
+    expect(trigger.props.className).not.toContain("hover:bg-update/12");
+    expect(testState.downloadUpdate).not.toHaveBeenCalled();
+  });
+
+  it("marks the trigger and popover action disabled while an action is pending", () => {
+    testState.downloadUpdate.mockReturnValue(new Promise(() => undefined));
+    const { trigger } = renderPopover();
+    activateTrigger(trigger, "mouse");
+
+    const rerendered = renderPopover();
+    const releaseNotes = visitElements(
+      rerendered.output,
+      (element) => element.props.state === availableState && element.props.isActionPending === true,
+    );
+    if (!releaseNotes) throw new Error("Expected release notes content");
+    const actionButton = visitElements(
+      invokeComponent(releaseNotes),
+      (element) => element.props.children === "Download update",
+    );
+    activateTrigger(rerendered.trigger, "mouse");
+
+    expect(rerendered.trigger.props.disabled).toBe(false);
+    expect(rerendered.trigger.props["aria-disabled"]).toBe(true);
+    expect(rerendered.trigger.props.className).toContain("cursor-not-allowed");
+    expect(actionButton?.props.disabled).toBe(true);
+    expect(testState.downloadUpdate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -167,7 +167,6 @@ function SidebarUpdateReleaseNotesPopover({
   const suppressNextFocusOpenRef = useRef(false);
 
   const interactiveTrigger = cloneElement(trigger, {
-    "aria-disabled": undefined,
     disabled: false,
     onClick: (event) => {
       const pointerType = pointerTypeRef.current;
@@ -439,18 +438,27 @@ function SidebarUpdateControl() {
   const showReleaseNotes = Boolean(
     showUpdateDetails && state && state.channel === "nightly" && state.releaseNotes.length > 0,
   );
+  const isTriggerActionDisabled = disabled || isActionPending;
 
   const trigger = (
     <button
       type="button"
       aria-label={tooltip}
-      aria-disabled={disabled || isActionPending || undefined}
-      disabled={disabled || isActionPending}
+      aria-disabled={isTriggerActionDisabled || undefined}
+      disabled={isTriggerActionDisabled}
       className={cn(
-        "inline-flex size-8 items-center justify-center rounded-full outline-hidden ring-ring transition-colors enabled:cursor-pointer focus-visible:ring-2 disabled:cursor-not-allowed",
+        "inline-flex size-8 items-center justify-center rounded-full outline-hidden ring-ring transition-colors focus-visible:ring-2",
+        isTriggerActionDisabled ? "cursor-not-allowed" : "cursor-pointer",
         showUpdateIconState
-          ? "bg-update-surface text-update-foreground enabled:hover:bg-update/12"
-          : "text-[var(--sidebar-icon-color)] enabled:hover:bg-sidebar-row-hover enabled:hover:text-sidebar-foreground",
+          ? cn(
+              "bg-update-surface text-update-foreground",
+              !isTriggerActionDisabled && "hover:bg-update/12",
+            )
+          : cn(
+              "text-[var(--sidebar-icon-color)]",
+              !isTriggerActionDisabled &&
+                "hover:bg-sidebar-row-hover hover:text-sidebar-foreground",
+            ),
         disabled && !showUpdateIconState && "opacity-60",
       )}
       onClick={handleAction}

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -167,7 +167,6 @@ function SidebarUpdateReleaseNotesPopover({
   const suppressNextFocusOpenRef = useRef(false);
 
   const interactiveTrigger = cloneElement(trigger, {
-    disabled: false,
     onClick: (event) => {
       const pointerType = pointerTypeRef.current;
       pointerTypeRef.current = null;
@@ -445,7 +444,6 @@ function SidebarUpdateControl() {
       type="button"
       aria-label={tooltip}
       aria-disabled={isTriggerActionDisabled || undefined}
-      disabled={isTriggerActionDisabled}
       className={cn(
         "inline-flex size-8 items-center justify-center rounded-full outline-hidden ring-ring transition-colors focus-visible:ring-2",
         isTriggerActionDisabled ? "cursor-not-allowed" : "cursor-pointer",

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -227,6 +227,7 @@ function SidebarUpdateReleaseNotesPopover({
         <PopoverPopup
           align="center"
           className="max-w-[min(24rem,calc(100vw-2rem))]"
+          initialFocus={false}
           ref={popupRef}
           side="top"
           viewportClassName="max-h-[min(28rem,var(--available-height))] py-3"

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -1,5 +1,14 @@
 import { TriangleAlertIcon } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import {
+  cloneElement,
+  type ButtonHTMLAttributes,
+  type ReactElement,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
 import { isElectron } from "../../env";
 import { useMediaQuery } from "../../hooks/useMediaQuery";
 import { cn } from "../../lib/utils";
@@ -19,6 +28,8 @@ import {
 } from "../desktopUpdate.logic";
 import { showDesktopUpdateDownloadedToast } from "../desktopUpdate.toast";
 import { Alert, AlertDescription, AlertTitle } from "../ui/alert";
+import { Button } from "../ui/button";
+import { Popover, PopoverPopup, PopoverTitle, PopoverTrigger } from "../ui/popover";
 import { Separator } from "../ui/separator";
 import { SidebarMenuItem } from "../ui/sidebar";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
@@ -64,36 +75,52 @@ function keyReleaseNoteItems(items: ReadonlyArray<string>) {
   });
 }
 
-function SidebarUpdateReleaseNotesTooltip({
+function SidebarUpdateReleaseNotes({
+  action,
+  isActionPending,
+  onAction,
   state,
   tooltip,
 }: {
+  readonly action: ReturnType<typeof resolveDesktopUpdateButtonAction>;
+  readonly isActionPending: boolean;
+  readonly onAction: () => void;
   readonly state: NonNullable<ReturnType<typeof useDesktopUpdateState>>;
   readonly tooltip: string;
 }) {
-  if (state.channel !== "nightly" || state.releaseNotes.length === 0) {
-    return <>{tooltip}</>;
-  }
+  const actionLabel =
+    action === "download"
+      ? state.status === "error"
+        ? "Retry download"
+        : "Download update"
+      : action === "install"
+        ? state.status === "error"
+          ? "Retry install"
+          : "Restart and install"
+        : null;
 
   return (
-    <div className="w-fit max-w-[min(24rem,calc(100vw-2rem))] text-left">
-      <div className="px-1">
-        {state.status === "available" ? (
-          <div>
-            <div className="whitespace-nowrap text-sm leading-5 font-medium">
-              Update ready to download
+    <div className="text-left">
+      {state.status === "available" ? (
+        <div>
+          <PopoverTitle className="text-sm leading-5 font-medium">
+            Update ready to download
+          </PopoverTitle>
+          {state.availableVersion ? (
+            <div className="mt-0.5 text-update-foreground text-xs leading-4">
+              {state.availableVersion}
             </div>
-            {state.availableVersion ? (
-              <div className="mt-0.5 text-xs leading-4 text-update-foreground">
-                {state.availableVersion}
-              </div>
-            ) : null}
-          </div>
-        ) : (
-          <div className="text-sm leading-5 font-medium">{tooltip}</div>
-        )}
-      </div>
-      <div className="max-h-[min(28rem,calc(100vh-6rem))] overflow-y-auto px-1 pt-4 pb-1">
+          ) : null}
+        </div>
+      ) : (
+        <PopoverTitle className="text-sm leading-5 font-medium">{tooltip}</PopoverTitle>
+      )}
+      {actionLabel ? (
+        <Button className="mt-3" disabled={isActionPending} onClick={onAction} size="xs">
+          {actionLabel}
+        </Button>
+      ) : null}
+      <div className="pt-3">
         {state.releaseNotes.map((releaseNote, index) => (
           <div key={releaseNote.version}>
             {index > 0 && <Separator className="my-3 bg-border/60" />}
@@ -113,6 +140,111 @@ function SidebarUpdateReleaseNotesTooltip({
         ))}
       </div>
     </div>
+  );
+}
+
+type SidebarUpdateTriggerElement = ReactElement<ButtonHTMLAttributes<HTMLButtonElement>>;
+
+function SidebarUpdateReleaseNotesPopover({
+  action,
+  isActionPending,
+  onAction,
+  state,
+  tooltip,
+  trigger,
+}: {
+  readonly action: ReturnType<typeof resolveDesktopUpdateButtonAction>;
+  readonly isActionPending: boolean;
+  readonly onAction: () => Promise<void>;
+  readonly state: NonNullable<ReturnType<typeof useDesktopUpdateState>>;
+  readonly tooltip: string;
+  readonly trigger: SidebarUpdateTriggerElement;
+}) {
+  const [open, setOpen] = useState(false);
+  const popupRef = useRef<HTMLDivElement>(null);
+  const triggerId = useId();
+  const pointerTypeRef = useRef<string | null>(null);
+  const suppressNextFocusOpenRef = useRef(false);
+
+  const interactiveTrigger = cloneElement(trigger, {
+    "aria-disabled": undefined,
+    disabled: false,
+    onClick: (event) => {
+      const pointerType = pointerTypeRef.current;
+      pointerTypeRef.current = null;
+      // Mouse users keep the pill's one-click action after reading the hover content. Touch and
+      // pen users open the content first, then use its explicit action button.
+      if (pointerType && pointerType !== "mouse") {
+        setOpen(true);
+        (
+          event as typeof event & {
+            preventBaseUIHandler?: () => void;
+          }
+        ).preventBaseUIHandler?.();
+        return;
+      }
+      void onAction();
+    },
+    onFocus: () => {
+      if (suppressNextFocusOpenRef.current) {
+        suppressNextFocusOpenRef.current = false;
+        return;
+      }
+      setOpen(true);
+    },
+    onKeyDown: () => {
+      pointerTypeRef.current = null;
+    },
+    onPointerDown: (event) => {
+      pointerTypeRef.current = event.pointerType;
+    },
+    onPointerCancel: () => {
+      pointerTypeRef.current = null;
+    },
+  });
+
+  return (
+    <SidebarMenuItem className="ml-auto shrink-0">
+      <Popover
+        onOpenChange={(nextOpen, eventDetails) => {
+          if (
+            !nextOpen &&
+            eventDetails.reason === "escape-key" &&
+            popupRef.current?.contains(document.activeElement)
+          ) {
+            suppressNextFocusOpenRef.current = true;
+          }
+          setOpen(nextOpen);
+        }}
+        open={open}
+        triggerId={triggerId}
+      >
+        <PopoverTrigger
+          closeDelay={120}
+          delay={150}
+          id={triggerId}
+          openOnHover
+          render={interactiveTrigger}
+        />
+        <PopoverPopup
+          align="center"
+          className="max-w-[min(24rem,calc(100vw-2rem))]"
+          ref={popupRef}
+          side="top"
+          viewportClassName="max-h-[min(28rem,var(--available-height))] py-3"
+        >
+          <SidebarUpdateReleaseNotes
+            action={action}
+            isActionPending={isActionPending}
+            onAction={() => {
+              void onAction();
+            }}
+            state={state}
+            tooltip={tooltip}
+          />
+        </PopoverPopup>
+      </Popover>
+    </SidebarMenuItem>
   );
 }
 
@@ -304,44 +436,56 @@ function SidebarUpdateControl() {
     );
   }, [prefersReducedMotion, state?.status]);
 
+  const showReleaseNotes = Boolean(
+    showUpdateDetails && state && state.channel === "nightly" && state.releaseNotes.length > 0,
+  );
+
+  const trigger = (
+    <button
+      type="button"
+      aria-label={tooltip}
+      aria-disabled={disabled || isActionPending || undefined}
+      disabled={disabled || isActionPending}
+      className={cn(
+        "inline-flex size-8 items-center justify-center rounded-full outline-hidden ring-ring transition-colors enabled:cursor-pointer focus-visible:ring-2 disabled:cursor-not-allowed",
+        showUpdateIconState
+          ? "bg-update-surface text-update-foreground enabled:hover:bg-update/12"
+          : "text-[var(--sidebar-icon-color)] enabled:hover:bg-sidebar-row-hover enabled:hover:text-sidebar-foreground",
+        disabled && !showUpdateIconState && "opacity-60",
+      )}
+      onClick={handleAction}
+    >
+      <DesktopUpdateStatusIcon
+        key={showCheckIcon ? checkAnimationKey : iconStatus}
+        downloadPercent={state?.downloadPercent ?? null}
+        isCheckAnimating={showCheckIcon && !prefersReducedMotion}
+        onCheckAnimationIteration={handleCheckAnimationIteration}
+        status={iconStatus}
+      />
+    </button>
+  );
+
+  // Release notes are long enough to scroll and to read at your own pace, so they hover as a
+  // popover: its popup keeps pointer events, and its viewport scrolls within the space it has.
+  if (showReleaseNotes && state) {
+    return (
+      <SidebarUpdateReleaseNotesPopover
+        action={action}
+        isActionPending={isActionPending}
+        onAction={handleAction}
+        state={state}
+        tooltip={tooltip}
+        trigger={trigger}
+      />
+    );
+  }
+
   return (
     <SidebarMenuItem className="ml-auto shrink-0">
       <Tooltip>
-        <TooltipTrigger
-          render={
-            <button
-              type="button"
-              aria-label={tooltip}
-              aria-disabled={disabled || isActionPending || undefined}
-              disabled={disabled || isActionPending}
-              className={cn(
-                "inline-flex size-8 items-center justify-center rounded-full outline-hidden ring-ring transition-colors enabled:cursor-pointer focus-visible:ring-2 disabled:cursor-not-allowed",
-                showUpdateIconState
-                  ? "bg-update-surface text-update-foreground enabled:hover:bg-update/12"
-                  : "text-[var(--sidebar-icon-color)] enabled:hover:bg-sidebar-row-hover enabled:hover:text-sidebar-foreground",
-                disabled && !showUpdateIconState && "opacity-60",
-              )}
-              onClick={handleAction}
-            >
-              <DesktopUpdateStatusIcon
-                key={showCheckIcon ? checkAnimationKey : iconStatus}
-                downloadPercent={state?.downloadPercent ?? null}
-                isCheckAnimating={showCheckIcon && !prefersReducedMotion}
-                onCheckAnimationIteration={handleCheckAnimationIteration}
-                status={iconStatus}
-              />
-            </button>
-          }
-        />
+        <TooltipTrigger render={trigger} />
         <TooltipPopup
           align="center"
-          className={
-            showUpdateDetails && state?.channel === "nightly" && state.releaseNotes.length > 0
-              ? // pointer-events-auto overrides the positioner's pointer-events-none so the
-                // release notes stay open (and scrollable) when the cursor moves into them.
-                "pointer-events-auto max-w-none text-balance"
-              : undefined
-          }
           side="top"
           style={
             showUpdateDetails
@@ -354,11 +498,7 @@ function SidebarUpdateControl() {
           }
           variant={showUpdateDetails ? "glass" : "default"}
         >
-          {showUpdateDetails && state ? (
-            <SidebarUpdateReleaseNotesTooltip state={state} tooltip={tooltip} />
-          ) : (
-            tooltip
-          )}
+          {tooltip}
         </TooltipPopup>
       </Tooltip>
     </SidebarMenuItem>


### PR DESCRIPTION
Nightly update release notes were rendered in a tooltip, so the panel disappeared when users tried to move into it and long changelogs could not be read or scrolled reliably.

The update pill now uses an interactive popover for nightly release notes. It stays open across pointer movement, limits its height to the available space, and scrolls its contents. Mouse users keep the pill's one-click download or install behavior. Non-nightly updates and states without release notes keep the existing tooltip.

Touch and pen users open the release notes first, then use the explicit Download update or Restart and install button inside the popover. This gives them an action that does not depend on hover. Keyboard focus opens the notes while remaining on the pill, the popover has an accessible title, and Escape closes it without immediately reopening after users tab into the popover. While downloading or running an action, the update trigger remains focusable in both the popover and tooltip paths but exposes `aria-disabled` and non-actionable styling.

## Verification

- `vp test run apps/web/src/components/sidebar/SidebarUpdatePill.test.tsx apps/web/src/components/desktopUpdate.logic.test.ts apps/web/src/components/desktopUpdate.toast.test.tsx apps/web/src/state/desktopUpdate.test.ts` (45 tests passed)
- `vp lint --report-unused-disable-directives apps/web/src/components/sidebar/SidebarUpdatePill.tsx apps/web/src/components/sidebar/SidebarUpdatePill.test.tsx`
- `vp fmt --check apps/web/src/components/sidebar/SidebarUpdatePill.tsx apps/web/src/components/sidebar/SidebarUpdatePill.test.tsx`
- `git diff --check`
- `vp run --filter @t3tools/web typecheck` still reports the two existing `conditionalUI` type errors in `src/components/clerk/electronPasskeys.test.ts`
- Integrated local browser pass against isolated state with temporary update fixtures and a stubbed desktop bridge: verified nightly available, downloaded, and downloading states; stable downloading and no-notes tooltip fallbacks; mouse, keyboard, touch, and pen interactions; accessible labeling, focus retention, Escape restoration, and `aria-disabled`; popover scrolling at a 900 × 500 viewport; and both Cancel and Confirm restart/install paths.

## Screenshots

### Update ready to download

| Before | After |
| --- | --- |
| <img width="430" alt="Nightly update ready to download before" src="https://github.com/user-attachments/assets/30b48604-975d-484a-abd7-060796acde8e" /> | <img width="430" alt="Nightly update ready to download after, with an explicit Download update button" src="https://github.com/user-attachments/assets/09a0e48d-eeeb-4d89-94ac-f0809709f794" /> |

### Update downloaded

| Before | After |
| --- | --- |
| <img width="430" alt="Downloaded nightly update before" src="https://github.com/user-attachments/assets/cfb1af7f-2cb1-4371-847c-e14fcc9a4ba5" /> | <img width="430" alt="Downloaded nightly update after, with an explicit Restart and install button" src="https://github.com/user-attachments/assets/ba4f4773-d136-43c5-99c6-3ec93612063d" /> |

---
Built by GPT-5.6 Sol in T3 Code through the Codex harness.



