### PR TITLE
fix(web): cap terminal hyperlink hover range scan

### DIFF
--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -177,6 +177,33 @@ describe("terminalExplicitHyperlinkRange", () => {
     });
   });
 
+  it("counts failed probes toward the scan cap", () => {
+    const cols = 8;
+    const rowCount = 600;
+    const rowData = Array.from({ length: rowCount }, (_, index) =>
+      row({
+        wrapsToNext: index < rowCount - 1,
+        isWrapContinuation: index > 0,
+      }),
+    );
+    let probes = 0;
+    const result = terminalExplicitHyperlinkRange({ x: 3, y: 0 }, "https://t3.codes", {
+      cols,
+      rows: rowCount,
+      rowData,
+      hasSameHyperlink: (x, y) => {
+        probes += 1;
+        return !(x === 2 && y === 0);
+      },
+    });
+    expect(probes).toBe(MAX_HYPERLINK_RANGE_CELLS);
+    expect(result.start).toEqual({ x: 3, y: 0 });
+    expect(result.end).toEqual({
+      x: (3 + MAX_HYPERLINK_RANGE_CELLS - 1) % cols,
+      y: Math.floor((3 + MAX_HYPERLINK_RANGE_CELLS - 1) / cols),
+    });
+  });
+
   it("keeps oversized URIs to a single-cell range without probing neighbors", () => {
     let probes = 0;
     const result = terminalExplicitHyperlinkRange(

--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -102,33 +102,53 @@ describe("terminalExplicitHyperlinkRange", () => {
     ...over,
   });
 
-  const range = (
-    cell: { x: number; y: number },
-    linked: Set<string>,
-    rowData: GhosttyRow[],
-    cols: number,
-    uri = "https://t3.codes",
-  ) =>
-    terminalExplicitHyperlinkRange(cell, uri, {
-      cols,
-      rows: rowData.length,
-      rowData,
-      hasSameHyperlink: (x, y) => linked.has(`${x},${y}`),
+  const range = (options: {
+    cell: { x: number; y: number };
+    linked: Set<string>;
+    rowData: GhosttyRow[];
+    cols: number;
+  }) =>
+    terminalExplicitHyperlinkRange(options.cell, "https://t3.codes", {
+      cols: options.cols,
+      rows: options.rowData.length,
+      rowData: options.rowData,
+      hasSameHyperlink: (x, y) => options.linked.has(`${x},${y}`),
     });
 
   it("expands over adjacent cells carrying the same hyperlink", () => {
-    expect(range({ x: 2, y: 0 }, new Set(["1,0", "2,0", "3,0"]), [row()], 5)).toEqual({
+    expect(
+      range({
+        cell: { x: 2, y: 0 },
+        linked: new Set(["1,0", "2,0", "3,0"]),
+        rowData: [row()],
+        cols: 5,
+      }),
+    ).toEqual({
       start: { x: 1, y: 0 },
       end: { x: 3, y: 0 },
     });
   });
 
   it("stops at cells without the hyperlink and at grid edges", () => {
-    expect(range({ x: 4, y: 0 }, new Set(["4,0", "5,0"]), [row()], 5)).toEqual({
+    expect(
+      range({
+        cell: { x: 4, y: 0 },
+        linked: new Set(["4,0", "5,0"]),
+        rowData: [row()],
+        cols: 5,
+      }),
+    ).toEqual({
       start: { x: 4, y: 0 },
       end: { x: 4, y: 0 },
     });
-    expect(range({ x: 1, y: 0 }, new Set(["1,0"]), [row()], 5)).toEqual({
+    expect(
+      range({
+        cell: { x: 1, y: 0 },
+        linked: new Set(["1,0"]),
+        rowData: [row()],
+        cols: 5,
+      }),
+    ).toEqual({
       start: { x: 1, y: 0 },
       end: { x: 1, y: 0 },
     });
@@ -140,11 +160,25 @@ describe("terminalExplicitHyperlinkRange", () => {
       row({ wrapsToNext: true, isWrapContinuation: true }),
       row({ isWrapContinuation: true }),
     ];
-    expect(range({ x: 3, y: 0 }, new Set(["3,0", "0,1", "1,1"]), rowData, 4)).toEqual({
+    expect(
+      range({
+        cell: { x: 3, y: 0 },
+        linked: new Set(["3,0", "0,1", "1,1"]),
+        rowData,
+        cols: 4,
+      }),
+    ).toEqual({
       start: { x: 3, y: 0 },
       end: { x: 1, y: 1 },
     });
-    expect(range({ x: 0, y: 2 }, new Set(["3,1", "0,2"]), rowData, 4)).toEqual({
+    expect(
+      range({
+        cell: { x: 0, y: 2 },
+        linked: new Set(["3,1", "0,2"]),
+        rowData,
+        cols: 4,
+      }),
+    ).toEqual({
       start: { x: 3, y: 1 },
       end: { x: 0, y: 2 },
     });

--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -4,6 +4,8 @@ import type { GhosttyCell, GhosttyRow } from "./core";
 import {
   DEFAULT_TERMINAL_FONT_FAMILY,
   DEFAULT_TERMINAL_FONT_SIZE,
+  MAX_HYPERLINK_RANGE_CELLS,
+  MAX_HYPERLINK_RANGE_URI_LENGTH,
   advanceTerminalSelectionClickSequence,
   applyTerminalCopyEvent,
   clearPrimedTerminalCopyInput,
@@ -20,6 +22,7 @@ import {
   resolveTerminalMouseTrackingState,
   shouldBlinkTerminalCursor,
   shouldReportTerminalMouse,
+  terminalExplicitHyperlinkRange,
   terminalGridCellAt,
   terminalScrollbarGeometry,
   terminalScrollbarOffsetAtPointer,
@@ -87,6 +90,110 @@ describe("terminalGridCellAt", () => {
     expect(terminalGridCellAt({ ...options, clientX: 104, clientY: 223 })).toBeNull();
     expect(terminalGridCellAt({ ...options, clientX: 134, clientY: 224 })).toBeNull();
     expect(terminalGridCellAt({ ...options, clientX: 104, clientY: 264 })).toBeNull();
+  });
+});
+
+describe("terminalExplicitHyperlinkRange", () => {
+  const row = (over: Partial<GhosttyRow> = {}): GhosttyRow => ({
+    cells: [],
+    text: "",
+    isWrapContinuation: false,
+    wrapsToNext: false,
+    ...over,
+  });
+
+  const range = (
+    cell: { x: number; y: number },
+    linked: Set<string>,
+    rowData: GhosttyRow[],
+    cols: number,
+    uri = "https://t3.codes",
+  ) =>
+    terminalExplicitHyperlinkRange(cell, uri, {
+      cols,
+      rows: rowData.length,
+      rowData,
+      hasSameHyperlink: (x, y) => linked.has(`${x},${y}`),
+    });
+
+  it("expands over adjacent cells carrying the same hyperlink", () => {
+    expect(range({ x: 2, y: 0 }, new Set(["1,0", "2,0", "3,0"]), [row()], 5)).toEqual({
+      start: { x: 1, y: 0 },
+      end: { x: 3, y: 0 },
+    });
+  });
+
+  it("stops at cells without the hyperlink and at grid edges", () => {
+    expect(range({ x: 4, y: 0 }, new Set(["4,0", "5,0"]), [row()], 5)).toEqual({
+      start: { x: 4, y: 0 },
+      end: { x: 4, y: 0 },
+    });
+    expect(range({ x: 1, y: 0 }, new Set(["1,0"]), [row()], 5)).toEqual({
+      start: { x: 1, y: 0 },
+      end: { x: 1, y: 0 },
+    });
+  });
+
+  it("follows wrapped rows in both directions", () => {
+    const rowData = [
+      row({ wrapsToNext: true }),
+      row({ wrapsToNext: true, isWrapContinuation: true }),
+      row({ isWrapContinuation: true }),
+    ];
+    expect(range({ x: 3, y: 0 }, new Set(["3,0", "0,1", "1,1"]), rowData, 4)).toEqual({
+      start: { x: 3, y: 0 },
+      end: { x: 1, y: 1 },
+    });
+    expect(range({ x: 0, y: 2 }, new Set(["3,1", "0,2"]), rowData, 4)).toEqual({
+      start: { x: 3, y: 1 },
+      end: { x: 0, y: 2 },
+    });
+  });
+
+  it("truncates the walk at the scan cap when every probed cell matches", () => {
+    const cols = 8;
+    const rowCount = 600;
+    const rowData = Array.from({ length: rowCount }, (_, index) =>
+      row({
+        wrapsToNext: index < rowCount - 1,
+        isWrapContinuation: index > 0,
+      }),
+    );
+    let probes = 0;
+    const result = terminalExplicitHyperlinkRange({ x: 0, y: 0 }, "https://t3.codes", {
+      cols,
+      rows: rowCount,
+      rowData,
+      hasSameHyperlink: () => {
+        probes += 1;
+        return true;
+      },
+    });
+    expect(probes).toBe(MAX_HYPERLINK_RANGE_CELLS);
+    expect(result.start).toEqual({ x: 0, y: 0 });
+    expect(result.end).toEqual({
+      x: MAX_HYPERLINK_RANGE_CELLS % cols,
+      y: Math.floor(MAX_HYPERLINK_RANGE_CELLS / cols),
+    });
+  });
+
+  it("keeps oversized URIs to a single-cell range without probing neighbors", () => {
+    let probes = 0;
+    const result = terminalExplicitHyperlinkRange(
+      { x: 1, y: 1 },
+      "a".repeat(MAX_HYPERLINK_RANGE_URI_LENGTH + 1),
+      {
+        cols: 4,
+        rows: 2,
+        rowData: [row(), row()],
+        hasSameHyperlink: () => {
+          probes += 1;
+          return true;
+        },
+      },
+    );
+    expect(result).toEqual({ start: { x: 1, y: 1 }, end: { x: 1, y: 1 } });
+    expect(probes).toBe(0);
   });
 });
 

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -260,8 +260,9 @@ export function terminalExplicitHyperlinkRange(
         : start.y > 0 && options.rowData[start.y]?.isWrapContinuation
           ? { x: options.cols - 1, y: start.y - 1 }
           : null;
-    if (!previous || !options.hasSameHyperlink(previous.x, previous.y)) break;
+    if (!previous) break;
     scanned += 1;
+    if (!options.hasSameHyperlink(previous.x, previous.y)) break;
     start.x = previous.x;
     start.y = previous.y;
   }
@@ -272,8 +273,9 @@ export function terminalExplicitHyperlinkRange(
         : end.y + 1 < options.rows && options.rowData[end.y]?.wrapsToNext
           ? { x: 0, y: end.y + 1 }
           : null;
-    if (!next || !options.hasSameHyperlink(next.x, next.y)) break;
+    if (!next) break;
     scanned += 1;
+    if (!options.hasSameHyperlink(next.x, next.y)) break;
     end.x = next.x;
     end.y = next.y;
   }

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -230,6 +230,56 @@ export function terminalGridCellAt(options: {
   };
 }
 
+export const MAX_HYPERLINK_RANGE_URI_LENGTH = 4096;
+
+export const MAX_HYPERLINK_RANGE_CELLS = 4096;
+
+// The OSC 8 URI is attacker-controlled and unbounded, and every hyperlink
+// probe decodes it in full, so the hover range walk is capped on both factors.
+// Without the caps a single oversized hyperlink spanning the viewport makes
+// each hover refresh allocate/decode viewport × URI-length bytes and freezes
+// the renderer.
+export function terminalExplicitHyperlinkRange(
+  cell: { x: number; y: number },
+  uri: string,
+  options: {
+    cols: number;
+    rows: number;
+    rowData: GhosttySnapshot["rowData"];
+    hasSameHyperlink: (x: number, y: number) => boolean;
+  },
+): GhosttyCellRange {
+  const start = { ...cell };
+  const end = { ...cell };
+  if (uri.length > MAX_HYPERLINK_RANGE_URI_LENGTH) return { start, end };
+  let scanned = 0;
+  while (scanned < MAX_HYPERLINK_RANGE_CELLS) {
+    const previous =
+      start.x > 0
+        ? { x: start.x - 1, y: start.y }
+        : start.y > 0 && options.rowData[start.y]?.isWrapContinuation
+          ? { x: options.cols - 1, y: start.y - 1 }
+          : null;
+    if (!previous || !options.hasSameHyperlink(previous.x, previous.y)) break;
+    scanned += 1;
+    start.x = previous.x;
+    start.y = previous.y;
+  }
+  while (scanned < MAX_HYPERLINK_RANGE_CELLS) {
+    const next =
+      end.x + 1 < options.cols
+        ? { x: end.x + 1, y: end.y }
+        : end.y + 1 < options.rows && options.rowData[end.y]?.wrapsToNext
+          ? { x: 0, y: end.y + 1 }
+          : null;
+    if (!next || !options.hasSameHyperlink(next.x, next.y)) break;
+    scanned += 1;
+    end.x = next.x;
+    end.y = next.y;
+  }
+  return { start, end };
+}
+
 function terminalRowText(row: GhosttySnapshot["rowData"][number], trimRight: boolean): string {
   const text = row.cells.map((cell) => cell.text || " ").join("");
   return trimRight ? text.trimEnd() : text;
@@ -1800,7 +1850,8 @@ export class GhosttyTerminalSurface {
   }
 
   private linkAt(clientX: number, clientY: number): TerminalLinkWithRange | null {
-    if (!this.snapshot) return null;
+    const snapshot = this.snapshot;
+    if (!snapshot) return null;
     const cell = terminalGridCellAt({
       bounds: this.canvas.getBoundingClientRect(),
       clientX,
@@ -1814,36 +1865,17 @@ export class GhosttyTerminalSurface {
     if (!cell) return null;
     const explicitHyperlink = this.core.hyperlinkAt(cell.x, cell.y);
     if (explicitHyperlink) {
-      const start = { ...cell };
-      const end = { ...cell };
-      while (true) {
-        const previous =
-          start.x > 0
-            ? { x: start.x - 1, y: start.y }
-            : start.y > 0 && this.snapshot.rowData[start.y]?.isWrapContinuation
-              ? { x: this.cols - 1, y: start.y - 1 }
-              : null;
-        if (!previous || this.core.hyperlinkAt(previous.x, previous.y) !== explicitHyperlink) break;
-        start.x = previous.x;
-        start.y = previous.y;
-      }
-      while (true) {
-        const next =
-          end.x + 1 < this.cols
-            ? { x: end.x + 1, y: end.y }
-            : end.y + 1 < this.rows && this.snapshot.rowData[end.y]?.wrapsToNext
-              ? { x: 0, y: end.y + 1 }
-              : null;
-        if (!next || this.core.hyperlinkAt(next.x, next.y) !== explicitHyperlink) break;
-        end.x = next.x;
-        end.y = next.y;
-      }
       return {
         text: explicitHyperlink,
-        range: { start, end },
+        range: terminalExplicitHyperlinkRange(cell, explicitHyperlink, {
+          cols: this.cols,
+          rows: this.rows,
+          rowData: snapshot.rowData,
+          hasSameHyperlink: (x, y) => this.core.hyperlinkAt(x, y) === explicitHyperlink,
+        }),
       };
     }
-    return terminalLinkAtPositionWithRange(this.snapshot.rowData, cell.y, cell.x);
+    return terminalLinkAtPositionWithRange(snapshot.rowData, cell.y, cell.x);
   }
 
   private sendMouse(action: TerminalMouseAction, button: number | null, event: MouseEvent): void {


### PR DESCRIPTION
## Problem

Hovering an explicit OSC 8 hyperlink expands the hover range by walking every adjacent linked cell (across wrapped rows) and calls `core.hyperlinkAt` once per cell. Each call allocates and decodes the **full** attacker-controlled URI from WASM memory, and `renderFrame` repeats the walk every frame while the pointer rests on the link. A crafted terminal can emit a hyperlink with a huge URI spanning the viewport: a 256 KiB URI on a 200×50 grid reaches ~10k probes and ~2.5 GB of decoded bytes per refresh — the renderer hangs or crashes on plain terminal output.

## Fix

The range walk moves into an exported pure helper, `terminalExplicitHyperlinkRange`, with two explicit bounds:

- at most `MAX_HYPERLINK_RANGE_CELLS` (4096) probed cells per walk;
- URIs longer than `MAX_HYPERLINK_RANGE_URI_LENGTH` (4096 chars) skip expansion entirely and keep the single-cell hover of the pre-expansion behavior.

Loop semantics are unchanged otherwise (same adjacency, wrap-continuation checks, and string comparison). Worst-case work per refresh drops from unbounded to ~16 MiB of decodes.

## Verification

- New regression tests in `surface.test.ts`: same-row/wrapped-range expansion, stop conditions, probe-count hard cap on a fully-linked 8×600 grid, oversized URI returning a single-cell range with zero probes.
- Full ghostty suite green (65 tests; `runtimeAbi.test.ts` fails to load in this worktree for its pre-existing `.wasm?inline` import issue, unrelated).
- `tsgo --noEmit` clean for apps/web.

ox-alpha via opencode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bounds malicious or extreme OSC 8 output that could freeze the renderer; legitimate links longer than 4096 chars or spanning more than 4096 probed cells get truncated hover ranges.
> 
> **Overview**
> Fixes a **DoS on terminal hover** where expanding OSC 8 hyperlink highlights walked every adjacent cell with no limit, calling `hyperlinkAt` (full URI decode) on each probe and again every `renderFrame` while the pointer rests on the link.
> 
> The unbounded walk in `GhosttyTerminalSurface.linkAt` is replaced by exported helper **`terminalExplicitHyperlinkRange`**, which keeps the same adjacency and soft-wrap behavior but caps work at **`MAX_HYPERLINK_RANGE_CELLS` (4096)** probes per expansion and skips neighbor scanning when the URI exceeds **`MAX_HYPERLINK_RANGE_URI_LENGTH` (4096)** (single-cell hover only). Implicit URL detection via `terminalLinkAtPositionWithRange` is unchanged.
> 
> Regression tests cover same-row and wrapped expansion, edge stops, probe-count limits, and oversized URIs with zero probes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a0beeb1e55381431c6bcba9246cab2f26c5a3a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cap hyperlink range scan in `GhosttyTerminalSurface.linkAt`
> - Replaces the unbounded while-loop in `linkAt` with `terminalExplicitHyperlinkRange`, which stops scanning after `MAX_HYPERLINK_RANGE_CELLS` (4096) probes across wrapped rows.
> - URIs longer than `MAX_HYPERLINK_RANGE_URI_LENGTH` (4096) skip neighbor probing entirely and return a single-cell range.
> - Behavioral Change: explicit hyperlink hit-testing may now return shorter ranges for large continuous hyperlinks than the previous unbounded scan.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a0beeb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of explicit terminal hyperlinks.
  * Very long hyperlink URLs now remain limited to the hovered cell.
  * Hyperlink range detection is bounded to maintain responsiveness, including across wrapped lines and grid edges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->