### PR TITLE
fix(files): refresh the open file when it changes on disk

### DIFF
--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -78,6 +78,8 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.sourceControlPublishRepository]: AuthOrchestrationOperateScope,
   [WS_METHODS.projectsListEntries]: AuthOrchestrationReadScope,
   [WS_METHODS.projectsReadFile]: AuthOrchestrationReadScope,
+  // Watching a file you are already allowed to read is still reading.
+  [WS_METHODS.subscribeProjectFileChanges]: AuthOrchestrationReadScope,
   [WS_METHODS.projectsSearchContents]: AuthOrchestrationReadScope,
   [WS_METHODS.projectsSearchEntries]: AuthOrchestrationReadScope,
   [WS_METHODS.projectsWriteFile]: AuthOrchestrationOperateScope,

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -4784,6 +4784,53 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
     }).pipe(Effect.provide(NodeHttpServer.layerTest), TestClock.withLive),
   );
 
+  it.effect("routes websocket rpc subscribeProjectFileChanges for edits made outside the app", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const workspaceDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-ws-project-watch-" });
+      const filePath = path.join(workspaceDir, "package.json");
+      const before = '{ "description": "An awesome horse platform" }\n';
+      const after = '{ "description": "An awesome course platform" }\n';
+      yield* fs.writeFileString(filePath, before);
+
+      yield* buildAppUnderTest();
+
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const result = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          Effect.gen(function* () {
+            const watcher = yield* client[WS_METHODS.subscribeProjectFileChanges]({
+              cwd: workspaceDir,
+              relativePath: "package.json",
+            }).pipe(Stream.runHead, Effect.forkChild());
+            // `fs.watch` registration is not observable, so rewrite until the
+            // subscription reports rather than racing a fixed startup delay.
+            // The pause outlasts the watcher's debounce window.
+            const writer = yield* fs
+              .writeFileString(filePath, after)
+              .pipe(
+                Effect.orDie,
+                Effect.delay(Duration.millis(300)),
+                Effect.forever,
+                Effect.forkChild(),
+              );
+            const event = yield* Fiber.join(watcher).pipe(Effect.timeout(Duration.seconds(10)));
+            yield* Fiber.interrupt(writer);
+            const file = yield* client[WS_METHODS.projectsReadFile]({
+              cwd: workspaceDir,
+              relativePath: "package.json",
+            });
+            return { event, file };
+          }),
+        ),
+      );
+
+      assert.deepEqual(result.event, Option.some({ relativePath: "package.json" }));
+      assert.equal(result.file.contents, after);
+    }).pipe(Effect.provide(NodeHttpServer.layerTest), TestClock.withLive),
+  );
+
   it.effect("routes websocket rpc projects.searchEntries excludes gitignored files", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/apps/server/src/workspace/WorkspaceFileSystem.test.ts
+++ b/apps/server/src/workspace/WorkspaceFileSystem.test.ts
@@ -335,6 +335,21 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceFileSystemLive", (i
       }),
     );
 
+    it.effect("reports a file that does not exist yet when it appears", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir;
+        // No file at this path: the watcher must still attach, so a tab whose
+        // file is momentarily absent keeps its live refresh.
+        const event = yield* awaitFirstChange(
+          cwd,
+          "later.txt",
+          writeTextFile(cwd, "later.txt", "created\n"),
+        );
+
+        expect(event).toEqual(Option.some({ relativePath: "later.txt" }));
+      }),
+    );
+
     it.effect("rejects a watch that escapes the workspace through a symlink", () =>
       Effect.gen(function* () {
         const workspaceFileSystem = yield* WorkspaceFileSystem.WorkspaceFileSystem;

--- a/apps/server/src/workspace/WorkspaceFileSystem.test.ts
+++ b/apps/server/src/workspace/WorkspaceFileSystem.test.ts
@@ -377,6 +377,34 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceFileSystemLive", (i
       }),
     );
 
+    it.effect("reports an atomic replace of the symlink's own path", () =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(cwd, "real/config.json", '{ "value": "before" }\n');
+        const alias = path.join(cwd, "alias.json");
+        yield* fileSystem.symlink(path.join(cwd, "real", "config.json"), alias).pipe(Effect.orDie);
+
+        // The editor/git pattern: write a temp file beside the alias and rename
+        // over it. That fires in the alias's directory, not the target's, so a
+        // watch that only followed the canonical path would miss it.
+        //
+        // Like the sibling symlink test, this discriminates on inotify and not
+        // on macOS, where FSEvents coalesces to directory granularity and
+        // delivers a matching event either way.
+        const temp = path.join(cwd, "alias.json.tmp");
+        const replaceAlias = Effect.gen(function* () {
+          yield* fileSystem.writeFileString(temp, '{ "value": "after" }\n').pipe(Effect.orDie);
+          yield* fileSystem.rename(temp, alias).pipe(Effect.orDie);
+        });
+
+        const event = yield* awaitFirstChange(cwd, "alias.json", replaceAlias);
+
+        expect(event).toEqual(Option.some({ relativePath: "alias.json" }));
+      }),
+    );
+
     it.effect("rejects a watch that escapes the workspace through a symlink", () =>
       Effect.gen(function* () {
         const workspaceFileSystem = yield* WorkspaceFileSystem.WorkspaceFileSystem;

--- a/apps/server/src/workspace/WorkspaceFileSystem.test.ts
+++ b/apps/server/src/workspace/WorkspaceFileSystem.test.ts
@@ -335,6 +335,28 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceFileSystemLive", (i
       }),
     );
 
+    it.effect("rejects a watch that escapes the workspace through a symlink", () =>
+      Effect.gen(function* () {
+        const workspaceFileSystem = yield* WorkspaceFileSystem.WorkspaceFileSystem;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir;
+        const outside = yield* makeTempDir;
+        yield* fileSystem
+          .writeFileString(path.join(outside, "secret.txt"), "secret\n")
+          .pipe(Effect.orDie);
+        // Lexically `link/secret.txt` sits inside the workspace; physically it
+        // does not, so no watcher may be pointed at it.
+        yield* fileSystem.symlink(outside, path.join(cwd, "link")).pipe(Effect.orDie);
+
+        const error = yield* workspaceFileSystem
+          .watchFile({ cwd, relativePath: "link/secret.txt" })
+          .pipe(Stream.runHead, Effect.flip);
+
+        expect(error._tag).toBe("WorkspaceFilePathEscapeError");
+      }),
+    );
+
     it.effect("rejects watches outside the workspace root", () =>
       Effect.gen(function* () {
         const workspaceFileSystem = yield* WorkspaceFileSystem.WorkspaceFileSystem;

--- a/apps/server/src/workspace/WorkspaceFileSystem.test.ts
+++ b/apps/server/src/workspace/WorkspaceFileSystem.test.ts
@@ -350,6 +350,33 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceFileSystemLive", (i
       }),
     );
 
+    it.effect("follows a symlinked file to edits made through its target", () =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(cwd, "real/config.json", '{ "value": "before" }\n');
+        yield* fileSystem
+          .symlink(path.join(cwd, "real", "config.json"), path.join(cwd, "alias.json"))
+          .pipe(Effect.orDie);
+
+        // Watching through the alias must see a write to the canonical path,
+        // which lives in a different directory under a different name.
+        //
+        // This discriminates on inotify platforms, where a watch on the alias's
+        // own directory would never hear about the target. It does not on
+        // macOS: FSEvents reports the alias entry as touched when its target is
+        // written, so this passes there even with the parent-only resolve.
+        const event = yield* awaitFirstChange(
+          cwd,
+          "alias.json",
+          writeTextFile(cwd, "real/config.json", '{ "value": "after" }\n'),
+        );
+
+        expect(event).toEqual(Option.some({ relativePath: "alias.json" }));
+      }),
+    );
+
     it.effect("rejects a watch that escapes the workspace through a symlink", () =>
       Effect.gen(function* () {
         const workspaceFileSystem = yield* WorkspaceFileSystem.WorkspaceFileSystem;

--- a/apps/server/src/workspace/WorkspaceFileSystem.test.ts
+++ b/apps/server/src/workspace/WorkspaceFileSystem.test.ts
@@ -1,9 +1,13 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it, describe, expect } from "@effect/vitest";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Path from "effect/Path";
+import * as Stream from "effect/Stream";
 
 import * as ServerConfig from "../config.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
@@ -262,6 +266,87 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceFileSystemLive", (i
           .stat(escapedPath)
           .pipe(Effect.orElseSucceed(() => null));
         expect(escapedStat).toBeNull();
+      }),
+    );
+  });
+
+  describe("watchFile", () => {
+    /**
+     * `fs.watch` registration is not observable, so the writer keeps rewriting
+     * until the watcher reports instead of racing a fixed startup delay. It
+     * pauses longer than the debounce window between rewrites so the stream
+     * gets the quiet period it waits for.
+     */
+    const awaitFirstChange = Effect.fn("awaitFirstChange")(function* (
+      cwd: string,
+      relativePath: string,
+      rewrite: Effect.Effect<void, never, FileSystem.FileSystem | Path.Path>,
+    ) {
+      const workspaceFileSystem = yield* WorkspaceFileSystem.WorkspaceFileSystem;
+      const watcher = yield* workspaceFileSystem
+        .watchFile({ cwd, relativePath })
+        .pipe(Stream.runHead, Effect.forkChild());
+      const writer = yield* rewrite.pipe(
+        Effect.delay(Duration.millis(300)),
+        Effect.forever,
+        Effect.forkChild(),
+      );
+      const event = yield* Fiber.join(watcher).pipe(Effect.timeout(Duration.seconds(10)));
+      yield* Fiber.interrupt(writer);
+      return event;
+    });
+
+    it.effect("reports a plain on-disk write", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(
+          cwd,
+          "package.json",
+          '{ "description": "An awesome horse platform" }\n',
+        );
+
+        const event = yield* awaitFirstChange(
+          cwd,
+          "package.json",
+          writeTextFile(cwd, "package.json", '{ "description": "An awesome course platform" }\n'),
+        );
+
+        expect(event).toEqual(Option.some({ relativePath: "package.json" }));
+      }),
+    );
+
+    it.effect("reports an atomic replace that swaps the file's inode", () =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(cwd, "src/index.ts", "export const answer = 42;\n");
+
+        const target = path.join(cwd, "src/index.ts");
+        const temp = path.join(cwd, "src/index.ts.tmp");
+        const replace = Effect.gen(function* () {
+          yield* fileSystem.writeFileString(temp, "export const answer = 43;\n").pipe(Effect.orDie);
+          yield* fileSystem.rename(temp, target).pipe(Effect.orDie);
+        });
+
+        const event = yield* awaitFirstChange(cwd, "src/index.ts", replace);
+
+        expect(event).toEqual(Option.some({ relativePath: "src/index.ts" }));
+      }),
+    );
+
+    it.effect("rejects watches outside the workspace root", () =>
+      Effect.gen(function* () {
+        const workspaceFileSystem = yield* WorkspaceFileSystem.WorkspaceFileSystem;
+        const cwd = yield* makeTempDir;
+
+        const error = yield* workspaceFileSystem
+          .watchFile({ cwd, relativePath: "../escape.md" })
+          .pipe(Stream.runHead, Effect.flip);
+
+        expect(error.message).toContain(
+          "Workspace file path must be relative to the project root: ../escape.md",
+        );
       }),
     );
   });

--- a/apps/server/src/workspace/WorkspaceFileSystem.ts
+++ b/apps/server/src/workspace/WorkspaceFileSystem.ts
@@ -150,65 +150,65 @@ export const make = Effect.gen(function* () {
   const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
 
   /**
-   * Resolve a workspace-relative path to a real path proven to sit inside the
+   * Resolve one absolute path with `realpath` and prove it sits inside the
    * workspace root. Lexical containment is not enough: a symlink inside the
-   * workspace can point anywhere, so both ends are resolved with `realpath`
-   * and compared physically. Every operation that touches a workspace path
-   * goes through here so the checks cannot drift apart.
+   * workspace can point anywhere, so both ends are resolved physically and
+   * compared. Callers pick what they need contained — `readFile` contains the
+   * file it opens, `watchFile` the directory it watches.
    */
-  const resolveContainedRealPath = Effect.fn("WorkspaceFileSystem.resolveContainedRealPath")(
-    function* (input: ProjectReadFileInput) {
-      const target = yield* workspacePaths.resolveRelativePathWithinRoot({
-        workspaceRoot: input.cwd,
-        relativePath: input.relativePath,
-      });
-
-      const realWorkspaceRoot = yield* Effect.tryPromise({
-        try: () => NodeFSP.realpath(input.cwd),
-        catch: (cause) =>
-          new WorkspaceFileSystemOperationError({
-            workspaceRoot: input.cwd,
-            relativePath: input.relativePath,
-            resolvedPath: target.absolutePath,
-            operationPath: input.cwd,
-            operation: "realpath-workspace-root",
-            cause,
-          }),
-      });
-      const realTargetPath = yield* Effect.tryPromise({
-        try: () => NodeFSP.realpath(target.absolutePath),
-        catch: (cause) =>
-          new WorkspaceFileSystemOperationError({
-            workspaceRoot: input.cwd,
-            relativePath: input.relativePath,
-            resolvedPath: target.absolutePath,
-            operationPath: target.absolutePath,
-            operation: "realpath-target",
-            cause,
-          }),
-      });
-      const relativeRealPath = path.relative(realWorkspaceRoot, realTargetPath);
-      if (
-        relativeRealPath.startsWith(`..${path.sep}`) ||
-        relativeRealPath === ".." ||
-        path.isAbsolute(relativeRealPath)
-      ) {
-        return yield* new WorkspaceFilePathEscapeError({
+  const realPathWithinRoot = Effect.fn("WorkspaceFileSystem.realPathWithinRoot")(function* (
+    input: ProjectReadFileInput,
+    absolutePath: string,
+  ) {
+    const realWorkspaceRoot = yield* Effect.tryPromise({
+      try: () => NodeFSP.realpath(input.cwd),
+      catch: (cause) =>
+        new WorkspaceFileSystemOperationError({
           workspaceRoot: input.cwd,
           relativePath: input.relativePath,
-          resolvedWorkspaceRoot: realWorkspaceRoot,
-          resolvedPath: realTargetPath,
-        });
-      }
+          resolvedPath: absolutePath,
+          operationPath: input.cwd,
+          operation: "realpath-workspace-root",
+          cause,
+        }),
+    });
+    const realPath = yield* Effect.tryPromise({
+      try: () => NodeFSP.realpath(absolutePath),
+      catch: (cause) =>
+        new WorkspaceFileSystemOperationError({
+          workspaceRoot: input.cwd,
+          relativePath: input.relativePath,
+          resolvedPath: absolutePath,
+          operationPath: absolutePath,
+          operation: "realpath-target",
+          cause,
+        }),
+    });
+    const relativeRealPath = path.relative(realWorkspaceRoot, realPath);
+    if (
+      relativeRealPath.startsWith(`..${path.sep}`) ||
+      relativeRealPath === ".." ||
+      path.isAbsolute(relativeRealPath)
+    ) {
+      return yield* new WorkspaceFilePathEscapeError({
+        workspaceRoot: input.cwd,
+        relativePath: input.relativePath,
+        resolvedWorkspaceRoot: realWorkspaceRoot,
+        resolvedPath: realPath,
+      });
+    }
 
-      return { target, realTargetPath };
-    },
-  );
+    return realPath;
+  });
 
   const readFile: WorkspaceFileSystem["Service"]["readFile"] = Effect.fn(
     "WorkspaceFileSystem.readFile",
   )(function* (input) {
-    const { target, realTargetPath } = yield* resolveContainedRealPath(input);
+    const target = yield* workspacePaths.resolveRelativePathWithinRoot({
+      workspaceRoot: input.cwd,
+      relativePath: input.relativePath,
+    });
+    const realTargetPath = yield* realPathWithinRoot(input, target.absolutePath);
 
     return yield* Effect.acquireUseRelease(
       Effect.tryPromise({
@@ -337,18 +337,25 @@ export const make = Effect.gen(function* () {
   const watchFile: WorkspaceFileSystem["Service"]["watchFile"] = (input) =>
     Stream.unwrap(
       Effect.gen(function* () {
-        // Physical containment, not just lexical: a symlink inside the
-        // workspace must not get a watcher pointed at an external directory.
-        const { target, realTargetPath } = yield* resolveContainedRealPath(input);
-        const directory = path.dirname(realTargetPath);
-        const fileName = path.basename(realTargetPath);
+        const target = yield* workspacePaths.resolveRelativePathWithinRoot({
+          workspaceRoot: input.cwd,
+          relativePath: input.relativePath,
+        });
+        // Contain the directory rather than the file: the directory is what
+        // gets watched, and requiring the leaf to resolve would refuse to watch
+        // a path that is momentarily absent — mid atomic-replace, or not yet
+        // created. A symlinked leaf stays safe because the re-read still goes
+        // through `readFile`, which contains the file it opens.
+        const directory = yield* realPathWithinRoot(input, path.dirname(target.absolutePath));
+        const fileName = path.basename(target.absolutePath);
+        const watchedPath = path.join(directory, fileName);
 
         return fileSystem.watch(directory).pipe(
           Stream.filter(
             (event) =>
               event.path === fileName ||
-              event.path === realTargetPath ||
-              path.resolve(directory, event.path) === realTargetPath,
+              event.path === watchedPath ||
+              path.resolve(directory, event.path) === watchedPath,
           ),
           // Debounce so the file is fully written before subscribers re-read it.
           Stream.debounce(Duration.millis(100)),
@@ -358,7 +365,7 @@ export const make = Effect.gen(function* () {
               new WorkspaceFileSystemOperationError({
                 workspaceRoot: input.cwd,
                 relativePath: input.relativePath,
-                resolvedPath: realTargetPath,
+                resolvedPath: watchedPath,
                 operationPath: directory,
                 operation: "watch",
                 cause,

--- a/apps/server/src/workspace/WorkspaceFileSystem.ts
+++ b/apps/server/src/workspace/WorkspaceFileSystem.ts
@@ -149,51 +149,66 @@ export const make = Effect.gen(function* () {
   const workspacePaths = yield* WorkspacePaths.WorkspacePaths;
   const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
 
+  /**
+   * Resolve a workspace-relative path to a real path proven to sit inside the
+   * workspace root. Lexical containment is not enough: a symlink inside the
+   * workspace can point anywhere, so both ends are resolved with `realpath`
+   * and compared physically. Every operation that touches a workspace path
+   * goes through here so the checks cannot drift apart.
+   */
+  const resolveContainedRealPath = Effect.fn("WorkspaceFileSystem.resolveContainedRealPath")(
+    function* (input: ProjectReadFileInput) {
+      const target = yield* workspacePaths.resolveRelativePathWithinRoot({
+        workspaceRoot: input.cwd,
+        relativePath: input.relativePath,
+      });
+
+      const realWorkspaceRoot = yield* Effect.tryPromise({
+        try: () => NodeFSP.realpath(input.cwd),
+        catch: (cause) =>
+          new WorkspaceFileSystemOperationError({
+            workspaceRoot: input.cwd,
+            relativePath: input.relativePath,
+            resolvedPath: target.absolutePath,
+            operationPath: input.cwd,
+            operation: "realpath-workspace-root",
+            cause,
+          }),
+      });
+      const realTargetPath = yield* Effect.tryPromise({
+        try: () => NodeFSP.realpath(target.absolutePath),
+        catch: (cause) =>
+          new WorkspaceFileSystemOperationError({
+            workspaceRoot: input.cwd,
+            relativePath: input.relativePath,
+            resolvedPath: target.absolutePath,
+            operationPath: target.absolutePath,
+            operation: "realpath-target",
+            cause,
+          }),
+      });
+      const relativeRealPath = path.relative(realWorkspaceRoot, realTargetPath);
+      if (
+        relativeRealPath.startsWith(`..${path.sep}`) ||
+        relativeRealPath === ".." ||
+        path.isAbsolute(relativeRealPath)
+      ) {
+        return yield* new WorkspaceFilePathEscapeError({
+          workspaceRoot: input.cwd,
+          relativePath: input.relativePath,
+          resolvedWorkspaceRoot: realWorkspaceRoot,
+          resolvedPath: realTargetPath,
+        });
+      }
+
+      return { target, realTargetPath };
+    },
+  );
+
   const readFile: WorkspaceFileSystem["Service"]["readFile"] = Effect.fn(
     "WorkspaceFileSystem.readFile",
   )(function* (input) {
-    const target = yield* workspacePaths.resolveRelativePathWithinRoot({
-      workspaceRoot: input.cwd,
-      relativePath: input.relativePath,
-    });
-
-    const realWorkspaceRoot = yield* Effect.tryPromise({
-      try: () => NodeFSP.realpath(input.cwd),
-      catch: (cause) =>
-        new WorkspaceFileSystemOperationError({
-          workspaceRoot: input.cwd,
-          relativePath: input.relativePath,
-          resolvedPath: target.absolutePath,
-          operationPath: input.cwd,
-          operation: "realpath-workspace-root",
-          cause,
-        }),
-    });
-    const realTargetPath = yield* Effect.tryPromise({
-      try: () => NodeFSP.realpath(target.absolutePath),
-      catch: (cause) =>
-        new WorkspaceFileSystemOperationError({
-          workspaceRoot: input.cwd,
-          relativePath: input.relativePath,
-          resolvedPath: target.absolutePath,
-          operationPath: target.absolutePath,
-          operation: "realpath-target",
-          cause,
-        }),
-    });
-    const relativeRealPath = path.relative(realWorkspaceRoot, realTargetPath);
-    if (
-      relativeRealPath.startsWith(`..${path.sep}`) ||
-      relativeRealPath === ".." ||
-      path.isAbsolute(relativeRealPath)
-    ) {
-      return yield* new WorkspaceFilePathEscapeError({
-        workspaceRoot: input.cwd,
-        relativePath: input.relativePath,
-        resolvedWorkspaceRoot: realWorkspaceRoot,
-        resolvedPath: realTargetPath,
-      });
-    }
+    const { target, realTargetPath } = yield* resolveContainedRealPath(input);
 
     return yield* Effect.acquireUseRelease(
       Effect.tryPromise({
@@ -322,19 +337,18 @@ export const make = Effect.gen(function* () {
   const watchFile: WorkspaceFileSystem["Service"]["watchFile"] = (input) =>
     Stream.unwrap(
       Effect.gen(function* () {
-        const target = yield* workspacePaths.resolveRelativePathWithinRoot({
-          workspaceRoot: input.cwd,
-          relativePath: input.relativePath,
-        });
-        const directory = path.dirname(target.absolutePath);
-        const fileName = path.basename(target.absolutePath);
+        // Physical containment, not just lexical: a symlink inside the
+        // workspace must not get a watcher pointed at an external directory.
+        const { target, realTargetPath } = yield* resolveContainedRealPath(input);
+        const directory = path.dirname(realTargetPath);
+        const fileName = path.basename(realTargetPath);
 
         return fileSystem.watch(directory).pipe(
           Stream.filter(
             (event) =>
               event.path === fileName ||
-              event.path === target.absolutePath ||
-              path.resolve(directory, event.path) === target.absolutePath,
+              event.path === realTargetPath ||
+              path.resolve(directory, event.path) === realTargetPath,
           ),
           // Debounce so the file is fully written before subscribers re-read it.
           Stream.debounce(Duration.millis(100)),
@@ -344,7 +358,7 @@ export const make = Effect.gen(function* () {
               new WorkspaceFileSystemOperationError({
                 workspaceRoot: input.cwd,
                 relativePath: input.relativePath,
-                resolvedPath: target.absolutePath,
+                resolvedPath: realTargetPath,
                 operationPath: directory,
                 operation: "watch",
                 cause,

--- a/apps/server/src/workspace/WorkspaceFileSystem.ts
+++ b/apps/server/src/workspace/WorkspaceFileSystem.ts
@@ -341,47 +341,63 @@ export const make = Effect.gen(function* () {
           workspaceRoot: input.cwd,
           relativePath: input.relativePath,
         });
-        // Prefer the canonical leaf, so a symlinked file follows edits made
-        // through its target's own path. Fall back to the parent when the leaf
-        // does not resolve, so a watch still attaches to a path that is
-        // momentarily absent — mid atomic-replace, or not yet created. Either
-        // way the directory that gets watched is proven inside the workspace,
-        // and an escaping symlink still fails rather than falling back.
+
+        // A symlinked file can be changed from either end, and the two land in
+        // different directories: an edit through the target's own path fires
+        // beside the target, while an atomic rename-over-temp save on the alias
+        // fires beside the alias. Watch both, and the ordinary case collapses
+        // back to one watcher because the two coincide.
+        const aliasDirectory = yield* realPathWithinRoot(input, path.dirname(target.absolutePath));
+        const aliasWatch = {
+          directory: aliasDirectory,
+          fileName: path.basename(target.absolutePath),
+        };
+        const watched: Array<typeof aliasWatch> = [aliasWatch];
+
+        // Missing leaf is not an error: a watch must still attach to a path
+        // that is momentarily absent, mid atomic-replace or not yet created.
         const canonical = yield* Effect.tryPromise({
           try: () => NodeFSP.realpath(target.absolutePath),
           catch: () => null,
         }).pipe(Effect.orElseSucceed(() => null));
-        const watchedPath =
-          canonical === null
-            ? path.join(
-                yield* realPathWithinRoot(input, path.dirname(target.absolutePath)),
-                path.basename(target.absolutePath),
-              )
-            : yield* realPathWithinRoot(input, canonical);
-        const directory = path.dirname(watchedPath);
-        const fileName = path.basename(watchedPath);
+        if (canonical !== null) {
+          // Contained, not merely resolved: an escaping symlink fails here
+          // rather than quietly falling back to the alias-only watch.
+          const canonicalPath = yield* realPathWithinRoot(input, canonical);
+          const directory = path.dirname(canonicalPath);
+          const fileName = path.basename(canonicalPath);
+          if (directory !== aliasWatch.directory || fileName !== aliasWatch.fileName) {
+            watched.push({ directory, fileName });
+          }
+        }
 
-        return fileSystem.watch(directory).pipe(
-          Stream.filter(
-            (event) =>
-              event.path === fileName ||
-              event.path === watchedPath ||
-              path.resolve(directory, event.path) === watchedPath,
+        const changes = watched.map(({ directory, fileName }) =>
+          fileSystem.watch(directory).pipe(
+            Stream.filter(
+              (event) =>
+                event.path === fileName ||
+                path.resolve(directory, event.path) === path.join(directory, fileName),
+            ),
+            Stream.mapError(
+              (cause) =>
+                new WorkspaceFileSystemOperationError({
+                  workspaceRoot: input.cwd,
+                  relativePath: input.relativePath,
+                  resolvedPath: path.join(directory, fileName),
+                  operationPath: directory,
+                  operation: "watch",
+                  cause,
+                }),
+            ),
           ),
-          // Debounce so the file is fully written before subscribers re-read it.
+        );
+
+        const [first, second] = changes;
+        return (second === undefined ? first! : Stream.merge(first!, second)).pipe(
+          // Debounce so the file is fully written before subscribers re-read it,
+          // and so both watchers reporting one save stay a single event.
           Stream.debounce(Duration.millis(100)),
           Stream.map(() => ({ relativePath: target.relativePath })),
-          Stream.mapError(
-            (cause) =>
-              new WorkspaceFileSystemOperationError({
-                workspaceRoot: input.cwd,
-                relativePath: input.relativePath,
-                resolvedPath: watchedPath,
-                operationPath: directory,
-                operation: "watch",
-                cause,
-              }),
-          ),
         );
       }),
     );

--- a/apps/server/src/workspace/WorkspaceFileSystem.ts
+++ b/apps/server/src/workspace/WorkspaceFileSystem.ts
@@ -341,14 +341,25 @@ export const make = Effect.gen(function* () {
           workspaceRoot: input.cwd,
           relativePath: input.relativePath,
         });
-        // Contain the directory rather than the file: the directory is what
-        // gets watched, and requiring the leaf to resolve would refuse to watch
-        // a path that is momentarily absent — mid atomic-replace, or not yet
-        // created. A symlinked leaf stays safe because the re-read still goes
-        // through `readFile`, which contains the file it opens.
-        const directory = yield* realPathWithinRoot(input, path.dirname(target.absolutePath));
-        const fileName = path.basename(target.absolutePath);
-        const watchedPath = path.join(directory, fileName);
+        // Prefer the canonical leaf, so a symlinked file follows edits made
+        // through its target's own path. Fall back to the parent when the leaf
+        // does not resolve, so a watch still attaches to a path that is
+        // momentarily absent — mid atomic-replace, or not yet created. Either
+        // way the directory that gets watched is proven inside the workspace,
+        // and an escaping symlink still fails rather than falling back.
+        const canonical = yield* Effect.tryPromise({
+          try: () => NodeFSP.realpath(target.absolutePath),
+          catch: () => null,
+        }).pipe(Effect.orElseSucceed(() => null));
+        const watchedPath =
+          canonical === null
+            ? path.join(
+                yield* realPathWithinRoot(input, path.dirname(target.absolutePath)),
+                path.basename(target.absolutePath),
+              )
+            : yield* realPathWithinRoot(input, canonical);
+        const directory = path.dirname(watchedPath);
+        const fileName = path.basename(watchedPath);
 
         return fileSystem.watch(directory).pipe(
           Stream.filter(

--- a/apps/server/src/workspace/WorkspaceFileSystem.ts
+++ b/apps/server/src/workspace/WorkspaceFileSystem.ts
@@ -10,17 +10,20 @@
 import * as NodeFSP from "node:fs/promises";
 
 import type {
+  ProjectFileChangedEvent,
   ProjectReadFileInput,
   ProjectReadFileResult,
   ProjectWriteFileInput,
   ProjectWriteFileResult,
 } from "@t3tools/contracts";
 import * as Context from "effect/Context";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
 
 import * as WorkspaceEntries from "./WorkspaceEntries.ts";
 import * as WorkspacePaths from "./WorkspacePaths.ts";
@@ -43,6 +46,7 @@ export class WorkspaceFileSystemOperationError extends Schema.TaggedErrorClass<W
       "close",
       "make-directory",
       "write-file",
+      "watch",
     ]),
     cause: Schema.Defect(),
   },
@@ -121,6 +125,19 @@ export class WorkspaceFileSystem extends Context.Service<
       input: ProjectWriteFileInput,
     ) => Effect.Effect<
       ProjectWriteFileResult,
+      WorkspaceFileSystemError | WorkspacePaths.WorkspacePathOutsideRootError
+    >;
+    /**
+     * Emit a change event every time the file changes on disk.
+     *
+     * The stream is a signal only: subscribers re-read through `readFile`, so
+     * every size, binary and error rule stays in one place. Events are
+     * debounced because a single save is several `fs.watch` events.
+     */
+    readonly watchFile: (
+      input: ProjectReadFileInput,
+    ) => Stream.Stream<
+      ProjectFileChangedEvent,
       WorkspaceFileSystemError | WorkspacePaths.WorkspacePathOutsideRootError
     >;
   }
@@ -297,7 +314,47 @@ export const make = Effect.gen(function* () {
     return { relativePath: target.relativePath };
   });
 
-  return WorkspaceFileSystem.of({ readFile, writeFile });
+  /**
+   * Watches the containing directory rather than the file itself: saves that
+   * land as rename-over-temp (git, most editors, atomic writers) replace the
+   * inode, and a file-level watch would follow the discarded one.
+   */
+  const watchFile: WorkspaceFileSystem["Service"]["watchFile"] = (input) =>
+    Stream.unwrap(
+      Effect.gen(function* () {
+        const target = yield* workspacePaths.resolveRelativePathWithinRoot({
+          workspaceRoot: input.cwd,
+          relativePath: input.relativePath,
+        });
+        const directory = path.dirname(target.absolutePath);
+        const fileName = path.basename(target.absolutePath);
+
+        return fileSystem.watch(directory).pipe(
+          Stream.filter(
+            (event) =>
+              event.path === fileName ||
+              event.path === target.absolutePath ||
+              path.resolve(directory, event.path) === target.absolutePath,
+          ),
+          // Debounce so the file is fully written before subscribers re-read it.
+          Stream.debounce(Duration.millis(100)),
+          Stream.map(() => ({ relativePath: target.relativePath })),
+          Stream.mapError(
+            (cause) =>
+              new WorkspaceFileSystemOperationError({
+                workspaceRoot: input.cwd,
+                relativePath: input.relativePath,
+                resolvedPath: target.absolutePath,
+                operationPath: directory,
+                operation: "watch",
+                cause,
+              }),
+          ),
+        );
+      }),
+    );
+
+  return WorkspaceFileSystem.of({ readFile, writeFile, watchFile });
 });
 
 export const layer = Layer.effect(WorkspaceFileSystem, make);

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1899,6 +1899,21 @@ const makeWsRpcLayer = (
             ),
             { "rpc.aggregate": "workspace" },
           ),
+        [WS_METHODS.subscribeProjectFileChanges]: (input) =>
+          observeRpcStream(
+            WS_METHODS.subscribeProjectFileChanges,
+            workspaceFileSystem.watchFile(input).pipe(
+              Stream.mapError(
+                (cause) =>
+                  new ProjectReadFileError({
+                    ...input,
+                    ...projectFileFailureContext(cause),
+                    cause,
+                  }),
+              ),
+            ),
+            { "rpc.aggregate": "workspace" },
+          ),
         [WS_METHODS.projectsWriteFile]: (input) =>
           observeRpcEffect(
             WS_METHODS.projectsWriteFile,

--- a/packages/client-runtime/src/rpc/client.ts
+++ b/packages/client-runtime/src/rpc/client.ts
@@ -52,6 +52,7 @@ export type EnvironmentSubscriptionRpcTag =
   | typeof WS_METHODS.subscribeResourceTelemetry
   | typeof WS_METHODS.previewAutomationConnect
   | typeof WS_METHODS.subscribeVcsStatus
+  | typeof WS_METHODS.subscribeProjectFileChanges
   | typeof WS_METHODS.terminalAttach;
 
 export type EnvironmentStreamCommandRpcTag =

--- a/packages/client-runtime/src/state/projectCommands.ts
+++ b/packages/client-runtime/src/state/projectCommands.ts
@@ -8,6 +8,7 @@ import {
   createEnvironmentRpcCommand,
   createEnvironmentRpcQueryAtomFamily,
 } from "./runtime.ts";
+import { subscribe } from "../rpc/client.ts";
 import {
   type CreateProjectInput,
   type DeleteProjectInput,
@@ -66,11 +67,16 @@ export function createProjectEnvironmentAtoms<R, E>(
       staleTimeMs: 30_000,
       idleTtlMs: 5 * 60_000,
     }),
+    // The server watches the open file and says when it moved, so an agent (or
+    // anything else) editing on disk lands in the viewer without polling and
+    // without waiting for a focus change. Web, desktop and mobile all read this
+    // atom, so they all stop serving stale contents together.
     readFile: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:projects:read-file",
       tag: WS_METHODS.projectsReadFile,
       staleTimeMs: 30_000,
       idleTtlMs: 5 * 60_000,
+      invalidate: (input) => subscribe(WS_METHODS.subscribeProjectFileChanges, input),
     }),
     optimisticFile: (target: OptimisticProjectFileTarget) =>
       optimisticFileFamily(optimisticProjectFileKey(target)),

--- a/packages/client-runtime/src/state/runtime.test.ts
+++ b/packages/client-runtime/src/state/runtime.test.ts
@@ -12,7 +12,9 @@ import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity";
 import {
   environmentRpcKey,
   createAtomCommandScheduler,
+  createInvalidatableQueryAtom,
   createRuntimeCommand,
+  createStreamRevisionAtom,
   scheduleAtomCommandEffect,
   executeAtomCommand,
   executeAtomQuery,
@@ -495,6 +497,96 @@ describe("runtime command runner", () => {
     expect(await second).toMatchObject({ _tag: "Success", value: 3, waiting: false });
     expect(await third).toMatchObject({ _tag: "Success", value: 3, waiting: false });
     expect(executed).toEqual([1, 3]);
+    registry.dispose();
+  });
+});
+
+describe("createInvalidatableQueryAtom", () => {
+  it("refetches when the revision changes, and only then, inside the stale window", async () => {
+    const runtime = Atom.runtime(Layer.empty);
+    const revisions = Atom.make(0);
+    let reads = 0;
+    const query = createInvalidatableQueryAtom(runtime, {
+      label: "test.invalidatable",
+      staleTimeMs: 30_000,
+      idleTtlMs: 60_000,
+      revisions,
+      execute: () => Effect.sync(() => (reads += 1)),
+    });
+    const registry = AtomRegistry.make();
+
+    expect(await executeAtomQuery(registry, query)).toMatchObject({
+      _tag: "Success",
+      value: 1,
+    });
+
+    // Fresh within `staleTime`: reading again must not hit the source.
+    expect(await executeAtomQuery(registry, query)).toMatchObject({
+      _tag: "Success",
+      value: 1,
+    });
+    expect(reads).toBe(1);
+
+    // A revision bump means the underlying data moved, so the stale window
+    // stops applying — this is the stale-file-viewer fix.
+    registry.set(revisions, 1);
+
+    expect(await executeAtomQuery(registry, query)).toMatchObject({
+      _tag: "Success",
+      value: 2,
+    });
+    expect(reads).toBe(2);
+    registry.dispose();
+  });
+
+  it("keeps serving the stale window when no revisions are supplied", async () => {
+    const runtime = Atom.runtime(Layer.empty);
+    let reads = 0;
+    const query = createInvalidatableQueryAtom(runtime, {
+      label: "test.plain",
+      staleTimeMs: 30_000,
+      idleTtlMs: 60_000,
+      execute: () => Effect.sync(() => (reads += 1)),
+    });
+    const registry = AtomRegistry.make();
+
+    await executeAtomQuery(registry, query);
+    await executeAtomQuery(registry, query);
+
+    expect(reads).toBe(1);
+    registry.dispose();
+  });
+});
+
+describe("createStreamRevisionAtom", () => {
+  it("counts emissions and ignores everything else", async () => {
+    const runtime = Atom.runtime(Layer.empty);
+    const latch = Latch.makeUnsafe();
+    const revisions = createStreamRevisionAtom(
+      runtime,
+      Stream.fromArray(["changed", "changed"]).pipe(Stream.concat(Stream.fromEffect(latch.await))),
+      { label: "test.revisions", idleTtlMs: 60_000 },
+    );
+    const registry = AtomRegistry.make();
+    const observed: Array<number> = [];
+    let unsubscribe = () => {};
+    const secondRevision = new Promise<number>((resolve) => {
+      unsubscribe = registry.subscribe(
+        revisions,
+        (revision) => {
+          observed.push(revision);
+          if (revision === 2) resolve(revision);
+        },
+        { immediate: true },
+      );
+    });
+
+    // Two emissions, two revisions — identical payloads still count as two,
+    // because the emission is the signal, not its contents.
+    expect(await secondRevision).toBe(2);
+    // Waiting states never rewind the revision.
+    expect(observed).toEqual([...observed].toSorted((a, b) => a - b));
+    unsubscribe();
     registry.dispose();
   });
 });

--- a/packages/client-runtime/src/state/runtime.ts
+++ b/packages/client-runtime/src/state/runtime.ts
@@ -52,6 +52,14 @@ interface EnvironmentQueryAtomOptions<Input, A, E, R> extends EnvironmentAtomOpt
   readonly staleTimeMs?: number;
   readonly idleTtlMs?: number;
   readonly refreshIntervalMs?: number;
+  /**
+   * Server-pushed staleness signal. Every emission recomputes the query, which
+   * re-runs `execute` outright — `staleTimeMs` only gates SWR's own background
+   * revalidation, so a change that lands inside the stale window still lands in
+   * the UI. Use this instead of polling when the server can say when the
+   * underlying data moved.
+   */
+  readonly invalidate?: (input: Input) => Stream.Stream<unknown, unknown, R>;
 }
 
 interface EnvironmentSubscriptionAtomOptions<Input, A, E, R> {
@@ -505,11 +513,27 @@ export function createEnvironmentQueryAtomFamily<R, ER, Input, A, E>(
       { initialValue: null },
     ),
   );
+  const invalidate = options.invalidate;
   const family = Atom.family((key: string) => {
     const target = parseEnvironmentRpcKey<Input>(key);
     const idleTtlMs = options.idleTtlMs ?? 5 * 60_000;
-    const queryAtom = runtime
-      .atom((get) => {
+    const revisions =
+      invalidate === undefined
+        ? undefined
+        : createStreamRevisionAtom(
+            runtime,
+            followStreamInEnvironment(target.environmentId, invalidate(target.input)),
+            { label: `${options.label}:invalidate:${key}`, idleTtlMs },
+          );
+    return createInvalidatableQueryAtom(runtime, {
+      label: `${options.label}:${key}`,
+      idleTtlMs,
+      staleTimeMs: options.staleTimeMs ?? 30_000,
+      ...(options.refreshIntervalMs === undefined
+        ? {}
+        : { refreshIntervalMs: options.refreshIntervalMs }),
+      ...(revisions === undefined ? {} : { revisions }),
+      execute: (get) => {
         const generation = Option.getOrNull(
           AsyncResult.value(get(rpcGenerationAtom(target.environmentId))),
         );
@@ -517,21 +541,80 @@ export function createEnvironmentQueryAtomFamily<R, ER, Input, A, E>(
           return Effect.never;
         }
         return runInEnvironment(target.environmentId, options.execute(target.input));
-      })
-      .pipe(
-        Atom.swr({
-          staleTime: options.staleTimeMs ?? 30_000,
-          revalidateOnMount: true,
-        }),
-        Atom.setIdleTTL(idleTtlMs),
-      );
-    return (
-      options.refreshIntervalMs === undefined
-        ? queryAtom
-        : queryAtom.pipe(Atom.withRefresh(options.refreshIntervalMs))
-    ).pipe(Atom.setIdleTTL(idleTtlMs), Atom.withLabel(`${options.label}:${key}`));
+      },
+    });
   });
   return (target) => family(environmentRpcKey(target));
+}
+
+/**
+ * Counts emissions of `stream` as a plain revision number.
+ *
+ * Counting on the client keeps the revision insensitive to everything a query
+ * should not refetch for: waiting states, reconnects and repeated payloads all
+ * map back to the same number, and the atom's `Object.is` equality drops them.
+ */
+export function createStreamRevisionAtom<R, ER, A, E>(
+  runtime: Atom.AtomRuntime<R, ER>,
+  stream: Stream.Stream<A, E, R>,
+  options: { readonly label: string; readonly idleTtlMs: number },
+): Atom.Atom<number> {
+  return runtime
+    .atom(
+      stream.pipe(
+        Stream.mapAccum(
+          () => 0,
+          (revision: number) => [revision + 1, [revision + 1]] as const,
+        ),
+      ),
+      { initialValue: 0 },
+    )
+    .pipe(
+      Atom.map((result: AsyncResult.AsyncResult<unknown, unknown>) => {
+        const revision = AsyncResult.value(result);
+        return Option.isSome(revision) && typeof revision.value === "number" ? revision.value : 0;
+      }),
+      Atom.setIdleTTL(options.idleTtlMs),
+      Atom.withLabel(options.label),
+    );
+}
+
+/**
+ * Stale-while-revalidate query atom that also re-executes whenever `revisions`
+ * changes.
+ *
+ * `staleTimeMs` only gates SWR's own background revalidation, so a revision
+ * bump refetches even inside the stale window. That is the point: a push that
+ * says the data moved must not be answered with a cached value.
+ */
+export function createInvalidatableQueryAtom<R, ER, A, E>(
+  runtime: Atom.AtomRuntime<R, ER>,
+  options: {
+    readonly label: string;
+    readonly execute: (get: Atom.AtomContext) => Effect.Effect<A, E, R>;
+    readonly revisions?: Atom.Atom<number>;
+    readonly staleTimeMs: number;
+    readonly idleTtlMs: number;
+    readonly refreshIntervalMs?: number;
+  },
+): Atom.Atom<AsyncResult.AsyncResult<A, E | ER | Error>> {
+  const revisions = options.revisions;
+  const queryAtom = runtime
+    .atom((get: Atom.AtomContext) => {
+      if (revisions !== undefined) {
+        get(revisions);
+      }
+      return options.execute(get);
+    })
+    .pipe(
+      Atom.swr({ staleTime: options.staleTimeMs, revalidateOnMount: true }),
+      Atom.setIdleTTL(options.idleTtlMs),
+    );
+  return (
+    options.refreshIntervalMs === undefined
+      ? queryAtom
+      : queryAtom.pipe(Atom.withRefresh(options.refreshIntervalMs))
+  ).pipe(Atom.setIdleTTL(options.idleTtlMs), Atom.withLabel(options.label));
 }
 
 export function createEnvironmentSubscriptionAtomFamily<R, ER, Input, A, E>(
@@ -598,8 +681,17 @@ export function createEnvironmentRpcQueryAtomFamily<R, ER, TTag extends Environm
     readonly staleTimeMs?: number;
     readonly idleTtlMs?: number;
     readonly refreshIntervalMs?: number;
+    /**
+     * Server-pushed staleness signal for this query — see the `invalidate`
+     * option on {@link createEnvironmentQueryAtomFamily}. Pass a subscription
+     * whose emissions mean "this query's data changed"; the payload is ignored.
+     */
+    readonly invalidate?: (
+      input: EnvironmentRpcInput<TTag>,
+    ) => Stream.Stream<unknown, unknown, EnvironmentSupervisor | R>;
   },
 ) {
+  const invalidate = options.invalidate;
   return createEnvironmentQueryAtomFamily(runtime, {
     label: options.label,
     ...(options.staleTimeMs === undefined ? {} : { staleTimeMs: options.staleTimeMs }),
@@ -607,6 +699,14 @@ export function createEnvironmentRpcQueryAtomFamily<R, ER, TTag extends Environm
     ...(options.refreshIntervalMs === undefined
       ? {}
       : { refreshIntervalMs: options.refreshIntervalMs }),
+    ...(invalidate === undefined
+      ? {}
+      : {
+          // A watcher that cannot start must not take the query down with it:
+          // the query keeps working, it just stops self-refreshing.
+          invalidate: (input: EnvironmentRpcInput<TTag>) =>
+            invalidate(input).pipe(Stream.catchCause(() => Stream.empty)),
+        }),
     execute: (input: EnvironmentRpcInput<TTag>) => request(options.tag, input),
   });
 }

--- a/packages/contracts/src/project.ts
+++ b/packages/contracts/src/project.ts
@@ -205,6 +205,17 @@ export const ProjectReadFileResult = Schema.Struct({
 });
 export type ProjectReadFileResult = typeof ProjectReadFileResult.Type;
 
+/**
+ * Emitted by `subscribeProjectFileChanges` whenever a watched workspace file
+ * changes on disk. It is a signal, not a payload: clients re-read the file
+ * through `projects.readFile` so size limits, binary detection and error
+ * mapping keep living in one place.
+ */
+export const ProjectFileChangedEvent = Schema.Struct({
+  relativePath: TrimmedNonEmptyString,
+});
+export type ProjectFileChangedEvent = typeof ProjectFileChangedEvent.Type;
+
 export const ProjectFileFailure = Schema.Literals([
   "workspace_path_outside_root",
   "resolved_path_outside_root",
@@ -223,6 +234,7 @@ export const ProjectFileOperation = Schema.Literals([
   "close",
   "make-directory",
   "write-file",
+  "watch",
 ]);
 export type ProjectFileOperation = typeof ProjectFileOperation.Type;
 

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -99,6 +99,7 @@ import {
   RelayClientStatusSchema,
 } from "./relayClient.ts";
 import {
+  ProjectFileChangedEvent,
   ProjectListEntriesError,
   ProjectListEntriesInput,
   ProjectListEntriesResult,
@@ -304,6 +305,7 @@ export const WS_METHODS = {
 
   // Streaming subscriptions
   subscribeVcsStatus: "subscribeVcsStatus",
+  subscribeProjectFileChanges: "subscribeProjectFileChanges",
   subscribeTerminalEvents: "subscribeTerminalEvents",
   subscribeTerminalMetadata: "subscribeTerminalMetadata",
   subscribePreviewEvents: "subscribePreviewEvents",
@@ -640,6 +642,17 @@ export const WsProjectsReadFileRpc = Rpc.make(WS_METHODS.projectsReadFile, {
   payload: ProjectReadFileInput,
   success: ProjectReadFileResult,
   error: Schema.Union([ProjectReadFileError, EnvironmentAuthorizationError]),
+});
+
+/**
+ * Watches one workspace file and emits whenever it changes on disk, so an open
+ * viewer re-reads instead of pinning whatever it read when it was opened.
+ */
+export const WsSubscribeProjectFileChangesRpc = Rpc.make(WS_METHODS.subscribeProjectFileChanges, {
+  payload: ProjectReadFileInput,
+  success: ProjectFileChangedEvent,
+  error: Schema.Union([ProjectReadFileError, EnvironmentAuthorizationError]),
+  stream: true,
 });
 
 export const WsProjectsWriteFileRpc = Rpc.make(WS_METHODS.projectsWriteFile, {
@@ -1028,6 +1041,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsSourceControlPublishRepositoryRpc,
   WsProjectsListEntriesRpc,
   WsProjectsReadFileRpc,
+  WsSubscribeProjectFileChangesRpc,
   WsProjectsSearchContentsRpc,
   WsProjectsSearchEntriesRpc,
   WsProjectsWriteFileRpc,


### PR DESCRIPTION
## The problem

An open file tab keeps showing whatever it read when it was opened. If the file changes on disk — an agent edits it, a script rewrites it, you run a command in T3's own terminal — the viewer stays stale until you reload the window.

The cause is the SWR query atom behind `projects.readFile` (`packages/client-runtime/src/state/projectCommands.ts`). It has `staleTime: 30_000` and `idleTtl: 5 * 60_000`, but no refresh interval and no revalidation trigger. `Atom.swr` only evaluates staleness when the atom node recomputes, and once mounted nothing recomputes it — no timer, no focus signal, no dependency that moves when disk moves. So `staleTime` means "30s old at the next read", not "refetch every 30s", and while the panel stays open the value is pinned indefinitely.

Everything else in the path is fine: the server read is uncached, and the editor document and highlight caches are content-addressed.

Closing and reopening the tab does not help — the node is parked by `idleTtl`, not disposed, so a reopen inside ~5 minutes replays the cached value with no RPC. That is why only a reload works.

This is not a terminal bug. It reproduces with a plain `sed` on disk while the window is focused, which is also the common agent-edits-while-you-watch case.

## The fix

The server watches the open file and pushes a change signal; the client treats that signal as a query dependency, so the read re-runs.

- New `subscribeProjectFileChanges` subscription (`packages/contracts/src/rpc.ts`), payload `ProjectReadFileInput`.
- `WorkspaceFileSystem.watchFile` follows the existing `FileSystem.watch` pattern in `apps/server/src/serverSettings.ts` and `apps/server/src/keybindings.ts`: debounced, filtered, scoped to the subscription. Same path-escape check as `readFile`.
- `createEnvironmentQueryAtomFamily` gains an optional `invalidate` stream, wired through the same dependency mechanism the existing connection-generation atom already uses.

Two details worth calling out:

**`staleTime` is not bypassed by accident.** It only gates SWR's own background revalidation. A revision bump recomputes the inner atom, which re-runs the RPC outright — so a change landing five seconds after the last read still reaches the UI. That is deliberate, and it is what makes this work without polling.

**The watch is on the containing directory, not the file.** Atomic rename-over-temp saves (git, most editors) replace the inode, and a file-level watch would follow the discarded one.

The event is a signal, not a payload — subscribers re-read through `projects.readFile`, so size limits, binary detection and error mapping stay in one place. A watcher that fails to start does not take the query down with it; the query keeps working, it just stops self-refreshing.

Unsaved optimistic edits still shadow the query, so nothing clobbers in-progress work.

### Why not the cheaper options

- **`refreshIntervalMs`** is one line and already supported, but it is polling: an RPC per open file per interval, on every client including mobile, forever.
- **Focus/visibility revalidation** via the existing `useLiveRefresh` hook adds no background traffic, but does not fix the agent-edits-while-focused case, which is the common one.

## Surfaces

The atom is shared, so web, desktop and mobile all stop serving stale contents together. Mobile previously papered over this with pull-to-refresh and a header Refresh action that the web panel lacks.

`useT3ProjectFileScripts` reads `t3.json` through the same atom, so project scripts now pick up on-disk edits too.

## Tests

There was no staleness coverage to extend, so this adds:

- `WorkspaceFileSystem.test.ts` — `watchFile` reports a plain on-disk write, reports an atomic rename-replace, and rejects paths outside the workspace root.
- `server.test.ts` — end-to-end over a real WebSocket: subscribe, edit the file on disk, receive the event, confirm `projects.readFile` returns the new contents.
- `runtime.test.ts` — a revision bump refetches inside the stale window and only then; queries without an invalidation stream still honour the stale window; revision counting ignores waiting states and reconnects.

No sleeps or polling in any of them. The two watcher tests rewrite until the watcher reports rather than racing a fixed startup delay, because `fs.watch` registration is not observable.

## Verification

Live, against a minimal fixture (a one-line `package.json` in a throwaway git repo), on an isolated `--home-dir`, with the browser window focused throughout — no click, no blur, no refresh button, no agent turn:

| Step | Disk | Viewer |
|---|---|---|
| Open `package.json` | `zebra` | `zebra` ok |
| plain `sed` on disk, window focused | `course` | `course` ok |
| atomic write + `mv` replace | `atomic` | `atomic` ok |

Before/after screenshots are in the first comment below, along with the pixel hashes that back them up.

## Related

Likely the same defect as #7377, which is currently closed. It was auto-closed by #7490's `Fixes` keyword one second after that merge, while still carrying `needs-triage`. #7490 wires the explorer's refresh button to also refresh the selected file — user-initiated only, by its own description — and does not touch the stale atom, so #7377's repro still reproduces on current `main`. Deliberately not using a closing keyword here; reopening #7377 is your call.

---

Written by Claude Opus 5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds live directory watches and a new streaming RPC over workspace paths, including symlink/escape checks. Query invalidation also changes how all clients refetch file contents.
> 
> **Overview**
> Open file tabs no longer stay stuck on the first `projects.readFile` result. The server now watches the file and pushes a change signal so the shared query atom refetches even inside the SWR stale window.
> 
> Adds `WorkspaceFileSystem.watchFile` and streaming RPC `subscribeProjectFileChanges` (read scope). The watch is on the containing directory (and the symlink target when they differ) so atomic rename-over-temp saves are not missed; events are debounced and are a signal only—clients re-read through `readFile`. Escaping paths and escaping symlinks are rejected.
> 
> Client query atoms gain an optional `invalidate` stream (`createInvalidatableQueryAtom` / `createStreamRevisionAtom`). `readFile` subscribes to the new RPC; a failed watcher does not take the query down. Unsaved optimistic edits still shadow the live contents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f426631580a1a0d00c126da33affe5aa3643de98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `subscribeProjectFileChanges` WS RPC to refresh open files on disk change
> - Introduces a streaming websocket RPC `subscribeProjectFileChanges` that emits `ProjectFileChangedEvent` when a workspace file changes, debounced at 100ms.
> - `WorkspaceFileSystem.watchFile` resolves the target within the workspace, watches both lexical and canonical directories as needed, filters by filename, and handles atomic replaces and symlinked paths while rejecting escapes outside the root.
> - Client `projects.readFile` query atom is configured to invalidate on the `subscribeProjectFileChanges` stream, triggering immediate refetch even inside the stale window.
> - Adds `createStreamRevisionAtom` and `createInvalidatableQueryAtom` helpers to support stream-driven query invalidation across environment-scoped queries.
> - Risk: `readFile` in [WorkspaceFileSystem.ts](https://github.com/pingdotgg/t3code/pull/7896/files#diff-81ad8ace22ddc05dfe7959b2ca3ad910979a2924cd4c8bfe5469150f44c421d2) now resolves via `realPathWithinRoot` to assert physical containment; symlinked paths that previously resolved but escape the workspace root will now be rejected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f426631.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->