### PR TITLE
fix(web): stop marking mixed tool runs as failed

### DIFF
--- a/apps/server/src/orchestration/ActivityPayloadProjection.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.ts
@@ -342,11 +342,17 @@ export function projectActivityPayload(
     return activity;
   }
 
+  const itemStatus = asRecord(data.item)?.status;
+  const projectedPayload =
+    payload.status === "completed" && (itemStatus === "failed" || itemStatus === "declined")
+      ? { ...payload, status: itemStatus }
+      : payload;
+
   if (payload.itemType === "mcp_tool_call") {
     return {
       ...activity,
       payload: {
-        ...payload,
+        ...projectedPayload,
         data: projectMcpToolCallData(data),
       },
     };
@@ -384,7 +390,7 @@ export function projectActivityPayload(
   return {
     ...activity,
     payload: {
-      ...payload,
+      ...projectedPayload,
       data: projectedData,
     },
   };

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -614,6 +614,66 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
     }),
   );
 
+  it.effect("preserves failed and declined outcomes on completed tool items", () =>
+    Effect.gen(function* () {
+      const { adapter, runtime } = yield* startLifecycleRuntime();
+      const items = [
+        {
+          type: "commandExecution",
+          id: "failed-command",
+          command: "vp test run",
+          commandActions: [],
+          cwd: "/tmp",
+          exitCode: 1,
+          status: "failed",
+        },
+        {
+          type: "mcpToolCall",
+          id: "failed-mcp",
+          server: "simulator",
+          tool: "build",
+          arguments: {},
+          error: { message: "Build failed" },
+          status: "failed",
+        },
+        {
+          type: "fileChange",
+          id: "declined-change",
+          changes: [],
+          status: "declined",
+        },
+      ] as const;
+
+      for (const item of items) {
+        const firstEventFiber = yield* Stream.runHead(adapter.streamEvents).pipe(Effect.forkChild);
+
+        yield* runtime.emit({
+          id: asEventId(`evt-${item.id}`),
+          kind: "notification",
+          provider: ProviderDriverKind.make("codex"),
+          createdAt: "2026-01-01T00:00:00.000Z",
+          method: "item/completed",
+          threadId: asThreadId("thread-1"),
+          turnId: asTurnId("turn-1"),
+          itemId: asItemId(item.id),
+          payload: {
+            completedAtMs: 1_778_000_000_000,
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item,
+          },
+        });
+
+        const firstEvent = yield* Fiber.join(firstEventFiber);
+        NodeAssert.equal(firstEvent._tag, "Some");
+        if (firstEvent._tag !== "Some" || firstEvent.value.type !== "item.completed") {
+          return;
+        }
+        NodeAssert.equal(firstEvent.value.payload.status, item.status);
+      }
+    }),
+  );
+
   it.effect("maps completed plan items to canonical proposed-plan completion events", () =>
     Effect.gen(function* () {
       const { adapter, runtime } = yield* startLifecycleRuntime();

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -480,7 +480,9 @@ function mapItemLifecycle(
     lifecycle === "item.started"
       ? "inProgress"
       : lifecycle === "item.completed"
-        ? "completed"
+        ? "status" in item && (item.status === "failed" || item.status === "declined")
+          ? item.status
+          : "completed"
         : undefined;
 
   return {

--- a/apps/server/test/ActivityPayloadProjection.test.ts
+++ b/apps/server/test/ActivityPayloadProjection.test.ts
@@ -220,6 +220,40 @@ describe("projectActivityPayload", () => {
     }
   });
 
+  it("preserves failed stored tool outcomes for web and mobile clients", () => {
+    const activities = [
+      makeActivity("failed-command", "command_execution", {
+        item: {
+          command: "vp test run",
+          exitCode: 1,
+          status: "failed",
+        },
+      }),
+      makeActivity("failed-mcp", "mcp_tool_call", {
+        item: {
+          server: "simulator",
+          tool: "build",
+          arguments: {},
+          status: "failed",
+        },
+      }),
+    ];
+
+    for (const activity of activities) {
+      const projected = projectActivityPayload(activity);
+      expect(projected.payload).toMatchObject({ status: "failed" });
+
+      const [webEntry] = deriveWorkLogEntries([projected]);
+      expect(webEntry?.toolLifecycleStatus).toBe("failed");
+
+      const [mobileGroup] = buildThreadFeed(makeThread([projected]));
+      expect(mobileGroup).toMatchObject({ type: "activity-group" });
+      if (mobileGroup?.type === "activity-group") {
+        expect(mobileGroup.activities[0]?.status).toBe("failure");
+      }
+    }
+  });
+
   it("projects snapshot and event transports without mutating their sources", () => {
     const activity = fixtures[0]!;
     const thread = makeThread([activity]);

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1376,39 +1376,89 @@ describe("deriveMessagesTimelineRows", () => {
   });
 
   it.each([
-    ["mixed", ["failed", "completed"], false],
+    ["recovered", ["failed", "completed"], false],
+    ["ending in failure", ["completed", "failed"], true],
     ["failed", ["failed", "failed"], true],
-  ] as const)(
-    "marks %s tool groups failed only when every call fails",
-    (_, statuses, hasFailure) => {
-      const timelineEntries = statuses.map((status, index) => ({
-        id: `work-entry-${index}`,
-        kind: "work" as const,
+  ] as const)("uses the final call for %s tool groups", (_, statuses, hasFailure) => {
+    const timelineEntries = statuses.map((status, index) => ({
+      id: `work-entry-${index}`,
+      kind: "work" as const,
+      createdAt: `2026-01-01T00:00:0${index}Z`,
+      entry: {
+        id: `work-${index}`,
         createdAt: `2026-01-01T00:00:0${index}Z`,
-        entry: {
-          id: `work-${index}`,
-          createdAt: `2026-01-01T00:00:0${index}Z`,
-          label: "Ran command",
-          tone: "tool" as const,
-          itemType: "command_execution" as const,
-          toolLifecycleStatus: status,
+        label: "Ran command",
+        tone: "tool" as const,
+        itemType: "command_execution" as const,
+        toolLifecycleStatus: status,
+      },
+    }));
+
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries,
+      isWorking: false,
+      activeTurnStartedAt: null,
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.find((row) => row.kind === "work-toggle")).toMatchObject({
+      hiddenCount: 2,
+      hasFailure,
+    });
+  });
+
+  it("keeps a failure visible when other hidden entries succeeded", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [
+        {
+          id: "failed-work-entry",
+          kind: "work",
+          createdAt: "2026-01-01T00:00:01Z",
+          entry: {
+            id: "failed-work",
+            createdAt: "2026-01-01T00:00:01Z",
+            label: "Ran command",
+            tone: "tool",
+            toolLifecycleStatus: "failed",
+          },
         },
-      }));
+        {
+          id: "completed-work-entry",
+          kind: "work",
+          createdAt: "2026-01-01T00:00:02Z",
+          entry: {
+            id: "completed-work",
+            createdAt: "2026-01-01T00:00:02Z",
+            label: "Ran command",
+            tone: "tool",
+            toolLifecycleStatus: "completed",
+          },
+        },
+        {
+          id: "visible-info-entry",
+          kind: "work",
+          createdAt: "2026-01-01T00:00:03Z",
+          entry: {
+            id: "visible-info",
+            createdAt: "2026-01-01T00:00:03Z",
+            label: "Status updated",
+            tone: "info",
+          },
+        },
+      ],
+      isWorking: false,
+      activeTurnStartedAt: null,
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
 
-      const rows = deriveMessagesTimelineRows({
-        timelineEntries,
-        isWorking: false,
-        activeTurnStartedAt: null,
-        turnDiffSummaryByAssistantMessageId: new Map(),
-        revertTurnCountByUserMessageId: new Map(),
-      });
-
-      expect(rows.find((row) => row.kind === "work-toggle")).toMatchObject({
-        hiddenCount: 2,
-        hasFailure,
-      });
-    },
-  );
+    expect(rows.find((row) => row.kind === "work-toggle")).toMatchObject({
+      hiddenCount: 2,
+      summary: null,
+      hasFailure: true,
+    });
+  });
 });
 
 describe("computeStableMessagesTimelineRows", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1374,6 +1374,41 @@ describe("deriveMessagesTimelineRows", () => {
       expanded: true,
     });
   });
+
+  it.each([
+    ["mixed", ["failed", "completed"], false],
+    ["failed", ["failed", "failed"], true],
+  ] as const)(
+    "marks %s tool groups failed only when every call fails",
+    (_, statuses, hasFailure) => {
+      const timelineEntries = statuses.map((status, index) => ({
+        id: `work-entry-${index}`,
+        kind: "work" as const,
+        createdAt: `2026-01-01T00:00:0${index}Z`,
+        entry: {
+          id: `work-${index}`,
+          createdAt: `2026-01-01T00:00:0${index}Z`,
+          label: "Ran command",
+          tone: "tool" as const,
+          itemType: "command_execution" as const,
+          toolLifecycleStatus: status,
+        },
+      }));
+
+      const rows = deriveMessagesTimelineRows({
+        timelineEntries,
+        isWorking: false,
+        activeTurnStartedAt: null,
+        turnDiffSummaryByAssistantMessageId: new Map(),
+        revertTurnCountByUserMessageId: new Map(),
+      });
+
+      expect(rows.find((row) => row.kind === "work-toggle")).toMatchObject({
+        hiddenCount: 2,
+        hasFailure,
+      });
+    },
+  );
 });
 
 describe("computeStableMessagesTimelineRows", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -894,7 +894,7 @@ export function deriveMessagesTimelineRows(input: {
             onlyToolEntries: true,
             summary: summarizeToolGroup(visibleGroupedEntries),
             summaryKind,
-            hasFailure: visibleGroupedEntries.some((entry) =>
+            hasFailure: visibleGroupedEntries.every((entry) =>
               workEntryDisplayIndicatesToolFailure(entry),
             ),
           });
@@ -960,7 +960,7 @@ export function deriveMessagesTimelineRows(input: {
               onlyToolEntries: hiddenEntries.every(workLogEntryIsToolLike),
               summary: null,
               summaryKind: null,
-              hasFailure: hiddenEntries.some((entry) =>
+              hasFailure: hiddenEntries.every((entry) =>
                 workEntryDisplayIndicatesToolFailure(entry),
               ),
             });

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -894,9 +894,7 @@ export function deriveMessagesTimelineRows(input: {
             onlyToolEntries: true,
             summary: summarizeToolGroup(visibleGroupedEntries),
             summaryKind,
-            hasFailure: visibleGroupedEntries.every((entry) =>
-              workEntryDisplayIndicatesToolFailure(entry),
-            ),
+            hasFailure: workEntryDisplayIndicatesToolFailure(visibleGroupedEntries.at(-1)!),
           });
           if (expanded) {
             for (const [entryIndex, workEntry] of visibleGroupedEntries.entries()) {
@@ -960,7 +958,7 @@ export function deriveMessagesTimelineRows(input: {
               onlyToolEntries: hiddenEntries.every(workLogEntryIsToolLike),
               summary: null,
               summaryKind: null,
-              hasFailure: hiddenEntries.every((entry) =>
+              hasFailure: hiddenEntries.some((entry) =>
                 workEntryDisplayIndicatesToolFailure(entry),
               ),
             });

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -813,6 +813,45 @@ describe("MessagesTimeline", () => {
     expect(markup).not.toContain("C:/Users/mike/dev-stuff/t3code/apps/web/src/session-logic.ts");
   });
 
+  it("keeps mixed-success tool groups neutral", () => {
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-failed",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-failed",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "Run search",
+              tone: "tool",
+              itemType: "command_execution",
+              toolLifecycleStatus: "failed",
+            },
+          },
+          {
+            id: "entry-completed",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:29.000Z",
+            entry: {
+              id: "work-completed",
+              createdAt: "2026-03-17T19:12:29.000Z",
+              label: "Run tests",
+              tone: "tool",
+              itemType: "command_execution",
+              toolLifecycleStatus: "completed",
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("Ran 2 commands");
+    expect(markup).not.toContain('aria-label="Tool call failed"');
+  });
+
   it("shows the animated one-line label for a live tool group", () => {
     const turnId = TurnId.make("turn-live");
     const markup = renderToStaticMarkup(


### PR DESCRIPTION
One failed tool call made a mostly successful tool run look like the entire run failed. Real Codex tool failures were also marked successful, so more serious errors could disappear.

Show the failure icon when the final tool call in a group fails. Preserve real tool outcomes for new Codex events and existing threads across web and mobile.

Tests: 120 focused tests, web and server typechecks, targeted lint, and formatting.

Model: GPT-5.6 Sol
Harness: Codex in T3 Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Codex item-status mapping and activity projection that feed web/mobile tool UI. Wrong status handling could hide or overstate tool failures, but the change is small and covered by tests.
> 
> **Overview**
> Tool groups no longer show a failure icon unless **every** call in the group failed, so mixed-success runs stay neutral.
> 
> Codex `item.completed` events now keep real `failed`/`declined` item statuses instead of always mapping to `completed`. Activity payload projection does the same for stored threads so web and mobile still see those outcomes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3760cca06611d4dedfd6c53030e8461b2b12f3dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix mixed tool runs being marked as failed in activity projection and timeline
> - Server-side `projectActivityPayload` now overrides a top-level `payload.status` of `"completed"` with the embedded `item.status` when it is `"failed"` or `"declined"` ([ActivityPayloadProjection.ts](https://github.com/pingdotgg/t3code/pull/7893/files#diff-debcaf6e868575f9d95bb6918b9983c3a8929d664039039b54e9e1c7ea3b4130)).
> - `mapItemLifecycle` in the Codex adapter propagates `"failed"` or `"declined"` from the source item into `item.completed` events instead of always emitting `"completed"` ([CodexAdapter.ts](https://github.com/pingdotgg/t3code/pull/7893/files#diff-f37bcac225467446dcf6198df38d357c15304b19eebacbdcdea70047f507707d)).
> - Web `deriveMessagesTimelineRows` computes `hasFailure` for work-toggle groups from the last visible grouped entry only, so mixed-success groups ending in success are no longer marked failed ([MessagesTimeline.logic.ts](https://github.com/pingdotgg/t3code/pull/7893/files#diff-6cdfacc6ebbdbc5c4b4058c0a430b87d768ac2b6accf35fb4c9dfc23500914fe)).
> - Adds tests across adapter, projection, timeline logic, and component rendering to cover mixed-outcome tool groups.
> - Risk: `hasFailure` now reflects only the terminal entry in a tool group; groups where an earlier entry failed but the last entry succeeded will no longer show a failure indicator.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 70e686b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->