### PR TITLE
feat(web): configure worktree branch prefixes

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -1475,6 +1475,11 @@ describe("ProviderCommandReactor", () => {
       generated: "My-Team/feature/gpt-5-6-luna",
       expected: "my-team/feature/gpt-5-6-luna",
     },
+    {
+      prefix: "t3code/my-team",
+      generated: "t3code/my-team/feature/gpt-5-6-luna",
+      expected: "t3code/my-team/feature/gpt-5-6-luna",
+    },
     { prefix: "", generated: "feature/gpt-5-6-luna", expected: "feature/gpt-5-6-luna" },
   ])(
     "generates a worktree branch name with prefix $prefix",

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -150,6 +150,7 @@ describe("ProviderCommandReactor", () => {
     readonly requiresNewThreadForModelChange?: boolean;
     readonly titleRegenerationCompletionDispatchFailures?: number;
     readonly titleRegenerationBeforeStart?: "one" | "two";
+    readonly worktreeBranchPrefix?: string;
     readonly startSessionEffect?: (
       session: ProviderSession,
     ) => Effect.Effect<ProviderSession, ProviderAdapterRequestError>;
@@ -413,7 +414,13 @@ describe("ProviderCommandReactor", () => {
           generateThreadTitle,
         }),
       ),
-      Layer.provideMerge(ServerSettingsService.layerTest()),
+      Layer.provideMerge(
+        ServerSettingsService.layerTest(
+          input?.worktreeBranchPrefix === undefined
+            ? {}
+            : { worktreeBranchPrefix: input.worktreeBranchPrefix },
+        ),
+      ),
       Layer.provideMerge(ServerConfig.layerTest(process.cwd(), baseDir)),
       Layer.provideMerge(NodeServices.layer),
     );
@@ -1457,59 +1464,67 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.title).toBe("Reconnect spinner resume bug");
   });
 
-  it("generates a worktree branch name for the first turn", async () => {
-    const harness = await createHarness();
-    const now = "2026-01-01T00:00:00.000Z";
+  it.each([
+    {
+      prefix: undefined,
+      generated: "feature/gpt-5-6-luna",
+      expected: "t3code/feature/gpt-5-6-luna",
+    },
+    {
+      prefix: "my-team",
+      generated: "My-Team/feature/gpt-5-6-luna",
+      expected: "my-team/feature/gpt-5-6-luna",
+    },
+    { prefix: "", generated: "feature/gpt-5-6-luna", expected: "feature/gpt-5-6-luna" },
+  ])(
+    "generates a worktree branch name with prefix $prefix",
+    async ({ prefix, generated, expected }) => {
+      const harness = await createHarness(
+        prefix === undefined ? undefined : { worktreeBranchPrefix: prefix },
+      );
+      const now = "2026-01-01T00:00:00.000Z";
 
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.meta.update",
-        commandId: CommandId.make("cmd-thread-branch"),
-        threadId: ThreadId.make("thread-1"),
-        branch: "t3code/1234abcd",
-        worktreePath: "/tmp/provider-project-worktree",
-      }),
-    );
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.meta.update",
+          commandId: CommandId.make("cmd-thread-branch"),
+          threadId: ThreadId.make("thread-1"),
+          branch: "t3code/1234abcd",
+          worktreePath: "/tmp/provider-project-worktree",
+        }),
+      );
 
-    harness.generateBranchName.mockImplementation((input: unknown) =>
-      Effect.succeed({
-        branch:
-          typeof input === "object" &&
-          input !== null &&
-          "modelSelection" in input &&
-          typeof input.modelSelection === "object" &&
-          input.modelSelection !== null &&
-          "model" in input.modelSelection &&
-          typeof input.modelSelection.model === "string"
-            ? `feature/${input.modelSelection.model}`
-            : "feature/generated",
-      }),
-    );
+      harness.generateBranchName.mockReturnValue(Effect.succeed({ branch: generated }));
 
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.turn.start",
-        commandId: CommandId.make("cmd-turn-start-branch-model"),
-        threadId: ThreadId.make("thread-1"),
-        message: {
-          messageId: asMessageId("user-message-branch-model"),
-          role: "user",
-          text: "Add a safer reconnect backoff.",
-          attachments: [],
-        },
-        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
-        runtimeMode: "approval-required",
-        createdAt: now,
-      }),
-    );
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.make("cmd-turn-start-branch-model"),
+          threadId: ThreadId.make("thread-1"),
+          message: {
+            messageId: asMessageId("user-message-branch-model"),
+            role: "user",
+            text: "Add a safer reconnect backoff.",
+            attachments: [],
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          createdAt: now,
+        }),
+      );
 
-    await waitFor(() => harness.generateBranchName.mock.calls.length === 1);
-    await waitFor(() => harness.refreshStatus.mock.calls.length === 1);
-    expect(harness.generateBranchName.mock.calls[0]?.[0]).toMatchObject({
-      message: "Add a safer reconnect backoff.",
-    });
-    expect(harness.refreshStatus.mock.calls[0]?.[0]).toBe("/tmp/provider-project-worktree");
-  });
+      await waitFor(() => harness.generateBranchName.mock.calls.length === 1);
+      await waitFor(() => harness.refreshStatus.mock.calls.length === 1);
+      expect(harness.generateBranchName.mock.calls[0]?.[0]).toMatchObject({
+        message: "Add a safer reconnect backoff.",
+      });
+      expect(harness.refreshStatus.mock.calls[0]?.[0]).toBe("/tmp/provider-project-worktree");
+      expect(harness.renameBranch.mock.calls[0]?.[0]).toMatchObject({
+        oldBranch: "t3code/1234abcd",
+        newBranch: expected,
+      });
+    },
+  );
 
   it("forwards codex model options through session start and turn send", async () => {
     const harness = await createHarness();

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -12,7 +12,11 @@ import {
   type RuntimeMode,
   type TurnId,
 } from "@t3tools/contracts";
-import { isTemporaryWorktreeBranch, WORKTREE_BRANCH_PREFIX } from "@t3tools/shared/git";
+import {
+  isTemporaryWorktreeBranch,
+  sanitizeBranchFragment,
+  WORKTREE_BRANCH_PREFIX,
+} from "@t3tools/shared/git";
 import * as Cache from "effect/Cache";
 import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
@@ -275,7 +279,7 @@ function stalePendingRequestDetail(
   return `Stale pending ${requestKind} request: ${requestId}. Provider callback state does not survive app restarts or recovered sessions. Restart the turn to continue.`;
 }
 
-function buildGeneratedWorktreeBranchName(raw: string): string {
+function buildGeneratedWorktreeBranchName(raw: string, prefix: string): string {
   const normalized = raw
     .trim()
     .toLowerCase()
@@ -284,18 +288,12 @@ function buildGeneratedWorktreeBranchName(raw: string): string {
 
   const withoutPrefix = normalized.startsWith(`${WORKTREE_BRANCH_PREFIX}/`)
     ? normalized.slice(`${WORKTREE_BRANCH_PREFIX}/`.length)
-    : normalized;
+    : prefix.length > 0 && normalized.startsWith(`${prefix}/`)
+      ? normalized.slice(`${prefix}/`.length)
+      : normalized;
 
-  const branchFragment = withoutPrefix
-    .replace(/[^a-z0-9/_-]+/g, "-")
-    .replace(/\/+/g, "/")
-    .replace(/-+/g, "-")
-    .replace(/^[./_-]+|[./_-]+$/g, "")
-    .slice(0, 64)
-    .replace(/[./_-]+$/g, "");
-
-  const safeFragment = branchFragment.length > 0 ? branchFragment : "update";
-  return `${WORKTREE_BRANCH_PREFIX}/${safeFragment}`;
+  const safeFragment = sanitizeBranchFragment(withoutPrefix);
+  return prefix.length > 0 ? `${prefix}/${safeFragment}` : safeFragment;
 }
 
 const make = Effect.gen(function* () {
@@ -818,7 +816,10 @@ const make = Effect.gen(function* () {
       });
       if (!generated) return;
 
-      const targetBranch = buildGeneratedWorktreeBranchName(generated.branch);
+      const targetBranch = buildGeneratedWorktreeBranchName(
+        generated.branch,
+        settings.worktreeBranchPrefix,
+      );
       if (targetBranch === oldBranch) return;
 
       const renamed = yield* gitWorkflow.renameBranch({ cwd, oldBranch, newBranch: targetBranch });

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -286,11 +286,12 @@ function buildGeneratedWorktreeBranchName(raw: string, prefix: string): string {
     .replace(/^refs\/heads\//, "")
     .replace(/['"`]/g, "");
 
-  const withoutPrefix = normalized.startsWith(`${WORKTREE_BRANCH_PREFIX}/`)
-    ? normalized.slice(`${WORKTREE_BRANCH_PREFIX}/`.length)
-    : prefix.length > 0 && normalized.startsWith(`${prefix}/`)
+  const withoutPrefix =
+    prefix.length > 0 && normalized.startsWith(`${prefix}/`)
       ? normalized.slice(`${prefix}/`.length)
-      : normalized;
+      : normalized.startsWith(`${WORKTREE_BRANCH_PREFIX}/`)
+        ? normalized.slice(`${WORKTREE_BRANCH_PREFIX}/`.length)
+        : normalized;
 
   const safeFragment = sanitizeBranchFragment(withoutPrefix);
   return prefix.length > 0 ? `${prefix}/${safeFragment}` : safeFragment;

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -37,6 +37,7 @@ import {
 } from "@t3tools/contracts/settings";
 import { resolveServerBackgroundActivitySettings } from "@t3tools/shared/backgroundActivitySettings";
 import { createModelSelection } from "@t3tools/shared/model";
+import { sanitizeBranchFragment } from "@t3tools/shared/git";
 import * as Duration from "effect/Duration";
 import * as Equal from "effect/Equal";
 import * as Schema from "effect/Schema";
@@ -523,6 +524,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin
         ? ["New worktrees start from origin"]
         : []),
+      ...(settings.worktreeBranchPrefix !== DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix
+        ? ["Worktree branch prefix"]
+        : []),
       ...(settings.addProjectBaseDirectory !== DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory
         ? ["Add project base directory"]
         : []),
@@ -556,6 +560,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.addProjectBaseDirectory,
       settings.defaultThreadEnvMode,
       settings.newWorktreesStartFromOrigin,
+      settings.worktreeBranchPrefix,
       settings.diffIgnoreWhitespace,
       settings.environmentIdentificationMode,
       settings.fontFamilyCode,
@@ -662,6 +667,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       providerHealthRefreshInterval: DEFAULT_UNIFIED_SETTINGS.providerHealthRefreshInterval,
       defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
       newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
+      worktreeBranchPrefix: DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix,
       addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
       confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
       confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
@@ -2227,6 +2233,42 @@ export function GeneralSettingsPanel() {
                 </SelectItem>
               </SelectPopup>
             </Select>
+          }
+        />
+
+        <SettingsRow
+          {...searchableSetting("worktree-branch-prefix")}
+          description="Prefix for automatically generated worktree branch names. Leave empty for no prefix."
+          resetAction={
+            settings.worktreeBranchPrefix !== DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix ? (
+              <SettingResetButton
+                label="worktree branch prefix"
+                onClick={() =>
+                  updateSettings({
+                    worktreeBranchPrefix: DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Input
+              key={settings.worktreeBranchPrefix}
+              className="w-full sm:w-44"
+              defaultValue={settings.worktreeBranchPrefix}
+              placeholder="t3code"
+              aria-label="Worktree branch prefix"
+              onBlur={(event) => {
+                const rawPrefix = event.target.value.trim();
+                const worktreeBranchPrefix = /[a-z0-9]/i.test(rawPrefix)
+                  ? sanitizeBranchFragment(rawPrefix)
+                  : "";
+                event.currentTarget.value = worktreeBranchPrefix;
+                if (worktreeBranchPrefix !== settings.worktreeBranchPrefix) {
+                  updateSettings({ worktreeBranchPrefix });
+                }
+              }}
+            />
           }
         />
 

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -2236,42 +2236,6 @@ export function GeneralSettingsPanel() {
           }
         />
 
-        <SettingsRow
-          {...searchableSetting("worktree-branch-prefix")}
-          description="Prefix for automatically generated worktree branch names. Leave empty for no prefix."
-          resetAction={
-            settings.worktreeBranchPrefix !== DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix ? (
-              <SettingResetButton
-                label="worktree branch prefix"
-                onClick={() =>
-                  updateSettings({
-                    worktreeBranchPrefix: DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix,
-                  })
-                }
-              />
-            ) : null
-          }
-          control={
-            <Input
-              key={settings.worktreeBranchPrefix}
-              className="w-full sm:w-44"
-              defaultValue={settings.worktreeBranchPrefix}
-              placeholder="t3code"
-              aria-label="Worktree branch prefix"
-              onBlur={(event) => {
-                const rawPrefix = event.target.value.trim();
-                const worktreeBranchPrefix = /[a-z0-9]/i.test(rawPrefix)
-                  ? sanitizeBranchFragment(rawPrefix)
-                  : "";
-                event.currentTarget.value = worktreeBranchPrefix;
-                if (worktreeBranchPrefix !== settings.worktreeBranchPrefix) {
-                  updateSettings({ worktreeBranchPrefix });
-                }
-              }}
-            />
-          }
-        />
-
         {settings.defaultThreadEnvMode === "worktree" ? (
           <SettingsRow
             className="bg-muted/20 sm:pl-9"
@@ -2302,6 +2266,41 @@ export function GeneralSettingsPanel() {
             }
           />
         ) : null}
+
+        <SettingsRow
+          {...searchableSetting("worktree-branch-prefix")}
+          description="Prefix for automatically generated worktree branch names. Leave empty for no prefix."
+          resetAction={
+            settings.worktreeBranchPrefix !== DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix ? (
+              <SettingResetButton
+                label="worktree branch prefix"
+                onClick={() =>
+                  updateSettings({
+                    worktreeBranchPrefix: DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <DraftInput
+              className="w-full sm:w-44"
+              value={settings.worktreeBranchPrefix}
+              placeholder="t3code"
+              spellCheck={false}
+              aria-label="Worktree branch prefix"
+              onCommit={(next) => {
+                const rawPrefix = next.trim();
+                const worktreeBranchPrefix = /[a-z0-9]/i.test(rawPrefix)
+                  ? sanitizeBranchFragment(rawPrefix)
+                  : "";
+                if (worktreeBranchPrefix !== settings.worktreeBranchPrefix) {
+                  updateSettings({ worktreeBranchPrefix });
+                }
+              }}
+            />
+          }
+        />
 
         <SettingsRow
           {...searchableSetting("add-project-starts-in")}

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -148,6 +148,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     targetId: "new-threads",
   },
   {
+    id: "worktree-branch-prefix",
+    title: "Worktree branch prefix",
+    to: "/settings/general",
+  },
+  {
     id: "add-project-starts-in",
     title: "Add project starts in",
     to: "/settings/general",

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -2,6 +2,9 @@
 
 T3 Code connects to your Git hosting provider so you can create pull requests, review code, and manage repositories without leaving the app.
 
+T3 Code prefixes automatically generated worktree branches with `t3code` by default. Change or
+remove the prefix under **Settings → General → Worktree branch prefix**.
+
 ## Supported Providers
 
 T3 Code works with the platforms your team already uses:

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -246,6 +246,12 @@ describe("ServerSettings worktree defaults", () => {
       decodeServerSettingsPatch({ newWorktreesStartFromOrigin: false }).newWorktreesStartFromOrigin,
     ).toBe(false);
   });
+
+  it("defaults the worktree branch prefix and accepts an empty prefix", () => {
+    expect(decodeServerSettings({}).worktreeBranchPrefix).toBe("t3code");
+    expect(decodeServerSettingsPatch({ worktreeBranchPrefix: "" }).worktreeBranchPrefix).toBe("");
+    expect(() => decodeServerSettingsPatch({ worktreeBranchPrefix: "/.." })).toThrow();
+  });
 });
 
 describe("ServerSettings.sourceControlWritingStyle", () => {

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -277,6 +277,17 @@ const makeBinaryPathSetting = (fallback: string) =>
     Schema.withDecodingDefault(Effect.succeed(fallback)),
   );
 
+const WorktreeBranchPrefix = TrimmedString.check(
+  Schema.makeFilter(
+    (value) =>
+      value.length === 0 ||
+      (value.length <= 64 &&
+        /^[a-z0-9](?:[a-z0-9/_-]*[a-z0-9])?$/.test(value) &&
+        !value.includes("//")) ||
+      "must be an empty string or a normalized Git branch prefix",
+  ),
+);
+
 export type ProviderSettingsFormControl = "text" | "password" | "textarea" | "switch";
 
 export interface ProviderSettingsFormAnnotation {
@@ -638,6 +649,9 @@ export const ServerSettings = Schema.Struct({
   newWorktreesStartFromOrigin: Schema.Boolean.pipe(
     Schema.withDecodingDefault(Effect.succeed(true)),
   ),
+  worktreeBranchPrefix: WorktreeBranchPrefix.pipe(
+    Schema.withDecodingDefault(Effect.succeed("t3code")),
+  ),
   addProjectBaseDirectory: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   textGenerationModelSelection: ModelSelection.pipe(
     Schema.withDecodingDefault(
@@ -837,6 +851,7 @@ export const ServerSettingsPatch = Schema.Struct({
   backgroundActivityProfile: Schema.optionalKey(BackgroundActivityProfile),
   defaultThreadEnvMode: Schema.optionalKey(ThreadEnvMode),
   newWorktreesStartFromOrigin: Schema.optionalKey(Schema.Boolean),
+  worktreeBranchPrefix: Schema.optionalKey(WorktreeBranchPrefix),
   addProjectBaseDirectory: Schema.optionalKey(TrimmedString),
   textGenerationModelSelection: Schema.optionalKey(ModelSelectionPatch),
   sourceControlWritingStyle: Schema.optionalKey(


### PR DESCRIPTION
## What Changed

- Added a server setting for the prefix used when T3 Code promotes temporary worktree branches to generated names.
- Added a **Worktree branch prefix** field under **Settings → General**. It defaults to `t3code`, accepts a normalized custom prefix, and can be left empty for unprefixed branch names.
- Added settings search, restore-default behavior, user documentation, and focused contract/server tests.
- Kept temporary branch naming and the wire protocol unchanged. The configured prefix is applied at the shared server rename boundary, so web, desktop, mobile, local, and remote clients receive the same behavior.

## Why

Generated worktree branches were always placed under the hard-coded `t3code/` namespace. Fork maintainers and teams commonly need a personal or team namespace, while some workflows require no prefix at all.

This makes that namespace configurable without adding client-specific flows or changing worktree creation semantics. Existing installations remain backward compatible because `t3code` is still the default.

## UI Changes

**Before:** Settings had no branch-prefix control, and generated worktree branches always used `t3code/`.

**After:** Settings → General includes a Worktree branch prefix field with inline guidance.

<img width="1280" height="720" alt="Worktree branch prefix setting in Settings General" src="https://github.com/user-attachments/assets/9369a6de-e4d7-4482-a921-7ecd42ba1c0d" />

## Verification

- Rebased onto the latest `main` before publishing.
- `96` focused tests passed across shared Git helpers, settings contracts, and the provider command reactor.
- Shared, contracts, server, and web typechecks passed.
- Changed-file lint, formatting, and `git diff --check` passed.
- Three independent review passes covered correctness, multi-surface/remote behavior, and unnecessary complexity; follow-up delta reviews found no actionable issues.
- Confirmed the functionality is not already present on upstream `main` and found no open upstream PR implementing it.

## Checklist

- [x] This PR is small and focused on one change
- [x] The problem and implementation are explained above
- [x] UI evidence is included above; the before state had no corresponding control
- [x] Video is not applicable because this change adds no animation or timing-dependent interaction

Built with Codex through the Codex harness in T3 Code.

Generated with Codex


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches git branch renaming and persisted server settings. Validation and a backward-compatible default limit blast radius, but a bad prefix still affects generated branch names across clients.
> 
> **Overview**
> Makes the namespace for auto-generated worktree branches configurable. Default remains `t3code`; users can set a custom prefix or leave it empty.
> 
> Adds `worktreeBranchPrefix` to server settings (validated Git prefix, max 64 chars) and a **Settings → General** field with search, reset, and sanitization on commit. The provider reactor applies that prefix when renaming the first-turn temp branch, stripping a duplicate configured or default prefix from the model output.
> 
> Temporary branch creation is unchanged. Missing configs still decode to `t3code`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4660733933ed50128b03bd38c7b3e1e1ca9f96ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add configurable `worktreeBranchPrefix` setting for generated worktree branches
> - Introduces `WorktreeBranchPrefix` schema in [settings.ts](https://github.com/pingdotgg/t3code/pull/7887/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c) that validates either an empty string or a normalized git branch prefix (length <= 64, alphanumeric boundaries, no `//`). Added to both `ServerSettings` (default `'t3code'`) and `ServerSettingsPatch`.
> - `buildGeneratedWorktreeBranchName` in [ProviderCommandReactor.ts](https://github.com/pingdotgg/t3code/pull/7887/files#diff-0630e9ad70d5dcd1c8586d29297f9b7d5f5436cc8e10fc88dc22acc511f1450d) now accepts a caller-supplied `prefix` and uses `sanitizeBranchFragment` to normalize it before composing the generated branch name.
> - Adds a `DraftInput`-based settings row in [SettingsPanels.tsx](https://github.com/pingdotgg/t3code/pull/7887/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18) for editing the prefix, with dirty-state tracking, reset-to-default, and normalization on commit (empty if no alphanumeric characters).
> - Registers the new setting in [settingsSearch.ts](https://github.com/pingdotgg/t3code/pull/7887/files#diff-194ff52e4b6663ea95b9f4b9bb5202fa7a3d26d917a79e9239910fa073fd9ff8) and documents it in [source-control.md](https://github.com/pingdotgg/t3code/pull/7887/files#diff-a171985f6d647c7bc51efc65cf1a0b7261bb1313fe7c275c74f3836f919d1c05).
> - Behavioral Change: generated worktree branch names now prefix with the configured value (default `'t3code'`) instead of a hardcoded prefix; existing server settings without `worktreeBranchPrefix` will decode to `'t3code'` by default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4660733.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->