### PR TITLE
fix(web): stop the sidebar project menu from highlighting the first project on open

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3531,6 +3531,10 @@ export default function Sidebar() {
                               variant="ghost-muted"
                               aria-label={`Project settings for ${project.displayName}`}
                               title={`Project settings for ${project.displayName}`}
+                              // Keep the gear out of the tab order: on open the menu focuses
+                              // the first tabbable element, and a tabbable gear drags focus and
+                              // the highlight onto this row before the pointer touches it.
+                              tabIndex={-1}
                               className="ml-auto size-6 [--control-icon-color:currentColor] text-icon-muted focus-visible:bg-accent focus-visible:text-foreground"
                               onPointerDown={(event) => event.stopPropagation()}
                               onClick={(event) => {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3531,12 +3531,21 @@ export default function Sidebar() {
                               variant="ghost-muted"
                               aria-label={`Project settings for ${project.displayName}`}
                               title={`Project settings for ${project.displayName}`}
-                              // Keep the gear out of the tab order: on open the menu focuses
-                              // the first tabbable element, and a tabbable gear drags focus and
-                              // the highlight onto this row before the pointer touches it.
-                              tabIndex={-1}
                               className="ml-auto size-6 [--control-icon-color:currentColor] text-icon-muted focus-visible:bg-accent focus-visible:text-foreground"
                               onPointerDown={(event) => event.stopPropagation()}
+                              onFocus={(event) => {
+                                // On open, Base UI focuses the first tabbable element in the popup,
+                                // which is the gear on the first row. Focus bubbling into the row
+                                // would highlight it before the pointer gets there, so hand that
+                                // open-time focus to the menu instead. Tab from a highlighted row
+                                // still lands here.
+                                const menu =
+                                  event.currentTarget.closest<HTMLElement>('[role="menu"]');
+                                if (menu && !menu.contains(event.relatedTarget)) {
+                                  event.stopPropagation();
+                                  menu.focus({ preventScroll: true });
+                                }
+                              }}
                               onClick={(event) => {
                                 void handleProjectSettings(event, project);
                               }}


### PR DESCRIPTION
Opening the sidebar project filter with the mouse highlighted the first project row even though the pointer was not over it. It looked like a stray hover state.

Base UI's `MenuPopup` focuses the first tabbable element on open. Menu rows are `tabIndex=-1` until highlighted, so that element was the project settings gear button in the first project row; focus bubbled into the row and highlighted it. The gear now hands that open-time focus to the menu itself (only when focus arrives from outside the popup) so the row does not light up. The gear stays in the tab order: Tab from a highlighted row still reaches it, arrow keys still move between rows, and the gear still opens settings by mouse and keyboard.

Fixes #7915. Related to #1399 and #5521, which cover the broader keyboard/screen-reader story for these gear buttons.

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/ishaanko/t3code/2e0af8c74ffed2ebc0d35183acb2f8dc3c25de46/project-menu-open-before.png) | ![after](https://raw.githubusercontent.com/ishaanko/t3code/2e0af8c74ffed2ebc0d35183acb2f8dc3c25de46/project-menu-open-after.png) |

Made with Claude Fable 5 in Claude Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single localized focus-handling change in sidebar UI with no auth, data, or API impact.
> 
> **Overview**
> Fixes a misleading highlight when opening the sidebar **project filter** with the mouse: the first project row looked selected even though the cursor was not over it.
> 
> **Base UI** focuses the first tabbable control when the menu opens; in this list that is the per-row **settings gear**, and focus bubbling into the `MenuRadioItem` triggered row highlight. The gear’s new **`onFocus`** handler detects focus entering from outside the popup (`relatedTarget` not inside `[role="menu"]`), stops propagation, and moves focus to the menu container with `preventScroll`. **Tab** from a keyboard-highlighted row still reaches the gear; mouse click and existing `onPointerDown` behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58cd938a7d4fc75813df3fcff84e461ce7190403. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sidebar project menu highlighting first project's settings button on open
> Adds an `onFocus` handler to the project settings `Button` in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/7916/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1). When focus enters the menu from outside (e.g., on menu open), the handler stops propagation and programmatically focuses the menu container with `preventScroll=true`, so the first row's gear icon does not receive initial focus. Click handling and tab navigation from a highlighted row are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 58cd938.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->