### PR TITLE
fix(swift-ios): clean up settings, environments, and thread actions

### DIFF
--- a/apps/swift-ios/DesignSystem/T3Theme.swift
+++ b/apps/swift-ios/DesignSystem/T3Theme.swift
@@ -2,17 +2,16 @@ import SwiftUI
 import UIKit
 
 enum T3Colors {
-    // Keep these values aligned with apps/mobile/global.css. UIKit variants
-    // let recycled collection and terminal surfaces participate in the same
-    // system appearance changes as SwiftUI views.
-    static let uiBackground = adaptive(light: rgb(0xF2F2F7), dark: rgb(0x0A0A0A))
+    // UIKit variants let recycled collection and terminal surfaces participate
+    // in the same system appearance changes as SwiftUI views.
+    static let uiBackground = adaptive(light: rgb(0xF2F2F7), dark: rgb(0x000000))
     static let uiTextPrimary = adaptive(light: rgb(0x262626), dark: rgb(0xF5F5F5))
     static let uiTextSecondary = adaptive(light: rgb(0x525252), dark: rgb(0xA3A3A3))
     static let uiSurfaceRaised = adaptive(light: rgb(0xF5F5F5), dark: rgb(0x1C1C1C))
     static let uiAccent = adaptive(light: rgb(0x007AFF), dark: rgb(0x0A84FF))
 
     static let background = Color(uiColor: uiBackground)
-    static let sheet = color(light: rgb(0xF2F2F7, alpha: 0.98), dark: rgb(0x0E0E0E, alpha: 0.98))
+    static let sheet = color(light: rgb(0xF2F2F7, alpha: 0.98), dark: rgb(0x000000, alpha: 0.98))
     static let surface = color(light: rgb(0xFFFFFF), dark: rgb(0x171717))
     static let surfaceRaised = Color(uiColor: uiSurfaceRaised)
     static let input = color(light: rgb(0xFFFFFF), dark: rgb(0x141414))
@@ -34,7 +33,7 @@ enum T3Colors {
     static let placeholder = color(light: rgb(0xA3A3A3), dark: rgb(0x8E8E93))
 
     static let primaryAction = color(light: rgb(0x262626), dark: rgb(0xF5F5F5))
-    static let primaryActionForeground = color(light: rgb(0xFFFFFF), dark: rgb(0x0A0A0A))
+    static let primaryActionForeground = color(light: rgb(0xFFFFFF), dark: rgb(0x000000))
     static let accent = Color(uiColor: uiAccent)
     static let statusRunning = color(light: rgb(0x0284C7), dark: rgb(0x22D3EE))
     static let statusInput = color(light: rgb(0x4F46E5), dark: rgb(0xA5B4FC))

--- a/apps/swift-ios/Features/Chat/FeatureComposerCommandPopover.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerCommandPopover.swift
@@ -27,6 +27,7 @@ struct FeatureComposerCommandPopover: View {
                                 FeatureComposerCommandRow(item: item)
                             }
                             .buttonStyle(.plain)
+                            .accessibilityLabel(accessibilityLabel(for: item))
                             .accessibilityIdentifier("composer-suggestion-\(item.id)")
 
                             if index < items.count - 1 {
@@ -42,9 +43,9 @@ struct FeatureComposerCommandPopover: View {
         }
         .frame(height: menuHeight, alignment: .top)
         .background(T3Colors.surfaceRaised.opacity(0.98))
-        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
         .overlay {
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .stroke(T3Colors.border, lineWidth: 1)
         }
         .accessibilityLabel(groupLabel)
@@ -64,12 +65,16 @@ struct FeatureComposerCommandPopover: View {
         if isLoading { return "Searching files…" }
         if let errorMessage, !errorMessage.isEmpty { return errorMessage }
         switch triggerKind {
-        case .slashCommand: return "No matching commands."
-        case .model: return "No matching models."
-        case .skill: return "No matching skills."
-        case .path where !pathSearchAvailable: return "File search is unavailable."
-        case .path: return "Type a file name to search."
+        case .slashCommand: return "No matching commands"
+        case .model: return "No matching models"
+        case .skill: return "No matching skills"
+        case .path where !pathSearchAvailable: return "File search unavailable"
+        case .path: return "Type a file name"
         }
+    }
+
+    private func accessibilityLabel(for item: FeatureComposerMenuItem) -> String {
+        item.description.isEmpty ? item.label : "\(item.label), \(item.description)"
     }
 
     private var menuHeight: CGFloat {
@@ -99,6 +104,7 @@ private struct FeatureComposerCommandRow: View {
                 .font(T3Typography.control)
                 .foregroundStyle(T3Colors.textPrimary)
                 .lineLimit(1)
+                .layoutPriority(1)
 
             if !item.description.isEmpty {
                 Text(item.description)
@@ -117,8 +123,8 @@ private struct FeatureComposerCommandRow: View {
 
     private var iconName: String {
         switch item {
-        case .modelCommand, .providerCommand: return "terminal"
-        case .model: return "cpu"
+        case .modelCommand, .model: return "cpu"
+        case .providerCommand: return "terminal"
         case .skill: return "shippingbox"
         case let .path(entry): return entry.kind == .directory ? "folder" : "doc"
         }

--- a/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerTextInput.swift
@@ -37,6 +37,8 @@ struct FeatureComposerTextInput: UIViewRepresentable {
         textView.tintColor = T3Colors.uiAccent
         textView.font = UIFont.preferredFont(forTextStyle: .body)
         textView.adjustsFontForContentSizeCategory = true
+        textView.smartQuotesType = .no
+        textView.smartDashesType = .no
         // Match the metrics of the SwiftUI text field this view replaced so
         // the swap is invisible: the surrounding paddings stay in SwiftUI.
         textView.textContainerInset = .zero
@@ -120,9 +122,9 @@ struct FeatureComposerTextInput: UIViewRepresentable {
     private func updateAccessibility(_ textView: FeatureComposerUITextView) {
         textView.accessibilityLabel = "Message agent"
         textView.accessibilityHint = acceptsImages
-            ? "Enter a message or paste images to attach them."
-            : "Enter a message."
-        textView.accessibilityValue = text.isEmpty ? placeholder : nil
+            ? "Enter a message or paste images"
+            : "Enter a message"
+        textView.accessibilityValue = text.isEmpty ? placeholder : text
     }
 
     final class Coordinator: NSObject, UITextViewDelegate {

--- a/apps/swift-ios/Features/Chat/FeatureComposerView.swift
+++ b/apps/swift-ios/Features/Chat/FeatureComposerView.swift
@@ -4,6 +4,8 @@ import UIKit
 struct FeatureComposerView: View {
     @State private var isManuallyExpanded = false
     @State private var isAttachmentFlowActive = false
+    @State private var isModelPickerPresented = false
+    @State private var restoresFocusAfterModelPickerDismissal = false
     @State private var attachmentPreparation = FeatureAttachmentPreparationState()
     @State private var pathEntries: [FeatureComposerPathEntry] = []
     @State private var isPathSearchLoading = false
@@ -120,7 +122,7 @@ struct FeatureComposerView: View {
                     isFocused: focused,
                     textIsEmpty: textIsEmpty,
                     attachmentsAreEmpty: attachments.isEmpty,
-                    isAttachmentFlowActive: isAttachmentFlowActive,
+                    isAttachmentFlowActive: isAttachmentFlowActive || isModelPickerPresented,
                     isPreparingAttachments: attachmentPreparation.isPreparing
                 ) {
                     isManuallyExpanded = false
@@ -193,7 +195,7 @@ struct FeatureComposerView: View {
                     focused = true
                 }
             } label: {
-                Text(isWorking ? "Message to queue…" : "Ask anything…")
+                Text(composerPlaceholder)
                     .font(T3Typography.composer)
                     .foregroundStyle(T3Colors.textTertiary)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -226,12 +228,11 @@ struct FeatureComposerView: View {
 
             // Return is always editing input. Sending is deliberately
             // button-only, which is UITextView's native return behavior.
-            let placeholder = isWorking ? "Message to queue…" : "Ask anything…"
             ZStack(alignment: .topLeading) {
                 FeatureComposerTextInput(
                     text: $text,
                     focused: $focused,
-                    placeholder: placeholder,
+                    placeholder: composerPlaceholder,
                     acceptsImages: imagesAllowed,
                     selectionRequest: textSelectionRequest,
                     onPasteImages: attachImageProviders,
@@ -241,7 +242,7 @@ struct FeatureComposerView: View {
                 .padding(.top, 14)
 
                 if text.isEmpty {
-                    Text(placeholder)
+                    Text(composerPlaceholder)
                         .font(T3Typography.composer)
                         .foregroundStyle(T3Colors.textTertiary)
                         .padding(.horizontal, 16)
@@ -290,7 +291,8 @@ struct FeatureComposerView: View {
                 selection: $selection,
                 style: .compact,
                 threadSelection: threadSelection,
-                materializesDefaultSelection: materializesDefaultSelection
+                materializesDefaultSelection: materializesDefaultSelection,
+                onPresentationChange: handleModelPickerPresentation
             )
             .frame(maxWidth: 220, alignment: .leading)
             .layoutPriority(2)
@@ -311,27 +313,34 @@ struct FeatureComposerView: View {
 
     private var submitButton: some View {
         Button(action: performPrimaryAction) {
-            Group {
-                if isSending {
-                    ProgressView()
-                        .controlSize(.small)
-                        .tint(.white)
-                } else {
-                    Image(systemName: showsStop ? "stop.fill" : "arrow.up")
-                        .font(.system(size: showsStop ? 11 : 14, weight: .bold))
-                }
-            }
-            .foregroundStyle(.white)
-            .frame(width: 34, height: 34)
-            .background(showsStop ? T3Colors.danger : T3Colors.accent, in: Circle())
+            Image(systemName: submitSymbol)
+                .font(.system(size: showsStop ? 11 : 14, weight: .bold))
+                .foregroundStyle(.white)
+                .frame(width: 34, height: 34)
+                .background(showsStop ? T3Colors.danger : T3Colors.accent, in: Circle())
+                .frame(width: T3Metrics.minimumTapTarget, height: T3Metrics.minimumTapTarget)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .disabled(submitDisabled)
         .opacity(submitDisabled ? 0.3 : 1)
-        .frame(width: T3Metrics.minimumTapTarget, height: T3Metrics.minimumTapTarget)
-        .contentShape(Rectangle())
-        .accessibilityLabel(showsStop ? "Stop agent" : "Send")
+        .accessibilityLabel(submitAccessibilityLabel)
         .accessibilityIdentifier(showsStop ? "thread-stop" : "message-send")
+    }
+
+    private var composerPlaceholder: String {
+        isWorking ? "Queue a message…" : "Ask anything…"
+    }
+
+    private var submitSymbol: String {
+        if isSending { return "ellipsis" }
+        return showsStop ? "stop.fill" : "arrow.up"
+    }
+
+    private var submitAccessibilityLabel: String {
+        if isSending { return "Sending message" }
+        if showsStop { return "Stop agent" }
+        return isWorking ? "Queue message" : "Send message"
     }
 
     private var composerShape: RoundedRectangle {
@@ -497,6 +506,23 @@ struct FeatureComposerView: View {
         } else if FeatureComposerSubmissionPolicy.allowsSend(for: .explicitButton),
                   canSend {
             onSend()
+        }
+    }
+
+    private func handleModelPickerPresentation(_ isPresented: Bool) {
+        if isPresented {
+            restoresFocusAfterModelPickerDismissal = focused
+            isManuallyExpanded = true
+            isModelPickerPresented = true
+            return
+        }
+
+        isModelPickerPresented = false
+        guard restoresFocusAfterModelPickerDismissal else { return }
+        restoresFocusAfterModelPickerDismissal = false
+        Task { @MainActor in
+            await Task.yield()
+            focused = true
         }
     }
 

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -42,16 +42,18 @@ public struct ThreadDetailView: View {
 
     public var body: some View {
         Group {
-            if isLoading {
-                FeatureThreadOpeningView(isRefreshing: detail != nil)
-            } else if let detail {
+            if let detail {
                 timeline(detail)
+            } else if isLoading {
+                FeatureThreadOpeningView()
             } else {
-                ContentUnavailableView(
-                    "Thread unavailable",
-                    systemImage: "exclamationmark.bubble",
-                    description: Text("The thread could not be loaded.")
-                )
+                ContentUnavailableView {
+                    Label("Thread unavailable", systemImage: "exclamationmark.bubble")
+                } description: {
+                    Text("The thread could not be loaded.")
+                } actions: {
+                    Button("Retry", action: reloadThread)
+                }
             }
         }
         .background(T3Colors.background)
@@ -69,7 +71,7 @@ public struct ThreadDetailView: View {
         .task(id: thread.id) {
             let restoreBaseline = composerDraft
             let restoreKey = draftKey
-            isLoading = true
+            isLoading = detail == nil
             _ = await model.detail(for: thread.id, force: true)
             await restoreDraft(from: restoreBaseline, key: restoreKey)
             isLoading = false
@@ -83,21 +85,23 @@ public struct ThreadDetailView: View {
         }
         .sheet(item: $toolSurface) { surface in
             NavigationStack {
-                switch surface {
-                case .files:
-                    FeatureFilesView(client: model.client, threadID: thread.id)
-                case .review:
-                    FeatureReviewView(client: model.client, threadID: thread.id)
-                case .sourceControl:
-                    FeatureSourceControlView(client: model.client, threadID: thread.id)
-                case .terminal:
-                    FeatureTerminalView(client: model.client, threadID: thread.id)
+                Group {
+                    switch surface {
+                    case .files:
+                        FeatureFilesView(client: model.client, threadID: thread.id)
+                    case .review:
+                        FeatureReviewView(client: model.client, threadID: thread.id)
+                    case .sourceControl:
+                        FeatureSourceControlView(client: model.client, threadID: thread.id)
+                    case .terminal:
+                        FeatureTerminalView(client: model.client, threadID: thread.id)
+                    }
                 }
-            }
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Done") {
-                        toolSurface = nil
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Done") {
+                            toolSurface = nil
+                        }
                     }
                 }
             }
@@ -227,21 +231,7 @@ public struct ThreadDetailView: View {
 
     private var threadActionsMenu: some View {
         Menu {
-            Section("Workspace") {
-                Button { toolSurface = .files } label: {
-                    Label("Files", systemImage: "folder")
-                }
-                Button { toolSurface = .review } label: {
-                    Label("Review changes", systemImage: "doc.text.magnifyingglass")
-                }
-                Button { toolSurface = .sourceControl } label: {
-                    Label("Source Control", systemImage: "arrow.triangle.branch")
-                }
-                Button { toolSurface = .terminal } label: {
-                    Label("Terminal", systemImage: "terminal")
-                }
-            }
-            Section {
+            Section("Thread") {
                 if currentThread.supportsTitleRegeneration == true {
                     Button {
                         Task { await model.regenerateThreadTitle(thread.id) }
@@ -264,11 +254,36 @@ public struct ThreadDetailView: View {
                         )
                     }
                 }
-                Button {
-                    Task { _ = await model.detail(for: thread.id, force: true) }
-                } label: {
+                if currentThread.canToggleSettlement, !currentThread.isArchived {
+                    let isSettled = currentThread.isEffectivelySettled(at: .now)
+                    Button {
+                        Task { await model.setSettled(thread.id, settled: !isSettled) }
+                    } label: {
+                        Label(
+                            isSettled ? "Reopen" : "Settle",
+                            systemImage: isSettled ? "arrow.counterclockwise" : "checkmark"
+                        )
+                    }
+                }
+                Button(action: reloadThread) {
                     Label("Reload", systemImage: "arrow.clockwise")
                 }
+            }
+            Section("Workspace") {
+                Button { toolSurface = .files } label: {
+                    Label("Files", systemImage: "folder")
+                }
+                Button { toolSurface = .review } label: {
+                    Label("Review changes", systemImage: "doc.text.magnifyingglass")
+                }
+                Button { toolSurface = .sourceControl } label: {
+                    Label("Source control", systemImage: "arrow.triangle.branch")
+                }
+                Button { toolSurface = .terminal } label: {
+                    Label("Terminal", systemImage: "terminal")
+                }
+            }
+            Section {
                 Button {
                     Task {
                         await model.setArchived(thread.id, archived: !currentThread.isArchived)
@@ -290,6 +305,16 @@ public struct ThreadDetailView: View {
         .buttonStyle(.plain)
         .foregroundStyle(T3Colors.textSecondary)
         .accessibilityLabel("Thread actions")
+        .accessibilityHint("Shows thread actions and workspace tools")
+        .accessibilityIdentifier("thread-actions-menu")
+    }
+
+    private func reloadThread() {
+        isLoading = detail == nil
+        Task {
+            _ = await model.detail(for: thread.id, force: true)
+            isLoading = false
+        }
     }
 
     private var headerBranch: String {
@@ -540,13 +565,11 @@ public struct ThreadDetailView: View {
 }
 
 private struct FeatureThreadOpeningView: View {
-    let isRefreshing: Bool
-
     var body: some View {
         VStack(spacing: 12) {
             ProgressView()
                 .controlSize(.regular)
-            Text(isRefreshing ? "Refreshing thread…" : "Loading thread…")
+            Text("Loading thread…")
                 .font(T3Typography.supporting)
                 .foregroundStyle(T3Colors.textSecondary)
         }

--- a/apps/swift-ios/Features/Connection/ConnectionOnboardingView.swift
+++ b/apps/swift-ios/Features/Connection/ConnectionOnboardingView.swift
@@ -17,6 +17,7 @@ public struct ConnectionOnboardingView: View {
     @State private var showsPermissionAction = false
     @State private var showingScanner = false
     @State private var entryHeading = "Connect manually"
+    @State private var connectionReturnStage = ConnectionStage.details
     @State private var connectionTask: Task<Void, Never>?
     @State private var connectionAttemptID: UUID?
     @FocusState private var focusedField: ConnectionField?
@@ -63,20 +64,24 @@ public struct ConnectionOnboardingView: View {
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(T3Colors.background)
+            .background(T3Colors.background.ignoresSafeArea())
             .animation(.snappy(duration: 0.24), value: stage)
-        }
-        .toolbar {
-            if stage == .welcome, let onCancel {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Close", action: onCancel)
-                }
-            } else if stage == .checking {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") {
-                        cancelConnectionAttempt()
-                        model.errorMessage = nil
-                        stage = .details
+            .toolbarBackground(T3Colors.background, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
+            .toolbar {
+                if stage == .welcome, let onCancel {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Close", action: onCancel)
+                            .accessibilityIdentifier("connection-onboarding-close")
+                    }
+                } else if stage == .checking || stage == .connecting {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") {
+                            cancelConnectionAttempt()
+                            model.errorMessage = nil
+                            stage = connectionReturnStage
+                        }
+                        .accessibilityIdentifier("connection-onboarding-cancel")
                     }
                 }
             }
@@ -109,7 +114,7 @@ public struct ConnectionOnboardingView: View {
                 errorMessage = nil
             }
         }
-        .interactiveDismissDisabled(stage == .connecting)
+        .interactiveDismissDisabled(stage == .checking || stage == .connecting)
         .onDisappear {
             cancelConnectionAttempt()
         }
@@ -118,22 +123,27 @@ public struct ConnectionOnboardingView: View {
     private var welcomeView: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                Spacer(minLength: 48)
+                Spacer(minLength: 36)
 
                 Text("T3")
                     .font(.system(size: 34, weight: .black, design: .rounded))
                     .foregroundStyle(Color(red: 0.02, green: 0.74, blue: 0.5))
                     .accessibilityLabel("T3 Code")
 
-                Text("Your agents,\nwherever you are.")
-                    .font(.system(size: 38, weight: .bold, design: .default))
-                    .tracking(-1.1)
-                    .padding(.top, 24)
+                Text("Connect an environment")
+                    .font(.largeTitle.bold())
+                    .foregroundStyle(T3Colors.textPrimary)
+                    .padding(.top, 20)
 
-                Text("Connect securely to T3 Code running on your computer.")
+                Text("Choose how to connect to T3 Code.")
                     .font(.body)
                     .foregroundStyle(T3Colors.textSecondary)
-                    .padding(.top, 12)
+                    .padding(.top, 8)
+
+                if let errorMessage {
+                    connectionError(message: errorMessage)
+                        .padding(.top, 20)
+                }
 
                 if showsT3ConnectOption,
                    let capability = model.client as? any T3ConnectCapable,
@@ -144,20 +154,23 @@ public struct ConnectionOnboardingView: View {
                             onConnected()
                         }
                     } label: {
-                        Label("Continue with T3 Connect", systemImage: "cloud")
+                        Label("T3 Connect", systemImage: "cloud")
                             .frame(maxWidth: .infinity)
                     }
                     .buttonStyle(ConnectionPrimaryButtonStyle())
-                    .padding(.top, 36)
-                    .accessibilityHint("Sign in to connect an environment linked to your T3 account")
+                    .padding(.top, 32)
+                    .accessibilityHint("Sign in to connect a linked environment")
+                    .accessibilityIdentifier("connection-onboarding-t3-connect")
                 }
 
                 VStack(spacing: 0) {
                     connectionAction(
                         title: "Scan QR code",
-                        subtitle: "Pair directly with a computer nearby",
+                        subtitle: "Use the code on your computer",
                         systemImage: "qrcode.viewfinder"
                     ) {
+                        errorMessage = nil
+                        showsPermissionAction = false
                         showingScanner = true
                     }
 
@@ -165,7 +178,7 @@ public struct ConnectionOnboardingView: View {
 
                     connectionAction(
                         title: "Paste connection link",
-                        subtitle: "Copy it from T3 Code on your computer",
+                        subtitle: "Use a link from your computer",
                         systemImage: "doc.on.clipboard"
                     ) {
                         pasteConnectionLink()
@@ -174,16 +187,17 @@ public struct ConnectionOnboardingView: View {
                     Divider().overlay(T3Colors.border)
 
                     connectionAction(
-                        title: "Enter details manually",
-                        subtitle: "Use the server address and pairing code",
+                        title: "Enter details",
+                        subtitle: "Use an address and pairing code",
                         systemImage: "keyboard"
                     ) {
                         entryHeading = "Connect manually"
                         errorMessage = nil
+                        showsPermissionAction = false
                         stage = .details
                     }
                 }
-                .padding(.top, 12)
+                .padding(.top, showsT3ConnectOption ? 20 : 28)
 
                 knownEnvironments
             }
@@ -199,10 +213,10 @@ public struct ConnectionOnboardingView: View {
     private var knownEnvironments: some View {
         if !knownEnvironmentValues.isEmpty {
             VStack(alignment: .leading, spacing: 0) {
-                Text("KNOWN SERVERS")
-                    .font(T3Typography.eyebrow)
-                    .foregroundStyle(T3Colors.textSecondary)
-                    .padding(.top, 34)
+                Text("Saved environments")
+                    .font(.headline)
+                    .foregroundStyle(T3Colors.textPrimary)
+                    .padding(.top, 36)
                     .padding(.bottom, 8)
 
                 ForEach(knownEnvironmentValues) { environment in
@@ -237,7 +251,9 @@ public struct ConnectionOnboardingView: View {
                         .padding(.vertical, 12)
                     }
                     .buttonStyle(.plain)
-                    .accessibilityHint("Reconnects to this server")
+                    .accessibilityLabel(environment.name)
+                    .accessibilityValue(environment.endpoint)
+                    .accessibilityHint("Connects to this saved environment")
 
                     if environment.id != knownEnvironmentValues.last?.id {
                         Divider().overlay(T3Colors.border)
@@ -248,8 +264,8 @@ public struct ConnectionOnboardingView: View {
     }
 
     private var knownEnvironmentValues: [FeatureEnvironment] {
-        guard !showsT3ConnectOption else { return model.snapshot.environments }
-        return model.snapshot.environments.filter { $0.source == .direct }
+        guard showsT3ConnectOption else { return [] }
+        return model.snapshot.environments
     }
 
     private var detailsView: some View {
@@ -258,50 +274,71 @@ public struct ConnectionOnboardingView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     Text(entryHeading)
                         .font(.largeTitle.bold())
-                        .tracking(-0.6)
-                    Text("Both values are shown in T3 Code when you create a mobile connection.")
+                        .foregroundStyle(T3Colors.textPrimary)
+                    Text("Find these details in T3 Code on your computer.")
                         .font(T3Typography.threadBody)
                         .foregroundStyle(T3Colors.textSecondary)
                 }
 
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("SERVER ADDRESS")
-                        .font(T3Typography.eyebrow)
-                        .foregroundStyle(T3Colors.textSecondary)
+                    Text("Server address")
+                        .font(T3Typography.control)
+                        .foregroundStyle(T3Colors.textPrimary)
 
-                    TextField("http://192.168.1.5:3773", text: $endpoint)
+                    TextField(
+                        "Server address",
+                        text: $endpoint,
+                        prompt: Text("http://192.168.1.5:3773")
+                            .foregroundStyle(T3Colors.placeholder)
+                    )
                         .textInputAutocapitalization(.never)
                         .keyboardType(.URL)
                         .autocorrectionDisabled()
                         .focused($focusedField, equals: .endpoint)
                         .connectionInput()
                         .accessibilityLabel("Server address")
+                        .accessibilityIdentifier("connection-onboarding-address")
+                        .submitLabel(.next)
+                        .onSubmit { focusedField = .pairingCode }
                         .onChange(of: endpoint) { _, value in
                             autofillIfPairingLink(value)
                         }
                 }
 
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("PAIRING CODE")
-                        .font(T3Typography.eyebrow)
-                        .foregroundStyle(T3Colors.textSecondary)
+                    Text("Pairing code")
+                        .font(T3Typography.control)
+                        .foregroundStyle(T3Colors.textPrimary)
 
-                    TextField("12-character code", text: $pairingCode)
+                    TextField(
+                        "Pairing code",
+                        text: $pairingCode,
+                        prompt: Text("Enter pairing code")
+                            .foregroundStyle(T3Colors.placeholder)
+                    )
                         .textInputAutocapitalization(.never)
                         .textContentType(.oneTimeCode)
                         .autocorrectionDisabled()
                         .focused($focusedField, equals: .pairingCode)
                         .connectionInput()
+                        .privacySensitive()
                         .accessibilityLabel("Pairing code")
+                        .accessibilityIdentifier("connection-onboarding-pairing-code")
+                        .submitLabel(.go)
+                        .onSubmit {
+                            if canSubmit { submitDetails() }
+                        }
                 }
 
                 Button {
                     pasteConnectionLink()
                 } label: {
-                    Label("Paste a connection link instead", systemImage: "doc.on.clipboard")
+                    Label("Paste connection link", systemImage: "doc.on.clipboard")
                         .font(T3Typography.control.weight(.semibold))
                 }
                 .buttonStyle(.plain)
+                .frame(minHeight: T3Metrics.minimumTapTarget, alignment: .leading)
+                .accessibilityIdentifier("connection-onboarding-paste-link")
 
                 if let errorMessage {
                     connectionError(message: errorMessage)
@@ -316,6 +353,7 @@ public struct ConnectionOnboardingView: View {
                 .buttonStyle(ConnectionPrimaryButtonStyle())
                 .disabled(!canSubmit)
                 .opacity(canSubmit ? 1 : 0.45)
+                .accessibilityIdentifier("connection-onboarding-submit")
             }
             .padding(.horizontal, 24)
             .padding(.top, 24)
@@ -324,7 +362,7 @@ public struct ConnectionOnboardingView: View {
             .frame(maxWidth: .infinity)
         }
         .scrollDismissesKeyboard(.interactively)
-        .navigationTitle("Connect")
+        .navigationTitle("Add environment")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {
@@ -344,13 +382,13 @@ public struct ConnectionOnboardingView: View {
         VStack(alignment: .leading, spacing: 34) {
             Spacer()
 
-            Text(stage == .checking ? "Finding your T3" : "Connecting securely")
+            Text(stage == .checking ? "Checking connection" : "Connecting")
                 .font(.largeTitle.bold())
-                .tracking(-0.7)
+                .foregroundStyle(T3Colors.textPrimary)
 
             VStack(alignment: .leading, spacing: 20) {
                 progressRow(
-                    title: "Server details",
+                    title: "Server address",
                     state: .complete
                 )
                 progressRow(
@@ -360,16 +398,17 @@ public struct ConnectionOnboardingView: View {
                     state: stage == .checking ? .active : .complete
                 )
                 progressRow(
-                    title: "Secure pairing",
+                    title: "Pairing",
                     state: stage == .connecting ? .active : .waiting
                 )
             }
 
             Spacer()
 
-            Text("Keep T3 Code open on your computer.")
+            Text(endpoint)
                 .font(T3Typography.supporting)
                 .foregroundStyle(T3Colors.textSecondary)
+                .lineLimit(1)
         }
         .padding(.horizontal, 32)
         .padding(.vertical, 28)
@@ -382,9 +421,9 @@ public struct ConnectionOnboardingView: View {
             Image(systemName: "checkmark.circle.fill")
                 .font(.system(size: 54))
                 .foregroundStyle(.green)
-            Text("You're connected")
+            Text("Connected")
                 .font(.title.bold())
-            Text("Loading your projects and threads.")
+            Text("Loading your projects.")
                 .font(T3Typography.threadBody)
                 .foregroundStyle(T3Colors.textSecondary)
         }
@@ -419,6 +458,8 @@ public struct ConnectionOnboardingView: View {
             .padding(.vertical, 14)
         }
         .buttonStyle(.plain)
+        .frame(minHeight: T3Metrics.minimumTapTarget)
+        .accessibilityElement(children: .combine)
     }
 
     private func connectionError(message: String) -> some View {
@@ -435,7 +476,7 @@ public struct ConnectionOnboardingView: View {
                 .font(T3Typography.control.weight(.semibold))
             }
         }
-        .accessibilityElement(children: .combine)
+        .accessibilityElement(children: .contain)
     }
 
     private func progressRow(title: String, state: ProgressRowState) -> some View {
@@ -546,6 +587,12 @@ public struct ConnectionOnboardingView: View {
         cancelConnectionAttempt()
         let attemptID = UUID()
         connectionAttemptID = attemptID
+        switch action {
+        case .pair:
+            connectionReturnStage = .details
+        case .activate:
+            connectionReturnStage = .welcome
+        }
         endpoint = action.endpoint
         errorMessage = nil
         showsPermissionAction = false
@@ -558,13 +605,17 @@ public struct ConnectionOnboardingView: View {
             case .ready:
                 stage = .connecting
             case .localNetworkDenied:
-                errorMessage = "Allow Local Network access so this iPhone can find T3 Code on your computer."
+                errorMessage = "Allow Local Network access to connect to this environment."
                 showsPermissionAction = true
-                stage = .details
+                connectionAttemptID = nil
+                connectionTask = nil
+                stage = connectionReturnStage
                 return
             case .unreachable:
-                errorMessage = "This iPhone cannot reach that server. Confirm the address and that both devices are on the same network."
-                stage = .details
+                errorMessage = "Cannot reach this environment. Check the address and network connection."
+                connectionAttemptID = nil
+                connectionTask = nil
+                stage = connectionReturnStage
                 return
             }
 
@@ -589,7 +640,7 @@ public struct ConnectionOnboardingView: View {
                 errorMessage = ConnectionErrorCopy.message(for: rawError)
                 connectionAttemptID = nil
                 connectionTask = nil
-                stage = .details
+                stage = connectionReturnStage
             }
         }
     }
@@ -637,6 +688,7 @@ private extension View {
     func connectionInput() -> some View {
         self
             .font(.body.monospaced())
+            .foregroundStyle(T3Colors.textPrimary)
             .padding(.horizontal, 14)
             .frame(minHeight: 50)
             .background(T3Colors.input)

--- a/apps/swift-ios/Features/Connection/T3ConnectView.swift
+++ b/apps/swift-ios/Features/Connection/T3ConnectView.swift
@@ -39,27 +39,14 @@ public struct T3ConnectView: View {
         content
             .navigationTitle("T3 Connect")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                if controller.account != nil {
-                    ToolbarItem(placement: .topBarTrailing) {
-                        Button("Sign out", role: .destructive) {
-                            guard !isSigningOut else { return }
-                            isSigningOut = true
-                            Task {
-                                await signOut()
-                                isSigningOut = false
-                                presentAuthenticationIfNeeded()
-                            }
-                        }
-                        .disabled(controller.isRefreshing || isSigningOut)
-                    }
-                }
-            }
+            .toolbarBackground(T3Colors.background, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
             .refreshable {
                 await controller.refresh()
             }
             .task {
                 await controller.refresh()
+                guard !Task.isCancelled else { return }
                 didFinishInitialRefresh = true
                 presentAuthenticationIfNeeded()
             }
@@ -97,15 +84,15 @@ public struct T3ConnectView: View {
             }
         } else if let account = controller.account {
             connectList {
-                accountSection(account)
                 environmentSection
+                accountSection(account)
             }
+        } else if isSigningOut {
+            loadingView("Signing out")
+        } else if didFinishInitialRefresh {
+            signedOutView
         } else {
-            ZStack {
-                T3Colors.background.ignoresSafeArea()
-                ProgressView()
-                    .tint(T3Colors.textPrimary)
-            }
+            loadingView("Checking account")
         }
     }
 
@@ -116,8 +103,45 @@ public struct T3ConnectView: View {
             content()
         }
         .listStyle(.plain)
+        .listSectionSpacing(28)
         .scrollContentBackground(.hidden)
-        .background(T3Colors.background)
+        .background(T3Colors.background.ignoresSafeArea())
+    }
+
+    private var signedOutView: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Sign in to T3 Connect")
+                .font(.title2.bold())
+                .foregroundStyle(T3Colors.textPrimary)
+
+            Text("Access environments linked to your account.")
+                .font(T3Typography.threadBody)
+                .foregroundStyle(T3Colors.textSecondary)
+
+            Button("Sign in") {
+                isAuthPresented = true
+            }
+            .font(T3Typography.control.weight(.semibold))
+            .frame(minHeight: T3Metrics.minimumTapTarget)
+            .padding(.top, 4)
+            .accessibilityIdentifier("t3-connect-sign-in")
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(24)
+        .background(T3Colors.background.ignoresSafeArea())
+    }
+
+    private func loadingView(_ message: String) -> some View {
+        VStack(spacing: 12) {
+            ProgressView()
+                .tint(T3Colors.textPrimary)
+            Text(message)
+                .font(T3Typography.supporting)
+                .foregroundStyle(T3Colors.textSecondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(T3Colors.background.ignoresSafeArea())
+        .accessibilityElement(children: .combine)
     }
 
     @ViewBuilder
@@ -134,11 +158,7 @@ public struct T3ConnectView: View {
                 .environment(\.clerkTheme, T3ConnectClerkAppearance.theme)
                 .environment(clerk)
         } else {
-            ZStack {
-                T3Colors.background.ignoresSafeArea()
-                ProgressView()
-                    .tint(T3Colors.textPrimary)
-            }
+            loadingView("Loading sign-in")
         }
     }
 
@@ -160,12 +180,12 @@ public struct T3ConnectView: View {
     private func unavailableSection(_ reason: String) -> some View {
         Section {
             VStack(alignment: .leading, spacing: 10) {
-                Label("Unavailable in this build", systemImage: "cloud.slash")
+                Label("T3 Connect unavailable", systemImage: "cloud.slash")
                     .font(T3Typography.homeTitle)
                 Text(reason)
                     .font(T3Typography.threadBody)
                     .foregroundStyle(T3Colors.textSecondary)
-                Text("Direct and local connections still work without an account.")
+                Text("You can still connect directly.")
                     .font(T3Typography.supporting)
                     .foregroundStyle(T3Colors.textTertiary)
             }
@@ -190,20 +210,45 @@ public struct T3ConnectView: View {
             }
             .padding(.vertical, 3)
             .listRowBackground(T3Colors.background)
+            .accessibilityElement(children: .combine)
+
+            Button(role: .destructive) {
+                handleSignOut()
+            } label: {
+                HStack {
+                    Text("Sign out")
+                    Spacer()
+                    if isSigningOut {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+                }
+                .frame(minHeight: T3Metrics.minimumTapTarget)
+            }
+            .disabled(controller.isRefreshing || isSigningOut || connectingEnvironmentID != nil)
+            .listRowBackground(T3Colors.background)
+            .accessibilityIdentifier("t3-connect-sign-out")
         }
     }
 
     private var environmentSection: some View {
-        Section(purpose == .manage ? "Linked machines" : "Cloud environments") {
+        Section("Environments") {
             if controller.environments.isEmpty, !controller.isRefreshing {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("No linked machines")
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("No linked environments")
                         .font(T3Typography.homeTitle)
-                    Text("Link an environment from T3 Code on desktop, then pull to refresh.")
+                    Text("Link an environment in T3 Code on your computer.")
                         .font(T3Typography.supporting)
                         .foregroundStyle(T3Colors.textSecondary)
+
+                    Button("Refresh") {
+                        Task { await controller.refresh() }
+                    }
+                    .font(T3Typography.control)
+                    .frame(minHeight: T3Metrics.minimumTapTarget)
+                    .accessibilityIdentifier("t3-connect-refresh")
                 }
-                .padding(.vertical, 8)
+                .padding(.top, 8)
                 .listRowBackground(T3Colors.background)
             }
 
@@ -226,11 +271,14 @@ public struct T3ConnectView: View {
             if controller.isRefreshing {
                 HStack(spacing: 10) {
                     ProgressView()
-                    Text("Refreshing environments…")
+                        .controlSize(.small)
+                    Text("Checking environments")
                         .font(T3Typography.supporting)
                         .foregroundStyle(T3Colors.textSecondary)
                 }
+                .frame(minHeight: T3Metrics.minimumTapTarget)
                 .listRowBackground(T3Colors.background)
+                .accessibilityElement(children: .combine)
             }
         }
     }
@@ -249,9 +297,12 @@ public struct T3ConnectView: View {
                     .lineLimit(1)
                 Text(statusText(item))
                     .font(T3Typography.supporting)
-                    .foregroundStyle(T3Colors.textSecondary)
-                    .lineLimit(1)
+                    .foregroundStyle(
+                        item.statusError == nil ? T3Colors.textSecondary : T3Colors.danger
+                    )
+                    .lineLimit(2)
             }
+            .accessibilityElement(children: .combine)
 
             Spacer(minLength: 8)
 
@@ -263,20 +314,37 @@ public struct T3ConnectView: View {
                         || connectingEnvironmentID == item.id {
                         ProgressView()
                             .frame(width: 54)
+                            .accessibilityLabel("Connecting to \(item.environment.label)")
                     } else {
                         Text("Connect")
                             .font(T3Typography.supportingStrong)
                     }
                 }
                 .buttonStyle(.borderless)
+                .frame(minHeight: T3Metrics.minimumTapTarget)
                 .disabled(
                     controller.busyEnvironmentID != nil
                         || connectingEnvironmentID != nil
                         || item.status?.status == .offline
                 )
+                .accessibilityLabel("Connect to \(item.environment.label)")
+                .accessibilityHint(item.status?.status == .offline ? "Environment is offline" : "")
+                .accessibilityIdentifier("t3-connect-environment-\(item.id)")
             }
         }
         .padding(.vertical, 5)
+    }
+
+    private func handleSignOut() {
+        guard !isSigningOut else { return }
+        isSigningOut = true
+        Task {
+            await signOut()
+            isSigningOut = false
+            if controller.account == nil {
+                dismiss()
+            }
+        }
     }
 
     private func handleConnect(_ environment: T3ConnectRelayEnvironment) async {
@@ -301,12 +369,15 @@ public struct T3ConnectView: View {
         switch item.status?.status {
         case .online: return "Online"
         case .offline: return item.status?.error ?? "Offline"
-        case nil: return "Checking…"
+        case nil: return "Checking"
         }
     }
 
     private func statusColor(_ item: T3ConnectCloudEnvironment) -> Color {
-        switch item.status?.status {
+        if item.statusError != nil {
+            return T3Colors.danger
+        }
+        return switch item.status?.status {
         case .online: T3Colors.success
         case .offline: T3Colors.danger
         case nil: T3Colors.textTertiary
@@ -343,12 +414,12 @@ private struct T3ConnectAuthenticationView: View {
                     brand
                         .padding(.bottom, 38)
 
-                    Text("Continue to T3 Code")
+                    Text("Sign in to T3 Connect")
                         .font(.system(.largeTitle, design: .default, weight: .bold))
                         .foregroundStyle(T3Colors.textPrimary)
                         .padding(.bottom, 10)
 
-                    Text("Sign in to reach your environments from anywhere.")
+                    Text("Access your linked environments.")
                         .font(T3Typography.threadBody)
                         .foregroundStyle(T3Colors.textSecondary)
                         .fixedSize(horizontal: false, vertical: true)
@@ -379,6 +450,7 @@ private struct T3ConnectAuthenticationView: View {
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel("Close")
+                    .accessibilityIdentifier("t3-connect-auth-close")
                 }
             }
             .toolbarBackground(.hidden, for: .navigationBar)
@@ -429,7 +501,7 @@ private struct T3ConnectAuthenticationView: View {
             HStack(spacing: 10) {
                 ProgressView()
                     .tint(T3Colors.textPrimary)
-                Text("Loading sign-in options…")
+                Text("Loading sign-in options")
                     .font(T3Typography.control)
                     .foregroundStyle(T3Colors.textSecondary)
             }
@@ -485,7 +557,7 @@ private struct T3ConnectAuthenticationView: View {
             HStack(spacing: 10) {
                 Image(systemName: "envelope")
                     .font(.system(size: 15, weight: .medium))
-                Text("Use email instead")
+                Text(availableProviders.isEmpty ? "Continue with email" : "Use email")
                     .font(T3Typography.control)
                 Spacer()
                 Image(systemName: "chevron.right")
@@ -496,6 +568,8 @@ private struct T3ConnectAuthenticationView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .disabled(activeProvider != nil)
+        .accessibilityIdentifier("t3-connect-auth-email")
     }
 
     private var availableProviders: [OAuthProvider] {

--- a/apps/swift-ios/Features/Settings/ConnectionHubPresentation.swift
+++ b/apps/swift-ios/Features/Settings/ConnectionHubPresentation.swift
@@ -1,5 +1,23 @@
 import Foundation
 
+enum ConnectionHubStatus: Equatable {
+    case disabled
+    case checking
+    case connecting
+    case offline
+    case online
+
+    var title: String {
+        switch self {
+        case .disabled: "Off"
+        case .checking: "Checking"
+        case .connecting: "Connecting"
+        case .offline: "Offline"
+        case .online: "Online"
+        }
+    }
+}
+
 struct T3ConnectEnvironmentPresentation: Identifiable, Equatable {
     let linkedEnvironment: T3ConnectCloudEnvironment?
     let savedEnvironment: FeatureEnvironment?
@@ -16,19 +34,87 @@ struct T3ConnectEnvironmentPresentation: Identifiable, Equatable {
         savedEnvironment?.isEnabled ?? false
     }
 
+    var endpoint: String? {
+        linkedEnvironment?.environment.endpoint.httpBaseUrl ?? savedEnvironment?.endpoint
+    }
+
     var isOnline: Bool {
-        if savedEnvironment?.connectionState == .connected {
-            return true
+        status == .online
+    }
+
+    var status: ConnectionHubStatus {
+        connectionStatus()
+    }
+
+    func connectionStatus(
+        pendingEnabled: Bool? = nil,
+        isConnecting: Bool = false
+    ) -> ConnectionHubStatus {
+        if isConnecting || (pendingEnabled == true && savedEnvironment == nil) {
+            return .connecting
         }
-        return linkedEnvironment?.status?.status == .online
+
+        if let savedEnvironment {
+            return ConnectionHubPresentation.status(
+                for: savedEnvironment,
+                pendingEnabled: pendingEnabled
+            )
+        }
+
+        return switch linkedEnvironment?.status?.status {
+        case .online: .online
+        case .offline: .offline
+        case nil: linkedEnvironment?.statusError == nil ? .checking : .offline
+        }
     }
 }
 
 enum ConnectionHubPresentation {
+    static func status(
+        for environment: FeatureEnvironment,
+        pendingEnabled: Bool? = nil
+    ) -> ConnectionHubStatus {
+        guard pendingEnabled ?? environment.isEnabled else { return .disabled }
+
+        if pendingEnabled == true && !environment.isEnabled {
+            return .connecting
+        }
+
+        return switch environment.connectionState {
+        case .connected: .online
+        case .connecting, .reconnecting: .connecting
+        case .disconnected: .offline
+        case nil: .checking
+        }
+    }
+
+    static func disambiguatingEndpoint(
+        _ endpoint: String,
+        for name: String,
+        among names: [String]
+    ) -> String? {
+        let matchingNames = names.filter {
+            $0.localizedCaseInsensitiveCompare(name) == .orderedSame
+        }
+        guard matchingNames.count > 1,
+              let components = URLComponents(string: endpoint),
+              let host = components.host else { return nil }
+
+        return components.port.map { "\(host):\($0)" } ?? host
+    }
+
     static func directEnvironments(
         in environments: [FeatureEnvironment]
     ) -> [FeatureEnvironment] {
-        environments.filter { $0.source == .direct }
+        environments.enumerated()
+            .filter { $0.element.source == .direct }
+            .sorted { first, second in
+                if first.element.isEnabled != second.element.isEnabled {
+                    return first.element.isEnabled
+                }
+                return first.offset < second.offset
+            }
+            .map(\.element)
     }
 
     /// T3 Connect owns the account catalog while Core owns the environments

--- a/apps/swift-ios/Features/Settings/ConnectionsView.swift
+++ b/apps/swift-ios/Features/Settings/ConnectionsView.swift
@@ -15,7 +15,7 @@ struct ConnectionsView: View {
     var body: some View {
         VStack(spacing: 0) {
             ScrollView {
-                LazyVStack(alignment: .leading, spacing: 28) {
+                LazyVStack(alignment: .leading, spacing: 32) {
                     directConnectionsSection
                     t3ConnectSection
                     accessSection
@@ -127,10 +127,10 @@ struct ConnectionsView: View {
     }
 
     private var directConnectionsSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 12) {
-                Text("DIRECT CONNECTIONS")
-                    .font(T3Typography.eyebrow)
+                Text("Direct")
+                    .font(T3Typography.supportingStrong)
                     .foregroundStyle(T3Colors.textSecondary)
                 Spacer(minLength: 0)
                 Button("Add") { showingAddConnection = true }
@@ -139,13 +139,11 @@ struct ConnectionsView: View {
             }
 
             if directEnvironments.isEmpty {
-                emptyRow("No direct connections")
+                emptyRow("No paired environments")
             } else {
                 VStack(spacing: 0) {
-                    Divider().overlay(T3Colors.separator)
                     ForEach(directEnvironments) { environment in
                         directConnectionRow(environment)
-                        Divider().overlay(T3Colors.separator)
                     }
                 }
             }
@@ -162,10 +160,15 @@ struct ConnectionsView: View {
                         .font(.system(size: 18, weight: .medium))
                         .foregroundStyle(T3Colors.textSecondary)
                         .frame(width: 25)
+                        .accessibilityHidden(true)
 
                     environmentLabel(
                         name: environment.name,
-                        isOnline: environment.connectionState == .connected
+                        status: ConnectionHubPresentation.status(
+                            for: environment,
+                            pendingEnabled: pendingEnabledValues[environment.id]
+                        ),
+                        endpoint: directEndpointLabel(for: environment)
                     )
 
                     Spacer(minLength: 8)
@@ -173,12 +176,18 @@ struct ConnectionsView: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .accessibilityHint("Shows connection details")
 
             Toggle("Enabled", isOn: enabledBinding(for: environment))
                 .labelsHidden()
                 .tint(T3Colors.success)
                 .disabled(pendingEnabledValues[environment.id] != nil)
-                .accessibilityLabel("Enable \(environment.name)")
+                .accessibilityLabel(
+                    toggleAccessibilityLabel(
+                        name: environment.name,
+                        endpoint: directEndpointLabel(for: environment)
+                    )
+                )
         }
         .frame(minHeight: 70)
         .contextMenu {
@@ -191,16 +200,18 @@ struct ConnectionsView: View {
     }
 
     private var t3ConnectSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 12) {
-                Text("T3 CONNECT")
-                    .font(T3Typography.eyebrow)
+                Text("T3 Connect")
+                    .font(T3Typography.supportingStrong)
                     .foregroundStyle(T3Colors.textSecondary)
                 Spacer(minLength: 0)
-                Button("Manage") { showingT3Connect = true }
-                    .font(T3Typography.control)
-                    .disabled(t3ConnectCapability == nil)
-                    .accessibilityIdentifier("connections-manage-t3-connect-button")
+                Button(t3ConnectController?.account == nil ? "Sign in" : "Manage") {
+                    showingT3Connect = true
+                }
+                .font(T3Typography.control)
+                .disabled(t3ConnectCapability == nil)
+                .accessibilityIdentifier("connections-manage-t3-connect-button")
             }
 
             if t3ConnectRows.isEmpty {
@@ -212,29 +223,22 @@ struct ConnectionsView: View {
                             .font(T3Typography.supporting)
                             .foregroundStyle(T3Colors.textSecondary)
                     }
-                    .frame(minHeight: 58)
+                    .frame(minHeight: 44)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .overlay(alignment: .top) { Divider().overlay(T3Colors.separator) }
-                    .overlay(alignment: .bottom) { Divider().overlay(T3Colors.separator) }
+                } else if t3ConnectCapability == nil {
+                    emptyRow("T3 Connect unavailable")
                 } else if t3ConnectController?.account == nil {
-                    emptyRow("Sign in to access your T3 Connect machines")
+                    emptyRow("Sign in to see your environments")
                 } else {
-                    emptyRow("No linked machines")
+                    emptyRow("No linked environments")
                 }
             } else {
                 VStack(spacing: 0) {
-                    Divider().overlay(T3Colors.separator)
                     ForEach(t3ConnectRows) { item in
                         t3ConnectConnectionRow(item)
-                        Divider().overlay(T3Colors.separator)
                     }
                 }
             }
-
-            Text("Turn on any online machine to use it on this iPhone.")
-                .font(T3Typography.supporting)
-                .foregroundStyle(T3Colors.textTertiary)
-                .padding(.top, 2)
         }
     }
 
@@ -250,6 +254,7 @@ struct ConnectionsView: View {
                         t3ConnectEnvironmentLabel(item)
                     }
                     .buttonStyle(.plain)
+                    .accessibilityHint("Shows connection details")
                 } else {
                     t3ConnectEnvironmentLabel(item)
                 }
@@ -259,7 +264,17 @@ struct ConnectionsView: View {
                 .labelsHidden()
                 .tint(T3Colors.success)
                 .disabled(isT3ConnectToggleDisabled(item))
-                .accessibilityLabel("Enable \(item.name)")
+                .accessibilityHint(
+                    item.savedEnvironment == nil && item.status == .offline
+                        ? "Environment is offline"
+                        : ""
+                )
+                .accessibilityLabel(
+                    toggleAccessibilityLabel(
+                        name: item.name,
+                        endpoint: t3ConnectEndpointLabel(for: item)
+                    )
+                )
         }
         .frame(minHeight: 70)
     }
@@ -268,49 +283,71 @@ struct ConnectionsView: View {
         _ item: T3ConnectEnvironmentPresentation
     ) -> some View {
         HStack(spacing: 12) {
-            Image(systemName: "desktopcomputer")
+            Image(systemName: "cloud")
                 .font(.system(size: 18, weight: .medium))
                 .foregroundStyle(T3Colors.textSecondary)
                 .frame(width: 25)
+                .accessibilityHidden(true)
 
-            environmentLabel(name: item.name, isOnline: item.isOnline)
+            environmentLabel(
+                name: item.name,
+                status: item.connectionStatus(
+                    pendingEnabled: pendingEnabledValues[item.id],
+                    isConnecting: connectingEnvironmentID == item.id
+                        || t3ConnectController?.busyEnvironmentID == item.id
+                ),
+                endpoint: t3ConnectEndpointLabel(for: item)
+            )
             Spacer(minLength: 8)
         }
         .contentShape(Rectangle())
     }
 
-    private func environmentLabel(name: String, isOnline: Bool) -> some View {
+    private func environmentLabel(
+        name: String,
+        status: ConnectionHubStatus,
+        endpoint: String?
+    ) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             Text(name)
                 .font(T3Typography.homeTitle)
                 .foregroundStyle(T3Colors.textPrimary)
                 .lineLimit(1)
 
-            HStack(spacing: 6) {
+            HStack(spacing: 7) {
                 Circle()
-                    .fill(isOnline ? T3Colors.success : T3Colors.danger)
+                    .fill(status.color)
                     .frame(width: 7, height: 7)
-                Text(isOnline ? "Online" : "Offline")
+                    .accessibilityHidden(true)
+
+                Text(status.title)
+                    .fixedSize(horizontal: true, vertical: false)
+
+                if let endpoint {
+                    Text(endpoint)
+                        .foregroundStyle(T3Colors.textTertiary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
             }
             .font(T3Typography.supporting)
             .foregroundStyle(T3Colors.textSecondary)
         }
+        .accessibilityElement(children: .combine)
     }
 
     private func emptyRow(_ message: String) -> some View {
         Text(message)
-            .font(T3Typography.threadBody)
+            .font(T3Typography.supporting)
             .foregroundStyle(T3Colors.textSecondary)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .frame(minHeight: 58)
-            .overlay(alignment: .top) { Divider().overlay(T3Colors.separator) }
-            .overlay(alignment: .bottom) { Divider().overlay(T3Colors.separator) }
+            .frame(minHeight: 38)
     }
 
     private var accessSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("ACCESS")
-                .font(T3Typography.eyebrow)
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Access")
+                .font(T3Typography.supportingStrong)
                 .foregroundStyle(T3Colors.textSecondary)
             Button {
                 showingDevices = true
@@ -320,6 +357,7 @@ struct ConnectionsView: View {
                         .font(.system(size: 18, weight: .medium))
                         .foregroundStyle(T3Colors.accent)
                         .frame(width: 25)
+                        .accessibilityHidden(true)
                     Text("Devices and sessions")
                         .font(T3Typography.threadBody)
                         .foregroundStyle(T3Colors.textPrimary)
@@ -327,14 +365,37 @@ struct ConnectionsView: View {
                     Image(systemName: "chevron.right")
                         .font(T3Typography.supportingStrong)
                         .foregroundStyle(T3Colors.textTertiary)
+                        .accessibilityHidden(true)
                 }
                 .frame(minHeight: 54)
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .overlay(alignment: .top) { Divider().overlay(T3Colors.separator) }
-            .overlay(alignment: .bottom) { Divider().overlay(T3Colors.separator) }
         }
+    }
+
+    private func directEndpointLabel(for environment: FeatureEnvironment) -> String? {
+        ConnectionHubPresentation.disambiguatingEndpoint(
+            environment.endpoint,
+            for: environment.name,
+            among: directEnvironments.map(\.name)
+        )
+    }
+
+    private func t3ConnectEndpointLabel(
+        for item: T3ConnectEnvironmentPresentation
+    ) -> String? {
+        guard let endpoint = item.endpoint else { return nil }
+        return ConnectionHubPresentation.disambiguatingEndpoint(
+            endpoint,
+            for: item.name,
+            among: t3ConnectRows.map(\.name)
+        )
+    }
+
+    private func toggleAccessibilityLabel(name: String, endpoint: String?) -> String {
+        guard let endpoint else { return "Enable \(name)" }
+        return "Enable \(name), \(endpoint)"
     }
 
     private func enabledBinding(for environment: FeatureEnvironment) -> Binding<Bool> {
@@ -400,6 +461,7 @@ struct ConnectionsView: View {
         pendingEnabledValues[item.id] != nil
             || (connectingEnvironmentID != nil && connectingEnvironmentID != item.id)
             || t3ConnectController?.busyEnvironmentID != nil
+            || (item.savedEnvironment == nil && item.status == .offline)
     }
 
     private var directEnvironments: [FeatureEnvironment] {
@@ -451,7 +513,13 @@ private struct ConnectionDetailView: View {
                     Toggle("Enabled", isOn: enabledBinding(for: environment))
                         .tint(T3Colors.success)
                         .disabled(pendingEnabledValues[environment.id] != nil)
-                    LabeledContent("Status", value: environment.status.title)
+                    LabeledContent(
+                        "Status",
+                        value: ConnectionHubPresentation.status(
+                            for: environment,
+                            pendingEnabled: pendingEnabledValues[environment.id]
+                        ).title
+                    )
                     LabeledContent("Connection", value: environment.source.title)
                 }
 
@@ -530,25 +598,13 @@ private extension FeatureEnvironment.Source {
 
 }
 
-private extension FeatureEnvironment {
-    var status: ConnectionStatusPresentation {
-        guard isEnabled else {
-            return ConnectionStatusPresentation(title: "Off", color: T3Colors.textTertiary)
-        }
-        switch connectionState {
-        case .connected:
-            return ConnectionStatusPresentation(title: "Online", color: T3Colors.success)
-        case .connecting, .reconnecting:
-            return ConnectionStatusPresentation(title: "Connecting", color: T3Colors.warning)
-        case .disconnected:
-            return ConnectionStatusPresentation(title: "Unreachable", color: T3Colors.danger)
-        case nil:
-            return ConnectionStatusPresentation(title: "Checking", color: T3Colors.textTertiary)
+private extension ConnectionHubStatus {
+    var color: Color {
+        switch self {
+        case .disabled, .checking: T3Colors.textTertiary
+        case .connecting: T3Colors.warning
+        case .offline: T3Colors.danger
+        case .online: T3Colors.success
         }
     }
-}
-
-private struct ConnectionStatusPresentation {
-    let title: String
-    let color: Color
 }

--- a/apps/swift-ios/Features/Settings/SettingsView.swift
+++ b/apps/swift-ios/Features/Settings/SettingsView.swift
@@ -300,10 +300,16 @@ public struct SettingsView: View {
         let pendingAppearanceSave = appearanceSaveTask
         isSaving = true
         Task {
-            _ = await pendingAppearanceSave?.value
+            let appearanceDidSave = await pendingAppearanceSave?.value ?? true
+            if !appearanceDidSave, !hasUnsavedChanges {
+                isSaving = false
+                return
+            }
+
             let didSave = await model.saveSettings(settings)
             isSaving = false
             if didSave {
+                saveErrorMessage = nil
                 dismiss()
             } else {
                 saveErrorMessage = model.errorMessage ?? "Settings could not be saved."

--- a/apps/swift-ios/Features/Settings/SettingsView.swift
+++ b/apps/swift-ios/Features/Settings/SettingsView.swift
@@ -300,11 +300,7 @@ public struct SettingsView: View {
         let pendingAppearanceSave = appearanceSaveTask
         isSaving = true
         Task {
-            if let pendingAppearanceSave, await pendingAppearanceSave.value == false {
-                isSaving = false
-                return
-            }
-
+            _ = await pendingAppearanceSave?.value
             let didSave = await model.saveSettings(settings)
             isSaving = false
             if didSave {

--- a/apps/swift-ios/Features/Settings/SettingsView.swift
+++ b/apps/swift-ios/Features/Settings/SettingsView.swift
@@ -5,6 +5,7 @@ public struct SettingsView: View {
     @Bindable private var model: FeatureRootModel
     @State private var settings: FeatureSettings
     @State private var isSaving = false
+    @State private var appearanceSaveTask: Task<Bool, Never>?
     @State private var saveErrorMessage: String?
     @State private var showingDiscardConfirmation = false
 
@@ -79,14 +80,7 @@ public struct SettingsView: View {
                 model.setConnectionManagementPresented(false)
             }
             .onChange(of: settings.appearance) { _, appearance in
-                Task {
-                    let didSave = await model.saveAppearance(appearance)
-                    if !didSave {
-                        settings.appearance = model.snapshot.settings.appearance
-                        saveErrorMessage = model.errorMessage
-                            ?? "Theme preference could not be saved."
-                    }
-                }
+                saveAppearance(appearance)
             }
         }
         .interactiveDismissDisabled(isSaving || hasUnsavedChanges)
@@ -248,29 +242,9 @@ public struct SettingsView: View {
     }
 
     private var connectedEnvironments: [FeatureEnvironment] {
-        let enabled = model.snapshot.environments.filter(\.isEnabled)
-        let connected = enabled.filter { $0.connectionState == .connected }
-        guard connected.isEmpty, model.snapshot.connection.state == .connected else {
-            return connected
+        model.snapshot.environments.filter {
+            ConnectionHubPresentation.status(for: $0) == .online
         }
-
-        let unchecked = enabled.filter { $0.connectionState == nil }
-        let connection = model.snapshot.connection
-        if let endpoint = connection.endpoint,
-           let environment = unchecked.first(where: { $0.endpoint == endpoint }) {
-            return [environment]
-        }
-
-        if let name = connection.environmentName,
-           let environment = unchecked.first(where: { $0.name == name }) {
-            return [environment]
-        }
-
-        if let environment = unchecked.first(where: \.isActive) {
-            return [environment]
-        }
-
-        return []
     }
 
     private var environmentCountLabel: String? {
@@ -306,9 +280,31 @@ public struct SettingsView: View {
     }
 
     @MainActor
+    private func saveAppearance(_ appearance: FeatureAppearance) {
+        let previousSave = appearanceSaveTask
+        appearanceSaveTask = Task {
+            _ = await previousSave?.value
+
+            let didSave = await model.saveAppearance(appearance)
+            if !didSave {
+                settings.appearance = model.snapshot.settings.appearance
+                saveErrorMessage = model.errorMessage
+                    ?? "Theme preference could not be saved."
+            }
+            return didSave
+        }
+    }
+
+    @MainActor
     private func save() {
+        let pendingAppearanceSave = appearanceSaveTask
         isSaving = true
         Task {
+            if let pendingAppearanceSave, await pendingAppearanceSave.value == false {
+                isSaving = false
+                return
+            }
+
             let didSave = await model.saveSettings(settings)
             isSaving = false
             if didSave {

--- a/apps/swift-ios/Features/Settings/SettingsView.swift
+++ b/apps/swift-ios/Features/Settings/SettingsView.swift
@@ -15,26 +15,44 @@ public struct SettingsView: View {
 
     public var body: some View {
         NavigationStack {
-            VStack(spacing: 0) {
-                settingsHeader
-
-                Divider()
-                    .overlay(T3Colors.border)
-
-                ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 36) {
-                        connectionSection
-                        generalSection
-                        preferencesSection
-                        aboutSection
-                    }
-                    .padding(.top, 24)
-                    .padding(.bottom, 36)
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 36) {
+                    connectionSection
+                    generalSection
+                    preferencesSection
+                    aboutSection
                 }
-                .scrollDismissesKeyboard(.interactively)
+                .padding(.top, 24)
+                .padding(.bottom, 36)
             }
+            .scrollDismissesKeyboard(.interactively)
             .background(T3Colors.background)
-            .toolbar(.hidden, for: .navigationBar)
+            .navigationTitle("Settings")
+            .navigationBarTitleDisplayMode(.inline)
+            .t3NavigationChrome()
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") {
+                        if hasUnsavedChanges {
+                            showingDiscardConfirmation = true
+                        } else {
+                            dismiss()
+                        }
+                    }
+                    .disabled(isSaving)
+                    .accessibilityHint(
+                        hasUnsavedChanges
+                            ? "Asks before discarding unsaved changes"
+                            : "Closes settings"
+                    )
+                }
+
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(isSaving ? "Saving" : "Save", action: save)
+                        .disabled(!canSave)
+                        .accessibilityHint("Saves your preferences")
+                }
+            }
             .alert(
                 "Couldn’t save settings",
                 isPresented: Binding(
@@ -74,49 +92,6 @@ public struct SettingsView: View {
         .interactiveDismissDisabled(isSaving || hasUnsavedChanges)
         .presentationBackground(T3Colors.background)
         .presentationDragIndicator(.visible)
-    }
-
-    private var settingsHeader: some View {
-        HStack(spacing: 12) {
-            Button("Close") {
-                if hasUnsavedChanges {
-                    showingDiscardConfirmation = true
-                } else {
-                    dismiss()
-                }
-            }
-            .frame(width: 76, height: 44, alignment: .leading)
-            .foregroundStyle(T3Colors.accent)
-            .disabled(isSaving)
-            .accessibilityHint(
-                hasUnsavedChanges
-                    ? "Asks before discarding unsaved changes"
-                    : "Closes settings"
-            )
-
-            Spacer(minLength: 0)
-
-            Text("Settings")
-                .font(T3Typography.navigationTitle)
-                .foregroundStyle(T3Colors.textPrimary)
-                .accessibilityAddTraits(.isHeader)
-
-            Spacer(minLength: 0)
-
-            Button(isSaving ? "Saving" : "Save") {
-                save()
-            }
-            .fontWeight(.semibold)
-            .frame(width: 76, height: 44, alignment: .trailing)
-            .foregroundStyle(canSave ? T3Colors.accent : T3Colors.textTertiary)
-            .disabled(!canSave)
-            .accessibilityHint("Saves your preferences")
-        }
-        .font(T3Typography.control)
-        .lineLimit(1)
-        .minimumScaleFactor(0.8)
-        .padding(.horizontal, 20)
-        .frame(minHeight: 60)
     }
 
     private var connectionSection: some View {

--- a/apps/swift-ios/Features/Settings/SettingsView.swift
+++ b/apps/swift-ios/Features/Settings/SettingsView.swift
@@ -286,7 +286,7 @@ public struct SettingsView: View {
             _ = await previousSave?.value
 
             let didSave = await model.saveAppearance(appearance)
-            if !didSave {
+            if !didSave, settings.appearance == appearance {
                 settings.appearance = model.snapshot.settings.appearance
                 saveErrorMessage = model.errorMessage
                     ?? "Theme preference could not be saved."

--- a/apps/swift-ios/Features/Settings/SettingsView.swift
+++ b/apps/swift-ios/Features/Settings/SettingsView.swift
@@ -6,6 +6,7 @@ public struct SettingsView: View {
     @State private var settings: FeatureSettings
     @State private var isSaving = false
     @State private var saveErrorMessage: String?
+    @State private var showingDiscardConfirmation = false
 
     public init(model: FeatureRootModel) {
         self.model = model
@@ -21,13 +22,14 @@ public struct SettingsView: View {
                     .overlay(T3Colors.border)
 
                 ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 28) {
+                    LazyVStack(alignment: .leading, spacing: 36) {
                         connectionSection
                         generalSection
                         preferencesSection
                         aboutSection
                     }
-                    .padding(.vertical, 18)
+                    .padding(.top, 24)
+                    .padding(.bottom, 36)
                 }
                 .scrollDismissesKeyboard(.interactively)
             }
@@ -43,6 +45,14 @@ public struct SettingsView: View {
                 Button("OK") { saveErrorMessage = nil }
             } message: {
                 Text(saveErrorMessage ?? "Something went wrong.")
+            }
+            .confirmationDialog(
+                "Discard unsaved changes?",
+                isPresented: $showingDiscardConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button("Discard changes", role: .destructive) { dismiss() }
+                Button("Keep editing", role: .cancel) {}
             }
             .onAppear {
                 model.setConnectionManagementPresented(true)
@@ -61,62 +71,87 @@ public struct SettingsView: View {
                 }
             }
         }
+        .interactiveDismissDisabled(isSaving || hasUnsavedChanges)
+        .presentationBackground(T3Colors.background)
         .presentationDragIndicator(.visible)
     }
 
     private var settingsHeader: some View {
         HStack(spacing: 12) {
-            Button("Cancel") { dismiss() }
-                .frame(width: 72, alignment: .leading)
-                .foregroundStyle(T3Colors.accent)
+            Button("Close") {
+                if hasUnsavedChanges {
+                    showingDiscardConfirmation = true
+                } else {
+                    dismiss()
+                }
+            }
+            .frame(width: 76, height: 44, alignment: .leading)
+            .foregroundStyle(T3Colors.accent)
+            .disabled(isSaving)
+            .accessibilityHint(
+                hasUnsavedChanges
+                    ? "Asks before discarding unsaved changes"
+                    : "Closes settings"
+            )
 
             Spacer(minLength: 0)
 
             Text("Settings")
                 .font(T3Typography.navigationTitle)
                 .foregroundStyle(T3Colors.textPrimary)
+                .accessibilityAddTraits(.isHeader)
 
             Spacer(minLength: 0)
 
-            Button(isSaving ? "Saving…" : "Save") {
+            Button(isSaving ? "Saving" : "Save") {
                 save()
             }
             .fontWeight(.semibold)
-            .frame(width: 72, alignment: .trailing)
+            .frame(width: 76, height: 44, alignment: .trailing)
             .foregroundStyle(canSave ? T3Colors.accent : T3Colors.textTertiary)
             .disabled(!canSave)
+            .accessibilityHint("Saves your preferences")
         }
         .font(T3Typography.control)
+        .lineLimit(1)
+        .minimumScaleFactor(0.8)
         .padding(.horizontal, 20)
-        .frame(minHeight: 54)
+        .frame(minHeight: 60)
     }
 
     private var connectionSection: some View {
-        SettingsSection(title: "Environments") {
+        SettingsSection(title: "Connection") {
             NavigationLink {
                 ConnectionsView(model: model)
             } label: {
                 SettingsNavigationRow(
                     title: "Environments",
-                    systemImage: "server.rack"
+                    value: environmentCountLabel,
+                    subtitle: environmentSummary.text,
+                    systemImage: "server.rack",
+                    statusColor: environmentSummary.color
                 )
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("Environments")
+            .accessibilityValue(environmentAccessibilityValue)
+            .accessibilityHint("Manage saved environments")
         }
     }
 
     private var generalSection: some View {
-        SettingsSection(title: "General") {
+        SettingsSection(title: "Workspace") {
             VStack(spacing: 0) {
                 NavigationLink {
                     PullRequestsView(model: model)
                 } label: {
                     SettingsNavigationRow(
-                        title: "Pull Requests",
+                        title: "Pull requests",
                         systemImage: "arrow.triangle.pull"
                     )
                 }
                 .buttonStyle(.plain)
+                .accessibilityHint("Shows pull requests")
                 settingsDivider
                 NavigationLink {
                     UsageView(client: model.client)
@@ -127,10 +162,10 @@ public struct SettingsView: View {
                     )
                 }
                 .buttonStyle(.plain)
+                .accessibilityHint("Shows provider usage")
             }
         }
     }
-
 
     private var preferencesSection: some View {
         SettingsSection(title: "Preferences") {
@@ -139,6 +174,7 @@ public struct SettingsView: View {
                     SettingsRowIcon(systemName: "circle.lefthalf.filled")
                     Text("Theme")
                         .font(T3Typography.threadBody)
+                        .foregroundStyle(T3Colors.textPrimary)
                     Spacer(minLength: 12)
                     Picker("Theme", selection: $settings.appearance) {
                         Text("System").tag(FeatureAppearance.system)
@@ -148,9 +184,10 @@ public struct SettingsView: View {
                     .labelsHidden()
                     .pickerStyle(.menu)
                     .tint(T3Colors.textSecondary)
+                    .accessibilityLabel("Theme")
                 }
                 .padding(.horizontal, 20)
-                .frame(minHeight: 52)
+                .frame(minHeight: 56)
 
                 settingsDivider
                 SettingsToggleRow(
@@ -175,27 +212,16 @@ public struct SettingsView: View {
     }
 
     private var aboutSection: some View {
-        SettingsSection(title: "About") {
-            VStack(spacing: 0) {
-                SettingsValueRow(title: "App", value: appDisplayName)
-                settingsDivider
-                SettingsValueRow(title: "Platform", value: "Native SwiftUI")
-                settingsDivider
-                SettingsValueRow(title: "Version", value: appVersionLabel)
-                if let appCommit {
-                    settingsDivider
-                    SettingsValueRow(title: "Commit", value: appCommit)
-                }
-                settingsDivider
-                Link(destination: URL(string: "https://github.com/pingdotgg/t3code")!) {
-                    SettingsNavigationRow(
-                        title: "Open source",
-                        systemImage: "chevron.left.forwardslash.chevron.right",
-                        trailingSystemImage: "arrow.up.right"
-                    )
-                }
-                .buttonStyle(.plain)
+        SettingsSection(title: "About", footer: "Version \(appVersionLabel)") {
+            Link(destination: URL(string: "https://github.com/pingdotgg/t3code")!) {
+                SettingsNavigationRow(
+                    title: "Source code",
+                    systemImage: "chevron.left.forwardslash.chevron.right",
+                    trailingSystemImage: "arrow.up.right"
+                )
             }
+            .buttonStyle(.plain)
+            .accessibilityHint("Opens GitHub in your browser")
         }
     }
 
@@ -206,9 +232,86 @@ public struct SettingsView: View {
             .padding(.trailing, 20)
     }
 
-    private var appDisplayName: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
-            ?? "T3 Code SwiftUI"
+    private var environmentSummary: (text: String, color: Color) {
+        let environments = model.snapshot.environments
+        guard !environments.isEmpty else {
+            return ("Add an environment", T3Colors.textTertiary)
+        }
+
+        let connected = connectedEnvironments
+        if connected.count == 1, let environment = connected.first {
+            return ("\(environment.name) online", T3Colors.success)
+        }
+        if connected.count > 1 {
+            return ("\(connected.count) online", T3Colors.success)
+        }
+
+        let enabled = environments.filter(\.isEnabled)
+        guard !enabled.isEmpty else {
+            let text = environments.count == 1 ? "Off" : "All off"
+            return (text, T3Colors.textTertiary)
+        }
+
+        if let connecting = enabled.first(where: {
+            $0.connectionState == .connecting || $0.connectionState == .reconnecting
+        }) {
+            let state = connecting.connectionState == .reconnecting
+                ? "reconnecting"
+                : "connecting"
+            return ("\(connecting.name) \(state)", T3Colors.warning)
+        }
+
+        if let checking = enabled.first(where: { $0.connectionState == nil }) {
+            let text = enabled.count == 1
+                ? "\(checking.name) checking"
+                : "Checking environments"
+            return (text, T3Colors.textTertiary)
+        }
+
+        let text = enabled.count == 1 ? "\(enabled[0].name) offline" : "All offline"
+        return (text, T3Colors.danger)
+    }
+
+    private var connectedEnvironments: [FeatureEnvironment] {
+        let enabled = model.snapshot.environments.filter(\.isEnabled)
+        let connected = enabled.filter { $0.connectionState == .connected }
+        guard connected.isEmpty, model.snapshot.connection.state == .connected else {
+            return connected
+        }
+
+        let unchecked = enabled.filter { $0.connectionState == nil }
+        let connection = model.snapshot.connection
+        if let endpoint = connection.endpoint,
+           let environment = unchecked.first(where: { $0.endpoint == endpoint }) {
+            return [environment]
+        }
+
+        if let name = connection.environmentName,
+           let environment = unchecked.first(where: { $0.name == name }) {
+            return [environment]
+        }
+
+        if let environment = unchecked.first(where: \.isActive) {
+            return [environment]
+        }
+
+        return []
+    }
+
+    private var environmentCountLabel: String? {
+        let environments = model.snapshot.environments
+        guard !environments.isEmpty else { return nil }
+        return "\(connectedEnvironments.count)/\(environments.count)"
+    }
+
+    private var environmentAccessibilityValue: String {
+        let environmentCount = model.snapshot.environments.count
+        guard environmentCount > 0 else {
+            return environmentSummary.text
+        }
+
+        let connectedCount = connectedEnvironments.count
+        return "\(environmentSummary.text), \(connectedCount) of \(environmentCount) online"
     }
 
     private var appVersionLabel: String {
@@ -219,15 +322,12 @@ public struct SettingsView: View {
         return "\(version) (\(build))"
     }
 
-    private var appCommit: String? {
-        guard let commit = Bundle.main.object(forInfoDictionaryKey: "T3GitCommit") as? String,
-              commit.isEmpty == false,
-              commit.hasPrefix("$(") == false else { return nil }
-        return String(commit.prefix(8))
+    private var hasUnsavedChanges: Bool {
+        settings != model.snapshot.settings
     }
 
     private var canSave: Bool {
-        !isSaving && settings != model.snapshot.settings
+        !isSaving && hasUnsavedChanges
     }
 
     @MainActor
@@ -261,11 +361,12 @@ private struct SettingsSection<Content: View>: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 12) {
             Text(title)
-                .font(T3Typography.supportingStrong)
-                .foregroundStyle(T3Colors.textSecondary)
+                .font(T3Typography.navigationTitle)
+                .foregroundStyle(T3Colors.textPrimary)
                 .padding(.horizontal, 20)
+                .accessibilityAddTraits(.isHeader)
 
             content
 
@@ -274,7 +375,6 @@ private struct SettingsSection<Content: View>: View {
                     .font(T3Typography.supporting)
                     .foregroundStyle(T3Colors.textTertiary)
                     .padding(.horizontal, 20)
-                    .padding(.top, 2)
             }
         }
     }
@@ -282,7 +382,7 @@ private struct SettingsSection<Content: View>: View {
 
 private struct SettingsRowIcon: View {
     let systemName: String
-    var color: Color = T3Colors.accent
+    var color: Color = T3Colors.textSecondary
 
     var body: some View {
         Image(systemName: systemName)
@@ -296,21 +396,44 @@ private struct SettingsRowIcon: View {
 private struct SettingsNavigationRow: View {
     let title: String
     var value: String? = nil
+    var subtitle: String? = nil
     let systemImage: String
+    var statusColor: Color? = nil
     var trailingSystemImage = "chevron.right"
 
     var body: some View {
         HStack(spacing: 12) {
             SettingsRowIcon(systemName: systemImage)
-            Text(title)
-                .font(T3Typography.threadBody)
-                .foregroundStyle(T3Colors.textPrimary)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(T3Typography.threadBody)
+                    .foregroundStyle(T3Colors.textPrimary)
+
+                if let subtitle {
+                    HStack(spacing: 6) {
+                        if let statusColor {
+                            Circle()
+                                .fill(statusColor)
+                                .frame(width: 7, height: 7)
+                                .accessibilityHidden(true)
+                        }
+
+                        Text(subtitle)
+                            .font(T3Typography.supporting)
+                            .foregroundStyle(T3Colors.textSecondary)
+                            .lineLimit(1)
+                    }
+                }
+            }
+
             Spacer(minLength: 8)
             if let value {
                 Text(value)
                     .font(T3Typography.supporting)
                     .foregroundStyle(T3Colors.textSecondary)
                     .lineLimit(1)
+                    .layoutPriority(1)
             }
             Image(systemName: trailingSystemImage)
                 .font(T3Typography.supportingStrong)
@@ -318,51 +441,8 @@ private struct SettingsNavigationRow: View {
                 .accessibilityHidden(true)
         }
         .padding(.horizontal, 20)
-        .frame(minHeight: 52)
+        .frame(minHeight: subtitle == nil ? 56 : 68)
         .contentShape(Rectangle())
-    }
-}
-
-private struct SettingsActionRow: View {
-    let title: String
-    let systemImage: String
-    var color: Color = T3Colors.accent
-
-    var body: some View {
-        HStack(spacing: 12) {
-            SettingsRowIcon(systemName: systemImage, color: color)
-            Text(title)
-                .font(T3Typography.threadBody)
-                .foregroundStyle(color)
-            Spacer(minLength: 8)
-        }
-        .padding(.horizontal, 20)
-        .frame(minHeight: 52)
-        .contentShape(Rectangle())
-    }
-}
-
-private struct SettingsValueRow: View {
-    let title: String
-    let value: String
-    var systemImage: String? = nil
-
-    var body: some View {
-        HStack(spacing: 12) {
-            if let systemImage {
-                SettingsRowIcon(systemName: systemImage)
-            }
-            Text(title)
-                .font(T3Typography.threadBody)
-                .foregroundStyle(T3Colors.textPrimary)
-            Spacer(minLength: 12)
-            Text(value)
-                .font(T3Typography.threadBody)
-                .foregroundStyle(T3Colors.textSecondary)
-                .lineLimit(1)
-        }
-        .padding(.horizontal, 20)
-        .frame(minHeight: 52)
         .accessibilityElement(children: .combine)
     }
 }
@@ -383,15 +463,6 @@ private struct SettingsToggleRow: View {
         }
         .tint(T3Colors.accent)
         .padding(.horizontal, 20)
-        .frame(minHeight: 52)
-    }
-}
-
-private struct SettingsStatusLabelStyle: LabelStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        HStack(spacing: 4) {
-            configuration.icon
-            configuration.title
-        }
+        .frame(minHeight: 56)
     }
 }

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -264,15 +264,20 @@ struct HomeThreadCollectionView: UIViewRepresentable {
         }
 
         private func configureAccessibility(_ cell: HomeCollectionCell, item: HomeCollectionItem) {
+            cell.accessibilityCustomActions = nil
             switch item {
-            case let .thread(thread, context, _, _, _):
+            case let .thread(thread, context, _, isArchived, _):
                 cell.isAccessibilityElement = true
                 cell.accessibilityTraits = selectedThreadID == thread.id
                     ? [.button, .selected]
                     : .button
                 cell.accessibilityLabel = thread.title
                 cell.accessibilityValue = threadAccessibilityValue(thread, context: context)
-                cell.accessibilityHint = "Opens task"
+                cell.accessibilityHint = "Opens thread. More actions are available."
+                cell.accessibilityCustomActions = threadAccessibilityActions(
+                    for: thread,
+                    isArchived: isArchived
+                )
                 cell.onAccessibilityActivate = { [weak self] in
                     guard let self else { return }
                     let previousSelection = self.selectedThreadID
@@ -288,14 +293,14 @@ struct HomeThreadCollectionView: UIViewRepresentable {
             case let .shelfHeader(shelf, count, isExpanded):
                 cell.isAccessibilityElement = true
                 cell.accessibilityTraits = .button
-                cell.accessibilityLabel = "\(shelf.title), \(count) tasks"
+                cell.accessibilityLabel = "\(shelf.title), \(count) \(count == 1 ? "task" : "tasks")"
                 cell.accessibilityValue = isExpanded ? "Expanded" : "Collapsed"
-                cell.accessibilityHint = nil
+                cell.accessibilityHint = isExpanded ? "Collapses the task list" : "Expands the task list"
                 cell.onAccessibilityActivate = { [weak self] in self?.toggle(shelf) }
             case let .showMoreSettled(remaining):
                 cell.isAccessibilityElement = true
                 cell.accessibilityTraits = .button
-                cell.accessibilityLabel = "Show \(remaining) more settled tasks"
+                cell.accessibilityLabel = "Show \(remaining) more settled \(remaining == 1 ? "task" : "tasks")"
                 cell.accessibilityValue = nil
                 cell.accessibilityHint = nil
                 cell.onAccessibilityActivate = { [weak self] in
@@ -325,15 +330,102 @@ struct HomeThreadCollectionView: UIViewRepresentable {
             _ thread: FeatureThread,
             context: HomeThreadRowContext
         ) -> String {
-            var values = [thread.homeStatusLabel ?? "Ready", "Project \(context.projectName)"]
-            values.append("Harness \(context.providerName)")
+            var status = thread.homeStatusLabel ?? "Ready"
             if let duration = thread.homeWorkingDuration(at: .now) {
-                values.append("for \(duration)")
+                status += " for \(duration)"
             }
+            var values = [status, "Project \(context.projectName)"]
+            if thread.pinnedAt != nil {
+                values.append("Pinned")
+            }
+            if thread.isArchived {
+                values.append("Archived")
+            } else if thread.isEffectivelySnoozed(at: .now) {
+                values.append("Snoozed")
+            } else if thread.isEffectivelySettled(at: .now) {
+                values.append("Settled")
+            }
+            values.append("Provider \(context.providerName)")
             if let environment = context.environmentLabel {
                 values.append("on \(environment)")
             }
             return values.joined(separator: ". ")
+        }
+
+        private func threadAccessibilityActions(
+            for thread: FeatureThread,
+            isArchived: Bool
+        ) -> [UIAccessibilityCustomAction] {
+            var actions = [accessibilityAction("Rename", systemImage: "pencil") { coordinator in
+                coordinator.parent.onRename(thread)
+            }]
+
+            if thread.supportsTitleRegeneration == true {
+                actions.append(accessibilityAction("Regenerate title", systemImage: "sparkles") { coordinator in
+                    coordinator.parent.onRegenerateTitle(thread)
+                })
+            }
+
+            if !isArchived {
+                if thread.canTogglePin {
+                    let isPinned = thread.pinnedAt != nil
+                    actions.append(accessibilityAction(
+                        isPinned ? "Unpin" : "Pin",
+                        systemImage: isPinned ? "pin.slash" : "pin"
+                    ) { coordinator in
+                        coordinator.parent.onPin(thread, !isPinned)
+                    })
+                }
+
+                if thread.canToggleSettlement {
+                    let isSettled = thread.isEffectivelySettled(at: .now)
+                    actions.append(accessibilityAction(
+                        isSettled ? "Reopen" : "Settle",
+                        systemImage: isSettled ? "arrow.counterclockwise" : "checkmark"
+                    ) { coordinator in
+                        coordinator.parent.onSettle(thread, !isSettled)
+                    })
+                }
+
+                if thread.canToggleSnooze {
+                    if thread.isEffectivelySnoozed(at: .now) {
+                        actions.append(accessibilityAction("Wake", systemImage: "bell") { coordinator in
+                            coordinator.parent.onSnooze(thread, nil)
+                        })
+                    } else if thread.state != .queued,
+                              thread.state != .waitingForApproval,
+                              thread.state != .waitingForInput {
+                        actions.append(contentsOf: DailyUXSnoozePresets.resolve(now: .now).map { preset in
+                            accessibilityAction("Snooze: \(preset.label)", systemImage: "clock") { coordinator in
+                                coordinator.parent.onSnooze(thread, preset.until)
+                            }
+                        })
+                    }
+                }
+            }
+
+            actions.append(accessibilityAction(
+                isArchived ? "Restore" : "Archive",
+                systemImage: isArchived ? "arrow.uturn.backward" : "archivebox"
+            ) { coordinator in
+                coordinator.parent.onArchive(thread, !isArchived)
+            })
+            actions.append(accessibilityAction("Delete thread", systemImage: "trash") { coordinator in
+                coordinator.parent.onDelete(thread)
+            })
+            return actions
+        }
+
+        private func accessibilityAction(
+            _ title: String,
+            systemImage: String,
+            perform: @escaping (Coordinator) -> Void
+        ) -> UIAccessibilityCustomAction {
+            UIAccessibilityCustomAction(name: title, image: UIImage(systemName: systemImage)) { [weak self] _ in
+                guard let self else { return false }
+                perform(self)
+                return true
+            }
         }
 
         private func synchronizeSelection(in collectionView: UICollectionView) {
@@ -379,16 +471,10 @@ struct HomeThreadCollectionView: UIViewRepresentable {
             let rename = UIAction(title: "Rename", image: UIImage(systemName: "pencil")) { [weak self] _ in
                 self?.parent.onRename(thread)
             }
-            let archive = UIAction(
-                title: isArchived ? "Restore" : "Archive",
-                image: UIImage(systemName: isArchived ? "arrow.uturn.backward" : "archivebox")
-            ) { [weak self] _ in
-                self?.parent.onArchive(thread, !isArchived)
-            }
 
-            var actions: [UIMenuElement] = [rename]
+            var titleActions: [UIMenuElement] = [rename]
             if thread.supportsTitleRegeneration == true {
-                actions.append(
+                titleActions.append(
                     UIAction(
                         title: "Regenerate title",
                         image: UIImage(systemName: "sparkles")
@@ -397,11 +483,12 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                     }
                 )
             }
-            actions.append(archive)
+
+            var statusActions: [UIMenuElement] = []
             if !isArchived {
                 if thread.canTogglePin {
                     let isPinned = thread.pinnedAt != nil
-                    actions.append(
+                    statusActions.append(
                         UIAction(
                             title: isPinned ? "Unpin" : "Pin",
                             image: UIImage(systemName: isPinned ? "pin.slash" : "pin")
@@ -412,7 +499,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 }
                 if thread.canToggleSettlement {
                     let isSettled = thread.isEffectivelySettled(at: .now)
-                    actions.append(
+                    statusActions.append(
                         UIAction(
                             title: isSettled ? "Reopen" : "Settle",
                             image: UIImage(
@@ -427,8 +514,8 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 if thread.canToggleSnooze {
                     let isSnoozed = thread.isEffectivelySnoozed(at: .now)
                     if isSnoozed {
-                        actions.append(
-                            UIAction(title: "Wake thread", image: UIImage(systemName: "bell")) {
+                        statusActions.append(
+                            UIAction(title: "Wake", image: UIImage(systemName: "bell")) {
                                 [weak self] _ in
                                 self?.parent.onSnooze(thread, nil)
                             }
@@ -451,18 +538,32 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                             image: UIImage(systemName: "clock"),
                             children: children
                         )
-                        actions.append(snooze)
+                        statusActions.append(snooze)
                     }
                 }
             }
 
-            actions.append(
-                UIAction(title: "Delete", image: UIImage(systemName: "trash"), attributes: .destructive) {
-                    [weak self] _ in
-                    self?.parent.onDelete(thread)
-                }
-            )
-            return actions
+            let archive = UIAction(
+                title: isArchived ? "Restore" : "Archive",
+                image: UIImage(systemName: isArchived ? "arrow.uturn.backward" : "archivebox")
+            ) { [weak self] _ in
+                self?.parent.onArchive(thread, !isArchived)
+            }
+            let delete = UIAction(
+                title: "Delete thread",
+                image: UIImage(systemName: "trash"),
+                attributes: .destructive
+            ) { [weak self] _ in
+                self?.parent.onDelete(thread)
+            }
+
+            var sections = [UIMenu(options: .displayInline, children: titleActions)]
+            if !statusActions.isEmpty {
+                sections.append(UIMenu(options: .displayInline, children: statusActions))
+            }
+            sections.append(UIMenu(options: .displayInline, children: [archive]))
+            sections.append(UIMenu(options: .displayInline, children: [delete]))
+            return sections
         }
 
         /// Working rows show a live per-second duration, so they need a 1 Hz
@@ -550,11 +651,10 @@ struct HomeThreadCollectionView: UIViewRepresentable {
             })
         }
 
-        items.append(.shelfHeader(.snoozed, presentation.snoozed.count, isSnoozedExpanded))
-        if isSnoozedExpanded {
-            items.append(contentsOf: presentation.snoozed.isEmpty
-                ? [.empty(.snoozed)]
-                : presentation.snoozed.map {
+        if !presentation.snoozed.isEmpty {
+            items.append(.shelfHeader(.snoozed, presentation.snoozed.count, isSnoozedExpanded))
+            if isSnoozedExpanded {
+                items.append(contentsOf: presentation.snoozed.map {
                     .thread(
                         $0,
                         presentation.rowContexts[$0.id] ?? .fallback,
@@ -563,21 +663,24 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                         forceRichRows
                     )
                 })
+            }
         }
 
-        items.append(.shelfHeader(.settled, presentation.settled.count, isSettledExpanded))
-        if isSettledExpanded {
-            items.append(contentsOf: presentation.settled.prefix(settledLimit).map {
-                .thread(
-                    $0,
-                    presentation.rowContexts[$0.id] ?? .fallback,
-                    forceRichRows ? .rich : .slim,
-                    false,
-                    forceRichRows
-                )
-            })
-            if presentation.settled.count > settledLimit {
-                items.append(.showMoreSettled(presentation.settled.count - settledLimit))
+        if !presentation.settled.isEmpty {
+            items.append(.shelfHeader(.settled, presentation.settled.count, isSettledExpanded))
+            if isSettledExpanded {
+                items.append(contentsOf: presentation.settled.prefix(settledLimit).map {
+                    .thread(
+                        $0,
+                        presentation.rowContexts[$0.id] ?? .fallback,
+                        forceRichRows ? .rich : .slim,
+                        false,
+                        forceRichRows
+                    )
+                })
+                if presentation.settled.count > settledLimit {
+                    items.append(.showMoreSettled(presentation.settled.count - settledLimit))
+                }
             }
         }
 

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -578,12 +578,6 @@ public struct NewThreadView: View {
         guard selectedProject != nil else { return "Choose a project." }
         if let selectedEnvironment {
             guard selectedEnvironment.isEnabled else { return "Environment is off." }
-            switch selectedEnvironment.connectionState {
-            case .disconnected: return "Environment is offline."
-            case .connecting: return "Environment is connecting."
-            case .reconnecting: return "Environment is reconnecting."
-            case .connected, .none: break
-            }
         }
         guard restoredDraftProjectID == projectID else { return "Project is loading." }
         guard concreteSelection != nil else {

--- a/apps/swift-ios/Features/Workspace/NewThreadView.swift
+++ b/apps/swift-ios/Features/Workspace/NewThreadView.swift
@@ -27,11 +27,13 @@ public struct NewThreadView: View {
     @State private var activePicker: NewTaskPicker?
     @State private var isSubmitting = false
     @State private var submissionFailed = false
+    @State private var submissionValidationError: String?
     @State private var restoredDraftProjectID: String?
     @State private var draftRestoreContext: NewTaskDraftRestoreContext?
     @State private var draftSaveTask: Task<Void, Never>?
     @State private var immediateDraftSaveTasks: [String: Task<Void, Never>] = [:]
     @State private var submittedSuccessfully = false
+    @State private var restoresPromptAfterPickerDismissal = false
     // Plain state, not `FocusState`; see the note on `composerFocused` in
     // ThreadDetailView.
     @State private var promptFocused = false
@@ -71,6 +73,16 @@ public struct NewThreadView: View {
         .safeAreaInset(edge: .bottom, spacing: 0) {
             if !creationProjects.isEmpty {
                 VStack(spacing: 0) {
+                    if let submissionValidationError {
+                        Label(submissionValidationError, systemImage: "exclamationmark.circle")
+                            .font(T3Typography.supporting)
+                            .foregroundStyle(T3Colors.danger)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, 18)
+                            .padding(.vertical, 6)
+                            .accessibilityElement(children: .combine)
+                    }
+
                     workspaceControls
 
                     FeatureComposerView(
@@ -139,12 +151,21 @@ public struct NewThreadView: View {
         .onChange(of: workspaceMode) { scheduleDraftSave() }
         .onChange(of: selectedBranch) { scheduleDraftSave() }
         .onChange(of: startFromOrigin) { scheduleDraftSave() }
+        .onChange(of: submissionValidationMessage) { _, _ in
+            submissionValidationError = nil
+        }
         .task(id: projectID) { await restoreDraftAndLoadBranches() }
         .onDisappear {
             guard !submittedSuccessfully else { return }
             persistCurrentDraftImmediately()
         }
-        .sheet(item: $activePicker) { picker in
+        .sheet(item: $activePicker, onDismiss: {
+            let shouldRestorePrompt = restoresPromptAfterPickerDismissal
+            restoresPromptAfterPickerDismissal = false
+            if shouldRestorePrompt, !creationProjects.isEmpty, !isSubmitting {
+                promptFocused = true
+            }
+        }) { picker in
             switch picker {
             case .project:
                 NewTaskProjectPicker(
@@ -190,7 +211,9 @@ public struct NewThreadView: View {
             Button("Cancel") { dismiss() }
                 .font(.body)
                 .foregroundStyle(T3Colors.textSecondary)
+                .frame(minHeight: 44)
                 .disabled(isSubmitting)
+                .accessibilityLabel("Cancel new task")
             Spacer()
         }
         .padding(.horizontal, 16)
@@ -198,50 +221,57 @@ public struct NewThreadView: View {
     }
 
     private var hero: some View {
-        VStack(spacing: 10) {
-            Text("What should we build")
-            HStack(spacing: 0) {
-                Text("in")
-                Button {
-                    activePicker = .project
-                } label: {
-                    Text(selectedProjectGroup?.name ?? selectedProject?.name ?? "a project")
-                        .foregroundStyle(T3Colors.textPrimary)
-                        .overlay(alignment: .bottom) {
-                            DottedUnderline()
-                                .stroke(
-                                    T3Colors.textPrimary.opacity(0.58),
-                                    style: StrokeStyle(lineWidth: 1, dash: [2, 3])
-                                )
-                                .frame(height: 1)
-                                .offset(y: 3)
-                        }
+        VStack(spacing: 8) {
+            VStack(spacing: 4) {
+                Text("What should we build")
+
+                HStack(spacing: 0) {
+                    Text("in")
+
+                    Button {
+                        presentPicker(.project)
+                    } label: {
+                        Text(selectedProjectGroup?.name ?? selectedProject?.name ?? "a project")
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                            .foregroundStyle(T3Colors.textPrimary)
+                            .overlay(alignment: .bottom) {
+                                DottedUnderline()
+                                    .stroke(
+                                        T3Colors.textPrimary.opacity(0.58),
+                                        style: StrokeStyle(lineWidth: 1, dash: [2, 3])
+                                    )
+                                    .frame(height: 1)
+                                    .offset(y: 3)
+                            }
+                            .frame(minHeight: 44)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(isSubmitting)
+                    .padding(.leading, 5)
+                    .layoutPriority(1)
+                    .accessibilityLabel("Choose project")
+                    .accessibilityValue(
+                        selectedProjectGroup?.name ?? selectedProject?.name ?? "Not selected"
+                    )
+
+                    Text("?")
                 }
-                .buttonStyle(.plain)
-                .disabled(isSubmitting)
-                .padding(.leading, 5)
-                .accessibilityLabel("Choose project")
-                .accessibilityValue(
-                    selectedProjectGroup?.name ?? selectedProject?.name ?? "a project"
-                )
-                Text("?")
             }
-        }
-        .font(T3Typography.threadHeading1.weight(.regular))
-        .tracking(-0.35)
-        .foregroundStyle(T3Colors.textPrimary)
-        .multilineTextAlignment(.center)
-        .frame(maxWidth: .infinity)
-        .overlay(alignment: .bottom) {
+            .font(T3Typography.threadHeading1.weight(.regular))
+            .foregroundStyle(T3Colors.textPrimary)
+            .multilineTextAlignment(.center)
+
             Menu {
                 ForEach(creationEnvironments) { environment in
                     Button {
                         selectEnvironment(environment.id)
                     } label: {
                         if environment.id == selectedProject?.environmentID {
-                            Label(environment.name, systemImage: "checkmark")
+                            Label(environmentLabel(environment), systemImage: "checkmark")
                         } else {
-                            Text(environment.name)
+                            Text(environmentLabel(environment))
                         }
                     }
                 }
@@ -249,22 +279,30 @@ public struct NewThreadView: View {
                 HStack(spacing: 6) {
                     Image(systemName: "server.rack")
                         .font(.system(size: 11, weight: .medium))
-                    Text("on \(environmentName)")
+                    Text(environmentName)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    if let environmentStatus {
+                        Text(environmentStatus)
+                            .foregroundStyle(T3Colors.warning)
+                    }
                     if creationEnvironments.count > 1 {
                         Image(systemName: "chevron.down")
                             .font(.system(size: 8, weight: .bold))
                     }
                 }
                 .font(T3Typography.supporting)
-                .foregroundStyle(T3Colors.textTertiary)
+                .foregroundStyle(T3Colors.textSecondary)
+                .frame(minHeight: 44)
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .disabled(isSubmitting || creationEnvironments.count < 2)
-            .accessibilityLabel("Computer")
-            .accessibilityValue(environmentName)
-            .offset(y: 31)
+            .accessibilityLabel("Environment")
+            .accessibilityValue(environmentAccessibilityValue)
         }
+        .padding(.horizontal, 24)
+        .frame(maxWidth: .infinity)
         .accessibilityElement(children: .contain)
     }
 
@@ -273,14 +311,10 @@ public struct NewThreadView: View {
             Image(systemName: "folder.badge.plus")
                 .font(.system(size: 28, weight: .regular))
                 .foregroundStyle(T3Colors.textSecondary)
-            Text("Create a project first")
+            Text("No projects")
                 .font(T3Typography.threadHeading1.weight(.regular))
                 .foregroundStyle(T3Colors.textPrimary)
-            Text("Tasks need a workspace on one of your connected environments.")
-                .font(T3Typography.threadBody)
-                .foregroundStyle(T3Colors.textSecondary)
-                .multilineTextAlignment(.center)
-            Button("Create project") {
+            Button("Add project") {
                 dismiss()
                 Task { @MainActor in
                     await Task.yield()
@@ -288,6 +322,7 @@ public struct NewThreadView: View {
                 }
             }
             .buttonStyle(.borderedProminent)
+            .controlSize(.large)
             .tint(T3Colors.primaryAction)
             .foregroundStyle(T3Colors.primaryActionForeground)
             .padding(.top, 6)
@@ -313,79 +348,84 @@ public struct NewThreadView: View {
     }
 
     private var workspaceControls: some View {
-        HStack(spacing: 14) {
-            Menu {
-                Button {
-                    setWorkspaceMode(.local)
-                } label: {
-                    Label(
-                        FeatureWorkspaceMode.local.title,
-                        systemImage: workspaceMode == .local ? "checkmark" : "folder"
-                    )
-                }
-                Button {
-                    setWorkspaceMode(.worktree)
-                } label: {
-                    Label(
-                        FeatureWorkspaceMode.worktree.title,
-                        systemImage: workspaceMode == .worktree
-                            ? "checkmark"
-                            : "arrow.triangle.branch"
-                    )
-                }
-            } label: {
-                workspaceControlLabel(
-                    workspaceMode.title,
-                    systemImage: workspaceMode.systemImage,
-                    showsChevron: true
-                )
-            }
-            .disabled(isSubmitting)
-
-            if workspaceMode == .worktree {
-                Button {
-                    activePicker = .branch
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 14) {
+                Menu {
+                    Button {
+                        setWorkspaceMode(.local)
+                    } label: {
+                        Label(
+                            FeatureWorkspaceMode.local.title,
+                            systemImage: workspaceMode == .local ? "checkmark" : "folder"
+                        )
+                    }
+                    Button {
+                        setWorkspaceMode(.worktree)
+                    } label: {
+                        Label(
+                            FeatureWorkspaceMode.worktree.title,
+                            systemImage: workspaceMode == .worktree
+                                ? "checkmark"
+                                : "arrow.triangle.branch"
+                        )
+                    }
                 } label: {
                     workspaceControlLabel(
-                        selectedBranch?.name
-                            ?? (branchesLoading ? "Loading branches" : "Choose branch"),
-                        systemImage: "arrow.triangle.branch",
+                        workspaceMode.title,
+                        systemImage: workspaceMode.systemImage,
                         showsChevron: true
                     )
                 }
-                .buttonStyle(.plain)
                 .disabled(isSubmitting)
-                .accessibilityLabel("Base branch")
-                .accessibilityValue(selectedBranch?.name ?? "Not selected")
+                .accessibilityLabel("Workspace")
+                .accessibilityValue(workspaceMode.title)
 
-                Button {
-                    workspaceSelectionIsExplicit = true
-                    startFromOrigin.toggle()
-                } label: {
-                    Label(
-                        "Latest origin",
-                        systemImage: startFromOrigin ? "checkmark.circle.fill" : "circle"
+                if workspaceMode == .worktree {
+                    Button {
+                        presentPicker(.branch)
+                    } label: {
+                        workspaceControlLabel(
+                            selectedBranch?.name
+                                ?? (branchesLoading ? "Loading branches" : "Choose branch"),
+                            systemImage: "arrow.triangle.branch",
+                            showsChevron: true
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(isSubmitting)
+                    .accessibilityLabel("Base branch")
+                    .accessibilityValue(selectedBranch?.name ?? "Not selected")
+
+                    Button {
+                        workspaceSelectionIsExplicit = true
+                        startFromOrigin.toggle()
+                    } label: {
+                        Label(
+                            "Latest origin",
+                            systemImage: startFromOrigin ? "checkmark.circle.fill" : "circle"
+                        )
+                        .lineLimit(1)
+                        .frame(minHeight: 44)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(
+                        startFromOrigin ? T3Colors.textSecondary : T3Colors.textTertiary
                     )
-                    .lineLimit(1)
+                    .disabled(isSubmitting)
+                    .accessibilityLabel("Start from latest origin")
+                    .accessibilityValue(startFromOrigin ? "On" : "Off")
+                } else if let selectedBranch {
+                    Label(selectedBranch.name, systemImage: "arrow.triangle.branch")
+                        .lineLimit(1)
+                        .foregroundStyle(T3Colors.textTertiary)
+                        .accessibilityLabel("Current branch, \(selectedBranch.name)")
                 }
-                .buttonStyle(.plain)
-                .foregroundStyle(
-                    startFromOrigin ? T3Colors.textSecondary : T3Colors.textTertiary
-                )
-                .disabled(isSubmitting)
-                .accessibilityValue(startFromOrigin ? "On" : "Off")
-            } else if let selectedBranch {
-                Label(selectedBranch.name, systemImage: "arrow.triangle.branch")
-                    .lineLimit(1)
-                    .foregroundStyle(T3Colors.textTertiary)
-                    .accessibilityLabel("Current branch, \(selectedBranch.name)")
             }
-
-            Spacer(minLength: 0)
+            .padding(.horizontal, 18)
         }
         .font(T3Typography.supporting)
-        .padding(.horizontal, 18)
-        .frame(minHeight: 38)
+        .frame(minHeight: 44)
         .animation(.snappy(duration: 0.18), value: workspaceMode)
     }
 
@@ -405,6 +445,7 @@ public struct NewThreadView: View {
             }
         }
         .foregroundStyle(T3Colors.textSecondary)
+        .frame(minHeight: 44)
         .contentShape(Rectangle())
     }
 
@@ -421,12 +462,39 @@ public struct NewThreadView: View {
         return model.snapshot.environments.filter { environmentIDs.contains($0.id) }
     }
 
+    private var selectedEnvironment: FeatureEnvironment? {
+        guard let environmentID = selectedProject?.environmentID else { return nil }
+        return model.snapshot.environments.first { $0.id == environmentID }
+    }
+
     private var environmentName: String {
-        if let environmentID = selectedProject?.environmentID,
-           let environment = model.snapshot.environments.first(where: { $0.id == environmentID }) {
-            return environment.name
-        }
+        if let selectedEnvironment { return selectedEnvironment.name }
         return model.snapshot.connection.environmentName ?? "this server"
+    }
+
+    private var environmentStatus: String? {
+        guard let selectedEnvironment else { return nil }
+        return environmentStatus(selectedEnvironment)
+    }
+
+    private var environmentAccessibilityValue: String {
+        guard let environmentStatus else { return environmentName }
+        return "\(environmentName), \(environmentStatus)"
+    }
+
+    private func environmentLabel(_ environment: FeatureEnvironment) -> String {
+        guard let status = environmentStatus(environment) else { return environment.name }
+        return "\(environment.name) · \(status)"
+    }
+
+    private func environmentStatus(_ environment: FeatureEnvironment) -> String? {
+        guard environment.isEnabled else { return "Off" }
+        switch environment.connectionState {
+        case .disconnected: return "Offline"
+        case .connecting: return "Connecting"
+        case .reconnecting: return "Reconnecting"
+        case .connected, .none: return nil
+        }
     }
 
     private var initialSelection: FeatureSelection? {
@@ -450,8 +518,11 @@ public struct NewThreadView: View {
         Binding(
             get: { selection },
             set: { value in
-                selectionIsExplicit = true
+                let materializesProjectDefault = !selectionIsExplicit
+                    && value == initialSelection
                 selection = value
+                guard !materializesProjectDefault else { return }
+                selectionIsExplicit = true
                 preferredSelection = value
             }
         )
@@ -500,13 +571,43 @@ public struct NewThreadView: View {
     }
 
     private var canSubmit: Bool {
-        !isSubmitting
-            && selectedProject != nil
-            && restoredDraftProjectID == projectID
-            && concreteSelection != nil
-            && (!trimmedPrompt.isEmpty || !attachments.isEmpty)
-            && (attachments.isEmpty || imagesAllowed)
-            && (workspaceMode != .worktree || selectedBranch != nil)
+        !isSubmitting && submissionValidationMessage == nil
+    }
+
+    private var submissionValidationMessage: String? {
+        guard selectedProject != nil else { return "Choose a project." }
+        if let selectedEnvironment {
+            guard selectedEnvironment.isEnabled else { return "Environment is off." }
+            switch selectedEnvironment.connectionState {
+            case .disconnected: return "Environment is offline."
+            case .connecting: return "Environment is connecting."
+            case .reconnecting: return "Environment is reconnecting."
+            case .connected, .none: break
+            }
+        }
+        guard restoredDraftProjectID == projectID else { return "Project is loading." }
+        guard concreteSelection != nil else {
+            guard !creationProviders.isEmpty else { return "No providers available." }
+            guard creationProviders.contains(where: \.isAvailable) else {
+                return "No providers are online."
+            }
+            guard creationProviders.contains(where: { $0.isAvailable && !$0.models.isEmpty })
+            else {
+                return "No models available."
+            }
+            return "Choose a model."
+        }
+        guard !trimmedPrompt.isEmpty || !attachments.isEmpty else {
+            return "Add a message or image."
+        }
+        guard attachments.isEmpty || imagesAllowed else {
+            return "This model does not support images."
+        }
+        guard workspaceMode != .worktree || selectedBranch != nil else {
+            if branchesLoading { return "Branches are loading." }
+            return branchLoadFailed ? "Could not load branches." : "Choose a base branch."
+        }
+        return nil
     }
 
     private var trimmedPrompt: String {
@@ -521,15 +622,31 @@ public struct NewThreadView: View {
     }
 
     private var concreteSelection: FeatureSelection? {
-        ProviderModelSelectionResolver.materialized(selection, in: creationProviders)
+        guard creationProviders.contains(where: { $0.isAvailable && !$0.models.isEmpty }) else {
+            return nil
+        }
+        return ProviderModelSelectionResolver.materialized(selection, in: creationProviders)
+    }
+
+    private func presentPicker(_ picker: NewTaskPicker) {
+        restoresPromptAfterPickerDismissal = promptFocused
+        promptFocused = false
+        activePicker = picker
     }
 
     private func startTask() {
+        guard !isSubmitting else { return }
         guard canSubmit,
               let project = selectedProject,
               let concreteSelection else {
+            submissionValidationError = submissionValidationMessage
+            if submissionValidationError == "Choose a base branch."
+                || submissionValidationError == "Could not load branches." {
+                presentPicker(.branch)
+            }
             return
         }
+        submissionValidationError = nil
         promptFocused = false
         isSubmitting = true
         let pendingDraftSaveTask = draftSaveTask
@@ -966,6 +1083,31 @@ private enum NewTaskPicker: String, Identifiable {
     var id: String { rawValue }
 }
 
+enum NewTaskProjectPickerSearch {
+    static func matching(
+        _ groups: [DailyUXProjectGroup],
+        query: String,
+        environments: [FeatureEnvironment]
+    ) -> [DailyUXProjectGroup] {
+        let query = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return groups }
+
+        let environmentNames = Dictionary(
+            environments.map { ($0.id, $0.name) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        return groups.filter { group in
+            group.name.localizedCaseInsensitiveContains(query)
+                || group.projects.contains { project in
+                    project.path.localizedCaseInsensitiveContains(query)
+                        || environmentNames[project.environmentID]?
+                            .localizedCaseInsensitiveContains(query) == true
+                }
+        }
+    }
+}
+
 private struct NewTaskProjectPicker: View {
     @SwiftUI.Environment(\.dismiss) private var dismiss
     let groups: [DailyUXProjectGroup]
@@ -974,18 +1116,24 @@ private struct NewTaskProjectPicker: View {
     let selectionID: String?
     let onSelect: (DailyUXProjectGroup) -> Void
 
+    @State private var query = ""
+
     var body: some View {
         NavigationStack {
             Group {
                 if groups.isEmpty {
                     ContentUnavailableView(
-                        "No projects available",
-                        systemImage: "folder",
-                        description: Text("Reconnect an environment or add a project to continue.")
+                        "No projects",
+                        systemImage: "folder"
+                    )
+                } else if filteredGroups.isEmpty {
+                    ContentUnavailableView(
+                        "No matching projects",
+                        systemImage: "magnifyingglass"
                     )
                 } else {
                     let sections = DailyUXProjectPickerSections(
-                        groups: groups,
+                        groups: filteredGroups,
                         recentGroupIDs: recentGroupIDs
                     )
                     List {
@@ -1011,11 +1159,13 @@ private struct NewTaskProjectPicker: View {
                     }
                     .listStyle(.plain)
                     .scrollContentBackground(.hidden)
+                    .scrollDismissesKeyboard(.interactively)
                 }
             }
             .background(T3Colors.background)
             .navigationTitle("Project")
             .navigationBarTitleDisplayMode(.inline)
+            .searchable(text: $query, prompt: "Search projects")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
@@ -1035,19 +1185,11 @@ private struct NewTaskProjectPicker: View {
                     Text(group.name)
                         .foregroundStyle(T3Colors.textPrimary)
 
-                    ForEach(group.projects.prefix(2)) { project in
-                        Text(projectLocation(project))
-                            .font(T3Typography.supporting)
-                            .foregroundStyle(T3Colors.textTertiary)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                    }
-
-                    if group.projects.count > 2 {
-                        Text("+\(group.projects.count - 2) more locations")
-                            .font(T3Typography.supporting)
-                            .foregroundStyle(T3Colors.textTertiary)
-                    }
+                    Text(projectLocation(group))
+                        .font(T3Typography.supporting)
+                        .foregroundStyle(T3Colors.textTertiary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
                 }
 
                 Spacer(minLength: 10)
@@ -1062,16 +1204,36 @@ private struct NewTaskProjectPicker: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(group.name)
+        .accessibilityValue(projectLocation(group))
         .accessibilityAddTraits(
             group.id == selectionID ? .isSelected : []
         )
         .listRowBackground(T3Colors.background)
     }
 
-    private func projectLocation(_ project: FeatureProject) -> String {
-        let environment = environments.first { $0.id == project.environmentID }?.name
-            ?? project.environmentID
-        return "\(environment) · \(project.path)"
+    private var filteredGroups: [DailyUXProjectGroup] {
+        NewTaskProjectPickerSearch.matching(
+            groups,
+            query: query,
+            environments: environments
+        )
+    }
+
+    private func projectLocation(_ group: DailyUXProjectGroup) -> String {
+        guard let firstProject = group.projects.first else { return "" }
+
+        var seenEnvironmentIDs = Set<String>()
+        let allNames = group.projects.compactMap { project -> String? in
+            guard seenEnvironmentIDs.insert(project.environmentID).inserted else { return nil }
+            return environments.first { $0.id == project.environmentID }?.name
+                ?? project.environmentID
+        }
+        let names = Array(allNames.prefix(2))
+        let additionalCount = allNames.count - names.count
+        let additionalLocations = additionalCount > 0 ? " +\(additionalCount)" : ""
+
+        return "\(names.joined(separator: ", "))\(additionalLocations) · \(firstProject.path)"
     }
 }
 
@@ -1097,17 +1259,17 @@ private struct NewTaskBranchPicker: View {
                 } else if filteredBranches.isEmpty {
                     ContentUnavailableView {
                         Label(
-                            loadFailed ? "Branches unavailable" : "No branches found",
+                            loadFailed
+                                ? "Could not load branches"
+                                : query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                                    ? "No branches available"
+                                    : "No matching branches",
                             systemImage: loadFailed
                                 ? "exclamationmark.triangle"
                                 : "arrow.triangle.branch"
                         )
                     } description: {
-                        Text(
-                            loadFailed
-                                ? "Check the connection and try again."
-                                : "Try a different search."
-                        )
+                        EmptyView()
                     } actions: {
                         if loadFailed {
                             Button("Try again", action: onRefresh)
@@ -1140,12 +1302,21 @@ private struct NewTaskBranchPicker: View {
                                         .foregroundStyle(T3Colors.accent)
                                 }
                             }
-                            .frame(minHeight: 34)
+                            .frame(minHeight: 44)
+                            .contentShape(Rectangle())
                         }
                         .buttonStyle(.plain)
+                        .accessibilityLabel(
+                            branch.badge.map { "\(branch.name), \($0)" } ?? branch.name
+                        )
+                        .accessibilityAddTraits(
+                            branch.id == selection?.id ? .isSelected : []
+                        )
                         .listRowBackground(T3Colors.background)
                     }
                     .listStyle(.plain)
+                    .scrollContentBackground(.hidden)
+                    .scrollDismissesKeyboard(.interactively)
                     .refreshable { onRefresh() }
                 }
             }

--- a/apps/swift-ios/Features/Workspace/ProviderModelPicker.swift
+++ b/apps/swift-ios/Features/Workspace/ProviderModelPicker.swift
@@ -763,7 +763,7 @@ struct ProviderModelDisplaySections {
 
         let matchingLabels = Dictionary(grouping: catalog.all) { option in
             ModelPresentationKey(
-                providerID: option.provider.id,
+                providerName: option.provider.name,
                 name: option.model.name,
                 detail: option.model.detail ?? option.model.id
             )
@@ -776,7 +776,7 @@ struct ProviderModelDisplaySections {
     }
 
     private struct ModelPresentationKey: Hashable {
-        let providerID: String
+        let providerName: String
         let name: String
         let detail: String
     }

--- a/apps/swift-ios/Features/Workspace/ProviderModelPicker.swift
+++ b/apps/swift-ios/Features/Workspace/ProviderModelPicker.swift
@@ -74,6 +74,7 @@ public struct ProviderModelPicker: View {
                 }
                 .font(T3Typography.supportingStrong)
                 .foregroundStyle(T3Colors.textSecondary)
+                .compositingGroup()
                 .frame(minHeight: T3Metrics.minimumTapTarget)
                 .contentShape(Rectangle())
             }

--- a/apps/swift-ios/Features/Workspace/ProviderModelPicker.swift
+++ b/apps/swift-ios/Features/Workspace/ProviderModelPicker.swift
@@ -13,6 +13,7 @@ public struct ProviderModelPicker: View {
     let isLoading: Bool
     let threadSelection: FeatureSelection?
     let materializesDefaultSelection: Bool
+    private let onPresentationChange: ((Bool) -> Void)?
 
     @State private var isPresented = false
 
@@ -22,7 +23,8 @@ public struct ProviderModelPicker: View {
         style: Style = .row,
         isLoading: Bool = false,
         threadSelection: FeatureSelection? = nil,
-        materializesDefaultSelection: Bool = true
+        materializesDefaultSelection: Bool = true,
+        onPresentationChange: ((Bool) -> Void)? = nil
     ) {
         self.providers = providers
         normalizedProviders = ProviderModelCatalogNormalizer.normalized(providers)
@@ -31,10 +33,12 @@ public struct ProviderModelPicker: View {
         self.isLoading = isLoading
         self.threadSelection = threadSelection
         self.materializesDefaultSelection = materializesDefaultSelection
+        self.onPresentationChange = onPresentationChange
     }
 
     public var body: some View {
         Button {
+            onPresentationChange?(true)
             isPresented = true
         } label: {
             switch style {
@@ -56,6 +60,7 @@ public struct ProviderModelPicker: View {
                         .font(T3Typography.supportingStrong)
                         .foregroundStyle(T3Colors.textTertiary)
                 }
+                .frame(minHeight: T3Metrics.minimumTapTarget)
                 .contentShape(Rectangle())
             case .compact:
                 HStack(spacing: 5) {
@@ -69,13 +74,15 @@ public struct ProviderModelPicker: View {
                 }
                 .font(T3Typography.supportingStrong)
                 .foregroundStyle(T3Colors.textSecondary)
+                .frame(minHeight: T3Metrics.minimumTapTarget)
                 .contentShape(Rectangle())
             }
         }
         .buttonStyle(.plain)
         .accessibilityLabel("Choose model")
         .accessibilityValue(selectionLabel)
-        .sheet(isPresented: $isPresented) {
+        .accessibilityIdentifier("model-picker")
+        .sheet(isPresented: $isPresented, onDismiss: { onPresentationChange?(false) }) {
             ModelPickerSheet(
                 providers: normalizedProviders,
                 selection: $selection,
@@ -126,7 +133,7 @@ public struct ProviderModelPicker: View {
 
     private var selectionLabel: String {
         guard let selectedOption else {
-            return "Choose model"
+            return unavailableSelectionLabel
         }
         let base = "\(selectedOption.provider.name) · \(selectedOption.model.name)"
         guard let resolvedSelection,
@@ -141,9 +148,19 @@ public struct ProviderModelPicker: View {
 
     private var compactModelName: String {
         guard let selectedOption else {
-            return "Choose model"
+            return unavailableSelectionLabel
         }
         return selectedOption.model.name
+    }
+
+    private var unavailableSelectionLabel: String {
+        if isLoading { return "Loading models" }
+        if normalizedProviders.isEmpty { return "No providers" }
+        if !normalizedProviders.contains(where: \.isAvailable) { return "Providers offline" }
+        if !normalizedProviders.contains(where: { $0.isAvailable && !$0.models.isEmpty }) {
+            return "No models"
+        }
+        return "Choose model"
     }
 
     @ViewBuilder
@@ -184,7 +201,10 @@ private struct ModelPickerSheet: View {
             Group {
                 if isLoading, availableModelCount == 0 {
                     VStack(spacing: 12) {
-                        ProgressView()
+                        Image(systemName: "cpu")
+                            .font(.title2)
+                            .foregroundStyle(T3Colors.textTertiary)
+                            .accessibilityHidden(true)
                         Text("Loading models")
                             .font(T3Typography.control)
                             .foregroundStyle(T3Colors.textSecondary)
@@ -192,9 +212,9 @@ private struct ModelPickerSheet: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else if availableModelCount == 0 {
                     ContentUnavailableView(
-                        "No models available",
-                        systemImage: "cpu",
-                        description: Text("Check the providers enabled on this environment.")
+                        emptyStateTitle,
+                        systemImage: emptyStateSymbol,
+                        description: Text(emptyStateMessage)
                     )
                 } else {
                     modelList
@@ -231,11 +251,12 @@ private struct ModelPickerSheet: View {
     private var modelList: some View {
         let catalog = cachedCatalog
         let sections = ProviderModelDisplaySections(catalog: catalog)
+        let isSearching = !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         return List {
             if modelChangesAreLocked {
                 Section {
                     Label(
-                        "This provider fixes the model when a task starts.",
+                        "This task cannot change models.",
                         systemImage: "lock"
                     )
                     .font(T3Typography.supporting)
@@ -243,44 +264,69 @@ private struct ModelPickerSheet: View {
                 }
             }
 
-            if !sections.favorites.isEmpty {
-                Section("Favorites") {
-                    ForEach(sections.favorites) { option in
-                        modelRow(option)
-                    }
+            if isSearching {
+                ForEach(catalog.all) { option in
+                    modelRow(
+                        option,
+                        showsProvider: true,
+                        disambiguatesModel: sections.disambiguatedModelIDs.contains(option.id)
+                    )
                 }
-            }
-
-            if !sections.recents.isEmpty {
-                Section("Recent") {
-                    ForEach(sections.recents) { option in
-                        modelRow(option)
-                    }
-                }
-            }
-
-            ForEach(sections.currentProviderGroups, id: \.provider.id) { group in
-                Section(group.provider.name) {
-                    ForEach(group.models) { option in
-                        modelRow(option)
-                    }
-                }
-            }
-
-            if !sections.legacy.isEmpty {
-                Section {
-                    DisclosureGroup(isExpanded: $legacyModelsExpanded) {
-                        ForEach(sections.legacy) { option in
-                            modelRow(option)
+            } else {
+                if !sections.favorites.isEmpty {
+                    Section("Favorites") {
+                        ForEach(sections.favorites) { option in
+                            modelRow(
+                                option,
+                                showsProvider: true,
+                                disambiguatesModel: sections.disambiguatedModelIDs.contains(option.id)
+                            )
                         }
-                    } label: {
-                        HStack {
-                            Text("Legacy models")
-                                .font(T3Typography.control.weight(.semibold))
-                            Spacer()
-                            Text("\(sections.legacy.count)")
-                                .font(T3Typography.supporting.monospacedDigit())
-                                .foregroundStyle(T3Colors.textTertiary)
+                    }
+                }
+
+                if !sections.recents.isEmpty {
+                    Section("Recent") {
+                        ForEach(sections.recents) { option in
+                            modelRow(
+                                option,
+                                showsProvider: true,
+                                disambiguatesModel: sections.disambiguatedModelIDs.contains(option.id)
+                            )
+                        }
+                    }
+                }
+
+                ForEach(sections.currentProviderGroups, id: \.provider.id) { group in
+                    Section(group.provider.name) {
+                        ForEach(group.models) { option in
+                            modelRow(
+                                option,
+                                disambiguatesModel: sections.disambiguatedModelIDs.contains(option.id)
+                            )
+                        }
+                    }
+                }
+
+                if !sections.legacy.isEmpty {
+                    Section {
+                        DisclosureGroup(isExpanded: $legacyModelsExpanded) {
+                            ForEach(sections.legacy) { option in
+                                modelRow(
+                                    option,
+                                    showsProvider: true,
+                                    disambiguatesModel: sections.disambiguatedModelIDs.contains(option.id)
+                                )
+                            }
+                        } label: {
+                            HStack {
+                                Text("Legacy models")
+                                    .font(T3Typography.control.weight(.semibold))
+                                Spacer()
+                                Text("\(sections.legacy.count)")
+                                    .font(T3Typography.supporting.monospacedDigit())
+                                    .foregroundStyle(T3Colors.textTertiary)
+                            }
                         }
                     }
                 }
@@ -293,12 +339,28 @@ private struct ModelPickerSheet: View {
         }
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
+        .scrollDismissesKeyboard(.interactively)
         .background(T3Colors.background)
-        .onChange(of: query) { _, value in
-            if !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                legacyModelsExpanded = true
-            }
+    }
+
+    private var emptyStateTitle: String {
+        if providers.isEmpty { return "No providers" }
+        if !providers.contains(where: \.isAvailable) { return "Providers offline" }
+        return "No models available"
+    }
+
+    private var emptyStateSymbol: String {
+        providers.isEmpty || !providers.contains(where: \.isAvailable)
+            ? "wifi.slash"
+            : "cpu"
+    }
+
+    private var emptyStateMessage: String {
+        if providers.isEmpty { return "Connect an environment to see its models." }
+        if !providers.contains(where: \.isAvailable) {
+            return "Reconnect this environment to choose a model."
         }
+        return "This environment has no available models."
     }
 
     private var availableModelCount: Int {
@@ -309,39 +371,62 @@ private struct ModelPickerSheet: View {
             }
     }
 
-    private func modelRow(_ option: DailyUXModelOption) -> some View {
-        HStack(spacing: 10) {
+    private func modelRow(
+        _ option: DailyUXModelOption,
+        showsProvider: Bool = false,
+        disambiguatesModel: Bool = false
+    ) -> some View {
+        let isSelected = resolvedSelection?.providerID == option.provider.id
+            && resolvedSelection?.modelID == option.model.id
+        let isFavorite = favoriteIDs.contains(option.id)
+        return HStack(spacing: 10) {
             Button {
                 select(option)
             } label: {
                 ModelOptionLabel(
                     option: option,
-                    isSelected: resolvedSelection?.providerID == option.provider.id
-                        && resolvedSelection?.modelID == option.model.id
+                    isSelected: isSelected,
+                    showsProvider: showsProvider,
+                    disambiguatesModel: disambiguatesModel
                 )
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .disabled(isLocked(option))
+            .opacity(isLocked(option) ? 0.36 : 1)
+            .accessibilityLabel(option.model.name)
+            .accessibilityValue(
+                disambiguatesModel
+                    ? "\(option.provider.name), \(option.model.id)"
+                    : option.provider.name
+            )
+            .accessibilityAddTraits(isSelected ? .isSelected : [])
+            .accessibilityHint(
+                isLocked(option)
+                    ? "This task cannot change models."
+                    : option.model.options.isEmpty
+                        ? "Use this model."
+                        : "Configure and use this model."
+            )
 
             Button {
                 toggleFavorite(option.id)
             } label: {
-                Image(systemName: favoriteIDs.contains(option.id) ? "star.fill" : "star")
+                Image(systemName: isFavorite ? "star.fill" : "star")
                     .font(.system(size: 15))
                     .foregroundStyle(
-                        favoriteIDs.contains(option.id)
-                            ? T3Colors.warning
-                            : T3Colors.textTertiary
+                        isFavorite ? T3Colors.warning : T3Colors.textTertiary
                     )
-                    .frame(width: 34, height: 34)
+                    .frame(
+                        width: T3Metrics.minimumTapTarget,
+                        height: T3Metrics.minimumTapTarget
+                    )
+                    .contentShape(Rectangle())
             }
             .buttonStyle(.borderless)
-            .accessibilityLabel(
-                favoriteIDs.contains(option.id) ? "Remove favorite" : "Add favorite"
-            )
+            .accessibilityLabel(isFavorite ? "Remove from favorites" : "Add to favorites")
+            .accessibilityValue(option.model.name)
         }
-        .disabled(isLocked(option))
-        .opacity(isLocked(option) ? 0.36 : 1)
         .listRowBackground(T3Colors.background)
     }
 
@@ -459,14 +544,39 @@ private final class ModelPickerCatalogCache {
         if self.key == key, let value { return value }
 
         let value = DailyUXModelCatalog(
-            providers: providers,
-            query: query,
+            providers: ProviderModelSearch.matching(providers, query: query),
+            query: "",
             favoriteIDs: Set(favoriteStorage.split(separator: "\n").map(String.init)),
             recentIDs: recentStorage.split(separator: "\n").map(String.init)
         )
         self.key = key
         self.value = value
         return value
+    }
+}
+
+enum ProviderModelSearch {
+    static func matching(_ providers: [FeatureProvider], query: String) -> [FeatureProvider] {
+        let terms = query.split { !$0.isLetter && !$0.isNumber }.map(String.init)
+        guard !terms.isEmpty else { return providers }
+
+        return providers.compactMap { provider in
+            var matchingProvider = provider
+            matchingProvider.models = provider.models.filter { model in
+                let searchableFields = [
+                    provider.name,
+                    provider.id,
+                    model.name,
+                    model.id,
+                    model.detail ?? "",
+                    model.supportsImages ? "images vision" : "",
+                ]
+                return terms.allSatisfy { term in
+                    searchableFields.contains { $0.localizedCaseInsensitiveContains(term) }
+                }
+            }
+            return matchingProvider.models.isEmpty ? nil : matchingProvider
+        }
     }
 }
 
@@ -627,6 +737,7 @@ struct ProviderModelDisplaySections {
         models: [DailyUXModelOption]
     )]
     let legacy: [DailyUXModelOption]
+    let disambiguatedModelIDs: Set<String>
 
     init(catalog: DailyUXModelCatalog) {
         let currentIDs = Set(catalog.all.compactMap { option in
@@ -636,7 +747,10 @@ struct ProviderModelDisplaySections {
             ) ? option.id : nil
         })
         favorites = catalog.favorites.filter { currentIDs.contains($0.id) }
-        recents = catalog.recents.filter { currentIDs.contains($0.id) }
+        var seenRecentIDs = Set<String>()
+        recents = catalog.recents.filter {
+            currentIDs.contains($0.id) && seenRecentIDs.insert($0.id).inserted
+        }
         let promoted = Set((favorites + recents).map(\.id))
         currentProviderGroups = catalog.providerGroups.compactMap { group in
             let models = group.models.filter {
@@ -645,6 +759,25 @@ struct ProviderModelDisplaySections {
             return models.isEmpty ? nil : (group.provider, models)
         }
         legacy = catalog.all.filter { !currentIDs.contains($0.id) }
+
+        let matchingLabels = Dictionary(grouping: catalog.all) { option in
+            ModelPresentationKey(
+                providerID: option.provider.id,
+                name: option.model.name,
+                detail: option.model.detail ?? option.model.id
+            )
+        }
+        disambiguatedModelIDs = Set(
+            matchingLabels.values
+                .filter { $0.count > 1 }
+                .flatMap { $0.map(\.id) }
+        )
+    }
+
+    private struct ModelPresentationKey: Hashable {
+        let providerID: String
+        let name: String
+        let detail: String
     }
 }
 
@@ -797,6 +930,8 @@ enum ProviderModelConfiguration {
 private struct ModelOptionLabel: View {
     let option: DailyUXModelOption
     let isSelected: Bool
+    var showsProvider = false
+    var disambiguatesModel = false
 
     var body: some View {
         HStack(spacing: 12) {
@@ -811,7 +946,7 @@ private struct ModelOptionLabel: View {
                         capability("Images", icon: "photo")
                     }
                 }
-                Text(option.model.detail ?? option.model.id)
+                Text(modelDetail)
                     .font(T3Typography.supporting)
                     .foregroundStyle(T3Colors.textSecondary)
                     .lineLimit(1)
@@ -825,6 +960,13 @@ private struct ModelOptionLabel: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.vertical, 4)
+    }
+
+    private var modelDetail: String {
+        let detail = disambiguatesModel
+            ? option.model.id
+            : option.model.detail ?? option.model.id
+        return showsProvider ? "\(option.provider.name) · \(detail)" : detail
     }
 
     private var providerMark: some View {

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -37,6 +37,7 @@ public struct WorkspaceView: View {
     @State private var showingNewTask = false
     @State private var newTaskInitialProjectID: String?
     @State private var showingAddProject = false
+    @State private var showingEnvironments = false
     @State private var showingSettings = false
     @State private var renamingThread: FeatureThread?
     @State private var renameTitle = ""
@@ -138,6 +139,19 @@ public struct WorkspaceView: View {
         }
         .sheet(isPresented: $showingAddProject) {
             AddProjectView(model: model)
+        }
+        .sheet(isPresented: $showingEnvironments) {
+            NavigationStack {
+                ConnectionsView(model: model)
+                    .toolbar {
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button("Done") { showingEnvironments = false }
+                        }
+                    }
+            }
+            .presentationDragIndicator(.visible)
+            .onAppear { model.setConnectionManagementPresented(true) }
+            .onDisappear { model.setConnectionManagementPresented(false) }
         }
         .sheet(isPresented: $showingSettings) {
             SettingsView(model: model)
@@ -341,27 +355,25 @@ public struct WorkspaceView: View {
     @ViewBuilder
     private var connectionBrand: some View {
         if !unreachableEnvironments.isEmpty {
-            HStack(spacing: 7) {
-                Image(systemName: "network.slash")
-                    .font(.system(size: 13, weight: .semibold))
-                Text(unreachableBrandLabel)
-                    .lineLimit(2)
-                    .font(.system(size: 13, weight: .semibold))
-                Button("Reconnect") {
-                    Task { await model.reload() }
+            Button { showingEnvironments = true } label: {
+                HStack(spacing: 7) {
+                    Image(systemName: "network.slash")
+                        .font(.system(size: 13, weight: .semibold))
+                    Text(unreachableBrandLabel)
+                        .lineLimit(1)
+                        .font(.system(size: 13, weight: .semibold))
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 10, weight: .semibold))
                 }
-                .font(.caption.weight(.bold))
-                .buttonStyle(.plain)
-                .padding(.horizontal, 9)
-                .frame(height: 26)
-                .overlay {
-                    Capsule().stroke(T3Colors.danger.opacity(0.42), lineWidth: 1)
-                }
+                .frame(minHeight: T3Metrics.minimumTapTarget)
+                .contentShape(Rectangle())
             }
+            .buttonStyle(.plain)
             .foregroundStyle(T3Colors.danger)
-            .accessibilityElement(children: .contain)
+            .accessibilityLabel("\(unreachableBrandLabel). Manage environments")
+            .accessibilityIdentifier("sidebar-environments-button")
         } else if let reconnecting = reconnectingEnvironments.first {
-            Button { showingSettings = true } label: {
+            Button { showingEnvironments = true } label: {
                 HStack(spacing: 7) {
                     Image(systemName: "wifi.exclamationmark")
                         .font(.system(size: 13, weight: .semibold))
@@ -373,21 +385,33 @@ public struct WorkspaceView: View {
                 }
                 .font(.system(size: 14, weight: .semibold))
                 .foregroundStyle(T3Colors.warning)
+                .frame(minHeight: T3Metrics.minimumTapTarget)
+                .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("\(reconnecting.name) reconnecting")
+            .accessibilityLabel("\(reconnecting.name) reconnecting. Manage environments")
+            .accessibilityIdentifier("sidebar-environments-button")
         } else {
-            HStack(alignment: .firstTextBaseline, spacing: 4) {
-                Text("T3")
-                    .fontWeight(.bold)
-                    .foregroundStyle(T3Colors.textPrimary)
-                Text("Code")
-                    .fontWeight(.medium)
-                    .foregroundStyle(T3Colors.textSecondary)
+            Button { showingEnvironments = true } label: {
+                HStack(alignment: .firstTextBaseline, spacing: 4) {
+                    Text("T3")
+                        .fontWeight(.bold)
+                        .foregroundStyle(T3Colors.textPrimary)
+                    Text("Code")
+                        .fontWeight(.medium)
+                        .foregroundStyle(T3Colors.textSecondary)
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(T3Colors.textTertiary)
+                        .padding(.leading, 2)
+                }
+                .font(.system(size: 16))
+                .frame(minHeight: T3Metrics.minimumTapTarget)
+                .contentShape(Rectangle())
             }
-            .font(.system(size: 16))
-            .accessibilityElement(children: .combine)
-            .accessibilityLabel("T3 Code")
+            .buttonStyle(.plain)
+            .accessibilityLabel("T3 Code. Manage environments")
+            .accessibilityIdentifier("sidebar-environments-button")
         }
     }
 
@@ -528,9 +552,9 @@ public struct WorkspaceView: View {
 
     private var unreachableBrandLabel: String {
         if unreachableEnvironments.count == 1 {
-            return "\(unreachableEnvironments[0].name) unreachable"
+            return "\(unreachableEnvironments[0].name) offline"
         }
-        return "\(unreachableEnvironments.count) devices unreachable"
+        return "\(unreachableEnvironments.count) environments offline"
     }
 
     private var nextSidebarBoundary: Date? {
@@ -608,6 +632,7 @@ public struct WorkspaceView: View {
     private func dismissTransientPresentations() {
         showingNewTask = false
         showingAddProject = false
+        showingEnvironments = false
         showingSettings = false
         renamingThread = nil
     }

--- a/apps/swift-ios/Tests/FeatureTests/ConnectionHubPresentationTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/ConnectionHubPresentationTests.swift
@@ -14,6 +14,33 @@ struct ConnectionHubPresentationTests {
     }
 
     @Test
+    func directSectionShowsEnabledConnectionsBeforeDisabledConnections() {
+        let disabledFirst = environment(
+            id: "disabled-first",
+            source: .direct,
+            isEnabled: false
+        )
+        let enabledFirst = environment(id: "enabled-first", source: .direct)
+        let disabledSecond = environment(
+            id: "disabled-second",
+            source: .direct,
+            isEnabled: false
+        )
+        let enabledSecond = environment(id: "enabled-second", source: .direct)
+
+        #expect(
+            ConnectionHubPresentation.directEnvironments(
+                in: [disabledFirst, enabledFirst, disabledSecond, enabledSecond]
+            ).map(\.id) == [
+                "enabled-first",
+                "enabled-second",
+                "disabled-first",
+                "disabled-second",
+            ]
+        )
+    }
+
+    @Test
     func t3ConnectSectionJoinsSavedAndAccountMachinesWithoutDuplicates() {
         let saved = [
             environment(
@@ -45,6 +72,149 @@ struct ConnectionHubPresentationTests {
         #expect(rows[1].isOnline)
         #expect(rows[2].savedEnvironment?.id == "saved-only")
         #expect(rows[2].linkedEnvironment == nil)
+    }
+
+    @Test(
+        arguments: [
+            (FeatureConnection.State.connected, ConnectionHubStatus.online),
+            (.connecting, .connecting),
+            (.reconnecting, .connecting),
+            (.disconnected, .offline),
+        ]
+    )
+    func savedEnvironmentStatusMatchesConnectionState(
+        connectionState: FeatureConnection.State,
+        expectedStatus: ConnectionHubStatus
+    ) {
+        let saved = environment(
+            id: "direct",
+            source: .direct,
+            connectionState: connectionState
+        )
+
+        #expect(ConnectionHubPresentation.status(for: saved) == expectedStatus)
+    }
+
+    @Test
+    func disabledEnvironmentDoesNotAppearOfflineOrOnline() {
+        let saved = environment(
+            id: "disabled",
+            source: .direct,
+            isEnabled: false,
+            connectionState: .connected
+        )
+
+        #expect(ConnectionHubPresentation.status(for: saved) == .disabled)
+        #expect(ConnectionHubPresentation.status(for: saved, pendingEnabled: true) == .connecting)
+    }
+
+    @Test
+    func environmentWithoutAReachabilityProbeIsChecking() {
+        let saved = environment(id: "pending", source: .direct)
+
+        #expect(ConnectionHubPresentation.status(for: saved) == .checking)
+        #expect(ConnectionHubPresentation.status(for: saved, pendingEnabled: false) == .disabled)
+    }
+
+    @Test
+    func managedEnvironmentUsesSavedConnectionStateBeforeCloudAvailability() {
+        let linked = cloudEnvironment(id: "managed", name: "Studio", isOnline: true)
+        let disabled = T3ConnectEnvironmentPresentation(
+            linkedEnvironment: linked,
+            savedEnvironment: environment(
+                id: "managed",
+                source: .t3Connect,
+                isEnabled: false,
+                connectionState: .connected
+            )
+        )
+        let offline = T3ConnectEnvironmentPresentation(
+            linkedEnvironment: linked,
+            savedEnvironment: environment(
+                id: "managed",
+                source: .t3Connect,
+                connectionState: .disconnected
+            )
+        )
+
+        #expect(disabled.status == .disabled)
+        #expect(offline.status == .offline)
+        #expect(!disabled.isOnline)
+        #expect(!offline.isOnline)
+    }
+
+    @Test
+    func linkedEnvironmentShowsCloudStatusUntilItIsSaved() {
+        let online = T3ConnectEnvironmentPresentation(
+            linkedEnvironment: cloudEnvironment(id: "online", name: "Studio", isOnline: true),
+            savedEnvironment: nil
+        )
+        let offline = T3ConnectEnvironmentPresentation(
+            linkedEnvironment: cloudEnvironment(id: "offline", name: "Studio", isOnline: false),
+            savedEnvironment: nil
+        )
+
+        #expect(online.status == .online)
+        #expect(offline.status == .offline)
+        #expect(online.connectionStatus(pendingEnabled: true) == .connecting)
+        #expect(offline.connectionStatus(isConnecting: true) == .connecting)
+    }
+
+    @Test
+    func linkedEnvironmentSeparatesUnknownStatusFromFailedReachability() {
+        let linked = cloudEnvironment(id: "linked", name: "Studio", isOnline: true)
+        let unchecked = T3ConnectEnvironmentPresentation(
+            linkedEnvironment: T3ConnectCloudEnvironment(environment: linked.environment),
+            savedEnvironment: nil
+        )
+        let failed = T3ConnectEnvironmentPresentation(
+            linkedEnvironment: T3ConnectCloudEnvironment(
+                environment: linked.environment,
+                statusError: "Connection failed"
+            ),
+            savedEnvironment: nil
+        )
+
+        #expect(unchecked.status == .checking)
+        #expect(failed.status == .offline)
+    }
+
+    @Test
+    func duplicateMachineNamesShowOnlyTheirSanitizedHostAndPort() {
+        let names = ["leftbook", "LeftBook", "studio"]
+
+        #expect(
+            ConnectionHubPresentation.disambiguatingEndpoint(
+                "https://agent:secret@leftbook.tailnet.ts.net:8443/work?token=private#code",
+                for: "leftbook",
+                among: names
+            ) == "leftbook.tailnet.ts.net:8443"
+        )
+        #expect(
+            ConnectionHubPresentation.disambiguatingEndpoint(
+                "https://second.tailnet.ts.net/private?token=hidden",
+                for: "LeftBook",
+                among: names
+            ) == "second.tailnet.ts.net"
+        )
+        #expect(
+            ConnectionHubPresentation.disambiguatingEndpoint(
+                "https://studio.example/",
+                for: "studio",
+                among: names
+            ) == nil
+        )
+    }
+
+    @Test
+    func managedEnvironmentUsesLinkedEndpointForDisambiguation() {
+        let linked = cloudEnvironment(id: "linked", name: "leftbook", isOnline: true)
+        let row = T3ConnectEnvironmentPresentation(
+            linkedEnvironment: linked,
+            savedEnvironment: environment(id: "saved", name: "leftbook", source: .t3Connect)
+        )
+
+        #expect(row.endpoint == "https://linked.example")
     }
 
     private func environment(

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
@@ -965,6 +965,39 @@ struct DailyUXNewTaskTests {
     }
 
     @Test
+    func modelPickerDisambiguatesProvidersWithTheSameVisibleName() {
+        let providers = [
+            FeatureProvider(
+                id: "opencode-work",
+                name: "OpenCode",
+                models: [
+                    .init(id: "work/gpt-5.6-luna", name: "GPT-5.6 Luna", detail: "openai"),
+                ]
+            ),
+            FeatureProvider(
+                id: "opencode-personal",
+                name: "OpenCode",
+                models: [
+                    .init(id: "personal/gpt-5.6-luna", name: "GPT-5.6 Luna", detail: "openai"),
+                ]
+            ),
+        ]
+        let sections = ProviderModelDisplaySections(
+            catalog: DailyUXModelCatalog(
+                providers: providers,
+                query: "",
+                favoriteIDs: [],
+                recentIDs: []
+            )
+        )
+
+        #expect(sections.disambiguatedModelIDs == Set([
+            "opencode-work::work/gpt-5.6-luna",
+            "opencode-personal::personal/gpt-5.6-luna",
+        ]))
+    }
+
+    @Test
     func projectPickerSearchMatchesNamesPathsAndEnvironmentNames() {
         let studio = FeatureEnvironment(
             id: "studio",

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXNewTaskTests.swift
@@ -910,6 +910,175 @@ struct DailyUXNewTaskTests {
         #expect(sections.others.isEmpty)
     }
 
+    @Test
+    func modelPickerSearchMatchesNamesAcrossSpacesAndPunctuation() {
+        let codex = FeatureProvider(
+            id: "codex",
+            name: "Codex",
+            models: [
+                .init(id: "gpt-5.6-luna", name: "GPT 5.6 Luna"),
+                .init(id: "gpt-5.6-terra", name: "GPT 5.6 Terra"),
+            ]
+        )
+        let openCode = FeatureProvider(
+            id: "opencode",
+            name: "OpenCode",
+            models: [.init(id: "openai/gpt-5.6-luna", name: "GPT-5.6 Luna")]
+        )
+
+        let matching = ProviderModelSearch.matching(
+            [codex, openCode],
+            query: "GPT 5.6 Luna"
+        )
+
+        #expect(matching.map(\.id) == ["codex", "opencode"])
+        #expect(matching.flatMap { $0.models.map(\.id) } == [
+            "gpt-5.6-luna",
+            "openai/gpt-5.6-luna",
+        ])
+    }
+
+    @Test
+    func modelPickerDisambiguatesModelsWithTheSameVisibleDetails() {
+        let provider = FeatureProvider(
+            id: "opencode",
+            name: "OpenCode",
+            models: [
+                .init(id: "kilo/openai/gpt-5.6-luna", name: "GPT-5.6 Luna", detail: "kilo"),
+                .init(id: "kilo/xai/gpt-5.6-luna", name: "GPT-5.6 Luna", detail: "kilo"),
+                .init(id: "openai/gpt-5.6-luna", name: "GPT-5.6 Luna", detail: "openai"),
+            ]
+        )
+        let sections = ProviderModelDisplaySections(
+            catalog: DailyUXModelCatalog(
+                providers: [provider],
+                query: "",
+                favoriteIDs: [],
+                recentIDs: []
+            )
+        )
+
+        #expect(sections.disambiguatedModelIDs == Set([
+            "opencode::kilo/openai/gpt-5.6-luna",
+            "opencode::kilo/xai/gpt-5.6-luna",
+        ]))
+    }
+
+    @Test
+    func projectPickerSearchMatchesNamesPathsAndEnvironmentNames() {
+        let studio = FeatureEnvironment(
+            id: "studio",
+            name: "Studio Mac",
+            endpoint: "http://studio"
+        )
+        let laptop = FeatureEnvironment(
+            id: "laptop",
+            name: "Travel Laptop",
+            endpoint: "http://laptop"
+        )
+        let alpha = rankedProject("ios-app", name: "Alpha", environmentID: studio.id)
+        let beta = rankedProject("web-client", name: "Beta", environmentID: laptop.id)
+        let groups = DailyUXProjectGrouping.groups(projects: [beta, alpha])
+
+        #expect(
+            NewTaskProjectPickerSearch.matching(
+                groups,
+                query: "ALPHA",
+                environments: [studio, laptop]
+            ).map(\.name) == ["Alpha"]
+        )
+        #expect(
+            NewTaskProjectPickerSearch.matching(
+                groups,
+                query: "web-client",
+                environments: [studio, laptop]
+            ).map(\.name) == ["Beta"]
+        )
+        #expect(
+            NewTaskProjectPickerSearch.matching(
+                groups,
+                query: "travel",
+                environments: [studio, laptop]
+            ).map(\.name) == ["Beta"]
+        )
+    }
+
+    @Test
+    func projectPickerSearchTrimsQueriesAndPreservesGroupOrder() {
+        let alpha = rankedProject("alpha", name: "Alpha")
+        let beta = rankedProject("beta", name: "Beta")
+        let groups = DailyUXProjectGrouping.groups(projects: [beta, alpha])
+
+        #expect(
+            NewTaskProjectPickerSearch.matching(
+                groups,
+                query: "  \n ",
+                environments: []
+            ).map(\.id) == groups.map(\.id)
+        )
+        #expect(
+            NewTaskProjectPickerSearch.matching(
+                groups,
+                query: "  BET  ",
+                environments: []
+            ).map(\.name) == ["Beta"]
+        )
+    }
+
+    @Test
+    func projectPickerSearchFindsSecondaryEnvironmentsAndKeepsRecentSections() throws {
+        let studio = FeatureEnvironment(
+            id: "studio",
+            name: "Studio Mac",
+            endpoint: "http://studio"
+        )
+        let laptop = FeatureEnvironment(
+            id: "laptop",
+            name: "Travel Laptop",
+            endpoint: "http://laptop"
+        )
+        let sharedOnStudio = rankedProject(
+            "studio-project",
+            name: "Shared",
+            environmentID: studio.id,
+            repositoryKey: "github.com/example/shared"
+        )
+        let sharedOnLaptop = rankedProject(
+            "laptop-project",
+            name: "Shared",
+            environmentID: laptop.id,
+            repositoryKey: "github.com/example/shared"
+        )
+        let unrelated = rankedProject(
+            "other-project",
+            name: "Other",
+            environmentID: studio.id
+        )
+        let groups = DailyUXProjectGrouping.groups(
+            projects: [unrelated, sharedOnStudio, sharedOnLaptop]
+        )
+        let sharedGroup = try #require(
+            DailyUXProjectGrouping.group(containing: sharedOnStudio.id, in: groups)
+        )
+        let unrelatedGroup = try #require(
+            DailyUXProjectGrouping.group(containing: unrelated.id, in: groups)
+        )
+
+        let filtered = NewTaskProjectPickerSearch.matching(
+            groups,
+            query: "travel",
+            environments: [studio, laptop]
+        )
+        let sections = DailyUXProjectPickerSections(
+            groups: filtered,
+            recentGroupIDs: [unrelatedGroup.id, sharedGroup.id]
+        )
+
+        #expect(filtered.map(\.id) == [sharedGroup.id])
+        #expect(sections.recents.map(\.id) == [sharedGroup.id])
+        #expect(sections.others.isEmpty)
+    }
+
     private func rankedProject(
         _ id: String,
         name: String,


### PR DESCRIPTION
Settings, environment management, and thread actions were noisy and hard to navigate. Connection states were easy to misread, several sheets could not be dismissed, and model search showed indistinguishable results.

This pass adds direct environment access from Home, groups settings and thread actions, restores missing Close and Done controls, clarifies connection states, removes empty home sections, and improves task creation, model search, composer behavior, dark mode, and VoiceOver support.

Verified on the iPhone simulator with a real GPT 5.6 Luna prompt. All 97 focused SwiftUI tests pass.

Model: GPT-5.6 Sol
Harness: Codex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connection-status presentation, T3 Connect sign-out, and settings save/discard, plus model-search filtering. UI-only, but status semantics and picker results can change what users enable or select.
> 
> **Overview**
> Clarifies environment management and connection state across Home, Settings, and T3 Connect. The sidebar brand now opens environments directly. Status uses a shared `ConnectionHubStatus` (Off / Checking / Connecting / Offline / Online), duplicate names show a sanitized host, and empty home shelves are hidden.
> 
> Settings gets a real nav bar with Save/Close, unsaved-change confirmation, and a live environment summary. Onboarding and T3 Connect copy, cancel/return stages, signed-out/sign-out flows, and accessibility identifiers are tightened.
> 
> Task creation and the composer get inline validation, project search, model multi-term search with disambiguation, focus restore after pickers, and richer VoiceOver actions (pin, settle, snooze, archive). Dark backgrounds go true black; thread menus add Settle/Reopen and Retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5083494d45a247d8c5bd8398aaeb18267630fb30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clean up iOS settings, environment connections, and thread actions
> - Settings screen uses standard navigation chrome with Close/Save actions, unsaved-changes detection, and a discard confirmation dialog. Appearance saves are serialized and reverted on failure.
> - Connections and environments views use a new `ConnectionHubStatus` type with granular states (disabled, checking, connecting, offline, online) and endpoint disambiguation for duplicate names. Direct environments sort enabled before disabled.
> - Model picker adds multi-term search across provider/model metadata via `ProviderModelSearch.matching`, shows flat search results with provider labels, and disambiguates models with identical visible names.
> - Thread cells expose VoiceOver custom actions for rename, pin, settle, snooze, archive, and delete. Context menus are reorganized into grouped sections. Empty snoozed/settled shelves are hidden.
> - New Task view gains inline validation, a submission error banner, project picker search, and branch picker accessibility improvements.
> - Behavioral Change: dark-mode backgrounds (`uiBackground`, `sheet`, `primaryActionForeground`) change from near-black to pure black (`0x000000`). Multiple user-facing copy strings change across settings, connections, and onboarding. `FeatureEnvironment.status` extension and `ConnectionStatusPresentation` struct are removed and replaced by `ConnectionHubStatus`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5083494.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->