### PR TITLE
fix(web): triple-click selects the clicked composer line

### DIFF
--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -1076,6 +1076,71 @@ function ComposerHomeEndKeyPlugin() {
   return null;
 }
 
+function ComposerTripleClickLinePlugin() {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    let snapshot: {
+      anchorNode: Node;
+      anchorOffset: number;
+      focusNode: Node;
+      focusOffset: number;
+    } | null = null;
+
+    const captureClick = (event: MouseEvent) => {
+      snapshot = null;
+      if (event.detail !== 3) return;
+      const rootElement = editor.getRootElement();
+      if (!rootElement || !(event.target instanceof Node) || !rootElement.contains(event.target)) {
+        return;
+      }
+      const selection = window.getSelection();
+      if (!selection?.anchorNode || !selection.focusNode || selection.isCollapsed) return;
+      snapshot = {
+        anchorNode: selection.anchorNode,
+        anchorOffset: selection.anchorOffset,
+        focusNode: selection.focusNode,
+        focusOffset: selection.focusOffset,
+      };
+    };
+
+    const restoreClick = (event: MouseEvent) => {
+      const saved = snapshot;
+      snapshot = null;
+      if (!saved || event.detail !== 3) return;
+      if (!saved.anchorNode.isConnected || !saved.focusNode.isConnected) return;
+      const selection = window.getSelection();
+      if (!selection) return;
+      if (
+        selection.anchorNode === saved.anchorNode &&
+        selection.anchorOffset === saved.anchorOffset &&
+        selection.focusNode === saved.focusNode &&
+        selection.focusOffset === saved.focusOffset
+      ) {
+        return;
+      }
+      selection.setBaseAndExtent(
+        saved.anchorNode,
+        saved.anchorOffset,
+        saved.focusNode,
+        saved.focusOffset,
+      );
+      editor.update(() => {
+        $setSelection($createRangeSelectionFromDom(selection, editor));
+      });
+    };
+
+    document.addEventListener("click", captureClick, true);
+    document.addEventListener("click", restoreClick);
+    return () => {
+      document.removeEventListener("click", captureClick, true);
+      document.removeEventListener("click", restoreClick);
+    };
+  }, [editor]);
+
+  return null;
+}
+
 function ComposerInlineTokenSelectionNormalizePlugin() {
   const [editor] = useLexicalComposerContext();
 
@@ -1776,6 +1841,7 @@ function ComposerPromptEditorInner({
         <ComposerCommandKeyPlugin {...(onCommandKeyDown ? { onCommandKeyDown } : {})} />
         <ComposerSurroundSelectionPlugin terminalContexts={terminalContexts} skills={skills} />
         <ComposerHomeEndKeyPlugin />
+        <ComposerTripleClickLinePlugin />
         <ComposerInlineTokenArrowPlugin />
         <ComposerInlineTokenSelectionNormalizePlugin />
         <ComposerInlineTokenBackspacePlugin />


### PR DESCRIPTION
# In one line

Currently, triple-clicking a line in the prompt input selects the whole input rather than the line, due to a Lexical quirk. This PR fixes this to allow triple-clicks to select the clicked line only.

# Problem

A UI/UX bug - Triple-clicking any line above the last in a multi-line composer draft selected the entire prompt instead of the clicked line, with no way to select only that line by clicking. The exception is the last line, where for this line and this line only, triple-clicking selects only the line, as expected. 

This goes against typical conventions of "double-click selects word" and "triple-click selects line", and was a point of frustration for me personally.

# Demonstration

**Before**

https://github.com/user-attachments/assets/d13079ec-cc8d-4bc4-82b0-1497de2305e6


**After**

https://github.com/user-attachments/assets/7094c7a9-cbde-49eb-9e72-c0f21cb7915b


# Cause

Lexical's triple-click normalization assumes one paragraph per line, but the composer keeps the whole prompt in a single paragraph separated by line breaks. So Lexical's "select the clicked paragraph" behavior inadvertently became "select the whole input." The bottom line only worked because the native selection never crossed into a following node there.

# Fix 

We capture a snapshot of the browser's native correct line selection in a click listener before Lexical takes over, and restore the snapshot afterwards.

In this way we keep the correct behavior without swallowing any events, so React handlers, click-outside dismissal, and Lexical's CLICK_COMMAND all still work.

There was a potential smaller fix of stopping propagation of `detail === 3` clicks so Lexical's normalization doesn't run for triple-clicks. But this would have swallowed events and potentially caused latent bugs.

Web only; desktop inherits the fix through the shared web app, and mobile uses a native input and is unaffected.
Fix implemented with Fable 5 via Claude Code (in t3code of course ;) )

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only selection fix in the composer. Document click listeners are gated to triple-clicks inside the editor and do not change data or auth.
> 
> **Overview**
> Makes triple-click in the prompt composer select the **clicked line** instead of the whole draft.
> 
> Lexical treats a triple-click as “select the paragraph,” but the composer stores the prompt as **one paragraph with line breaks**. The new `ComposerTripleClickLinePlugin` snapshots the browser’s native line selection on capture and restores it after Lexical’s click handling, without swallowing the event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7b9a9bb616f20a0630590ad843f7815c93a7eca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix triple-click to select clicked line in `ComposerPromptEditor`
> Adds `ComposerTripleClickLinePlugin` to the Lexical editor in [ComposerPromptEditor.tsx](https://github.com/pingdotgg/t3code/pull/7879/files#diff-12fcb05b3e147eba955638d8df57440b8cf7f796941af0989c9bfa57b5b4f4a4). On triple-click, it snapshots the DOM selection on the capture phase and restores it on the bubble phase, syncing the Lexical selection via `$setSelection($createRangeSelectionFromDom(...))`. This prevents the browser from overriding the line selection with a different range.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e7b9a9b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->