### PR TITLE
feat(web): copy a link to a thread

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -112,6 +112,7 @@ import { vcsEnvironment } from "../state/vcs";
 import { threadEnvironment } from "../state/threads";
 import { useEnvironmentQuery } from "../state/query";
 import { useAtomCommand } from "../state/use-atom-command";
+import { readThreadLink } from "../threadLink";
 import {
   buildThreadRouteParams,
   resolveActiveThreadRouteRef,
@@ -1772,6 +1773,25 @@ export default function Sidebar() {
       );
     },
   });
+  const { copyToClipboard: copyLinkToClipboard } = useCopyToClipboard<{ link: string }>({
+    target: "link",
+    onCopy: ({ link }) => {
+      toastManager.add({
+        type: "success",
+        title: "Link copied",
+        description: link,
+      });
+    },
+    onError: (error) => {
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Failed to copy link",
+          description: error instanceof Error ? error.message : "An error occurred.",
+        }),
+      );
+    },
+  });
   const { copyToClipboard: copyThreadIdToClipboard } = useCopyToClipboard<{ threadId: ThreadId }>({
     onCopy: ({ threadId }) => {
       toastManager.add({
@@ -3065,6 +3085,7 @@ export default function Sidebar() {
         const isPinned = thread.pinnedAt != null;
         // Presets resolve at menu-open time (same as the popover).
         const snoozePresets = resolveSnoozePresets(new Date(), timestampFormat);
+        const threadLink = readThreadLink(threadRef);
         const clicked = await settlePromise(() =>
           api.contextMenu.show(
             buildThreadActionMenuItems({
@@ -3083,6 +3104,7 @@ export default function Sidebar() {
                 titleRegeneration: supportsTitleRegeneration,
               },
               snoozePresets,
+              canCopyLink: threadLink !== null,
             }),
             position,
           ),
@@ -3157,6 +3179,11 @@ export default function Sidebar() {
           }
           case "mark-unread":
             markThreadUnread(threadKey, thread.latestTurn?.completedAt);
+            return;
+          case "copy-link":
+            if (threadLink) {
+              copyLinkToClipboard(threadLink, { link: threadLink });
+            }
             return;
           case "copy-path":
             if (!threadWorkspacePath) {
@@ -3250,6 +3277,7 @@ export default function Sidebar() {
       confirmThreadArchive,
       confirmThreadDelete,
       copyBranchToClipboard,
+      copyLinkToClipboard,
       copyPathToClipboard,
       copyThreadIdToClipboard,
       deleteThread,

--- a/apps/web/src/components/threadActionMenu.logic.test.ts
+++ b/apps/web/src/components/threadActionMenu.logic.test.ts
@@ -11,6 +11,7 @@ const baseState: ThreadActionMenuState = {
   isRegeneratingTitle: false,
   isRunning: false,
   supports: { settlement: true, snooze: true, pinning: true, titleRegeneration: true },
+  canCopyLink: true,
   snoozePresets: [
     { id: "hour", label: "In 1 hour", whenLabel: "3:00 PM", snoozedUntil: "2026-08-07T15:00:00Z" },
   ],
@@ -42,6 +43,11 @@ describe("buildThreadActionMenuItems", () => {
     expect(withBranch).toContain("copy-branch");
     expect(allIds(baseState)).not.toContain("new-thread-on-branch");
     expect(allIds(baseState)).not.toContain("copy-branch");
+  });
+
+  it("offers the thread link only when this client can build one", () => {
+    expect(allIds(baseState)).toContain("copy-link");
+    expect(allIds({ ...baseState, canCopyLink: false })).not.toContain("copy-link");
   });
 
   it("flips lifecycle labels with thread state", () => {

--- a/apps/web/src/components/threadActionMenu.logic.ts
+++ b/apps/web/src/components/threadActionMenu.logic.ts
@@ -19,6 +19,7 @@ export type ThreadActionMenuId =
   | "regenerate-title"
   | "mark-unread"
   | "copy"
+  | "copy-link"
   | "copy-path"
   | "copy-branch"
   | "copy-thread-id"
@@ -41,6 +42,8 @@ export interface ThreadActionMenuState {
     readonly titleRegeneration: boolean;
   };
   readonly snoozePresets: ReadonlyArray<SnoozePreset>;
+  /** False when this client cannot express the thread's address as a URL. */
+  readonly canCopyLink: boolean;
 }
 
 /**
@@ -112,6 +115,7 @@ export function buildThreadActionMenuItems(
       icon: "copy",
       separatorBefore: true,
       children: [
+        ...(state.canCopyLink ? [{ id: "copy-link" as const, label: "Link", icon: "link" }] : []),
         { id: "copy-path", label: "Path", icon: "folder" },
         ...(state.branch
           ? [{ id: "copy-branch" as const, label: "Branch", icon: "git-branch" }]

--- a/apps/web/src/contextMenuFallback.ts
+++ b/apps/web/src/contextMenuFallback.ts
@@ -51,6 +51,10 @@ const ICON_PATHS: Record<string, ReadonlyArray<{ tag: string; attrs: Record<stri
     { tag: "line", attrs: { x1: "10", x2: "8", y1: "3", y2: "21" } },
     { tag: "line", attrs: { x1: "16", x2: "14", y1: "3", y2: "21" } },
   ],
+  link: [
+    { tag: "path", attrs: { d: "M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" } },
+    { tag: "path", attrs: { d: "M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" } },
+  ],
   "mail-open": [
     {
       tag: "path",

--- a/apps/web/src/hooks/useThreadActionMenu.ts
+++ b/apps/web/src/hooks/useThreadActionMenu.ts
@@ -30,6 +30,7 @@ import {
   readThreadShell,
 } from "../state/entities";
 import { readLocalApi } from "../localApi";
+import { readThreadLink } from "../threadLink";
 import { useUiStateStore } from "../uiStateStore";
 import { useCopyToClipboard } from "./useCopyToClipboard";
 import { useNewThreadHandler } from "./useHandleNewThread";
@@ -98,6 +99,13 @@ export function useThreadActionMenu(input: {
     },
     onError: (error) => failureToast("Failed to copy branch", error),
   });
+  const { copyToClipboard: copyLinkToClipboard } = useCopyToClipboard<{ link: string }>({
+    target: "link",
+    onCopy: ({ link }) => {
+      toastManager.add({ type: "success", title: "Link copied", description: link });
+    },
+    onError: (error) => failureToast("Failed to copy link", error),
+  });
   const { copyToClipboard: copyThreadIdToClipboard } = useCopyToClipboard<{ threadId: ThreadId }>({
     onCopy: ({ threadId }) => {
       toastManager.add({ type: "success", title: "Thread ID copied", description: threadId });
@@ -124,6 +132,7 @@ export function useThreadActionMenu(input: {
         };
         const isRegeneratingTitle = thread.titleRegeneration != null;
         const snoozePresets = resolveSnoozePresets(now, timestampFormat);
+        const threadLink = readThreadLink(threadRef);
         const items = buildThreadActionMenuItems({
           branch: thread.branch ?? null,
           isPinned: thread.pinnedAt != null,
@@ -144,6 +153,7 @@ export function useThreadActionMenu(input: {
           isRunning: thread.session?.status === "running" && thread.session.activeTurnId != null,
           supports,
           snoozePresets,
+          canCopyLink: threadLink !== null,
         });
         const clicked = await settlePromise(() => api.contextMenu.show(items, position));
         if (clicked._tag === "Failure" || clicked.value === null) return;
@@ -233,6 +243,11 @@ export function useThreadActionMenu(input: {
           case "mark-unread":
             markThreadUnread(scopedThreadKey(threadRef), thread.latestTurn?.completedAt);
             return;
+          case "copy-link":
+            if (threadLink) {
+              copyLinkToClipboard(threadLink, { link: threadLink });
+            }
+            return;
           case "copy-path": {
             const workspacePath = thread.worktreePath ?? projectCwd;
             if (!workspacePath) {
@@ -316,6 +331,7 @@ export function useThreadActionMenu(input: {
       confirmThreadArchive,
       confirmThreadDelete,
       copyBranchToClipboard,
+      copyLinkToClipboard,
       copyPathToClipboard,
       copyThreadIdToClipboard,
       deleteThread,

--- a/apps/web/src/threadLink.test.ts
+++ b/apps/web/src/threadLink.test.ts
@@ -1,0 +1,50 @@
+import type { EnvironmentId, ScopedThreadRef, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveThreadLink } from "./threadLink";
+
+const ref = {
+  environmentId: "env_local" as EnvironmentId,
+  threadId: "thr_123" as ThreadId,
+} as ScopedThreadRef;
+
+describe("resolveThreadLink", () => {
+  it("uses the browser origin the client is served from", () => {
+    expect(
+      resolveThreadLink({
+        clientOrigin: "https://app.t3.codes",
+        environmentHttpBaseUrl: "http://192.168.1.4:3773",
+        ref,
+      }),
+    ).toBe("https://app.t3.codes/env_local/thr_123");
+  });
+
+  it("falls back to the environment server when the origin is not a web origin", () => {
+    expect(
+      resolveThreadLink({
+        clientOrigin: "t3code://app",
+        environmentHttpBaseUrl: "http://127.0.0.1:3773/",
+        ref,
+      }),
+    ).toBe("http://127.0.0.1:3773/env_local/thr_123");
+  });
+
+  it("returns null when neither the client nor the environment has a web origin", () => {
+    expect(
+      resolveThreadLink({ clientOrigin: "t3code://app", environmentHttpBaseUrl: null, ref }),
+    ).toBeNull();
+    expect(
+      resolveThreadLink({ clientOrigin: null, environmentHttpBaseUrl: "not a url", ref }),
+    ).toBeNull();
+  });
+
+  it("drops any path the environment base URL carries", () => {
+    expect(
+      resolveThreadLink({
+        clientOrigin: null,
+        environmentHttpBaseUrl: "https://tunnel.example.com/base/",
+        ref,
+      }),
+    ).toBe("https://tunnel.example.com/env_local/thr_123");
+  });
+});

--- a/apps/web/src/threadLink.ts
+++ b/apps/web/src/threadLink.ts
@@ -1,0 +1,47 @@
+import type { ScopedThreadRef } from "@t3tools/contracts";
+
+import { readPreparedConnection } from "~/state/session";
+import { buildThreadRoutePath } from "./threadRoutes";
+
+function browserOrigin(value: string | null): string | null {
+  if (value === null) {
+    return null;
+  }
+  return value.startsWith("http://") || value.startsWith("https://") ? value : null;
+}
+
+/**
+ * The address a browser can open to land on a thread.
+ *
+ * In a browser the answer is the address bar: the app is served from the
+ * origin the user is already on. The desktop app has no address bar and its
+ * renderer origin (`t3code://app`) means nothing outside the app, so the link
+ * falls back to the environment's own HTTP base URL — the T3 server that owns
+ * the thread and serves the web client for it. Environments reachable only
+ * through a target we cannot express as an HTTP origin get no link.
+ */
+export function resolveThreadLink(input: {
+  /** `window.location.origin`, or null off a browser origin. */
+  readonly clientOrigin: string | null;
+  readonly environmentHttpBaseUrl: string | null;
+  readonly ref: ScopedThreadRef;
+}): string | null {
+  const base = browserOrigin(input.clientOrigin) ?? browserOrigin(input.environmentHttpBaseUrl);
+  if (base === null) {
+    return null;
+  }
+  try {
+    return new URL(buildThreadRoutePath(input.ref), base).toString();
+  } catch {
+    return null;
+  }
+}
+
+/** `resolveThreadLink` against this client's origin and live connection. */
+export function readThreadLink(ref: ScopedThreadRef): string | null {
+  return resolveThreadLink({
+    clientOrigin: typeof window === "undefined" ? null : window.location.origin,
+    environmentHttpBaseUrl: readPreparedConnection(ref.environmentId)?.httpBaseUrl ?? null,
+    ref,
+  });
+}

--- a/apps/web/src/threadRoutes.ts
+++ b/apps/web/src/threadRoutes.ts
@@ -101,3 +101,8 @@ export function resolveActiveThreadRouteRef(
   }
   return draftThread.promotedTo;
 }
+
+/** The pathname the web client renders a thread at. */
+export function buildThreadRoutePath(ref: ScopedThreadRef): string {
+  return `/${encodeURIComponent(ref.environmentId)}/${encodeURIComponent(ref.threadId)}`;
+}

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -12,6 +12,18 @@ If reordering is unavailable for one environment, update the T3 Code server runn
 environment. Older servers can still pin and unpin threads, but do not understand synced ordering;
 their pinned threads keep the default newest-first order below the ones you have arranged.
 
+## Linking to a thread
+
+Open a thread's context menu and choose **Copy → Link** to put its address on the clipboard. In a
+browser the link uses the address you are already on; in the desktop app, which has no address bar,
+it uses the address this client reaches the environment at — a `localhost` address for a server on
+this machine, or its tunnel address when you connect remotely.
+
+The link opens the thread on any device that can reach that address and is paired with the
+environment, so it is worth checking that the address is one the other device can reach before you
+send it. It is not a public share link: someone without access to the environment cannot read the
+thread through it.
+
 ## Environment artwork
 
 Dev and Nightly environments can identify themselves with artwork at the top of the sidebar and in


### PR DESCRIPTION
## Problem

In a browser, a thread's URL *is* its link — you can copy it out of the address bar. The desktop app is served from `t3code://app` and has no address bar, and nothing in the UI exposes a thread's address, so there is no way to get a link to a thread out of desktop at all.

## Change

Thread context menus now offer **Copy → Link**. The sidebar row menu and the chat header menu share one builder, so both surfaces get it.

`resolveThreadLink` picks the base the same way a user would: the client's own web origin when there is one (browser and hosted app), otherwise the address this client reaches the environment at, which is the T3 server that owns the thread — `localhost` for a server on this machine, the tunnel host for T3 Connect. When neither is an http(s) origin the item is hidden rather than copying something that cannot be opened.

The link is not a share link: the other device still has to reach that address and be paired with the environment. `docs/user/thread-sidebar.md` says so explicitly.

Mobile is deliberately untouched — it has no thread copy actions at all, so there is no parity to keep.

## Before / after

Sidebar thread context menu, Copy submenu.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/fbehrens/t3code/pr-assets/t3-before.png" width="420"> | <img src="https://raw.githubusercontent.com/fbehrens/t3code/pr-assets/t3-after.png" width="420"> |

## Verification

- `vp test run apps/web/src/threadLink.test.ts apps/web/src/components/threadActionMenu.logic.test.ts` — 14 passed
- `tsgo --noEmit` in `apps/web` — clean
- Lint on the touched files — clean
- Screenshots above are from a real client: `vp run dev` against an isolated `.t3` home with seeded fixture threads, driven through a browser

Written by Claude Opus 5 (1M context) in T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Clipboard and URL construction only; no auth or access-control changes. Links still require environment pairing and network reachability.
> 
> **Overview**
> Adds **Copy → Link** to the shared thread action menu (sidebar and chat header) so desktop users can copy a thread URL without an address bar.
> 
> `resolveThreadLink` uses the browser origin when it is http(s); otherwise it falls back to the environment’s HTTP base (localhost or tunnel). The menu item is hidden when neither is a web origin. Links are not public shares—the recipient still needs reachability and pairing.
> 
> User docs in `thread-sidebar.md` describe the behavior. Mobile copy actions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0657a62fdb813ede2801b0a6528a70b54090905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add "Copy → Link" thread action in web sidebar and chat header menu
> - Adds `buildThreadRoutePath` in [threadRoutes.ts](https://github.com/pingdotgg/t3code/pull/7902/files#diff-2786ca87c67654801c30d674118b89515b8a9e7fa2d9806b90b36f71c887a7b3) to build a thread pathname as `/{environmentId}/{threadId}` with URL-encoded segments.
> - Adds `resolveThreadLink` and `readThreadLink` in [threadLink.ts](https://github.com/pingdotgg/t3code/pull/7902/files#diff-6d078c2cb3d7a12de6cfb1c594f2c75d3ea0562907458b6993ae2c7d1b3c8c12) to compose a full HTTP(S) URL, preferring `window.location.origin` and falling back to the environment `httpBaseUrl`; returns `null` when no valid origin exists.
> - Registers a new `'copy-link'` action with a `canCopyLink` state flag in `buildThreadActionMenuItems` ([threadActionMenu.logic.ts](https://github.com/pingdotgg/t3code/pull/7902/files#diff-211932e245bdc70e1ec59f9ccae53633aaf071501b9315582c4abad22c790446)), wired up in both [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/7902/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) and [useThreadActionMenu.ts](https://github.com/pingdotgg/t3code/pull/7902/files#diff-d31aea23d18521fa1c03e05a4d3c2e45d0ca6fab34084d74f072cecc48d21e17) using `useCopyToClipboard` with success/error toasts.
> - Adds a `'link'` icon entry in [contextMenuFallback.ts](https://github.com/pingdotgg/t3code/pull/7902/files#diff-032cd4155f179490fdc876b54fb96f2609ab2552587ed8b42b9963c1d250a3be) and documents the feature in [thread-sidebar.md](https://github.com/pingdotgg/t3code/pull/7902/files#diff-7bdc679f37b354bbc78160b5dc7435fb0d2d5a7d72c6a7015a8b682032a7150a).
> - Risk: the link is only shown when an HTTP(S) origin is resolvable; on non-web runtimes without a valid `httpBaseUrl`, `readThreadLink` returns `null` and the menu item is hidden.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0657a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->