### PR TITLE
fix(web): give sidebar project menu rows the same side padding as other menus

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3515,7 +3515,7 @@ export default function Sidebar() {
                       <MenuRadioItem
                         value="all"
                         closeOnClick
-                        className="h-8 min-h-8 px-1 py-0 text-sm font-medium [&>span:last-child]:flex [&>span:last-child]:min-w-0 [&>span:last-child]:items-center [&>span:last-child]:gap-2"
+                        className="h-8 min-h-8 py-0 text-sm font-medium [&>span:last-child]:flex [&>span:last-child]:min-w-0 [&>span:last-child]:items-center [&>span:last-child]:gap-2"
                       >
                         <FolderIcon className="size-4 shrink-0" />
                         <span className="min-w-0 truncate text-sm">All projects</span>
@@ -3527,7 +3527,7 @@ export default function Sidebar() {
                             key={scopeKey}
                             value={scopeKey}
                             closeOnClick
-                            className="h-8 min-h-8 px-1 py-0 text-sm font-medium [&>span:last-child]:flex [&>span:last-child]:min-w-0 [&>span:last-child]:items-center [&>span:last-child]:gap-2"
+                            className="h-8 min-h-8 py-0 text-sm font-medium [&>span:last-child]:flex [&>span:last-child]:min-w-0 [&>span:last-child]:items-center [&>span:last-child]:gap-2"
                           >
                             <ProjectFavicon
                               environmentId={project.environmentId}


### PR DESCRIPTION
The project filter dropdown in the sidebar felt cramped: the folder icon sat 2px from the left edge of the hover highlight.

The two `MenuRadioItem`s in the project scope menu overrode the shared menu item's `px-2` with `px-1`, and the shared `[&_svg]:-mx-0.5` nudge pushed the icon to the edge. Dropping the override gives the rows the same 8px side padding as every other menu, and the folder icon now lines up with the trigger's icon.

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/ishaanko/t3code/5ef13516b674b540faaac8b24ca3856d31e53a95/project-menu-before.png) | ![after](https://raw.githubusercontent.com/ishaanko/t3code/5ef13516b674b540faaac8b24ca3856d31e53a95/project-menu-after.png) |

Made with Claude Fable 5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic className-only padding tweak on a dropdown; no logic, data, or security impact.
> 
> **Overview**
> Removes the `px-1` override on sidebar project-scope `MenuRadioItem`s so they keep the shared menu `px-2` padding.
> 
> That extra 4px of inset keeps the folder/favicon from sitting on the hover highlight edge and lines the icons up with the filter trigger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa9ddbd3d7b1de4a919756bfde25b26abde1307b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sidebar project menu row side padding to match other menus
> Removes the `px-1` utility class from the 'All projects' and project group `MenuRadioItem` elements in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/7913/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1). This aligns their horizontal padding with the rest of the sidebar menus.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa9ddbd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->