### PR TITLE
fix(chat): stop pushing follow-up messages to the top

### DIFF
--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -257,9 +257,10 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
   const listRef = useRef<LegendListRef>(null);
   const feedTouchStartRef = useRef<{ pageX: number; pageY: number } | null>(null);
   const selectedThreadKeyRef = useRef(selectedThreadKey);
-  const lastScrolledAnchorMessageIdRef = useRef<MessageId | null>(null);
+  const lastScrolledSubmittedMessageIdRef = useRef<MessageId | null>(null);
   const [composerExpanded, setComposerExpanded] = useState(false);
   const [anchorMessageId, setAnchorMessageId] = useState<MessageId | null>(null);
+  const [submittedMessageId, setSubmittedMessageId] = useState<MessageId | null>(null);
   const [endFollowEnabled, setEndFollowEnabled] = useState(true);
   // Android keys the safe-area padding on keyboard visibility (#5988): the
   // back gesture closes the keyboard while the editor stays focused, and a
@@ -458,17 +459,20 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
 
   useEffect(() => {
     setAnchorMessageId(null);
-    lastScrolledAnchorMessageIdRef.current = null;
+    setSubmittedMessageId(null);
+    lastScrolledSubmittedMessageIdRef.current = null;
     setEndFollowEnabled(true);
     freeze.set(false);
   }, [freeze, selectedThreadKey]);
 
   useEffect(() => {
     if (
-      anchorMessageId === null ||
-      lastScrolledAnchorMessageIdRef.current === anchorMessageId ||
+      submittedMessageId === null ||
+      lastScrolledSubmittedMessageIdRef.current === submittedMessageId ||
       contentPresentationKind !== "ready" ||
-      !selectedThreadFeed.some((entry) => entry.type === "message" && entry.id === anchorMessageId)
+      !selectedThreadFeed.some(
+        (entry) => entry.type === "message" && entry.id === submittedMessageId,
+      )
     ) {
       return;
     }
@@ -478,7 +482,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
       if (selectedThreadKeyRef.current !== targetThreadKey) {
         return;
       }
-      lastScrolledAnchorMessageIdRef.current = anchorMessageId;
+      lastScrolledSubmittedMessageIdRef.current = submittedMessageId;
       // Wait for the keyboard dismissal (started by blur() on send) to finish
       // before scrolling: scrollMessageToEnd freezes keyboard-driven inset
       // updates while it runs, and a close event swallowed by that freeze
@@ -488,7 +492,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
         .then(() => {
           if (
             selectedThreadKeyRef.current !== targetThreadKey ||
-            lastScrolledAnchorMessageIdRef.current !== anchorMessageId
+            lastScrolledSubmittedMessageIdRef.current !== submittedMessageId
           ) {
             return;
           }
@@ -497,17 +501,17 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
         .catch(() => {
           if (
             selectedThreadKeyRef.current !== targetThreadKey ||
-            lastScrolledAnchorMessageIdRef.current !== anchorMessageId
+            lastScrolledSubmittedMessageIdRef.current !== submittedMessageId
           ) {
             return;
           }
-          lastScrolledAnchorMessageIdRef.current = null;
+          lastScrolledSubmittedMessageIdRef.current = null;
           freeze.set(false);
         });
     });
     return () => cancelAnimationFrame(frame);
   }, [
-    anchorMessageId,
+    submittedMessageId,
     freeze,
     contentPresentationKind,
     selectedThreadFeed,
@@ -517,15 +521,21 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
 
   const handleSendMessage = useCallback(async () => {
     const targetThreadKey = selectedThreadKey;
+    const shouldAnchorFirstMessage =
+      props.selectedThread.latestTurn === null &&
+      !selectedThreadFeed.some(
+        (entry) => entry.type === "message" && entry.message.role === "user",
+      );
     const messageId = await props.onSendMessage();
     if (messageId === null || selectedThreadKeyRef.current !== targetThreadKey) {
       return messageId;
     }
 
-    setAnchorMessageId(messageId);
+    setSubmittedMessageId(messageId);
+    setAnchorMessageId(shouldAnchorFirstMessage ? messageId : null);
     composerEditorRef.current?.blur();
     return messageId;
-  }, [props.onSendMessage, selectedThreadKey]);
+  }, [props.onSendMessage, props.selectedThread.latestTurn, selectedThreadFeed, selectedThreadKey]);
 
   const collapseComposer = useCallback(() => {
     composerEditorRef.current?.blur();
@@ -595,6 +605,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
             listRef={listRef}
             freeze={freeze}
             anchorMessageId={anchorMessageId}
+            submittedMessageId={submittedMessageId}
             contentInsetEndAdjustment={combinedContentInsetEndAdjustment}
             contentTopInset={0}
             contentBottomInset={estimatedOverlayHeight}

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -79,6 +79,7 @@ import {
 } from "./ThreadComposer";
 import { ThreadFeed } from "./ThreadFeed";
 import type { ThreadContentPresentation } from "./threadContentPresentation";
+import { resolveThreadFeedSubmissionAnchor } from "./thread-feed-live-follow";
 
 export interface ThreadDetailScreenProps {
   readonly selectedThread: OrchestrationThreadShell;
@@ -521,21 +522,34 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
 
   const handleSendMessage = useCallback(async () => {
     const targetThreadKey = selectedThreadKey;
-    const shouldAnchorFirstMessage =
-      props.selectedThread.latestTurn === null &&
-      !selectedThreadFeed.some(
-        (entry) => entry.type === "message" && entry.message.role === "user",
-      );
+    const hasUserMessage = selectedThreadFeed.some(
+      (entry) => entry.type === "message" && entry.message.role === "user",
+    );
     const messageId = await props.onSendMessage();
     if (messageId === null || selectedThreadKeyRef.current !== targetThreadKey) {
       return messageId;
     }
 
     setSubmittedMessageId(messageId);
-    setAnchorMessageId(shouldAnchorFirstMessage ? messageId : null);
+    setAnchorMessageId(
+      resolveThreadFeedSubmissionAnchor({
+        currentAnchorMessageId: anchorMessageId,
+        submittedMessageId: messageId,
+        hasStartedTurn: props.selectedThread.latestTurn !== null,
+        hasUserMessage,
+        queuedMessageCount: props.selectedThreadQueueCount,
+      }),
+    );
     composerEditorRef.current?.blur();
     return messageId;
-  }, [props.onSendMessage, props.selectedThread.latestTurn, selectedThreadFeed, selectedThreadKey]);
+  }, [
+    anchorMessageId,
+    props.onSendMessage,
+    props.selectedThread.latestTurn,
+    props.selectedThreadQueueCount,
+    selectedThreadFeed,
+    selectedThreadKey,
+  ]);
 
   const collapseComposer = useCallback(() => {
     composerEditorRef.current?.blur();

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -151,6 +151,7 @@ export interface ThreadFeedProps {
   readonly listRef: RefObject<LegendListRef | null>;
   readonly freeze: SharedValue<boolean>;
   readonly anchorMessageId: MessageId | null;
+  readonly submittedMessageId: MessageId | null;
   readonly contentInsetEndAdjustment: SharedValue<number>;
   readonly contentTopInset?: number;
   readonly contentBottomInset?: number;
@@ -1546,12 +1547,12 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
     transitionEndFollow({ type: "reset" });
   }, [clearUserScrollSettle, feedThreadKey, transitionEndFollow]);
   useEffect(() => {
-    if (props.anchorMessageId !== null) {
+    if (props.submittedMessageId !== null) {
       clearUserScrollSettle();
       userScrollSessionRef.current = false;
       transitionEndFollow({ type: "reset" });
     }
-  }, [clearUserScrollSettle, props.anchorMessageId, transitionEndFollow]);
+  }, [clearUserScrollSettle, props.submittedMessageId, transitionEndFollow]);
 
   const expandedWorkGroupIds = useMemo(() => {
     const ids = new Set<string>();
@@ -1600,7 +1601,7 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
       resolveChatListAnchoredEndSpace(
         presentedFeed,
         props.anchorMessageId,
-        (entry) => (entry.type === "message" ? entry.id : null),
+        (entry) => (entry.type === "message" && entry.message.role === "user" ? entry.id : null),
         { anchorOffset: anchorTopInset + CHAT_LIST_ANCHOR_OFFSET },
       ),
     [presentedFeed, props.anchorMessageId, anchorTopInset],

--- a/apps/mobile/src/features/threads/thread-feed-live-follow.test.ts
+++ b/apps/mobile/src/features/threads/thread-feed-live-follow.test.ts
@@ -30,6 +30,18 @@ describe("resolveThreadFeedSubmissionAnchor", () => {
     ).toBe("first-message");
   });
 
+  it("preserves the first-message anchor after its outbox entry drains", () => {
+    expect(
+      resolveThreadFeedSubmissionAnchor({
+        currentAnchorMessageId: "first-message",
+        submittedMessageId: "second-message",
+        hasStartedTurn: false,
+        hasUserMessage: false,
+        queuedMessageCount: 0,
+      }),
+    ).toBe("first-message");
+  });
+
   it("does not anchor a follow-up after a user message appears", () => {
     expect(
       resolveThreadFeedSubmissionAnchor({

--- a/apps/mobile/src/features/threads/thread-feed-live-follow.test.ts
+++ b/apps/mobile/src/features/threads/thread-feed-live-follow.test.ts
@@ -1,6 +1,59 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { resolveThreadFeedLiveFollow } from "./thread-feed-live-follow";
+import {
+  resolveThreadFeedLiveFollow,
+  resolveThreadFeedSubmissionAnchor,
+} from "./thread-feed-live-follow";
+
+describe("resolveThreadFeedSubmissionAnchor", () => {
+  it("anchors the first user message in a thread", () => {
+    expect(
+      resolveThreadFeedSubmissionAnchor({
+        currentAnchorMessageId: null,
+        submittedMessageId: "first-message",
+        hasStartedTurn: false,
+        hasUserMessage: false,
+        queuedMessageCount: 0,
+      }),
+    ).toBe("first-message");
+  });
+
+  it("preserves the first-message anchor when another message is queued", () => {
+    expect(
+      resolveThreadFeedSubmissionAnchor({
+        currentAnchorMessageId: "first-message",
+        submittedMessageId: "second-message",
+        hasStartedTurn: false,
+        hasUserMessage: false,
+        queuedMessageCount: 1,
+      }),
+    ).toBe("first-message");
+  });
+
+  it("does not anchor a follow-up after a user message appears", () => {
+    expect(
+      resolveThreadFeedSubmissionAnchor({
+        currentAnchorMessageId: "first-message",
+        submittedMessageId: "second-message",
+        hasStartedTurn: false,
+        hasUserMessage: true,
+        queuedMessageCount: 0,
+      }),
+    ).toBeNull();
+  });
+
+  it("does not anchor a thread that has already started a turn", () => {
+    expect(
+      resolveThreadFeedSubmissionAnchor({
+        currentAnchorMessageId: null,
+        submittedMessageId: "second-message",
+        hasStartedTurn: true,
+        hasUserMessage: false,
+        queuedMessageCount: 0,
+      }),
+    ).toBeNull();
+  });
+});
 
 describe("resolveThreadFeedLiveFollow", () => {
   it("pauses immediately when the user starts scrolling", () => {

--- a/apps/mobile/src/features/threads/thread-feed-live-follow.ts
+++ b/apps/mobile/src/features/threads/thread-feed-live-follow.ts
@@ -23,7 +23,11 @@ export function resolveThreadFeedSubmissionAnchor<AnchorId>(input: {
     return null;
   }
 
-  return input.queuedMessageCount > 0 ? input.currentAnchorMessageId : input.submittedMessageId;
+  if (input.currentAnchorMessageId !== null) {
+    return input.currentAnchorMessageId;
+  }
+
+  return input.queuedMessageCount > 0 ? null : input.submittedMessageId;
 }
 
 export function resolveThreadFeedLiveFollow(

--- a/apps/mobile/src/features/threads/thread-feed-live-follow.ts
+++ b/apps/mobile/src/features/threads/thread-feed-live-follow.ts
@@ -12,6 +12,20 @@ export type ThreadFeedLiveFollowEvent =
       readonly userScrollSessionActive: boolean;
     };
 
+export function resolveThreadFeedSubmissionAnchor<AnchorId>(input: {
+  readonly currentAnchorMessageId: AnchorId | null;
+  readonly submittedMessageId: AnchorId;
+  readonly hasStartedTurn: boolean;
+  readonly hasUserMessage: boolean;
+  readonly queuedMessageCount: number;
+}): AnchorId | null {
+  if (input.hasStartedTurn || input.hasUserMessage) {
+    return null;
+  }
+
+  return input.queuedMessageCount > 0 ? input.currentAnchorMessageId : input.submittedMessageId;
+}
+
 export function resolveThreadFeedLiveFollow(
   current: boolean,
   event: ThreadFeedLiveFollowEvent,

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -638,6 +638,29 @@ describe("hasServerAcknowledgedLocalDispatch", () => {
     ).toBe(false);
   });
 
+  it("keeps a follow-up active while its provider session is starting", () => {
+    const localDispatch = createLocalDispatchSnapshot(
+      makeThread({ latestTurn: completedTurn, session: readySession }),
+    );
+
+    expect(
+      hasServerAcknowledgedLocalDispatch({
+        localDispatch,
+        phase: "connecting",
+        latestTurn: completedTurn,
+        latestUserMessageId: MessageId.make("message-followup"),
+        session: {
+          ...readySession,
+          status: "starting",
+          updatedAt: "2026-03-29T00:01:00.000Z",
+        },
+        hasPendingApproval: false,
+        hasPendingUserInput: false,
+        threadError: null,
+      }),
+    ).toBe(false);
+  });
+
   it("acknowledges a settled newer turn", () => {
     const localDispatch = createLocalDispatchSnapshot(
       makeThread({ latestTurn: completedTurn, session: readySession }),

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -601,6 +601,9 @@ export function hasServerAcknowledgedLocalDispatch(input: {
   if (input.hasPendingApproval || input.hasPendingUserInput || Boolean(input.threadError)) {
     return true;
   }
+  if (input.phase === "connecting") {
+    return false;
+  }
 
   const latestTurn = input.latestTurn ?? null;
   const session = input.session ?? null;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5297,21 +5297,25 @@ function ChatViewContent(props: ChatViewProps) {
       sizeBytes: image.sizeBytes,
       previewUrl: image.previewUrl,
     }));
-    // Sending always returns to the live edge. The new row becomes the
-    // anchored end-space target so it lands near the top while the response
-    // streams into the reserved space below it.
-    isAtEndRef.current = true;
-    timelineScrollModeRef.current = "anchoring-new-turn";
-    liveFollowUserScrollGenerationRef.current = anchorUserScrollGenerationRef.current;
-    setTimelineLiveFollowEnabled(true);
-    pendingTimelineAnchorRef.current = messageIdForSend;
-    activeTimelineAnchorIndexRef.current = null;
-    showScrollDebouncer.current.cancel();
-    setShowScrollToBottom(false);
-    setTimelineAnchor({
-      threadKey: scopedThreadKey(scopeThreadRef(activeThread.environmentId, threadIdForSend)),
-      messageId: messageIdForSend,
-    });
+    const shouldAnchorFirstMessage =
+      activeThread.latestTurn === null &&
+      !timelineMessages.some((message) => message.role === "user");
+    if (shouldAnchorFirstMessage) {
+      isAtEndRef.current = true;
+      timelineScrollModeRef.current = "anchoring-new-turn";
+      liveFollowUserScrollGenerationRef.current = anchorUserScrollGenerationRef.current;
+      setTimelineLiveFollowEnabled(true);
+      pendingTimelineAnchorRef.current = messageIdForSend;
+      activeTimelineAnchorIndexRef.current = null;
+      showScrollDebouncer.current.cancel();
+      setShowScrollToBottom(false);
+      setTimelineAnchor({
+        threadKey: scopedThreadKey(scopeThreadRef(activeThread.environmentId, threadIdForSend)),
+        messageId: messageIdForSend,
+      });
+    } else {
+      scrollToEnd();
+    }
     setOptimisticUserMessages((existing) => [
       ...existing,
       {
@@ -5815,19 +5819,7 @@ function ChatViewContent(props: ChatViewProps) {
       beginLocalDispatch({ preparingWorktree: false });
       setThreadError(threadIdForSend, null);
 
-      // Position this sent row once LegendList has measured the anchored tail.
-      isAtEndRef.current = true;
-      timelineScrollModeRef.current = "anchoring-new-turn";
-      liveFollowUserScrollGenerationRef.current = anchorUserScrollGenerationRef.current;
-      setTimelineLiveFollowEnabled(true);
-      pendingTimelineAnchorRef.current = messageIdForSend;
-      activeTimelineAnchorIndexRef.current = null;
-      showScrollDebouncer.current.cancel();
-      setShowScrollToBottom(false);
-      setTimelineAnchor({
-        threadKey: scopedThreadKey(scopeThreadRef(activeThread.environmentId, threadIdForSend)),
-        messageId: messageIdForSend,
-      });
+      scrollToEnd();
 
       setOptimisticUserMessages((existing) => [
         ...existing,
@@ -5922,6 +5914,7 @@ function ChatViewContent(props: ChatViewProps) {
       persistThreadSettingsForNextTurn,
       resetLocalDispatch,
       runtimeMode,
+      scrollToEnd,
       setComposerDraftInteractionMode,
       setThreadError,
       startThreadTurn,

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -434,15 +434,12 @@ describe("MessagesTimeline", () => {
     expect(resolveTimelineMinimapInteractiveWidth(40, true)).toBe("22rem");
   });
 
-  it("anchors a sent attachment message using its measured height", () => {
+  it("anchors the first user message using its measured height", () => {
     const onAnchorReady = vi.fn();
-    const firstEntry = buildUserTimelineEntry("First prompt.");
-    const secondEntry = {
-      ...buildUserTimelineEntry("Newest prompt."),
-      id: "entry-2",
+    const firstEntry = {
+      ...buildUserTimelineEntry("First prompt."),
       message: {
-        ...buildUserTimelineEntry("Newest prompt.").message,
-        id: MessageId.make("message-2"),
+        ...buildUserTimelineEntry("First prompt.").message,
         attachments: [
           {
             type: "image" as const,
@@ -458,14 +455,14 @@ describe("MessagesTimeline", () => {
     const markup = renderToStaticMarkup(
       <MessagesTimeline
         {...buildProps()}
-        anchorMessageId={secondEntry.message.id}
+        anchorMessageId={firstEntry.message.id}
         onAnchorReady={onAnchorReady}
         contentInsetEndAdjustment={144}
-        timelineEntries={[firstEntry, secondEntry]}
+        timelineEntries={[firstEntry]}
       />,
     );
 
-    expect(markup).toContain('data-anchor-index="1"');
+    expect(markup).toContain('data-anchor-index="0"');
     expect(markup).toContain('data-anchor-offset="16"');
     expect(markup).toContain('data-anchor-on-ready="true"');
     expect(markup).not.toContain("data-anchor-max-size=");
@@ -477,7 +474,32 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain('data-maintain-visible-content-position-size="true"');
     expect(markup).toContain('data-maintain-visible-content-position-restore="true"');
     expect(onAnchorReady).toHaveBeenCalledOnce();
-    expect(onAnchorReady).toHaveBeenCalledWith(secondEntry.message.id, 1);
+    expect(onAnchorReady).toHaveBeenCalledWith(firstEntry.message.id, 0);
+  });
+
+  it("does not reserve end space for a follow-up user message", () => {
+    const onAnchorReady = vi.fn();
+    const firstEntry = buildUserTimelineEntry("First prompt.");
+    const secondEntry = {
+      ...buildUserTimelineEntry("Newest prompt."),
+      id: "entry-2",
+      message: {
+        ...buildUserTimelineEntry("Newest prompt.").message,
+        id: MessageId.make("message-2"),
+      },
+    };
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        anchorMessageId={secondEntry.message.id}
+        onAnchorReady={onAnchorReady}
+        timelineEntries={[firstEntry, secondEntry]}
+      />,
+    );
+
+    expect(markup).not.toContain("data-anchor-index=");
+    expect(markup).toContain('data-maintain-scroll-at-end="enabled"');
+    expect(onAnchorReady).not.toHaveBeenCalled();
   });
 
   it("hands end-following back to the list once the send anchor is released", () => {
@@ -498,7 +520,7 @@ describe("MessagesTimeline", () => {
       renderToStaticMarkup(
         <MessagesTimeline
           {...buildProps()}
-          anchorMessageId={secondEntry.message.id}
+          anchorMessageId={firstEntry.message.id}
           timelineEntries={timelineEntries}
         />,
       ),

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -446,7 +446,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   );
   const anchoredEndSpace = useMemo(() => {
     const config = resolveChatListAnchoredEndSpace(rows, anchorMessageId, (row) =>
-      row.kind === "message" ? row.message.id : null,
+      row.kind === "message" && row.message.role === "user" ? row.message.id : null,
     );
     return config ? { ...config, onReady: handleAnchorReady } : undefined;
   }, [anchorMessageId, handleAnchorReady, rows]);

--- a/packages/shared/src/chatList.test.ts
+++ b/packages/shared/src/chatList.test.ts
@@ -16,21 +16,32 @@ const rows: ReadonlyArray<Row> = [
 const getAnchorId = (row: Row) => (row.anchorable ? row.id : null);
 
 describe("resolveChatListAnchoredEndSpace", () => {
-  it("anchors the matching row using its measured height", () => {
-    expect(resolveChatListAnchoredEndSpace(rows, "latest", getAnchorId)).toEqual({
-      anchorIndex: 2,
+  it("anchors only the first eligible row", () => {
+    expect(resolveChatListAnchoredEndSpace(rows, "first", getAnchorId)).toEqual({
+      anchorIndex: 0,
       anchorOffset: CHAT_LIST_ANCHOR_OFFSET,
     });
   });
 
   it("allows a surface to keep the anchor below its own header", () => {
     expect(
-      resolveChatListAnchoredEndSpace(rows, "latest", getAnchorId, {
+      resolveChatListAnchoredEndSpace(rows, "first", getAnchorId, {
         anchorOffset: 132,
       }),
     ).toEqual({
-      anchorIndex: 2,
+      anchorIndex: 0,
       anchorOffset: 132,
+    });
+  });
+
+  it("does not reserve end space for later eligible rows", () => {
+    expect(resolveChatListAnchoredEndSpace(rows, "latest", getAnchorId)).toBeUndefined();
+  });
+
+  it("skips ineligible rows before the first anchor", () => {
+    expect(resolveChatListAnchoredEndSpace(rows.slice(1), "latest", getAnchorId)).toEqual({
+      anchorIndex: 1,
+      anchorOffset: CHAT_LIST_ANCHOR_OFFSET,
     });
   });
 

--- a/packages/shared/src/chatList.ts
+++ b/packages/shared/src/chatList.ts
@@ -19,14 +19,23 @@ export function resolveChatListAnchoredEndSpace<Item, AnchorId>(
     return undefined;
   }
 
-  for (let index = items.length - 1; index >= 0; index -= 1) {
+  for (let index = 0; index < items.length; index += 1) {
     const item = items[index];
-    if (item !== undefined && getAnchorId(item) === anchorId) {
-      return {
-        anchorIndex: index,
-        anchorOffset: options.anchorOffset ?? CHAT_LIST_ANCHOR_OFFSET,
-      };
+    if (item === undefined) {
+      continue;
     }
+
+    const itemAnchorId = getAnchorId(item);
+    if (itemAnchorId === null) {
+      continue;
+    }
+
+    return itemAnchorId === anchorId
+      ? {
+          anchorIndex: index,
+          anchorOffset: options.anchorOffset ?? CHAT_LIST_ANCHOR_OFFSET,
+        }
+      : undefined;
   }
 
   return undefined;


### PR DESCRIPTION
Follow-up messages jumped to the top of a thread and left most of the screen empty.

Only the first user message now gets top anchoring and reserved space. Follow-ups stay at the real bottom on web, desktop, and mobile, including plan follow-ups.

Tests: 48 focused tests, web/mobile/shared type checks, targeted lint.

Model: GPT-5.6 Sol
Harness: Codex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared chat-list anchoring and send-time scroll on web and mobile, so a regression could mis-scroll threads or leave empty reserved space. Logic is covered by focused tests but still touches a high-traffic UX path.
> 
> **Overview**
> Stops follow-up sends from jumping to the top of the thread and leaving a large empty gap. **Only the first user message** still gets reserved end-space; later sends stay at the live bottom on web and mobile.
> 
> `resolveChatListAnchoredEndSpace` now walks from the start and anchors **only the first eligible user row**. Web `ChatView` sets that first-message anchor when a thread has no turn and no user messages yet; otherwise it `scrollToEnd()`. Mobile splits submit vs. layout: `submittedMessageId` drives post-send scroll/follow reset, while `resolveThreadFeedSubmissionAnchor` keeps the first-message layout pin through queued outbox sends.
> 
> Also treats a `connecting` phase as not yet acknowledging a local dispatch so follow-ups stay active while the provider session starts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d72b362f9fddc995566dc86847033fc9d3d3ca7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Anchor only the first user message and scroll follow-ups to end
> - Introduces `resolveThreadFeedSubmissionAnchor` to decide at submission time whether a message gets an anchor: only the first user message in a not-yet-started turn qualifies; follow-up sends in an active turn get no anchor and rely on end-follow scrolling.
> - Updates both mobile (`ThreadDetailScreen`, `ThreadFeed`) and web (`ChatViewContent`, `MessagesTimeline`) send paths to use the new rule, tracking `submittedMessageId` instead of `anchorMessageId` for scroll-to-end behavior.
> - Reworks `resolveChatListAnchoredEndSpace` to scan forward and reserve end space only for the first eligible user-role message; later eligible rows are ignored.
> - Fixes `hasServerAcknowledgedLocalDispatch` to return false during the `'connecting'` phase, preventing premature acknowledgement of follow-ups while a provider session is starting.
> - Risk: `resolveChatListAnchoredEndSpace` now returns `undefined` when the anchor id does not match the first eligible user message; any caller expecting reverse-scan semantics or anchoring of later rows will no longer reserve end space.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6d72b36.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->