### PR TITLE
fix(web): retry legacy Connect auth backfill

### DIFF
--- a/apps/web/src/cloud/connectAuth.tsx
+++ b/apps/web/src/cloud/connectAuth.tsx
@@ -20,7 +20,10 @@ import { resolveClerkSignInProps } from "../components/clerk/authRedirect";
 import { PrimaryEnvironmentHttpClient } from "../environments/primary/httpClient";
 import { runPrimaryHttp } from "../lib/runtime";
 import { resolveRelayClerkTokenOptions } from "./publicConfig";
-import { shouldRetryDesktopConnectAuthState } from "./connectAuthState";
+import {
+  isDesktopConnectAuthIdentityPending,
+  shouldRetryDesktopConnectAuthState,
+} from "./connectAuthState";
 
 /**
  * One T3 Connect session surface across auth backends. The hosted web app
@@ -30,6 +33,8 @@ import { shouldRetryDesktopConnectAuthState } from "./connectAuthState";
  */
 export interface T3ConnectAuth {
   readonly isLoaded: boolean;
+  /** A legacy desktop credential is waiting for its account id backfill. */
+  readonly isIdentityPending: boolean;
   readonly isSignedIn: boolean;
   readonly userId: string | null;
   /** Account label for display (desktop; web renders Clerk's UserButton). */
@@ -53,6 +58,7 @@ export interface T3ConnectAuth {
 // gates itself on hasCloudPublicConfig, so this is just a safe floor.
 const signedOutAuth: T3ConnectAuth = {
   isLoaded: true,
+  isIdentityPending: false,
   isSignedIn: false,
   userId: null,
   identity: null,
@@ -78,6 +84,7 @@ export function ClerkConnectAuthProvider({ children }: { readonly children: Reac
   const value = useMemo<T3ConnectAuth>(
     () => ({
       isLoaded,
+      isIdentityPending: false,
       isSignedIn: isSignedIn === true,
       userId: userId ?? null,
       identity: null,
@@ -268,6 +275,7 @@ export function DesktopConnectAuthProvider({ children }: { readonly children: Re
   const value = useMemo<T3ConnectAuth>(
     () => ({
       isLoaded,
+      isIdentityPending: isDesktopConnectAuthIdentityPending(state),
       // accountId can lag behind authorization for legacy `t3 connect`
       // credentials while the server backfills it; relay features need the
       // account id, so hold "signed in" until it resolves.

--- a/apps/web/src/cloud/connectAuth.tsx
+++ b/apps/web/src/cloud/connectAuth.tsx
@@ -20,6 +20,7 @@ import { resolveClerkSignInProps } from "../components/clerk/authRedirect";
 import { PrimaryEnvironmentHttpClient } from "../environments/primary/httpClient";
 import { runPrimaryHttp } from "../lib/runtime";
 import { resolveRelayClerkTokenOptions } from "./publicConfig";
+import { shouldRetryDesktopConnectAuthState } from "./connectAuthState";
 
 /**
  * One T3 Connect session surface across auth backends. The hosted web app
@@ -191,11 +192,12 @@ export function DesktopConnectAuthProvider({ children }: { readonly children: Re
   // The bundled server may still be starting when the app mounts; retry until
   // the first state read lands.
   const isLoaded = state !== null;
+  const shouldRetryAuthState = shouldRetryDesktopConnectAuthState(state);
   useEffect(() => {
-    if (isLoaded) return;
+    if (!shouldRetryAuthState) return;
     const interval = setInterval(() => void refresh(), 3_000);
     return () => clearInterval(interval);
-  }, [isLoaded, refresh]);
+  }, [refresh, shouldRetryAuthState]);
 
   // The credential is shared with `t3 connect`, so a CLI sign-in or logout
   // can change it while the app is open; re-read when the window regains

--- a/apps/web/src/cloud/connectAuth.tsx
+++ b/apps/web/src/cloud/connectAuth.tsx
@@ -23,6 +23,7 @@ import { resolveRelayClerkTokenOptions } from "./publicConfig";
 import {
   isDesktopConnectAuthIdentityPending,
   shouldRetryDesktopConnectAuthState,
+  startSettledPolling,
 } from "./connectAuthState";
 
 /**
@@ -202,8 +203,7 @@ export function DesktopConnectAuthProvider({ children }: { readonly children: Re
   const shouldRetryAuthState = shouldRetryDesktopConnectAuthState(state);
   useEffect(() => {
     if (!shouldRetryAuthState) return;
-    const interval = setInterval(() => void refresh(), 3_000);
-    return () => clearInterval(interval);
+    return startSettledPolling(refresh, 3_000);
   }, [refresh, shouldRetryAuthState]);
 
   // The credential is shared with `t3 connect`, so a CLI sign-in or logout
@@ -220,8 +220,7 @@ export function DesktopConnectAuthProvider({ children }: { readonly children: Re
   const pendingLogin = state?.pendingLogin ?? false;
   useEffect(() => {
     if (!pendingLogin) return;
-    const interval = setInterval(() => void refresh(), LOGIN_WATCH_INTERVAL_MS);
-    return () => clearInterval(interval);
+    return startSettledPolling(refresh, LOGIN_WATCH_INTERVAL_MS);
   }, [pendingLogin, refresh]);
 
   const getToken = useCallback(async () => {

--- a/apps/web/src/cloud/connectAuthState.test.ts
+++ b/apps/web/src/cloud/connectAuthState.test.ts
@@ -1,0 +1,32 @@
+import type { EnvironmentConnectAuthState } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { shouldRetryDesktopConnectAuthState } from "./connectAuthState";
+
+const authState = (
+  overrides: Partial<EnvironmentConnectAuthState> = {},
+): EnvironmentConnectAuthState => ({
+  authorized: false,
+  pendingLogin: false,
+  authorizationUrl: null,
+  accountId: null,
+  identity: null,
+  ...overrides,
+});
+
+describe("desktop Connect auth state retry", () => {
+  it("retries before the first auth state response arrives", () => {
+    expect(shouldRetryDesktopConnectAuthState(null)).toBe(true);
+  });
+
+  it("retries an authorized legacy credential until its account id is backfilled", () => {
+    expect(shouldRetryDesktopConnectAuthState(authState({ authorized: true }))).toBe(true);
+  });
+
+  it("stops retrying once the state is stable", () => {
+    expect(shouldRetryDesktopConnectAuthState(authState())).toBe(false);
+    expect(
+      shouldRetryDesktopConnectAuthState(authState({ authorized: true, accountId: "user-123" })),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/cloud/connectAuthState.test.ts
+++ b/apps/web/src/cloud/connectAuthState.test.ts
@@ -1,9 +1,10 @@
 import type { EnvironmentConnectAuthState } from "@t3tools/contracts";
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
   isDesktopConnectAuthIdentityPending,
   shouldRetryDesktopConnectAuthState,
+  startSettledPolling,
 } from "./connectAuthState";
 
 const authState = (
@@ -32,6 +33,40 @@ describe("desktop Connect auth state retry", () => {
     expect(
       isDesktopConnectAuthIdentityPending(authState({ authorized: true, accountId: "user-123" })),
     ).toBe(false);
+  });
+
+  it("waits for each refresh to settle before scheduling another poll", async () => {
+    vi.useFakeTimers();
+    try {
+      let releaseFirst: (() => void) | undefined;
+      let refreshCount = 0;
+      const refresh = vi.fn(() => {
+        refreshCount += 1;
+        if (refreshCount === 1) {
+          return new Promise<void>((resolve) => {
+            releaseFirst = resolve;
+          });
+        }
+        return Promise.resolve();
+      });
+      const stop = startSettledPolling(refresh, 3_000);
+
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(refresh).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(refresh).toHaveBeenCalledTimes(1);
+
+      releaseFirst?.();
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(2_999);
+      expect(refresh).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(refresh).toHaveBeenCalledTimes(2);
+
+      stop();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("stops retrying once the state is stable", () => {

--- a/apps/web/src/cloud/connectAuthState.test.ts
+++ b/apps/web/src/cloud/connectAuthState.test.ts
@@ -1,7 +1,10 @@
 import type { EnvironmentConnectAuthState } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
-import { shouldRetryDesktopConnectAuthState } from "./connectAuthState";
+import {
+  isDesktopConnectAuthIdentityPending,
+  shouldRetryDesktopConnectAuthState,
+} from "./connectAuthState";
 
 const authState = (
   overrides: Partial<EnvironmentConnectAuthState> = {},
@@ -21,6 +24,14 @@ describe("desktop Connect auth state retry", () => {
 
   it("retries an authorized legacy credential until its account id is backfilled", () => {
     expect(shouldRetryDesktopConnectAuthState(authState({ authorized: true }))).toBe(true);
+  });
+
+  it("marks legacy identity backfill without changing stable load states", () => {
+    expect(isDesktopConnectAuthIdentityPending(authState({ authorized: true }))).toBe(true);
+    expect(isDesktopConnectAuthIdentityPending(authState())).toBe(false);
+    expect(
+      isDesktopConnectAuthIdentityPending(authState({ authorized: true, accountId: "user-123" })),
+    ).toBe(false);
   });
 
   it("stops retrying once the state is stable", () => {

--- a/apps/web/src/cloud/connectAuthState.ts
+++ b/apps/web/src/cloud/connectAuthState.ts
@@ -6,6 +6,26 @@ export function isDesktopConnectAuthIdentityPending(
   return state?.authorized === true && state.accountId === null;
 }
 
+export function startSettledPolling(task: () => Promise<void>, intervalMs: number): () => void {
+  let cancelled = false;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+
+  const poll = async () => {
+    await task();
+    if (!cancelled) {
+      timeout = setTimeout(poll, intervalMs);
+    }
+  };
+
+  timeout = setTimeout(poll, intervalMs);
+  return () => {
+    cancelled = true;
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+  };
+}
+
 export function shouldRetryDesktopConnectAuthState(
   state: EnvironmentConnectAuthState | null,
 ): boolean {

--- a/apps/web/src/cloud/connectAuthState.ts
+++ b/apps/web/src/cloud/connectAuthState.ts
@@ -1,0 +1,10 @@
+import type { EnvironmentConnectAuthState } from "@t3tools/contracts";
+
+export function shouldRetryDesktopConnectAuthState(
+  state: EnvironmentConnectAuthState | null,
+): boolean {
+  // Legacy CLI credentials are authorized before the server lazily backfills
+  // their Clerk account id. Keep polling so the desktop can reach a usable
+  // signed-in state without requiring a focus change or another login.
+  return state === null || (state.authorized && state.accountId === null);
+}

--- a/apps/web/src/cloud/connectAuthState.ts
+++ b/apps/web/src/cloud/connectAuthState.ts
@@ -1,10 +1,16 @@
 import type { EnvironmentConnectAuthState } from "@t3tools/contracts";
 
+export function isDesktopConnectAuthIdentityPending(
+  state: EnvironmentConnectAuthState | null,
+): boolean {
+  return state?.authorized === true && state.accountId === null;
+}
+
 export function shouldRetryDesktopConnectAuthState(
   state: EnvironmentConnectAuthState | null,
 ): boolean {
   // Legacy CLI credentials are authorized before the server lazily backfills
   // their Clerk account id. Keep polling so the desktop can reach a usable
   // signed-in state without requiring a focus change or another login.
-  return state === null || (state.authorized && state.accountId === null);
+  return state === null || isDesktopConnectAuthIdentityPending(state);
 }

--- a/apps/web/src/components/cloud/ConnectOnboardingDialog.tsx
+++ b/apps/web/src/components/cloud/ConnectOnboardingDialog.tsx
@@ -47,7 +47,7 @@ export function ConnectOnboardingDialog() {
 type OnboardingStep = "publish" | "devices";
 
 function ConfiguredConnectOnboardingDialog() {
-  const { isLoaded, isSignedIn, userId } = useT3ConnectAuth();
+  const { isIdentityPending, isLoaded, isSignedIn, userId } = useT3ConnectAuth();
   const [optOutState, setOptOutState] = useLocalStorage(
     CONNECT_ONBOARDING_OPT_OUT_STORAGE_KEY,
     EMPTY_CONNECT_ONBOARDING_OPT_OUT_STATE,
@@ -94,7 +94,9 @@ function ConfiguredConnectOnboardingDialog() {
   // environments, so each new session starts with no devices to reach. A cold
   // load observes undefined → account and must not re-prompt.
   useEffect(() => {
-    if (!isLoaded) return;
+    // A legacy credential is authorized before its account id is backfilled;
+    // do not record that incomplete snapshot as a signed-out cold load.
+    if (!isLoaded || isIdentityPending) return;
     // A loaded-but-incomplete snapshot (signed in, user id not yet populated)
     // must not be recorded as signed-out — the next render would then look
     // like a fresh sign-in on a cold load.
@@ -105,7 +107,7 @@ function ConfiguredConnectOnboardingDialog() {
     if (previousAccount !== undefined && previousAccount !== nextAccount && nextAccount !== null) {
       setRequestedAccount(nextAccount);
     }
-  }, [isLoaded, isSignedIn, userId]);
+  }, [isIdentityPending, isLoaded, isSignedIn, userId]);
 
   // A manageable session implies a primary environment, so when the scopes
   // allow publishing, wait for the connection target too — otherwise the


### PR DESCRIPTION
## Problem

The desktop Connect auth provider stops retrying after the first successful `authState` response. A legacy CLI credential can be authorized while its `accountId` is still null during the server's lazy identity backfill, so the desktop keeps `isSignedIn` false until a focus refresh or another sign-in.

## Fix

- Extract the desktop auth-state retry predicate into a small pure helper.
- Keep polling while the initial state is unavailable.
- Also keep polling for an authorized legacy credential until `accountId` is backfilled.
- Stop polling for stable signed-out and signed-in states.

This is a focused follow-up to #7483 and is intended to be merged with, or applied on top of, `t3code/move-electron-auth-to-browser`. It does not change the server, CLI token storage, OAuth flow, or mobile surface.

## Tests

- RED reproduced before the fix: the legacy authorized/null-account case failed.
- `pnpm exec vp test run --project unit src/cloud/connectAuthState.test.ts`
- `pnpm exec vp test run --project unit src/cloud/connectAuthState.test.ts src/cloud/managedAuth.test.ts`
- `pnpm exec vp run --filter @t3tools/web typecheck`
- `pnpm exec vp fmt --check apps/web/src/cloud/connectAuth.tsx apps/web/src/cloud/connectAuthState.ts apps/web/src/cloud/connectAuthState.test.ts`
- `pnpm exec vp lint apps/web/src/cloud/connectAuth.tsx apps/web/src/cloud/connectAuthState.ts apps/web/src/cloud/connectAuthState.test.ts --report-unused-disable-directives`

Related to #7816. The issue is not marked closed because this patch only covers the legacy Linux/Desktop state-backfill case.

Built with GPT-5.6 Luna via Hermes Agent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desktop session signed-in detection and polling. A stuck backfill could poll indefinitely, but this is client-only and does not change tokens or OAuth.
> 
> **Overview**
> Desktop Connect no longer treats the first `authState` response as final when a legacy CLI credential is authorized but `accountId` is still null. It keeps polling until identity backfill completes so the session can become signed-in without a focus refresh or another login.
> 
> Adds `isIdentityPending` on `T3ConnectAuth` and settled (non-overlapping) polling helpers. Onboarding skips recording that incomplete snapshot as a signed-out cold load so the wizard does not fire when the id arrives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6998c9e9d108318e19a3ffc69e26a686ba08a460. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry legacy Connect auth backfill when `accountId` is missing
> - Legacy desktop credentials that are authorized but have a null `accountId` now keep polling until the identity is backfilled, using new `shouldRetryDesktopConnectAuthState` and `isDesktopConnectAuthIdentityPending` helpers in [connectAuthState.ts](https://github.com/pingdotgg/t3code/pull/7903/files#diff-dfdb042aa1bda569082eb5f552bce473ee73482bdb517653d5790ec0100bcbc1)
> - Replaces `setInterval` loops with `startSettledPolling`, which waits for each refresh to settle before scheduling the next tick, preventing overlapping refreshes in `DesktopConnectAuthProvider`
> - Adds `isIdentityPending` boolean to `T3ConnectAuth` and surfaces it to consumers so [ConnectOnboardingDialog.tsx](https://github.com/pingdotgg/t3code/pull/7903/files#diff-1709bef12343d5d5282b49ead0ee5486f72301db4d6228a649c648e40818b1fb) can skip signed-out cold-load recording and onboarding prompts during backfill
> - Behavioral Change: `DesktopConnectAuthProvider` now polls at 3s intervals on startup when `shouldRetryDesktopConnectAuthState` is true instead of using the previous fixed interval; consumers reading `T3ConnectAuth` must handle the new `isIdentityPending` field
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6998c9e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->