### PR TITLE
fix(ci): shrink release app token lifetime in manual mobile builds

### DIFF
--- a/.github/workflows/mobile-eas-production.yml
+++ b/.github/workflows/mobile-eas-production.yml
@@ -152,6 +152,8 @@ jobs:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
 
       - name: Apply manual version override
         if: steps.version_app_token.outcome == 'success'
@@ -196,9 +198,13 @@ jobs:
           git commit \
             -m "chore(mobile): bump app version to $RELEASE_VERSION" \
             -m "Co-authored-by: codex <codex@users.noreply.github.com>"
-          # One-shot credential: overrides the read-only github.token that
-          # checkout persisted, without persisting the App token anywhere.
-          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)" \
+          # One-shot credential: the leading empty value resets the header list
+          # checkout persisted (extraheader is multi-valued), so the read-only
+          # github.token never reaches github.com and the App token is not
+          # persisted anywhere.
+          git \
+            -c http.https://github.com/.extraheader= \
+            -c "http.https://github.com/.extraheader=AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)" \
             push origin "HEAD:refs/heads/${GITHUB_REF_NAME}"
 
       - name: Summarize manual build version

--- a/.github/workflows/mobile-eas-production.yml
+++ b/.github/workflows/mobile-eas-production.yml
@@ -95,21 +95,11 @@ jobs:
             echo "EXPO_TOKEN is not available; skipping EAS production job."
           fi
 
-      - id: version_app_token
-        name: Mint release app token for version override
-        if: steps.expo-token.outputs.present == 'true' && github.event_name == 'workflow_dispatch' && inputs.mode == 'build' && inputs.version != ''
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
       - name: Checkout
         if: steps.expo-token.outputs.present == 'true'
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ steps.version_app_token.outputs.token || github.token }}
           # No sparse-checkout here: it makes actions/checkout fetch with
           # --filter=blob:none, and eas-cli archives the project via
           # `git clone --depth 1 file://<workspace>`, which fails (exit 128)
@@ -150,6 +140,18 @@ jobs:
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: eas env:pull production --non-interactive
+
+      # Minted immediately before use so the write-capable Release App token
+      # never exists during checkout or dependency setup, and is passed only
+      # to the push below instead of being persisted by actions/checkout.
+      - id: version_app_token
+        name: Mint release app token for version override
+        if: steps.expo-token.outputs.present == 'true' && github.event_name == 'workflow_dispatch' && inputs.mode == 'build' && inputs.version != ''
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Apply manual version override
         if: steps.version_app_token.outcome == 'success'
@@ -194,7 +196,10 @@ jobs:
           git commit \
             -m "chore(mobile): bump app version to $RELEASE_VERSION" \
             -m "Co-authored-by: codex <codex@users.noreply.github.com>"
-          git push origin "HEAD:refs/heads/${GITHUB_REF_NAME}"
+          # One-shot credential: overrides the read-only github.token that
+          # checkout persisted, without persisting the App token anywhere.
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)" \
+            push origin "HEAD:refs/heads/${GITHUB_REF_NAME}"
 
       - name: Summarize manual build version
         if: steps.expo-token.outputs.present == 'true' && github.event_name == 'workflow_dispatch' && inputs.mode == 'build'


### PR DESCRIPTION
## Problem

A manual production build with a version override minted the Release App token at the top of the job and passed it to `actions/checkout`, which persisted it into the workspace git credentials for the whole run. Every third-party setup and install step (`setup-vp`, pnpm, `expo-github-action`, `eas env:pull`) then executed while a write-capable credential sat in `.git/config` — a compromised action or dependency lifecycle script could read it and push as the Release App.

## Fix

- Checkout uses the default read-only `github.token` (push events already did; only the dispatch+version path changed).
- The Release App token is minted immediately before the version override step, so it exists for the shortest window and never overlaps setup/install.
- The version push carries the token as a one-shot `http.extraheader` via `git -c`, overriding checkout's persisted read-only credential for that single command without persisting anything.

Behavior is unchanged: same step gating (`steps.version_app_token.outcome == 'success'`), same bot identity on the commit, same push ref.

ox-alpha via opencode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches GitHub App credentials and git push auth in production CI. Behavior is intended to be equivalent, but a mis-set extraheader could break version-override pushes or leak a write token if the one-shot override fails.
> 
> **Overview**
> Hardens the manual production version-override path so a write-capable Release App token is no longer minted at the start of the job and persisted into git credentials by `actions/checkout`.
> 
> Checkout now uses the default read-only `github.token`. The App token is minted immediately before the version bump, scoped to this repo with `contents: write`, and used only as a one-shot `http.extraheader` on `git push` so it never sits in `.git/config` during setup/install.
> 
> Version-override gating, bot commit identity, and push ref are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b45ce19bf0467ad8ad55ef181b4ebf0100a53951. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Shrink GitHub App token lifetime in manual mobile build workflow
> Restricts the `version_app_token` in [mobile-eas-production.yml](https://github.com/pingdotgg/t3code/pull/7898/files#diff-1173866b4fc223964409b7aaca9a01d1217d3356ed437d34882e23fdb02e6f24) to the moment it is needed and scopes it to the current repository with `contents:write`.
> - `actions/checkout` now uses the default read-only token instead of a write-capable App token.
> - The version override commit is pushed with a one-shot HTTP `Authorization` header built from the minted App token, clearing any persisted extraheaders so the read-only checkout token is never used for the push.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b45ce19.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the production release workflow’s authentication handling.
  * Reduced the duration and exposure of release credentials during automated checkout and version updates.
  * Maintained existing release and versioning behavior while making the process more secure and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->