### PR TITLE
fix(provider): resolve skills and slash commands against the workspace root

### DIFF
--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -83,6 +83,9 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.projectsWriteFile]: AuthOrchestrationOperateScope,
   [WS_METHODS.shellOpenInEditor]: AuthOrchestrationOperateScope,
   [WS_METHODS.filesystemBrowse]: AuthOrchestrationReadScope,
+  // Reads a thread, its project's workspace root, and that directory's
+  // skill definitions. Read-only, so it sits with the other read methods.
+  [WS_METHODS.providersWorkspaceSkills]: AuthOrchestrationReadScope,
   [WS_METHODS.assetsCreateUrl]: AuthOrchestrationReadScope,
   [WS_METHODS.subscribeVcsStatus]: AuthOrchestrationReadScope,
   [WS_METHODS.subscribeResourceTelemetry]: AuthOrchestrationReadScope,

--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -54,11 +54,15 @@ import {
   makeProviderSnapshotSettingsSource,
   type ProviderSnapshotSettings,
 } from "../providerUpdateSettings.ts";
-import { makeClaudeCapabilitiesCacheKey, makeClaudeContinuationGroupKey } from "./ClaudeHome.ts";
+import { makeClaudeContinuationGroupKey } from "./ClaudeHome.ts";
+import { discoverClaudeSkills } from "./ClaudeSkills.ts";
 const decodeClaudeSettings = Schema.decodeSync(ClaudeSettings);
 
 const DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
 const CAPABILITIES_PROBE_TTL = Duration.minutes(5);
+// One entry per workspace the user has open. Small enough to bound CLI
+// spawns, large enough that switching between projects does not re-probe.
+const CAPABILITIES_PROBE_CACHE_CAPACITY = 16;
 
 function isClaudeNativeCommandPath(commandPath: string): boolean {
   const normalized = normalizeCommandPath(commandPath);
@@ -151,21 +155,27 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
       const adapter = yield* makeClaudeAdapter(effectiveConfig, adapterOptions);
       const textGeneration = yield* makeClaudeTextGeneration(effectiveConfig, processEnv);
 
-      // Per-instance capabilities cache: keyed on binary + resolved HOME so
-      // account-specific probes never share auth metadata across instances.
+      // Per-instance capabilities cache, keyed by working directory.
+      //
+      // This cache lives in one instance's scope, so binary path and resolved
+      // HOME are already constant here — they cannot leak account metadata
+      // across instances. The only thing that varies is the cwd, and it
+      // genuinely does vary: the CLI's init handshake reports PROJECT-scoped
+      // slash commands, so a probe run from the server's own cwd sees only the
+      // built-ins. Keying on cwd lets each workspace get its own answer while
+      // still costing one CLI spawn per workspace per TTL.
       const capabilitiesProbeCache = yield* Cache.make({
-        capacity: 1,
+        capacity: CAPABILITIES_PROBE_CACHE_CAPACITY,
         timeToLive: CAPABILITIES_PROBE_TTL,
-        lookup: () =>
-          probeClaudeCapabilities(effectiveConfig, processEnv, cwd).pipe(
+        lookup: (probeCwd: string) =>
+          probeClaudeCapabilities(effectiveConfig, processEnv, probeCwd).pipe(
             Effect.provideService(Path.Path, path),
           ),
       });
-      const capabilitiesCacheKey = yield* makeClaudeCapabilitiesCacheKey(effectiveConfig, cwd);
 
       const checkProvider = checkClaudeProviderStatus(
         effectiveConfig,
-        () => Cache.get(capabilitiesProbeCache, capabilitiesCacheKey),
+        () => Cache.get(capabilitiesProbeCache, cwd),
         processEnv,
         cwd,
       ).pipe(
@@ -216,6 +226,26 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         snapshot,
         adapter,
         textGeneration,
+        // Project-scoped skills. The snapshot's own `skills` are scanned once
+        // against `ServerConfig.cwd`, which a packaged build sets to the home
+        // directory, so it can never see a project's `.claude/skills`. This is
+        // a filesystem scan, not a CLI probe, so it is cheap enough to run per
+        // request and needs no cache.
+        discoverSkillsForCwd: (skillsCwd: string) =>
+          discoverClaudeSkills(effectiveConfig, skillsCwd, processEnv).pipe(
+            Effect.provideService(FileSystem.FileSystem, fileSystem),
+            Effect.provideService(Path.Path, path),
+          ),
+        // Slash commands come from the CLI's init handshake, so this spawns a
+        // process. It goes through the same cwd-keyed cache the snapshot probe
+        // uses, which bounds it to one spawn per workspace per TTL. A failed
+        // probe resolves empty so the caller falls back to the snapshot rather
+        // than surfacing an error in a picker.
+        discoverSlashCommandsForCwd: (commandsCwd: string) =>
+          Cache.get(capabilitiesProbeCache, commandsCwd).pipe(
+            Effect.map((capabilities) => capabilities?.slashCommands ?? []),
+            Effect.orElseSucceed(() => []),
+          ),
       } satisfies ProviderInstance;
     }),
 };

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -27,6 +27,8 @@ import {
   ProviderDriverKind,
   type ProviderInstanceId,
   type ServerProvider,
+  type ServerProviderSkill,
+  type ServerProviderSlashCommand,
   type ServerProviderUpdateState,
 } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
@@ -508,6 +510,33 @@ export const ProviderRegistryLive = Layer.effect(
       );
     });
 
+    const discoverSkillsForInstance = Effect.fn("discoverSkillsForInstance")(function* (
+      instanceId: ProviderInstanceId,
+      cwd: string,
+    ) {
+      const instance = Array.from((yield* Ref.get(liveSubsRef)).values()).find(
+        (candidate) => candidate.instanceId === instanceId,
+      );
+      // Not live, or a driver with no directory-scoped skill concept: resolve
+      // empty so the caller falls back to the snapshot instead of failing.
+      if (!instance?.discoverSkillsForCwd) {
+        return [] as ReadonlyArray<ServerProviderSkill>;
+      }
+      return yield* instance.discoverSkillsForCwd(cwd);
+    });
+
+    const discoverSlashCommandsForInstance = Effect.fn("discoverSlashCommandsForInstance")(
+      function* (instanceId: ProviderInstanceId, cwd: string) {
+        const instance = Array.from((yield* Ref.get(liveSubsRef)).values()).find(
+          (candidate) => candidate.instanceId === instanceId,
+        );
+        if (!instance?.discoverSlashCommandsForCwd) {
+          return [] as ReadonlyArray<ServerProviderSlashCommand>;
+        }
+        return yield* instance.discoverSlashCommandsForCwd(cwd);
+      },
+    );
+
     /**
      * Diff the aggregator's live-source set against the current
      * `ProviderInstanceRegistry` and:
@@ -711,6 +740,8 @@ export const ProviderRegistryLive = Layer.effect(
       refreshInstance: (instanceId: ProviderInstanceId) =>
         refreshInstance(instanceId).pipe(Effect.catchCause(recoverRefreshFailure)),
       getProviderMaintenanceCapabilitiesForInstance,
+      discoverSkillsForInstance,
+      discoverSlashCommandsForInstance,
       setProviderMaintenanceActionState,
       get streamChanges() {
         return Stream.fromPubSub(changesPubSub);

--- a/apps/server/src/provider/ProviderDriver.ts
+++ b/apps/server/src/provider/ProviderDriver.ts
@@ -25,6 +25,8 @@ import type {
   ProviderDriverKind,
   ProviderInstanceEnvironment,
   ProviderInstanceId,
+  ServerProviderSkill,
+  ServerProviderSlashCommand,
 } from "@t3tools/contracts";
 import type * as Effect from "effect/Effect";
 import type * as Schema from "effect/Schema";
@@ -71,6 +73,37 @@ export interface ProviderInstance {
   readonly snapshot: ServerProviderShape;
   readonly adapter: ProviderAdapterShape<ProviderAdapterError>;
   readonly textGeneration: TextGeneration.TextGeneration["Service"];
+  /**
+   * Skills visible from a specific workspace root.
+   *
+   * `snapshot.skills` is machine-scoped: it is produced once per instance
+   * against the server's own cwd, which for a packaged desktop build is the
+   * user's home directory. Skills are project-scoped, so that snapshot can
+   * only ever report the user-scope ones. Callers that know which project
+   * they are asking about (a thread's worktree or its project's workspace
+   * root) use this instead, and drivers that can enumerate skills per
+   * directory implement it.
+   *
+   * Optional: a driver that has no directory-scoped skill concept simply
+   * omits it and callers fall back to the snapshot.
+   */
+  readonly discoverSkillsForCwd?: (
+    cwd: string,
+  ) => Effect.Effect<ReadonlyArray<ServerProviderSkill>>;
+  /**
+   * Slash commands visible from a specific workspace root.
+   *
+   * Same scoping problem as `discoverSkillsForCwd`, different source: these
+   * come from the agent CLI's own init handshake, which reports PROJECT-scoped
+   * commands. `snapshot.slashCommands` is probed once against the server's cwd
+   * and therefore lists only the CLI's built-ins.
+   *
+   * Unlike the skills scan this spawns the CLI, so implementations should
+   * cache per directory rather than probe per call.
+   */
+  readonly discoverSlashCommandsForCwd?: (
+    cwd: string,
+  ) => Effect.Effect<ReadonlyArray<ServerProviderSlashCommand>>;
 }
 
 export interface ProviderContinuationIdentity {

--- a/apps/server/src/provider/Services/ProviderRegistry.ts
+++ b/apps/server/src/provider/Services/ProviderRegistry.ts
@@ -10,6 +10,8 @@ import type {
   ProviderInstanceId,
   ProviderDriverKind,
   ServerProvider,
+  ServerProviderSkill,
+  ServerProviderSlashCommand,
   ServerProviderUpdateState,
 } from "@t3tools/contracts";
 import * as Context from "effect/Context";
@@ -56,6 +58,36 @@ export interface ProviderRegistryShape {
     instanceId: ProviderInstanceId,
     provider: ProviderDriverKind,
   ) => Effect.Effect<ProviderMaintenanceCapabilities>;
+
+  /**
+   * Skills one live instance can see from a specific workspace root.
+   *
+   * `ServerProvider.skills` is machine-scoped — scanned once against the
+   * server's own cwd, which a packaged desktop build sets to the home
+   * directory — so it reports user-scope skills only. Callers holding a
+   * project context ask here instead.
+   *
+   * Resolves to an empty array when the instance is not live or its driver
+   * has no directory-scoped skill concept; callers then fall back to the
+   * snapshot rather than treating it as an error.
+   */
+  readonly discoverSkillsForInstance: (
+    instanceId: ProviderInstanceId,
+    cwd: string,
+  ) => Effect.Effect<ReadonlyArray<ServerProviderSkill>>;
+
+  /**
+   * Slash commands one live instance can see from a specific workspace root.
+   *
+   * Same scoping story as `discoverSkillsForInstance`, but sourced from the
+   * agent CLI's init handshake rather than the filesystem, so it may spawn a
+   * process. Resolves empty when the instance is not live or its driver cannot
+   * enumerate commands per directory.
+   */
+  readonly discoverSlashCommandsForInstance: (
+    instanceId: ProviderInstanceId,
+    cwd: string,
+  ) => Effect.Effect<ReadonlyArray<ServerProviderSlashCommand>>;
 
   /**
    * Apply volatile maintenance-action state to one configured instance.

--- a/apps/server/src/provider/providerMaintenanceRunner.test.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.test.ts
@@ -191,6 +191,8 @@ function makeRegistry(
       refreshInstance: () => Ref.get(providersRef),
       getProviderMaintenanceCapabilitiesForInstance: (_instanceId, provider) =>
         Effect.succeed(lifecycleFor(provider)),
+      discoverSkillsForInstance: () => Effect.succeed([]),
+      discoverSlashCommandsForInstance: () => Effect.succeed([]),
       setProviderMaintenanceActionState,
       streamChanges: Stream.empty,
     };

--- a/apps/server/src/provider/testUtils/providerRegistryMock.ts
+++ b/apps/server/src/provider/testUtils/providerRegistryMock.ts
@@ -13,6 +13,8 @@ export const makeProviderRegistryMock = (
   refreshInstance: () => Effect.succeed(providers),
   getProviderMaintenanceCapabilitiesForInstance: (_instanceId, provider) =>
     Effect.succeed(makeManualOnlyProviderMaintenanceCapabilities({ provider, packageName: null })),
+  discoverSkillsForInstance: () => Effect.succeed([]),
+  discoverSlashCommandsForInstance: () => Effect.succeed([]),
   setProviderMaintenanceActionState: () => Effect.succeed(providers),
   streamChanges: Stream.empty,
 });

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1934,6 +1934,57 @@ const makeWsRpcLayer = (
             ),
             { "rpc.aggregate": "workspace" },
           ),
+        [WS_METHODS.providersWorkspaceSkills]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.providersWorkspaceSkills,
+            Effect.gen(function* () {
+              // The project root is the base; a persisted thread's worktree
+              // overrides it. Keyed on the project rather than the thread so a
+              // DRAFT thread still resolves — it has no server-side row yet,
+              // and that is exactly when the skill picker matters most.
+              const project = yield* projectionSnapshotQuery
+                .getProjectShellById(input.projectId)
+                .pipe(
+                  Effect.mapError(
+                    (cause) =>
+                      new OrchestrationGetSnapshotError({
+                        message: "Failed to load project for skill discovery",
+                        cause,
+                      }),
+                  ),
+                );
+              if (Option.isNone(project)) {
+                return yield* new OrchestrationGetSnapshotError({
+                  message: `Unknown project ${input.projectId}`,
+                });
+              }
+              // An unknown thread id is not an error: a draft thread has no row.
+              const worktreePath = input.threadId
+                ? yield* projectionSnapshotQuery.getThreadShellById(input.threadId).pipe(
+                    Effect.map((thread) =>
+                      Option.isSome(thread) ? thread.value.worktreePath : null,
+                    ),
+                    Effect.orElseSucceed(() => null),
+                  )
+                : null;
+              const workspaceRoot = worktreePath ?? project.value.workspaceRoot;
+              // Run both against the same resolved root. The skills scan is
+              // filesystem-only; the slash-command probe may spawn the CLI but
+              // is cached per directory by the driver.
+              const [skills, slashCommands] = yield* Effect.all(
+                [
+                  providerRegistry.discoverSkillsForInstance(input.instanceId, workspaceRoot),
+                  providerRegistry.discoverSlashCommandsForInstance(
+                    input.instanceId,
+                    workspaceRoot,
+                  ),
+                ],
+                { concurrency: 2 },
+              );
+              return { workspaceRoot, skills, slashCommands };
+            }),
+            { "rpc.aggregate": "provider" },
+          ),
         [WS_METHODS.assetsCreateUrl]: (input) =>
           observeRpcEffect(
             WS_METHODS.assetsCreateUrl,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -239,6 +239,7 @@ import { environmentCatalog } from "../connection/catalog";
 import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../terminalUiStateStore";
 import { useKnownTerminalSessions, useThreadRunningTerminalIds } from "../state/terminalSessions";
 import { projectEnvironment } from "../state/projects";
+import { providerSkillsEnvironment } from "../state/providerSkills";
 import { useEnvironmentQuery } from "../state/query";
 import {
   primaryServerAvailableEditorsAtom,
@@ -2720,6 +2721,38 @@ function ChatViewContent(props: ChatViewProps) {
     const defaultInstanceId = defaultInstanceIdForDriver(selectedProvider);
     return providerStatuses.find((status) => status.instanceId === defaultInstanceId) ?? null;
   }, [activeProviderInstanceId, providerStatuses, selectedProvider]);
+  // Skills for the `$` picker, resolved against this thread's workspace root.
+  // `activeProviderStatus.skills` is machine-scoped: the server scans it once
+  // per provider instance against its own cwd, which a packaged desktop build
+  // sets to the user's home directory, so it reports user-scope skills only and
+  // is empty on a machine that keeps none there. Falling back to it keeps the
+  // picker working against a server that predates this RPC.
+  const workspaceCapabilitiesQuery = useEnvironmentQuery(
+    activeThread && activeProject && activeProviderInstanceId
+      ? providerSkillsEnvironment.workspaceSkills({
+          environmentId: activeThread.environmentId,
+          input: {
+            projectId: activeProject.id,
+            instanceId: activeProviderInstanceId,
+            // Only a persisted thread has a server-side row; a draft has none,
+            // and the project root is the right answer for it anyway.
+            ...(activeServerThread ? { threadId: activeServerThread.id } : {}),
+          },
+        })
+      : null,
+  );
+  const activeSkills =
+    workspaceCapabilitiesQuery.data?.skills ??
+    activeProviderStatus?.skills ??
+    EMPTY_PROVIDER_SKILLS;
+  // Same story for `/`: the snapshot's slashCommands come from a probe run
+  // against the server's own cwd, so they are the CLI's built-ins only. The
+  // workspace-scoped result adds the project's own commands.
+  const activeSlashCommands =
+    workspaceCapabilitiesQuery.data?.slashCommands &&
+    workspaceCapabilitiesQuery.data.slashCommands.length > 0
+      ? workspaceCapabilitiesQuery.data.slashCommands
+      : undefined;
   const providerStatusBannerKey = getProviderStatusBannerKey(activeProviderStatus);
   const [dismissedProviderStatusBannerKey, setDismissedProviderStatusBannerKey] = useState<
     string | null
@@ -6534,7 +6567,7 @@ function ChatViewContent(props: ChatViewProps) {
                 resolvedTheme={resolvedTheme}
                 timestampFormat={timestampFormat}
                 workspaceRoot={activeWorkspaceRoot}
-                skills={activeProviderStatus?.skills ?? EMPTY_PROVIDER_SKILLS}
+                skills={activeSkills}
                 anchorMessageId={timelineAnchorMessageId}
                 onAnchorReady={onTimelineAnchorReady}
                 contentInsetEndAdjustment={composerOverlayHeight}
@@ -6661,6 +6694,8 @@ function ChatViewContent(props: ChatViewProps) {
                             interactionMode={interactionMode}
                             lockedProvider={lockedProvider}
                             providerStatuses={providerStatuses as ServerProvider[]}
+                            workspaceSkills={activeSkills}
+                            workspaceSlashCommands={activeSlashCommands}
                             activeProjectDefaultModelSelection={
                               activeProject?.defaultModelSelection
                             }

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -9,6 +9,8 @@ import type {
   RuntimeMode,
   ScopedThreadRef,
   ServerProvider,
+  ServerProviderSkill,
+  ServerProviderSlashCommand,
   ThreadId,
   TurnId,
 } from "@t3tools/contracts";
@@ -526,6 +528,9 @@ export interface ChatComposerHandle {
 // Props
 // --------------------------------------------------------------------------
 
+const EMPTY_COMPOSER_SKILLS: ReadonlyArray<ServerProviderSkill> = [];
+const EMPTY_COMPOSER_SLASH_COMMANDS: ReadonlyArray<ServerProviderSlashCommand> = [];
+
 export interface ChatComposerProps {
   composerDraftTarget: ScopedThreadRef | DraftId;
   environmentId: EnvironmentId;
@@ -584,6 +589,19 @@ export interface ChatComposerProps {
   // Provider / model
   lockedProvider: ProviderDriverKind | null;
   providerStatuses: ServerProvider[];
+  /**
+   * Skills for the active workspace. `providerStatuses[].skills` is
+   * machine-scoped — the server scans it once per provider instance against
+   * its own cwd — so it reports user-scope skills only. Falls back to the
+   * snapshot when absent.
+   */
+  workspaceSkills?: ReadonlyArray<ServerProviderSkill> | undefined;
+  /**
+   * Slash commands for the active workspace. `providerStatuses[].slashCommands`
+   * is probed once against the server's own cwd and therefore lists only the
+   * agent CLI's built-ins. Falls back to the snapshot when absent.
+   */
+  workspaceSlashCommands?: ReadonlyArray<ServerProviderSlashCommand> | undefined;
   activeProjectDefaultModelSelection: ModelSelection | null | undefined;
   activeThreadModelSelection: ModelSelection | null | undefined;
 
@@ -676,6 +694,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     interactionMode,
     lockedProvider,
     providerStatuses,
+    workspaceSkills,
+    workspaceSlashCommands,
     activeProjectDefaultModelSelection,
     activeThreadModelSelection,
     activeThreadActivities,
@@ -889,6 +909,15 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const selectedProviderModels = useMemo<ReadonlyArray<ServerProvider["models"][number]>>(
     () => selectedProviderEntry?.models ?? [],
     [selectedProviderEntry],
+  );
+  // Prefer workspace-scoped capabilities; fall back to the machine-scoped
+  // snapshot so an older server still populates the pickers.
+  const composerSkills = useMemo<ReadonlyArray<ServerProviderSkill>>(
+    () =>
+      workspaceSkills && workspaceSkills.length > 0
+        ? workspaceSkills
+        : (selectedProviderStatus?.skills ?? EMPTY_COMPOSER_SKILLS),
+    [workspaceSkills, selectedProviderStatus],
   );
 
   const composerPromptInjectionState = useMemo(
@@ -1107,16 +1136,18 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
             ] as const)
           : []),
       ] satisfies ReadonlyArray<Extract<ComposerCommandItem, { type: "slash-command" }>>;
-      const providerSlashCommandItems = (selectedProviderStatus?.slashCommands ?? []).map(
-        (command) => ({
-          id: `provider-slash-command:${selectedProvider}:${command.name}`,
-          type: "provider-slash-command" as const,
-          provider: selectedProvider,
-          command,
-          label: `/${command.name}`,
-          description: command.description ?? command.input?.hint ?? "Run provider command",
-        }),
-      );
+      const providerSlashCommandItems = (
+        workspaceSlashCommands ??
+        selectedProviderStatus?.slashCommands ??
+        EMPTY_COMPOSER_SLASH_COMMANDS
+      ).map((command) => ({
+        id: `provider-slash-command:${selectedProvider}:${command.name}`,
+        type: "provider-slash-command" as const,
+        provider: selectedProvider,
+        command,
+        label: `/${command.name}`,
+        description: command.description ?? command.input?.hint ?? "Run provider command",
+      }));
       const query = composerTrigger.query.trim().toLowerCase();
       const skillItems = (selectedProviderStatus?.skills ?? [])
         .filter((skill) => skill.enabled)
@@ -1139,22 +1170,22 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       return searchSlashCommandItems(slashCommandItems, query);
     }
     if (composerTrigger.kind === "skill") {
-      return searchProviderSkills(selectedProviderStatus?.skills ?? [], composerTrigger.query).map(
-        (skill) => ({
-          id: `skill:${selectedProvider}:${skill.name}`,
-          type: "skill" as const,
-          provider: selectedProvider,
-          skill,
-          label: formatProviderSkillDisplayName(skill),
-          description:
-            skill.shortDescription ??
-            skill.description ??
-            (skill.scope ? `${skill.scope} skill` : "Run provider skill"),
-        }),
-      );
+      return searchProviderSkills(composerSkills, composerTrigger.query).map((skill) => ({
+        id: `skill:${selectedProvider}:${skill.name}`,
+        type: "skill" as const,
+        provider: selectedProvider,
+        skill,
+        label: formatProviderSkillDisplayName(skill),
+        description:
+          skill.shortDescription ??
+          skill.description ??
+          (skill.scope ? `${skill.scope} skill` : "Run provider skill"),
+      }));
     }
     return [];
   }, [
+    composerSkills,
+    workspaceSlashCommands,
     composerTrigger,
     planModeUiEnabled,
     selectedProvider,
@@ -3227,7 +3258,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                       ? composerTerminalContexts
                       : []
                   }
-                  skills={selectedProviderStatus?.skills ?? []}
+                  skills={composerSkills}
                   {...(showMobilePendingAnswerActions ? { className: "max-sm:pb-11" } : {})}
                   onRemoveTerminalContext={removeComposerTerminalContextFromDraft}
                   onChange={onPromptChange}

--- a/apps/web/src/state/providerSkills.ts
+++ b/apps/web/src/state/providerSkills.ts
@@ -1,0 +1,6 @@
+import { createProviderSkillsEnvironmentAtoms } from "@t3tools/client-runtime/state/providerSkills";
+
+import { connectionAtomRuntime } from "../connection/runtime";
+
+export const providerSkillsEnvironment =
+  createProviderSkillsEnvironmentAtoms(connectionAtomRuntime);

--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -95,6 +95,10 @@
       "types": "./src/state/projectGrouping.ts",
       "default": "./src/state/projectGrouping.ts"
     },
+    "./state/providerSkills": {
+      "types": "./src/state/providerSkills.ts",
+      "default": "./src/state/providerSkills.ts"
+    },
     "./state/relay": {
       "types": "./src/state/relayDiscovery.ts",
       "default": "./src/state/relayDiscovery.ts"

--- a/packages/client-runtime/src/state/providerSkills.ts
+++ b/packages/client-runtime/src/state/providerSkills.ts
@@ -1,0 +1,40 @@
+/**
+ * providerSkills — project-scoped skill discovery for the `$` composer picker.
+ *
+ * `ServerProvider.skills` on the provider snapshot is machine-scoped: the
+ * server scans it once per provider instance against its own cwd, which a
+ * packaged desktop build sets to the user's home directory. Skills are
+ * project-scoped, so that snapshot reports user-scope skills only and is empty
+ * on a machine that keeps none there.
+ *
+ * This family asks per project instead, and the server resolves the project's
+ * workspace root (or a persisted thread's worktree) before scanning. Keying on
+ * the project means a DRAFT thread resolves too, which is when the picker
+ * matters most. Consumers fall
+ * back to the snapshot when the query has no data yet, so the picker degrades
+ * to the old behaviour rather than to nothing.
+ *
+ * @module state/providerSkills
+ */
+import { WS_METHODS } from "@t3tools/contracts";
+
+import type { Atom } from "effect/unstable/reactivity";
+
+import type { EnvironmentRegistry } from "../connection/registry.ts";
+import { createEnvironmentRpcQueryAtomFamily } from "./runtime.ts";
+
+export function createProviderSkillsEnvironmentAtoms<R, E>(
+  runtime: Atom.AtomRuntime<EnvironmentRegistry | R, E>,
+) {
+  return {
+    workspaceSkills: createEnvironmentRpcQueryAtomFamily(runtime, {
+      label: "environment-data:providers:workspace-skills",
+      tag: WS_METHODS.providersWorkspaceSkills,
+      // A skill set changes when files change on disk, not per keystroke, so a
+      // generous stale window keeps the picker instant without pinning the
+      // scan in memory for threads the user has moved away from.
+      staleTimeMs: 30_000,
+      idleTtlMs: 5 * 60_000,
+    }),
+  };
+}

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -2,6 +2,7 @@ import * as Schema from "effect/Schema";
 import * as Rpc from "effect/unstable/rpc/Rpc";
 import * as RpcGroup from "effect/unstable/rpc/RpcGroup";
 
+import { ProjectId, ThreadId, TrimmedNonEmptyString } from "./baseSchemas.ts";
 import { ExternalLauncherError, LaunchEditorInput } from "./editor.ts";
 import {
   AuthAccessStreamError,
@@ -170,6 +171,8 @@ import {
   ServerProcessResourceHistoryResult,
   ServerSignalProcessInput,
   ServerSignalProcessResult,
+  ServerProviderSkill,
+  ServerProviderSlashCommand,
   ServerUpsertKeybindingInput,
   ServerUpsertKeybindingResult,
 } from "./server.ts";
@@ -250,6 +253,10 @@ export const WS_METHODS = {
   previewAutomationConnect: "previewAutomation.connect",
   previewAutomationRespond: "previewAutomation.respond",
   previewAutomationFocusHost: "previewAutomation.focusHost",
+
+  // Provider capability methods. Project-scoped, unlike the machine-scoped
+  // provider snapshot: resolved against one thread's workspace root.
+  providersWorkspaceSkills: "providers.workspaceSkills",
 
   // Server meta
   serverProbe: "server.probe",
@@ -636,6 +643,48 @@ export const WsProjectsListEntriesRpc = Rpc.make(WS_METHODS.projectsListEntries,
   error: Schema.Union([ProjectListEntriesError, EnvironmentAuthorizationError]),
 });
 
+/**
+ * Skills visible to a thread, resolved against its workspace root.
+ *
+ * `ServerProvider.skills` on the provider snapshot is machine-scoped: it is
+ * scanned once per instance against the server's own cwd, which a packaged
+ * desktop build sets to the user's home directory. Skills are project-scoped,
+ * so the snapshot can only ever report user-scope ones. Clients showing a
+ * skill picker for a specific thread ask here instead.
+ */
+export const ProvidersWorkspaceSkillsInput = Schema.Struct({
+  /** Project whose workspace root is scanned. Present for draft threads too. */
+  projectId: ProjectId,
+  /** Provider instance whose skills are wanted. */
+  instanceId: ProviderInstanceId,
+  /**
+   * Optional: a persisted thread whose worktree overrides the project root.
+   * A draft thread has no server-side row yet, so callers omit it and still
+   * get the project's skills — which is exactly when the picker matters most.
+   */
+  threadId: Schema.optional(ThreadId),
+});
+export type ProvidersWorkspaceSkillsInput = typeof ProvidersWorkspaceSkillsInput.Type;
+
+export const ProvidersWorkspaceSkillsResult = Schema.Struct({
+  /** Workspace root everything was resolved against, for display and debugging. */
+  workspaceRoot: TrimmedNonEmptyString,
+  skills: Schema.Array(ServerProviderSkill),
+  /**
+   * Slash commands the agent CLI reports from that workspace root, which
+   * include project-scoped commands the machine-scoped snapshot cannot see.
+   * Empty when the driver cannot enumerate commands per directory.
+   */
+  slashCommands: Schema.Array(ServerProviderSlashCommand),
+});
+export type ProvidersWorkspaceSkillsResult = typeof ProvidersWorkspaceSkillsResult.Type;
+
+export const WsProvidersWorkspaceSkillsRpc = Rpc.make(WS_METHODS.providersWorkspaceSkills, {
+  payload: ProvidersWorkspaceSkillsInput,
+  success: ProvidersWorkspaceSkillsResult,
+  error: Schema.Union([OrchestrationGetSnapshotError, EnvironmentAuthorizationError]),
+});
+
 export const WsProjectsReadFileRpc = Rpc.make(WS_METHODS.projectsReadFile, {
   payload: ProjectReadFileInput,
   success: ProjectReadFileResult,
@@ -983,6 +1032,7 @@ export const WsSubscribeResourceTelemetryRpc = Rpc.make(WS_METHODS.subscribeReso
 });
 
 export const WsRpcGroup = RpcGroup.make(
+  WsProvidersWorkspaceSkillsRpc,
   WsServerProbeRpc,
   WsServerGetConfigRpc,
   WsServerRefreshProvidersRpc,


### PR DESCRIPTION
## What changed

Both composer pickers are empty or incomplete in a packaged desktop build. This resolves skills and slash commands against the **workspace root** instead of the server's single global cwd.

## Why

`DesktopEnvironment.ts` sets the backend cwd to the user's home directory when packaged:

```ts
backendCwd: input.isPackaged ? homeDirectory : appRoot,
```

`ServerProvider.skills` and `ServerProvider.slashCommands` are produced once per provider instance against that one cwd — but both are **project-scoped**:

- `ClaudeSkills` scans `<configDir>/skills` and `<cwd>/.claude/skills`. With cwd pinned to `$HOME`, the "project" root resolves to `~/.claude/skills` for *every* project, so a user who keeps no skills there sees none at all and `$` reports "No skills found". It reports the mis-scoped scan accurately; it is not a UI bug.
- the CLI's init handshake reports project-scoped slash commands, so `/` lists only the built-ins. Measured on one real workspace: the CLI reports **140** commands from the project root versus **48** from a neutral directory.

Running sessions are unaffected — they get the right scope through the CLI's own settings resolution — so this is a discovery gap, not a loss of capability.

## Approach

A provider is a machine-level installation in this model, and version/auth/models genuinely are per-machine. So rather than making the snapshot project-aware, this adds a workspace-scoped surface **beside** it:

- `ProviderInstance` gains optional `discoverSkillsForCwd` / `discoverSlashCommandsForCwd`. Optional, so the other four drivers are untouched.
- `ProviderRegistry` gains matching `*ForInstance` methods, following the existing `getProviderMaintenanceCapabilitiesForInstance` delegation pattern, resolving empty when a driver cannot enumerate per directory.
- new `providers.workspaceSkills` RPC resolves `thread.worktreePath ?? project.workspaceRoot` — the same idiom `assets.createUrl` already uses — mapped to `orchestration:read`.
- the composer prefers the workspace result for `$` and `/`, **falling back to the snapshot**, so an older server behaves exactly as today.

It is keyed on the **project** with an optional thread, because the composer is frequently on a draft thread with no persisted row, and that is precisely when the pickers matter.

## The cache

`ClaudeDriver`'s capabilities cache is now keyed by cwd (capacity 16) rather than holding a single entry probed against the server's cwd.

This completes something already designed for: `makeClaudeCapabilitiesCacheKey` **already includes cwd**, and `ClaudeHome.test.ts` **already asserts that two cwds produce two keys** — the driver simply never varied it. Binary path and resolved HOME are constant within one instance's scope, so keying on cwd preserves the isolation the composite key provided.

**Cost**: one CLI probe per workspace per the existing 5-minute TTL. Measured ~1.6 s cold, ~20 ms warm.

## Deliberately not done

Skills are still read from the filesystem rather than `init.skills`. The handshake carries bare names, while `ServerProviderSkill` requires `path` and displays `description`, which only the scan can supply — the rationale in `ClaudeSkills.ts`'s own docstring still holds.

## Testing

`contracts` 258, `server` 2625, `web` 2696 — all passing on this branch; typecheck, `fmt --check` and lint clean. The new RPC is covered by the existing "declares exactly one scope for every RPC in the server group" test.

Verified against a live server: the RPC returns 92 skills (all with descriptions) and 140 slash commands for a workspace where the snapshot returned 0 and 48.

No UI layout changes — the pickers render exactly as before, with populated data.

---

Happy to split this or move it to an issue-first discussion if you'd prefer; I read CONTRIBUTING and this is larger than a one-liner, though it is a single change with no scope expansion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new read RPC that scans a project workspace and may spawn the Claude CLI, plus cwd-keyed capability caching. Fallback to the machine snapshot keeps older servers working, but probe/cache behavior is now per workspace.
> 
> **Overview**
> Fixes empty/incomplete `$` and `/` pickers in packaged desktop builds, where the provider snapshot was scanned against `$HOME` and missed project `.claude/skills` and CLI project commands.
> 
> Adds `providers.workspaceSkills` (orchestration read). It resolves `thread.worktreePath ?? project.workspaceRoot` so draft threads still work, then returns workspace skills plus slash commands. The composer prefers that result and falls back to the machine-scoped snapshot.
> 
> Claude-only optional `discoverSkillsForCwd` / `discoverSlashCommandsForCwd` on the instance; other drivers omit them. Skills stay a cheap filesystem scan. Slash commands reuse the capabilities probe cache, now keyed by cwd (capacity 16, 5-minute TTL) instead of a single server-cwd entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e69659875bd04594d98565d213c19867baeee52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve skills and slash commands against workspace root via new `providers.workspaceSkills` RPC
> - Adds `providers.workspaceSkills` RPC that derives the workspace root from a thread's worktree path or the project root, then returns project-scoped skills and slash commands for a given provider instance
> - `ClaudeDriver` now probes and caches capabilities per working directory (`cwd`) with a capacity-16 LRU, and exposes `discoverSkillsForCwd` / `discoverSlashCommandsForCwd` on the `ProviderInstance` interface
> - `ProviderRegistry` forwards discovery calls to the live instance, returning empty arrays when unsupported or not live
> - The chat UI (`ChatView`, `ChatComposer`) prefers workspace-scoped results for the `$` and `/` menus, falling back to the machine-scoped snapshot when unavailable
> - Risk: capabilities cache in `ClaudeDriver.create` is now keyed by `cwd` instead of a single global key; any code that relied on the old `makeClaudeCapabilitiesCacheKey` singleton cache will no longer share state across workspaces
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 8e69659. 12 files reviewed, 4 issues evaluated, 1 issue filtered, 3 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/web/src/components/chat/ChatComposer.tsx — 1 comment posted, 2 evaluated, 1 filtered</summary>
>
> - [line 917](https://github.com/pingdotgg/t3code/blob/8e69659875bd04594d98565d213c19867baeee52/apps/web/src/components/chat/ChatComposer.tsx#L917): `composerSkills` treats an explicitly returned empty `workspaceSkills` array as unavailable and falls back to `selectedProviderStatus.skills`. When a workspace legitimately has no skills, the `$` picker and editor therefore show the machine-cwd skills instead of no workspace skills, reintroducing the incorrect-scope behavior this change is meant to fix. Use nullish availability rather than `length > 0` so only an absent result falls back. <b>[ Already posted ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

Closes #12214
