### PR TITLE
fix: filter ephemeral title-generation sessions from listSessions

### DIFF
--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -1031,7 +1031,24 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
       for (const session of activeSessions) {
         const binding = bindingsByThreadId.get(session.threadId);
         if (!binding) {
-          sessions.push(session);
+          // Skip sessions without a persisted directory binding.
+          //
+          // Title-generation and branch-name helper sessions are spawned
+          // ephemerally (e.g. `codex exec --ephemeral`) and never go through
+          // the orchestration `thread.create` command, so they have no entry
+          // in `provider_session_runtime`.  Including them in the list
+          // returned by `listSessions` causes them to leak into downstream
+          // consumers — startup reconciliation, the provider command
+          // reactor, and the shell projection — where they appear as ghost
+          // threads in Studio that cannot be resumed.
+          //
+          // Sessions that *should* be visible always have a persisted binding
+          // written during `startSession`, so filtering on binding presence
+          // is a safe and precise way to exclude ephemeral helpers.
+          yield* Effect.logDebug(
+            "ProviderService.listSessions: skipping session without persisted binding",
+            { threadId: session.threadId, provider: session.provider },
+          ).pipe(Effect.ignore);
           continue;
         }
 
@@ -1118,15 +1135,17 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
   });
 
   const runStopAll = Effect.fn("runStopAll")(function* () {
-    const threadIds = yield* directory.listThreadIds();
+    const threadIds = new Set(yield* directory.listThreadIds());
     const currentAdapters = yield* getAdapterEntries;
     const activeSessions = yield* Effect.forEach(currentAdapters, ([instanceId, adapter]) =>
       adapter.listSessions().pipe(
         Effect.map((sessions) =>
-          sessions.map((session) => ({
-            ...session,
-            providerInstanceId: instanceId,
-          })),
+          sessions
+            .filter((session) => threadIds.has(session.threadId))
+            .map((session) => ({
+              ...session,
+              providerInstanceId: instanceId,
+            })),
         ),
       ),
     ).pipe(Effect.map((sessionsByAdapter) => sessionsByAdapter.flatMap((sessions) => sessions)));


### PR DESCRIPTION
## Problem

Title-generation and branch-name helper sessions are spawned ephemerally (e.g. `codex exec --ephemeral`) using the text generation model (`gpt-5.6-luna` by default). These sessions never go through the orchestration `thread.create` command, so they have no entry in `provider_session_runtime`.

Previously, `ProviderService.listSessions` included adapter sessions even when no persisted directory binding existed for their thread ID. This caused ephemeral helper sessions to leak into downstream consumers — startup reconciliation, the provider command reactor, checkpointing, and the shell projection — where they appeared as **ghost threads in Studio** that cannot be resumed.

When a user clicks resume on one of these ghost threads, Codex returns:
```
ERROR: No saved session found with ID 01a029ed-e0f0-7673-b07a-ebc216f507c6
```

because the ephemeral session was never persisted to disk.

## Investigation

Forensic analysis of a specific ghost session (`01a029ed-e0f0-7673-b07a-ebc216f507c6`):

| Location | Found? |
|---|---|
| `~/.codex/sessions/` (rollout files) | ❌ |
| `~/.codex/.codex-global-state.json` | ❌ |
| `~/.t3/userdata/state.sqlite` (all 17 tables) | ❌ |
| `~/.t3/userdata/logs/` (server + provider traces) | ❌ |

The session ID is a UUIDv7 with timestamp `2026-08-22T14:44:10.608Z` — 94ms after a real thread was created (`81965c78`, "General Check-In"). This confirms it is the title-generation helper for that thread.

The root cause: `listSessions` returns sessions from the adapter's in-memory `sessions` Map without checking whether they have a persisted binding. Sessions without bindings are ephemeral helpers that should not be exposed to downstream consumers.

## Fix

Filter out sessions without a persisted directory binding in two places:

### 1. `listSessions`
Skip sessions whose thread ID has no entry in `provider_session_runtime`, with a debug log for observability.

### 2. `runStopAll`
Only upsert stop-event bindings for sessions whose thread ID is already tracked in the directory, preventing ephemeral sessions from accidentally acquiring a persisted binding during shutdown.

## Safety

Sessions that should be visible always have a persisted binding written during `startSession`, so filtering on binding presence is a safe and precise way to exclude ephemeral helpers. Existing tests that call `listSessions` after `startSession` continue to pass because those sessions have bindings.

## Related issues

- #5359 — Thread title generation fail silently when text generation provider is unhealthy
- #5447 — Hidden duplicate agent session from title-generation call
- #5734 — Branch-name helper session works on the main task instead of just generating a branch name

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider session listing and shutdown binding writes, which feed reconciliation and the Studio thread list. Filtering is conservative (bindings written on startSession) but a Set vs `.length` analytics bug is introduced.
> 
> **Overview**
> Stops ephemeral title-generation and branch-name helper sessions from leaking into Studio as unresumable ghost threads.
> 
> `listSessions` now **skips adapter sessions with no persisted directory binding** (they never went through `thread.create` / `startSession`) and logs a debug line. `runStopAll` only upserts stop bindings for thread IDs already in the directory, so shutdown cannot persist those helpers.
> 
> **Review note:** `threadIds` is now a `Set`, but `sessionCount: threadIds.length` still uses `.length` (`Set` uses `.size`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9b59dfef25a535b025aff34bde6a0b6a737ca4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Filter ephemeral title-generation sessions from `listSessions` and `runStopAll`
> - In [ProviderService.ts](https://github.com/pingdotgg/t3code/pull/7911/files#diff-b9b9384b78856ff56cff5dd0ccb106054fb5d2d1b7500fcd30d8938ebfec5775), `listSessions` now skips sessions that lack a persisted directory binding and emits a debug log with `threadId` and `provider` for each skipped session.
> - `runStopAll` wraps `directory.listThreadIds()` in a `Set` and filters adapter-reported sessions to only those whose `threadId` exists in the directory before running upsert operations.
> - Behavioral Change: sessions without a persisted binding are now excluded from both the returned session list and stop-all handling.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f9b59df. 1 file reviewed, 2 issues evaluated, 1 issue filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/server/src/provider/Layers/ProviderService.ts — 1 comment posted, 2 evaluated, 1 filtered</summary>
>
> - [line 1138](https://github.com/pingdotgg/t3code/blob/f9b59dfef25a535b025aff34bde6a0b6a737ca4c/apps/server/src/provider/Layers/ProviderService.ts#L1138): `threadIds` is changed from an array to a `Set`, but `runStopAll` still records `sessionCount: threadIds.length`. `Set` has no `length`, so every `provider.sessions.stopped_all` analytics event now receives `undefined` instead of the number of stopped/tracked sessions; use `threadIds.size`. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->